### PR TITLE
[fix]: xai - image generation usage no longer drops cost_in_usd_ticks

### DIFF
--- a/core/schemas/images.go
+++ b/core/schemas/images.go
@@ -203,6 +203,11 @@ type ImageUsage struct {
 	OutputTokens        int                `json:"output_tokens,omitempty"` // Always image tokens unless OutputTokensDetails is not nil
 	OutputTokensDetails *ImageTokenDetails `json:"output_tokens_details,omitempty"`
 	NumInputImages      int                `json:"-"` // Number of input images from the request (populated by Bifrost)
+
+	// CostInUsdTicks is xAI's exact billed cost for this request, in ticks
+	// (1 USD = 10,000,000,000 ticks). Present instead of token-based usage
+	// on xAI image generation responses.
+	CostInUsdTicks *int64 `json:"cost_in_usd_ticks,omitempty"`
 }
 
 type ImageTokenDetails struct {
@@ -226,6 +231,10 @@ func (u *ImageUsage) DeepCopy() *ImageUsage {
 	if u.OutputTokensDetails != nil {
 		details := *u.OutputTokensDetails
 		out.OutputTokensDetails = &details
+	}
+	if u.CostInUsdTicks != nil {
+		ticks := *u.CostInUsdTicks
+		out.CostInUsdTicks = &ticks
 	}
 	return &out
 }

--- a/framework/modelcatalog/datasheet/cost.go
+++ b/framework/modelcatalog/datasheet/cost.go
@@ -154,6 +154,13 @@ func (s *Store) calculateBaseCost(result *schemas.BifrostResponse, scopes Lookup
 		return input.usage.Cost.TotalCost
 	}
 
+	// xAI image responses report exact billed cost in ticks (1 USD = 1e10
+	// ticks) instead of token/pixel usage — use it directly rather than
+	// falling through to pricing-table math that has nothing to key off of.
+	if input.imageUsage != nil && input.imageUsage.CostInUsdTicks != nil {
+		return usdTicksToUSD(*input.imageUsage.CostInUsdTicks)
+	}
+
 	// If no usage data at all, nothing to price
 	if input.usage == nil && input.audioSeconds == nil && input.audioTokenDetails == nil && input.imageUsage == nil && input.videoSeconds == nil && input.audioTextInputChars == 0 && input.ocrProcessedPages == nil && input.containerIdentifierString == "" {
 		return 0
@@ -379,6 +386,11 @@ func responsesUsageToBifrostUsage(u *schemas.ResponsesResponseUsage) *schemas.Bi
 		CompletionTokens: u.OutputTokens,
 		TotalTokens:      u.TotalTokens,
 		Cost:             u.Cost,
+	}
+	// xAI reports exact billed cost in ticks (1 USD = 1e10 ticks) instead of
+	// a "cost" object — use it directly when no cost was already supplied.
+	if usage.Cost == nil && u.CostInUsdTicks != nil {
+		usage.Cost = &schemas.BifrostCost{TotalCost: usdTicksToUSD(*u.CostInUsdTicks)}
 	}
 	// Map token details for cache and search query pricing
 	if u.InputTokensDetails != nil {
@@ -666,6 +678,12 @@ func computeAudioOutputCost(pricing *configstoreTables.TableModelPricing, usage 
 	}
 
 	return 0
+}
+
+// usdTicksToUSD converts xAI's cost_in_usd_ticks (1 USD = 10,000,000,000 ticks)
+// into a dollar amount.
+func usdTicksToUSD(ticks int64) float64 {
+	return float64(ticks) / 1e10
 }
 
 // computeImageCost handles image generation requests.


### PR DESCRIPTION
## Summary

- xAI's image generation endpoint reports exact billed cost via `usage.cost_in_usd_ticks` instead of token counts. `ImageUsage` had no field for it, so the value was silently dropped on unmarshal, producing an empty `"usage": {}` in responses and $0 tracked cost in logs.
- Adds `CostInUsdTicks` to `ImageUsage` and wires it into the cost engine as a direct-cost bypass (ticks / 1e10 = USD), mirroring the existing provider-computed-cost pattern already used for chat/Responses usage.
- Also wires the same field through for xAI chat/Responses usage (`ResponsesResponseUsage.CostInUsdTicks`), which had the same gap — captured in the schema but never converted into billed cost.

Fixes #5948

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## Test plan
- [x] `go build ./core/... ./framework/...` passes
- [x] `go test ./framework/modelcatalog/... ./core/schemas/...` passes
- [x] Reproduced against a local `make dev` instance with a real xAI key: POST `/v1/images/generations` with `model: xai/grok-imagine-image-quality` now returns `"usage":{"cost_in_usd_ticks":500000000}` instead of `{}`
- [x] Confirmed `/api/logs` shows `"cost": 0.05` for that request (500,000,000 ticks / 1e10, matching xAI's $0.05/image pricing)

## Screenshots/Recordings

## Breaking changes

- [ ] Yes
- [ ] No

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


