### PR TITLE
service_teir patches

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
+- feat: add `BifrostContextKeyCompatDroppedParams` so the compat plugin can carry its dropped-parameter list per request instead of on the shared plugin struct (#5902)
 - fix: always emit a well-formed `message_start` on the Anthropic surface - the frame now carries a `message` object with a `usage` object and an array `content` even when the upstream created event has no payload, and the chat-completions converter no longer panics on a content-less assistant message
 - fix: carry tool-result `is_error` across the chat/Responses mux in both directions, and stop the unmarshal reattach gate from dropping a tool message that marks a failure without a `tool_call_id` (#5890)
 - fix: mark failed MCP tool executions as errors instead of replaying them to the model as successful results - covers agent-loop execution errors, the MCP protocol's own `isError` flag which was previously discarded, and CodeMode lookup/sandbox failures (#5890)

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -381,6 +381,7 @@ const (
 	BifrostContextKeyCompatShouldDropParams              BifrostContextKey = "bifrost-compat-should-drop-params"          // bool (per-request override from x-bf-compat header)
 	BifrostContextKeyCompatShouldConvertParams           BifrostContextKey = "bifrost-compat-should-convert-params"       // bool (per-request override from x-bf-compat header)
 	BifrostContextKeySupportsAssistantPrefill            BifrostContextKey = "bifrost-supports-assistant-prefill"         // bool (set by compat plugin) - if model supports assistant prefill
+	BifrostContextKeyCompatDroppedParams                 BifrostContextKey = "bifrost-compat-dropped-params"              // []string (set by compat plugin) - params stripped from the request because the model catalog did not allowlist them; read back in PostLLMHook to populate extra_fields.dropped_compat_plugin_params
 	BifrostContextKeyAttemptTrail                        BifrostContextKey = "bifrost-attempt-trail"                      // []KeyAttemptRecord (set by bifrost - DO NOT SET THIS MANUALLY) - per-attempt key selection history
 	BifrostContextKeyDimensions                          BifrostContextKey = "bifrost-dimensions"                         // map[string]string (set by HTTP transport from x-bf-dim-* headers) BifrostContextKeyDimensions holds per-request key/value dimensions supplied via x-bf-dim-<key> request headers. These dimensions are forwarded to internal logs (as metadata)
 	IsAPIKeyAuthContextKey                               BifrostContextKey = "is_api_key_auth"

--- a/framework/modelcatalog/datasheet/store.go
+++ b/framework/modelcatalog/datasheet/store.go
@@ -437,6 +437,18 @@ func NewTestStore(baseModelIndex map[string]string) *Store {
 	}
 }
 
+// SetSupportedParamsForTest replaces the supported-parameter index. Test-only
+// seam for packages outside datasheet (e.g. the compat plugin) that need a
+// catalog answering GetSupportedParameters without running a sync.
+func (s *Store) SetSupportedParamsForTest(params map[string][]string) {
+	if params == nil {
+		params = make(map[string][]string)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.supportedParams = params
+}
+
 // --- Internal: rebuild the datasheet view from current pricingData ---
 
 // rebuildDatasheetViewUnsafe regenerates baseModelIndex, datasheetByProvider,

--- a/plugins/compat/changelog.md
+++ b/plugins/compat/changelog.md
@@ -1,1 +1,3 @@
+- fix: scope the compat plugin's dropped-parameter list to the request that produced it - the list was held on the process-wide plugin struct, so concurrent requests raced on it and `extra_fields.dropped_compat_plugin_params` could report another request's dropped params (#5902)
+- feat: log parameters scrubbed by `should_drop_params` at Debug, and a dropped `service_tier` at Warn - a silently stripped `service_tier` downgrades the request to the provider's default tier with no upstream error, which was previously untraceable (#5902)
 - chore: upgraded core to v1.7.6 and framework to v1.5.6

--- a/plugins/compat/dropparams_test.go
+++ b/plugins/compat/dropparams_test.go
@@ -171,6 +171,87 @@ func TestDropUnsupportedParams_ChatMaxCompletionTokensUnchanged(t *testing.T) {
 	}
 }
 
+// TestDropUnsupportedParams_ServiceTier pins service_tier passthrough on both
+// request paths. A dropped service_tier is invisible to the caller - the
+// provider simply serves the request at its default tier and bills it as such -
+// so this guards that the param survives whenever the catalog allowlists it.
+func TestDropUnsupportedParams_ServiceTier(t *testing.T) {
+	tests := []struct {
+		name          string
+		supported     []string
+		wantPreserved bool
+	}{
+		{
+			name:          "catalog lists service_tier",
+			supported:     []string{"temperature", "service_tier"},
+			wantPreserved: true,
+		},
+		{
+			name:          "catalog omits service_tier",
+			supported:     []string{"temperature"},
+			wantPreserved: false,
+		},
+		{
+			name:          "empty catalog",
+			supported:     []string{},
+			wantPreserved: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+"/chat", func(t *testing.T) {
+			req := &schemas.BifrostRequest{
+				RequestType: schemas.ChatCompletionRequest,
+				ChatRequest: &schemas.BifrostChatRequest{
+					Provider: schemas.OpenAI,
+					Model:    "gpt-5.4",
+					Params: &schemas.ChatParameters{
+						ServiceTier: schemas.Ptr(schemas.BifrostServiceTierPriority),
+						Temperature: schemas.Ptr(0.5),
+					},
+				},
+			}
+
+			dropped := dropUnsupportedParams(newTestContext(), req, tt.supported)
+			assertServiceTier(t, req.ChatRequest.Params.ServiceTier, dropped, tt.wantPreserved, tt.supported)
+		})
+
+		t.Run(tt.name+"/responses", func(t *testing.T) {
+			req := newResponsesRequest(schemas.OpenAI, "gpt-5.4", &schemas.ResponsesParameters{
+				ServiceTier: schemas.Ptr(schemas.BifrostServiceTierPriority),
+				Temperature: schemas.Ptr(0.5),
+			})
+
+			dropped := dropUnsupportedParams(newTestContext(), req, tt.supported)
+			assertServiceTier(t, req.ResponsesRequest.Params.ServiceTier, dropped, tt.wantPreserved, tt.supported)
+		})
+	}
+}
+
+func assertServiceTier(t *testing.T, got *schemas.BifrostServiceTier, dropped []string, wantPreserved bool, supported []string) {
+	t.Helper()
+
+	if wantPreserved {
+		if got == nil {
+			t.Fatalf("service_tier = dropped, want preserved (supported=%v)", supported)
+		}
+		if *got != schemas.BifrostServiceTierPriority {
+			t.Errorf("service_tier = %q, want %q", *got, schemas.BifrostServiceTierPriority)
+		}
+		if slices.Contains(dropped, "service_tier") {
+			t.Errorf("service_tier reported in dropped=%v, want absent", dropped)
+		}
+		return
+	}
+
+	if got != nil {
+		t.Fatalf("service_tier = %q, want dropped (supported=%v)", *got, supported)
+	}
+	if !slices.Contains(dropped, "service_tier") {
+		t.Errorf("service_tier not reported in dropped=%v, want present", dropped)
+	}
+}
+
 func TestDropUnsupportedParams_ChatReasoningWithUnsupportedTools(t *testing.T) {
 	newChat := func() *schemas.BifrostRequest {
 		return &schemas.BifrostRequest{

--- a/plugins/compat/hooks_test.go
+++ b/plugins/compat/hooks_test.go
@@ -1,0 +1,175 @@
+package compat
+
+import (
+	"fmt"
+	"slices"
+	"sync"
+	"testing"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/modelcatalog"
+	"github.com/maximhq/bifrost/framework/modelcatalog/datasheet"
+)
+
+// newTestPlugin builds a drop-params-enabled plugin backed by an in-memory
+// catalog seeded with supported, so tests can exercise the full
+// PreLLMHook/PostLLMHook pair without a datasheet sync.
+func newTestPlugin(t *testing.T, supported map[string][]string) *CompatPlugin {
+	t.Helper()
+	ds := datasheet.NewTestStore(nil)
+	ds.SetSupportedParamsForTest(supported)
+	p, err := Init(Config{ShouldDropParams: true}, bifrost.NewNoOpLogger(), modelcatalog.NewTestCatalogWithDatasheet(ds))
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	return p
+}
+
+// newServiceTierChatRequest builds a chat request carrying service_tier plus a
+// param every model in these tests supports, so a mix-up between two concurrent
+// requests shows up as a difference in the reported dropped list.
+func newServiceTierChatRequest(model string) *schemas.BifrostRequest {
+	return &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    model,
+			Params: &schemas.ChatParameters{
+				ServiceTier: schemas.Ptr(schemas.BifrostServiceTierPriority),
+				Temperature: schemas.Ptr(0.5),
+			},
+		},
+	}
+}
+
+// TestPluginDroppedParamsAreRequestScoped guards that the dropped-parameter
+// list reported on a response belongs to that response's own request.
+//
+// The plugin is registered once per process, so any per-request state parked on
+// the plugin struct is shared by every in-flight request: one request's
+// PreLLMHook overwrites another's list before that other request reaches
+// PostLLMHook. Callers debugging a silently scrubbed param (see the service_tier
+// drop in dropUnsupportedParams) read exactly this field, so it has to describe
+// the request it is attached to.
+func TestPluginDroppedParamsAreRequestScoped(t *testing.T) {
+	p := newTestPlugin(t, map[string][]string{
+		"tier-model":   {"service_tier", "temperature"},
+		"notier-model": {"temperature"},
+	})
+
+	cases := []struct {
+		model       string
+		wantDropped []string
+	}{
+		{model: "tier-model", wantDropped: nil},
+		{model: "notier-model", wantDropped: []string{"service_tier"}},
+	}
+
+	if len(cases) != 2 {
+		t.Fatalf("the rendezvous below is a two-party barrier; got %d cases", len(cases))
+	}
+
+	const iterations = 200
+	failures := make(chan string, len(cases)*iterations)
+
+	// Rendezvous between the two goroutines, one buffered slot each. Both park
+	// here after PreLLMHook and before PostLLMHook, so the interleaving that
+	// exposes plugin-level state - one request's PreLLMHook landing between the
+	// other's PreLLMHook and PostLLMHook - happens on every iteration instead of
+	// whenever the scheduler happens to produce it. Nothing below may return
+	// early: a goroutine that leaves the loop strands its partner at the barrier.
+	arrived := [2]chan struct{}{make(chan struct{}, 1), make(chan struct{}, 1)}
+
+	var wg sync.WaitGroup
+	for i, tc := range cases {
+		wg.Add(1)
+		go func(self int, model string, want []string) {
+			defer wg.Done()
+			for range iterations {
+				ctx := newTestContext()
+				_, _, preErr := p.PreLLMHook(ctx, newServiceTierChatRequest(model))
+
+				arrived[self] <- struct{}{}
+				<-arrived[1-self]
+
+				if preErr != nil {
+					failures <- fmt.Sprintf("model %s: PreLLMHook: %v", model, preErr)
+					continue
+				}
+
+				resp := &schemas.BifrostResponse{ChatResponse: &schemas.BifrostChatResponse{}}
+				if _, _, err := p.PostLLMHook(ctx, resp, nil); err != nil {
+					failures <- fmt.Sprintf("model %s: PostLLMHook: %v", model, err)
+					continue
+				}
+
+				got := resp.ChatResponse.ExtraFields.DroppedCompatPluginParams
+				if !slices.Equal(got, want) {
+					failures <- fmt.Sprintf("model %s: dropped_compat_plugin_params = %v, want %v", model, got, want)
+				}
+			}
+		}(i, tc.model, tc.wantDropped)
+	}
+	wg.Wait()
+	close(failures)
+
+	for msg := range failures {
+		t.Error(msg)
+	}
+}
+
+// TestPluginDroppedParamsSingleRequest pins the same reporting contract on the
+// sequential path, so a regression in the concurrent test is not mistaken for
+// the field having stopped being populated at all.
+func TestPluginDroppedParamsSingleRequest(t *testing.T) {
+	p := newTestPlugin(t, map[string][]string{"notier-model": {"temperature"}})
+
+	ctx := newTestContext()
+	if _, _, err := p.PreLLMHook(ctx, newServiceTierChatRequest("notier-model")); err != nil {
+		t.Fatalf("PreLLMHook: %v", err)
+	}
+
+	resp := &schemas.BifrostResponse{ChatResponse: &schemas.BifrostChatResponse{}}
+	if _, _, err := p.PostLLMHook(ctx, resp, nil); err != nil {
+		t.Fatalf("PostLLMHook: %v", err)
+	}
+
+	got := resp.ChatResponse.ExtraFields.DroppedCompatPluginParams
+	if !slices.Contains(got, "service_tier") {
+		t.Errorf("dropped_compat_plugin_params = %v, want it to report service_tier", got)
+	}
+}
+
+// TestPluginDroppedParamsClearedBetweenAttempts guards the fallback path, where
+// the same context is carried into a second attempt against a different model.
+// PreLLMHook only writes the dropped list when something was dropped, so an
+// attempt that drops nothing must not inherit the previous attempt's list.
+func TestPluginDroppedParamsClearedBetweenAttempts(t *testing.T) {
+	p := newTestPlugin(t, map[string][]string{
+		"notier-model": {"temperature"},
+		"tier-model":   {"service_tier", "temperature"},
+	})
+
+	ctx := newTestContext()
+
+	// First attempt drops service_tier.
+	if _, _, err := p.PreLLMHook(ctx, newServiceTierChatRequest("notier-model")); err != nil {
+		t.Fatalf("PreLLMHook (first attempt): %v", err)
+	}
+
+	// Fallback to a model that supports every param on the request, on the same
+	// context the first attempt used.
+	if _, _, err := p.PreLLMHook(ctx, newServiceTierChatRequest("tier-model")); err != nil {
+		t.Fatalf("PreLLMHook (fallback attempt): %v", err)
+	}
+
+	resp := &schemas.BifrostResponse{ChatResponse: &schemas.BifrostChatResponse{}}
+	if _, _, err := p.PostLLMHook(ctx, resp, nil); err != nil {
+		t.Fatalf("PostLLMHook: %v", err)
+	}
+
+	if got := resp.ChatResponse.ExtraFields.DroppedCompatPluginParams; len(got) != 0 {
+		t.Errorf("dropped_compat_plugin_params = %v, want empty - the fallback attempt dropped nothing", got)
+	}
+}

--- a/plugins/compat/main.go
+++ b/plugins/compat/main.go
@@ -5,6 +5,8 @@
 package compat
 
 import (
+	"slices"
+
 	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
@@ -49,11 +51,13 @@ func (c Config) IsEnabled() bool {
 // completion requests for models that only support chat completions, matching
 // LiteLLM's behavior. It also converts chat completion requests to responses
 // for models that only support the responses endpoint.
+// The plugin is registered once per process, so it holds no per-request state:
+// anything PreLLMHook needs to hand to PostLLMHook travels on the request's
+// BifrostContext instead.
 type CompatPlugin struct {
-	config        Config
-	logger        schemas.Logger
-	modelCatalog  *modelcatalog.ModelCatalog
-	droppedParams []string
+	config       Config
+	logger       schemas.Logger
+	modelCatalog *modelcatalog.ModelCatalog
 }
 
 // Init creates a new compat plugin instance with model catalog support.
@@ -100,6 +104,12 @@ func (p *CompatPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 		return req, nil, nil
 	}
 
+	// A fallback re-runs the full plugin pipeline on the same context, and the
+	// dropped-param list below is only written when something was actually
+	// dropped. Without this clear, an attempt that drops nothing inherits the
+	// previous attempt's list and PostLLMHook reports it as this response's.
+	ctx.ClearValue(schemas.BifrostContextKeyCompatDroppedParams)
+
 	convertTextToChatOverride, convertTextToChatOverrideEnabled := ctx.Value(schemas.BifrostContextKeyCompatConvertTextToChat).(bool)
 	convertChatToResponsesOverride, convertChatToResponsesOverrideEnabled := ctx.Value(schemas.BifrostContextKeyCompatConvertChatToResponses).(bool)
 	shouldDropParamsOverride, shouldDropParamsOverrideEnabled := ctx.Value(schemas.BifrostContextKeyCompatShouldDropParams).(bool)
@@ -109,7 +119,6 @@ func (p *CompatPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 	if (shouldDropParamsOverrideEnabled && shouldDropParamsOverride) || (shouldConvertParamsOverrideEnabled && shouldConvertParamsOverride) || p.config.ShouldConvertParams || p.config.ShouldDropParams {
 		modifiedReq = cloneBifrostReq(req)
 	}
-	p.droppedParams = nil
 
 	// Text completion → chat conversion
 	if (convertTextToChatOverrideEnabled && convertTextToChatOverride) || p.config.ConvertTextToChat {
@@ -132,7 +141,15 @@ func (p *CompatPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 			if supportedParams := p.modelCatalog.GetSupportedParameters(model); supportedParams != nil {
 				droppedParams := dropUnsupportedParams(ctx, modifiedReq, supportedParams)
 				if len(droppedParams) > 0 {
-					p.droppedParams = droppedParams
+					ctx.SetValue(schemas.BifrostContextKeyCompatDroppedParams, droppedParams)
+					p.logger.Debug("compat: dropped unsupported params for model %s: %v", model, droppedParams)
+					// service_tier decides what the caller is billed. Dropping it
+					// downgrades the request to the provider's default tier with no
+					// upstream error and no difference in the response body, so it
+					// is worth surfacing above Debug.
+					if slices.Contains(droppedParams, "service_tier") {
+						p.logger.Warn("compat: dropped service_tier for model %s - the model catalog does not list service_tier support for this model, so the request will be served and billed at the provider's default tier", model)
+					}
 				}
 			}
 		}
@@ -164,8 +181,10 @@ func (p *CompatPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	}
 
 	if result != nil {
-		if extraFields := result.GetExtraFields(); extraFields != nil {
-			extraFields.DroppedCompatPluginParams = p.droppedParams
+		if droppedParams, ok := ctx.Value(schemas.BifrostContextKeyCompatDroppedParams).([]string); ok {
+			if extraFields := result.GetExtraFields(); extraFields != nil {
+				extraFields.DroppedCompatPluginParams = droppedParams
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

The compat plugin held its dropped-parameter list on the plugin struct itself, which is a single process-wide instance. Concurrent requests raced on this field, causing `extra_fields.dropped_compat_plugin_params` to report another request's dropped params instead of its own. This PR moves that list onto the per-request `BifrostContext` via the new `BifrostContextKeyCompatDroppedParams` key, eliminating the race.

Closes #5902

## Changes

- Removed `droppedParams []string` from `CompatPlugin` struct; the plugin now carries no per-request state.
- Added `BifrostContextKeyCompatDroppedParams` context key (`[]string`) so `PreLLMHook` can store the dropped-parameter list on the request context and `PostLLMHook` can read it back from the same context to populate `extra_fields.dropped_compat_plugin_params`.
- Added `Debug`\-level logging when params are scrubbed by `should_drop_params`, and a `Warn`\-level log specifically when `service_tier` is dropped — a silently stripped `service_tier` downgrades the request to the provider's default billing tier with no upstream error, making it previously untraceable.
- Added `SetSupportedParamsForTest` on the datasheet `Store` as a test seam so packages outside the datasheet package (e.g. the compat plugin) can seed the supported-parameter index without running a full catalog sync.
- Added `hooks_test.go` with a concurrent test (`TestPluginDroppedParamsAreRequestScoped`) that runs 200 iterations of two goroutines with different models to confirm the dropped-param list is always scoped to the correct request, plus a sequential baseline test.
- Added `TestDropUnsupportedParams_ServiceTier` to pin `service_tier` passthrough on both the chat and responses request paths.

## Type of change

- [x] Bug fix
- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Plugins

## How to test

```sh
go test ./plugins/compat/...
go test ./framework/modelcatalog/...
go test ./core/...
```

The concurrent test `TestPluginDroppedParamsAreRequestScoped` will reliably fail on the old code due to the data race, and pass on this change. Running with `-race` is recommended:

```sh
go test -race ./plugins/compat/...
```

## Breaking changes

- [x] No

## Related issues

Closes #5902

## Security considerations

None. The change is scoped to request-local context propagation within the plugin lifecycle.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable