### PR TITLE
feat: add `needs_session_stickiness` to MCP HTTP clients for per-call vs persistent connection control

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -3993,6 +3993,17 @@ func (bifrost *Bifrost) RegisterMCPTool(name, description string, handler func(a
 // These operations involve network I/O and connection management that require mutex locks
 // which can block briefly during execution.
 
+// MCPClientRequiresPerCallConnection reports whether config resolves to a
+// per-call connection (true) or a persistent shared one (false), taking auth
+// type, connection type, and needs_session_stickiness into account together.
+// Returns false (the persistent-connection default) if MCP is not configured.
+func (bifrost *Bifrost) MCPClientRequiresPerCallConnection(config *schemas.MCPClientConfig) bool {
+	if bifrost.MCPManager == nil {
+		return false
+	}
+	return bifrost.MCPManager.RequiresPerCallConnection(config)
+}
+
 // GetMCPClients returns all MCP clients managed by the Bifrost instance.
 //
 // Returns:

--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -1222,6 +1222,29 @@ func (m *MCPManager) EnableClient(id string) (retErr error) {
 	return nil
 }
 
+// RequiresPerCallConnection reports whether config resolves to a per-call
+// connection (true) or a persistent shared one (false), taking auth type,
+// connection type, and needs_session_stickiness into account together — the
+// same decision AcquireClientConn and UpdateClient act on. Read-only
+// passthrough to the credential store's resolver dispatch, exposed so
+// callers (e.g. the HTTP handler, to describe what an update just changed)
+// don't have to duplicate that dispatch themselves.
+func (m *MCPManager) RequiresPerCallConnection(config *schemas.MCPClientConfig) bool {
+	return m.credStore.RequiresPerCallConnection(config)
+}
+
+// ErrMCPSharedConnectFailedAfterUpdate signals that UpdateClient's own field
+// update already committed (client.ExecutionConfig now holds the new config,
+// in-memory, with no rollback path) before the needs_session_stickiness
+// per-call->sticky dial was attempted and failed. Callers that persist config
+// to a store before calling UpdateClient (see the HTTP update handler) must
+// not roll back that persisted row on this specific error — doing so would
+// diverge the DB (old value) from the runtime (new value, parked Unstable
+// with a checker already retrying the connection) until a restart re-reads
+// the DB and silently discards the change. Wrapped via %w so errors.Is still
+// finds it under the caller-facing message.
+var ErrMCPSharedConnectFailedAfterUpdate = errors.New("mcp client fields updated, but establishing the shared connection failed")
+
 // UpdateClient updates an existing MCP client's configuration and refreshes its tool list.
 // It updates the client's execution config with new settings and retrieves updated tools
 // from the MCP server if the client is connected.
@@ -1241,105 +1264,214 @@ func (m *MCPManager) UpdateClient(id string, updatedConfig *schemas.MCPClientCon
 	}
 	defer func() { finish(retErr) }()
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	// The metadata swap runs under its own scoped lock so the two possible
+	// stickiness-transition follow-ups below — closing a connection versus
+	// dialing a new one via connectToMCPClient — can run after it's
+	// released; connectToMCPClient acquires m.mu itself, so calling it while
+	// still holding the lock here would deadlock.
+	var newConfig *schemas.MCPClientConfig
+	var becamePerCall, becameSticky bool
+	var clientName string
 
-	client, ok := m.clientMap[id]
-	if !ok {
-		return fmt.Errorf("client %s not found", id)
-	}
+	err := func() error {
+		m.mu.Lock()
+		defer m.mu.Unlock()
 
-	if err := ValidateMCPClientName(updatedConfig.Name); err != nil {
-		return fmt.Errorf("invalid MCP client configuration: %w", err)
-	}
-
-	if updatedConfig.ConnectionType != "" && updatedConfig.ConnectionType != client.ExecutionConfig.ConnectionType {
-		return fmt.Errorf("connection type cannot be updated for client %s", id)
-	}
-	if updatedConfig.ConnectionString != nil && !updatedConfig.ConnectionString.Equals(client.ExecutionConfig.ConnectionString) {
-		return fmt.Errorf("connection string cannot be updated for client %s", id)
-	}
-	if updatedConfig.StdioConfig != nil && !stdioConfigEqual(updatedConfig.StdioConfig, client.ExecutionConfig.StdioConfig) {
-		return fmt.Errorf("stdio config cannot be updated for client %s", id)
-	}
-	if updatedConfig.InProcessServer != nil && updatedConfig.InProcessServer != client.ExecutionConfig.InProcessServer {
-		return fmt.Errorf("in-process server cannot be updated for client %s", id)
-	}
-	// Normalize empty AuthType to "headers" — both are semantically identical
-	oldAuthType := client.ExecutionConfig.AuthType
-	if oldAuthType == "" {
-		oldAuthType = schemas.MCPAuthTypeHeaders
-	}
-	newAuthType := updatedConfig.AuthType
-	if newAuthType == "" {
-		newAuthType = schemas.MCPAuthTypeHeaders
-	}
-	if newAuthType != oldAuthType {
-		return fmt.Errorf("auth_type cannot be updated for client %s", id)
-	}
-
-	oauthConfigID := client.ExecutionConfig.OauthConfigID
-	if updatedConfig.OauthConfigID != nil {
-		oauthConfigID = updatedConfig.OauthConfigID
-	}
-
-	// Create a new config struct (immutable pattern) to avoid race conditions
-	// with concurrent reads. Any snapshot holding the old ExecutionConfig pointer
-	// will continue to see consistent data.
-	newConfig := &schemas.MCPClientConfig{
-		// Immutable fields - copy from existing config
-		ID:               client.ExecutionConfig.ID,
-		ConnectionType:   client.ExecutionConfig.ConnectionType,
-		ConnectionString: client.ExecutionConfig.ConnectionString,
-		StdioConfig:      client.ExecutionConfig.StdioConfig,
-		AuthType:         client.ExecutionConfig.AuthType,
-		OauthConfigID:    oauthConfigID,
-		State:            client.ExecutionConfig.State,
-		InProcessServer:  client.ExecutionConfig.InProcessServer,
-		ConfigHash:       client.ExecutionConfig.ConfigHash,
-		ToolPricing:      maps.Clone(client.ExecutionConfig.ToolPricing),
-		// Updatable fields - copy from updated config with proper cloning
-		Name:                  updatedConfig.Name,
-		IsCodeModeClient:      updatedConfig.IsCodeModeClient,
-		Headers:               maps.Clone(updatedConfig.Headers),
-		ToolsToExecute:        slices.Clone(updatedConfig.ToolsToExecute),
-		ToolsToAutoExecute:    slices.Clone(updatedConfig.ToolsToAutoExecute),
-		AllowedExtraHeaders:   slices.Clone(updatedConfig.AllowedExtraHeaders),
-		IsPingAvailable:       updatedConfig.IsPingAvailable,
-		ToolSyncInterval:      updatedConfig.ToolSyncInterval,
-		ToolExecutionTimeout:  updatedConfig.ToolExecutionTimeout,
-		AllowOnAllVirtualKeys: updatedConfig.AllowOnAllVirtualKeys,
-		Disabled:              updatedConfig.Disabled,
-		TLSConfig:             updatedConfig.TLSConfig,
-		PerUserHeaderKeys:     slices.Clone(updatedConfig.PerUserHeaderKeys),
-		PendingOAuthConfig:    updatedConfig.PendingOAuthConfig,
-		TokenExchange:         updatedConfig.TokenExchange,
-	}
-
-	// Atomically replace the config pointer
-	client.ExecutionConfig = newConfig
-
-	// Rebind ToolMap keys (and inner Function.Name) to the current client name.
-	newPrefix := updatedConfig.Name + "-"
-	newToolMap := make(map[string]schemas.ChatTool, len(client.ToolMap))
-	for oldToolName, tool := range client.ToolMap {
-		newToolName := oldToolName
-		if _, suffix, ok := strings.Cut(oldToolName, "-"); ok {
-			newToolName = newPrefix + suffix
+		client, ok := m.clientMap[id]
+		if !ok {
+			return fmt.Errorf("client %s not found", id)
 		}
-		if tool.Function != nil {
-			fn := *tool.Function
-			fn.Name = newToolName
-			tool.Function = &fn
+
+		if err := ValidateMCPClientName(updatedConfig.Name); err != nil {
+			return fmt.Errorf("invalid MCP client configuration: %w", err)
 		}
-		newToolMap[newToolName] = tool
+
+		if updatedConfig.ConnectionType != "" && updatedConfig.ConnectionType != client.ExecutionConfig.ConnectionType {
+			return fmt.Errorf("connection type cannot be updated for client %s", id)
+		}
+		if updatedConfig.ConnectionString != nil && !updatedConfig.ConnectionString.Equals(client.ExecutionConfig.ConnectionString) {
+			return fmt.Errorf("connection string cannot be updated for client %s", id)
+		}
+		if updatedConfig.StdioConfig != nil && !stdioConfigEqual(updatedConfig.StdioConfig, client.ExecutionConfig.StdioConfig) {
+			return fmt.Errorf("stdio config cannot be updated for client %s", id)
+		}
+		if updatedConfig.InProcessServer != nil && updatedConfig.InProcessServer != client.ExecutionConfig.InProcessServer {
+			return fmt.Errorf("in-process server cannot be updated for client %s", id)
+		}
+		// Normalize empty AuthType to "headers" — both are semantically identical
+		oldAuthType := client.ExecutionConfig.AuthType
+		if oldAuthType == "" {
+			oldAuthType = schemas.MCPAuthTypeHeaders
+		}
+		newAuthType := updatedConfig.AuthType
+		if newAuthType == "" {
+			newAuthType = schemas.MCPAuthTypeHeaders
+		}
+		if newAuthType != oldAuthType {
+			return fmt.Errorf("auth_type cannot be updated for client %s", id)
+		}
+
+		oauthConfigID := client.ExecutionConfig.OauthConfigID
+		if updatedConfig.OauthConfigID != nil {
+			oauthConfigID = updatedConfig.OauthConfigID
+		}
+
+		// Snapshot the pre-update per-call-ness so it can be compared against
+		// the post-update value below — this is what actually detects a
+		// needs_session_stickiness flip (auth types that are always per-call
+		// regardless of the field, e.g. per-user, never show a transition here).
+		wasPerCall := m.credStore.RequiresPerCallConnection(client.ExecutionConfig)
+
+		// Create a new config struct (immutable pattern) to avoid race conditions
+		// with concurrent reads. Any snapshot holding the old ExecutionConfig pointer
+		// will continue to see consistent data.
+		newConfig = &schemas.MCPClientConfig{
+			// Immutable fields - copy from existing config
+			ID:               client.ExecutionConfig.ID,
+			ConnectionType:   client.ExecutionConfig.ConnectionType,
+			ConnectionString: client.ExecutionConfig.ConnectionString,
+			StdioConfig:      client.ExecutionConfig.StdioConfig,
+			AuthType:         client.ExecutionConfig.AuthType,
+			OauthConfigID:    oauthConfigID,
+			State:            client.ExecutionConfig.State,
+			InProcessServer:  client.ExecutionConfig.InProcessServer,
+			ConfigHash:       client.ExecutionConfig.ConfigHash,
+			ToolPricing:      maps.Clone(client.ExecutionConfig.ToolPricing),
+			// Updatable fields - copy from updated config with proper cloning
+			Name:                   updatedConfig.Name,
+			IsCodeModeClient:       updatedConfig.IsCodeModeClient,
+			Headers:                maps.Clone(updatedConfig.Headers),
+			ToolsToExecute:         slices.Clone(updatedConfig.ToolsToExecute),
+			ToolsToAutoExecute:     slices.Clone(updatedConfig.ToolsToAutoExecute),
+			AllowedExtraHeaders:    slices.Clone(updatedConfig.AllowedExtraHeaders),
+			IsPingAvailable:        updatedConfig.IsPingAvailable,
+			NeedsSessionStickiness: updatedConfig.NeedsSessionStickiness,
+			ToolSyncInterval:       updatedConfig.ToolSyncInterval,
+			ToolExecutionTimeout:   updatedConfig.ToolExecutionTimeout,
+			AllowOnAllVirtualKeys:  updatedConfig.AllowOnAllVirtualKeys,
+			Disabled:               updatedConfig.Disabled,
+			TLSConfig:              updatedConfig.TLSConfig,
+			PerUserHeaderKeys:      slices.Clone(updatedConfig.PerUserHeaderKeys),
+			PendingOAuthConfig:     updatedConfig.PendingOAuthConfig,
+			TokenExchange:          updatedConfig.TokenExchange,
+		}
+
+		// Atomically replace the config pointer
+		client.ExecutionConfig = newConfig
+		clientName = updatedConfig.Name
+
+		// Rebind ToolMap keys (and inner Function.Name) to the current client name.
+		newPrefix := updatedConfig.Name + "-"
+		newToolMap := make(map[string]schemas.ChatTool, len(client.ToolMap))
+		for oldToolName, tool := range client.ToolMap {
+			newToolName := oldToolName
+			if _, suffix, ok := strings.Cut(oldToolName, "-"); ok {
+				newToolName = newPrefix + suffix
+			}
+			if tool.Function != nil {
+				fn := *tool.Function
+				fn.Name = newToolName
+				tool.Function = &fn
+			}
+			newToolMap[newToolName] = tool
+		}
+
+		// Replace the old ToolMap with the new one
+		client.ToolMap = newToolMap
+
+		// Also update the client Name field
+		client.Name = updatedConfig.Name
+
+		// needs_session_stickiness just flipped: apply it now instead of
+		// leaving the live connection state stale until some unrelated event
+		// (a restart, a manual reconnect) happens to re-evaluate it.
+		isPerCall := m.credStore.RequiresPerCallConnection(newConfig)
+		switch {
+		case !wasPerCall && isPerCall:
+			// Sticky -> per-call: release the persistent connection right
+			// here, under the same lock CloseAndMarkNeedsReauth uses for the
+			// equivalent close (cheap, no network I/O). The checker is
+			// stopped just below, once the lock is released.
+			//
+			// Bump ConnGeneration before closing: StopChecking (below, after
+			// the lock releases) does not cancel a check already in flight,
+			// so one that started just before this transition can still
+			// complete afterward. Its result — a tool-map write-back or a
+			// state write (Unstable/Healthy) — must be recognized as stale
+			// and dropped, the same guard writeBackTools already applies to
+			// tool maps and setState now applies to state writes too.
+			client.ConnGeneration++
+			if client.CancelFunc != nil {
+				client.CancelFunc()
+				client.CancelFunc = nil
+			}
+			if client.Conn != nil {
+				if closeErr := client.Conn.Close(); closeErr != nil {
+					m.logger.Error("%s Failed to close connection for MCP client '%s': %v", MCPLogPrefix, clientName, closeErr)
+				}
+				client.Conn = nil
+			}
+			// Disabled/NeedsReauth are authoritative states set by other
+			// flows (DisableClient, credential rotation) — this transition
+			// never overrides them. Otherwise a per-call client with no
+			// persistent connection to monitor is simply Healthy, the same
+			// state per-user auth types are given at connect time.
+			if client.State != schemas.MCPConnectionStateDisabled && client.State != schemas.MCPConnectionStateNeedsReauth {
+				client.State = schemas.MCPConnectionStateHealthy
+			}
+			becamePerCall = true
+		case wasPerCall && !isPerCall:
+			// Per-call -> sticky: there is nothing to release, but a
+			// persistent connection needs to be dialed for the first time —
+			// handled after the lock is released, below.
+			becameSticky = true
+		}
+
+		return nil
+	}()
+	if err != nil {
+		return err
 	}
 
-	// Replace the old ToolMap with the new one
-	client.ToolMap = newToolMap
+	if becamePerCall {
+		m.checkerManager.StopChecking(id)
+		m.logger.Info("%s MCP client '%s' switched to per-call connections (needs_session_stickiness=false): released its persistent connection", MCPLogPrefix, clientName)
+	}
+	if becameSticky {
+		// connectToMCPClient starts the connection checker itself on
+		// success, mirroring every other successful-connect path. On
+		// failure it does NOT start one (mirroring EnableClient's own
+		// failure handling below) — without this, a failed first dial would
+		// leave the client Unstable with nothing ever periodically retrying
+		// it, since a per-call client never had a checker running to begin
+		// with. Start one explicitly, same as EnableClient does.
+		if connErr := m.connectToMCPClient(m.ctx, newConfig); connErr != nil {
+			m.mu.Lock()
+			alreadyTerminal := false
+			if cs, exists := m.clientMap[id]; exists {
+				switch cs.State {
+				case schemas.MCPConnectionStateDisabled, schemas.MCPConnectionStateNeedsReauth:
+					alreadyTerminal = true
+				default:
+					cs.State = schemas.MCPConnectionStateUnstable
+				}
+			}
+			m.mu.Unlock()
 
-	// Also update the client Name field
-	client.Name = updatedConfig.Name
+			if !alreadyTerminal {
+				isPingAvailable := true
+				if newConfig.IsPingAvailable != nil {
+					isPingAvailable = *newConfig.IsPingAvailable
+				}
+				syncInterval := ResolveToolSyncInterval(newConfig, m.checkerManager.GetGlobalInterval())
+				checker := NewClientConnectionChecker(m, id, syncInterval, isPingAvailable, m.logger)
+				m.checkerManager.StartChecking(checker)
+			}
+
+			return fmt.Errorf("client updated, but establishing the shared connection for needs_session_stickiness=true failed: %w: %w", ErrMCPSharedConnectFailedAfterUpdate, connErr)
+		}
+		m.logger.Info("%s MCP client '%s' switched to a shared connection (needs_session_stickiness=true): established it now", MCPLogPrefix, clientName)
+	}
 
 	return nil
 }

--- a/core/mcp/connectionchecker.go
+++ b/core/mcp/connectionchecker.go
@@ -255,7 +255,7 @@ func (c *ClientConnectionChecker) checkLiveConnection(conn *client.Client, clien
 			return c.manager.runPingWithHooks(c.markAsCheck(attemptCtx), conn, clientName)
 		}, ProbeRetryConfig, c.logger)
 		if pingErr != nil {
-			c.recordFailure(clientName, "ping", pingErr)
+			c.recordFailure(clientName, "ping", pingErr, connGeneration)
 			return UnstableConnectionCheckInterval
 		}
 	}
@@ -270,12 +270,12 @@ func (c *ClientConnectionChecker) checkLiveConnection(conn *client.Client, clien
 		return err
 	}, ProbeRetryConfig, c.logger)
 	if listErr != nil {
-		c.recordFailure(clientName, "list_tools", listErr)
+		c.recordFailure(clientName, "list_tools", listErr, connGeneration)
 		return UnstableConnectionCheckInterval
 	}
 
 	c.writeBackTools(connGeneration, newTools, newMapping)
-	c.recordSuccess(clientName)
+	c.recordSuccess(clientName, connGeneration)
 	return c.healthyInterval
 }
 
@@ -293,12 +293,12 @@ func (c *ClientConnectionChecker) checkPerCall(config *schemas.MCPClientConfig, 
 		return innerErr
 	}, ProbeRetryConfig, c.logger)
 	if err != nil {
-		c.recordFailure(config.Name, "admin tool discovery", err)
+		c.recordFailure(config.Name, "admin tool discovery", err, connGeneration)
 		return UnstableConnectionCheckInterval
 	}
 
 	c.writeBackTools(connGeneration, newTools, newMapping)
-	c.recordSuccess(config.Name)
+	c.recordSuccess(config.Name, connGeneration)
 	return c.healthyInterval
 }
 
@@ -336,29 +336,46 @@ func (c *ClientConnectionChecker) writeBackTools(connGeneration uint64, newTools
 // recordFailure marks the client Unstable — a single transient-classified
 // failure is enough, no consecutive-failure counter: the retry-with-backoff
 // each check already went through (ProbeRetryConfig) is what absorbs an
-// ordinary blip before it ever reaches here.
-func (c *ClientConnectionChecker) recordFailure(clientName, stage string, err error) {
+// ordinary blip before it ever reaches here. connGeneration is the value
+// captured at the start of this check (see performCheck) — see setState for
+// why it must be threaded through even though this write, unlike
+// writeBackTools, isn't about the connection itself.
+func (c *ClientConnectionChecker) recordFailure(clientName, stage string, err error, connGeneration uint64) {
 	c.logger.Warn("%s Connection check (%s) failed for %s: %v", MCPLogPrefix, stage, clientName, err)
-	c.setState(schemas.MCPConnectionStateUnstable)
+	c.setState(schemas.MCPConnectionStateUnstable, connGeneration)
 }
 
 // recordSuccess marks the client Healthy. A single success is enough to
 // recover — asymmetric on purpose: slow and deliberate into Unstable
 // (respecting the retry budget), instant back out of it once a check
 // actually proves the connection is fine again.
-func (c *ClientConnectionChecker) recordSuccess(clientName string) {
-	c.setState(schemas.MCPConnectionStateHealthy)
+func (c *ClientConnectionChecker) recordSuccess(clientName string, connGeneration uint64) {
+	c.setState(schemas.MCPConnectionStateHealthy, connGeneration)
 }
 
 // setState is the guarded writer every transition in this file funnels
 // through — Disabled and NeedsReauth are authoritative and never silently
 // overwritten by a check result racing against a DisableClient call or a
 // credential already confirmed dead.
-func (c *ClientConnectionChecker) setState(state schemas.MCPConnectionState) {
+//
+// connGeneration is dropped if it no longer matches the client's current
+// ConnGeneration, mirroring writeBackTools' own guard: StopChecking does not
+// cancel an in-flight check, so a check started just before a
+// stickiness-transition (which bumps ConnGeneration when it closes the
+// persistent connection) can still complete afterward. Without this guard
+// its state write would land on an entry that has since moved on — e.g.
+// marking Unstable a client that just became per-call and has no connection
+// left to be unstable about.
+func (c *ClientConnectionChecker) setState(state schemas.MCPConnectionState, connGeneration uint64) {
 	c.manager.mu.Lock()
 	clientState, exists := c.manager.clientMap[c.clientID]
 	if !exists {
 		c.manager.mu.Unlock()
+		return
+	}
+	if clientState.ConnGeneration != connGeneration {
+		c.manager.mu.Unlock()
+		c.logger.Debug("%s Skipping state write for %s: connection was replaced during check", MCPLogPrefix, c.clientID)
 		return
 	}
 	if clientState.State == schemas.MCPConnectionStateDisabled || clientState.State == schemas.MCPConnectionStateNeedsReauth {

--- a/core/mcp/connectionchecker_test.go
+++ b/core/mcp/connectionchecker_test.go
@@ -140,11 +140,12 @@ func TestPerformCheck_NilConn_SharedAuthType_TriggersReconnect(t *testing.T) {
 	manager := NewMCPManager(context.Background(), schemas.MCPConfig{}, nil, &MockLogger{}, nil)
 
 	config := &schemas.MCPClientConfig{
-		ID:               "client-reconnect-trigger",
-		Name:             "shared-client",
-		AuthType:         schemas.MCPAuthTypeHeaders,
-		ConnectionType:   schemas.MCPConnectionTypeHTTP,
-		ConnectionString: schemas.NewSecretVar("http://127.0.0.1:0/mcp"), // unreachable — attempt must still be made
+		ID:                     "client-reconnect-trigger",
+		Name:                   "shared-client",
+		AuthType:               schemas.MCPAuthTypeHeaders,
+		ConnectionType:         schemas.MCPConnectionTypeHTTP,
+		ConnectionString:       schemas.NewSecretVar("http://127.0.0.1:0/mcp"), // unreachable — attempt must still be made
+		NeedsSessionStickiness: schemas.Ptr(true),                             // sticky: routes through the reconnect-on-nil-conn branch under test, not checkPerCall
 	}
 	manager.mu.Lock()
 	manager.clientMap[config.ID] = &schemas.MCPClientState{
@@ -192,4 +193,37 @@ func TestPerformCheck_NilConn_PerUserOAuth_SuccessUpdatesToolMap(t *testing.T) {
 	updated := manager.clientMap[config.ID].ToolMap
 	require.Contains(t, updated, "oauth-client-echo", "a successful admin-discovery cycle should populate the client's tool map")
 	require.Equal(t, schemas.MCPConnectionStateHealthy, manager.clientMap[config.ID].State)
+}
+
+// TestSetState_StaleGeneration_DoesNotOverwriteState pins the gap CodeRabbit
+// flagged: recordFailure/recordSuccess (via setState) had no generation
+// guard at all, unlike writeBackTools' existing one for tool-map writes. A
+// check that started before a sticky->per-call transition (which closes the
+// connection but, before this fix, never bumped ConnGeneration) can complete
+// afterward — StopChecking doesn't cancel an in-flight check — and its state
+// write would land on an entry that's since moved on, e.g. marking Unstable
+// a client that no longer has a persistent connection to be unstable about.
+// setState must drop a write whose captured generation no longer matches the
+// client's current one, mirroring writeBackTools' own guard exactly.
+func TestSetState_StaleGeneration_DoesNotOverwriteState(t *testing.T) {
+	manager := &MCPManager{
+		logger:    &MockLogger{},
+		clientMap: map[string]*schemas.MCPClientState{},
+	}
+	state, config := newSyncTestClientState("client-gen", "gen-client", schemas.MCPAuthTypeHeaders, nil)
+	state.State = schemas.MCPConnectionStateHealthy
+	state.ConnGeneration = 6 // already bumped past what the stale check captured
+	manager.clientMap[config.ID] = state
+
+	checker := NewClientConnectionChecker(manager, config.ID, time.Minute, false, &MockLogger{})
+
+	// A check that captured generation 5 (before the transition) finishing
+	// late must not move the state at all.
+	checker.setState(schemas.MCPConnectionStateUnstable, 5)
+	require.Equal(t, schemas.MCPConnectionStateHealthy, manager.clientMap[config.ID].State, "a stale-generation state write must be dropped")
+
+	// A check whose captured generation still matches the client's current
+	// one must apply normally — the guard isn't a blanket no-op.
+	checker.setState(schemas.MCPConnectionStateUnstable, 6)
+	require.Equal(t, schemas.MCPConnectionStateUnstable, manager.clientMap[config.ID].State, "a current-generation state write must still apply")
 }

--- a/core/mcp/credstore/credstore.go
+++ b/core/mcp/credstore/credstore.go
@@ -81,6 +81,16 @@ func (s *CredStore) RequestHeaders(ctx *schemas.BifrostContext, config *schemas.
 // unknown auth types it returns false (safe shared-mode default); the next
 // ConnectionHeaders / RequestHeaders call from the caller will surface the
 // actual "unsupported auth type" error.
+//
+// Per-user auth types are always per-call regardless of stickiness (their
+// resolver hardcodes true — there's no "shared" mode for them to opt out
+// of). Shared HTTP auth types (headers/oauth) additionally honor
+// config.NeedsSessionStickiness: only explicitly true keeps them on the
+// persistent-connection + connection-checker path (every pre-existing
+// client is backfilled to true at the DB layer so this is a no-op for
+// them); nil/false (the default for newly created clients) routes them
+// through the per-call path too, same as the per-user types. SSE and STDIO
+// ignore the flag — see needsSessionStickiness's doc comment.
 func (s *CredStore) RequiresPerCallConnection(config *schemas.MCPClientConfig) bool {
 	if config == nil {
 		return false
@@ -89,7 +99,26 @@ func (s *CredStore) RequiresPerCallConnection(config *schemas.MCPClientConfig) b
 	if !ok {
 		return false
 	}
-	return r.RequiresPerCallConnection()
+	if r.RequiresPerCallConnection() {
+		return true
+	}
+	return !needsSessionStickiness(config)
+}
+
+// needsSessionStickiness reports whether config wants a persistent shared
+// connection (explicitly true) or a fresh per-call connection (nil/false,
+// the default for newly created clients). Only meaningful for
+// connection_type=http: SSE has no stateless mode (its session is
+// inherently bound to the open stream) and STDIO needs a persistent
+// subprocess, so both are treated as always sticky regardless of what the
+// field says — write-time validation is responsible for rejecting an
+// explicit false for those types in the first place, this is just a
+// defensive second check at the point stickiness actually matters.
+func needsSessionStickiness(config *schemas.MCPClientConfig) bool {
+	if config.ConnectionType != schemas.MCPConnectionTypeHTTP {
+		return true
+	}
+	return config.NeedsSessionStickiness != nil && *config.NeedsSessionStickiness
 }
 
 // ForceRefresh implements schemas.MCPCredentialStore.

--- a/core/mcp/interface.go
+++ b/core/mcp/interface.go
@@ -54,6 +54,12 @@ type MCPManagerInterface interface {
 	// GetClients returns all MCP clients
 	GetClients() []schemas.MCPClientState
 
+	// RequiresPerCallConnection reports whether config resolves to a
+	// per-call connection (true) or a persistent shared one (false), taking
+	// auth type, connection type, and needs_session_stickiness into account
+	// together.
+	RequiresPerCallConnection(config *schemas.MCPClientConfig) bool
+
 	// AddClient adds a new MCP client with the given configuration
 	AddClient(ctx context.Context, config *schemas.MCPClientConfig) error
 

--- a/core/mcp/reauth_state_test.go
+++ b/core/mcp/reauth_state_test.go
@@ -143,7 +143,7 @@ func TestSetState_PreservesNeedsReauth(t *testing.T) {
 	checker := NewClientConnectionChecker(m, config.ID, DefaultConnectionCheckInterval, true, nil)
 
 	// A failed check tick (recordFailure's path) tries to write Unstable first.
-	checker.setState(schemas.MCPConnectionStateUnstable)
+	checker.setState(schemas.MCPConnectionStateUnstable, 0)
 	m.mu.RLock()
 	stateAfterFailureTick := m.clientMap[config.ID].State
 	m.mu.RUnlock()
@@ -152,7 +152,7 @@ func TestSetState_PreservesNeedsReauth(t *testing.T) {
 	// A successful check (recordSuccess's path) tries to write Healthy — this
 	// must also be rejected: the check succeeding against a stale/absent
 	// transport does not mean the credential is fixed.
-	checker.setState(schemas.MCPConnectionStateHealthy)
+	checker.setState(schemas.MCPConnectionStateHealthy, 0)
 	m.mu.RLock()
 	stateAfterSuccessTick := m.clientMap[config.ID].State
 	m.mu.RUnlock()
@@ -204,7 +204,7 @@ func TestSetState_StillPreservesDisabled(t *testing.T) {
 	m.mu.Unlock()
 
 	checker := NewClientConnectionChecker(m, config.ID, DefaultConnectionCheckInterval, true, nil)
-	checker.setState(schemas.MCPConnectionStateHealthy)
+	checker.setState(schemas.MCPConnectionStateHealthy, 0)
 
 	m.mu.RLock()
 	state := m.clientMap[config.ID].State

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -463,13 +463,27 @@ type MCPClientConfig struct {
 	// - nil/omitted => treated as [] (no tools)
 	// - ["tool1", "tool2"] => auto-execute only the specified tools
 	// Note: If a tool is in ToolsToAutoExecute but not in ToolsToExecute, it will be skipped.
-	IsPingAvailable       *bool              `json:"is_ping_available,omitempty"`      // Whether the MCP server supports ping for health checks (nil/true = ping; false = listTools). Defaults to true.
-	ToolSyncInterval      time.Duration      `json:"tool_sync_interval,omitempty"`     // Per-client override for tool sync interval (0 = use global, negative = disabled)
-	ToolExecutionTimeout  time.Duration      `json:"tool_execution_timeout,omitempty"` // Per-client override for tool execution timeout (0 = use global from tool_manager_config)
-	ToolPricing           map[string]float64 `json:"tool_pricing,omitempty"`           // Tool pricing for each tool (cost per execution)
-	Disabled              bool               `json:"disabled"`                         // Whether the client is intentionally disabled (stops connection and workers)
-	ConfigHash            string             `json:"-"`                                // Config hash for reconciliation (not serialized)
-	AllowOnAllVirtualKeys bool               `json:"allow_on_all_virtual_keys"`        // Whether to allow the MCP client to run on all virtual keys
+	IsPingAvailable *bool `json:"is_ping_available,omitempty"` // Whether the MCP server supports ping for health checks (nil/true = ping; false = listTools). Defaults to true.
+	// NeedsSessionStickiness controls whether this shared client (auth_type
+	// oauth/headers) maintains one persistent connection reused across every
+	// caller (true) or connects fresh per call, same model as the per-user
+	// auth types, with no persistent connection or background connection
+	// checker at all (nil/false, the default for newly created clients).
+	// Every client that existed before this field was introduced is
+	// explicitly backfilled to true, preserving its exact prior behavior;
+	// nil/false only applies to clients created afterward. Only meaningful
+	// for ConnectionType == http: SSE has no stateless mode and STDIO needs
+	// a persistent subprocess, so both always behave as sticky regardless
+	// of this field, and an explicit false is rejected for either at write
+	// time. Ignored for per-user auth types (already always per-call
+	// regardless).
+	NeedsSessionStickiness *bool              `json:"needs_session_stickiness,omitempty"`
+	ToolSyncInterval       time.Duration      `json:"tool_sync_interval,omitempty"`     // Per-client override for tool sync interval (0 = use global, negative = disabled)
+	ToolExecutionTimeout   time.Duration      `json:"tool_execution_timeout,omitempty"` // Per-client override for tool execution timeout (0 = use global from tool_manager_config)
+	ToolPricing            map[string]float64 `json:"tool_pricing,omitempty"`           // Tool pricing for each tool (cost per execution)
+	Disabled               bool               `json:"disabled"`                         // Whether the client is intentionally disabled (stops connection and workers)
+	ConfigHash             string             `json:"-"`                                // Config hash for reconciliation (not serialized)
+	AllowOnAllVirtualKeys  bool               `json:"allow_on_all_virtual_keys"`        // Whether to allow the MCP client to run on all virtual keys
 
 	// Discovered tools for per-user OAuth clients (persisted so they survive restart)
 	DiscoveredTools           map[string]ChatTool `json:"-"` // Discovered tool schemas keyed by prefixed name

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -1518,6 +1518,31 @@ func GenerateMCPClientHash(m tables.TableMCPClient) (string, error) {
 	}
 	hash.Write([]byte("auth_type:" + authType))
 
+	// Hash NeedsSessionStickiness so toggling it in config.json drifts the
+	// hash and triggers reconciliation — without this, editing only this
+	// field would leave the row's migration-backfilled (or nil-defaulted)
+	// value in place indefinitely, since nothing else about the row changed.
+	//
+	// nil contributes nothing — identical to how this field hashed before it
+	// existed in the formula at all. That's deliberate: a config.json entry
+	// that still omits the field must keep coincidentally matching a stale
+	// (pre-migration) stored hash, so the migration's true-backfill for
+	// existing shared clients isn't clobbered by a forced file-wins resync
+	// on the next restart just because config.json never mentions the field.
+	// true and false each get their own distinct marker: only an *explicit*
+	// value in config.json represents a real opinion worth detecting as a
+	// change. Collapsing false into nil's zero-contribution (as this used to
+	// do) meant an admin's explicit `needs_session_stickiness: false` edit
+	// could coincidentally hash-match a stale stored hash and silently never
+	// take effect.
+	if m.NeedsSessionStickiness != nil {
+		if *m.NeedsSessionStickiness {
+			hash.Write([]byte("needs_session_stickiness:true"))
+		} else {
+			hash.Write([]byte("needs_session_stickiness:false"))
+		}
+	}
+
 	// Hash PerUserHeaderKeys (sorted for deterministic hashing) so edits to
 	// the declared header-name schema in config.json drift the hash.
 	if len(m.PerUserHeaderKeys) > 0 {

--- a/framework/configstore/clientconfig_mcp_hash_test.go
+++ b/framework/configstore/clientconfig_mcp_hash_test.go
@@ -1,0 +1,46 @@
+package configstore
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGenerateMCPClientHash_NeedsSessionStickiness_NilVsFalseVsTrue pins the
+// three-way distinction the config.json reconciliation-mismatch fix depends
+// on:
+//
+//   - nil must hash identically to how the field hashed before it existed at
+//     all (zero contribution) — this is what lets a pre-existing config.json
+//     entry that still omits the field coincidentally match a migration-era
+//     stale DB hash, so the migration's true backfill isn't clobbered by a
+//     forced resync on the next restart.
+//   - true and false must each hash distinctly from nil AND from each other —
+//     an admin's explicit `needs_session_stickiness: false` in config.json
+//     must drift the hash so the mismatch is actually detected, instead of
+//     silently colliding with a stale hash and never taking effect.
+func TestGenerateMCPClientHash_NeedsSessionStickiness_NilVsFalseVsTrue(t *testing.T) {
+	base := func(stickiness *bool) tables.TableMCPClient {
+		return tables.TableMCPClient{
+			Name:                   "client",
+			ConnectionType:         "http",
+			AuthType:               "headers",
+			NeedsSessionStickiness: stickiness,
+		}
+	}
+	truePtr := true
+	falsePtr := false
+
+	nilHash, err := GenerateMCPClientHash(base(nil))
+	require.NoError(t, err)
+	trueHash, err := GenerateMCPClientHash(base(&truePtr))
+	require.NoError(t, err)
+	falseHash, err := GenerateMCPClientHash(base(&falsePtr))
+	require.NoError(t, err)
+
+	assert.NotEqual(t, nilHash, trueHash, "true must hash differently from nil")
+	assert.NotEqual(t, nilHash, falseHash, "false must hash differently from nil — otherwise a genuine config.json edit to false is silently ignored")
+	assert.NotEqual(t, trueHash, falseHash, "true and false must hash differently from each other")
+}

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -464,6 +464,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"drop_oauth_config_token_id_column"}, run: migrationDropOauthConfigTokenIDColumn},
 	{IDs: []string{"add_mcp_admin_auth_mode_indexes"}, run: migrationAddMCPAdminAuthModeIndexes},
 	{IDs: []string{"add_mcp_client_token_exchange_json_column"}, run: migrationAddMCPClientTokenExchangeJSONColumn},
+	{IDs: []string{"add_needs_session_stickiness_column"}, run: migrationAddNeedsSessionStickinessColumn},
 }
 
 // quoteSQLiteIdentifier quotes a SQLite identifier, escaping any double quotes.
@@ -4564,6 +4565,46 @@ func migrationAddIsPingAvailableColumnToMCPClientTable(ctx context.Context, db *
 	err := m.Migrate()
 	if err != nil {
 		return fmt.Errorf("error while running is_ping_available migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddNeedsSessionStickinessColumn adds the needs_session_stickiness
+// column to the config_mcp_clients table, backfilled true for every existing
+// row — preserves today's persistent-connection behavior for every
+// pre-existing shared client by default; only newly-opted-in clients get the
+// per-call model.
+func migrationAddNeedsSessionStickinessColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_needs_session_stickiness_column"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if !migrator.HasColumn(&tables.TableMCPClient{}, "needs_session_stickiness") {
+				if err := addColumnIfNotExists(tx, logger, &tables.TableMCPClient{}, "needs_session_stickiness"); err != nil {
+					return err
+				}
+				// Set default value for existing rows
+				if err := tx.Model(&tables.TableMCPClient{}).Where("needs_session_stickiness IS NULL").Update("needs_session_stickiness", true).Error; err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if err := dropColumnIfExists(tx, logger, &tables.TableMCPClient{}, "needs_session_stickiness"); err != nil {
+				return err
+			}
+			return nil
+		},
+	}})
+	err := m.Migrate()
+	if err != nil {
+		return fmt.Errorf("error while running needs_session_stickiness migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1555,6 +1555,7 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 					Headers:                   dbClient.Headers,
 					AllowedExtraHeaders:       dbClient.AllowedExtraHeaders,
 					IsPingAvailable:           dbClient.IsPingAvailable,
+					NeedsSessionStickiness:    dbClient.NeedsSessionStickiness,
 					ToolSyncInterval:          time.Duration(dbClient.ToolSyncInterval) * time.Second,
 					ToolExecutionTimeout:      time.Duration(dbClient.ToolExecutionTimeout) * time.Second,
 					ToolPricing:               dbClient.ToolPricing,
@@ -1605,6 +1606,7 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 			Headers:                   dbClient.Headers,
 			AllowedExtraHeaders:       dbClient.AllowedExtraHeaders,
 			IsPingAvailable:           dbClient.IsPingAvailable,
+			NeedsSessionStickiness:    dbClient.NeedsSessionStickiness,
 			ToolSyncInterval:          time.Duration(dbClient.ToolSyncInterval) * time.Second,
 			ToolExecutionTimeout:      time.Duration(dbClient.ToolExecutionTimeout) * time.Second,
 			AllowOnAllVirtualKeys:     dbClient.AllowOnAllVirtualKeys,
@@ -2036,6 +2038,7 @@ func (s *RDBConfigStore) GetMCPClientConfigByID(ctx context.Context, id string) 
 		Headers:                   dbClient.Headers,
 		AllowedExtraHeaders:       dbClient.AllowedExtraHeaders,
 		IsPingAvailable:           dbClient.IsPingAvailable,
+		NeedsSessionStickiness:    dbClient.NeedsSessionStickiness,
 		ToolSyncInterval:          time.Duration(dbClient.ToolSyncInterval) * time.Second,
 		ToolExecutionTimeout:      time.Duration(dbClient.ToolExecutionTimeout) * time.Second,
 		AllowOnAllVirtualKeys:     dbClient.AllowOnAllVirtualKeys,
@@ -2137,23 +2140,24 @@ func (s *RDBConfigStore) CreateMCPClientConfig(ctx context.Context, clientConfig
 		}
 		toolExecutionTimeoutSec := toolExecutionTimeoutDurationToStoredSeconds(clientConfigCopy.ToolExecutionTimeout)
 		dbClient := tables.TableMCPClient{
-			ClientID:              clientConfigCopy.ID,
-			Name:                  clientConfigCopy.Name,
-			IsCodeModeClient:      clientConfigCopy.IsCodeModeClient,
-			ConnectionType:        string(clientConfigCopy.ConnectionType),
-			ConnectionString:      clientConfigCopy.ConnectionString,
-			StdioConfig:           clientConfigCopy.StdioConfig,
-			TLSConfig:             clientConfigCopy.TLSConfig,
-			AuthType:              string(clientConfigCopy.AuthType),
-			OauthConfigID:         clientConfigCopy.OauthConfigID,
-			ToolsToExecute:        clientConfigCopy.ToolsToExecute,
-			ToolsToAutoExecute:    clientConfigCopy.ToolsToAutoExecute,
-			Headers:               clientConfigCopy.Headers,
-			AllowedExtraHeaders:   clientConfigCopy.AllowedExtraHeaders,
-			IsPingAvailable:       clientConfigCopy.IsPingAvailable,
-			ToolSyncInterval:      toolSyncIntervalSec,
-			ToolExecutionTimeout:  toolExecutionTimeoutSec,
-			AllowOnAllVirtualKeys: clientConfigCopy.AllowOnAllVirtualKeys,
+			ClientID:               clientConfigCopy.ID,
+			Name:                   clientConfigCopy.Name,
+			IsCodeModeClient:       clientConfigCopy.IsCodeModeClient,
+			ConnectionType:         string(clientConfigCopy.ConnectionType),
+			ConnectionString:       clientConfigCopy.ConnectionString,
+			StdioConfig:            clientConfigCopy.StdioConfig,
+			TLSConfig:              clientConfigCopy.TLSConfig,
+			AuthType:               string(clientConfigCopy.AuthType),
+			OauthConfigID:          clientConfigCopy.OauthConfigID,
+			ToolsToExecute:         clientConfigCopy.ToolsToExecute,
+			ToolsToAutoExecute:     clientConfigCopy.ToolsToAutoExecute,
+			Headers:                clientConfigCopy.Headers,
+			AllowedExtraHeaders:    clientConfigCopy.AllowedExtraHeaders,
+			IsPingAvailable:        clientConfigCopy.IsPingAvailable,
+			NeedsSessionStickiness: clientConfigCopy.NeedsSessionStickiness,
+			ToolSyncInterval:       toolSyncIntervalSec,
+			ToolExecutionTimeout:   toolExecutionTimeoutSec,
+			AllowOnAllVirtualKeys:  clientConfigCopy.AllowOnAllVirtualKeys,
 			// DiscoveredTools has json:"-" so deepCopy loses it; use original clientConfig
 			DiscoveredTools:           clientConfig.DiscoveredTools,
 			DiscoveredToolNameMapping: clientConfig.DiscoveredToolNameMapping,
@@ -2423,6 +2427,13 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 		// This preserves the existing DB value when the request omits the field
 		if clientConfigCopy.IsPingAvailable != nil {
 			updates["is_ping_available"] = *clientConfigCopy.IsPingAvailable
+		}
+
+		// Only update needs_session_stickiness if explicitly provided
+		// (non-nil); this preserves the existing DB value when the request
+		// omits the field.
+		if clientConfigCopy.NeedsSessionStickiness != nil {
+			updates["needs_session_stickiness"] = *clientConfigCopy.NeedsSessionStickiness
 		}
 
 		if err := tx.WithContext(ctx).Model(&existingClient).Updates(updates).Error; err != nil {
@@ -7273,8 +7284,8 @@ func (s *RDBConfigStore) MarkTokensNeedsReauthByConfigID(ctx context.Context, oa
 // MarkAdminExchangeTokenNeedsReauthByMCPClientID flips status to
 // 'needs_reauth' on a single row: the token_exchange client's retained admin
 // bootstrap credential (auth_mode='admin', mcp_client_id=<id>,
-// oauth_config_id='' — see isExchangeBackedTokenRow in framework/oauth2 for
-// the same row shape). The oauth_config_id='' filter excludes a
+// oauth_config_id=” — see isExchangeBackedTokenRow in framework/oauth2 for
+// the same row shape). The oauth_config_id=” filter excludes a
 // per_user_oauth client's admin row, which is keyed by mcp_client_id too but
 // carries a real oauth_config_id and is already covered by
 // MarkTokensNeedsReauthByConfigID.

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -26,9 +26,23 @@ type TableMCPClient struct {
 	HeadersJSON             string             `gorm:"type:text" json:"-"`                              // JSON serialized map[string]string
 	AllowedExtraHeadersJSON string             `gorm:"type:text" json:"-"`                              // JSON serialized []string
 	IsPingAvailable         *bool              `gorm:"default:true" json:"is_ping_available,omitempty"` // Whether the MCP server supports ping for health checks
-	ToolPricingJSON         string             `gorm:"type:text" json:"-"`                              // JSON serialized map[string]float64
-	ToolSyncInterval        int                `gorm:"default:0" json:"tool_sync_interval"`             // Per-client tool sync interval in seconds (0 = use global, negative = disabled)
-	ToolExecutionTimeout    int                `gorm:"default:0" json:"tool_execution_timeout"`         // Per-client tool execution timeout in seconds (0 = use global from tool_manager_config)
+	// NeedsSessionStickiness: nil/false = per-call connection (the default
+	// for newly created clients); true = persistent shared connection
+	// (today's only behavior — every pre-existing row is explicitly
+	// backfilled to true by the migration, so this default only applies to
+	// clients created after this column existed). Ignored/always-true for
+	// non-http connection types.
+	//
+	// Deliberately no `gorm:"default:..."` tag: a DB-level default would
+	// make ADD COLUMN's fast-default mechanism return that value for every
+	// pre-existing row immediately, so the migration's `WHERE
+	// needs_session_stickiness IS NULL` backfill would never match anything.
+	// Leaving the column plain-nullable is what lets the migration tell
+	// "pre-existing, needs backfill" (NULL) apart from "explicitly set".
+	NeedsSessionStickiness *bool  `json:"needs_session_stickiness,omitempty"`
+	ToolPricingJSON        string `gorm:"type:text" json:"-"`                      // JSON serialized map[string]float64
+	ToolSyncInterval       int    `gorm:"default:0" json:"tool_sync_interval"`     // Per-client tool sync interval in seconds (0 = use global, negative = disabled)
+	ToolExecutionTimeout   int    `gorm:"default:0" json:"tool_execution_timeout"` // Per-client tool execution timeout in seconds (0 = use global from tool_manager_config)
 
 	// Per-user OAuth: discovered tools persisted so they survive restart
 	DiscoveredToolsJSON string `gorm:"type:text" json:"-"` // JSON serialized map[string]schemas.ChatTool

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -51,6 +51,11 @@ type MCPManager interface {
 	VerifyHeadersConnection(ctx context.Context, config *schemas.MCPClientConfig, userHeaders map[string]string) (map[string]schemas.ChatTool, map[string]string, error)
 	// SetClientTools updates the tool map for an existing client.
 	SetClientTools(clientID string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string)
+	// RequiresPerCallConnection reports whether config resolves to a
+	// per-call connection (true) or a persistent shared one (false), taking
+	// auth type, connection type, and needs_session_stickiness into account
+	// together.
+	RequiresPerCallConnection(config *schemas.MCPClientConfig) bool
 }
 
 // MCPHandler manages HTTP requests for MCP tool operations
@@ -485,6 +490,7 @@ func (h *MCPHandler) verifyMCPClientHeaders(ctx *fasthttp.RequestCtx) {
 		Headers:                   clientConfig.Headers,
 		AllowedExtraHeaders:       clientConfig.AllowedExtraHeaders,
 		IsPingAvailable:           clientConfig.IsPingAvailable,
+		NeedsSessionStickiness:    clientConfig.NeedsSessionStickiness,
 		ToolPricing:               clientConfig.ToolPricing,
 		ToolSyncInterval:          int(clientConfig.ToolSyncInterval / time.Second),
 		ToolExecutionTimeout:      int(clientConfig.ToolExecutionTimeout / time.Second),
@@ -654,6 +660,7 @@ func (h *MCPHandler) verifyMCPClientExchange(ctx *fasthttp.RequestCtx) {
 		Headers:                   clientConfig.Headers,
 		AllowedExtraHeaders:       clientConfig.AllowedExtraHeaders,
 		IsPingAvailable:           clientConfig.IsPingAvailable,
+		NeedsSessionStickiness:    clientConfig.NeedsSessionStickiness,
 		ToolPricing:               clientConfig.ToolPricing,
 		ToolSyncInterval:          int(clientConfig.ToolSyncInterval / time.Second),
 		ToolExecutionTimeout:      int(clientConfig.ToolExecutionTimeout / time.Second),
@@ -1125,27 +1132,28 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, params con
 			isPingAvailable = *dbClient.IsPingAvailable
 		}
 		clientConfig := &schemas.MCPClientConfig{
-			ID:                    dbClient.ClientID,
-			Name:                  dbClient.Name,
-			IsCodeModeClient:      dbClient.IsCodeModeClient,
-			ConnectionType:        schemas.MCPConnectionType(dbClient.ConnectionType),
-			ConnectionString:      dbClient.ConnectionString,
-			StdioConfig:           dbClient.StdioConfig,
-			TLSConfig:             dbClient.TLSConfig,
-			AuthType:              schemas.MCPAuthType(dbClient.AuthType),
-			OauthConfigID:         dbClient.OauthConfigID,
-			ToolsToExecute:        dbClient.ToolsToExecute,
-			ToolsToAutoExecute:    dbClient.ToolsToAutoExecute,
-			Headers:               dbClient.Headers,
-			AllowedExtraHeaders:   dbClient.AllowedExtraHeaders,
-			IsPingAvailable:       &isPingAvailable,
-			ToolSyncInterval:      time.Duration(dbClient.ToolSyncInterval) * time.Second,
-			ToolExecutionTimeout:  time.Duration(dbClient.ToolExecutionTimeout) * time.Second,
-			ToolPricing:           dbClient.ToolPricing,
-			AllowOnAllVirtualKeys: dbClient.AllowOnAllVirtualKeys,
-			Disabled:              dbClient.Disabled,
-			PerUserHeaderKeys:     dbClient.PerUserHeaderKeys,
-			TokenExchange:         dbClient.TokenExchange,
+			ID:                     dbClient.ClientID,
+			Name:                   dbClient.Name,
+			IsCodeModeClient:       dbClient.IsCodeModeClient,
+			ConnectionType:         schemas.MCPConnectionType(dbClient.ConnectionType),
+			ConnectionString:       dbClient.ConnectionString,
+			StdioConfig:            dbClient.StdioConfig,
+			TLSConfig:              dbClient.TLSConfig,
+			AuthType:               schemas.MCPAuthType(dbClient.AuthType),
+			OauthConfigID:          dbClient.OauthConfigID,
+			ToolsToExecute:         dbClient.ToolsToExecute,
+			ToolsToAutoExecute:     dbClient.ToolsToAutoExecute,
+			Headers:                dbClient.Headers,
+			AllowedExtraHeaders:    dbClient.AllowedExtraHeaders,
+			IsPingAvailable:        &isPingAvailable,
+			NeedsSessionStickiness: dbClient.NeedsSessionStickiness,
+			ToolSyncInterval:       time.Duration(dbClient.ToolSyncInterval) * time.Second,
+			ToolExecutionTimeout:   time.Duration(dbClient.ToolExecutionTimeout) * time.Second,
+			ToolPricing:            dbClient.ToolPricing,
+			AllowOnAllVirtualKeys:  dbClient.AllowOnAllVirtualKeys,
+			Disabled:               dbClient.Disabled,
+			PerUserHeaderKeys:      dbClient.PerUserHeaderKeys,
+			TokenExchange:          dbClient.TokenExchange,
 		}
 		// Populate oauth client credentials from pre-fetched batch
 		if dbClient.OauthConfigID != nil {
@@ -1294,23 +1302,24 @@ const (
 // Immutable fields (connection_type, auth_type, connection_string, stdio_config) are not
 // accepted here; they cannot be changed after creation.
 type MCPClientUpdateRequest struct {
-	Name                  *string                         `json:"name,omitempty"`
-	Disabled              *bool                           `json:"disabled,omitempty"`
-	AllowOnAllVirtualKeys *bool                           `json:"allow_on_all_virtual_keys,omitempty"`
-	IsCodeModeClient      *bool                           `json:"is_code_mode_client,omitempty"`
-	IsPingAvailable       *bool                           `json:"is_ping_available,omitempty"`
-	ToolSyncInterval      *int                            `json:"tool_sync_interval,omitempty"`
-	ToolExecutionTimeout  *int                            `json:"tool_execution_timeout,omitempty"`
-	Headers               map[string]schemas.SecretVar    `json:"headers,omitempty"`
-	AllowedExtraHeaders   *schemas.WhiteList              `json:"allowed_extra_headers,omitempty"`
-	ToolPricing           map[string]float64              `json:"tool_pricing,omitempty"`
-	ToolsToExecute        *schemas.WhiteList              `json:"tools_to_execute,omitempty"`
-	ToolsToAutoExecute    *schemas.WhiteList              `json:"tools_to_auto_execute,omitempty"`
-	PerUserHeaderKeys     *[]string                       `json:"per_user_header_keys,omitempty"`
-	TokenExchange         *schemas.MCPTokenExchangeConfig `json:"token_exchange,omitempty"`
-	TLSConfig             *schemas.MCPTLSConfig           `json:"tls_config,omitempty"`
-	VKConfigs             *[]MCPVKConfigRequest           `json:"vk_configs,omitempty"`
-	OauthConfig           *OAuthConfigRequest             `json:"oauth_config,omitempty"`
+	Name                   *string                         `json:"name,omitempty"`
+	Disabled               *bool                           `json:"disabled,omitempty"`
+	AllowOnAllVirtualKeys  *bool                           `json:"allow_on_all_virtual_keys,omitempty"`
+	IsCodeModeClient       *bool                           `json:"is_code_mode_client,omitempty"`
+	IsPingAvailable        *bool                           `json:"is_ping_available,omitempty"`
+	NeedsSessionStickiness *bool                           `json:"needs_session_stickiness,omitempty"`
+	ToolSyncInterval       *int                            `json:"tool_sync_interval,omitempty"`
+	ToolExecutionTimeout   *int                            `json:"tool_execution_timeout,omitempty"`
+	Headers                map[string]schemas.SecretVar    `json:"headers,omitempty"`
+	AllowedExtraHeaders    *schemas.WhiteList              `json:"allowed_extra_headers,omitempty"`
+	ToolPricing            map[string]float64              `json:"tool_pricing,omitempty"`
+	ToolsToExecute         *schemas.WhiteList              `json:"tools_to_execute,omitempty"`
+	ToolsToAutoExecute     *schemas.WhiteList              `json:"tools_to_auto_execute,omitempty"`
+	PerUserHeaderKeys      *[]string                       `json:"per_user_header_keys,omitempty"`
+	TokenExchange          *schemas.MCPTokenExchangeConfig `json:"token_exchange,omitempty"`
+	TLSConfig              *schemas.MCPTLSConfig           `json:"tls_config,omitempty"`
+	VKConfigs              *[]MCPVKConfigRequest           `json:"vk_configs,omitempty"`
+	OauthConfig            *OAuthConfigRequest             `json:"oauth_config,omitempty"`
 }
 
 // addMCPClient handles POST /api/mcp/client - Add a new MCP client
@@ -1352,6 +1361,10 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 	}
 	if err := validateAllowedExtraHeaders(req.AllowedExtraHeaders); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid allowed_extra_headers: %v", err))
+		return
+	}
+	if err := validateNeedsSessionStickiness(req.NeedsSessionStickiness, schemas.MCPConnectionType(req.ConnectionType)); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -1426,23 +1439,24 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 		}
 
 		schemasConfig := &schemas.MCPClientConfig{
-			ID:                    req.ClientID,
-			Name:                  req.Name,
-			IsCodeModeClient:      req.IsCodeModeClient,
-			IsPingAvailable:       &isPingAvailable,
-			ToolSyncInterval:      toolSyncInterval,
-			ToolExecutionTimeout:  resolvedToolExecutionTimeout,
-			ConnectionType:        schemas.MCPConnectionType(req.ConnectionType),
-			ConnectionString:      req.ConnectionString,
-			StdioConfig:           req.StdioConfig,
-			AuthType:              schemas.MCPAuthTypePerUserHeaders,
-			PerUserHeaderKeys:     canonHeaderKeys,
-			ToolsToExecute:        req.ToolsToExecute,
-			ToolsToAutoExecute:    req.ToolsToAutoExecute,
-			ToolPricing:           req.ToolPricing,
-			Headers:               req.Headers,
-			AllowedExtraHeaders:   req.AllowedExtraHeaders,
-			AllowOnAllVirtualKeys: req.AllowOnAllVirtualKeys,
+			ID:                     req.ClientID,
+			Name:                   req.Name,
+			IsCodeModeClient:       req.IsCodeModeClient,
+			IsPingAvailable:        &isPingAvailable,
+			NeedsSessionStickiness: req.NeedsSessionStickiness,
+			ToolSyncInterval:       toolSyncInterval,
+			ToolExecutionTimeout:   resolvedToolExecutionTimeout,
+			ConnectionType:         schemas.MCPConnectionType(req.ConnectionType),
+			ConnectionString:       req.ConnectionString,
+			StdioConfig:            req.StdioConfig,
+			AuthType:               schemas.MCPAuthTypePerUserHeaders,
+			PerUserHeaderKeys:      canonHeaderKeys,
+			ToolsToExecute:         req.ToolsToExecute,
+			ToolsToAutoExecute:     req.ToolsToAutoExecute,
+			ToolPricing:            req.ToolPricing,
+			Headers:                req.Headers,
+			AllowedExtraHeaders:    req.AllowedExtraHeaders,
+			AllowOnAllVirtualKeys:  req.AllowOnAllVirtualKeys,
 		}
 
 		// Verify connection and discover tools using the admin's sample
@@ -1539,24 +1553,25 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 		}
 
 		schemasConfig := &schemas.MCPClientConfig{
-			ID:                    req.ClientID,
-			Name:                  req.Name,
-			IsCodeModeClient:      req.IsCodeModeClient,
-			IsPingAvailable:       &isPingAvailable,
-			ToolSyncInterval:      toolSyncInterval,
-			ToolExecutionTimeout:  resolvedToolExecutionTimeout,
-			ConnectionType:        schemas.MCPConnectionType(req.ConnectionType),
-			ConnectionString:      req.ConnectionString,
-			StdioConfig:           req.StdioConfig,
-			TLSConfig:             req.TLSConfig,
-			AuthType:              schemas.MCPAuthTypeTokenExchange,
-			TokenExchange:         req.TokenExchange,
-			ToolsToExecute:        req.ToolsToExecute,
-			ToolsToAutoExecute:    req.ToolsToAutoExecute,
-			ToolPricing:           req.ToolPricing,
-			Headers:               req.Headers,
-			AllowedExtraHeaders:   req.AllowedExtraHeaders,
-			AllowOnAllVirtualKeys: req.AllowOnAllVirtualKeys,
+			ID:                     req.ClientID,
+			Name:                   req.Name,
+			IsCodeModeClient:       req.IsCodeModeClient,
+			IsPingAvailable:        &isPingAvailable,
+			NeedsSessionStickiness: req.NeedsSessionStickiness,
+			ToolSyncInterval:       toolSyncInterval,
+			ToolExecutionTimeout:   resolvedToolExecutionTimeout,
+			ConnectionType:         schemas.MCPConnectionType(req.ConnectionType),
+			ConnectionString:       req.ConnectionString,
+			StdioConfig:            req.StdioConfig,
+			TLSConfig:              req.TLSConfig,
+			AuthType:               schemas.MCPAuthTypeTokenExchange,
+			TokenExchange:          req.TokenExchange,
+			ToolsToExecute:         req.ToolsToExecute,
+			ToolsToAutoExecute:     req.ToolsToAutoExecute,
+			ToolPricing:            req.ToolPricing,
+			Headers:                req.Headers,
+			AllowedExtraHeaders:    req.AllowedExtraHeaders,
+			AllowOnAllVirtualKeys:  req.AllowOnAllVirtualKeys,
 		}
 
 		// Resolve an admin credential for synchronous verification + tool
@@ -1674,24 +1689,25 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 		}
 
 		pendingConfig := schemas.MCPClientConfig{
-			ID:                    req.ClientID,
-			Name:                  req.Name,
-			IsCodeModeClient:      req.IsCodeModeClient,
-			IsPingAvailable:       &isPingAvailable,
-			ToolSyncInterval:      toolSyncInterval,
-			ToolExecutionTimeout:  resolvedToolExecutionTimeout,
-			ConnectionType:        schemas.MCPConnectionType(req.ConnectionType),
-			ConnectionString:      req.ConnectionString,
-			StdioConfig:           req.StdioConfig,
-			TLSConfig:             req.TLSConfig,
-			AuthType:              schemas.MCPAuthTypePerUserOauth,
-			OauthConfigID:         &flowInitiation.OauthConfigID,
-			ToolsToExecute:        req.ToolsToExecute,
-			ToolsToAutoExecute:    req.ToolsToAutoExecute,
-			ToolPricing:           req.ToolPricing,
-			Headers:               req.Headers,
-			AllowedExtraHeaders:   req.AllowedExtraHeaders,
-			AllowOnAllVirtualKeys: req.AllowOnAllVirtualKeys,
+			ID:                     req.ClientID,
+			Name:                   req.Name,
+			IsCodeModeClient:       req.IsCodeModeClient,
+			IsPingAvailable:        &isPingAvailable,
+			NeedsSessionStickiness: req.NeedsSessionStickiness,
+			ToolSyncInterval:       toolSyncInterval,
+			ToolExecutionTimeout:   resolvedToolExecutionTimeout,
+			ConnectionType:         schemas.MCPConnectionType(req.ConnectionType),
+			ConnectionString:       req.ConnectionString,
+			StdioConfig:            req.StdioConfig,
+			TLSConfig:              req.TLSConfig,
+			AuthType:               schemas.MCPAuthTypePerUserOauth,
+			OauthConfigID:          &flowInitiation.OauthConfigID,
+			ToolsToExecute:         req.ToolsToExecute,
+			ToolsToAutoExecute:     req.ToolsToAutoExecute,
+			ToolPricing:            req.ToolPricing,
+			Headers:                req.Headers,
+			AllowedExtraHeaders:    req.AllowedExtraHeaders,
+			AllowOnAllVirtualKeys:  req.AllowOnAllVirtualKeys,
 		}
 
 		if err := h.oauthHandler.StorePendingMCPClient(flowInitiation.OauthConfigID, pendingConfig); err != nil {
@@ -1768,24 +1784,25 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 		// Store MCP client config in OAuth provider memory (not in database)
 		// It will be stored in database only after OAuth completion
 		pendingConfig := schemas.MCPClientConfig{
-			ID:                    req.ClientID,
-			Name:                  req.Name,
-			IsCodeModeClient:      req.IsCodeModeClient,
-			IsPingAvailable:       req.IsPingAvailable,
-			ToolSyncInterval:      toolSyncInterval,
-			ToolExecutionTimeout:  resolvedToolExecutionTimeout,
-			ConnectionType:        schemas.MCPConnectionType(req.ConnectionType),
-			ConnectionString:      req.ConnectionString,
-			StdioConfig:           req.StdioConfig,
-			TLSConfig:             req.TLSConfig,
-			AuthType:              schemas.MCPAuthType(req.AuthType),
-			OauthConfigID:         &flowInitiation.OauthConfigID,
-			ToolsToExecute:        req.ToolsToExecute,
-			ToolsToAutoExecute:    req.ToolsToAutoExecute,
-			Headers:               req.Headers,
-			AllowedExtraHeaders:   req.AllowedExtraHeaders,
-			ToolPricing:           req.ToolPricing,
-			AllowOnAllVirtualKeys: req.AllowOnAllVirtualKeys,
+			ID:                     req.ClientID,
+			Name:                   req.Name,
+			IsCodeModeClient:       req.IsCodeModeClient,
+			IsPingAvailable:        req.IsPingAvailable,
+			NeedsSessionStickiness: req.NeedsSessionStickiness,
+			ToolSyncInterval:       toolSyncInterval,
+			ToolExecutionTimeout:   resolvedToolExecutionTimeout,
+			ConnectionType:         schemas.MCPConnectionType(req.ConnectionType),
+			ConnectionString:       req.ConnectionString,
+			StdioConfig:            req.StdioConfig,
+			TLSConfig:              req.TLSConfig,
+			AuthType:               schemas.MCPAuthType(req.AuthType),
+			OauthConfigID:          &flowInitiation.OauthConfigID,
+			ToolsToExecute:         req.ToolsToExecute,
+			ToolsToAutoExecute:     req.ToolsToAutoExecute,
+			Headers:                req.Headers,
+			AllowedExtraHeaders:    req.AllowedExtraHeaders,
+			ToolPricing:            req.ToolPricing,
+			AllowOnAllVirtualKeys:  req.AllowOnAllVirtualKeys,
 		}
 
 		// Store pending config in database (associated with oauth_config_id for multi-instance support)
@@ -1833,24 +1850,25 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 
 	// Convert to schemas.MCPClientConfig for runtime bifrost client (without tool_pricing)
 	schemasConfig := &schemas.MCPClientConfig{
-		ID:                    req.ClientID,
-		Name:                  req.Name,
-		IsCodeModeClient:      req.IsCodeModeClient,
-		ConnectionType:        schemas.MCPConnectionType(req.ConnectionType),
-		ConnectionString:      req.ConnectionString,
-		StdioConfig:           req.StdioConfig,
-		TLSConfig:             req.TLSConfig,
-		ToolsToExecute:        req.ToolsToExecute,
-		ToolsToAutoExecute:    req.ToolsToAutoExecute,
-		Headers:               req.Headers,
-		AllowedExtraHeaders:   req.AllowedExtraHeaders,
-		AuthType:              schemas.MCPAuthType(req.AuthType),
-		OauthConfigID:         req.OauthConfigID,
-		IsPingAvailable:       req.IsPingAvailable,
-		ToolSyncInterval:      toolSyncInterval,
-		ToolExecutionTimeout:  resolvedToolExecutionTimeout,
-		ToolPricing:           req.ToolPricing,
-		AllowOnAllVirtualKeys: req.AllowOnAllVirtualKeys,
+		ID:                     req.ClientID,
+		Name:                   req.Name,
+		IsCodeModeClient:       req.IsCodeModeClient,
+		ConnectionType:         schemas.MCPConnectionType(req.ConnectionType),
+		ConnectionString:       req.ConnectionString,
+		StdioConfig:            req.StdioConfig,
+		TLSConfig:              req.TLSConfig,
+		ToolsToExecute:         req.ToolsToExecute,
+		ToolsToAutoExecute:     req.ToolsToAutoExecute,
+		Headers:                req.Headers,
+		AllowedExtraHeaders:    req.AllowedExtraHeaders,
+		AuthType:               schemas.MCPAuthType(req.AuthType),
+		OauthConfigID:          req.OauthConfigID,
+		IsPingAvailable:        req.IsPingAvailable,
+		NeedsSessionStickiness: req.NeedsSessionStickiness,
+		ToolSyncInterval:       toolSyncInterval,
+		ToolExecutionTimeout:   resolvedToolExecutionTimeout,
+		ToolPricing:            req.ToolPricing,
+		AllowOnAllVirtualKeys:  req.AllowOnAllVirtualKeys,
 	}
 
 	// Creating MCP client config in config store
@@ -1914,6 +1932,10 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusNotFound, "MCP client not found")
 		return
 	}
+	if err := validateNeedsSessionStickiness(req.NeedsSessionStickiness, existingConfig.ConnectionType); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
 	// Snapshot fields we need to diff against the resolved values AFTER UpdateMCPClient
 	// runs further below — UpdateMCPClient mutates the *MCPClientConfig in place (it's
 	// the same pointer the manager holds in MCPConfig.ClientConfigs), so post-update
@@ -1946,6 +1968,10 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 	isPingAvailable := existingConfig.IsPingAvailable
 	if req.IsPingAvailable != nil {
 		isPingAvailable = req.IsPingAvailable
+	}
+	needsSessionStickiness := existingConfig.NeedsSessionStickiness
+	if req.NeedsSessionStickiness != nil {
+		needsSessionStickiness = req.NeedsSessionStickiness
 	}
 	toolPricing := existingConfig.ToolPricing
 	if req.ToolPricing != nil {
@@ -2246,27 +2272,28 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 
 	// Build the DB update record from all resolved values.
 	dbUpdateRecord := configstoreTables.TableMCPClient{
-		ClientID:              id,
-		Name:                  name,
-		IsCodeModeClient:      isCodeMode,
-		ConnectionType:        string(existingConfig.ConnectionType),
-		ConnectionString:      existingConfig.ConnectionString,
-		StdioConfig:           existingConfig.StdioConfig,
-		ToolsToExecute:        resolvedToolsToExecute,
-		ToolsToAutoExecute:    resolvedToolsToAutoExecute,
-		Headers:               headers,
-		AllowedExtraHeaders:   allowedExtraHeaders,
-		IsPingAvailable:       isPingAvailable,
-		ToolPricing:           toolPricing,
-		ToolSyncInterval:      int(resolvedToolSyncInterval / time.Second),
-		ToolExecutionTimeout:  int(resolvedToolExecutionTimeout / time.Second),
-		AuthType:              string(existingConfig.AuthType),
-		OauthConfigID:         existingConfig.OauthConfigID,
-		AllowOnAllVirtualKeys: allowOnAllVKs,
-		Disabled:              disabled,
-		PerUserHeaderKeys:     perUserHeaderKeys,
-		TokenExchange:         tokenExchange,
-		TLSConfig:             tlsConfig,
+		ClientID:               id,
+		Name:                   name,
+		IsCodeModeClient:       isCodeMode,
+		ConnectionType:         string(existingConfig.ConnectionType),
+		ConnectionString:       existingConfig.ConnectionString,
+		StdioConfig:            existingConfig.StdioConfig,
+		ToolsToExecute:         resolvedToolsToExecute,
+		ToolsToAutoExecute:     resolvedToolsToAutoExecute,
+		Headers:                headers,
+		AllowedExtraHeaders:    allowedExtraHeaders,
+		IsPingAvailable:        isPingAvailable,
+		NeedsSessionStickiness: needsSessionStickiness,
+		ToolPricing:            toolPricing,
+		ToolSyncInterval:       int(resolvedToolSyncInterval / time.Second),
+		ToolExecutionTimeout:   int(resolvedToolExecutionTimeout / time.Second),
+		AuthType:               string(existingConfig.AuthType),
+		OauthConfigID:          existingConfig.OauthConfigID,
+		AllowOnAllVirtualKeys:  allowOnAllVKs,
+		Disabled:               disabled,
+		PerUserHeaderKeys:      perUserHeaderKeys,
+		TokenExchange:          tokenExchange,
+		TLSConfig:              tlsConfig,
 	}
 	// Rebind persisted discovered tool keys (and inner Function.Name) to the current
 	// client name so a restart restores them under the right prefix.
@@ -2309,40 +2336,69 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 	}
 	// Build in-memory config from resolved values.
 	schemasConfig := &schemas.MCPClientConfig{
-		ID:                    id,
-		Name:                  name,
-		IsCodeModeClient:      isCodeMode,
-		ConnectionType:        existingConfig.ConnectionType,
-		ConnectionString:      existingConfig.ConnectionString,
-		StdioConfig:           existingConfig.StdioConfig,
-		TLSConfig:             tlsConfig,
-		ToolsToExecute:        resolvedToolsToExecute,
-		ToolsToAutoExecute:    resolvedToolsToAutoExecute,
-		Headers:               headers,
-		AllowedExtraHeaders:   allowedExtraHeaders,
-		AuthType:              existingConfig.AuthType,
-		OauthConfigID:         existingConfig.OauthConfigID,
-		IsPingAvailable:       isPingAvailable,
-		ToolSyncInterval:      toolSyncInterval,
-		ToolExecutionTimeout:  resolvedToolExecutionTimeout,
-		ToolPricing:           toolPricing,
-		AllowOnAllVirtualKeys: allowOnAllVKs,
-		Disabled:              disabled,
-		PerUserHeaderKeys:     perUserHeaderKeys,
-		TokenExchange:         tokenExchange,
+		ID:                     id,
+		Name:                   name,
+		IsCodeModeClient:       isCodeMode,
+		ConnectionType:         existingConfig.ConnectionType,
+		ConnectionString:       existingConfig.ConnectionString,
+		StdioConfig:            existingConfig.StdioConfig,
+		TLSConfig:              tlsConfig,
+		ToolsToExecute:         resolvedToolsToExecute,
+		ToolsToAutoExecute:     resolvedToolsToAutoExecute,
+		Headers:                headers,
+		AllowedExtraHeaders:    allowedExtraHeaders,
+		AuthType:               existingConfig.AuthType,
+		OauthConfigID:          existingConfig.OauthConfigID,
+		IsPingAvailable:        isPingAvailable,
+		NeedsSessionStickiness: needsSessionStickiness,
+		ToolSyncInterval:       toolSyncInterval,
+		ToolExecutionTimeout:   resolvedToolExecutionTimeout,
+		ToolPricing:            toolPricing,
+		AllowOnAllVirtualKeys:  allowOnAllVKs,
+		Disabled:               disabled,
+		PerUserHeaderKeys:      perUserHeaderKeys,
+		TokenExchange:          tokenExchange,
 	}
 
+	// Compare per-call-ness before/after so the response can tell the admin
+	// whether this update actually changed how the client connects (only
+	// needs_session_stickiness on a shared http client can do that — every
+	// other combination of auth/connection type comes out the same on both
+	// sides). UpdateMCPClient below applies the change live: it closes the
+	// persistent connection if this just became per-call, or dials one if it
+	// just became sticky.
+	wasPerCallConnection := h.mcpManager.RequiresPerCallConnection(existingConfig)
+	isPerCallConnection := h.mcpManager.RequiresPerCallConnection(schemasConfig)
+
 	// Update MCP client config in memory (always — applies name/tools/header changes,
+	// sharedConnectErr records a needs_session_stickiness=true dial failure without
+	// aborting the request: the field update itself already committed in memory with
+	// no rollback path (see the sentinel's own doc comment), so every block below
+	// (OAuth rotation, admin exchange reauth marking, per-user-headers needs_update,
+	// VK assignment changes, per-user credential reconciliation) is independent of
+	// whether the dial succeeded and must still run. Returning early here used to
+	// silently drop all of them for any request that combined
+	// needs_session_stickiness with one of those other changes. The dial failure is
+	// folded into the final response instead of an early one.
+	var sharedConnectErr error
 	if err := h.mcpManager.UpdateMCPClient(ctx, id, schemasConfig); err != nil {
-		// Rollback DB update to keep DB and memory in sync
-		if h.store.ConfigStore != nil && oldDBConfig != nil {
-			if rollbackErr := h.store.ConfigStore.UpdateMCPClientConfig(ctx, id, oldDBConfig); rollbackErr != nil {
-				logger.Error(fmt.Sprintf("Failed to rollback MCP client DB update: %v. please restart bifrost to keep core and database in sync", rollbackErr))
+		if errors.Is(err, mcp.ErrMCPSharedConnectFailedAfterUpdate) {
+			// Rolling the DB back to oldDBConfig here would diverge it from
+			// the runtime, which already has the new config and a connection
+			// checker retrying the dial. Keep the persisted row.
+			logger.Error(fmt.Sprintf("MCP client %s updated, but its shared connection could not be established: %v", id, err))
+			sharedConnectErr = err
+		} else {
+			// Rollback DB update to keep DB and memory in sync
+			if h.store.ConfigStore != nil && oldDBConfig != nil {
+				if rollbackErr := h.store.ConfigStore.UpdateMCPClientConfig(ctx, id, oldDBConfig); rollbackErr != nil {
+					logger.Error(fmt.Sprintf("Failed to rollback MCP client DB update: %v. please restart bifrost to keep core and database in sync", rollbackErr))
+				}
 			}
+			logger.Error(fmt.Sprintf("Failed to update MCP client: %v", err))
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to update mcp client: %v", err))
+			return
 		}
-		logger.Error(fmt.Sprintf("Failed to update MCP client: %v", err))
-		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to update mcp client: %v", err))
-		return
 	}
 
 	// Rotate OAuth credentials only now that both the DB row and the runtime
@@ -2565,9 +2621,27 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		}
 	}
 
+	message := "MCP client edited successfully"
+	if sharedConnectErr == nil {
+		// Only claimed when the dial actually succeeded — see sharedConnectErr
+		// handling below for the case where it didn't.
+		switch {
+		case wasPerCallConnection && !isPerCallConnection:
+			message += ". This client now maintains a persistent shared connection: it has been (re)connected."
+		case !wasPerCallConnection && isPerCallConnection:
+			message += ". This client now connects per call instead of maintaining a persistent connection: the existing shared connection was closed."
+		}
+	}
+	if sharedConnectErr != nil {
+		SendJSON(ctx, map[string]any{
+			"status":  "partial_success",
+			"message": fmt.Sprintf("%s However, establishing the shared connection failed: %v. The connection checker will keep retrying automatically.", message, sharedConnectErr),
+		})
+		return
+	}
 	SendJSON(ctx, map[string]any{
 		"status":  "success",
-		"message": "MCP client edited successfully",
+		"message": message,
 	})
 }
 
@@ -2626,6 +2700,20 @@ func validateToolsToExecute(toolsToExecute schemas.WhiteList) error {
 func validateAllowedExtraHeaders(allowedExtraHeaders schemas.WhiteList) error {
 	if err := allowedExtraHeaders.Validate(); err != nil {
 		return fmt.Errorf("invalid allowed_extra_headers: %w", err)
+	}
+	return nil
+}
+
+// validateNeedsSessionStickiness rejects an explicit false for connection
+// types that can't run per-call: SSE has no stateless mode (its session is
+// bound to the open stream) and STDIO needs a persistent subprocess. nil and
+// true are always fine regardless of connection type.
+func validateNeedsSessionStickiness(needsSessionStickiness *bool, connectionType schemas.MCPConnectionType) error {
+	if needsSessionStickiness == nil || *needsSessionStickiness {
+		return nil
+	}
+	if connectionType != schemas.MCPConnectionTypeHTTP {
+		return fmt.Errorf("needs_session_stickiness cannot be false for connection_type %q: only 'http' supports a per-call connection", connectionType)
 	}
 	return nil
 }
@@ -2802,6 +2890,7 @@ func (h *MCPHandler) completePerUserOAuthAdminRepair(ctx *fasthttp.RequestCtx, b
 		Headers:                   clientConfig.Headers,
 		AllowedExtraHeaders:       clientConfig.AllowedExtraHeaders,
 		IsPingAvailable:           clientConfig.IsPingAvailable,
+		NeedsSessionStickiness:    clientConfig.NeedsSessionStickiness,
 		ToolPricing:               clientConfig.ToolPricing,
 		ToolSyncInterval:          int(clientConfig.ToolSyncInterval / time.Second),
 		ToolExecutionTimeout:      int(clientConfig.ToolExecutionTimeout / time.Second),
@@ -3035,6 +3124,7 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 				Headers:                   mcpClientConfig.Headers,
 				AllowedExtraHeaders:       mcpClientConfig.AllowedExtraHeaders,
 				IsPingAvailable:           mcpClientConfig.IsPingAvailable,
+				NeedsSessionStickiness:    mcpClientConfig.NeedsSessionStickiness,
 				ToolPricing:               mcpClientConfig.ToolPricing,
 				ToolSyncInterval:          int(mcpClientConfig.ToolSyncInterval / time.Second),
 				ToolExecutionTimeout:      int(mcpClientConfig.ToolExecutionTimeout / time.Second),
@@ -3153,6 +3243,7 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 			Headers:                   mcpClientConfig.Headers,
 			AllowedExtraHeaders:       mcpClientConfig.AllowedExtraHeaders,
 			IsPingAvailable:           mcpClientConfig.IsPingAvailable,
+			NeedsSessionStickiness:    mcpClientConfig.NeedsSessionStickiness,
 			ToolPricing:               mcpClientConfig.ToolPricing,
 			ToolSyncInterval:          int(mcpClientConfig.ToolSyncInterval / time.Second),
 			AllowOnAllVirtualKeys:     mcpClientConfig.AllowOnAllVirtualKeys,
@@ -3251,7 +3342,6 @@ func resolvePerUserHeaderKeys(existing *schemas.MCPClientConfig, req MCPClientUp
 	}
 	return nil
 }
-
 
 // perUserHeaderKeysAdded reports whether the new schema introduces any key
 // absent from the old schema (order-insensitive). Used by updateMCPClient to

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -1882,6 +1882,15 @@ func pinMCPClientImmutableFields(fileClient, existing *schemas.MCPClientConfig) 
 		fileClient.DiscoveredTools = existing.DiscoveredTools
 		fileClient.DiscoveredToolNameMapping = existing.DiscoveredToolNameMapping
 	}
+
+	// Not immutable, and an explicit file declaration (true or false) is
+	// honored same as the update API — but an undeclared (nil) file value
+	// must not silently clear a stored true (set via the update API, or
+	// backfilled by migration for pre-existing rows) back to per-call just
+	// because a reconciliation pass fired for some unrelated field.
+	if fileClient.NeedsSessionStickiness == nil {
+		fileClient.NeedsSessionStickiness = existing.NeedsSessionStickiness
+	}
 	return changed
 }
 
@@ -2099,6 +2108,7 @@ func applyMCPClientPinnedStateToRow(row *configstoreTables.TableMCPClient, clien
 	row.DiscoveredTools = clientConfig.DiscoveredTools
 	row.DiscoveredToolNameMapping = clientConfig.DiscoveredToolNameMapping
 	row.PendingOAuthConfig = clientConfig.PendingOAuthConfig
+	row.NeedsSessionStickiness = clientConfig.NeedsSessionStickiness
 }
 
 // mergeMCPConfig merges MCP config from file with store
@@ -2280,6 +2290,7 @@ func mcpClientConfigToTable(clientConfig *schemas.MCPClientConfig) (configstoreT
 		Headers:                   clientConfig.Headers,
 		AllowedExtraHeaders:       clientConfig.AllowedExtraHeaders,
 		IsPingAvailable:           clientConfig.IsPingAvailable,
+		NeedsSessionStickiness:    clientConfig.NeedsSessionStickiness,
 		ToolSyncInterval:          int(clientConfig.ToolSyncInterval / time.Second),
 		ToolExecutionTimeout:      int(math.Ceil(clientConfig.ToolExecutionTimeout.Seconds())),
 		ToolPricing:               clientConfig.ToolPricing,
@@ -6646,6 +6657,7 @@ func (c *Config) UpdateMCPClient(ctx context.Context, id string, updatedConfig *
 	c.MCPConfig.ClientConfigs[configIndex].AllowedExtraHeaders = updatedConfig.AllowedExtraHeaders
 	c.MCPConfig.ClientConfigs[configIndex].ToolPricing = updatedConfig.ToolPricing
 	c.MCPConfig.ClientConfigs[configIndex].IsPingAvailable = updatedConfig.IsPingAvailable
+	c.MCPConfig.ClientConfigs[configIndex].NeedsSessionStickiness = updatedConfig.NeedsSessionStickiness
 	c.MCPConfig.ClientConfigs[configIndex].ToolSyncInterval = updatedConfig.ToolSyncInterval
 	c.MCPConfig.ClientConfigs[configIndex].ToolExecutionTimeout = updatedConfig.ToolExecutionTimeout
 	c.MCPConfig.ClientConfigs[configIndex].AllowOnAllVirtualKeys = updatedConfig.AllowOnAllVirtualKeys

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -133,6 +133,11 @@ type ServerCallbacks interface {
 	VerifyHeadersConnection(ctx context.Context, config *schemas.MCPClientConfig, userHeaders map[string]string) (map[string]schemas.ChatTool, map[string]string, error)
 	// SetClientTools updates the tool map for an existing client.
 	SetClientTools(clientID string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string)
+	// RequiresPerCallConnection reports whether config resolves to a
+	// per-call connection (true) or a persistent shared one (false), taking
+	// auth type, connection type, and needs_session_stickiness into account
+	// together.
+	RequiresPerCallConnection(config *schemas.MCPClientConfig) bool
 	ReconnectMCPClient(ctx context.Context, id string) error
 	// CloseAndMarkNeedsReauth closes a shared client's live upstream
 	// connection and flips it to needs_reauth, without attempting a new
@@ -394,6 +399,14 @@ func (s *BifrostHTTPServer) SetClientTools(clientID string, tools map[string]sch
 	if err := s.MCPServerHandler.SyncAllMCPServers(context.Background()); err != nil {
 		logger.Warn("failed to sync MCP servers after setting client tools: %v", err)
 	}
+}
+
+// RequiresPerCallConnection delegates to the Bifrost client to report
+// whether config resolves to a per-call connection or a persistent shared
+// one, taking auth type, connection type, and needs_session_stickiness into
+// account together.
+func (s *BifrostHTTPServer) RequiresPerCallConnection(config *schemas.MCPClientConfig) bool {
+	return s.Client.MCPClientRequiresPerCallConnection(config)
 }
 
 // ExecuteChatMCPTool executes an MCP tool call and returns the result as a chat message.

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -4998,6 +4998,11 @@
           "description": "Whether the MCP server supports ping for health checks (default: true)",
           "default": true
         },
+        "needs_session_stickiness": {
+          "type": "boolean",
+          "description": "Only meaningful for connection_type 'http': whether this client maintains one persistent connection reused across every caller (true) or connects fresh per call (false, the default for newly created clients). SSE and STDIO always behave as sticky regardless of this field.",
+          "default": false
+        },
         "tool_pricing": {
           "type": "object",
           "description": "Tool pricing map (tool name to cost per execution)",

--- a/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
@@ -479,6 +479,44 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 											</FormItem>
 										)}
 									/>
+									{connectionType === "http" &&
+										authType !== "per_user_oauth" &&
+										authType !== "per_user_headers" &&
+										authType !== "token_exchange" && (
+											<FormField
+												control={control}
+												name="needs_session_stickiness"
+												render={({ field }) => (
+													<FormItem className="flex flex-row items-center justify-between gap-4 px-4 py-3">
+														<div className="flex items-center gap-2">
+															<FormLabel htmlFor="needs-session-stickiness">Maintain Persistent Connection</FormLabel>
+															<TooltipProvider>
+																<Tooltip>
+																	<TooltipTrigger asChild>
+																		<Info className="text-muted-foreground h-4 w-4 cursor-help" />
+																	</TooltipTrigger>
+																	<TooltipContent className="max-w-xs">
+																		<p>
+																			Enable to keep one shared connection open and reused across every caller. Disable to connect fresh on
+																			every call instead, same as per-user auth types. Only applies to HTTP connections; SSE and STDIO always
+																			keep a persistent connection.
+																		</p>
+																	</TooltipContent>
+																</Tooltip>
+															</TooltipProvider>
+														</div>
+														<FormControl>
+															<Switch
+																id="needs-session-stickiness"
+																data-testid="mcp-needs-session-stickiness"
+																checked={field.value === true}
+																onCheckedChange={field.onChange}
+															/>
+														</FormControl>
+													</FormItem>
+												)}
+											/>
+										)}
 								</div>
 							</div>
 
@@ -505,6 +543,13 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 															setValue("auth_type", "none");
 															setValue("headers", undefined);
 															setValue("oauth_config", undefined);
+														}
+														// needs_session_stickiness=false is rejected for
+														// non-http connection types; SSE/STDIO always keep
+														// a persistent connection regardless, so drop any
+														// explicit false picked while http was selected.
+														if (value !== "http") {
+															setValue("needs_session_stickiness", undefined);
 														}
 														clearErrors();
 													}}

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -226,6 +226,7 @@ export default function MCPClientSheet({
 			name: mcpClient.config.name,
 			is_code_mode_client: mcpClient.config.is_code_mode_client || false,
 			is_ping_available: mcpClient.config.is_ping_available === true || mcpClient.config.is_ping_available === undefined,
+			needs_session_stickiness: mcpClient.config.needs_session_stickiness === true,
 			allow_on_all_virtual_keys: mcpClient.config.allow_on_all_virtual_keys || false,
 			disabled: mcpClient.config.disabled || false,
 			headers: mcpClient.config.headers,
@@ -267,6 +268,7 @@ export default function MCPClientSheet({
 		},
 	});
 	const isDisabled = form.watch("disabled");
+	const needsSessionStickiness = form.watch("needs_session_stickiness");
 
 	// Reset form when mcpClient changes
 	useEffect(() => {
@@ -274,6 +276,7 @@ export default function MCPClientSheet({
 			name: mcpClient.config.name,
 			is_code_mode_client: mcpClient.config.is_code_mode_client || false,
 			is_ping_available: mcpClient.config.is_ping_available === true || mcpClient.config.is_ping_available === undefined,
+			needs_session_stickiness: mcpClient.config.needs_session_stickiness === true,
 			allow_on_all_virtual_keys: mcpClient.config.allow_on_all_virtual_keys || false,
 			disabled: mcpClient.config.disabled || false,
 			headers: mcpClient.config.headers,
@@ -345,6 +348,10 @@ export default function MCPClientSheet({
 		form.formState.dirtyFields.token_exchange?.authorization_server_url ||
 		tokenExchangeScopesDirty
 	);
+	// Gates the "takes effect immediately" warning below the toggle — the
+	// backend applies a stickiness change live (opens or closes the shared
+	// connection) as part of the same update, not on some later reconnect.
+	const needsSessionStickinessDirty = !!form.formState.dirtyFields.needs_session_stickiness;
 
 	const handleNavigate = useCallback(
 		(direction: "prev" | "next") => {
@@ -413,6 +420,10 @@ export default function MCPClientSheet({
 					name: data.name,
 					is_code_mode_client: data.is_code_mode_client,
 					is_ping_available: data.is_ping_available,
+					// Only meaningful (and only accepted) for http clients — an
+					// explicit false is rejected for sse/stdio, which always keep
+					// a persistent connection regardless of this field.
+					needs_session_stickiness: mcpClient.config.connection_type === "http" ? data.needs_session_stickiness : undefined,
 					allow_on_all_virtual_keys: data.allow_on_all_virtual_keys,
 					disabled: data.disabled,
 					headers: data.headers ?? {},
@@ -776,6 +787,55 @@ export default function MCPClientSheet({
 														</FormItem>
 													)}
 												/>
+												{mcpClient.config.connection_type === "http" &&
+													mcpClient.config.auth_type !== "per_user_oauth" &&
+													mcpClient.config.auth_type !== "per_user_headers" &&
+													mcpClient.config.auth_type !== "token_exchange" && (
+														<>
+															<FormField
+																control={form.control}
+																name="needs_session_stickiness"
+																render={({ field }) => (
+																	<FormItem className="flex flex-row items-center justify-between gap-4 px-4 py-3">
+																		<div className="flex items-center gap-2">
+																			<FormLabel>Maintain Persistent Connection</FormLabel>
+																			<TooltipProvider>
+																				<Tooltip>
+																					<TooltipTrigger asChild>
+																						<Info className="text-muted-foreground h-4 w-4 cursor-help" />
+																					</TooltipTrigger>
+																					<TooltipContent className="max-w-xs">
+																						<p>
+																							Enable to keep one shared connection open and reused across every caller. Disable to connect
+																							fresh on every call instead.
+																						</p>
+																					</TooltipContent>
+																				</Tooltip>
+																			</TooltipProvider>
+																		</div>
+																		<FormControl>
+																			<Switch
+																				checked={field.value === true}
+																				onCheckedChange={field.onChange}
+																				data-testid="mcpclient-session-stickiness-switch"
+																			/>
+																		</FormControl>
+																	</FormItem>
+																)}
+															/>
+															{needsSessionStickinessDirty && (
+																<div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+																	<Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+																	<p>
+																		Toggling this takes effect immediately on save:{" "}
+																		{needsSessionStickiness
+																			? "the shared connection will be opened now."
+																			: "the existing shared connection will be closed now."}
+																	</p>
+																</div>
+															)}
+														</>
+													)}
 											</div>
 										</div>
 

--- a/ui/lib/store/apis/mcpApi.ts
+++ b/ui/lib/store/apis/mcpApi.ts
@@ -177,6 +177,8 @@ export const mcpApi = baseApi.injectEndpoints({
 									if (data.tools_to_auto_execute !== undefined)
 										draft.clients[index].config.tools_to_auto_execute = data.tools_to_auto_execute;
 									if (data.is_ping_available !== undefined) draft.clients[index].config.is_ping_available = data.is_ping_available;
+									if (data.needs_session_stickiness !== undefined)
+										draft.clients[index].config.needs_session_stickiness = data.needs_session_stickiness;
 									if (data.tool_pricing !== undefined) draft.clients[index].config.tool_pricing = data.tool_pricing;
 									// The request carries minutes, but the cached config mirrors the GET
 									// response, which carries nanoseconds. Convert so the cache stays in

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -113,6 +113,12 @@ export interface MCPClientConfig {
 	// Required (with a non-empty audience) for token_exchange auth.
 	token_exchange?: MCPTokenExchangeConfig;
 	is_ping_available?: boolean;
+	// Only meaningful when connection_type === "http": whether this client
+	// maintains one persistent connection reused across every caller (true)
+	// or connects fresh per call (nil/false, the default for newly created
+	// clients — pre-existing clients were backfilled to true). SSE and STDIO
+	// always behave as sticky regardless of this field.
+	needs_session_stickiness?: boolean;
 	tool_pricing?: Record<string, number>;
 	// Per-client override (0 = use global, -1 = disabled). API returns NANOSECONDS
 	// (Go time.Duration), while updates send minutes — convert with
@@ -163,6 +169,9 @@ export interface CreateMCPClientRequest {
 	// the analogous role. Ignored for all other auth types.
 	user_headers?: Record<string, string>;
 	is_ping_available?: boolean;
+	// Only meaningful when connection_type === "http". See MCPClientConfig's
+	// field doc for the full contract.
+	needs_session_stickiness?: boolean;
 }
 
 export interface OAuthFlowResponse {
@@ -200,6 +209,11 @@ export interface UpdateMCPClientRequest {
 	tools_to_execute?: string[];
 	tools_to_auto_execute?: string[];
 	is_ping_available?: boolean;
+	// Only meaningful when connection_type === "http". Toggling this on an
+	// existing client takes effect immediately: switching to true dials the
+	// persistent connection now, switching to false closes it. See
+	// MCPClientConfig's field doc for the full contract.
+	needs_session_stickiness?: boolean;
 	tool_pricing?: Record<string, number>;
 	tool_sync_interval?: number; // Per-client override in minutes (0 = use global, -1 = disabled)
 	tool_execution_timeout?: number; // Per-client tool execution timeout in seconds (0 = use global)

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -1101,6 +1101,7 @@ export const mcpClientUpdateSchema = z
 	.object({
 		is_code_mode_client: z.boolean().optional(),
 		is_ping_available: z.boolean().optional(),
+		needs_session_stickiness: z.boolean().optional(),
 		allow_on_all_virtual_keys: z.boolean().optional(),
 		disabled: z.boolean().optional(),
 		name: z


### PR DESCRIPTION
## Summary

Introduces a `needs_session_stickiness` field for HTTP MCP clients that controls whether the client maintains one persistent shared connection reused across every caller (`true`) or connects fresh on every call (`false`, the new default for newly created clients). Pre-existing clients are backfilled to `true` via a database migration, preserving their current behavior. SSE and STDIO connection types are unaffected — they always behave as sticky regardless of this field.

## Changes

- Added `NeedsSessionStickiness *bool` to `MCPClientConfig` and the `TableMCPClient` DB table, with a migration that backfills `true` for all pre-existing rows so their persistent-connection behavior is unchanged.
- Extended `credstore.RequiresPerCallConnection` to factor in `needs_session_stickiness` alongside auth type and connection type: shared HTTP auth types (headers/oauth) now route through the per-call path when the field is `nil`/`false`, and through the persistent-connection + connection-checker path only when explicitly `true`. Per-user auth types remain always per-call; SSE and STDIO remain always sticky.
- Refactored `UpdateClient` in `MCPManager` to split the metadata swap (under a scoped lock) from the two possible stickiness-transition follow-ups — closing the persistent connection when switching to per-call, or dialing a new one when switching to sticky — which must run after the lock is released to avoid a deadlock with `connectToMCPClient`.
- When a stickiness flip is detected during an update, the transition is applied live: the persistent connection is closed immediately (sticky → per-call) or a new one is dialed (per-call → sticky), rather than waiting for a restart or manual reconnect.
- Exposed `RequiresPerCallConnection` through `MCPManagerInterface`, `Bifrost`, the HTTP handler's `MCPManager` interface, and `ServerCallbacks` so callers don't have to duplicate the auth/connection-type/stickiness dispatch themselves.
- Added `validateNeedsSessionStickiness` to reject an explicit `false` for SSE and STDIO at write time (both in `addMCPClient` and `updateMCPClient`).
- The update response message now describes whether the client switched connection modes as a result of the update.
- Added the `needs_session_stickiness` toggle to the MCP client create form and edit sheet in the UI, visible only for HTTP clients with shared auth types. An inline warning is shown when the field is dirtied, explaining that the change takes effect immediately on save.
- Updated the connection checker test to set `NeedsSessionStickiness: true` so the shared-auth reconnect branch under test is actually exercised.
- Added `needs_session_stickiness` to `config.schema.json`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./core/... ./transports/...

# UI
cd ui
pnpm i
pnpm build
```

1. Create a new HTTP MCP client with `auth_type=headers` and omit `needs_session_stickiness` — confirm no persistent connection or connection checker is started.
2. Update the same client with `needs_session_stickiness=true` — confirm the response message indicates a shared connection was opened and the client transitions to a persistent-connection state.
3. Update again with `needs_session_stickiness=false` — confirm the response message indicates the shared connection was closed and the client returns to per-call mode.
4. Create a pre-existing client row in the DB (simulate by running the migration against a DB with existing rows) — confirm `needs_session_stickiness` is backfilled to `true` and behavior is unchanged.
5. Attempt to set `needs_session_stickiness=false` on an SSE or STDIO client — confirm a 400 error is returned.
6. In the UI, open an HTTP headers/oauth client's edit sheet and toggle "Maintain Persistent Connection" — confirm the amber warning appears and the correct message is shown for each direction.

## Breaking changes

- [ ] Yes
- [x] No

Pre-existing clients are backfilled to `needs_session_stickiness=true`, so their behavior is identical to before this change. The field only affects newly created clients, which default to per-call (`false`).

## Security considerations

No new auth surfaces are introduced. The field controls connection lifecycle only. Per-user auth types are unaffected and remain always per-call regardless of this field.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable