### PR TITLE
feat: add separate headers support for traces and metrics in OTEL collector

### DIFF
--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -86,19 +86,21 @@ type Profile struct {
 	// Enabled gates whether this profile exports anything. The plugin itself is always on;
 	// a disabled profile builds no trace client or metrics exporter, so no traces/metrics
 	// are sent for it. Defaults to true when omitted.
-	Enabled      bool               `json:"enabled"`
+	Enabled bool `json:"enabled"`
 
 	// TracesEnabled gates trace export. When false, no trace client is built and
 	// CollectorURL is not required: a metrics-only profile. Defaults to true when omitted.
 	TracesEnabled bool `json:"traces_enabled"`
 
-	ServiceName  string             `json:"service_name"`
-	CollectorURL *schemas.SecretVar `json:"collector_url"`
-	Headers      map[string]string  `json:"headers,omitempty"`
-	TraceType    TraceType          `json:"trace_type"`
-	Protocol     Protocol           `json:"protocol"`
-	TLSCACert    string             `json:"tls_ca_cert,omitempty"`
-	Insecure     bool               `json:"insecure"` // Skip TLS when true; ignored if TLSCACert is set. Defaults to true when omitted.
+	ServiceName    string             `json:"service_name"`
+	CollectorURL   *schemas.SecretVar `json:"collector_url"`
+	Headers        map[string]string  `json:"headers,omitempty"`         // Shared between traces and metrics endpoints
+	TraceHeaders   map[string]string  `json:"trace_headers,omitempty"`   // Traces only headers
+	MetricsHeaders map[string]string  `json:"metrics_headers,omitempty"` // Metrics only headers
+	TraceType      TraceType          `json:"trace_type"`
+	Protocol       Protocol           `json:"protocol"`
+	TLSCACert      string             `json:"tls_ca_cert,omitempty"`
+	Insecure       bool               `json:"insecure"` // Skip TLS when true; ignored if TLSCACert is set. Defaults to true when omitted.
 
 	// ExportTimeout bounds a single trace export, in seconds (default 5, max 60).
 	// This is the only deadline on the export: the caller passes context.Background(),
@@ -254,6 +256,8 @@ type profileForStorage struct {
 	ServiceName            string            `json:"service_name"`
 	CollectorURL           string            `json:"collector_url"`
 	Headers                map[string]string `json:"headers,omitempty"`
+	TraceHeaders           map[string]string `json:"trace_headers,omitempty"`
+	MetricsHeaders         map[string]string `json:"metrics_headers,omitempty"`
 	TraceType              TraceType         `json:"trace_type"`
 	Protocol               Protocol          `json:"protocol"`
 	TLSCACert              string            `json:"tls_ca_cert,omitempty"`
@@ -293,6 +297,8 @@ func (c *Config) MarshalForStorage() ([]byte, error) {
 			ServiceName:            p.ServiceName,
 			CollectorURL:           schemas.SecretVarAsString(p.CollectorURL),
 			Headers:                p.Headers,
+			TraceHeaders:           p.TraceHeaders,
+			MetricsHeaders:         p.MetricsHeaders,
 			TraceType:              p.TraceType,
 			Protocol:               p.Protocol,
 			TLSCACert:              p.TLSCACert,
@@ -331,12 +337,9 @@ func (c *Config) Redacted() *Config {
 			rp := *p
 			rp.CollectorURL = hideResolvedEnvValue(p.CollectorURL)
 			rp.MetricsEndpoint = hideResolvedEnvValue(p.MetricsEndpoint)
-			if p.Headers != nil {
-				rp.Headers = make(map[string]string, len(p.Headers))
-				for k, v := range p.Headers {
-					rp.Headers[k] = redactHeaderValue(v)
-				}
-			}
+			rp.Headers = redactHeaderMap(p.Headers)
+			rp.TraceHeaders = redactHeaderMap(p.TraceHeaders)
+			rp.MetricsHeaders = redactHeaderMap(p.MetricsHeaders)
 			redacted.Profiles = append(redacted.Profiles, &rp)
 		}
 	}
@@ -351,6 +354,18 @@ func redactHeaderValue(v string) string {
 		return v
 	}
 	return schemas.SecretVarAsString(schemas.NewSecretVar(v).Redacted())
+}
+
+// redactHeaderMap redacts every value in a copy of h, returning nil for nil h.
+func redactHeaderMap(h map[string]string) map[string]string {
+	if h == nil {
+		return nil
+	}
+	out := make(map[string]string, len(h))
+	for k, v := range h {
+		out[k] = redactHeaderValue(v)
+	}
+	return out
 }
 
 // hideResolvedEnvValue returns v unchanged for literal values (URLs are not secrets).
@@ -539,12 +554,23 @@ func (p *OtelPlugin) buildTarget(index int, profile *Profile) (*otelTarget, erro
 		}
 	}
 
-	// Copy headers before resolving so the stored config is never mutated, then resolve
-	// any "env." references against the environment (errors if a referenced var is unset).
-	headers := make(map[string]string, len(profile.Headers))
-	maps.Copy(headers, profile.Headers)
-	if err := injectEnvToHeaders(headers); err != nil {
-		return nil, fmt.Errorf("profile %d: %w", index, err)
+	// Common headers go to both endpoints; per-signal headers override on collision.
+	var (
+		traceHeaders   map[string]string
+		metricsHeaders map[string]string
+		err            error
+	)
+	if profile.TracesEnabled {
+		traceHeaders, err = mergedResolvedHeaders(profile.Headers, profile.TraceHeaders)
+		if err != nil {
+			return nil, fmt.Errorf("profile %d: %w", index, err)
+		}
+	}
+	if profile.MetricsEnabled {
+		metricsHeaders, err = mergedResolvedHeaders(profile.Headers, profile.MetricsHeaders)
+		if err != nil {
+			return nil, fmt.Errorf("profile %d: %w", index, err)
+		}
 	}
 
 	exportTimeout, err := resolveExportTimeout(profile.ExportTimeout)
@@ -573,9 +599,9 @@ func (p *OtelPlugin) buildTarget(index int, profile *Profile) (*otelTarget, erro
 		case ProtocolGRPC:
 			// gRPC has no client-side timeout of its own; the per-export context deadline
 			// applied in Inject is what bounds it.
-			target.client, err = NewOtelClientGRPC(url, headers, profile.TLSCACert, profile.Insecure)
+			target.client, err = NewOtelClientGRPC(url, traceHeaders, profile.TLSCACert, profile.Insecure)
 		case ProtocolHTTP:
-			target.client, err = NewOtelClientHTTP(url, headers, profile.TLSCACert, profile.Insecure, exportTimeout)
+			target.client, err = NewOtelClientHTTP(url, traceHeaders, profile.TLSCACert, profile.Insecure, exportTimeout)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("profile %d: %w", index, err)
@@ -602,7 +628,7 @@ func (p *OtelPlugin) buildTarget(index int, profile *Profile) (*otelTarget, erro
 		metricsConfig := &MetricsConfig{
 			ServiceName:  serviceName,
 			Endpoint:     profile.MetricsEndpoint.GetValue(),
-			Headers:      headers,
+			Headers:      metricsHeaders,
 			Protocol:     profile.Protocol,
 			TLSCACert:    profile.TLSCACert,
 			Insecure:     profile.Insecure,
@@ -620,6 +646,18 @@ func (p *OtelPlugin) buildTarget(index int, profile *Profile) (*otelTarget, erro
 	}
 
 	return target, nil
+}
+
+// mergedResolvedHeaders overlays overlay onto common (overlay wins) and resolves "env."
+// references. Inputs are not mutated.
+func mergedResolvedHeaders(common, overlay map[string]string) (map[string]string, error) {
+	merged := make(map[string]string, len(common)+len(overlay))
+	maps.Copy(merged, common)
+	maps.Copy(merged, overlay)
+	if err := injectEnvToHeaders(merged); err != nil {
+		return nil, err
+	}
+	return merged, nil
 }
 
 // resolveExportTimeout validates a configured export_timeout (in seconds) and returns

--- a/plugins/otel/profiles_test.go
+++ b/plugins/otel/profiles_test.go
@@ -488,6 +488,119 @@ func TestTracesEnabledStorageRoundTrip(t *testing.T) {
 	}
 }
 
+// TestMergedResolvedHeaders verifies per-signal headers overlay the common ones (same key
+// wins), env refs resolve, and the inputs are not mutated.
+func TestMergedResolvedHeaders(t *testing.T) {
+	t.Setenv("OTEL_TOKEN", "resolved")
+	common := map[string]string{"Authorization": "env.OTEL_TOKEN", "X-Shared": "base"}
+	overlay := map[string]string{"X-Shared": "override", "X-Table": "my_table"}
+
+	merged, err := mergedResolvedHeaders(common, overlay)
+	if err != nil {
+		t.Fatalf("mergedResolvedHeaders: %v", err)
+	}
+	if merged["Authorization"] != "resolved" {
+		t.Errorf("Authorization = %q, want resolved", merged["Authorization"])
+	}
+	if merged["X-Shared"] != "override" {
+		t.Errorf("X-Shared = %q, want override (overlay wins)", merged["X-Shared"])
+	}
+	if merged["X-Table"] != "my_table" {
+		t.Errorf("X-Table = %q, want my_table", merged["X-Table"])
+	}
+	// Inputs untouched.
+	if common["Authorization"] != "env.OTEL_TOKEN" || common["X-Shared"] != "base" {
+		t.Errorf("common map was mutated: %v", common)
+	}
+	if overlay["X-Shared"] != "override" {
+		t.Errorf("overlay map was mutated: %v", overlay)
+	}
+}
+
+// TestPerSignalHeadersStorageRoundTrip verifies trace_headers and metrics_headers survive
+// storage marshalling and redaction.
+func TestPerSignalHeadersStorageRoundTrip(t *testing.T) {
+	raw := `{"profiles": [
+		{
+			"collector_url": "a:4317", "trace_type": "genai_extension", "protocol": "grpc",
+			"headers": {"Authorization": "env.OTEL_TOKEN"},
+			"trace_headers": {"X-Trace": "t"},
+			"metrics_enabled": true, "metrics_endpoint": "a:4318",
+			"metrics_headers": {"X-Databricks-Table": "my_table"}
+		}
+	]}`
+	var cfg Config
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	stored, err := cfg.MarshalForStorage()
+	if err != nil {
+		t.Fatalf("MarshalForStorage: %v", err)
+	}
+	var back Config
+	if err := json.Unmarshal(stored, &back); err != nil {
+		t.Fatalf("round-trip unmarshal: %v", err)
+	}
+	p := back.Profiles[0]
+	if p.TraceHeaders["X-Trace"] != "t" {
+		t.Errorf("trace_headers lost: %v", p.TraceHeaders)
+	}
+	if p.MetricsHeaders["X-Databricks-Table"] != "my_table" {
+		t.Errorf("metrics_headers lost: %v", p.MetricsHeaders)
+	}
+
+	// Redaction preserves env refs and masks literals across all three maps.
+	red := cfg.Redacted().Profiles[0]
+	if red.Headers["Authorization"] != "env.OTEL_TOKEN" {
+		t.Errorf("common env header not preserved: %q", red.Headers["Authorization"])
+	}
+	if red.MetricsHeaders["X-Databricks-Table"] == "my_table" {
+		t.Errorf("metrics literal header was not masked")
+	}
+}
+
+// TestInitMetricsOnlyIgnoresTraceHeaderEnv verifies a metrics-only profile does not
+// resolve trace_headers, so an unset env reference there does not fail Init.
+func TestInitMetricsOnlyIgnoresTraceHeaderEnv(t *testing.T) {
+	raw := `{"profiles": [
+		{
+			"traces_enabled": false, "protocol": "http",
+			"trace_headers": {"X-Trace": "env.OTEL_UNSET_TRACE_XYZ"},
+			"metrics_enabled": true, "metrics_endpoint": "localhost:4318"
+		}
+	]}`
+	var cfg Config
+	if err := sonic.Unmarshal([]byte(raw), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	plugin, err := Init(context.Background(), &cfg, testLogger{}, nil, "")
+	if err != nil {
+		t.Fatalf("Init metrics-only with unset trace_headers env: %v", err)
+	}
+	t.Cleanup(func() { _ = plugin.Cleanup() })
+}
+
+// TestInitTracesOnlyIgnoresMetricsHeaderEnv verifies a traces-only profile does not
+// resolve metrics_headers, so an unset env reference there does not fail Init.
+func TestInitTracesOnlyIgnoresMetricsHeaderEnv(t *testing.T) {
+	raw := `{"profiles": [
+		{
+			"collector_url": "localhost:4317", "trace_type": "genai_extension", "protocol": "grpc",
+			"metrics_enabled": false,
+			"metrics_headers": {"X-Table": "env.OTEL_UNSET_METRICS_XYZ"}
+		}
+	]}`
+	var cfg Config
+	if err := sonic.Unmarshal([]byte(raw), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	plugin, err := Init(context.Background(), &cfg, testLogger{}, nil, "")
+	if err != nil {
+		t.Fatalf("Init traces-only with unset metrics_headers env: %v", err)
+	}
+	t.Cleanup(func() { _ = plugin.Cleanup() })
+}
+
 type testLogger struct{}
 
 func (testLogger) Debug(string, ...any)                   {}

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -3222,7 +3222,21 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "Custom headers for the collector. Supports env.VAR_NAME prefix for environment variable substitution."
+          "description": "Custom headers sent to both the trace and metrics endpoints. Supports env.VAR_NAME prefix for environment variable substitution."
+        },
+        "trace_headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra headers sent only to the trace endpoint, overlaid on headers (same key wins). Supports env.VAR_NAME prefix."
+        },
+        "metrics_headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra headers sent only to the metrics endpoint, overlaid on headers (same key wins). Useful when a collector requires a per-signal header, e.g. a Databricks table name. Supports env.VAR_NAME prefix."
         },
         "tls_ca_cert": {
           "type": "string",

--- a/ui/app/workspace/observability/fragments/otelFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/otelFormFragment.tsx
@@ -29,6 +29,8 @@ interface StoredOtelProfile {
 	service_name?: string;
 	collector_url?: string | SecretVar;
 	headers?: Record<string, string | SecretVar>;
+	trace_headers?: Record<string, string | SecretVar>;
+	metrics_headers?: Record<string, string | SecretVar>;
 	trace_type?: "genai_extension" | "vercel" | "open_inference";
 	protocol?: "http" | "grpc";
 	tls_ca_cert?: string;
@@ -95,6 +97,8 @@ const emptyProfile = (): ProfileForm => ({
 	service_name: "bifrost",
 	collector_url: emptySecretVar(),
 	headers: {},
+	trace_headers: {},
+	metrics_headers: {},
 	trace_type: "genai_extension",
 	protocol: "http",
 	tls_ca_cert: "",
@@ -116,6 +120,8 @@ const toProfileForm = (p?: StoredOtelProfile): ProfileForm => ({
 	service_name: p?.service_name ?? "bifrost",
 	collector_url: toSecretVarFormValue(p?.collector_url),
 	headers: toSecretVarMapFormValue(p?.headers),
+	trace_headers: toSecretVarMapFormValue(p?.trace_headers),
+	metrics_headers: toSecretVarMapFormValue(p?.metrics_headers),
 	trace_type: p?.trace_type ?? "genai_extension",
 	protocol: p?.protocol ?? "http",
 	tls_ca_cert: p?.tls_ca_cert ?? "",
@@ -438,8 +444,15 @@ function OtelProfileSection({ form, control, index, hasOtelAccess, canRemove, op
 						render={({ field }) => (
 							<FormItem className="w-full">
 								<FormControl>
-									<HeadersTable value={field.value || {}} onChange={field.onChange} disabled={!hasOtelAccess} useSecretVarInput />
+									<HeadersTable
+										label="Common Headers"
+										value={field.value || {}}
+										onChange={field.onChange}
+										disabled={!hasOtelAccess}
+										useSecretVarInput
+									/>
 								</FormControl>
+								<FormDescription>Sent to both the trace and metrics endpoints.</FormDescription>
 								<FormMessage />
 							</FormItem>
 						)}
@@ -564,6 +577,25 @@ function OtelProfileSection({ form, control, index, hasOtelAccess, canRemove, op
 														{...field}
 													/>
 												</FormControl>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
+									<FormField
+										control={control}
+										name={`${base}.trace_headers`}
+										render={({ field }) => (
+											<FormItem className="w-full">
+												<FormControl>
+													<HeadersTable
+														label="Trace Headers"
+														value={field.value || {}}
+														onChange={field.onChange}
+														disabled={!hasOtelAccess}
+														useSecretVarInput
+													/>
+												</FormControl>
+												<FormDescription>Sent only to the trace endpoint, in addition to the common headers.</FormDescription>
 												<FormMessage />
 											</FormItem>
 										)}
@@ -776,6 +808,28 @@ function OtelProfileSection({ form, control, index, hasOtelAccess, canRemove, op
 														{...field}
 													/>
 												</FormControl>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
+
+									<FormField
+										control={control}
+										name={`${base}.metrics_headers`}
+										render={({ field }) => (
+											<FormItem className="w-full">
+												<FormControl>
+													<HeadersTable
+														label="Metrics Headers"
+														value={field.value || {}}
+														onChange={field.onChange}
+														disabled={!hasOtelAccess}
+														useSecretVarInput
+													/>
+												</FormControl>
+												<FormDescription>
+													Sent only to the metrics endpoint, in addition to the common headers (e.g. a Databricks table name).
+												</FormDescription>
 												<FormMessage />
 											</FormItem>
 										)}

--- a/ui/app/workspace/observability/views/plugins/otelView.tsx
+++ b/ui/app/workspace/observability/views/plugins/otelView.tsx
@@ -25,6 +25,8 @@ export default function OtelView({ onDelete, isDeleting }: OtelViewProps) {
 		const profiles = config.profiles.map((profile) => ({
 			...profile,
 			headers: toHeaderStringMap(profile.headers),
+			trace_headers: toHeaderStringMap(profile.trace_headers),
+			metrics_headers: toHeaderStringMap(profile.metrics_headers),
 		}));
 
 		return new Promise((resolve, reject) => {

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -879,7 +879,10 @@ export const otelConfigSchema = z
 				message: "Please select a trace type",
 			})
 			.default("genai_extension"),
+		// Common headers go to both endpoints; per-signal headers override on collision.
 		headers: z.record(z.string(), secretVarSchema).optional(),
+		trace_headers: z.record(z.string(), secretVarSchema).optional(),
+		metrics_headers: z.record(z.string(), secretVarSchema).optional(),
 		protocol: z
 			.enum(["http", "grpc"], {
 				message: "Please select a protocol",


### PR DESCRIPTION
## Summary

Adds support for per-signal HTTP headers in OTel profiles, allowing separate headers to be sent exclusively to the trace endpoint or the metrics endpoint, in addition to the existing shared `headers` field. This is particularly useful when a metrics collector requires a signal-specific header (e.g. a Databricks table name) that should not be forwarded to the trace endpoint.

## Changes

- Added `trace_headers` and `metrics_headers` fields to the `Profile` struct and `profileForStorage` struct, alongside the existing `headers` field.
- `headers` continues to apply to both endpoints. `trace_headers` and `metrics_headers` are overlaid on top of the common headers at build time, with per-signal keys winning on collision.
- Introduced `mergedResolvedHeaders` to merge common and per-signal header maps and resolve `env.VAR_NAME` references without mutating the inputs.
- Extracted `redactHeaderMap` to eliminate duplicated redaction logic and applied it to all three header maps in `Redacted()`.
- Updated the JSON schema (`config.schema.json`) with descriptions for all three header fields.
- Updated the UI form to render separate `HeadersTable` inputs for common, trace-only, and metrics-only headers, each with descriptive labels and `FormDescription` text.
- Updated the Zod schema and form serialization to include `trace_headers` and `metrics_headers`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./plugins/otel/...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Configure an OTel profile with all three header fields:

```json
{
  "headers": { "Authorization": "env.OTEL_TOKEN" },
  "trace_headers": { "X-Trace-Only": "trace-value" },
  "metrics_headers": { "X-Databricks-Table": "my_table" }
}
```

Verify that:
- Trace requests include `Authorization` and `X-Trace-Only` but not `X-Databricks-Table`.
- Metrics requests include `Authorization` and `X-Databricks-Table` but not `X-Trace-Only`.
- `env.OTEL_TOKEN` is resolved from the environment on both endpoints.
- Redacted config masks literal header values and preserves `env.` references across all three maps.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

All three header maps (`headers`, `trace_headers`, `metrics_headers`) are subject to the same redaction logic in `Redacted()`. Literal header values are masked and `env.` references are preserved as-is, consistent with prior behavior. No new secret storage paths are introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable