### PR TITLE
fix: bedrock files handling in inference

### DIFF
--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -2,6 +2,7 @@ package bedrock_test
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"os"
 	"strings"
@@ -4550,6 +4551,216 @@ func TestDocumentFormatMapping(t *testing.T) {
 				"File type %q should map to format %q", tt.fileType, tt.expectedFormat)
 		})
 	}
+}
+
+// chatFileBlockDocument converts a single OpenAI-style file content block and
+// returns the resulting Bedrock document.
+func chatFileBlockDocument(t *testing.T, file *schemas.ChatInputFile) *bedrock.BedrockDocumentSource {
+	t.Helper()
+
+	bifrostReq := &schemas.BifrostChatRequest{
+		Provider: schemas.Bedrock,
+		Model:    "anthropic.claude-sonnet-4-5-20250929-v1:0",
+		Input: []schemas.ChatMessage{
+			{
+				Role: schemas.ChatMessageRoleUser,
+				Content: &schemas.ChatMessageContent{
+					ContentBlocks: []schemas.ChatContentBlock{
+						{Type: schemas.ChatContentBlockTypeText, Text: schemas.Ptr("Summarize this document.")},
+						{Type: schemas.ChatContentBlockTypeFile, File: file},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	result, err := bedrock.ToBedrockChatCompletionRequest(ctx, bifrostReq)
+	require.NoError(t, err)
+	require.Len(t, result.Messages, 1)
+	require.Len(t, result.Messages[0].Content, 2)
+	require.NotNil(t, result.Messages[0].Content[1].Document)
+
+	return result.Messages[0].Content[1].Document
+}
+
+// The standard OpenAI chat `type:"file"` part carries the document's MIME type only
+// inside the file_data data URL - file_type is a Bifrost extension normal clients
+// don't send. Without reading it, every non-PDF document was labeled format "pdf"
+// and Bedrock rejected it with "The PDF specified was not valid".
+func TestDocumentFormatFromDataURL(t *testing.T) {
+	t.Parallel()
+
+	const payload = "UEsDBBQABgAI"
+
+	tests := []struct {
+		name           string
+		mediaType      string
+		filename       string
+		expectedFormat string
+	}{
+		{"XLSX", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "sheet.xlsx", "xlsx"},
+		{"DOCX", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "report.docx", "docx"},
+		{"XLS", "application/vnd.ms-excel", "legacy.xls", "xls"},
+		{"DOC", "application/msword", "legacy.doc", "doc"},
+		{"CSV", "text/csv", "rows.csv", "csv"},
+		{"Markdown", "text/markdown", "notes.md", "md"},
+		{"PDF", "application/pdf", "paper.pdf", "pdf"},
+		{"MediaTypeWithParameter", "text/plain;charset=utf-8", "notes.txt", "txt"},
+		{"UppercaseMediaType", "APPLICATION/PDF", "paper.pdf", "pdf"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := chatFileBlockDocument(t, &schemas.ChatInputFile{
+				Filename: schemas.Ptr(tt.filename),
+				FileData: schemas.Ptr("data:" + tt.mediaType + ";base64," + payload),
+			})
+
+			assert.Equal(t, tt.expectedFormat, doc.Format,
+				"data URL media type %q should map to format %q", tt.mediaType, tt.expectedFormat)
+			require.NotNil(t, doc.Source.Bytes)
+			assert.Equal(t, payload, *doc.Source.Bytes, "data URL prefix must be stripped from source.bytes")
+		})
+	}
+}
+
+// Format resolution order: file_type, then the data URL media type, then the
+// filename extension, then the historical "pdf" default.
+func TestDocumentFormatResolutionPrecedence(t *testing.T) {
+	t.Parallel()
+
+	t.Run("FileTypeWinsOverDataURL", func(t *testing.T) {
+		doc := chatFileBlockDocument(t, &schemas.ChatInputFile{
+			Filename: schemas.Ptr("sheet.xlsx"),
+			FileType: schemas.Ptr("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+			FileData: schemas.Ptr("data:application/octet-stream;base64,UEsDBBQABgAI"),
+		})
+		assert.Equal(t, "xlsx", doc.Format)
+	})
+
+	t.Run("FilenameExtensionWhenMediaTypeIsOpaque", func(t *testing.T) {
+		doc := chatFileBlockDocument(t, &schemas.ChatInputFile{
+			Filename: schemas.Ptr("report.docx"),
+			FileData: schemas.Ptr("data:application/octet-stream;base64,UEsDBBQABgAI"),
+		})
+		assert.Equal(t, "docx", doc.Format)
+	})
+
+	t.Run("UnidentifiableDocumentKeepsPDFDefault", func(t *testing.T) {
+		doc := chatFileBlockDocument(t, &schemas.ChatInputFile{
+			Filename: schemas.Ptr("blob"),
+			FileData: schemas.Ptr("data:application/octet-stream;base64,UEsDBBQABgAI"),
+		})
+		assert.Equal(t, "pdf", doc.Format)
+	})
+}
+
+// A non-base64 data URL carries percent-encoded text, not base64 - sending it
+// verbatim as source.bytes shipped the whole "data:..." string to Bedrock.
+func TestDocumentInlineTextDataURL(t *testing.T) {
+	t.Parallel()
+
+	doc := chatFileBlockDocument(t, &schemas.ChatInputFile{
+		Filename: schemas.Ptr("notes.txt"),
+		FileData: schemas.Ptr("data:text/plain,Hello%20World"),
+	})
+
+	assert.Equal(t, "txt", doc.Format)
+	require.NotNil(t, doc.Source.Text)
+	assert.Equal(t, "Hello World", *doc.Source.Text)
+	require.NotNil(t, doc.Source.Bytes)
+	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("Hello World")), *doc.Source.Bytes)
+
+	// A binary format never gets source.text, matching the raw file_data path.
+	doc = chatFileBlockDocument(t, &schemas.ChatInputFile{
+		Filename: schemas.Ptr("paper.pdf"),
+		FileData: schemas.Ptr("data:application/pdf,%25PDF-1.4"),
+	})
+
+	assert.Equal(t, "pdf", doc.Format)
+	assert.Nil(t, doc.Source.Text, "binary documents must not carry source.text")
+	require.NotNil(t, doc.Source.Bytes)
+	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("%PDF-1.4")), *doc.Source.Bytes)
+}
+
+// The Responses path had its own copy of the format mapping with the same defect.
+func TestToBedrockResponsesRequest_DocumentFormatFromDataURL(t *testing.T) {
+	t.Parallel()
+
+	const payload = "UEsDBBQABgAI"
+	bifrostReq := &schemas.BifrostResponsesRequest{
+		Provider: schemas.Bedrock,
+		Model:    "anthropic.claude-sonnet-4-5-20250929-v1:0",
+		Input: []schemas.ResponsesMessage{
+			{
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+				Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+				Content: &schemas.ResponsesMessageContent{
+					ContentBlocks: []schemas.ResponsesMessageContentBlock{
+						{Type: schemas.ResponsesInputMessageContentBlockTypeText, Text: schemas.Ptr("Summarize this document.")},
+						{
+							Type: schemas.ResponsesInputMessageContentBlockTypeFile,
+							ResponsesInputMessageContentBlockFile: &schemas.ResponsesInputMessageContentBlockFile{
+								Filename: schemas.Ptr("sheet.xlsx"),
+								FileData: schemas.Ptr("data:application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;base64," + payload),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	result, err := bedrock.ToBedrockResponsesRequest(ctx, bifrostReq)
+	require.NoError(t, err)
+	require.Len(t, result.Messages, 1)
+
+	var doc *bedrock.BedrockDocumentSource
+	for _, contentBlock := range result.Messages[0].Content {
+		if contentBlock.Document != nil {
+			doc = contentBlock.Document
+		}
+	}
+	require.NotNil(t, doc)
+	assert.Equal(t, "xlsx", doc.Format)
+	require.NotNil(t, doc.Source.Bytes)
+	assert.Equal(t, payload, *doc.Source.Bytes)
+}
+
+// The Responses path ignored file_url entirely, emitting a document block with an
+// empty source. It now inlines the bytes like the chat path does, so an unreachable
+// URL surfaces as an error instead of silently shipping an empty document.
+func TestToBedrockResponsesRequest_DocumentFileURLIsFetched(t *testing.T) {
+	t.Parallel()
+
+	bifrostReq := &schemas.BifrostResponsesRequest{
+		Provider: schemas.Bedrock,
+		Model:    "anthropic.claude-sonnet-4-5-20250929-v1:0",
+		Input: []schemas.ResponsesMessage{
+			{
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+				Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+				Content: &schemas.ResponsesMessageContent{
+					ContentBlocks: []schemas.ResponsesMessageContentBlock{
+						{Type: schemas.ResponsesInputMessageContentBlockTypeText, Text: schemas.Ptr("Summarize this document.")},
+						{
+							Type: schemas.ResponsesInputMessageContentBlockTypeFile,
+							ResponsesInputMessageContentBlockFile: &schemas.ResponsesInputMessageContentBlockFile{
+								Filename: schemas.Ptr("sheet.xlsx"),
+								FileURL:  schemas.Ptr("http://127.0.0.1:1/sheet.xlsx"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	_, err := bedrock.ToBedrockResponsesRequest(ctx, bifrostReq)
+	require.Error(t, err, "file_url must be fetched, not silently dropped")
 }
 
 func TestBedrockStopReasonMapping(t *testing.T) {

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -3266,10 +3267,12 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 	if len(bifrostMessages) == 1 && bifrostMessages[0].Role != nil && (*bifrostMessages[0].Role == schemas.ResponsesInputMessageRoleSystem || *bifrostMessages[0].Role == schemas.ResponsesInputMessageRoleDeveloper) {
 		msg := bifrostMessages[0]
 		msg.Role = schemas.Ptr(schemas.ResponsesInputMessageRoleUser)
-		if bedrockMsg := convertBifrostMessageToBedrockMessage(ctx, &msg); bedrockMsg != nil {
-			if len(bedrockMsg.Content) > 0 {
-				return []BedrockMessage{*bedrockMsg}, nil, nil
-			}
+		bedrockMsg, err := convertBifrostMessageToBedrockMessage(ctx, &msg)
+		if err != nil {
+			return nil, nil, err
+		}
+		if bedrockMsg != nil && len(bedrockMsg.Content) > 0 {
+			return []BedrockMessage{*bedrockMsg}, nil, nil
 		}
 	}
 
@@ -3660,7 +3663,10 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 				}
 			} else {
 				// Convert user/assistant text message
-				bedrockMsg := convertBifrostMessageToBedrockMessage(ctx, &msg)
+				bedrockMsg, err := convertBifrostMessageToBedrockMessage(ctx, &msg)
+				if err != nil {
+					return nil, nil, err
+				}
 				if bedrockMsg != nil {
 					// Prepend buffered server-managed tool blocks (nova_grounding / nova_code_interpreter)
 					// to the assistant message they belong to — they're part of the same turn.
@@ -3982,11 +3988,13 @@ func convertBifrostSystemReminderToBedrockUserMessage(msg *schemas.ResponsesMess
 }
 
 // convertBifrostMessageToBedrockMessage converts a regular Bifrost message to Bedrock message.
-// The ctx is propagated to URL fetches inside content blocks.
-func convertBifrostMessageToBedrockMessage(ctx context.Context, msg *schemas.ResponsesMessage) *BedrockMessage {
+// The ctx is propagated to URL fetches inside content blocks. A conversion failure
+// (e.g. an image or document URL that can't be fetched) is returned rather than
+// swallowed - dropping the message would send Bedrock a request missing the turn.
+func convertBifrostMessageToBedrockMessage(ctx context.Context, msg *schemas.ResponsesMessage) (*BedrockMessage, error) {
 	// Ensure Content is present
 	if msg.Content == nil {
-		return nil
+		return nil, nil
 	}
 
 	bedrockMsg := BedrockMessage{
@@ -3996,11 +4004,11 @@ func convertBifrostMessageToBedrockMessage(ctx context.Context, msg *schemas.Res
 	// Convert content
 	contentBlocks, err := convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(ctx, *msg.Content)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	bedrockMsg.Content = contentBlocks
 
-	return &bedrockMsg
+	return &bedrockMsg, nil
 }
 
 // convertBedrockSystemMessageToBifrostMessages converts a Bedrock system message to Bifrost messages
@@ -4669,7 +4677,7 @@ func convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(ctx conte
 				// (only from/to model names), so skip it entirely.
 				continue
 			case schemas.ResponsesInputMessageContentBlockTypeFile:
-				if block.ResponsesInputMessageContentBlockFile != nil {
+				if file := block.ResponsesInputMessageContentBlockFile; file != nil {
 					doc := &BedrockDocumentSource{
 						Name:   "document", // Default
 						Format: "pdf",      // Default
@@ -4677,53 +4685,75 @@ func convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(ctx conte
 					}
 
 					// Set filename (normalized for Bedrock)
-					if block.ResponsesInputMessageContentBlockFile.Filename != nil {
-						doc.Name = normalizeBedrockFilename(*block.ResponsesInputMessageContentBlockFile.Filename)
+					if file.Filename != nil {
+						doc.Name = normalizeBedrockFilename(*file.Filename)
 					}
 
-					// Determine format: text or PDF based on FileType
-					isTextFile := false
-					if block.ResponsesInputMessageContentBlockFile.FileType != nil {
-						fileType := *block.ResponsesInputMessageContentBlockFile.FileType
-						// Check if it's a text type
-						if fileType == "text/markdown" || fileType == "md" {
-							doc.Format = "md"
-							isTextFile = true
-						} else if fileType == "text/html" || fileType == "html" {
-							doc.Format = "html"
-							isTextFile = true
-						} else if fileType == "text/csv" || fileType == "csv" {
-							doc.Format = "csv"
-							isTextFile = true
-						} else if strings.HasPrefix(fileType, "text/") || fileType == "txt" {
-							doc.Format = "txt"
-							isTextFile = true
-						} else if strings.Contains(fileType, "pdf") || fileType == "pdf" {
-							doc.Format = "pdf"
-						} else if strings.Contains(fileType, "spreadsheetml") || fileType == "xlsx" {
-							doc.Format = "xlsx"
-						} else if fileType == "application/vnd.ms-excel" || fileType == "xls" {
-							doc.Format = "xls"
-						} else if strings.Contains(fileType, "wordprocessingml") || fileType == "docx" {
-							doc.Format = "docx"
-						} else if fileType == "application/msword" || fileType == "doc" {
-							doc.Format = "doc"
+					// Parse the data URL once; it carries both the payload and (for
+					// standard OpenAI clients, which have no file_type field) the
+					// document's MIME type.
+					dataURLMediaType, dataURLPayload := "", ""
+					dataURLIsBase64, isDataURL := false, false
+					if file.FileData != nil && strings.HasPrefix(*file.FileData, "data:") {
+						dataURLMediaType, dataURLIsBase64, dataURLPayload, isDataURL = schemas.ParseDataURL(*file.FileData)
+					}
+
+					// Resolve the document format, most authoritative hint first. Falls
+					// back to the "pdf" default only when nothing identifies the document.
+					format, isTextFile := "", false
+					if file.FileType != nil {
+						format, isTextFile, _ = bedrockDocumentFormat(*file.FileType)
+					}
+					if format == "" && isDataURL {
+						format, isTextFile, _ = bedrockDocumentFormat(dataURLMediaType)
+					}
+					if format == "" && file.Filename != nil {
+						if dot := strings.LastIndex(*file.Filename, "."); dot >= 0 {
+							format, isTextFile, _ = bedrockDocumentFormat((*file.Filename)[dot+1:])
 						}
+					}
+					if format != "" {
+						doc.Format = format
+					}
+
+					// URL-sourced document: fetch and inline the bytes (Bedrock Converse
+					// only accepts inline source bytes, not remote URLs).
+					if file.FileURL != nil && *file.FileURL != "" {
+						fetchedMediaType, fetchedB64, fetchErr := providerUtils.FetchAndEncodeURL(ctx, *file.FileURL)
+						if fetchErr != nil {
+							return nil, fetchErr
+						}
+						// Refine format from response Content-Type when present (more
+						// reliable than file extension or upstream-declared media type).
+						if fetchedFormat, _, ok := bedrockDocumentFormat(fetchedMediaType); ok {
+							doc.Format = fetchedFormat
+						}
+						doc.Source.Bytes = &fetchedB64
+						bedrockBlock.Document = doc
+						break
 					}
 
 					// Handle file data
-					if block.ResponsesInputMessageContentBlockFile.FileData != nil {
-						fileData := *block.ResponsesInputMessageContentBlockFile.FileData
+					if file.FileData != nil {
+						fileData := *file.FileData
 
 						// Check if it's a data URL (e.g., "data:application/pdf;base64,...")
-						if strings.HasPrefix(fileData, "data:") {
-							urlInfo := schemas.ExtractURLTypeInfo(fileData)
-							if urlInfo.DataURLWithoutPrefix != nil {
-								// PDF or other binary - keep as base64
-								doc.Source.Bytes = urlInfo.DataURLWithoutPrefix
-								bedrockBlock.Document = doc
-								break
+						if isDataURL {
+							if dataURLIsBase64 {
+								doc.Source.Bytes = &dataURLPayload
+							} else {
+								// Inline percent-encoded payload (data:text/plain,Hello%20World)
+								if decoded, err := url.PathUnescape(dataURLPayload); err == nil {
+									dataURLPayload = decoded
+								}
+								if isTextFile {
+									doc.Source.Text = &dataURLPayload
+								}
+								encoded := base64.StdEncoding.EncodeToString([]byte(dataURLPayload))
+								doc.Source.Bytes = &encoded
 							}
+							bedrockBlock.Document = doc
+							break
 						}
 
 						// Not a data URL - use as-is

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"mime"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -186,6 +187,48 @@ func normalizeBedrockFilename(filename string) string {
 	}
 
 	return normalized
+}
+
+// bedrockDocumentFormat maps a MIME type or bare file extension to a Bedrock Converse
+// document format. Media type parameters (e.g. "; charset=utf-8") are ignored. ok is
+// false when the input maps to no format Bedrock supports, so callers can fall through
+// to the next available hint.
+func bedrockDocumentFormat(fileType string) (format string, isText bool, ok bool) {
+	fileType = strings.ToLower(strings.TrimSpace(fileType))
+	if mediaType, _, err := mime.ParseMediaType(fileType); err == nil {
+		fileType = mediaType
+	} else if idx := strings.Index(fileType, ";"); idx >= 0 {
+		fileType = strings.TrimSpace(fileType[:idx])
+	}
+	fileType = strings.TrimPrefix(fileType, ".")
+
+	switch fileType {
+	case "text/plain", "txt":
+		return "txt", true, true
+	case "text/markdown", "md":
+		return "md", true, true
+	case "text/html", "html", "htm":
+		return "html", true, true
+	case "text/csv", "csv":
+		return "csv", true, true
+	case "application/msword", "doc":
+		return "doc", false, true
+	case "application/vnd.ms-excel", "xls":
+		return "xls", false, true
+	}
+
+	switch {
+	case strings.Contains(fileType, "wordprocessingml") || fileType == "docx":
+		return "docx", false, true
+	case strings.Contains(fileType, "spreadsheetml") || fileType == "xlsx":
+		return "xlsx", false, true
+	case strings.Contains(fileType, "pdf"):
+		return "pdf", false, true
+	case strings.HasPrefix(fileType, "text/"):
+		return "txt", true, true
+	}
+
+	return "", false, false
 }
 
 // bedrockAliasToolName returns a Bedrock-safe tool name and records a reverse mapping.
@@ -1192,34 +1235,30 @@ func convertContentBlock(ctx context.Context, block schemas.ChatContentBlock) ([
 			documentSource.Name = normalizeBedrockFilename(*block.File.Filename)
 		}
 
-		// Convert MIME type to Bedrock format
-		isText := false
+		// Parse the data URL once; it carries both the payload and (for standard
+		// OpenAI clients, which have no file_type field) the document's MIME type.
+		dataURLMediaType, dataURLPayload := "", ""
+		dataURLIsBase64, isDataURL := false, false
+		if block.File.FileData != nil && strings.HasPrefix(*block.File.FileData, "data:") {
+			dataURLMediaType, dataURLIsBase64, dataURLPayload, isDataURL = schemas.ParseDataURL(*block.File.FileData)
+		}
+
+		// Resolve the document format, most authoritative hint first. Falls back to
+		// the "pdf" default only when nothing identifies the document.
+		format, isText := "", false
 		if block.File.FileType != nil {
-			fileType := *block.File.FileType
-			switch {
-			case fileType == "text/plain" || fileType == "txt":
-				documentSource.Format = "txt"
-				isText = true
-			case fileType == "text/markdown" || fileType == "md":
-				documentSource.Format = "md"
-				isText = true
-			case fileType == "text/html" || fileType == "html":
-				documentSource.Format = "html"
-				isText = true
-			case fileType == "text/csv" || fileType == "csv":
-				documentSource.Format = "csv"
-				isText = true
-			case fileType == "application/msword" || fileType == "doc":
-				documentSource.Format = "doc"
-			case strings.Contains(fileType, "wordprocessingml") || fileType == "docx":
-				documentSource.Format = "docx"
-			case fileType == "application/vnd.ms-excel" || fileType == "xls":
-				documentSource.Format = "xls"
-			case strings.Contains(fileType, "spreadsheetml") || fileType == "xlsx":
-				documentSource.Format = "xlsx"
-			case strings.Contains(fileType, "pdf") || fileType == "pdf":
-				documentSource.Format = "pdf"
+			format, isText, _ = bedrockDocumentFormat(*block.File.FileType)
+		}
+		if format == "" && isDataURL {
+			format, isText, _ = bedrockDocumentFormat(dataURLMediaType)
+		}
+		if format == "" && block.File.Filename != nil {
+			if dot := strings.LastIndex(*block.File.Filename, "."); dot >= 0 {
+				format, isText, _ = bedrockDocumentFormat((*block.File.Filename)[dot+1:])
 			}
+		}
+		if format != "" {
+			documentSource.Format = format
 		}
 
 		// URL-sourced document: fetch and inline the bytes (Bedrock Converse only
@@ -1230,34 +1269,9 @@ func convertContentBlock(ctx context.Context, block schemas.ChatContentBlock) ([
 				return nil, fetchErr
 			}
 			// Refine format from response Content-Type when present (more reliable
-			// than file extension or upstream-declared media type). Normalize to
-			// strip parameters (e.g. "; charset=utf-8") and lowercase the base type.
-			if mt, _, err := mime.ParseMediaType(fetchedMediaType); err == nil {
-				fetchedMediaType = mt
-			}
-			switch fetchedMediaType {
-			case "application/pdf":
-				documentSource.Format = "pdf"
-			case "text/plain":
-				documentSource.Format = "txt"
-				isText = true
-			case "text/markdown":
-				documentSource.Format = "md"
-				isText = true
-			case "text/html":
-				documentSource.Format = "html"
-				isText = true
-			case "text/csv":
-				documentSource.Format = "csv"
-				isText = true
-			case "application/msword":
-				documentSource.Format = "doc"
-			case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
-				documentSource.Format = "docx"
-			case "application/vnd.ms-excel":
-				documentSource.Format = "xls"
-			case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
-				documentSource.Format = "xlsx"
+			// than file extension or upstream-declared media type).
+			if fetchedFormat, _, ok := bedrockDocumentFormat(fetchedMediaType); ok {
+				documentSource.Format = fetchedFormat
 			}
 			documentSource.Source.Bytes = &fetchedB64
 			return []BedrockContentBlock{
@@ -1271,17 +1285,25 @@ func convertContentBlock(ctx context.Context, block schemas.ChatContentBlock) ([
 		if block.File.FileData != nil {
 			fileData := *block.File.FileData
 
-			// Check if it's a data URL and extract raw base64
-			if strings.HasPrefix(fileData, "data:") {
-				urlInfo := schemas.ExtractURLTypeInfo(fileData)
-				if urlInfo.DataURLWithoutPrefix != nil {
-					documentSource.Source.Bytes = urlInfo.DataURLWithoutPrefix
-					return []BedrockContentBlock{
-						{
-							Document: documentSource,
-						},
-					}, nil
+			if isDataURL {
+				if dataURLIsBase64 {
+					documentSource.Source.Bytes = &dataURLPayload
+				} else {
+					// Inline percent-encoded payload (data:text/plain,Hello%20World)
+					if decoded, err := url.PathUnescape(dataURLPayload); err == nil {
+						dataURLPayload = decoded
+					}
+					if isText {
+						documentSource.Source.Text = &dataURLPayload
+					}
+					encoded := base64.StdEncoding.EncodeToString([]byte(dataURLPayload))
+					documentSource.Source.Bytes = &encoded
 				}
+				return []BedrockContentBlock{
+					{
+						Document: documentSource,
+					},
+				}, nil
 			}
 
 			// Set text or bytes based on file type

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -142,7 +142,9 @@ func ParseFallbacks(fallbacks []string) []Fallback {
 
 // dataURIRegex is a precompiled regex for matching data URI format patterns.
 // It matches patterns like: data:image/png;base64,iVBORw0KGgo...
-var dataURIRegex = regexp.MustCompile(`^data:([^;]+)(;base64)?,(.+)$`)
+// Group 1 is the header (media type plus any parameters, e.g. ";charset=utf-8;base64"),
+// group 2 the payload.
+var dataURIRegex = regexp.MustCompile(`^data:([^,]*),([\s\S]+)$`)
 
 // base64Regex is a precompiled regex for matching base64 strings.
 // It matches strings containing only valid base64 characters with optional padding.
@@ -207,7 +209,7 @@ func sanitizeImageURL(rawURL string, allowedSchemes []string) (string, error) {
 	// Check if it's already a proper data URL
 	if strings.HasPrefix(rawURL, "data:") {
 		// Validate data URL format
-		if !dataURIRegex.MatchString(rawURL) {
+		if _, _, _, ok := ParseDataURL(rawURL); !ok {
 			return rawURL, fmt.Errorf("invalid data URL format")
 		}
 		return rawURL, nil
@@ -267,21 +269,41 @@ func ExtractURLTypeInfo(sanitizedURL string) URLTypeInfo {
 	return extractRegularURLInfo(sanitizedURL)
 }
 
+// ParseDataURL splits a data URL (data:[<mediatype>][;<param>=<value>][;base64],<data>)
+// into its media type, base64 flag and payload. Media type parameters such as
+// ";charset=utf-8" are dropped from mediaType and the payload is returned as-is
+// (still base64-encoded when isBase64 is true, percent-encoded otherwise).
+// ok is false when the input is not a data URL carrying both a media type and a payload.
+func ParseDataURL(dataURL string) (mediaType string, isBase64 bool, payload string, ok bool) {
+	matches := dataURIRegex.FindStringSubmatch(dataURL)
+	if len(matches) != 3 {
+		return "", false, "", false
+	}
+
+	segments := strings.Split(matches[1], ";")
+	mediaType = strings.ToLower(strings.TrimSpace(segments[0]))
+	if mediaType == "" {
+		return "", false, "", false
+	}
+	for _, segment := range segments[1:] {
+		if strings.EqualFold(strings.TrimSpace(segment), "base64") {
+			isBase64 = true
+		}
+	}
+
+	return mediaType, isBase64, matches[2], true
+}
+
 // extractDataURLInfo extracts information from a data URL
 func extractDataURLInfo(dataURL string) URLTypeInfo {
-	// Parse data URL: data:[<mediatype>][;base64],<data>
-	matches := dataURIRegex.FindStringSubmatch(dataURL)
-
-	if len(matches) != 4 {
+	mediaType, isBase64, payload, ok := ParseDataURL(dataURL)
+	if !ok {
 		return URLTypeInfo{Type: ImageContentTypeBase64}
 	}
 
-	mediaType := matches[1]
-	isBase64 := matches[2] == ";base64"
-
 	dataURLWithoutPrefix := dataURL
 	if isBase64 {
-		dataURLWithoutPrefix = dataURL[len("data:")+len(mediaType)+len(";base64,"):]
+		dataURLWithoutPrefix = payload
 	}
 
 	info := URLTypeInfo{

--- a/core/schemas/utils_test.go
+++ b/core/schemas/utils_test.go
@@ -50,3 +50,57 @@ func TestSanitizeImageURLDataURLUnaffectedByAllowlist(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, dataURL, got)
 }
+
+func TestParseDataURL(t *testing.T) {
+	tests := []struct {
+		name              string
+		dataURL           string
+		expectedMediaType string
+		expectedBase64    bool
+		expectedPayload   string
+		expectedOK        bool
+	}{
+		{"Base64", "data:image/png;base64,iVBORw0KGgo=", "image/png", true, "iVBORw0KGgo=", true},
+		// Browsers and OpenAI-compatible clients routinely emit a charset parameter;
+		// dropping the whole URL on the floor shipped "data:..." as the payload.
+		{"MediaTypeParameter", "data:text/plain;charset=utf-8;base64,QUJD", "text/plain", true, "QUJD", true},
+		{"ParameterWithoutBase64", "data:text/plain;charset=utf-8,Hello%20World", "text/plain", false, "Hello%20World", true},
+		{"Uppercase", "data:IMAGE/PNG;BASE64,iVBORw0KGgo=", "image/png", true, "iVBORw0KGgo=", true},
+		{"OfficeDocument", "data:application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;base64,UEsDBBQ", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", true, "UEsDBBQ", true},
+		{"PayloadWithNewlines", "data:image/png;base64,iVBOR\nw0KGgo=", "image/png", true, "iVBOR\nw0KGgo=", true},
+		{"MissingMediaType", "data:;base64,iVBORw0KGgo=", "", false, "", false},
+		{"MissingPayload", "data:image/png;base64,", "", false, "", false},
+		{"NotADataURL", "https://example.com/image.png", "", false, "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mediaType, isBase64, payload, ok := ParseDataURL(tt.dataURL)
+			assert.Equal(t, tt.expectedOK, ok)
+			assert.Equal(t, tt.expectedMediaType, mediaType)
+			assert.Equal(t, tt.expectedBase64, isBase64)
+			assert.Equal(t, tt.expectedPayload, payload)
+		})
+	}
+}
+
+func TestExtractURLTypeInfoDropsMediaTypeParameters(t *testing.T) {
+	info := ExtractURLTypeInfo("data:text/plain;charset=utf-8;base64,QUJD")
+	require.NotNil(t, info.MediaType)
+	assert.Equal(t, "text/plain", *info.MediaType)
+	assert.Equal(t, ImageContentTypeBase64, info.Type)
+	require.NotNil(t, info.DataURLWithoutPrefix)
+	assert.Equal(t, "QUJD", *info.DataURLWithoutPrefix)
+}
+
+func TestSanitizeImageURLAcceptsDataURLWithParameters(t *testing.T) {
+	dataURL := "data:image/png;charset=binary;base64,iVBORw0KGgo="
+	got, err := SanitizeImageURL(dataURL)
+	require.NoError(t, err)
+	assert.Equal(t, dataURL, got)
+
+	// A data URL with no media type stays invalid: providers reject "data:;base64,...".
+	_, err = SanitizeImageURL("data:;base64,iVBORw0KGgo=")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid data URL format")
+}


### PR DESCRIPTION
## Summary

Bedrock was rejecting documents with "The PDF specified was not valid" because the document format was always resolved to `"pdf"` regardless of the actual file type. Standard OpenAI clients encode the MIME type inside the data URL (e.g. `data:application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;base64,...`) rather than in the `file_type` field, which was the only source previously consulted. This PR fixes format resolution for both the Chat and Responses paths, unifies the mapping logic, and corrects several related data URL parsing defects.  
  
Fixes #5472

## Changes

- Extracted a shared `bedrockDocumentFormat` helper in `utils.go` that maps MIME types and bare file extensions to Bedrock Converse document format strings, replacing two duplicated inline switch blocks that were missing most MIME types.
- Format resolution now follows a priority chain: `file_type` → data URL media type → filename extension → `"pdf"` default. Previously only `file_type` was consulted.
- `ParseDataURL` in `schemas/utils.go` is now a public function that correctly handles media type parameters (e.g. `;charset=utf-8`), uppercase media types, and payloads containing newlines. The old regex silently dropped any data URL whose header contained a parameter, causing the entire `"data:..."` string to be forwarded to Bedrock as the document payload.
- Non-base64 data URLs (e.g. `data:text/plain,Hello%20World`) are now percent-decoded and their text content is populated in both `source.text` and `source.bytes` instead of being forwarded verbatim.
- The Responses path (`responses.go`) previously ignored `file_url` entirely, emitting a document block with an empty source. It now fetches and inlines the bytes the same way the Chat path does, and propagates fetch errors rather than swallowing them.
- `convertBifrostMessageToBedrockMessage` now returns an error instead of silently returning `nil` on conversion failure, so a missing turn is never silently dropped from the request.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/bedrock/... ./core/schemas/...
```

Key test cases added:

- `TestDocumentFormatFromDataURL` — verifies that each supported MIME type embedded in a data URL resolves to the correct Bedrock format string and that the `data:...` prefix is stripped from `source.bytes`.
- `TestDocumentFormatResolutionPrecedence` — verifies the `file_type` → data URL → filename extension → default priority chain.
- `TestDocumentInlineTextDataURL` — verifies that non-base64 data URLs are percent-decoded and stored in both `source.text` and `source.bytes`.
- `TestToBedrockResponsesRequest_DocumentFormatFromDataURL` — same format fix verified on the Responses path.
- `TestToBedrockResponsesRequest_DocumentFileURLIsFetched` — verifies that an unreachable `file_url` surfaces as an error rather than producing an empty document block.
- `TestParseDataURL` — unit tests for the new public `ParseDataURL` function covering parameters, uppercase, newlines in payload, and invalid inputs.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

`file_url` values are now fetched over the network on the Responses path (matching existing Chat path behaviour). The fetch is performed with the existing `providerUtils.FetchAndEncodeURL` helper, which is subject to the same controls already in place for image URL fetching.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable