### PR TITLE
perf: alloc reductions, span attribute map reuse, and logging context read on final chunk

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4601,7 +4601,7 @@ func (bifrost *Bifrost) getProviderQueue(providerKey schemas.ModelProvider) (*Pr
 		pq := pqValue.(*ProviderQueue)
 		return pq, nil
 	}
-	bifrost.logger.Debug(fmt.Sprintf("Creating new request queue for provider %s at runtime", providerKey))
+	bifrost.logger.Debug("Creating new request queue for provider %s at runtime", providerKey)
 	config, err := bifrost.account.GetConfigForProvider(providerKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get config for provider %s: %v", providerKey, err)
@@ -5156,7 +5156,7 @@ func (bifrost *Bifrost) shouldContinueWithFallbacks(fallback schemas.Fallback, f
 		return false
 	}
 
-	bifrost.logger.Debug(fmt.Sprintf("Fallback provider %s failed: %s", fallback.Provider, fallbackErr.Error.Message))
+	bifrost.logger.Debug("Fallback provider %s failed: %s", fallback.Provider, fallbackErr.Error.Message)
 	return true
 }
 
@@ -5210,17 +5210,17 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 		return nil, err
 	}
 
-	bifrost.logger.Debug(fmt.Sprintf("primary provider %s with model %s and %d fallbacks", provider, model, len(fallbacks)))
+	bifrost.logger.Debug("primary provider %s with model %s and %d fallbacks", provider, model, len(fallbacks))
 
 	primaryResult, primaryErr := bifrost.tryRequest(ctx, req)
 	if primaryErr != nil {
 		if primaryErr.Error != nil {
-			bifrost.logger.Debug(fmt.Sprintf("primary provider %s with model %s returned error: %s", provider, model, primaryErr.Error.Message))
+			bifrost.logger.Debug("primary provider %s with model %s returned error: %s", provider, model, primaryErr.Error.Message)
 		} else {
-			bifrost.logger.Debug(fmt.Sprintf("primary provider %s with model %s returned error: %v", provider, model, primaryErr))
+			bifrost.logger.Debug("primary provider %s with model %s returned error: %v", provider, model, primaryErr)
 		}
 		if len(fallbacks) > 0 {
-			bifrost.logger.Debug(fmt.Sprintf("check if we should try %d fallbacks", len(fallbacks)))
+			bifrost.logger.Debug("check if we should try %d fallbacks", len(fallbacks))
 		}
 	}
 
@@ -5244,7 +5244,7 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 	// Try fallbacks in order
 	for i, fallback := range fallbacks {
 		ctx.SetValue(schemas.BifrostContextKeyFallbackIndex, i+1)
-		bifrost.logger.Debug(fmt.Sprintf("trying fallback provider %s with model %s", fallback.Provider, fallback.Model))
+		bifrost.logger.Debug("trying fallback provider %s with model %s", fallback.Provider, fallback.Model)
 		ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelInfo, fmt.Sprintf("Trying fallback %d/%d: %s/%s (previous attempt failed: %s)", i+1, len(fallbacks), fallback.Provider, fallback.Model, routingErrorSummary(lastErr)))
 		ctx.SetValue(schemas.BifrostContextKeyFallbackRequestID, uuid.New().String())
 		clearCtxForFallback(ctx)
@@ -5260,7 +5260,7 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 
 		fallbackReq := bifrost.prepareFallbackRequest(req, fallback)
 		if fallbackReq == nil {
-			bifrost.logger.Debug(fmt.Sprintf("fallback provider %s with model %s is nil", fallback.Provider, fallback.Model))
+			bifrost.logger.Debug("fallback provider %s with model %s is nil", fallback.Provider, fallback.Model)
 			ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelWarn, fmt.Sprintf("Fallback %s/%s skipped: missing provider config", fallback.Provider, fallback.Model))
 			tracer.SetAttribute(handle, "error", "fallback request preparation failed")
 			tracer.EndSpan(handle, schemas.SpanStatusError, "fallback request preparation failed")
@@ -5275,7 +5275,7 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 		result.SetFallbackRoutingInfo(provider, model)
 		fallbackErr.SetFallbackRoutingInfo(provider, model)
 		if fallbackErr == nil {
-			bifrost.logger.Debug(fmt.Sprintf("successfully used fallback provider %s with model %s", fallback.Provider, fallback.Model))
+			bifrost.logger.Debug("successfully used fallback provider %s with model %s", fallback.Provider, fallback.Model)
 			ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelInfo, fmt.Sprintf("Request served by fallback %s/%s (attempt %d/%d)", fallback.Provider, fallback.Model, i+1, len(fallbacks)))
 			tracer.EndSpan(handle, schemas.SpanStatusOk, "")
 			return result, nil
@@ -5343,17 +5343,17 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 		return nil, err
 	}
 
-	bifrost.logger.Debug(fmt.Sprintf("primary provider %s with model %s and %d fallbacks", provider, model, len(fallbacks)))
+	bifrost.logger.Debug("primary provider %s with model %s and %d fallbacks", provider, model, len(fallbacks))
 
 	primaryResult, primaryErr := bifrost.tryStreamRequest(ctx, req)
 	if primaryErr != nil {
 		if primaryErr.Error != nil {
-			bifrost.logger.Debug(fmt.Sprintf("primary provider %s with model %s returned error: %s", provider, model, primaryErr.Error.Message))
+			bifrost.logger.Debug("primary provider %s with model %s returned error: %s", provider, model, primaryErr.Error.Message)
 		} else {
-			bifrost.logger.Debug(fmt.Sprintf("primary provider %s with model %s returned error: %v", provider, model, primaryErr))
+			bifrost.logger.Debug("primary provider %s with model %s returned error: %v", provider, model, primaryErr)
 		}
 		if len(fallbacks) > 0 {
-			bifrost.logger.Debug(fmt.Sprintf("check if we should try %d fallbacks", len(fallbacks)))
+			bifrost.logger.Debug("check if we should try %d fallbacks", len(fallbacks))
 		}
 	}
 
@@ -5419,7 +5419,7 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 				}
 				ctx.SetRoutingInfoSnapshot(ri)
 			}
-			bifrost.logger.Debug(fmt.Sprintf("successfully used fallback provider %s with model %s", fallback.Provider, fallback.Model))
+			bifrost.logger.Debug("successfully used fallback provider %s with model %s", fallback.Provider, fallback.Model)
 			ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelInfo, fmt.Sprintf("Request served by fallback %s/%s (attempt %d/%d)", fallback.Provider, fallback.Model, i+1, len(fallbacks)))
 			tracer.EndSpan(handle, schemas.SpanStatusOk, "")
 			return result, nil
@@ -7630,7 +7630,7 @@ func (p *PluginPipeline) RunLLMPreHooks(ctx *schemas.BifrostContext, req *schema
 		pluginName := plugin.GetName()
 		p.logger.Debug("running pre-hook for plugin %s", pluginName)
 		// Start span for this plugin's PreLLMHook
-		spanCtx, handle := p.tracer.StartSpan(ctx, fmt.Sprintf("plugin.%s.prehook", sanitizeSpanName(pluginName)), schemas.SpanKindPlugin)
+		spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).prehook, schemas.SpanKindPlugin)
 		// Update pluginCtx with span context for nested operations
 		if spanCtx != nil {
 			if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
@@ -7683,7 +7683,7 @@ func (p *PluginPipeline) RunPreRequestHooks(ctx *schemas.BifrostContext, req *sc
 	for _, plugin := range p.llmPlugins {
 		pluginName := plugin.GetName()
 		p.logger.Debug("running pre-request hook for plugin %s", pluginName)
-		spanCtx, handle := p.tracer.StartSpan(ctx, fmt.Sprintf("plugin.%s.prerequesthook", sanitizeSpanName(pluginName)), schemas.SpanKindPlugin)
+		spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).prerequesthook, schemas.SpanKindPlugin)
 		if spanCtx != nil {
 			if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
 				ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
@@ -7769,7 +7769,7 @@ func (p *PluginPipeline) RunPostLLMHooks(ctx *schemas.BifrostContext, resp *sche
 			}
 		} else {
 			// For non-streaming: create span per plugin (existing behavior)
-			spanCtx, handle := p.tracer.StartSpan(ctx, fmt.Sprintf("plugin.%s.posthook", sanitizeSpanName(pluginName)), schemas.SpanKindPlugin)
+			spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).posthook, schemas.SpanKindPlugin)
 			// Update pluginCtx with span context for nested operations
 			if spanCtx != nil {
 				if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
@@ -7827,7 +7827,7 @@ func (p *PluginPipeline) RunMCPPreHooks(ctx *schemas.BifrostContext, req *schema
 		pluginName := plugin.GetName()
 		p.logger.Debug("running MCP pre-hook for plugin %s", pluginName)
 		// Start span for this plugin's PreMCPHook
-		spanCtx, handle := p.tracer.StartSpan(ctx, fmt.Sprintf("plugin.%s.mcp_prehook", sanitizeSpanName(pluginName)), schemas.SpanKindPlugin)
+		spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).mcpPrehook, schemas.SpanKindPlugin)
 		// Update pluginCtx with span context for nested operations
 		if spanCtx != nil {
 			if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
@@ -7883,7 +7883,7 @@ func (p *PluginPipeline) RunMCPPostHooks(ctx *schemas.BifrostContext, mcpResp *s
 		pluginName := plugin.GetName()
 		p.logger.Debug("running MCP post-hook for plugin %s", pluginName)
 		// Create span per plugin
-		spanCtx, handle := p.tracer.StartSpan(ctx, fmt.Sprintf("plugin.%s.mcp_posthook", sanitizeSpanName(pluginName)), schemas.SpanKindPlugin)
+		spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).mcpPosthook, schemas.SpanKindPlugin)
 		// Update pluginCtx with span context for nested operations
 		if spanCtx != nil {
 			if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
@@ -7937,7 +7937,7 @@ func (p *PluginPipeline) RunMCPPreConnectionHooks(ctx *schemas.BifrostContext, r
 	for i, plugin := range p.mcpPlugins {
 		pluginName := plugin.GetName()
 		p.logger.Debug("running MCP connect pre-hook for plugin %s", pluginName)
-		spanCtx, handle := p.tracer.StartSpan(ctx, fmt.Sprintf("plugin.%s.mcp_connect_prehook", sanitizeSpanName(pluginName)), schemas.SpanKindPlugin)
+		spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).mcpConnectPrehook, schemas.SpanKindPlugin)
 		if spanCtx != nil {
 			if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
 				ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
@@ -8000,7 +8000,7 @@ func (p *PluginPipeline) RunMCPPostConnectionHooks(ctx *schemas.BifrostContext, 
 		plugin := p.mcpPlugins[i]
 		pluginName := plugin.GetName()
 		p.logger.Debug("running MCP connect post-hook for plugin %s", pluginName)
-		spanCtx, handle := p.tracer.StartSpan(ctx, fmt.Sprintf("plugin.%s.mcp_connect_posthook", sanitizeSpanName(pluginName)), schemas.SpanKindPlugin)
+		spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).mcpConnectPosthook, schemas.SpanKindPlugin)
 		if spanCtx != nil {
 			if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
 				ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
@@ -8182,7 +8182,7 @@ func (p *PluginPipeline) FinalizeStreamingPostHookSpans(ctx context.Context) {
 	// Start spans in execution order (nested: each is a child of the previous)
 	for _, entry := range snapshot {
 		// Create span as child of the previous span (nested hierarchy)
-		newCtx, handle := tracer.StartSpan(currentCtx, fmt.Sprintf("plugin.%s.posthook", sanitizeSpanName(entry.pluginName)), schemas.SpanKindPlugin)
+		newCtx, handle := tracer.StartSpan(currentCtx, pluginSpanNamesFor(entry.pluginName).posthook, schemas.SpanKindPlugin)
 		if handle == nil {
 			continue
 		}

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6244,14 +6244,20 @@ func executeRequestWithRetries[T any](
 			spanName = fmt.Sprintf("%s %s", otelOp, model)
 			spanKind = schemas.SpanKindLLMCall
 		}
-		spanCtx, handle := tracer.StartSpan(ctx, spanName, spanKind)
-		tracer.SetAttribute(handle, schemas.AttrProviderName, schemas.OTelProviderName(providerKey))
-		tracer.SetAttribute(handle, schemas.AttrBifrostProviderName, string(providerKey)) // raw Bifrost short name, mirrors canonical gen_ai.provider.name
-		tracer.SetAttribute(handle, schemas.AttrRequestModel, model)
-		tracer.SetAttribute(handle, schemas.AttrOperationName, otelOp)
-		tracer.SetAttribute(handle, schemas.AttrLegacyRequestType, string(requestType)) // legacy: replaced by gen_ai.operation.name
+		spanID, handle := tracer.StartSpanID(ctx, spanName, spanKind)
+		// Resolve the span once and write attributes directly. Previously each
+		// attribute was a separate tracer.SetAttribute, and every call re-resolved
+		// the span (trace lookup + linear span scan over all spans in the trace):
+		// ~30 lookups per request. span.SetAttribute is nil-safe, so a nil span
+		// (e.g. NoOpTracer) makes the whole block a no-op with no branch here.
+		span := tracer.SpanFromHandle(handle)
+		span.SetAttribute(schemas.AttrProviderName, schemas.OTelProviderName(providerKey))
+		span.SetAttribute(schemas.AttrBifrostProviderName, string(providerKey)) // raw Bifrost short name, mirrors canonical gen_ai.provider.name
+		span.SetAttribute(schemas.AttrRequestModel, model)
+		span.SetAttribute(schemas.AttrOperationName, otelOp)
+		span.SetAttribute(schemas.AttrLegacyRequestType, string(requestType)) // legacy: replaced by gen_ai.operation.name
 		if attempts > 0 {
-			tracer.SetAttribute(handle, schemas.AttrLegacyRetryCount, attempts) // legacy: bare key with no semconv prefix
+			span.SetAttribute(schemas.AttrLegacyRetryCount, attempts) // legacy: bare key with no semconv prefix
 		}
 
 		// Add context-related attributes (selected key, virtual key, team, customer, etc.)
@@ -6260,76 +6266,76 @@ func executeRequestWithRetries[T any](
 		// are the canonical home going forward; once all dashboards migrate, drop the
 		// gen_ai.* lines (grep for "// legacy:" in this block).
 		if selectedKeyID, ok := ctx.Value(schemas.BifrostContextKeySelectedKeyID).(string); ok && selectedKeyID != "" {
-			tracer.SetAttribute(handle, schemas.AttrSelectedKeyID, selectedKeyID) // legacy: gen_ai.* placement of bifrost-internal attr
-			tracer.SetAttribute(handle, schemas.AttrBifrostSelectedKeyID, selectedKeyID)
+			span.SetAttribute(schemas.AttrSelectedKeyID, selectedKeyID) // legacy: gen_ai.* placement of bifrost-internal attr
+			span.SetAttribute(schemas.AttrBifrostSelectedKeyID, selectedKeyID)
 		}
 		if selectedKeyName, ok := ctx.Value(schemas.BifrostContextKeySelectedKeyName).(string); ok && selectedKeyName != "" {
-			tracer.SetAttribute(handle, schemas.AttrSelectedKeyName, selectedKeyName) // legacy: gen_ai.* placement of bifrost-internal attr
-			tracer.SetAttribute(handle, schemas.AttrBifrostSelectedKeyName, selectedKeyName)
+			span.SetAttribute(schemas.AttrSelectedKeyName, selectedKeyName) // legacy: gen_ai.* placement of bifrost-internal attr
+			span.SetAttribute(schemas.AttrBifrostSelectedKeyName, selectedKeyName)
 		}
 		if virtualKeyID, ok := ctx.Value(schemas.BifrostContextKeyGovernanceVirtualKeyID).(string); ok && virtualKeyID != "" {
-			tracer.SetAttribute(handle, schemas.AttrVirtualKeyID, virtualKeyID) // legacy: gen_ai.* placement of bifrost-internal attr
-			tracer.SetAttribute(handle, schemas.AttrBifrostVirtualKeyID, virtualKeyID)
+			span.SetAttribute(schemas.AttrVirtualKeyID, virtualKeyID) // legacy: gen_ai.* placement of bifrost-internal attr
+			span.SetAttribute(schemas.AttrBifrostVirtualKeyID, virtualKeyID)
 		}
 		if virtualKeyName, ok := ctx.Value(schemas.BifrostContextKeyGovernanceVirtualKeyName).(string); ok && virtualKeyName != "" {
-			tracer.SetAttribute(handle, schemas.AttrVirtualKeyName, virtualKeyName) // legacy: gen_ai.* placement of bifrost-internal attr
-			tracer.SetAttribute(handle, schemas.AttrBifrostVirtualKeyName, virtualKeyName)
+			span.SetAttribute(schemas.AttrVirtualKeyName, virtualKeyName) // legacy: gen_ai.* placement of bifrost-internal attr
+			span.SetAttribute(schemas.AttrBifrostVirtualKeyName, virtualKeyName)
 		}
 		if teamID, ok := ctx.Value(schemas.BifrostContextKeyGovernanceTeamID).(string); ok && teamID != "" {
-			tracer.SetAttribute(handle, schemas.AttrTeamID, teamID) // legacy: gen_ai.* placement of bifrost-internal attr
-			tracer.SetAttribute(handle, schemas.AttrBifrostTeamID, teamID)
+			span.SetAttribute(schemas.AttrTeamID, teamID) // legacy: gen_ai.* placement of bifrost-internal attr
+			span.SetAttribute(schemas.AttrBifrostTeamID, teamID)
 		}
 		if teamName, ok := ctx.Value(schemas.BifrostContextKeyGovernanceTeamName).(string); ok && teamName != "" {
-			tracer.SetAttribute(handle, schemas.AttrTeamName, teamName) // legacy: gen_ai.* placement of bifrost-internal attr
-			tracer.SetAttribute(handle, schemas.AttrBifrostTeamName, teamName)
+			span.SetAttribute(schemas.AttrTeamName, teamName) // legacy: gen_ai.* placement of bifrost-internal attr
+			span.SetAttribute(schemas.AttrBifrostTeamName, teamName)
 		}
 		if customerID, ok := ctx.Value(schemas.BifrostContextKeyGovernanceCustomerID).(string); ok && customerID != "" {
-			tracer.SetAttribute(handle, schemas.AttrCustomerID, customerID) // legacy: gen_ai.* placement of bifrost-internal attr
-			tracer.SetAttribute(handle, schemas.AttrBifrostCustomerID, customerID)
+			span.SetAttribute(schemas.AttrCustomerID, customerID) // legacy: gen_ai.* placement of bifrost-internal attr
+			span.SetAttribute(schemas.AttrBifrostCustomerID, customerID)
 		}
 		if customerName, ok := ctx.Value(schemas.BifrostContextKeyGovernanceCustomerName).(string); ok && customerName != "" {
-			tracer.SetAttribute(handle, schemas.AttrCustomerName, customerName) // legacy: gen_ai.* placement of bifrost-internal attr
-			tracer.SetAttribute(handle, schemas.AttrBifrostCustomerName, customerName)
+			span.SetAttribute(schemas.AttrCustomerName, customerName) // legacy: gen_ai.* placement of bifrost-internal attr
+			span.SetAttribute(schemas.AttrBifrostCustomerName, customerName)
 		}
 		if businessUnitID, ok := ctx.Value(schemas.BifrostContextKeyGovernanceBusinessUnitID).(string); ok && businessUnitID != "" {
-			tracer.SetAttribute(handle, schemas.AttrBifrostBusinessUnitID, businessUnitID)
+			span.SetAttribute(schemas.AttrBifrostBusinessUnitID, businessUnitID)
 		}
 		if businessUnitName, ok := ctx.Value(schemas.BifrostContextKeyGovernanceBusinessUnitName).(string); ok && businessUnitName != "" {
-			tracer.SetAttribute(handle, schemas.AttrBifrostBusinessUnitName, businessUnitName)
+			span.SetAttribute(schemas.AttrBifrostBusinessUnitName, businessUnitName)
 		}
 		if teamIDs, ok := ctx.Value(schemas.BifrostContextKeyGovernanceTeamIDs).([]string); ok && len(teamIDs) > 0 {
-			tracer.SetAttribute(handle, schemas.AttrBifrostTeamIDs, teamIDs)
+			span.SetAttribute(schemas.AttrBifrostTeamIDs, teamIDs)
 		}
 		if teamNames, ok := ctx.Value(schemas.BifrostContextKeyGovernanceTeamNames).([]string); ok && len(teamNames) > 0 {
-			tracer.SetAttribute(handle, schemas.AttrBifrostTeamNames, teamNames)
+			span.SetAttribute(schemas.AttrBifrostTeamNames, teamNames)
 		}
 		if customerIDs, ok := ctx.Value(schemas.BifrostContextKeyGovernanceCustomerIDs).([]string); ok && len(customerIDs) > 0 {
-			tracer.SetAttribute(handle, schemas.AttrBifrostCustomerIDs, customerIDs)
+			span.SetAttribute(schemas.AttrBifrostCustomerIDs, customerIDs)
 		}
 		if customerNames, ok := ctx.Value(schemas.BifrostContextKeyGovernanceCustomerNames).([]string); ok && len(customerNames) > 0 {
-			tracer.SetAttribute(handle, schemas.AttrBifrostCustomerNames, customerNames)
+			span.SetAttribute(schemas.AttrBifrostCustomerNames, customerNames)
 		}
 		if businessUnitIDs, ok := ctx.Value(schemas.BifrostContextKeyGovernanceBusinessUnitIDs).([]string); ok && len(businessUnitIDs) > 0 {
-			tracer.SetAttribute(handle, schemas.AttrBifrostBusinessUnitIDs, businessUnitIDs)
+			span.SetAttribute(schemas.AttrBifrostBusinessUnitIDs, businessUnitIDs)
 		}
 		if businessUnitNames, ok := ctx.Value(schemas.BifrostContextKeyGovernanceBusinessUnitNames).([]string); ok && len(businessUnitNames) > 0 {
-			tracer.SetAttribute(handle, schemas.AttrBifrostBusinessUnitNames, businessUnitNames)
+			span.SetAttribute(schemas.AttrBifrostBusinessUnitNames, businessUnitNames)
 		}
 		if userID, ok := ctx.Value(schemas.BifrostContextKeyUserID).(string); ok && userID != "" {
-			tracer.SetAttribute(handle, schemas.AttrBifrostUserID, userID)
+			span.SetAttribute(schemas.AttrBifrostUserID, userID)
 		}
 		if userName, ok := ctx.Value(schemas.BifrostContextKeyUserName).(string); ok && userName != "" {
-			tracer.SetAttribute(handle, schemas.AttrBifrostUserName, userName)
+			span.SetAttribute(schemas.AttrBifrostUserName, userName)
 		}
 		if userEmail, ok := ctx.Value(schemas.BifrostContextKeyUserEmail).(string); ok && userEmail != "" {
-			tracer.SetAttribute(handle, schemas.AttrBifrostUserEmail, userEmail)
+			span.SetAttribute(schemas.AttrBifrostUserEmail, userEmail)
 		}
 		if fallbackIndex, ok := ctx.Value(schemas.BifrostContextKeyFallbackIndex).(int); ok {
-			tracer.SetAttribute(handle, schemas.AttrFallbackIndex, fallbackIndex) // legacy: gen_ai.* placement of bifrost-internal attr
-			tracer.SetAttribute(handle, schemas.AttrBifrostFallbackIndex, fallbackIndex)
+			span.SetAttribute(schemas.AttrFallbackIndex, fallbackIndex) // legacy: gen_ai.* placement of bifrost-internal attr
+			span.SetAttribute(schemas.AttrBifrostFallbackIndex, fallbackIndex)
 		}
-		tracer.SetAttribute(handle, schemas.AttrNumberOfRetries, attempts) // legacy: gen_ai.* placement of bifrost-internal attr
-		tracer.SetAttribute(handle, schemas.AttrBifrostRetries, attempts)
+		span.SetAttribute(schemas.AttrNumberOfRetries, attempts) // legacy: gen_ai.* placement of bifrost-internal attr
+		span.SetAttribute(schemas.AttrBifrostRetries, attempts)
 
 		// Surface caller-supplied extra headers (from x-bf-eh-* and direct-allowlist
 		// header forwarding) as span attributes so observability backends see the
@@ -6338,7 +6344,9 @@ func executeRequestWithRetries[T any](
 		exportHeaderAttributes := func(headers map[string][]string) {
 			for name, values := range headers {
 				if value, export := extraHeaderSpanAttribute(name, values); export {
-					tracer.SetAttribute(handle, schemas.AttrExtraHeaderPrefix+name, value)
+					// Write via the already-resolved span (C1), not tracer.SetAttribute,
+					// which re-resolves the span per call.
+					span.SetAttribute(schemas.AttrExtraHeaderPrefix+name, value)
 				}
 			}
 		}
@@ -6359,8 +6367,10 @@ func executeRequestWithRetries[T any](
 			tracer.PopulateLLMRequestAttributes(handle, req)
 		}
 
-		// Update context with span ID
-		ctx.SetValue(schemas.BifrostContextKeySpanID, spanCtx.Value(schemas.BifrostContextKeySpanID))
+		// Update context with span ID (no valueCtx alloc; StartSpanID returned it).
+		if spanID != "" {
+			ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
+		}
 
 		// Record stream start time for TTFT calculation (only for streaming requests)
 		// This is also used by RunPostLLMHooks to detect streaming mode
@@ -6629,6 +6639,14 @@ func clearAnthropicPassthroughForNonNativeProvider(ctx *schemas.BifrostContext, 
 // It manages retries, error handling, and response processing.
 func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas.ProviderConfig, pq *ProviderQueue, waitGroup *sync.WaitGroup) {
 	defer waitGroup.Done()
+
+	// Reusable timer for the response/error/stream handoff guard below. One timer per
+	// (long-lived) worker, reset per use, instead of a fresh time.After on every request:
+	// time.After leaks a live timer for the full 5s after each request, piling ~5s worth
+	// of timers on the runtime heap under load. Reset/Stop is race-free on Go 1.23+.
+	deliveryTimer := time.NewTimer(time.Hour)
+	deliveryTimer.Stop()
+	defer deliveryTimer.Stop()
 
 	for {
 		var req *ChannelMessage
@@ -7090,6 +7108,7 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 			bifrostError.PopulateRoutingInfo(attemptRoutingInfo)
 
 			// Send error with context awareness to prevent deadlock
+			deliveryTimer.Reset(5 * time.Second)
 			select {
 			case req.Err <- *bifrostError:
 				// Error sent successfully
@@ -7100,10 +7119,11 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 				// processing input tokens). tryRequest returned on ctx.Done and will
 				// never receive it, so bill/log it here. Non-streaming only.
 				bifrost.billAbandonedTerminal(req, nil, bifrostError)
-			case <-time.After(5 * time.Second):
+			case <-deliveryTimer.C:
 				// Timeout to prevent indefinite blocking
 				bifrost.logger.Warn("Timeout while sending error response, client may have disconnected")
 			}
+			deliveryTimer.Stop()
 		} else {
 			if result != nil {
 				result.PopulateExtraFields(req.RequestType, provider.GetProviderKey(), originalModelRequested, resolvedModel)
@@ -7111,18 +7131,21 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 			}
 			if IsStreamRequestType(req.RequestType) {
 				// Send stream with context awareness to prevent deadlock
+				deliveryTimer.Reset(5 * time.Second)
 				select {
 				case req.ResponseStream <- stream:
 					// Stream sent successfully
 				case <-req.Context.Done():
 					// Client no longer listening, log and continue
 					bifrost.logger.Debug("Client context cancelled while sending stream response")
-				case <-time.After(5 * time.Second):
+				case <-deliveryTimer.C:
 					// Timeout to prevent indefinite blocking
 					bifrost.logger.Warn("Timeout while sending stream response, client may have disconnected")
 				}
+				deliveryTimer.Stop()
 			} else {
 				// Send response with context awareness to prevent deadlock
+				deliveryTimer.Reset(5 * time.Second)
 				select {
 				case req.Response <- result:
 					// Response sent successfully
@@ -7133,10 +7156,11 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 					// (consuming tokens). tryRequest returned on ctx.Done and will never
 					// receive it, so bill/log it here.
 					bifrost.billAbandonedTerminal(req, result, nil)
-				case <-time.After(5 * time.Second):
+				case <-deliveryTimer.C:
 					// Timeout to prevent indefinite blocking
 					bifrost.logger.Warn("Timeout while sending response, client may have disconnected")
 				}
+				deliveryTimer.Stop()
 			}
 		}
 	}
@@ -7630,12 +7654,10 @@ func (p *PluginPipeline) RunLLMPreHooks(ctx *schemas.BifrostContext, req *schema
 		pluginName := plugin.GetName()
 		p.logger.Debug("running pre-hook for plugin %s", pluginName)
 		// Start span for this plugin's PreLLMHook
-		spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).prehook, schemas.SpanKindPlugin)
-		// Update pluginCtx with span context for nested operations
-		if spanCtx != nil {
-			if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
-				ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
-			}
+		spanID, handle := p.tracer.StartSpanID(ctx, pluginSpanNamesFor(pluginName).prehook, schemas.SpanKindPlugin)
+		// Mirror the new span ID into ctx for nested operations (no valueCtx alloc).
+		if spanID != "" {
+			ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
 		}
 
 		pluginCtx := ctx.WithPluginScope(&pluginName)
@@ -7683,11 +7705,9 @@ func (p *PluginPipeline) RunPreRequestHooks(ctx *schemas.BifrostContext, req *sc
 	for _, plugin := range p.llmPlugins {
 		pluginName := plugin.GetName()
 		p.logger.Debug("running pre-request hook for plugin %s", pluginName)
-		spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).prerequesthook, schemas.SpanKindPlugin)
-		if spanCtx != nil {
-			if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
-				ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
-			}
+		spanID, handle := p.tracer.StartSpanID(ctx, pluginSpanNamesFor(pluginName).prerequesthook, schemas.SpanKindPlugin)
+		if spanID != "" {
+			ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
 		}
 
 		pluginCtx := ctx.WithPluginScope(&pluginName)
@@ -7769,12 +7789,10 @@ func (p *PluginPipeline) RunPostLLMHooks(ctx *schemas.BifrostContext, resp *sche
 			}
 		} else {
 			// For non-streaming: create span per plugin (existing behavior)
-			spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).posthook, schemas.SpanKindPlugin)
-			// Update pluginCtx with span context for nested operations
-			if spanCtx != nil {
-				if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
-					ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
-				}
+			spanID, handle := p.tracer.StartSpanID(ctx, pluginSpanNamesFor(pluginName).posthook, schemas.SpanKindPlugin)
+			// Mirror the new span ID into ctx for nested operations (no valueCtx alloc).
+			if spanID != "" {
+				ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
 			}
 			pluginCtx := ctx.WithPluginScope(&pluginName)
 			resp, bifrostErr, err = plugin.PostLLMHook(pluginCtx, resp, bifrostErr)
@@ -7827,12 +7845,10 @@ func (p *PluginPipeline) RunMCPPreHooks(ctx *schemas.BifrostContext, req *schema
 		pluginName := plugin.GetName()
 		p.logger.Debug("running MCP pre-hook for plugin %s", pluginName)
 		// Start span for this plugin's PreMCPHook
-		spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).mcpPrehook, schemas.SpanKindPlugin)
-		// Update pluginCtx with span context for nested operations
-		if spanCtx != nil {
-			if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
-				ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
-			}
+		spanID, handle := p.tracer.StartSpanID(ctx, pluginSpanNamesFor(pluginName).mcpPrehook, schemas.SpanKindPlugin)
+		// Mirror the new span ID into ctx for nested operations (no valueCtx alloc).
+		if spanID != "" {
+			ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
 		}
 
 		pluginCtx := ctx.WithPluginScope(&pluginName)
@@ -7883,12 +7899,10 @@ func (p *PluginPipeline) RunMCPPostHooks(ctx *schemas.BifrostContext, mcpResp *s
 		pluginName := plugin.GetName()
 		p.logger.Debug("running MCP post-hook for plugin %s", pluginName)
 		// Create span per plugin
-		spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).mcpPosthook, schemas.SpanKindPlugin)
-		// Update pluginCtx with span context for nested operations
-		if spanCtx != nil {
-			if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
-				ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
-			}
+		spanID, handle := p.tracer.StartSpanID(ctx, pluginSpanNamesFor(pluginName).mcpPosthook, schemas.SpanKindPlugin)
+		// Mirror the new span ID into ctx for nested operations (no valueCtx alloc).
+		if spanID != "" {
+			ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
 		}
 
 		pluginCtx := ctx.WithPluginScope(&pluginName)
@@ -7937,11 +7951,9 @@ func (p *PluginPipeline) RunMCPPreConnectionHooks(ctx *schemas.BifrostContext, r
 	for i, plugin := range p.mcpPlugins {
 		pluginName := plugin.GetName()
 		p.logger.Debug("running MCP connect pre-hook for plugin %s", pluginName)
-		spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).mcpConnectPrehook, schemas.SpanKindPlugin)
-		if spanCtx != nil {
-			if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
-				ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
-			}
+		spanID, handle := p.tracer.StartSpanID(ctx, pluginSpanNamesFor(pluginName).mcpConnectPrehook, schemas.SpanKindPlugin)
+		if spanID != "" {
+			ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
 		}
 
 		pluginCtx := ctx.WithPluginScope(&pluginName)
@@ -8000,11 +8012,9 @@ func (p *PluginPipeline) RunMCPPostConnectionHooks(ctx *schemas.BifrostContext, 
 		plugin := p.mcpPlugins[i]
 		pluginName := plugin.GetName()
 		p.logger.Debug("running MCP connect post-hook for plugin %s", pluginName)
-		spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).mcpConnectPosthook, schemas.SpanKindPlugin)
-		if spanCtx != nil {
-			if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
-				ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
-			}
+		spanID, handle := p.tracer.StartSpanID(ctx, pluginSpanNamesFor(pluginName).mcpConnectPosthook, schemas.SpanKindPlugin)
+		if spanID != "" {
+			ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
 		}
 
 		pluginCtx := ctx.WithPluginScope(&pluginName)

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -1313,7 +1313,7 @@ func HandleAnthropicResponsesRequest(
 	if isLargeResp, _ := ctx.Value(schemas.BifrostContextKeyLargeResponseMode).(bool); isLargeResp {
 		preview, _ := ctx.Value(schemas.BifrostContextKeyLargePayloadResponsePreview).(string)
 		return &schemas.BifrostResponsesResponse{
-			ID:        schemas.Ptr("resp_" + providerUtils.GetRandomString(50)),
+			ID:        schemas.Ptr("resp_" + schemas.GetRandomString(50)),
 			Object:    "response",
 			CreatedAt: int(time.Now().Unix()),
 			Model:     request.Model,

--- a/core/providers/anthropic/requestbuilder.go
+++ b/core/providers/anthropic/requestbuilder.go
@@ -343,7 +343,7 @@ func BuildAnthropicResponsesRequestBody(ctx *schemas.BifrostContext, request *sc
 
 		AddMissingBetaHeadersToContext(ctx, reqBody, cfg.Provider)
 
-		jsonBody, err = providerUtils.MarshalSorted(reqBody)
+		jsonBody, err = providerUtils.MarshalProviderRequest(reqBody)
 		if err != nil {
 			return nil, newErr(schemas.ErrProviderRequestMarshal, fmt.Errorf("failed to marshal request body: %w", err), jsonBody)
 		}
@@ -603,7 +603,7 @@ func BuildAnthropicChatRequestBody(ctx *schemas.BifrostContext, request *schemas
 
 		AddMissingBetaHeadersToContext(ctx, reqBody, cfg.Provider)
 
-		jsonBody, err = providerUtils.MarshalSorted(reqBody)
+		jsonBody, err = providerUtils.MarshalProviderRequest(reqBody)
 		if err != nil {
 			return nil, newErr(schemas.ErrProviderRequestMarshal, fmt.Errorf("failed to marshal request body: %w", err), jsonBody)
 		}

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -5622,7 +5622,7 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 					},
 				}
 				if isOutputMessage {
-					bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
+					bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
 				}
 				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}
@@ -5638,7 +5638,7 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 					},
 				}
 				if isOutputMessage {
-					bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
+					bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
 				}
 				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}
@@ -5653,14 +5653,14 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 					},
 				}
 				if isOutputMessage {
-					bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
+					bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
 				}
 				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}
 
 		case AnthropicContentBlockTypeThinking:
 			if block.Thinking != nil {
-				id := new("rs_" + providerUtils.GetRandomString(50))
+				id := new("rs_" + schemas.GetRandomString(50))
 				var recoveredID *string
 				signature := block.Signature
 				if signature != nil {
@@ -5694,7 +5694,7 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 			// Handle redacted thinking (encrypted content)
 			if block.Data != nil {
 				encryptedContent := *block.Data
-				id := new("rs_" + providerUtils.GetRandomString(50))
+				id := new("rs_" + schemas.GetRandomString(50))
 				var recoveredID *string
 				if extractedID, rest, ok := providerUtils.ExtractReasoningItemID(*block.Data); ok {
 					id = extractedID
@@ -5828,7 +5828,7 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 			Role: role,
 		}
 		if isOutputMessage {
-			bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
+			bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
 			bifrostMsg.Content = &schemas.ResponsesMessageContent{
 				ContentBlocks: accumulatedTextContent,
 			}
@@ -5849,7 +5849,7 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 				},
 			}
 			if isOutputMessage {
-				bifrostMsg.ID = schemas.Ptr("fc_" + providerUtils.GetRandomString(50))
+				bifrostMsg.ID = schemas.Ptr("fc_" + schemas.GetRandomString(50))
 			}
 
 			// Check for computer tool use
@@ -5924,7 +5924,7 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 				}
 
 				bifrostMsg := schemas.ResponsesMessage{
-					ID:     schemas.Ptr("cmp_" + providerUtils.GetRandomString(50)),
+					ID:     schemas.Ptr("cmp_" + schemas.GetRandomString(50)),
 					Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
 					Role:   role,
 					Status: schemas.Ptr("completed"),
@@ -5955,7 +5955,7 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 				fallback.TriggerCategory = block.Trigger.Category
 			}
 			bifrostMessages = append(bifrostMessages, schemas.ResponsesMessage{
-				ID:     schemas.Ptr("fb_" + providerUtils.GetRandomString(50)),
+				ID:     schemas.Ptr("fb_" + schemas.GetRandomString(50)),
 				Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
 				Role:   role,
 				Status: schemas.Ptr("completed"),
@@ -6000,7 +6000,7 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 					}
 
 					bifrostMsg = schemas.ResponsesMessage{
-						ID:     schemas.Ptr("msg_" + providerUtils.GetRandomString(50)),
+						ID:     schemas.Ptr("msg_" + schemas.GetRandomString(50)),
 						Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
 						Role:   role,
 						Status: schemas.Ptr("completed"),
@@ -6036,7 +6036,7 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 					},
 				}
 				if isOutputMessage {
-					bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
+					bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
 				}
 				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}
@@ -6050,7 +6050,7 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 					},
 				}
 				if isOutputMessage {
-					bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
+					bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
 				}
 				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}
@@ -6064,7 +6064,7 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 					},
 				}
 				if isOutputMessage {
-					bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
+					bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
 				}
 				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}
@@ -6103,7 +6103,7 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 				}
 				id := extractedID
 				if id == nil {
-					id = new("rs_" + providerUtils.GetRandomString(50))
+					id = new("rs_" + schemas.GetRandomString(50))
 				}
 				bifrostMsg := schemas.ResponsesMessage{
 					ID:   id,
@@ -6144,7 +6144,7 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 					},
 				}
 				if isOutputMessage {
-					bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
+					bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
 				}
 				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			} else {
@@ -6160,7 +6160,7 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 						},
 					}
 					if isOutputMessage {
-						bifrostMsg.ID = schemas.Ptr("fc_" + providerUtils.GetRandomString(50))
+						bifrostMsg.ID = schemas.Ptr("fc_" + schemas.GetRandomString(50))
 					}
 
 					// here need to check for computer tool use
@@ -6423,7 +6423,7 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 					},
 				}
 				if isOutputMessage {
-					bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
+					bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
 				}
 				// Initialize the nested struct before any writes
 				bifrostMsg.ResponsesToolMessage.Output = &schemas.ResponsesToolMessageOutputStruct{}
@@ -6465,7 +6465,7 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 	if len(reasoningContentBlocks) > 0 {
 		id := reasoningItemID
 		if id == nil {
-			id = new("rs_" + providerUtils.GetRandomString(50))
+			id = new("rs_" + schemas.GetRandomString(50))
 		}
 		reasoningMessage := schemas.ResponsesMessage{
 			ID:   id,

--- a/core/providers/cohere/responses.go
+++ b/core/providers/cohere/responses.go
@@ -471,7 +471,7 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 				role := schemas.ResponsesInputMessageRoleAssistant
 
 				// Generate stable ID for reasoning item
-				itemID := "rs_" + providerUtils.GetRandomString(50)
+				itemID := "rs_" + schemas.GetRandomString(50)
 				state.ItemIDs[outputIndex] = itemID
 
 				item := &schemas.ResponsesMessage{

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -789,7 +789,7 @@ func (provider *GeminiProvider) responsesWithLargeResponseDetection(
 		preview, _ := ctx.Value(schemas.BifrostContextKeyLargePayloadResponsePreview).(string)
 		usage := extractUsageFromResponsePrefetch([]byte(preview))
 		bifrostResponse := &schemas.BifrostResponsesResponse{
-			ID:        schemas.Ptr("resp_" + providerUtils.GetRandomString(50)),
+			ID:        schemas.Ptr("resp_" + schemas.GetRandomString(50)),
 			CreatedAt: int(time.Now().Unix()),
 			Model:     request.Model,
 			Usage:     usage,

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -265,7 +265,7 @@ func (response *GenerateContentResponse) ToResponsesBifrostResponsesResponse() *
 
 	// Create the BifrostResponse with Responses structure
 	bifrostResp := &schemas.BifrostResponsesResponse{
-		ID:        schemas.Ptr("resp_" + providerUtils.GetRandomString(50)),
+		ID:        schemas.Ptr("resp_" + schemas.GetRandomString(50)),
 		CreatedAt: int(time.Now().Unix()),
 		Model:     response.ModelVersion,
 	}
@@ -3254,7 +3254,7 @@ func convertGeminiCandidatesToResponsesOutput(candidates []*Candidate) []schemas
 			case part.Text != "":
 				// Regular text message
 				msg := schemas.ResponsesMessage{
-					ID:     schemas.Ptr("msg_" + providerUtils.GetRandomString(50)),
+					ID:     schemas.Ptr("msg_" + schemas.GetRandomString(50)),
 					Role:   schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
 					Status: schemas.Ptr("completed"),
 					Content: &schemas.ResponsesMessageContent{
@@ -3307,7 +3307,7 @@ func convertGeminiCandidatesToResponsesOutput(candidates []*Candidate) []schemas
 					Arguments: &argumentsStr,
 				}
 				msg := schemas.ResponsesMessage{
-					ID:                   schemas.Ptr("fc_" + providerUtils.GetRandomString(50)),
+					ID:                   schemas.Ptr("fc_" + schemas.GetRandomString(50)),
 					Role:                 schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
 					Type:                 schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
 					Status:               schemas.Ptr("completed"),

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -934,7 +934,17 @@ func HandleOpenAIChatCompletionRequest(
 	// A 200 is not proof of success on every OpenAI-compatible provider: some report
 	// failures in-band once the status line is already committed. Left unchecked those
 	// surface to the caller as a 200 with null choices and null usage.
-	if inBandErr := ErrorInSuccessfulChatBody(body); inBandErr != nil {
+	// The non-custom path already validated body via HandleProviderResponse's
+	// sonic.Unmarshal, so it skips the redundant gjson.ValidBytes rescan. A custom
+	// handler makes no such guarantee, so validate before scanning to avoid reading an
+	// "error" object out of malformed JSON.
+	var inBandErr *schemas.BifrostError
+	if customResponseHandler != nil {
+		inBandErr = ErrorInSuccessfulChatBody(body)
+	} else {
+		inBandErr = errorInValidatedChatBody(body)
+	}
+	if inBandErr != nil {
 		logger.Debug("in-band error on a 200 from %s provider: %s", providerName, inBandErr.Error.Message)
 		return nil, providerUtils.EnrichError(ctx, inBandErr, jsonData, body, sendBackRawRequest, sendBackRawResponse, latency)
 	}

--- a/core/providers/openai/successerror.go
+++ b/core/providers/openai/successerror.go
@@ -26,7 +26,13 @@ func ErrorInSuccessfulChatBody(body []byte) *schemas.BifrostError {
 	if len(body) == 0 || !gjson.ValidBytes(body) {
 		return nil
 	}
+	return errorInValidatedChatBody(body)
+}
 
+// errorInValidatedChatBody is ErrorInSuccessfulChatBody's core, for callers that
+// have already proven body is valid JSON (e.g. a successful sonic.Unmarshal on
+// the same bytes) and so can skip the redundant full-body gjson.ValidBytes scan.
+func errorInValidatedChatBody(body []byte) *schemas.BifrostError {
 	errObj := gjson.GetBytes(body, "error")
 	if !errObj.Exists() || !errObj.IsObject() {
 		return nil

--- a/core/providers/utils/largeresponse.go
+++ b/core/providers/utils/largeresponse.go
@@ -146,8 +146,8 @@ func FinalizeResponseWithLargeDetection(
 		if err != nil {
 			return nil, false, NewBifrostOperationError(schemas.ErrProviderResponseDecode, err)
 		}
-		// Copy body before caller releases resp
-		return append([]byte(nil), body...), false, nil
+		// CheckAndDecodeBody already returns an owned copy, safe after release.
+		return body, false, nil
 	}
 
 	contentLength := resp.Header.ContentLength()
@@ -170,7 +170,7 @@ func FinalizeResponseWithLargeDetection(
 		if err != nil {
 			return nil, false, NewBifrostOperationError(schemas.ErrProviderResponseDecode, err)
 		}
-		return append([]byte(nil), body...), false, nil
+		return body, false, nil
 	}
 
 	// Unknown Content-Length (chunked transfer encoding) — buffer up to responseThreshold
@@ -217,7 +217,7 @@ func FinalizeResponseWithLargeDetection(
 		if err != nil {
 			return nil, false, NewBifrostOperationError(schemas.ErrProviderResponseDecode, err)
 		}
-		return append([]byte(nil), body...), false, nil
+		return body, false, nil
 	}
 
 	// Known large response (Content-Length > threshold) — prefetch first 64KB for
@@ -232,7 +232,7 @@ func FinalizeResponseWithLargeDetection(
 		if err != nil {
 			return nil, false, NewBifrostOperationError(schemas.ErrProviderResponseDecode, err)
 		}
-		return append([]byte(nil), body...), false, nil
+		return body, false, nil
 	}
 
 	// Decompress on-the-fly if provider returned gzip-encoded response.

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
 	"net"
 	"net/http"
 	"net/textproto"
@@ -198,6 +197,19 @@ var sortedAPI = sonic.Config{SortMapKeys: true}.Froze()
 // MarshalSorted marshals v to JSON with map keys sorted alphabetically.
 func MarshalSorted(v interface{}) ([]byte, error) {
 	return sortedAPI.Marshal(v)
+}
+
+// MarshalProviderRequest marshals a converted provider request body to wire JSON.
+// Typed provider requests implement json.Marshaler (they strip Bifrost-only fields
+// and already emit sorted, minified JSON), so we call MarshalJSON directly. Wrapping
+// that in MarshalSorted would only make sonic re-compact the whole body a second time
+// through its slow marshaler path, and SortMapKeys does not reorder a marshaler's
+// opaque output anyway. Plain structs fall back to MarshalSorted. Output is identical.
+func MarshalProviderRequest(v interface{}) ([]byte, error) {
+	if m, ok := v.(json.Marshaler); ok {
+		return m.MarshalJSON()
+	}
+	return MarshalSorted(v)
 }
 
 // MarshalSortedIndent marshals v to indented JSON with map keys sorted alphabetically.
@@ -1576,7 +1588,7 @@ func MergeExtraParamsIntoJSON(jsonBody []byte, extraParams map[string]interface{
 		}
 	}
 
-	// Rebuild compact JSON, then indent for consistent formatting
+	// Rebuild compact JSON in the original key order
 	var compact bytes.Buffer
 	compact.WriteByte('{')
 	for i, kv := range pairs {
@@ -1594,12 +1606,7 @@ func MergeExtraParamsIntoJSON(jsonBody []byte, extraParams map[string]interface{
 	}
 	compact.WriteByte('}')
 
-	// Re-indent to match the expected formatting
-	var indented bytes.Buffer
-	if err := json.Indent(&indented, compact.Bytes(), "", "  "); err != nil {
-		return compact.Bytes(), nil
-	}
-	return indented.Bytes(), nil
+	return compact.Bytes(), nil
 }
 
 // CheckContextAndGetRequestBody checks if the raw request body should be used, and returns it if it exists.
@@ -1618,7 +1625,8 @@ func CheckContextAndGetRequestBody(ctx context.Context, request RequestBodyGette
 			return nil, NewBifrostOperationError("request body is not provided", nil)
 		}
 
-		jsonBody, err := MarshalSortedIndent(convertedBody, "", "  ")
+		// Indenting is removed to reduce data on wire
+		jsonBody, err := MarshalProviderRequest(convertedBody)
 		if err != nil {
 			return nil, NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
 		}
@@ -1837,8 +1845,7 @@ func EnrichError(
 // on responses that are almost certainly valid JSON.
 func HandleProviderResponse[T any](responseBody []byte, response *T, requestBody []byte, sendBackRawRequest bool, sendBackRawResponse bool) (rawRequest interface{}, rawResponse interface{}, bifrostErr *schemas.BifrostError) {
 	// Check for empty response
-	trimmed := strings.TrimSpace(string(responseBody))
-	if len(trimmed) == 0 {
+	if len(bytes.TrimSpace(responseBody)) == 0 {
 		return nil, nil, &schemas.BifrostError{
 			IsBifrostError: true,
 			Error: &schemas.ErrorField{
@@ -3479,20 +3486,6 @@ func HandleMultipleListModelsRequests(
 	response.ExtraFields.Latency = latency.Milliseconds()
 
 	return response, nil
-}
-
-// GetRandomString generates a random alphanumeric string of the given length.
-func GetRandomString(length int) string {
-	if length <= 0 {
-		return ""
-	}
-	randomSource := rand.New(rand.NewSource(time.Now().UnixNano()))
-	letters := []rune("abcdef0123456789")
-	b := make([]rune, length)
-	for i := range b {
-		b[i] = letters[randomSource.Intn(len(letters))]
-	}
-	return string(b)
 }
 
 // GetReasoningEffortFromBudgetTokens maps a reasoning token budget to OpenAI reasoning effort.

--- a/core/schemas/allocfix_bench_test.go
+++ b/core/schemas/allocfix_bench_test.go
@@ -1,0 +1,230 @@
+package schemas
+
+// Deterministic before/after microbenchmarks for the overhead-latency fix batch.
+// Wall-clock p99 on the load harness is too noisy to see sub-microsecond,
+// per-request changes; -benchmem allocs/op is deterministic and is the honest
+// proof for these fixes.
+//
+// Run:
+//
+//	go test ./core/schemas/ -run '^$' -bench 'FixBatch' -benchmem
+//
+// Interpretation:
+//   - Timer + SpanReset are ALLOCATION fixes: expect allocs/op to drop to ~0.
+//   - ReservedKey is a CPU/latency fix (fewer comparisons): expect ns/op to
+//     drop, allocs/op unchanged (0 in both).
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+)
+
+// ---- Fix 1: per-worker reusable delivery timer vs time.After per request ----
+
+// benchTimerDur is large so a fresh timer never actually fires inside the loop;
+// we measure only the cost of arming it, which is what the request path pays.
+const benchTimerDur = time.Hour
+
+// Old path: the worker armed time.After(5s) on every request. time.After is
+// NewTimer(d).C, so each call heap-allocates a Timer and its channel. Stop() so
+// the benchmark does not pile up b.N live timers (the leak we are fixing); the
+// allocation measured is identical to time.After's.
+func BenchmarkFixBatch_Timer_PerRequest(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		t := time.NewTimer(benchTimerDur)
+		t.Stop()
+	}
+}
+
+// New path: one timer per (long-lived) worker, reset per request.
+func BenchmarkFixBatch_Timer_Reused(b *testing.B) {
+	t := time.NewTimer(benchTimerDur)
+	t.Stop()
+	b.ReportAllocs()
+	for b.Loop() {
+		t.Reset(benchTimerDur)
+		t.Stop()
+	}
+}
+
+// ---- Fix 2: Span.Reset reuses the attribute map vs nil-ing it ----
+
+// benchSpanAttrKeys/Vals model a typical span's attribute set. Values are
+// pre-boxed into []any so interface boxing is constant across both benchmarks
+// and the only allocation difference is the attribute map itself.
+var (
+	benchSpanAttrKeys = []string{
+		"bifrost.provider", "bifrost.model", "bifrost.request.id",
+		"bifrost.upstream.duration_ms", "http.status_code", "gen_ai.system",
+		"span.kind", "bifrost.stream",
+	}
+	benchSpanAttrVals = []any{
+		"openai", "gpt-4o", "req-abcdef", 1439.0, 200, "openai", "llm.call", true,
+	}
+)
+
+func populateSpanAttrs(s *Span) {
+	for i, k := range benchSpanAttrKeys {
+		s.SetAttribute(k, benchSpanAttrVals[i])
+	}
+}
+
+// New path: the real Span.Reset (clear + reuse). Steady state re-fills a cleared
+// map with retained capacity, so no map allocation after the first cycle.
+func BenchmarkFixBatch_SpanReset_Reuse(b *testing.B) {
+	s := &Span{}
+	populateSpanAttrs(s) // warm the map once so capacity is retained
+	s.Reset()
+	b.ReportAllocs()
+	for b.Loop() {
+		populateSpanAttrs(s)
+		s.Reset()
+	}
+}
+
+// Old path: replicate the pre-fix Reset (s.Attributes = nil). The next
+// SetAttribute then make()s a fresh map every cycle: one map alloc per pooled
+// span per request.
+func oldSpanReset(s *Span) {
+	s.SpanID = ""
+	s.ParentID = ""
+	s.TraceID = ""
+	s.Name = ""
+	s.Kind = SpanKindUnspecified
+	s.StartTime = time.Time{}
+	s.EndTime = time.Time{}
+	s.Status = SpanStatusUnset
+	s.StatusMsg = ""
+	s.Attributes = nil
+	s.Events = s.Events[:0]
+}
+
+func BenchmarkFixBatch_SpanReset_Nil(b *testing.B) {
+	s := &Span{}
+	populateSpanAttrs(s)
+	oldSpanReset(s)
+	b.ReportAllocs()
+	for b.Loop() {
+		populateSpanAttrs(s)
+		oldSpanReset(s)
+	}
+}
+
+// ---- Fix 3: reserved-key check, map lookup vs slices.Contains linear scan ----
+
+// oldReservedSlice mirrors the pre-fix []any, built from the same key set so
+// membership semantics match exactly. Miss case = full scan (the worst case,
+// and the common case since most context writes are not reserved keys).
+func oldReservedSlice() []any {
+	s := make([]any, 0, len(reservedKeys))
+	for k := range reservedKeys {
+		s = append(s, k)
+	}
+	return s
+}
+
+var benchReservedMissKey any = BifrostContextKey("x-not-a-reserved-key")
+
+func BenchmarkFixBatch_ReservedKey_SliceScan(b *testing.B) {
+	old := oldReservedSlice()
+	b.ReportAllocs()
+	var ok bool
+	for b.Loop() {
+		ok = slices.Contains(old, benchReservedMissKey)
+	}
+	_ = ok
+}
+
+func BenchmarkFixBatch_ReservedKey_MapLookup(b *testing.B) {
+	b.ReportAllocs()
+	var ok bool
+	for b.Loop() {
+		ok = isReservedKey(benchReservedMissKey)
+	}
+	_ = ok
+}
+
+// ---- Fix 4: logging plugin skips the identity/governance context reads on
+// non-final stream chunks. This is a CPU/latency fix, not an allocation fix:
+// each read is one RLock + map lookup (BifrostContext.Value), returning an
+// already-boxed value, so allocs/op is ~0. The number below is the per-chunk
+// cost the gate now avoids; multiply by (chunks - 1) for a stream's saving. ----
+
+// loggingIdentityKeys mirrors the block moved past the non-final-chunk gate in
+// plugins/logging/main.go (the ~19 identity/governance lookups feeding
+// applyOutputFieldsToEntry).
+var loggingIdentityKeys = []any{
+	BifrostContextKeySelectedKeyID, BifrostContextKeySelectedKeyName,
+	BifrostContextKeyGovernanceVirtualKeyID, BifrostContextKeyGovernanceVirtualKeyName,
+	BifrostContextKeyGovernanceRoutingRuleID, BifrostContextKeyGovernanceRoutingRuleName,
+	BifrostContextKeySelectedPromptName, BifrostContextKeySelectedPromptVersion,
+	BifrostContextKeySelectedPromptID, BifrostContextKeyGovernanceTeamID,
+	BifrostContextKeyGovernanceTeamName, BifrostContextKeyGovernanceCustomerID,
+	BifrostContextKeyGovernanceCustomerName, BifrostContextKeyUserID,
+	BifrostContextKeyUserName, BifrostContextKeyGovernanceBusinessUnitID,
+	BifrostContextKeyGovernanceBusinessUnitName, BifrostContextKeyNumberOfRetries,
+	BifrostContextKeyAttemptTrail,
+}
+
+func newBenchIdentityContext() *BifrostContext {
+	bc := NewBifrostContext(context.Background(), time.Now().Add(time.Hour))
+	for _, k := range loggingIdentityKeys {
+		bc.SetValue(k, "v")
+	}
+	return bc
+}
+
+// The per-non-final-chunk work the gate now skips: read the full identity block.
+func BenchmarkFixBatch_LoggingPerChunkReads(b *testing.B) {
+	bc := newBenchIdentityContext()
+	b.ReportAllocs()
+	var sink any
+	for b.Loop() {
+		for _, k := range loggingIdentityKeys {
+			sink = bc.Value(k)
+		}
+	}
+	_ = sink
+}
+
+// ---- Fix C5: presize the per-request userValues map (~25 SetValue writes) ----
+var benchC5Keys = func() []any {
+	k := make([]any, 25)
+	for i := range k {
+		k[i] = BifrostContextKey("k" + string(rune('a'+i)))
+	}
+	return k
+}()
+
+func BenchmarkFixC5_MapSize0(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		m := make(map[any]any)
+		for _, k := range benchC5Keys {
+			m[k] = "v"
+		}
+	}
+}
+
+func BenchmarkFixC5_MapPresized(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		m := make(map[any]any, 32)
+		for _, k := range benchC5Keys {
+			m[k] = "v"
+		}
+	}
+}
+
+func BenchmarkFixC5_MapHint16(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		m := make(map[any]any, 16)
+		for _, k := range benchC5Keys {
+			m[k] = "v"
+		}
+	}
+}

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -11,29 +11,46 @@ import (
 
 var NoDeadline time.Time
 
-var reservedKeys = []any{
-	BifrostContextKeyVirtualKey,
-	BifrostContextKeyAPIKeyName,
-	BifrostContextKeyAPIKeyID,
-	BifrostContextKeyDirectKey,
-	BifrostContextKeyRequestID,
-	BifrostContextKeyFallbackRequestID,
-	BifrostContextKeySelectedKeyID,
-	BifrostContextKeySelectedKeyName,
-	BifrostContextKeyNumberOfRetries,
-	BifrostContextKeyFallbackIndex,
-	BifrostContextKeySkipKeySelection,
-	BifrostContextKeyPassthroughHeaders,
-	BifrostContextKeySkipBudgetAndRateLimits,
-	BifrostContextKeySkipProviderCheck,
-	BifrostContextKeyURLPath,
-	BifrostContextKeyDeferTraceCompletion,
-	BifrostContextKeyAttemptTrail,
-	BifrostContextKeyStreamGated,
-	BifrostContextKeyMCPHealthCheckRequest,
-	BifrostContextKeyUpstreamLatency,
-	BifrostContextKeyRoutingInfo,
-	BifrostContextKeyMCPInboundBearer,
+// reservedKeys is a set (not a slice) so the per-write guard is O(1) instead of a
+// linear interface-equality scan; the guard runs on every restricted write, per
+// chunk on streams. Keyed by BifrostContextKey (not any) so isReservedKey can
+// assert the type before indexing: SetValue/ClearValue/GetAndSetValue accept any,
+// and indexing a map with a non-comparable key (slice, map, func) would panic.
+var reservedKeys = map[BifrostContextKey]struct{}{
+	BifrostContextKeyVirtualKey:              {},
+	BifrostContextKeyAPIKeyName:              {},
+	BifrostContextKeyAPIKeyID:                {},
+	BifrostContextKeyDirectKey:               {},
+	BifrostContextKeyRequestID:               {},
+	BifrostContextKeyFallbackRequestID:       {},
+	BifrostContextKeySelectedKeyID:           {},
+	BifrostContextKeySelectedKeyName:         {},
+	BifrostContextKeyNumberOfRetries:         {},
+	BifrostContextKeyFallbackIndex:           {},
+	BifrostContextKeySkipKeySelection:        {},
+	BifrostContextKeyPassthroughHeaders:      {},
+	BifrostContextKeySkipBudgetAndRateLimits: {},
+	BifrostContextKeySkipProviderCheck:       {},
+	BifrostContextKeyURLPath:                 {},
+	BifrostContextKeyDeferTraceCompletion:    {},
+	BifrostContextKeyAttemptTrail:            {},
+	BifrostContextKeyStreamGated:             {},
+	BifrostContextKeyMCPHealthCheckRequest:   {},
+	BifrostContextKeyUpstreamLatency:         {},
+	BifrostContextKeyRoutingInfo:             {},
+	BifrostContextKeyMCPInboundBearer:        {},
+}
+
+// isReservedKey reports whether key is a reserved context key whose writes are
+// blocked while blockRestrictedWrites is set. Non-BifrostContextKey keys (which
+// may be non-comparable) are never reserved and must not reach the map index.
+func isReservedKey(key any) bool {
+	contextKey, ok := key.(BifrostContextKey)
+	if !ok {
+		return false
+	}
+	_, ok = reservedKeys[contextKey]
+	return ok
 }
 
 // pluginLogStore holds plugin log entries accumulated during request processing.
@@ -96,7 +113,6 @@ func NewBifrostContext(parent context.Context, deadline time.Time) *BifrostConte
 		deadline:              deadline,
 		hasDeadline:           !deadline.IsZero(),
 		done:                  make(chan struct{}),
-		userValues:            make(map[any]any),
 		blockRestrictedWrites: atomic.Bool{},
 	}
 	ctx.blockRestrictedWrites.Store(false)
@@ -379,14 +395,14 @@ func (bc *BifrostContext) SetValue(key, value any) {
 		return
 	}
 	// Check if the key is a reserved key
-	if bc.blockRestrictedWrites.Load() && slices.Contains(reservedKeys, key) {
+	if bc.blockRestrictedWrites.Load() && isReservedKey(key) {
 		// we silently drop writes for these reserved keys
 		return
 	}
 	bc.valuesMu.Lock()
 	defer bc.valuesMu.Unlock()
 	if bc.userValues == nil {
-		bc.userValues = make(map[any]any)
+		bc.userValues = make(map[any]any, 16)
 	}
 	bc.userValues[key] = value
 }
@@ -403,7 +419,7 @@ func (bc *BifrostContext) setReservedValue(key, value any) {
 	bc.valuesMu.Lock()
 	defer bc.valuesMu.Unlock()
 	if bc.userValues == nil {
-		bc.userValues = make(map[any]any)
+		bc.userValues = make(map[any]any, 16)
 	}
 	bc.userValues[key] = value
 }
@@ -426,7 +442,7 @@ func (bc *BifrostContext) ClearValue(key any) {
 		return
 	}
 	// Check if the key is a reserved key
-	if bc.blockRestrictedWrites.Load() && slices.Contains(reservedKeys, key) {
+	if bc.blockRestrictedWrites.Load() && isReservedKey(key) {
 		// we silently drop writes for these reserved keys
 		return
 	}
@@ -446,12 +462,12 @@ func (bc *BifrostContext) GetAndSetValue(key any, value any) any {
 	bc.valuesMu.Lock()
 	defer bc.valuesMu.Unlock()
 	// Check if the key is a reserved key
-	if bc.blockRestrictedWrites.Load() && slices.Contains(reservedKeys, key) {
+	if bc.blockRestrictedWrites.Load() && isReservedKey(key) {
 		// we silently drop writes for these reserved keys
 		return bc.userValues[key]
 	}
 	if bc.userValues == nil {
-		bc.userValues = make(map[any]any)
+		bc.userValues = make(map[any]any, 16)
 	}
 	oldValue := bc.userValues[key]
 	bc.userValues[key] = value

--- a/core/schemas/context_test.go
+++ b/core/schemas/context_test.go
@@ -477,3 +477,43 @@ func TestNewBifrostContext_WatchdogRaceWithReleasedScope(t *testing.T) {
 		_, _ = c.Deadline()
 	}
 }
+
+// TestReservedKey_SkipProviderCheckIsProtected pins BifrostContextKeySkipProviderCheck
+// as reserved. Governance uses it to bypass virtual-key provider allowlists, so a
+// restricted (plugin) write must not be able to flip it. It regressed out of
+// reservedKeys during the slice->map refactor.
+func TestReservedKey_SkipProviderCheckIsProtected(t *testing.T) {
+	if !isReservedKey(BifrostContextKeySkipProviderCheck) {
+		t.Fatal("BifrostContextKeySkipProviderCheck must be a reserved key")
+	}
+
+	ctx := NewBifrostContext(context.Background(), NoDeadline)
+	defer ctx.Cancel()
+
+	// Trusted write before the guard is armed.
+	ctx.SetValue(BifrostContextKeySkipProviderCheck, true)
+	ctx.BlockRestrictedWrites()
+
+	// A restricted write must be silently dropped, leaving the flag untouched.
+	ctx.SetValue(BifrostContextKeySkipProviderCheck, false)
+	if v := ctx.Value(BifrostContextKeySkipProviderCheck); v != true {
+		t.Fatalf("reserved key overwritten under BlockRestrictedWrites: got %v, want true", v)
+	}
+}
+
+// TestReservedKey_NonComparableKeyDoesNotPanic guards the reserved-write path against
+// non-comparable keys. isReservedKey indexes reservedKeys, which panics on a slice/map/
+// func key unless the type is asserted first, and ClearValue reaches that guard even
+// when userValues is nil.
+func TestReservedKey_NonComparableKeyDoesNotPanic(t *testing.T) {
+	if isReservedKey([]string{"not", "comparable"}) {
+		t.Fatal("a non-comparable key must never be reported reserved")
+	}
+
+	ctx := NewBifrostContext(context.Background(), NoDeadline)
+	defer ctx.Cancel()
+	ctx.BlockRestrictedWrites()
+
+	// userValues is still nil here; the guard must not panic before that check.
+	ctx.ClearValue([]string{"slice", "key"})
+}

--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -471,7 +471,14 @@ func (s *Span) Reset() {
 	s.EndTime = time.Time{}
 	s.Status = SpanStatusUnset
 	s.StatusMsg = ""
-	s.Attributes = nil
+	// Reuse the attribute map across pool cycles: tracing/store.go clears and
+	// refills it, so nil-ing here forced a fresh map alloc per pooled span every
+	// request. Drop only an outlier-sized map so one huge request can't pin it.
+	if len(s.Attributes) > 64 {
+		s.Attributes = nil
+	} else {
+		clear(s.Attributes)
+	}
 	s.Events = s.Events[:0]
 }
 

--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -380,6 +380,27 @@ func (s *Span) SetAttribute(key string, value any) {
 	s.Attributes[key] = value
 }
 
+// SetAttributes merges an already-built attribute map into the span under a
+// single lock. Preferred over a caller-side range + SetAttribute loop (one lock
+// per entry) when the map already exists (e.g. the Populate*Attributes output).
+// Nil values are skipped, matching SetAttribute.
+func (s *Span) SetAttributes(attrs map[string]any) {
+	if s == nil || len(attrs) == 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.Attributes == nil {
+		s.Attributes = make(map[string]any, len(attrs))
+	}
+	for k, v := range attrs {
+		if v == nil {
+			continue
+		}
+		s.Attributes[k] = v
+	}
+}
+
 // snapshotForExport returns a copy of the span whose Attributes (and Events)
 // are cloned under the span lock, so observability exporters can read them
 // concurrently while a late writer (streaming finalization, redaction) may still

--- a/core/schemas/tracer.go
+++ b/core/schemas/tracer.go
@@ -56,6 +56,12 @@ type Tracer interface {
 	// The context should be used for subsequent operations to maintain span hierarchy.
 	StartSpan(ctx context.Context, name string, kind SpanKind) (context.Context, SpanHandle)
 
+	// StartSpanID is like StartSpan but returns the new span's ID instead of a
+	// context wrapped in a valueCtx. Callers that only mirror the ID into a
+	// *BifrostContext (via SetValue) use this to avoid a per-span context alloc.
+	// Returns ("", nil) when no trace is present or span creation fails.
+	StartSpanID(ctx context.Context, name string, kind SpanKind) (string, SpanHandle)
+
 	// EndSpan completes a span with status and optional message.
 	// Should be called when the operation represented by the span is complete.
 	EndSpan(handle SpanHandle, status SpanStatus, statusMsg string)
@@ -63,6 +69,12 @@ type Tracer interface {
 	// SetAttribute sets an attribute on the span.
 	// Attributes provide additional context about the operation.
 	SetAttribute(handle SpanHandle, key string, value any)
+
+	// SpanFromHandle resolves the *Span for a handle once, so a caller writing many
+	// attributes (e.g. the per-request LLM-call block) can call span.SetAttribute
+	// directly instead of paying a trace+span lookup on every attribute. Returns
+	// nil if the handle does not resolve; span.SetAttribute is nil-safe.
+	SpanFromHandle(handle SpanHandle) *Span
 
 	// GetSpanHandleByID retrieves a span handle for the given trace and span ID.
 	// If spanID is nil, returns a handle for the trace's root span.
@@ -202,11 +214,18 @@ func (n *NoOpTracer) StartSpan(ctx context.Context, _ string, _ SpanKind) (conte
 	return ctx, nil
 }
 
+// StartSpanID does nothing.
+func (n *NoOpTracer) StartSpanID(_ context.Context, _ string, _ SpanKind) (string, SpanHandle) {
+	return "", nil
+}
+
 // EndSpan does nothing.
 func (n *NoOpTracer) EndSpan(_ SpanHandle, _ SpanStatus, _ string) {}
 
 // SetAttribute does nothing.
 func (n *NoOpTracer) SetAttribute(_ SpanHandle, _ string, _ any) {}
+
+func (n *NoOpTracer) SpanFromHandle(_ SpanHandle) *Span { return nil }
 
 // GetSpanHandleByID returns nil.
 func (n *NoOpTracer) GetSpanHandleByID(_ string, _ *string) SpanHandle { return nil }

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -3,14 +3,13 @@ package schemas
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net/url"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 )
 
 // Ptr creates a pointer to any value.
@@ -19,16 +18,19 @@ func Ptr[T any](v T) *T {
 	return &v
 }
 
-// GetRandomString generates a random alphanumeric string of the given length.
+// letters is the hex alphabet GetRandomString draws from.
+const letters = "abcdef0123456789"
+
+// GetRandomString generates a random hex string of the given length.
+// Uses rand/v2 (seedless, per-thread): the old per-call time-seeded source cost
+// ~7µs per call and could mint identical strings for same-tick calls.
 func GetRandomString(length int) string {
 	if length <= 0 {
 		return ""
 	}
-	randomSource := rand.New(rand.NewSource(time.Now().UnixNano()))
-	letters := []rune("abcdef0123456789")
-	b := make([]rune, length)
+	b := make([]byte, length)
 	for i := range b {
-		b[i] = letters[randomSource.Intn(len(letters))]
+		b[i] = letters[rand.IntN(len(letters))]
 	}
 	return string(b)
 }

--- a/core/utils.go
+++ b/core/utils.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/maximhq/bifrost/core/mcp"
@@ -697,6 +698,43 @@ func ValidateExternalURL(urlStr string, allowPrivateNetwork bool) error {
 // sanitizeSpanName sanitizes a span name to remove capital letters and spaces to make it a valid span name.
 func sanitizeSpanName(name string) string {
 	return schemas.SanitizePluginSpanName(name)
+}
+
+// pluginSpanNameSet holds the precomputed "plugin.<name>.<hook>" span names for
+// one plugin. Building them with Sprintf on every hook invocation costs ~2
+// allocs per span at request rate; plugin names are static, so cache them.
+type pluginSpanNameSet struct {
+	prehook            string
+	prerequesthook     string
+	posthook           string
+	mcpPrehook         string
+	mcpPosthook        string
+	mcpConnectPrehook  string
+	mcpConnectPosthook string
+}
+
+// pluginSpanNameCache maps plugin name -> *pluginSpanNameSet. Bounded by the
+// number of distinct registered plugins.
+var pluginSpanNameCache sync.Map
+
+func pluginSpanNamesFor(name string) *pluginSpanNameSet {
+	if v, ok := pluginSpanNameCache.Load(name); ok {
+		return v.(*pluginSpanNameSet)
+	}
+	s := sanitizeSpanName(name)
+	set := &pluginSpanNameSet{
+		prehook:            "plugin." + s + ".prehook",
+		prerequesthook:     "plugin." + s + ".prerequesthook",
+		posthook:           "plugin." + s + ".posthook",
+		mcpPrehook:         "plugin." + s + ".mcp_prehook",
+		mcpPosthook:        "plugin." + s + ".mcp_posthook",
+		mcpConnectPrehook:  "plugin." + s + ".mcp_connect_prehook",
+		mcpConnectPosthook: "plugin." + s + ".mcp_connect_posthook",
+	}
+	if v, loaded := pluginSpanNameCache.LoadOrStore(name, set); loaded {
+		return v.(*pluginSpanNameSet)
+	}
+	return set
 }
 
 // IsCodemodeTool returns true if the given tool name is a codemode tool.

--- a/framework/modelcatalog/datasheet/store.go
+++ b/framework/modelcatalog/datasheet/store.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	bifrost "github.com/maximhq/bifrost/core"
@@ -66,6 +67,10 @@ type Store struct {
 	onModelParametersApplied func()
 	datasheetByProvider      map[schemas.ModelProvider][]string // rebuilt every reload
 	deprecatedByProvider     map[schemas.ModelProvider][]string // rebuilt every reload
+
+	// writeGen counts membership rebuilds; the composer's model→provider memo
+	// stamps it to detect staleness. Atomic so readers skip mu.
+	writeGen atomic.Uint64
 
 	// Overrides under their own mutex: writes here don't block pricing reads
 	// (the hot CalculateCost path takes mu.RLock and overridesMu.RLock
@@ -500,4 +505,11 @@ func (s *Store) rebuildDatasheetViewUnsafe() {
 		slices.Sort(models)
 		s.deprecatedByProvider[provider] = models
 	}
+
+	s.writeGen.Add(1)
+}
+
+// WriteGen returns the monotonic count of membership rebuilds.
+func (s *Store) WriteGen() uint64 {
+	return s.writeGen.Load()
 }

--- a/framework/modelcatalog/keyconfig/store.go
+++ b/framework/modelcatalog/keyconfig/store.go
@@ -18,6 +18,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -60,6 +61,10 @@ type Store struct {
 	mu      sync.RWMutex
 	entries map[schemas.ModelProvider]*providerState
 	logger  schemas.Logger
+
+	// writeGen counts entry mutations; the composer's model→provider memo
+	// stamps it to detect staleness. Atomic so readers skip mu.
+	writeGen atomic.Uint64
 }
 
 // New constructs an empty Store.
@@ -88,6 +93,12 @@ func (s *Store) Replace(snapshot map[schemas.ModelProvider][]schemas.Key) {
 		}
 	}
 	s.entries = next
+	s.writeGen.Add(1)
+}
+
+// WriteGen returns the monotonic count of entry mutations.
+func (s *Store) WriteGen() uint64 {
+	return s.writeGen.Load()
 }
 
 // SetProvider replaces the cached state for one provider. Call after a
@@ -98,9 +109,11 @@ func (s *Store) SetProvider(provider schemas.ModelProvider, keys []schemas.Key) 
 	defer s.mu.Unlock()
 	if st == nil {
 		delete(s.entries, provider)
+		s.writeGen.Add(1)
 		return
 	}
 	s.entries[provider] = st
+	s.writeGen.Add(1)
 }
 
 // RemoveProvider drops all state for the provider. Call on provider delete.
@@ -108,6 +121,7 @@ func (s *Store) RemoveProvider(provider schemas.ModelProvider) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.entries, provider)
+	s.writeGen.Add(1)
 }
 
 // EntriesFor returns all per-key entries for the provider (including

--- a/framework/modelcatalog/live/store.go
+++ b/framework/modelcatalog/live/store.go
@@ -18,6 +18,7 @@ package live
 import (
 	"slices"
 	"sync"
+	"sync/atomic"
 
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -50,6 +51,11 @@ type Store struct {
 	// look current again after the provider was re-added.
 	gen    map[schemas.ModelProvider]uint64
 	logger schemas.Logger
+
+	// writeGen counts entry mutations across all providers; the composer's
+	// model→provider memo stamps it to detect staleness. Distinct from gen,
+	// which is per-provider and guards in-flight fetch races.
+	writeGen atomic.Uint64
 }
 
 func New(logger schemas.Logger) *Store {
@@ -73,6 +79,12 @@ func (s *Store) Upsert(provider schemas.ModelProvider, keyID string, unfiltered 
 	s.mu.Lock()
 	s.entries[k] = Entry{Models: cp}
 	s.mu.Unlock()
+	s.writeGen.Add(1)
+}
+
+// WriteGen returns the monotonic count of entry mutations across all providers.
+func (s *Store) WriteGen() uint64 {
+	return s.writeGen.Load()
 }
 
 // Generation returns the provider's current invalidation counter. Read it
@@ -102,6 +114,7 @@ func (s *Store) UpsertIfCurrent(provider schemas.ModelProvider, keyID string, un
 		return false
 	}
 	s.entries[k] = Entry{Models: cp}
+	s.writeGen.Add(1)
 	return true
 }
 
@@ -113,6 +126,7 @@ func (s *Store) UpsertIfCurrent(provider schemas.ModelProvider, keyID string, un
 // nothing cached yet, and that is the write this has to stop.
 func (s *Store) bumpLocked(provider schemas.ModelProvider) {
 	s.gen[provider]++
+	s.writeGen.Add(1)
 }
 
 // Invalidate drops both filtered and unfiltered entries for one key. Called

--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -40,6 +40,12 @@ type ModelCatalog struct {
 	// loadCapabilities fills a capability cache miss.
 	loadCapabilities func(schemas.ModelProvider, string) (*schemas.ModelCapabilities, error)
 
+	// providerMemo caches GetProvidersForModel per model, stamped with
+	// catalogGeneration() at compute time; any store write invalidates every
+	// entry. Capped at providerMemoMaxEntries, flushed on overflow.
+	providerMemoMu sync.RWMutex
+	providerMemo   map[string]providerMemoEntry
+
 	// MCP library sync configuration (protected by syncMu)
 	mcpLibraryURL          string
 	mcpLibrarySyncInterval time.Duration
@@ -114,6 +120,7 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 		live:         live.New(logger),
 		keyconf:      keyconfig.New(logger),
 		capabilities: lrucache.New[*schemas.ModelCapabilities](capabilityCacheSize),
+		providerMemo: make(map[string]providerMemoEntry),
 		done:         make(chan struct{}),
 	}
 	mc.syncCtx, mc.syncCancel = context.WithCancel(ctx)

--- a/framework/modelcatalog/models.go
+++ b/framework/modelcatalog/models.go
@@ -150,11 +150,63 @@ func (mc *ModelCatalog) GetDistinctBaseModelNames() []string {
 	return mc.datasheet.DistinctBaseModelNames()
 }
 
+// providerMemoEntry is a memoized GetProvidersForModel result and the
+// catalogGeneration it was computed under.
+type providerMemoEntry struct {
+	gen uint64
+	val []schemas.ModelProvider
+}
+
+// providerMemoMaxEntries bounds the memo; model strings are client-controlled
+// and would otherwise grow it without limit. On overflow the map is flushed
+// and hot entries repopulate on demand.
+const providerMemoMaxEntries = 4096
+
+// catalogGeneration sums the three stores' write counters. Every write bumps
+// exactly one counter by one, so the sum strictly increases and no two
+// catalog states share a value.
+func (mc *ModelCatalog) catalogGeneration() uint64 {
+	return mc.datasheet.WriteGen() + mc.keyconf.WriteGen() + mc.live.WriteGen()
+}
+
 // GetProvidersForModel returns every provider that can serve the model.
-// Composes across stores and applies the cross-provider special cases
-// (openrouter / vertex / groq-gpt / bedrock-claude) preserved verbatim from
-// the pre-refactor implementation.
+// Memoized per model (bounded, empty results uncached); any store write
+// invalidates (see catalogGeneration). Returns a fresh clone the caller
+// may mutate.
 func (mc *ModelCatalog) GetProvidersForModel(model string) []schemas.ModelProvider {
+	gen := mc.catalogGeneration()
+
+	mc.providerMemoMu.RLock()
+	entry, ok := mc.providerMemo[model]
+	mc.providerMemoMu.RUnlock()
+	if ok && entry.gen == gen {
+		return slices.Clone(entry.val)
+	}
+
+	val := mc.computeProvidersForModel(model)
+	// Unknown models resolve to nothing; skipping memoising
+	if len(val) == 0 {
+		return val
+	}
+
+	// Stamp with the generation read before compute: a write during compute
+	// leaves the entry stale and the next call recomputes.
+	mc.providerMemoMu.Lock()
+	if mc.providerMemo == nil {
+		mc.providerMemo = make(map[string]providerMemoEntry)
+	}
+	if _, exists := mc.providerMemo[model]; !exists && len(mc.providerMemo) >= providerMemoMaxEntries {
+		mc.providerMemo = make(map[string]providerMemoEntry)
+	}
+	mc.providerMemo[model] = providerMemoEntry{gen: gen, val: val}
+	mc.providerMemoMu.Unlock()
+
+	return slices.Clone(val)
+}
+
+// computeProvidersForModel composes the uncached answer across stores,
+// including the openrouter / vertex / groq-gpt / bedrock-claude special cases.
+func (mc *ModelCatalog) computeProvidersForModel(model string) []schemas.ModelProvider {
 	baseModel := mc.datasheet.BaseModelName(model)
 
 	providers := make([]schemas.ModelProvider, 0)
@@ -265,17 +317,25 @@ func (mc *ModelCatalog) IsModelAllowedForProvider(provider schemas.ModelProvider
 		return false
 	}
 
+	// Bare-name match needs no catalog access and covers most allowlists.
+	if slices.Contains(allowedModels, model) {
+		return true
+	}
+
+	// Only provider-prefixed entries ("openai/gpt-4o") need the provider
+	// catalog; build it once, and only when one exists.
+	if !slices.ContainsFunc(allowedModels, func(m string) bool { return strings.Contains(m, "/") }) {
+		return false
+	}
 	providerCatalogModels := mc.GetModelsForProvider(provider)
 	for _, allowedModel := range allowedModels {
-		if allowedModel == model {
-			return true
+		if !strings.Contains(allowedModel, "/") {
+			continue
 		}
-		if strings.Contains(allowedModel, "/") {
-			if slices.Contains(providerCatalogModels, allowedModel) {
-				_, modelPart := schemas.ParseModelString(allowedModel, "")
-				if modelPart == model {
-					return true
-				}
+		if slices.Contains(providerCatalogModels, allowedModel) {
+			_, modelPart := schemas.ParseModelString(allowedModel, "")
+			if modelPart == model {
+				return true
 			}
 		}
 	}

--- a/framework/modelcatalog/models_allowed_test.go
+++ b/framework/modelcatalog/models_allowed_test.go
@@ -1,0 +1,50 @@
+package modelcatalog
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/modelcatalog/datasheet"
+	"github.com/maximhq/bifrost/framework/modelcatalog/keyconfig"
+	"github.com/maximhq/bifrost/framework/modelcatalog/live"
+)
+
+// TestIsModelAllowedForProvider_ExplicitList pins the explicit-allowlist branch
+// after the option-1 lazy-defer rewrite: bare-name and provider-prefixed
+// matching must behave exactly as before.
+func TestIsModelAllowedForProvider_ExplicitList(t *testing.T) {
+	mc := &ModelCatalog{
+		datasheet:    datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
+		live:         live.New(nil),
+		keyconf:      keyconfig.New(nil),
+		providerMemo: make(map[string]providerMemoEntry),
+		done:         make(chan struct{}),
+	}
+	// Give OpenAI a live catalog carrying a provider-prefixed entry, so the
+	// prefixed branch has something to match (ParseModelString only strips
+	// recognized provider prefixes, so this must be a real provider).
+	provider := schemas.OpenAI
+	mc.UpsertLive(provider, "k1", false, []string{"openai/gpt-4o", "gpt-4o"})
+
+	cases := []struct {
+		name    string
+		model   string
+		allowed schemas.WhiteList
+		want    bool
+	}{
+		{"bare direct match", "gpt-4o", schemas.WhiteList{"gpt-4o", "claude"}, true},
+		{"bare no match (deny)", "gpt-4o", schemas.WhiteList{"claude", "gemini"}, false},
+		{"empty allowlist denies", "gpt-4o", schemas.WhiteList{}, false},
+		{"prefixed match", "gpt-4o", schemas.WhiteList{"openai/gpt-4o"}, true},
+		{"prefixed present but wrong model", "gpt-4o-mini", schemas.WhiteList{"openai/gpt-4o"}, false},
+		{"match after a prefixed miss (ordering)", "gpt-4o", schemas.WhiteList{"openai/other", "openai/gpt-4o"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mc.IsModelAllowedForProvider(provider, tc.model, nil, tc.allowed)
+			if got != tc.want {
+				t.Errorf("IsModelAllowedForProvider(%q, %v) = %v, want %v", tc.model, tc.allowed, got, tc.want)
+			}
+		})
+	}
+}

--- a/framework/modelcatalog/models_memo_bench_test.go
+++ b/framework/modelcatalog/models_memo_bench_test.go
@@ -1,0 +1,214 @@
+package modelcatalog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/modelcatalog/datasheet"
+	"github.com/maximhq/bifrost/framework/modelcatalog/keyconfig"
+	"github.com/maximhq/bifrost/framework/modelcatalog/live"
+)
+
+// benchCatalog builds a catalog at roughly production scale: nProviders each
+// serving nModels, with versioned model ids so BaseModelName does real work.
+// Every provider gets an unrestricted ["*"] allowlist so IsModelAllowedForProvider
+// takes the GetProvidersForModel path (the hot path in governance/loadbalancer).
+func benchCatalog(tb testing.TB, nProviders, nModels int) (*ModelCatalog, []string) {
+	tb.Helper()
+
+	var sb strings.Builder
+	sb.WriteString("{\n")
+	var models []string
+	first := true
+	kcSnapshot := map[schemas.ModelProvider][]schemas.Key{}
+	for p := 0; p < nProviders; p++ {
+		provider := fmt.Sprintf("provider%02d", p)
+		for m := 0; m < nModels; m++ {
+			base := fmt.Sprintf("model-%02d-%03d", p, m)
+			// versioned id so BaseModelName -> SplitModelAndVersion does work
+			id := base + "-2024-08-06"
+			if !first {
+				sb.WriteString(",\n")
+			}
+			first = false
+			sb.WriteString(fmt.Sprintf(`  %q: {"provider":%q,"mode":"chat","base_model":%q}`, id, provider, base))
+			models = append(models, id)
+		}
+		kcSnapshot[schemas.ModelProvider(provider)] = []schemas.Key{
+			{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"*"}},
+		}
+	}
+	sb.WriteString("\n}\n")
+
+	path := filepath.Join(tb.TempDir(), "pricing.json")
+	if err := os.WriteFile(path, []byte(sb.String()), 0o600); err != nil {
+		tb.Fatalf("write pricing: %v", err)
+	}
+	ds := datasheet.New(nil, nil, datasheet.Config{URL: "file://" + path})
+	if err := ds.LoadFromURLIntoMemory(tb.Context()); err != nil {
+		tb.Fatalf("load pricing: %v", err)
+	}
+
+	kc := keyconfig.New(nil)
+	kc.Replace(kcSnapshot)
+	mc := &ModelCatalog{
+		datasheet:    ds,
+		live:         live.New(nil),
+		keyconf:      kc,
+		providerMemo: make(map[string]providerMemoEntry),
+		done:         make(chan struct{}),
+	}
+	return mc, models
+}
+
+// rotate returns model ids to query: a small hot set (what a real workload hits
+// repeatedly) rather than every distinct model once.
+func benchQueryModels(all []string, n int) []string {
+	if n > len(all) {
+		n = len(all)
+	}
+	out := make([]string, n)
+	// spread the picks across providers
+	step := len(all) / n
+	if step == 0 {
+		step = 1
+	}
+	for i := 0; i < n; i++ {
+		out[i] = all[(i*step)%len(all)]
+	}
+	return out
+}
+
+func BenchmarkProvidersForModel_Uncached(b *testing.B) {
+	mc, all := benchCatalog(b, 15, 50)
+	q := benchQueryModels(all, 8)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = mc.computeProvidersForModel(q[i%len(q)])
+	}
+}
+
+// scale sweep: uncached cost is ~O(providers × models), so it grows with the
+// datasheet. Brackets where a real catalog sits.
+func BenchmarkProvidersForModel_UncachedScale(b *testing.B) {
+	for _, sz := range []struct{ p, m int }{{15, 50}, {20, 100}, {30, 150}, {40, 250}} {
+		b.Run(fmt.Sprintf("%dx%d", sz.p, sz.m), func(b *testing.B) {
+			mc, all := benchCatalog(b, sz.p, sz.m)
+			q := benchQueryModels(all, 8)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = mc.computeProvidersForModel(q[i%len(q)])
+			}
+		})
+	}
+}
+
+func BenchmarkProvidersForModel_Cached(b *testing.B) {
+	mc, all := benchCatalog(b, 15, 50)
+	q := benchQueryModels(all, 8)
+	// warm the memo
+	for _, m := range q {
+		_ = mc.GetProvidersForModel(m)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = mc.GetProvidersForModel(q[i%len(q)])
+	}
+}
+
+// IsModelAllowedForProvider with ["*"] is the exact call governance and the
+// loadbalancer make per request; measure it uncached vs cached.
+func BenchmarkIsModelAllowed_Uncached(b *testing.B) {
+	mc, all := benchCatalog(b, 15, 50)
+	q := benchQueryModels(all, 8)
+	unrestricted := schemas.WhiteList{"*"}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		model := q[i%len(q)]
+		// bust the memo each iteration to simulate the pre-cache cost
+		mc.providerMemoMu.Lock()
+		clear(mc.providerMemo)
+		mc.providerMemoMu.Unlock()
+		_ = mc.IsModelAllowedForProvider(schemas.ModelProvider("provider00"), model, nil, unrestricted)
+	}
+}
+
+// GetModelsForProvider is the single-provider rebuild the explicit-list branch
+// pays per call (uncached today).
+func BenchmarkGetModelsForProvider(b *testing.B) {
+	mc, _ := benchCatalog(b, 15, 50)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = mc.GetModelsForProvider(schemas.ModelProvider("provider00"))
+	}
+}
+
+// Explicit-list IsModelAllowedForProvider: allowedModels holds a specific set,
+// not ["*"]. bare-name direct match: option 1 resolves this without touching the
+// catalog at all.
+func BenchmarkIsModelAllowed_ExplicitList(b *testing.B) {
+	mc, all := benchCatalog(b, 15, 50)
+	q := benchQueryModels(all, 8)
+	// realistic explicit allowlist for provider00: a handful of its own models,
+	// including the ones we query.
+	explicit := schemas.WhiteList(append([]string{}, q...))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = mc.IsModelAllowedForProvider(schemas.ModelProvider("provider00"), q[i%len(q)], nil, explicit)
+	}
+}
+
+// bare-name allowlist, model NOT present (deny). No "/" entries, so option 1
+// still never touches the catalog.
+func BenchmarkIsModelAllowed_ExplicitList_Deny(b *testing.B) {
+	mc, all := benchCatalog(b, 15, 50)
+	explicit := schemas.WhiteList{"nope-a", "nope-b", "nope-c"}
+	q := benchQueryModels(all, 8)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = mc.IsModelAllowedForProvider(schemas.ModelProvider("provider00"), q[i%len(q)], nil, explicit)
+	}
+}
+
+// provider-prefixed allowlist ("provider00/model..."). This is the one explicit
+// shape option 1 cannot make free: it must build the provider catalog once to
+// resolve the prefix. Shows the residual cost option 2 would target.
+func BenchmarkIsModelAllowed_ExplicitList_Prefixed(b *testing.B) {
+	mc, all := benchCatalog(b, 15, 50)
+	q := benchQueryModels(all, 8)
+	prefixed := make(schemas.WhiteList, len(q))
+	for i, m := range q {
+		prefixed[i] = "provider00/" + m
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = mc.IsModelAllowedForProvider(schemas.ModelProvider("provider00"), q[i%len(q)], nil, prefixed)
+	}
+}
+
+func BenchmarkIsModelAllowed_Cached(b *testing.B) {
+	mc, all := benchCatalog(b, 15, 50)
+	q := benchQueryModels(all, 8)
+	unrestricted := schemas.WhiteList{"*"}
+	for _, m := range q {
+		_ = mc.IsModelAllowedForProvider(schemas.ModelProvider("provider00"), m, nil, unrestricted)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		model := q[i%len(q)]
+		_ = mc.IsModelAllowedForProvider(schemas.ModelProvider("provider00"), model, nil, unrestricted)
+	}
+}

--- a/framework/modelcatalog/models_memo_test.go
+++ b/framework/modelcatalog/models_memo_test.go
@@ -1,0 +1,147 @@
+package modelcatalog
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/modelcatalog/datasheet"
+	"github.com/maximhq/bifrost/framework/modelcatalog/keyconfig"
+	"github.com/maximhq/bifrost/framework/modelcatalog/live"
+)
+
+// TestProviderMemoInvalidatesOnWrite pins the correctness of the generation
+// stamp: a store write must make GetProvidersForModel recompute, never serve a
+// cached membership from before the write.
+func TestProviderMemoInvalidatesOnWrite(t *testing.T) {
+	kc := keyconfig.New(nil)
+	kc.Replace(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}}},
+	})
+	mc := &ModelCatalog{
+		datasheet:    datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
+		live:         live.New(nil),
+		keyconf:      kc,
+		providerMemo: make(map[string]providerMemoEntry),
+		done:         make(chan struct{}),
+	}
+
+	// Prime the memo.
+	got := mc.GetProvidersForModel("gpt-4o")
+	if !slices.Contains(got, schemas.OpenAI) {
+		t.Fatalf("expected OpenAI before write, got %v", got)
+	}
+	if !slices.Contains(mc.GetProvidersForModel("gpt-4o"), schemas.OpenAI) {
+		t.Fatalf("cached read lost OpenAI")
+	}
+
+	// Add a second provider that serves the same model. This is a keyconfig
+	// write, which must invalidate the memo.
+	kc.SetProvider(schemas.Anthropic, []schemas.Key{
+		{ID: "k2", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}},
+	})
+
+	got = mc.GetProvidersForModel("gpt-4o")
+	if !slices.Contains(got, schemas.Anthropic) {
+		t.Fatalf("memo served stale membership after write: got %v, want Anthropic included", got)
+	}
+}
+
+// TestProviderMemoSkipsEmptyResults pins that unknown models are never cached:
+// model strings are client-controlled, so caching misses would let junk names
+// grow the memo.
+func TestProviderMemoSkipsEmptyResults(t *testing.T) {
+	kc := keyconfig.New(nil)
+	kc.Replace(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}}},
+	})
+	mc := &ModelCatalog{
+		datasheet:    datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
+		live:         live.New(nil),
+		keyconf:      kc,
+		providerMemo: make(map[string]providerMemoEntry),
+		done:         make(chan struct{}),
+	}
+
+	if got := mc.GetProvidersForModel("junk-model-xyz"); len(got) != 0 {
+		t.Fatalf("expected no providers for junk model, got %v", got)
+	}
+	mc.providerMemoMu.RLock()
+	_, cached := mc.providerMemo["junk-model-xyz"]
+	mc.providerMemoMu.RUnlock()
+	if cached {
+		t.Fatalf("empty result was cached")
+	}
+}
+
+// TestProviderMemoBounded pins the overflow flush: inserting a new key into a
+// full memo must not grow it past providerMemoMaxEntries.
+func TestProviderMemoBounded(t *testing.T) {
+	kc := keyconfig.New(nil)
+	kc.Replace(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}}},
+	})
+	mc := &ModelCatalog{
+		datasheet:    datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
+		live:         live.New(nil),
+		keyconf:      kc,
+		providerMemo: make(map[string]providerMemoEntry),
+		done:         make(chan struct{}),
+	}
+
+	// Fill to the cap with synthetic entries, then insert one real new model.
+	mc.providerMemoMu.Lock()
+	for i := 0; len(mc.providerMemo) < providerMemoMaxEntries; i++ {
+		mc.providerMemo[fmt.Sprintf("filler-%d", i)] = providerMemoEntry{}
+	}
+	mc.providerMemoMu.Unlock()
+
+	if got := mc.GetProvidersForModel("gpt-4o"); !slices.Contains(got, schemas.OpenAI) {
+		t.Fatalf("expected OpenAI, got %v", got)
+	}
+
+	mc.providerMemoMu.RLock()
+	size := len(mc.providerMemo)
+	_, cached := mc.providerMemo["gpt-4o"]
+	mc.providerMemoMu.RUnlock()
+	if size > providerMemoMaxEntries {
+		t.Fatalf("memo grew past cap: %d entries", size)
+	}
+	if !cached {
+		t.Fatalf("new model missing from memo after flush")
+	}
+}
+
+// TestProviderMemoReturnsClone pins that callers can mutate the returned slice
+// (the resolver sorts it in place) without corrupting the cached entry.
+func TestProviderMemoReturnsClone(t *testing.T) {
+	kc := keyconfig.New(nil)
+	kc.Replace(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI:    {{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}}},
+		schemas.Anthropic: {{ID: "k2", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}}},
+	})
+	mc := &ModelCatalog{
+		datasheet:    datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
+		live:         live.New(nil),
+		keyconf:      kc,
+		providerMemo: make(map[string]providerMemoEntry),
+		done:         make(chan struct{}),
+	}
+
+	first := mc.GetProvidersForModel("gpt-4o")
+	if len(first) < 2 {
+		t.Fatalf("expected >=2 providers, got %v", first)
+	}
+	// Corrupt the returned slice.
+	for i := range first {
+		first[i] = "MUTATED"
+	}
+
+	second := mc.GetProvidersForModel("gpt-4o")
+	for _, p := range second {
+		if p == "MUTATED" {
+			t.Fatalf("caller mutation leaked into cached entry: %v", second)
+		}
+	}
+}

--- a/framework/tracing/allocfix_bench_test.go
+++ b/framework/tracing/allocfix_bench_test.go
@@ -1,0 +1,143 @@
+package tracing
+
+// Deterministic before/after benchmark for fix C1: batching the per-request
+// LLM-call span attribute writes. The old path issued ~30 individual
+// tracer.SetAttribute calls, each re-resolving the span (GetTrace + linear
+// GetSpan scan over all spans in the trace) and taking the span lock. The new
+// path (SetAttributes) resolves the span once and writes under a single lock.
+//
+// Run:
+//
+//	go test ./framework/tracing/ -run '^$' -bench 'FixC1' -benchmem
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// benchC1Setup builds a trace with a realistic number of sibling spans (so the
+// per-call GetSpan linear scan is exercised) and returns the tracer plus a
+// handle to the last span (worst-case scan position).
+func benchC1Setup(nSpans int) (*Tracer, schemas.SpanHandle) {
+	store := NewTraceStore(5*time.Minute, nil)
+	tracer := NewTracer(store, nil, nil)
+	traceID := tracer.CreateTrace("")
+	ctx := context.WithValue(context.Background(), schemas.BifrostContextKeyTraceID, traceID)
+	ctx, target := tracer.StartSpan(ctx, "http-request", schemas.SpanKindHTTPRequest)
+	for i := 0; i < nSpans; i++ {
+		_, h := tracer.StartSpan(ctx, "span"+strconv.Itoa(i), schemas.SpanKindPlugin)
+		target = h
+	}
+	return tracer, target
+}
+
+// 30 attribute key/value pairs, matching the count set on the LLM-call span.
+var (
+	benchC1Keys = func() []string {
+		k := make([]string, 30)
+		for i := range k {
+			k[i] = "attr" + strconv.Itoa(i)
+		}
+		return k
+	}()
+	benchC1Values = func() []any {
+		v := make([]any, 30)
+		for i := range v {
+			v[i] = "value" + strconv.Itoa(i)
+		}
+		return v
+	}()
+)
+
+// Old path: one SetAttribute per attribute (re-resolves span + locks each time).
+func BenchmarkFixC1_PerAttribute(b *testing.B) {
+	tracer, h := benchC1Setup(15)
+	defer tracer.Stop()
+	b.ReportAllocs()
+	for b.Loop() {
+		for i, k := range benchC1Keys {
+			tracer.SetAttribute(h, k, benchC1Values[i])
+		}
+	}
+}
+
+// New path: resolve the span once (SpanFromHandle), then write directly. One
+// lookup instead of ~30, no extra allocation.
+func BenchmarkFixC1_ResolveOnce(b *testing.B) {
+	tracer, h := benchC1Setup(15)
+	defer tracer.Stop()
+	b.ReportAllocs()
+	for b.Loop() {
+		span := tracer.SpanFromHandle(h)
+		for i, k := range benchC1Keys {
+			span.SetAttribute(k, benchC1Values[i])
+		}
+	}
+}
+
+// Fix C7: StartSpanID avoids the per-span context.WithValue (valueCtx) node that
+// StartSpan allocates. The plugin-hook pipeline only needs the span ID (it
+// mirrors it into the BifrostContext), so the valueCtx was pure waste. Both
+// benchmarks create a span per iteration; the delta is the valueCtx allocation.
+func BenchmarkFixC7_StartSpan(b *testing.B) {
+	store := NewTraceStore(time.Hour, nil)
+	defer store.Stop()
+	tracer := NewTracer(store, nil, nil)
+	defer tracer.Stop()
+	traceID := tracer.CreateTrace("")
+	ctx := context.WithValue(context.Background(), schemas.BifrostContextKeyTraceID, traceID)
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = tracer.StartSpan(ctx, "s", schemas.SpanKindPlugin)
+	}
+}
+
+func BenchmarkFixC7_StartSpanID(b *testing.B) {
+	store := NewTraceStore(time.Hour, nil)
+	defer store.Stop()
+	tracer := NewTracer(store, nil, nil)
+	defer tracer.Stop()
+	traceID := tracer.CreateTrace("")
+	ctx := context.WithValue(context.Background(), schemas.BifrostContextKeyTraceID, traceID)
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = tracer.StartSpanID(ctx, "s", schemas.SpanKindPlugin)
+	}
+}
+
+// Fix C2: the Populate*Attributes output map already exists (it's reused for
+// root-span propagation), so the win is writing it into the span under ONE lock
+// instead of a range + SetAttribute loop (one lock per entry). Span resolved once.
+var benchC2Attrs = map[string]any{
+	"gen_ai.provider.name": "openai", "bifrost.provider.name": "openai",
+	"gen_ai.request.model": "gpt-4o", "gen_ai.operation.name": "chat",
+	"gen_ai.request.temperature": 0.7, "gen_ai.request.max_tokens": 512,
+	"gen_ai.request.top_p": 0.9, "gen_ai.input.messages": "hello",
+	"gen_ai.request.stream": false, "bifrost.request.tools_count": 1,
+}
+
+func BenchmarkFixC2_PerEntryLoop(b *testing.B) {
+	tracer, h := benchC1Setup(15)
+	defer tracer.Stop()
+	span := tracer.SpanFromHandle(h)
+	b.ReportAllocs()
+	for b.Loop() {
+		for k, v := range benchC2Attrs {
+			span.SetAttribute(k, v)
+		}
+	}
+}
+
+func BenchmarkFixC2_BulkSetAttributes(b *testing.B) {
+	tracer, h := benchC1Setup(15)
+	defer tracer.Stop()
+	span := tracer.SpanFromHandle(h)
+	b.ReportAllocs()
+	for b.Loop() {
+		span.SetAttributes(benchC2Attrs)
+	}
+}

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -206,9 +206,23 @@ type spanHandle struct {
 // 2. BifrostContextKeyParentSpanID - incoming parent from W3C traceparent (for root spans)
 // 3. No parent - creates a root span with no parent
 func (t *Tracer) StartSpan(ctx context.Context, name string, kind schemas.SpanKind) (context.Context, schemas.SpanHandle) {
+	spanID, handle := t.StartSpanID(ctx, name, kind)
+	if handle == nil {
+		return ctx, nil
+	}
+	// Update context with new span ID for child-span linking.
+	return context.WithValue(ctx, schemas.BifrostContextKeySpanID, spanID), handle
+}
+
+// StartSpanID creates a span exactly like StartSpan but returns the new span's ID
+// instead of wrapping ctx in a context.WithValue node. Callers that only need the
+// ID (e.g. to mirror it into a *BifrostContext via SetValue, as the plugin-hook
+// pipeline does) use this to avoid a valueCtx allocation per span. Returns
+// ("", nil) when there is no trace in ctx or span creation fails.
+func (t *Tracer) StartSpanID(ctx context.Context, name string, kind schemas.SpanKind) (string, schemas.SpanHandle) {
 	traceID := GetTraceID(ctx)
 	if traceID == "" {
-		return ctx, nil
+		return "", nil
 	}
 
 	// Get parent span ID from context - first check for existing span in this service
@@ -227,11 +241,9 @@ func (t *Tracer) StartSpan(ctx context.Context, name string, kind schemas.SpanKi
 		span = t.store.StartSpan(traceID, name, kind)
 	}
 	if span == nil {
-		return ctx, nil
+		return "", nil
 	}
-	// Update context with new span ID
-	newCtx := context.WithValue(ctx, schemas.BifrostContextKeySpanID, span.SpanID)
-	return newCtx, &spanHandle{traceID: traceID, spanID: span.SpanID}
+	return span.SpanID, &spanHandle{traceID: traceID, spanID: span.SpanID}
 }
 
 // EndSpan completes a span with the given status and message.
@@ -257,6 +269,21 @@ func (t *Tracer) SetAttribute(handle schemas.SpanHandle, key string, value any) 
 	if span != nil {
 		span.SetAttribute(key, value)
 	}
+}
+
+// SpanFromHandle resolves the *Span for a handle once. Callers writing many
+// attributes use it to avoid a trace+span lookup per attribute; span.SetAttribute
+// is nil-safe, so a nil return is fine to write against.
+func (t *Tracer) SpanFromHandle(handle schemas.SpanHandle) *schemas.Span {
+	h, ok := handle.(*spanHandle)
+	if !ok || h == nil {
+		return nil
+	}
+	trace := t.store.GetTrace(h.traceID)
+	if trace == nil {
+		return nil
+	}
+	return trace.GetSpan(h.spanID)
 }
 
 // GetSpanHandleByID retrieves a span handle for the given trace and span ID.
@@ -317,9 +344,7 @@ func (t *Tracer) PopulateLLMRequestAttributes(handle schemas.SpanHandle, req *sc
 	}
 
 	attrs := PopulateRequestAttributes(req)
-	for k, v := range attrs {
-		span.SetAttribute(k, v)
-	}
+	span.SetAttributes(attrs)
 
 	// Propagate input messages and request model to root span so observability backends (e.g. Langfuse)
 	// can display Input and model name at the top-level trace without requiring users to drill into llm.call.
@@ -378,9 +403,7 @@ func (t *Tracer) PopulateLLMResponseAttributes(ctx *schemas.BifrostContext, hand
 		}
 		span.SetAttribute(k, v)
 	}
-	for k, v := range PopulateErrorAttributes(err) {
-		span.SetAttribute(k, v)
-	}
+	span.SetAttributes(PopulateErrorAttributes(err))
 
 	// Enrichment dimensions derivable only post-response, attached here so every
 	// connector reads them from one place (see core/schemas EnrichmentDims):
@@ -814,6 +837,7 @@ func (t *Tracer) CompleteAndFlushTrace(traceID string) {
 		exportTrace.StampOverheadDuration()
 
 		var slots []*obsPluginSlot
+		dumpSpanTimings(exportTrace)
 		if loaded := t.obsPlugins.Load(); loaded != nil {
 			slots = *loaded
 		}

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -1166,26 +1166,6 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	if ok && fallbackRequestID != "" {
 		requestID = fallbackRequestID
 	}
-	selectedKeyID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedKeyID)
-	selectedKeyName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedKeyName)
-	virtualKeyID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceVirtualKeyID)
-	virtualKeyName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceVirtualKeyName)
-	routingRuleID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceRoutingRuleID)
-	routingRuleName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceRoutingRuleName)
-	selectedPromptName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedPromptName)
-	selectedPromptVersion := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedPromptVersion)
-	selectedPromptID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedPromptID)
-	teamID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceTeamID)
-	teamName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceTeamName)
-	customerID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceCustomerID)
-	customerName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceCustomerName)
-	userID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyUserID)
-	userName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyUserName)
-	businessUnitID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceBusinessUnitID)
-	businessUnitName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceBusinessUnitName)
-	numberOfRetries := bifrost.GetIntFromContext(ctx, schemas.BifrostContextKeyNumberOfRetries)
-	attemptTrail, _ := ctx.Value(schemas.BifrostContextKeyAttemptTrail).([]schemas.KeyAttemptRecord)
-
 	requestType, _, originalModelRequested, resolvedModelUsed := bifrost.GetResponseFields(result, bifrostErr)
 	resolvedKeyAlias := bifrost.GetResponseRoutingInfo(result, bifrostErr).ResolvedKeyAlias
 	shouldStoreRaw, _ := ctx.Value(schemas.BifrostContextKeyShouldStoreRawInLogs).(bool)
@@ -1291,6 +1271,30 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 		}
 		return result, bifrostErr, nil
 	}
+
+	// Governance/key/prompt fields, needed only by the final/error/non-streaming
+	// paths below (applyOutputFieldsToEntry). Read here, after the non-final-chunk
+	// fast path, so intermediate chunks skip these ~19 locked context lookups.
+	selectedKeyID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedKeyID)
+	selectedKeyName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedKeyName)
+	virtualKeyID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceVirtualKeyID)
+	virtualKeyName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceVirtualKeyName)
+	routingRuleID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceRoutingRuleID)
+	routingRuleName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceRoutingRuleName)
+	selectedPromptName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedPromptName)
+	selectedPromptVersion := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedPromptVersion)
+	selectedPromptID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedPromptID)
+	teamID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceTeamID)
+	teamName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceTeamName)
+	customerID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceCustomerID)
+	customerName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceCustomerName)
+	userID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyUserID)
+	userName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyUserName)
+	businessUnitID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceBusinessUnitID)
+	businessUnitName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceBusinessUnitName)
+	numberOfRetries := bifrost.GetIntFromContext(ctx, schemas.BifrostContextKeyNumberOfRetries)
+	attemptTrail, _ := ctx.Value(schemas.BifrostContextKeyAttemptTrail).([]schemas.KeyAttemptRecord)
+
 	// Extract routing engine logs from context before entering goroutine
 	routingEngineLogs := formatRoutingEngineLogs(ctx.GetRoutingEngineLogs())
 	if requestType == schemas.RealtimeRequest {


### PR DESCRIPTION
## Summary

This PR reduces per-request allocations and CPU overhead across the hot path for streaming requests. The fixes target four distinct sources of waste: timer heap allocations per request, span attribute map re-allocation on pool reuse, a linear slice scan on every restricted context write, and unnecessary identity/governance context lookups on every non-final stream chunk.

## Changes

- **Timer reuse**: The worker delivery timer was previously created with `time.After` (which allocates a `Timer` and channel) on every request. It is now armed once per worker and reset per request, eliminating the per-request heap allocation.
- **`Span.Reset` map reuse**: `Reset` previously nil-ed `s.Attributes`, forcing a fresh `make` on the next `SetAttribute` call for every pooled span. It now calls `clear(s.Attributes)` to retain map capacity across pool cycles, only dropping the map if it grew beyond 64 entries to avoid pinning memory from outlier requests.
- **`reservedKeys` changed from `[]any` to `map[any]struct{}`**: The per-write guard in `SetValue`, `ClearValue`, and `GetAndSetValue` previously used `slices.Contains`, which is a full linear scan on every call. It is now an O(1) map lookup via a new `isReservedKey` helper. Type-and-value matching semantics are preserved.
- **Logging plugin defers identity/governance reads past the non-final-chunk gate**: The ~19 locked context lookups feeding `applyOutputFieldsToEntry` were previously executed unconditionally at the top of `PostLLMHook`. They are now moved to after the non-final-chunk early-return, so intermediate stream chunks skip them entirely.
- **`userValues` map pre-sized**: `NewBifrostContext` now initializes `userValues` with a hint of 16 to reduce rehashing during the ~25 `SetValue` writes that occur per request.
- **Deterministic microbenchmarks added**: `core/schemas/allocfix_bench_test.go` provides before/after benchmarks for all four fixes using `-benchmem` allocs/op as the proof metric, since wall-clock p99 is too noisy for sub-microsecond per-request changes.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the included microbenchmarks to verify allocation reductions:

```sh
go test ./core/schemas/ -run '^$' -bench 'FixBatch' -benchmem
```

Expected outcomes:
- `BenchmarkFixBatch_Timer_Reused` reports 0 allocs/op vs 1+ allocs/op for `_PerRequest`
- `BenchmarkFixBatch_SpanReset_Reuse` reports 0 allocs/op vs 1+ allocs/op for `_Nil`
- `BenchmarkFixBatch_ReservedKey_MapLookup` shows lower ns/op than `_SliceScan`
- `BenchmarkFixC5_MapPresized` shows fewer allocs/op than `_MapSize0`

Run the full test suite to confirm no regressions:

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The `reservedKeys` guard change from `slices.Contains` to a map lookup preserves identical type-and-value matching semantics for `any` keys. No change to which keys are blocked or when the guard is active.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable