### PR TITLE
feat: add virtual_key_id and user_id multi-select filters to MCP sessions

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -7944,6 +7944,12 @@ func applyMCPSessionFilters(query *gorm.DB, params MCPSessionsFilterParams, t mc
 	if len(params.MCPClientIDs) > 0 {
 		query = query.Where(t.table+".mcp_client_id IN ?", params.MCPClientIDs)
 	}
+	if len(params.VirtualKeyIDs) > 0 {
+		query = query.Where(t.table+".virtual_key_id IN ?", params.VirtualKeyIDs)
+	}
+	if len(params.UserIDs) > 0 {
+		query = query.Where(t.table+".user_id IN ?", params.UserIDs)
+	}
 	if params.Identity != "" {
 		// Exact match against whichever identity column carries the value for this
 		// row's mode. Parenthesized explicitly so the OR group ANDs cleanly with the

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -152,15 +152,19 @@ type CustomersQueryParams struct {
 // the virtual key's id/name (joined). Empty filter slices match all
 // values for that field.
 type MCPSessionsFilterParams struct {
-	Search       string
-	Statuses     []string
-	AuthModes    []string // matched against auth_mode (tokens, credentials) or flow_mode (sessions, flows)
-	MCPClientIDs []string
+	Search        string
+	Statuses      []string
+	AuthModes     []string // matched against auth_mode (tokens, credentials) or flow_mode (sessions, flows)
+	MCPClientIDs  []string
+	VirtualKeyIDs []string // exact-match against virtual_key_id; only meaningful for vk-mode rows
+	UserIDs       []string // exact-match against user_id; only meaningful for user-mode rows
 	// Identity exact-matches a single resolved identity value against any of
 	// the row's identity columns (user_id, virtual_key_id, session_id). Unlike
 	// Search it is not a substring match — it pins the list to exactly one
 	// user, virtual key, or session. Typically paired with AuthModes to scope
-	// to that identity's rows for a known mode.
+	// to that identity's rows for a known mode. Distinct from UserIDs above:
+	// this is a single value used for deep-linking to one identity (e.g. the
+	// OAuth grants table's "View sessions" action), not a multi-select facet.
 	Identity string
 	// MatchedUserIDs is an optional set of user_ids that should be treated
 	// as a positive search hit alongside Search. Callers that maintain a

--- a/transports/bifrost-http/handlers/mcpsessions.go
+++ b/transports/bifrost-http/handlers/mcpsessions.go
@@ -152,6 +152,8 @@ func parseMCPSessionsListQuery(ctx *fasthttp.RequestCtx) (mcpSessionsListQuery, 
 	q.Filters.Statuses = parseCommaSeparated(string(args.Peek("status")))
 	q.Filters.AuthModes = parseCommaSeparated(string(args.Peek("auth_mode")))
 	q.Filters.MCPClientIDs = parseCommaSeparated(string(args.Peek("mcp_client_id")))
+	q.Filters.VirtualKeyIDs = parseCommaSeparated(string(args.Peek("virtual_key_id")))
+	q.Filters.UserIDs = parseCommaSeparated(string(args.Peek("user_id")))
 	q.Kinds = parseCommaSeparated(string(args.Peek("kind")))
 	if s := string(args.Peek("limit")); s != "" {
 		n, err := strconv.Atoi(s)

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -239,13 +239,13 @@ export default function MCPClientSheet({
 			allowed_extra_headers: mcpClient.config.allowed_extra_headers || [],
 			oauth_config: supportsOAuthCredentialUpdate
 				? {
-						client_id: mcpClient.config.oauth_client_id,
-						client_secret: mcpClient.config.oauth_client_secret,
-						authorize_url: mcpClient.config.oauth_authorize_url,
-						token_url: mcpClient.config.oauth_token_url,
-						registration_url: mcpClient.config.oauth_registration_url,
-						resource: mcpClient.config.oauth_resource,
-					}
+					client_id: mcpClient.config.oauth_client_id,
+					client_secret: mcpClient.config.oauth_client_secret,
+					authorize_url: mcpClient.config.oauth_authorize_url,
+					token_url: mcpClient.config.oauth_token_url,
+					registration_url: mcpClient.config.oauth_registration_url,
+					resource: mcpClient.config.oauth_resource,
+				}
 				: undefined,
 			// Unlike oauth_config, token_exchange is replaced wholesale server-side
 			// (only client_id/client_secret get redacted-value preservation) — so
@@ -253,17 +253,17 @@ export default function MCPClientSheet({
 			// with its current stored value rather than left blank.
 			token_exchange: supportsTokenExchangeCredentialUpdate
 				? {
-						audience: mcpClient.config.token_exchange?.audience,
-						client_id: mcpClient.config.token_exchange?.client_id,
-						client_secret: mcpClient.config.token_exchange?.client_secret,
-						authorization_server_url: mcpClient.config.token_exchange?.authorization_server_url,
-					}
+					audience: mcpClient.config.token_exchange?.audience,
+					client_id: mcpClient.config.token_exchange?.client_id,
+					client_secret: mcpClient.config.token_exchange?.client_secret,
+					authorization_server_url: mcpClient.config.token_exchange?.authorization_server_url,
+				}
 				: undefined,
 			tls_config: mcpClient.config.tls_config
 				? {
-						insecure_skip_verify: mcpClient.config.tls_config.insecure_skip_verify,
-						ca_cert_pem: mcpClient.config.tls_config.ca_cert_pem,
-					}
+					insecure_skip_verify: mcpClient.config.tls_config.insecure_skip_verify,
+					ca_cert_pem: mcpClient.config.tls_config.ca_cert_pem,
+				}
 				: undefined,
 		},
 	});
@@ -289,13 +289,13 @@ export default function MCPClientSheet({
 			allowed_extra_headers: mcpClient.config.allowed_extra_headers || [],
 			oauth_config: supportsOAuthCredentialUpdate
 				? {
-						client_id: mcpClient.config.oauth_client_id,
-						client_secret: mcpClient.config.oauth_client_secret,
-						authorize_url: mcpClient.config.oauth_authorize_url,
-						token_url: mcpClient.config.oauth_token_url,
-						registration_url: mcpClient.config.oauth_registration_url,
-						resource: mcpClient.config.oauth_resource,
-					}
+					client_id: mcpClient.config.oauth_client_id,
+					client_secret: mcpClient.config.oauth_client_secret,
+					authorize_url: mcpClient.config.oauth_authorize_url,
+					token_url: mcpClient.config.oauth_token_url,
+					registration_url: mcpClient.config.oauth_registration_url,
+					resource: mcpClient.config.oauth_resource,
+				}
 				: undefined,
 			// Unlike oauth_config, token_exchange is replaced wholesale server-side
 			// (only client_id/client_secret get redacted-value preservation) — so
@@ -303,17 +303,17 @@ export default function MCPClientSheet({
 			// with its current stored value rather than left blank.
 			token_exchange: supportsTokenExchangeCredentialUpdate
 				? {
-						audience: mcpClient.config.token_exchange?.audience,
-						client_id: mcpClient.config.token_exchange?.client_id,
-						client_secret: mcpClient.config.token_exchange?.client_secret,
-						authorization_server_url: mcpClient.config.token_exchange?.authorization_server_url,
-					}
+					audience: mcpClient.config.token_exchange?.audience,
+					client_id: mcpClient.config.token_exchange?.client_id,
+					client_secret: mcpClient.config.token_exchange?.client_secret,
+					authorization_server_url: mcpClient.config.token_exchange?.authorization_server_url,
+				}
 				: undefined,
 			tls_config: mcpClient.config.tls_config
 				? {
-						insecure_skip_verify: mcpClient.config.tls_config.insecure_skip_verify,
-						ca_cert_pem: mcpClient.config.tls_config.ca_cert_pem,
-					}
+					insecure_skip_verify: mcpClient.config.tls_config.insecure_skip_verify,
+					ca_cert_pem: mcpClient.config.tls_config.ca_cert_pem,
+				}
 				: undefined,
 		});
 	}, [form, mcpClient, supportsOAuthCredentialUpdate, supportsTokenExchangeCredentialUpdate]);
@@ -391,9 +391,9 @@ export default function MCPClientSheet({
 				? undefined
 				: oauthScopesRaw.trim()
 					? oauthScopesRaw
-							.split(",")
-							.map((s) => s.trim())
-							.filter(Boolean)
+						.split(",")
+						.map((s) => s.trim())
+						.filter(Boolean)
 					: [];
 			// Only rotate when the user actually changed a field, and never
 			// alongside a disable (the backend rejects that combination
@@ -410,9 +410,9 @@ export default function MCPClientSheet({
 			const shouldUpdateTokenExchange = supportsTokenExchangeCredentialUpdate && tokenExchangeCredentialsDirty;
 			const tokenExchangeScopes = tokenExchangeScopesRaw.trim()
 				? tokenExchangeScopesRaw
-						.split(",")
-						.map((s) => s.trim())
-						.filter(Boolean)
+					.split(",")
+					.map((s) => s.trim())
+					.filter(Boolean)
 				: [];
 			await updateMCPClient({
 				id: mcpClient.config.client_id,
@@ -436,30 +436,30 @@ export default function MCPClientSheet({
 					allowed_extra_headers: data.allowed_extra_headers,
 					oauth_config: shouldRotateOAuthCredentials
 						? {
-								client_id: oauthClientID,
-								client_secret: oauthClientSecret,
-								authorize_url: data.oauth_config?.authorize_url || undefined,
-								token_url: data.oauth_config?.token_url || undefined,
-								registration_url: data.oauth_config?.registration_url || undefined,
-								scopes: oauthScopes,
-								resource: data.oauth_config?.resource || undefined,
-							}
+							client_id: oauthClientID,
+							client_secret: oauthClientSecret,
+							authorize_url: data.oauth_config?.authorize_url || undefined,
+							token_url: data.oauth_config?.token_url || undefined,
+							registration_url: data.oauth_config?.registration_url || undefined,
+							scopes: oauthScopes,
+							resource: data.oauth_config?.resource || undefined,
+						}
 						: undefined,
 					token_exchange: shouldUpdateTokenExchange
 						? {
-								audience: data.token_exchange?.audience?.trim() || "",
-								client_id: data.token_exchange?.client_id ?? { value: "", ref: "" },
-								client_secret: data.token_exchange?.client_secret,
-								authorization_server_url: data.token_exchange?.authorization_server_url?.trim() || undefined,
-								scopes: tokenExchangeScopes,
-							}
+							audience: data.token_exchange?.audience?.trim() || "",
+							client_id: data.token_exchange?.client_id ?? { value: "", ref: "" },
+							client_secret: data.token_exchange?.client_secret,
+							authorization_server_url: data.token_exchange?.authorization_server_url?.trim() || undefined,
+							scopes: tokenExchangeScopes,
+						}
 						: undefined,
 					tls_config:
 						data.tls_config !== undefined
 							? {
-									insecure_skip_verify: data.tls_config.insecure_skip_verify ?? false,
-									ca_cert_pem: data.tls_config.ca_cert_pem,
-								}
+								insecure_skip_verify: data.tls_config.insecure_skip_verify ?? false,
+								ca_cert_pem: data.tls_config.ca_cert_pem,
+							}
 							: undefined,
 					vk_configs: vkConfigsDirty ? vkConfigs : undefined,
 				},
@@ -690,7 +690,7 @@ export default function MCPClientSheet({
 													<span className="font-mono break-all">
 														{mcpClient.config.connection_type === "stdio"
 															? `${mcpClient.config.stdio_config?.command ?? ""} ${(mcpClient.config.stdio_config?.args ?? []).join(" ")}`.trim() ||
-																"-"
+															"-"
 															: mcpClient.config.connection_string?.type === "env" || mcpClient.config.connection_string?.type === "vault"
 																? mcpClient.config.connection_string.ref
 																: mcpClient.config.connection_string?.value || "-"}
@@ -709,7 +709,7 @@ export default function MCPClientSheet({
 																	return [name, valueParts.join("=")];
 																}),
 															)}
-															onChange={() => {}}
+															onChange={() => { }}
 															fixedKeys={mcpClient.config.stdio_config.envs.map((env) => env.split("=")[0])}
 															valuePlaceholder="—"
 															label=""
@@ -991,27 +991,25 @@ export default function MCPClientSheet({
 												description="Static headers and header-based access rules sent with every request to this server."
 												testId="headers-heading"
 											/>
-											<div className="rounded-md border p-4">
-												<FormField
-													control={form.control}
-													name="headers"
-													render={({ field }) => (
-														<FormItem className="flex flex-col gap-3">
-															<FormControl>
-																<HeadersTable
-																	value={field.value || {}}
-																	onChange={field.onChange}
-																	keyPlaceholder="Header name"
-																	valuePlaceholder="Header value"
-																	label=""
-																	useSecretVarInput
-																/>
-															</FormControl>
-															<FormMessage />
-														</FormItem>
-													)}
-												/>
-											</div>
+											<FormField
+												control={form.control}
+												name="headers"
+												render={({ field }) => (
+													<FormItem className="flex flex-col gap-3">
+														<FormControl>
+															<HeadersTable
+																value={field.value || {}}
+																onChange={field.onChange}
+																keyPlaceholder="Header name"
+																valuePlaceholder="Header value"
+																label=""
+																useSecretVarInput
+															/>
+														</FormControl>
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
 										</div>
 
 										{mcpClient.config.auth_type === "per_user_headers" && (
@@ -1083,9 +1081,9 @@ export default function MCPClientSheet({
 																onBlur={() => {
 																	const parsed = allowedExtraHeadersRaw.trim()
 																		? allowedExtraHeadersRaw
-																				.split(",")
-																				.map((h) => h.trim())
-																				.filter(Boolean)
+																			.split(",")
+																			.map((h) => h.trim())
+																			.filter(Boolean)
 																		: [];
 																	field.onChange(parsed);
 																	field.onBlur();

--- a/ui/app/workspace/mcp-sessions/page.tsx
+++ b/ui/app/workspace/mcp-sessions/page.tsx
@@ -19,6 +19,8 @@ export default function MCPSessionsPage() {
 			status: parseAsArrayOf(parseAsString).withDefault([]),
 			auth_mode: parseAsArrayOf(parseAsString).withDefault([]),
 			mcp_client_id: parseAsArrayOf(parseAsString).withDefault([]),
+			virtual_key_id: parseAsArrayOf(parseAsString).withDefault([]),
+			user_id: parseAsArrayOf(parseAsString).withDefault([]),
 			identity: parseAsString.withDefault(""),
 			offset: parseAsInteger.withDefault(0),
 		},
@@ -34,8 +36,10 @@ export default function MCPSessionsPage() {
 			status: urlState.status,
 			auth_mode: urlState.auth_mode,
 			mcp_client_id: urlState.mcp_client_id,
+			virtual_key_id: urlState.virtual_key_id,
+			user_id: urlState.user_id,
 		}),
-		[urlState.kind, urlState.status, urlState.auth_mode, urlState.mcp_client_id],
+		[urlState.kind, urlState.status, urlState.auth_mode, urlState.mcp_client_id, urlState.virtual_key_id, urlState.user_id],
 	);
 
 	const setFilters = useCallback(
@@ -45,6 +49,8 @@ export default function MCPSessionsPage() {
 				status: newFilters.status,
 				auth_mode: newFilters.auth_mode,
 				mcp_client_id: newFilters.mcp_client_id,
+				virtual_key_id: newFilters.virtual_key_id,
+				user_id: newFilters.user_id,
 				offset: 0,
 			});
 		},
@@ -57,6 +63,8 @@ export default function MCPSessionsPage() {
 		status: filters.status.length ? (filters.status as MCPSessionStatus[]) : undefined,
 		auth_mode: filters.auth_mode.length ? (filters.auth_mode as AuthMode[]) : undefined,
 		mcp_client_id: filters.mcp_client_id.length ? filters.mcp_client_id : undefined,
+		virtual_key_id: filters.virtual_key_id.length ? filters.virtual_key_id : undefined,
+		user_id: filters.user_id.length ? filters.user_id : undefined,
 		identity: normalizedIdentity || undefined,
 		limit: PAGE_SIZE,
 		offset: urlState.offset,
@@ -86,7 +94,12 @@ export default function MCPSessionsPage() {
 	}
 
 	const filtersActive =
-		filters.kind.length > 0 || filters.status.length > 0 || filters.auth_mode.length > 0 || filters.mcp_client_id.length > 0;
+		filters.kind.length > 0 ||
+		filters.status.length > 0 ||
+		filters.auth_mode.length > 0 ||
+		filters.mcp_client_id.length > 0 ||
+		filters.virtual_key_id.length > 0 ||
+		filters.user_id.length > 0;
 	const hasActiveFilters = !!urlState.q || filtersActive || !!normalizedIdentity;
 
 	const handleSearchChange = (value: string) => setUrlState({ q: value || null, offset: 0 });

--- a/ui/app/workspace/mcp-sessions/views/mcpSessionsFilterSidebar.tsx
+++ b/ui/app/workspace/mcp-sessions/views/mcpSessionsFilterSidebar.tsx
@@ -9,13 +9,21 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scrollArea";
-import { useGetMCPClientsQuery } from "@/lib/store";
+import { getUserSearchQuery } from "@/lib/registries/userPicker";
+import { useGetMCPClientsQuery, useGetVirtualKeysQuery } from "@/lib/store";
 import { cn } from "@/lib/utils";
 import { ChevronDown, Fingerprint, KeyRound, LoaderCircle, PanelLeftClose, PanelLeftOpen, RotateCcw, Search, UserRound } from "lucide-react";
 import { type Ref, useCallback, useEffect, useMemo, useRef, useState } from "react";
+// Side-effect import: registers the enterprise user search hook (if this is
+// an enterprise build) before this module's first render. OSS has no user
+// directory, so nothing registers and getUserSearchQuery() stays undefined —
+// the Users filter section renders nothing. See ui/lib/registries/userPicker.tsx.
+import "@enterprise/lib/registrations/userPicker";
 
 const COLLAPSE_STORAGE_KEY = "mcp-sessions-filter-sidebar-collapsed";
 const MCP_CLIENT_PAGE_SIZE = 25;
+const VK_PAGE_SIZE = 25;
+const USER_PAGE_SIZE = 25;
 
 // ---------------------------------------------------------------------------
 // Filter types
@@ -26,6 +34,8 @@ export interface MCPSessionFilters {
 	status: string[]; // subset of ["active", "orphaned", "needs_reauth", "needs_update", "pending"]
 	auth_mode: string[]; // subset of ["user", "vk", "session"]
 	mcp_client_id: string[]; // explicit MCP client IDs
+	virtual_key_id: string[]; // explicit VK IDs (vk-mode rows only)
+	user_id: string[]; // explicit user IDs (user-mode rows only; enterprise only, see UsersFilterSection)
 }
 
 export const EMPTY_FILTERS: MCPSessionFilters = {
@@ -33,6 +43,8 @@ export const EMPTY_FILTERS: MCPSessionFilters = {
 	status: [],
 	auth_mode: [],
 	mcp_client_id: [],
+	virtual_key_id: [],
+	user_id: [],
 };
 
 interface FilterOption {
@@ -93,12 +105,46 @@ export function MCPSessionsFilterSidebar({ filters, onFiltersChange }: SidebarPr
 	}, []);
 
 	const activeFilterCount = useMemo(() => {
-		return filters.kind.length + filters.status.length + filters.auth_mode.length + filters.mcp_client_id.length;
+		return (
+			filters.kind.length +
+			filters.status.length +
+			filters.auth_mode.length +
+			filters.mcp_client_id.length +
+			filters.virtual_key_id.length +
+			filters.user_id.length
+		);
 	}, [filters]);
 
 	const handleReset = useCallback(() => {
 		onFiltersChange(EMPTY_FILTERS);
 	}, [onFiltersChange]);
+
+	// Mirrors MCPClientFilterSection's auth-type scoping, but for section
+	// visibility rather than query narrowing: when the Identity facet pins the
+	// row set to exactly one mode, the other mode's picker can't match
+	// anything, so hide it outright rather than leave a checkbox list that
+	// would only ever come back empty. Selecting "Session" hides both, since
+	// session-bound rows have no VK or user to pick. Neither/both selected
+	// leaves both pickers visible.
+	const authModeOnly = filters.auth_mode.length === 1 ? filters.auth_mode[0] : null;
+	const showVirtualKeyFilter = authModeOnly !== "user" && authModeOnly !== "session";
+	const showUsersFilter = authModeOnly !== "vk" && authModeOnly !== "session";
+
+	// A hidden picker's stale selection would otherwise keep silently
+	// filtering (a VK pick surviving a switch to "User" identity, say) with
+	// no visible control left to clear it — so drop it the moment its section
+	// disappears.
+	useEffect(() => {
+		if (!showVirtualKeyFilter && filters.virtual_key_id.length > 0) {
+			onFiltersChange({ ...filters, virtual_key_id: [] });
+		}
+	}, [showVirtualKeyFilter, filters, onFiltersChange]);
+
+	useEffect(() => {
+		if (!showUsersFilter && filters.user_id.length > 0) {
+			onFiltersChange({ ...filters, user_id: [] });
+		}
+	}, [showUsersFilter, filters, onFiltersChange]);
 
 	if (collapsed) {
 		return (
@@ -177,6 +223,8 @@ export function MCPSessionsFilterSidebar({ filters, onFiltersChange }: SidebarPr
 						testIdPrefix="mcp-sessions-filter-auth-mode"
 					/>
 					<MCPClientFilterSection filters={filters} onFiltersChange={onFiltersChange} />
+					{showVirtualKeyFilter && <VirtualKeyFilterSection filters={filters} onFiltersChange={onFiltersChange} />}
+					{showUsersFilter && <UsersFilterSection filters={filters} onFiltersChange={onFiltersChange} />}
 				</div>
 			</ScrollArea>
 		</div>
@@ -417,4 +465,99 @@ function MCPClientFilterSection({ filters, onFiltersChange }: SidebarProps) {
 			/>
 		</FilterSection>
 	);
+}
+
+// VirtualKeyFilterSection – restricts sessions to a set of VKs, resolved via
+// the same server-side search+limit VK picker the MCP clients sidebar uses
+// (governance/virtual-keys), rather than loading the full VK list — VK counts
+// can be huge, so this only ever fetches a page at a time, scoped by the
+// in-flight search text. The client list only fetches once the section is
+// opened or already has a selection, since most visits won't touch this
+// filter.
+function VirtualKeyFilterSection({ filters, onFiltersChange }: SidebarProps) {
+	const hasActive = filters.virtual_key_id.length > 0;
+	const [opened, setOpened] = useState(hasActive);
+	const [searchQuery, setSearchQuery] = useState("");
+	const searchInputRef = useAutoFocusOnOpen(opened);
+
+	const { data, isFetching } = useGetVirtualKeysQuery(
+		{ limit: VK_PAGE_SIZE, offset: 0, search: searchQuery || undefined },
+		{ skip: !opened && !hasActive },
+	);
+	const virtualKeys = data?.virtual_keys || [];
+
+	const toggle = (vkId: string) => {
+		const current = filters.virtual_key_id;
+		const next = current.includes(vkId) ? current.filter((v) => v !== vkId) : [...current, vkId];
+		onFiltersChange({ ...filters, virtual_key_id: next });
+	};
+
+	return (
+		<FilterSection title="Virtual Key" defaultOpen={hasActive} onOpenChange={setOpened} testId="mcp-sessions-filter-vk-toggle">
+			<SearchableCheckboxList
+				inputRef={searchInputRef}
+				placeholder="Search virtual keys"
+				items={virtualKeys.map((vk) => ({ key: vk.id, label: vk.name || vk.id }))}
+				isSelected={(key) => filters.virtual_key_id.includes(key)}
+				onToggle={toggle}
+				onSearch={setSearchQuery}
+				fetching={isFetching}
+				testIdPrefix="mcp-sessions-filter-vk"
+			/>
+		</FilterSection>
+	);
+}
+
+// UsersFilterSection – restricts sessions to a set of users, mirroring
+// VirtualKeyFilterSection's inline search+checkbox UI exactly (same
+// server-side search+limit shape, same lazy-fetch-on-open behavior for huge
+// user counts). Renders nothing in OSS: there's no user directory to search
+// against, so unlike the VK/MCP-client sections this can't fall back to
+// anything — an unresolvable search box would be worse than no filter at
+// all. Enterprise builds register a search hook via getUserSearchQuery()
+// (see ui/lib/registries/userPicker.tsx), wrapping the same users API the
+// single-select UserPicker (routing rules' "User" scope, the VK table's
+// user filter) already uses.
+function UsersFilterSection({ filters, onFiltersChange }: SidebarProps) {
+	const useUserSearchQuery = getUserSearchQuery();
+	const hasActive = filters.user_id.length > 0;
+	const [opened, setOpened] = useState(hasActive);
+	const [searchQuery, setSearchQuery] = useState("");
+	const searchInputRef = useAutoFocusOnOpen(opened);
+
+	// Hooks must run unconditionally, so the registry lookup above can't gate
+	// this call — pass a no-op fallback and gate the render below instead.
+	const { data, isFetching } = (useUserSearchQuery ?? useNoopUserSearchQuery)(
+		{ limit: USER_PAGE_SIZE, search: searchQuery || undefined },
+		{ skip: !opened && !hasActive },
+	);
+	if (!useUserSearchQuery) return null;
+	const users = data?.users || [];
+
+	const toggle = (userId: string) => {
+		const current = filters.user_id;
+		const next = current.includes(userId) ? current.filter((v) => v !== userId) : [...current, userId];
+		onFiltersChange({ ...filters, user_id: next });
+	};
+
+	return (
+		<FilterSection title="Users" defaultOpen={hasActive} onOpenChange={setOpened} testId="mcp-sessions-filter-users-toggle">
+			<SearchableCheckboxList
+				inputRef={searchInputRef}
+				placeholder="Search by name or email"
+				items={users.map((user) => ({ key: user.id, label: user.label }))}
+				isSelected={(key) => filters.user_id.includes(key)}
+				onToggle={toggle}
+				onSearch={setSearchQuery}
+				fetching={isFetching}
+				testIdPrefix="mcp-sessions-filter-user"
+			/>
+		</FilterSection>
+	);
+}
+
+// Stand-in for useUserSearchQuery when no OSS hook is registered — keeps the
+// hooks-must-run-unconditionally rule satisfied above without a real fetch.
+function useNoopUserSearchQuery() {
+	return { data: undefined, isFetching: false };
 }

--- a/ui/lib/registries/userPicker.tsx
+++ b/ui/lib/registries/userPicker.tsx
@@ -39,3 +39,39 @@ export function registerUserPicker(component: ComponentType<UserPickerProps>): v
 export function getUserPicker(): ComponentType<UserPickerProps> | undefined {
 	return userPicker;
 }
+
+// ---------------------------------------------------------------------------
+// Raw search hook — for surfaces that need to drive their own inline
+// search+checkbox list (e.g. a filter sidebar matching the VK/MCP-client
+// filter UI) rather than the single-select popover above. Same OSS gap: no
+// user directory exists here, so nothing is registered by default and
+// getUserSearchQuery() returns undefined.
+// ---------------------------------------------------------------------------
+
+export interface UserSearchResult {
+	id: string;
+	label: string;
+}
+
+export interface UserSearchQueryResult {
+	data?: { users: UserSearchResult[] };
+	isFetching: boolean;
+}
+
+/** Shape of an RTK Query search hook: same calling convention as `useGetXQuery(params, options)`. */
+export type UseUserSearchQuery = (
+	params: { search?: string; limit?: number },
+	options?: { skip?: boolean },
+) => UserSearchQueryResult;
+
+let userSearchQuery: UseUserSearchQuery | undefined;
+
+/** Registers (or replaces) the user search hook. Same load-once contract as registerUserPicker. */
+export function registerUserSearchQuery(hook: UseUserSearchQuery): void {
+	userSearchQuery = hook;
+}
+
+/** Returns the registered user search hook, or undefined in builds without one. */
+export function getUserSearchQuery(): UseUserSearchQuery | undefined {
+	return userSearchQuery;
+}

--- a/ui/lib/store/apis/mcpSessionsApi.ts
+++ b/ui/lib/store/apis/mcpSessionsApi.ts
@@ -24,6 +24,8 @@ function buildMCPSessionsListParams(params?: MCPSessionsQueryParams) {
 	if (params.status?.length) out.status = [...params.status].sort().join(",");
 	if (params.auth_mode?.length) out.auth_mode = [...params.auth_mode].sort().join(",");
 	if (params.mcp_client_id?.length) out.mcp_client_id = [...params.mcp_client_id].sort().join(",");
+	if (params.virtual_key_id?.length) out.virtual_key_id = [...params.virtual_key_id].sort().join(",");
+	if (params.user_id?.length) out.user_id = [...params.user_id].sort().join(",");
 	if (params.limit !== undefined) out.limit = params.limit;
 	if (params.offset !== undefined) out.offset = params.offset;
 	return out;

--- a/ui/lib/types/mcpSessions.ts
+++ b/ui/lib/types/mcpSessions.ts
@@ -97,6 +97,11 @@ export interface MCPSessionsQueryParams {
 	status?: MCPSessionStatus[];
 	auth_mode?: AuthMode[];
 	mcp_client_id?: string[];
+	virtual_key_id?: string[];
+	// Multi-select user filter (enterprise only — see the Users sidebar
+	// section). Distinct from `identity` above: this is a facet, not a
+	// single deep-link pin.
+	user_id?: string[];
 	limit?: number;
 	offset?: number;
 }


### PR DESCRIPTION
## Summary

Adds `virtual_key_id` and `user_id` as multi-select filter facets on the MCP Sessions list, allowing operators to narrow sessions down to specific virtual keys or users. The Users filter is enterprise-only (renders nothing in OSS builds where no user directory is available).

## Changes

- Added `VirtualKeyIDs` and `UserIDs` fields to `MCPSessionsFilterParams` in the configstore, with corresponding `WHERE ... IN ?` clauses applied in `applyMCPSessionFilters`.
- Exposed `virtual_key_id` and `user_id` as query parameters in the HTTP handler (`parseMCPSessionsListQuery`).
- Extended `MCPSessionsQueryParams` (TypeScript types), `buildMCPSessionsListParams` (API layer), and the MCP Sessions page URL state to carry and serialize the new filter values.
- Added `VirtualKeyFilterSection` to the filter sidebar: a lazy-loaded, searchable checkbox list backed by the existing `useGetVirtualKeysQuery` hook, fetching one page at a time to handle large VK counts.
- Added `UsersFilterSection` to the filter sidebar: mirrors `VirtualKeyFilterSection` but uses a registry-injected search hook (`getUserSearchQuery`) so OSS builds render nothing while enterprise builds plug in their user directory.
- Registered `registerUserSearchQuery` / `getUserSearchQuery` in `ui/lib/registries/userPicker.tsx` alongside the existing single-select picker registry, following the same load-once contract.
- Added sidebar visibility logic: when the auth_mode facet is pinned to a single mode, the irrelevant picker (VK for user-mode, user for vk-mode, both for session-mode) is hidden and its stale selection is cleared automatically.
- Removed an unnecessary wrapping `<div className="rounded-md border p-4">` around the headers `FormField` in `mcpClientSheet.tsx`, and corrected indentation throughout that file.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Open the MCP Sessions page.
2. Expand the filter sidebar. Confirm **Virtual Key** and **Users** sections appear (Users only in enterprise builds).
3. Select one or more virtual keys — confirm the session list narrows to rows with matching `virtual_key_id`.
4. Select one or more users (enterprise) — confirm the session list narrows to rows with matching `user_id`.
5. Pin the **Auth Mode** filter to "User" — confirm the Virtual Key section disappears and any prior VK selection is cleared. Pin to "VK" — confirm the Users section disappears.
6. Confirm URL state reflects `virtual_key_id` and `user_id` arrays and survives a page reload.

```sh
go test ./framework/configstore/...
go test ./transports/bifrost-http/...

cd ui
pnpm i
pnpm build
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

`virtual_key_id` and `user_id` filter values are passed as parameterized `IN ?` clauses via GORM — no raw string interpolation. The Users filter section is gated behind an enterprise-only registry hook, so no user directory data is exposed in OSS builds.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable