### PR TITLE
[DO-NOT-MERGE-YET] feat(complexity): add session state foundation and identity resolution

### DIFF
--- a/framework/kvstore/kvstore.go
+++ b/framework/kvstore/kvstore.go
@@ -15,6 +15,7 @@ var (
 	ErrEmptyKey   = errors.New("key cannot be empty")
 	ErrNotFound   = errors.New("key not found")
 	ErrInvalidTTL = errors.New("ttl cannot be negative")
+	ErrNilUpdate  = errors.New("update callback cannot be nil")
 )
 
 const (
@@ -51,9 +52,10 @@ type Store struct {
 	stopOnce  sync.Once
 	cleanupWg sync.WaitGroup
 
-	delegate  SyncDelegate
-	decoders  map[string]TypeDecoder
-	decoderMu sync.RWMutex
+	delegate   SyncDelegate
+	delegateMu sync.RWMutex
+	decoders   map[string]TypeDecoder
+	decoderMu  sync.RWMutex
 }
 
 // SyncDelegate is notified of all mutations, enabling cross-node replication.
@@ -70,9 +72,18 @@ type SyncDelegate interface {
 // Register decoders by key prefix via RegisterDecoder.
 type TypeDecoder func(data []byte) (any, error)
 
-// SetDelegate plugs in the cluster sync implementation.
+// SetDelegate installs or replaces the cluster sync implementation. Only
+// mutations that start after this call are guaranteed to use the new delegate.
 func (s *Store) SetDelegate(d SyncDelegate) {
+	s.delegateMu.Lock()
 	s.delegate = d
+	s.delegateMu.Unlock()
+}
+
+// HasSyncDelegate reports whether local mutations are currently forwarded to a
+// cluster sync implementation.
+func (s *Store) HasSyncDelegate() bool {
+	return s.syncDelegate() != nil
 }
 
 // RegisterDecoder registers a decoder for keys matching the given prefix.
@@ -119,6 +130,7 @@ func (s *Store) SetWithTTL(key string, value any, ttl time.Duration) error {
 	if err := s.validateMutable(key, ttl); err != nil {
 		return err
 	}
+	delegate := s.syncDelegate()
 
 	now := time.Now().UnixNano()
 	var expiresAt int64
@@ -129,7 +141,7 @@ func (s *Store) SetWithTTL(key string, value any, ttl time.Duration) error {
 	var valueJSON []byte
 	var err error
 
-	if s.delegate != nil {
+	if delegate != nil {
 		valueJSON, err = sonic.Marshal(value)
 		if err != nil {
 			return err
@@ -144,8 +156,8 @@ func (s *Store) SetWithTTL(key string, value any, ttl time.Duration) error {
 	}
 	s.mu.Unlock()
 
-	if s.delegate != nil {
-		s.delegate.OnSet(key, valueJSON, now, expiresAt)
+	if delegate != nil {
+		delegate.OnSet(key, valueJSON, now, expiresAt)
 	}
 
 	return nil
@@ -158,6 +170,7 @@ func (s *Store) SetNXWithTTL(key string, value any, ttl time.Duration) (bool, er
 	if err := s.validateMutable(key, ttl); err != nil {
 		return false, err
 	}
+	delegate := s.syncDelegate()
 
 	now := time.Now().UnixNano()
 	var expiresAt int64
@@ -168,7 +181,7 @@ func (s *Store) SetNXWithTTL(key string, value any, ttl time.Duration) (bool, er
 	var valueJSON []byte
 	var err error
 
-	if s.delegate != nil {
+	if delegate != nil {
 		valueJSON, err = sonic.Marshal(value)
 		if err != nil {
 			return false, err
@@ -176,7 +189,7 @@ func (s *Store) SetNXWithTTL(key string, value any, ttl time.Duration) (bool, er
 	}
 
 	s.mu.Lock()
-	
+
 	// Check if key exists and is not expired
 	if existing, ok := s.data[key]; ok {
 		if !isExpired(existing, now) {
@@ -185,7 +198,7 @@ func (s *Store) SetNXWithTTL(key string, value any, ttl time.Duration) (bool, er
 		}
 		// Key exists but is expired, allow overwrite
 	}
-	
+
 	// Key doesn't exist or is expired, set it
 	s.data[key] = entry{
 		value:     value,
@@ -194,11 +207,77 @@ func (s *Store) SetNXWithTTL(key string, value any, ttl time.Duration) (bool, er
 	}
 	s.mu.Unlock()
 
-	if s.delegate != nil {
-		s.delegate.OnSet(key, valueJSON, now, expiresAt)
+	if delegate != nil {
+		delegate.OnSet(key, valueJSON, now, expiresAt)
 	}
 
 	return true, nil
+}
+
+// UpdateWithTTL atomically replaces an existing, non-expired value and resets
+// its TTL. update runs while the store is locked and must complete promptly; it
+// must not call back into this store. Returning an error leaves the value and
+// TTL unchanged. A missing or expired key returns found=false without invoking
+// update. ttl=0 means no expiration.
+func (s *Store) UpdateWithTTL(key string, ttl time.Duration, update func(current any) (replacement any, err error)) (value any, found bool, err error) {
+	if err := s.validateMutable(key, ttl); err != nil {
+		return nil, false, err
+	}
+	if update == nil {
+		return nil, false, ErrNilUpdate
+	}
+	delegate := s.syncDelegate()
+
+	var (
+		valueJSON []byte
+		writtenAt int64
+		expiresAt int64
+	)
+
+	value, found, err = func() (any, bool, error) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		current, ok := s.data[key]
+		now := time.Now().UnixNano()
+		if !ok || isExpired(current, now) {
+			if ok {
+				delete(s.data, key)
+			}
+			return nil, false, nil
+		}
+
+		replacement, err := update(current.value)
+		if err != nil {
+			return nil, true, err
+		}
+
+		if delegate != nil {
+			valueJSON, err = sonic.Marshal(replacement)
+			if err != nil {
+				return nil, true, err
+			}
+		}
+
+		writtenAt = time.Now().UnixNano()
+		if ttl > 0 {
+			expiresAt = writtenAt + int64(ttl)
+		}
+		s.data[key] = entry{
+			value:     replacement,
+			writtenAt: writtenAt,
+			expiresAt: expiresAt,
+		}
+		return replacement, true, nil
+	}()
+	if err != nil || !found {
+		return value, found, err
+	}
+
+	if delegate != nil {
+		delegate.OnSet(key, valueJSON, writtenAt, expiresAt)
+	}
+	return value, true, nil
 }
 
 // SetRemote applies a remotely-gossiped entry without triggering OnSet.
@@ -265,6 +344,7 @@ func (s *Store) GetAndDelete(key string) (any, error) {
 	}
 
 	now := time.Now().UnixNano()
+	delegate := s.syncDelegate()
 
 	s.mu.Lock()
 	e, ok := s.data[key]
@@ -276,8 +356,8 @@ func (s *Store) GetAndDelete(key string) (any, error) {
 	if !ok || isExpired(e, now) {
 		return nil, ErrNotFound
 	}
-	if s.delegate != nil {
-		s.delegate.OnDelete(key, now)
+	if delegate != nil {
+		delegate.OnDelete(key, now)
 	}
 	return e.value, nil
 }
@@ -292,6 +372,7 @@ func (s *Store) Delete(key string) (bool, error) {
 	}
 
 	deletedAt := time.Now().UnixNano()
+	delegate := s.syncDelegate()
 
 	s.mu.Lock()
 	_, ok := s.data[key]
@@ -303,8 +384,8 @@ func (s *Store) Delete(key string) (bool, error) {
 	if !ok {
 		return false, nil
 	}
-	if s.delegate != nil {
-		s.delegate.OnDelete(key, deletedAt)
+	if delegate != nil {
+		delegate.OnDelete(key, deletedAt)
 	}
 	return true, nil
 }
@@ -401,6 +482,13 @@ func (s *Store) validateMutable(key string, ttl time.Duration) error {
 		return ErrClosed
 	}
 	return nil
+}
+
+func (s *Store) syncDelegate() SyncDelegate {
+	s.delegateMu.RLock()
+	delegate := s.delegate
+	s.delegateMu.RUnlock()
+	return delegate
 }
 
 // decodeValue uses the registered decoder for the key's prefix, falling back

--- a/framework/kvstore/kvstore_test.go
+++ b/framework/kvstore/kvstore_test.go
@@ -1,10 +1,36 @@
 package kvstore
 
 import (
+	"encoding/json"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
+
+type recordingSyncDelegate struct {
+	mu        sync.Mutex
+	setCalls  int
+	lastKey   string
+	lastValue []byte
+}
+
+func (d *recordingSyncDelegate) OnSet(key string, valueJSON []byte, _ int64, _ int64) {
+	d.mu.Lock()
+	d.setCalls++
+	d.lastKey = key
+	d.lastValue = append(d.lastValue[:0], valueJSON...)
+	d.mu.Unlock()
+}
+
+func (d *recordingSyncDelegate) OnDelete(string, int64) {}
+
+func (d *recordingSyncDelegate) snapshot() (calls int, key string, value []byte) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.setCalls, d.lastKey, append([]byte(nil), d.lastValue...)
+}
 
 func TestStoreSetGetDelete(t *testing.T) {
 	store, err := New(Config{})
@@ -79,6 +105,219 @@ func TestStoreGetAndDelete(t *testing.T) {
 
 	if _, err := store.Get("k"); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected missing key after get-and-delete, got: %v", err)
+	}
+}
+
+func TestStoreUpdateWithTTL(t *testing.T) {
+	store, err := New(Config{})
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.SetWithTTL("counter", 1, time.Second); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+
+	value, found, err := store.UpdateWithTTL("counter", time.Second, func(current any) (any, error) {
+		return current.(int) + 1, nil
+	})
+	if err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected existing key to be updated")
+	}
+	if value.(int) != 2 {
+		t.Fatalf("unexpected updated value: %v", value)
+	}
+
+	stored, err := store.Get("counter")
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if stored.(int) != 2 {
+		t.Fatalf("unexpected stored value: %v", stored)
+	}
+}
+
+func TestStoreUpdateWithTTLMissingOrExpired(t *testing.T) {
+	store, err := New(Config{CleanupInterval: time.Hour})
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	var calls atomic.Int32
+	update := func(current any) (any, error) {
+		calls.Add(1)
+		return current, nil
+	}
+
+	if value, found, err := store.UpdateWithTTL("missing", time.Second, update); err != nil || found || value != nil {
+		t.Fatalf("expected missing result, got value=%v found=%v err=%v", value, found, err)
+	}
+
+	if err := store.SetWithTTL("expired", "value", time.Millisecond); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	if value, found, err := store.UpdateWithTTL("expired", time.Second, update); err != nil || found || value != nil {
+		t.Fatalf("expected expired result, got value=%v found=%v err=%v", value, found, err)
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("update callback ran %d times for missing records", calls.Load())
+	}
+}
+
+func TestStoreUpdateWithTTLFailureDoesNotMutate(t *testing.T) {
+	store, err := New(Config{})
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.Set("key", "original"); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+	wantErr := errors.New("update failed")
+	_, found, err := store.UpdateWithTTL("key", time.Second, func(any) (any, error) {
+		return "replacement", wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected update error, got: %v", err)
+	}
+	if !found {
+		t.Fatal("expected update to report the existing key")
+	}
+
+	value, err := store.Get("key")
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if value.(string) != "original" {
+		t.Fatalf("failed update changed value to %v", value)
+	}
+}
+
+func TestStoreUpdateWithTTLConcurrent(t *testing.T) {
+	store, err := New(Config{})
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.Set("counter", 0); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+
+	const updates = 100
+	errCh := make(chan error, updates)
+	var wg sync.WaitGroup
+	for range updates {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, found, err := store.UpdateWithTTL("counter", time.Second, func(current any) (any, error) {
+				return current.(int) + 1, nil
+			})
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if !found {
+				errCh <- ErrNotFound
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Errorf("concurrent update failed: %v", err)
+	}
+
+	value, err := store.Get("counter")
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if value.(int) != updates {
+		t.Fatalf("lost concurrent updates: got %v, want %d", value, updates)
+	}
+}
+
+func TestStoreUpdateWithTTLDelegate(t *testing.T) {
+	store, err := New(Config{})
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	if store.HasSyncDelegate() {
+		t.Fatal("new store unexpectedly has a sync delegate")
+	}
+	delegate := &recordingSyncDelegate{}
+	store.SetDelegate(delegate)
+	if !store.HasSyncDelegate() {
+		t.Fatal("expected configured sync delegate")
+	}
+
+	if err := store.Set("counter", 1); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+	if _, _, err := store.UpdateWithTTL("counter", time.Second, func(current any) (any, error) {
+		return current.(int) + 1, nil
+	}); err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+
+	calls, key, valueJSON := delegate.snapshot()
+	if calls != 2 {
+		t.Fatalf("unexpected delegate call count: got %d, want 2", calls)
+	}
+	if key != "counter" {
+		t.Fatalf("unexpected delegate key: %q", key)
+	}
+	var value int
+	if err := json.Unmarshal(valueJSON, &value); err != nil {
+		t.Fatalf("decode delegated value: %v", err)
+	}
+	if value != 2 {
+		t.Fatalf("unexpected delegated value: got %d, want 2", value)
+	}
+
+	store.SetDelegate(nil)
+	if store.HasSyncDelegate() {
+		t.Fatal("expected sync delegate to be cleared")
+	}
+}
+
+func TestStoreUpdateWithTTLMarshalFailureDoesNotMutate(t *testing.T) {
+	store, err := New(Config{})
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+	store.SetDelegate(&recordingSyncDelegate{})
+
+	if err := store.Set("key", "original"); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+	_, found, err := store.UpdateWithTTL("key", time.Second, func(any) (any, error) {
+		return make(chan struct{}), nil
+	})
+	if err == nil {
+		t.Fatal("expected marshal failure")
+	}
+	if !found {
+		t.Fatal("expected update to report the existing key")
+	}
+
+	value, getErr := store.Get("key")
+	if getErr != nil {
+		t.Fatalf("get failed: %v", getErr)
+	}
+	if value.(string) != "original" {
+		t.Fatalf("marshal failure changed value to %v", value)
 	}
 }
 

--- a/plugins/governance/complexitysession.go
+++ b/plugins/governance/complexitysession.go
@@ -4,18 +4,33 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
 	"strings"
 	"time"
 	"unicode/utf8"
 
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/kvstore"
 )
 
 const (
-	claudeCodeSessionIDHeader          = "x-claude-code-session-id"
-	complexitySessionFingerprintDomain = "complexity-session-fingerprint:v1"
-	complexitySessionKeyPrefix         = "complexity-session:v1:"
+	claudeCodeSessionIDHeader       = "x-claude-code-session-id"
+	complexitySessionKeyPrefix      = "complexity-session:v1:"
+	complexitySessionStoreBackendKV = "kvstore"
+	maxComplexitySessionIDBytes     = 255
+)
+
+var (
+	errNilComplexitySessionStore   = errors.New("complexity session kvstore cannot be nil")
+	errNilComplexitySessionContext = errors.New("complexity session context cannot be nil")
+	errNilComplexitySessionRecord  = errors.New("complexity session record cannot be nil")
+	errNilComplexitySessionUpdater = errors.New("complexity session updater cannot be nil")
+	errInvalidComplexitySessionTTL = errors.New("complexity session ttl must be positive")
+	errInvalidComplexitySession    = errors.New("invalid complexity session record")
 )
 
 // SessionRouteObservation records provider facts for one effective route in a
@@ -82,8 +97,8 @@ type SessionStoreStatus struct {
 
 // SessionRecordUpdater mutates a caller-owned copy of the current session
 // record. A store backed by compare-and-swap may invoke it more than once, so an
-// updater must be deterministic and free of side effects. Returning an error
-// aborts the write.
+// updater must be deterministic, free of side effects, and complete promptly.
+// It must not call back into the same store. Returning an error aborts the write.
 type SessionRecordUpdater func(*SessionComplexityRecord) error
 
 // SessionStore persists typed complexity-session state behind a backend-neutral
@@ -109,6 +124,180 @@ type SessionStore interface {
 	// Status reports the backend's current replication and atomicity guarantees.
 	// An error means readiness could not be determined.
 	Status(ctx context.Context) (SessionStoreStatus, error)
+}
+
+// kvSessionStore persists complexity-session records in framework/kvstore. Its
+// atomicity is process-local: a configured gossip delegate shares committed
+// values across replicas but does not turn updates into distributed transactions.
+type kvSessionStore struct {
+	store *kvstore.Store
+}
+
+var _ SessionStore = (*kvSessionStore)(nil)
+
+// newKVSessionStore creates a typed complexity-session view over store. The
+// registered decoder ensures remotely replicated records retain their concrete
+// type instead of falling back to raw JSON bytes.
+func newKVSessionStore(store *kvstore.Store) (*kvSessionStore, error) {
+	if store == nil {
+		return nil, errNilComplexitySessionStore
+	}
+	store.RegisterDecoder(complexitySessionKeyPrefix, func(data []byte) (any, error) {
+		var record SessionComplexityRecord
+		if err := json.Unmarshal(data, &record); err != nil {
+			return nil, fmt.Errorf("decode complexity session record: %w", err)
+		}
+		return &record, nil
+	})
+	return &kvSessionStore{store: store}, nil
+}
+
+// Get reads a caller-owned record and refreshes its sliding TTL atomically. A
+// successful read is also a write, so a configured sync delegate receives one
+// replication event for each refresh.
+func (s *kvSessionStore) Get(ctx context.Context, key string, ttl time.Duration) (*SessionComplexityRecord, bool, error) {
+	if err := validateComplexitySessionStoreRequest(ctx, ttl); err != nil {
+		return nil, false, err
+	}
+
+	value, found, err := s.store.UpdateWithTTL(key, ttl, func(current any) (any, error) {
+		return complexitySessionRecordFromValue(current)
+	})
+	if err != nil {
+		return nil, found, fmt.Errorf("refresh complexity session %q: %w", key, err)
+	}
+	if !found {
+		return nil, false, nil
+	}
+
+	record, err := complexitySessionRecordFromValue(value)
+	if err != nil {
+		return nil, true, fmt.Errorf("read complexity session %q: %w", key, err)
+	}
+	return record, true, nil
+}
+
+// Create stores a detached record snapshot when key is currently absent or
+// expired.
+func (s *kvSessionStore) Create(ctx context.Context, key string, record *SessionComplexityRecord, ttl time.Duration) (bool, error) {
+	if err := validateComplexitySessionStoreRequest(ctx, ttl); err != nil {
+		return false, err
+	}
+	if record == nil {
+		return false, errNilComplexitySessionRecord
+	}
+
+	created, err := s.store.SetNXWithTTL(key, cloneSessionComplexityRecord(record), ttl)
+	if err != nil {
+		return false, fmt.Errorf("create complexity session %q: %w", key, err)
+	}
+	return created, nil
+}
+
+// Update applies update to a detached copy and atomically commits another copy,
+// preventing caller-owned RouteObservations maps from aliasing stored state.
+func (s *kvSessionStore) Update(ctx context.Context, key string, ttl time.Duration, update SessionRecordUpdater) (*SessionComplexityRecord, bool, error) {
+	if err := validateComplexitySessionStoreRequest(ctx, ttl); err != nil {
+		return nil, false, err
+	}
+	if update == nil {
+		return nil, false, errNilComplexitySessionUpdater
+	}
+
+	value, found, err := s.store.UpdateWithTTL(key, ttl, func(current any) (any, error) {
+		record, err := complexitySessionRecordFromValue(current)
+		if err != nil {
+			return nil, err
+		}
+		if err := update(record); err != nil {
+			return nil, err
+		}
+		return cloneSessionComplexityRecord(record), nil
+	})
+	if err != nil {
+		return nil, found, fmt.Errorf("update complexity session %q: %w", key, err)
+	}
+	if !found {
+		return nil, false, nil
+	}
+
+	record, err := complexitySessionRecordFromValue(value)
+	if err != nil {
+		return nil, true, fmt.Errorf("read updated complexity session %q: %w", key, err)
+	}
+	return record, true, nil
+}
+
+// Delete removes a live session record. Expired records are treated as absent.
+func (s *kvSessionStore) Delete(ctx context.Context, key string) (bool, error) {
+	if err := validateComplexitySessionStoreContext(ctx); err != nil {
+		return false, err
+	}
+
+	_, err := s.store.GetAndDelete(key)
+	if errors.Is(err, kvstore.ErrNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("delete complexity session %q: %w", key, err)
+	}
+	return true, nil
+}
+
+// Status reports the guarantees relevant to session routing. Gossip makes
+// records visible across replicas, but updates remain atomic only within one
+// process.
+func (s *kvSessionStore) Status(ctx context.Context) (SessionStoreStatus, error) {
+	if err := validateComplexitySessionStoreContext(ctx); err != nil {
+		return SessionStoreStatus{}, err
+	}
+
+	sharedAcrossReplicas := s.store.HasSyncDelegate()
+	return SessionStoreStatus{
+		Backend:              complexitySessionStoreBackendKV,
+		SharedAcrossReplicas: sharedAcrossReplicas,
+		AtomicUpdates:        !sharedAcrossReplicas,
+	}, nil
+}
+
+func validateComplexitySessionStoreRequest(ctx context.Context, ttl time.Duration) error {
+	if err := validateComplexitySessionStoreContext(ctx); err != nil {
+		return err
+	}
+	if ttl <= 0 {
+		return errInvalidComplexitySessionTTL
+	}
+	return nil
+}
+
+func validateComplexitySessionStoreContext(ctx context.Context) error {
+	if ctx == nil {
+		return errNilComplexitySessionContext
+	}
+	return ctx.Err()
+}
+
+func complexitySessionRecordFromValue(value any) (*SessionComplexityRecord, error) {
+	switch record := value.(type) {
+	case *SessionComplexityRecord:
+		if record == nil {
+			return nil, fmt.Errorf("%w: nil pointer", errInvalidComplexitySession)
+		}
+		return cloneSessionComplexityRecord(record), nil
+	case SessionComplexityRecord:
+		return cloneSessionComplexityRecord(&record), nil
+	default:
+		return nil, fmt.Errorf("%w: got %T", errInvalidComplexitySession, value)
+	}
+}
+
+func cloneSessionComplexityRecord(record *SessionComplexityRecord) *SessionComplexityRecord {
+	if record == nil {
+		return nil
+	}
+	cloned := *record
+	cloned.RouteObservations = maps.Clone(record.RouteObservations)
+	return &cloned
 }
 
 // resolveSessionID walks the enabled identity sources in their fixed precedence

--- a/plugins/governance/complexitysession_test.go
+++ b/plugins/governance/complexitysession_test.go
@@ -1,14 +1,20 @@
 package governance
 
 import (
+	"context"
+	"errors"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/kvstore"
 )
 
 func TestResolveSessionIDPrecedence(t *testing.T) {
@@ -267,6 +273,326 @@ func TestBuildComplexitySessionKeyRejectsBlankIdentity(t *testing.T) {
 			assert.Empty(t, key)
 		})
 	}
+}
+
+func TestKVSessionStoreRoundTripAndOwnership(t *testing.T) {
+	sessionStore, _ := newTestKVSessionStore(t)
+	key := testComplexitySessionKey(t, "tenant", "round-trip")
+	decidedAt := time.Date(2026, time.August, 10, 12, 0, 0, 0, time.UTC)
+	lastSeenAt := decidedAt.Add(time.Minute)
+	record := &SessionComplexityRecord{
+		Tier:                "complex",
+		DecidedAt:           decidedAt,
+		RuleID:              "rule-1",
+		SwitchCount:         2,
+		PendingTier:         "medium",
+		PendingTurns:        1,
+		PendingMinScore:     0.91,
+		ConsecutiveFailures: 1,
+		RouteObservations: map[string]SessionRouteObservation{
+			"route-1": {
+				CachedReadTokens: 4096,
+				CacheObserved:    true,
+				LastSeenAt:       lastSeenAt,
+			},
+		},
+	}
+	want := cloneSessionComplexityRecord(record)
+
+	created, err := sessionStore.Create(context.Background(), key, record, time.Hour)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	// Mutating the input after Create must not mutate stored state.
+	record.Tier = "simple"
+	record.RouteObservations["route-1"] = SessionRouteObservation{CachedReadTokens: 1}
+
+	got, found, err := sessionStore.Get(context.Background(), key, time.Hour)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, want, got)
+
+	// Mutating a returned record must not mutate stored state either.
+	got.PendingTurns = 99
+	got.RouteObservations["route-1"] = SessionRouteObservation{CachedReadTokens: 2}
+
+	gotAgain, found, err := sessionStore.Get(context.Background(), key, time.Hour)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, want, gotAgain)
+}
+
+func TestKVSessionStoreCreateIsAtomic(t *testing.T) {
+	sessionStore, _ := newTestKVSessionStore(t)
+	key := testComplexitySessionKey(t, "tenant", "create-race")
+
+	const contenders = 50
+	var createdCount atomic.Int32
+	errCh := make(chan error, contenders)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for range contenders {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			created, err := sessionStore.Create(context.Background(), key, &SessionComplexityRecord{
+				Tier:   "complex",
+				RuleID: "rule-1",
+			}, time.Hour)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if created {
+				createdCount.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Errorf("create failed: %v", err)
+	}
+	assert.EqualValues(t, 1, createdCount.Load())
+}
+
+func TestKVSessionStoreUpdateIsAtomic(t *testing.T) {
+	sessionStore, _ := newTestKVSessionStore(t)
+	key := testComplexitySessionKey(t, "tenant", "update-race")
+	created, err := sessionStore.Create(context.Background(), key, &SessionComplexityRecord{
+		Tier:              "complex",
+		RuleID:            "rule-1",
+		RouteObservations: map[string]SessionRouteObservation{},
+	}, time.Hour)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	const updates = 100
+	errCh := make(chan error, updates)
+	var wg sync.WaitGroup
+	for range updates {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, found, err := sessionStore.Update(context.Background(), key, time.Hour, func(record *SessionComplexityRecord) error {
+				record.PendingTurns++
+				return nil
+			})
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if !found {
+				errCh <- kvstore.ErrNotFound
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Errorf("update failed: %v", err)
+	}
+
+	record, found, err := sessionStore.Get(context.Background(), key, time.Hour)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, updates, record.PendingTurns)
+}
+
+func TestKVSessionStoreUpdateFailureDoesNotMutate(t *testing.T) {
+	sessionStore, _ := newTestKVSessionStore(t)
+	key := testComplexitySessionKey(t, "tenant", "failed-update")
+	created, err := sessionStore.Create(context.Background(), key, &SessionComplexityRecord{
+		Tier:         "complex",
+		RuleID:       "rule-1",
+		PendingTurns: 1,
+	}, time.Hour)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	wantErr := errors.New("policy rejected update")
+	_, found, err := sessionStore.Update(context.Background(), key, time.Hour, func(record *SessionComplexityRecord) error {
+		record.PendingTurns = 99
+		return wantErr
+	})
+	require.ErrorIs(t, err, wantErr)
+	require.True(t, found)
+
+	record, found, err := sessionStore.Get(context.Background(), key, time.Hour)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, 1, record.PendingTurns)
+}
+
+func TestKVSessionStoreSlidingTTL(t *testing.T) {
+	sessionStore, _ := newTestKVSessionStore(t)
+	key := testComplexitySessionKey(t, "tenant", "sliding-ttl")
+	const ttl = 250 * time.Millisecond
+
+	created, err := sessionStore.Create(context.Background(), key, &SessionComplexityRecord{
+		Tier:   "complex",
+		RuleID: "rule-1",
+	}, ttl)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	time.Sleep(150 * time.Millisecond)
+	_, found, err := sessionStore.Get(context.Background(), key, ttl)
+	require.NoError(t, err)
+	require.True(t, found, "record should exist before its original deadline")
+
+	time.Sleep(150 * time.Millisecond)
+	_, found, err = sessionStore.Get(context.Background(), key, ttl)
+	require.NoError(t, err)
+	require.True(t, found, "successful Get should extend the deadline")
+
+	time.Sleep(300 * time.Millisecond)
+	_, found, err = sessionStore.Get(context.Background(), key, ttl)
+	require.NoError(t, err)
+	assert.False(t, found, "record should expire when its TTL is no longer refreshed")
+}
+
+func TestKVSessionStoreRegistersReplicationDecoder(t *testing.T) {
+	source, sourceKV := newTestKVSessionStore(t)
+	target, targetKV := newTestKVSessionStore(t)
+	delegate := &forwardingKVDelegate{target: targetKV}
+	sourceKV.SetDelegate(delegate)
+
+	key := testComplexitySessionKey(t, "tenant", "replicated")
+	want := &SessionComplexityRecord{
+		Tier:   "complex",
+		RuleID: "rule-1",
+		RouteObservations: map[string]SessionRouteObservation{
+			"route-1": {CachedReadTokens: 2048, CacheObserved: true},
+		},
+	}
+	created, err := source.Create(context.Background(), key, want, time.Hour)
+	require.NoError(t, err)
+	require.True(t, created)
+	require.NoError(t, delegate.Err())
+
+	replicatedValue, err := targetKV.Get(key)
+	require.NoError(t, err)
+	assert.IsType(t, &SessionComplexityRecord{}, replicatedValue)
+
+	got, found, err := target.Get(context.Background(), key, time.Hour)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, want, got)
+}
+
+func TestKVSessionStoreRejectsInvalidReplicatedRecord(t *testing.T) {
+	sessionStore, store := newTestKVSessionStore(t)
+	key := testComplexitySessionKey(t, "tenant", "invalid-replica")
+	require.NoError(t, store.SetRemote(key, []byte("{"), time.Now().UnixNano(), 0))
+
+	_, found, err := sessionStore.Get(context.Background(), key, time.Hour)
+	require.ErrorIs(t, err, errInvalidComplexitySession)
+	assert.True(t, found)
+}
+
+func TestKVSessionStoreDeleteAndValidation(t *testing.T) {
+	sessionStore, _ := newTestKVSessionStore(t)
+	key := testComplexitySessionKey(t, "tenant", "delete")
+	record := &SessionComplexityRecord{Tier: "complex", RuleID: "rule-1"}
+
+	created, err := sessionStore.Create(context.Background(), key, record, time.Hour)
+	require.NoError(t, err)
+	require.True(t, created)
+	deleted, err := sessionStore.Delete(context.Background(), key)
+	require.NoError(t, err)
+	assert.True(t, deleted)
+	deleted, err = sessionStore.Delete(context.Background(), key)
+	require.NoError(t, err)
+	assert.False(t, deleted)
+
+	_, err = sessionStore.Create(context.Background(), key, record, 0)
+	require.ErrorIs(t, err, errInvalidComplexitySessionTTL)
+	_, err = sessionStore.Create(context.Background(), key, nil, time.Hour)
+	require.ErrorIs(t, err, errNilComplexitySessionRecord)
+	_, _, err = sessionStore.Update(context.Background(), key, time.Hour, nil)
+	require.ErrorIs(t, err, errNilComplexitySessionUpdater)
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = sessionStore.Create(canceled, key, record, time.Hour)
+	require.ErrorIs(t, err, context.Canceled)
+	_, err = sessionStore.Status(nil)
+	require.ErrorIs(t, err, errNilComplexitySessionContext)
+}
+
+func TestKVSessionStoreStatus(t *testing.T) {
+	sessionStore, store := newTestKVSessionStore(t)
+
+	status, err := sessionStore.Status(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, SessionStoreStatus{
+		Backend:              complexitySessionStoreBackendKV,
+		SharedAcrossReplicas: false,
+		AtomicUpdates:        true,
+	}, status)
+
+	_, targetKV := newTestKVSessionStore(t)
+	store.SetDelegate(&forwardingKVDelegate{target: targetKV})
+	status, err = sessionStore.Status(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, SessionStoreStatus{
+		Backend:              complexitySessionStoreBackendKV,
+		SharedAcrossReplicas: true,
+		AtomicUpdates:        false,
+	}, status)
+}
+
+func newTestKVSessionStore(t *testing.T) (*kvSessionStore, *kvstore.Store) {
+	t.Helper()
+	store, err := kvstore.New(kvstore.Config{CleanupInterval: time.Hour})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+	sessionStore, err := newKVSessionStore(store)
+	require.NoError(t, err)
+	return sessionStore, store
+}
+
+func testComplexitySessionKey(t *testing.T, scopeID, sessionID string) string {
+	t.Helper()
+	key, ok := buildComplexitySessionKey(scopeID, sessionID)
+	require.True(t, ok)
+	return key
+}
+
+type forwardingKVDelegate struct {
+	target *kvstore.Store
+	mu     sync.Mutex
+	err    error
+}
+
+func (d *forwardingKVDelegate) OnSet(key string, valueJSON []byte, writtenAt int64, expiresAt int64) {
+	d.recordError(d.target.SetRemote(key, valueJSON, writtenAt, expiresAt))
+}
+
+func (d *forwardingKVDelegate) OnDelete(key string, deletedAt int64) {
+	d.recordError(d.target.DeleteRemote(key, deletedAt))
+}
+
+func (d *forwardingKVDelegate) recordError(err error) {
+	if err == nil {
+		return
+	}
+	d.mu.Lock()
+	if d.err == nil {
+		d.err = err
+	}
+	d.mu.Unlock()
+}
+
+func (d *forwardingKVDelegate) Err() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.err
 }
 
 func complexitySessionChatRequest(systemText string, userTexts ...string) *schemas.BifrostRequest {


### PR DESCRIPTION
## Summary

Adds an atomic `UpdateWithTTL` operation to `kvstore.Store` and builds a `kvstore`-backed `SessionStore` implementation (`kvSessionStore`) for complexity-session state. This eliminates the read-modify-write race that would otherwise occur when updating session records and provides a concrete, process-local store with optional gossip-based replication.

## Changes

- **`kvstore.UpdateWithTTL`**: New method that reads, transforms, and writes a value under a single lock acquisition. The update callback runs while the store is held, so the replacement is committed atomically. Missing or expired keys return `found=false` without invoking the callback; a callback error leaves the stored value and TTL unchanged. A `ErrNilUpdate` sentinel is returned when a nil callback is supplied.
- **`kvstore` delegate thread-safety**: `SetDelegate` and all delegate reads are now protected by a dedicated `delegateMu` `RWMutex`. The delegate is snapshotted before any lock is acquired so that the store lock and the delegate lock are never held simultaneously.
- **`kvstore.HasSyncDelegate`**: New predicate that reports whether a sync delegate is currently installed, used by `kvSessionStore.Status` to populate `SharedAcrossReplicas` and `AtomicUpdates`.
- **`kvSessionStore`**: Implements `SessionStore` over `kvstore.Store`. `Get` refreshes the sliding TTL atomically via `UpdateWithTTL`. `Create` delegates to `SetNXWithTTL`. `Update` applies a `SessionRecordUpdater` inside `UpdateWithTTL`, cloning the record before and after mutation to prevent caller-owned maps from aliasing stored state. A type decoder is registered on construction so that gossip-replicated JSON bytes are decoded back to `*SessionComplexityRecord` rather than raw `[]byte`.
- **Cloning discipline**: `cloneSessionComplexityRecord` performs a shallow struct copy plus `maps.Clone` on `RouteObservations`, ensuring that neither input records passed to `Create` nor records returned from `Get`/`Update` share map references with stored state.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/kvstore/...
go test ./plugins/governance/...
```

Key scenarios covered by the new tests:

- `TestStoreUpdateWithTTL` — basic read-modify-write and persistence.
- `TestStoreUpdateWithTTLMissingOrExpired` — callback is never invoked for absent or expired keys.
- `TestStoreUpdateWithTTLFailureDoesNotMutate` — a callback error leaves the stored value unchanged.
- `TestStoreUpdateWithTTLConcurrent` — 100 concurrent increments produce the correct final count.
- `TestStoreUpdateWithTTLDelegate` — delegate receives one `OnSet` event per committed update.
- `TestStoreUpdateWithTTLMarshalFailureDoesNotMutate` — an unmarshalable replacement leaves the stored value unchanged.
- `TestKVSessionStoreRoundTripAndOwnership` — post-`Create` and post-`Get` mutations do not affect stored state.
- `TestKVSessionStoreCreateIsAtomic` — 50 concurrent creates result in exactly one winner.
- `TestKVSessionStoreUpdateIsAtomic` — 100 concurrent increments of `PendingTurns` produce the correct final count.
- `TestKVSessionStoreSlidingTTL` — `Get` extends the deadline; records expire when no longer refreshed.
- `TestKVSessionStoreRegistersReplicationDecoder` — gossip-forwarded records are decoded to the concrete type on the target replica.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The update callback runs while the store's internal mutex is held. Callers must not perform blocking I/O or call back into the same store from within the callback, as documented in the `UpdateWithTTL` and `SessionRecordUpdater` doc comments.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable