### PR TITLE
last_reset and current_usage override bug fix

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -4599,6 +4599,15 @@ func (s *RDBConfigStore) UpdateRateLimit(ctx context.Context, rateLimit *tables.
 			}
 			return err
 		}
+		// Same ownership boundary as UpdateBudget: the four counters are advanced
+		// by the governance dump path and UpdateRateLimitUsage, never by a
+		// configuration write, which is why GenerateRateLimitHash excludes them.
+		// The existing row is already read under the same lock that guards the
+		// Save below, so this adds no new race window.
+		rateLimit.TokenCurrentUsage = existing.TokenCurrentUsage
+		rateLimit.TokenLastReset = existing.TokenLastReset
+		rateLimit.RequestCurrentUsage = existing.RequestCurrentUsage
+		rateLimit.RequestLastReset = existing.RequestLastReset
 	}
 	if err := txDB.WithContext(ctx).Save(rateLimit).Error; err != nil {
 		return s.parseGormError(err)
@@ -4746,6 +4755,18 @@ func (s *RDBConfigStore) UpdateBudget(ctx context.Context, budget *tables.TableB
 			}
 			return err
 		}
+		// Usage accounting is runtime-owned, never authored by a configuration
+		// write: it is advanced by the governance dump path and UpdateBudgetUsage,
+		// which is why GenerateBudgetHash excludes both columns. Carrying them
+		// forward is what stops a source_of_truth=config.json startup force-sync
+		// from replaying the file row's zero values over live accounting — the
+		// file declares max_limit and reset_duration, so a whole-row Save of it
+		// would otherwise write current_usage=0 and a zero last_reset.
+		//
+		// Consequence: current_usage / last_reset in config.json are seed values
+		// applied by CreateBudget on first import, and inert thereafter.
+		budget.CurrentUsage = existing.CurrentUsage
+		budget.LastReset = existing.LastReset
 		// Overrides are managed by the dedicated override path, not UpdateBudget;
 		// carry them forward so partial updates can't wipe an active override.
 		// The grant columns must travel with the derived remaining count: dropping

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -749,6 +749,46 @@ func TestUpdateBudget(t *testing.T) {
 	assert.Equal(t, 200.0, result.MaxLimit)
 }
 
+// TestUpdateBudgetPreservesRuntimeCounters verifies a configuration-shaped update
+// cannot clobber the runtime-owned counters.
+//
+// CurrentUsage and LastReset are advanced by the governance dump path, never by
+// config.json, which is why GenerateBudgetHash deliberately excludes them. A
+// source_of_truth=config.json startup force-sync replays the file row through
+// UpdateBudget with those fields at their Go zero values, so UpdateBudget must
+// carry the persisted values forward the same way it already does for the
+// override grant and the owner FKs.
+func TestUpdateBudgetPreservesRuntimeCounters(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	lastReset := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, store.CreateBudget(ctx, &tables.TableBudget{
+		ID:            "budget-runtime-counters",
+		MaxLimit:      100.0,
+		ResetDuration: "1h",
+		CurrentUsage:  42.5,
+		LastReset:     lastReset,
+	}))
+
+	// The shape config.json produces: configuration-owned fields only, with the
+	// runtime counters absent and therefore zero.
+	require.NoError(t, store.UpdateBudget(ctx, &tables.TableBudget{
+		ID:            "budget-runtime-counters",
+		MaxLimit:      200.0,
+		ResetDuration: "1h",
+	}))
+
+	result, err := store.GetBudget(ctx, "budget-runtime-counters")
+	require.NoError(t, err)
+	assert.Equal(t, 200.0, result.MaxLimit, "configuration-owned max_limit must follow the file")
+	assert.Equal(t, "1h", result.ResetDuration, "configuration-owned reset_duration must follow the file")
+	assert.Equal(t, 42.5, result.CurrentUsage, "runtime-owned current_usage must survive a config-shaped update")
+	assert.True(t, result.LastReset.Equal(lastReset),
+		"runtime-owned last_reset must survive a config-shaped update: got %s, want %s",
+		result.LastReset.UTC(), lastReset)
+}
+
 // TestCreateBudgetWithOverride verifies finite and permanent override state round-trips through the config store.
 func TestCreateBudgetWithOverride(t *testing.T) {
 	store := setupRDBTestStore(t)
@@ -991,6 +1031,56 @@ func TestUpdateRateLimit(t *testing.T) {
 	result, err := store.GetRateLimit(ctx, "rate-limit-update")
 	require.NoError(t, err)
 	assert.Equal(t, int64(200000), *result.TokenMaxLimit)
+}
+
+// TestUpdateRateLimitPreservesRuntimeCounters is the rate-limit counterpart of
+// TestUpdateBudgetPreservesRuntimeCounters: the same startup force-sync replays
+// the file-shaped rate limit, and the token/request counters are runtime-owned
+// for the same reason (GenerateRateLimitHash excludes them).
+func TestUpdateRateLimitPreservesRuntimeCounters(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	tokenMax := int64(100000)
+	tokenDuration := "1h"
+	requestMax := int64(500)
+	requestDuration := "1h"
+	tokenLastReset := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+	requestLastReset := time.Date(2026, time.August, 1, 0, 30, 0, 0, time.UTC)
+
+	require.NoError(t, store.CreateRateLimit(ctx, &tables.TableRateLimit{
+		ID:                   "rate-limit-runtime-counters",
+		TokenMaxLimit:        &tokenMax,
+		TokenResetDuration:   &tokenDuration,
+		TokenCurrentUsage:    1234,
+		TokenLastReset:       tokenLastReset,
+		RequestMaxLimit:      &requestMax,
+		RequestResetDuration: &requestDuration,
+		RequestCurrentUsage:  56,
+		RequestLastReset:     requestLastReset,
+	}))
+
+	newTokenMax := int64(200000)
+	require.NoError(t, store.UpdateRateLimit(ctx, &tables.TableRateLimit{
+		ID:                   "rate-limit-runtime-counters",
+		TokenMaxLimit:        &newTokenMax,
+		TokenResetDuration:   &tokenDuration,
+		RequestMaxLimit:      &requestMax,
+		RequestResetDuration: &requestDuration,
+	}))
+
+	result, err := store.GetRateLimit(ctx, "rate-limit-runtime-counters")
+	require.NoError(t, err)
+	require.NotNil(t, result.TokenMaxLimit)
+	assert.Equal(t, int64(200000), *result.TokenMaxLimit, "configuration-owned token_max_limit must follow the file")
+	assert.Equal(t, int64(1234), result.TokenCurrentUsage, "runtime-owned token_current_usage must survive a config-shaped update")
+	assert.Equal(t, int64(56), result.RequestCurrentUsage, "runtime-owned request_current_usage must survive a config-shaped update")
+	assert.True(t, result.TokenLastReset.Equal(tokenLastReset),
+		"runtime-owned token_last_reset must survive a config-shaped update: got %s, want %s",
+		result.TokenLastReset.UTC(), tokenLastReset)
+	assert.True(t, result.RequestLastReset.Equal(requestLastReset),
+		"runtime-owned request_last_reset must survive a config-shaped update: got %s, want %s",
+		result.RequestLastReset.UTC(), requestLastReset)
 }
 
 // =============================================================================

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -2398,6 +2398,17 @@ func mergeGovernanceConfig(ctx context.Context, config *Config, configData *Conf
 				if forceFileSync || existingBudget.ConfigHash != fileBudgetHash {
 					logger.Debug("config hash mismatch for budget %s, syncing from config file", newBudget.ID)
 					configData.Governance.Budgets[i].ConfigHash = fileBudgetHash
+					// config.json is authoritative for configuration, never for
+					// accounting. The file row carries CurrentUsage=0 and a zero
+					// LastReset because it declares neither, so adopt the persisted
+					// values before any copy is taken. Mutating the source element
+					// rather than the copies fixes all three consumers at once: the
+					// row handed to UpdateBudget, the merged snapshot below, and
+					// pruneGovernanceConfigToFile's wholesale replacement of
+					// config.GovernanceConfig.Budgets, which runs after this and
+					// would otherwise re-zero what we just repaired.
+					configData.Governance.Budgets[i].CurrentUsage = existingBudget.CurrentUsage
+					configData.Governance.Budgets[i].LastReset = existingBudget.LastReset
 					budgetsToUpdate = append(budgetsToUpdate, configData.Governance.Budgets[i])
 					governanceConfig.Budgets[j] = configData.Governance.Budgets[i]
 				} else {
@@ -2429,6 +2440,11 @@ func mergeGovernanceConfig(ctx context.Context, config *Config, configData *Conf
 				if forceFileSync || existingRateLimit.ConfigHash != fileRLHash {
 					logger.Debug("config hash mismatch for rate limit %s, syncing from config file", newRateLimit.ID)
 					configData.Governance.RateLimits[i].ConfigHash = fileRLHash
+					// Same ownership boundary as budgets above.
+					configData.Governance.RateLimits[i].TokenCurrentUsage = existingRateLimit.TokenCurrentUsage
+					configData.Governance.RateLimits[i].TokenLastReset = existingRateLimit.TokenLastReset
+					configData.Governance.RateLimits[i].RequestCurrentUsage = existingRateLimit.RequestCurrentUsage
+					configData.Governance.RateLimits[i].RequestLastReset = existingRateLimit.RequestLastReset
 					rateLimitsToUpdate = append(rateLimitsToUpdate, configData.Governance.RateLimits[i])
 					governanceConfig.RateLimits[j] = configData.Governance.RateLimits[i]
 				} else {

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -412,6 +412,12 @@ type MockConfigStore struct {
 		teams       []tables.TableTeam
 		virtualKeys []tables.TableVirtualKey
 	}
+	// governanceItemsUpdated records the rows handed to the store's update path,
+	// so a test can assert on the exact struct the config sync would persist
+	// rather than only on what the mock chose to keep.
+	governanceItemsUpdated struct {
+		budgets []tables.TableBudget
+	}
 	flushSessionsCalled bool
 }
 
@@ -760,6 +766,12 @@ func (m *MockConfigStore) CreateBudget(ctx context.Context, budget *tables.Table
 }
 
 func (m *MockConfigStore) UpdateBudget(ctx context.Context, budget *tables.TableBudget, tx ...*gorm.DB) error {
+	// Recording only: deliberately does not simulate the store's own field
+	// preservation, so a test can assert on exactly what the config sync hands
+	// down rather than on the store's compensation for it.
+	if budget != nil {
+		m.governanceItemsUpdated.budgets = append(m.governanceItemsUpdated.budgets, *budget)
+	}
 	return nil
 }
 
@@ -1699,6 +1711,68 @@ func (m *MockConfigStore) RescheduleWebhookJob(ctx context.Context, id, runnerID
 
 func (m *MockConfigStore) DeleteWebhookJob(ctx context.Context, id, runnerID string, leaseUntil time.Time) error {
 	return nil
+}
+
+// TestMergeGovernanceConfig_ForceFileSyncPreservesBudgetRuntimeState verifies the
+// startup force-sync keeps runtime-owned budget counters.
+//
+// With source_of_truth=config.json every file-present budget is pushed into
+// budgetsToUpdate even when its ConfigHash matches, because the stored hash cannot
+// prove the row is unmodified. That is correct for configuration-owned fields, but
+// the file row carries CurrentUsage=0 and a zero LastReset, and those two are
+// runtime-owned: GenerateBudgetHash excludes them precisely because config.json
+// never authors them.
+func TestMergeGovernanceConfig_ForceFileSyncPreservesBudgetRuntimeState(t *testing.T) {
+	initTestLogger()
+
+	lastReset := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+	store := NewMockConfigStore()
+	dbGovernance := &configstore.GovernanceConfig{
+		Budgets: []tables.TableBudget{{
+			ID:            "budget-runtime-state",
+			MaxLimit:      100,
+			ResetDuration: "1h",
+			CurrentUsage:  42.5,
+			LastReset:     lastReset,
+		}},
+	}
+	store.governanceConfig = dbGovernance
+	config := &Config{
+		ConfigStore:      store,
+		GovernanceConfig: dbGovernance,
+	}
+	configData := &ConfigData{
+		SourceOfTruth: SourceOfTruthConfigJSON,
+		Governance: &configstore.GovernanceConfig{
+			// Configuration-owned fields only, exactly as declared in config.json.
+			Budgets: []tables.TableBudget{{
+				ID:            "budget-runtime-state",
+				MaxLimit:      250,
+				ResetDuration: "1h",
+			}},
+		},
+	}
+
+	mergeGovernanceConfig(context.Background(), config, configData, dbGovernance)
+
+	require.Len(t, store.governanceItemsUpdated.budgets, 1,
+		"force sync must push the file-present budget through the update path")
+	persisted := store.governanceItemsUpdated.budgets[0]
+	assert.Equal(t, 250.0, persisted.MaxLimit, "configuration-owned max_limit must follow the file")
+	assert.Equal(t, 42.5, persisted.CurrentUsage,
+		"runtime-owned current_usage must not be written back as the file's zero value")
+	assert.True(t, persisted.LastReset.Equal(lastReset),
+		"runtime-owned last_reset must not be written back as the Go zero timestamp: got %s, want %s",
+		persisted.LastReset.UTC(), lastReset)
+
+	require.Len(t, config.GovernanceConfig.Budgets, 1)
+	inMemory := config.GovernanceConfig.Budgets[0]
+	assert.Equal(t, 250.0, inMemory.MaxLimit, "in-memory snapshot must pick up the file's max_limit")
+	assert.Equal(t, 42.5, inMemory.CurrentUsage,
+		"in-memory snapshot must keep the persisted usage the governance store will load")
+	assert.True(t, inMemory.LastReset.Equal(lastReset),
+		"in-memory snapshot must keep the persisted last_reset: got %s, want %s",
+		inMemory.LastReset.UTC(), lastReset)
 }
 
 func TestMergeGovernanceConfig_SyncsComplexityAnalyzerConfig(t *testing.T) {

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -493,13 +493,13 @@
               },
               "current_usage": {
                 "type": "number",
-                "description": "Current usage in dollars",
+                "description": "Seed value only: current usage in dollars, applied when the budget is first created. Runtime-owned thereafter - the value here is ignored on every subsequent sync so a config.json reload cannot overwrite live accounting.",
                 "default": 0
               },
               "last_reset": {
                 "type": "string",
                 "format": "date-time",
-                "description": "Last time budget was reset"
+                "description": "Seed value only: last time the budget was reset, applied when the budget is first created. Runtime-owned thereafter, like current_usage."
               },
               "virtual_key_id": {
                 "type": "string",
@@ -624,13 +624,13 @@
               },
               "token_current_usage": {
                 "type": "integer",
-                "description": "Current token usage",
+                "description": "Seed value only: current token usage, applied when the rate limit is first created. Runtime-owned thereafter - the value here is ignored on every subsequent sync so a config.json reload cannot overwrite live counters.",
                 "default": 0
               },
               "token_last_reset": {
                 "type": "string",
                 "format": "date-time",
-                "description": "Last time token counter was reset"
+                "description": "Seed value only: last time the token counter was reset, applied when the rate limit is first created. Runtime-owned thereafter, like token_current_usage."
               },
               "request_max_limit": {
                 "type": "integer",
@@ -642,13 +642,13 @@
               },
               "request_current_usage": {
                 "type": "integer",
-                "description": "Current request usage",
+                "description": "Seed value only: current request usage, applied when the rate limit is first created. Runtime-owned thereafter - the value here is ignored on every subsequent sync so a config.json reload cannot overwrite live counters.",
                 "default": 0
               },
               "request_last_reset": {
                 "type": "string",
                 "format": "date-time",
-                "description": "Last time request counter was reset"
+                "description": "Seed value only: last time the request counter was reset, applied when the rate limit is first created. Runtime-owned thereafter, like request_current_usage."
               },
               "calendar_aligned": {
                 "type": "boolean",


### PR DESCRIPTION
## Summary

`UpdateBudget` and `UpdateRateLimit` were overwriting live runtime counters (`current_usage`, `last_reset`, `token_current_usage`, `token_last_reset`, `request_current_usage`, `request_last_reset`) with zero values whenever a `source_of_truth=config.json` startup force-sync replayed the file row. Because `config.json` never declares these fields, the file-shaped struct carries Go zero values, and a whole-row `Save` was writing those zeros over live accounting data.

Closes #5925

## Changes

- `UpdateBudget` now carries `CurrentUsage` and `LastReset` forward from the existing row before saving, matching the pattern already used for override grants and owner FKs.
- `UpdateRateLimit` now carries all four runtime counters (`TokenCurrentUsage`, `TokenLastReset`, `RequestCurrentUsage`, `RequestLastReset`) forward from the existing row before saving.
- `mergeGovernanceConfig` adopts the persisted runtime counters into the source element before appending to `budgetsToUpdate` / `rateLimitsToUpdate`. Mutating the source element fixes all three consumers at once: the row handed to the store's update path, the merged in-memory snapshot, and `pruneGovernanceConfigToFile`'s wholesale replacement of `config.GovernanceConfig.Budgets`.
- Schema descriptions for `current_usage`, `last_reset`, `token_current_usage`, `token_last_reset`, `request_current_usage`, and `request_last_reset` are updated to make clear these are seed values applied only at `CreateBudget`/`CreateRateLimit` time and are inert on every subsequent sync.
- `TestUpdateBudgetPreservesRuntimeCounters` and `TestUpdateRateLimitPreservesRuntimeCounters` verify the store-level fix directly.
- `TestMergeGovernanceConfig_ForceFileSyncPreservesBudgetRuntimeState` verifies the config-merge-level fix, using a new `governanceItemsUpdated` recorder on `MockConfigStore` to assert on the exact struct handed to the update path rather than on what the mock retains.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/... -run TestUpdateBudgetPreservesRuntimeCounters
go test ./framework/configstore/... -run TestUpdateRateLimitPreservesRuntimeCounters
go test ./transports/bifrost-http/lib/... -run TestMergeGovernanceConfig_ForceFileSyncPreservesBudgetRuntimeState
go test ./framework/configstore/... ./transports/bifrost-http/lib/...
```

Set `source_of_truth=config.json`, seed a budget or rate limit with non-zero `current_usage`, restart the service, and confirm the counters are unchanged after the startup sync.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. This change only prevents accounting data from being silently zeroed; it does not affect authentication, secrets, or access control.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable