### PR TITLE
streamreader locks to avoid concurrent stream writes

### DIFF
--- a/.claude/skills/investigate-issue/SKILL.md
+++ b/.claude/skills/investigate-issue/SKILL.md
@@ -14,9 +14,16 @@ Fetch a GitHub issue, analyze the report, search the codebase for relevant code,
 3. Codebase Analysis + Documentation Research (from Step 3, including sub-step 3e)
 4. Impact Analysis (from Step 4)
 5. Test Plan (from Step 5)
-6. Full Presentation (Step 6 template)
+6. Regression Rerun Scope (from Step 5e) -- which existing tests must rerun, and why
+7. TDD: Failing Tests (from Step 5f) -- Bug issues only: the test source AND the actual
+   red output from the applicable Makefile recipe, pasted verbatim, BEFORE asking to
+   implement
+8. Full Presentation (Step 6 template)
 
 If any section is missing, go back and complete it before presenting the report.
+
+For Bug issues the approval gate is NOT "may I write a test?" -- the failing test is already
+written and shown to be red. The gate is "may I write the fix?"
 
 ## Usage
 
@@ -32,8 +39,13 @@ If any section is missing, go back and complete it before presenting the report.
 3. **Search the codebase and research docs** -- Find relevant code, then research the libraries it depends on via Context7 and WebSearch
 4. **Analyze impact** -- Cross-reference codebase findings with documentation to identify side effects, dependencies, and breaking changes
 5. **Suggest tests** -- If changes touch `core/`, recommend specific LLM and MCP test additions
-6. **Present the plan** -- Show findings and recommended changes to the user
-7. **Implement with approval** -- After plan approval, make changes one at a time with user confirmation. For Bug issues, tests are written and confirmed failing (red) before the fix is implemented (green), per AGENTS.md's "Bug fixes: red before green" rule
+5b. **Scope the reruns** -- Use coverage to determine which existing tests exercise the lines
+    you plan to change, and tier them by necessity
+5c. **Go red (Bug issues)** -- Write the regression test(s) and run them to confirm failure for
+    the right reason, BEFORE presenting the plan
+6. **Present the plan** -- Show findings, the red test output, the rerun scope, and the
+   recommended fix
+7. **Implement with approval** -- After approval, apply the fix and show red-to-green
 
 ## Step 1: Fetch the Issue
 
@@ -410,6 +422,127 @@ If UI changes are involved, recommend E2E test updates following the patterns in
 make run-e2e FLOW=<feature>
 ```
 
+### 5e. Determine Rerun Scope from Coverage
+
+Do not guess which tests are affected -- measure it. Package-level coverage is too coarse:
+it proves the package is tested, not that any test executes the specific lines you are
+changing. Attribute coverage per test.
+
+**Step 1 -- Establish the changed-line set.** For each file in the Implementation Plan, list
+the functions/methods you will modify AND the line ranges within them. Step 3 filters the
+coverage profile by line range, so symbol names alone are not enough.
+
+**Step 2 -- Find candidate tests.** Every test in the changed file's package, plus every test
+in the packages of its callers (from the Step 4b `grep` for callers):
+
+Enumerate by PACKAGE, not by file or by symbol name. All `_test.go` files in a directory
+compile into one test binary, and many tests reach the target through helpers or fixtures
+rather than naming it -- so a textual grep for `<TargetSymbol>` under-reports badly (in
+`core/mcp`, 60 test functions exist but only one file names `MCPManager`).
+
+```bash
+# 1. Changed file's own package -- every test file, not just the matching one
+grep -hn "^func Test" <pkg>/*_test.go
+
+# 2. Caller packages -- map Step 4b's caller hits to directories, then enumerate each
+grep -rl "<TargetSymbol>" --include='*.go' core/ framework/ transports/ plugins/ \
+  | xargs -n1 dirname | sort -u \
+  | while read -r d; do grep -Hn "^func Test" "$d"/*_test.go 2>/dev/null; done
+```
+
+Over-inclusion is fine here -- Step 3 narrows the list by measurement. Omission is not:
+a dropped candidate never gets coverage-checked and silently disappears from the report.
+
+**Step 3 -- Attribute coverage per test.** Run each candidate with its OWN profile and check
+whether it actually reaches the target symbol. A profile from the whole package cannot tell
+you this.
+
+Coverage attribution is the ONE place raw `go test` is allowed: no Makefile recipe accepts
+`-coverprofile`. This profile is a measurement tool only -- it is never the red/green
+evidence in the report. Red and green validation always runs through the Make target
+(Step 5f).
+
+```bash
+cd <module>
+# -coverpkg is REQUIRED: by default a test only instruments its OWN package, so a
+# caller-package test would show zero blocks for the target and be wrongly dropped.
+go test ./<candidate-pkg>/... -run '^<TestName>$' -covermode=count \
+  -coverpkg=./... -coverprofile=<scratchpad>/cover-<TestName>.out
+
+# Filter the raw profile to the changed line range. Do NOT use `go tool cover -func`:
+# it reports a per-FUNCTION percentage, so a test covering another branch of the same
+# function reads as "covered" while your changed line has count=0.
+awk -v file="<changed-file>" -v lo=<startLine> -v hi=<endLine> 'NR>1 {
+  split($1, a, ":"); split(a[2], r, ","); split(r[1], s, "."); split(r[2], e, ".");
+  if (a[1] ~ file && s[1] <= hi && e[1] >= lo)
+    printf "  lines %s-%s  count=%s\n", s[1], e[1], $3
+}' <scratchpad>/cover-<TestName>.out
+```
+
+Profile line grammar: `<import-path>/file.go:startLine.startCol,endLine.endCol numStmt count`.
+Pass `<changed-file>` to `file` exactly as it appears in the diff, with no extra extension:
+`~` is a regex match against that import-path-qualified field, so a repo-relative path such as
+`bifrost-http/lib/streamreader.go` is the right granularity. A bare `streamreader.go` would
+also match a same-named file in any other package `-coverpkg=./...` pulled in, and a doubled
+extension (`streamreader.go.go`) matches nothing -- which is indistinguishable from "no test
+covers this change" and silently drops every required rerun. The last
+field is the execution count. A non-zero count on ANY block overlapping your changed range
+means that test executes the code you are changing -- it is a required rerun. All-zero (or
+no overlapping block) means it does not.
+
+For UI changes, use the framework's own dependency graph instead of Go coverage:
+```bash
+cd ui && ./node_modules/.bin/vitest related <changed-file> --run
+```
+Use the lockfile-pinned binary, not `npx vitest`: with a non-TTY stdin (which is every agent
+run) npm assumes `--yes` and silently installs whatever version the registry currently calls
+latest when `ui/node_modules` is missing, bypassing `ui/package-lock.json`.
+
+**Step 4 -- Tier the results.** Report reruns in three tiers so the user can see what is
+mandatory versus precautionary:
+
+| Tier | Definition | Obligation |
+|------|-----------|------------|
+| **Tier 1 -- Must rerun** | Coverage shows the test executes a changed line | Blocking. A failure here is caused by your change |
+| **Tier 2 -- Should rerun** | Same package, or asserts a contract your change touches, but does not cover the changed line | Run before handing off. Cheap and catches contract drift |
+| **Tier 3 -- Downstream** | Tests in packages of callers/dependents identified in Step 4b | Run if Tier 1 or 2 revealed anything, or if the change altered an exported signature or shared invariant |
+
+Explicitly list any test you are NOT rerunning and why (e.g. requires live provider
+credentials, unrelated subsystem). Silent omission reads as "everything passed."
+
+Note that provider-gated suites (`make test-core PROVIDER=...`) hit live APIs. If a Tier 1
+test is provider-gated, say so -- the user decides whether to spend the call.
+
+### 5f. Write and Run the Failing Tests -- Red (Bug issues only)
+
+For issues classified **Bug** in Step 2a, write the regression test(s) and confirm red
+*before* presenting the plan. This is a change from asking permission first: a plan whose
+test has not been run is a hypothesis, and reviewers cannot distinguish a real reproduction
+from a plausible one.
+
+1. Write the test(s) from the Step 5 Test Plan, targeting the actual root cause from Step 3/4.
+   Write them against the CURRENT code -- do not write the fix.
+2. Run them with the correct Makefile recipe (never raw `go test` for suites that have one).
+3. Confirm the failure is for the **expected reason**: the missing behavior, wrong bytes, or
+   absent field. A compile error, typo, nil panic, or unrelated assertion is NOT a valid red
+   -- fix the test and rerun until the failure is the real defect.
+4. Capture the verbatim failure output. Do not paraphrase or summarize it.
+5. **Redact before it leaves the scratchpad.** Provider-gated suites hit live APIs with real
+   credentials (`OPENAI_API_KEY`, `AWS_SECRET_ACCESS_KEY`, and ~20 others), and upstream
+   401/403 bodies echoed through `bifrostErr.Error.Message` can carry the key or auth header.
+   Keep the raw output in `<scratchpad>/` -- never commit it, never paste it. Produce a
+   redacted transcript for the report, replacing each secret with `[REDACTED: <what>]` so the
+   removal is visible. Redaction is narrow: it MUST preserve the command, the failing
+   assertion with actual-vs-expected values, and the stack trace. If redacting would remove
+   the evidence itself, say so rather than trimming the assertion.
+
+If the test unexpectedly PASSES, stop. The diagnosis in Step 3/4 is wrong or incomplete.
+Return to Step 3 and say so plainly in the report rather than adjusting the test until it
+fails.
+
+Creating test files is the one write action permitted before plan approval, because the test
+is itself the evidence. Do not touch any non-test source file at this stage.
+
 ## Step 6: Present Findings
 
 Present everything to the user in this structured format:
@@ -485,6 +618,41 @@ Copy the research table from Step 3e here. If you skipped Step 3e, go back and d
 |------|------|---------------|
 | `TestNewScenario` | `<path>` | <scenario description> |
 
+### TDD: Failing Tests (Red)
+
+<Bug issues only. If the issue is a Feature or Docs, write "N/A -- <type> issue, red-before-green
+does not apply per AGENTS.md" and omit the rest of this section.>
+
+#### Test Source
+<The full source of each new/extended test, as written. Not a description -- the actual code.>
+
+#### Red Output (verbatim, redacted)
+```
+<paste the failing test output, including the command that produced it. Secrets replaced
+with [REDACTED: <what>] -- nothing else altered. Raw output stays in <scratchpad>/.>
+```
+
+#### Why This Failure Is the Real Defect
+<Explain how the assertion that failed maps to the root cause in the Codebase Analysis. State
+explicitly that this is not a compile error, typo, or unrelated panic.>
+
+### Regression Rerun Scope
+
+<From Step 5e. Coverage-attributed, not guessed.>
+
+| Tier | Test | File | Covers Changed Line? | Why It Reruns |
+|------|------|------|---------------------|---------------|
+| 1 | `TestX` | `<path>` | Yes -- `<symbol>` count N | <what it guards> |
+| 2 | `TestY` | `<path>` | No -- same package | <contract it asserts> |
+| 3 | `TestZ` | `<path>` | No -- caller package | <downstream invariant> |
+
+**Rerun commands:**
+```bash
+<exact commands, tier by tier>
+```
+
+**Not rerunning:** <list with reasons, or "None -- full scope covered above">
+
 <If changes touch core/>
 #### LLM Test Additions
 <Specific LLM test recommendations per Section 5b format>
@@ -504,34 +672,55 @@ Copy the research table from Step 3e here. If you skipped Step 3e, go back and d
 
 ---
 
-**Proceed with implementation?** (yes / no / modify plan)
+<If Bug>
+The failing test above is committed to disk and confirmed red. No source file has been
+modified.
+</If>
+<If Feature or Docs>
+No source file has been modified. Red-before-green does not apply to <type> issues per
+AGENTS.md; tests are written alongside the implementation in Step 7.
+</If>
+
+**Implement the fix now?** (yes / no / modify plan)
 ```
 
 ## Step 7: Implement with Per-Change Approval
 
 Once the user approves the plan:
 
-### 7a. Bug issues: red before green (per AGENTS.md "Testing" section)
+### 7a. Bug issues: the red already happened (per AGENTS.md "Testing" section)
 
-If the issue was classified as **Bug** in Step 2a, tests are written and confirmed failing *before* any fix code is written:
+For **Bug** issues the failing test was written and confirmed red in Step 5f, before the
+approval gate. Step 7 therefore starts at the fix, not the test:
 
-1. Write (or extend) the test(s) from the Test Plan first, targeting the actual root cause identified in Step 3/4 -- not a placeholder.
-2. Run them and confirm they fail **for the expected reason** (the missing behavior/field/branch) -- not a compile error, typo, or unrelated panic.
-3. Only then implement the fix changes from the plan (Step 7c below).
-4. Re-run the same tests and confirm they now pass. Do not consider the change complete until red-then-green is shown for each new/extended test.
+1. Apply the fix changes from the plan (Step 7c below).
+2. Re-run the exact same command from the Step 6 "Red Output" block and confirm it now passes.
+3. Present red-then-green as a pair: the command, the prior failure, the new pass.
+4. Run the Tier 1 and Tier 2 reruns from the Regression Rerun Scope. Report every result,
+   including any pre-existing failure unrelated to this change -- say so explicitly rather
+   than omitting it.
 
-This does not apply to Feature or Docs-classified issues -- AGENTS.md scopes "red before green" to bug fixes specifically, not all work. For those, tests are still added per the Test Plan, but there's no requirement to write them before the implementation.
+Do not modify the test while implementing the fix. If the test needs to change to pass, the
+diagnosis was wrong: stop and tell the user rather than editing the test to match the code.
+
+This does not apply to Feature or Docs issues -- AGENTS.md scopes "red before green" to bug
+fixes. For those, tests are added per the Test Plan after the implementation, and Step 5f is
+skipped.
 
 ### 7b. Create a Todo List
 
-Create a todo item for each change in the plan. For Bug issues, order test-writing before the corresponding fix so the red-before-green sequence in 7a is reflected in the todo list itself:
+Create a todo item for each change in the plan. For Bug issues the regression test already
+exists and was confirmed red in Step 5f, before the approval gate -- so it enters the list
+already completed and the first pending task is the fix. Do not re-write or modify it (see 7a):
 ```
-1. Write failing test: <description> -- pending      (Bug issues only; confirm red before continuing)
+1. Write failing test: <description> -- completed    (Bug issues only; confirmed red in Step 5f)
 2. Change 1: <description> -- pending
 3. Change 2: <description> -- pending
 4. Update existing test: <description> -- pending
 5. Verify all tests pass -- pending
 ```
+For Feature and Docs issues, omit item 1 entirely: Step 5f is skipped for those, and the new
+tests from the Test Plan are added after the implementation, as their own pending items.
 
 ### 7c. For Each Change
 

--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -308,15 +308,18 @@ func (h *MCPServerHandler) handleMCPServerSSE(ctx *fasthttp.RequestCtx) {
 		}
 
 		// Periodic SSE comment heartbeats keep idle connections alive through
-		// proxies and let us detect client disconnect via reader.Send() returning
-		// false — fasthttp.RequestCtx never cancels bifrostCtx on its own.
+		// proxies and let us detect client disconnect via reader.SendHeartbeat()
+		// returning false — fasthttp.RequestCtx never cancels bifrostCtx on its own.
+		//
+		// Use the shared frame, never a local one: a hand-rolled ": ping\n\n" carries the
+		// trailing blank line #5883 removed (some decoders dispatch it as an empty event,
+		// #5874) and bypasses the line-boundary gate #5905 added.
 		ticker := time.NewTicker(sseHeartbeatInterval)
 		defer ticker.Stop()
-		ping := []byte(": ping\n\n")
 		for {
 			select {
 			case <-ticker.C:
-				if !reader.Send(ping) {
+				if !reader.SendHeartbeat() {
 					return
 				}
 			case <-(*bifrostCtx).Done():

--- a/transports/bifrost-http/lib/streamreader.go
+++ b/transports/bifrost-http/lib/streamreader.go
@@ -21,6 +21,18 @@ type SSEStreamReader struct {
 	closeCh   chan struct{}
 	closeOnce sync.Once
 	current   []byte // remaining bytes from a partial read
+
+	// mu guards atLineBoundary and makes "check the write position, then write" atomic against
+	// a concurrent producer. Heartbeats are written by an independent goroutine (see
+	// StartSSEHeartbeat), so an unsynchronized check could go stale between the check and the
+	// write: the producer can enqueue a partial line into that gap, which is exactly #5905.
+	// An atomic flag is NOT sufficient for the same reason -- the pair must be atomic, not the
+	// flag.
+	mu sync.Mutex
+	// atLineBoundary reports whether the last bytes handed to Send terminated a line, i.e.
+	// whether the next byte written starts a fresh SSE line. True initially: the start of a
+	// stream is a line boundary.
+	atLineBoundary bool
 }
 
 // NewSSEStreamReader creates a new SSEStreamReader with a buffered event channel.
@@ -28,8 +40,9 @@ type SSEStreamReader struct {
 // the producer goroutine and fasthttp's writeBodyChunked loop.
 func NewSSEStreamReader() *SSEStreamReader {
 	return &SSEStreamReader{
-		eventCh: make(chan []byte, 1),
-		closeCh: make(chan struct{}),
+		eventCh:        make(chan []byte, 1),
+		closeCh:        make(chan struct{}),
+		atLineBoundary: true,
 	}
 }
 
@@ -62,7 +75,24 @@ func (r *SSEStreamReader) Close() error {
 
 // Send delivers a pre-formatted event to the reader. Returns false if the reader
 // has been closed (client disconnected), in which case the producer should stop.
+//
+// event need not be a complete SSE frame. The raw passthrough path forwards arbitrary
+// upstream network chunks (core's StreamPassthrough reads into a fixed 4096-byte buffer), so
+// a chunk can end anywhere, including mid-line. Send therefore records where it left off so
+// SendHeartbeat can tell whether injecting a comment line there is safe.
 func (r *SSEStreamReader) Send(event []byte) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.sendLocked(event)
+}
+
+// sendLocked is Send's body; callers must hold r.mu. Split out so SendHeartbeat can check the
+// write position and send without releasing the lock in between -- otherwise a producer could
+// write a partial line into the gap and the safety check would already be stale.
+//
+// Blocking on eventCh while holding r.mu is safe: Close() closes closeCh, which the inner
+// select watches, so a stalled send is always unblockable without acquiring r.mu.
+func (r *SSEStreamReader) sendLocked(event []byte) bool {
 	// Check closeCh first (non-blocking) to avoid sending after Close
 	select {
 	case <-r.closeCh:
@@ -71,6 +101,10 @@ func (r *SSEStreamReader) Send(event []byte) bool {
 	}
 	select {
 	case r.eventCh <- event:
+		// A zero-length send writes nothing, so it cannot move the write position.
+		if len(event) > 0 {
+			r.atLineBoundary = event[len(event)-1] == '\n'
+		}
 		return true
 	case <-r.closeCh:
 		return false
@@ -124,8 +158,40 @@ var sseHeartbeatFrame = []byte(": heartbeat\n")
 // disconnect goes undetected and the stream completes as if nothing happened.
 // A caller sending this periodically (independent of real data) closes that
 // window. Returns false if the reader has been closed (client disconnected).
+//
+// The frame is only emitted when the stream is at a line boundary. An SSE comment is only a
+// comment when the colon is the FIRST character of a line; the spec then ignores the line
+// without resetting or dispatching the event buffers, so start-of-line is sufficient and a
+// full event boundary is not required. Spliced mid-line it is not a comment at all: it is
+// appended to the half-written line, its "\n" terminates that line early, and the remainder
+// arrives without its "data:" prefix, which decoders silently discard as an unknown field
+// (openai-python _streaming.py: `pass  # Field is ignored.`). The client then sees truncated
+// JSON and raises a decode error. That is #5905, and no heartbeat frame SHAPE can fix it --
+// #5883's trailing-blank-line change is a separate, complementary fix.
+//
+// Ordering matters: a closed reader reports false (a real disconnect) even when mid-line, so
+// StartSSEHeartbeat still discovers the disconnect. Only on a live reader does mid-line mean
+// "skip", which returns true -- StartSSEHeartbeat reads false as "client gone" and would
+// cancel an otherwise healthy stream. Skipping costs nothing: being mid-line means real bytes
+// are actively flowing, so the reactive write-failure detector already has the coverage a
+// heartbeat would provide.
+//
+// On the typed paths (handleStreaming, handleStreamingResponse) Bifrost frames every event
+// itself and each Send ends in "\n\n", so the stream is always at a boundary there and
+// heartbeats are never skipped.
 func (r *SSEStreamReader) SendHeartbeat() bool {
-	return r.Send(sseHeartbeatFrame)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// A real disconnect outranks a skip: report it even when mid-line.
+	select {
+	case <-r.closeCh:
+		return false
+	default:
+	}
+	if !r.atLineBoundary {
+		return true
+	}
+	return r.sendLocked(sseHeartbeatFrame)
 }
 
 // Done closes the event channel, signaling to Read that the stream is finished.

--- a/transports/bifrost-http/lib/streamreader_test.go
+++ b/transports/bifrost-http/lib/streamreader_test.go
@@ -1,14 +1,452 @@
 package lib
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
 )
+
+// TestSSEStreamReaderHeartbeatNeverSplitsDataLine is the regression test for #5905.
+//
+// handlePassthroughStream forwards raw upstream network reads (core's passthrough producer
+// reads into a fixed 4096-byte buffer), so a chunk is an arbitrary slice of the TCP stream
+// and is NOT guaranteed to end on an SSE line boundary. A large `data:` JSON value therefore
+// spans many chunks. Because the heartbeat goroutine writes through the same reader, a tick
+// landing between two of those chunks splices `: heartbeat\n` into the middle of a half-written
+// `data:` line.
+//
+// Per the SSE spec (https://html.spec.whatwg.org/multipage/server-sent-events.html) a comment
+// is only a comment when the colon is the FIRST character of a line -- and a comment is then
+// ignored without resetting or dispatching buffers, so start-of-line is sufficient and a full
+// event boundary is not required. Spliced mid-line it is not a comment at all: its `\n`
+// terminates the `data:` line early, and the JSON remainder becomes an unrecognized field that
+// decoders silently discard (openai-python `_streaming.py`: `pass  # Field is ignored.`),
+// yielding truncated JSON and a JSONDecodeError at the exact byte offset of the split.
+//
+// No heartbeat frame SHAPE can fix this -- #5883's trailing-blank-line fix is orthogonal.
+// The reader must refuse to emit a heartbeat unless it is at a line boundary.
+func TestSSEStreamReaderHeartbeatNeverSplitsDataLine(t *testing.T) {
+	// One valid SSE event whose data payload is split across two raw chunks, mirroring a
+	// large response.in_progress event delivered over multiple 4096-byte reads.
+	payload := `{"type":"response.in_progress","content":"` + strings.Repeat("A", 64) + `"}`
+	full := "event: response.in_progress\ndata: " + payload + "\n\n"
+	splitAt := len("event: response.in_progress\ndata: ") + 20 // mid-JSON, mid-line
+	chunk1, chunk2 := full[:splitAt], full[splitAt:]
+
+	r := NewSSEStreamReader()
+
+	readDone := make(chan []byte, 1)
+	go func() {
+		b, err := io.ReadAll(r)
+		if err != nil {
+			t.Errorf("ReadAll: %v", err)
+		}
+		readDone <- b
+	}()
+
+	// Deterministic interleaving: the heartbeat tick lands exactly between the two chunks,
+	// which is the race the production heartbeat goroutine hits nondeterministically.
+	r.Send([]byte(chunk1))
+	r.SendHeartbeat()
+	r.Send([]byte(chunk2))
+	r.Done()
+
+	got := <-readDone
+
+	// 1. Structural: every heartbeat emitted must start its own line.
+	for idx := 0; ; {
+		i := bytes.Index(got[idx:], sseHeartbeatFrame)
+		if i < 0 {
+			break
+		}
+		at := idx + i
+		if at != 0 && got[at-1] != '\n' {
+			t.Errorf("heartbeat spliced mid-line at offset %d; preceding byte is %q, want '\\n'.\n"+
+				"SSE comments are only comments at start-of-line; here it corrupts the data: line.\n"+
+				"stream:\n%s", at, got[at-1], got)
+		}
+		idx = at + len(sseHeartbeatFrame)
+	}
+
+	// 2. Payload integrity: stripping heartbeat lines must recover the original bytes exactly.
+	stripped := bytes.ReplaceAll(got, sseHeartbeatFrame, nil)
+	if string(stripped) != full {
+		t.Errorf("provider bytes not forwarded 1:1 after removing heartbeats.\ngot:  %q\nwant: %q", stripped, full)
+	}
+
+	// 3. Client-observable: the data payload must still parse as JSON, which is what the
+	//    reporter's OpenAI SDK client failed to do (JSONDecodeError at char 95636).
+	var data string
+	for _, line := range strings.Split(string(got), "\n") {
+		if after, ok := strings.CutPrefix(line, "data: "); ok {
+			data += after
+		}
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(data), &decoded); err != nil {
+		t.Errorf("client-visible data payload is not valid JSON: %v\npayload: %q", err, data)
+	}
+}
+
+// TestSSEStreamReaderHeartbeatStillSentAtLineBoundary guards against over-correcting #5905 by
+// simply disabling heartbeats. Disconnect detection depends on a real write happening during
+// idle gaps (see SendHeartbeat's doc and #5010), so when the stream IS at a line boundary --
+// which is always the case on the typed paths, where Bifrost frames each event itself and
+// every Send ends in "\n\n" -- the heartbeat must still be emitted.
+func TestSSEStreamReaderHeartbeatStillSentAtLineBoundary(t *testing.T) {
+	r := NewSSEStreamReader()
+
+	readDone := make(chan []byte, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		readDone <- b
+	}()
+
+	r.Send([]byte("data: {\"a\":1}\n\n")) // complete frame: reader is at a line boundary
+	if !r.SendHeartbeat() {
+		t.Fatal("SendHeartbeat returned false (disconnect) on a live reader at a line boundary")
+	}
+	r.Send([]byte("data: {\"b\":2}\n\n"))
+	r.Done()
+
+	got := <-readDone
+	if !bytes.Contains(got, sseHeartbeatFrame) {
+		t.Errorf("heartbeat suppressed at a valid line boundary; disconnect detection would regress.\nstream: %q", got)
+	}
+}
+
+// TestSSEStreamReaderHeartbeatBoundaryMatrix walks every way a write can leave the stream
+// positioned, and pins whether a heartbeat may follow. The rule is start-of-line, NOT
+// end-of-event: per the SSE spec a comment neither dispatches nor resets the event buffers,
+// so it is legal between an "event:" line and its "data:" line, or between two "data:" lines
+// of a multi-line payload.
+func TestSSEStreamReaderHeartbeatBoundaryMatrix(t *testing.T) {
+	cases := []struct {
+		name  string
+		write string
+		want  bool // may a heartbeat be emitted after this write?
+	}{
+		{"complete event", "data: {\"a\":1}\n\n", true},
+		{"single line terminated", "event: ping\n", true},
+		{"between multi-line data fields", "data: line one\ndata: line two\n", true},
+		{"mid JSON value", "data: {\"a\":\"partial", false},
+		{"mid field name", "dat", false},
+		{"after colon only", "data:", false},
+		{"CRLF terminated", "data: {\"a\":1}\r\n", true},
+		// A bare CR is a legal SSE line terminator, but we only recognize '\n'. The result is
+		// a suppressed heartbeat, never a corrupted line -- degrade safely, don't guess.
+		{"bare CR terminated", "data: {\"a\":1}\r", false},
+		{"trailing space after newline", "data: x\n ", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewSSEStreamReader()
+			go func() { _, _ = io.ReadAll(r) }()
+			r.Send([]byte(tc.write))
+			if got := r.atLineBoundary; got != tc.want {
+				t.Errorf("after writing %q: atLineBoundary=%v, want %v", tc.write, got, tc.want)
+			}
+			r.Done()
+		})
+	}
+}
+
+// TestSSEStreamReaderWrapperMethodsLeaveBoundary covers the typed paths (handleStreaming,
+// handleStreamingResponse), which never call Send directly -- they use these wrappers, each of
+// which emits a complete frame. Every one must leave the stream at a boundary, otherwise the
+// #5905 gate would start suppressing heartbeats on paths that were never affected and silently
+// regress the disconnect detection from #5010.
+func TestSSEStreamReaderWrapperMethodsLeaveBoundary(t *testing.T) {
+	cases := []struct {
+		name string
+		send func(*SSEStreamReader) bool
+	}{
+		{"SendEvent with type", func(r *SSEStreamReader) bool { return r.SendEvent("delta", []byte(`{"a":1}`)) }},
+		{"SendEvent without type", func(r *SSEStreamReader) bool { return r.SendEvent("", []byte(`{"a":1}`)) }},
+		{"SendEvent empty data", func(r *SSEStreamReader) bool { return r.SendEvent("ping", nil) }},
+		{"SendError", func(r *SSEStreamReader) bool { return r.SendError([]byte(`{"error":"x"}`)) }},
+		{"SendDone", func(r *SSEStreamReader) bool { return r.SendDone() }},
+		{"SendHeartbeat", func(r *SSEStreamReader) bool { return r.SendHeartbeat() }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewSSEStreamReader()
+			go func() { _, _ = io.ReadAll(r) }()
+			if !tc.send(r) {
+				t.Fatal("send returned false on a live reader")
+			}
+			if !r.atLineBoundary {
+				t.Error("wrapper method left the stream mid-line; heartbeats would be suppressed " +
+					"on a typed path that never had #5905")
+			}
+			if !r.SendHeartbeat() {
+				t.Error("heartbeat refused after a complete frame")
+			}
+			r.Done()
+		})
+	}
+}
+
+// TestSSEStreamReaderZeroLengthSendKeepsBoundary covers the guard in sendLocked: a zero-length
+// send writes no bytes, so it cannot move the write position. Reading event[len-1] without the
+// guard would panic.
+func TestSSEStreamReaderZeroLengthSendKeepsBoundary(t *testing.T) {
+	r := NewSSEStreamReader()
+	go func() { _, _ = io.ReadAll(r) }()
+
+	r.Send([]byte("data: partial")) // mid-line
+	r.Send([]byte{})                // must not reset the position
+	if r.atLineBoundary {
+		t.Error("empty Send wrongly reported a line boundary")
+	}
+	r.Send([]byte("\n")) // now terminated
+	r.Send(nil)          // must not reset it either
+	if !r.atLineBoundary {
+		t.Error("nil Send wrongly cleared the line boundary")
+	}
+	r.Done()
+}
+
+// TestSSEStreamReaderClosedMidLineReportsDisconnect pins the ordering inside SendHeartbeat: a
+// real disconnect outranks a mid-line skip. If the boundary check ran first, a client that
+// disconnected while the stream sat mid-line would return true ("skipped"), StartSSEHeartbeat
+// would never call onDisconnect, and the proactive detection from #5010 would be dead exactly
+// on the passthrough path #5905 affects.
+func TestSSEStreamReaderClosedMidLineReportsDisconnect(t *testing.T) {
+	r := NewSSEStreamReader()
+	go func() { _, _ = io.ReadAll(r) }()
+
+	r.Send([]byte("data: {\"partial\":\"no newline")) // leave the stream mid-line
+	r.Close()                                         // client disconnects
+
+	if r.SendHeartbeat() {
+		t.Error("mid-line heartbeat on a CLOSED reader returned true; the disconnect would " +
+			"go undetected because StartSSEHeartbeat only reacts to false")
+	}
+}
+
+// TestSSEStreamReaderHeartbeatRaceAcrossRandomSplits is the full-fidelity reproduction: a real
+// StartSSEHeartbeat goroutine ticking against a producer that forwards one SSE stream in
+// arbitrary, uneven chunks -- the actual shape of handlePassthroughStream, where core's
+// StreamPassthrough hands over whatever a 4096-byte Read returned.
+//
+// The assertions are timing-independent: they hold for any number of heartbeats at any
+// interleaving, so this cannot flake on a loaded CI worker. Run under -race, since the whole
+// point is two goroutines writing one stream.
+func TestSSEStreamReaderHeartbeatRaceAcrossRandomSplits(t *testing.T) {
+	var original strings.Builder
+	for i := range 12 {
+		payload := fmt.Sprintf(`{"seq":%d,"blob":%q}`, i, strings.Repeat("X", 512))
+		fmt.Fprintf(&original, "event: chunk.%d\ndata: %s\n\n", i, payload)
+	}
+	full := original.String()
+
+	// Uneven, co-prime-ish sizes so splits land mid-token, mid-JSON, and occasionally on a
+	// terminator -- mimicking arbitrary TCP segmentation rather than tidy frame boundaries.
+	sizes := []int{7, 1, 131, 13, 4096, 2, 997, 64, 3}
+
+	r := NewSSEStreamReader()
+	readDone := make(chan []byte, 1)
+	go func() {
+		b, err := io.ReadAll(r)
+		if err != nil {
+			t.Errorf("ReadAll: %v", err)
+		}
+		readDone <- b
+	}()
+
+	// A deliberately aggressive interval: maximize the number of interleaving attempts. The
+	// callback is wrapped so the producer can rendezvous with it below -- a sleep would only
+	// hope the ticker fires, leaving the assertions vacuous on a stalled worker. The signal
+	// send is non-blocking: blocking here would stall the heartbeat goroutine inside send(),
+	// which is StopSSEHeartbeat's job to rescue, not this test's scenario.
+	var callbacks atomic.Int64
+	beat := make(chan struct{}, 1)
+	heartbeat := func() bool {
+		ok := r.SendHeartbeat()
+		callbacks.Add(1)
+		select {
+		case beat <- struct{}{}:
+		default:
+		}
+		return ok
+	}
+	done, exited := StartSSEHeartbeat(50*time.Microsecond, heartbeat, func() {})
+
+	remaining := full
+	for i := 0; len(remaining) > 0; i++ {
+		n := min(sizes[i%len(sizes)], len(remaining))
+		if !r.Send([]byte(remaining[:n])) {
+			t.Fatal("Send returned false on a live reader")
+		}
+		remaining = remaining[n:]
+		// Wait for a heartbeat callback rather than sleeping: this proves a heartbeat ran
+		// between these two raw chunks, which is the interleaving under test.
+		select {
+		case <-beat:
+		case <-time.After(5 * time.Second):
+			t.Fatal("heartbeat goroutine never ticked; the interleaving under test never happened")
+		}
+	}
+
+	if callbacks.Load() == 0 {
+		t.Fatal("heartbeat callback never ran -- the assertions below would pass vacuously")
+	}
+
+	StopSSEHeartbeat(r, done, exited)
+	r.Done()
+	got := <-readDone
+
+	// 1. Every heartbeat starts its own line.
+	beats := 0
+	for idx := 0; ; {
+		i := bytes.Index(got[idx:], sseHeartbeatFrame)
+		if i < 0 {
+			break
+		}
+		at := idx + i
+		beats++
+		if at != 0 && got[at-1] != '\n' {
+			t.Fatalf("heartbeat spliced mid-line at offset %d (preceding byte %q)", at, got[at-1])
+		}
+		idx = at + len(sseHeartbeatFrame)
+	}
+	t.Logf("interleaved %d heartbeats across %d bytes without corruption", beats, len(got))
+
+	// 2. Provider bytes forwarded 1:1 once heartbeats are removed.
+	if stripped := string(bytes.ReplaceAll(got, sseHeartbeatFrame, nil)); stripped != full {
+		t.Errorf("provider bytes not forwarded 1:1 (got %d bytes, want %d)", len(stripped), len(full))
+	}
+
+	// 3. Every event a client would decode still carries complete, parseable JSON.
+	events := 0
+	for _, block := range strings.Split(string(got), "\n\n") {
+		var data string
+		for _, line := range strings.Split(block, "\n") {
+			if after, ok := strings.CutPrefix(line, "data: "); ok {
+				data += after
+			}
+		}
+		if data == "" {
+			continue
+		}
+		events++
+		var decoded map[string]any
+		if err := json.Unmarshal([]byte(data), &decoded); err != nil {
+			t.Errorf("event %d payload not valid JSON: %v", events, err)
+		}
+	}
+	if events != 12 {
+		t.Errorf("decoded %d complete events, want 12", events)
+	}
+}
+
+// TestSSEStreamReaderConcurrentProducersWithHeartbeat stresses the mutex itself: several
+// producers plus a live heartbeat goroutine all writing at once. Nothing here asserts
+// ordering between producers -- only that the line-boundary invariant holds no matter how the
+// writes interleave, and that the reader neither panics nor deadlocks. Run under -race.
+func TestSSEStreamReaderConcurrentProducersWithHeartbeat(t *testing.T) {
+	r := NewSSEStreamReader()
+	readDone := make(chan []byte, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		readDone <- b
+	}()
+
+	// The property under test is OVERLAP, not ordering: a heartbeat that fired before the
+	// producers started proves nothing, and 200 SendEvent calls can easily complete inside a
+	// single tick interval. So the heartbeat callback observes the producers rather than the
+	// other way round -- it reads how many are mid-loop at the instant it runs, and producers
+	// keep emitting past their nominal 50 events until one such overlapping beat is seen.
+	// Without this the boundary scan below is a no-op loop over zero heartbeat frames.
+	var concurrentBeats, live atomic.Int64
+	sawConcurrent := make(chan struct{})
+	var once sync.Once
+	heartbeat := func() bool {
+		ok := r.SendHeartbeat()
+		if live.Load() > 0 {
+			concurrentBeats.Add(1)
+			once.Do(func() { close(sawConcurrent) })
+		}
+		return ok
+	}
+	done, exited := StartSSEHeartbeat(50*time.Microsecond, heartbeat, func() {})
+
+	var wg sync.WaitGroup
+	for p := range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			live.Add(1)
+			defer live.Add(-1)
+			// Bounded only so a heartbeat goroutine that died can't spin here forever; the
+			// 50us ticker means the loop normally exits within a handful of extra events.
+			deadline := time.Now().Add(5 * time.Second)
+			for i := 0; ; i++ {
+				// Always complete frames, so every producer leaves a boundary behind.
+				r.SendEvent(fmt.Sprintf("p%d", p), fmt.Appendf(nil, `{"i":%d}`, i))
+				if i < 50 {
+					continue
+				}
+				select {
+				case <-sawConcurrent:
+					return
+				default:
+				}
+				if time.Now().After(deadline) {
+					t.Error("no heartbeat callback ran while a producer was mid-loop")
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	if concurrentBeats.Load() == 0 {
+		t.Fatal("no heartbeat overlapped a live producer -- the boundary scan below is vacuous")
+	}
+	t.Logf("%d heartbeat(s) landed while producers were mid-loop", concurrentBeats.Load())
+
+	StopSSEHeartbeat(r, done, exited)
+	r.Done()
+	got := <-readDone
+
+	for idx := 0; ; {
+		i := bytes.Index(got[idx:], sseHeartbeatFrame)
+		if i < 0 {
+			break
+		}
+		at := idx + i
+		if at != 0 && got[at-1] != '\n' {
+			t.Fatalf("heartbeat spliced mid-line at offset %d under concurrent producers", at)
+		}
+		idx = at + len(sseHeartbeatFrame)
+	}
+}
+
+// TestSSEStreamReaderSkippedHeartbeatIsNotDisconnect pins the contract StartSSEHeartbeat
+// depends on: its send callback returning false means "the reader was closed, the client is
+// gone" and triggers onDisconnect/cancel. Declining to emit a heartbeat because the stream is
+// mid-line is NOT a disconnect, so it must still return true. Returning false here would abort
+// every passthrough stream that happens to tick mid-line -- a far worse bug than #5905 itself.
+func TestSSEStreamReaderSkippedHeartbeatIsNotDisconnect(t *testing.T) {
+	r := NewSSEStreamReader()
+	go func() { _, _ = io.ReadAll(r) }()
+
+	r.Send([]byte("data: {\"partial\":\"no trailing newline")) // leaves the reader mid-line
+	if !r.SendHeartbeat() {
+		t.Error("mid-line heartbeat returned false; StartSSEHeartbeat reads false as a client " +
+			"disconnect and would cancel a healthy stream")
+	}
+	r.Done()
+}
 
 func TestSSEStreamReaderSingleEventPerRead(t *testing.T) {
 	r := NewSSEStreamReader()


### PR DESCRIPTION
## Summary

Fixes #5905: SSE heartbeat frames injected mid-line corrupt the `data:` payload on passthrough streams. When Bifrost forwards raw upstream bytes (e.g. via `StreamPassthrough`, which reads into a fixed 4096-byte buffer), chunks are arbitrary TCP slices and are not guaranteed to end on an SSE line boundary. A heartbeat tick landing between two such chunks splices `: heartbeat\n` into the middle of a half-written `data:` line. Per the SSE spec, a comment is only a comment when the colon is the **first character of a line**; spliced mid-line, the `\n` terminates the `data:` line early and the JSON remainder becomes an unrecognized field that decoders silently discard, producing truncated JSON and a `JSONDecodeError` at the client.

No heartbeat frame shape can fix this — the reader must refuse to emit a heartbeat unless it is at a line boundary.

closes #5905

## Changes

- **`SSEStreamReader`** **now tracks** **`atLineBoundary`**: a mutex-guarded boolean, initialized `true`, updated on every `Send` call based on whether the last byte written was `\n`. The mutex makes the "check position, then write" pair atomic against the concurrent heartbeat goroutine — an atomic flag alone is insufficient because the producer can enqueue a partial line between the check and the write.
- **`Send`** **is split into** **`Send`** **(acquires lock) and** **`sendLocked`** **(body)**: `SendHeartbeat` calls `sendLocked` without releasing the lock between the boundary check and the write, closing the race window that caused #5905.
- **`SendHeartbeat`** **skips emission when mid-line, but still returns** **`true`**: a skipped heartbeat is not a disconnect. Returning `false` would cause `StartSSEHeartbeat` to invoke `onDisconnect` and cancel a healthy stream. A real disconnect (`closeCh` closed) returns `false` even when mid-line, preserving the proactive disconnect detection from #5010.
- **`mcpserver.go`** **switches from a hand-rolled** **`": ping\n\n"`** **byte slice to** **`reader.SendHeartbeat()`**: the old local frame bypassed the line-boundary gate and carried the trailing blank line that #5883 removed (some decoders dispatch it as an empty event).
- **Investigate-issue skill updated**: regression tests are now written and confirmed red _before_ the plan is presented to the user, rather than after approval. The checklist, approval gate wording, and Step 7 flow are updated accordingly. A new "Regression Rerun Scope" section (Step 5e) requires coverage-attributed test tiers rather than guessed reruns.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd transports/bifrost-http
go test ./lib/... -run TestSSEStreamReaderHeartbeat -race -v
go test ./lib/... -run TestSSEStreamReaderHeartbeatRaceAcrossRandomSplits -race -count=5
go test ./lib/... -race
```

Key tests added:

- `TestSSEStreamReaderHeartbeatNeverSplitsDataLine` — deterministic interleaving: heartbeat tick lands exactly between two chunks of a split `data:` line; asserts structural integrity, byte-for-byte forwarding, and JSON parseability.
- `TestSSEStreamReaderHeartbeatStillSentAtLineBoundary` — guards against over-correction by verifying heartbeats are still emitted on the typed paths (where every `Send` ends in `\n\n`).
- `TestSSEStreamReaderHeartbeatBoundaryMatrix` — exhaustive matrix of write endings vs. expected `atLineBoundary` state.
- `TestSSEStreamReaderWrapperMethodsLeaveBoundary` — all high-level wrapper methods (`SendEvent`, `SendError`, `SendDone`, `SendHeartbeat`) must leave the stream at a boundary.
- `TestSSEStreamReaderClosedMidLineReportsDisconnect` — disconnect outranks mid-line skip.
- `TestSSEStreamReaderHeartbeatRaceAcrossRandomSplits` — full-fidelity race test with a live `StartSSEHeartbeat` goroutine and co-prime chunk sizes; run under `-race`.
- `TestSSEStreamReaderConcurrentProducersWithHeartbeat` — multiple concurrent producers plus a live heartbeat goroutine; asserts no mid-line splice and no deadlock under `-race`.
- `TestSSEStreamReaderSkippedHeartbeatIsNotDisconnect` — mid-line skip must return `true`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #5905. Complements #5883 (trailing blank line removal) and #5010 (proactive disconnect detection).

## Security considerations

None. This change affects SSE framing only; no auth, secrets, or PII are involved.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable