### PR TITLE
fix: add anthropic error branch on stripping on encrypted content

### DIFF
--- a/core/encryptedreasoning.go
+++ b/core/encryptedreasoning.go
@@ -40,8 +40,11 @@ func isEncryptedReasoningRejection(err *schemas.BifrostError) bool {
 		return true
 	}
 	message := strings.ToLower(err.Error.Message)
+	// Anthropic sends no code and names the offending block instead:
+	// "messages.1.content.0: Invalid `data` in `redacted_thinking` block".
 	return strings.Contains(message, encryptedContentErrorCode) ||
-		(strings.Contains(message, "encrypted content") && strings.Contains(message, "could not be verified"))
+		(strings.Contains(message, "encrypted content") && strings.Contains(message, "could not be verified")) ||
+		(strings.Contains(message, "invalid `data`") && strings.Contains(message, "`redacted_thinking` block"))
 }
 
 // stripResponsesEncryptedContent removes encrypted_content from every reasoning item

--- a/core/encryptedreasoning_test.go
+++ b/core/encryptedreasoning_test.go
@@ -436,6 +436,39 @@ func TestIsEncryptedReasoningRejection(t *testing.T) {
 			want: true,
 		},
 		{
+			// Anthropic's refusal of a foreign payload: no code, block named in the message.
+			name: "anthropic redacted_thinking rejection",
+			err: &schemas.BifrostError{
+				StatusCode: schemas.Ptr(400),
+				Error: &schemas.ErrorField{
+					Type:    schemas.Ptr("invalid_request_error"),
+					Message: "messages.1.content.0: Invalid `data` in `redacted_thinking` block",
+				},
+			},
+			want: true,
+		},
+		{
+			// Anthropic rejects a thinking signature too, but the strip only clears
+			// encrypted_content, so a retry would resend the same payload.
+			name: "anthropic thinking signature rejection stays unhandled",
+			err: &schemas.BifrostError{
+				StatusCode: schemas.Ptr(400),
+				Error: &schemas.ErrorField{
+					Type:    schemas.Ptr("invalid_request_error"),
+					Message: "messages.1.content.0: Invalid `signature` in `thinking` block",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "unrelated anthropic 400 naming thinking",
+			err: &schemas.BifrostError{
+				StatusCode: schemas.Ptr(400),
+				Error:      &schemas.ErrorField{Message: "Invalid value for `thinking.budget_tokens`: must be >= 1024"},
+			},
+			want: false,
+		},
+		{
 			name: "unrelated 400",
 			err: &schemas.BifrostError{
 				StatusCode: schemas.Ptr(400),

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -49654,6 +49654,144 @@
           }
         }
       ]
+    },
+    {
+      "name": "44. Encrypted Reasoning Fail-Soft (unverifiable payload degrades instead of 400)",
+      "description": "Bifrost's encrypted-reasoning fail-soft (core/encryptedreasoning.go) detects an upstream refusal of a replayed\nreasoning payload, strips encrypted_content from the reasoning items, and retries once on the same key, so the\nturn degrades to a normal answer instead of failing. This fires whenever a conversation changes model family or\ncredential mid-flight (a routing rule or a fallback is enough) and the client replays the earlier provider’s\nreasoning verbatim.\n\nThe detector originally recognised only OpenAI’s wording (invalid_encrypted_content / \"could not be verified\").\nAnthropic refuses with \"messages.N.content.0: Invalid `data` in `redacted_thinking` block\" — HTTP 400 and no error\ncode — which fell through and reached the client as a hard 400.\n\nFIXTURE CONSTRAINT — do not \"normalise\" these bodies: the reasoning item must carry NO \"content\" key at all.\nBifrost’s own Responses output emits \"content\": [], and an empty-but-present array sends\nconvertBifrostReasoningToAnthropicThinking down its content-blocks branch, which emits nothing and silently drops\nencrypted_content. The request then succeeds without the upstream ever validating the payload — a silent false pass.\n\nA synthetic unverifiable blob is used rather than a captured one: the upstream rejects any payload it cannot\nverify identically, and this keeps each case self-contained (no capture chaining, one request each).",
+      "item": [
+        {
+          "name": "anthropic/claude-haiku-4-5 /openai/v1/responses unverifiable encrypted reasoning degrades - failsoft",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('unverifiable encrypted reasoning degrades instead of 400ing', function () {",
+                  "  var body = pm.response.text() || '';",
+                  "  pm.expect(body, 'Anthropic rejection reached the client; the encrypted-reasoning fail-soft did not fire').to.not.include('redacted_thinking');",
+                  "  pm.expect(pm.response.code, 'request failed: ' + body).to.be.below(400);",
+                  "  pm.expect(pm.response.json().output, 'no output returned after the stripped retry').to.be.an('array').that.is.not.empty;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"anthropic/claude-haiku-4-5-20251001\",\"input\":[{\"type\":\"reasoning\",\"id\":\"rs_bfharness0000000000000000000000000000000000001\",\"summary\":[],\"encrypted_content\":\"gAAAAABqdgntZpz92rFHmQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0Iv\"},{\"type\":\"message\",\"id\":\"msg_bfharness01\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"391\"}]},{\"role\":\"user\",\"content\":\"Reply with just the number 782.\"}],\"reasoning\":{\"max_tokens\":1024},\"max_output_tokens\":256}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/openai/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "openai",
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "anthropic/claude-haiku-4-5 /openai/v1/responses streaming unverifiable encrypted reasoning degrades - failsoft",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('streaming turn degrades instead of erroring on unverifiable reasoning', function () {",
+                  "  var body = pm.response.text() || '';",
+                  "  pm.expect(body, 'Anthropic rejection surfaced in the stream; the fail-soft did not fire').to.not.include('redacted_thinking');",
+                  "  pm.expect(pm.response.code, 'stream request failed: ' + body).to.be.below(400);",
+                  "  pm.expect(body, 'stream never completed').to.include('response.completed');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"anthropic/claude-haiku-4-5-20251001\",\"input\":[{\"type\":\"reasoning\",\"id\":\"rs_bfharness0000000000000000000000000000000000001\",\"summary\":[],\"encrypted_content\":\"gAAAAABqdgntZpz92rFHmQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0Iv\"},{\"type\":\"message\",\"id\":\"msg_bfharness01\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"391\"}]},{\"role\":\"user\",\"content\":\"Reply with just the number 782.\"}],\"reasoning\":{\"max_tokens\":1024},\"max_output_tokens\":256,\"stream\":true}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/openai/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "openai",
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "openai/gpt-5-mini /openai/v1/responses unverifiable encrypted reasoning degrades - failsoft",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('OpenAI-side encrypted reasoning fail-soft still heals', function () {",
+                  "  var body = pm.response.text() || '';",
+                  "  pm.expect(body, 'OpenAI rejection reached the client; the original fail-soft clause regressed').to.not.include('invalid_encrypted_content');",
+                  "  pm.expect(pm.response.code, 'request failed: ' + body).to.be.below(400);",
+                  "  pm.expect(pm.response.json().output, 'no output returned after the stripped retry').to.be.an('array').that.is.not.empty;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"openai/gpt-5-mini\",\"input\":[{\"type\":\"reasoning\",\"id\":\"rs_bfharness0000000000000000000000000000000000001\",\"summary\":[],\"encrypted_content\":\"gAAAAABqdgntZpz92rFHmQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0Iv\"},{\"type\":\"message\",\"id\":\"msg_bfharness01\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"391\"}]},{\"role\":\"user\",\"content\":\"Reply with just the number 782.\"}],\"reasoning\":{\"effort\":\"low\"},\"max_output_tokens\":256}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/openai/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "openai",
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Anthropic returns a 400 error with no error code when it rejects a `redacted_thinking` block containing a foreign or invalid payload. The existing `isEncryptedReasoningRejection` detection did not match this error format, causing the retry logic to miss these rejections and fail to strip the offending encrypted content before retrying.

## Changes

- Extended `isEncryptedReasoningRejection` to also match Anthropic's `redacted_thinking`-specific rejection message: `"Invalid \`data\` in \`redacted_thinking\` block"`.
- Added a comment explaining why this additional check is needed (Anthropic omits an error code and names the offending block in the message text instead).
- Added three new test cases:
  - Confirms the `redacted_thinking` rejection is correctly detected.
  - Confirms that a `thinking` block signature rejection is intentionally **not** matched (since stripping encrypted content would not fix it and would cause an infinite retry loop).
  - Confirms that an unrelated Anthropic 400 mentioning `thinking` (e.g., invalid `budget_tokens`) is not incorrectly matched.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/...
```

The three new test cases in `TestIsEncryptedReasoningRejection` cover the added detection logic and the intentional non-matches.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No auth, secrets, or PII implications. The change only affects error message pattern matching used to decide whether to strip encrypted reasoning content before retrying a request.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable