### PR TITLE
docs: add `needs_session_stickiness` field, session stickiness behavior, and per-call vs sticky connection docs

### DIFF
--- a/docs/deployment-guides/config-json/schema-reference.mdx
+++ b/docs/deployment-guides/config-json/schema-reference.mdx
@@ -290,6 +290,7 @@ Common fields on each `client_configs` entry:
 | `tools_to_auto_execute` | array | Subset of `tools_to_execute` that runs without user confirmation |
 | `headers` | object | Static admin headers (used by `headers` and as additions on `per_user_headers`) |
 | `is_code_mode_client` | boolean | Wrap tools as Python code-mode helpers instead of raw tool calls |
+| `needs_session_stickiness` | boolean | HTTP-only, and only meaningful for `oauth`/`headers`/`none` (per-user auth types are always per-call). `true` holds one persistent upstream connection reused for every tool call; `false`/omitted (default) dials fresh per tool call. Cannot be `false` for `connection_type` `"sse"`/`"stdio"` — both are always sticky. See [Session Stickiness](/mcp/connecting-to-servers#session-stickiness-http-only). |
 
 Auth-type-specific fields:
 

--- a/docs/mcp/auth/headers.mdx
+++ b/docs/mcp/auth/headers.mdx
@@ -100,6 +100,8 @@ Use `"env.MY_VAR"` for environment variable references — e.g. `"Authorization"
 </Tab>
 </Tabs>
 
+By default this connection is per-call (a fresh connection per tool call, no shared upstream connection to keep alive) — see [Session Stickiness](../connecting-to-servers#session-stickiness-http-only) to make it sticky instead.
+
 ---
 
 ## Header lifecycle

--- a/docs/mcp/auth/oauth.mdx
+++ b/docs/mcp/auth/oauth.mdx
@@ -164,6 +164,8 @@ Once authorized, the OAuth credentials live in the encrypted `oauth_configs` tab
 </Tab>
 </Tabs>
 
+By default this connection is per-call (a fresh connection and credential resolution per tool call, no shared upstream connection to keep alive) — see [Session Stickiness](../connecting-to-servers#session-stickiness-http-only) to make it sticky instead.
+
 ---
 
 ## PKCE for public clients

--- a/docs/mcp/connecting-to-servers.mdx
+++ b/docs/mcp/connecting-to-servers.mdx
@@ -67,6 +67,65 @@ HTTP connections communicate with MCP servers via HTTP requests. Ideal for remot
 
 For authenticated upstream servers, see [Authentication →](./auth/overview) and pick the auth type that matches: [Headers](./auth/headers), [OAuth 2.0](./auth/oauth), [Per-User OAuth](./auth/per-user-oauth), or [Per-User Headers](./auth/per-user-headers).
 
+#### Session Stickiness (HTTP only)
+
+For a **server-level** client (`auth_type` `oauth`, `headers`, or `none` — not the per-user auth types below, which are always per-call regardless of this setting), `needs_session_stickiness` controls whether Bifrost holds one persistent upstream connection or dials fresh for every tool call:
+
+| Value | Behavior |
+| --- | --- |
+| `true` | **Sticky.** One shared connection is opened once and reused for every tool call, with an automatic health-checked reconnect on failure. Lower per-call latency; if the connection's credential dies, the client needs an admin `reauthorize` to recover. |
+| `false` / omitted (default) | **Per-call.** A fresh connection (and, for `oauth`, a fresh credential resolution) is opened for every tool call and closed immediately after. Slightly higher per-call latency, but a dead upstream credential only affects the calls made while it's dead — nothing to manually reconnect once it's fixed. |
+
+Only meaningful for `connection_type: "http"` — `sse` and `stdio` connections are always sticky (an SSE session is inherently bound to its open stream, and STDIO needs a persistent subprocess), and explicitly setting `needs_session_stickiness: false` on either is rejected at creation.
+
+<Tabs>
+<Tab title="Web UI">
+
+Toggle **Session Stickiness** in the client's create/edit sheet (HTTP connections only):
+
+<Frame>
+  <img src="/media/ui-mcp-session-stickiness.png" alt="MCP client edit sheet showing the Session Stickiness toggle" />
+</Frame>
+
+</Tab>
+<Tab title="API">
+
+```bash
+curl -X POST http://localhost:8080/api/mcp/client \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "shared-api",
+    "connection_type": "http",
+    "connection_string": "https://mcp-server.example.com/mcp",
+    "auth_type": "oauth",
+    "needs_session_stickiness": false
+  }'
+```
+
+Omit the field to get the default (per-call). Existing clients can flip it via `PUT /api/mcp/client/{id}`.
+
+</Tab>
+<Tab title="config.json">
+
+```json
+{
+  "mcp": {
+    "client_configs": [
+      {
+        "name": "shared-api",
+        "connection_type": "http",
+        "connection_string": "https://mcp-server.example.com/mcp",
+        "auth_type": "oauth",
+        "needs_session_stickiness": false
+      }
+    ]
+  }
+}
+```
+
+</Tab>
+</Tabs>
+
 ### SSE Connections
 
 Server-Sent Events (SSE) connections provide a persistent transport to MCP servers that stream events. Supports the same auth options as HTTP.

--- a/docs/openapi/schemas/management/mcp.yaml
+++ b/docs/openapi/schemas/management/mcp.yaml
@@ -194,6 +194,17 @@ MCPClientCreateRequestBase:
         Whether the MCP server supports ping for health checks.
         If true, uses lightweight ping method for health checks.
         If false, uses listTools method for health checks instead.
+    needs_session_stickiness:
+      type: boolean
+      default: false
+      description: |
+        HTTP-only. Only meaningful for auth_type "oauth", "headers", or "none"
+        (a server-level connection) — per-user auth types are always per-call
+        regardless of this field. When true, Bifrost holds one persistent
+        upstream connection, reused for every tool call. When false or
+        omitted (the default), a fresh connection is dialed per tool call.
+        Cannot be set to false for connection_type "sse" or "stdio" — both
+        are always sticky.
     tool_sync_interval:
       type: integer
       description: |
@@ -376,6 +387,15 @@ MCPClientUpdateRequest:
         Whether the MCP server supports ping for health checks.
         If true, uses lightweight ping method for health checks.
         If false, uses listTools method for health checks instead.
+    needs_session_stickiness:
+      type: boolean
+      description: |
+        HTTP-only. Only meaningful for auth_type "oauth", "headers", or "none"
+        — per-user auth types are always per-call regardless of this field.
+        When true, Bifrost holds one persistent upstream connection, reused
+        for every tool call. When false, a fresh connection is dialed per
+        tool call. Cannot be set to false for connection_type "sse" or
+        "stdio" — both are always sticky.
     tool_sync_interval:
       type: integer
       description: |


### PR DESCRIPTION
## Summary

Documents the new `needs_session_stickiness` field for HTTP MCP client configurations, which controls whether Bifrost holds a single persistent upstream connection or opens a fresh connection per tool call.

## Changes

- Added `needs_session_stickiness` to the schema reference table with a full description of its behavior, constraints, and relationship to auth types and connection types.
- Added a new **Session Stickiness (HTTP only)** section to the connecting-to-servers page, including a behavior comparison table and Web UI, API, and `config.json` usage examples.
- Added per-call default behavior callouts to the `headers` and `oauth` auth pages, linking to the new session stickiness section.
- Added `needs_session_stickiness` to both `MCPClientCreateRequestBase` and `MCPClientUpdateRequest` in the OpenAPI schema with full field descriptions.

The field is only meaningful for server-level auth types (`oauth`, `headers`, `none`) on HTTP connections. SSE and STDIO connections are always sticky by nature, and setting `needs_session_stickiness: false` on either is rejected. Per-user auth types are always per-call regardless of this field.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation for:
- The `needs_session_stickiness` row in the schema reference table at `docs/deployment-guides/config-json/schema-reference.mdx`
- The new Session Stickiness section in `docs/mcp/connecting-to-servers.mdx`, including the behavior table and all three tabs (Web UI, API, config.json)
- The per-call default callouts at the bottom of the `headers` and `oauth` auth pages

Verify that the OpenAPI schema descriptions for `needs_session_stickiness` are accurate in both the create and update request objects.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. This field controls connection lifecycle behavior only and does not affect credential handling or secret exposure.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable