### PR TITLE
docs: add `token_exchange` auth type, per-client TLS/sync/timeout fields, tool list persistence, and reconnect per-call clarifications to MCP docs and OpenAPI spec

### DIFF
--- a/docs/deployment-guides/config-json/schema-reference.mdx
+++ b/docs/deployment-guides/config-json/schema-reference.mdx
@@ -285,12 +285,17 @@ Common fields on each `client_configs` entry:
 | `client_id` | string | Optional stable client identifier (defaults to a generated UUID) |
 | `connection_type` | string | `"http"`, `"sse"`, or `"stdio"` |
 | `connection_string` | object/string | HTTP/SSE URL or stdio command spec |
-| `auth_type` | string | `"none"`, `"headers"`, `"oauth"`, `"per_user_oauth"`, or `"per_user_headers"` |
+| `auth_type` | string | `"none"`, `"headers"`, `"oauth"`, `"per_user_oauth"`, `"per_user_headers"`, or `"token_exchange"` (enterprise only — see below) |
 | `tools_to_execute` | array | Allow-list of tool names; `["*"]` for all |
 | `tools_to_auto_execute` | array | Subset of `tools_to_execute` that runs without user confirmation |
 | `headers` | object | Static admin headers (used by `headers` and as additions on `per_user_headers`) |
 | `is_code_mode_client` | boolean | Wrap tools as Python code-mode helpers instead of raw tool calls |
 | `needs_session_stickiness` | boolean | HTTP-only, and only meaningful for `oauth`/`headers`/`none` (per-user auth types are always per-call). `true` holds one persistent upstream connection reused for every tool call; `false`/omitted (default) dials fresh per tool call. Cannot be `false` for `connection_type` `"sse"`/`"stdio"` — both are always sticky. See [Session Stickiness](/mcp/connecting-to-servers#session-stickiness-http-only). |
+| `is_ping_available` | boolean | Default `true`. Whether the MCP server supports a lightweight ping for health checks; `false` falls back to a full `listTools` call instead. |
+| `tool_sync_interval` | integer | Per-client tool-list sync interval in minutes. `0`/omitted falls back to the global `client.mcp_tool_sync_interval`; negative disables periodic sync for this client. |
+| `tool_execution_timeout` | integer | Per-client tool execution timeout in seconds. `0`/omitted falls back to the global `client.mcp_tool_execution_timeout`. |
+| `allow_on_all_virtual_keys` | boolean | When `true`, every virtual key can use this client without an explicit allowlist entry. |
+| `tls_config` | object | `{ "insecure_skip_verify": bool, "ca_cert_pem": string }` — skip TLS verification (development only) and/or trust a custom CA certificate for this client's connection. `ca_cert_pem` supports `env.VAR_NAME`. |
 
 Auth-type-specific fields:
 
@@ -298,14 +303,19 @@ Auth-type-specific fields:
 |-------|-----------|-------------|
 | `oauth_config` | `oauth`, `per_user_oauth` | Optional inline OAuth provider block. The whole block can be omitted, and any inner field (`client_id`, `client_secret`, `authorize_url`, `token_url`, `registration_url`, `scopes`) can be omitted individually — RFC 8414 metadata discovery + RFC 7591 dynamic client registration fill the gaps off `connection_string` at admin-click time. `client_id` / `client_secret` support `env.VAR_NAME` and `vault.path` references (resolved at runtime, reference stored); the other fields take literal values (encrypted at rest, redacted in API responses). |
 | `per_user_header_keys` | `per_user_headers` | Required, non-empty. Array of header names each end-user must supply. |
+| `token_exchange` | `token_exchange` | Required. `{ "audience": string, "client_id": SecretVar, "client_secret": SecretVar (optional, public clients), "scopes": string[] (optional), "authorization_server_url": string (optional) }`. `client_id`/`client_secret` support `env.VAR_NAME`/`vault.path` references. Include `"offline_access"` in `scopes` where the identity provider supports it to keep the retained admin discovery credential self-renewing instead of expiring into `needs_reauth`. |
 
-The schema enforces these pairings: `oauth_config` is rejected on non-OAuth auth types, and `per_user_header_keys` is rejected on any auth type other than `per_user_headers` — a misplaced block fails `$schema` validation instead of being silently ignored.
+The schema enforces these pairings: `oauth_config` is rejected on non-OAuth auth types, `per_user_header_keys` is rejected on any auth type other than `per_user_headers`, and `token_exchange` is rejected on any auth type other than `token_exchange` — a misplaced block fails `$schema` validation instead of being silently ignored.
+
+<Warning>
+**Enterprise only:** `auth_type: "token_exchange"` in `config.json` is rejected on OSS — the client is skipped entirely at boot with an error logged naming it. Declare `token_exchange` clients via the API/Web UI on an enterprise deployment instead if you need them in a non-enterprise `config.json` environment during a migration.
+</Warning>
 
 <Warning>
 **Migration note:** `oauth_config_id` is no longer a valid field on MCP client entries in `config.json`. Older guidance for shared OAuth suggested checking it in after completing an OAuth flow — remove it from existing config files (declare an `oauth_config` block instead, or leave the client to the dashboard). Bifrost now **ignores** the field if present (with a warning at boot): the OAuth link is managed server-side and survives restarts and config re-syncs on its own, and `$schema`-based editor/CI validation rejects the field.
 </Warning>
 
-Clients declared with `auth_type` in `{oauth, per_user_oauth, per_user_headers}` boot into a **`pending_verification`** state. The MCP Gateway UI surfaces an **Authorize** / **Verify** CTA on each pending row; one admin click runs the same verification flow the Web UI Create form uses, after which the client transitions to `connected`. The same steps are scriptable via `POST /api/mcp/client/{id}/initiate-verification` (OAuth types) and `POST /api/mcp/client/{id}/verify-headers` (per-user headers). Verified state is server-side and survives restarts and config re-syncs. Immutable fields (`auth_type`, `connection_type`, `connection_string`, `stdio_config`, `oauth_config`) cannot be changed after creation — file edits to them are ignored with a boot warning naming the fields, matching the update API; delete and re-declare the client to change them. See [MCP Auth](/mcp/auth/overview).
+Clients declared with `auth_type` in `{oauth, per_user_oauth, per_user_headers, token_exchange}` boot into a **`pending_verification`** state. The MCP Gateway UI surfaces an **Authorize** / **Verify** CTA on each pending row; one admin click runs the same verification flow the Web UI Create form uses, after which the client transitions to `healthy`. The same steps are scriptable via `POST /api/mcp/client/{id}/initiate-verification` (OAuth types), `POST /api/mcp/client/{id}/verify-headers` (per-user headers), or `POST /api/mcp/client/{id}/verify-exchange` (token exchange). Verified state is server-side and survives restarts and config re-syncs. Immutable fields (`auth_type`, `connection_type`, `connection_string`, `stdio_config`, `oauth_config`) cannot be changed after creation — file edits to them are ignored with a boot warning naming the fields, matching the update API; delete and re-declare the client to change them. See [MCP Auth](/mcp/auth/overview) and [Connections, States & Lifecycles](/mcp/connections).
 
 ---
 

--- a/docs/mcp/auth/per-user-headers.mdx
+++ b/docs/mcp/auth/per-user-headers.mdx
@@ -283,6 +283,8 @@ Per-user clients hold no persistent upstream connection, but their tool list sti
 
 A failed sync keeps the existing tool set and retries on the next cycle. In `config.json`, the field also accepts duration strings such as `"10m"` (recommended); a bare number there is a legacy nanosecond value, unlike the API which takes minutes.
 
+Every sync's result persists to the database (skipped when it's byte-identical to what's already stored), so a restart doesn't revert the tool list to whatever was discovered at the client's original bootstrap verification.
+
 ---
 
 ## Configuration reference

--- a/docs/mcp/auth/per-user-oauth.mdx
+++ b/docs/mcp/auth/per-user-oauth.mdx
@@ -243,6 +243,8 @@ Per-user clients hold no persistent upstream connection, but their tool list sti
 
 A failed sync keeps the existing tool set and retries on the next cycle. In `config.json`, the field also accepts duration strings such as `"10m"` (recommended); a bare number there is a legacy nanosecond value, unlike the API which takes minutes.
 
+Every sync's result persists to the database (skipped when it's byte-identical to what's already stored), so a restart doesn't revert the tool list to whatever was discovered at the client's original bootstrap verification.
+
 ---
 
 ## Public URL configuration

--- a/docs/mcp/connecting-to-servers.mdx
+++ b/docs/mcp/connecting-to-servers.mdx
@@ -779,7 +779,7 @@ curl -X POST http://localhost:8080/api/mcp/client/{id}/reconnect
 ```
 
 <Note>
-Reconnect returns `400` for per-user auth clients (no shared upstream connection to re-establish) and for clients in `pending_verification` — complete the admin verification instead.
+Reconnect returns `400` for any per-call client — a shared client running per-call ([`needs_session_stickiness`](./connections#two-independent-axes) false/omitted) as well as any per-user auth type — since none of them hold a shared upstream connection to re-establish. Also `400` for clients in `pending_verification` — complete the admin verification instead.
 </Note>
 
 **Edit client configuration:**
@@ -1000,7 +1000,7 @@ You can also trigger manual reconnection at any time:
 curl -X POST http://localhost:8080/api/mcp/client/{id}/reconnect
 ```
 
-Manual reconnection also uses the retry logic for robustness. Not applicable (`400`) to per-user auth clients — each user's connection is managed per request — or to clients in `pending_verification`, which need the one-time admin verification instead.
+Manual reconnection also uses the retry logic for robustness. Not applicable (`400`) to any per-call client — a shared client running per-call, or any per-user auth type — each call resolves its own connection/credential per request, with nothing shared to reconnect. Also not applicable to clients in `pending_verification`, which need the one-time admin verification instead.
 
 </Tab>
 <Tab title="Go SDK">

--- a/docs/mcp/gateway.mdx
+++ b/docs/mcp/gateway.mdx
@@ -325,6 +325,8 @@ The MCP Server dynamically updates its tool registry from the tool manager.
 
 Runtime updates run on a periodic tool sync per client. The cadence is the per-client `tool_sync_interval` (minutes on the API; `0` or unset inherits the global `mcp_tool_sync_interval` client setting, default 10 minutes; negative disables sync for that client). Server-level clients sync over their live connection; per-user clients (`per_user_oauth`, `per_user_headers`) hold no persistent connection, so the syncer uses the retained admin discovery credential for a one-shot connect, `tools/list`, disconnect cycle (see [Per-User OAuth](./auth/per-user-oauth#admin-discovery-credential) and [Per-User Headers](./auth/per-user-headers#admin-discovery-credential)). A failed sync keeps the existing tool set and retries on the next cycle.
 
+Every discovered tool list — from the initial connect and from every periodic sync — persists to the database, so a restart doesn't lose anything a running instance had already discovered. Persistence is skipped when a sync's result is byte-identical to what's already stored, so an unchanged tick doesn't cause a write.
+
 ---
 
 ## Per-User Auth on the Gateway

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -43966,7 +43966,7 @@
       "post": {
         "operationId": "reconnectMCPClient",
         "summary": "Reconnect MCP client",
-        "description": "Reconnects an MCP client that is in an error or disconnected state.\nNot applicable (400) to per-user auth clients (no shared upstream\nconnection) or to clients in pending_verification state — complete the\nadmin verification instead.\n",
+        "description": "Reconnects an MCP client that is in an error or unstable state.\nNot applicable (400) to any per-call client — a shared client running\nper-call (needs_session_stickiness false/omitted) as well as any\nper-user auth type — since none of them hold a shared upstream\nconnection to re-establish. Also not applicable to clients in\npending_verification state — complete the admin verification instead.\n",
         "tags": [
           "MCP"
         ],

--- a/docs/openapi/paths/management/mcp.yaml
+++ b/docs/openapi/paths/management/mcp.yaml
@@ -283,10 +283,12 @@ client-reconnect:
     operationId: reconnectMCPClient
     summary: Reconnect MCP client
     description: |
-      Reconnects an MCP client that is in an error or disconnected state.
-      Not applicable (400) to per-user auth clients (no shared upstream
-      connection) or to clients in pending_verification state — complete the
-      admin verification instead.
+      Reconnects an MCP client that is in an error or unstable state.
+      Not applicable (400) to any per-call client — a shared client running
+      per-call (needs_session_stickiness false/omitted) as well as any
+      per-user auth type — since none of them hold a shared upstream
+      connection to re-establish. Also not applicable to clients in
+      pending_verification state — complete the admin verification instead.
     tags:
       - MCP
     parameters:


### PR DESCRIPTION
## Summary

This PR updates the MCP documentation to reflect new client configuration fields, the `token_exchange` auth type (enterprise only), clarified reconnect behavior for per-call clients, and tool list persistence across restarts.

## Changes

- Added `token_exchange` as a valid `auth_type` in the `config.json` schema reference, including its required `token_exchange` block fields, enterprise-only restriction, and the new `POST /api/mcp/client/{id}/verify-exchange` verification endpoint.
- Documented new `client_configs` fields: `is_ping_available`, `tool_sync_interval`, `tool_execution_timeout`, `allow_on_all_virtual_keys`, and `tls_config`.
- Clarified that the reconnect endpoint returns `400` not only for per-user auth clients but for any per-call client (including shared clients with `needs_session_stickiness` false/omitted), since none hold a shared upstream connection to re-establish. Updated this in `connecting-to-servers.mdx`, `gateway.mdx`, the OpenAPI YAML, and the generated `openapi.json`.
- Updated the post-verification state label from `connected` to `healthy` and added `token_exchange` to the set of auth types that boot into `pending_verification`.
- Added a note across `gateway.mdx`, `per-user-headers.mdx`, and `per-user-oauth.mdx` clarifying that every discovered tool list is persisted to the database, so a restart does not revert the tool list to what was found at original bootstrap verification. Persistence is skipped when the result is byte-identical to what is already stored.
- Updated schema enforcement language to include `token_exchange` block rejection on non-`token_exchange` auth types.
- Added a reference to the new [Connections, States & Lifecycles](/mcp/connections) page alongside the existing MCP Auth link.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation pages for:
- `docs/deployment-guides/config-json/schema-reference.mdx` — confirm new fields and `token_exchange` auth type appear correctly, including the enterprise warning block.
- `docs/mcp/connecting-to-servers.mdx` — confirm the reconnect `400` note accurately describes per-call clients.
- `docs/mcp/gateway.mdx`, `docs/mcp/auth/per-user-headers.mdx`, `docs/mcp/auth/per-user-oauth.mdx` — confirm the tool list persistence note is present.
- `docs/openapi/paths/management/mcp.yaml` and `docs/openapi/openapi.json` — confirm the reconnect endpoint description matches the prose documentation.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The `token_exchange` auth type is explicitly documented as enterprise-only and is rejected at boot on OSS deployments with an error logged. The `tls_config.insecure_skip_verify` field is documented as development-only. The `token_exchange` block fields (`client_id`, `client_secret`) support `env.VAR_NAME` and `vault.path` references, consistent with existing secret handling patterns.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable