### PR TITLE
[fix]: Gemini - truncated responses report finishReason MAX_TOKENS instead of OTHER

### DIFF
--- a/core/providers/gemini/incompletefinishreason_test.go
+++ b/core/providers/gemini/incompletefinishreason_test.go
@@ -1,0 +1,49 @@
+package gemini
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// Issue #5978: the IncompleteDetails fallback in ToGeminiResponsesResponse
+// switched on "max_tokens", a string that never occurs — the schema constant is
+// "max_output_tokens" — so truncated responses reported finishReason OTHER
+// instead of MAX_TOKENS. Clients keying on MAX_TOKENS (raise limit and retry,
+// truncation UX) misclassified every truncated stop.
+func TestGeminiIncompleteReasonFinishReason(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		reason string
+		want   FinishReason
+	}{
+		{"truncation maps to MAX_TOKENS", schemas.ResponsesResponseIncompleteReasonMaxOutputTokens, FinishReasonMaxTokens},
+		{"content filter maps to SAFETY", schemas.ResponsesResponseIncompleteReasonContentFilter, FinishReasonSafety},
+		{"unknown reason falls back to OTHER", "some_future_reason", FinishReasonOther},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			msgType := schemas.ResponsesMessageTypeMessage
+			role := schemas.ResponsesInputMessageRoleAssistant
+			bifrostResp := &schemas.BifrostResponsesResponse{
+				Output: []schemas.ResponsesMessage{{
+					Type: &msgType,
+					Role: &role,
+					Content: &schemas.ResponsesMessageContent{
+						ContentBlocks: []schemas.ResponsesMessageContentBlock{
+							{Type: schemas.ResponsesOutputMessageContentTypeText, Text: schemas.Ptr("truncated tex")},
+						},
+					},
+				}},
+				IncompleteDetails: &schemas.ResponsesResponseIncompleteDetails{Reason: tc.reason},
+			}
+
+			geminiResp := ToGeminiResponsesResponse(bifrostResp)
+			if geminiResp == nil || len(geminiResp.Candidates) == 0 {
+				t.Fatalf("no candidates: %+v", geminiResp)
+			}
+			if got := geminiResp.Candidates[0].FinishReason; got != tc.want {
+				t.Errorf("finish reason = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -546,10 +546,13 @@ func ToGeminiResponsesResponse(bifrostResp *schemas.BifrostResponsesResponse) *G
 			if bifrostResp.StopReason != nil {
 				candidate.FinishReason = ConvertBifrostFinishReasonToGemini(*bifrostResp.StopReason)
 			} else if bifrostResp.IncompleteDetails != nil {
+				// Match the schema's incomplete-reason vocabulary; a literal
+				// "max_tokens" never occurs here, so truncations reported OTHER
+				// instead of MAX_TOKENS (issue #5978).
 				switch bifrostResp.IncompleteDetails.Reason {
-				case "max_tokens":
+				case schemas.ResponsesResponseIncompleteReasonMaxOutputTokens:
 					candidate.FinishReason = FinishReasonMaxTokens
-				case "content_filter":
+				case schemas.ResponsesResponseIncompleteReasonContentFilter:
 					candidate.FinishReason = FinishReasonSafety
 				default:
 					candidate.FinishReason = FinishReasonOther


### PR DESCRIPTION
## Summary

The IncompleteDetails fallback in ToGeminiResponsesResponse switched on the literal "max_tokens", but IncompleteDetails.Reason never holds that value - the schema constant is "max_output_tokens" and every writer in the codebase mints it. The truncation arm was unreachable, so every truncated response reaching the Gemini egress reported finishReason OTHER instead of MAX_TOKENS, and client keying on MAX_TOKENS (raise limit and retry, truncation UX) misclassified the stop as anomalous failure. Present since the Gemini native converters. (#1018)

## Changes

- The switch now matches the schema constants (ResponsesResponseIncompleteReasonMaxOutputTokens → MAX_TOKENS, ResponsesResponseIncompleteReasonContentFilter → SAFETY) so the vocabulary cannot drift again; unknown reasons still fall back to OTHER
- Regression test covering all three arms; the truncation case fails on current dev


## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)

## How to test

`cd core && go test ./providers/gemini/ -run TestGeminiIncompleteReasonFinishReason -v`

Fails on dev (truncation reports OTHER), passes with the fix. Full ./providers/gemini/ green.

## Breaking changes

- [x] No


## Related issues

Closes #5978 

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable


