### PR TITLE
quarterly budget

### DIFF
--- a/framework/configstore/budgetresetconfighash_test.go
+++ b/framework/configstore/budgetresetconfighash_test.go
@@ -1,0 +1,107 @@
+package configstore
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// legacyBudgetDigest restates the pre-quarter hashing contract - ID, then the
+// marshalled MaxLimit, then ResetDuration - independently of the implementation.
+// A budget with no quarter definition must keep producing exactly this digest,
+// so an unguarded new field in GenerateBudgetHash fails here rather than
+// silently forcing every deployment to resync its budgets on upgrade.
+func legacyBudgetDigest(t *testing.T, b tables.TableBudget) string {
+	t.Helper()
+	h := sha256.New()
+	h.Write([]byte(b.ID))
+	data, err := sonic.Marshal(b.MaxLimit)
+	require.NoError(t, err)
+	h.Write(data)
+	h.Write([]byte(b.ResetDuration))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// TestGenerateBudgetHashUnchangedForNonQuarterlyBudgets pins the back-compat
+// contract: adding the quarter definition must not shift the digest of any
+// budget that has none, or every upgraded gateway would see a spurious
+// "config.json changed" on first boot.
+func TestGenerateBudgetHashUnchangedForNonQuarterlyBudgets(t *testing.T) {
+	for _, duration := range []string{"5m", "1h", "1d", "1w", "1M"} {
+		budget := tables.TableBudget{ID: "budget-1", MaxLimit: 1000, ResetDuration: duration}
+		got, err := GenerateBudgetHash(budget)
+		require.NoError(t, err)
+		assert.Equal(t, legacyBudgetDigest(t, budget), got, "duration %s", duration)
+	}
+}
+
+// TestGenerateBudgetHashAgreesAcrossConfigAndDatabaseSources is the test that
+// matters most here.
+//
+// GenerateBudgetHash exists to decide whether a budget in config.json differs
+// from the one in the database. The two sources populate the reset config
+// differently: a budget parsed from config.json has ResetConfig set and
+// ResetConfigJSON still empty, because BeforeSave has not run on it, while a
+// budget read back from the database has both. Hashing the raw JSON blob would
+// therefore make the two sides disagree for every quarterly budget - not a
+// missed change, but a change detected on every single comparison, resyncing
+// forever. The hash has to read the effective quarter month instead.
+func TestGenerateBudgetHashAgreesAcrossConfigAndDatabaseSources(t *testing.T) {
+	fromConfigFile := tables.TableBudget{
+		ID:            "budget-quarterly",
+		MaxLimit:      5000,
+		ResetDuration: "1Q",
+		ResetConfig:   &tables.BudgetResetConfig{QuarterStartMonth: int(time.April)},
+	}
+	fromDatabase := tables.TableBudget{
+		ID:              "budget-quarterly",
+		MaxLimit:        5000,
+		ResetDuration:   "1Q",
+		ResetConfig:     &tables.BudgetResetConfig{QuarterStartMonth: int(time.April)},
+		ResetConfigJSON: `{"quarter_start_month":4}`,
+	}
+
+	configHash, err := GenerateBudgetHash(fromConfigFile)
+	require.NoError(t, err)
+	dbHash, err := GenerateBudgetHash(fromDatabase)
+	require.NoError(t, err)
+
+	assert.Equal(t, configHash, dbHash,
+		"a config.json budget and its persisted counterpart must hash identically, or change detection resyncs on every comparison")
+}
+
+// TestGenerateBudgetHashTracksQuarterStartMonth verifies the whole point of the
+// change: editing the quarter definition in config.json is detected.
+func TestGenerateBudgetHashTracksQuarterStartMonth(t *testing.T) {
+	april := tables.TableBudget{
+		ID: "budget-quarterly", MaxLimit: 5000, ResetDuration: "1Q",
+		ResetConfig: &tables.BudgetResetConfig{QuarterStartMonth: int(time.April)},
+	}
+	october := tables.TableBudget{
+		ID: "budget-quarterly", MaxLimit: 5000, ResetDuration: "1Q",
+		ResetConfig: &tables.BudgetResetConfig{QuarterStartMonth: int(time.October)},
+	}
+	unset := tables.TableBudget{ID: "budget-quarterly", MaxLimit: 5000, ResetDuration: "1Q"}
+	january := tables.TableBudget{
+		ID: "budget-quarterly", MaxLimit: 5000, ResetDuration: "1Q",
+		ResetConfig: &tables.BudgetResetConfig{QuarterStartMonth: int(time.January)},
+	}
+
+	aprilHash, err := GenerateBudgetHash(april)
+	require.NoError(t, err)
+	octoberHash, err := GenerateBudgetHash(october)
+	require.NoError(t, err)
+	unsetHash, err := GenerateBudgetHash(unset)
+	require.NoError(t, err)
+	januaryHash, err := GenerateBudgetHash(january)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, aprilHash, octoberHash, "a quarter-start edit must be detected as a change")
+	assert.Equal(t, unsetHash, januaryHash, "an unset quarter start and an explicit January are the same window")
+}

--- a/framework/configstore/budgetresetconfigstore_test.go
+++ b/framework/configstore/budgetresetconfigstore_test.go
@@ -1,0 +1,171 @@
+package configstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// setupBudgetDBWithoutResetConfigColumn builds the pre-migration state: a
+// governance_budgets table as it existed before reset_config_json.
+//
+// A fresh database is not a useful test of this migration, because CreateTable
+// derives the schema from the current struct and produces the column whether or
+// not the migration exists. Only an already-provisioned table can tell the two
+// apart, which is the case that matters: every deployment upgrading into this
+// release has one.
+func setupBudgetDBWithoutResetConfigColumn(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err, "Failed to create test database")
+
+	require.NoError(t, db.Exec(`
+		CREATE TABLE governance_budgets (
+			id VARCHAR(255) PRIMARY KEY,
+			max_limit REAL NOT NULL,
+			reset_duration VARCHAR(50) NOT NULL,
+			last_reset DATETIME,
+			current_usage REAL DEFAULT 0,
+			override_amount REAL NOT NULL DEFAULT 0,
+			override_mode VARCHAR(20) NOT NULL DEFAULT '',
+			override_cycles_remaining INTEGER NOT NULL DEFAULT 0,
+			override_cycles_total INTEGER NOT NULL DEFAULT 0,
+			override_anchor_reset DATETIME,
+			team_id VARCHAR(255),
+			virtual_key_id VARCHAR(255),
+			provider_config_id INTEGER,
+			model_config_id VARCHAR(255),
+			customer_id VARCHAR(255),
+			config_hash VARCHAR(255),
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL
+		)
+	`).Error, "Failed to create pre-migration governance_budgets table")
+
+	require.NoError(t, db.Exec(`
+		CREATE TABLE IF NOT EXISTS migrations (
+			id VARCHAR(255) PRIMARY KEY
+		)
+	`).Error, "Failed to create migrations table")
+
+	return db
+}
+
+// TestMigrationAddsBudgetResetConfigColumnToExistingTable verifies the upgrade
+// path: an already-provisioned budgets table gains the column, and running the
+// migration again is a no-op.
+func TestMigrationAddsBudgetResetConfigColumnToExistingTable(t *testing.T) {
+	db := setupBudgetDBWithoutResetConfigColumn(t)
+	ctx := context.Background()
+
+	require.False(t, db.Migrator().HasColumn(&tables.TableBudget{}, "reset_config_json"),
+		"precondition: the column must be absent before the migration runs")
+
+	require.NoError(t, migrationAddBudgetResetConfigColumn(ctx, db, testMigrationLogger))
+	assert.True(t, db.Migrator().HasColumn(&tables.TableBudget{}, "reset_config_json"))
+
+	// Re-running must not error: migrations are replayed on every boot.
+	require.NoError(t, migrationAddBudgetResetConfigColumn(ctx, db, testMigrationLogger))
+	assert.True(t, db.Migrator().HasColumn(&tables.TableBudget{}, "reset_config_json"))
+}
+
+// TestExistingBudgetsKeepTheirCadenceAfterMigration is the upgrade-safety test.
+//
+// The migration is additive with no backfill, so every budget that predates it
+// has a NULL reset config. That must read back as a nil ResetConfig and a
+// January quarter start, leaving the budget's window arithmetic byte-identical
+// to what it was before the upgrade. A backfill writing an explicit month here
+// would be indistinguishable in the data but would start reporting these rows
+// as quarterly-configured to the API and the UI.
+func TestExistingBudgetsKeepTheirCadenceAfterMigration(t *testing.T) {
+	db := setupBudgetDBWithoutResetConfigColumn(t)
+	ctx := context.Background()
+
+	// A budget written before the column existed.
+	require.NoError(t, db.WithContext(ctx).Exec(
+		`INSERT INTO governance_budgets (id, max_limit, reset_duration, last_reset, current_usage, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"legacy-budget", 250.0, "1M", time.Now().UTC(), 42.0, time.Now().UTC(), time.Now().UTC(),
+	).Error)
+
+	require.NoError(t, migrationAddBudgetResetConfigColumn(ctx, db, testMigrationLogger))
+
+	var loaded tables.TableBudget
+	require.NoError(t, db.WithContext(ctx).First(&loaded, "id = ?", "legacy-budget").Error)
+	assert.Nil(t, loaded.ResetConfig)
+	assert.Empty(t, loaded.ResetConfigJSON)
+	assert.Equal(t, time.January, loaded.QuarterStartMonth())
+	assert.Equal(t, "1M", loaded.ResetDuration)
+	assert.Equal(t, 42.0, loaded.CurrentUsage)
+}
+
+// TestUpdateBudgetPersistsResetConfig verifies the quarter definition is
+// config-owned: unlike usage and override state, which UpdateBudget carries
+// forward from the stored row, the caller's value wins, exactly as it does for
+// max_limit and reset_duration.
+func TestUpdateBudgetPersistsResetConfig(t *testing.T) {
+	store, db := setupFullMigrationDB(t)
+	ctx := context.Background()
+
+	budget := &tables.TableBudget{
+		ID:            "budget-under-edit",
+		MaxLimit:      1000,
+		ResetDuration: "1Q",
+		LastReset:     time.Now().UTC(),
+		ResetConfig:   &tables.BudgetResetConfig{QuarterStartMonth: int(time.April)},
+	}
+	require.NoError(t, store.CreateBudget(ctx, budget))
+
+	var afterCreate tables.TableBudget
+	require.NoError(t, db.WithContext(ctx).First(&afterCreate, "id = ?", budget.ID).Error)
+	require.NotNil(t, afterCreate.ResetConfig)
+	assert.Equal(t, int(time.April), afterCreate.ResetConfig.QuarterStartMonth)
+
+	// Editing the quarter start persists the new definition.
+	afterCreate.ResetConfig = &tables.BudgetResetConfig{QuarterStartMonth: int(time.October)}
+	require.NoError(t, store.UpdateBudget(ctx, &afterCreate))
+
+	var afterUpdate tables.TableBudget
+	require.NoError(t, db.WithContext(ctx).First(&afterUpdate, "id = ?", budget.ID).Error)
+	require.NotNil(t, afterUpdate.ResetConfig)
+	assert.Equal(t, int(time.October), afterUpdate.ResetConfig.QuarterStartMonth)
+}
+
+// TestUpdateBudgetClearsResetConfigWhenLeavingQuarterly verifies switching a
+// budget off a quarterly window drops the now-meaningless quarter definition
+// rather than leaving it stranded in the column, where a later switch back to
+// quarterly would silently resurrect a start month the operator never re-chose.
+func TestUpdateBudgetClearsResetConfigWhenLeavingQuarterly(t *testing.T) {
+	store, db := setupFullMigrationDB(t)
+	ctx := context.Background()
+
+	budget := &tables.TableBudget{
+		ID:            "budget-leaving-quarterly",
+		MaxLimit:      1000,
+		ResetDuration: "1Q",
+		LastReset:     time.Now().UTC(),
+		ResetConfig:   &tables.BudgetResetConfig{QuarterStartMonth: int(time.April)},
+	}
+	require.NoError(t, store.CreateBudget(ctx, budget))
+
+	var loaded tables.TableBudget
+	require.NoError(t, db.WithContext(ctx).First(&loaded, "id = ?", budget.ID).Error)
+	loaded.ResetDuration = "1M"
+	loaded.ResetConfig = nil
+	require.NoError(t, store.UpdateBudget(ctx, &loaded))
+
+	var afterUpdate tables.TableBudget
+	require.NoError(t, db.WithContext(ctx).First(&afterUpdate, "id = ?", budget.ID).Error)
+	assert.Equal(t, "1M", afterUpdate.ResetDuration)
+	assert.Nil(t, afterUpdate.ResetConfig)
+	assert.Empty(t, afterUpdate.ResetConfigJSON)
+}

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -1056,6 +1056,19 @@ func GenerateBudgetHash(b tables.TableBudget) (string, error) {
 	// Hash ResetDuration
 	hash.Write([]byte(b.ResetDuration))
 
+	// Hash the quarter definition, without which a quarter-start edit in
+	// config.json is invisible to change detection and never reaches the database.
+	//
+	// Read the effective month rather than ResetConfigJSON: this function compares
+	// a budget parsed from config.json against one read from the database, and only
+	// the latter has the blob populated, since BeforeSave has not run on the former.
+	// Hashing the blob would make the two disagree on every comparison and resync
+	// forever. Gating on the duration keeps every non-quarterly budget's digest
+	// byte-identical, so upgrading does not look like a config change.
+	if tables.IsQuarterlyDuration(b.ResetDuration) {
+		hash.Write([]byte(strconv.Itoa(int(b.QuarterStartMonth()))))
+	}
+
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -459,6 +459,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_budget_override_anchor_columns"}, run: migrationAddBudgetOverrideAnchorColumns},
 	{IDs: []string{"add_live_models_sync_interval_column"}, run: migrationAddLiveModelsSyncIntervalColumn},
 	{IDs: []string{"add_pricing_override_user_id_column"}, run: migrationAddPricingOverrideUserIDColumn},
+	{IDs: []string{"add_budget_reset_config_column"}, run: migrationAddBudgetResetConfigColumn},
 }
 
 // quoteSQLiteIdentifier quotes a SQLite identifier, escaping any double quotes.
@@ -11004,6 +11005,46 @@ func migrationAddWebhookConfigClientColumn(ctx context.Context, db *gorm.DB, log
 		return fmt.Errorf("error while running webhook config client column migration: %s", err.Error())
 	}
 	return nil
+}
+
+// migrationAddBudgetResetConfigColumn adds the reset_config_json column to
+// governance_budgets.
+//
+// Additive and nullable with no backfill: an existing budget has no quarter
+// definition, and a NULL column reads back as a nil ResetConfig, which every
+// window call site treats as January. Pre-existing budgets therefore keep their
+// current cadence exactly.
+func migrationAddBudgetResetConfigColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_budget_reset_config_column"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if !mg.HasColumn(&tables.TableBudget{}, "reset_config_json") {
+				if err := mg.AddColumn(&tables.TableBudget{}, "ResetConfigJSON"); err != nil {
+					return fmt.Errorf("add reset_config_json column: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: rollbackBudgetResetConfigColumn,
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running budget reset config column migration: %s", err.Error())
+	}
+	return nil
+}
+
+// rollbackBudgetResetConfigColumn refuses to undo
+// migrationAddBudgetResetConfigColumn. reset_config_json is the only home for a
+// budget's quarter definition, and QuarterStartMonth reads a nil ResetConfig as
+// January, so dropping the column would not merely lose data: it would silently
+// re-window every fiscal-year budget onto the calendar year.
+func rollbackBudgetResetConfigColumn(*gorm.DB) error {
+	return fmt.Errorf("add_budget_reset_config_column is non-rollbackable: dropping reset_config_json would permanently delete every budget's fiscal-quarter definition and silently revert those budgets to the January default; the column is additive and older binaries safely ignore it")
 }
 
 // migrationAddWebhookJobsTable creates the webhook_jobs work-queue table.

--- a/framework/configstore/migrations_test.go
+++ b/framework/configstore/migrations_test.go
@@ -2937,3 +2937,44 @@ func TestMigrationAddBudgetOverrideAnchorColumns(t *testing.T) {
 	require.NotNil(t, anchor)
 	assert.True(t, anchor.UTC().Equal(lastReset))
 }
+
+// TestMigrationAddBudgetResetConfigColumn_NonRollbackable pins that rolling the
+// fiscal-quarter column back is refused rather than performed. reset_config_json
+// is the only home for a budget's quarter definition, and QuarterStartMonth
+// reads a nil ResetConfig as January, so dropping the column would not merely
+// lose data: it would silently re-window every fiscal-year budget onto the
+// calendar year. The rollback must fail loudly and leave the column in place.
+func TestMigrationAddBudgetResetConfigColumn_NonRollbackable(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	require.NoError(t, db.AutoMigrate(&tables.TableBudget{}))
+	require.NoError(t, db.Migrator().DropColumn(&tables.TableBudget{}, "reset_config_json"))
+	require.False(t, db.Migrator().HasColumn(&tables.TableBudget{}, "reset_config_json"),
+		"precondition: the column must be absent to reproduce the upgrade path")
+
+	require.NoError(t, migrationAddBudgetResetConfigColumn(ctx, db, testMigrationLogger))
+	require.True(t, db.Migrator().HasColumn(&tables.TableBudget{}, "reset_config_json"),
+		"migration should have added reset_config_json")
+
+	// A budget carrying a non-default fiscal quarter is exactly the state a
+	// rollback would destroy.
+	seed := &tables.TableBudget{
+		ID:            "fiscal-budget",
+		MaxLimit:      100,
+		ResetDuration: "1Q",
+		ResetConfig:   &tables.BudgetResetConfig{QuarterStartMonth: int(time.April)},
+	}
+	require.NoError(t, db.Create(seed).Error)
+
+	err := rollbackBudgetResetConfigColumn(db)
+	require.Error(t, err, "rollback must refuse: dropping the column destroys unrecoverable fiscal-quarter state")
+	assert.Contains(t, err.Error(), "non-rollbackable")
+	assert.True(t, db.Migrator().HasColumn(&tables.TableBudget{}, "reset_config_json"),
+		"a refused rollback must leave the column intact")
+
+	var got tables.TableBudget
+	require.NoError(t, db.Where("id = ?", seed.ID).First(&got).Error)
+	assert.Equal(t, time.April, got.QuarterStartMonth(),
+		"the fiscal quarter definition must survive the refused rollback")
+}

--- a/framework/configstore/tables/budget.go
+++ b/framework/configstore/tables/budget.go
@@ -1,6 +1,7 @@
 package tables
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"time"
@@ -19,6 +20,21 @@ const (
 	// BudgetOverrideModeForever keeps an override active until it is explicitly removed.
 	BudgetOverrideModeForever BudgetOverrideMode = "forever"
 )
+
+// BudgetResetConfig carries per-budget settings that shape the reset window
+// beyond what the duration string alone can express.
+//
+// Persisted as a JSON blob rather than a dedicated column so a future window
+// setting (week start day, a timezone other than UTC) needs no migration.
+type BudgetResetConfig struct {
+	// QuarterStartMonth is the first month of Q1 as a 1-12 value, so an
+	// organisation whose fiscal year opens in April gets Apr-Jun / Jul-Sep /
+	// Oct-Dec / Jan-Mar. Zero means unset and reads back as January.
+	//
+	// Only meaningful for a "Q" duration; BeforeSave rejects it on any other
+	// window rather than persisting a setting that silently does nothing.
+	QuarterStartMonth int `json:"quarter_start_month,omitempty"`
+}
 
 // TableBudget defines spending limits with configurable reset periods
 type TableBudget struct {
@@ -67,6 +83,21 @@ type TableBudget struct {
 	// rewrites the whole table on its dump tick.
 	OverrideAnchorReset *time.Time `json:"override_anchor_reset,omitempty"`
 
+	// ResetConfigJSON holds ResetConfig as a JSON blob, serialized by BeforeSave
+	// and deserialized by AfterFind.
+	ResetConfigJSON string `gorm:"column:reset_config_json;type:text" json:"-"`
+
+	// ResetConfig carries window settings the duration string cannot express,
+	// currently the fiscal quarter start. Nil for every non-quarterly budget.
+	//
+	// AfterFind repopulating this is what makes a quarter definition agree across
+	// a cluster: the gossip path carries usage only, and a config change
+	// broadcasts nothing but an entity ID, which each peer answers by re-reading
+	// the row. A hook that failed to fire on a nested preload would leave every
+	// peer computing January quarters against a leader computing April ones,
+	// with no error anywhere to show for it.
+	ResetConfig *BudgetResetConfig `gorm:"-" json:"reset_config,omitempty"`
+
 	// Owner FKs: a budget belongs to at most one Team, VK, ProviderConfig, ModelConfig, or Customer
 	TeamID           *string `gorm:"type:varchar(255);index" json:"team_id,omitempty"`
 	VirtualKeyID     *string `gorm:"type:varchar(255);index" json:"virtual_key_id,omitempty"`
@@ -97,6 +128,63 @@ type TableBudget struct {
 
 // TableName sets the table name for each model
 func (TableBudget) TableName() string { return "governance_budgets" }
+
+// QuarterStartMonth returns the first month of Q1 for this budget, defaulting to
+// January when no quarter definition is configured.
+//
+// Safe on a nil receiver and a nil ResetConfig so every window call site can read
+// it unconditionally. That matters more than convenience: a call site that
+// skipped the read on nil would compute a January boundary for an April-start
+// budget, and the two would disagree only for the six months of the year when
+// the quarters happen not to coincide.
+func (b *TableBudget) QuarterStartMonth() time.Month {
+	if b == nil || b.ResetConfig == nil {
+		return time.January
+	}
+	if b.ResetConfig.QuarterStartMonth < int(time.January) || b.ResetConfig.QuarterStartMonth > int(time.December) {
+		return time.January
+	}
+	return time.Month(b.ResetConfig.QuarterStartMonth)
+}
+
+// IsQuarterlyDuration reports whether a duration string denotes a quarter window.
+func IsQuarterlyDuration(duration string) bool {
+	return duration != "" && duration[len(duration)-1] == 'Q'
+}
+
+// validateResetConfig checks the quarter definition is in range and attached to a
+// window that actually has quarters.
+func (b *TableBudget) validateResetConfig() error {
+	if b.ResetConfig == nil {
+		return nil
+	}
+	if !IsQuarterlyDuration(b.ResetDuration) {
+		return fmt.Errorf("reset_config is only valid on a quarterly reset duration, got: %s", b.ResetDuration)
+	}
+	// Zero means unset and reads back as January, so only an out-of-range
+	// non-zero value is an error.
+	if month := b.ResetConfig.QuarterStartMonth; month != 0 && (month < int(time.January) || month > int(time.December)) {
+		return fmt.Errorf("quarter_start_month must be between 1 and 12, got: %d", month)
+	}
+	return nil
+}
+
+// AfterFind deserializes the reset config blob after a row is read.
+//
+// GORM fires this on preloaded associations too, which is what carries the
+// quarter definition to a cluster peer reloading a virtual key by ID.
+func (b *TableBudget) AfterFind(tx *gorm.DB) error {
+	if b.ResetConfigJSON == "" {
+		b.ResetConfig = nil
+		return nil
+	}
+	var cfg BudgetResetConfig
+	if err := json.Unmarshal([]byte(b.ResetConfigJSON), &cfg); err != nil {
+		return err
+	}
+	b.ResetConfig = &cfg
+	return nil
+}
 
 // WindowStart returns the budget's current reset-window boundary at or before
 // now: the calendar period for a calendar-aligned budget whose duration has a
@@ -385,7 +473,7 @@ func (b *TableBudget) BeforeSave(tx *gorm.DB) error {
 	if owners > 1 {
 		return fmt.Errorf("budget cannot have more than one owner (team/virtual key/provider config/model config/customer)")
 	}
-	// Validate that ResetDuration is in correct format (e.g., "30s", "5m", "1h", "1d", "1w", "1M", "1Y")
+	// Validate that ResetDuration is in correct format (e.g., "30s", "5m", "1h", "1d", "1w", "1M", "1Q", "1Y")
 	if d, err := ParseDuration(b.ResetDuration); err != nil {
 		return fmt.Errorf("invalid reset duration format: %s", b.ResetDuration)
 	} else if d <= 0 {
@@ -397,6 +485,19 @@ func (b *TableBudget) BeforeSave(tx *gorm.DB) error {
 	}
 	if err := b.validateOverride(); err != nil {
 		return err
+	}
+	if err := b.validateResetConfig(); err != nil {
+		return err
+	}
+	// Serialize last, so a rejected config is never written to the column.
+	if b.ResetConfig != nil {
+		data, err := json.Marshal(b.ResetConfig)
+		if err != nil {
+			return err
+		}
+		b.ResetConfigJSON = string(data)
+	} else {
+		b.ResetConfigJSON = ""
 	}
 
 	return nil

--- a/framework/configstore/tables/budgetresetconfig_test.go
+++ b/framework/configstore/tables/budgetresetconfig_test.go
@@ -1,0 +1,259 @@
+package tables
+
+import (
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// setupBudgetTestDB creates an in-memory SQLite database with the budget table
+// and its virtual key owner migrated. Kept separate from setupTestDB so the
+// nested-preload test can rely on exactly these two tables being present.
+func setupBudgetTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&TableVirtualKey{}, &TableBudget{}))
+	return db
+}
+
+// TestParseDurationQuarter verifies the "Q" suffix parses as an approximate
+// 90-day window, mirroring how "M" approximates a month as 30 days. The
+// approximation only drives rolling windows; a calendar-aligned quarter uses
+// the exact boundary instead.
+func TestParseDurationQuarter(t *testing.T) {
+	oneQuarter, err := ParseDuration("1Q")
+	require.NoError(t, err)
+	assert.Equal(t, 90*24*time.Hour, oneQuarter)
+
+	twoQuarters, err := ParseDuration("2Q")
+	require.NoError(t, err)
+	assert.Equal(t, 180*24*time.Hour, twoQuarters)
+
+	// A quarter must sort above a month so inheritUsageFromClosestShorterBudget
+	// treats a monthly budget as the closest shorter window.
+	oneMonth, err := ParseDuration("1M")
+	require.NoError(t, err)
+	assert.Greater(t, oneQuarter, oneMonth)
+
+	_, err = ParseDuration("Q")
+	assert.Error(t, err, "a bare suffix with no multiplier must be rejected")
+}
+
+// TestBudgetResetConfigRoundTripsThroughDatabase verifies the quarter definition
+// survives a save/reload cycle via the JSON column.
+func TestBudgetResetConfigRoundTripsThroughDatabase(t *testing.T) {
+	db := setupBudgetTestDB(t)
+
+	budget := &TableBudget{
+		ID:            "budget-quarterly",
+		MaxLimit:      1000,
+		ResetDuration: "1Q",
+		LastReset:     time.Now().UTC(),
+		ResetConfig:   &BudgetResetConfig{QuarterStartMonth: int(time.April)},
+	}
+	require.NoError(t, db.Create(budget).Error)
+
+	var reloaded TableBudget
+	require.NoError(t, db.First(&reloaded, "id = ?", "budget-quarterly").Error)
+	require.NotNil(t, reloaded.ResetConfig)
+	assert.Equal(t, int(time.April), reloaded.ResetConfig.QuarterStartMonth)
+	assert.Equal(t, time.April, reloaded.QuarterStartMonth())
+}
+
+// TestBudgetResetConfigSurvivesNestedPreload is the cluster-correctness test.
+//
+// Enterprise peers never receive a budget's configuration over the wire: the
+// gossip payload carries usage only, and a config change broadcasts just an
+// entity ID, which each peer answers by re-reading the row (ReloadVirtualKey).
+// The quarter definition therefore reaches other nodes solely through the
+// AfterFind hook firing on a nested preload. If it does not fire, the writing
+// node computes April quarters while every peer computes January ones, with
+// nothing in the logs to show for it.
+func TestBudgetResetConfigSurvivesNestedPreload(t *testing.T) {
+	db := setupBudgetTestDB(t)
+
+	vk := &TableVirtualKey{
+		ID:    "vk-quarterly",
+		Name:  "quarterly-vk",
+		Value: schemas.SecretVar{Val: "bf-vk-quarterly"},
+		Budgets: []TableBudget{{
+			ID:            "budget-nested",
+			MaxLimit:      500,
+			ResetDuration: "1Q",
+			LastReset:     time.Now().UTC(),
+			ResetConfig:   &BudgetResetConfig{QuarterStartMonth: int(time.October)},
+		}},
+	}
+	require.NoError(t, db.Create(vk).Error)
+
+	var reloaded TableVirtualKey
+	require.NoError(t, db.Preload("Budgets").First(&reloaded, "id = ?", "vk-quarterly").Error)
+	require.Len(t, reloaded.Budgets, 1)
+	require.NotNil(t, reloaded.Budgets[0].ResetConfig,
+		"AfterFind must fire on preloaded budgets, otherwise cluster peers silently default to January quarters")
+	assert.Equal(t, int(time.October), reloaded.Budgets[0].ResetConfig.QuarterStartMonth)
+}
+
+// TestBudgetResetConfigAbsentStaysNil verifies a budget without a quarter
+// definition round-trips as nil rather than as a zeroed struct, so the JSON API
+// omits the field and QuarterStartMonth falls back to January.
+func TestBudgetResetConfigAbsentStaysNil(t *testing.T) {
+	db := setupBudgetTestDB(t)
+
+	budget := &TableBudget{
+		ID:            "budget-monthly",
+		MaxLimit:      100,
+		ResetDuration: "1M",
+		LastReset:     time.Now().UTC(),
+	}
+	require.NoError(t, db.Create(budget).Error)
+
+	var reloaded TableBudget
+	require.NoError(t, db.First(&reloaded, "id = ?", "budget-monthly").Error)
+	assert.Nil(t, reloaded.ResetConfig)
+	assert.Empty(t, reloaded.ResetConfigJSON)
+	assert.Equal(t, time.January, reloaded.QuarterStartMonth())
+}
+
+// TestBudgetResetConfigRejectsInvalidQuarterStartMonth verifies BeforeSave
+// guards the month range. A zero value means "unset" and is accepted.
+func TestBudgetResetConfigRejectsInvalidQuarterStartMonth(t *testing.T) {
+	db := setupBudgetTestDB(t)
+
+	for _, month := range []int{-1, 13, 99} {
+		budget := &TableBudget{
+			ID:            "budget-bad-month",
+			MaxLimit:      100,
+			ResetDuration: "1Q",
+			LastReset:     time.Now().UTC(),
+			ResetConfig:   &BudgetResetConfig{QuarterStartMonth: month},
+		}
+		err := db.Create(budget).Error
+		require.Error(t, err, "quarter_start_month %d must be rejected", month)
+		assert.Contains(t, err.Error(), "quarter_start_month")
+	}
+}
+
+// TestBudgetResetConfigRejectedOnNonQuarterlyDuration verifies a quarter
+// definition cannot be attached to a window that has no quarters, which would
+// otherwise persist a setting that silently does nothing.
+func TestBudgetResetConfigRejectedOnNonQuarterlyDuration(t *testing.T) {
+	db := setupBudgetTestDB(t)
+
+	budget := &TableBudget{
+		ID:            "budget-monthly-with-quarter-config",
+		MaxLimit:      100,
+		ResetDuration: "1M",
+		LastReset:     time.Now().UTC(),
+		ResetConfig:   &BudgetResetConfig{QuarterStartMonth: int(time.April)},
+	}
+	err := db.Create(budget).Error
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reset_config")
+}
+
+// TestIsQuarterlyDurationIsCaseSensitive pins the suffix grammar.
+//
+// The duration suffixes are case-significant - "M" is a month while "m" is a
+// minute - so "1q" must not be mistaken for a quarter. Reset durations arrive
+// as free-form strings from config.json and the API, where a lowercase typo is
+// an easy mistake; treating it as quarterly would silently give the budget a
+// 90-day window, whereas rejecting it surfaces the typo. ParseDuration already
+// rejects "1q" outright, and this keeps the two in agreement.
+func TestIsQuarterlyDurationIsCaseSensitive(t *testing.T) {
+	assert.True(t, IsQuarterlyDuration("1Q"))
+	assert.True(t, IsQuarterlyDuration("2Q"))
+
+	assert.False(t, IsQuarterlyDuration("1q"))
+	assert.False(t, IsQuarterlyDuration(""))
+	assert.False(t, IsQuarterlyDuration("1M"))
+	assert.False(t, IsQuarterlyDuration("Quarterly"))
+
+	_, err := ParseDuration("1q")
+	assert.Error(t, err, "a lowercase suffix must not silently parse as a quarter")
+}
+
+// TestBudgetRejectsZeroLengthQuarter verifies "0Q" is caught by the existing
+// non-positive duration guard rather than persisting a window of length zero,
+// which the reset path would see as perpetually due.
+func TestBudgetRejectsZeroLengthQuarter(t *testing.T) {
+	db := setupBudgetTestDB(t)
+
+	budget := &TableBudget{
+		ID:            "budget-zero-quarter",
+		MaxLimit:      100,
+		ResetDuration: "0Q",
+		LastReset:     time.Now().UTC(),
+	}
+	err := db.Create(budget).Error
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reset duration must be > 0")
+}
+
+// TestBudgetResetConfigNotSerializedWhenValidationFails pins the ordering inside
+// BeforeSave: validation runs before serialization, so a rejected quarter
+// definition never reaches the column. Were the order reversed, a failed save
+// would leave the blob populated on the in-memory struct, and a later save that
+// cleared ResetConfig would still carry the stale JSON through.
+func TestBudgetResetConfigNotSerializedWhenValidationFails(t *testing.T) {
+	db := setupBudgetTestDB(t)
+
+	budget := &TableBudget{
+		ID:            "budget-rejected",
+		MaxLimit:      100,
+		ResetDuration: "1M",
+		LastReset:     time.Now().UTC(),
+		ResetConfig:   &BudgetResetConfig{QuarterStartMonth: int(time.April)},
+	}
+	require.Error(t, db.Create(budget).Error)
+	assert.Empty(t, budget.ResetConfigJSON,
+		"a rejected reset config must not be serialized onto the struct")
+}
+
+// TestBudgetAfterFindRejectsMalformedResetConfig verifies a corrupt blob surfaces
+// as a read error rather than silently degrading to a January quarter. A budget
+// whose quarter definition cannot be read is not the same as one that has none,
+// and enforcing against the wrong window is worse than failing the read.
+func TestBudgetAfterFindRejectsMalformedResetConfig(t *testing.T) {
+	db := setupBudgetTestDB(t)
+
+	budget := &TableBudget{
+		ID:            "budget-corrupt",
+		MaxLimit:      100,
+		ResetDuration: "1Q",
+		LastReset:     time.Now().UTC(),
+		ResetConfig:   &BudgetResetConfig{QuarterStartMonth: int(time.April)},
+	}
+	require.NoError(t, db.Create(budget).Error)
+
+	// Corrupt the column behind the model's back.
+	require.NoError(t, db.Exec(
+		`UPDATE governance_budgets SET reset_config_json = ? WHERE id = ?`,
+		"{not json", budget.ID,
+	).Error)
+
+	var reloaded TableBudget
+	err := db.First(&reloaded, "id = ?", budget.ID).Error
+	require.Error(t, err, "a malformed reset config must fail the read, not default to January")
+}
+
+// TestBudgetQuarterStartMonthDefaultsToJanuary verifies the accessor is safe on
+// a nil receiver and on a budget whose config was never set, so every call site
+// can read it without a nil check.
+func TestBudgetQuarterStartMonthDefaultsToJanuary(t *testing.T) {
+	var nilBudget *TableBudget
+	assert.Equal(t, time.January, nilBudget.QuarterStartMonth())
+
+	assert.Equal(t, time.January, (&TableBudget{}).QuarterStartMonth())
+	assert.Equal(t, time.January, (&TableBudget{ResetConfig: &BudgetResetConfig{}}).QuarterStartMonth())
+	assert.Equal(t, time.July, (&TableBudget{ResetConfig: &BudgetResetConfig{QuarterStartMonth: 7}}).QuarterStartMonth())
+}

--- a/framework/configstore/tables/utils.go
+++ b/framework/configstore/tables/utils.go
@@ -144,6 +144,12 @@ func ParseDuration(duration string) (time.Duration, error) {
 			return m * 24 * 30, nil // Approximate month as 30 days
 		}
 		return 0, fmt.Errorf("invalid month duration: %s", duration)
+	case duration[len(duration)-1:] == "Q":
+		quarters := duration[:len(duration)-1]
+		if q, err := time.ParseDuration(quarters + "h"); err == nil {
+			return q * 24 * 90, nil // Approximate quarter as 90 days
+		}
+		return 0, fmt.Errorf("invalid quarter duration: %s", duration)
 	case duration[len(duration)-1:] == "Y":
 		years := duration[:len(duration)-1]
 		if y, err := time.ParseDuration(years + "h"); err == nil {


### PR DESCRIPTION
## Summary

Budgets with a quarterly reset duration (`1Q`) previously had no way to configure which month begins Q1. This meant all quarterly budgets defaulted to a January fiscal year, making it impossible to model an April or October fiscal year start. This PR introduces a `BudgetResetConfig` struct persisted as a JSON blob (`reset_config_json`) on the `governance_budgets` table, allowing operators to specify a `quarter_start_month` per budget.

## Changes

- Added `BudgetResetConfig` struct with a `QuarterStartMonth` field (1–12), persisted as `reset_config_json` via GORM `BeforeSave`/`AfterFind` hooks on `TableBudget`.
- Added `QuarterStartMonth()` accessor on `TableBudget` that defaults to `time.January` on nil receivers, nil configs, and zero values, so all call sites can read it unconditionally.
- Added `IsQuarterlyDuration()` helper and `"Q"` suffix support to `ParseDuration`, approximating one quarter as 90 days (matching how `"M"` approximates 30 days).
- Updated `GenerateBudgetHash` to include the effective quarter start month in the digest for quarterly budgets, so editing the quarter definition in `config.json` is detected as a change. Non-quarterly budgets produce byte-identical digests to avoid spurious resyncs on upgrade.
- The hash reads `QuarterStartMonth()` rather than the raw `ResetConfigJSON` blob, ensuring a budget parsed from `config.json` (no blob yet) and its persisted counterpart hash identically.
- Added `migrationAddBudgetResetConfigColumn` to add the nullable `reset_config_json` column to existing `governance_budgets` tables with no backfill, preserving the January-default cadence of all pre-existing budgets.
- `BeforeSave` validates that `ResetConfig` is only set on quarterly durations and that `QuarterStartMonth` is in range before serializing, so a rejected config never reaches the column.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/... ./framework/configstore/tables/...
```

Key test scenarios covered:

- `TestGenerateBudgetHashUnchangedForNonQuarterlyBudgets` — upgrading does not trigger spurious config resyncs for non-quarterly budgets.
- `TestGenerateBudgetHashAgreesAcrossConfigAndDatabaseSources` — a `config.json` budget and its persisted counterpart hash identically.
- `TestGenerateBudgetHashTracksQuarterStartMonth` — editing the quarter start is detected as a change.
- `TestMigrationAddsBudgetResetConfigColumnToExistingTable` — migration is idempotent on an already-provisioned table.
- `TestExistingBudgetsKeepTheirCadenceAfterMigration` — pre-existing budgets read back with nil `ResetConfig` and a January quarter start.
- `TestBudgetResetConfigSurvivesNestedPreload` — `AfterFind` fires on preloaded associations, ensuring cluster peers receive the correct quarter definition.

## Breaking changes

- [ ] Yes
- [x] No

The migration is additive and nullable with no backfill. All existing budgets continue to operate with a January quarter start, which is identical to their previous behavior.

## Related issues

## Security considerations

No auth, secrets, or PII implications. The `reset_config_json` column stores only a fiscal month integer.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable