### PR TITLE
docs: add `connections` page with full state table, connection-mode matrix, and per-auth-type lifecycle; rename `connected`→`healthy`, `disconnected`→`unstable`

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -181,6 +181,7 @@
             "pages": [
               "mcp/overview",
               "mcp/connecting-to-servers",
+              "mcp/connections",
               {
                 "group": "Authentication",
                 "icon": "shield-check",

--- a/docs/mcp/auth/oauth.mdx
+++ b/docs/mcp/auth/oauth.mdx
@@ -153,7 +153,7 @@ The `oauth_config` block itself is optional, and every inner field is optional. 
 `client_id` and `client_secret` support `env.VAR_NAME` and `vault.path` references — `"client_secret": "env.GITHUB_SECRET"` resolves from the environment at runtime, and the reference (not the resolved secret) is what gets stored. Plain values also work (encrypted at rest, redacted in API responses). The other fields (`authorize_url`, `token_url`, `registration_url`, `scopes`) take literal values only.
 </Note>
 
-At boot the client lands in **`pending_verification`** state because the OAuth flow still needs a live admin browser session to complete. From the MCP Gateway UI, open the client and click **Authorize** — the same browser popup the Web UI Create flow uses. On success the OAuth tokens are stored, the tool list is discovered, and the client transitions to `connected`.
+At boot the client lands in **`pending_verification`** state because the OAuth flow still needs a live admin browser session to complete. From the MCP Gateway UI, open the client and click **Authorize** — the same browser popup the Web UI Create flow uses. On success the OAuth tokens are stored, the tool list is discovered, and the client transitions to `healthy`.
 
 The same flow is scriptable: `POST /api/mcp/client/{id}/initiate-verification` (this time `{id}` *is* the MCP client ID) returns the same `authorize_url` / `status_url` / `complete_url` payload as the create flow above — open `authorize_url` in a browser, poll `status_url`, then POST `complete_url`. Safe to call again if a previous attempt expired or was abandoned.
 
@@ -310,7 +310,7 @@ Rotating `client_id` or `client_secret` immediately signs out every current sess
 
 A shared OAuth client whose credential permanently dies lands in the **`needs_reauth`** connection state: the client was authorized and connected at least once, but the token can no longer be refreshed (provider-side revocation, expired refresh token, or a credential rotation). This is distinct from `pending_verification`, which means initial setup never completed.
 
-`needs_reauth` is sticky: the health monitor and enable/disable toggles will not flip the client back to `connected` or `disconnected`, and the **Reconnect** action is disabled for it (reconnecting cannot help when the credential itself is dead). Only a human redoing consent clears it.
+`needs_reauth` is sticky: the health monitor and enable/disable toggles will not flip the client back to `healthy` or `unstable`, and the **Reconnect** action is disabled for it (reconnecting cannot help when the credential itself is dead). Only a human redoing consent clears it.
 
 From the dashboard, open the client and click **Reauthorize**: Bifrost redoes the OAuth consent flow in a popup against the currently stored credentials, and on completion reconnects the client.
 

--- a/docs/mcp/auth/overview.mdx
+++ b/docs/mcp/auth/overview.mdx
@@ -54,21 +54,9 @@ Per-user auth requires every request to carry an identity. See [Identity modes](
 
 [Token Exchange](./token-exchange) (`token_exchange`) is a third shape that doesn't fit either column cleanly: like per-user auth, every caller reaches the upstream server under their own identity — but unlike `per_user_oauth` / `per_user_headers`, no credential is persisted per caller. Each tool call carries the caller's identity-provider token, and Bifrost exchanges it on a cache miss (with a short in-memory cache), so there's no consent step, no Sessions UI row, and no per-user revoke step — offboarding a user at the identity provider is reflected within the token's cached lifetime (up to 5 minutes, or the identity provider's own token expiry if shorter), not instantly. It requires identity authentication on every request; a virtual key alone is not sufficient.
 
-Connection-state semantics (`connected`, `disconnected`, `error`, `pending_tools`, `disabled`, shown on the MCP client list) describe a persistent upstream connection, so they only apply to server-level clients. Per-user clients don't maintain a persistent upstream connection between calls: each tool call resolves and uses the caller's credential on its own, with nothing held open between calls, so the dashboard links a per-user client to its [MCP Sessions](../sessions) rows instead of showing a connection state for it. Two lifecycle states are the exception: `pending_verification` appears for every auth type, and `needs_reauth` appears for `oauth`, `per_user_oauth`, `per_user_headers`, and `token_exchange`.
+Connection-state semantics describe a persistent upstream connection, so most of them only apply to server-level clients. Per-user clients don't maintain a persistent upstream connection between calls: each tool call resolves and uses the caller's credential on its own, with nothing held open between calls, so the dashboard links a per-user client to its [MCP Sessions](../sessions) rows instead of showing a connection state for it. Two lifecycle states are the exception: `pending_verification` appears for every auth type, and `needs_reauth` appears for `oauth`, `per_user_oauth`, `per_user_headers`, and `token_exchange`.
 
-### Connection states
-
-| State | Meaning | Applies to |
-| --- | --- | --- |
-| `connected` | Reachable and serving tool calls. | Server-level only |
-| `disconnected` | Not currently connected, e.g. before the first connect attempt or after a disable/re-enable cycle. | Server-level only |
-| `error` | The last connection attempt failed. | Server-level only |
-| `pending_tools` | Connected; the tool list sync is still in progress. | Server-level only |
-| `disabled` | An admin turned the client off; its configuration is preserved while its connection and background workers are shut down. | Server-level only |
-| `pending_verification` | Declared in `config.json`; needs a one-time OAuth authorization or headers/token-exchange verification before use. All six auth types can be declared this way, and the four that need an admin verification step (`oauth`, `per_user_oauth`, `per_user_headers`, `token_exchange`) land here at boot. The MCP Gateway UI surfaces an **Authorize** / **Verify** CTA on each pending row that runs the same verification flow the Web UI Create form uses. See each auth type's page for the `config.json` shape. | All auth types |
-| `needs_reauth` | Server-level: the connection credential itself died and must be reauthorized via the **Reauthorize** button on the client sheet (or [`POST /api/mcp/client/{id}/reauthorize`](./oauth#reauthorization)). Per-user (`per_user_oauth`, `per_user_headers`, `token_exchange`): the admin credential Bifrost retains to refresh the server's tool list needs repair, a display-level state only; end-user credentials and tool calls keep working, only tool-list refresh pauses until an admin repairs it from the client sheet: **Repair OAuth** for [`per_user_oauth`](./per-user-oauth#admin-discovery-credential), **Update headers** for [`per_user_headers`](./per-user-headers#admin-discovery-credential), or **Re-verify as me** for [`token_exchange`](./token-exchange#admin-discovery-credential). | `oauth`, `per_user_oauth`, `per_user_headers`, `token_exchange` |
-
-Short of the `needs_reauth` case (which requires manual repair before reconnection), token rotation and reauthorization never require downtime for HTTP/SSE server-level clients: reconnection is [make-before-break](../gateway#reconnection-behavior), so the existing connection keeps serving tool calls until the new one is ready.
+For the full connection-state table, connection-mode (sticky vs. per-call) matrix, and per-auth-type lifecycle walkthroughs, see **[Connections, States & Lifecycles →](../connections)**.
 
 ---
 

--- a/docs/mcp/auth/per-user-headers.mdx
+++ b/docs/mcp/auth/per-user-headers.mdx
@@ -137,7 +137,7 @@ Declare the client with `auth_type: "per_user_headers"` and the required header-
 }
 ```
 
-At boot the client lands in **`pending_verification`** state. From the MCP Gateway UI, open the client and click **Verify** — Bifrost opens the same sample-values dialog the Web UI Create flow uses. Submit values, the upstream verify runs, tools are discovered, the values are retained as the [admin discovery credential](#admin-discovery-credential) for later tool-list refresh, and the client transitions to `connected`.
+At boot the client lands in **`pending_verification`** state. From the MCP Gateway UI, open the client and click **Verify** — Bifrost opens the same sample-values dialog the Web UI Create flow uses. Submit values, the upstream verify runs, tools are discovered, the values are retained as the [admin discovery credential](#admin-discovery-credential) for later tool-list refresh, and the client transitions to `healthy`.
 
 The same step is scriptable — no browser involved:
 
@@ -152,7 +152,7 @@ curl -X POST http://localhost:8080/api/mcp/client/{id}/verify-headers \
   }'
 ```
 
-`user_headers` must cover every declared key. On success the response carries `tools_count` and the client transitions to `connected`; a `422` means the upstream verify failed (retry with different values). A `409` means the client was already verified and its [admin discovery credential](#admin-discovery-credential) is healthy (or absent), so there is nothing to re-verify. The one legitimate repeat call is a repair: while the admin credential sits in `needs_update`, the endpoint accepts fresh sample values and flips the credential back to `active` on success.
+`user_headers` must cover every declared key. On success the response carries `tools_count` and the client transitions to `healthy`; a `422` means the upstream verify failed (retry with different values). A `409` means the client was already verified and its [admin discovery credential](#admin-discovery-credential) is healthy (or absent), so there is nothing to re-verify. The one legitimate repeat call is a repair: while the admin credential sits in `needs_update`, the endpoint accepts fresh sample values and flips the credential back to `active` on success.
 
 **Lifecycle across restarts and config edits:** the verified state (discovered tools) is server-side and survives restarts and config.json re-syncs, including edits to `per_user_header_keys` — new keys apply to end-user submissions without re-verification. The key list cannot be *emptied*, though: an edit that removes all keys is ignored and the stored keys kept (with a warning at boot). Immutable fields — `auth_type`, `connection_type`, `connection_string`, `stdio_config` — cannot be changed after creation: file edits to them are ignored with a boot warning, matching the update API. Delete the client and re-declare it to change them.
 

--- a/docs/mcp/auth/per-user-oauth.mdx
+++ b/docs/mcp/auth/per-user-oauth.mdx
@@ -86,7 +86,7 @@ The `oauth_config` block itself is optional, and every inner field is optional. 
 `client_id` and `client_secret` support `env.VAR_NAME` and `vault.path` references — `"client_secret": "env.GITHUB_SECRET"` resolves from the environment at runtime, and the reference (not the resolved secret) is what gets stored. Plain values also work (encrypted at rest, redacted in API responses). The other fields (`authorize_url`, `token_url`, `registration_url`, `scopes`) take literal values only.
 </Note>
 
-At boot the client lands in **`pending_verification`** state. From the MCP Gateway UI, open the client and click **Verify** — Bifrost runs the same admin test login popup the Web UI flow uses. On success the client transitions to `connected` with the tool list discovered, and the admin's bootstrap token is retained as the [admin discovery credential](#admin-discovery-credential) for later tool-list refresh.
+At boot the client lands in **`pending_verification`** state. From the MCP Gateway UI, open the client and click **Verify** — Bifrost runs the same admin test login popup the Web UI flow uses. On success the client transitions to `healthy` with the tool list discovered, and the admin's bootstrap token is retained as the [admin discovery credential](#admin-discovery-credential) for later tool-list refresh.
 
 The same flow is scriptable: `POST /api/mcp/client/{id}/initiate-verification` (`{id}` = MCP client ID) returns `authorize_url` plus `status_url` / `complete_url` hints — open `authorize_url` in a browser for the one-time admin login, poll `status_url` until `authorized`, then POST `complete_url` to run verification and tool discovery.
 

--- a/docs/mcp/connecting-to-servers.mdx
+++ b/docs/mcp/connecting-to-servers.mdx
@@ -262,7 +262,7 @@ Response:
       {"name": "write_file", "description": "Write contents to a file"},
       {"name": "list_directory", "description": "List directory contents"}
     ],
-    "state": "connected"
+    "state": "healthy"
   }
 ]
 ```
@@ -758,11 +758,15 @@ response, err := client.ChatCompletionRequest(bifrostCtx, request)
 
 | State | Description |
 |-------|-------------|
-| `connected` | Client is active and tools are available |
-| `connecting` | Client is establishing connection |
-| `disconnected` | Client lost connection but can be reconnected |
+| `healthy` | Client is active and tools are available |
+| `unstable` | The last periodic health check failed transiently — self-heals, tool calls still attempted normally |
+| `needs_reauth` | The connection credential died and needs an admin to reauthorize (server-level), or the retained admin discovery credential needs repair (per-user) |
 | `pending_verification` | Declared (typically via config.json) with an auth type that needs a one-time admin step — complete it via the UI's Authorize/Verify button, `POST /api/mcp/client/{id}/initiate-verification` (OAuth types), or `POST /api/mcp/client/{id}/verify-headers` (per-user headers) |
-| `error` | Client configuration or connection failed |
+| `disabled` | An admin intentionally turned the client off |
+| `error` | A data-consistency fallback — the client is registered but missing from the runtime manager |
+| `degraded` | Cluster-only: instances currently disagree on this client's state |
+
+See [Connections, States & Lifecycles](./connections) for the full picture — connection mode, self-healing behavior, and per-auth-type lifecycles.
 
 ### Managing Clients at Runtime
 
@@ -906,10 +910,9 @@ err := client.EditMCPClient(context.Background(), schemas.MCPClientConfig{
 
 ### Health Check Behavior
 
-When a client disconnects:
-1. State changes to `disconnected`
-2. Tools from that client become unavailable
-3. You can reconnect via API or UI
+When a client's periodic health check fails:
+1. State changes to `unstable` — purely informational, tool calls are still attempted normally against it
+2. You can also reconnect manually via API or UI, though `unstable` self-heals on its own once the next check succeeds
 
 **Note:** Changing `is_ping_available` takes effect immediately without requiring a client reconnection.
 
@@ -979,11 +982,10 @@ Bifrost applies retry logic to these critical operations:
 
 When a client reaches 5 consecutive health check failures:
 
-1. Client state changes to `disconnected`
+1. Client state changes to `unstable`
 2. Bifrost automatically attempts reconnection **in the background**
 3. Reconnection uses the same exponential backoff retry logic
-4. Once reconnected, health checks resume normal operation
-5. Tools become available again without manual intervention
+4. Once reconnected, health checks resume normal operation and state returns to `healthy`
 
 This automatic reconnection happens asynchronously and doesn't block other operations.
 

--- a/docs/mcp/connections.mdx
+++ b/docs/mcp/connections.mdx
@@ -1,0 +1,150 @@
+---
+title: "Connections, States & Lifecycles"
+sidebarTitle: "Connections & States"
+description: "How Bifrost holds a connection to each MCP server type, every connection state, and what a client's lifecycle looks like end to end."
+icon: "diagram-project"
+---
+
+This page is the canonical reference for **connection mode** (sticky vs. per-call) and **connection state** across every MCP auth type. For the auth-type decision itself (which credential shape to use), see [MCP Authentication](./auth/overview).
+
+---
+
+## Two independent axes
+
+Every MCP client sits somewhere on two independent axes:
+
+1. **Who authenticates** — server-level (`none`, `headers`, `oauth`) vs. per-user (`per_user_headers`, `per_user_oauth`, `token_exchange`). Covered in [MCP Authentication](./auth/overview).
+2. **How the connection is held** — **sticky** (one persistent upstream connection, reused for every tool call) vs. **per-call** (a fresh connection dialed per tool call, closed immediately after). This page's focus.
+
+The two axes aren't fully independent — which connection modes are even available depends on auth type and connection type:
+
+| Auth type | Connection type | Connection mode |
+| --- | --- | --- |
+| `none`, `headers`, `oauth` | `http` | **Choosable** via [`needs_session_stickiness`](./connecting-to-servers#session-stickiness-http-only) — sticky if `true`, per-call if `false`/omitted (default) |
+| `none`, `headers`, `oauth` | `sse`, `stdio` | **Always sticky** — an SSE session is inherently bound to its open stream, and STDIO needs a persistent subprocess. Setting `needs_session_stickiness: false` on either is rejected at creation. |
+| `per_user_headers`, `per_user_oauth`, `token_exchange` | any | **Always per-call**, regardless of `needs_session_stickiness` (the field is ignored for these auth types) — each caller's own credential is resolved fresh per request; there is no single shared connection to keep alive |
+
+So `needs_session_stickiness` only ever has an effect on `http` connections using a server-level auth type. Everything else is fixed by construction.
+
+<Note>
+Two entirely separate credential-resolution paths exist for per-user auth types, and they're easy to conflate: the **admin discovery credential** (retained once, used only for periodically refreshing the server's tool list) and the **end-user's own credential** (resolved per request, used only for the actual tool call). See [Per-user lifecycle](#per-user-lifecycle-per_user_oauth-per_user_headers-token_exchange) below.
+</Note>
+
+---
+
+## Connection states
+
+| State | Meaning | Self-heals? | Gates tool execution? | Applies to |
+| --- | --- | --- | --- | --- |
+| `healthy` | Bifrost's own periodic connection check (ping/`list_tools` for sticky, `list_tools` for per-call) most recently succeeded. | — | No | Sticky and per-call (server-level) |
+| `unstable` | The periodic check most recently failed with a transient-classified error. Purely informational — tool calls are still attempted normally regardless. Reflects only Bifrost's own health checks, never the outcome of real tool calls. | Yes — next successful check | **No** | Sticky and per-call (server-level) |
+| `needs_reauth` | **Server-level:** the connection credential itself died with no way to silently recover (e.g. an OAuth refresh token rejected upstream) — a hard gate, tool calls are refused outright rather than attempted against a known-dead credential, and the periodic checker goes quiet on this client until a human reauthorizes. **Per-user** (`per_user_oauth`, `per_user_headers`, `token_exchange`): a **response-only projection**, computed at list-time, never stored in the runtime manager. It means the *retained admin discovery credential* needs repair — end-user credentials and tool calls keep working the whole time; only the periodic tool-list refresh pauses. Overlays onto both `healthy` and `unstable` runtime readings (it's a more actionable signal than either), but never onto `disabled` or `pending_verification` — those already carry a more specific, authoritative meaning of their own. | **No** — human action required either way | Server-level: **yes**. Per-user: no (only the discovery refresh pauses) | All except `none` |
+| `pending_verification` | Declared (typically via `config.json`) but the one-time auth/verification flow hasn't been completed by an admin yet. | No — needs the one-time verification | Yes, implicitly (nothing to call yet) | All auth types |
+| `disabled` | An admin intentionally turned the client off. Configuration is preserved; connection and background workers are shut down. Authoritative — never silently overridden by a check result or the `needs_reauth` projection. | No — needs a manual re-enable | Yes | Sticky and per-call (server-level) |
+| `error` | A data-consistency fallback used only when a client is registered in the config store but missing from the runtime manager entirely — a deeper anomaly than anything in the normal lifecycle, and never assigned by the connect/health-check machinery itself. | — | Yes | All (rare) |
+| `degraded` | A **read-time cluster aggregate**, never a single node's own local state: multiple instances of a distributed deployment each currently hold a different self-reported state for the same client (e.g. one instance sees `healthy` while another currently sees `unstable`). Only meaningful for states that can genuinely vary per instance (`healthy`, `unstable`, `pending_verification`); `needs_reauth`/`disabled` are config-sourced facts expected to already agree everywhere, so disagreement there is a propagation problem, not something this value covers. Never appears in a single-instance deployment. | Depends on the underlying disagreement resolving | — | Cluster deployments only |
+
+<Note>
+`pending_tools` and a bare `connected`/`disconnected` naming existed in older versions of this doc set — the current state names are exactly the seven above. If you see `connected`, `disconnected`, `connecting`, or `pending_tools` referenced anywhere else in these docs, that's stale and maps to `healthy`, `unstable`, (nothing — was never a real state), and (removed — an empty `healthy` tool map already communicates the same thing) respectively.
+</Note>
+
+---
+
+## Lifecycle: sticky server-level (`needs_session_stickiness: true`, or `sse`/`stdio`)
+
+```mermaid
+flowchart LR
+    A[Create] --> B[Connect]
+    B -->|success| C[healthy]
+    B -->|failure, transient| D[unstable]
+    C -->|periodic check fails, transient| D
+    D -->|periodic check succeeds| C
+    D -->|credential dead, no silent recovery| E[needs_reauth]
+    C -->|credential dead| E
+    E -->|admin reauthorizes| B
+```
+
+- **Connect** happens once at `AddClient` (boot, or client creation) and again on every reconnect. Reconnects are [make-before-break](./gateway#reconnection-behavior): the old connection keeps serving until the new one is ready, so token rotation never causes downtime.
+- **`unstable`** is purely informational — a network blip doesn't stop tool calls, and the client self-heals on the next successful check with no human involvement.
+- **`needs_reauth`** is a hard gate specifically for server-level clients: the periodic checker stops retrying entirely (retrying against a known-dead credential is pointless), and tool calls are refused outright rather than attempted. Recovery is [`POST /api/mcp/client/{id}/reauthorize`](./auth/oauth#reauthorization) (also covers `oauth`; `headers`/`none` credentials don't expire the same way, so this state is effectively OAuth-only in practice for server-level clients).
+- Every discovered tool list — from the initial connect and from every periodic refresh — persists to the DB, gated on the tool list actually having changed (no write on an unchanged tick), so a restart doesn't lose anything a running instance had already discovered.
+
+---
+
+## Lifecycle: per-call server-level (`needs_session_stickiness: false`/omitted, `http` only)
+
+```mermaid
+flowchart LR
+    A[Create] --> B[Synchronous first discovery]
+    B -->|success| C[healthy, 0+ tools]
+    B -->|failure| D[unstable]
+    C -->|periodic re-discovery ticks| C
+    D -->|periodic re-discovery succeeds| C
+    D -->|periodic re-discovery fails| D
+```
+
+- No persistent connection ever exists — every tool call dials fresh and closes immediately after. There's nothing to reconnect (`POST /reconnect` returns `400` for this mode), and `needs_reauth` doesn't apply here (there's no single connection credential to die — `headers`/`none`/`oauth` per-call clients cycle through a fresh credential resolution on every call).
+- `AddClient` runs a **synchronous** first discovery pass if no tools are already known (e.g. from a prior successful discovery persisted to the DB) — without this, a client would sit at `healthy`/0-tools until the periodic checker's slow first tick, which can be minutes away for an already-`healthy` client.
+- The periodic checker's ongoing ticks are the *only* thing revisiting this client afterward — same content-hash gating as the sticky case, so an unchanged tool list doesn't cause a write.
+
+---
+
+## Lifecycle: per-user (`per_user_oauth`, `per_user_headers`, `token_exchange`)
+
+Per-user clients have **two entirely separate credential paths**, which is the single most important thing to understand about them:
+
+```mermaid
+flowchart TB
+    subgraph Admin["Admin discovery credential (retained once)"]
+        A1[Bootstrap verify: admin submits sample credential] --> A2[Credential retained]
+        A2 --> A3[AddClient / periodic checker: refreshes the server's advertised tool list]
+        A3 -->|credential dies| A4[needs_reauth projection]
+        A4 -->|admin repairs| A2
+    end
+    subgraph User["End-user credential (per caller, lazy)"]
+        U1[Caller's first tool call] -->|no credential yet| U2[mcp_auth_required + auth URL]
+        U2 --> U3[User completes their own auth]
+        U3 --> U4[Credential stored, keyed to identity]
+        U4 --> U5[Every later call: resolved transparently]
+    end
+```
+
+**Admin discovery credential** — exists purely to keep the *advertised tool list* current, independent of any individual user:
+
+1. **Bootstrap.** An admin submits a sample credential once (`POST /verify-headers`, `POST /verify-exchange`, or the `complete-oauth` callback for `per_user_oauth`). This is the one and only time a live admin session is required. As a side effect, that credential is **retained** server-side.
+2. **Ongoing refresh.** `AddClient`'s own synchronous first-discovery pass and the periodic checker's ongoing ticks both reuse the *retained* credential (never a fresh admin login) to keep the tool list current — same content-hash-gated persistence as server-level clients.
+3. **Repair.** If the retained credential itself dies (OAuth refresh fails, or a header schema change flips it to stale), it projects as `needs_reauth` in the client list — but only when the underlying runtime reading is `healthy` or `unstable`; a client sitting in `pending_verification` or `disabled` keeps that state instead. Repair is auth-type-specific: `POST /verify-headers` (headers), `POST /verify-exchange` (token exchange), or `reauthorize` → `complete-oauth` (`per_user_oauth`).
+
+**End-user credential** — resolved per caller, on the actual tool-call path, with no relationship to the admin credential above:
+
+1. A caller's request carries an identity (VK, signed-in user, or session ID — see [Identity modes](./auth/overview#identity-modes)).
+2. Bifrost looks up that identity's own stored credential for this MCP client. Found and active → the call proceeds transparently. Missing or stale → an `mcp_auth_required` payload with an auth URL is returned instead of executing the tool.
+3. The caller completes their own auth (OAuth consent, or submitting header values) once; every later call resolves transparently from then on.
+
+<Warning>
+Because these two paths are independent, a per-user client's tool list can go stale (admin credential dead) while every end-user's actual tool calls keep working perfectly, or vice versa — a specific user can be locked out (their own credential expired) while the tool list stays perfectly current for everyone else. Don't assume `needs_reauth` on a per-user client means anyone is blocked; check which credential it actually refers to.
+</Warning>
+
+---
+
+## Recovery endpoints by combination
+
+| Endpoint | Sticky server-level | Per-call server-level | Per-user |
+| --- | --- | --- | --- |
+| `POST /api/mcp/client/{id}/reconnect` | ✅ Re-dials the persistent connection | ❌ `400` — nothing to reconnect | ❌ `400` — nothing to reconnect |
+| `POST /api/mcp/client/{id}/reauthorize` | ✅ Re-establishes a dead `oauth` credential | ✅ Same, for `oauth` | ✅ Re-establishes the *admin discovery* credential for `per_user_oauth` only |
+| `POST /api/mcp/client/{id}/verify-headers` | — (`headers` has no expiring credential) | — | ✅ `per_user_headers` bootstrap + repair |
+| `POST /api/mcp/client/{id}/verify-exchange` | — | — | ✅ `token_exchange` bootstrap + repair |
+| `POST /api/mcp/client/{id}/initiate-verification` | ✅ `oauth` clients still in `pending_verification` (config.json bootstrap) | ✅ Same | ✅ `per_user_oauth` bootstrap (first step of the two-step OAuth dance) |
+| `POST /api/mcp/client/{oauth_config_id}/complete-oauth` | ✅ Completes the bootstrap or reauthorize OAuth dance | ✅ Same | ✅ Completes `per_user_oauth` bootstrap or admin-credential repair |
+| `PUT /api/mcp/client/{id}` (disable/enable, non-credential edits) | ✅ | ✅ | ✅ |
+
+A `reconnect`/`reauthorize`/`close` call that doesn't apply to a client's current connection mode returns a consistent error (`client uses per-call connections; there is no persistent connection to reconnect/close`) rather than one that implies something is specifically wrong with per-user auth — the same message applies to any per-call client, shared or per-user.
+
+---
+
+## Next Steps
+
+- [Session Stickiness](./connecting-to-servers#session-stickiness-http-only) — how to set `needs_session_stickiness`
+- [MCP Authentication](./auth/overview) — which auth type to pick
+- [MCP Gateway](./gateway) — reconnection behavior, dynamic tool discovery, health monitoring

--- a/docs/mcp/filtering.mdx
+++ b/docs/mcp/filtering.mdx
@@ -472,7 +472,7 @@ curl http://localhost:8080/api/mcp/clients
       { "name": "read_file", "description": "Read file contents" },
       { "name": "write_file", "description": "Write to file" }
     ],
-    "state": "connected"
+    "state": "healthy"
   }
 ]
 ```

--- a/docs/mcp/gateway.mdx
+++ b/docs/mcp/gateway.mdx
@@ -255,7 +255,7 @@ Bifrost automatically monitors the health of connected MCP clients:
 **How it works:**
 - **Ping Mechanism:** Every 10 seconds (configurable), sends a ping to each connected client
 - **Check Timeout:** Each ping has a 5-second timeout
-- **Failure Threshold:** After 5 consecutive failed pings, client is marked as `disconnected`
+- **Failure Threshold:** After 5 consecutive failed pings, client is marked as `unstable`
 - **State Tracking:** Real-time state updates (connected ↔ disconnected)
 - **Manual Reconnection:** Once disconnected by failed health checks, requires manual reconnect via API or UI. One exception: when a live tool call hits a clean upstream auth rejection, Bifrost force-refreshes the credential and reconnects in the background on its own (see [Auth failure recovery](./tool-execution#auth-failure-recovery))
 - **`needs_reauth` is sticky:** clients whose OAuth credential permanently died are parked in `needs_reauth`, health checks won't flip them back, and Reconnect is disabled for them; an admin must [reauthorize](./auth/oauth#reauthorization) instead

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -837,7 +837,7 @@ export default function MCPClientsTable({
 												</p>
 												<a
 													data-testid="mcp-client-state-link"
-													href="https://docs.getbifrost.ai/mcp/auth/overview#connection-states"
+													href="https://docs.getbifrost.ai/mcp/connections"
 													target="_blank"
 													rel="noreferrer"
 													className="text-primary mt-2 inline-block underline"


### PR DESCRIPTION
## Summary

Introduces a new canonical reference page for MCP connection states and client lifecycles, and updates all existing docs and UI links to use the revised state naming (`healthy`/`unstable` replacing `connected`/`disconnected`).

## Changes

- Added `docs/mcp/connections.mdx` — a new dedicated page covering connection mode (sticky vs. per-call), the full connection-state table with self-healing and tool-execution-gating behavior, lifecycle flowcharts for each client type (sticky server-level, per-call server-level, per-user), and a recovery-endpoint matrix by combination.
- Registered the new page in `docs/docs.json` under the MCP sidebar.
- Renamed `connected` → `healthy` and `disconnected` → `unstable` throughout all MCP docs (`connecting-to-servers.mdx`, `filtering.mdx`, `gateway.mdx`, `auth/oauth.mdx`, `auth/per-user-oauth.mdx`, `auth/per-user-headers.mdx`) and updated all prose that referenced the old state names.
- Removed the inline connection-state table from `auth/overview.mdx` and replaced it with a pointer to the new canonical page, keeping the overview focused on auth-type selection.
- Updated the UI's "learn more about connection states" link from the old `auth/overview#connection-states` anchor to `mcp/connections`.
- Clarified `needs_reauth` semantics: for server-level clients it gates tool execution; for per-user clients it is a response-only projection that only pauses tool-list refresh while end-user calls continue unaffected.
- Added a note in `connections.mdx` mapping old state names (`connected`, `disconnected`, `connecting`, `pending_tools`) to their current equivalents for readers coming from older docs.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
# UI
cd ui
pnpm i || npm i
pnpm build || npm run build
```

Verify the new `mcp/connections` page renders correctly in the docs site and that the sidebar entry appears between `connecting-to-servers` and the Authentication group. Confirm the UI's state-info link navigates to `https://docs.getbifrost.ai/mcp/connections`.

## Screenshots/Recordings

N/A — documentation and a single link update only.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None — documentation and a UI hyperlink change only.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable