### PR TITLE
feat: add MCP state-change callback and `degraded` cluster-aggregate state with per-instance drill-down

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4004,6 +4004,18 @@ func (bifrost *Bifrost) MCPClientRequiresPerCallConnection(config *schemas.MCPCl
 	return bifrost.MCPManager.RequiresPerCallConnection(config)
 }
 
+// SetMCPStateChangeCallback registers cb to be invoked on every reactive
+// (non-admin-driven) MCP client connection-state transition — periodic
+// checker transitions and reactive connect-failure classification into
+// NeedsReauth. Pass nil to clear a previously registered callback. A no-op
+// if MCP is not configured.
+func (bifrost *Bifrost) SetMCPStateChangeCallback(cb func(clientID, name string, oldState, newState schemas.MCPConnectionState)) {
+	if bifrost.MCPManager == nil {
+		return
+	}
+	bifrost.MCPManager.SetStateChangeCallback(cb)
+}
+
 // GetMCPClients returns all MCP clients managed by the Bifrost instance.
 //
 // Returns:

--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -2202,6 +2202,8 @@ func (m *MCPManager) closeConnHandles(cancel context.CancelFunc, conn *client.Cl
 // attempt must not mutate that replacement.
 func (m *MCPManager) failConnectAttempt(entry *schemas.MCPClientState, config *schemas.MCPClientConfig, newCancel context.CancelFunc, newConn *client.Client, oldCancel context.CancelFunc, oldConn *client.Client, needsReauth bool) {
 	m.mu.Lock()
+	var oldState, newState schemas.MCPConnectionState
+	stateChanged := false
 	if clientState, exists := m.clientMap[config.ID]; exists && clientState == entry && clientState.State != schemas.MCPConnectionStateDisabled {
 		clientState.Conn = nil
 		clientState.CancelFunc = nil
@@ -2218,16 +2220,33 @@ func (m *MCPManager) failConnectAttempt(entry *schemas.MCPClientState, config *s
 			Type: config.ConnectionType,
 		}
 		clientState.ConnGeneration++
+		oldState = clientState.State
 		if needsReauth {
-			clientState.State = schemas.MCPConnectionStateNeedsReauth
+			newState = schemas.MCPConnectionStateNeedsReauth
 		} else {
-			clientState.State = schemas.MCPConnectionStateUnstable
+			newState = schemas.MCPConnectionStateUnstable
 		}
+		stateChanged = oldState != newState
+		clientState.State = newState
 	}
+	cb := m.stateChangeCallback
 	m.mu.Unlock()
 
 	m.closeConnHandles(newCancel, newConn, config.Name)
 	m.closeConnHandles(oldCancel, oldConn, config.Name)
+
+	// Fired outside the lock — same rationale as ClientConnectionChecker's
+	// setState: a registered callback is caller-supplied and may do
+	// arbitrary work (including I/O), which must never run while holding
+	// m.mu. This is specifically the "reactive" NeedsReauth path (a connect
+	// attempt — triggered by a live request, a manual reconnect, or the
+	// periodic checker's own reconnect-on-nil-conn branch — classifying its
+	// failure as permanent), which unlike CloseAndMarkNeedsReauth has no
+	// admin-API call site of its own for a caller to observe the change
+	// through.
+	if stateChanged && cb != nil {
+		cb(config.ID, config.Name, oldState, newState)
+	}
 }
 
 // buildTLSHTTPClient constructs an *http.Client with a custom TLS configuration derived

--- a/core/mcp/clientmanager_test.go
+++ b/core/mcp/clientmanager_test.go
@@ -107,6 +107,74 @@ func TestCloseAndMarkNeedsReauth_ClosesLiveConnectionAndFlipsState(t *testing.T)
 	assert.Equal(t, schemas.MCPConnectionStateNeedsReauth, state.State)
 }
 
+// TestFailConnectAttempt_NeedsReauthTransition_FiresStateChangeCallback
+// verifies that failConnectAttempt's reactive classification of a connect
+// failure as permanent (needsReauth=true) fires the registered state-change
+// callback with the correct old/new states — this transition (unlike
+// CloseAndMarkNeedsReauth) has no admin-API call site of its own for a
+// caller to observe the change through otherwise.
+func TestFailConnectAttempt_NeedsReauthTransition_FiresStateChangeCallback(t *testing.T) {
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, expiredOAuthCredStore{}, nil, nil)
+	config := newSharedOAuthClientConfig("client-fail-reauth")
+
+	type call struct {
+		clientID, name     string
+		oldState, newState schemas.MCPConnectionState
+	}
+	var calls []call
+	m.SetStateChangeCallback(func(clientID, name string, oldState, newState schemas.MCPConnectionState) {
+		calls = append(calls, call{clientID, name, oldState, newState})
+	})
+
+	entry := &schemas.MCPClientState{
+		Name:            config.Name,
+		ExecutionConfig: config,
+		State:           schemas.MCPConnectionStateUnstable,
+	}
+	m.mu.Lock()
+	m.clientMap[config.ID] = entry
+	m.mu.Unlock()
+
+	m.failConnectAttempt(entry, config, nil, nil, nil, nil, true)
+
+	require.Len(t, calls, 1, "the callback must fire exactly once for a genuine state transition")
+	assert.Equal(t, config.ID, calls[0].clientID)
+	assert.Equal(t, config.Name, calls[0].name)
+	assert.Equal(t, schemas.MCPConnectionStateUnstable, calls[0].oldState)
+	assert.Equal(t, schemas.MCPConnectionStateNeedsReauth, calls[0].newState)
+
+	m.mu.RLock()
+	state := m.clientMap[config.ID].State
+	m.mu.RUnlock()
+	assert.Equal(t, schemas.MCPConnectionStateNeedsReauth, state)
+}
+
+// TestFailConnectAttempt_NoStateChange_DoesNotFireCallback verifies the
+// callback is a pure transition signal — reclassifying a client that's
+// already Unstable as Unstable again must not fire it.
+func TestFailConnectAttempt_NoStateChange_DoesNotFireCallback(t *testing.T) {
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, expiredOAuthCredStore{}, nil, nil)
+	config := newSharedOAuthClientConfig("client-no-change")
+
+	fired := false
+	m.SetStateChangeCallback(func(clientID, name string, oldState, newState schemas.MCPConnectionState) {
+		fired = true
+	})
+
+	entry := &schemas.MCPClientState{
+		Name:            config.Name,
+		ExecutionConfig: config,
+		State:           schemas.MCPConnectionStateUnstable,
+	}
+	m.mu.Lock()
+	m.clientMap[config.ID] = entry
+	m.mu.Unlock()
+
+	m.failConnectAttempt(entry, config, nil, nil, nil, nil, false)
+
+	assert.False(t, fired, "the callback must not fire when the transition is a no-op")
+}
+
 // TestCloseAndMarkNeedsReauth_MissingClient_Errors covers the not-found path.
 func TestCloseAndMarkNeedsReauth_MissingClient_Errors(t *testing.T) {
 	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, expiredOAuthCredStore{}, nil, nil)

--- a/core/mcp/connectionchecker.go
+++ b/core/mcp/connectionchecker.go
@@ -382,7 +382,8 @@ func (c *ClientConnectionChecker) setState(state schemas.MCPConnectionState, con
 		c.manager.mu.Unlock()
 		return
 	}
-	stateChanged := clientState.State != state
+	oldState := clientState.State
+	stateChanged := oldState != state
 	name := ""
 	if clientState.ExecutionConfig != nil {
 		name = clientState.ExecutionConfig.Name
@@ -390,10 +391,17 @@ func (c *ClientConnectionChecker) setState(state schemas.MCPConnectionState, con
 	if stateChanged {
 		clientState.State = state
 	}
+	cb := c.manager.stateChangeCallback
 	c.manager.mu.Unlock()
 
 	if stateChanged {
 		c.logger.Info("%s Client %s connection state changed to: %s", MCPLogPrefix, name, state)
+		// Fired outside the lock — a registered callback is caller-supplied
+		// and may do arbitrary work (including I/O), which must never run
+		// while holding m.mu.
+		if cb != nil {
+			cb(c.clientID, name, oldState, state)
+		}
 	}
 }
 

--- a/core/mcp/connectionchecker_test.go
+++ b/core/mcp/connectionchecker_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -145,7 +146,7 @@ func TestPerformCheck_NilConn_SharedAuthType_TriggersReconnect(t *testing.T) {
 		AuthType:               schemas.MCPAuthTypeHeaders,
 		ConnectionType:         schemas.MCPConnectionTypeHTTP,
 		ConnectionString:       schemas.NewSecretVar("http://127.0.0.1:0/mcp"), // unreachable — attempt must still be made
-		NeedsSessionStickiness: schemas.Ptr(true),                             // sticky: routes through the reconnect-on-nil-conn branch under test, not checkPerCall
+		NeedsSessionStickiness: schemas.Ptr(true),                              // sticky: routes through the reconnect-on-nil-conn branch under test, not checkPerCall
 	}
 	manager.mu.Lock()
 	manager.clientMap[config.ID] = &schemas.MCPClientState{
@@ -226,4 +227,53 @@ func TestSetState_StaleGeneration_DoesNotOverwriteState(t *testing.T) {
 	// one must apply normally — the guard isn't a blanket no-op.
 	checker.setState(schemas.MCPConnectionStateUnstable, 6)
 	require.Equal(t, schemas.MCPConnectionStateUnstable, manager.clientMap[config.ID].State, "a current-generation state write must still apply")
+}
+
+// TestSetState_FiresStateChangeCallbackOnGenuineTransition verifies
+// ClientConnectionChecker.setState — the single writer every periodic-check
+// transition in this file funnels through — fires the manager's registered
+// state-change callback exactly once per genuine transition, with the
+// correct old/new states, and not at all when the target state matches the
+// current one.
+func TestSetState_FiresStateChangeCallbackOnGenuineTransition(t *testing.T) {
+	manager := NewMCPManager(context.Background(), schemas.MCPConfig{}, nil, &MockLogger{}, nil)
+	config := &schemas.MCPClientConfig{ID: "client-checker-callback", Name: "checker-callback-client"}
+
+	type call struct {
+		clientID, name     string
+		oldState, newState schemas.MCPConnectionState
+	}
+	var calls []call
+	manager.SetStateChangeCallback(func(clientID, name string, oldState, newState schemas.MCPConnectionState) {
+		calls = append(calls, call{clientID, name, oldState, newState})
+	})
+
+	manager.mu.Lock()
+	manager.clientMap[config.ID] = &schemas.MCPClientState{
+		Name:            config.Name,
+		ExecutionConfig: config,
+		State:           schemas.MCPConnectionStateHealthy,
+	}
+	manager.mu.Unlock()
+
+	checker := NewClientConnectionChecker(manager, config.ID, time.Minute, false, &MockLogger{})
+
+	// Healthy -> Unstable: a genuine transition, must fire once. Generation 0
+	// matches this client's zero-value ConnGeneration (never bumped here).
+	checker.recordFailure(config.Name, "ping", errors.New("boom"), 0)
+	require.Len(t, calls, 1)
+	assert.Equal(t, config.ID, calls[0].clientID)
+	assert.Equal(t, config.Name, calls[0].name)
+	assert.Equal(t, schemas.MCPConnectionStateHealthy, calls[0].oldState)
+	assert.Equal(t, schemas.MCPConnectionStateUnstable, calls[0].newState)
+
+	// Unstable -> Unstable: a no-op, must not fire again.
+	checker.recordFailure(config.Name, "ping", errors.New("boom again"), 0)
+	require.Len(t, calls, 1, "a repeat failure that doesn't change state must not re-fire the callback")
+
+	// Unstable -> Healthy: a genuine transition, must fire again.
+	checker.recordSuccess(config.Name, 0)
+	require.Len(t, calls, 2)
+	assert.Equal(t, schemas.MCPConnectionStateUnstable, calls[1].oldState)
+	assert.Equal(t, schemas.MCPConnectionStateHealthy, calls[1].newState)
 }

--- a/core/mcp/interface.go
+++ b/core/mcp/interface.go
@@ -60,6 +60,12 @@ type MCPManagerInterface interface {
 	// together.
 	RequiresPerCallConnection(config *schemas.MCPClientConfig) bool
 
+	// SetStateChangeCallback registers cb to be invoked on every reactive
+	// (non-admin-driven) client connection-state transition — periodic
+	// checker transitions and reactive connect-failure classification into
+	// NeedsReauth. Pass nil to clear a previously registered callback.
+	SetStateChangeCallback(cb func(clientID, name string, oldState, newState schemas.MCPConnectionState))
+
 	// AddClient adds a new MCP client with the given configuration
 	AddClient(ctx context.Context, config *schemas.MCPClientConfig) error
 

--- a/core/mcp/mcp.go
+++ b/core/mcp/mcp.go
@@ -55,6 +55,41 @@ type MCPManager struct {
 	// existing execute-tool hooks.
 	pluginPipelineProvider func() PluginPipeline
 	releasePluginPipeline  func(pipeline PluginPipeline)
+
+	// stateChangeCallback, if set, is invoked whenever a client's live
+	// connection state changes via a path with no admin-API call site of its
+	// own for a caller to observe the change through: reactive connect-
+	// failure classification (failConnectAttempt) and the periodic
+	// connection checker's own transitions (ClientConnectionChecker.setState).
+	// Deliberately NOT fired from admin-driven transitions
+	// (CloseAndMarkNeedsReauth, DisableClient/EnableClient, UpdateClient) —
+	// those already have their own return value/call site for a caller to
+	// react to, so firing here too would just be a redundant second signal
+	// for the same change. nil-safe: OSS behaves identically whether a
+	// callback is registered or not.
+	//
+	// No cross-transition ordering guarantee: each call site commits its
+	// state change under m.mu, then invokes cb after releasing it (a
+	// registered callback may do arbitrary work, including I/O, which must
+	// never run while holding m.mu — see the two call sites' own comments).
+	// Two transitions committed in quick succession from different
+	// goroutines can therefore have their callback invocations observed out
+	// of commit order. A consumer that needs to track a client's presumed
+	// current state across every event would need its own sequencing; one
+	// that only reacts to a specific newState value in an idempotent way
+	// (the only kind of consumer this exists for today) is unaffected.
+	stateChangeCallback func(clientID, name string, oldState, newState schemas.MCPConnectionState)
+}
+
+// SetStateChangeCallback registers cb to be invoked on every reactive
+// (non-admin-driven) client state transition — see the stateChangeCallback
+// field doc for exactly which transitions that covers. Pass nil to clear a
+// previously registered callback. Safe to call at any time; takes effect on
+// the next transition.
+func (m *MCPManager) SetStateChangeCallback(cb func(clientID, name string, oldState, newState schemas.MCPConnectionState)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stateChangeCallback = cb
 }
 
 // MCPToolFunction is a generic function type for handling tool calls with typed arguments.

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -783,6 +783,17 @@ const (
 	//     keep working, only the tool list stops refreshing until an admin repairs
 	//     the discovery credential.
 	MCPConnectionStateNeedsReauth MCPConnectionState = "needs_reauth"
+	// MCPConnectionStateDegraded is a read-time aggregate value, never a
+	// node's own local State: it means multiple instances of a distributed
+	// deployment each hold a different self-reported state for the same
+	// client (e.g. one instance's periodic check currently sees Healthy
+	// while another's currently sees Unstable). Only meaningful for states
+	// that can genuinely vary per instance in the first place (Healthy,
+	// Unstable, PendingVerification); NeedsReauth/Disabled are config-
+	// sourced facts expected to already agree everywhere, so disagreement
+	// on those is a propagation problem, not something this value covers.
+	// A single-instance deployment never produces this value.
+	MCPConnectionStateDegraded MCPConnectionState = "degraded"
 )
 
 // MCPClientState represents a connected MCP client with its configuration and tools.

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -729,6 +729,25 @@ type MCPClientResponse struct {
 	Tools     []schemas.ChatToolFunction `json:"tools"`
 	State     schemas.MCPConnectionState `json:"state"`
 	VKConfigs []MCPVKConfigResponse      `json:"vk_configs"`
+	// NodeStates is the per-instance breakdown behind State when it is
+	// schemas.MCPConnectionStateDegraded (instance ID -> that instance's own
+	// self-reported state). Only ever populated by a configured
+	// MCPClusterStateAggregator; nil in a single-instance deployment.
+	NodeStates map[string]string `json:"node_states,omitempty"`
+}
+
+// MCPClusterStateAggregator is an optional capability the configured
+// MCPManager may additionally implement: given a client and the state its
+// own runtime already reports locally, it returns the cluster-aggregated
+// view — the same value when every instance agrees, or
+// schemas.MCPConnectionStateDegraded plus a per-instance breakdown when they
+// don't. A nil aggregated map means "agreement" or "not applicable"; a
+// non-nil one is only ever attached to the response when the returned state
+// is actually Degraded. Single-instance deployments never implement this,
+// so the type assertion in getMCPClientsPaginated simply misses and the
+// response is unchanged from today.
+type MCPClusterStateAggregator interface {
+	AggregateMCPClientState(clientID string, localState schemas.MCPConnectionState) (state schemas.MCPConnectionState, nodeStates map[string]string)
 }
 
 // getMCPClients handles GET /api/mcp/clients - Get all MCP clients
@@ -1187,17 +1206,25 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, params con
 			sort.Slice(sortedTools, func(i, j int) bool {
 				return sortedTools[i].Name < sortedTools[j].Name
 			})
-			clients = append(clients, MCPClientResponse{
-				Config: redactedConfig,
-				Tools:  sortedTools,
-				State: projectPerUserAdminCredentialState(
-					clientConfig.AuthType,
-					connectedClient.State,
-					adminTokenStatusByClientID[dbClient.ClientID],
-					adminCredStatusByClientID[dbClient.ClientID],
-				),
+			resolvedState := projectPerUserAdminCredentialState(
+				clientConfig.AuthType,
+				connectedClient.State,
+				adminTokenStatusByClientID[dbClient.ClientID],
+				adminCredStatusByClientID[dbClient.ClientID],
+			)
+			resp := MCPClientResponse{
+				Config:    redactedConfig,
+				Tools:     sortedTools,
+				State:     resolvedState,
 				VKConfigs: vkConfigs,
-			})
+			}
+			if aggregator, ok := h.mcpManager.(MCPClusterStateAggregator); ok {
+				if aggState, nodeStates := aggregator.AggregateMCPClientState(clientConfig.ID, resolvedState); aggState == schemas.MCPConnectionStateDegraded {
+					resp.State = aggState
+					resp.NodeStates = nodeStates
+				}
+			}
+			clients = append(clients, resp)
 		} else {
 			clients = append(clients, MCPClientResponse{
 				Config:    redactedConfig,

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -955,8 +955,9 @@ export default function MCPClientsTable({
 												    per-user auth types, so this is just the badge uniformly,
 												    same as shared clients. Column-header tooltip above explains
 												    that "unstable" reflects Bifrost's own connection checks, not
-												    caller traffic. */}
-												<Badge className={MCP_STATUS_COLORS[c.state]}>{titleCaseFromSnakeCase(c.state)}</Badge>
+												    caller traffic. "degraded" additionally gets a drill-down —
+												    see StateBadge below. */}
+												<StateBadge state={c.state} nodeStates={c.node_states} />
 											</TableCell>
 											<TableCell onClick={(e) => e.stopPropagation()}>
 												<Switch
@@ -1134,6 +1135,46 @@ export default function MCPClientsTable({
 				/>
 			)}
 		</div>
+	);
+}
+
+// StateBadge renders the plain state badge, except for "degraded" — a
+// distributed deployment's instances currently disagreeing about a client's
+// state — which additionally gets a hover drill-down showing the
+// per-instance breakdown behind the aggregate. summarizeNodeStates groups
+// instance IDs by their reported state so the drill-down reads as counts
+// ("2 instances: Healthy, 1 instance: Unstable") rather than a raw ID list.
+function summarizeNodeStates(nodeStates: Record<string, string>): string[] {
+	const countByState = new Map<string, number>();
+	for (const state of Object.values(nodeStates)) {
+		countByState.set(state, (countByState.get(state) ?? 0) + 1);
+	}
+	return Array.from(countByState.entries()).map(
+		([state, count]) => `${count} ${count === 1 ? "instance" : "instances"}: ${titleCaseFromSnakeCase(state)}`,
+	);
+}
+
+function StateBadge({ state, nodeStates }: { state: string; nodeStates?: Record<string, string> }) {
+	const badge = <Badge className={MCP_STATUS_COLORS[state]}>{titleCaseFromSnakeCase(state)}</Badge>;
+	if (state !== "degraded" || !nodeStates || Object.keys(nodeStates).length === 0) {
+		return badge;
+	}
+	return (
+		<Popover>
+			<PopoverTrigger asChild>
+				<button type="button" data-testid="mcp-client-state-degraded-trigger" className="cursor-help">
+					{badge}
+				</button>
+			</PopoverTrigger>
+			<PopoverContent className="w-xs text-xs" align="start">
+				<p className="text-muted-foreground mb-1.5">Instances disagree about this client&apos;s state:</p>
+				<ul className="space-y-0.5">
+					{summarizeNodeStates(nodeStates).map((line) => (
+						<li key={line}>{line}</li>
+					))}
+				</ul>
+			</PopoverContent>
+		</Popover>
 	);
 }
 

--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -136,6 +136,12 @@ export const MCP_STATUS_COLORS: Record<string, string> = {
 	// used until a human reauthorizes it, mirroring the "destructive" treatment
 	// this status already gets on the MCP sessions table.
 	needs_reauth: "bg-red-100 text-red-800",
+	// Distinct blue/purple, not amber/red: unlike unstable, this isn't "one
+	// instance's check currently failing" — it's "instances disagree with
+	// each other about the state," which needs its own visual signal to
+	// prompt a look at the per-instance breakdown rather than being read as
+	// just another flavor of unhealthy.
+	degraded: "bg-blue-100 text-blue-800",
 };
 
 // Mapping of what IS supported by each base provider

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -9,7 +9,12 @@ export type MCPConnectionState =
 	| "error"
 	| "pending_verification"
 	| "disabled"
-	| "needs_reauth";
+	| "needs_reauth"
+	// Read-time aggregate value, never a single instance's own reported
+	// state: multiple instances of a distributed deployment currently
+	// report different states for this client. Never produced by a
+	// single-instance deployment.
+	| "degraded";
 
 export type MCPAuthType = "none" | "headers" | "oauth" | "per_user_oauth" | "per_user_headers" | "token_exchange";
 
@@ -141,6 +146,10 @@ export interface MCPClient {
 	tools: ToolFunction[];
 	state: MCPConnectionState;
 	vk_configs: MCPVKConfigResponse[];
+	// Per-instance breakdown behind `state` when it's "degraded" (instance ID
+	// -> that instance's own self-reported state). Only ever present in a
+	// distributed deployment; absent otherwise.
+	node_states?: Record<string, string>;
 }
 
 export interface CreateMCPClientRequest {


### PR DESCRIPTION
## Summary

Adds a `stateChangeCallback` hook to `MCPManager` that fires on every reactive (non-admin-driven) MCP client connection-state transition, and introduces a `degraded` aggregate state for distributed deployments where multiple instances report conflicting states for the same client.

## Changes

- **State-change callback**: A new `stateChangeCallback` field on `MCPManager` is invoked whenever a client's state changes through `ClientConnectionChecker.setState` (periodic checker transitions) or `failConnectAttempt` (reactive connect-failure classification into `NeedsReauth`). Deliberately excluded from admin-driven transitions (`CloseAndMarkNeedsReauth`, `DisableClient`/`EnableClient`, `UpdateClient`) since those already have their own call sites. The callback is always fired outside the manager lock to avoid holding `m.mu` across arbitrary caller-supplied work.
- **`SetMCPStateChangeCallback` on `Bifrost`**: Exposes the callback registration through the top-level `Bifrost` type, no-op when MCP is not configured.
- **`MCPConnectionStateDegraded`**: A new read-time aggregate `MCPConnectionState` value (`"degraded"`) that is never a node's own local state — it signals that instances in a distributed deployment currently disagree about a client's state. Single-instance deployments never produce it.
- **`MCPClusterStateAggregator` interface**: An optional interface the configured `MCPManager` may implement. When present, `getMCPClientsPaginated` calls `AggregateMCPClientState` and, if the result is `Degraded`, replaces the response state and attaches a `node_states` per-instance breakdown map.
- **`MCPClientResponse.NodeStates`**: New optional field (`node_states`) on the HTTP response carrying the per-instance state breakdown when `state` is `"degraded"`.
- **UI — `StateBadge` component**: Replaces the inline `<Badge>` in the MCP clients table with a `StateBadge` that renders a plain badge for all states except `"degraded"`, which additionally gets a hover `Popover` drill-down. `summarizeNodeStates` groups instance IDs by their reported state so the drill-down reads as counts ("2 instances: Healthy, 1 instance: Unstable") rather than a raw ID list.
- **UI — `degraded` color token**: Added `degraded: "bg-blue-100 text-blue-800"` to `MCP_STATUS_COLORS` — a distinct blue/purple rather than amber/red to signal "instances disagree" rather than "one instance is unhealthy."
- **Tests**: Added `TestFailConnectAttempt_NeedsReauthTransition_FiresStateChangeCallback`, `TestFailConnectAttempt_NoStateChange_DoesNotFireCallback`, and `TestSetState_FiresStateChangeCallbackOnGenuineTransition` covering genuine transitions firing the callback exactly once and no-op transitions not firing it.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./core/mcp/... ./core/...

# UI
cd ui
pnpm i
pnpm build
```

To exercise the `degraded` state manually, implement `MCPClusterStateAggregator` on a custom `MCPManager` that returns `MCPConnectionStateDegraded` with a populated `nodeStates` map for a given client, register it, and call `GET /api/mcp/clients`. The response for that client should include `"state": "degraded"` and a populated `node_states` object. In the UI, hovering the "Degraded" badge should show the per-instance breakdown grouped by state.

## Screenshots/Recordings

The "Degraded" badge renders in blue/purple and, on hover, shows a popover listing instance counts per state (e.g. "2 instances: Healthy, 1 instance: Unstable").

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The `stateChangeCallback` is caller-supplied and may perform arbitrary work including I/O. It is always invoked outside `m.mu` to prevent lock contention or deadlocks. No secrets or PII are passed through the callback — only client ID, name, and state enum values.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable