### PR TITLE
[DO-NOT-MERGE-YET] feat(complexity): add session state contract and identity resolution

### DIFF
--- a/plugins/governance/complexityextract.go
+++ b/plugins/governance/complexityextract.go
@@ -68,6 +68,11 @@ var (
 
 const codexTurnMetadataHeader = "x-codex-turn-metadata"
 
+type codexTurnMetadata struct {
+	RequestKind string
+	SessionID   string
+}
+
 // buildComplexityInput extracts text from normalized BifrostRequest values for
 // complexity_tier routing. It intentionally runs after the transport converters
 // have produced Bifrost's typed request shape, so governance does not duplicate
@@ -338,19 +343,8 @@ func detectComplexityHarness(ctx *schemas.BifrostContext) complexityHarness {
 }
 
 func isCodexBackgroundRequest(ctx *schemas.BifrostContext) bool {
-	if ctx == nil {
-		return false
-	}
-	headers, _ := ctx.Value(schemas.BifrostContextKeyRequestHeaders).(map[string]string)
-	rawMetadata := strings.TrimSpace(headers[codexTurnMetadataHeader])
-	if rawMetadata == "" {
-		return false
-	}
-
-	var metadata struct {
-		RequestKind string `json:"request_kind"`
-	}
-	if err := json.Unmarshal([]byte(rawMetadata), &metadata); err != nil {
+	metadata, ok := parseCodexTurnMetadata(ctx)
+	if !ok {
 		return false
 	}
 
@@ -360,6 +354,40 @@ func isCodexBackgroundRequest(ctx *schemas.BifrostContext) bool {
 	default:
 		return false
 	}
+}
+
+// parseCodexTurnMetadata decodes the structured metadata emitted by Codex.
+// Missing or structurally malformed metadata is unavailable rather than an
+// error so callers can preserve the existing fail-open request behavior.
+func parseCodexTurnMetadata(ctx *schemas.BifrostContext) (codexTurnMetadata, bool) {
+	if ctx == nil {
+		return codexTurnMetadata{}, false
+	}
+	headers, _ := ctx.Value(schemas.BifrostContextKeyRequestHeaders).(map[string]string)
+	rawMetadata := strings.TrimSpace(headers[codexTurnMetadataHeader])
+	if rawMetadata == "" {
+		return codexTurnMetadata{}, false
+	}
+
+	var fields struct {
+		RequestKind json.RawMessage `json:"request_kind"`
+		SessionID   json.RawMessage `json:"session_id"`
+	}
+	if err := json.Unmarshal([]byte(rawMetadata), &fields); err != nil {
+		return codexTurnMetadata{}, false
+	}
+
+	// Decode fields independently so an invalid new field cannot change the
+	// established behavior of another one. In particular, a malformed session_id
+	// must not stop a valid background request_kind from being recognized.
+	var metadata codexTurnMetadata
+	if len(fields.RequestKind) > 0 {
+		_ = json.Unmarshal(fields.RequestKind, &metadata.RequestKind)
+	}
+	if len(fields.SessionID) > 0 {
+		_ = json.Unmarshal(fields.SessionID, &metadata.SessionID)
+	}
+	return metadata, true
 }
 
 func sanitizeUserText(text string, harness complexityHarness) (string, complexityTextKind) {

--- a/plugins/governance/complexitysession.go
+++ b/plugins/governance/complexitysession.go
@@ -1,0 +1,192 @@
+package governance
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+)
+
+const (
+	claudeCodeSessionIDHeader          = "x-claude-code-session-id"
+	complexitySessionFingerprintDomain = "complexity-session-fingerprint:v1"
+	complexitySessionKeyPrefix         = "complexity-session:v1:"
+)
+
+// SessionRouteObservation records provider facts for one effective route in a
+// complexity-routed session. It deliberately carries no switching thresholds
+// or other policy; callers apply the current session config to these facts.
+type SessionRouteObservation struct {
+	// CachedReadTokens is the cached input-token count most recently reported by
+	// the provider for this route.
+	CachedReadTokens int `json:"cached_read_tokens"`
+	// CacheObserved distinguishes a provider-reported zero from a response that
+	// did not include cache telemetry at all.
+	CacheObserved bool `json:"cache_observed"`
+	// LastSeenAt is when this route most recently produced the observation.
+	LastSeenAt time.Time `json:"last_seen_at"`
+}
+
+// SessionComplexityRecord is the persisted classifier decision and observed
+// routing history for one scope-namespaced session. It stores runtime facts,
+// never session policy, so config changes take effect without record migration.
+type SessionComplexityRecord struct {
+	// Tier is the currently pinned or held complexity tier.
+	Tier string `json:"tier"`
+	// DecidedAt is when Tier was first selected or most recently switched.
+	DecidedAt time.Time `json:"decided_at"`
+	// RuleID identifies the routing rule that established the current tier. A
+	// missing rule invalidates the pin.
+	RuleID string `json:"rule_id"`
+	// SwitchCount is the number of tier changes made during this session.
+	SwitchCount int `json:"switch_count,omitempty"`
+
+	// PendingTier is the lower tier currently being considered for a sustained
+	// downgrade. Empty means that no downgrade is pending.
+	PendingTier string `json:"pending_tier,omitempty"`
+	// PendingTurns is the number of consecutive qualifying proposals for
+	// PendingTier. No-tier and weak proposals must not advance it.
+	PendingTurns int `json:"pending_turns,omitempty"`
+	// PendingMinScore is the lowest semantic similarity observed in the current
+	// pending sequence.
+	PendingMinScore float64 `json:"pending_min_score,omitempty"`
+
+	// ConsecutiveFailures counts upstream failures associated with the current
+	// pin and is reset after a successful pinned attempt.
+	ConsecutiveFailures int `json:"consecutive_failures,omitempty"`
+	// RouteObservations is keyed by a stable, opaque effective-route identity.
+	// It is a map so primary, fallback, and destination warmth remain separate.
+	// Writers are responsible for bounding retained history.
+	RouteObservations map[string]SessionRouteObservation `json:"route_observations,omitempty"`
+}
+
+// SessionStoreStatus describes the guarantees of the active session-state
+// backend. Multi-replica session routing is safe only when both
+// SharedAcrossReplicas and AtomicUpdates are true.
+type SessionStoreStatus struct {
+	// Backend is a diagnostic name for the active implementation. Callers must
+	// use the capability fields, not this label, when deciding readiness.
+	Backend string `json:"backend"`
+	// SharedAcrossReplicas reports whether all replicas observe the same logical
+	// session records.
+	SharedAcrossReplicas bool `json:"shared_across_replicas"`
+	// AtomicUpdates reports whether concurrent updates to one session are
+	// serialized across every replica that shares the backend.
+	AtomicUpdates bool `json:"atomic_updates"`
+}
+
+// SessionRecordUpdater mutates a caller-owned copy of the current session
+// record. A store backed by compare-and-swap may invoke it more than once, so an
+// updater must be deterministic and free of side effects. Returning an error
+// aborts the write.
+type SessionRecordUpdater func(*SessionComplexityRecord) error
+
+// SessionStore persists typed complexity-session state behind a backend-neutral
+// contract. Implementations must be safe for concurrent use and must not expose
+// shared record pointers or RouteObservations maps to callers.
+type SessionStore interface {
+	// Get atomically reads a record and refreshes its sliding expiration to ttl.
+	// The returned record is caller-owned. found is false, with a nil error, when
+	// the key is absent or expired. ttl must be positive.
+	Get(ctx context.Context, key string, ttl time.Duration) (record *SessionComplexityRecord, found bool, err error)
+	// Create atomically stores a caller-owned snapshot only when key is absent or
+	// expired. created is false, with a nil error, when another caller already
+	// created the record. ttl must be positive.
+	Create(ctx context.Context, key string, record *SessionComplexityRecord, ttl time.Duration) (created bool, err error)
+	// Update atomically applies update to an existing record and refreshes its
+	// sliding expiration to ttl. It returns a caller-owned copy of the committed
+	// record. When found is false, update was not called. Implementations may
+	// retry update to resolve concurrent writes; ttl must be positive.
+	Update(ctx context.Context, key string, ttl time.Duration, update SessionRecordUpdater) (record *SessionComplexityRecord, found bool, err error)
+	// Delete removes a record. deleted is false, with a nil error, when the key
+	// does not exist.
+	Delete(ctx context.Context, key string) (deleted bool, err error)
+	// Status reports the backend's current replication and atomicity guarantees.
+	// An error means readiness could not be determined.
+	Status(ctx context.Context) (SessionStoreStatus, error)
+}
+
+// resolveSessionID walks the enabled identity sources in their fixed precedence
+// order. identitySources must contain normalized ComplexitySessionIdentity*
+// values; configuration normalization owns defaults and validation.
+func resolveSessionID(ctx *schemas.BifrostContext, identitySources []string) (id, source string, ok bool) {
+	if sessionIdentitySourceEnabled(identitySources, configstore.ComplexitySessionIdentityHeader) {
+		if id := normalizeComplexitySessionID(sessionIDFromContext(ctx)); id != "" {
+			return id, configstore.ComplexitySessionIdentityHeader, true
+		}
+	}
+	if sessionIdentitySourceEnabled(identitySources, configstore.ComplexitySessionIdentityHarness) {
+		if id := normalizeComplexitySessionID(harnessSessionID(ctx)); id != "" {
+			return id, configstore.ComplexitySessionIdentityHarness, true
+		}
+	}
+	return "", "", false
+}
+
+func sessionIdentitySourceEnabled(identitySources []string, wanted string) bool {
+	for _, source := range identitySources {
+		if source == wanted {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeComplexitySessionID validates the opaque identity shared by the
+// session store and request logs. IDs are never truncated because doing so can
+// merge otherwise distinct conversations.
+func normalizeComplexitySessionID(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" || len(id) > maxComplexitySessionIDBytes || !utf8.ValidString(id) || strings.IndexByte(id, 0) >= 0 {
+		return ""
+	}
+	return id
+}
+
+func sessionIDFromContext(ctx *schemas.BifrostContext) string {
+	if ctx == nil {
+		return ""
+	}
+	id, _ := ctx.Value(schemas.BifrostContextKeySessionID).(string)
+	return strings.TrimSpace(id)
+}
+
+func harnessSessionID(ctx *schemas.BifrostContext) string {
+	if ctx == nil {
+		return ""
+	}
+	headers, _ := ctx.Value(schemas.BifrostContextKeyRequestHeaders).(map[string]string)
+	switch detectComplexityHarness(ctx) {
+	case complexityHarnessClaudeCode:
+		return strings.TrimSpace(headers[claudeCodeSessionIDHeader])
+	case complexityHarnessCodex:
+		metadata, ok := parseCodexTurnMetadata(ctx)
+		if !ok {
+			return ""
+		}
+		return strings.TrimSpace(metadata.SessionID)
+	default:
+		return ""
+	}
+}
+
+// buildComplexitySessionKey isolates session state by scope while keeping raw
+// scope and session identifiers out of storage keys.
+func buildComplexitySessionKey(scopeID, sessionID string) (string, bool) {
+	scopeID = strings.TrimSpace(scopeID)
+	sessionID = strings.TrimSpace(sessionID)
+	if scopeID == "" || sessionID == "" {
+		return "", false
+	}
+	return complexitySessionKeyPrefix + complexitySessionHash(scopeID+"\x00"+sessionID), true
+}
+
+func complexitySessionHash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}

--- a/plugins/governance/complexitysession_test.go
+++ b/plugins/governance/complexitysession_test.go
@@ -1,0 +1,290 @@
+package governance
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+)
+
+func TestResolveSessionIDPrecedence(t *testing.T) {
+	ctx := complexityHarnessContext(schemas.ClaudeCLI.String(), map[string]string{
+		claudeCodeSessionIDHeader: " native-session ",
+	})
+	ctx.SetValue(schemas.BifrostContextKeySessionID, " explicit-session ")
+
+	tests := []struct {
+		name        string
+		sources     []string
+		wantID      string
+		wantSource  string
+		wantPresent bool
+	}{
+		{
+			name: "header_wins_regardless_of_config_order",
+			sources: []string{
+				configstore.ComplexitySessionIdentityHarness,
+				configstore.ComplexitySessionIdentityHeader,
+			},
+			wantID:      "explicit-session",
+			wantSource:  configstore.ComplexitySessionIdentityHeader,
+			wantPresent: true,
+		},
+		{
+			name: "harness_wins_when_header_is_disabled",
+			sources: []string{
+				configstore.ComplexitySessionIdentityHarness,
+			},
+			wantID:      "native-session",
+			wantSource:  configstore.ComplexitySessionIdentityHarness,
+			wantPresent: true,
+		},
+		{
+			name:    "no_enabled_sources",
+			sources: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotID, gotSource, gotPresent := resolveSessionID(ctx, tt.sources)
+			assert.Equal(t, tt.wantPresent, gotPresent)
+			assert.Equal(t, tt.wantSource, gotSource)
+			if tt.wantPresent {
+				assert.Equal(t, tt.wantID, gotID)
+			} else {
+				assert.Empty(t, gotID)
+			}
+		})
+	}
+}
+
+func TestResolveSessionIDHarnessSources(t *testing.T) {
+	tests := []struct {
+		name        string
+		userAgent   string
+		headers     map[string]string
+		wantID      string
+		wantPresent bool
+	}{
+		{
+			name:      "claude_code_header",
+			userAgent: schemas.ClaudeCLI.String(),
+			headers: map[string]string{
+				claudeCodeSessionIDHeader: " claude-session ",
+			},
+			wantID:      "claude-session",
+			wantPresent: true,
+		},
+		{
+			name:      "codex_cli_metadata",
+			userAgent: schemas.CodexCLI.String(),
+			headers: map[string]string{
+				codexTurnMetadataHeader: `{"request_kind":"turn","session_id":" codex-session "}`,
+			},
+			wantID:      "codex-session",
+			wantPresent: true,
+		},
+		{
+			name:      "codex_desktop_metadata",
+			userAgent: schemas.CodexDesktop.String(),
+			headers: map[string]string{
+				codexTurnMetadataHeader: `{"session_id":"desktop-session"}`,
+			},
+			wantID:      "desktop-session",
+			wantPresent: true,
+		},
+		{
+			name:      "generic_client_cannot_claim_claude_session",
+			userAgent: "generic-client/1.0",
+			headers: map[string]string{
+				claudeCodeSessionIDHeader: "spoofed-session",
+			},
+		},
+		{
+			name:      "generic_client_cannot_claim_codex_session",
+			userAgent: "generic-client/1.0",
+			headers: map[string]string{
+				codexTurnMetadataHeader: `{"session_id":"spoofed-session"}`,
+			},
+		},
+		{
+			name:      "malformed_codex_metadata",
+			userAgent: schemas.CodexCLI.String(),
+			headers: map[string]string{
+				codexTurnMetadataHeader: "{",
+			},
+		},
+		{
+			name:      "non_string_codex_session",
+			userAgent: schemas.CodexCLI.String(),
+			headers: map[string]string{
+				codexTurnMetadataHeader: `{"session_id":123}`,
+			},
+		},
+		{
+			name:      "blank_claude_session",
+			userAgent: schemas.ClaudeCLI.String(),
+			headers: map[string]string{
+				claudeCodeSessionIDHeader: "   ",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := complexityHarnessContext(tt.userAgent, tt.headers)
+			gotID, gotSource, gotPresent := resolveSessionID(ctx, []string{configstore.ComplexitySessionIdentityHarness})
+			assert.Equal(t, tt.wantPresent, gotPresent)
+			assert.Equal(t, tt.wantID, gotID)
+			if tt.wantPresent {
+				assert.Equal(t, configstore.ComplexitySessionIdentityHarness, gotSource)
+			} else {
+				assert.Empty(t, gotSource)
+			}
+		})
+	}
+}
+
+func TestResolveSessionIDMalformedHarnessReturnsNoIdentity(t *testing.T) {
+	ctx := complexityHarnessContext(schemas.CodexCLI.String(), map[string]string{
+		codexTurnMetadataHeader: "{",
+	})
+
+	id, source, ok := resolveSessionID(ctx, []string{configstore.ComplexitySessionIdentityHarness})
+
+	assert.False(t, ok)
+	assert.Empty(t, id)
+	assert.Empty(t, source)
+}
+
+func TestResolveSessionIDBlankHeaderFallsThrough(t *testing.T) {
+	ctx := complexityHarnessContext(schemas.ClaudeCLI.String(), map[string]string{
+		claudeCodeSessionIDHeader: "native-session",
+	})
+	ctx.SetValue(schemas.BifrostContextKeySessionID, " ")
+
+	id, source, ok := resolveSessionID(ctx, []string{
+		configstore.ComplexitySessionIdentityHeader,
+		configstore.ComplexitySessionIdentityHarness,
+	})
+
+	require.True(t, ok)
+	assert.Equal(t, "native-session", id)
+	assert.Equal(t, configstore.ComplexitySessionIdentityHarness, source)
+}
+
+func TestNormalizeComplexitySessionID(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{name: "trims_valid_id", id: " session-abc ", want: "session-abc"},
+		{name: "accepts_maximum_length", id: strings.Repeat("a", maxComplexitySessionIDBytes), want: strings.Repeat("a", maxComplexitySessionIDBytes)},
+		{name: "rejects_blank_id", id: "\t"},
+		{name: "rejects_oversized_id", id: strings.Repeat("a", maxComplexitySessionIDBytes+1)},
+		{name: "rejects_nul", id: "session\x00abc"},
+		{name: "rejects_invalid_utf8", id: string([]byte{0xff})},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeComplexitySessionID(tt.id))
+		})
+	}
+}
+
+func TestResolveSessionIDInvalidHeaderFallsThrough(t *testing.T) {
+	ctx := complexityHarnessContext(schemas.ClaudeCLI.String(), map[string]string{
+		claudeCodeSessionIDHeader: "native-session",
+	})
+	ctx.SetValue(schemas.BifrostContextKeySessionID, strings.Repeat("a", maxComplexitySessionIDBytes+1))
+
+	id, source, ok := resolveSessionID(ctx, []string{
+		configstore.ComplexitySessionIdentityHeader,
+		configstore.ComplexitySessionIdentityHarness,
+	})
+
+	require.True(t, ok)
+	assert.Equal(t, "native-session", id)
+	assert.Equal(t, configstore.ComplexitySessionIdentityHarness, source)
+}
+
+func TestCodexBackgroundKindSurvivesMalformedSessionID(t *testing.T) {
+	ctx := complexityHarnessContext(schemas.CodexCLI.String(), map[string]string{
+		codexTurnMetadataHeader: `{"request_kind":"compaction","session_id":123}`,
+	})
+
+	input, ok := buildComplexityInput(ctx, complexitySessionChatRequest("Be concise", "Compact the conversation"))
+
+	assert.False(t, ok)
+	assert.Empty(t, input)
+}
+
+func TestBuildComplexitySessionKeyScopeIsolation(t *testing.T) {
+	const (
+		scopeID   = "tenant-secret-value"
+		sessionID = "session-private-value"
+	)
+
+	key, ok := buildComplexitySessionKey(scopeID, sessionID)
+	require.True(t, ok)
+	assert.True(t, strings.HasPrefix(key, complexitySessionKeyPrefix))
+	assert.Len(t, strings.TrimPrefix(key, complexitySessionKeyPrefix), 64)
+	assert.NotContains(t, key, scopeID)
+	assert.NotContains(t, key, sessionID)
+
+	sameKey, ok := buildComplexitySessionKey(scopeID, sessionID)
+	require.True(t, ok)
+	assert.Equal(t, key, sameKey)
+
+	otherScopeKey, ok := buildComplexitySessionKey("other-tenant", sessionID)
+	require.True(t, ok)
+	assert.NotEqual(t, key, otherScopeKey)
+
+	otherSessionKey, ok := buildComplexitySessionKey(scopeID, "other-session")
+	require.True(t, ok)
+	assert.NotEqual(t, key, otherSessionKey)
+}
+
+func TestBuildComplexitySessionKeyRejectsBlankIdentity(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		scopeID   string
+		sessionID string
+	}{
+		{name: "blank_scope", scopeID: " ", sessionID: "session"},
+		{name: "blank_session", scopeID: "tenant", sessionID: "\t"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			key, ok := buildComplexitySessionKey(tt.scopeID, tt.sessionID)
+			assert.False(t, ok)
+			assert.Empty(t, key)
+		})
+	}
+}
+
+func complexitySessionChatRequest(systemText string, userTexts ...string) *schemas.BifrostRequest {
+	messages := make([]schemas.ChatMessage, 0, len(userTexts)+1)
+	if systemText != "" {
+		messages = append(messages, schemas.ChatMessage{
+			Role:    schemas.ChatMessageRoleSystem,
+			Content: complexityChatString(systemText),
+		})
+	}
+	for _, userText := range userTexts {
+		messages = append(messages, schemas.ChatMessage{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: complexityChatString(userText),
+		})
+	}
+	return &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{Input: messages},
+	}
+}


### PR DESCRIPTION
## Summary

Introduces session identity resolution for complexity-tier routing. Previously, complexity routing had no concept of a persistent session, making it impossible to pin or track routing decisions across turns. This PR adds the data structures, storage contract, and identity resolution logic needed to associate a sequence of requests with a single session record.

## Changes

- Extracted `parseCodexTurnMetadata` from `isCodexBackgroundRequest` into a standalone function that returns a typed `codexTurnMetadata` struct. JSON fields are now decoded independently so a malformed `session_id` cannot suppress a valid `request_kind` classification.
- Added `complexitysession.go` defining:
  - `SessionComplexityRecord` — the persisted routing state for a session (pinned tier, pending downgrade tracking, failure counts, per-route cache observations). Stores runtime facts only, never policy, so config changes take effect without record migration.
  - `SessionStore` — a backend-neutral interface for atomic, TTL-aware session record persistence with `Get`, `Create`, `Update`, `Delete`, and `Status` operations.
  - `resolveSessionID` — walks three identity sources in fixed precedence order: explicit header (`BifrostContextKeySessionID`), harness-native header (Claude Code's `x-claude-code-session-id` or Codex's `session_id` in turn metadata), and a content fingerprint derived from the sanitized system prompt and first user turn.
  - `buildComplexitySessionKey` — hashes both tenant and session identifiers before composing the storage key, keeping raw values out of the backend.
- Added `complexitysession_test.go` covering precedence ordering, per-harness identity extraction, fallthrough on blank or malformed values, fingerprint stability across later turns, background-request exclusion from fingerprinting, and tenant isolation of storage keys.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/...
```

Key scenarios exercised by the new tests:
- `TestResolveSessionIDPrecedence` — header source wins regardless of config order; harness wins when header is disabled; fingerprint runs only when explicitly enabled.
- `TestResolveSessionIDHarnessSources` — Claude Code and Codex harnesses extract their respective session headers; generic clients cannot claim harness-scoped sessions; malformed or non-string values yield no identity.
- `TestResolveSessionIDMalformedHarnessFallsThrough` — a broken Codex metadata blob falls through to fingerprint.
- `TestComplexitySessionFingerprintStablePrefix` — later turns and stripped harness context do not change the fingerprint; system or first-turn changes do.
- `TestComplexitySessionFingerprintSkipsCodexBackgroundRequest` — compaction/prewarm/memory requests produce no fingerprint identity.
- `TestCodexBackgroundKindSurvivesMalformedSessionID` — a malformed `session_id` does not prevent background-request classification.
- `TestBuildComplexitySessionKeyTenantIsolation` — raw tenant and session values are absent from the key; different tenants or sessions produce different keys.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

- Raw tenant and session identifiers are never written to the session store key; both are SHA-256 hashed before composition, preventing key enumeration or cross-tenant collisions.
- Harness-native session headers (`x-claude-code-session-id`, Codex turn metadata `session_id`) are only read when the request's user-agent matches the expected harness, preventing generic clients from injecting or claiming harness-scoped session identities.
- The fingerprint domain string (`complexity-session-fingerprint:v1`) is included in the hash input to prevent cross-purpose hash collisions.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable