### PR TITLE
docs: rename MCP states to `healthy`/`unstable`, add `degraded` and `needs_session_stickiness`, and expand 409/OAuth flow descriptions

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -42703,10 +42703,10 @@
           {
             "name": "state",
             "in": "query",
-            "description": "Comma-separated runtime connection states to include (OR semantics),\nresolved against live engine state. Only `connected` and\n`disconnected` are meaningful filter values: `connected` matches\nclients the engine currently reports as connected; `disconnected`\nmatches everything else (error, pending states, needs_reauth,\ndisabled, not present in the engine). Selecting both, or neither,\napplies no state filter. Note the response-only needs_reauth\nprojection on per-user clients happens after filtering, so such\nclients still match `connected`.\n",
+            "description": "Comma-separated runtime connection states to include (OR semantics),\nresolved against live engine state. Only `healthy` and\n`unstable` are meaningful filter values: `healthy` matches\nclients the engine currently reports as healthy; `unstable`\nmatches everything else (error, pending states, needs_reauth,\ndisabled, not present in the engine). Selecting both, or neither,\napplies no state filter. Note the response-only needs_reauth\nprojection on per-user clients happens after filtering, so such\nclients still match `healthy`.\n",
             "schema": {
               "type": "string",
-              "example": "connected"
+              "example": "healthy"
             }
           },
           {
@@ -42922,6 +42922,11 @@
                             "type": "boolean",
                             "default": true,
                             "description": "Whether the MCP server supports ping for health checks.\nIf true, uses lightweight ping method for health checks.\nIf false, uses listTools method for health checks instead.\n"
+                          },
+                          "needs_session_stickiness": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "HTTP-only. Only meaningful for auth_type \"oauth\", \"headers\", or \"none\"\n(a server-level connection) — per-user auth types are always per-call\nregardless of this field. When true, Bifrost holds one persistent\nupstream connection, reused for every tool call. When false or\nomitted (the default), a fresh connection is dialed per tool call.\nCannot be set to false for connection_type \"sse\" or \"stdio\" — both\nare always sticky.\n"
                           },
                           "tool_sync_interval": {
                             "type": "integer",
@@ -43175,6 +43180,11 @@
                             "default": true,
                             "description": "Whether the MCP server supports ping for health checks.\nIf true, uses lightweight ping method for health checks.\nIf false, uses listTools method for health checks instead.\n"
                           },
+                          "needs_session_stickiness": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "HTTP-only. Only meaningful for auth_type \"oauth\", \"headers\", or \"none\"\n(a server-level connection) — per-user auth types are always per-call\nregardless of this field. When true, Bifrost holds one persistent\nupstream connection, reused for every tool call. When false or\nomitted (the default), a fresh connection is dialed per tool call.\nCannot be set to false for connection_type \"sse\" or \"stdio\" — both\nare always sticky.\n"
+                          },
                           "tool_sync_interval": {
                             "type": "integer",
                             "description": "Per-client tool-list sync interval in minutes. 0 (or omitted) falls back\nto the global mcp_tool_sync_interval client config; a negative value\ndisables periodic tool sync for this client.\n"
@@ -43426,6 +43436,11 @@
                             "type": "boolean",
                             "default": true,
                             "description": "Whether the MCP server supports ping for health checks.\nIf true, uses lightweight ping method for health checks.\nIf false, uses listTools method for health checks instead.\n"
+                          },
+                          "needs_session_stickiness": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "HTTP-only. Only meaningful for auth_type \"oauth\", \"headers\", or \"none\"\n(a server-level connection) — per-user auth types are always per-call\nregardless of this field. When true, Bifrost holds one persistent\nupstream connection, reused for every tool call. When false or\nomitted (the default), a fresh connection is dialed per tool call.\nCannot be set to false for connection_type \"sse\" or \"stdio\" — both\nare always sticky.\n"
                           },
                           "tool_sync_interval": {
                             "type": "integer",
@@ -43702,6 +43717,10 @@
                   "is_ping_available": {
                     "type": "boolean",
                     "description": "Whether the MCP server supports ping for health checks.\nIf true, uses lightweight ping method for health checks.\nIf false, uses listTools method for health checks instead.\n"
+                  },
+                  "needs_session_stickiness": {
+                    "type": "boolean",
+                    "description": "HTTP-only. Only meaningful for auth_type \"oauth\", \"headers\", or \"none\"\n— per-user auth types are always per-call regardless of this field.\nWhen true, Bifrost holds one persistent upstream connection, reused\nfor every tool call. When false, a fresh connection is dialed per\ntool call. Cannot be set to false for connection_type \"sse\" or\n\"stdio\" — both are always sticky.\n"
                   },
                   "tool_sync_interval": {
                     "type": "integer",
@@ -44005,7 +44024,7 @@
       "post": {
         "operationId": "completeMCPClientOAuth",
         "summary": "Complete MCP client OAuth flow",
-        "description": "Completes an OAuth flow for an MCP client after the admin has authorized\nthe request upstream. Call it once the flow's status_url reports\n\"authorized\". It serves every admin-side OAuth completion with one\nendpoint:\n\n- Create-time and config.json-bootstrap flows: retrieves the pending MCP\n  client configuration and establishes the connection with the\n  OAuth-provided credentials (per_user_oauth clients instead verify with\n  the admin token, discover tools, and retain the token as the admin\n  discovery credential).\n- Reauthorize flows (started via POST /api/mcp/client/{id}/reauthorize):\n  for shared \"oauth\" clients, reconnects the client with the fresh\n  credential; for per_user_oauth clients, verifies the fresh admin token\n  upstream, re-discovers tools, and promotes it to the retained admin\n  discovery credential.\n\nReplays are rejected with 409: hitting the endpoint again after the flow\nalready completed (no pending configuration and no freshly-written\ntoken) returns \"OAuth flow has already been completed\".\n",
+        "description": "Completes an OAuth flow for an MCP client after the admin has authorized\nthe request upstream. Call it once the flow's status_url reports\n\"authorized\". It serves every admin-side OAuth completion with one\nendpoint:\n\n- Create-time and config.json-bootstrap flows: retrieves the pending MCP\n  client configuration and establishes the connection with the\n  OAuth-provided credentials (per_user_oauth clients instead verify with\n  the admin token, discover tools, and retain the token as the admin\n  discovery credential).\n- Reauthorize flows (started via POST /api/mcp/client/{id}/reauthorize):\n  for shared \"oauth\" clients, reconnects the client with the fresh\n  credential; for per_user_oauth clients, verifies the fresh admin token\n  upstream, re-discovers tools, and promotes it to the retained admin\n  discovery credential.\n\nReplays are rejected with 409: hitting the endpoint again after the flow\nalready completed (no pending configuration and no freshly-written\ntoken) returns \"OAuth flow has already been completed\". A shared\n\"oauth\" reauthorize is also rejected with 409 if its flow never\nactually resolved via a real callback — e.g. the upstream authorization\nserver rejected the request outright before ever redirecting back —\nreturning \"Authorization has not completed yet\". This is detected via\nthe flow's own row rather than the client's overall OAuth status,\nwhich never regresses once a client has been authorized once and so\ncan't distinguish a stale prior authorization from a fresh one.\n",
         "tags": [
           "MCP",
           "OAuth"
@@ -44058,7 +44077,7 @@
             }
           },
           "409": {
-            "description": "OAuth flow has already been completed for this MCP client (replay)",
+            "description": "Either \"OAuth flow has already been completed for this MCP client\"\n(replay), or \"Authorization has not completed yet: the browser\nflow may still be open, or the upstream provider rejected it\nbefore redirecting back\" (a shared \"oauth\" reauthorize whose flow\nnever actually resolved via a callback).\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -81714,15 +81733,15 @@
           "state": {
             "type": "string",
             "enum": [
-              "connected",
-              "disconnected",
+              "healthy",
+              "unstable",
               "error",
-              "pending_tools",
               "pending_verification",
               "needs_reauth",
-              "disabled"
+              "disabled",
+              "degraded"
             ],
-            "description": "Connection state of an MCP client:\n- connected: Client is connected and ready to use\n- disconnected: Client is not connected (will be auto-recovered by health monitor)\n- error: Client is in an unrecoverable error state\n- pending_tools: Connected but tools not yet populated (per-user clients)\n- pending_verification: Declared (typically via config.json) but the one-time\n  admin verification has not been completed yet. Complete it via\n  POST /api/mcp/client/{id}/initiate-verification (auth_type oauth /\n  per_user_oauth) or POST /api/mcp/client/{id}/verify-headers\n  (auth_type per_user_headers).\n- needs_reauth: Setup completed at least once, but a credential an admin is\n  responsible for has permanently died and needs a human to repair it.\n  For shared OAuth clients the connection credential itself was\n  rejected/expired with no silent recovery; the state is sticky (the health\n  monitor will not clobber it) until an admin runs\n  POST /api/mcp/client/{id}/reauthorize. For per-user clients this is a\n  response-only projection meaning the retained admin discovery credential\n  needs repair; end-user credentials and tool calls keep working, only\n  periodic tool-list refresh pauses. Repair via reauthorize\n  (per_user_oauth), verify-headers with fresh sample values\n  (per_user_headers), or verify-exchange (token_exchange, which\n  re-exchanges the signed-in admin's own identity token — no sample\n  values to supply).\n- disabled: Client has been intentionally disabled; no connection or workers are active\n"
+            "description": "Connection state of an MCP client:\n- healthy: Bifrost's own periodic connection check (ping/list_tools for\n  sticky clients, list_tools for per-call clients) most recently\n  succeeded.\n- unstable: The periodic connection check most recently failed with a\n  transient-classified error. Purely informational — unlike\n  needs_reauth, this never gates execution; tool calls are still\n  attempted normally. Self-heals to healthy on the next successful\n  check, no human action required.\n- error: A data-consistency fallback used only when a client is\n  registered in the config store but missing from the runtime manager\n  entirely — a deeper anomaly than anything in the normal\n  connect/health-check lifecycle, which never assigns this value itself.\n- pending_verification: Declared (typically via config.json) but the one-time\n  admin verification has not been completed yet. Complete it via\n  POST /api/mcp/client/{id}/initiate-verification (auth_type oauth /\n  per_user_oauth) or POST /api/mcp/client/{id}/verify-headers\n  (auth_type per_user_headers).\n- needs_reauth: Setup completed at least once, but a credential an admin is\n  responsible for has permanently died and needs a human to repair it.\n  For shared OAuth clients the connection credential itself was\n  rejected/expired with no silent recovery; the state is sticky (the health\n  monitor will not clobber it) until an admin runs\n  POST /api/mcp/client/{id}/reauthorize. For per-user clients this is a\n  response-only projection — computed at list-time, never stored in the\n  runtime manager — meaning the retained admin discovery credential\n  needs repair; end-user credentials and tool calls keep working, only\n  periodic tool-list refresh pauses. Overlays onto both healthy and\n  unstable runtime readings, never onto disabled or\n  pending_verification. Repair via reauthorize (per_user_oauth),\n  verify-headers with fresh sample values (per_user_headers), or\n  verify-exchange (token_exchange, which re-exchanges the signed-in\n  admin's own identity token — no sample values to supply).\n- disabled: Client has been intentionally disabled; no connection or workers are active\n- degraded: A read-time cluster aggregate, never a single node's own\n  local state — multiple instances of a distributed deployment each\n  currently hold a different self-reported state for the same client.\n  Only meaningful for states that can genuinely vary per instance\n  (healthy, unstable, pending_verification); needs_reauth/disabled are\n  config-sourced facts expected to already agree everywhere. Never\n  appears in a single-instance deployment.\n"
           },
           "vk_configs": {
             "type": "array",

--- a/docs/openapi/paths/management/mcp.yaml
+++ b/docs/openapi/paths/management/mcp.yaml
@@ -124,17 +124,17 @@ clients:
         in: query
         description: |
           Comma-separated runtime connection states to include (OR semantics),
-          resolved against live engine state. Only `connected` and
-          `disconnected` are meaningful filter values: `connected` matches
-          clients the engine currently reports as connected; `disconnected`
+          resolved against live engine state. Only `healthy` and
+          `unstable` are meaningful filter values: `healthy` matches
+          clients the engine currently reports as healthy; `unstable`
           matches everything else (error, pending states, needs_reauth,
           disabled, not present in the engine). Selecting both, or neither,
           applies no state filter. Note the response-only needs_reauth
           projection on per-user clients happens after filtering, so such
-          clients still match `connected`.
+          clients still match `healthy`.
         schema:
           type: string
-          example: connected
+          example: healthy
       - name: all_virtual_keys
         in: query
         description: When true, include clients that are open to all virtual keys (allow_on_all_virtual_keys). ORs with virtual_keys.
@@ -333,7 +333,14 @@ client-complete-oauth:
 
       Replays are rejected with 409: hitting the endpoint again after the flow
       already completed (no pending configuration and no freshly-written
-      token) returns "OAuth flow has already been completed".
+      token) returns "OAuth flow has already been completed". A shared
+      "oauth" reauthorize is also rejected with 409 if its flow never
+      actually resolved via a real callback — e.g. the upstream authorization
+      server rejected the request outright before ever redirecting back —
+      returning "Authorization has not completed yet". This is detected via
+      the flow's own row rather than the client's overall OAuth status,
+      which never regresses once a client has been authorized once and so
+      can't distinguish a stale prior authorization from a fresh one.
     tags:
       - MCP
       - OAuth
@@ -363,7 +370,12 @@ client-complete-oauth:
         description: OAuth config not found, or no MCP client is linked to this OAuth flow
         $ref: '../../openapi.yaml#/components/responses/NotFound'
       '409':
-        description: OAuth flow has already been completed for this MCP client (replay)
+        description: |
+          Either "OAuth flow has already been completed for this MCP client"
+          (replay), or "Authorization has not completed yet: the browser
+          flow may still be open, or the upstream provider rejected it
+          before redirecting back" (a shared "oauth" reauthorize whose flow
+          never actually resolved via a callback).
         $ref: '../../openapi.yaml#/components/responses/Conflict'
       '500':
         $ref: '../../openapi.yaml#/components/responses/InternalError'

--- a/docs/openapi/schemas/management/mcp.yaml
+++ b/docs/openapi/schemas/management/mcp.yaml
@@ -67,13 +67,21 @@ MCPConnectionType:
 
 MCPConnectionState:
   type: string
-  enum: [connected, disconnected, error, pending_tools, pending_verification, needs_reauth, disabled]
+  enum: [healthy, unstable, error, pending_verification, needs_reauth, disabled, degraded]
   description: |
     Connection state of an MCP client:
-    - connected: Client is connected and ready to use
-    - disconnected: Client is not connected (will be auto-recovered by health monitor)
-    - error: Client is in an unrecoverable error state
-    - pending_tools: Connected but tools not yet populated (per-user clients)
+    - healthy: Bifrost's own periodic connection check (ping/list_tools for
+      sticky clients, list_tools for per-call clients) most recently
+      succeeded.
+    - unstable: The periodic connection check most recently failed with a
+      transient-classified error. Purely informational — unlike
+      needs_reauth, this never gates execution; tool calls are still
+      attempted normally. Self-heals to healthy on the next successful
+      check, no human action required.
+    - error: A data-consistency fallback used only when a client is
+      registered in the config store but missing from the runtime manager
+      entirely — a deeper anomaly than anything in the normal
+      connect/health-check lifecycle, which never assigns this value itself.
     - pending_verification: Declared (typically via config.json) but the one-time
       admin verification has not been completed yet. Complete it via
       POST /api/mcp/client/{id}/initiate-verification (auth_type oauth /
@@ -85,14 +93,23 @@ MCPConnectionState:
       rejected/expired with no silent recovery; the state is sticky (the health
       monitor will not clobber it) until an admin runs
       POST /api/mcp/client/{id}/reauthorize. For per-user clients this is a
-      response-only projection meaning the retained admin discovery credential
+      response-only projection — computed at list-time, never stored in the
+      runtime manager — meaning the retained admin discovery credential
       needs repair; end-user credentials and tool calls keep working, only
-      periodic tool-list refresh pauses. Repair via reauthorize
-      (per_user_oauth), verify-headers with fresh sample values
-      (per_user_headers), or verify-exchange (token_exchange, which
-      re-exchanges the signed-in admin's own identity token — no sample
-      values to supply).
+      periodic tool-list refresh pauses. Overlays onto both healthy and
+      unstable runtime readings, never onto disabled or
+      pending_verification. Repair via reauthorize (per_user_oauth),
+      verify-headers with fresh sample values (per_user_headers), or
+      verify-exchange (token_exchange, which re-exchanges the signed-in
+      admin's own identity token — no sample values to supply).
     - disabled: Client has been intentionally disabled; no connection or workers are active
+    - degraded: A read-time cluster aggregate, never a single node's own
+      local state — multiple instances of a distributed deployment each
+      currently hold a different self-reported state for the same client.
+      Only meaningful for states that can genuinely vary per instance
+      (healthy, unstable, pending_verification); needs_reauth/disabled are
+      config-sourced facts expected to already agree everywhere. Never
+      appears in a single-instance deployment.
 
 MCPStdioConfig:
   type: object


### PR DESCRIPTION
## Summary

This PR updates the MCP client connection state model and API surface to better reflect how Bifrost actually tracks client health. The old `connected`/`disconnected` terminology is replaced with `healthy`/`unstable`, and two new states (`degraded`, and a redefined `error`) are introduced. A new `needs_session_stickiness` field is also added to MCP client configs, and the OAuth completion endpoint gains a new 409 rejection case for reauthorize flows that never resolved via a real callback.

## Changes

- **Renamed connection states**: `connected` → `healthy` and `disconnected` → `unstable`. The `healthy` state reflects that Bifrost's periodic health check (ping or list_tools) most recently succeeded. The `unstable` state indicates the most recent check failed with a transient error but does not gate tool call execution — it self-heals on the next successful check.
- **Removed `pending_tools` state**: This state no longer exists in the enum.
- **Redefined `error` state**: Now used only as a data-consistency fallback when a client is registered in the config store but missing from the runtime manager entirely, rather than as a general unrecoverable error.
- **Added `degraded` state**: A read-time cluster aggregate state that appears only in distributed deployments when multiple instances report different states for the same client. Never appears in single-instance deployments.
- **Clarified `needs_reauth` for per-user clients**: Documented that it is a list-time projection computed from the runtime manager, never stored there, and that it overlays onto `healthy` or `unstable` readings but never onto `disabled` or `pending_verification`.
- **Updated `state` filter query parameter**: The example and description now reference `healthy`/`unstable` instead of `connected`/`disconnected`.
- **Added `needs_session_stickiness` field**: A new boolean field on HTTP MCP client configs. When `true`, Bifrost holds one persistent upstream connection reused across tool calls. When `false` (the default), a fresh connection is dialed per tool call. Only meaningful for server-level auth types (`oauth`, `headers`, `none`); per-user auth types are always per-call. SSE and stdio connection types are always sticky regardless of this field.
- **Extended OAuth completion 409 response**: The `completeMCPClientOAuth` endpoint now also returns 409 with "Authorization has not completed yet" when a shared `oauth` reauthorize flow never resolved via a real callback (e.g., the upstream provider rejected the request before redirecting back). This is detected via the flow's own row rather than the client's overall OAuth status.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Verify that the OpenAPI spec renders correctly and that the updated state enum values, field descriptions, and 409 response documentation are accurate and consistent across `openapi.json`, `mcp.yaml` paths, and `mcp.yaml` schemas.

```sh
# Validate OpenAPI spec
npx @redocly/cli lint docs/openapi/openapi.json
```

## Breaking changes

- [x] Yes
- [ ] No

The `state` enum values `connected`, `disconnected`, and `pending_tools` have been removed and replaced with `healthy`, `unstable`, and `degraded`. Any client filtering on `state=connected` or `state=disconnected` must be updated to use `state=healthy` or `state=unstable` respectively.

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable