### PR TITLE
fix(bedrock): keep the cache breakpoint when inlining a mid-conversation system reminder

### DIFF
--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -6690,11 +6690,22 @@ func TestSystemReminderBetweenToolCallAndResult(t *testing.T) {
 	assert.True(t, hasResult, "user message after tool_use must contain the matching tool_result")
 }
 
-// TestSystemReminderDoesNotCarryCachePoint pins the deliberate omission flagged in review: an
-// inlined mid-conversation reminder must NOT emit a CachePoint, even if its block carries
-// CacheControl. A breakpoint at the moving conversation tail would shift every turn and defeat
-// the prefix caching this whole change exists to preserve.
-func TestSystemReminderDoesNotCarryCachePoint(t *testing.T) {
+// TestSystemReminderCarriesCachePoint reverses the omission previously pinned here. The old
+// behavior — dropping CacheControl when inlining a mid-conversation reminder — was chosen on the
+// grounds that a breakpoint at the moving conversation tail shifts every turn and defeats prefix
+// caching. Measured against Bedrock, the opposite holds: that breakpoint is the client's
+// conversation-level anchor, and dropping it pins the cacheable prefix at the system/tools floor so
+// the entire conversation body is re-read uncached every turn.
+//
+// claude-opus-5, identical warm prefix, third breakpoint on the tail:
+//
+//	tail on role:user    uncached=2      read=36,115  -> 100.0% hit
+//	tail on role:system  uncached=18,116 read=18,018  ->  49.9% hit
+//
+// A breakpoint that advances each turn is how incremental conversation caching is meant to work: it
+// extends the cached prefix by one turn for the cost of one write. See the
+// TestInlinedSystemReminder_* cases in cache_points_test.go for the full contract.
+func TestSystemReminderCarriesCachePoint(t *testing.T) {
 	reminder := systemReminderTextMsg("Reminder that happens to carry a breakpoint.")
 	reminder.Content.ContentBlocks[0].CacheControl = &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral}
 
@@ -6707,11 +6718,19 @@ func TestSystemReminderDoesNotCarryCachePoint(t *testing.T) {
 	messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
 	require.NoError(t, err)
 
+	var cachePoints int
 	for _, m := range messages {
-		for _, b := range m.Content {
-			assert.Nil(t, b.CachePoint, "inlined reminder must not introduce a CachePoint block")
+		for i, b := range m.Content {
+			if b.CachePoint == nil {
+				continue
+			}
+			cachePoints++
+			// A cachePoint terminates the cacheable prefix, so it must follow the text it closes over.
+			require.Greater(t, i, 0, "cachePoint must not be the first block in its message")
+			assert.NotNil(t, m.Content[i-1].Text, "cachePoint must follow a text block")
 		}
 	}
+	assert.Equal(t, 1, cachePoints, "inlined reminder must carry the client's breakpoint through")
 }
 
 // TestToolCacheControlBecomesCachePointWithTTL is the positive counterpart to

--- a/core/providers/bedrock/cache_points_test.go
+++ b/core/providers/bedrock/cache_points_test.go
@@ -1,6 +1,7 @@
 package bedrock
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -313,4 +314,204 @@ func TestBuildBedrockTokenUsage_StreamMatchesNonStream(t *testing.T) {
 		t.Errorf("cache tokens: want read=2000 write=647, got read=%d write=%d",
 			streamEvent.Usage.CacheReadInputTokens, streamEvent.Usage.CacheWriteInputTokens)
 	}
+}
+
+// --------------------------------------------------------------------------
+// Inlined mid-conversation system reminders keep their cache breakpoint.
+//
+// role:"system" inside the messages array is a real Anthropic API feature
+// (mid-conversation system messages, Opus 4.8+) that Claude Code uses for
+// <system-reminder> turns. Bedrock has no message-level system role, so
+// ConvertBifrostMessagesToBedrockMessages inlines those turns as user messages.
+// That inlining must carry the block's CacheControl across: it is the client's
+// conversation-level cache anchor, and dropping it pins the cacheable prefix at
+// the system/tools floor, leaving the whole conversation body uncached.
+// --------------------------------------------------------------------------
+
+func ephemeral() *schemas.CacheControl {
+	return &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral}
+}
+
+func responsesMessage(role schemas.ResponsesMessageRoleType, blocks ...schemas.ResponsesMessageContentBlock) schemas.ResponsesMessage {
+	return schemas.ResponsesMessage{
+		Role:    schemas.Ptr(role),
+		Content: &schemas.ResponsesMessageContent{ContentBlocks: blocks},
+	}
+}
+
+func responsesTextBlock(text string, cacheControl *schemas.CacheControl) schemas.ResponsesMessageContentBlock {
+	return schemas.ResponsesMessageContentBlock{
+		Type:         schemas.ResponsesInputMessageContentBlockTypeText,
+		Text:         schemas.Ptr(text),
+		CacheControl: cacheControl,
+	}
+}
+
+func countMessageCachePoints(messages []BedrockMessage) int {
+	total := 0
+	for _, msg := range messages {
+		for _, block := range msg.Content {
+			if block.CachePoint != nil {
+				total++
+			}
+		}
+	}
+	return total
+}
+
+func countSystemCachePoints(systemMessages []BedrockSystemMessage) int {
+	total := 0
+	for _, msg := range systemMessages {
+		if msg.CachePoint != nil {
+			total++
+		}
+	}
+	return total
+}
+
+// claudeCodeShape mirrors what Claude Code sends: two breakpoints in the leading
+// system run, then a mid-conversation reminder carrying the third,
+// conversation-level breakpoint.
+func claudeCodeShape(reminderRole schemas.ResponsesMessageRoleType) []schemas.ResponsesMessage {
+	return []schemas.ResponsesMessage{
+		responsesMessage(schemas.ResponsesInputMessageRoleSystem,
+			responsesTextBlock("You are Claude Code.", ephemeral()),
+			responsesTextBlock("Extra instructions.", ephemeral())),
+		responsesMessage(schemas.ResponsesInputMessageRoleUser, responsesTextBlock("Analyze this.", nil)),
+		responsesMessage(schemas.ResponsesInputMessageRoleAssistant, responsesTextBlock("Understood.", nil)),
+		responsesMessage(reminderRole, responsesTextBlock("Keep going.", ephemeral())),
+	}
+}
+
+// TestInlinedSystemReminder_KeepsCachePoint — the client sends 3 cache_control
+// breakpoints, so 3 cachePoints must reach Bedrock: 2 hoisted into system, and 1
+// on the inlined reminder.
+func TestInlinedSystemReminder_KeepsCachePoint(t *testing.T) {
+	messages, systemMessages, err := ConvertBifrostMessagesToBedrockMessages(
+		context.Background(), claudeCodeShape(schemas.ResponsesInputMessageRoleSystem), true)
+	if err != nil {
+		t.Fatalf("conversion error: %v", err)
+	}
+
+	if got := countSystemCachePoints(systemMessages); got != 2 {
+		t.Errorf("system cachePoints: want 2 (hoisted leading run), got %d", got)
+	}
+	if got := countMessageCachePoints(messages); got != 1 {
+		t.Errorf("message cachePoints: want 1 (the inlined reminder's anchor), got %d", got)
+	}
+	if got := countSystemCachePoints(systemMessages) + countMessageCachePoints(messages); got != 3 {
+		t.Errorf("total cachePoints: want 3 to match the 3 client breakpoints, got %d", got)
+	}
+}
+
+// TestInlinedSystemReminder_CachePointFollowsText — a cachePoint terminates the
+// cacheable prefix, so it must come after the text it closes over.
+func TestInlinedSystemReminder_CachePointFollowsText(t *testing.T) {
+	messages, _, err := ConvertBifrostMessagesToBedrockMessages(
+		context.Background(), claudeCodeShape(schemas.ResponsesInputMessageRoleSystem), true)
+	if err != nil {
+		t.Fatalf("conversion error: %v", err)
+	}
+
+	for _, msg := range messages {
+		for i, block := range msg.Content {
+			if block.CachePoint == nil {
+				continue
+			}
+			if i == 0 {
+				t.Fatal("cachePoint is the first block in its message; it must follow the text it terminates")
+			}
+			if msg.Content[i-1].Text == nil {
+				t.Errorf("block before cachePoint has no text; cachePoint must terminate a text block")
+			}
+		}
+	}
+}
+
+// TestInlinedSystemReminder_UserRoleTailUnchanged — the equivalent user-role tail
+// is the control: it already worked and must keep working identically.
+func TestInlinedSystemReminder_UserRoleTailUnchanged(t *testing.T) {
+	messages, systemMessages, err := ConvertBifrostMessagesToBedrockMessages(
+		context.Background(), claudeCodeShape(schemas.ResponsesInputMessageRoleUser), true)
+	if err != nil {
+		t.Fatalf("conversion error: %v", err)
+	}
+
+	if got := countSystemCachePoints(systemMessages) + countMessageCachePoints(messages); got != 3 {
+		t.Errorf("total cachePoints: want 3 for the control shape, got %d", got)
+	}
+}
+
+// TestInlinedSystemReminder_MultipleBreakpointsEmitOne — only the last breakpoint
+// in a single reminder is emitted, so a pathological input cannot exceed
+// Bedrock's per-request checkpoint budget.
+func TestInlinedSystemReminder_MultipleBreakpointsEmitOne(t *testing.T) {
+	input := []schemas.ResponsesMessage{
+		responsesMessage(schemas.ResponsesInputMessageRoleSystem, responsesTextBlock("You are Claude Code.", ephemeral())),
+		responsesMessage(schemas.ResponsesInputMessageRoleUser, responsesTextBlock("Analyze this.", nil)),
+		responsesMessage(schemas.ResponsesInputMessageRoleSystem,
+			responsesTextBlock("reminder one", ephemeral()),
+			responsesTextBlock("reminder two", ephemeral()),
+			responsesTextBlock("reminder three", ephemeral())),
+	}
+
+	messages, _, err := ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	if err != nil {
+		t.Fatalf("conversion error: %v", err)
+	}
+
+	if got := countMessageCachePoints(messages); got != 1 {
+		t.Errorf("message cachePoints: want 1 (last breakpoint only), got %d", got)
+	}
+}
+
+// TestInlinedSystemReminder_NoCacheControlNoCachePoint — a reminder carrying no
+// cache_control must not gain an invented cachePoint.
+func TestInlinedSystemReminder_NoCacheControlNoCachePoint(t *testing.T) {
+	input := []schemas.ResponsesMessage{
+		responsesMessage(schemas.ResponsesInputMessageRoleSystem, responsesTextBlock("You are Claude Code.", nil)),
+		responsesMessage(schemas.ResponsesInputMessageRoleUser, responsesTextBlock("Analyze this.", nil)),
+		responsesMessage(schemas.ResponsesInputMessageRoleSystem, responsesTextBlock("plain reminder", nil)),
+	}
+
+	messages, _, err := ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	if err != nil {
+		t.Fatalf("conversion error: %v", err)
+	}
+
+	if got := countMessageCachePoints(messages); got != 0 {
+		t.Errorf("message cachePoints: want 0 when the client sent no cache_control, got %d", got)
+	}
+}
+
+// TestInlinedSystemReminder_PreservesOneHourTTL — a 1h breakpoint must not be
+// silently downgraded to the 5m default.
+func TestInlinedSystemReminder_PreservesOneHourTTL(t *testing.T) {
+	input := []schemas.ResponsesMessage{
+		responsesMessage(schemas.ResponsesInputMessageRoleSystem, responsesTextBlock("You are Claude Code.", nil)),
+		responsesMessage(schemas.ResponsesInputMessageRoleUser, responsesTextBlock("Analyze this.", nil)),
+		responsesMessage(schemas.ResponsesInputMessageRoleSystem,
+			responsesTextBlock("reminder", &schemas.CacheControl{
+				Type: schemas.CacheControlTypeEphemeral,
+				TTL:  schemas.Ptr("1h"),
+			})),
+	}
+
+	messages, _, err := ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	if err != nil {
+		t.Fatalf("conversion error: %v", err)
+	}
+
+	for _, msg := range messages {
+		for _, block := range msg.Content {
+			if block.CachePoint == nil {
+				continue
+			}
+			if block.CachePoint.TTL == nil || *block.CachePoint.TTL != "1h" {
+				t.Errorf("cachePoint TTL: want \"1h\", got %v", block.CachePoint.TTL)
+			}
+			return
+		}
+	}
+	t.Fatal("no cachePoint emitted inside messages")
 }

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -3912,21 +3912,34 @@ func convertBifrostSystemReminderToBedrockUserMessage(msg *schemas.ResponsesMess
 		contentBlocks = append(contentBlocks, BedrockContentBlock{Text: &wrapped})
 	}
 
-	// Text-only by design: reminders never carry images, and we deliberately attach no cache point
-	// here — a breakpoint on this moving-tail message would shift every turn and defeat the prefix
-	// caching this inlining exists for.
+	// Text-only by design: reminders never carry images. The breakpoint below does move as the
+	// conversation grows, but it is the client's conversation-level cache anchor — dropping it pins
+	// the cacheable prefix at the system/tools floor and leaves the whole conversation body uncached,
+	// which is the collapse this inlining exists to avoid.
+	var lastCacheControl *schemas.CacheControl
 	if msg.Content.ContentStr != nil {
 		wrap(*msg.Content.ContentStr)
 	} else if msg.Content.ContentBlocks != nil {
 		for _, block := range msg.Content.ContentBlocks {
 			if block.Text != nil {
 				wrap(*block.Text)
+				if block.CacheControl != nil {
+					lastCacheControl = block.CacheControl
+				}
 			}
 		}
 	}
 
 	if len(contentBlocks) == 0 {
 		return nil
+	}
+
+	// A cachePoint terminates the cacheable prefix, so it follows the text it closes over. Only the
+	// last breakpoint in the message is emitted, to stay inside Bedrock's per-request checkpoint budget.
+	if lastCacheControl != nil {
+		contentBlocks = append(contentBlocks, BedrockContentBlock{
+			CachePoint: newBedrockCachePoint(lastCacheControl.TTL),
+		})
 	}
 
 	return &BedrockMessage{


### PR DESCRIPTION
## Summary

A mid-conversation `role:"system"` message loses its `cache_control` when inlined for Bedrock, so the client's conversation-level cache breakpoint never reaches the provider: **3 `cache_control` breakpoints in, 2 `cachePoint`s out.** With that anchor gone the cacheable prefix is pinned at the system/tools floor and the entire conversation body is re-read uncached on every turn.

`role:"system"` inside `messages` is a supported Anthropic API feature (mid-conversation system messages, Opus 4.8+ — `SupportsMidConversationSystem` returns `false` for Bedrock, correctly). Claude Code uses it for `<system-reminder>` turns, so this fires on ordinary Claude Code traffic through Bedrock.

## Reproduction

`claude-opus-5` on Bedrock via `/anthropic/v1/messages`. Both arms send identical content and an identical third breakpoint; the only difference is whether the tail breakpoint rides on a `role:"user"` or `role:"system"` turn. Each arm is called twice — once to warm the prefix, once to measure.

| Tail breakpoint rides on | uncached `input_tokens` | `cache_read_input_tokens` | Real hit rate |
|---|---:|---:|---:|
| `role:"user"` (control) | 2 | 36,115 | **100.0%** |
| `role:"system"` | 18,116 | 18,018 | **49.9%** |

Roughly half the input goes uncached on an otherwise identical, already-warm prefix.

Wire-level, same pair of calls — both received `cache_control` × 3:

| Arm | `cachePoint` emitted | Placement |
|---|---:|---|
| control | 3 | 2 in `system` + 1 in `messages` |
| affected | 2 | 2 in `system`, **none in `messages`** |

Also reproduces via `/openai/v1/responses` with `claude-sonnet-5` (100.0% → 66.5%), so it is in the Bedrock converter rather than one inbound translation layer.

The reproduction is self-contained: any Claude-Code-shaped payload with two `system` breakpoints plus a third on a trailing `role:"system"` turn shows it, and the arms differ by ~18K cached tokens — far outside noise. Sampling large real requests and inspecting the emitted Converse body separated cleanly on the same marker: affected requests emit 2 `cachePoint`s and end in a `role:system` item, unaffected ones emit 3.

A representative sequence of three consecutive requests over one growing conversation, seconds apart, same model and key:

| # | cache read ÷ prompt tokens | cache write |
|---|---:|---:|
| 1 | 99.9% | small |
| 2 | **8.0%** | **0** |
| 3 | 99.4% | small |

Request 2 reads 8% of a prefix that was warm one second earlier and writes nothing — not a cold start, not TTL expiry, not a routing change. Its only distinguishing feature is a trailing `role:system` item carrying the breakpoint.

## On the previous behavior

`TestSystemReminderDoesNotCarryCachePoint` pinned the omission deliberately, reasoning that a breakpoint at the moving conversation tail shifts every turn and defeats prefix caching. I think the premise is right and the conclusion inverted:

1. A breakpoint that advances each turn is how incremental conversation caching is meant to work — it extends the cached prefix by one turn for the cost of one write.
2. Dropping it doesn't fall back to a safe state; it removes the *only* conversation-level breakpoint, which is the collapse `inlineSystemReminders` exists to prevent.
3. Measured: preserving it is 100% vs 49.9%.

The rationale would hold if the reminder were appended *after* the last breakpoint. Here the reminder **carries** the breakpoint. That test is replaced by `TestSystemReminderCarriesCachePoint`; happy to revisit if there's a case I'm not seeing.

## Changes

- `convertBifrostSystemReminderToBedrockUserMessage` carries the block's `CacheControl` through and appends a `cachePoint` **after** the text block it terminates (Converse semantics).
- Only the **last** breakpoint within a single reminder is emitted, so a pathological input can't exceed Bedrock's per-request checkpoint budget.
- Reminders with no `cache_control` are unchanged — no invented `cachePoint`.
- The `1h` TTL is preserved rather than silently downgraded to 5m.

## Tests

Six cases in `cache_points_test.go` covering the contract: breakpoint preserved, ordering after text, user-role control unchanged, multiple breakpoints collapse to one, absent `cache_control` stays absent, 1h TTL preserved. Verified to **fail against unpatched `dev`** (3 of 6) and pass with the change. Full `core/providers/...` and `core/schemas/...` suites pass; `gofmt` and `go vet` clean.
