### PR TITLE
feat: add virtual key and user identity filters to OAuth2 grants sidebar

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -8634,6 +8634,23 @@ func (s *RDBConfigStore) ListOAuth2Sessions(ctx context.Context, params OAuth2Se
 	if len(params.Modes) > 0 {
 		base = base.Where("rt.bf_mode IN ?", params.Modes)
 	}
+	if len(params.VirtualKeyIDs) > 0 || len(params.UserIDs) > 0 {
+		// bf_sub has no dedicated identity column to scope by, so each set is
+		// paired with its own bf_mode = '...' guard and the two groups OR
+		// together — a row matches if it hits either scoped set. Parenthesized
+		// explicitly so this OR group ANDs cleanly with the filters above.
+		var clauses []string
+		var args []any
+		if len(params.VirtualKeyIDs) > 0 {
+			clauses = append(clauses, "(rt.bf_mode = 'vk' AND rt.bf_sub IN ?)")
+			args = append(args, params.VirtualKeyIDs)
+		}
+		if len(params.UserIDs) > 0 {
+			clauses = append(clauses, "(rt.bf_mode = 'user' AND rt.bf_sub IN ?)")
+			args = append(args, params.UserIDs)
+		}
+		base = base.Where(strings.Join(clauses, " OR "), args...)
+	}
 
 	var totalCount int64
 	if err := base.Session(&gorm.Session{}).Count(&totalCount).Error; err != nil {

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -185,8 +185,14 @@ type MCPSessionsFilterParams struct {
 type OAuth2SessionsQueryParams struct {
 	Search string
 	Modes  []string
-	Limit  int
-	Offset int
+	// VirtualKeyIDs/UserIDs exact-match bf_sub, scoped to rows of the
+	// matching bf_mode (there is no separate identity column to filter on —
+	// bf_sub is a single generic subject disambiguated only by bf_mode). Both
+	// may be set together: a row matches if it hits either scoped set.
+	VirtualKeyIDs []string
+	UserIDs       []string
+	Limit         int
+	Offset        int
 }
 
 // PricingOverrideFilters holds the filters for pricing overrides.

--- a/transports/bifrost-http/handlers/mcpoauth2sessions.go
+++ b/transports/bifrost-http/handlers/mcpoauth2sessions.go
@@ -50,10 +50,12 @@ type oauth2SessionsListResponse struct {
 // substring matched against the client name/id and the bound identity.
 // Limit/Offset paginate the filtered result.
 type oauth2SessionsListQuery struct {
-	Search string
-	Modes  []string
-	Limit  int
-	Offset int
+	Search        string
+	Modes         []string
+	VirtualKeyIDs []string
+	UserIDs       []string
+	Limit         int
+	Offset        int
 }
 
 // parseOAuth2SessionsListQuery extracts pagination + filter params from the
@@ -75,6 +77,8 @@ func parseOAuth2SessionsListQuery(ctx *fasthttp.RequestCtx) (oauth2SessionsListQ
 			return q, false
 		}
 	}
+	q.VirtualKeyIDs = parseCommaSeparated(string(args.Peek("virtual_key_id")))
+	q.UserIDs = parseCommaSeparated(string(args.Peek("user_id")))
 	if s := string(args.Peek("limit")); s != "" {
 		n, err := strconv.Atoi(s)
 		if err != nil {
@@ -120,10 +124,12 @@ func (h *OAuth2SessionsHandler) listSessions(ctx *fasthttp.RequestCtx) {
 		return
 	}
 	sessions, totalCount, err := h.store.ConfigStore.ListOAuth2Sessions(ctx, configstore.OAuth2SessionsQueryParams{
-		Search: q.Search,
-		Modes:  q.Modes,
-		Limit:  q.Limit,
-		Offset: q.Offset,
+		Search:        q.Search,
+		Modes:         q.Modes,
+		VirtualKeyIDs: q.VirtualKeyIDs,
+		UserIDs:       q.UserIDs,
+		Limit:         q.Limit,
+		Offset:        q.Offset,
 	})
 	if err != nil {
 		logger.Error("oauth2 sessions: failed to list sessions: %v", err)

--- a/ui/app/workspace/oauth-grants/page.tsx
+++ b/ui/app/workspace/oauth-grants/page.tsx
@@ -17,6 +17,8 @@ export default function OAuthGrantsPage() {
 		{
 			q: parseAsString.withDefault(""),
 			bf_mode: parseAsArrayOf(parseAsString).withDefault([]),
+			virtual_key_id: parseAsArrayOf(parseAsString).withDefault([]),
+			user_id: parseAsArrayOf(parseAsString).withDefault([]),
 			offset: parseAsInteger.withDefault(0),
 		},
 		{ history: "push" },
@@ -24,11 +26,19 @@ export default function OAuthGrantsPage() {
 
 	const debouncedSearch = useDebouncedValue(urlState.q, 300);
 
-	const filters: OAuthGrantFilters = useMemo(() => ({ mode: urlState.bf_mode }), [urlState.bf_mode]);
+	const filters: OAuthGrantFilters = useMemo(
+		() => ({ mode: urlState.bf_mode, virtual_key_id: urlState.virtual_key_id, user_id: urlState.user_id }),
+		[urlState.bf_mode, urlState.virtual_key_id, urlState.user_id],
+	);
 
 	const setFilters = useCallback(
 		(newFilters: OAuthGrantFilters) => {
-			void setUrlState({ bf_mode: newFilters.mode.length ? newFilters.mode : null, offset: 0 });
+			void setUrlState({
+				bf_mode: newFilters.mode.length ? newFilters.mode : null,
+				virtual_key_id: newFilters.virtual_key_id.length ? newFilters.virtual_key_id : null,
+				user_id: newFilters.user_id.length ? newFilters.user_id : null,
+				offset: 0,
+			});
 		},
 		[setUrlState],
 	);
@@ -36,6 +46,8 @@ export default function OAuthGrantsPage() {
 	const { data, isLoading, isFetching, isError, error } = useGetOAuth2GrantsQuery({
 		q: debouncedSearch || undefined,
 		bf_mode: filters.mode.length ? filters.mode : undefined,
+		virtual_key_id: filters.virtual_key_id.length ? filters.virtual_key_id : undefined,
+		user_id: filters.user_id.length ? filters.user_id : undefined,
 		limit: PAGE_SIZE,
 		offset: urlState.offset,
 	});
@@ -46,7 +58,7 @@ export default function OAuthGrantsPage() {
 
 	const page = data?.sessions ?? [];
 	const totalCount = data?.total_count ?? 0;
-	const hasActiveFilters = !!urlState.q || filters.mode.length > 0;
+	const hasActiveFilters = !!urlState.q || filters.mode.length > 0 || filters.virtual_key_id.length > 0 || filters.user_id.length > 0;
 
 	// Snap the offset back into range when the total shrinks past the current
 	// page (e.g. a revoke removes the last row on the last page). Without this

--- a/ui/app/workspace/oauth-grants/views/oauthGrantsFilterSidebar.tsx
+++ b/ui/app/workspace/oauth-grants/views/oauthGrantsFilterSidebar.tsx
@@ -7,12 +7,22 @@
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scrollArea";
+import { getUserSearchQuery } from "@/lib/registries/userPicker";
+import { useGetVirtualKeysQuery } from "@/lib/store";
 import { cn } from "@/lib/utils";
-import { ChevronDown, Fingerprint, KeyRound, PanelLeftClose, PanelLeftOpen, RotateCcw, UserRound } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { ChevronDown, Fingerprint, KeyRound, LoaderCircle, PanelLeftClose, PanelLeftOpen, RotateCcw, Search, UserRound } from "lucide-react";
+import { type Ref, useCallback, useEffect, useMemo, useRef, useState } from "react";
+// Side-effect import: registers the enterprise user search hook (if this is
+// an enterprise build) before this module's first render. OSS has no user
+// directory, so nothing registers and getUserSearchQuery() stays undefined —
+// the Users filter section renders nothing. See ui/lib/registries/userPicker.tsx.
+import "@enterprise/lib/registrations/userPicker";
 
 const COLLAPSE_STORAGE_KEY = "oauth-grants-filter-sidebar-collapsed";
+const VK_PAGE_SIZE = 25;
+const USER_PAGE_SIZE = 25;
 
 // ---------------------------------------------------------------------------
 // Filter types
@@ -20,10 +30,14 @@ const COLLAPSE_STORAGE_KEY = "oauth-grants-filter-sidebar-collapsed";
 
 export interface OAuthGrantFilters {
 	mode: string[]; // subset of ["user", "vk", "session"] → bf_mode
+	virtual_key_id: string[]; // explicit VK IDs (vk-mode rows only)
+	user_id: string[]; // explicit user IDs (user-mode rows only; enterprise only, see UsersFilterSection)
 }
 
 export const EMPTY_FILTERS: OAuthGrantFilters = {
 	mode: [],
+	virtual_key_id: [],
+	user_id: [],
 };
 
 interface FilterOption {
@@ -68,11 +82,40 @@ export function OAuthGrantsFilterSidebar({ filters, onFiltersChange }: SidebarPr
 		});
 	}, []);
 
-	const activeFilterCount = useMemo(() => filters.mode.length, [filters]);
+	const activeFilterCount = useMemo(
+		() => filters.mode.length + filters.virtual_key_id.length + filters.user_id.length,
+		[filters],
+	);
 
 	const handleReset = useCallback(() => {
 		onFiltersChange(EMPTY_FILTERS);
 	}, [onFiltersChange]);
+
+	// Mirrors mcpSessionsFilterSidebar's auth-mode guard: when Identity pins
+	// the row set to exactly one mode, the other mode's picker can't match
+	// anything, so hide it outright rather than leave a checkbox list that
+	// would only ever come back empty. Selecting "Session" hides both, since
+	// session-bound rows have no VK or user to pick. Neither/both selected
+	// leaves both pickers visible.
+	const modeOnly = filters.mode.length === 1 ? filters.mode[0] : null;
+	const showVirtualKeyFilter = modeOnly !== "user" && modeOnly !== "session";
+	const showUsersFilter = modeOnly !== "vk" && modeOnly !== "session";
+
+	// A hidden picker's stale selection would otherwise keep silently
+	// filtering (a VK pick surviving a switch to "User" identity, say) with
+	// no visible control left to clear it — so drop it the moment its section
+	// disappears.
+	useEffect(() => {
+		if (!showVirtualKeyFilter && filters.virtual_key_id.length > 0) {
+			onFiltersChange({ ...filters, virtual_key_id: [] });
+		}
+	}, [showVirtualKeyFilter, filters, onFiltersChange]);
+
+	useEffect(() => {
+		if (!showUsersFilter && filters.user_id.length > 0) {
+			onFiltersChange({ ...filters, user_id: [] });
+		}
+	}, [showUsersFilter, filters, onFiltersChange]);
 
 	if (collapsed) {
 		return (
@@ -136,6 +179,8 @@ export function OAuthGrantsFilterSidebar({ filters, onFiltersChange }: SidebarPr
 						onChange={(mode) => onFiltersChange({ ...filters, mode })}
 						testIdPrefix="oauth-grants-filter-mode"
 					/>
+					{showVirtualKeyFilter && <VirtualKeyFilterSection filters={filters} onFiltersChange={onFiltersChange} />}
+					{showUsersFilter && <UsersFilterSection filters={filters} onFiltersChange={onFiltersChange} />}
 				</div>
 			</ScrollArea>
 		</div>
@@ -150,11 +195,13 @@ function FilterSection({
 	title,
 	children,
 	defaultOpen = false,
+	onOpenChange,
 	testId,
 }: {
 	title: string;
 	children: React.ReactNode;
 	defaultOpen?: boolean;
+	onOpenChange?: (open: boolean) => void;
 	testId?: string;
 }) {
 	const [open, setOpen] = useState(defaultOpen);
@@ -163,8 +210,13 @@ function FilterSection({
 		if (defaultOpen) setOpen(true);
 	}, [defaultOpen]);
 
+	const handleOpenChange = (next: boolean) => {
+		setOpen(next);
+		onOpenChange?.(next);
+	};
+
 	return (
-		<Collapsible open={open} onOpenChange={setOpen} className="last:pb-2">
+		<Collapsible open={open} onOpenChange={handleOpenChange} className="last:pb-2">
 			<CollapsibleTrigger
 				className="flex h-8 w-full cursor-pointer items-center gap-1.5 px-2 py-2 text-sm font-medium hover:opacity-80"
 				data-testid={testId}
@@ -238,6 +290,177 @@ function CheckboxFilterSection({
 					testId={testIdPrefix ? `${testIdPrefix}-checkbox-${option.value}` : undefined}
 				/>
 			))}
+		</FilterSection>
+	);
+}
+
+function useAutoFocusOnOpen(isOpen: boolean) {
+	const ref = useRef<HTMLInputElement>(null);
+	// Skip the initial mount so focus isn't stolen when the section starts open
+	// from URL state; only focus on an explicit open action by the user.
+	const mounted = useRef(false);
+	useEffect(() => {
+		if (!mounted.current) {
+			mounted.current = true;
+			return;
+		}
+		if (isOpen) ref.current?.focus({ preventScroll: true });
+	}, [isOpen]);
+	return ref;
+}
+
+// SearchableCheckboxList – checkbox rows with a search input. Client-side label
+// filtering is applied on top of the (debounced) onSearch callback so the caller
+// can fetch server-side results. Mirrors the MCP sessions filter sidebar pattern.
+function SearchableCheckboxList({
+	items,
+	isSelected,
+	onToggle,
+	placeholder = "Search...",
+	inputRef,
+	testIdPrefix,
+	onSearch,
+	fetching,
+}: {
+	items: { key: string; label: string }[];
+	isSelected: (key: string) => boolean;
+	onToggle: (key: string) => void;
+	placeholder?: string;
+	inputRef?: Ref<HTMLInputElement>;
+	testIdPrefix?: string;
+	onSearch?: (query: string) => void;
+	fetching?: boolean;
+}) {
+	const [query, setQuery] = useState("");
+	const normalized = query.trim().toLowerCase();
+	const filtered = normalized ? items.filter((item) => item.label.toLowerCase().includes(normalized)) : items;
+
+	useEffect(() => {
+		if (!onSearch) return;
+		const timer = setTimeout(() => onSearch(query.trim()), 300);
+		return () => clearTimeout(timer);
+	}, [query, onSearch]);
+
+	return (
+		<>
+			<div className="relative border-b">
+				{fetching ? (
+					<LoaderCircle className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 animate-spin" />
+				) : (
+					<Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
+				)}
+				<Input
+					ref={inputRef}
+					value={query}
+					onChange={(e) => setQuery(e.target.value)}
+					placeholder={placeholder}
+					className="h-8 border-0 pl-8 text-xs"
+					data-testid={testIdPrefix ? `${testIdPrefix}-search` : undefined}
+				/>
+			</div>
+			{filtered.map((item) => (
+				<CheckboxFilterItem
+					key={item.key}
+					label={item.label}
+					checked={isSelected(item.key)}
+					onCheckedChange={() => onToggle(item.key)}
+					testId={testIdPrefix ? `${testIdPrefix}-checkbox-${item.key}` : undefined}
+				/>
+			))}
+			{filtered.length === 0 && <div className="text-muted-foreground flex h-9 items-center px-3 text-xs">No results</div>}
+		</>
+	);
+}
+
+// VirtualKeyFilterSection – restricts grants to a set of VKs, resolved via
+// the same server-side search+limit VK picker the MCP filter sidebars use
+// (governance/virtual-keys), rather than loading the full VK list — VK counts
+// can be huge, so this only ever fetches a page at a time, scoped by the
+// in-flight search text. The list only fetches once the section is opened or
+// already has a selection, since most visits won't touch this filter.
+function VirtualKeyFilterSection({ filters, onFiltersChange }: SidebarProps) {
+	const hasActive = filters.virtual_key_id.length > 0;
+	const [opened, setOpened] = useState(hasActive);
+	const [searchQuery, setSearchQuery] = useState("");
+	const searchInputRef = useAutoFocusOnOpen(opened);
+
+	const { data, isFetching } = useGetVirtualKeysQuery(
+		{ limit: VK_PAGE_SIZE, offset: 0, search: searchQuery || undefined },
+		{ skip: !opened && !hasActive },
+	);
+	const virtualKeys = data?.virtual_keys || [];
+
+	const toggle = (vkId: string) => {
+		const current = filters.virtual_key_id;
+		const next = current.includes(vkId) ? current.filter((v) => v !== vkId) : [...current, vkId];
+		onFiltersChange({ ...filters, virtual_key_id: next });
+	};
+
+	return (
+		<FilterSection title="Virtual Key" defaultOpen={hasActive} onOpenChange={setOpened} testId="oauth-grants-filter-vk-toggle">
+			<SearchableCheckboxList
+				inputRef={searchInputRef}
+				placeholder="Search virtual keys"
+				items={virtualKeys.map((vk) => ({ key: vk.id, label: vk.name || vk.id }))}
+				isSelected={(key) => filters.virtual_key_id.includes(key)}
+				onToggle={toggle}
+				onSearch={setSearchQuery}
+				fetching={isFetching}
+				testIdPrefix="oauth-grants-filter-vk"
+			/>
+		</FilterSection>
+	);
+}
+
+// Stand-in for useUserSearchQuery when no OSS hook is registered — keeps the
+// hooks-must-run-unconditionally rule satisfied below without a real fetch.
+function useNoopUserSearchQuery() {
+	return { data: undefined, isFetching: false };
+}
+
+// UsersFilterSection – restricts grants to a set of users, mirroring
+// VirtualKeyFilterSection's inline search+checkbox UI exactly (same
+// server-side search+limit shape, same lazy-fetch-on-open behavior for huge
+// user counts). Renders nothing in OSS: there's no user directory to search
+// against, so unlike the VK section this can't fall back to anything — an
+// unresolvable search box would be worse than no filter at all. Enterprise
+// builds register a search hook via getUserSearchQuery() (see
+// ui/lib/registries/userPicker.tsx), wrapping the same users API the MCP
+// sessions Users filter and the single-select UserPicker already use.
+function UsersFilterSection({ filters, onFiltersChange }: SidebarProps) {
+	const useUserSearchQuery = getUserSearchQuery();
+	const hasActive = filters.user_id.length > 0;
+	const [opened, setOpened] = useState(hasActive);
+	const [searchQuery, setSearchQuery] = useState("");
+	const searchInputRef = useAutoFocusOnOpen(opened);
+
+	// Hooks must run unconditionally, so the registry lookup above can't gate
+	// this call — pass a no-op fallback and gate the render below instead.
+	const { data, isFetching } = (useUserSearchQuery ?? useNoopUserSearchQuery)(
+		{ limit: USER_PAGE_SIZE, search: searchQuery || undefined },
+		{ skip: !opened && !hasActive },
+	);
+	if (!useUserSearchQuery) return null;
+	const users = data?.users || [];
+
+	const toggle = (userId: string) => {
+		const current = filters.user_id;
+		const next = current.includes(userId) ? current.filter((v) => v !== userId) : [...current, userId];
+		onFiltersChange({ ...filters, user_id: next });
+	};
+
+	return (
+		<FilterSection title="Users" defaultOpen={hasActive} onOpenChange={setOpened} testId="oauth-grants-filter-users-toggle">
+			<SearchableCheckboxList
+				inputRef={searchInputRef}
+				placeholder="Search by name or email"
+				items={users.map((user) => ({ key: user.id, label: user.label }))}
+				isSelected={(key) => filters.user_id.includes(key)}
+				onToggle={toggle}
+				onSearch={setSearchQuery}
+				fetching={isFetching}
+				testIdPrefix="oauth-grants-filter-user"
+			/>
 		</FilterSection>
 	);
 }

--- a/ui/lib/store/apis/oauth2SessionsApi.ts
+++ b/ui/lib/store/apis/oauth2SessionsApi.ts
@@ -23,19 +23,27 @@ export interface OAuth2GrantsListResponse {
 export interface OAuth2GrantsQueryParams {
 	q?: string;
 	bf_mode?: string[];
+	// Exact-match on bf_sub, scoped server-side to vk-mode / user-mode rows
+	// respectively (bf_sub is a single generic subject column with no
+	// dedicated identity column to filter on). user_id is enterprise only —
+	// see the Users sidebar section.
+	virtual_key_id?: string[];
+	user_id?: string[];
 	limit?: number;
 	offset?: number;
 }
 
 // buildOAuth2GrantsListParams shapes the filter+page params for the URL.
-// bf_mode is csv-joined (matches the backend's parseCommaSeparated) and sorted
-// so selection order doesn't fragment the RTK Query cache key. Empty values
-// are dropped so the key doesn't fragment on "" vs unset.
+// Array filters are csv-joined (matches the backend's parseCommaSeparated)
+// and sorted so selection order doesn't fragment the RTK Query cache key.
+// Empty values are dropped so the key doesn't fragment on "" vs unset.
 function buildOAuth2GrantsListParams(params?: OAuth2GrantsQueryParams) {
 	if (!params) return {};
 	const out: Record<string, string | number> = {};
 	if (params.q) out.q = params.q;
 	if (params.bf_mode?.length) out.bf_mode = [...params.bf_mode].sort().join(",");
+	if (params.virtual_key_id?.length) out.virtual_key_id = [...params.virtual_key_id].sort().join(",");
+	if (params.user_id?.length) out.user_id = [...params.user_id].sort().join(",");
 	if (params.limit !== undefined) out.limit = params.limit;
 	if (params.offset !== undefined) out.offset = params.offset;
 	return out;


### PR DESCRIPTION
## Summary

Adds Virtual Key and User identity filters to the OAuth Grants filter sidebar, allowing administrators to scope the grants list to rows belonging to specific virtual keys or users. Because `bf_sub` is a single generic subject column disambiguated only by `bf_mode`, each identity filter is paired with its corresponding mode guard (`bf_mode = 'vk'` or `bf_mode = 'user'`) and the two groups are OR'd together server-side.

## Changes

- Added `VirtualKeyIDs` and `UserIDs` fields to `OAuth2SessionsQueryParams` and the corresponding SQL filter in `ListOAuth2Sessions`, pairing each ID set with a `bf_mode` guard so `bf_sub` lookups are correctly scoped.
- Extended the HTTP handler and query parser to accept `virtual_key_id` and `user_id` as comma-separated query parameters, forwarding them to the store layer.
- Added `VirtualKeyFilterSection` and `UsersFilterSection` components to the OAuth Grants filter sidebar, each using a searchable checkbox list with lazy server-side fetching (only fetches once the section is opened or already has a selection).
- The Users filter section renders nothing in OSS builds — it depends on an enterprise-registered user search hook via `getUserSearchQuery()`. If no hook is registered, the section is omitted entirely rather than showing an unresolvable search box.
- When the Identity mode filter pins to a single mode (e.g. "User"), the opposing picker (e.g. Virtual Key) is hidden and its stale selection is cleared automatically to prevent invisible filtering.
- URL state is extended with `virtual_key_id` and `user_id` array params, included in `hasActiveFilters` detection and reset logic.
- The RTK Query API layer sorts and CSV-joins `virtual_key_id` and `user_id` arrays to keep the cache key stable regardless of selection order.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm build
```

1. Open the OAuth Grants page and expand the filter sidebar.
2. Expand the **Virtual Key** section and search for a key by name — confirm the grants list filters to rows bound to that VK.
3. Select the **User** identity mode — confirm the Virtual Key picker disappears and any prior VK selection is cleared.
4. In an enterprise build, expand the **Users** section and search by name or email — confirm the grants list filters to rows bound to that user.
5. In an OSS build, confirm the **Users** section does not appear.
6. Confirm that selecting both a VK and a user (with no mode filter) returns rows matching either identity.
7. Confirm URL state reflects `virtual_key_id` and `user_id` params and that the reset button clears them.

## Screenshots/Recordings

_Add before/after screenshots of the filter sidebar showing the new Virtual Key and Users sections._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Filters are applied server-side with parameterized `IN` clauses — no raw user input is interpolated into SQL. The `user_id` filter is enterprise-only and gated behind the registered user search hook, so OSS deployments have no exposure to user directory data through this surface.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable