### PR TITLE
[fix]: Chat streaming - continuation deltas no longer materialize absent function name as null

### DIFF
--- a/core/providers/openai/toolcalldeltanull_test.go
+++ b/core/providers/openai/toolcalldeltanull_test.go
@@ -1,0 +1,58 @@
+package openai
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bytedance/sonic"
+)
+
+// Issue #5900: continuation deltas of a streamed tool call legally omit the
+// optional id/type/function.name members. Bifrost must not materialize them as
+// explicit JSON nulls when re-encoding: strict clients distinguish absent from
+// null, and the OpenAI schema marks these members optional, not nullable.
+func TestToolCallContinuationDeltaOmitsAbsentMetadata(t *testing.T) {
+	// First chunk carries full metadata; continuation carries only arguments,
+	// mirroring the issue's DeepSeek capture.
+	openerChunk := `data: {"id":"chatcmpl-repro","object":"chat.completion.chunk","created":1,"model":"repro-model",` +
+		`"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"bash","arguments":""}}]},"finish_reason":null}]}` + "\n\n"
+	continuationChunk := `data: {"id":"chatcmpl-repro","object":"chat.completion.chunk","created":1,"model":"repro-model",` +
+		`"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{"}}]},"finish_reason":null}]}` + "\n\n"
+	finishChunk := `data: {"id":"chatcmpl-repro","object":"chat.completion.chunk","created":1,"model":"repro-model",` +
+		`"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n"
+
+	server := completeSSEServer(t, openerChunk+continuationChunk+finishChunk+"data: [DONE]\n\n")
+	defer server.Close()
+
+	provider := newStreamTestProvider(server.URL)
+	stream, bifrostErr := provider.ChatCompletionStream(newStreamTestContext(), passthroughPostHook, nil, testKey(), basicChatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectChunks(t, stream)
+	var continuationJSON string
+	for _, chunk := range chunks {
+		if chunk.BifrostError != nil {
+			t.Fatalf("unexpected error chunk: %+v", chunk.BifrostError)
+		}
+		// Marshal exactly as the transport does before writing the SSE frame.
+		data, err := sonic.Marshal(chunk)
+		if err != nil {
+			t.Fatalf("marshal chunk: %v", err)
+		}
+		s := string(data)
+		if strings.Contains(s, `"arguments":"{"`) {
+			continuationJSON = s
+		}
+	}
+	if continuationJSON == "" {
+		t.Fatal("continuation delta chunk not found in stream output")
+	}
+
+	for _, forbidden := range []string{`"id":null`, `"type":null`, `"name":null`} {
+		if strings.Contains(continuationJSON, forbidden) {
+			t.Errorf("continuation delta materializes %s: %s", forbidden, continuationJSON)
+		}
+	}
+}

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -1487,8 +1487,8 @@ type ChatAssistantMessageToolCall struct {
 
 // ChatAssistantMessageToolCallFunction represents a call to a function.
 type ChatAssistantMessageToolCallFunction struct {
-	Name      *string `json:"name"`
-	Arguments string  `json:"arguments"` // stringified json as retured by OpenAI, might not be a valid JSON always
+	Name      *string `json:"name,omitempty"` // omitted on streaming continuation deltas; strict clients reject an explicit null (issue #5900)
+	Arguments string  `json:"arguments"`      // stringified json as retured by OpenAI, might not be a valid JSON always
 }
 
 // ChatAudioMessageAudio represents audio data in a message.


### PR DESCRIPTION
## Summary

Streamed tool-call continuation deltas legally omit the optional id/type/function.name members; only argument fragments repeat. ChatAssistantMessageToolCallFunction.Name lacked omitempty, so Bifrost re-encoded the absent name as an explicit "name": null on every continuation delta. The OpenAI streaming schema marks these members optional, not nullable, so strict typed clients reject the frames. Verified with an end-to-end repro (mock upstream emitting the issue's DeepSeek-shaped deltas through the real provider streaming path and the transport's exact marshal).

## Changes

- Added omitempty to ChatAssistantMessageToolCallFunction.Name
- Regression test drives the issue's exact chunk sequence through ChatCompletionStream and asserts the marshaled continuation frame contains none of "id":null / "type":null / "name":null. Note: id and type already carry omitempty on current dev and did not reproduce; the test pins all three regardless
## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)

## How to test

`cd core && go test ./providers/openai/ -run TestToolCallContinuationDeltaOmitsAbsentMetadata -v`

Fails on dev with "name":null in the continuation frame, passes with the fix. Full ./schemas/, ./providers/..., and framework/streaming green.



## Breaking changes

- [x] No


## Related issues

Closes #5900 

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable


