### PR TITLE
fix: gate verify-headers replay guard on pre-request pending_verification state, project needs_reauth over unstable, and block premature shared-OAuth completion

### DIFF
--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -356,6 +356,55 @@ type VerifyMCPClientHeadersRequest struct {
 // Synchronous: no callback, no popup. On success the client transitions
 // to connected; on failure the row stays in pending_verification and the
 // admin can retry.
+// isConcurrentVerifyReplay reports whether a reloaded row's DiscoveredTools
+// reflects a DIFFERENT (concurrent) verify-headers request completing this
+// client's one-time bootstrap during this request's own upstream
+// round-trip — the only scenario the replay guard exists to catch. Gated on
+// the client's STATE at the start of the request, not on DiscoveredTools'
+// own nil-ness: only a client that was genuinely still pending its one-time
+// bootstrap (pending_verification) can race another request finishing that
+// same bootstrap. A client repairing an already-verified admin credential
+// starts in some other state (Healthy, Unstable, ...) and must run through
+// to completion — in particular the admin-credential retention step below
+// — or that credential could never be repaired once a client has been
+// verified once.
+func isConcurrentVerifyReplay(wasPendingVerificationBeforeThisRequest, reloadedHasTools bool) bool {
+	return wasPendingVerificationBeforeThisRequest && reloadedHasTools
+}
+
+// isPrematureOAuthCompletion reports whether a complete-oauth request
+// should be rejected because the admin reauth flow it corresponds to never
+// actually resolved via a real callback. TableOauthConfig.Status can't be
+// used for this: it's write-once and never regresses once "authorized" (see
+// its own doc comment), so a client reauthorizing after an earlier
+// successful auth reads stale "authorized" throughout a failed attempt.
+// CompleteOAuthFlow always cleans up the flow row on completion, success or
+// failure alike, so a row still sitting there pending — and not yet expired
+// — means the callback never ran at all (e.g. the upstream/mock
+// authorization server rejected the request with a dead-end error page
+// instead of redirecting back).
+func isPrematureOAuthCompletion(flow *configstoreTables.TableMCPOauthFlow, now time.Time) bool {
+	return flow != nil && flow.Status == "pending" && now.Before(flow.ExpiresAt)
+}
+
+// getMCPClientRuntimeState returns the live MCPConnectionState the running
+// manager currently holds for id, or "" if the client isn't registered
+// there — MCPClientConfig.State (the DB-sourced struct) is never populated
+// by GetMCPClientConfigByID, since state isn't a DB column; this is the
+// only way to read it for a single client outside the paginated list path.
+func (h *MCPHandler) getMCPClientRuntimeState(id string) (schemas.MCPConnectionState, error) {
+	clients, err := h.client.GetMCPClients()
+	if err != nil {
+		return "", err
+	}
+	for _, c := range clients {
+		if c.Config != nil && c.Config.ID == id {
+			return c.State, nil
+		}
+	}
+	return "", nil
+}
+
 func (h *MCPHandler) verifyMCPClientHeaders(ctx *fasthttp.RequestCtx) {
 	if h.store.ConfigStore == nil {
 		SendError(ctx, fasthttp.StatusServiceUnavailable, "MCP operations unavailable: config store is disabled")
@@ -389,6 +438,15 @@ func (h *MCPHandler) verifyMCPClientHeaders(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("verify-headers only applies to auth_type='per_user_headers' clients, got %q", clientConfig.AuthType))
 		return
 	}
+	// Snapshot before verification runs — see isConcurrentVerifyReplay's doc:
+	// this is what tells a genuine concurrent double-submit of the one-time
+	// bootstrap apart from a legitimate repair of an already-verified client.
+	runtimeState, err := h.getMCPClientRuntimeState(id)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to check MCP client runtime state: %v", err))
+		return
+	}
+	wasPendingVerificationBeforeThisRequest := runtimeState == schemas.MCPConnectionStatePendingVerification
 	// No replay guard: mirrors reauthorizeMCPClient's OAuth equivalent
 	// (POST /reauthorize) — always re-runs verification against whatever
 	// sample values are submitted, no branching on whether the admin
@@ -436,7 +494,14 @@ func (h *MCPHandler) verifyMCPClientHeaders(ctx *fasthttp.RequestCtx) {
 	// (verified, tools discovered) was already reached by the other
 	// request, so there's nothing left to do here — redoing the
 	// persist/activation below would only risk clobbering its tool set.
-	if clientConfig.DiscoveredTools != nil {
+	//
+	// Gated on isConcurrentVerifyReplay (not a bare DiscoveredTools != nil
+	// check): a client that wasn't pending_verification when this request
+	// started isn't racing another request's bootstrap, it's a legitimate
+	// repair of an already-verified client — that case must fall through
+	// and run to completion, or the admin credential (retained further
+	// below) could never be repaired once a client has been verified once.
+	if isConcurrentVerifyReplay(wasPendingVerificationBeforeThisRequest, clientConfig.DiscoveredTools != nil) {
 		SendJSON(ctx, map[string]any{
 			"status":      "success",
 			"message":     fmt.Sprintf("MCP client verified. %d tools discovered. Each user will submit their own header values on first tool use.", len(clientConfig.DiscoveredTools)),
@@ -991,15 +1056,24 @@ func (h *MCPHandler) forceSyncMCPLibrary(ctx *fasthttp.RequestCtx) {
 // projectPerUserAdminCredentialState overlays a response-only needs_reauth
 // state onto a per-user client's runtime state when the retained admin
 // credential used for periodic tool-list discovery needs repair. The runtime
-// manager is never touched: per-user clients stay connected (end-user
+// manager is never touched: per-user clients keep serving (end-user
 // credentials and tool calls keep working); this projection only tells the
 // registry UI that an admin should repair the discovery credential.
 // adminTokenStatus is the admin OAuth token row's status ("" when no row
 // exists), adminCredStatus the admin header credential row's status ("" when
 // no row exists). A missing row leaves the state alone: clients verified
 // before credential retention existed have no admin row and are healthy.
+//
+// Applies over both Healthy and Unstable runtime states: needs_reauth is a
+// more actionable signal than Unstable (a dead admin credential never
+// self-heals — Unstable might, on the next successful check), so it must
+// win rather than being masked by a pre-existing Unstable reading. It does
+// NOT apply over Disabled/PendingVerification/anything else: those already
+// carry a more specific, authoritative meaning of their own (an explicit
+// admin action, or a one-time bootstrap that was never completed at all)
+// that a stale discovery credential shouldn't override.
 func projectPerUserAdminCredentialState(authType schemas.MCPAuthType, runtimeState schemas.MCPConnectionState, adminTokenStatus, adminCredStatus string) schemas.MCPConnectionState {
-	if runtimeState != schemas.MCPConnectionStateHealthy {
+	if runtimeState != schemas.MCPConnectionStateHealthy && runtimeState != schemas.MCPConnectionStateUnstable {
 		return runtimeState
 	}
 	switch authType {
@@ -3080,6 +3154,18 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 					return
 				}
 				h.completePerUserOAuthAdminRepair(ctx, bifrostCtx, oauthConfigID, dbClient.ClientID)
+				return
+			}
+			// Shared oauth's own freshness check: unlike per_user_oauth's
+			// sharedToken-presence check above, a shared client already has
+			// an active token from its ORIGINAL auth sitting there the whole
+			// time a reauth is in flight — token presence/status alone can't
+			// tell a stale credential from a freshly-rotated one. The flow
+			// row can: see isPrematureOAuthCompletion's doc.
+			if pendingFlow, flowErr := h.store.ConfigStore.GetOauthUserSessionByModeIdentityAndMCPClient(ctx, schemas.MCPAuthModeAdmin, "", dbClient.ClientID); flowErr != nil {
+				logger.Warn(fmt.Sprintf("failed to check for an in-flight reauth flow for MCP client %s: %v", dbClient.ClientID, flowErr))
+			} else if isPrematureOAuthCompletion(pendingFlow, time.Now()) {
+				SendError(ctx, fasthttp.StatusConflict, "Authorization has not completed yet: the browser flow may still be open, or the upstream provider rejected it before redirecting back. Wait for it to finish, or retry reauthorize.")
 				return
 			}
 			reauthClientConfig, err := h.store.ConfigStore.GetMCPClientConfigByID(ctx, dbClient.ClientID)

--- a/transports/bifrost-http/handlers/mcp_oauth_premature_completion_test.go
+++ b/transports/bifrost-http/handlers/mcp_oauth_premature_completion_test.go
@@ -1,0 +1,62 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+)
+
+// TestIsPrematureOAuthCompletion pins the signal that catches a
+// shared-OAuth reauthorize completing without its callback ever actually
+// running (e.g. the upstream/mock authorization server rejected the request
+// before redirecting back — a dead-end error page, not an OAuth redirect).
+// TableOauthConfig.Status can't be used for this: it's write-once and never
+// regresses once "authorized" (see its own doc comment), so a client
+// reauthorizing after an earlier successful auth always reads stale
+// "authorized" throughout a failed attempt. CompleteOAuthFlow always cleans
+// up the flow row on completion, success or failure alike — so a row still
+// sitting there pending (and not yet expired) means the callback never ran
+// at all, and completion must be rejected rather than reconnecting with
+// whatever (possibly still-broken) credential was already on file.
+func TestIsPrematureOAuthCompletion(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	future := now.Add(time.Hour)
+	past := now.Add(-time.Hour)
+
+	tests := []struct {
+		name string
+		flow *tables.TableMCPOauthFlow
+		want bool
+	}{
+		{
+			name: "nil flow (already cleaned up by a genuine completion) is not premature",
+			flow: nil,
+			want: false,
+		},
+		{
+			name: "pending, unexpired flow means the callback never ran: premature",
+			flow: &tables.TableMCPOauthFlow{Status: "pending", ExpiresAt: future},
+			want: true,
+		},
+		{
+			name: "pending but expired flow (abandoned attempt) does not block a later fresh completion",
+			flow: &tables.TableMCPOauthFlow{Status: "pending", ExpiresAt: past},
+			want: false,
+		},
+		{
+			name: "failed flow row is not premature (already resolved, just unsuccessfully)",
+			flow: &tables.TableMCPOauthFlow{Status: "failed", ExpiresAt: future},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isPrematureOAuthCompletion(tt.flow, now)
+			if got != tt.want {
+				t.Errorf("isPrematureOAuthCompletion(%+v, %v) = %v, want %v", tt.flow, now, got, tt.want)
+			}
+		})
+	}
+}

--- a/transports/bifrost-http/handlers/mcp_peruser_state_projection_test.go
+++ b/transports/bifrost-http/handlers/mcp_peruser_state_projection_test.go
@@ -74,7 +74,7 @@ func TestProjectPerUserAdminCredentialState(t *testing.T) {
 			adminTokenStatus: "needs_reauth", want: connected,
 		},
 		{
-			name:     "non-connected runtime state passes through even with a dead admin token",
+			name:     "pending_verification runtime state passes through even with a dead admin token",
 			authType: schemas.MCPAuthTypePerUserOauth, runtimeState: schemas.MCPConnectionStatePendingVerification,
 			adminTokenStatus: "needs_reauth", want: schemas.MCPConnectionStatePendingVerification,
 		},
@@ -82,6 +82,21 @@ func TestProjectPerUserAdminCredentialState(t *testing.T) {
 			name:     "disabled runtime state passes through even with a stale admin credential",
 			authType: schemas.MCPAuthTypePerUserHeaders, runtimeState: schemas.MCPConnectionStateDisabled,
 			adminCredStatus: "needs_update", want: schemas.MCPConnectionStateDisabled,
+		},
+		{
+			name:     "per_user_oauth unstable with a dead admin token projects needs_reauth (needs_reauth is a bigger indicator than unstable)",
+			authType: schemas.MCPAuthTypePerUserOauth, runtimeState: schemas.MCPConnectionStateUnstable,
+			adminTokenStatus: "needs_reauth", want: needsReauth,
+		},
+		{
+			name:     "per_user_headers unstable with a stale admin credential projects needs_reauth",
+			authType: schemas.MCPAuthTypePerUserHeaders, runtimeState: schemas.MCPConnectionStateUnstable,
+			adminCredStatus: "needs_update", want: needsReauth,
+		},
+		{
+			name:     "per_user_oauth unstable with an active admin token stays unstable",
+			authType: schemas.MCPAuthTypePerUserOauth, runtimeState: schemas.MCPConnectionStateUnstable,
+			adminTokenStatus: "active", want: schemas.MCPConnectionStateUnstable,
 		},
 		{
 			name:     "shared oauth clients are never projected",

--- a/transports/bifrost-http/handlers/mcp_verifyheaders_replay_test.go
+++ b/transports/bifrost-http/handlers/mcp_verifyheaders_replay_test.go
@@ -1,0 +1,51 @@
+package handlers
+
+import "testing"
+
+// TestIsConcurrentVerifyReplay table-tests the guard that decides whether a
+// reloaded row's DiscoveredTools reflects a genuinely concurrent
+// verify-headers request finishing this client's one-time bootstrap during
+// this request's own upstream round-trip (the only case that should
+// short-circuit as success) versus this client simply already being
+// verified and undergoing a legitimate repair (which must run through to
+// completion — in particular the admin-credential retention step — rather
+// than bailing out early). Confusing the two is exactly what left a
+// per-user-headers client's admin credential permanently stuck at
+// needs_update: every repair attempt hit the "already verified" guard
+// before ever reaching UpsertCredential.
+func TestIsConcurrentVerifyReplay(t *testing.T) {
+	tests := []struct {
+		name                                    string
+		wasPendingVerificationBeforeThisRequest bool
+		reloadedHasTools                        bool
+		want                                    bool
+	}{
+		{
+			name:                                    "genuine concurrent race: started pending_verification, another request finished the bootstrap first",
+			wasPendingVerificationBeforeThisRequest: true,
+			reloadedHasTools:                        true,
+			want:                                    true,
+		},
+		{
+			name:                                    "repair on an already-verified client: not pending_verification, tools already present",
+			wasPendingVerificationBeforeThisRequest: false,
+			reloadedHasTools:                        true,
+			want:                                    false,
+		},
+		{
+			name:                                    "first-time verification with no race: started pending_verification, still no tools after reload",
+			wasPendingVerificationBeforeThisRequest: true,
+			reloadedHasTools:                        false,
+			want:                                    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isConcurrentVerifyReplay(tt.wasPendingVerificationBeforeThisRequest, tt.reloadedHasTools)
+			if got != tt.want {
+				t.Errorf("isConcurrentVerifyReplay(%v, %v) = %v, want %v", tt.wasPendingVerificationBeforeThisRequest, tt.reloadedHasTools, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes two bugs in the MCP client verification and OAuth reauthorization flows:

1. **Verify-headers repair was permanently broken for already-verified per-user-headers clients.** The concurrent-replay guard used a bare `DiscoveredTools != nil` check, which caused every legitimate admin-credential repair attempt to short-circuit before reaching the `UpsertCredential` step — leaving the credential permanently stuck at `needs_update` once a client had been verified once.

2. **Shared-OAuth reauthorization could complete prematurely.** When an upstream/mock authorization server rejected a reauth request with a dead-end error page (instead of redirecting back via the OAuth callback), `complete-oauth` could still succeed using the stale credential already on file. The existing per-user-oauth freshness check (shared token presence) doesn't apply to shared-oauth clients, which always have an active token in flight during reauth.

## Changes

- **`isConcurrentVerifyReplay`**: Replaces the bare `DiscoveredTools != nil` guard with a two-condition check: a replay is only detected when the client was genuinely in `pending_verification` state at the start of the request AND the reloaded row now has tools. A client that was already verified (any other state) falls through to completion regardless of whether tools are present, ensuring the admin-credential retention step always runs during a repair.

- **`isPrematureOAuthCompletion`**: Adds a freshness check for shared-OAuth reauthorization using the OAuth flow row rather than token status. `TableOauthConfig.Status` is write-once and never regresses once `"authorized"`, so it can't distinguish a stale credential from a freshly-rotated one during a failed reauth. A flow row still in `"pending"` and not yet expired means the callback never ran, and completion is rejected with a `409 Conflict`.

- **`getMCPClientRuntimeState`**: Extracts a helper to read the live `MCPConnectionState` from the running manager for a single client by ID, since `GetMCPClientConfigByID` does not populate state (it is not a DB column).

- **`projectPerUserAdminCredentialState`**: Extends the `needs_reauth` projection to also apply over `Unstable` runtime states, not just `Healthy`. A dead admin credential never self-heals, so `needs_reauth` is a more actionable signal than `Unstable` and must win. `Disabled` and `PendingVerification` still pass through unchanged.

- Adds unit tests for `isConcurrentVerifyReplay`, `isPrematureOAuthCompletion`, and the updated `projectPerUserAdminCredentialState` projection cases.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Transports (HTTP)

## How to test

```sh
go test ./transports/bifrost-http/handlers/...
```

- `TestIsConcurrentVerifyReplay`: verifies the three cases — genuine concurrent race, legitimate repair on an already-verified client, and first-time verification with no race.
- `TestIsPrematureOAuthCompletion`: verifies nil flow, pending+unexpired (premature), pending+expired (abandoned), and failed flow rows.
- `TestProjectPerUserAdminCredentialState`: verifies that `Unstable` with a dead admin credential projects to `needs_reauth`, `Unstable` with an active credential stays `Unstable`, and `PendingVerification`/`Disabled` pass through unchanged.

## Breaking changes

- [x] No

## Security considerations

The premature-OAuth-completion guard prevents a reauthorization from silently succeeding with a stale or broken credential when the upstream authorization server rejects the flow before the callback runs. Without it, an admin could believe reauth succeeded while the client continues operating on an invalid credential.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)