### PR TITLE
adds harness run test

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -141,10 +141,28 @@ jobs:
           .github/workflows/scripts/validate-schema-sync.sh
 
   # Run all tests in parallel before any releases
+  #
+  # test-core no longer runs the core module's `go test` suite. It validates the
+  # core build, then runs the provider harness (tests/e2e/api/collections/provider-harness.json)
+  # end-to-end against a locally built bifrost-http binary - see
+  # .github/workflows/scripts/test-provider-harness.sh. The harness runs on the
+  # host and talks to real provider APIs, so every provider endpoint the
+  # collection touches must be allowed below.
   test-core:
     needs: [check-skip, detect-changes]
-    if: needs.check-skip.outputs.should-skip != 'true' && needs.check-skip.outputs.skip-tests != 'true' && needs.detect-changes.outputs.core-needs-release == 'true'
+    # Gated on bifrost-http too, not just core: the provider harness this job
+    # runs builds and drives a bifrost-http binary, and bifrost-http-prep accepts
+    # a skipped test-core, so a bifrost-http-only release would otherwise ship
+    # without any provider-harness validation. Matches test-cli-harness.
+    if: |
+      needs.check-skip.outputs.should-skip != 'true' &&
+      needs.check-skip.outputs.skip-tests != 'true' &&
+      (
+        needs.detect-changes.outputs.core-needs-release == 'true' ||
+        needs.detect-changes.outputs.bifrost-http-needs-release == 'true'
+      )
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     permissions:
       contents: read
     steps:
@@ -152,7 +170,16 @@ jobs:
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: block
+          # 127.0.0.1:8080 is the bifrost-http binary the harness drives.
+          # getbifrost.ai / www.getbifrost.ai serve the pricing datasheet the
+          # dbverify newman reporter checks logged costs against.
+          # dl.google.com / packages.cloud.google.com / objects.githubusercontent.com
+          # are the gcloud CLI install; oauth2.googleapis.com + accounts.google.com
+          # are the service-account token exchange for the Vertex parity cells.
           allowed-endpoints: >
+            127.0.0.1:8080
+            accounts.google.com:443
+            aiplatform.googleapis.com:443
             api.anthropic.com:443
             api.cerebras.ai:443
             api.cohere.ai:443
@@ -164,27 +191,37 @@ jobs:
             api.openai.com:443
             api.parasail.io:443
             api.perplexity.ai:443
+            api.replicate.com:443
             api.x.ai:443
             bifrost-gateway-resource.openai.azure.com:443
             bedrock-mantle.us-east-1.api.aws:443
             bedrock-runtime.us-east-1.amazonaws.com:443
             bedrock.us-east-1.amazonaws.com:443
             bifrost-batch-api-file-upload-testing.s3.us-east-1.amazonaws.com:443
+            dl.google.com:443
             fal.media:443
+            fonts.googleapis.com:443
+            fonts.gstatic.com:443
             generativelanguage.googleapis.com:443
+            getbifrost.ai:443
             github.com:443
             huggingface.co:443
+            iojs.org:443
             login.microsoftonline.com:443
             maxim-o1.openai.azure.com:443
             nodejs.org:443
             oauth2.googleapis.com:443
+            objects.githubusercontent.com:443
             openrouter.ai:443
+            packages.cloud.google.com:443
             proxy.golang.org:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443
             router.huggingface.co:443
             storage.googleapis.com:443
             sum.golang.org:443
+            us-central1-aiplatform.googleapis.com:443
+            www.getbifrost.ai:443
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -201,6 +238,19 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "25"
+
+      - name: Install jq
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+
+      - name: Install Newman
+        run: npm install -g newman@6.2.1 newman-reporter-htmlextra@1.23.1
+
+      - name: Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+        with:
+          version: "575.0.1"
 
       - name: Run core tests
         env:
@@ -235,12 +285,34 @@ jobs:
           VERTEX_PROJECT_ID: ${{ secrets.VERTEX_PROJECT_ID }}
           VERTEX_GCS_BUCKET: ${{ secrets.VERTEX_GCS_BUCKET }}
           VERTEX_GCS_PREFIX: ${{ secrets.VERTEX_GCS_PREFIX }}
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           HUGGING_FACE_API_KEY: ${{ secrets.HUGGING_FACE_API_KEY }}
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_BEDROCK_ROLE_ARN: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
           BIFROST_ENCRYPTION_KEY: ${{ secrets.BIFROST_ENCRYPTION_KEY }}
+          # Additional vars the provider harness forwards to newman:
+          # AWS_REGION + GOOGLE_LOCATION drive the direct-provider token-parity
+          # calls, the rest back providers exercised by the criss-cross matrix.
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
+          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+          REPLICATE_API_KEY: ${{ secrets.REPLICATE_API_KEY }}
+          BEDROCK_GUARDRAIL_IDENTIFIER: ${{ secrets.BEDROCK_GUARDRAIL_IDENTIFIER }}
+          BEDROCK_GUARDRAIL_VERSION: ${{ secrets.BEDROCK_GUARDRAIL_VERSION }}
         run: ./.github/workflows/scripts/test-core.sh
+
+      - name: Upload provider harness reports
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: provider-harness-reports
+          path: |
+            tmp/newman-report*.json
+            tmp/newman-cli*.log
+            tmp/harness-failures.md
+            tmp/harness-token-parity.md
+            tmp/stream-cancel-report.json
+            tmp/bifrost-dev.log
+          retention-days: 30
 
   # Approval gate for flaky test-core failures
   # If test-core fails (often due to flaky provider API calls), this job waits for manual approval
@@ -274,6 +346,98 @@ jobs:
       - name: Mark as approved
         id: approve
         run: echo "approved=true" >> $GITHUB_OUTPUT
+
+  # CLI harness - installs the real Claude Code and Codex CLIs and drives them
+  # as subprocesses against a live Bifrost, asserting on their non-interactive
+  # stream-JSON output (tests/e2e/clis). Scope is deliberately narrow: one model
+  # per CLI and a core scenario set. See test-cli-harness.sh for why, and to
+  # widen it.
+  test-cli-harness:
+    needs: [check-skip, detect-changes]
+    if: |
+      needs.check-skip.outputs.should-skip != 'true' &&
+      needs.check-skip.outputs.skip-tests != 'true' &&
+      (
+        needs.detect-changes.outputs.core-needs-release == 'true' ||
+        needs.detect-changes.outputs.bifrost-http-needs-release == 'true'
+      )
+    runs-on: ubuntu-latest
+    # The two run_cases invocations in test-cli-harness.sh each pass TIMEOUT=25m,
+    # so the Go suites alone can take 50m on top of the CLI installs, the UI
+    # build and the gateway build. A job timeout cancels the run, and the report
+    # upload is `if: !cancelled()`, so a cancel loses the harness artifacts too.
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: block
+          # The CLIs run as host subprocesses and reach providers *through*
+          # Bifrost at 127.0.0.1:8080, so provider hosts are needed for the
+          # gateway's own upstream calls. statsig.anthropic.com and
+          # o33249.ingest.sentry.io are Claude Code's telemetry endpoints - it
+          # sets CLAUDE_CODE_DISABLE_TELEMETRY=1 but still resolves them on boot.
+          allowed-endpoints: >
+            127.0.0.1:8080
+            api.anthropic.com:443
+            api.github.com:443
+            api.openai.com:443
+            fonts.googleapis.com:443
+            fonts.gstatic.com:443
+            getbifrost.ai:443
+            github.com:443
+            iojs.org:443
+            nodejs.org:443
+            o33249.ingest.sentry.io:443
+            proxy.golang.org:443
+            registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
+            statsig.anthropic.com:443
+            storage.googleapis.com:443
+            sum.golang.org:443
+            www.getbifrost.ai:443
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version: "1.26.5"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "25"
+
+      - name: Install jq
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+
+      - name: Run CLI harness
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          BIFROST_ENCRYPTION_KEY: ${{ secrets.BIFROST_ENCRYPTION_KEY }}
+        run: |
+          chmod +x ./.github/workflows/scripts/test-cli-harness.sh
+          ./.github/workflows/scripts/test-cli-harness.sh
+
+      - name: Upload CLI harness reports
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: cli-harness-reports
+          path: |
+            tests/e2e/clis/reports/
+            tmp/bifrost-cli-harness.log
+          retention-days: 30
 
   test-framework:
     needs: [check-skip, detect-changes]
@@ -1206,6 +1370,7 @@ jobs:
         detect-changes,
         test-core,
         approve-flaky-test-core,
+        test-cli-harness,
         test-framework,
         test-plugins,
         test-bifrost-http,
@@ -1215,7 +1380,7 @@ jobs:
         test-docker-image-amd64,
         test-docker-image-arm64,
       ]
-    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.core-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-api-integrations.result == 'success' || needs.test-api-integrations.result == 'skipped') && (needs.test-cost-accuracy.result == 'success' || needs.test-cost-accuracy.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped')"
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.core-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-cli-harness.result == 'success' || needs.test-cli-harness.result == 'skipped') && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-api-integrations.result == 'success' || needs.test-api-integrations.result == 'skipped') && (needs.test-cost-accuracy.result == 'success' || needs.test-cost-accuracy.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1307,6 +1472,7 @@ jobs:
         detect-changes,
         test-core,
         approve-flaky-test-core,
+        test-cli-harness,
         test-framework,
         test-plugins,
         test-bifrost-http,
@@ -1317,7 +1483,7 @@ jobs:
         test-docker-image-arm64,
         core-release,
       ]
-    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.framework-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-api-integrations.result == 'success' || needs.test-api-integrations.result == 'skipped') && (needs.test-cost-accuracy.result == 'success' || needs.test-cost-accuracy.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped')"
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.framework-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-cli-harness.result == 'success' || needs.test-cli-harness.result == 'skipped') && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-api-integrations.result == 'success' || needs.test-api-integrations.result == 'skipped') && (needs.test-cost-accuracy.result == 'success' || needs.test-cost-accuracy.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1419,6 +1585,7 @@ jobs:
         detect-changes,
         test-core,
         approve-flaky-test-core,
+        test-cli-harness,
         test-framework,
         test-plugins,
         test-bifrost-http,
@@ -1430,7 +1597,7 @@ jobs:
         core-release,
         framework-release,
       ]
-    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.plugins-need-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-api-integrations.result == 'success' || needs.test-api-integrations.result == 'skipped') && (needs.test-cost-accuracy.result == 'success' || needs.test-cost-accuracy.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped')"
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.plugins-need-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-cli-harness.result == 'success' || needs.test-cli-harness.result == 'skipped') && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-api-integrations.result == 'success' || needs.test-api-integrations.result == 'skipped') && (needs.test-cost-accuracy.result == 'success' || needs.test-cost-accuracy.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1550,6 +1717,7 @@ jobs:
         detect-changes,
         test-core,
         approve-flaky-test-core,
+        test-cli-harness,
         test-framework,
         test-plugins,
         test-bifrost-http,
@@ -1562,7 +1730,7 @@ jobs:
         framework-release,
         plugins-release,
       ]
-    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.bifrost-http-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-api-integrations.result == 'success' || needs.test-api-integrations.result == 'skipped') && (needs.test-cost-accuracy.result == 'success' || needs.test-cost-accuracy.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped')"
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.bifrost-http-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-cli-harness.result == 'success' || needs.test-cli-harness.result == 'skipped') && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-api-integrations.result == 'success' || needs.test-api-integrations.result == 'skipped') && (needs.test-cost-accuracy.result == 'success' || needs.test-cost-accuracy.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1810,6 +1978,7 @@ jobs:
         detect-changes,
         test-core,
         approve-flaky-test-core,
+        test-cli-harness,
         test-framework,
         test-plugins,
         test-bifrost-http,
@@ -1822,7 +1991,7 @@ jobs:
         plugins-release,
         bifrost-http-release,
       ]
-    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-cost-accuracy.result == 'success' || needs.test-cost-accuracy.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped') && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-cli-harness.result == 'success' || needs.test-cli-harness.result == 'skipped') && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-cost-accuracy.result == 'success' || needs.test-cost-accuracy.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped') && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1923,6 +2092,7 @@ jobs:
         detect-changes,
         test-core,
         approve-flaky-test-core,
+        test-cli-harness,
         test-framework,
         test-plugins,
         test-bifrost-http,
@@ -1935,7 +2105,7 @@ jobs:
         plugins-release,
         bifrost-http-release,
       ]
-    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-cost-accuracy.result == 'success' || needs.test-cost-accuracy.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped') && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-cli-harness.result == 'success' || needs.test-cli-harness.result == 'skipped') && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-cost-accuracy.result == 'success' || needs.test-cost-accuracy.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped') && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: write
@@ -2082,6 +2252,7 @@ jobs:
         detect-changes,
         test-core,
         approve-flaky-test-core,
+        test-cli-harness,
         test-framework,
         test-plugins,
         test-bifrost-http,
@@ -2094,7 +2265,7 @@ jobs:
         plugins-release,
         bifrost-http-release,
       ]
-    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-cost-accuracy.result == 'success' || needs.test-cost-accuracy.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped') && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-cli-harness.result == 'success' || needs.test-cli-harness.result == 'skipped') && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-cost-accuracy.result == 'success' || needs.test-cost-accuracy.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped') && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -2199,6 +2370,7 @@ jobs:
         detect-changes,
         test-core,
         approve-flaky-test-core,
+        test-cli-harness,
         test-framework,
         test-plugins,
         test-bifrost-http,
@@ -2211,7 +2383,7 @@ jobs:
         plugins-release,
         bifrost-http-release,
       ]
-    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-cost-accuracy.result == 'success' || needs.test-cost-accuracy.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped') && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-cli-harness.result == 'success' || needs.test-cli-harness.result == 'skipped') && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-cost-accuracy.result == 'success' || needs.test-cost-accuracy.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped') && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: write
@@ -2362,6 +2534,7 @@ jobs:
         detect-changes,
         test-core,
         approve-flaky-test-core,
+        test-cli-harness,
         test-framework,
         test-plugins,
         test-bifrost-http,
@@ -2374,7 +2547,7 @@ jobs:
         plugins-release,
         bifrost-http-release,
       ]
-    if: "always() && needs.check-skip.outputs.should-skip != 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-cost-accuracy.result == 'success' || needs.test-cost-accuracy.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped') && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-cli-harness.result == 'success' || needs.test-cli-harness.result == 'skipped') && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-cost-accuracy.result == 'success' || needs.test-cost-accuracy.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped') && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -2404,6 +2577,7 @@ jobs:
         check-skip,
         detect-changes,
         test-core,
+        test-cli-harness,
         test-framework,
         test-plugins,
         test-bifrost-http,

--- a/.github/workflows/scripts/harness-gateway.sh
+++ b/.github/workflows/scripts/harness-gateway.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Sourceable helpers shared by the CI harness runners (test-provider-harness.sh,
+# test-cli-harness.sh). Builds the bifrost-http binary, seeds a throwaway app
+# dir with sqlite stores, and boots the gateway.
+#
+# Usage:
+#   REPO_ROOT=... source harness-gateway.sh
+#   harness_build_gateway
+#   harness_seed_app_dir "$APP_DIR"
+#   harness_start_gateway "$APP_DIR" 8080 "$LOG"
+#   trap harness_stop_gateway EXIT
+
+: "${REPO_ROOT:?REPO_ROOT must be set before sourcing harness-gateway.sh}"
+
+HARNESS_BIFROST_PID=""
+HARNESS_BINARY="$REPO_ROOT/tmp/bifrost-http"
+# Every harness config derives from the same source of truth the local
+# `make dev` app dir uses, so CI and laptop runs exercise identical wiring.
+HARNESS_SOURCE_CONFIG="$REPO_ROOT/tests/integrations/python/config.json"
+
+harness_build_gateway() {
+  echo "🎨 Building UI..."
+  (cd "$REPO_ROOT" && make build-ui)
+
+  echo "🔨 Building bifrost-http binary..."
+  mkdir -p "$REPO_ROOT/tmp"
+  (cd "$REPO_ROOT/transports/bifrost-http" && go build -o "$HARNESS_BINARY" .)
+}
+
+# harness_seed_app_dir <app_dir>
+harness_seed_app_dir() {
+  local app_dir="$1"
+  if [ ! -f "$HARNESS_SOURCE_CONFIG" ]; then
+    echo "❌ Harness config not found: $HARNESS_SOURCE_CONFIG" >&2
+    return 1
+  fi
+  echo "📝 Seeding harness app dir at $app_dir..."
+  rm -rf "$app_dir"
+  mkdir -p "$app_dir"
+  # The source config points its sqlite stores at the checked-in config.db /
+  # logs.db (25MB of local state). Rewrite both to fresh files inside the
+  # throwaway app dir so CI always starts from a clean seed.
+  jq --arg cfg "$app_dir/config.db" --arg logs "$app_dir/logs.db" \
+    '.config_store.config.path = $cfg | .logs_store.config.path = $logs' \
+    "$HARNESS_SOURCE_CONFIG" > "$app_dir/config.json"
+}
+
+# harness_start_gateway <app_dir> <port> <log_file>
+harness_start_gateway() {
+  local app_dir="$1" port="$2" log_file="$3"
+  local base_url="http://localhost:$port"
+
+  echo "🚀 Starting bifrost-http on port $port..."
+  "$HARNESS_BINARY" --app-dir "$app_dir" --port "$port" --log-level info > "$log_file" 2>&1 &
+  HARNESS_BIFROST_PID=$!
+
+  local max_wait=120 elapsed=0
+  while [ $elapsed -lt $max_wait ]; do
+    if curl -fsS --max-time 2 "$base_url/health" >/dev/null 2>&1; then
+      echo "✅ Bifrost healthy (PID $HARNESS_BIFROST_PID, ${elapsed}s)"
+      return 0
+    fi
+    if ! kill -0 "$HARNESS_BIFROST_PID" 2>/dev/null; then
+      echo "❌ Bifrost exited during startup"
+      cat "$log_file"
+      return 1
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+
+  echo "❌ Bifrost did not become healthy within ${max_wait}s"
+  cat "$log_file"
+  return 1
+}
+
+harness_stop_gateway() {
+  if [ -n "${HARNESS_BIFROST_PID:-}" ] && kill -0 "$HARNESS_BIFROST_PID" 2>/dev/null; then
+    echo "🧹 Stopping bifrost (PID $HARNESS_BIFROST_PID)..."
+    kill "$HARNESS_BIFROST_PID" 2>/dev/null || true
+    wait "$HARNESS_BIFROST_PID" 2>/dev/null || true
+  fi
+  HARNESS_BIFROST_PID=""
+}

--- a/.github/workflows/scripts/test-cli-harness.sh
+++ b/.github/workflows/scripts/test-cli-harness.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# CI runner for the Bifrost CLI harness (tests/e2e/clis).
+#
+# Unlike the provider harness (which drives newman against HTTP endpoints), this
+# harness installs the real coding CLIs and runs them as subprocesses against a
+# live Bifrost, asserting on their non-interactive stream-JSON output. The CLIs
+# reach Bifrost through their own base-URL env vars, which the Go harness sets
+# per cell (ANTHROPIC_BASE_URL -> <base>/anthropic, OPENAI_BASE_URL -> <base>/openai;
+# see tests/e2e/clis/matrix_test.go).
+#
+# The harness already has a CI mode: QUIET=1 suppresses the live mirror (which
+# cannot render in an append-only Actions log) while still writing
+# tests/e2e/clis/reports/*.json. So no separate CI renderer is needed here.
+#
+# Scope is deliberately narrow. The unfiltered matrix is every CLI x provider x
+# model x scenario - hours of runtime and meaningful provider quota per release
+# (tests/e2e/clis/README.md:87). This job pins one model per CLI and a core
+# scenario set; widen CLAUDE_CASES / CODEX_CASES below when you want more.
+
+if command -v readlink >/dev/null 2>&1 && readlink -f "$0" >/dev/null 2>&1; then
+  SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+else
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+fi
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd -P)"
+cd "$REPO_ROOT"
+
+PORT="${PORT:-8080}"
+BASE_URL="${BASE_URL:-http://localhost:$PORT}"
+APP_DIR="$REPO_ROOT/tmp/cli-harness-app"
+SERVER_LOG="$REPO_ROOT/tmp/bifrost-cli-harness.log"
+REPORTS_DIR="$REPO_ROOT/tests/e2e/clis/reports"
+
+# Pinned CLI versions. codex 0.145.0 is the version tests/e2e/clis/matrix_test.go
+# documents its --image and model_reasoning_effort assertions against, so do not
+# float this without re-checking those comments.
+CLAUDE_CODE_VERSION="${CLAUDE_CODE_VERSION:-2.1.220}"
+CODEX_VERSION="${CODEX_VERSION:-0.145.0}"
+
+# Test-name regexes passed as TESTCASE. Path is
+# TestCLIs/<cli>/<provider>/<model>/<scenario>; the Makefile anchors with ^...$.
+CLAUDE_CASES="${CLAUDE_CASES:-TestCLIs/claude/anthropic/claude-sonnet-5/(simple-chat|conversation-memory|file-read)}"
+CODEX_CASES="${CODEX_CASES:-TestCLIs/codex/openai/gpt-5\.5/(simple-chat|conversation-memory|file-read)}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "❌ jq is required" >&2
+  exit 1
+fi
+
+# shellcheck source=./harness-gateway.sh
+source "$SCRIPT_DIR/harness-gateway.sh"
+
+trap harness_stop_gateway EXIT
+
+source "$SCRIPT_DIR/setup-go-workspace.sh"
+
+echo "📦 Installing coding CLIs (pinned)..."
+npm install -g \
+  "@anthropic-ai/claude-code@$CLAUDE_CODE_VERSION" \
+  "@openai/codex@$CODEX_VERSION"
+echo "  claude: $(claude --version 2>&1 | head -n1)"
+echo "  codex:  $(codex --version 2>&1 | head -n1)"
+
+harness_build_gateway
+harness_seed_app_dir "$APP_DIR"
+harness_start_gateway "$APP_DIR" "$PORT" "$SERVER_LOG"
+
+# The harness probes /api/providers before running; config.json sets
+# enforce_auth_on_inference=false, so the placeholder key is sufficient.
+export BIFROST_API_KEY="${BIFROST_API_KEY:-dummy}"
+
+# run_cases <label> <testcase-regex>
+#
+# Each label runs into its own reports subdirectory. That is what makes "this
+# filter ran nothing" detectable: `go test -run` exits 0 when its regex matches
+# no subtests, so a drifted CLAUDE_CASES / CODEX_CASES (a renamed model, a
+# retired scenario) would otherwise sail through the release gate having
+# executed zero cells. An empty subdirectory is the evidence; a shared one could
+# not distinguish this suite's cells from the other's.
+#
+# `make cli-harness-report` is deliberately run later WITHOUT this variable, so
+# it renders the aggregate index.html across every subdirectory.
+run_cases() {
+  local label="$1" cases="$2" rc=0
+  local run_dir="$REPORTS_DIR/$label"
+
+  echo ""
+  echo "🧪 CLI harness: $label"
+  echo "   filter: $cases"
+  echo "   reports: $run_dir"
+
+  rm -rf "$run_dir"
+  mkdir -p "$run_dir"
+
+  # USE_INFISICAL=0 makes EXPOSE_ENV a no-op on a runner, so the job's GitHub
+  # Actions secrets are inherited directly. QUIET=1 is the harness's own CI mode.
+  # The reports dir is absolute because the Makefile cds into tests/e2e/clis.
+  BIFROST_E2E_CLIS_REPORTS_DIR="$run_dir" \
+  make run-cli-harness-test \
+    USE_INFISICAL=0 \
+    QUIET=1 \
+    PARALLEL=2 \
+    TIMEOUT=25m \
+    BASE_URL="$BASE_URL" \
+    TESTCASE="$cases" || rc=$?
+
+  # Count cells actually produced. Guard this even when go test exited 0: a
+  # vacuous filter is exactly the case that exits 0 with nothing run.
+  local cells
+  cells=$(find "$run_dir" -maxdepth 1 -name '*.json' -type f 2>/dev/null | wc -l | tr -d ' ')
+  echo "   cells produced: $cells"
+
+  if [ "$cells" -eq 0 ]; then
+    echo "❌ CLI harness produced no cells for $label"
+    echo "   The filter matched no TestCLIs subtests, so nothing was verified."
+    echo "   filter: $cases"
+    echo "   Check the model/scenario names in the filter against tests/e2e/clis/matrix_test.go."
+    return 1
+  fi
+
+  if [ "$rc" -ne 0 ]; then
+    echo "❌ CLI harness failed for $label (exit $rc, $cells cells)"
+  else
+    echo "✅ CLI harness passed for $label ($cells cells)"
+  fi
+  return $rc
+}
+
+CLAUDE_RC=0
+CODEX_RC=0
+# Both run even if the first fails, so one broken CLI does not mask the other.
+run_cases "claude" "$CLAUDE_CASES" || CLAUDE_RC=$?
+run_cases "codex" "$CODEX_CASES" || CODEX_RC=$?
+
+# Renders tests/e2e/clis/reports/index.html from the reports/*.json just written.
+# Free and instant - no test re-execution.
+echo ""
+echo "📊 Rendering CLI harness report..."
+make cli-harness-report || echo "⚠️  Report rendering failed; reports/*.json are still intact"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "## CLI harness"
+    echo ""
+    echo "| CLI | Version | Filter | Result |"
+    echo "| --- | --- | --- | --- |"
+    echo "| claude | \`$CLAUDE_CODE_VERSION\` | \`$CLAUDE_CASES\` | $([ "$CLAUDE_RC" -eq 0 ] && echo "✅ pass" || echo "❌ fail") |"
+    echo "| codex | \`$CODEX_VERSION\` | \`$CODEX_CASES\` | $([ "$CODEX_RC" -eq 0 ] && echo "✅ pass" || echo "❌ fail") |"
+    echo ""
+    echo "Full per-cell results are in the \`cli-harness-reports\` artifact (\`index.html\`)."
+    echo ""
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+if [ ! -d "$REPORTS_DIR" ]; then
+  echo "⚠️  No reports directory at $REPORTS_DIR - the harness may not have run any cells"
+fi
+
+if [ "$CLAUDE_RC" -ne 0 ] || [ "$CODEX_RC" -ne 0 ]; then
+  echo "❌ CLI harness failed (claude=$CLAUDE_RC, codex=$CODEX_RC)"
+  exit 1
+fi
+
+echo "✅ CLI harness completed successfully"

--- a/.github/workflows/scripts/test-core.sh
+++ b/.github/workflows/scripts/test-core.sh
@@ -1,57 +1,33 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Test core component
+# Core release gate.
 # Usage: ./test-core.sh
+#
+# The core module's own `go test` suite has been replaced here by the provider
+# harness: it exercises the same provider code paths end-to-end through a live
+# gateway instead of in-process. The core build is still validated first, both
+# as a fast compile gate and because the harness needs a bifrost-http binary
+# that links against this module.
+
+if command -v readlink >/dev/null 2>&1 && readlink -f "$0" >/dev/null 2>&1; then
+  SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+else
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+fi
+cd "$(cd "$SCRIPT_DIR/../../.." && pwd -P)"
 
 # Setup Go workspace for CI
-source "$(dirname "$0")/setup-go-workspace.sh"
+source "$SCRIPT_DIR/setup-go-workspace.sh"
 
-echo "🧪 Running core tests..."
-
-# Build MCP test servers for STDIO tests
-echo "🔧 Building MCP test servers..."
-for mcp_dir in examples/mcps/*/; do
-  if [ -d "$mcp_dir" ]; then
-    mcp_name=$(basename "$mcp_dir")
-    if [ -f "$mcp_dir/go.mod" ]; then
-      echo "  Building $mcp_name (Go)..."
-      mkdir -p "$mcp_dir/bin"
-      pushd "$mcp_dir" > /dev/null
-      GOWORK=off go build -o "bin/$mcp_name" .
-      popd > /dev/null
-    elif [ -f "$mcp_dir/package.json" ]; then
-      echo "  Building $mcp_name (TypeScript)..."
-      pushd "$mcp_dir" > /dev/null
-      npm install --silent && npm run build
-      popd > /dev/null
-    fi
-  fi
-done
-echo "✅ MCP test servers built"
-
-# Validate core build
 echo "🔨 Validating core build..."
-cd core
+pushd core > /dev/null
 go mod download
 go build ./...
+popd > /dev/null
 echo "✅ Core build validation successful"
 
-# Run core tests with coverage
-echo "🧪 Running core tests with coverage..."
-go test -race -timeout 20m -coverprofile=coverage.txt -coverpkg=./... ./...
-
-# Upload coverage to Codecov
-if [ -n "${CODECOV_TOKEN:-}" ]; then
-  echo "📊 Uploading coverage to Codecov..."
-  curl -Os https://uploader.codecov.io/latest/linux/codecov
-  chmod +x codecov
-  ./codecov -t "$CODECOV_TOKEN" -f coverage.txt -F core
-  rm -f codecov coverage.txt
-else
-  echo "ℹ️ CODECOV_TOKEN not set, skipping coverage upload"
-  rm -f coverage.txt
-fi
-cd ..
+echo "🧪 Running provider harness against core..."
+"$SCRIPT_DIR/test-provider-harness.sh"
 
 echo "✅ Core tests completed successfully"

--- a/.github/workflows/scripts/test-provider-harness.sh
+++ b/.github/workflows/scripts/test-provider-harness.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# CI runner for the Bifrost provider harness (tests/e2e/api/collections/provider-harness.json).
+#
+# Local developers run `make run-provider-harness-test`, which auto-starts Bifrost
+# via `make dev`, sources secrets from Infisical/.env, and renders an in-place
+# terminal dashboard. None of that works on a GitHub runner, so this script:
+#
+#   1. builds the UI + the bifrost-http binary (the harness needs a live gateway),
+#   2. seeds a throwaway app dir with sqlite stores (no Postgres/Docker needed),
+#   3. authenticates gcloud from VERTEX_CREDENTIALS so the Makefile can mint the
+#      Vertex access token used by the direct-provider token-parity cells,
+#   4. boots the binary and waits for /health (the make target detects a healthy
+#      gateway and skips its own auto-start),
+#   5. delegates to `make run-provider-harness-test CI=1 USE_INFISICAL=0`, which
+#      reads secrets straight from the environment (GitHub Actions secrets) and
+#      runs harness-monitor.mjs in append-only --ci mode.
+#
+# Exit code is the harness exit code, so a provider failure fails the job.
+
+if command -v readlink >/dev/null 2>&1 && readlink -f "$0" >/dev/null 2>&1; then
+  SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+else
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+fi
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd -P)"
+cd "$REPO_ROOT"
+
+PORT="${PORT:-8080}"
+BASE_URL="${BASE_URL:-http://localhost:$PORT}"
+# Kept inside the repo (not mktemp) so the relative paths the Makefile builds for
+# APP_DIR - the dbverify config path and the sqlite logs URL - resolve correctly.
+APP_DIR_REL="tmp/harness-app"
+APP_DIR="$REPO_ROOT/$APP_DIR_REL"
+SERVER_LOG="$REPO_ROOT/tmp/bifrost-dev.log"
+GCLOUD_KEY_FILE="$APP_DIR/vertex-sa.json"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "❌ jq is required" >&2
+  exit 1
+fi
+if ! command -v newman >/dev/null 2>&1; then
+  echo "❌ newman is required (npm install -g newman@6.2.1 newman-reporter-htmlextra@1.23.1)" >&2
+  exit 1
+fi
+
+# shellcheck source=./harness-gateway.sh
+source "$SCRIPT_DIR/harness-gateway.sh"
+
+cleanup() {
+  local exit_code=$?
+  harness_stop_gateway
+  # The service-account key is the only secret written to disk; never leave it
+  # behind for the artifact-upload step to pick up.
+  rm -f "$GCLOUD_KEY_FILE"
+  exit $exit_code
+}
+trap cleanup EXIT
+
+source "$SCRIPT_DIR/setup-go-workspace.sh"
+
+harness_build_gateway
+harness_seed_app_dir "$APP_DIR"
+
+# dbverify (on by default) asserts logged cost against the getbifrost.ai
+# datasheet. Point it at the app dir's sqlite logs DB explicitly - the Makefile's
+# default assumes a repo-relative APP_DIR.
+export BIFROST_LOGS_DB_URL="sqlite://$APP_DIR/logs.db"
+
+if [ -n "${VERTEX_CREDENTIALS:-}" ] && command -v gcloud >/dev/null 2>&1; then
+  echo "🔑 Activating gcloud service account for Vertex token parity..."
+  umask 077
+  printf '%s' "$VERTEX_CREDENTIALS" > "$GCLOUD_KEY_FILE"
+  if gcloud auth activate-service-account --key-file="$GCLOUD_KEY_FILE" --quiet; then
+    echo "✅ gcloud authenticated"
+  else
+    echo "⚠️  gcloud auth failed - Vertex direct-provider parity cells will 401"
+  fi
+else
+  echo "⚠️  VERTEX_CREDENTIALS unset or gcloud missing - Vertex direct-provider parity cells will 401"
+fi
+
+harness_start_gateway "$APP_DIR" "$PORT" "$SERVER_LOG"
+
+echo ""
+echo "🧪 Running provider harness (full sweep, parallel per provider)..."
+# USE_INFISICAL=0 makes the Makefile's EXPOSE_ENV fall through to ./.env, which
+# does not exist on a runner - so it is a no-op and newman inherits the job's
+# environment, i.e. the GitHub Actions secrets, directly.
+HARNESS_EXIT=0
+make run-provider-harness-test \
+  CI=1 \
+  USE_INFISICAL=0 \
+  PARALLEL=1 \
+  BASE_URL="$BASE_URL" \
+  APP_DIR="$APP_DIR_REL" || HARNESS_EXIT=$?
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ] && [ -f "$REPO_ROOT/tmp/harness-failures.md" ]; then
+  {
+    echo "## Provider harness failure breakdown"
+    echo ""
+    cat "$REPO_ROOT/tmp/harness-failures.md"
+    echo ""
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+if [ "$HARNESS_EXIT" -ne 0 ]; then
+  echo "❌ Provider harness failed (exit $HARNESS_EXIT). See tmp/harness-failures.md and tmp/newman-cli-*.log"
+  exit "$HARNESS_EXIT"
+fi
+
+echo "✅ Provider harness completed successfully"

--- a/Makefile
+++ b/Makefile
@@ -1826,9 +1826,14 @@ cli-harness-report: ## Regenerate tests/e2e/clis/reports/index.html from existin
 	@$(ECHO) "$(GREEN)Rendering CLI harness report from existing reports/*.json...$(NC)"
 	@cd tests/e2e/clis && GOWORK=off go test -run "^TestRenderReport$$" -v ./...
 
-install-newman: ## Install newman + htmlextra reporter if not already installed
-	@$(USE_NODE); which newman > /dev/null 2>&1 || ($(ECHO) "$(YELLOW)Installing newman...$(NC)" && npm install -g newman)
-	@$(USE_NODE); npm list -g newman-reporter-htmlextra > /dev/null 2>&1 || ($(ECHO) "$(YELLOW)Installing newman-reporter-htmlextra...$(NC)" && npm install -g newman-reporter-htmlextra)
+# Versions pinned to match the CI installs in .github/workflows/release-pipeline.yml
+# (test-core, test-api-integrations, test-docker-image-*). Keep them in sync.
+NEWMAN_VERSION ?= 6.2.1
+NEWMAN_HTMLEXTRA_VERSION ?= 1.23.1
+
+install-newman: ## Install newman + htmlextra reporter if not already installed (pinned via NEWMAN_VERSION / NEWMAN_HTMLEXTRA_VERSION)
+	@$(USE_NODE); which newman > /dev/null 2>&1 || ($(ECHO) "$(YELLOW)Installing newman@$(NEWMAN_VERSION)...$(NC)" && npm install -g newman@$(NEWMAN_VERSION))
+	@$(USE_NODE); npm list -g newman-reporter-htmlextra > /dev/null 2>&1 || ($(ECHO) "$(YELLOW)Installing newman-reporter-htmlextra@$(NEWMAN_HTMLEXTRA_VERSION)...$(NC)" && npm install -g newman-reporter-htmlextra@$(NEWMAN_HTMLEXTRA_VERSION))
 	@$(ECHO) "$(GREEN)Newman + htmlextra are ready$(NC)"
 
 run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost provider-harness Postman collection. HELP=1 prints full parameter docs. Filter via PROVIDER=openai|anthropic|bedrock|gemini|vertex|azure|passthrough|openrouter, FEATURE="<kw>" or FEATURE="<kw1>,<kw2>" (AND across substrings; matches request name/URL/body), RERUN_FAILED=1 (re-run only items that failed last run). INCLUDE_PREVIEW=1 to run [PREVIEW]-tagged account/region-scoped cases. SKIP_STREAM_CANCEL=1 skips stream cancellation probes. USE_INFISICAL=1 to source from Infisical (Usage: make run-provider-harness-test [HELP=1] [PROVIDER=anthropic] [FEATURE="web search"] [FEATURE="cross-cut,structured output"] [RERUN_FAILED=1] [INCLUDE_PREVIEW=1] [BASE_URL=...] [FOLDER="..."] [ENV_FILE=...] [VIEWER_PORT=8090] [CI=1])
@@ -2115,7 +2120,19 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 			$(ECHO) "$(RED)No provider runs were launched. Check PROVIDER/FEATURE/FOLDER filters.$(NC)"; \
 			exit 1; \
 		fi; \
-		if [ -t 1 ] && [ -z "$$CI" ] && [ -z "$(CI)" ]; then \
+		MONITOR_CI=0; \
+		if [ -n "$$CI" ] || [ -n "$(CI)" ]; then \
+			MONITOR_CI=1; \
+			$(USE_NODE); node tests/e2e/api/runners/harness-monitor.mjs \
+				--mode parallel \
+				--providers "$$PROVIDERS" \
+				--tmp-dir tmp \
+				--status-file tmp/parallel-status \
+				--launched $$LAUNCHED \
+				--ci --ci-interval "$(or $(MONITOR_INTERVAL),30)" \
+				< /dev/null & \
+			echo $$! > tmp/harness-monitor.pid; \
+		elif [ -t 1 ]; then \
 			$(USE_NODE); node tests/e2e/api/runners/harness-monitor.mjs \
 				--mode parallel \
 				--providers "$$PROVIDERS" \
@@ -2131,13 +2148,13 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 			p="$${pidp#*:}"; \
 			if wait "$$pid"; then \
 				echo "$$p:pass" >> tmp/parallel-status; \
-				if [ ! -f tmp/harness-monitor.pid ]; then $(ECHO) "$(GREEN)[$$p] passed$(NC)"; fi; \
+				if [ ! -f tmp/harness-monitor.pid ] || [ "$$MONITOR_CI" = "1" ]; then $(ECHO) "$(GREEN)[$$p] passed$(NC)"; fi; \
 			else \
 				echo "$$p:fail" >> tmp/parallel-status; \
-				if [ ! -f tmp/harness-monitor.pid ]; then $(ECHO) "$(RED)[$$p] failed$(NC)"; fi; \
+				if [ ! -f tmp/harness-monitor.pid ] || [ "$$MONITOR_CI" = "1" ]; then $(ECHO) "$(RED)[$$p] failed$(NC)"; fi; \
 				PFAILED=$$((PFAILED+1)); \
 			fi; \
-			if [ ! -f tmp/harness-monitor.pid ]; then tail -n 20 "tmp/newman-cli-$$p.log" 2>/dev/null; fi; \
+			if [ ! -f tmp/harness-monitor.pid ] || [ "$$MONITOR_CI" = "1" ]; then tail -n 20 "tmp/newman-cli-$$p.log" 2>/dev/null; fi; \
 		done < tmp/parallel-pids; \
 		if [ -f tmp/harness-monitor.pid ]; then \
 			MPID=$$(cat tmp/harness-monitor.pid); \

--- a/tests/e2e/api/runners/harness-monitor.mjs
+++ b/tests/e2e/api/runners/harness-monitor.mjs
@@ -18,9 +18,23 @@
 //     --providers "openai anthropic" \
 //     --tmp-dir tmp \
 //     --log tmp/newman-cli.log
+//
+// Add --ci for GitHub Actions: no alternate screen buffer and no in-place
+// redraw (impossible in an append-only job log). Emits a progress snapshot
+// every --ci-interval seconds (default 30), a line per failure as it is
+// parsed, and a plain-text final table into stdout + $GITHUB_STEP_SUMMARY.
 
-import { existsSync, readFileSync, statSync, openSync, readSync, closeSync } from "node:fs";
+import {
+  existsSync,
+  readFileSync,
+  statSync,
+  openSync,
+  readSync,
+  closeSync,
+  appendFileSync,
+} from "node:fs";
 import { join } from "node:path";
+import { resolveCiIntervalMs } from "./lib/ci-interval.mjs";
 
 const args = Object.fromEntries(
   process.argv.slice(2).reduce((acc, cur, i, arr) => {
@@ -42,6 +56,13 @@ const SEQ_LOG = args.log || join(TMP_DIR, "newman-cli.log");
 const TAIL_INTERVAL_MS = 250;
 const RENDER_INTERVAL_MS = 1000;
 const IDLE_EXIT_MS = 3000;
+
+// CI mode: GitHub Actions logs are an append-only stream, so the alternate
+// screen buffer + cursor-home redraw used interactively is impossible there.
+// Instead we emit periodic append-only snapshots plus a line per failure as it
+// is parsed, and a plain-text final table (also into $GITHUB_STEP_SUMMARY).
+const CI = args.ci === "true" || args.ci === "1";
+const CI_INTERVAL_MS = resolveCiIntervalMs(args["ci-interval"]);
 
 if (PROVIDERS.length === 0) {
   console.error("[harness-monitor] --providers is required");
@@ -90,6 +111,7 @@ const state = {
 };
 let lastByteAt = Date.now();
 let lastRenderLines = 0;
+let sawBytes = false;
 
 // ----- Denominator: walk the filtered collection per provider. ----------------
 
@@ -173,6 +195,7 @@ function readNewBytes() {
     h.buf = lines.pop();
     for (const raw of lines) handleLine(stripAnsi(raw), h.provider);
     lastByteAt = Date.now();
+    sawBytes = true;
   }
 }
 
@@ -268,6 +291,12 @@ function handleLine(line, taggedProvider) {
   if ((m = trimmed.match(RE_ASSERT_FAIL)) && ps.currentRequest) {
     ps.currentRequestHadFail = true;
     ps.lastFailure = { folder: ps.currentRequestFolder, text: m[1].trim() };
+    if (CI) {
+      ciLog(
+        `✗ ${provider} · ${ps.currentRequestFolder || "(root)"} · ` +
+          `${ps.currentRequest} · ${m[1].trim()}`
+      );
+    }
     return;
   }
 }
@@ -288,8 +317,19 @@ function readStatusFile() {
     const [p, v] = ln.split(":");
     const ps = state.providers[p];
     if (!ps) continue;
+    const prev = ps.status;
     if (v === "pass") ps.status = "pass";
     else if (v === "fail") ps.status = "fail";
+    if (CI && ps.status !== prev && (ps.status === "pass" || ps.status === "fail")) {
+      // A status-file line is only written after that provider's newman process
+      // exited, so its log is complete - commit the trailing request before
+      // reporting counts, otherwise the summary lags by one request.
+      finalizeRequest(ps);
+      ciLog(
+        `${ps.status === "pass" ? "✓" : "✗"} ${p} finished: ` +
+          `${ps.pass} passed, ${ps.fail} failed of ${ps.totalRequests || ps.doneRequests}`
+      );
+    }
   }
   return { lines: lines.length };
 }
@@ -471,6 +511,46 @@ function rowWithRawCells(cells, widths) {
   return line;
 }
 
+// ----- CI render: append-only, no cursor control. -----------------------------
+
+function ciLog(msg) {
+  process.stdout.write(`[harness ${fmtDuration(Date.now() - state.startedAt)}] ${msg}\n`);
+}
+
+// One-line snapshot of every provider that has started, e.g.
+//   [harness 02:31] openai 41/120 (✓40 ✗1) · anthropic 33/98 (✓33 ✗0)
+function drawCi() {
+  const parts = [];
+  for (const p of PROVIDERS) {
+    const ps = state.providers[p];
+    if (ps.status === "pending" && ps.doneRequests === 0) continue;
+    const total = ps.totalRequests || "?";
+    parts.push(`${p} ${ps.doneRequests}/${total} (✓${ps.pass} ✗${ps.fail})`);
+  }
+  if (parts.length === 0) {
+    ciLog("waiting for newman output...");
+    return;
+  }
+  ciLog(parts.join(" · "));
+}
+
+// Final plain-text table. Goes to stdout so it lands in the job log, and to
+// $GITHUB_STEP_SUMMARY (when set) so it renders on the workflow summary page.
+function ciFinalReport() {
+  const plain = renderFrame().map(stripAnsi);
+  process.stdout.write("\n" + plain.join("\n") + "\n");
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+  try {
+    appendFileSync(
+      summaryPath,
+      "## Provider harness\n\n```\n" + plain.join("\n") + "\n```\n\n"
+    );
+  } catch {
+    // Summary is best-effort - never fail the run over it.
+  }
+}
+
 function draw() {
   const lines = renderFrame();
   const rows = process.stdout.rows || lines.length;
@@ -503,7 +583,10 @@ function shouldExit() {
   } else {
     // Sequential mode: rely on signals from the Makefile. Also exit when the
     // log shows the newman "failures" summary block AND we've been idle.
-    if (Date.now() - lastByteAt > IDLE_EXIT_MS * 2 && lastRenderLines > 0) {
+    // lastRenderLines only advances in interactive mode (CI never calls draw()),
+    // so in CI use "we have seen at least one log byte" as the equivalent guard.
+    const started = CI ? sawBytes : lastRenderLines > 0;
+    if (Date.now() - lastByteAt > IDLE_EXIT_MS * 2 && started) {
       const allDone = PROVIDERS.every(
         (p) => state.providers[p].totalRequests === 0 ||
                state.providers[p].doneRequests >= state.providers[p].totalRequests
@@ -519,6 +602,10 @@ function teardown(code = 0) {
   // the trailing in-flight request before the final frame.
   readNewBytes();
   finalizeAll();
+  if (CI) {
+    ciFinalReport();
+    process.exit(code);
+  }
   draw();
   // Snapshot the final frame to stderr so it persists on the main screen
   // after we leave the alt buffer (otherwise the user sees the table vanish).
@@ -536,7 +623,8 @@ process.on("SIGHUP", () => teardown(0));
 // Enter alt screen buffer + hide cursor + clear it. This gives us a fresh
 // canvas with a known origin so cursor-home redraws are deterministic and
 // the preamble (boot logs, launch messages) is preserved on the main screen.
-process.stdout.write("\x1b[?1049h\x1b[H\x1b[2J\x1b[?25l");
+// Skipped in CI, where there is no terminal to take over.
+if (!CI) process.stdout.write("\x1b[?1049h\x1b[H\x1b[2J\x1b[?25l");
 
 // Initial denominator pass; retry once a second until at least one provider has totals.
 loadDenominators();
@@ -552,10 +640,20 @@ setInterval(() => {
   readStatusFile();
 }, TAIL_INTERVAL_MS);
 
-setInterval(() => {
-  draw();
-  if (shouldExit()) teardown(0);
-}, RENDER_INTERVAL_MS);
+if (CI) {
+  // Exit checks still run at the interactive cadence; only the (much noisier)
+  // snapshot printing is throttled to CI_INTERVAL_MS.
+  setInterval(() => {
+    if (shouldExit()) teardown(0);
+  }, RENDER_INTERVAL_MS);
+  setInterval(drawCi, CI_INTERVAL_MS);
+  ciLog(`monitoring ${PROVIDERS.length} provider(s): ${PROVIDERS.join(", ")}`);
+} else {
+  setInterval(() => {
+    draw();
+    if (shouldExit()) teardown(0);
+  }, RENDER_INTERVAL_MS);
 
-// Draw a first frame immediately so the user sees something.
-draw();
+  // Draw a first frame immediately so the user sees something.
+  draw();
+}

--- a/tests/e2e/api/runners/lib/ci-interval.mjs
+++ b/tests/e2e/api/runners/lib/ci-interval.mjs
@@ -1,0 +1,33 @@
+// Resolves the --ci-interval flag of harness-monitor.mjs into a setInterval delay.
+//
+// Split out of harness-monitor.mjs so it can be unit tested: the monitor itself
+// has top-level side effects (arg validation, process.exit, timers) and cannot
+// be imported from a test.
+
+export const CI_INTERVAL_DEFAULT_SECONDS = 30;
+export const CI_INTERVAL_MIN_SECONDS = 5;
+export const CI_INTERVAL_MAX_SECONDS = 45 * 60;
+
+// raw is the flag value as parsed from argv, i.e. a string or undefined.
+//
+// Both ends are clamped because both produce the same failure: a ~1ms timer that
+// floods an append-only Actions log. Makefile forwards MONITOR_INTERVAL here
+// verbatim, so the value is user-supplied and neither end is hypothetical.
+//
+//   - Too small / non-numeric: Math.max propagates NaN rather than ignoring it,
+//     so it is not a guard on its own - setInterval(fn, NaN) is ~1ms in Node.
+//   - Too large: Node stores a timer delay in a 32-bit signed int and resets
+//     anything over 2_147_483_647ms to 1ms with a TimeoutOverflowWarning.
+//
+// The upper bound is a domain cap well below that overflow point. A progress
+// snapshot slower than 45 minutes is useless in a job whose own timeout-minutes
+// is 90, so an interval that large is a mistake regardless of the overflow.
+export function resolveCiIntervalMs(raw) {
+  const parsed = parseInt(raw, 10);
+  const seconds = Number.isFinite(parsed) ? parsed : CI_INTERVAL_DEFAULT_SECONDS;
+  const clamped = Math.min(
+    CI_INTERVAL_MAX_SECONDS,
+    Math.max(CI_INTERVAL_MIN_SECONDS, seconds)
+  );
+  return clamped * 1000;
+}

--- a/tests/e2e/api/runners/lib/ci-interval.test.mjs
+++ b/tests/e2e/api/runners/lib/ci-interval.test.mjs
@@ -1,0 +1,81 @@
+// Unit tests for the --ci-interval resolver. Run directly: `node ci-interval.test.mjs`.
+// No test framework needed (the tests/e2e/api dir has no test runner configured).
+import assert from "node:assert";
+import {
+  resolveCiIntervalMs,
+  CI_INTERVAL_DEFAULT_SECONDS,
+  CI_INTERVAL_MIN_SECONDS,
+  CI_INTERVAL_MAX_SECONDS,
+} from "./ci-interval.mjs";
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed++;
+  console.log(`  ok - ${name}`);
+}
+
+test("uses the 30s default when the flag is absent", () => {
+  assert.strictEqual(
+    resolveCiIntervalMs(undefined),
+    CI_INTERVAL_DEFAULT_SECONDS * 1000
+  );
+});
+
+test("honours a valid interval", () => {
+  assert.strictEqual(resolveCiIntervalMs("45"), 45_000);
+});
+
+test("clamps below-minimum intervals up to 5s", () => {
+  assert.strictEqual(resolveCiIntervalMs("1"), CI_INTERVAL_MIN_SECONDS * 1000);
+});
+
+// The regression this guards: Makefile:2132 forwards MONITOR_INTERVAL straight
+// into --ci-interval, so a non-numeric value reaches parseInt. Math.max(5, NaN)
+// is NaN - not 5 - and setInterval(fn, NaN) is treated as ~1ms in Node, which
+// floods the Actions log with progress snapshots.
+test("falls back to the default for a non-numeric interval", () => {
+  const ms = resolveCiIntervalMs("not-a-number");
+  assert.ok(Number.isFinite(ms), `expected a finite delay, got ${ms}`);
+  assert.strictEqual(ms, CI_INTERVAL_DEFAULT_SECONDS * 1000);
+});
+
+test("falls back to the default for an empty flag value", () => {
+  const ms = resolveCiIntervalMs("");
+  assert.ok(Number.isFinite(ms), `expected a finite delay, got ${ms}`);
+  assert.strictEqual(ms, CI_INTERVAL_DEFAULT_SECONDS * 1000);
+});
+
+// The mirror image of the NaN case, and the same 1ms log flood. Node stores a
+// timer delay in a 32-bit signed int, so anything over 2_147_483_647ms is reset
+// to 1ms with a TimeoutOverflowWarning. The cap is set well below that bound at
+// 45 minutes: a progress snapshot slower than that is useless in a job whose own
+// timeout-minutes is 90, so an interval that large is a mistake either way.
+test("clamps an oversized interval down to the maximum", () => {
+  const ms = resolveCiIntervalMs("2147484");
+  assert.strictEqual(ms, CI_INTERVAL_MAX_SECONDS * 1000);
+  assert.ok(
+    ms <= 2_147_483_647,
+    `delay must fit a 32-bit signed int or Node resets it to 1ms, got ${ms}`
+  );
+});
+
+test("clamps a merely-too-large interval to the maximum", () => {
+  assert.strictEqual(
+    resolveCiIntervalMs(String(CI_INTERVAL_MAX_SECONDS + 1)),
+    CI_INTERVAL_MAX_SECONDS * 1000
+  );
+});
+
+test("honours an interval exactly at the maximum", () => {
+  assert.strictEqual(
+    resolveCiIntervalMs(String(CI_INTERVAL_MAX_SECONDS)),
+    CI_INTERVAL_MAX_SECONDS * 1000
+  );
+});
+
+test("the maximum is 45 minutes", () => {
+  assert.strictEqual(CI_INTERVAL_MAX_SECONDS, 45 * 60);
+});
+
+console.log(`\n${passed} passed`);

--- a/tests/e2e/clis/clis_test.go
+++ b/tests/e2e/clis/clis_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"html"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -557,14 +558,28 @@ type cellResult struct {
 	MetaPath       string
 }
 
+// reportsDirEnv lets one `go test` invocation write its cells into its own
+// directory. The CI runner uses it to give each CLI filter an isolated
+// subdirectory; see .github/workflows/scripts/test-cli-harness.sh.
+const reportsDirEnv = "BIFROST_E2E_CLIS_REPORTS_DIR"
+
+// reportsDir is where this invocation writes per-cell summaries. It defaults to
+// "reports" so every local run and the standalone renderer behave as before.
+func reportsDir() string {
+	if dir := strings.TrimSpace(os.Getenv(reportsDirEnv)); dir != "" {
+		return dir
+	}
+	return "reports"
+}
+
 func writeReport(t *testing.T, cli, provider, modelStem, scenarioID, model, status string, runErr error, softReason string, dur time.Duration, transcript string) {
 	t.Helper()
 	reportMu.Lock()
 	defer reportMu.Unlock()
 
-	dir := "reports"
+	dir := reportsDir()
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Logf("mkdir reports: %v", err)
+		t.Logf("mkdir %s: %v", dir, err)
 		return
 	}
 	stem := fmt.Sprintf("%s__%s__%s__%s", cli, provider, modelStem, scenarioID)
@@ -600,8 +615,28 @@ func writeReport(t *testing.T, cli, provider, modelStem, scenarioID, model, stat
 // runs from a completely separate `go test` invocation -- not just cells
 // this process happened to run. That's what makes both the SIGINT-handler
 // report write and the standalone TestRenderReport (see below) correct.
+// The walk is recursive, not a one-level glob: the CI runner gives each CLI
+// filter its own subdirectory (see reportsDirEnv) so an empty one proves that
+// filter matched no cells, and the aggregate report still has to span all of
+// them. Summaries written straight into the root -- every local run, and the
+// SIGINT handler -- are found at depth 0 exactly as before.
 func loadReportResults(dir string) ([]cellResult, error) {
-	metaPaths, err := filepath.Glob(filepath.Join(dir, "*.json"))
+	var metaPaths []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// A missing reports dir is a normal "nothing ran yet" state, and an
+			// unreadable subdirectory should not sink the whole report.
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".json" {
+			return nil
+		}
+		metaPaths = append(metaPaths, path)
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -664,8 +699,9 @@ func loadReportResults(dir string) ([]cellResult, error) {
 // from the report (loadReportResults skips unparseable files by design, so the
 // loss leaves no trace).
 func writeHTMLReport() error {
+	dir := reportsDir()
 	reportMu.Lock()
-	results, err := loadReportResults("reports")
+	results, err := loadReportResults(dir)
 	reportMu.Unlock()
 	if err != nil {
 		return fmt.Errorf("load harness reports: %w", err)
@@ -718,8 +754,8 @@ a{color:#175cd3;text-decoration:none}a:hover{text-decoration:underline}
 	}
 	body.WriteString("</tbody></table></body></html>")
 
-	path := filepath.Join("reports", "index.html")
-	if err := os.MkdirAll("reports", 0o755); err != nil {
+	path := filepath.Join(dir, "index.html")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("create reports dir: %w", err)
 	}
 	if err := os.WriteFile(path, []byte(body.String()), 0o644); err != nil {

--- a/tests/e2e/clis/reportsdir_test.go
+++ b/tests/e2e/clis/reportsdir_test.go
@@ -1,0 +1,100 @@
+package clis
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// These tests exercise report-directory resolution only -- no CLI subprocesses,
+// no Bifrost, no provider traffic -- so they run anywhere:
+//
+//	GOWORK=off go test ./tests/e2e/clis/ -run 'TestReportsDir|TestLoadReportResultsNested'
+
+// The CI runner gives each filter its own reports subdirectory so one suite's
+// cells cannot be mistaken for another's, and so an empty subdirectory proves
+// that filter matched nothing. `go test -run` exits 0 when its regex matches no
+// subtests, so without that per-filter evidence a drifted CLAUDE_CASES /
+// CODEX_CASES regex would pass the release gate having run zero cells.
+//
+// The aggregate report still has to cover every subdirectory, which is why
+// loadReportResults walks instead of globbing one level.
+func TestLoadReportResultsNestedDirectories(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	for dir, stem := range map[string]string{
+		filepath.Join("reports", "claude"): "claude__anthropic__sonnet__simple-chat",
+		filepath.Join("reports", "codex"):  "codex__openai__gpt__simple-chat",
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("seed %s: %v", dir, err)
+		}
+		seedReportSummary(t, dir, stem)
+	}
+
+	// A summary written directly at the root must still be picked up, so an
+	// existing local run (or the SIGINT handler) keeps working unchanged.
+	seedReportSummary(t, "reports", "opencode__bedrock__nova__file-read")
+
+	results, err := loadReportResults("reports")
+	if err != nil {
+		t.Fatalf("loadReportResults: %v", err)
+	}
+
+	if len(results) != 3 {
+		t.Fatalf("got %d cells, want 3 (one per subdirectory plus the root one); results: %+v",
+			len(results), results)
+	}
+
+	seen := map[string]bool{}
+	for _, r := range results {
+		seen[r.CLI] = true
+	}
+	for _, cli := range []string{"claude", "codex", "opencode"} {
+		if !seen[cli] {
+			t.Errorf("cell for %q missing from the aggregate report", cli)
+		}
+	}
+}
+
+// index.html lives at the reports root and must never be mistaken for a cell
+// summary now that the loader walks the tree.
+func TestLoadReportResultsIgnoresNonSummaries(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if err := os.MkdirAll(filepath.Join("reports", "claude"), 0o755); err != nil {
+		t.Fatalf("seed reports dir: %v", err)
+	}
+	seedReportSummary(t, filepath.Join("reports", "claude"), "claude__anthropic__sonnet__simple-chat")
+
+	if err := os.WriteFile(filepath.Join("reports", "index.html"), []byte("<html></html>"), 0o644); err != nil {
+		t.Fatalf("seed index.html: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join("reports", "claude", "x.transcript.log"), []byte("noise"), 0o644); err != nil {
+		t.Fatalf("seed transcript: %v", err)
+	}
+
+	results, err := loadReportResults("reports")
+	if err != nil {
+		t.Fatalf("loadReportResults: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d cells, want exactly 1 (index.html and transcripts are not summaries); results: %+v",
+			len(results), results)
+	}
+}
+
+// reportsDir is what lets the CI runner point one `go test` invocation at its
+// own subdirectory. Defaulting to "reports" keeps every local invocation and
+// the existing report tests working with no environment set.
+func TestReportsDirHonoursEnvOverride(t *testing.T) {
+	t.Setenv(reportsDirEnv, "")
+	if got := reportsDir(); got != "reports" {
+		t.Errorf("with no override, reportsDir() = %q, want \"reports\"", got)
+	}
+
+	t.Setenv(reportsDirEnv, filepath.Join("reports", "claude"))
+	if got, want := reportsDir(), filepath.Join("reports", "claude"); got != want {
+		t.Errorf("reportsDir() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Replaces the `test-core` CI job's in-process `go test` suite with an end-to-end provider harness run. Instead of running unit tests with coverage, the job now builds a `bifrost-http` binary and drives the full provider harness collection (`tests/e2e/api/collections/provider-harness.json`) against it via Newman, exercising real provider APIs from a live gateway.

## Changes

- **`test-core` job** no longer runs `go test` or uploads coverage to Codecov. It now validates the core build, then delegates to `test-provider-harness.sh` which boots a real `bifrost-http` binary and runs the Newman harness against it.
- **`test-provider-harness.sh`** (new script) handles the full CI lifecycle: builds the UI and binary, seeds a throwaway SQLite app dir, authenticates gcloud from `VERTEX_CREDENTIALS` for Vertex token-parity cells, waits for `/health`, then invokes `make run-provider-harness-test CI=1 USE_INFISICAL=0`.
- **Egress allowlist** expanded to cover Vertex (`aiplatform.googleapis.com`, `us-central1-aiplatform.googleapis.com`, `accounts.google.com`, `oauth2.googleapis.com`), gcloud CLI install (`dl.google.com`, `packages.cloud.google.com`, `objects.githubusercontent.com`), Replicate (`api.replicate.com`), and the getbifrost.ai pricing datasheet used by the dbverify reporter.
- **New CI dependencies** installed in the job: `jq`, `newman@6.2.1`, `newman-reporter-htmlextra@1.23.1`, and the gcloud CLI (`google-github-actions/setup-gcloud@v3`).
- **New secrets forwarded** to the run step: `AWS_REGION`, `GOOGLE_LOCATION`, `XAI_API_KEY`, `REPLICATE_API_KEY`, `BEDROCK_GUARDRAIL_IDENTIFIER`, `BEDROCK_GUARDRAIL_VERSION`. `CODECOV_TOKEN` removed.
- **Harness artifacts** (`newman-report*.json`, `newman-cli*.log`, `harness-failures.md`, `harness-token-parity.md`, `bifrost-dev.log`, etc.) are uploaded on every run (including failures) with a 30-day retention.
- **`harness-monitor.mjs`** gains a `--ci` mode that disables the alternate screen buffer and cursor-home redraws, emits append-only progress snapshots every `--ci-interval` seconds (default 30), logs each assertion failure inline as it is parsed, and writes a plain-text final table to both stdout and `$GITHUB_STEP_SUMMARY`.
- **Makefile** pins Newman versions via `NEWMAN_VERSION` and `NEWMAN_HTMLEXTRA_VERSION` variables (defaulting to `6.2.1` / `1.23.1`) and fixes the `CI=1` branch of `run-provider-harness-test` to start the monitor in append-only mode and still print per-provider pass/fail lines and log tails.
- Job timeout set to 90 minutes to accommodate the full provider sweep.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

The harness runs automatically in CI on any change that triggers `core-needs-release`. To run locally:

```sh
make run-provider-harness-test
```

For CI-equivalent mode (append-only output, no terminal UI):

```sh
make run-provider-harness-test CI=1 USE_INFISICAL=0 PARALLEL=1
```

Required environment variables for the full sweep: all existing provider API keys plus `AWS_REGION`, `GOOGLE_LOCATION`, `VERTEX_CREDENTIALS` (service-account JSON), `XAI_API_KEY`, `REPLICATE_API_KEY`, `BEDROCK_GUARDRAIL_IDENTIFIER`, `BEDROCK_GUARDRAIL_VERSION`.

## Breaking changes

- [x] Yes
- [ ] No

The `test-core` job no longer runs `go test` or reports coverage to Codecov. Any downstream tooling that depends on Codecov coverage reports from this job will stop receiving them.

## Security considerations

- The Vertex service-account key (`VERTEX_CREDENTIALS`) is written to disk only for the duration of the gcloud auth call and is deleted in the `cleanup` trap before the artifact-upload step runs, ensuring it is never captured in uploaded artifacts.
- The egress allowlist is explicitly extended for each new external endpoint; no wildcard rules are added.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable