### PR TITLE
fix: align budget override validity with calendar boundaries

### DIFF
--- a/ui/lib/utils/governance.test.ts
+++ b/ui/lib/utils/governance.test.ts
@@ -33,4 +33,19 @@ describe("budget overrides", () => {
 			getBudgetOverrideValidUntil({ max_limit: 100, last_reset: "2026-01-01T00:00:00.000Z", reset_duration: "1M" }, 2, true)?.toISOString(),
 		).toBe("2026-03-01T00:00:00.000Z");
 	});
+
+	it("anchors calendar-aligned validity to the current period boundary", () => {
+		expect(
+			getBudgetOverrideValidUntil({ max_limit: 100, last_reset: "2026-08-03T08:59:52.077Z", reset_duration: "1M" }, 1, true)?.toISOString(),
+		).toBe("2026-09-01T00:00:00.000Z");
+		expect(
+			getBudgetOverrideValidUntil({ max_limit: 100, last_reset: "2026-08-05T08:59:52.077Z", reset_duration: "1w" }, 1, true)?.toISOString(),
+		).toBe("2026-08-10T00:00:00.000Z");
+		expect(
+			getBudgetOverrideValidUntil({ max_limit: 100, last_reset: "2026-08-03T08:59:52.077Z", reset_duration: "1d" }, 1, true)?.toISOString(),
+		).toBe("2026-08-04T00:00:00.000Z");
+		expect(
+			getBudgetOverrideValidUntil({ max_limit: 100, last_reset: "2026-08-03T08:59:52.077Z", reset_duration: "1Y" }, 1, true)?.toISOString(),
+		).toBe("2027-01-01T00:00:00.000Z");
+	});
 });

--- a/ui/lib/utils/governance.ts
+++ b/ui/lib/utils/governance.ts
@@ -68,6 +68,30 @@ function addUTCMonthsClamped(date: Date, months: number): void {
 	date.setUTCDate(Math.min(day, lastDay));
 }
 
+/** Snaps a calendar-aligned reset timestamp to its UTC period boundary. */
+function snapToCalendarPeriodStart(date: Date, unit: string): void {
+	switch (unit) {
+		case "d":
+			date.setUTCHours(0, 0, 0, 0);
+			break;
+		case "w": {
+			date.setUTCHours(0, 0, 0, 0);
+			const daysFromMonday = (date.getUTCDay() + 6) % 7;
+			date.setUTCDate(date.getUTCDate() - daysFromMonday);
+			break;
+		}
+		case "M":
+			date.setUTCDate(1);
+			date.setUTCHours(0, 0, 0, 0);
+			break;
+		case "y":
+		case "Y":
+			date.setUTCMonth(0, 1);
+			date.setUTCHours(0, 0, 0, 0);
+			break;
+	}
+}
+
 /** Calculates when a cycle-based override will expire on the budget's current reset schedule. */
 export function getBudgetOverrideValidUntil(
 	budget: Pick<BudgetOverrideFields, "max_limit"> & { last_reset: string; reset_duration: string },
@@ -79,8 +103,10 @@ export function getBudgetOverrideValidUntil(
 	const validUntil = new Date(budget.last_reset);
 	if (!match || Number.isNaN(validUntil.getTime())) return null;
 
+	const unit = match[2];
+	if (calendarAligned) snapToCalendarPeriodStart(validUntil, unit);
 	const durationValue = Number(match[1]) * cycles;
-	switch (match[2]) {
+	switch (unit) {
 		case "s":
 			validUntil.setTime(validUntil.getTime() + durationValue * 1000);
 			break;


### PR DESCRIPTION
## Summary

Fix the budget override **Valid until** preview for calendar-aligned budgets.
The UI now calculates expiry from the current UTC calendar-period boundary
instead of directly from a preserved, mid-period `last_reset` timestamp.

For example, a monthly calendar-aligned budget with `last_reset = Aug 3` should
expire at the next monthly boundary on Sep 1, not Sep 3:

```text
Aug 1 00:00 UTC                 Aug 3                 Sep 1 00:00 UTC
       |--------------------------|--------------------------|
       calendar period start      last_reset                 valid until

Old UI: Aug 3 + 1 month  -> Sep 3 08:59 UTC
New UI: Aug 1 + 1 month  -> Sep 1 00:00 UTC
```

The backend override cycle was already correct; this only fixes the date
displayed by the UI.

## Changes

- Added a helper that snaps calendar-aligned reset timestamps to their current
  UTC period boundary:
  - Day: 00:00 UTC on the current day
  - Week: Monday at 00:00 UTC
  - Month: first day of the month at 00:00 UTC
  - Year: January 1 at 00:00 UTC
- Applied that boundary before adding override cycles in
  `getBudgetOverrideValidUntil`.
- Kept rolling and sub-day calculations unchanged.
- Added regression coverage for daily, weekly, monthly, and yearly
  calendar-aligned overrides.

The calculation now follows this flow:

```text
preserved last_reset
   Aug 3 08:59
        |
        v
snap to calendar period
   Aug 1 00:00
        |
        v
add one monthly cycle
   Sep 1 00:00
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Run the focused utility tests:

```sh
cd ui
npx vitest run lib/utils/governance.test.ts
```

Expected outcome:

```text
Test Files  1 passed
Tests       5 passed
```

Run the TypeScript typecheck:

```sh
cd ui
npm run typecheck
```

Expected outcome: the command completes without TypeScript errors.

The regression test verifies these representative cases:

```text
Monthly: Aug 3 08:59 + 1 cycle -> Sep 1 00:00 UTC
Weekly:  Wed Aug 5 + 1 cycle    -> Mon Aug 10 00:00 UTC
Daily:   Aug 3 08:59 + 1 cycle -> Aug 4 00:00 UTC
Yearly:  Aug 3 2026 + 1 cycle  -> Jan 1 2027 00:00 UTC
```

No new configuration or environment variables are introduced.

## Screenshots/Recordings

Not included. This changes the date calculation behind the existing **Valid
until** field without changing the UI layout.

Before:

```text
Valid until: Sep 3, 2026
```

After:

```text
Valid until: Sep 1, 2026
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

No linked issue.

## Security considerations

No security implications. This change only adjusts a client-side date preview
and does not affect authentication, authorization, secrets, PII, or backend
enforcement.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
