### PR TITLE
feat: add tools-change callback funnel with content-hash gating and targeted DB persist for all MCP discovery paths

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4016,6 +4016,18 @@ func (bifrost *Bifrost) SetMCPStateChangeCallback(cb func(clientID, name string,
 	bifrost.MCPManager.SetStateChangeCallback(cb)
 }
 
+// SetMCPToolsChangeCallback registers cb to be invoked whenever an MCP
+// client's tool map is freshly (re)discovered — connect/reconnect, per-call
+// discovery, and the periodic checker's own refresh. core/mcp has no DB
+// access; this is the seam the transport layer persists through. Pass nil to
+// clear a previously registered callback. A no-op if MCP is not configured.
+func (bifrost *Bifrost) SetMCPToolsChangeCallback(cb func(clientID, name string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string)) {
+	if bifrost.MCPManager == nil {
+		return
+	}
+	bifrost.MCPManager.SetToolsChangeCallback(cb)
+}
+
 // GetMCPClients returns all MCP clients managed by the Bifrost instance.
 //
 // Returns:

--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -629,6 +629,13 @@ func (m *MCPManager) AddClient(requestCtx context.Context, config *schemas.MCPCl
 				}
 				client.ToolNameMapping = config.DiscoveredToolNameMapping
 				client.State = schemas.MCPConnectionStateHealthy
+				// Seed the change-detection hash from what was just
+				// restored (without firing the callback — restoring
+				// already-known tools is not a change) so a subsequent
+				// rediscovery of the exact same tools correctly no-ops
+				// instead of looking like a change on the first post-boot
+				// tick.
+				client.LastToolsHash = computeToolsHash(config.DiscoveredTools, config.DiscoveredToolNameMapping)
 				m.logger.Debug("%s Per-user (%s) MCP client '%s' restored with %d tools", MCPLogPrefix, config.AuthType, config.Name, len(config.DiscoveredTools))
 			} else {
 				// No dedicated "pending tools" state: Healthy + an empty
@@ -1045,13 +1052,21 @@ func (m *MCPManager) performAdminToolDiscovery(ctx context.Context, config *sche
 //   - toolNameMapping: mapping from sanitized tool names to original MCP names
 func (m *MCPManager) SetClientTools(clientID string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
+	client, exists := m.clientMap[clientID]
+	if !exists {
+		m.mu.Unlock()
+		return
+	}
+	maps.Copy(client.ToolMap, tools)
+	client.ToolNameMapping = toolNameMapping
+	client.State = schemas.MCPConnectionStateHealthy
+	m.logger.Debug("%s Set %d tools on client '%s'", MCPLogPrefix, len(tools), client.Name)
+	fire := m.toolsChangedCallback(client, clientID, tools, toolNameMapping)
+	m.mu.Unlock()
 
-	if client, exists := m.clientMap[clientID]; exists {
-		maps.Copy(client.ToolMap, tools)
-		client.ToolNameMapping = toolNameMapping
-		client.State = schemas.MCPConnectionStateHealthy
-		m.logger.Debug("%s Set %d tools on client '%s'", MCPLogPrefix, len(tools), client.Name)
+	// Fired outside the lock — see toolsChangeCallback's field doc.
+	if fire != nil {
+		fire()
 	}
 }
 
@@ -2211,7 +2226,18 @@ func (m *MCPManager) connectToMCPClient(requestCtx context.Context, config *sche
 
 	// Release lock BEFORE starting monitors to prevent deadlock
 	// (StartMonitoring -> Start() tries to acquire RLock on the same mutex)
+	fire := m.toolsChangedCallback(client, config.ID, tools, toolNameMapping)
 	m.mu.Unlock()
+
+	// Fired outside the lock — see toolsChangeCallback's field doc. Covers
+	// both the initial dial and every reconnect (make-before-break swap):
+	// sticky clients have the same "freshly discovered tools never reach the
+	// DB" gap per-call clients do. Gated on genuine content change — a
+	// reconnect after a network blip almost always rediscovers the exact
+	// same tools.
+	if fire != nil {
+		fire()
+	}
 
 	// Register OnConnectionLost hook for SSE connections to detect idle timeouts
 	if config.ConnectionType == schemas.MCPConnectionTypeSSE && externalClient != nil {

--- a/core/mcp/connectionchecker.go
+++ b/core/mcp/connectionchecker.go
@@ -319,18 +319,32 @@ func (c *ClientConnectionChecker) markAsCheck(ctx context.Context) *schemas.Bifr
 // — the next tick syncs against whatever is current.
 func (c *ClientConnectionChecker) writeBackTools(connGeneration uint64, newTools map[string]schemas.ChatTool, newMapping map[string]string) {
 	c.manager.mu.Lock()
-	defer c.manager.mu.Unlock()
 
 	clientState, exists := c.manager.clientMap[c.clientID]
 	if !exists {
+		c.manager.mu.Unlock()
 		return
 	}
 	if clientState.ConnGeneration != connGeneration {
+		c.manager.mu.Unlock()
 		c.logger.Debug("%s Skipping tool write-back for %s: connection was replaced during check", MCPLogPrefix, c.clientID)
 		return
 	}
 	clientState.ToolMap = newTools
 	clientState.ToolNameMapping = newMapping
+	fire := c.manager.toolsChangedCallback(clientState, c.clientID, newTools, newMapping)
+	c.manager.mu.Unlock()
+
+	// Fired outside the lock — see toolsChangeCallback's field doc. Covers
+	// the periodic checker's own refresh for both sticky (checkLiveConnection)
+	// and per-call (checkPerCall) clients — previously the one path where a
+	// client's tools could drift out of sync with the DB indefinitely, since
+	// nothing else revisits a per-call client after its first discovery.
+	// Gated on genuine content change: this is the highest-frequency firing
+	// point (every checker tick), and most ticks rediscover identical tools.
+	if fire != nil {
+		fire()
+	}
 }
 
 // recordFailure marks the client Unstable — a single transient-classified

--- a/core/mcp/interface.go
+++ b/core/mcp/interface.go
@@ -66,6 +66,13 @@ type MCPManagerInterface interface {
 	// NeedsReauth. Pass nil to clear a previously registered callback.
 	SetStateChangeCallback(cb func(clientID, name string, oldState, newState schemas.MCPConnectionState))
 
+	// SetToolsChangeCallback registers cb to be invoked whenever a client's
+	// tool map is freshly (re)discovered — connect/reconnect, per-call
+	// discovery, and the periodic checker's own refresh. core/mcp has no DB
+	// access; this is the seam the transport layer persists through. Pass
+	// nil to clear a previously registered callback.
+	SetToolsChangeCallback(cb func(clientID, name string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string))
+
 	// AddClient adds a new MCP client with the given configuration
 	AddClient(ctx context.Context, config *schemas.MCPClientConfig) error
 

--- a/core/mcp/mcp.go
+++ b/core/mcp/mcp.go
@@ -79,6 +79,23 @@ type MCPManager struct {
 	// that only reacts to a specific newState value in an idempotent way
 	// (the only kind of consumer this exists for today) is unaffected.
 	stateChangeCallback func(clientID, name string, oldState, newState schemas.MCPConnectionState)
+
+	// toolsChangeCallback, if set, is invoked whenever a client's tool
+	// map/name mapping is freshly (re)discovered — connectToMCPClient's
+	// initial dial or reconnect, SetClientTools (per-call clients' own
+	// discovery, called both internally and by admin-verify HTTP handlers),
+	// and the periodic connection checker's writeBackTools (both the sticky
+	// and per-call variants). Deliberately NOT fired when AddClient restores
+	// an already-known tool set from a config that was just read back out of
+	// the DB (clientmanager.go's per-call restore branch) — nothing changed
+	// in that case, so there is nothing new to persist.
+	//
+	// core/mcp has no DB access of its own; this is the seam a caller (the
+	// transport layer) uses to persist the fresh result, mirroring
+	// stateChangeCallback's own role for state transitions. Fired outside
+	// m.mu for the same reason: a registered callback may do arbitrary work,
+	// including I/O.
+	toolsChangeCallback func(clientID, name string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string)
 }
 
 // SetStateChangeCallback registers cb to be invoked on every reactive
@@ -90,6 +107,41 @@ func (m *MCPManager) SetStateChangeCallback(cb func(clientID, name string, oldSt
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.stateChangeCallback = cb
+}
+
+// SetToolsChangeCallback registers cb to be invoked whenever a client's tool
+// map is freshly (re)discovered — see the toolsChangeCallback field doc for
+// exactly which paths that covers. Pass nil to clear a previously registered
+// callback. Safe to call at any time; takes effect on the next discovery.
+func (m *MCPManager) SetToolsChangeCallback(cb func(clientID, name string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.toolsChangeCallback = cb
+}
+
+// toolsChangedCallback compares tools/toolNameMapping's content hash against
+// clientState.LastToolsHash — gating the funnel to genuine changes only, so
+// a rediscovery that returns byte-identical tools (the common case on most
+// periodic ticks and reconnects) doesn't re-trigger a registered callback's
+// work (DB persist, external MCP server resync). On a genuine change,
+// updates the stored hash and returns a closure that invokes the callback;
+// returns nil if nothing changed or no callback is registered.
+//
+// Must be called with m.mu (or the checker's c.manager.mu — the same
+// mutex) already held; the returned closure must be invoked AFTER releasing
+// the lock, per toolsChangeCallback's own field doc.
+func (m *MCPManager) toolsChangedCallback(clientState *schemas.MCPClientState, clientID string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string) func() {
+	hash := computeToolsHash(tools, toolNameMapping)
+	if clientState.LastToolsHash == hash {
+		return nil
+	}
+	clientState.LastToolsHash = hash
+	cb := m.toolsChangeCallback
+	if cb == nil {
+		return nil
+	}
+	name := clientState.Name
+	return func() { cb(clientID, name, tools, toolNameMapping) }
 }
 
 // MCPToolFunction is a generic function type for handling tool calls with typed arguments.

--- a/core/mcp/toolschangecallback_test.go
+++ b/core/mcp/toolschangecallback_test.go
@@ -1,0 +1,150 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// toolsChangeCall records one invocation of a registered SetToolsChangeCallback.
+type toolsChangeCall struct {
+	clientID, name  string
+	tools           map[string]schemas.ChatTool
+	toolNameMapping map[string]string
+}
+
+// TestSetClientTools_FiresToolsChangeCallback pins the funnel's simplest
+// entry point: SetClientTools (used by per-call clients' own AddClient/
+// UpdateClientCredentials discovery, and directly by admin-verify HTTP
+// handlers) must notify a registered callback with the fresh result so the
+// transport layer can persist it — core/mcp has no DB access of its own.
+func TestSetClientTools_FiresToolsChangeCallback(t *testing.T) {
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, nil, &MockLogger{}, nil)
+	config := &schemas.MCPClientConfig{ID: "client-1", Name: "client-one"}
+	m.mu.Lock()
+	m.clientMap[config.ID] = &schemas.MCPClientState{Name: config.Name, ExecutionConfig: config, ToolMap: map[string]schemas.ChatTool{}}
+	m.mu.Unlock()
+
+	var calls []toolsChangeCall
+	m.SetToolsChangeCallback(func(clientID, name string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string) {
+		calls = append(calls, toolsChangeCall{clientID, name, tools, toolNameMapping})
+	})
+
+	tools := map[string]schemas.ChatTool{"echo": {Type: "function"}}
+	mapping := map[string]string{"echo": "echo-server"}
+	m.SetClientTools(config.ID, tools, mapping)
+
+	require.Len(t, calls, 1)
+	assert.Equal(t, config.ID, calls[0].clientID)
+	assert.Equal(t, config.Name, calls[0].name)
+	assert.Equal(t, tools, calls[0].tools)
+	assert.Equal(t, mapping, calls[0].toolNameMapping)
+}
+
+// TestSetClientTools_UnknownClient_DoesNotFireCallback confirms the callback
+// only fires for a real mutation — calling SetClientTools for a client that
+// isn't (or is no longer) registered must not notify a stale/nonexistent
+// entry.
+func TestSetClientTools_UnknownClient_DoesNotFireCallback(t *testing.T) {
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, nil, &MockLogger{}, nil)
+
+	fired := false
+	m.SetToolsChangeCallback(func(clientID, name string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string) {
+		fired = true
+	})
+
+	m.SetClientTools("does-not-exist", map[string]schemas.ChatTool{}, map[string]string{})
+
+	assert.False(t, fired)
+}
+
+// TestConnectToMCPClient_SuccessfulDial_FiresToolsChangeCallback covers the
+// sticky-client funnel entry point: a live connect/reconnect that discovers
+// tools via list_tools must also notify, exactly like the per-call path —
+// sticky clients have the identical "freshly discovered tools never reach
+// the DB" gap per-call ones do, so both must go through the same seam.
+func TestConnectToMCPClient_SuccessfulDial_FiresToolsChangeCallback(t *testing.T) {
+	ts := buildGatedMCPServer(t, nil)
+
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, nil, &MockLogger{}, nil)
+	config := newMakeBeforeBreakConfig("sticky-dial-client", ts.URL)
+	toolName := config.Name + "-echo"
+
+	var calls []toolsChangeCall
+	m.SetToolsChangeCallback(func(clientID, name string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string) {
+		calls = append(calls, toolsChangeCall{clientID, name, tools, toolNameMapping})
+	})
+
+	require.NoError(t, m.connectToMCPClient(context.Background(), config))
+
+	require.Len(t, calls, 1)
+	assert.Equal(t, config.ID, calls[0].clientID)
+	assert.Contains(t, calls[0].tools, toolName)
+}
+
+// TestPerformCheck_PerCall_SuccessfulDiscovery_FiresToolsChangeCallback
+// covers the periodic checker's own refresh (checkPerCall -> writeBackTools)
+// — the path that, before this funnel existed, was the one place a client's
+// tools could silently drift out of sync with the DB indefinitely, since
+// nothing else revisits a per-call client after its first discovery.
+func TestPerformCheck_PerCall_SuccessfulDiscovery_FiresToolsChangeCallback(t *testing.T) {
+	ts, _ := buildAdminDiscoveryHTTPServer(t)
+
+	cred := &fakeAdminCredStore{headers: http.Header{"Authorization": []string{"Bearer shared-token"}}}
+	manager := &MCPManager{
+		credStore: cred,
+		logger:    &MockLogger{},
+		clientMap: map[string]*schemas.MCPClientState{},
+	}
+
+	state, config := newSyncTestClientState("client-checker-percall", "checker-client", schemas.MCPAuthTypeHeaders, map[string]schemas.ChatTool{})
+	config.ConnectionType = schemas.MCPConnectionTypeHTTP
+	config.ConnectionString = schemas.NewSecretVar(ts.URL)
+	manager.clientMap[config.ID] = state
+
+	var calls []toolsChangeCall
+	manager.SetToolsChangeCallback(func(clientID, name string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string) {
+		calls = append(calls, toolsChangeCall{clientID, name, tools, toolNameMapping})
+	})
+
+	checker := NewClientConnectionChecker(manager, config.ID, time.Minute, false, &MockLogger{})
+	checker.performCheck()
+
+	require.Len(t, calls, 1)
+	assert.Equal(t, config.ID, calls[0].clientID)
+	assert.Contains(t, calls[0].tools, "checker-client-echo")
+}
+
+// TestAddClient_RestoreFromConfig_DoesNotFireToolsChangeCallback pins the
+// deliberate exception: AddClient restoring an already-known tool set read
+// back out of the config it was just given (the normal boot path for a
+// per-call client whose tools are already in the DB) must NOT notify —
+// nothing changed, so there is nothing new to persist. Only a genuine fresh
+// discovery result should reach the callback.
+func TestAddClient_RestoreFromConfig_DoesNotFireToolsChangeCallback(t *testing.T) {
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, nil, &MockLogger{}, nil)
+
+	fired := false
+	m.SetToolsChangeCallback(func(clientID, name string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string) {
+		fired = true
+	})
+
+	config := &schemas.MCPClientConfig{
+		ID:                "restore-client",
+		Name:              "restore_client",
+		ConnectionType:    schemas.MCPConnectionTypeHTTP,
+		ConnectionString:  schemas.NewSecretVar("https://example.invalid/mcp"),
+		AuthType:          schemas.MCPAuthTypePerUserHeaders,
+		PerUserHeaderKeys: []string{"X-User-Token"},
+		DiscoveredTools:   map[string]schemas.ChatTool{"tool-a": {}},
+	}
+
+	require.NoError(t, m.AddClient(context.Background(), config))
+
+	assert.False(t, fired, "restoring already-known tools from the config passed in must not re-trigger persistence")
+}

--- a/core/mcp/toolshash_test.go
+++ b/core/mcp/toolshash_test.go
@@ -1,0 +1,134 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestComputeToolsHash_StableAcrossMapIterationOrder pins the core property
+// the gating logic depends on: hashing the same content twice (built via
+// different map literals, so iteration order differs) must produce the same
+// hash — Go's json.Marshal already sorts map string keys, but this asserts
+// that invariant directly rather than trusting it implicitly.
+func TestComputeToolsHash_StableAcrossMapIterationOrder(t *testing.T) {
+	toolsA := map[string]schemas.ChatTool{"b": {Type: "function"}, "a": {Type: "function"}}
+	toolsB := map[string]schemas.ChatTool{"a": {Type: "function"}, "b": {Type: "function"}}
+	mapping := map[string]string{"a": "a-orig", "b": "b-orig"}
+
+	assert.Equal(t, computeToolsHash(toolsA, mapping), computeToolsHash(toolsB, mapping))
+}
+
+// TestComputeToolsHash_DiffersOnContentChange confirms the hash actually
+// reflects content, not just key sets — a change to a tool's own fields
+// (not just which names are present) must produce a different hash.
+func TestComputeToolsHash_DiffersOnContentChange(t *testing.T) {
+	base := computeToolsHash(map[string]schemas.ChatTool{"echo": {Type: "function"}}, map[string]string{"echo": "echo-orig"})
+	changedType := computeToolsHash(map[string]schemas.ChatTool{"echo": {Type: "custom"}}, map[string]string{"echo": "echo-orig"})
+	changedMapping := computeToolsHash(map[string]schemas.ChatTool{"echo": {Type: "function"}}, map[string]string{"echo": "renamed"})
+
+	assert.NotEqual(t, base, changedType)
+	assert.NotEqual(t, base, changedMapping)
+}
+
+// TestSetClientTools_UnchangedTools_DoesNotFireCallback pins the funnel's
+// gating: rediscovering byte-identical tools must not re-notify — the
+// registered callback's whole purpose (persist to DB, resync the local MCP
+// server) is wasted work when nothing actually changed.
+func TestSetClientTools_UnchangedTools_DoesNotFireCallback(t *testing.T) {
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, nil, &MockLogger{}, nil)
+	config := &schemas.MCPClientConfig{ID: "client-1", Name: "client-one"}
+	m.mu.Lock()
+	m.clientMap[config.ID] = &schemas.MCPClientState{Name: config.Name, ExecutionConfig: config, ToolMap: map[string]schemas.ChatTool{}}
+	m.mu.Unlock()
+
+	tools := map[string]schemas.ChatTool{"echo": {Type: "function"}}
+	mapping := map[string]string{"echo": "echo-server"}
+
+	callCount := 0
+	m.SetToolsChangeCallback(func(clientID, name string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string) {
+		callCount++
+	})
+
+	m.SetClientTools(config.ID, tools, mapping)
+	require.Equal(t, 1, callCount, "the first discovery must always fire")
+
+	// Re-set with the exact same content (a fresh map literal, so this isn't
+	// just testing pointer equality).
+	m.SetClientTools(config.ID, map[string]schemas.ChatTool{"echo": {Type: "function"}}, map[string]string{"echo": "echo-server"})
+	assert.Equal(t, 1, callCount, "an unchanged rediscovery must not re-fire the callback")
+
+	// A genuine change must still fire.
+	m.SetClientTools(config.ID, map[string]schemas.ChatTool{"echo": {Type: "function"}, "new-tool": {Type: "function"}}, map[string]string{"echo": "echo-server", "new-tool": "new-tool-server"})
+	assert.Equal(t, 2, callCount, "a genuine content change must fire")
+}
+
+// TestWriteBackTools_UnchangedTools_DoesNotFireCallback covers the periodic
+// checker's own refresh path — the highest-frequency firing point, and the
+// one most likely to rediscover identical tools tick after tick.
+func TestWriteBackTools_UnchangedTools_DoesNotFireCallback(t *testing.T) {
+	manager := &MCPManager{
+		logger:    &MockLogger{},
+		clientMap: map[string]*schemas.MCPClientState{},
+	}
+	state, config := newSyncTestClientState("client-checker", "checker-client", schemas.MCPAuthTypeHeaders, map[string]schemas.ChatTool{})
+	manager.clientMap[config.ID] = state
+
+	callCount := 0
+	manager.SetToolsChangeCallback(func(clientID, name string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string) {
+		callCount++
+	})
+
+	checker := NewClientConnectionChecker(manager, config.ID, 0, false, &MockLogger{})
+	tools := map[string]schemas.ChatTool{"echo": {Type: "function"}}
+	mapping := map[string]string{"echo": "echo-server"}
+
+	checker.writeBackTools(0, tools, mapping)
+	require.Equal(t, 1, callCount)
+
+	checker.writeBackTools(0, map[string]schemas.ChatTool{"echo": {Type: "function"}}, map[string]string{"echo": "echo-server"})
+	assert.Equal(t, 1, callCount, "an unchanged tick must not re-fire")
+
+	checker.writeBackTools(0, map[string]schemas.ChatTool{}, map[string]string{})
+	assert.Equal(t, 2, callCount, "the server legitimately losing all its tools is still a genuine change")
+}
+
+// TestAddClient_RestoreFromConfig_SeedsHashSoSubsequentIdenticalDiscoveryNoOps
+// pins that restoring already-known tools from DB (which deliberately
+// doesn't fire the callback, per TestAddClient_RestoreFromConfig_
+// DoesNotFireToolsChangeCallback in toolschangecallback_test.go) still seeds
+// LastToolsHash — otherwise the first real discovery after a restart would
+// look like a "change" even when it rediscovers the exact same tools,
+// causing a needless persist/resync immediately after every boot.
+func TestAddClient_RestoreFromConfig_SeedsHashSoSubsequentIdenticalDiscoveryNoOps(t *testing.T) {
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, nil, &MockLogger{}, nil)
+
+	callCount := 0
+	m.SetToolsChangeCallback(func(clientID, name string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string) {
+		callCount++
+	})
+
+	restoredTools := map[string]schemas.ChatTool{"tool-a": {Type: "function"}}
+	restoredMapping := map[string]string{"tool-a": "tool-a-orig"}
+	config := &schemas.MCPClientConfig{
+		ID:                        "restore-seed-client",
+		Name:                      "restore_seed_client",
+		ConnectionType:            schemas.MCPConnectionTypeHTTP,
+		ConnectionString:          schemas.NewSecretVar("https://example.invalid/mcp"),
+		AuthType:                  schemas.MCPAuthTypePerUserHeaders,
+		PerUserHeaderKeys:         []string{"X-User-Token"},
+		DiscoveredTools:           restoredTools,
+		DiscoveredToolNameMapping: restoredMapping,
+	}
+	require.NoError(t, m.AddClient(context.Background(), config))
+	require.Equal(t, 0, callCount, "restoring from config must not itself fire")
+
+	// Simulate the periodic checker rediscovering the exact same tools right
+	// after boot — must not fire, since nothing actually changed from what
+	// was restored.
+	m.SetClientTools(config.ID, map[string]schemas.ChatTool{"tool-a": {Type: "function"}}, map[string]string{"tool-a": "tool-a-orig"})
+	assert.Equal(t, 0, callCount, "rediscovering the exact tools that were just restored must not fire")
+}

--- a/core/mcp/utils.go
+++ b/core/mcp/utils.go
@@ -2,6 +2,8 @@ package mcp
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,6 +18,28 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/maximhq/bifrost/core/schemas"
 )
+
+// computeToolsHash returns a stable content hash of a tool map + name
+// mapping, used to gate the tools-change funnel (SetClientTools,
+// connectToMCPClient, writeBackTools) to genuine changes only — a
+// rediscovery that returns byte-identical tools (the common case on most
+// periodic ticks and reconnects) must not re-trigger a registered
+// callback's work (DB persist, external MCP server resync). json.Marshal
+// sorts map string keys, so this is deterministic regardless of the maps'
+// iteration order; errors are treated as "never matches" (marshal failure
+// on these plain data types isn't expected, but must never panic or block
+// a genuine discovery result from being recorded).
+func computeToolsHash(tools map[string]schemas.ChatTool, toolNameMapping map[string]string) string {
+	h := sha256.New()
+	if data, err := json.Marshal(tools); err == nil {
+		h.Write(data)
+	}
+	h.Write([]byte{0}) // separator so {"a":"b"} tools + {} mapping can't collide with {} tools + {"a":"b"} mapping
+	if data, err := json.Marshal(toolNameMapping); err == nil {
+		h.Write(data)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
 
 // RetryConfig defines the retry behavior with exponential backoff
 type RetryConfig struct {

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -808,6 +808,7 @@ type MCPClientState struct {
 	CancelFunc      context.CancelFunc       `json:"-"`               // Cancel function for SSE connections (not serialized)
 	State           MCPConnectionState       // Connection state (healthy, unstable, needs_reauth, ...)
 	ConnGeneration  uint64                   `json:"-"` // Counts connection swaps; late writers bound to an older Conn compare against it to detect staleness (not serialized)
+	LastToolsHash   string                   `json:"-"` // Content hash of the last ToolMap/ToolNameMapping the tools-change callback fired for; gates the funnel to genuine changes only (not serialized)
 }
 
 // MCPClientConnectionInfo stores metadata about how a client is connected.

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2100,6 +2100,38 @@ func (s *RDBConfigStore) UpdateMCPClientOAuthConfigID(ctx context.Context, clien
 	return nil
 }
 
+// UpdateMCPClientTools persists an MCP client's discovered tools and tool
+// name mapping as a targeted column update — unlike UpdateMCPClientConfig's
+// full-row overwrite, this never touches any other column, so it's safe to
+// call from a periodic background refresh without racing a concurrent config
+// edit. An empty (non-nil) map is a legitimate "server has zero tools"
+// result and is written as-is, same as a populated one.
+func (s *RDBConfigStore) UpdateMCPClientTools(ctx context.Context, clientID string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string) error {
+	toolsJSON, err := json.Marshal(tools)
+	if err != nil {
+		return fmt.Errorf("failed to marshal discovered_tools: %w", err)
+	}
+	mappingJSON, err := json.Marshal(toolNameMapping)
+	if err != nil {
+		return fmt.Errorf("failed to marshal tool_name_mapping: %w", err)
+	}
+	res := s.DB().WithContext(ctx).
+		Model(&tables.TableMCPClient{}).
+		Where("client_id = ?", clientID).
+		Updates(map[string]interface{}{
+			"discovered_tools_json":  string(toolsJSON),
+			"tool_name_mapping_json": string(mappingJSON),
+			"updated_at":             time.Now(),
+		})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 // ClearMCPClientPendingOAuthConfig sets pending_oauth_config_json to NULL for
 // the given client. Called once OAuth authorization succeeds so the runtime no
 // longer sees the bootstrap stash and the next reconnect runs the normal

--- a/framework/configstore/rdb_mcp_tools_test.go
+++ b/framework/configstore/rdb_mcp_tools_test.go
@@ -1,0 +1,75 @@
+package configstore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdateMCPClientTools_TargetedColumnUpdate pins that UpdateMCPClientTools
+// only ever touches discovered_tools_json/tool_name_mapping_json — unlike
+// UpdateMCPClientConfig's full-row overwrite, a periodic tool-sync writer
+// using this method can never clobber an unrelated field a concurrent config
+// edit just wrote (e.g. Name).
+func TestUpdateMCPClientTools_TargetedColumnUpdate(t *testing.T) {
+	s := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.CreateMCPClientConfig(ctx, &schemas.MCPClientConfig{
+		ID:               "mcp-tools-client",
+		Name:             "original_name",
+		ConnectionType:   schemas.MCPConnectionTypeHTTP,
+		ConnectionString: schemas.NewSecretVar("https://example.invalid/mcp"),
+	}))
+
+	tools := map[string]schemas.ChatTool{
+		"echo": {Type: "function"},
+	}
+	mapping := map[string]string{"echo": "echo-server"}
+
+	require.NoError(t, s.UpdateMCPClientTools(ctx, "mcp-tools-client", tools, mapping))
+
+	got, err := s.GetMCPClientByID(ctx, "mcp-tools-client")
+	require.NoError(t, err)
+	assert.Equal(t, tools, got.DiscoveredTools)
+	assert.Equal(t, mapping, got.DiscoveredToolNameMapping)
+	// Untouched column proves this was a targeted update, not a full-row one.
+	assert.Equal(t, "original_name", got.Name)
+}
+
+// TestUpdateMCPClientTools_EmptyMapPersistsAsLegitimateZeroTools confirms an
+// empty (non-nil) result is written as-is — "the server has zero tools" is a
+// real, distinct outcome from "never discovered", and must round-trip rather
+// than being silently skipped.
+func TestUpdateMCPClientTools_EmptyMapPersistsAsLegitimateZeroTools(t *testing.T) {
+	s := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.CreateMCPClientConfig(ctx, &schemas.MCPClientConfig{
+		ID:               "mcp-empty-tools-client",
+		Name:             "empty_tools_client",
+		ConnectionType:   schemas.MCPConnectionTypeHTTP,
+		ConnectionString: schemas.NewSecretVar("https://example.invalid/mcp"),
+		DiscoveredTools:  map[string]schemas.ChatTool{"stale": {Type: "function"}},
+	}))
+
+	require.NoError(t, s.UpdateMCPClientTools(ctx, "mcp-empty-tools-client", map[string]schemas.ChatTool{}, map[string]string{}))
+
+	got, err := s.GetMCPClientByID(ctx, "mcp-empty-tools-client")
+	require.NoError(t, err)
+	assert.Empty(t, got.DiscoveredTools)
+}
+
+// TestUpdateMCPClientTools_UnknownClientReturnsNotFound mirrors
+// UpdateMCPClientOAuthConfigID's own not-found contract for the same
+// Updates()+RowsAffected==0 pattern.
+func TestUpdateMCPClientTools_UnknownClientReturnsNotFound(t *testing.T) {
+	s := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	err := s.UpdateMCPClientTools(ctx, "does-not-exist", map[string]schemas.ChatTool{}, map[string]string{})
+	assert.ErrorIs(t, err, ErrNotFound)
+}

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -269,6 +269,11 @@ type ConfigStore interface {
 	GetMCPClientsPaginated(ctx context.Context, params MCPClientsQueryParams) ([]tables.TableMCPClient, int64, error)
 	CreateMCPClientConfig(ctx context.Context, clientConfig *schemas.MCPClientConfig) error
 	UpdateMCPClientConfig(ctx context.Context, id string, clientConfig *tables.TableMCPClient) error
+	// UpdateMCPClientTools is a targeted column update for
+	// discovered_tools_json/tool_name_mapping_json only — safe to call from
+	// a periodic background tool-sync without racing a concurrent full
+	// UpdateMCPClientConfig call over unrelated fields.
+	UpdateMCPClientTools(ctx context.Context, clientID string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string) error
 	DeleteMCPClientConfig(ctx context.Context, id string) error
 
 	// MCP library catalog (synced + org-custom)

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -733,6 +733,19 @@ func (m *MockConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, 
 	return nil
 }
 
+func (m *MockConfigStore) UpdateMCPClientTools(ctx context.Context, clientID string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string) error {
+	if m.mcpConfig != nil {
+		for _, cfg := range m.mcpConfig.ClientConfigs {
+			if cfg.ID == clientID {
+				cfg.DiscoveredTools = tools
+				cfg.DiscoveredToolNameMapping = toolNameMapping
+				return nil
+			}
+		}
+	}
+	return configstore.ErrNotFound
+}
+
 func (m *MockConfigStore) GetMCPClientsPaginated(ctx context.Context, params configstore.MCPClientsQueryParams) ([]tables.TableMCPClient, int64, error) {
 	return nil, 0, nil
 }

--- a/transports/bifrost-http/server/mcp_tools_persist_test.go
+++ b/transports/bifrost-http/server/mcp_tools_persist_test.go
@@ -1,0 +1,95 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingToolsConfigStore captures every UpdateMCPClientTools call for
+// assertion, and can be made to fail once to exercise the error-logging path.
+type recordingToolsConfigStore struct {
+	configstore.ConfigStore
+	calls   []toolsUpdateCall
+	failErr error
+}
+
+type toolsUpdateCall struct {
+	clientID string
+	tools    map[string]schemas.ChatTool
+	mapping  map[string]string
+}
+
+func (s *recordingToolsConfigStore) UpdateMCPClientTools(ctx context.Context, clientID string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string) error {
+	if s.failErr != nil {
+		return s.failErr
+	}
+	s.calls = append(s.calls, toolsUpdateCall{clientID: clientID, tools: tools, mapping: toolNameMapping})
+	return nil
+}
+
+// TestPersistMCPClientTools_WritesThroughConfigStore pins the OSS side of the
+// funnel: the tools-change callback registered on the MCP manager must
+// persist the fresh result via ConfigStore.UpdateMCPClientTools — the
+// targeted column update, not a full-row overwrite.
+func TestPersistMCPClientTools_WritesThroughConfigStore(t *testing.T) {
+	store := &recordingToolsConfigStore{}
+	s := &BifrostHTTPServer{Config: &lib.Config{ConfigStore: store}}
+
+	tools := map[string]schemas.ChatTool{"echo": {Type: "function"}}
+	mapping := map[string]string{"echo": "echo-server"}
+	s.PersistMCPClientTools(context.Background(), "client-1", tools, mapping)
+
+	require.Len(t, store.calls, 1)
+	assert.Equal(t, "client-1", store.calls[0].clientID)
+	assert.Equal(t, tools, store.calls[0].tools)
+	assert.Equal(t, mapping, store.calls[0].mapping)
+}
+
+// TestPersistMCPClientTools_NilConfigStore_NoOp confirms the nil-guard
+// convention this package uses elsewhere (Config or ConfigStore not yet
+// wired) — must not panic.
+func TestPersistMCPClientTools_NilConfigStore_NoOp(t *testing.T) {
+	s := &BifrostHTTPServer{Config: &lib.Config{ConfigStore: nil}}
+	assert.NotPanics(t, func() {
+		s.PersistMCPClientTools(context.Background(), "client-1", map[string]schemas.ChatTool{}, map[string]string{})
+	})
+}
+
+// TestPersistMCPClientTools_StoreErrorLogsAndDoesNotPanic confirms a DB
+// failure is logged (best-effort — the periodic checker's own retry, or the
+// next discovery event, will try again) rather than propagated, since this
+// runs from a callback with no caller to return an error to.
+func TestPersistMCPClientTools_StoreErrorLogsAndDoesNotPanic(t *testing.T) {
+	prevLogger := logger
+	logger = noopTestLogger{}
+	defer func() { logger = prevLogger }()
+
+	store := &recordingToolsConfigStore{failErr: fmt.Errorf("db unavailable")}
+	s := &BifrostHTTPServer{Config: &lib.Config{ConfigStore: store}}
+
+	assert.NotPanics(t, func() {
+		s.PersistMCPClientTools(context.Background(), "client-1", map[string]schemas.ChatTool{}, map[string]string{})
+	})
+	assert.Empty(t, store.calls)
+}
+
+// TestSyncMCPServersAfterToolsChange_NilHandler_NoOp confirms the nil-guard
+// convention this package uses elsewhere — MCPServerHandler not yet wired
+// (e.g. in a partially-constructed test server) must not panic. The
+// underlying SyncAllMCPServers call itself is exercised the same way the
+// pre-existing SetClientTools wrapper's identical call already is: only via
+// full integration, since MCPServerHandler has no fake-able seam from this
+// package.
+func TestSyncMCPServersAfterToolsChange_NilHandler_NoOp(t *testing.T) {
+	s := &BifrostHTTPServer{}
+	assert.NotPanics(t, func() {
+		s.SyncMCPServersAfterToolsChange(context.Background(), "client-1")
+	})
+}

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -327,7 +327,39 @@ func (s *BifrostHTTPServer) UpdateMCPClient(ctx context.Context, id string, upda
 	return nil
 }
 
-// UpdateMCPClientCredentials reconnects an existing MCP client using updated headers
+// PersistMCPClientTools writes a freshly (re)discovered tool set to the DB
+// via ConfigStore's targeted column update. core/mcp has no DB access of its
+// own; this is registered as the MCP manager's tools-change callback so
+// every discovery path — connect/reconnect, per-call discovery, and the
+// periodic checker's own refresh — persists uniformly. Best-effort: a
+// failure here is logged, not propagated, since this runs from a callback
+// with no caller to return an error to — the next discovery event (or the
+// periodic checker's own retry) tries again.
+func (s *BifrostHTTPServer) PersistMCPClientTools(ctx context.Context, clientID string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string) {
+	if s.Config == nil || s.Config.ConfigStore == nil {
+		return
+	}
+	if err := s.Config.ConfigStore.UpdateMCPClientTools(ctx, clientID, tools, toolNameMapping); err != nil {
+		logger.Error(fmt.Sprintf("Failed to persist discovered tools for MCP client %s: %v", clientID, err))
+	}
+}
+
+// SyncMCPServersAfterToolsChange re-syncs Bifrost's own hosted MCP server(s)
+// so a freshly (re)discovered tool list is immediately visible via /mcp.
+// SetClientTools (below) already does this for handler-driven updates
+// (verify-headers, complete-oauth, admin-repair) — this is the same resync,
+// reachable from the tools-change callback so periodic-checker refreshes and
+// sticky reconnects get it too, not just one-time admin actions. Best-effort,
+// same reasoning as PersistMCPClientTools.
+func (s *BifrostHTTPServer) SyncMCPServersAfterToolsChange(ctx context.Context, clientID string) {
+	if s.MCPServerHandler == nil {
+		return
+	}
+	if err := s.MCPServerHandler.SyncAllMCPServers(ctx); err != nil {
+		logger.Warn(fmt.Sprintf("Failed to sync MCP servers after tools change for client %s: %v", clientID, err))
+	}
+}
+
 func (s *BifrostHTTPServer) UpdateMCPClientCredentials(ctx context.Context, id string, newConfig *schemas.MCPClientConfig) error {
 	if err := s.Config.UpdateMCPClientCredentials(ctx, id, newConfig); err != nil {
 		return err
@@ -2496,6 +2528,12 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 		}
 		return fmt.Errorf("failed to initialize inference routes: %v", err)
 	}
+	// Registered before ConnectConfiguredMCPClients so even the very first
+	// boot dial's discovered tools get persisted, not just later reconnects.
+	s.Client.SetMCPToolsChangeCallback(func(clientID, name string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string) {
+		go s.PersistMCPClientTools(s.Ctx, clientID, tools, toolNameMapping)
+		go s.SyncMCPServersAfterToolsChange(s.Ctx, clientID)
+	})
 	// Dial configured MCP clients now that every plugin is registered in the core.
 	// Construction (bifrost.Init) no longer connects MCP, so connecting here ensures
 	// each client's PreMCPConnectionHook runs against the full plugin set rather than


### PR DESCRIPTION
## Summary

MCP tool discovery results were not being persisted to the database after the initial client setup. Any tools freshly (re)discovered via reconnect, periodic checker refresh, or per-call discovery were silently lost — the DB retained only whatever was present at first boot. This introduces a `toolsChangeCallback` funnel in `core/mcp` that fires whenever a client's tool map genuinely changes, and wires it at the transport layer to persist the result via a new targeted `UpdateMCPClientTools` column update.

## Changes

- Added `toolsChangeCallback` field to `MCPManager` and a `SetToolsChangeCallback` method, mirroring the existing `stateChangeCallback` pattern. The callback fires from three paths: `connectToMCPClient` (initial dial and every reconnect), `SetClientTools` (per-call discovery and admin-verify handlers), and `writeBackTools` (periodic checker refresh for both sticky and per-call clients).
- Introduced `computeToolsHash` (SHA-256 over JSON-marshalled tools + name mapping) and `LastToolsHash` on `MCPClientState` to gate the funnel to genuine content changes only. Rediscovering byte-identical tools — the common case on most periodic ticks and reconnects — does not re-trigger the callback.
- `AddClient`'s per-call restore branch (boot path, restoring already-known tools from config) seeds `LastToolsHash` without firing the callback, so the first post-boot checker tick correctly no-ops instead of treating the restore as a change.
- Added `UpdateMCPClientTools` to `ConfigStore` and `RDBConfigStore` as a targeted `discovered_tools_json`/`tool_name_mapping_json` column update, safe to call from a background refresh without racing a concurrent full `UpdateMCPClientConfig` call over unrelated fields.
- Added `PersistMCPClientTools` and `SyncMCPServersAfterToolsChange` to `BifrostHTTPServer`. Both are best-effort (errors are logged, not propagated) since they run from a callback with no caller to return an error to.
- Registered the callback in `Bootstrap` before `ConnectConfiguredMCPClients` so even the very first boot dial's discovered tools are persisted.
- Refactored `SetClientTools` and `writeBackTools` to release `m.mu` before invoking the callback, consistent with `stateChangeCallback`'s own convention — callbacks may do arbitrary I/O and must not run under the manager lock.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/mcp/... ./framework/configstore/... ./transports/bifrost-http/...
```

New test files cover:

- `core/mcp/toolschangecallback_test.go` — callback fires on `SetClientTools`, `connectToMCPClient`, and the periodic checker's `writeBackTools`; does not fire for unknown clients or for `AddClient` restoring already-known tools.
- `core/mcp/toolshash_test.go` — hash is stable across map iteration order, differs on content change, and gates repeated identical discoveries to a single callback invocation; `AddClient` restore seeds the hash so the first post-boot rediscovery of identical tools correctly no-ops.
- `framework/configstore/rdb_mcp_tools_test.go` — `UpdateMCPClientTools` only touches the two tool columns (not `name` or other fields), persists an empty map as a legitimate zero-tools result, and returns `ErrNotFound` for an unknown client.
- `transports/bifrost-http/server/mcp_tools_persist_test.go` — `PersistMCPClientTools` writes through the config store, no-ops on a nil store, and logs (does not panic) on a store error; `SyncMCPServersAfterToolsChange` no-ops when `MCPServerHandler` is nil.

## Breaking changes

- [x] Yes
- [ ] No

`ConfigStore` interface gains `UpdateMCPClientTools`. Any external implementation of `ConfigStore` must add this method. The `MCPManagerInterface` gains `SetToolsChangeCallback` for the same reason.

## Related issues

## Security considerations

No new secrets, auth surfaces, or PII handling. The tools hash is derived from tool metadata (names and types), not from credentials or user data.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable