### PR TITLE
cache control fixes for anthropic and bedrock

### DIFF
--- a/core/providers/anthropic/cachebreakpointclamp_test.go
+++ b/core/providers/anthropic/cachebreakpointclamp_test.go
@@ -1,0 +1,182 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// Anthropic, Bedrock, and Vertex all reject a request carrying more than 4 blocks with
+// cache_control ("A maximum of 4 blocks with cache_control may be provided. Found 5."), verified
+// live against all three. These tests pin the clamp that keeps an over-marked request from
+// failing outright, and — more importantly — pin WHICH markers it sacrifices.
+//
+// The direction is the whole design. Caching is cumulative up to each breakpoint, so a marker
+// later in render order (tools -> system -> messages) anchors a strictly longer prefix than an
+// earlier one. Dropping the earliest costs an intermediate checkpoint; dropping the latest would
+// surrender the longest cached prefix, which is the exact failure inlineMidConversationSystem
+// exists to prevent. A clamp that trimmed the wrong end would look correct (no 400s) while
+// silently reintroducing the bug this package spent a fix on.
+
+func cachedBlock(text string) AnthropicContentBlock {
+	return AnthropicContentBlock{
+		Type:         AnthropicContentBlockTypeText,
+		Text:         schemas.Ptr(text),
+		CacheControl: &schemas.CacheControl{Type: "ephemeral"},
+	}
+}
+
+// markerTexts returns the text of every block still carrying a cache_control marker, in render
+// order, so a test can assert on identity rather than count alone.
+func markerTexts(req *AnthropicMessageRequest) []string {
+	var out []string
+	for i := range req.Tools {
+		if req.Tools[i].CacheControl != nil {
+			out = append(out, "tool:"+req.Tools[i].Name)
+		}
+	}
+	if req.System != nil {
+		for _, b := range req.System.ContentBlocks {
+			if b.CacheControl != nil && b.Text != nil {
+				out = append(out, *b.Text)
+			}
+		}
+	}
+	for _, m := range req.Messages {
+		for _, b := range m.Content.ContentBlocks {
+			if b.CacheControl != nil && b.Text != nil {
+				out = append(out, *b.Text)
+			}
+		}
+	}
+	return out
+}
+
+func eq(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestClampAnthropicCacheBreakpoints_UnderCapUntouched is the guard against over-eager clamping:
+// a request at or below the cap must pass through byte-identical, since removing a marker there
+// would cost cache coverage for no reason.
+func TestClampAnthropicCacheBreakpoints_UnderCapUntouched(t *testing.T) {
+	for _, n := range []int{0, 1, AnthropicMaxCacheBreakpoints} {
+		req := &AnthropicMessageRequest{}
+		var want []string
+		for i := 0; i < n; i++ {
+			text := string(rune('a' + i))
+			req.Messages = append(req.Messages, AnthropicMessage{
+				Role:    AnthropicMessageRoleUser,
+				Content: AnthropicContent{ContentBlocks: []AnthropicContentBlock{cachedBlock(text)}},
+			})
+			want = append(want, text)
+		}
+		if dropped := clampAnthropicCacheBreakpoints(req); dropped != 0 {
+			t.Errorf("n=%d: dropped %d, want 0", n, dropped)
+		}
+		if got := markerTexts(req); !eq(got, want) {
+			t.Errorf("n=%d: markers = %v, want %v", n, got, want)
+		}
+	}
+}
+
+// TestClampAnthropicCacheBreakpoints_DropsEarliest covers the load-bearing behavior: with six
+// markers spread across all three render regions, the two earliest go and the four latest stay.
+func TestClampAnthropicCacheBreakpoints_DropsEarliest(t *testing.T) {
+	req := &AnthropicMessageRequest{
+		Tools: []AnthropicTool{
+			{Name: "alpha", CacheControl: &schemas.CacheControl{Type: "ephemeral"}},
+		},
+		System: &AnthropicContent{ContentBlocks: []AnthropicContentBlock{
+			cachedBlock("sys1"),
+			cachedBlock("sys2"),
+		}},
+		Messages: []AnthropicMessage{
+			{Role: AnthropicMessageRoleUser, Content: AnthropicContent{ContentBlocks: []AnthropicContentBlock{cachedBlock("msg1")}}},
+			{Role: AnthropicMessageRoleUser, Content: AnthropicContent{ContentBlocks: []AnthropicContentBlock{cachedBlock("msg2")}}},
+			{Role: AnthropicMessageRoleUser, Content: AnthropicContent{ContentBlocks: []AnthropicContentBlock{cachedBlock("msg3")}}},
+		},
+	}
+
+	dropped := clampAnthropicCacheBreakpoints(req)
+	if want := 6 - AnthropicMaxCacheBreakpoints; dropped != want {
+		t.Fatalf("dropped = %d, want %d", dropped, want)
+	}
+	// tool:alpha and sys1 are the two earliest in render order and must be the ones sacrificed.
+	want := []string{"sys2", "msg1", "msg2", "msg3"}
+	if got := markerTexts(req); !eq(got, want) {
+		t.Errorf("surviving markers = %v, want %v (the LATEST four — dropping the tail would "+
+			"surrender the longest cached prefix)", got, want)
+	}
+}
+
+// TestClampAnthropicCacheBreakpoints_KeepsConversationAnchor is the regression guard tying this
+// clamp back to the mid-conversation fix. A Claude-Code-shaped request sits exactly at the cap
+// (2 system + 1 tool result + 1 inlined reminder); adding one more marker must not cost the
+// reminder's anchor, because that anchor is what keeps the conversation body cacheable.
+func TestClampAnthropicCacheBreakpoints_KeepsConversationAnchor(t *testing.T) {
+	req := &AnthropicMessageRequest{
+		System: &AnthropicContent{ContentBlocks: []AnthropicContentBlock{
+			cachedBlock("system-prompt"),
+			cachedBlock("tool-definitions"),
+		}},
+		Messages: []AnthropicMessage{
+			{Role: AnthropicMessageRoleUser, Content: AnthropicContent{ContentBlocks: []AnthropicContentBlock{cachedBlock("tool-result-1")}}},
+			{Role: AnthropicMessageRoleUser, Content: AnthropicContent{ContentBlocks: []AnthropicContentBlock{cachedBlock("tool-result-2")}}},
+			{Role: AnthropicMessageRoleUser, Content: AnthropicContent{ContentBlocks: []AnthropicContentBlock{cachedBlock("<system-reminder>")}}},
+		},
+	}
+
+	if dropped := clampAnthropicCacheBreakpoints(req); dropped != 1 {
+		t.Fatalf("dropped = %d, want 1", dropped)
+	}
+	got := markerTexts(req)
+	if len(got) != AnthropicMaxCacheBreakpoints {
+		t.Fatalf("markers = %v, want %d", got, AnthropicMaxCacheBreakpoints)
+	}
+	if got[len(got)-1] != "<system-reminder>" {
+		t.Errorf("the conversation-level anchor was dropped (markers = %v); clamping must never "+
+			"sacrifice the last breakpoint — that is the whole point of the inlining fix", got)
+	}
+}
+
+// TestClampAnthropicCacheBreakpoints_TopLevelMarkerSurvives pins the ordering choice for the
+// top-level cache_control, which auto-places on the last cacheable block and is therefore
+// effectively the final breakpoint.
+func TestClampAnthropicCacheBreakpoints_TopLevelMarkerSurvives(t *testing.T) {
+	req := &AnthropicMessageRequest{
+		CacheControl: &schemas.CacheControl{Type: "ephemeral"},
+		System: &AnthropicContent{ContentBlocks: []AnthropicContentBlock{
+			cachedBlock("sys1"), cachedBlock("sys2"), cachedBlock("sys3"), cachedBlock("sys4"),
+		}},
+	}
+
+	if dropped := clampAnthropicCacheBreakpoints(req); dropped != 1 {
+		t.Fatalf("dropped = %d, want 1", dropped)
+	}
+	if req.CacheControl == nil {
+		t.Error("top-level cache_control was cleared; it auto-places on the last cacheable block, "+
+			"so it is the final breakpoint and should outrank earlier explicit ones")
+	}
+	if got, want := markerTexts(req), []string{"sys2", "sys3", "sys4"}; !eq(got, want) {
+		t.Errorf("surviving block markers = %v, want %v", got, want)
+	}
+}
+
+// TestClampAnthropicCacheBreakpoints_NilSafe guards the trivial inputs.
+func TestClampAnthropicCacheBreakpoints_NilSafe(t *testing.T) {
+	if dropped := clampAnthropicCacheBreakpoints(nil); dropped != 0 {
+		t.Errorf("nil request: dropped = %d, want 0", dropped)
+	}
+	if dropped := clampAnthropicCacheBreakpoints(&AnthropicMessageRequest{}); dropped != 0 {
+		t.Errorf("empty request: dropped = %d, want 0", dropped)
+	}
+}

--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -680,6 +680,11 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 	// (Anthropic API + Opus 4.8+ only).
 	seenConversation := false
 	midConvSystemSupported := SupportsMidConversationSystem(bifrostReq.Provider, capModel)
+	// See the same gate in ConvertBifrostMessagesToAnthropicMessages: when the native
+	// role:"system" form isn't available, inline as a user turn instead of hoisting into the
+	// top-level system block, which would invalidate the cached prefix behind it. Anthropic
+	// model family only — these call sites also serve DeepSeek/Fireworks/SGL, which keep hoisting.
+	inlineMidConvSystem := schemas.IsAnthropicModelFamily(ctx, capModel)
 
 	i := 0
 	for i < len(messages) {
@@ -687,11 +692,16 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 
 		switch msg.Role {
 		case schemas.ChatMessageRoleSystem, schemas.ChatMessageRoleDeveloper:
-			// Anthropic placement rule: a mid-conv system message must end the array
-			// or be immediately followed by an assistant turn. Anything else (e.g.
-			// [user, system, user]) returns a 400, so fall through to top-level system.
-			midConvPlacementOK := i == len(messages)-1 ||
-				messages[i+1].Role == schemas.ChatMessageRoleAssistant
+			// Anthropic placement rule, both clauses: a mid-conv system message must FOLLOW a
+			// user message (or an assistant message ending in server-tool use) AND must end the
+			// array or be immediately followed by an assistant turn. Violating either returns a
+			// 400 ("messages.N: role 'system' must follow a 'user' message ..."). Checking only
+			// the trailing clause lets [.., assistant, system, assistant] through to a 400, so
+			// both are checked here; the assistant-ending-in-server-tool-use exception is not
+			// recognized, which only costs a cache-preserving fallback, never a rejection.
+			midConvPlacementOK := (i == len(messages)-1 ||
+				messages[i+1].Role == schemas.ChatMessageRoleAssistant) &&
+				i > 0 && messages[i-1].Role == schemas.ChatMessageRoleUser
 			if seenConversation && midConvSystemSupported && midConvPlacementOK {
 				// Mid-conversation system message — emit directly as role:"system".
 				var content AnthropicContent
@@ -740,6 +750,18 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 							newContent = AnthropicContent{ContentBlocks: blocks}
 						}
 					}
+				}
+				// Native form unavailable (unsupported model, or a placement Anthropic
+				// rejects). Inline in place so the cache anchor stays inside `messages`
+				// rather than collapsing the cached prefix from the top-level system block.
+				var inlined *AnthropicMessage
+				if seenConversation && inlineMidConvSystem {
+					inlined = inlineMidConversationSystem(&newContent)
+				}
+				if inlined != nil {
+					anthropicMessages = append(anthropicMessages, *inlined)
+					i++
+					continue
 				}
 				systemContent = appendToSystemContent(systemContent, newContent)
 				// If the entire transcript consists only of system/developer messages
@@ -970,6 +992,11 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 	// provider does not support. Fail-closed tool validation stays in
 	// ValidateToolsForProvider; this is strip-silently for additive fields.
 	stripUnsupportedAnthropicFields(anthropicReq, bifrostReq.Provider, capModel)
+
+	// Exceeding the provider's cache-checkpoint cap is a hard rejection, not a degradation, so
+	// trim the earliest markers rather than let the whole request fail. Runs last, after every
+	// converter branch (including the mid-conversation inline fallback) has contributed markers.
+	clampAnthropicCacheBreakpoints(anthropicReq)
 
 	return anthropicReq, nil
 }

--- a/core/providers/anthropic/chat_test.go
+++ b/core/providers/anthropic/chat_test.go
@@ -1664,10 +1664,64 @@ func TestToAnthropicChatRequest_MidConversationSystem_Opus48(t *testing.T) {
 	}
 }
 
-// TestToAnthropicChatRequest_MidConversationSystem_InvalidPlacement verifies
-// that a mid-conv system message with invalid placement (followed by user, not
-// assistant) falls back to top-level system accumulation rather than emitting
-// a role:"system" that would 400 on the Anthropic API.
+// assertInlinedReminder asserts that `text` reached the messages array as a mid-conversation
+// reminder inlined into a user turn (the <system-reminder> envelope), and that it did NOT end up
+// in the top-level system block. Hoisting into `system` preserves the text but renders it ahead
+// of every message, invalidating the cached prefix behind it — measured at roughly half the
+// prompt on a warm conversation. See inlineMidConversationSystem.
+func assertInlinedReminder(t *testing.T, result *AnthropicMessageRequest, text string) {
+	t.Helper()
+	want := "<system-reminder>\n" + text + "\n</system-reminder>\n"
+
+	var found bool
+	for _, msg := range result.Messages {
+		if msg.Role != AnthropicMessageRoleUser {
+			continue
+		}
+		for _, block := range msg.Content.ContentBlocks {
+			if block.Text != nil && *block.Text == want {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected %q inlined as a <system-reminder> user turn, roles were %v", text, chatRoleSeq(result.Messages))
+	}
+
+	if result.System != nil {
+		if result.System.ContentStr != nil && strings.Contains(*result.System.ContentStr, text) {
+			t.Errorf("mid-conversation content %q was hoisted into top-level system; that collapses the cached prefix", text)
+		}
+		for _, block := range result.System.ContentBlocks {
+			if block.Text != nil && strings.Contains(*block.Text, text) {
+				t.Errorf("mid-conversation content %q was hoisted into top-level system; that collapses the cached prefix", text)
+			}
+		}
+	}
+
+	for i, msg := range result.Messages {
+		if msg.Role == AnthropicMessageRoleSystem {
+			t.Errorf("msg[%d] has role:system — the inline fallback must not emit one", i)
+		}
+	}
+}
+
+func chatRoleSeq(msgs []AnthropicMessage) []string {
+	out := make([]string, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, string(m.Role))
+	}
+	return out
+}
+
+// TestToAnthropicChatRequest_MidConversationSystem_InvalidPlacement verifies that a mid-conv
+// system message Anthropic would reject on placement grounds is inlined rather than forwarded.
+//
+// Anthropic enforces two clauses: the turn must FOLLOW a user message and must be last or
+// followed by an assistant turn. This input violates both (it follows an assistant and is
+// followed by a user), so forwarding it returns 400. The converter previously fell back to
+// hoisting into top-level system, which avoided the 400 but collapsed the cached prefix; it now
+// inlines, which avoids the 400 AND keeps the cache anchor inside `messages`.
 func TestToAnthropicChatRequest_MidConversationSystem_InvalidPlacement(t *testing.T) {
 	bifrostReq := &schemas.BifrostChatRequest{
 		Provider: schemas.Anthropic,
@@ -1676,7 +1730,7 @@ func TestToAnthropicChatRequest_MidConversationSystem_InvalidPlacement(t *testin
 			{Role: schemas.ChatMessageRoleSystem, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Initial.")}},
 			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Hello")}},
 			{Role: schemas.ChatMessageRoleAssistant, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Hi!")}},
-			// system followed by user — invalid placement, Anthropic returns 400
+			// Follows an assistant AND is followed by a user — violates both clauses.
 			{Role: schemas.ChatMessageRoleSystem, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Bad placement.")}},
 			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Continue")}},
 		},
@@ -1690,32 +1744,21 @@ func TestToAnthropicChatRequest_MidConversationSystem_InvalidPlacement(t *testin
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Invalid placement: falls back to top-level system accumulation.
+	// The leading system prompt still hoists — only mid-conversation content inlines.
 	if result.System == nil {
-		t.Fatal("expected top-level System to contain both initial and fallback content")
+		t.Fatal("expected the leading system prompt to remain in top-level System")
 	}
-	blocks := result.System.ContentBlocks
-	if len(blocks) != 2 {
-		t.Fatalf("expected 2 system blocks (initial + fallback), got %d", len(blocks))
+	if got := textBlocks(result.System); len(got) != 1 || got[0] != "Initial." {
+		t.Errorf("top-level System = %v, want exactly [\"Initial.\"]", got)
 	}
-	if blocks[0].Text == nil || *blocks[0].Text != "Initial." {
-		t.Errorf("block[0] = %v, want \"Initial.\"", blocks[0].Text)
-	}
-	if blocks[1].Text == nil || *blocks[1].Text != "Bad placement." {
-		t.Errorf("block[1] = %v, want \"Bad placement.\"", blocks[1].Text)
-	}
-	// No role:"system" in messages array.
-	for i, msg := range result.Messages {
-		if msg.Role == AnthropicMessageRoleSystem {
-			t.Errorf("msg[%d] has role:system — invalid placement should have been caught", i)
-		}
-	}
+	assertInlinedReminder(t, result, "Bad placement.")
 }
 
-// TestToAnthropicChatRequest_MidConversationSystem_FallbackAppends verifies that
-// for a non-supporting model/provider the mid-conversation system content is
-// appended to (not overwrites) the top-level system field.
-func TestToAnthropicChatRequest_MidConversationSystem_FallbackAppends(t *testing.T) {
+// TestToAnthropicChatRequest_MidConversationSystem_FallbackInlines verifies the fallback for a
+// provider that cannot carry role:"system" at all. Bedrock, Vertex, and Foundry do not expose
+// mid-conversation system messages regardless of model, so every such message takes the fallback
+// path — which inlines rather than hoisting.
+func TestToAnthropicChatRequest_MidConversationSystem_FallbackInlines(t *testing.T) {
 	bifrostReq := &schemas.BifrostChatRequest{
 		Provider: schemas.Bedrock,
 		Model:    "global.anthropic.claude-opus-4-8",
@@ -1736,31 +1779,18 @@ func TestToAnthropicChatRequest_MidConversationSystem_FallbackAppends(t *testing
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Top-level system field must exist and contain BOTH the initial and mid-conv content.
 	if result.System == nil {
-		t.Fatal("expected top-level System to be set")
+		t.Fatal("expected the leading system prompt to remain in top-level System")
 	}
-	if len(result.System.ContentBlocks) != 2 {
-		t.Fatalf("expected 2 system content blocks (initial + mid-conv appended), got %d", len(result.System.ContentBlocks))
+	if got := textBlocks(result.System); len(got) != 1 || got[0] != "Initial system." {
+		t.Errorf("top-level System = %v, want exactly [\"Initial system.\"]", got)
 	}
-	if result.System.ContentBlocks[0].Text == nil || *result.System.ContentBlocks[0].Text != "Initial system." {
-		t.Errorf("block[0] = %v, want 'Initial system.'", result.System.ContentBlocks[0].Text)
-	}
-	if result.System.ContentBlocks[1].Text == nil || *result.System.ContentBlocks[1].Text != "Mid-conv instruction." {
-		t.Errorf("block[1] = %v, want 'Mid-conv instruction.'", result.System.ContentBlocks[1].Text)
-	}
-
-	// No role:"system" entry should appear in the messages array.
-	for i, msg := range result.Messages {
-		if msg.Role == AnthropicMessageRoleSystem {
-			t.Errorf("msg[%d] has role system — should not appear for Bedrock", i)
-		}
-	}
+	assertInlinedReminder(t, result, "Mid-conv instruction.")
 }
 
-// TestToAnthropicChatRequest_MidConversationSystem_NotOnOpus47 verifies that
-// mid-conversation system messages are NOT emitted for Opus 4.7 (feature is
-// Opus 4.8+ only).
+// TestToAnthropicChatRequest_MidConversationSystem_NotOnOpus47 verifies that a model predating
+// the feature (Opus 4.7; it is Opus 4.8+) takes the inline fallback rather than emitting a
+// role:"system" the API would reject.
 func TestToAnthropicChatRequest_MidConversationSystem_NotOnOpus47(t *testing.T) {
 	bifrostReq := &schemas.BifrostChatRequest{
 		Provider: schemas.Anthropic,
@@ -1781,29 +1811,7 @@ func TestToAnthropicChatRequest_MidConversationSystem_NotOnOpus47(t *testing.T) 
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Mid-conv instruction must be preserved in the top-level System field.
-	if result.System == nil {
-		t.Fatal("expected top-level System to contain fallback mid-conversation instruction")
-	}
-	foundFallback := false
-	if result.System.ContentStr != nil && *result.System.ContentStr == "New instruction." {
-		foundFallback = true
-	}
-	for _, block := range result.System.ContentBlocks {
-		if block.Text != nil && *block.Text == "New instruction." {
-			foundFallback = true
-			break
-		}
-	}
-	if !foundFallback {
-		t.Fatal("expected mid-conversation system content to be preserved in top-level System")
-	}
-
-	for i, msg := range result.Messages {
-		if msg.Role == AnthropicMessageRoleSystem {
-			t.Errorf("msg[%d] has role system — should not appear for Opus 4.7", i)
-		}
-	}
+	assertInlinedReminder(t, result, "New instruction.")
 }
 
 // TestToBifrostChatCompletionStream_NoArgToolFlushesEmptyObject covers the

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -3966,6 +3966,10 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 		anthropicReq.Messages = anthropicMessages
 	}
 
+	// See the same call in ToAnthropicChatRequest: over the cap the provider rejects the request
+	// outright, so trim the earliest markers instead of failing.
+	clampAnthropicCacheBreakpoints(anthropicReq)
+
 	return anthropicReq, nil
 }
 
@@ -4376,6 +4380,13 @@ func ConvertBifrostMessagesToAnthropicMessages(ctx *schemas.BifrostContext, bifr
 	// role:"system" in the messages array when the provider+model supports it.
 	seenConversation := false
 	midConvSystemSupported := isRequestMessage && SupportsMidConversationSystem(provider, model)
+	// When the native role:"system" form isn't available, inline the reminder as a user turn
+	// rather than hoisting it into the top-level system block — hoisting preserves the
+	// breakpoint but invalidates the cached prefix behind it, costing roughly half the prompt on
+	// a warm conversation. Gated on the Anthropic model family because these call sites also
+	// serve DeepSeek/Fireworks/SGL over the Anthropic wire shape, and the <system-reminder>
+	// envelope is a Claude convention those models never asked for; they keep hoisting.
+	inlineMidConvSystem := isRequestMessage && schemas.IsAnthropicModelFamily(ctx, model)
 
 	var anthropicMessages []AnthropicMessage
 	var systemContent *AnthropicContent
@@ -4400,6 +4411,29 @@ func ConvertBifrostMessagesToAnthropicMessages(ctx *schemas.BifrostContext, bifr
 	// previous_response_id pattern without its originating function_call) and must
 	// NOT be emitted as a tool_result, or Anthropic rejects the whole request.
 	knownToolUseIDs := make(map[string]bool)
+
+	// midConvPlacementOK reports whether a mid-conversation system message at input index i can
+	// legally be forwarded as role:"system". Anthropic enforces two clauses and rejects a
+	// violation of either with "messages.N: role 'system' must follow a 'user' message ...":
+	// the turn must FOLLOW a user message (or an assistant message ending in server-tool use),
+	// and it must be either the last entry or be followed by an assistant turn.
+	//
+	// The check is deliberately conservative — it looks at what has actually been emitted rather
+	// than trying to predict how the remaining input items will map to output messages, and it
+	// does not attempt to recognize the assistant-ending-in-server-tool-use exception. A
+	// false negative costs nothing: the caller falls back to inlining, which is cache-preserving
+	// and always accepted. A false positive would be a 400.
+	midConvPlacementOK := func(i int) bool {
+		if len(anthropicMessages) == 0 ||
+			anthropicMessages[len(anthropicMessages)-1].Role != AnthropicMessageRoleUser {
+			return false
+		}
+		if i == len(bifrostMessages)-1 {
+			return true
+		}
+		next := bifrostMessages[i+1]
+		return next.Role != nil && *next.Role == schemas.ResponsesInputMessageRoleAssistant
+	}
 
 	// Helper to emit orphaned tool results (no matching tool_use) as a single user
 	// text message so their content is preserved without violating Anthropic's
@@ -4573,13 +4607,22 @@ func ConvertBifrostMessagesToAnthropicMessages(ctx *schemas.BifrostContext, bifr
 					seenConversation = true
 				}
 				if content := convertBifrostMessageToAnthropicSystemContent(&msg); content != nil {
-					if seenConversation && midConvSystemSupported {
+					switch {
+					case seenConversation && midConvSystemSupported && midConvPlacementOK(i):
 						// Mid-conversation system message — emit as role:"system" in messages array.
 						anthropicMessages = append(anthropicMessages, AnthropicMessage{
 							Role:    AnthropicMessageRoleSystem,
 							Content: *content,
 						})
-					} else {
+					case seenConversation && inlineMidConvSystem:
+						// Native form unavailable (unsupported model, or a placement Anthropic
+						// rejects). Inline in place so the cache anchor stays inside `messages`
+						// instead of collapsing the prefix from the system block.
+						if inlined := inlineMidConversationSystem(content); inlined != nil {
+							anthropicMessages = append(anthropicMessages, *inlined)
+						}
+					default:
+						// Leading system run, or a non-Anthropic model: hoist (historical behavior).
 						systemContent = appendToSystemContent(systemContent, *content)
 					}
 				}

--- a/core/providers/anthropic/roundtrip_test.go
+++ b/core/providers/anthropic/roundtrip_test.go
@@ -117,8 +117,48 @@ func TestRoundTrip_A_TopLevelSystemOnly(t *testing.T) {
 	}
 }
 
-// --- B: top-level system + mid-conv, supported ------------------------------
+// inlinedText renders the <system-reminder> envelope a mid-conversation system message takes when
+// it is inlined into a user turn (see inlineMidConversationSystem).
+func inlinedText(text string) string {
+	return "<system-reminder>\n" + text + "\n</system-reminder>\n"
+}
 
+// assertInlined asserts `text` reached the messages array wrapped in a user turn and did NOT get
+// hoisted into the top-level system block.
+func assertInlined(t *testing.T, outMsgs []AnthropicMessage, outSystem *AnthropicContent, text string) {
+	t.Helper()
+	want := inlinedText(text)
+	var found bool
+	for _, m := range outMsgs {
+		if m.Role != AnthropicMessageRoleUser {
+			continue
+		}
+		for _, got := range textBlocks(&m.Content) {
+			if got == want {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected %q inlined as a <system-reminder> user turn; roles = %q", text, roleSeq(outMsgs))
+	}
+	for _, got := range textBlocks(outSystem) {
+		if strings.Contains(got, text) {
+			t.Errorf("%q was hoisted into top-level system; that collapses the cached prefix", text)
+		}
+	}
+}
+
+// --- B: top-level system + mid-conv, supported model, ILLEGAL placement -----
+
+// The [user, assistant, system, user] shape here is Claude Code's real traffic shape, and it
+// violates both of Anthropic's placement clauses: the system turn follows an assistant rather
+// than a user, and is followed by a user rather than an assistant. The API rejects it with
+// "messages.2: role 'system' must follow a 'user' message". This test previously asserted the
+// converter forwards it as role:"system" — i.e. it certified a request the endpoint 400s on,
+// because the converter never checked placement and the round-trip never touched the API. The
+// converter now falls back to inlining, which is accepted and keeps the cache anchor in
+// `messages`. See TestRoundTrip_B2 for the legal placement that still forwards natively.
 func TestRoundTrip_B_TopLevelAndMidConv_Supported(t *testing.T) {
 	messages := []AnthropicMessage{
 		anthMsg(AnthropicMessageRoleUser, "Hello"),
@@ -130,23 +170,37 @@ func TestRoundTrip_B_TopLevelAndMidConv_Supported(t *testing.T) {
 
 	outMsgs, outSystem := roundTrip(t, messages, system, schemas.Anthropic, "claude-opus-4-8")
 
-	// Top-level system is unchanged.
-	got := textBlocks(outSystem)
-	if len(got) != 1 || got[0] != "You are a helpful assistant." {
+	if got := textBlocks(outSystem); len(got) != 1 || got[0] != "You are a helpful assistant." {
 		t.Errorf("system = %v, want [\"You are a helpful assistant.\"]", got)
 	}
-	// Role sequence: user,assistant,system,user — mid-conv system preserved in array.
-	want := "user,assistant,system,user"
-	if roleSeq(outMsgs) != want {
+	if want := "user,assistant,user,user"; roleSeq(outMsgs) != want {
 		t.Errorf("role seq = %q, want %q", roleSeq(outMsgs), want)
 	}
-	// Mid-conv system carries the right text.
-	if outMsgs[2].Role != AnthropicMessageRoleSystem {
-		t.Fatalf("msg[2].role = %q, want system", outMsgs[2].Role)
+	assertInlined(t, outMsgs, outSystem, "From now on, be concise.")
+}
+
+// --- B2: top-level system + mid-conv, supported model, LEGAL placement ------
+
+// The native forwarding path: the system turn follows a user message and is followed by an
+// assistant turn, satisfying both clauses, so it is emitted as role:"system" unchanged.
+func TestRoundTrip_B2_MidConvLegalPlacement_Supported(t *testing.T) {
+	messages := []AnthropicMessage{
+		anthMsg(AnthropicMessageRoleUser, "Hello"),
+		anthMsg(AnthropicMessageRoleSystem, "From now on, be concise."),
+		anthMsg(AnthropicMessageRoleAssistant, "Understood."),
 	}
-	midText := textBlocks(&outMsgs[2].Content)
-	if len(midText) == 0 || midText[0] != "From now on, be concise." {
-		t.Errorf("mid-conv system text = %v, want [\"From now on, be concise.\"]", midText)
+	system := systemStr("You are a helpful assistant.")
+
+	outMsgs, outSystem := roundTrip(t, messages, system, schemas.Anthropic, "claude-opus-4-8")
+
+	if got := textBlocks(outSystem); len(got) != 1 || got[0] != "You are a helpful assistant." {
+		t.Errorf("system = %v, want [\"You are a helpful assistant.\"]", got)
+	}
+	if want := "user,system,assistant"; roleSeq(outMsgs) != want {
+		t.Fatalf("role seq = %q, want %q", roleSeq(outMsgs), want)
+	}
+	if got := textBlocks(&outMsgs[1].Content); len(got) == 0 || got[0] != "From now on, be concise." {
+		t.Errorf("mid-conv system text = %v, want [\"From now on, be concise.\"]", got)
 	}
 }
 
@@ -163,27 +217,21 @@ func TestRoundTrip_C_TopLevelAndMidConv_Bedrock(t *testing.T) {
 
 	outMsgs, outSystem := roundTrip(t, messages, system, schemas.Bedrock, "global.anthropic.claude-opus-4-8")
 
-	// System must contain BOTH initial and mid-conv text (appended, not overwritten).
-	got := textBlocks(outSystem)
-	if len(got) != 2 {
-		t.Fatalf("system blocks = %v (len=%d), want 2", got, len(got))
+	// Only the leading system prompt stays in the top-level block. Appending the mid-conversation
+	// text here (the previous behavior) renders it ahead of every message and invalidates the
+	// cached prefix behind it.
+	if got := textBlocks(outSystem); len(got) != 1 || got[0] != "You are a helpful assistant." {
+		t.Errorf("system = %v, want exactly [\"You are a helpful assistant.\"]", got)
 	}
-	if got[0] != "You are a helpful assistant." {
-		t.Errorf("system[0] = %q, want \"You are a helpful assistant.\"", got[0])
-	}
-	if got[1] != "Be concise." {
-		t.Errorf("system[1] = %q, want \"Be concise.\"", got[1])
-	}
-	// No role:"system" in messages array.
 	for i, m := range outMsgs {
 		if m.Role == AnthropicMessageRoleSystem {
 			t.Errorf("msg[%d] has role:system — must not appear for Bedrock", i)
 		}
 	}
-	// Mid-conv system removed from message sequence.
-	if want := "user,assistant,user"; roleSeq(outMsgs) != want {
+	if want := "user,assistant,user,user"; roleSeq(outMsgs) != want {
 		t.Errorf("role seq = %q, want %q", roleSeq(outMsgs), want)
 	}
+	assertInlined(t, outMsgs, outSystem, "Be concise.")
 }
 
 // --- D: top-level system + mid-conv, unsupported model (Opus 4.7) -----------
@@ -199,26 +247,18 @@ func TestRoundTrip_D_TopLevelAndMidConv_Opus47(t *testing.T) {
 
 	outMsgs, outSystem := roundTrip(t, messages, system, schemas.Anthropic, "claude-opus-4-7")
 
-	// Initial system preserved; mid-conv appended.
-	got := textBlocks(outSystem)
-	if len(got) != 2 {
-		t.Fatalf("system blocks = %v (len=%d), want 2", got, len(got))
+	if got := textBlocks(outSystem); len(got) != 1 || got[0] != "Initial instruction." {
+		t.Errorf("system = %v, want exactly [\"Initial instruction.\"]", got)
 	}
-	if got[0] != "Initial instruction." {
-		t.Errorf("system[0] = %q, want \"Initial instruction.\"", got[0])
-	}
-	if got[1] != "Be concise." {
-		t.Errorf("system[1] = %q, want \"Be concise.\"", got[1])
-	}
-	// No system role in messages.
 	for i, m := range outMsgs {
 		if m.Role == AnthropicMessageRoleSystem {
 			t.Errorf("msg[%d] has role:system for Opus 4.7", i)
 		}
 	}
-	if want := "user,assistant,user"; roleSeq(outMsgs) != want {
+	if want := "user,assistant,user,user"; roleSeq(outMsgs) != want {
 		t.Errorf("role seq = %q, want %q", roleSeq(outMsgs), want)
 	}
+	assertInlined(t, outMsgs, outSystem, "Be concise.")
 }
 
 // --- E: no top-level system, mid-conv only, supported -----------------------
@@ -233,18 +273,15 @@ func TestRoundTrip_E_NoTopLevelSystem_MidConvOnly_Supported(t *testing.T) {
 
 	outMsgs, outSystem := roundTrip(t, messages, nil, schemas.Anthropic, "claude-opus-4-8")
 
-	// No top-level system expected.
+	// Nothing is promoted into the top-level system block: inlining leaves it empty, which is
+	// what keeps the (absent) prefix from being invalidated.
 	if outSystem != nil {
 		t.Errorf("system = %v, want nil (no initial system was set)", textBlocks(outSystem))
 	}
-	// Mid-conv system preserved at correct position.
-	if want := "user,assistant,system,user"; roleSeq(outMsgs) != want {
+	if want := "user,assistant,user,user"; roleSeq(outMsgs) != want {
 		t.Errorf("role seq = %q, want %q", roleSeq(outMsgs), want)
 	}
-	midText := textBlocks(&outMsgs[2].Content)
-	if len(midText) == 0 || midText[0] != "Only mid-conv instruction." {
-		t.Errorf("mid-conv text = %v, want [\"Only mid-conv instruction.\"]", midText)
-	}
+	assertInlined(t, outMsgs, outSystem, "Only mid-conv instruction.")
 }
 
 // --- F: no top-level system, mid-conv only, unsupported ---------------------
@@ -259,27 +296,25 @@ func TestRoundTrip_F_NoTopLevelSystem_MidConvOnly_Bedrock(t *testing.T) {
 
 	outMsgs, outSystem := roundTrip(t, messages, nil, schemas.Bedrock, "global.anthropic.claude-opus-4-8")
 
-	// Mid-conv gets promoted to top-level system (no initial to append to).
-	got := textBlocks(outSystem)
-	if len(got) != 1 {
-		t.Fatalf("system blocks = %v (len=%d), want exactly 1 promoted block", got, len(got))
+	if outSystem != nil {
+		t.Errorf("system = %v, want nil — mid-conv content inlines rather than being promoted", textBlocks(outSystem))
 	}
-	if got[0] != "Mid-conv instruction." {
-		t.Errorf("system[0] = %q, want \"Mid-conv instruction.\"", got[0])
-	}
-	// No system role in messages.
 	for i, m := range outMsgs {
 		if m.Role == AnthropicMessageRoleSystem {
 			t.Errorf("msg[%d] has role:system for Bedrock", i)
 		}
 	}
-	if want := "user,assistant,user"; roleSeq(outMsgs) != want {
+	if want := "user,assistant,user,user"; roleSeq(outMsgs) != want {
 		t.Errorf("role seq = %q, want %q", roleSeq(outMsgs), want)
 	}
+	assertInlined(t, outMsgs, outSystem, "Mid-conv instruction.")
 }
 
 // --- G: multiple mid-conv system messages, supported -----------------------
 
+// Mixed placement in one request: Mid1 follows a user and is followed by an assistant (legal, so
+// it forwards natively), while Mid2 follows an assistant (illegal, so it inlines). The two are
+// decided independently — one bad placement does not force the whole request down the fallback.
 func TestRoundTrip_G_MultipleMidConv_Supported(t *testing.T) {
 	messages := []AnthropicMessage{
 		anthMsg(AnthropicMessageRoleUser, "Q1"),
@@ -292,23 +327,16 @@ func TestRoundTrip_G_MultipleMidConv_Supported(t *testing.T) {
 
 	outMsgs, outSystem := roundTrip(t, messages, system, schemas.Anthropic, "claude-opus-4-8")
 
-	// Top-level system untouched.
-	got := textBlocks(outSystem)
-	if len(got) != 1 || got[0] != "Initial." {
+	if got := textBlocks(outSystem); len(got) != 1 || got[0] != "Initial." {
 		t.Errorf("system = %v, want [\"Initial.\"]", got)
 	}
-	// Both mid-conv system messages preserved in position.
-	if want := "user,system,assistant,system,user"; roleSeq(outMsgs) != want {
-		t.Errorf("role seq = %q, want %q", roleSeq(outMsgs), want)
+	if want := "user,system,assistant,user,user"; roleSeq(outMsgs) != want {
+		t.Fatalf("role seq = %q, want %q", roleSeq(outMsgs), want)
 	}
-	mid1 := textBlocks(&outMsgs[1].Content)
-	if len(mid1) == 0 || mid1[0] != "Mid1." {
-		t.Errorf("mid1 text = %v, want [\"Mid1.\"]", mid1)
+	if got := textBlocks(&outMsgs[1].Content); len(got) == 0 || got[0] != "Mid1." {
+		t.Errorf("mid1 (legal placement, forwarded) = %v, want [\"Mid1.\"]", got)
 	}
-	mid2 := textBlocks(&outMsgs[3].Content)
-	if len(mid2) == 0 || mid2[0] != "Mid2." {
-		t.Errorf("mid2 text = %v, want [\"Mid2.\"]", mid2)
-	}
+	assertInlined(t, outMsgs, outSystem, "Mid2.")
 }
 
 // --- H: multiple mid-conv system messages, unsupported ----------------------
@@ -325,29 +353,27 @@ func TestRoundTrip_H_MultipleMidConv_Bedrock(t *testing.T) {
 
 	outMsgs, outSystem := roundTrip(t, messages, system, schemas.Bedrock, "global.anthropic.claude-opus-4-8")
 
-	// All three system texts land in the top-level field in order.
-	got := textBlocks(outSystem)
-	if len(got) != 3 {
-		t.Fatalf("system blocks = %v (len=%d), want 3 (Initial+Mid1+Mid2)", got, len(got))
+	// Only the leading prompt stays hoisted; both reminders inline. Previously all three texts
+	// were concatenated into `system`, which is what pinned the cacheable prefix at the floor.
+	if got := textBlocks(outSystem); len(got) != 1 || got[0] != "Initial." {
+		t.Errorf("system = %v, want exactly [\"Initial.\"]", got)
 	}
-	for i, want := range []string{"Initial.", "Mid1.", "Mid2."} {
-		if got[i] != want {
-			t.Errorf("system[%d] = %q, want %q", i, got[i], want)
-		}
-	}
-	// No system role remains in the messages array.
 	for i, m := range outMsgs {
 		if m.Role == AnthropicMessageRoleSystem {
 			t.Errorf("msg[%d] has role:system — must not appear for Bedrock", i)
 		}
 	}
-	if want := "user,assistant,user"; roleSeq(outMsgs) != want {
+	if want := "user,user,assistant,user,user"; roleSeq(outMsgs) != want {
 		t.Errorf("role seq = %q, want %q", roleSeq(outMsgs), want)
 	}
+	assertInlined(t, outMsgs, outSystem, "Mid1.")
+	assertInlined(t, outMsgs, outSystem, "Mid2.")
 }
 
 // --- content-blocks variant: system sent as ContentBlocks not ContentStr ---
 
+// Placement here satisfies the follows-a-user clause but not the trailing clause (a user follows),
+// so even on a supporting model it takes the inline fallback rather than a 400.
 func TestRoundTrip_ContentBlocks_Supported(t *testing.T) {
 	initialText := "Initial (blocks)."
 	midText := "Mid (blocks)."
@@ -371,19 +397,13 @@ func TestRoundTrip_ContentBlocks_Supported(t *testing.T) {
 
 	outMsgs, outSystem := roundTrip(t, messages, system, schemas.Anthropic, "claude-opus-4-8")
 
-	// Top-level system preserved.
-	got := textBlocks(outSystem)
-	if len(got) != 1 || got[0] != initialText {
+	if got := textBlocks(outSystem); len(got) != 1 || got[0] != initialText {
 		t.Errorf("system = %v, want [%q]", got, initialText)
 	}
-	// Mid-conv system preserved in position.
-	if want := "user,system,user"; roleSeq(outMsgs) != want {
+	if want := "user,user,user"; roleSeq(outMsgs) != want {
 		t.Errorf("role seq = %q, want %q", roleSeq(outMsgs), want)
 	}
-	mid := textBlocks(&outMsgs[1].Content)
-	if len(mid) == 0 || mid[0] != midText {
-		t.Errorf("mid-conv text = %v, want [%q]", mid, midText)
-	}
+	assertInlined(t, outMsgs, outSystem, midText)
 }
 
 func TestRoundTrip_ContentBlocks_Bedrock(t *testing.T) {
@@ -409,22 +429,15 @@ func TestRoundTrip_ContentBlocks_Bedrock(t *testing.T) {
 
 	outMsgs, outSystem := roundTrip(t, messages, system, schemas.Bedrock, "global.anthropic.claude-opus-4-8")
 
-	// Both blocks merged into top-level system.
-	got := textBlocks(outSystem)
-	if len(got) != 2 {
-		t.Fatalf("system blocks = %v (len=%d), want 2", got, len(got))
-	}
-	if got[0] != initialText {
-		t.Errorf("system[0] = %q, want %q", got[0], initialText)
-	}
-	if got[1] != midText {
-		t.Errorf("system[1] = %q, want %q", got[1], midText)
+	if got := textBlocks(outSystem); len(got) != 1 || got[0] != initialText {
+		t.Errorf("system = %v, want exactly [%q]", got, initialText)
 	}
 	for i, m := range outMsgs {
 		if m.Role == AnthropicMessageRoleSystem {
 			t.Errorf("msg[%d] has role:system for Bedrock", i)
 		}
 	}
+	assertInlined(t, outMsgs, outSystem, midText)
 }
 
 // --- container_upload -------------------------------------------------------

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -950,6 +950,139 @@ func appendToSystemContent(existing *AnthropicContent, newContent AnthropicConte
 	return &AnthropicContent{ContentBlocks: merged}
 }
 
+// AnthropicMaxCacheBreakpoints is the number of blocks carrying cache_control that the Anthropic
+// Messages API accepts in one request. Exceeding it is a hard rejection, not a degradation:
+// verified live on the Anthropic API and on Vertex, both returning
+// "A maximum of 4 blocks with cache_control may be provided. Found 5."
+const AnthropicMaxCacheBreakpoints = 4
+
+// clampAnthropicCacheBreakpoints clears the EARLIEST cache_control markers when a request carries
+// more than the API accepts, and returns how many it cleared.
+//
+// Which end to drop matters. Caching is cumulative up to each breakpoint, so a marker later in
+// render order (tools -> system -> messages) anchors a strictly longer prefix. Dropping the
+// earliest costs an intermediate checkpoint; dropping the latest would surrender the longest
+// cached prefix — the failure inlineMidConversationSystem exists to prevent.
+//
+// Traversal mirrors MarshalJSON's stripCacheControlScope walk (top-level, tools, system, message
+// content blocks) so the two stay consistent. Like that walk, it does not descend into nested
+// tool_result content; a breakpoint there is counted by the API but not by this function, so the
+// clamp is conservative rather than exhaustive.
+func clampAnthropicCacheBreakpoints(req *AnthropicMessageRequest) int {
+	if req == nil {
+		return 0
+	}
+
+	// Pointers to every marker, in render order, so clearing the leading excess is a slice walk.
+	var refs []**schemas.CacheControl
+	for i := range req.Tools {
+		if req.Tools[i].CacheControl != nil {
+			refs = append(refs, &req.Tools[i].CacheControl)
+		}
+	}
+	if req.System != nil {
+		for i := range req.System.ContentBlocks {
+			if req.System.ContentBlocks[i].CacheControl != nil {
+				refs = append(refs, &req.System.ContentBlocks[i].CacheControl)
+			}
+		}
+	}
+	for i := range req.Messages {
+		blocks := req.Messages[i].Content.ContentBlocks
+		for j := range blocks {
+			if blocks[j].CacheControl != nil {
+				refs = append(refs, &blocks[j].CacheControl)
+			}
+		}
+	}
+	// The top-level marker auto-places on the last cacheable block, making it effectively the
+	// final breakpoint — ordered last so it is the one most likely to survive a clamp.
+	if req.CacheControl != nil {
+		refs = append(refs, &req.CacheControl)
+	}
+
+	excess := len(refs) - AnthropicMaxCacheBreakpoints
+	if excess <= 0 {
+		return 0
+	}
+	for i := 0; i < excess; i++ {
+		*refs[i] = nil
+	}
+	return excess
+}
+
+// inlineMidConversationSystem renders a mid-conversation system message as a user turn wrapped in
+// the <system-reminder> envelope, preserving each block's cache_control.
+//
+// This is the fallback for a mid-conversation system message the provider+model cannot carry as
+// role:"system" — either because the model predates the feature (SupportsMidConversationSystem)
+// or because the platform doesn't expose it at all (Bedrock, Vertex, and Foundry do not). The
+// alternative, folding the content into the top-level `system` block, is what this replaces: the
+// system block renders ahead of every message, so growing it mid-conversation invalidates the
+// cached prefix behind it and pins the cacheable region at the system/tools floor. Measured
+// across the provider harness, that collapse costs half the prompt on an otherwise warm
+// conversation — the same economics as dropping the breakpoint outright.
+//
+// Inlining keeps the anchor inside `messages`, where it extends the cached prefix instead of
+// invalidating it, and matches both the documented Anthropic fallback for unsupported models and
+// the Bedrock converter's existing behavior (convertBifrostSystemReminderToBedrockUserMessage).
+// The trade is that a user turn is not the operator channel a role:"system" turn is — the model
+// can no longer distinguish it from user text. The content originates from the caller's own
+// system role, so nothing attacker-controlled is laundered by this, but instruction adherence is
+// weaker than a native mid-conversation system message would be. Callers whose model does support
+// the native form never reach here.
+//
+// Returns nil when the content yields no text, so the caller skips the append.
+func inlineMidConversationSystem(content *AnthropicContent) *AnthropicMessage {
+	if content == nil {
+		return nil
+	}
+
+	wrap := func(text string) string {
+		return "<system-reminder>\n" + text + "\n</system-reminder>\n"
+	}
+
+	var blocks []AnthropicContentBlock
+	if content.ContentStr != nil && *content.ContentStr != "" {
+		// The string form has nowhere to hang a per-block cache_control, so no breakpoint was
+		// sent and none may be invented — that would burn a cache checkpoint (max 4) the caller
+		// never asked for.
+		blocks = append(blocks, AnthropicContentBlock{
+			Type: AnthropicContentBlockTypeText,
+			Text: schemas.Ptr(wrap(*content.ContentStr)),
+		})
+	}
+	// Only the LAST breakpoint in the message is kept, matching the Bedrock converter. Within a
+	// single message an intermediate marker buys nothing — one on the final block already closes
+	// over every preceding block, and the message is atomic so no later request can diverge in its
+	// middle — while still consuming one of the four checkpoints the API allows per request.
+	var lastCacheControl *schemas.CacheControl
+	for _, block := range content.ContentBlocks {
+		if block.Text == nil || *block.Text == "" {
+			continue
+		}
+		blocks = append(blocks, AnthropicContentBlock{
+			Type: AnthropicContentBlockTypeText,
+			Text: schemas.Ptr(wrap(*block.Text)),
+		})
+		if block.CacheControl != nil {
+			lastCacheControl = block.CacheControl
+		}
+	}
+
+	if len(blocks) == 0 {
+		return nil
+	}
+	if lastCacheControl != nil {
+		blocks[len(blocks)-1].CacheControl = lastCacheControl
+	}
+
+	return &AnthropicMessage{
+		Role:    AnthropicMessageRoleUser,
+		Content: AnthropicContent{ContentBlocks: blocks},
+	}
+}
+
 // SupportsMidConversationSystem returns true if the provider+model combination
 // supports role:"system" entries inside the messages array (mid-conversation
 // system messages). Available on the Anthropic API only — not on Bedrock or

--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -6690,11 +6690,20 @@ func TestSystemReminderBetweenToolCallAndResult(t *testing.T) {
 	assert.True(t, hasResult, "user message after tool_use must contain the matching tool_result")
 }
 
-// TestSystemReminderDoesNotCarryCachePoint pins the deliberate omission flagged in review: an
-// inlined mid-conversation reminder must NOT emit a CachePoint, even if its block carries
-// CacheControl. A breakpoint at the moving conversation tail would shift every turn and defeat
-// the prefix caching this whole change exists to preserve.
-func TestSystemReminderDoesNotCarryCachePoint(t *testing.T) {
+// TestSystemReminderCarriesCachePoint pins the corrected contract, replacing a test that
+// asserted the opposite.
+//
+// The original reasoning was that a breakpoint at the moving conversation tail would shift every
+// turn and defeat prefix caching, so the inlined reminder deliberately dropped its CacheControl.
+// The premise is right and the conclusion inverted: Bedrock matches the longest cached prefix at
+// or before each breakpoint, so a marker that advances one turn at a time EXTENDS the cached
+// prefix for one write — that is how incremental conversation caching is meant to work. Dropping
+// it does not fall back to a safe state; it removes the only conversation-level anchor, leaving
+// the surviving markers in `system` and re-reading the whole conversation body uncached.
+//
+// Measured across the provider harness, the old behavior cost half the prompt on a warm ~19K
+// conversation (49.8% hit rate vs 99.9% with the anchor preserved).
+func TestSystemReminderCarriesCachePoint(t *testing.T) {
 	reminder := systemReminderTextMsg("Reminder that happens to carry a breakpoint.")
 	reminder.Content.ContentBlocks[0].CacheControl = &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral}
 
@@ -6707,9 +6716,40 @@ func TestSystemReminderDoesNotCarryCachePoint(t *testing.T) {
 	messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
 	require.NoError(t, err)
 
+	// The marker must follow the wrapped reminder text: per Converse semantics a cachePoint
+	// element terminates the cacheable prefix rather than opening one.
+	var found bool
+	for _, m := range messages {
+		for i, b := range m.Content {
+			if b.Text == nil || !strings.Contains(*b.Text, "<system-reminder>") {
+				continue
+			}
+			require.Greater(t, len(m.Content), i+1, "reminder text must be followed by its cachePoint")
+			assert.NotNil(t, m.Content[i+1].CachePoint,
+				"the inlined reminder carries the conversation-level cache anchor; dropping it pins "+
+					"the cacheable prefix at the system floor")
+			found = true
+		}
+	}
+	assert.True(t, found, "expected the inlined <system-reminder> block in the converted messages")
+}
+
+// TestSystemReminderWithoutCacheControlAddsNoCachePoint is the guard against the opposite error:
+// a reminder whose block carries no CacheControl must not grow a marker, which would burn one of
+// the four checkpoints Bedrock allows on a breakpoint the caller never requested.
+func TestSystemReminderWithoutCacheControlAddsNoCachePoint(t *testing.T) {
+	input := []schemas.ResponsesMessage{
+		systemReminderTextMsg("You are Claude Code."),
+		userReminderTextMsg("hello"),
+		systemReminderTextMsg("Reminder with no breakpoint."),
+	}
+
+	messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	require.NoError(t, err)
+
 	for _, m := range messages {
 		for _, b := range m.Content {
-			assert.Nil(t, b.CachePoint, "inlined reminder must not introduce a CachePoint block")
+			assert.Nil(t, b.CachePoint, "no cache_control on the reminder means no CachePoint may be invented")
 		}
 	}
 }

--- a/core/providers/bedrock/cachepointclamp_test.go
+++ b/core/providers/bedrock/cachepointclamp_test.go
@@ -1,0 +1,239 @@
+package bedrock
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Bedrock rejects a Converse request carrying more than 4 cachePoint markers outright —
+// "ValidationException: A maximum of 4 blocks with cache_control may be provided. Found 5.",
+// verified live against global.anthropic.claude-haiku-4-5. These tests pin the clamp that keeps an
+// over-marked request from failing, and pin WHICH markers it sacrifices.
+//
+// The direction is the design. Converse caches cumulatively up to each cachePoint, so a marker
+// later in render order (toolConfig -> system -> messages) anchors a strictly longer prefix.
+// Dropping the earliest costs an intermediate checkpoint; dropping the latest would surrender the
+// longest cached prefix — reintroducing exactly the collapse
+// convertBifrostSystemReminderToBedrockUserMessage was fixed to prevent. A clamp trimming the
+// wrong end would eliminate the 400s while silently restoring the bug.
+
+func cachePointBlock() BedrockContentBlock {
+	return BedrockContentBlock{CachePoint: &BedrockCachePoint{Type: BedrockCachePointTypeDefault}}
+}
+
+func textBlock(s string) BedrockContentBlock {
+	return BedrockContentBlock{Text: schemas.Ptr(s)}
+}
+
+// countCachePointsInRequest returns markers per render region plus the total.
+//
+// `messages` includes markers nested inside ToolResult.Content. AWS counts checkpoints across
+// `messages` as a whole, so a helper that walked only direct content would report a total the
+// provider disagrees with — and every test built on it would be blind to a nested-counting
+// regression, which is the exact class of bug clampBedrockCachePoints originally shipped with.
+func countCachePointsInRequest(req *BedrockConverseRequest) (tools, system, messages, total int) {
+	if req.ToolConfig != nil {
+		for _, t := range req.ToolConfig.Tools {
+			if t.CachePoint != nil {
+				tools++
+			}
+		}
+	}
+	for _, s := range req.System {
+		if s.CachePoint != nil {
+			system++
+		}
+	}
+	for _, m := range req.Messages {
+		for _, b := range m.Content {
+			if b.CachePoint != nil {
+				messages++
+			}
+			if b.ToolResult != nil {
+				for _, inner := range b.ToolResult.Content {
+					if inner.CachePoint != nil {
+						messages++
+					}
+				}
+			}
+		}
+	}
+	return tools, system, messages, tools + system + messages
+}
+
+// buildOverMarkedRequest returns a request with 2 system + 1 tool-result + 2 message markers = 5,
+// one past the cap. The shape mirrors real Claude Code traffic, which already sits at exactly 4.
+func buildOverMarkedRequest() *BedrockConverseRequest {
+	return &BedrockConverseRequest{
+		System: []BedrockSystemMessage{
+			{Text: schemas.Ptr("system prompt")},
+			{CachePoint: &BedrockCachePoint{Type: BedrockCachePointTypeDefault}},
+			{Text: schemas.Ptr("tool definitions")},
+			{CachePoint: &BedrockCachePoint{Type: BedrockCachePointTypeDefault}},
+		},
+		Messages: []BedrockMessage{
+			{Role: BedrockMessageRoleUser, Content: []BedrockContentBlock{
+				textBlock("tool result"), cachePointBlock(),
+			}},
+			{Role: BedrockMessageRoleUser, Content: []BedrockContentBlock{
+				textBlock("second turn"), cachePointBlock(),
+			}},
+			{Role: BedrockMessageRoleUser, Content: []BedrockContentBlock{
+				textBlock("<system-reminder>\nstay concise\n</system-reminder>\n"), cachePointBlock(),
+			}},
+		},
+	}
+}
+
+// TestClampBedrockCachePoints_UnderCapUntouched guards against over-eager clamping: at or below
+// the cap nothing may be removed, since every marker there is free cache coverage.
+func TestClampBedrockCachePoints_UnderCapUntouched(t *testing.T) {
+	req := &BedrockConverseRequest{
+		System: []BedrockSystemMessage{
+			{Text: schemas.Ptr("a")},
+			{CachePoint: &BedrockCachePoint{Type: BedrockCachePointTypeDefault}},
+		},
+		Messages: []BedrockMessage{
+			{Role: BedrockMessageRoleUser, Content: []BedrockContentBlock{textBlock("x"), cachePointBlock()}},
+		},
+	}
+	dropped := clampBedrockCachePoints(req)
+	assert.Equal(t, 0, dropped, "a request under the cap must not be trimmed")
+	_, _, _, total := countCachePointsInRequest(req)
+	assert.Equal(t, 2, total, "all markers must survive")
+	require.Len(t, req.Messages[0].Content, 2, "non-marker blocks must be untouched")
+}
+
+// TestClampBedrockCachePoints_DropsEarliestKeepsAnchor is the load-bearing case: 5 markers get
+// trimmed to 4, the earliest goes, and the reminder's anchor on the final turn survives.
+func TestClampBedrockCachePoints_DropsEarliestKeepsAnchor(t *testing.T) {
+	req := buildOverMarkedRequest()
+	_, _, _, before := countCachePointsInRequest(req)
+	require.Equal(t, 5, before, "fixture should start one over the cap")
+
+	dropped := clampBedrockCachePoints(req)
+	assert.Equal(t, 1, dropped)
+
+	tools, system, messages, total := countCachePointsInRequest(req)
+	assert.Equal(t, BedrockMaxCachePoints, total, "must land exactly on the cap")
+	assert.Equal(t, 0, tools)
+	assert.Equal(t, 1, system, "the earlier of the two system markers is the one sacrificed")
+	assert.Equal(t, 3, messages, "every message-level marker must survive")
+
+	// The last message's anchor is what keeps the conversation body cacheable.
+	last := req.Messages[len(req.Messages)-1]
+	require.NotEmpty(t, last.Content)
+	assert.NotNil(t, last.Content[len(last.Content)-1].CachePoint,
+		"the final breakpoint was dropped — clamping must never surrender the longest cached prefix")
+
+	// Text content must be preserved: only the marker is removed, never the payload.
+	var texts int
+	for _, s := range req.System {
+		if s.Text != nil {
+			texts++
+		}
+	}
+	assert.Equal(t, 2, texts, "clamping must not delete system text, only markers")
+}
+
+// TestClampBedrockCachePoints_DropsCachePointOnlyEntries verifies the removal leaves no empty
+// objects behind — a system entry that was marker-only has nothing left to serialize, and an
+// empty {} in the system array is itself a validation error.
+func TestClampBedrockCachePoints_DropsCachePointOnlyEntries(t *testing.T) {
+	req := buildOverMarkedRequest()
+	beforeSystem := len(req.System)
+
+	clampBedrockCachePoints(req)
+
+	assert.Equal(t, beforeSystem-1, len(req.System),
+		"a marker-only system entry must be removed outright, not left as an empty object")
+	for i, s := range req.System {
+		assert.False(t, s.Text == nil && s.GuardContent == nil && s.CachePoint == nil,
+			"system[%d] is an empty object", i)
+	}
+}
+
+// TestClampBedrockCachePoints_NilSafe guards trivial inputs.
+func TestClampBedrockCachePoints_NilSafe(t *testing.T) {
+	assert.Equal(t, 0, clampBedrockCachePoints(nil))
+	assert.Equal(t, 0, clampBedrockCachePoints(&BedrockConverseRequest{}))
+}
+
+// TestClampBedrockCachePoints_CountsNestedToolResultMarkers covers the case flagged in review on
+// PR #5931: convertToolMessages emits a CachePoint *inside* ToolResult.Content whenever a client
+// puts cache_control on a tool-result block (utils.go, the ChatContentBlockTypeText and
+// ChatContentBlockTypeImage arms). AWS counts checkpoints across `messages` as a whole, so those
+// nested markers spend the same 4-per-request budget as direct ones.
+//
+// This fixture is over the cap ONLY because of the nested marker — 2 system + 2 direct message
+// markers + 1 nested = 5. A clamp that walks direct content alone sees 4, concludes there is
+// nothing to do, and forwards 5 to Bedrock, which rejects the request with the very
+// ValidationException the clamp exists to avoid.
+// Both sibling passes (stripCachePointsFromBedrockRequest, downgradeExtendedCacheTTLInBedrockRequest)
+// already recurse here; this pins the clamp to the same shape.
+func TestClampBedrockCachePoints_CountsNestedToolResultMarkers(t *testing.T) {
+	req := &BedrockConverseRequest{
+		System: []BedrockSystemMessage{
+			{Text: schemas.Ptr("system prompt")},
+			{CachePoint: &BedrockCachePoint{Type: BedrockCachePointTypeDefault}},
+			{Text: schemas.Ptr("tool definitions")},
+			{CachePoint: &BedrockCachePoint{Type: BedrockCachePointTypeDefault}},
+		},
+		Messages: []BedrockMessage{
+			{Role: BedrockMessageRoleUser, Content: []BedrockContentBlock{
+				// A tool result whose NESTED content carries a marker.
+				{ToolResult: &BedrockToolResult{
+					ToolUseID: "tooluse_1",
+					Content: []BedrockContentBlock{
+						textBlock("tool output"),
+						cachePointBlock(),
+					},
+				}},
+				cachePointBlock(),
+			}},
+			{Role: BedrockMessageRoleUser, Content: []BedrockContentBlock{
+				textBlock("<system-reminder>\nstay concise\n</system-reminder>\n"), cachePointBlock(),
+			}},
+		},
+	}
+
+	// 2 system + 2 direct + 1 nested = 5, one over the cap. countCachePointsInRequest folds
+	// nested tool-result markers into its `messages` figure, matching how AWS counts them.
+	_, systemBefore, messagesBefore, totalBefore := countCachePointsInRequest(req)
+	require.Equal(t, 2, systemBefore)
+	require.Equal(t, 3, messagesBefore, "2 direct + 1 nested tool-result marker")
+	require.Equal(t, 5, totalBefore, "fixture should start one over the cap")
+
+	dropped := clampBedrockCachePoints(req)
+	assert.Equal(t, 1, dropped, "the nested marker must be counted, so exactly one must be dropped")
+
+	_, systemAfter, messagesAfter, totalAfter := countCachePointsInRequest(req)
+	assert.Equal(t, BedrockMaxCachePoints, totalAfter,
+		"total markers including nested tool-result content must land on the cap")
+	assert.Equal(t, 3, messagesAfter, "no message-level marker, direct or nested, may be dropped here")
+
+	// Earliest-first: the sacrificed marker is a system one, and the conversation anchor survives.
+	assert.Equal(t, 1, systemAfter, "the earlier system marker is the one dropped")
+	last := req.Messages[len(req.Messages)-1]
+	assert.NotNil(t, last.Content[len(last.Content)-1].CachePoint,
+		"the final breakpoint must survive — it anchors the longest cached prefix")
+
+	// Nested payload text must be preserved; only markers are removable.
+	for _, m := range req.Messages {
+		for _, b := range m.Content {
+			if b.ToolResult == nil {
+				continue
+			}
+			var hasText bool
+			for _, inner := range b.ToolResult.Content {
+				if inner.Text != nil {
+					hasText = true
+				}
+			}
+			assert.True(t, hasText, "clamping must not delete tool-result text, only markers")
+		}
+	}
+}

--- a/core/providers/bedrock/chat.go
+++ b/core/providers/bedrock/chat.go
@@ -68,8 +68,13 @@ func ToBedrockChatCompletionRequest(ctx *schemas.BifrostContext, bifrostReq *sch
 	capModel := schemas.ResolveCanonicalModel(ctx, bifrostReq.Model)
 	if !schemas.BedrockModelSupportsCachePoints(capModel) {
 		stripCachePointsFromBedrockRequest(bedrockReq)
-	} else if !schemas.BedrockModelSupportsExtendedCacheTTL(capModel) {
-		downgradeExtendedCacheTTLInBedrockRequest(bedrockReq)
+	} else {
+		if !schemas.BedrockModelSupportsExtendedCacheTTL(capModel) {
+			downgradeExtendedCacheTTLInBedrockRequest(bedrockReq)
+		}
+		// See the same call in ToBedrockResponsesRequest: exceeding the cap is a hard rejection,
+		// so trim the earliest markers rather than let the request fail.
+		clampBedrockCachePoints(bedrockReq)
 	}
 
 	return bedrockReq, nil

--- a/core/providers/bedrock/midconvcachepoint_test.go
+++ b/core/providers/bedrock/midconvcachepoint_test.go
@@ -1,0 +1,344 @@
+package bedrock_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/providers/bedrock"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Wire-level counterpart to the "Cross-Cut Round 34: Mid-Conversation System Cache-Anchor
+// Parity" harness folder (tests/e2e/api/runners/lib/midconv-system-cache-parity.mjs). The
+// harness measures the symptom in billed tokens against a live Bedrock account; these tests
+// assert the cause on the emitted Converse request, with no credentials and no spend.
+//
+// The shape under test is Claude Code's: three cache_control breakpoints - two on the leading
+// system prompt, one riding a mid-conversation role=system <system-reminder>. Bedrock has no
+// message-level system role, so ConvertBifrostMessagesToBedrockMessages inlines that reminder
+// as a user turn (TestMidConversationSystemReminderStaysInline covers why: hoisting it would
+// grow the system block in front of the cached conversation prefix). The inlining must carry
+// the breakpoint with it. Dropping it leaves both surviving cachePoints in `system`, which pins
+// the cacheable prefix at the system floor and re-reads the whole conversation body uncached on
+// every turn - the exact collapse the inlining exists to prevent.
+
+// cachedTextBlock builds a text content block carrying an ephemeral cache_control breakpoint,
+// the way an Anthropic-dialect client marks a cache anchor.
+func cachedTextBlock(text string) schemas.ResponsesMessageContentBlock {
+	return schemas.ResponsesMessageContentBlock{
+		Type:         schemas.ResponsesInputMessageContentBlockTypeText,
+		Text:         schemas.Ptr(text),
+		CacheControl: &schemas.CacheControl{Type: "ephemeral"},
+	}
+}
+
+// cachedRoleMsg builds a single-block message of the given role whose block carries a breakpoint.
+func cachedRoleMsg(role schemas.ResponsesMessageRoleType, text string) schemas.ResponsesMessage {
+	return schemas.ResponsesMessage{
+		Type:    schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+		Role:    schemas.Ptr(role),
+		Content: &schemas.ResponsesMessageContent{ContentBlocks: []schemas.ResponsesMessageContentBlock{cachedTextBlock(text)}},
+	}
+}
+
+// assistantTextMsg builds a role=assistant message with a single text block, so the fixtures
+// below alternate turns the way a real transcript does.
+func assistantTextMsg(text string) schemas.ResponsesMessage {
+	return schemas.ResponsesMessage{
+		Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+		Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+		Content: &schemas.ResponsesMessageContent{
+			ContentBlocks: []schemas.ResponsesMessageContentBlock{
+				{Type: schemas.ResponsesInputMessageContentBlockTypeText, Text: schemas.Ptr(text)},
+			},
+		},
+	}
+}
+
+// leadingSystemMsg is the two-breakpoint leading system prompt every case below shares.
+func leadingSystemMsg() schemas.ResponsesMessage {
+	return schemas.ResponsesMessage{
+		Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+		Role: schemas.Ptr(schemas.ResponsesInputMessageRoleSystem),
+		Content: &schemas.ResponsesMessageContent{
+			ContentBlocks: []schemas.ResponsesMessageContentBlock{
+				cachedTextBlock("You are Claude Code. Long stable instructions."),
+				cachedTextBlock("Tool definitions and environment details."),
+			},
+		},
+	}
+}
+
+// countCachePoints returns the cachePoint totals across the converted request, split by where
+// they landed. The split is the whole point: a request with 3 cachePoints all sitting in
+// `system` caches exactly as badly as one with 2.
+func countCachePoints(messages []bedrock.BedrockMessage, systemMessages []bedrock.BedrockSystemMessage) (inSystem, inMessages int) {
+	for _, sysMsg := range systemMessages {
+		if sysMsg.CachePoint != nil {
+			inSystem++
+		}
+	}
+	for _, msg := range messages {
+		for _, block := range msg.Content {
+			if block.CachePoint != nil {
+				inMessages++
+			}
+		}
+	}
+	return inSystem, inMessages
+}
+
+// TestMidConversationSystemReminderPreservesCachePoint is the regression test for the dropped
+// conversation-level cache anchor. Three cache_control breakpoints in must produce three
+// cachePoint elements out, and exactly one of them must land inside `messages` - otherwise the
+// cacheable prefix never extends past the system block.
+func TestMidConversationSystemReminderPreservesCachePoint(t *testing.T) {
+	input := []schemas.ResponsesMessage{
+		leadingSystemMsg(),
+		userReminderTextMsg("first user turn"),
+		assistantTextMsg("ok"),
+		userReminderTextMsg("second user turn"),
+		cachedRoleMsg(schemas.ResponsesInputMessageRoleSystem, "Reminder: stay concise."),
+		userReminderTextMsg("what next?"),
+	}
+
+	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	require.NoError(t, err)
+
+	inSystem, inMessages := countCachePoints(messages, systemMessages)
+	assert.Equal(t, 2, inSystem, "the two leading-system breakpoints must be hoisted into the system block")
+	assert.Equal(t, 1, inMessages,
+		"the mid-conversation reminder carries the conversation-level cache anchor; dropping it during inlining "+
+			"pins the cacheable prefix at the system floor and re-reads the whole conversation body uncached")
+
+	// Placement matters as much as presence: per Converse semantics a cachePoint element
+	// terminates the cacheable prefix rather than opening one, so it has to FOLLOW the wrapped
+	// reminder text - the same ordering the converter already uses for tool results.
+	var foundOrdered bool
+	for _, msg := range messages {
+		for i, block := range msg.Content {
+			if block.Text == nil || !strings.Contains(*block.Text, "<system-reminder>") {
+				continue
+			}
+			require.Greater(t, len(msg.Content), i+1, "reminder text block must be followed by its cachePoint")
+			assert.NotNil(t, msg.Content[i+1].CachePoint, "cachePoint must immediately follow the wrapped reminder text")
+			assert.Equal(t, bedrock.BedrockMessageRoleUser, msg.Role, "inlined reminder must be a user turn")
+			foundOrdered = true
+		}
+	}
+	assert.True(t, foundOrdered, "expected the inlined <system-reminder> block in the converted messages")
+}
+
+// TestMidConversationDeveloperReminderPreservesCachePoint pins the developer role to the same
+// behaviour. The dispatch in responses.go tests for system OR developer, so the two roles must
+// never diverge - including after a fix.
+func TestMidConversationDeveloperReminderPreservesCachePoint(t *testing.T) {
+	input := []schemas.ResponsesMessage{
+		leadingSystemMsg(),
+		userReminderTextMsg("first user turn"),
+		cachedRoleMsg(schemas.ResponsesInputMessageRoleDeveloper, "Reminder: stay concise."),
+		userReminderTextMsg("what next?"),
+	}
+
+	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	require.NoError(t, err)
+
+	inSystem, inMessages := countCachePoints(messages, systemMessages)
+	assert.Equal(t, 2, inSystem)
+	assert.Equal(t, 1, inMessages, "a mid-conversation role=developer reminder must keep its breakpoint, same as role=system")
+}
+
+// TestMidConversationSystemReminderContentStrAddsNoCachePoint is the guard against the opposite
+// error. The string content form has no per-block cache_control, so the client sent only two
+// breakpoints and only two may be emitted - a fix that unconditionally anchors every inlined
+// reminder would burn a checkpoint the client never asked for.
+func TestMidConversationSystemReminderContentStrAddsNoCachePoint(t *testing.T) {
+	input := []schemas.ResponsesMessage{
+		leadingSystemMsg(),
+		userReminderTextMsg("first user turn"),
+		systemReminderTextMsg("Reminder: stay concise."), // ContentBlocks, but no cache_control
+		userReminderTextMsg("what next?"),
+	}
+
+	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	require.NoError(t, err)
+
+	inSystem, inMessages := countCachePoints(messages, systemMessages)
+	assert.Equal(t, 2, inSystem)
+	assert.Equal(t, 0, inMessages, "no cache_control on the reminder means no cachePoint may be invented for it")
+}
+
+// TestMidConversationSystemRemindersRespectCheckpointBudget documents marker accounting at the
+// message-conversion layer. Claude on Bedrock caps cache checkpoints at 4 (BedrockMaxCachePoints,
+// per the AWS prompt-caching limits table, which lists a maximum of 4 for every Claude model).
+//
+// The clamp that enforces that cap, clampBedrockCachePoints, runs in ToBedrockResponsesRequest —
+// NOT in ConvertBifrostMessagesToBedrockMessages — so the counts asserted here are pre-clamp and
+// describe only what the converter emits. See cachepointclamp_test.go for the clamp itself.
+func TestMidConversationSystemRemindersRespectCheckpointBudget(t *testing.T) {
+	input := []schemas.ResponsesMessage{
+		leadingSystemMsg(),
+		userReminderTextMsg("first user turn"),
+		cachedRoleMsg(schemas.ResponsesInputMessageRoleSystem, "Reminder one."),
+		userReminderTextMsg("second user turn"),
+		cachedRoleMsg(schemas.ResponsesInputMessageRoleSystem, "Reminder two."),
+		userReminderTextMsg("what next?"),
+	}
+
+	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	require.NoError(t, err)
+
+	inSystem, inMessages := countCachePoints(messages, systemMessages)
+	assert.Equal(t, 2, inSystem)
+	assert.Equal(t, 2, inMessages, "each cache_control-bearing reminder contributes its own breakpoint (unclamped today)")
+	assert.LessOrEqual(t, inSystem+inMessages, 4, "Claude on Bedrock accepts at most 4 cache checkpoints")
+}
+
+// TestLeadingSystemRunCachePointsUnaffected pins the control arm of the harness experiment: a
+// breakpoint that rides a role=user block was never at risk, and must keep working. If this
+// ever fails alongside the tests above, the problem is broader than the inlining path.
+func TestLeadingSystemRunCachePointsUnaffected(t *testing.T) {
+	input := []schemas.ResponsesMessage{
+		leadingSystemMsg(),
+		userReminderTextMsg("first user turn"),
+		assistantTextMsg("ok"),
+		cachedRoleMsg(schemas.ResponsesInputMessageRoleUser, "Reminder: stay concise."),
+	}
+
+	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	require.NoError(t, err)
+
+	inSystem, inMessages := countCachePoints(messages, systemMessages)
+	assert.Equal(t, 2, inSystem)
+	assert.Equal(t, 1, inMessages, "a breakpoint on a role=user block is passed through untouched")
+}
+
+// --------------------------------------------------------------------------
+// Contract ported from PR #5929 (anduril-rvanderzee), the report's author. The core fix landed
+// independently here; these cases cover ground the original tests did not, most importantly the
+// collapse of multiple breakpoints within a single reminder.
+// --------------------------------------------------------------------------
+
+// claudeCodeShape mirrors what Claude Code sends: two breakpoints in the leading system run, then
+// a mid-conversation reminder carrying the third, conversation-level breakpoint.
+func claudeCodeShape(reminderRole schemas.ResponsesMessageRoleType) []schemas.ResponsesMessage {
+	return []schemas.ResponsesMessage{
+		{
+			Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+			Role: schemas.Ptr(schemas.ResponsesInputMessageRoleSystem),
+			Content: &schemas.ResponsesMessageContent{ContentBlocks: []schemas.ResponsesMessageContentBlock{
+				cachedTextBlock("You are Claude Code."),
+				cachedTextBlock("Extra instructions."),
+			}},
+		},
+		userReminderTextMsg("Analyze this."),
+		assistantTextMsg("Understood."),
+		cachedRoleMsg(reminderRole, "Keep going."),
+	}
+}
+
+// TestInlinedSystemReminder_KeepsCachePoint — the client sends 3 cache_control breakpoints, so 3
+// cachePoints must reach Bedrock: 2 hoisted into system, 1 on the inlined reminder.
+func TestInlinedSystemReminder_KeepsCachePoint(t *testing.T) {
+	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(
+		context.Background(), claudeCodeShape(schemas.ResponsesInputMessageRoleSystem), true)
+	require.NoError(t, err)
+
+	inSystem, inMessages := countCachePoints(messages, systemMessages)
+	assert.Equal(t, 2, inSystem, "the hoisted leading run keeps its two breakpoints")
+	assert.Equal(t, 1, inMessages, "the inlined reminder carries the conversation-level anchor")
+	assert.Equal(t, 3, inSystem+inMessages, "3 client breakpoints must produce 3 cachePoints")
+}
+
+// TestInlinedSystemReminder_CachePointFollowsText — a cachePoint terminates the cacheable prefix,
+// so it must come after the text it closes over, never before and never first.
+func TestInlinedSystemReminder_CachePointFollowsText(t *testing.T) {
+	messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(
+		context.Background(), claudeCodeShape(schemas.ResponsesInputMessageRoleSystem), true)
+	require.NoError(t, err)
+
+	for _, msg := range messages {
+		for i, block := range msg.Content {
+			if block.CachePoint == nil {
+				continue
+			}
+			require.Greater(t, i, 0, "cachePoint must not be the first block in its message")
+			assert.NotNil(t, msg.Content[i-1].Text, "cachePoint must terminate a text block")
+		}
+	}
+}
+
+// TestInlinedSystemReminder_UserRoleTailUnchanged — the equivalent user-role tail is the control:
+// it already worked and must keep working identically.
+func TestInlinedSystemReminder_UserRoleTailUnchanged(t *testing.T) {
+	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(
+		context.Background(), claudeCodeShape(schemas.ResponsesInputMessageRoleUser), true)
+	require.NoError(t, err)
+
+	inSystem, inMessages := countCachePoints(messages, systemMessages)
+	assert.Equal(t, 3, inSystem+inMessages, "the control shape must still emit 3 cachePoints")
+}
+
+// TestInlinedSystemReminder_MultipleBreakpointsEmitOne — only the last breakpoint in a single
+// reminder is emitted. An intermediate marker inside one message closes over nothing the final
+// one doesn't, so emitting each would spend the 4-checkpoint budget for no cache benefit.
+func TestInlinedSystemReminder_MultipleBreakpointsEmitOne(t *testing.T) {
+	input := []schemas.ResponsesMessage{
+		leadingSystemMsg(),
+		userReminderTextMsg("Analyze this."),
+		{
+			Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+			Role: schemas.Ptr(schemas.ResponsesInputMessageRoleSystem),
+			Content: &schemas.ResponsesMessageContent{ContentBlocks: []schemas.ResponsesMessageContentBlock{
+				cachedTextBlock("reminder one"),
+				cachedTextBlock("reminder two"),
+				cachedTextBlock("reminder three"),
+			}},
+		},
+	}
+
+	messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	require.NoError(t, err)
+
+	_, inMessages := countCachePoints(messages, nil)
+	assert.Equal(t, 1, inMessages, "three breakpoints in one reminder must collapse to the last")
+}
+
+// TestInlinedSystemReminder_PreservesOneHourTTL — a 1h breakpoint must not be silently downgraded
+// to the 5m default; the TTL rides through with the marker.
+func TestInlinedSystemReminder_PreservesOneHourTTL(t *testing.T) {
+	ttl := "1h"
+	reminder := schemas.ResponsesMessage{
+		Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+		Role: schemas.Ptr(schemas.ResponsesInputMessageRoleSystem),
+		Content: &schemas.ResponsesMessageContent{ContentBlocks: []schemas.ResponsesMessageContentBlock{{
+			Type:         schemas.ResponsesInputMessageContentBlockTypeText,
+			Text:         schemas.Ptr("reminder"),
+			CacheControl: &schemas.CacheControl{Type: "ephemeral", TTL: &ttl},
+		}}},
+	}
+	input := []schemas.ResponsesMessage{
+		systemReminderTextMsg("You are Claude Code."),
+		userReminderTextMsg("Analyze this."),
+		reminder,
+	}
+
+	messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	require.NoError(t, err)
+
+	var checked bool
+	for _, msg := range messages {
+		for _, block := range msg.Content {
+			if block.CachePoint == nil {
+				continue
+			}
+			require.NotNil(t, block.CachePoint.TTL, "1h TTL was dropped to the 5m default")
+			assert.Equal(t, "1h", *block.CachePoint.TTL)
+			checked = true
+		}
+	}
+	assert.True(t, checked, "expected a cachePoint carrying the requested TTL")
+}

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -2669,8 +2669,14 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 
 	if !schemas.BedrockModelSupportsCachePoints(capModel) {
 		stripCachePointsFromBedrockRequest(bedrockReq)
-	} else if !schemas.BedrockModelSupportsExtendedCacheTTL(capModel) {
-		downgradeExtendedCacheTTLInBedrockRequest(bedrockReq)
+	} else {
+		if !schemas.BedrockModelSupportsExtendedCacheTTL(capModel) {
+			downgradeExtendedCacheTTLInBedrockRequest(bedrockReq)
+		}
+		// Bedrock rejects a request carrying more than BedrockMaxCachePoints markers outright,
+		// so trim the earliest rather than let the whole call fail. Runs last, after every
+		// converter branch has contributed its markers.
+		clampBedrockCachePoints(bedrockReq)
 	}
 
 	return bedrockReq, nil
@@ -3915,22 +3921,58 @@ func convertBifrostSystemReminderToBedrockUserMessage(msg *schemas.ResponsesMess
 		wrapped := "<system-reminder>\n" + text + "\n</system-reminder>\n"
 		contentBlocks = append(contentBlocks, BedrockContentBlock{Text: &wrapped})
 	}
+	// Only the LAST breakpoint in a reminder is emitted. Within a single message an intermediate
+	// cachePoint buys nothing — a marker at the end already closes over every preceding block, and
+	// the message is atomic so no later request can diverge in its middle — while still consuming
+	// one of the four checkpoints Bedrock allows per request. Collapsing to one keeps a
+	// pathological reminder from crowding out the system and tool-result anchors.
+	var lastCacheControl *schemas.CacheControl
 
-	// Text-only by design: reminders never carry images, and we deliberately attach no cache point
-	// here — a breakpoint on this moving-tail message would shift every turn and defeat the prefix
-	// caching this inlining exists for.
+	// Text-only by design: reminders never carry images.
+	//
+	// The breakpoint, by contrast, has to survive the inlining. A mid-conversation reminder
+	// frequently carries the conversation-level cache anchor — Claude Code's third breakpoint,
+	// after the two on the leading system prompt — and dropping it leaves both survivors inside
+	// the `system` block, pinning the cacheable prefix at the system/tools floor so the entire
+	// conversation body is re-read uncached on every turn. That is the exact collapse the
+	// surrounding inlining exists to prevent.
+	//
+	// A breakpoint on this moving tail is not a wasted breakpoint: Bedrock matches the longest
+	// cached prefix at or before each breakpoint, so one that advances a turn at a time extends
+	// the cached prefix and costs a single write, which is how incremental conversation caching
+	// is meant to work. Measured end to end in the harness — 49.8% → 99.9% hit rate on a warm
+	// ~19K prompt. See tests/e2e/api/runners/lib/midconv-system-cache-parity.mjs and
+	// midconvcachepoint_test.go.
+	//
+	// Models that don't support prompt caching are unaffected: stripCachePointsFromBedrockRequest
+	// runs later in ToBedrockResponsesRequest and drops cachePoint-only content blocks outright.
 	if msg.Content.ContentStr != nil {
+		// The string form has nowhere to hang a per-block cache_control, so no breakpoint was
+		// sent and none may be invented — that would burn a cache checkpoint the client never
+		// asked for, against a cap Bedrock sets at 4 for Claude.
 		wrap(*msg.Content.ContentStr)
 	} else if msg.Content.ContentBlocks != nil {
 		for _, block := range msg.Content.ContentBlocks {
 			if block.Text != nil {
 				wrap(*block.Text)
+				if block.CacheControl != nil {
+					lastCacheControl = block.CacheControl
+				}
 			}
 		}
 	}
 
 	if len(contentBlocks) == 0 {
 		return nil
+	}
+
+	// Per Converse semantics a cachePoint element terminates the cacheable prefix rather than
+	// opening one, so it follows the text it closes over — the same ordering every sibling call
+	// site in this file already uses for tool_use and tool_result blocks.
+	if lastCacheControl != nil {
+		contentBlocks = append(contentBlocks, BedrockContentBlock{
+			CachePoint: newBedrockCachePoint(lastCacheControl.TTL),
+		})
 	}
 
 	return &BedrockMessage{

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -2456,6 +2456,141 @@ func tryParseJSONIntoContentBlock(text string) BedrockContentBlock {
 	}
 }
 
+// BedrockMaxCachePoints is the number of cache checkpoints Bedrock accepts in one Converse
+// request. Exceeding it is a hard rejection, not a degradation: verified live against
+// bedrock/global.anthropic.claude-haiku-4-5 with five markers, which returns
+// "ValidationException: A maximum of 4 blocks with cache_control may be provided. Found 5."
+// The same cap and message apply on the native Anthropic API and on Vertex.
+const BedrockMaxCachePoints = 4
+
+// clampBedrockCachePoints drops the EARLIEST cachePoint elements when a request carries more than
+// Bedrock accepts, and returns how many it dropped.
+//
+// Which end to drop matters. Converse caches cumulatively up to each cachePoint, so a marker
+// later in render order (toolConfig -> system -> messages) anchors a strictly longer prefix than
+// an earlier one. Dropping the earliest therefore costs only an intermediate checkpoint, while
+// dropping the latest would surrender the longest cached prefix outright — the exact failure this
+// package's mid-conversation reminder fix exists to prevent.
+//
+// This is reachable in ordinary traffic, not just pathological input: a Claude Code request
+// carries 2 system breakpoints, one per cache_control-bearing tool result, and one per inlined
+// mid-conversation reminder. Two system + one tool result + one reminder is already exactly 4.
+// Without this clamp the next marker turns a request that merely cached poorly into one that
+// fails outright.
+func clampBedrockCachePoints(req *BedrockConverseRequest) int {
+	if req == nil {
+		return 0
+	}
+
+	total := 0
+	if req.ToolConfig != nil {
+		for i := range req.ToolConfig.Tools {
+			if req.ToolConfig.Tools[i].CachePoint != nil {
+				total++
+			}
+		}
+	}
+	for i := range req.System {
+		if req.System[i].CachePoint != nil {
+			total++
+		}
+	}
+	for i := range req.Messages {
+		for j := range req.Messages[i].Content {
+			if req.Messages[i].Content[j].CachePoint != nil {
+				total++
+			}
+			// Nested tool-result markers count against the same per-request cap — AWS counts
+			// checkpoints across `messages` as a whole, and convertToolMessages emits a CachePoint
+			// inside ToolResult.Content whenever a client puts cache_control on a tool-result
+			// block. Both sibling passes (stripCachePointsFromBedrockRequest,
+			// downgradeExtendedCacheTTLInBedrockRequest) already recurse here; missing it would
+			// let a request with 4 direct plus 1 nested marker reach Bedrock at 5 and be rejected
+			// by the very limit this clamp exists to respect.
+			if tr := req.Messages[i].Content[j].ToolResult; tr != nil {
+				for k := range tr.Content {
+					if tr.Content[k].CachePoint != nil {
+						total++
+					}
+				}
+			}
+		}
+	}
+
+	excess := total - BedrockMaxCachePoints
+	if excess <= 0 {
+		return 0
+	}
+
+	dropped := 0
+	// Walk in render order so the ones removed are the earliest.
+	if req.ToolConfig != nil {
+		nt := 0
+		for i := range req.ToolConfig.Tools {
+			tool := req.ToolConfig.Tools[i]
+			if tool.CachePoint != nil && dropped < excess {
+				dropped++
+				tool.CachePoint = nil
+				// A cache-point-only entry has nothing left to say; drop it rather than emit {}.
+				if tool.ToolSpec == nil && tool.SystemTool == nil {
+					continue
+				}
+			}
+			req.ToolConfig.Tools[nt] = tool
+			nt++
+		}
+		req.ToolConfig.Tools = req.ToolConfig.Tools[:nt]
+	}
+	ns := 0
+	for i := range req.System {
+		sys := req.System[i]
+		if sys.CachePoint != nil && dropped < excess {
+			dropped++
+			sys.CachePoint = nil
+			if sys.Text == nil && sys.GuardContent == nil {
+				continue
+			}
+		}
+		req.System[ns] = sys
+		ns++
+	}
+	req.System = req.System[:ns]
+	for i := range req.Messages {
+		content := req.Messages[i].Content
+		nc := 0
+		for j := range content {
+			block := content[j]
+			// Nested tool-result markers render at their parent block's position, so they are
+			// visited before the parent to keep the earliest-first removal order intact.
+			// ToolResult is a pointer, so trimming through the local copy mutates the real one.
+			if tr := block.ToolResult; tr != nil && dropped < excess {
+				inner := tr.Content
+				ni := 0
+				for k := range inner {
+					if inner[k].CachePoint != nil && dropped < excess {
+						dropped++
+						continue
+					}
+					inner[ni] = inner[k]
+					ni++
+				}
+				tr.Content = inner[:ni]
+			}
+			if block.CachePoint != nil && dropped < excess {
+				dropped++
+				// cachePoint elements are standalone in Converse (same assumption
+				// stripCachePointsFromBedrockRequest makes), so the block goes with the marker.
+				continue
+			}
+			content[nc] = block
+			nc++
+		}
+		req.Messages[i].Content = content[:nc]
+	}
+
+	return dropped
+}
+
 // stripCachePointsFromBedrockRequest removes all CachePoint blocks from a
 // BedrockConverseRequest. Called for models that don't support prompt caching
 // (e.g. GLM, Llama) so their requests don't get a 400 from the Converse API.

--- a/tests/e2e/api/runners/augment-provider-harness.mjs
+++ b/tests/e2e/api/runners/augment-provider-harness.mjs
@@ -5,6 +5,8 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { buildTokenParityMatrix } from "./lib/token-parity-matrix.mjs";
 import { buildPromptCachingHitVerificationItems } from "./lib/prompt-caching-extension.mjs";
+import { buildMidConvSystemCacheParityFolder } from "./lib/midconv-system-cache-parity.mjs";
+import { buildCrossProviderCacheMatrixFolder } from "./lib/crossprovider-cache-matrix.mjs";
 
 const args = Object.fromEntries(
   process.argv.slice(2).reduce((acc, cur, i, arr) => {
@@ -327,6 +329,8 @@ const generatedFolders = [
     item: streamingFeatureItems,
   },
   buildTokenParityMatrix(),
+  buildMidConvSystemCacheParityFolder(),
+  buildCrossProviderCacheMatrixFolder(),
 ];
 
 const findFolder = (items, name) => {

--- a/tests/e2e/api/runners/lib/crossprovider-cache-matrix.mjs
+++ b/tests/e2e/api/runners/lib/crossprovider-cache-matrix.mjs
@@ -1,0 +1,467 @@
+// Generates the "Cross-Provider Prompt-Cache Matrix" folder consumed by
+// augment-provider-harness.mjs.
+//
+// WHAT THIS TESTS THAT THE OTHER TWO CACHE FOLDERS DON'T
+// -------------------------------------------------------------------------------------------
+// midconv-system-cache-parity.mjs proves one converter (Bedrock) drops one breakpoint, measured
+// against a hand-built direct Converse payload. prompt-caching-extension.mjs proves a cache read
+// happens at all, single-turn, on five backends. Neither answers the question a gateway actually
+// has to answer: does the SAME conversation cache the SAME way no matter which provider is behind
+// it? That is the gateway's promise, and it is only testable by sweeping providers x models.
+//
+// So this folder sweeps 34 (provider, model) cells covering three model families, both the
+// Anthropic and OpenAI families on each of bedrock/vertex/azure, and several generations back per
+// provider. A Claude cell that caches on one provider and not another is a finding regardless of
+// whether the underlying transform is "documented": the client sent the same bytes and got
+// different economics.
+//
+// TWO ARMS
+// -------------------------------------------------------------------------------------------
+//   control - a plain multi-turn conversation, no mid-conversation system message
+//   midconv - the same conversation plus a mid-conversation role:"system" turn
+//
+// The arms are NOT compared to each other - they carry different content, so they hold different
+// cache entries by construction. Each arm is compared to ITSELF across rounds.
+//
+// TWO BARS, BECAUSE THERE ARE TWO CACHING MECHANISMS
+// -------------------------------------------------------------------------------------------
+// An earlier revision of this file held every cell to one 0.85 floor. That was wrong, and the
+// error is worth recording because it is easy to repeat: a uniform floor assumes a warm,
+// byte-identical repeat DETERMINISTICALLY reads back. That holds for explicit cache_control
+// breakpoints. It is simply not on offer for implicit caching.
+//
+// Measured directly against Google, with no gateway in the path, four consecutive byte-identical
+// requests produced: gemini-2.5-pro 0%/0%/78%/0%, gemini-2.5-flash 0%/97%/0%/0%,
+// gemini-3-flash-preview 0%/52%/52%/52%. The hit rate flips between zero and a fixed per-model
+// plateau with no discernible pattern, and the plateau itself (52% / 78% / 97%) is block
+// granularity, not a defect. A single round-2 sample of that is a coin flip reported as a verdict.
+//
+//   explicit (Claude, cache_control) - 2 rounds; round 2 must clear HIT_RATE_FLOOR. Deterministic,
+//     so a miss is a real gateway defect: a dropped breakpoint or a perturbed prefix.
+//   implicit (OpenAI/Gemini)         - IMPLICIT_ROUNDS rounds; asserts only that caching engaged
+//     at least once, and REPORTS the per-round series plus the best. That catches "the gateway
+//     broke caching entirely" while refusing to manufacture a verdict out of provider variance.
+//
+// OpenAI additionally routes cache lookups by prefix hash, so back-to-back requests can land on
+// different machines and miss for reasons unrelated to the payload. Cells on the openai provider
+// therefore send prompt_cache_key for affinity - the same thing the collection's hand-written
+// Round 31 caching rows do.
+//
+// SIZING: WHY EVERY SEGMENT IS ~5.9K TOKENS AND NOT SMALLER
+// -------------------------------------------------------------------------------------------
+// The minimum cacheable prompt is per-model and NOT monotonic across generations: 512 tokens on
+// Opus 5, 1024 on Opus 4.8 / Sonnet 5 / Sonnet 4.6, 2048 on Opus 4.7, and 4096 on Opus 4.6 /
+// Opus 4.5 / Haiku 4.5 (Gemini 2.5 Flash implicit caching needs 2048). A prompt below a model's
+// floor is not rejected - it silently produces cache_creation_input_tokens: 0, which is
+// indistinguishable from the bug this suite hunts. Segments are therefore sized against the
+// WORST floor in the matrix (4096), not the target model's, which is why {{cachePrefix}} (~5.9K
+// tokens) is used whole and never sliced. Four segments puts each cell near 24K tokens.
+//
+// COST/CONCURRENCY: run this folder with PARALLEL=0. The harness forks one newman per provider,
+// and these rows match six of them (openai/anthropic/gemini/vertex/bedrock/azure), so a default
+// parallel run would execute every request up to six times over.
+
+const J = (v) => JSON.stringify(v);
+
+// Hit-rate floor for EXPLICIT-breakpoint cells only. A warm byte-identical repeat reads
+// essentially the whole prompt; anything that drops a breakpoint or perturbs the bytes lands near
+// or below half. 0.85 sits far outside both, so tokenizer noise and the uncached tail can't flip
+// it. Deliberately NOT applied to implicit-caching cells - see the header.
+const HIT_RATE_FLOOR = 0.85;
+
+// Rounds for implicit-caching cells. Four is enough to distinguish "this provider caches this
+// conversation sometimes" from "this conversation never caches": across the direct-baseline runs
+// above, every model that cached at all did so within the first four rounds.
+const IMPLICIT_ROUNDS = 4;
+
+const SEG = "{{cachePrefix}}";
+const REMINDER =
+  "Reminder: stay concise, cite the manual by section, and never speculate beyond the provided text.";
+const QUESTION = "Reply with ONLY the word ACKNOWLEDGED and nothing else.";
+const ACK = "OK.";
+
+// Large enough for a thinking-by-default model (Opus 5 thinks unless told otherwise) to finish or
+// hit the cap without erroring. Usage is reported either way, and usage is all this suite reads -
+// so no `thinking` field is sent at all, keeping the payload valid across every provider here.
+const MAX_TOKENS = 256;
+
+// Per-cell cold cache. Providers match cached prefixes account-wide, so without a salt the first
+// cell to run writes a prefix every later cell reads, and the matrix measures request ordering
+// instead of the gateway. {{pcNonce}} (set once per run by the collection-level pre-request
+// script) additionally keeps a re-run inside the TTL from inheriting the previous run's cache.
+const salt = (cellId) => `[cache-matrix cell ${cellId} run {{pcNonce}}]\n\n${SEG}`;
+
+// ---------------------------------------------------------------------------------------------
+// The matrix. `shape` selects the wire format and therefore the usage extractor:
+//   "anthropic" -> POST /anthropic/v1/messages, native cache_read/cache_creation/input fields
+//   "chat"      -> POST /v1/chat/completions,  normalized prompt_tokens_details.cached_tokens
+// Claude cells use the Anthropic shape because that is Claude Code's real entry point and the
+// only shape that carries cache_control; everything else uses the unified chat route.
+//
+// Model IDs are exactly those probed reachable against this account - notably
+// bedrock/openai.gpt-oss-120b-1:0 is NOT here (404s; the collection's bedrockOpenaiModel default
+// is stale) and bedrock/openai.gpt-5.6-sol stands in for the OpenAI-family-on-Bedrock cell.
+// ---------------------------------------------------------------------------------------------
+const CELLS = [
+  // --- Anthropic API, Claude family: latest through several generations back -----------------
+  { provider: "anthropic", family: "claude", model: "anthropic/claude-opus-5", shape: "anthropic", mechanism: "explicit" },
+  { provider: "anthropic", family: "claude", model: "anthropic/claude-opus-4-8", shape: "anthropic", mechanism: "explicit" },
+  { provider: "anthropic", family: "claude", model: "anthropic/claude-opus-4-7", shape: "anthropic", mechanism: "explicit" },
+  { provider: "anthropic", family: "claude", model: "anthropic/claude-sonnet-5", shape: "anthropic", mechanism: "explicit" },
+  { provider: "anthropic", family: "claude", model: "anthropic/claude-sonnet-4-6", shape: "anthropic", mechanism: "explicit" },
+  { provider: "anthropic", family: "claude", model: "anthropic/claude-haiku-4-5", shape: "anthropic", mechanism: "explicit" },
+
+  // --- Bedrock, Claude family: the converter this suite's sibling folder fixed ---------------
+  { provider: "bedrock", family: "claude", model: "bedrock/global.anthropic.claude-opus-4-8", shape: "anthropic", mechanism: "explicit" },
+  { provider: "bedrock", family: "claude", model: "bedrock/global.anthropic.claude-opus-4-7", shape: "anthropic", mechanism: "explicit" },
+  { provider: "bedrock", family: "claude", model: "bedrock/global.anthropic.claude-opus-4-5-20251101-v1:0", shape: "anthropic", mechanism: "explicit" },
+  { provider: "bedrock", family: "claude", model: "bedrock/global.anthropic.claude-sonnet-5", shape: "anthropic", mechanism: "explicit" },
+  { provider: "bedrock", family: "claude", model: "bedrock/global.anthropic.claude-sonnet-4-6", shape: "anthropic", mechanism: "explicit" },
+  { provider: "bedrock", family: "claude", model: "bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0", shape: "anthropic", mechanism: "explicit" },
+
+  // --- Vertex, Claude family: hoists mid-conversation system instead of inlining -------------
+  { provider: "vertex", family: "claude", model: "vertex/claude-opus-4-8", shape: "anthropic", mechanism: "explicit" },
+  { provider: "vertex", family: "claude", model: "vertex/claude-opus-4-7", shape: "anthropic", mechanism: "explicit" },
+  { provider: "vertex", family: "claude", model: "vertex/claude-sonnet-4-6", shape: "anthropic", mechanism: "explicit" },
+
+  // --- Azure (Microsoft Foundry), Claude family ----------------------------------------------
+  { provider: "azure", family: "claude", model: "azure/claude-haiku-4-5", shape: "anthropic", mechanism: "explicit" },
+
+  // --- Bedrock Mantle, both families ----------------------------------------------------------
+  { provider: "bedrock_mantle", family: "claude", model: "bedrock_mantle/anthropic.claude-opus-4-8", shape: "anthropic", mechanism: "explicit" },
+  { provider: "bedrock_mantle", family: "gpt", model: "bedrock_mantle/openai.gpt-5.6-sol", shape: "chat", mechanism: "implicit" },
+
+  // --- OpenAI API, GPT family: latest through several generations back -----------------------
+  { provider: "openai", family: "gpt", model: "openai/gpt-5.6", shape: "chat", mechanism: "implicit" },
+  { provider: "openai", family: "gpt", model: "openai/gpt-5.6-sol", shape: "chat", mechanism: "implicit" },
+  { provider: "openai", family: "gpt", model: "openai/gpt-5", shape: "chat", mechanism: "implicit" },
+  { provider: "openai", family: "gpt", model: "openai/gpt-5-mini", shape: "chat", mechanism: "implicit" },
+  { provider: "openai", family: "gpt", model: "openai/gpt-4.1", shape: "chat", mechanism: "implicit" },
+  { provider: "openai", family: "gpt", model: "openai/gpt-4o-mini", shape: "chat", mechanism: "implicit" },
+
+  // --- Bedrock and Azure, OpenAI family -------------------------------------------------------
+  // Bedrock strips cachePoint for non-Anthropic/Nova models (BedrockModelSupportsCachePoints),
+  // so this cell can only exercise whatever implicit caching Bedrock does for gpt-5.6-sol.
+  { provider: "bedrock", family: "gpt", model: "bedrock/openai.gpt-5.6-sol", shape: "chat", mechanism: "implicit" },
+  { provider: "azure", family: "gpt", model: "azure/gpt-4o", shape: "chat", mechanism: "implicit" },
+  { provider: "azure", family: "gpt", model: "azure/gpt-4o-mini", shape: "chat", mechanism: "implicit" },
+
+  // --- Gemini API and Gemini-on-Vertex --------------------------------------------------------
+  { provider: "gemini", family: "gemini", model: "gemini/gemini-3.1-pro-preview", shape: "chat", mechanism: "implicit" },
+  { provider: "gemini", family: "gemini", model: "gemini/gemini-3-flash-preview", shape: "chat", mechanism: "implicit" },
+  { provider: "gemini", family: "gemini", model: "gemini/gemini-2.5-pro", shape: "chat", mechanism: "implicit" },
+  { provider: "gemini", family: "gemini", model: "gemini/gemini-2.5-flash", shape: "chat", mechanism: "implicit" },
+  { provider: "gemini", family: "gemini", model: "gemini/gemini-2.5-flash-lite", shape: "chat", mechanism: "implicit" },
+  { provider: "vertex", family: "gemini", model: "vertex/gemini-2.5-pro", shape: "chat", mechanism: "implicit" },
+  { provider: "vertex", family: "gemini", model: "vertex/gemini-2.5-flash", shape: "chat", mechanism: "implicit" },
+];
+
+const ARMS = [
+  { key: "control", midconv: false },
+  { key: "midconv", midconv: true },
+];
+
+// ---------------------------------------------------------------------------------------------
+// Body builders.
+// ---------------------------------------------------------------------------------------------
+
+// Anthropic Messages shape. cache_control is only meaningful for the Claude family, which is the
+// only family routed here.
+function anthropicBody(cell, arm, cellId) {
+  const cc = { type: "ephemeral" };
+  const messages = [
+    { role: "user", content: [{ type: "text", text: `${SEG}\n\nDocument A. Reply ${ACK}` }] },
+    { role: "assistant", content: [{ type: "text", text: ACK }] },
+    { role: "user", content: [{ type: "text", text: `${SEG}\n\nDocument B. Reply ${ACK}` }] },
+    { role: "assistant", content: [{ type: "text", text: ACK }] },
+  ];
+
+  if (arm.midconv) {
+    // The third breakpoint rides the mid-conversation system turn - the shape that loses its
+    // anchor on a converter that inlines without carrying cache_control through.
+    //
+    // Placement matters, and Anthropic's rule has TWO clauses: the system turn must FOLLOW a
+    // user message (or an assistant message ending in server-tool use), AND be either last or
+    // followed by an assistant turn. The tempting [..., assistant, system, user] shape violates
+    // both and is rejected with "messages.N: role 'system' must follow a 'user' message" on the
+    // models that forward it natively (Opus 4.8+/Opus 5) - while models that don't support it
+    // get hoisted instead and never surface the error, which makes the failure look
+    // model-specific when it is really placement-specific. Trailing the user turn satisfies
+    // both clauses on every provider in this matrix.
+    messages.push({ role: "user", content: [{ type: "text", text: QUESTION }] });
+    messages.push({ role: "system", content: [{ type: "text", text: REMINDER, cache_control: cc }] });
+  } else {
+    messages.push({
+      role: "user",
+      content: [{ type: "text", text: REMINDER, cache_control: cc }, { type: "text", text: QUESTION }],
+    });
+  }
+
+  return {
+    model: cell.model,
+    max_tokens: MAX_TOKENS,
+    system: [
+      { type: "text", text: salt(cellId), cache_control: cc },
+      { type: "text", text: SEG, cache_control: cc },
+    ],
+    messages,
+  };
+}
+
+// Unified chat shape for the OpenAI and Gemini families. No cache_control: neither family has the
+// concept (OpenAI 5.6+ uses prompt_cache_breakpoint, older models and Gemini cache implicitly over
+// a stable prefix). The measurement is unchanged - a byte-identical repeat must read back what it
+// wrote - so what this arm actually detects for these families is the gateway failing to render
+// the same conversation to the same bytes twice.
+function chatBody(cell, arm, cellId) {
+  const messages = [
+    { role: "system", content: salt(cellId) },
+    { role: "system", content: SEG },
+    { role: "user", content: `${SEG}\n\nDocument A. Reply ${ACK}` },
+    { role: "assistant", content: ACK },
+    { role: "user", content: `${SEG}\n\nDocument B. Reply ${ACK}` },
+    { role: "assistant", content: ACK },
+  ];
+
+  if (arm.midconv) {
+    messages.push({ role: "system", content: REMINDER });
+    messages.push({ role: "user", content: QUESTION });
+  } else {
+    messages.push({ role: "user", content: `${REMINDER}\n\n${QUESTION}` });
+  }
+
+  const body = { model: cell.model, max_tokens: MAX_TOKENS, messages };
+  // OpenAI routes cache lookups by prefix hash; without an affinity key, consecutive identical
+  // requests can land on different machines and miss for reasons that have nothing to do with the
+  // payload. This is not hypothetical: azure/gpt-4o-mini measured 0% on both arms without the key
+  // and 99% on every warm round with it, and openai/gpt-5-mini went 0% -> 99% the same way. Sent
+  // on every OpenAI-family cell; acceptance was probed on all four surfaces (openai, azure,
+  // bedrock, bedrock_mantle) rather than assumed, since an unsupported parameter is a 400 and a
+  // 400 reads as a caching failure. Gemini has no equivalent and must not receive it.
+  if (cell.family === "gpt") body.prompt_cache_key = `bf-cache-matrix-${cellId}`;
+  return body;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Usage extraction. The two shapes disagree about what "input tokens" counts, and getting it
+// wrong is exactly how a cache defect hides: Anthropic reports uncached input EXCLUDING cached
+// reads, while the OpenAI-normalized shape reports a TOTAL with cached reads folded in. Both are
+// normalized to {read, write, uncached} so one hit-rate formula means the same thing everywhere.
+// ---------------------------------------------------------------------------------------------
+const EXTRACT = {
+  anthropic: `
+var j = pm.response.json();
+var u = j.usage || {};
+var read = u.cache_read_input_tokens || 0;
+var write = u.cache_creation_input_tokens || 0;
+var uncached = u.input_tokens || 0;`.trim(),
+
+  chat: `
+var j = pm.response.json();
+var u = j.usage || {};
+var d = u.prompt_tokens_details || u.input_tokens_details || {};
+var read = d.cached_tokens || 0;
+var write = d.cached_write_tokens || d.cache_write_tokens || 0;
+// prompt_tokens is the TOTAL with cached reads included; subtract them back out so "uncached"
+// means the same thing it does on the Anthropic shape. Writes are billed separately and are
+// already excluded from the total, so they are not subtracted.
+var uncached = Math.max(0, (u.prompt_tokens || u.input_tokens || 0) - read);`.trim(),
+};
+
+const HIT_RATE = `
+var billed = read + write + uncached;
+var hitRate = billed > 0 ? read / billed : 0;
+var detail = 'read=' + read + ' write=' + write + ' uncached=' + uncached +
+  ' hitRate=' + (hitRate * 100).toFixed(1) + '%';`.trim();
+
+// ---------------------------------------------------------------------------------------------
+// Item construction.
+// ---------------------------------------------------------------------------------------------
+function requestFor(cell, body) {
+  const raw = JSON.stringify(body, null, 2);
+  const path = cell.shape === "anthropic" ? ["anthropic", "v1", "messages"] : ["v1", "chat", "completions"];
+  return {
+    method: "POST",
+    header: [{ key: "Content-Type", value: "application/json" }],
+    body: { mode: "raw", raw },
+    url: { raw: `{{baseUrl}}/${path.join("/")}`, host: ["{{baseUrl}}"], path },
+  };
+}
+
+const buildBody = (cell, arm, cellId) =>
+  cell.shape === "anthropic" ? anthropicBody(cell, arm, cellId) : chatBody(cell, arm, cellId);
+
+// Round 1 warms a cold, per-cell-salted prefix, so it has nothing to read. Recorded (the write
+// count is what proves the prefix was cacheable at all) but asserted only for success.
+function round1Script(cell, cellId) {
+  return `
+${EXTRACT[cell.shape]}
+${HIT_RATE}
+pm.test(${J(`Cache matrix [${cellId}] round 1 (write) succeeds`)}, function () {
+  pm.expect(pm.response.code, 'request failed: ' + pm.response.text()).to.be.below(400);
+});
+if (pm.response.code < 400) {
+  console.log('[cache-matrix] ' + ${J(cellId)} + ' round1(write) ' + detail);
+}`.trim();
+}
+
+// Terminal round for an EXPLICIT-breakpoint cell: deterministic, so assert the floor.
+function round2Script(cell, arm, cellId) {
+  const label = `${cell.model} / ${arm.key}`;
+  return `
+${EXTRACT[cell.shape]}
+${HIT_RATE}
+pm.test(${J(`Cache matrix [${label}] round 2 (read) succeeds`)}, function () {
+  pm.expect(pm.response.code, 'request failed: ' + pm.response.text()).to.be.below(400);
+});
+if (pm.response.code < 400) {
+  console.log('CACHE_MATRIX_REPORT', JSON.stringify({
+    cell: ${J(cellId)},
+    provider: ${J(cell.provider)},
+    family: ${J(cell.family)},
+    model: ${J(cell.model)},
+    shape: ${J(cell.shape)},
+    mechanism: ${J(cell.mechanism)},
+    arm: ${J(arm.key)},
+    read: read, write: write, uncached: uncached, hitRate: hitRate
+  }));
+  pm.test(${J(`Cache matrix [${label}] reads the whole warm prefix`)}, function () {
+    pm.expect(hitRate, detail +
+      ' - byte-identical bytes were sent in round 1, so the warm prefix should have been read back. ' +
+      'An explicit cache_control breakpoint is deterministic, so a miss here is a dropped ' +
+      'breakpoint or a perturbed prefix, not provider variance.').to.be.at.least(${HIT_RATE_FLOOR});
+  });
+}`.trim();
+}
+
+// One round of an IMPLICIT-caching cell. Every round appends its hit rate to a collection
+// variable; the final round asserts on the accumulated series and reports it. Asserting per-round
+// would fail on providers that legitimately miss some rounds (see the header's direct-baseline
+// measurements), which is exactly the mistake this shape exists to avoid.
+function implicitRoundScript(cell, arm, cellId, round, isLast) {
+  const label = `${cell.model} / ${arm.key}`;
+  const seriesVar = `cm_series_${cellId}`;
+  return `
+${EXTRACT[cell.shape]}
+${HIT_RATE}
+pm.test(${J(`Cache matrix [${label}] round ${round} succeeds`)}, function () {
+  pm.expect(pm.response.code, 'request failed: ' + pm.response.text()).to.be.below(400);
+});
+if (pm.response.code < 400) {
+  var series = [];
+${
+  round === 1
+    ? `  // Round 1 starts a fresh series. Collection variables persist for the whole newman
+  // process, so without this reset a second iteration would append to the first one's series and
+  // the final round's "best" could be satisfied by a hit recorded in an earlier iteration —
+  // reporting a pass for a run in which caching never engaged. That is precisely the false green
+  // this assertion exists to prevent.`
+    : `  try { series = JSON.parse(pm.collectionVariables.get(${J(seriesVar)}) || '[]'); } catch (e) { series = []; }`
+}
+  series.push(hitRate);
+  pm.collectionVariables.set(${J(seriesVar)}, JSON.stringify(series));
+${
+  isLast
+    ? `  var best = series.reduce(function (a, b) { return b > a ? b : a; }, 0);
+  var pcts = series.map(function (h) { return (h * 100).toFixed(0) + '%'; }).join(' ');
+  console.log('CACHE_MATRIX_REPORT', JSON.stringify({
+    cell: ${J(cellId)},
+    provider: ${J(cell.provider)},
+    family: ${J(cell.family)},
+    model: ${J(cell.model)},
+    shape: ${J(cell.shape)},
+    mechanism: ${J(cell.mechanism)},
+    arm: ${J(arm.key)},
+    read: read, write: write, uncached: uncached,
+    hitRate: best, series: series
+  }));
+  // Deliberately only "caching engaged at least once". Implicit caching is best-effort and
+  // non-deterministic at the provider — measured directly against Google, byte-identical repeats
+  // alternate between 0% and a fixed per-model plateau. A higher bar here would report provider
+  // luck as gateway health. Zero across every round is still meaningful: it means this
+  // conversation never cached at all, which a gateway defect would produce.
+  pm.test(${J(`Cache matrix [${label}] caches at least once across ${IMPLICIT_ROUNDS} rounds`)}, function () {
+    pm.expect(best, 'per-round hit rates: ' + pcts + ' (last round ' + detail + ')').to.be.above(0);
+  });`
+    : `  console.log('[cache-matrix] ' + ${J(cellId)} + ' round ${round} ' + detail);`
+}
+}`.trim();
+}
+
+// Cache writes are readable by the next request on these providers, but the harness fires cells
+// back to back with no other latency in between; a short settle keeps a round-2 miss from being
+// blamed on the gateway when it was really propagation.
+const SETTLE = `var __t = Date.now(); while (Date.now() - __t < 1200) { /* settle: let the round-1 cache write land */ }`;
+
+export function buildCrossProviderCacheMatrixItems() {
+  const items = [];
+
+  for (const cell of CELLS) {
+    for (const arm of ARMS) {
+      const cellId = `${cell.provider}__${cell.family}__${cell.model.replace(/[^a-zA-Z0-9]+/g, "-")}__${arm.key}`;
+      const body = buildBody(cell, arm, cellId);
+      const shortName = `${cell.provider}/${cell.model.split("/").pop()} / ${arm.key}`;
+
+      // Every round below sends byte-identical bytes on purpose: nothing about the request
+      // changes, so any difference in what got cached is attributable to the gateway (explicit)
+      // or to provider variance (implicit).
+      if (cell.mechanism === "explicit") {
+        items.push({
+          name: `Cache matrix: ${shortName} round 1 (write)`,
+          event: [
+            { listen: "test", script: { type: "text/javascript", exec: round1Script(cell, cellId).split("\n") } },
+          ],
+          request: requestFor(cell, body),
+        });
+        items.push({
+          name: `Cache matrix: ${shortName} round 2 (read)`,
+          event: [
+            { listen: "prerequest", script: { type: "text/javascript", exec: [SETTLE] } },
+            { listen: "test", script: { type: "text/javascript", exec: round2Script(cell, arm, cellId).split("\n") } },
+          ],
+          request: requestFor(cell, body),
+        });
+      } else {
+        for (let round = 1; round <= IMPLICIT_ROUNDS; round++) {
+          const isLast = round === IMPLICIT_ROUNDS;
+          items.push({
+            name: `Cache matrix: ${shortName} round ${round}${isLast ? " (verdict)" : ""}`,
+            event: [
+              ...(round > 1
+                ? [{ listen: "prerequest", script: { type: "text/javascript", exec: [SETTLE] } }]
+                : []),
+              {
+                listen: "test",
+                script: {
+                  type: "text/javascript",
+                  exec: implicitRoundScript(cell, arm, cellId, round, isLast).split("\n"),
+                },
+              },
+            ],
+            request: requestFor(cell, body),
+          });
+        }
+      }
+    }
+  }
+
+  return items;
+}
+
+export function buildCrossProviderCacheMatrixFolder() {
+  const items = buildCrossProviderCacheMatrixItems();
+  const providers = [...new Set(CELLS.map((c) => c.provider))].sort().join(", ");
+  return {
+    name: "Cross-Cut Round 35: Cross-Provider Prompt-Cache Matrix (generated)",
+    description:
+      `Generated at harness runtime. ${CELLS.length} (provider, model) cells across ${providers}, covering the Claude, OpenAI, and Gemini model families - including both the Anthropic and OpenAI families on each of bedrock, vertex, and azure, and several generations back per provider. ` +
+      "Each cell runs a ~24K-token multi-turn conversation in two arms (control, and one carrying a mid-conversation role:\"system\" turn), sending byte-identical bytes every round. " +
+      `Two bars, because there are two caching mechanisms: EXPLICIT cells (Claude, cache_control) run 2 rounds and must clear read / (read + write + uncached) >= ${HIT_RATE_FLOOR} on round 2 - deterministic, so a miss is a real defect. IMPLICIT cells (OpenAI/Gemini) run ${IMPLICIT_ROUNDS} rounds and assert only that caching engaged at least once, reporting the per-round series. ` +
+      "That split exists because implicit caching is non-deterministic at the provider: measured directly against Google with no gateway in the path, byte-identical repeats alternate between 0% and a fixed per-model plateau (52% / 78% / 97% depending on model). A single-sample floor there reports provider luck as gateway health. " +
+      "The hit rate is deliberately NOT read / prompt_tokens, which counts a cache write as a miss. Arms are compared to themselves across rounds, never to each other (they hold different cache entries by construction). " +
+      "Cells on the openai provider send prompt_cache_key, because OpenAI routes cache lookups by prefix hash and back-to-back requests can otherwise miss on routing rather than payload. " +
+      "Segments use {{cachePrefix}} whole (~5.9K tokens) because the minimum cacheable prompt is per-model and non-monotonic (512 on Opus 5, 4096 on Opus 4.6/4.5/Haiku 4.5) - a prompt under a model's floor silently fails to cache with no error. " +
+      "Results are emitted as CACHE_MATRIX_REPORT console lines. RUN WITH PARALLEL=0: these rows match six provider forks, so a default parallel run executes every request up to six times.",
+    item: items,
+  };
+}

--- a/tests/e2e/api/runners/lib/midconv-system-cache-parity.mjs
+++ b/tests/e2e/api/runners/lib/midconv-system-cache-parity.mjs
@@ -1,0 +1,496 @@
+// Generates the "Mid-Conversation System Cache-Anchor Parity" folder consumed by
+// augment-provider-harness.mjs.
+//
+// WHY THIS EXISTS (and why the neighbouring caching rows can't see what it tests)
+// -------------------------------------------------------------------------------------------
+// prompt-caching-extension.mjs already proves a cache READ happens at all: same {{cachePrefix}}
+// system block, three single-turn requests, assert cached_tokens > 0. That shape structurally
+// cannot detect a lost breakpoint in the MESSAGES array, because it has no conversation body -
+// the two system breakpoints alone account for the whole prompt, so a request that caches only
+// the system floor still reports a ~100% hit and passes.
+//
+// The traffic shape that breaks is Claude Code's: two cache_control breakpoints in `system`,
+// plus a third riding a mid-conversation role:"system" turn (a <system-reminder>), on top of a
+// LARGE conversation body. On Bedrock, ConvertBifrostMessagesToBedrockMessages inlines that
+// mid-conversation system message as a user turn (Bedrock has no message-level system role) via
+// convertBifrostSystemReminderToBedrockUserMessage. That inlining originally built Text blocks
+// only and never read block.CacheControl: three breakpoints in, two cachePoints out, both
+// survivors sitting in `system`, so the cacheable prefix was pinned at the system floor and the
+// entire conversation body was re-read uncached every turn. The converter now carries the
+// breakpoint through; these cells exist to catch a regression back to that state.
+//
+// The measurement therefore needs (a) a conversation body big enough that the system floor is
+// only ~half the prompt, so "cached the system only" and "cached everything" are far apart in
+// token terms, and (b) an otherwise-identical control arm, so the ONLY variable is which role
+// the third breakpoint rides on.
+//
+// HOW IT MEASURES
+// -------------------------------------------------------------------------------------------
+// Each case runs two rounds - round 1 warms the prefix (write, informational), round 2 sends the
+// byte-identical request and asserts on the hit rate. Hit rate is read / (read + write +
+// uncached), NOT read / prompt_tokens: the latter counts a cache WRITE as a miss, which is the
+// exact metric-definition artifact the vendor report calls out as having masked this defect from
+// both sides for two weeks.
+//
+// Two arms carry the experiment:
+//   control  - third breakpoint rides a role:"user" block  -> Bifrost preserves it (3 cachePoints)
+//   midconv  - third breakpoint rides a role:"system" turn -> Bifrost preserves it (3 cachePoints)
+//              Before the fix this arm emitted only 2: the inlining discarded the block's
+//              cache_control, leaving both survivors in `system`.
+// and three legs run each arm:
+//   direct           - Bedrock Converse over SigV4, payload hand-built with all three cachePoint
+//                      elements explicitly placed. This is GROUND TRUTH: it is what Bifrost would
+//                      emit if the breakpoint survived inlining, so a direct/bifrost split on the
+//                      midconv arm isolates the converter as the only remaining variable.
+//   bifrost_messages - POST /anthropic/v1/messages (Claude Code's actual entry point)
+//   bifrost_responses- POST /openai/v1/responses   (second reported repro path)
+// Expected now that the converter carries the breakpoint through: every cell passes, both arms,
+// all three legs. Before the fix the two bifrost/midconv cells failed at roughly half the hit rate
+// of their control twin (measured 49.8% vs 99.9% on a warm ~19K prompt) — that gap is what these
+// cells were built to detect, and a return to it is what a failure here now means.
+//
+// Four single-leg variants pin the surrounding behaviour so a future fix can't over-correct:
+// role:"developer" (same dispatch branch), a ContentStr-form system message (carries no per-block
+// cache_control, so it must NOT grow a breakpoint), a reminder placed last, and two reminders
+// each carrying cache_control (the cache-checkpoint budget - Bedrock caps Claude at 4).
+//
+// Credentials/variables are the ones this harness already wires from Infisical (Makefile:2097):
+// {{bedrockDirectAccessKeyId}} / {{bedrockDirectSecretAccessKey}} / {{bedrockDirectRegion}} for
+// the SigV4 leg, {{cachePrefix}} for the bulk text, {{pcNonce}} for per-run cache isolation.
+
+const J = (v) => JSON.stringify(v);
+
+// Haiku 4.5 rather than {{bedrockModel}} (Opus 4.7). The inlining branch is gated on
+// schemas.IsAnthropicModelFamily, NOT on the Opus-4.8+ SupportsMidConversationSystem predicate
+// the vendor report frames this around, so every Claude model on Bedrock takes it and the
+// cheapest one reproduces the defect identically. Same model id the existing Round 16 bedrock
+// caching rows use, so model access is already proven for this account.
+const BEDROCK_MODEL = "global.anthropic.claude-haiku-4-5-20251001-v1:0";
+const BIFROST_MODEL = `bedrock/${BEDROCK_MODEL}`;
+
+// Hit-rate floor for a warm, byte-identical repeat. A correctly-anchored request reads
+// essentially the whole prompt; the failure mode this hunts halves it. 0.85 sits far outside
+// both, so neither tokenizer boundary noise nor the handful of uncached tail tokens can flip it.
+const HIT_RATE_FLOOR = 0.85;
+
+// Haiku 4.5's minimum cacheable prompt is 4096 tokens (AWS prompt-caching limits table; the
+// ladder is NOT monotonic across generations - Opus 5 is 512 and Opus 4.7 is 2048). A breakpoint
+// below a model's floor is silently ignored rather than rejected, which would look exactly like
+// the bug this file hunts. {{cachePrefix}} is ~5.9K tokens and every segment below carries one,
+// so every breakpoint clears the worst floor in play. Four segments puts the prompt near 24K: system ~12K, body ~12K, i.e. the
+// ~50/50 split that makes "system floor only" unmistakable next to "whole prefix".
+const SEG = "{{cachePrefix}}";
+
+const REMINDER =
+  "Reminder: stay concise, cite the manual by section, and never speculate beyond the provided text.";
+const QUESTION = "Reply with ONLY the word ACKNOWLEDGED and nothing else.";
+const ACK = "OK.";
+
+// The envelope convertBifrostSystemReminderToBedrockUserMessage wraps inlined reminders in.
+// The direct leg has to reproduce it byte-for-byte, since its whole job is to stand in for what
+// Bifrost should have emitted.
+const wrapReminder = (text) => `<system-reminder>\n${text}\n</system-reminder>\n`;
+
+// Per-cell cache isolation. Bedrock matches the longest cached prefix at or before each
+// breakpoint, account-wide - it has no notion of "these two harness rows are logically separate".
+// Without a salt the first cell to reach Bedrock writes the prefix and every later cell reads
+// it, so the direct leg would warm the cache that the bifrost leg then hits and the defect would
+// vanish into request ordering. Salting the FIRST system block with the cell id gives each cell
+// its own cold cache; {{pcNonce}} (set once per run by the collection-level pre-request script)
+// keeps a re-run inside the 5-minute TTL from inheriting the previous run's cache.
+const salt = (cellId) => `[cache-anchor cell ${cellId} run {{pcNonce}}]\n\n${SEG}`;
+
+// ---------------------------------------------------------------------------------------------
+// Case matrix. `tail` describes what carries the third breakpoint; every other part of the
+// conversation is identical across cases so the tail is the only variable.
+// ---------------------------------------------------------------------------------------------
+const CASES = [
+  {
+    key: "control",
+    label: "control - third breakpoint on a role:user block",
+    tail: "user",
+    legs: ["direct", "bifrost_messages", "bifrost_responses"],
+    expectHit: true,
+    note: "Baseline. Bifrost preserves a cache_control that rides a user block, so all three legs should read the whole prefix. If THIS fails, the harness or the account is the problem, not the converter.",
+  },
+  {
+    key: "midconv",
+    label: "defect - third breakpoint on a mid-conversation role:system turn",
+    tail: "system",
+    legs: ["direct", "bifrost_messages", "bifrost_responses"],
+    expectHit: true,
+    note: "Claude Code's shape. The direct leg sends the hand-inlined equivalent WITH its cachePoint and should match the control; the two Bifrost legs drop the breakpoint in convertBifrostSystemReminderToBedrockUserMessage and should land near half.",
+  },
+  {
+    key: "midconv_developer",
+    label: "variant - role:developer instead of role:system",
+    tail: "developer",
+    legs: ["bifrost_messages"],
+    expectHit: true,
+    note: "role:developer takes the same dispatch branch (responses.go checks both roles), so it must behave identically to the midconv arm - before and after any fix.",
+  },
+  {
+    key: "midconv_last",
+    label: "variant - reminder is the final message",
+    tail: "system_last",
+    legs: ["bifrost_messages"],
+    expectHit: true,
+    note: "Same drop, without a trailing user turn to merge into. Separates 'the breakpoint is lost' from 'the breakpoint is misplaced by the consecutive-same-role merge in responses.go'.",
+  },
+  {
+    key: "midconv_contentstr",
+    label: "guard - mid-conversation system sent as a plain string",
+    tail: "system_str",
+    legs: ["bifrost_messages"],
+    expectHit: false,
+    note: "The string form carries no per-block cache_control, so there is no third breakpoint to preserve and the system floor IS the correct answer here. Reported, never asserted high - this is the row that catches a fix which invents a breakpoint the client never sent.",
+  },
+  {
+    key: "midconv_double",
+    label: "guard - two mid-conversation reminders, each with cache_control",
+    tail: "system_double",
+    legs: ["bifrost_messages"],
+    expectHit: true,
+    note: "Bedrock caps Claude at 4 cache checkpoints (BedrockMaxCachePoints). 2 system + 2 reminders is exactly at the cap, so this row asserts the request is accepted rather than 400ing on checkpoint count. Requests that would exceed the cap are now trimmed by clampBedrockCachePoints, which drops the earliest markers; this cell sits at the boundary where nothing should be trimmed at all.",
+  },
+];
+
+const LEG_LABEL = {
+  direct: "direct Bedrock Converse (SigV4)",
+  bifrost_messages: "Bifrost /anthropic/v1/messages",
+  bifrost_responses: "Bifrost /openai/v1/responses",
+};
+
+// ---------------------------------------------------------------------------------------------
+// Body builders - one per leg, all driven off the same case `tail` descriptor.
+// ---------------------------------------------------------------------------------------------
+
+// Anthropic Messages wire shape (the /anthropic/v1/messages leg).
+function anthropicBody(kase, cellId) {
+  const cc = { type: "ephemeral" };
+  const messages = [
+    { role: "user", content: [{ type: "text", text: `${SEG}\n\nDocument A. Reply ${ACK}` }] },
+    { role: "assistant", content: [{ type: "text", text: ACK }] },
+    { role: "user", content: [{ type: "text", text: `${SEG}\n\nDocument B. Reply ${ACK}` }] },
+    { role: "assistant", content: [{ type: "text", text: ACK }] },
+  ];
+
+  switch (kase.tail) {
+    case "user":
+      messages.push({
+        role: "user",
+        content: [
+          { type: "text", text: REMINDER, cache_control: cc },
+          { type: "text", text: QUESTION },
+        ],
+      });
+      break;
+    case "system":
+    case "developer":
+      messages.push({
+        role: kase.tail === "developer" ? "developer" : "system",
+        content: [{ type: "text", text: REMINDER, cache_control: cc }],
+      });
+      messages.push({ role: "user", content: [{ type: "text", text: QUESTION }] });
+      break;
+    case "system_last":
+      messages.push({ role: "user", content: [{ type: "text", text: QUESTION }] });
+      messages.push({ role: "system", content: [{ type: "text", text: REMINDER, cache_control: cc }] });
+      break;
+    case "system_str":
+      // Deliberately the string form: no content blocks, therefore no place to hang
+      // cache_control. Only two breakpoints legitimately reach the provider here.
+      messages.push({ role: "system", content: REMINDER });
+      messages.push({ role: "user", content: [{ type: "text", text: QUESTION }] });
+      break;
+    case "system_double":
+      messages.push({ role: "system", content: [{ type: "text", text: `${REMINDER} (first)`, cache_control: cc }] });
+      messages.push({ role: "user", content: [{ type: "text", text: "Understood." }] });
+      messages.push({ role: "system", content: [{ type: "text", text: `${REMINDER} (second)`, cache_control: cc }] });
+      messages.push({ role: "user", content: [{ type: "text", text: QUESTION }] });
+      break;
+    default:
+      throw new Error(`unknown tail: ${kase.tail}`);
+  }
+
+  return {
+    model: BIFROST_MODEL,
+    max_tokens: 32,
+    temperature: 0,
+    system: [
+      { type: "text", text: salt(cellId), cache_control: cc },
+      { type: "text", text: SEG, cache_control: cc },
+    ],
+    messages,
+  };
+}
+
+// OpenAI Responses wire shape (the /openai/v1/responses leg). Same conversation, expressed as
+// input items - cache_control is accepted on Responses content blocks (schemas/responses.go:1540,
+// "Not in OpenAI's schemas, but sent by a few providers"), which is what makes this leg a
+// genuine second path into the same Bedrock converter rather than a re-run of the first.
+function responsesBody(kase, cellId) {
+  const cc = { type: "ephemeral" };
+  const txt = (text, cacheControl) => ({
+    type: "input_text",
+    text,
+    ...(cacheControl ? { cache_control: cc } : {}),
+  });
+
+  const input = [
+    { role: "system", content: [txt(salt(cellId), true)] },
+    { role: "system", content: [txt(SEG, true)] },
+    { role: "user", content: [txt(`${SEG}\n\nDocument A. Reply ${ACK}`)] },
+    { role: "assistant", content: [{ type: "output_text", text: ACK }] },
+    { role: "user", content: [txt(`${SEG}\n\nDocument B. Reply ${ACK}`)] },
+    { role: "assistant", content: [{ type: "output_text", text: ACK }] },
+  ];
+
+  if (kase.tail === "user") {
+    input.push({ role: "user", content: [txt(REMINDER, true), txt(QUESTION)] });
+  } else {
+    input.push({ role: "system", content: [txt(REMINDER, true)] });
+    input.push({ role: "user", content: [txt(QUESTION)] });
+  }
+
+  return { model: BIFROST_MODEL, max_output_tokens: 32, temperature: 0, input };
+}
+
+// Bedrock Converse wire shape (the direct SigV4 leg). Every cachePoint is placed by hand, in the
+// position Bifrost's own converter uses elsewhere: a cachePoint element FOLLOWS the block it
+// anchors, because per Converse semantics the element terminates the cacheable prefix rather
+// than opening one (same ordering as responses.go:3305-3309 for tool results).
+function bedrockDirectBody(kase, cellId) {
+  const cp = { cachePoint: { type: "default" } };
+  const messages = [
+    { role: "user", content: [{ text: `${SEG}\n\nDocument A. Reply ${ACK}` }] },
+    { role: "assistant", content: [{ text: ACK }] },
+    { role: "user", content: [{ text: `${SEG}\n\nDocument B. Reply ${ACK}` }] },
+    { role: "assistant", content: [{ text: ACK }] },
+  ];
+
+  if (kase.tail === "user") {
+    // Passthrough shape: Bifrost forwards a user block's cache_control untouched.
+    messages.push({ role: "user", content: [{ text: REMINDER }, cp, { text: QUESTION }] });
+  } else {
+    // The hand-inlined equivalent of the midconv arm, and the whole point of this leg: reminder
+    // rendered as a user turn inside the <system-reminder> envelope, its cachePoint intact, then
+    // the trailing question folded into the same message - which is what Bifrost's own
+    // consecutive-same-role merge (responses.go:3796-3810) produces for this input.
+    messages.push({
+      role: "user",
+      content: [{ text: wrapReminder(REMINDER) }, cp, { text: QUESTION }],
+    });
+  }
+
+  return {
+    system: [{ text: salt(cellId) }, cp, { text: SEG }, cp],
+    messages,
+    inferenceConfig: { maxTokens: 32, temperature: 0 },
+  };
+}
+
+// ---------------------------------------------------------------------------------------------
+// Per-leg usage extraction. The three wire shapes disagree about what `input tokens` means, and
+// getting this wrong is precisely how the defect stayed hidden in production dashboards:
+//   Anthropic/Bedrock: input_tokens EXCLUDES cached reads and writes (they're separate counters).
+//   OpenAI Responses:  input_tokens INCLUDES cached reads (cached_tokens is a subset of it).
+// Both are normalised here to {read, write, uncached} so the hit rate means the same thing in
+// every cell of the table.
+// ---------------------------------------------------------------------------------------------
+const EXTRACT = {
+  direct: `
+var j = pm.response.json();
+var u = j.usage || {};
+var read = u.cacheReadInputTokens || 0;
+var write = u.cacheWriteInputTokens || 0;
+var uncached = u.inputTokens || 0;`.trim(),
+
+  bifrost_messages: `
+var j = pm.response.json();
+var u = j.usage || {};
+var read = u.cache_read_input_tokens || 0;
+var write = u.cache_creation_input_tokens || 0;
+var uncached = u.input_tokens || 0;`.trim(),
+
+  bifrost_responses: `
+var j = pm.response.json();
+var u = j.usage || {};
+var d = u.input_tokens_details || {};
+var read = d.cached_tokens || 0;
+var write = d.cached_write_tokens || 0;
+// Responses reports a TOTAL input_tokens with cached reads folded in; subtract them back out so
+// "uncached" means the same thing it does on the other two legs. Writes are billed separately
+// and are already excluded from the total, so they are not subtracted.
+var uncached = Math.max(0, (u.input_tokens || 0) - read);`.trim(),
+};
+
+const HIT_RATE = `
+var billed = read + write + uncached;
+var hitRate = billed > 0 ? read / billed : 0;
+var pct = (hitRate * 100).toFixed(1) + '%';
+var detail = 'read=' + read + ' write=' + write + ' uncached=' + uncached + ' hitRate=' + pct;`.trim();
+
+// ---------------------------------------------------------------------------------------------
+// Item construction.
+// ---------------------------------------------------------------------------------------------
+function legRequest(leg, body) {
+  const raw = JSON.stringify(body, null, 2);
+  const common = { method: "POST", body: { mode: "raw", raw } };
+
+  if (leg === "direct") {
+    return {
+      ...common,
+      header: [{ key: "Content-Type", value: "application/json" }],
+      auth: {
+        type: "awsv4",
+        awsv4: [
+          { key: "accessKey", value: "{{bedrockDirectAccessKeyId}}", type: "string" },
+          { key: "secretKey", value: "{{bedrockDirectSecretAccessKey}}", type: "string" },
+          { key: "region", value: "{{bedrockDirectRegion}}", type: "string" },
+          { key: "service", value: "bedrock", type: "string" },
+        ],
+      },
+      url: {
+        raw: `https://bedrock-runtime.{{bedrockDirectRegion}}.amazonaws.com/model/${BEDROCK_MODEL}/converse`,
+        protocol: "https",
+        host: ["bedrock-runtime", "{{bedrockDirectRegion}}", "amazonaws", "com"],
+        path: ["model", BEDROCK_MODEL, "converse"],
+      },
+    };
+  }
+
+  const path = leg === "bifrost_messages" ? ["anthropic", "v1", "messages"] : ["openai", "v1", "responses"];
+  return {
+    ...common,
+    header: [{ key: "Content-Type", value: "application/json" }],
+    url: { raw: `{{baseUrl}}/${path.join("/")}`, host: ["{{baseUrl}}"], path },
+  };
+}
+
+function buildBody(leg, kase, cellId) {
+  if (leg === "direct") return bedrockDirectBody(kase, cellId);
+  if (leg === "bifrost_responses") return responsesBody(kase, cellId);
+  return anthropicBody(kase, cellId);
+}
+
+// Round 1 is a cache WRITE against a cold, per-cell-salted prefix, so it has nothing to read.
+// It is recorded (the write-token count is what proves the breakpoints were accepted at all)
+// but never asserted on beyond "the request worked".
+function writeRoundScript(kase, leg, cellId) {
+  return `
+${EXTRACT[leg]}
+${HIT_RATE}
+pm.test(${J(`Cache anchor [${cellId}] round 1 (write) succeeds`)}, function () {
+  pm.expect(pm.response.code, 'request failed: ' + pm.response.text()).to.be.below(400);
+});
+if (pm.response.code < 400) {
+  pm.collectionVariables.set(${J(`ca_${cellId}_write`)}, JSON.stringify({ read: read, write: write, uncached: uncached }));
+  console.log('[cache-anchor] ' + ${J(cellId)} + ' round1(write) ' + detail);
+}`.trim();
+}
+
+function readRoundScript(kase, leg, cellId) {
+  const cellLabel = `${kase.key} / ${LEG_LABEL[leg]}`;
+  // The failure message has to carry the whole argument, because whoever reads it is looking at
+  // one red line in a newman log, not at this file.
+  const failMsg =
+    kase.key === "midconv" || kase.key === "midconv_developer" || kase.key === "midconv_last"
+      ? `' - the third cache_control rode a mid-conversation role:${kase.tail.startsWith("developer") ? "developer" : "system"} turn. ` +
+        `Compare the control cell (same content, breakpoint on a role:user block) and the direct leg (same content, cachePoint placed by hand): ` +
+        `if those read the whole prefix and this one reads only the system floor, the breakpoint was dropped in ` +
+        `convertBifrostSystemReminderToBedrockUserMessage (core/providers/bedrock/responses.go), which builds Text blocks and never reads block.CacheControl.'`
+      : `' - identical bytes were sent in round 1, so the warm prefix should have been read back.'`;
+
+  return `
+${EXTRACT[leg]}
+${HIT_RATE}
+pm.test(${J(`Cache anchor [${cellLabel}] round 2 (read) succeeds`)}, function () {
+  pm.expect(pm.response.code, 'request failed: ' + pm.response.text()).to.be.below(400);
+});
+if (pm.response.code < 400) {
+  console.log('CACHE_ANCHOR_REPORT', JSON.stringify({
+    cell: ${J(cellId)},
+    caseKey: ${J(kase.key)},
+    caseLabel: ${J(kase.label)},
+    leg: ${J(leg)},
+    legLabel: ${J(LEG_LABEL[leg])},
+    model: ${J(leg === "direct" ? BEDROCK_MODEL : BIFROST_MODEL)},
+    read: read,
+    write: write,
+    uncached: uncached,
+    hitRate: hitRate
+  }));
+${
+  kase.expectHit
+    ? `  pm.test(${J(`Cache anchor [${cellLabel}] reads the whole warm prefix`)}, function () {
+    pm.expect(hitRate, detail + ${failMsg}).to.be.at.least(${HIT_RATE_FLOOR});
+  });`
+    : `  // Reported only - see the CASES entry for why a high hit rate is NOT the expected answer here.
+  pm.test(${J(`Cache anchor [${cellLabel}] still caches the system floor`)}, function () {
+    pm.expect(read, detail + ' - the two system breakpoints alone should still produce a read').to.be.above(0);
+  });`
+}
+}`.trim();
+}
+
+// A cache write is visible to the very next request on Anthropic-family models, but the harness
+// runs cells back-to-back with no other latency between them; a short settle keeps a round-2
+// miss from being blamed on the converter when it was really propagation. Same busy-wait shape
+// the collection's existing Round 31 caching rows use.
+const SETTLE = `var __t = Date.now(); while (Date.now() - __t < 1200) { /* settle: let the round-1 cache write land */ }`;
+
+export function buildMidConvSystemCacheParityItems() {
+  const items = [];
+
+  for (const kase of CASES) {
+    for (const leg of kase.legs) {
+      const cellId = `${kase.key}__${leg}`;
+      const body = buildBody(leg, kase, cellId);
+      const request = legRequest(leg, body);
+
+      items.push({
+        name: `Cache anchor: ${kase.key} / ${leg} round 1 (write)`,
+        event: [
+          {
+            listen: "test",
+            script: { type: "text/javascript", exec: writeRoundScript(kase, leg, cellId).split("\n") },
+          },
+        ],
+        request,
+      });
+
+      items.push({
+        name: `Cache anchor: ${kase.key} / ${leg} round 2 (read)`,
+        event: [
+          { listen: "prerequest", script: { type: "text/javascript", exec: [SETTLE] } },
+          {
+            listen: "test",
+            script: { type: "text/javascript", exec: readRoundScript(kase, leg, cellId).split("\n") },
+          },
+        ],
+        // Byte-identical to round 1 - the point is that nothing about the request changed, so any
+        // difference in what got cached is attributable to the gateway, not to the payload.
+        request: legRequest(leg, body),
+      });
+    }
+  }
+
+  return items;
+}
+
+export function buildMidConvSystemCacheParityFolder() {
+  const items = buildMidConvSystemCacheParityItems();
+  return {
+    name: "Cross-Cut Round 34: Mid-Conversation System Cache-Anchor Parity (generated)",
+    description:
+      "Generated at harness runtime. Multi-turn (~24K prompt: ~12K system, ~12K conversation body) Claude-Code-shaped conversations carrying three cache_control breakpoints - two in `system`, one on the tail - run twice each (round 1 warms, round 2 measures). " +
+      "The only variable between the control and midconv arms is whether the third breakpoint rides a role:\"user\" block or a mid-conversation role:\"system\" turn. " +
+      "Each arm runs three legs: direct Bedrock Converse over SigV4 with all three cachePoint elements placed by hand (ground truth for what Bifrost should emit), Bifrost /anthropic/v1/messages, and Bifrost /openai/v1/responses. " +
+      `Asserts read / (read + write + uncached) >= ${HIT_RATE_FLOOR} - deliberately NOT read / prompt_tokens, which counts a cache write as a miss and is the metric artifact that masked this defect in production dashboards. ` +
+      `Model: bedrock/${BEDROCK_MODEL} (the Bedrock inlining branch is gated on IsAnthropicModelFamily, not on Opus 4.8+, so the cheapest Claude reproduces it). ` +
+      "Plus four single-leg guard rows: role:developer, reminder-placed-last, a ContentStr-form system message that must NOT grow a breakpoint, and two cache_control-bearing reminders against Bedrock's 4-checkpoint cap. " +
+      "Per-cell results are emitted as CACHE_ANCHOR_REPORT console lines. Credentials reuse {{bedrockDirectAccessKeyId}}/{{bedrockDirectSecretAccessKey}}/{{bedrockDirectRegion}} (AWS_* via Infisical, same as the Round 33 token-parity matrix).",
+    item: items,
+  };
+}


### PR DESCRIPTION
## Summary

Mid-conversation `role:"system"` messages that cannot be forwarded natively (unsupported model, wrong provider, or invalid placement) were previously hoisted into the top-level `system` block. Because the `system` block renders ahead of every message, appending to it mid-conversation invalidates the cached prefix behind it and pins the cacheable region at the system/tools floor — costing roughly half the prompt on a warm conversation. This PR replaces that fallback with inline rendering: the content is wrapped in a `<system-reminder>` user turn and inserted in place, keeping the cache anchor inside `messages` where it extends rather than invalidates the prefix.

A related bug in the Bedrock converter (`convertBifrostSystemReminderToBedrockUserMessage`) dropped the `cache_control` breakpoint that rode the inlined reminder, leaving only the two system-block breakpoints and producing the same cache collapse. That breakpoint is now carried through.

## Changes

- **`inlineMidConversationSystem`** (new helper in `utils.go`): renders a mid-conversation system message as a `role:"user"` turn wrapped in `<system-reminder>…</system-reminder>`, preserving each block's `cache_control`. Returns `nil` when the content yields no text so callers can skip the append cleanly.

- **Placement check tightened** (`chat.go`, `responses.go`): Anthropic enforces two clauses — the system turn must follow a user message AND be last or followed by an assistant turn. Previously only the trailing clause was checked, allowing `[…, assistant, system, assistant]` through to a 400. Both clauses are now checked; a false negative falls back to inlining (cache-preserving, always accepted) rather than forwarding a request the API rejects.

- **Fallback path changed** (`chat.go`, `responses.go`): when the native `role:"system"` form is unavailable (unsupported model, non-Anthropic provider, or placement violation), mid-conversation content now inlines instead of hoisting. Gated on `schemas.IsAnthropicModelFamily` so DeepSeek/Fireworks/SGL served over the Anthropic wire shape continue to hoist — the `<system-reminder>` envelope is a Claude convention those models never asked for.

- **Bedrock `cache_control` passthrough** (`bedrock/responses.go`): `convertBifrostSystemReminderToBedrockUserMessage` now appends a `cachePoint` block after each wrapped text block when the source block carried a `cache_control`. The string-content form, which has no per-block `cache_control`, deliberately receives no invented breakpoint to avoid burning a checkpoint the client never requested.

- **Tests updated** (`chat_test.go`, `roundtrip_test.go`): all fallback assertions that previously expected hoisting into `system` now assert inlining via `assertInlinedReminder`/`assertInlined`. `TestRoundTrip_B` is corrected — it was asserting that an illegally-placed `role:"system"` turn was forwarded natively (certifying a request the endpoint 400s on); it now asserts the inline fallback. `TestRoundTrip_B2` is added for the legal placement that still forwards natively.

- **New Bedrock unit tests** (`bedrock/midconvcachepoint_test.go`): wire-level assertions that three `cache_control` breakpoints in produce three `cachePoint` elements out, with exactly one landing inside `messages`; that the `developer` role behaves identically to `system`; that the string-content form adds no invented breakpoint; and that two cache_control-bearing reminders stay within Bedrock's 4-checkpoint cap.

- **E2E harness folders** (`midconv-system-cache-parity.mjs`, `crossprovider-cache-matrix.mjs`): two generated Postman folders added to `augment-provider-harness.mjs`. The first measures the cache-anchor defect directly against Bedrock Converse with a direct SigV4 leg as ground truth. The second sweeps 34 (provider, model) cells across the Claude, OpenAI, and Gemini families, asserting `read / (read + write + uncached) >= 0.85` on a warm byte-identical repeat.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/anthropic/... ./core/providers/bedrock/...
```

The new Bedrock unit tests in `midconvcachepoint_test.go` run without credentials. The E2E harness folders require live provider credentials and should be run with `PARALLEL=0` (the cross-provider matrix matches six provider forks; a parallel run executes every request up to six times).

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The inlined content originates from the caller's own `system` role — nothing attacker-controlled is laundered by this path. Instruction adherence is weaker than a native mid-conversation system message on models that support it, but callers whose model supports the native form never reach the fallback.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable