### PR TITLE
feat: add compare-and-swap guard on refresh_token to `RefreshOauthTokenFieldsIfActive`

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -6817,16 +6817,31 @@ func (s *RDBConfigStore) UpdateOauthToken(ctx context.Context, token *tables.Tab
 }
 
 // RefreshOauthTokenFieldsIfActive persists a successful refresh's new
-// credential fields, but only while the row is still 'active' at write time.
+// credential fields, but only while the row is still 'active' AND its
+// stored refresh_token still equals expectedPriorRefreshToken at write time.
 // Reads the row FOR UPDATE (a Postgres row lock; a no-op on SQLite, see
-// dbForUpdate) inside a transaction so the status check and the write are
-// atomic with respect to a concurrent RotateMCPOAuthConfig cascade flipping
-// the same row to 'needs_reauth' — without this, a plain full-row Save keyed
-// only on ID could silently overwrite that flip back to 'active' with a
-// refresh that started before the rotation but finished after it. Loads
-// through the model (not a raw column UPDATE) so BeforeSave's encryption
-// hook still runs exactly as it does for every other token write.
-func (s *RDBConfigStore) RefreshOauthTokenFieldsIfActive(ctx context.Context, id string, accessToken, refreshToken string, expiresAt *time.Time, lastRefreshedAt time.Time) (bool, error) {
+// dbForUpdate) inside a transaction so both checks and the write are atomic
+// with respect to two distinct concurrent-write hazards:
+//   - A RotateMCPOAuthConfig cascade flipping the same row to 'needs_reauth'
+//     while this refresh's network round-trip was in flight — without the
+//     status check, a plain full-row Save keyed only on ID could silently
+//     overwrite that flip back to 'active'.
+//   - A second, concurrent refresh of this same row (typically from another
+//     cluster node — nothing upstream of this call prevents two nodes from
+//     independently redeeming the same refresh_token against the IdP at
+//     once) that already won the race and wrote its own newer credentials.
+//     The row lock alone does not prevent this: both writers' status checks
+//     would still pass since the row is 'active' the whole time, so without
+//     comparing refresh_token, the second writer to reach this transaction
+//     would simply overwrite the first writer's fresher credentials with
+//     its own now-stale ones. Comparing against expectedPriorRefreshToken
+//     (the value the caller redeemed upstream, read before the network
+//     call) makes this a compare-and-swap: only the writer whose redeemed
+//     token is still the row's current one gets to commit.
+//
+// Loads through the model (not a raw column UPDATE) so BeforeSave's
+// encryption hook still runs exactly as it does for every other token write.
+func (s *RDBConfigStore) RefreshOauthTokenFieldsIfActive(ctx context.Context, id string, expectedPriorRefreshToken, accessToken, refreshToken string, expiresAt *time.Time, lastRefreshedAt time.Time) (bool, error) {
 	updated := false
 	err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var current tables.TableMCPOauthToken
@@ -6837,6 +6852,11 @@ func (s *RDBConfigStore) RefreshOauthTokenFieldsIfActive(ctx context.Context, id
 			return err
 		}
 		if current.Status != "active" {
+			return nil
+		}
+		if current.RefreshToken != expectedPriorRefreshToken {
+			// Someone else already advanced this row past the refresh_token
+			// this call redeemed upstream — this refresh lost the race.
 			return nil
 		}
 		current.AccessToken = accessToken

--- a/framework/configstore/rdb_oauth2_test.go
+++ b/framework/configstore/rdb_oauth2_test.go
@@ -712,3 +712,73 @@ func TestSweepConvergence_TokenSweepThenClientSweep(t *testing.T) {
 	_, err = s.GetOAuth2ClientByClientID(ctx, "revoked-only")
 	assert.ErrorIs(t, err, ErrNotFound)
 }
+
+// TestRefreshOauthTokenFieldsIfActive_CAS verifies the compare-and-swap guard:
+// a write only commits while the row's stored refresh_token still matches the
+// value the caller redeemed upstream (expectedPriorRefreshToken). This is what
+// prevents two concurrent refreshes of the same row — e.g. from two different
+// cluster nodes racing the same MCP client's periodic connection checker —
+// from clobbering each other: whichever one wins the race and writes first
+// advances the row's refresh_token, and the loser's write (still carrying the
+// now-superseded prior value) is rejected instead of overwriting the winner's
+// fresher credentials.
+func TestRefreshOauthTokenFieldsIfActive_CAS(t *testing.T) {
+	s := setupRDBTestStore(t)
+	require.NoError(t, s.DB().AutoMigrate(&tables.TableMCPOauthToken{}))
+	ctx := context.Background()
+	future := time.Now().Add(time.Hour)
+
+	require.NoError(t, s.DB().Create(&tables.TableMCPOauthToken{
+		ID: "tok-1", AuthMode: "shared", OauthConfigID: "cfg-1", Status: "active",
+		AccessToken: "at-original", RefreshToken: "rt-original", TokenType: "Bearer",
+		ExpiresAt: &future, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}).Error)
+
+	// Two "nodes" both read the row with rt-original as the refresh_token and
+	// both redeem it upstream (out of scope here — we're testing only the
+	// store-level CAS), racing to write back their own new credentials.
+	updatedA, err := s.RefreshOauthTokenFieldsIfActive(ctx, "tok-1", "rt-original", "at-node-a", "rt-node-a", &future, time.Now())
+	require.NoError(t, err)
+	assert.True(t, updatedA, "the first writer, whose expectedPriorRefreshToken still matches the stored value, must win")
+
+	// The second writer's redemption is now stale: the row's refresh_token has
+	// already moved to rt-node-a, so its write (still keyed off rt-original)
+	// must be rejected rather than clobbering node A's fresher credentials.
+	updatedB, err := s.RefreshOauthTokenFieldsIfActive(ctx, "tok-1", "rt-original", "at-node-b", "rt-node-b", &future, time.Now())
+	require.NoError(t, err)
+	assert.False(t, updatedB, "a write whose expectedPriorRefreshToken no longer matches the stored value must lose the race")
+
+	stored, err := s.GetOauthTokenByID(ctx, "tok-1")
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Equal(t, "at-node-a", stored.AccessToken, "the loser's write must not have overwritten the winner's access token")
+	assert.Equal(t, "rt-node-a", stored.RefreshToken, "the loser's write must not have overwritten the winner's refresh token")
+
+	// A write with the now-current refresh_token still succeeds — the CAS
+	// guard rejects stale writers, not every subsequent write.
+	updatedC, err := s.RefreshOauthTokenFieldsIfActive(ctx, "tok-1", "rt-node-a", "at-node-c", "rt-node-c", &future, time.Now())
+	require.NoError(t, err)
+	assert.True(t, updatedC, "a write keyed off the row's actual current refresh_token must succeed")
+}
+
+// TestRefreshOauthTokenFieldsIfActive_StatusGuardStillApplies is a narrow
+// regression check that adding the refresh_token CAS comparison did not
+// regress the pre-existing status guard: a row already flipped to
+// 'needs_reauth' (e.g. by a concurrent RotateMCPOAuthConfig) must still
+// reject the write even when expectedPriorRefreshToken matches exactly.
+func TestRefreshOauthTokenFieldsIfActive_StatusGuardStillApplies(t *testing.T) {
+	s := setupRDBTestStore(t)
+	require.NoError(t, s.DB().AutoMigrate(&tables.TableMCPOauthToken{}))
+	ctx := context.Background()
+	future := time.Now().Add(time.Hour)
+
+	require.NoError(t, s.DB().Create(&tables.TableMCPOauthToken{
+		ID: "tok-2", AuthMode: "shared", OauthConfigID: "cfg-2", Status: "needs_reauth",
+		AccessToken: "at-original", RefreshToken: "rt-original", TokenType: "Bearer",
+		ExpiresAt: &future, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}).Error)
+
+	updated, err := s.RefreshOauthTokenFieldsIfActive(ctx, "tok-2", "rt-original", "at-new", "rt-new", &future, time.Now())
+	require.NoError(t, err)
+	assert.False(t, updated, "a non-'active' row must reject the write even with a matching expectedPriorRefreshToken")
+}

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -554,14 +554,23 @@ type ConfigStore interface {
 	UpdateOauthToken(ctx context.Context, token *tables.TableMCPOauthToken) error
 	// RefreshOauthTokenFieldsIfActive persists a successful refresh's new
 	// access_token/refresh_token/expires_at/last_refreshed_at onto the row
-	// with the given id, but ONLY while the row's status is still 'active' —
-	// a targeted column update, not a full-row Save, so it can't clobber a
-	// status a concurrent credential rotation (RotateMCPOAuthConfig) already
-	// flipped to 'needs_reauth' while this refresh's network round-trip was
-	// in flight. Returns updated=false (no error) when the row's status was
-	// no longer 'active' at write time; the caller must treat that as
-	// requiring reauthentication rather than a successful refresh.
-	RefreshOauthTokenFieldsIfActive(ctx context.Context, id string, accessToken, refreshToken string, expiresAt *time.Time, lastRefreshedAt time.Time) (updated bool, err error)
+	// with the given id, but ONLY while the row is still 'active' AND its
+	// stored refresh_token still equals expectedPriorRefreshToken (the value
+	// the caller read and redeemed upstream before this call) — a targeted,
+	// compare-and-swap column update, not a full-row Save, so it can't
+	// clobber either (a) a status a concurrent credential rotation
+	// (RotateMCPOAuthConfig) already flipped to 'needs_reauth', or (b) a
+	// newer refresh_token a different, concurrently-running refresh of this
+	// same row (typically from another cluster node, since nothing today
+	// prevents two nodes from independently redeeming the same refresh_token
+	// upstream) already wrote, while this refresh's network round-trip was
+	// in flight. Returns updated=false (no error) when either guard failed
+	// to hold at write time; the caller must treat that as its own refresh
+	// having lost the race rather than a successful one — its freshly
+	// redeemed credentials must be discarded, not retried, since the
+	// refresh_token they were redeemed against is no longer the row's live
+	// one.
+	RefreshOauthTokenFieldsIfActive(ctx context.Context, id string, expectedPriorRefreshToken, accessToken, refreshToken string, expiresAt *time.Time, lastRefreshedAt time.Time) (updated bool, err error)
 	DeleteOauthToken(ctx context.Context, id string) error
 	// DeleteSharedOauthTokensByConfigID deletes every auth_mode='shared' row
 	// for oauthConfigID, not just the one GetSharedOauthTokenByConfigID would

--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -377,12 +377,32 @@ func (p *OAuth2Provider) refreshAccessTokenLocked(ctx context.Context, tokenID s
 		newRefreshToken = strings.TrimSpace(newTokenResponse.RefreshToken)
 	}
 
-	updated, err := p.configStore.RefreshOauthTokenFieldsIfActive(ctx, token.ID, newAccessToken, newRefreshToken, newExpiresAt, now)
+	// expectedPriorRefreshToken is token.RefreshToken as read above, before
+	// the upstream exchangeRefreshToken call — it's the value this refresh
+	// actually redeemed. The store only commits if that's still the row's
+	// live refresh_token, so a concurrent refresh of the same row (e.g. from
+	// another cluster node) that already won the race is never overwritten.
+	updated, err := p.configStore.RefreshOauthTokenFieldsIfActive(ctx, token.ID, token.RefreshToken, newAccessToken, newRefreshToken, newExpiresAt, now)
 	if err != nil {
 		return fmt.Errorf("failed to update token: %w", err)
 	}
 	if !updated {
-		return fmt.Errorf("token was reauthorized or rotated during refresh, discarding this refresh: %w", schemas.ErrOAuth2TokenExpired)
+		// The CAS was lost — someone else (another cluster node, a concurrent
+		// refresh, an explicit reauthorize) already moved refresh_token past
+		// what this attempt read. That's not necessarily bad news: drop any
+		// stale cached copy and reload the row fresh. If it's still active,
+		// the winner already supplied current credentials — this attempt's
+		// own (now-discarded) result was simply redundant, not a sign the
+		// credential is dead. Only report ErrOAuth2TokenExpired (which
+		// callers map to NeedsReauth) when the row is genuinely gone or
+		// landed in a non-active terminal state.
+		p.EvictUserTokenByID(token.ID)
+		reloaded, reloadErr := p.configStore.GetOauthTokenByID(ctx, token.ID)
+		if reloadErr == nil && reloaded != nil && reloaded.Status == "active" {
+			logger.Debug("OAuth refresh CAS lost but the row is still active (refreshed elsewhere): token_id=%s auth_mode=%s", token.ID, token.AuthMode)
+			return nil
+		}
+		return fmt.Errorf("token was reauthorized, rotated, or already refreshed elsewhere during this refresh, discarding this refresh: %w", schemas.ErrOAuth2TokenExpired)
 	}
 
 	// Drop any cached copy of the old access token; the next lookup reads

--- a/framework/oauth2/sync_test.go
+++ b/framework/oauth2/sync_test.go
@@ -106,13 +106,15 @@ func (s *testConfigStore) UpdateOauthToken(_ context.Context, token *tables.Tabl
 }
 
 // RefreshOauthTokenFieldsIfActive is the test-double equivalent of the real
-// store's status-gated refresh write (see its doc comment on the interface):
-// applies the new credential fields only while the row is still 'active'.
-func (s *testConfigStore) RefreshOauthTokenFieldsIfActive(_ context.Context, id string, accessToken, refreshToken string, expiresAt *time.Time, lastRefreshedAt time.Time) (bool, error) {
+// store's status- and refresh-token-gated compare-and-swap write (see its
+// doc comment on the interface): applies the new credential fields only
+// while the row is still 'active' AND its stored refresh_token still equals
+// expectedPriorRefreshToken.
+func (s *testConfigStore) RefreshOauthTokenFieldsIfActive(_ context.Context, id string, expectedPriorRefreshToken, accessToken, refreshToken string, expiresAt *time.Time, lastRefreshedAt time.Time) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	token, ok := s.oauthTokens[id]
-	if !ok || token.Status != "active" {
+	if !ok || token.Status != "active" || token.RefreshToken != expectedPriorRefreshToken {
 		return false, nil
 	}
 	updated := *token
@@ -749,6 +751,65 @@ func TestTokenRefreshWorker_ConcurrentReauth_DoesNotOverwriteStaleRefresh(t *tes
 	assert.Equal(t, "needs_reauth", token.Status, "status flip during an in-flight refresh must not be overwritten by the stale response")
 	assert.Equal(t, "old-access-token", token.AccessToken, "stale refresh response must not overwrite credentials once needs_reauth has been set")
 	assert.Equal(t, "refresh-token", token.RefreshToken)
+}
+
+func TestRefreshAccessToken_CASLostToConcurrentActiveRefresh_ReturnsNilNotExpired(t *testing.T) {
+	// The CAS lost not because the credential died, but because a concurrent
+	// refresh of the same row (e.g. from another cluster node) already won
+	// the race and left the row active with fresh credentials. This attempt's
+	// own (now-discarded) result must not be treated as a dead credential —
+	// no ErrOAuth2TokenExpired, no NeedsReauth. Mirrors
+	// TestTokenRefreshWorker_ConcurrentReauth_DoesNotOverwriteStaleRefresh's
+	// blocking-server shape, but the concurrent write here keeps status
+	// "active" instead of flipping to needs_reauth.
+	started := make(chan struct{})
+	unblock := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-unblock
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "stale-refreshed-access-token",
+			"refresh_token": "stale-refreshed-refresh-token",
+			"token_type":    "bearer",
+			"expires_in":    3600,
+		})
+	}))
+	defer server.Close()
+
+	store := newTestConfigStore()
+	_, tokenID := seedFixtures(t, store, server.URL+"/token")
+	provider := newTestProvider(store)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var refreshErr error
+	go func() {
+		defer wg.Done()
+		refreshErr = provider.RefreshAccessToken(context.Background(), tokenID)
+	}()
+
+	<-started
+	// Simulate a concurrent refresh elsewhere winning the race: the row's
+	// refresh_token moves past what this in-flight attempt read, but status
+	// stays active — the credential is fine, just refreshed by someone else.
+	store.mu.Lock()
+	winner := *store.oauthTokens[tokenID]
+	winner.AccessToken = "winner-access-token"
+	winner.RefreshToken = "winner-refresh-token"
+	store.oauthTokens[tokenID] = &winner
+	store.mu.Unlock()
+	close(unblock)
+	wg.Wait()
+
+	assert.NoError(t, refreshErr, "a CAS loss to a still-active concurrent refresh must not surface as an error")
+	assert.NotErrorIs(t, refreshErr, schemas.ErrOAuth2TokenExpired)
+
+	token, err := store.GetOauthTokenByID(context.Background(), tokenID)
+	require.NoError(t, err)
+	assert.Equal(t, "active", token.Status)
+	assert.Equal(t, "winner-access-token", token.AccessToken, "the winning concurrent refresh's credentials must survive, not this attempt's discarded result")
+	assert.Equal(t, "winner-refresh-token", token.RefreshToken)
 }
 
 func TestTokenRefreshWorker_ConnectionRefused_DoesNotMarkNeedsReauth(t *testing.T) {

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1488,7 +1488,7 @@ func (m *MockConfigStore) UpdateOauthToken(ctx context.Context, token *tables.Ta
 	return nil
 }
 
-func (m *MockConfigStore) RefreshOauthTokenFieldsIfActive(ctx context.Context, id string, accessToken, refreshToken string, expiresAt *time.Time, lastRefreshedAt time.Time) (bool, error) {
+func (m *MockConfigStore) RefreshOauthTokenFieldsIfActive(ctx context.Context, id string, expectedPriorRefreshToken, accessToken, refreshToken string, expiresAt *time.Time, lastRefreshedAt time.Time) (bool, error) {
 	return true, nil
 }
 


### PR DESCRIPTION
## Summary

`RefreshOauthTokenFieldsIfActive` previously guarded token writes only by checking that the row's status was still `active`. This left a window where two cluster nodes could independently redeem the same refresh token against the IdP and race to write back their results: both would pass the status check, and whichever wrote second would silently overwrite the first writer's fresher credentials with its own now-stale ones. This PR adds a compare-and-swap guard on `refresh_token` to close that race.

## Changes

- Added `expectedPriorRefreshToken` parameter to `RefreshOauthTokenFieldsIfActive` across the interface, real implementation, and all test doubles/mocks. The store now reads the row inside the existing `FOR UPDATE` transaction and rejects the write if the stored `refresh_token` no longer matches the value the caller redeemed upstream — making the write a true compare-and-swap.
- The caller in `refreshAccessTokenLocked` passes `token.RefreshToken` (read before the upstream `exchangeRefreshToken` call) as `expectedPriorRefreshToken`, so only the node whose redeemed token is still the row's live one commits.
- The error message on a rejected write now explicitly mentions "already refreshed elsewhere" as a distinct rejection reason alongside reauthorization and rotation.
- Added two new tests: `TestRefreshOauthTokenFieldsIfActive_CAS` verifies that the first writer wins and the second writer's stale write is rejected without clobbering the winner's credentials, and that a subsequent write keyed off the now-current token still succeeds. `TestRefreshOauthTokenFieldsIfActive_StatusGuardStillApplies` is a regression check confirming the pre-existing status guard still rejects writes on `needs_reauth` rows even when `expectedPriorRefreshToken` matches.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)

## How to test

```sh
go test ./framework/configstore/... ./framework/oauth2/... ./transports/bifrost-http/lib/...
```

The two new tests in `rdb_oauth2_test.go` directly exercise the CAS behavior: `TestRefreshOauthTokenFieldsIfActive_CAS` simulates two nodes racing to write back credentials from the same redeemed refresh token and asserts only the first writer's credentials are persisted. `TestRefreshOauthTokenFieldsIfActive_StatusGuardStillApplies` confirms the status check is not regressed.

## Breaking changes

- [x] Yes

`RefreshOauthTokenFieldsIfActive` has a new required parameter `expectedPriorRefreshToken` inserted as the third argument. Any implementation of the `ConfigStore` interface must be updated to include this parameter.

## Security considerations

This closes a credential-clobbering race where a stale OAuth2 refresh (e.g. from a losing cluster node) could overwrite a fresher set of credentials already written by the winning node, potentially leaving the system with an access token that the IdP has already superseded. The fix ensures only the writer holding the currently-live refresh token can commit, matching standard compare-and-swap token rotation semantics.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)