### PR TITLE
fix(ui): skip password validation for redacted credential

### DIFF
--- a/ui/app/workspace/config/views/securityView.tsx
+++ b/ui/app/workspace/config/views/securityView.tsx
@@ -13,25 +13,12 @@ import { getErrorMessage, useGetCoreConfigQuery, useUpdateCoreConfigMutation } f
 import { AuthConfig, CoreConfig, DefaultCoreConfig } from "@/lib/types/config";
 import { SecretVar } from "@/lib/types/schemas";
 import { parseArrayFromText } from "@/lib/utils/array";
-import { isRedacted, validateOrigins } from "@/lib/utils/validation";
+import { getPasswordPolicyFailures, validateOrigins } from "@/lib/utils/validation";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { useGetAuthTypeQuery } from "@enterprise/lib/store/apis/scimApi";
 import { AlertTriangle, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
-
-const PASSWORD_REQUIREMENTS = [
-	{ label: "at least 12 characters", test: (password: string) => password.length >= 12 },
-	{ label: "one uppercase letter", test: (password: string) => /[A-Z]/.test(password) },
-	{ label: "one lowercase letter", test: (password: string) => /[a-z]/.test(password) },
-	{ label: "one number", test: (password: string) => /\d/.test(password) },
-	{ label: "one special character", test: (password: string) => /[^A-Za-z0-9]/.test(password) },
-];
-
-const getPasswordPolicyFailures = (password?: string) => {
-	if (!password || isRedacted(password)) return [];
-	return PASSWORD_REQUIREMENTS.filter((requirement) => !requirement.test(password)).map((requirement) => requirement.label);
-};
 
 export default function SecurityView() {
 	const hasSettingsUpdateAccess = useRbac(RbacResource.Settings, RbacOperation.Update);
@@ -42,6 +29,7 @@ export default function SecurityView() {
 	const [localConfig, setLocalConfig] = useState<CoreConfig>(DefaultCoreConfig);
 	const showPasswordSection = !IS_ENTERPRISE || (!authTypeLoading && !authTypeError && authType?.type !== "sso");
 	const passwordInputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
+	const passwordUnchangedRef = useRef(true);
 
 	const [localValues, setLocalValues] = useState<{
 		allowed_origins: string;
@@ -80,6 +68,7 @@ export default function SecurityView() {
 			});
 		}
 		if (bifrostConfig?.auth_config) {
+			passwordUnchangedRef.current = true;
 			setAuthConfig(bifrostConfig.auth_config);
 		}
 	}, [config, bifrostConfig]);
@@ -177,7 +166,8 @@ export default function SecurityView() {
 
 	const handleAuthFieldChange = useCallback((field: "admin_username" | "admin_password", value: SecretVar) => {
 		if (field === "admin_password") {
-			const passwordPolicyFailures = !value.ref && value.value ? getPasswordPolicyFailures(value.value) : [];
+			passwordUnchangedRef.current = false;
+			const passwordPolicyFailures = !value.ref && value.value ? getPasswordPolicyFailures(value.value, false) : [];
 			setPasswordError(passwordPolicyFailures.length > 0 ? `Password must include ${passwordPolicyFailures.join(", ")}.` : "");
 		}
 		setAuthConfig((prev) => ({ ...prev, [field]: value }));
@@ -197,7 +187,7 @@ export default function SecurityView() {
 			const hasPassword = authConfig.admin_password?.value || authConfig.admin_password?.ref;
 			const passwordPolicyFailures =
 				showPasswordSection && authConfig.is_enabled && !authConfig.admin_password?.ref && authConfig.admin_password?.value
-					? getPasswordPolicyFailures(authConfig.admin_password.value)
+					? getPasswordPolicyFailures(authConfig.admin_password.value, passwordUnchangedRef.current)
 					: [];
 
 			if (passwordPolicyFailures.length > 0) {

--- a/ui/app/workspace/config/views/securityView.tsx
+++ b/ui/app/workspace/config/views/securityView.tsx
@@ -13,7 +13,7 @@ import { getErrorMessage, useGetCoreConfigQuery, useUpdateCoreConfigMutation } f
 import { AuthConfig, CoreConfig, DefaultCoreConfig } from "@/lib/types/config";
 import { SecretVar } from "@/lib/types/schemas";
 import { parseArrayFromText } from "@/lib/utils/array";
-import { validateOrigins } from "@/lib/utils/validation";
+import { isRedacted, validateOrigins } from "@/lib/utils/validation";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { useGetAuthTypeQuery } from "@enterprise/lib/store/apis/scimApi";
 import { AlertTriangle, Loader2 } from "lucide-react";
@@ -29,7 +29,7 @@ const PASSWORD_REQUIREMENTS = [
 ];
 
 const getPasswordPolicyFailures = (password?: string) => {
-	if (!password) return [];
+	if (!password || isRedacted(password)) return [];
 	return PASSWORD_REQUIREMENTS.filter((requirement) => !requirement.test(password)).map((requirement) => requirement.label);
 };
 

--- a/ui/lib/utils/validation.test.ts
+++ b/ui/lib/utils/validation.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { isRedacted } from "./validation";
+
+describe("isRedacted", () => {
+	it.each(["<redacted>", "<REDACTED>", "[redacted]", "[REDACTED]"])("recognizes the backend sentinel %s", (value) => {
+		expect(isRedacted(value)).toBe(true);
+	});
+
+	it("does not classify a real password as redacted", () => {
+		expect(isRedacted("StrongPassword1!")).toBe(false);
+	});
+});

--- a/ui/lib/utils/validation.test.ts
+++ b/ui/lib/utils/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isRedacted } from "./validation";
+import { getPasswordPolicyFailures, isRedacted } from "./validation";
 
 describe("isRedacted", () => {
 	it.each(["<redacted>", "<REDACTED>", "[redacted]", "[REDACTED]"])("recognizes the backend sentinel %s", (value) => {
@@ -8,5 +8,22 @@ describe("isRedacted", () => {
 
 	it("does not classify a real password as redacted", () => {
 		expect(isRedacted("StrongPassword1!")).toBe(false);
+	});
+});
+
+describe("getPasswordPolicyFailures", () => {
+	it.each([
+		["<redacted>", ["at least 12 characters", "one uppercase letter", "one number"]],
+		["[REDACTED]", ["at least 12 characters", "one lowercase letter", "one number"]],
+	])("validates a newly entered sentinel %s", (password, expectedFailures) => {
+		expect(getPasswordPolicyFailures(password, false)).toEqual(expectedFailures);
+	});
+
+	it.each(["<redacted>", "[REDACTED]"])("skips an unchanged server sentinel %s", (password) => {
+		expect(getPasswordPolicyFailures(password, true)).toEqual([]);
+	});
+
+	it("accepts a strong newly entered password", () => {
+		expect(getPasswordPolicyFailures("StrongPassword1!", false)).toEqual([]);
 	});
 });

--- a/ui/lib/utils/validation.ts
+++ b/ui/lib/utils/validation.ts
@@ -192,6 +192,24 @@ export function isRedacted(value: string): boolean {
 	return false;
 }
 
+const PASSWORD_REQUIREMENTS = [
+	{ label: "at least 12 characters", test: (password: string) => password.length >= 12 },
+	{ label: "one uppercase letter", test: (password: string) => /[A-Z]/.test(password) },
+	{ label: "one lowercase letter", test: (password: string) => /[a-z]/.test(password) },
+	{ label: "one number", test: (password: string) => /\d/.test(password) },
+	{ label: "one special character", test: (password: string) => /[^A-Za-z0-9]/.test(password) },
+];
+
+/**
+ * Returns the password-policy requirements that are not satisfied.
+ * Existing credentials are skipped only when the caller explicitly confirms
+ * that the password field has not been edited.
+ */
+export function getPasswordPolicyFailures(password?: string, isUnchanged = false): string[] {
+	if (!password || isUnchanged) return [];
+	return PASSWORD_REQUIREMENTS.filter((requirement) => !requirement.test(password)).map((requirement) => requirement.label);
+}
+
 /**
  * Checks if a JSON string is valid
  * @param value - The JSON string to validate

--- a/ui/lib/utils/validation.ts
+++ b/ui/lib/utils/validation.ts
@@ -169,7 +169,12 @@ export function isRedacted(value: string): boolean {
 	if (value.startsWith("env.") || value.startsWith("vault.")) {
 		return true;
 	}
-	
+
+	// Check for fixed sentinels returned by backend secret redaction.
+	const normalizedValue = value.toLowerCase();
+	if (normalizedValue === "<redacted>" || normalizedValue === "[redacted]") {
+		return true;
+	}
 
 	// Check for exact redaction pattern: 4 chars + 24 asterisks + 4 chars (total 32)
 	if (value.length === 32) {


### PR DESCRIPTION
## Summary

Fix the Security Settings page incorrectly validating the backend's redacted password placeholder as a new password.

When dashboard authentication is already configured, the backend returns the stored password as `<redacted>`. Saving an unrelated setting, such as Allowed Headers, previously ran password-strength validation against this placeholder and blocked the update.

## Changes

- Updated the frontend `isRedacted()` helper to recognize the fixed redaction sentinels supported by the backend.
- Added case-insensitive support for both `<redacted>` and `[REDACTED]`.
- Skipped password-strength validation when the value represents an existing redacted credential.
- Added regression tests covering both sentinel formats and ordinary non-redacted values.

Although the dashboard authentication endpoint currently returns `<redacted>` (or `<REDACTED>` through `FullyRedacted()`), the frontend also recognizes `[REDACTED]` to stay aligned with the backend's shared `schemas.SecretVar.IsRedacted()` contract. The bracketed form is retained for compatibility with other backend serialization paths, including SCIM configuration.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test


## Screenshots/Recordings

Not applicable. This is a validation-only fix with no visual UI changes.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #5952

## Security considerations

The change does not expose or modify stored credentials.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


