### PR TITLE
feat(grayswan): docs for policy id field required in grayswan guardrail

### DIFF
--- a/docs/deployment-guides/config-json/guardrails.mdx
+++ b/docs/deployment-guides/config-json/guardrails.mdx
@@ -418,7 +418,7 @@ Calls CrowdStrike AIDR's `guard_chat_completions` endpoint for policy-driven AI 
           "base_url": "env.GRAYSWAN_BASE_URL",
           "reasoning_mode": "standard",
           "violation_threshold": 0.7,
-          "policy_id": "",
+          "policy_id": "YOUR_GRAYSWAN_POLICY_ID",
           "policy_ids": [],
           "rules": {},
           "sampling_rate": 100
@@ -629,7 +629,7 @@ Any field marked **env.\* supported** accepts a bare `"env.VAR_NAME"` string in 
 | `base_url` | No | Yes | Custom API base URL (uses Gray Swan default if unset) |
 | `reasoning_mode` | No | Yes | `"standard"` \| `"fast"` \| `"off"` (default: `"standard"`) |
 | `violation_threshold` | No | **Plain only** | `0.0`–`1.0`; higher = more permissive (default: `0.5`) |
-| `policy_id` | No | **Plain only** | Single policy ID string |
+| `policy_id` | Yes | **Plain only** | Required Gray Swan policy ID string |
 | `policy_ids` | No | **Plain only** | Multiple policy IDs (string array) |
 | `rules` | No | **Plain only** | Inline rule map (`{ "rule_name": "description" }`) |
 | `sampling_rate` | No | **Plain only** | `0`–`100`; percentage of requests to evaluate (default: `100`) |

--- a/docs/deployment-guides/helm/guardrails.mdx
+++ b/docs/deployment-guides/helm/guardrails.mdx
@@ -344,7 +344,7 @@ bifrost:
 
           # Plain-value fields (no env.* support)
           violation_threshold: 0.7              # 0.0–1.0; higher = more permissive
-          policy_id: ""                          # optional: single policy ID
+          policy_id: "YOUR_GRAYSWAN_POLICY_ID"    # required: single policy ID
           policy_ids: []                         # optional: multiple policy IDs
           rules: {}                              # optional: inline rule map
           sampling_rate: 100
@@ -527,7 +527,7 @@ Any field marked **env.\* supported** below accepts a bare `"env.VAR_NAME"` stri
 | `base_url` | No | Yes | Custom API base URL (uses Gray Swan default if unset) |
 | `reasoning_mode` | No | Yes | `"standard"` \| `"fast"` \| `"off"` (default: `"standard"`) |
 | `violation_threshold` | No | **Plain only** | `0.0`–`1.0`; higher = more permissive (default: `0.5`) |
-| `policy_id` | No | **Plain only** | Single policy ID string |
+| `policy_id` | Yes | **Plain only** | Required Gray Swan policy ID string |
 | `policy_ids` | No | **Plain only** | Multiple policy IDs (string array) |
 | `rules` | No | **Plain only** | Inline rule map (`{ "rule_name": "description" }`) |
 | `sampling_rate` | No | **Plain only** | `0`–`100`; percentage of requests to evaluate (default: `100`) |

--- a/docs/enterprise/guardrails.mdx
+++ b/docs/enterprise/guardrails.mdx
@@ -706,6 +706,7 @@ curl -X DELETE http://localhost:8080/api/guardrails/bedrock \
           "enabled": true,
           "config": {
             "api_key": "env.GRAYSWAN_API_KEY",
+            "policy_id": "YOUR_GRAYSWAN_POLICY_ID",
             "violation_threshold": 0.5,
             "reasoning_mode": "hybrid",
             "rules": {
@@ -817,6 +818,7 @@ bifrost:
         enabled: true
         config:
           api_key: "env.GRAYSWAN_API_KEY"
+          policy_id: "YOUR_GRAYSWAN_POLICY_ID"
           violation_threshold: 0.5
           reasoning_mode: "hybrid"
           rules:

--- a/docs/integrations/guardrails/grayswan.mdx
+++ b/docs/integrations/guardrails/grayswan.mdx
@@ -25,10 +25,12 @@ Bifrost integrates with **Gray Swan Cygnal Monitor** to provide AI safety monito
 | `base_url` | string | No | `https://api.grayswan.ai` | Gray Swan API base URL. Bifrost accepts either the API root or a URL that already ends in `/cygnal/monitor`. |
 | `violation_threshold` | number | No | 0.5 | Score threshold (0-1) for triggering intervention. Lower values are more strict. |
 | `reasoning_mode` | enum | No | "off" | Analysis depth: `off` (fastest), `hybrid` (balanced), or `thinking` (most thorough) |
-| `policy_id` | string | No | - | Single custom policy ID from Gray Swan platform |
+| `policy_id` | string | Yes | - | Required policy ID from the Gray Swan platform. Gray Swan rejects monitor requests that omit it. |
 | `policy_ids` | array | No | - | Multiple policy IDs for aggregated rule evaluation |
 | `rules` | object | No | - | Custom natural language rules as key-value pairs |
 | `timeout` | integer | No | provider default | Provider execution timeout in seconds. |
+
+`policy_id` is mandatory even when you define custom `rules`; Gray Swan does not apply a default policy. The Bifrost configuration **Name** is only a local profile name and is not a Gray Swan policy ID. Create or select a policy in Gray Swan and copy its ID into Bifrost.
 
 ## Request Header Metadata
 


### PR DESCRIPTION
## Summary

Clarifies that `policy_id` is a **required** field for the Gray Swan Cygnal Monitor guardrail integration. Previously, the docs presented it as optional and showed an empty string as the default, which caused Gray Swan to reject monitor requests silently. This update corrects the field's required status across all documentation surfaces and adds an explicit note explaining that Gray Swan does not apply a default policy and that the Bifrost profile name is not a substitute for a Gray Swan policy ID.

## Changes

- Marked `policy_id` as required (was `No`, now `Yes`) in the Gray Swan parameter tables across the config-json, Helm, and integration docs
- Replaced the empty `policy_id: ""` placeholder with `"YOUR_GRAYSWAN_POLICY_ID"` in all example snippets to make the requirement immediately visible
- Added `policy_id` to the enterprise guardrails example configurations (both JSON and Helm) where it was previously missing
- Added an explicit callout in the integration reference doc clarifying that `policy_id` is mandatory even when custom `rules` are defined, and that the Bifrost configuration name is not a Gray Swan policy ID

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation pages for the following:

- `docs/integrations/guardrails/grayswan.mdx` — confirm `policy_id` row shows `Yes` in the Required column and the new callout paragraph is present
- `docs/deployment-guides/config-json/guardrails.mdx` — confirm the example snippet shows `"YOUR_GRAYSWAN_POLICY_ID"` and the table reflects `Yes` / `Required Gray Swan policy ID string`
- `docs/deployment-guides/helm/guardrails.mdx` — same as above for the Helm variant
- `docs/enterprise/guardrails.mdx` — confirm `policy_id` appears in both the JSON and Helm example blocks

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No secrets or auth changes. The update ensures users do not accidentally omit a required policy identifier, which could result in unguarded requests reaching Gray Swan without any policy enforcement applied.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable