### PR TITLE
fix(vertex): route gemini-embedding-* via :batchEmbedContents

### DIFF
--- a/core/providers/vertex/embedding.go
+++ b/core/providers/vertex/embedding.go
@@ -130,8 +130,11 @@ func vertexGeminiEmbedTexts(bifrostReq *schemas.BifrostEmbeddingRequest) []strin
 // path (HTML 404) — using it and unmarshaling as GeminiEmbeddingResponse yields
 // "failed to unmarshal response from provider API".
 //
-// modelID must be canonical (see canonicalVertexModelID). The optional model
-// field is set to the fully-qualified publisher resource name Vertex expects.
+// The model is taken from the URL path only. Putting "model" in the JSON body
+// triggers Vertex INVALID_ARGUMENT:
+//   Invalid value (oneof), oneof field '_model' is already set. Cannot set 'model'
+// (modelID/projectID/region are kept in the signature for call-site clarity and
+// future use; they intentionally do not appear in the wire body).
 func ToVertexGeminiEmbedContentRequest(
 	bifrostReq *schemas.BifrostEmbeddingRequest,
 	text string,
@@ -142,8 +145,11 @@ func ToVertexGeminiEmbedContentRequest(
 	if bifrostReq == nil || text == "" {
 		return nil
 	}
+	_ = projectID
+	_ = region
+	_ = modelID
 	embeddingReq := &gemini.GeminiEmbeddingRequest{
-		Model: "projects/" + projectID + "/locations/" + region + "/publishers/google/models/" + modelID,
+		// Model intentionally empty — omitempty; identity is the URL resource.
 		Content: &gemini.Content{
 			Parts: []*gemini.Part{
 				{Text: text},

--- a/core/providers/vertex/embedding.go
+++ b/core/providers/vertex/embedding.go
@@ -27,8 +27,8 @@ func canonicalVertexModelID(model string) string {
 
 // usesGeminiEmbedContentAPI reports whether the model should be called via the
 // Gemini Generative Language embedding surface on Vertex
-// (:batchEmbedContents / :embedContent) rather than the legacy Vertex
-// prediction embedding API (:predict + instances).
+// (:embedContent) rather than the legacy Vertex prediction embedding API
+// (:predict + instances).
 //
 // Legacy :predict models include text-embedding-004, text-embedding-005,
 // text-multilingual-embedding-002, multimodalembedding@001, etc.
@@ -107,47 +107,69 @@ func ToVertexEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest) *Vert
 }
 
 // vertexGeminiEmbedTexts extracts the ordered list of input texts from a Bifrost
-// embedding request (single Text and/or Texts).
+// embedding request.
+//
+// Matches legacy ToVertexEmbeddingRequest semantics: Text takes precedence over
+// Texts (never both). Empty strings are skipped so a single "" in Texts does not
+// abort a multi-input request when building :embedContent bodies.
 func vertexGeminiEmbedTexts(bifrostReq *schemas.BifrostEmbeddingRequest) []string {
 	if bifrostReq == nil || bifrostReq.Input == nil {
 		return nil
 	}
-	var texts []string
-	if bifrostReq.Input.Text != nil && *bifrostReq.Input.Text != "" {
-		texts = append(texts, *bifrostReq.Input.Text)
+	var raw []string
+	if bifrostReq.Input.Text != nil {
+		raw = []string{*bifrostReq.Input.Text}
+	} else if len(bifrostReq.Input.Texts) > 0 {
+		raw = bifrostReq.Input.Texts
 	}
-	if len(bifrostReq.Input.Texts) > 0 {
-		texts = append(texts, bifrostReq.Input.Texts...)
+	if len(raw) == 0 {
+		return nil
+	}
+	texts := make([]string, 0, len(raw))
+	for _, t := range raw {
+		if t == "" {
+			continue
+		}
+		texts = append(texts, t)
 	}
 	return texts
+}
+
+// cloneStringAnyMap shallow-copies a map[string]interface{} so callers can
+// delete consumed keys without mutating the shared Params.ExtraParams map.
+func cloneStringAnyMap(in map[string]interface{}) map[string]interface{} {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]interface{}, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }
 
 // ToVertexGeminiEmbedContentRequest builds a single Vertex :embedContent body.
 //
 // Live Vertex AI (global / multi-region eu|us) serves gemini-embedding-* on
-// :embedContent with response shape {"embedding":{"values":[…]}}. The Google AI
-// Studio :batchEmbedContents endpoint is not available on the Vertex publisher
-// path (HTML 404) — using it and unmarshaling as GeminiEmbeddingResponse yields
-// "failed to unmarshal response from provider API".
+// :embedContent with response shape {"embedding":{"values":[…]}, "usageMetadata":…}.
+// The Google AI Studio :batchEmbedContents endpoint is not available on the
+// Vertex publisher path (HTML 404).
 //
 // The model is taken from the URL path only. Putting "model" in the JSON body
 // triggers Vertex INVALID_ARGUMENT:
-//   Invalid value (oneof), oneof field '_model' is already set. Cannot set 'model'
-// (modelID/projectID/region are kept in the signature for call-site clarity and
-// future use; they intentionally do not appear in the wire body).
+//
+//	Invalid value (oneof), oneof field '_model' is already set. Cannot set 'model'
+//
+// Consumed ExtraParams keys (taskType, title, dimensions and snake_case aliases)
+// are deleted from a cloned map so passthrough merge does not re-inject them as
+// duplicate JSON fields alongside the typed struct tags.
 func ToVertexGeminiEmbedContentRequest(
 	bifrostReq *schemas.BifrostEmbeddingRequest,
 	text string,
-	projectID string,
-	region string,
-	modelID string,
 ) *gemini.GeminiEmbeddingRequest {
 	if bifrostReq == nil || text == "" {
 		return nil
 	}
-	_ = projectID
-	_ = region
-	_ = modelID
 	embeddingReq := &gemini.GeminiEmbeddingRequest{
 		// Model intentionally empty — omitempty; identity is the URL resource.
 		Content: &gemini.Content{
@@ -157,26 +179,46 @@ func ToVertexGeminiEmbedContentRequest(
 		},
 	}
 	if bifrostReq.Params != nil {
-		embeddingReq.ExtraParams = bifrostReq.Params.ExtraParams
+		extra := cloneStringAnyMap(bifrostReq.Params.ExtraParams)
 		if bifrostReq.Params.Dimensions != nil {
 			embeddingReq.OutputDimensionality = bifrostReq.Params.Dimensions
+			delete(extra, "dimensions")
+			delete(extra, "outputDimensionality")
 		}
-		if bifrostReq.Params.ExtraParams != nil {
-			if taskType, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["taskType"]); ok {
+		if extra != nil {
+			// Prefer camelCase (Gemini wire); accept snake_case aliases from clients.
+			if taskType, ok := schemas.SafeExtractStringPointer(extra["taskType"]); ok {
+				embeddingReq.TaskType = taskType
+			} else if taskType, ok := schemas.SafeExtractStringPointer(extra["task_type"]); ok {
 				embeddingReq.TaskType = taskType
 			}
-			if title, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["title"]); ok {
+			delete(extra, "taskType")
+			delete(extra, "task_type")
+			if title, ok := schemas.SafeExtractStringPointer(extra["title"]); ok {
 				embeddingReq.Title = title
 			}
+			delete(extra, "title")
 		}
+		embeddingReq.ExtraParams = extra
 	}
 	return embeddingReq
 }
 
-// bifrostEmbeddingFromGeminiEmbedContent converts a Vertex/Google :embedContent
+// vertexGeminiEmbedContentResponse is the live Vertex :embedContent JSON shape.
+// usageMetadata is first-class on the wire; Embedding.Statistics is rarely set.
+type vertexGeminiEmbedContentResponse struct {
+	Embedding     gemini.GeminiEmbedding                         `json:"embedding"`
+	UsageMetadata *gemini.GenerateContentResponseUsageMetadata   `json:"usageMetadata,omitempty"`
+}
+
+// bifrostEmbeddingFromVertexGeminiEmbedContent converts a Vertex :embedContent
 // response into Bifrost form for one input at the given index.
-func bifrostEmbeddingFromGeminiEmbedContent(
-	resp *gemini.GeminiEmbedContentResponse,
+//
+// Token usage preference:
+//  1. usageMetadata.promptTokenCount / totalTokenCount (live Vertex body)
+//  2. embedding.statistics.tokenCount (fallback / Google AI Studio shapes)
+func bifrostEmbeddingFromVertexGeminiEmbedContent(
+	resp *vertexGeminiEmbedContentResponse,
 	model string,
 	index int,
 ) *schemas.BifrostEmbeddingResponse {
@@ -196,7 +238,21 @@ func bifrostEmbeddingFromGeminiEmbedContent(
 			},
 		},
 	}
-	if resp.Embedding.Statistics != nil {
+	switch {
+	case resp.UsageMetadata != nil && (resp.UsageMetadata.PromptTokenCount > 0 || resp.UsageMetadata.TotalTokenCount > 0):
+		prompt := int(resp.UsageMetadata.PromptTokenCount)
+		total := int(resp.UsageMetadata.TotalTokenCount)
+		if total == 0 {
+			total = prompt
+		}
+		if prompt == 0 {
+			prompt = total
+		}
+		out.Usage = &schemas.BifrostLLMUsage{
+			PromptTokens: prompt,
+			TotalTokens:  total,
+		}
+	case resp.Embedding.Statistics != nil:
 		tokens := int(resp.Embedding.Statistics.TokenCount)
 		out.Usage = &schemas.BifrostLLMUsage{
 			PromptTokens: tokens,

--- a/core/providers/vertex/embedding.go
+++ b/core/providers/vertex/embedding.go
@@ -7,6 +7,24 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
+// canonicalVertexModelID normalizes a client-supplied model string for Vertex
+// publisher model paths and resource names.
+//
+// Handles:
+//   - whitespace trim + gemini.NormalizeModelName (strips google/ when applicable)
+//   - optional "models/" prefix used by GenAI clients / Gemini wire format
+//
+// Does not lower-case the id — Vertex model resource names are case-sensitive
+// as published (e.g. gemini-embedding-2). Callers that only need family matching
+// should still compare with equal-fold / ToLower themselves.
+func canonicalVertexModelID(model string) string {
+	id := gemini.NormalizeModelName(model)
+	if len(id) >= len("models/") && strings.EqualFold(id[:len("models/")], "models/") {
+		id = id[len("models/"):]
+	}
+	return id
+}
+
 // usesGeminiEmbedContentAPI reports whether the model should be called via the
 // Gemini Generative Language embedding surface on Vertex
 // (:batchEmbedContents / :embedContent) rather than the legacy Vertex
@@ -19,10 +37,7 @@ import (
 // instances body yields 400 "Precondition check failed" from Vertex.
 // See https://github.com/maximhq/bifrost/issues/5003.
 func usesGeminiEmbedContentAPI(model string) bool {
-	normalized := strings.ToLower(gemini.NormalizeModelName(model))
-	// GenAI / some clients pass "models/{id}" — strip before matching.
-	normalized = strings.TrimPrefix(normalized, "models/")
-	return strings.HasPrefix(normalized, "gemini-embedding")
+	return strings.HasPrefix(strings.ToLower(canonicalVertexModelID(model)), "gemini-embedding")
 }
 
 // ToVertexEmbeddingRequest converts a Bifrost embedding request to Vertex AI
@@ -94,23 +109,30 @@ func ToVertexEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest) *Vert
 // ToVertexGeminiBatchEmbeddingRequest converts a Bifrost embedding request to
 // the Gemini :batchEmbedContents body used on Vertex for gemini-embedding-* models.
 //
-// On Vertex the model field inside each request must be a fully-qualified
-// publisher model resource name (projects/.../locations/.../publishers/google/models/...).
-// Google AI Studio accepts the short "models/{id}" form; Vertex rejects it.
+// modelID must already be a canonical publisher model id (see canonicalVertexModelID),
+// without a "models/" prefix. On Vertex each request.model must be a fully-qualified
+// publisher model resource name
+// (projects/.../locations/.../publishers/google/models/...). Google AI Studio
+// accepts the short "models/{id}" form; Vertex rejects it.
 func ToVertexGeminiBatchEmbeddingRequest(
 	bifrostReq *schemas.BifrostEmbeddingRequest,
 	projectID string,
 	region string,
+	modelID string,
 ) *gemini.GeminiBatchEmbeddingRequest {
-	batch := gemini.ToGeminiEmbeddingRequest(bifrostReq)
+	if bifrostReq == nil {
+		return nil
+	}
+	// Build the batch from a request whose Model is the bare id so
+	// gemini.ToGeminiEmbeddingRequest does not re-introduce a models/ prefix
+	// based on a client-supplied "models/…" string (we overwrite Model below
+	// with the FQ resource name anyway).
+	reqCopy := *bifrostReq
+	reqCopy.Model = modelID
+	batch := gemini.ToGeminiEmbeddingRequest(&reqCopy)
 	if batch == nil {
 		return nil
 	}
-	raw := gemini.NormalizeModelName(bifrostReq.Model)
-	if len(raw) >= len("models/") && strings.EqualFold(raw[:len("models/")], "models/") {
-		raw = raw[len("models/"):]
-	}
-	modelID := raw
 	fqModel := "projects/" + projectID + "/locations/" + region + "/publishers/google/models/" + modelID
 	for i := range batch.Requests {
 		batch.Requests[i].Model = fqModel

--- a/core/providers/vertex/embedding.go
+++ b/core/providers/vertex/embedding.go
@@ -106,38 +106,131 @@ func ToVertexEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest) *Vert
 	return vertexReq
 }
 
-// ToVertexGeminiBatchEmbeddingRequest converts a Bifrost embedding request to
-// the Gemini :batchEmbedContents body used on Vertex for gemini-embedding-* models.
+// vertexGeminiEmbedTexts extracts the ordered list of input texts from a Bifrost
+// embedding request (single Text and/or Texts).
+func vertexGeminiEmbedTexts(bifrostReq *schemas.BifrostEmbeddingRequest) []string {
+	if bifrostReq == nil || bifrostReq.Input == nil {
+		return nil
+	}
+	var texts []string
+	if bifrostReq.Input.Text != nil && *bifrostReq.Input.Text != "" {
+		texts = append(texts, *bifrostReq.Input.Text)
+	}
+	if len(bifrostReq.Input.Texts) > 0 {
+		texts = append(texts, bifrostReq.Input.Texts...)
+	}
+	return texts
+}
+
+// ToVertexGeminiEmbedContentRequest builds a single Vertex :embedContent body.
 //
-// modelID must already be a canonical publisher model id (see canonicalVertexModelID),
-// without a "models/" prefix. On Vertex each request.model must be a fully-qualified
-// publisher model resource name
-// (projects/.../locations/.../publishers/google/models/...). Google AI Studio
-// accepts the short "models/{id}" form; Vertex rejects it.
-func ToVertexGeminiBatchEmbeddingRequest(
+// Live Vertex AI (global / multi-region eu|us) serves gemini-embedding-* on
+// :embedContent with response shape {"embedding":{"values":[…]}}. The Google AI
+// Studio :batchEmbedContents endpoint is not available on the Vertex publisher
+// path (HTML 404) — using it and unmarshaling as GeminiEmbeddingResponse yields
+// "failed to unmarshal response from provider API".
+//
+// modelID must be canonical (see canonicalVertexModelID). The optional model
+// field is set to the fully-qualified publisher resource name Vertex expects.
+func ToVertexGeminiEmbedContentRequest(
 	bifrostReq *schemas.BifrostEmbeddingRequest,
+	text string,
 	projectID string,
 	region string,
 	modelID string,
-) *gemini.GeminiBatchEmbeddingRequest {
-	if bifrostReq == nil {
+) *gemini.GeminiEmbeddingRequest {
+	if bifrostReq == nil || text == "" {
 		return nil
 	}
-	// Build the batch from a request whose Model is the bare id so
-	// gemini.ToGeminiEmbeddingRequest does not re-introduce a models/ prefix
-	// based on a client-supplied "models/…" string (we overwrite Model below
-	// with the FQ resource name anyway).
-	reqCopy := *bifrostReq
-	reqCopy.Model = modelID
-	batch := gemini.ToGeminiEmbeddingRequest(&reqCopy)
-	if batch == nil {
+	embeddingReq := &gemini.GeminiEmbeddingRequest{
+		Model: "projects/" + projectID + "/locations/" + region + "/publishers/google/models/" + modelID,
+		Content: &gemini.Content{
+			Parts: []*gemini.Part{
+				{Text: text},
+			},
+		},
+	}
+	if bifrostReq.Params != nil {
+		embeddingReq.ExtraParams = bifrostReq.Params.ExtraParams
+		if bifrostReq.Params.Dimensions != nil {
+			embeddingReq.OutputDimensionality = bifrostReq.Params.Dimensions
+		}
+		if bifrostReq.Params.ExtraParams != nil {
+			if taskType, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["taskType"]); ok {
+				embeddingReq.TaskType = taskType
+			}
+			if title, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["title"]); ok {
+				embeddingReq.Title = title
+			}
+		}
+	}
+	return embeddingReq
+}
+
+// bifrostEmbeddingFromGeminiEmbedContent converts a Vertex/Google :embedContent
+// response into Bifrost form for one input at the given index.
+func bifrostEmbeddingFromGeminiEmbedContent(
+	resp *gemini.GeminiEmbedContentResponse,
+	model string,
+	index int,
+) *schemas.BifrostEmbeddingResponse {
+	if resp == nil || len(resp.Embedding.Values) == 0 {
 		return nil
 	}
-	fqModel := "projects/" + projectID + "/locations/" + region + "/publishers/google/models/" + modelID
-	for i := range batch.Requests {
-		batch.Requests[i].Model = fqModel
+	out := &schemas.BifrostEmbeddingResponse{
+		Object: "list",
+		Model:  model,
+		Data: []schemas.EmbeddingData{
+			{
+				Object: "embedding",
+				Index:  index,
+				Embedding: schemas.EmbeddingStruct{
+					EmbeddingArray: append([]float64(nil), resp.Embedding.Values...),
+				},
+			},
+		},
 	}
-	return batch
+	if resp.Embedding.Statistics != nil {
+		tokens := int(resp.Embedding.Statistics.TokenCount)
+		out.Usage = &schemas.BifrostLLMUsage{
+			PromptTokens: tokens,
+			TotalTokens:  tokens,
+		}
+	}
+	return out
+}
+
+// mergeBifrostEmbeddingResponses concatenates Data slices (preserving order)
+// and sums usage token counts. Used when multi-input embeddings are issued as
+// sequential :embedContent calls on Vertex.
+func mergeBifrostEmbeddingResponses(parts []*schemas.BifrostEmbeddingResponse, model string) *schemas.BifrostEmbeddingResponse {
+	if len(parts) == 0 {
+		return nil
+	}
+	out := &schemas.BifrostEmbeddingResponse{
+		Object: "list",
+		Model:  model,
+		Data:   make([]schemas.EmbeddingData, 0, len(parts)),
+	}
+	var usage *schemas.BifrostLLMUsage
+	for _, p := range parts {
+		if p == nil {
+			continue
+		}
+		out.Data = append(out.Data, p.Data...)
+		if p.Usage != nil {
+			if usage == nil {
+				usage = &schemas.BifrostLLMUsage{}
+			}
+			usage.PromptTokens += p.Usage.PromptTokens
+			usage.TotalTokens += p.Usage.TotalTokens
+		}
+	}
+	out.Usage = usage
+	if len(out.Data) == 0 {
+		return nil
+	}
+	return out
 }
 
 // ToBifrostEmbeddingResponse converts a Vertex AI legacy :predict embedding

--- a/core/providers/vertex/embedding.go
+++ b/core/providers/vertex/embedding.go
@@ -1,10 +1,32 @@
 package vertex
 
 import (
+	"strings"
+
+	"github.com/maximhq/bifrost/core/providers/gemini"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-// ToVertexEmbeddingRequest converts a Bifrost embedding request to Vertex AI format
+// usesGeminiEmbedContentAPI reports whether the model should be called via the
+// Gemini Generative Language embedding surface on Vertex
+// (:batchEmbedContents / :embedContent) rather than the legacy Vertex
+// prediction embedding API (:predict + instances).
+//
+// Legacy :predict models include text-embedding-004, text-embedding-005,
+// text-multilingual-embedding-002, multimodalembedding@001, etc.
+// Gemini-native embedding models are named gemini-embedding-* (e.g.
+// gemini-embedding-001, gemini-embedding-2). Calling those with :predict and an
+// instances body yields 400 "Precondition check failed" from Vertex.
+// See https://github.com/maximhq/bifrost/issues/5003.
+func usesGeminiEmbedContentAPI(model string) bool {
+	normalized := strings.ToLower(gemini.NormalizeModelName(model))
+	// GenAI / some clients pass "models/{id}" — strip before matching.
+	normalized = strings.TrimPrefix(normalized, "models/")
+	return strings.HasPrefix(normalized, "gemini-embedding")
+}
+
+// ToVertexEmbeddingRequest converts a Bifrost embedding request to Vertex AI
+// legacy :predict format (instances/parameters).
 func ToVertexEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest) *VertexEmbeddingRequest {
 	if bifrostReq == nil || bifrostReq.Input == nil || (bifrostReq.Input.Text == nil && bifrostReq.Input.Texts == nil) {
 		return nil
@@ -69,7 +91,35 @@ func ToVertexEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest) *Vert
 	return vertexReq
 }
 
-// ToBifrostEmbeddingResponse converts a Vertex AI embedding response to Bifrost format
+// ToVertexGeminiBatchEmbeddingRequest converts a Bifrost embedding request to
+// the Gemini :batchEmbedContents body used on Vertex for gemini-embedding-* models.
+//
+// On Vertex the model field inside each request must be a fully-qualified
+// publisher model resource name (projects/.../locations/.../publishers/google/models/...).
+// Google AI Studio accepts the short "models/{id}" form; Vertex rejects it.
+func ToVertexGeminiBatchEmbeddingRequest(
+	bifrostReq *schemas.BifrostEmbeddingRequest,
+	projectID string,
+	region string,
+) *gemini.GeminiBatchEmbeddingRequest {
+	batch := gemini.ToGeminiEmbeddingRequest(bifrostReq)
+	if batch == nil {
+		return nil
+	}
+	raw := gemini.NormalizeModelName(bifrostReq.Model)
+	if len(raw) >= len("models/") && strings.EqualFold(raw[:len("models/")], "models/") {
+		raw = raw[len("models/"):]
+	}
+	modelID := raw
+	fqModel := "projects/" + projectID + "/locations/" + region + "/publishers/google/models/" + modelID
+	for i := range batch.Requests {
+		batch.Requests[i].Model = fqModel
+	}
+	return batch
+}
+
+// ToBifrostEmbeddingResponse converts a Vertex AI legacy :predict embedding
+// response to Bifrost format.
 func (response *VertexEmbeddingResponse) ToBifrostEmbeddingResponse() *schemas.BifrostEmbeddingResponse {
 	if response == nil || len(response.Predictions) == 0 {
 		return nil

--- a/core/providers/vertex/embedding_test.go
+++ b/core/providers/vertex/embedding_test.go
@@ -63,33 +63,91 @@ func TestUsesGeminiEmbedContentAPI(t *testing.T) {
 	}
 }
 
-func TestToVertexGeminiEmbedContentRequest_FullyQualifiedModel(t *testing.T) {
+func TestVertexGeminiEmbedTexts_TextOrTextsNotBoth(t *testing.T) {
+	t.Parallel()
+
+	a, b, empty := "a", "b", ""
+	// Text takes precedence over Texts (legacy parity).
+	req := &schemas.BifrostEmbeddingRequest{
+		Input: &schemas.EmbeddingInput{
+			Text:  &a,
+			Texts: []string{b, "c"},
+		},
+	}
+	got := vertexGeminiEmbedTexts(req)
+	if len(got) != 1 || got[0] != "a" {
+		t.Fatalf("Text precedence: got %v, want [a]", got)
+	}
+
+	// Empty entries in Texts are skipped.
+	req = &schemas.BifrostEmbeddingRequest{
+		Input: &schemas.EmbeddingInput{Texts: []string{"x", empty, "y", ""}},
+	}
+	got = vertexGeminiEmbedTexts(req)
+	if len(got) != 2 || got[0] != "x" || got[1] != "y" {
+		t.Fatalf("empty filter: got %v, want [x y]", got)
+	}
+
+	// Empty single Text → no inputs.
+	req = &schemas.BifrostEmbeddingRequest{
+		Input: &schemas.EmbeddingInput{Text: &empty},
+	}
+	if got = vertexGeminiEmbedTexts(req); len(got) != 0 {
+		t.Fatalf("empty Text: got %v", got)
+	}
+}
+
+func TestToVertexGeminiEmbedContentRequest_BodyShapeAndExtraParams(t *testing.T) {
 	t.Parallel()
 
 	text := "Hello world"
 	dims := 768
+	extra := map[string]interface{}{
+		"taskType":    "RETRIEVAL_DOCUMENT",
+		"title":       "doc",
+		"dimensions":  dims, // should be consumed (typed field wins via Params.Dimensions)
+		"custom_flag": true, // should remain for passthrough
+	}
 	req := &schemas.BifrostEmbeddingRequest{
 		Model: "models/gemini-embedding-2",
 		Input: &schemas.EmbeddingInput{Text: &text},
 		Params: &schemas.EmbeddingParameters{
-			Dimensions: &dims,
+			Dimensions:  &dims,
+			ExtraParams: extra,
 		},
 	}
-	modelID := canonicalVertexModelID(req.Model)
 
-	embedReq := ToVertexGeminiEmbedContentRequest(req, text, "my-project", "eu", modelID)
+	embedReq := ToVertexGeminiEmbedContentRequest(req, text)
 	if embedReq == nil {
 		t.Fatal("expected non-nil embedContent request")
 	}
-
 	if embedReq.Model != "" {
-		t.Fatalf("model must be omitted from body (URL carries identity), got %q", embedReq.Model)
+		t.Fatalf("model must be omitted from body, got %q", embedReq.Model)
 	}
 	if embedReq.Content == nil || len(embedReq.Content.Parts) != 1 || embedReq.Content.Parts[0].Text != text {
 		t.Fatalf("content = %#v", embedReq.Content)
 	}
 	if embedReq.OutputDimensionality == nil || *embedReq.OutputDimensionality != dims {
 		t.Fatalf("outputDimensionality = %#v", embedReq.OutputDimensionality)
+	}
+	if embedReq.TaskType == nil || *embedReq.TaskType != "RETRIEVAL_DOCUMENT" {
+		t.Fatalf("taskType = %#v", embedReq.TaskType)
+	}
+	if embedReq.Title == nil || *embedReq.Title != "doc" {
+		t.Fatalf("title = %#v", embedReq.Title)
+	}
+	// Consumed keys must not remain in ExtraParams (passthrough merge).
+	for _, k := range []string{"taskType", "title", "dimensions", "outputDimensionality", "task_type"} {
+		if _, ok := embedReq.ExtraParams[k]; ok {
+			t.Fatalf("ExtraParams still has consumed key %q: %#v", k, embedReq.ExtraParams)
+		}
+	}
+	if v, ok := embedReq.ExtraParams["custom_flag"].(bool); !ok || !v {
+		t.Fatalf("custom_flag should remain for passthrough: %#v", embedReq.ExtraParams)
+	}
+	// Original map must be untouched.
+	if _, ok := extra["taskType"]; !ok {
+		t.Fatal("original ExtraParams was mutated")
 	}
 
 	raw, err := json.Marshal(embedReq)
@@ -98,13 +156,29 @@ func TestToVertexGeminiEmbedContentRequest_FullyQualifiedModel(t *testing.T) {
 	}
 	s := string(raw)
 	if strings.Contains(s, `"instances"`) || strings.Contains(s, `"requests"`) {
-		t.Fatalf("single embedContent body must not wrap instances/requests: %s", s)
+		t.Fatalf("body must not wrap instances/requests: %s", s)
 	}
 	if strings.Contains(s, `"model"`) {
-		t.Fatalf("body must not set model (Vertex oneof with URL): %s", s)
+		t.Fatalf("body must not set model: %s", s)
 	}
-	if !strings.Contains(s, `"content"`) {
-		t.Fatalf("body = %s", s)
+}
+
+func TestToVertexGeminiEmbedContentRequest_SnakeCaseTaskType(t *testing.T) {
+	t.Parallel()
+
+	text := "hi"
+	req := &schemas.BifrostEmbeddingRequest{
+		Input: &schemas.EmbeddingInput{Text: &text},
+		Params: &schemas.EmbeddingParameters{
+			ExtraParams: map[string]interface{}{"task_type": "SEMANTIC_SIMILARITY"},
+		},
+	}
+	embedReq := ToVertexGeminiEmbedContentRequest(req, text)
+	if embedReq.TaskType == nil || *embedReq.TaskType != "SEMANTIC_SIMILARITY" {
+		t.Fatalf("taskType = %#v", embedReq.TaskType)
+	}
+	if _, ok := embedReq.ExtraParams["task_type"]; ok {
+		t.Fatalf("task_type should be deleted from ExtraParams: %#v", embedReq.ExtraParams)
 	}
 }
 
@@ -174,12 +248,10 @@ func TestGetVertexEmbeddingURL_MethodByModel(t *testing.T) {
 	}
 }
 
-// TestGeminiEmbedContentResponse_PreservesValues is a fixture regression for the
-// Vertex :embedContent response path (live shape: embedding.values).
-func TestGeminiEmbedContentResponse_PreservesValues(t *testing.T) {
+// Live Vertex :embedContent fixture — usage comes from usageMetadata, not statistics.
+func TestVertexGeminiEmbedContentResponse_LiveUsageMetadata(t *testing.T) {
 	t.Parallel()
 
-	// Live Vertex response for gemini-embedding-2:embedContent (trimmed).
 	const fixture = `{
   "embedding": {
     "values": [0.11, 0.22, 0.33]
@@ -190,23 +262,23 @@ func TestGeminiEmbedContentResponse_PreservesValues(t *testing.T) {
   }
 }`
 
-	var embedResp gemini.GeminiEmbedContentResponse
+	var embedResp vertexGeminiEmbedContentResponse
 	if err := json.Unmarshal([]byte(fixture), &embedResp); err != nil {
 		t.Fatalf("unmarshal fixture: %v", err)
 	}
 	if len(embedResp.Embedding.Values) != 3 {
 		t.Fatalf("values len = %d", len(embedResp.Embedding.Values))
 	}
+	if embedResp.UsageMetadata == nil {
+		t.Fatal("expected usageMetadata on fixture")
+	}
 
-	got := bifrostEmbeddingFromGeminiEmbedContent(&embedResp, "gemini-embedding-2", 0)
+	got := bifrostEmbeddingFromVertexGeminiEmbedContent(&embedResp, "gemini-embedding-2", 0)
 	if got == nil {
 		t.Fatal("nil conversion")
 	}
-	if got.Model != "gemini-embedding-2" || len(got.Data) != 1 {
+	if got.Model != "gemini-embedding-2" || len(got.Data) != 1 || got.Data[0].Index != 0 {
 		t.Fatalf("got = %#v", got)
-	}
-	if got.Data[0].Index != 0 {
-		t.Fatalf("index = %d", got.Data[0].Index)
 	}
 	want := []float64{0.11, 0.22, 0.33}
 	for i, v := range want {
@@ -214,21 +286,44 @@ func TestGeminiEmbedContentResponse_PreservesValues(t *testing.T) {
 			t.Fatalf("values[%d] = %v, want %v", i, got.Data[0].Embedding.EmbeddingArray[i], v)
 		}
 	}
+	// Live shape assertions (CodeRabbit #3 / #5).
+	if got.Usage == nil {
+		t.Fatal("expected Usage from usageMetadata")
+	}
+	if got.Usage.PromptTokens != 2 || got.Usage.TotalTokens != 2 {
+		t.Fatalf("usage = %#v, want prompt=2 total=2", got.Usage)
+	}
+}
+
+func TestVertexGeminiEmbedContentResponse_StatisticsFallback(t *testing.T) {
+	t.Parallel()
+
+	got := bifrostEmbeddingFromVertexGeminiEmbedContent(&vertexGeminiEmbedContentResponse{
+		Embedding: gemini.GeminiEmbedding{
+			Values:     []float64{1},
+			Statistics: &gemini.ContentEmbeddingStatistics{TokenCount: 9},
+		},
+	}, "m", 0)
+	if got == nil || got.Usage == nil || got.Usage.PromptTokens != 9 || got.Usage.TotalTokens != 9 {
+		t.Fatalf("statistics fallback usage = %#v", got)
+	}
 }
 
 func TestMergeBifrostEmbeddingResponses_OrderAndUsage(t *testing.T) {
 	t.Parallel()
 
-	p0 := bifrostEmbeddingFromGeminiEmbedContent(&gemini.GeminiEmbedContentResponse{
-		Embedding: gemini.GeminiEmbedding{
-			Values:     []float64{1, 2},
-			Statistics: &gemini.ContentEmbeddingStatistics{TokenCount: 3},
+	p0 := bifrostEmbeddingFromVertexGeminiEmbedContent(&vertexGeminiEmbedContentResponse{
+		Embedding: gemini.GeminiEmbedding{Values: []float64{1, 2}},
+		UsageMetadata: &gemini.GenerateContentResponseUsageMetadata{
+			PromptTokenCount: 3,
+			TotalTokenCount:  3,
 		},
 	}, "gemini-embedding-2", 0)
-	p1 := bifrostEmbeddingFromGeminiEmbedContent(&gemini.GeminiEmbedContentResponse{
-		Embedding: gemini.GeminiEmbedding{
-			Values:     []float64{3, 4, 5},
-			Statistics: &gemini.ContentEmbeddingStatistics{TokenCount: 4},
+	p1 := bifrostEmbeddingFromVertexGeminiEmbedContent(&vertexGeminiEmbedContentResponse{
+		Embedding: gemini.GeminiEmbedding{Values: []float64{3, 4, 5}},
+		UsageMetadata: &gemini.GenerateContentResponseUsageMetadata{
+			PromptTokenCount: 4,
+			TotalTokenCount:  4,
 		},
 	}, "gemini-embedding-2", 1)
 
@@ -243,25 +338,22 @@ func TestMergeBifrostEmbeddingResponses_OrderAndUsage(t *testing.T) {
 		t.Fatalf("vector lens wrong: %#v", got.Data)
 	}
 	if got.Usage == nil || got.Usage.PromptTokens != 7 || got.Usage.TotalTokens != 7 {
-		t.Fatalf("usage = %#v", got.Usage)
+		t.Fatalf("merged usage = %#v, want 7/7 from usageMetadata parts", got.Usage)
 	}
 }
 
-// Ensure unmarshaling the batch-shaped response into EmbedContentResponse fails
-// loudly (documents why we must not call :batchEmbedContents on Vertex).
-func TestGeminiEmbedContentResponse_RejectsBatchShape(t *testing.T) {
+func TestVertexGeminiEmbedContentResponse_RejectsBatchShape(t *testing.T) {
 	t.Parallel()
 
 	const batchFixture = `{"embeddings":[{"values":[0.1,0.2]}]}`
-	var embedResp gemini.GeminiEmbedContentResponse
+	var embedResp vertexGeminiEmbedContentResponse
 	if err := json.Unmarshal([]byte(batchFixture), &embedResp); err != nil {
 		t.Fatalf("unexpected unmarshal err: %v", err)
 	}
-	// JSON ignores unknown "embeddings" key — Values stays empty.
 	if len(embedResp.Embedding.Values) != 0 {
-		t.Fatalf("expected empty values when given batch shape, got %v", embedResp.Embedding.Values)
+		t.Fatalf("expected empty values for batch shape, got %v", embedResp.Embedding.Values)
 	}
-	if bifrostEmbeddingFromGeminiEmbedContent(&embedResp, "m", 0) != nil {
-		t.Fatal("batch-shaped body must not convert to a Bifrost embedding")
+	if bifrostEmbeddingFromVertexGeminiEmbedContent(&embedResp, "m", 0) != nil {
+		t.Fatal("batch-shaped body must not convert")
 	}
 }

--- a/core/providers/vertex/embedding_test.go
+++ b/core/providers/vertex/embedding_test.go
@@ -5,8 +5,34 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/maximhq/bifrost/core/providers/gemini"
 	"github.com/maximhq/bifrost/core/schemas"
 )
+
+func TestCanonicalVertexModelID(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"gemini-embedding-2", "gemini-embedding-2"},
+		{"models/gemini-embedding-2", "gemini-embedding-2"},
+		{"Models/gemini-embedding-2", "gemini-embedding-2"},
+		{"  models/gemini-embedding-001  ", "gemini-embedding-001"},
+		{"google/gemini-embedding-2", "gemini-embedding-2"},
+		{"text-embedding-004", "text-embedding-004"},
+		{"models/text-embedding-004", "text-embedding-004"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			if got := canonicalVertexModelID(tc.in); got != tc.want {
+				t.Fatalf("canonicalVertexModelID(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
 
 func TestUsesGeminiEmbedContentAPI(t *testing.T) {
 	t.Parallel()
@@ -19,6 +45,7 @@ func TestUsesGeminiEmbedContentAPI(t *testing.T) {
 		{"gemini-embedding-001", true},
 		{"Gemini-Embedding-2", true},
 		{"models/gemini-embedding-2", true},
+		{"google/gemini-embedding-2", true},
 		{"text-embedding-004", false},
 		{"text-embedding-005", false},
 		{"text-multilingual-embedding-002", false},
@@ -42,14 +69,16 @@ func TestToVertexGeminiBatchEmbeddingRequest_FullyQualifiedModel(t *testing.T) {
 	text := "Hello world"
 	dims := 768
 	req := &schemas.BifrostEmbeddingRequest{
-		Model: "gemini-embedding-2",
+		// Client may pass models/…; URL + body must both use the bare id.
+		Model: "models/gemini-embedding-2",
 		Input: &schemas.EmbeddingInput{Text: &text},
 		Params: &schemas.EmbeddingParameters{
 			Dimensions: &dims,
 		},
 	}
+	modelID := canonicalVertexModelID(req.Model)
 
-	batch := ToVertexGeminiBatchEmbeddingRequest(req, "my-project", "europe-west1")
+	batch := ToVertexGeminiBatchEmbeddingRequest(req, "my-project", "europe-west1", modelID)
 	if batch == nil {
 		t.Fatal("expected non-nil batch request")
 	}
@@ -60,6 +89,9 @@ func TestToVertexGeminiBatchEmbeddingRequest_FullyQualifiedModel(t *testing.T) {
 	wantModel := "projects/my-project/locations/europe-west1/publishers/google/models/gemini-embedding-2"
 	if batch.Requests[0].Model != wantModel {
 		t.Fatalf("model = %q, want %q", batch.Requests[0].Model, wantModel)
+	}
+	if strings.Contains(batch.Requests[0].Model, "models/models/") {
+		t.Fatalf("double models/ prefix in FQ model: %q", batch.Requests[0].Model)
 	}
 	if batch.Requests[0].Content == nil || len(batch.Requests[0].Content.Parts) != 1 {
 		t.Fatalf("expected one content part, got %#v", batch.Requests[0].Content)
@@ -85,6 +117,40 @@ func TestToVertexGeminiBatchEmbeddingRequest_FullyQualifiedModel(t *testing.T) {
 	}
 	if !strings.Contains(s, wantModel) {
 		t.Fatalf("batch body missing FQ model: %s", s)
+	}
+}
+
+func TestGeminiBatchEmbeddingURL_UsesCanonicalModelID(t *testing.T) {
+	t.Parallel()
+
+	// Mirrors Embedding(): both URL path and body FQ name use the same modelID.
+	for _, clientModel := range []string{
+		"gemini-embedding-2",
+		"models/gemini-embedding-2",
+		"google/gemini-embedding-2",
+	} {
+		modelID := canonicalVertexModelID(clientModel)
+		url := getVertexModelAwarePublisherModelURL(
+			"europe-west1", "v1", "proj", "google", modelID, ":batchEmbedContents",
+			false, nil,
+		)
+		if !strings.HasSuffix(url, "/publishers/google/models/gemini-embedding-2:batchEmbedContents") {
+			t.Fatalf("clientModel=%q modelID=%q URL=%q", clientModel, modelID, url)
+		}
+		if strings.Contains(url, "/models/models/") {
+			t.Fatalf("double models/ in URL for clientModel=%q: %q", clientModel, url)
+		}
+
+		text := "x"
+		req := &schemas.BifrostEmbeddingRequest{
+			Model: clientModel,
+			Input: &schemas.EmbeddingInput{Text: &text},
+		}
+		batch := ToVertexGeminiBatchEmbeddingRequest(req, "proj", "europe-west1", modelID)
+		wantFQ := "projects/proj/locations/europe-west1/publishers/google/models/gemini-embedding-2"
+		if batch.Requests[0].Model != wantFQ {
+			t.Fatalf("clientModel=%q body model=%q want %q", clientModel, batch.Requests[0].Model, wantFQ)
+		}
 	}
 }
 
@@ -131,5 +197,85 @@ func TestGetVertexEmbeddingURL_MethodByModel(t *testing.T) {
 	legacyURL := getCompleteURLForGeminiEndpoint("text-embedding-004", "europe-west1", "proj", "", ":predict")
 	if !strings.HasSuffix(legacyURL, "/publishers/google/models/text-embedding-004:predict") {
 		t.Fatalf("legacy URL = %q", legacyURL)
+	}
+}
+
+// TestGeminiBatchEmbedContentsResponse_PreservesOrder is a fixture regression
+// for the new :batchEmbedContents response path (CodeRabbit nit on #6016).
+// Each embeddings[] item must map to BifrostEmbeddingResponse.Data in source
+// order with values and indexes preserved.
+func TestGeminiBatchEmbedContentsResponse_PreservesOrder(t *testing.T) {
+	t.Parallel()
+
+	// Wire fixture matching Vertex/Google AI Studio batchEmbedContents JSON.
+	const fixture = `{
+  "embeddings": [
+    {
+      "values": [0.11, 0.22, 0.33],
+      "statistics": { "tokenCount": 3 }
+    },
+    {
+      "values": [0.44, 0.55],
+      "statistics": { "tokenCount": 2 }
+    },
+    {
+      "values": [0.66]
+    }
+  ],
+  "metadata": {
+    "billableCharacterCount": 12
+  }
+}`
+
+	var geminiResp gemini.GeminiEmbeddingResponse
+	if err := json.Unmarshal([]byte(fixture), &geminiResp); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+	if len(geminiResp.Embeddings) != 3 {
+		t.Fatalf("fixture embeddings len = %d, want 3", len(geminiResp.Embeddings))
+	}
+
+	// Same converter used by VertexProvider.Embedding for the Gemini branch.
+	got := gemini.ToBifrostEmbeddingResponse(&geminiResp, "gemini-embedding-2")
+	if got == nil {
+		t.Fatal("ToBifrostEmbeddingResponse returned nil")
+	}
+	if got.Model != "gemini-embedding-2" {
+		t.Fatalf("model = %q", got.Model)
+	}
+	if got.Object != "list" {
+		t.Fatalf("object = %q", got.Object)
+	}
+	if len(got.Data) != 3 {
+		t.Fatalf("Data len = %d, want 3", len(got.Data))
+	}
+
+	wantVectors := [][]float64{
+		{0.11, 0.22, 0.33},
+		{0.44, 0.55},
+		{0.66},
+	}
+	for i, want := range wantVectors {
+		item := got.Data[i]
+		if item.Index != i {
+			t.Fatalf("Data[%d].Index = %d, want %d", i, item.Index, i)
+		}
+		if item.Object != "embedding" {
+			t.Fatalf("Data[%d].Object = %q", i, item.Object)
+		}
+		gotVec := item.Embedding.EmbeddingArray
+		if len(gotVec) != len(want) {
+			t.Fatalf("Data[%d] len = %d, want %d (%v)", i, len(gotVec), len(want), gotVec)
+		}
+		for j := range want {
+			if gotVec[j] != want[j] {
+				t.Fatalf("Data[%d][%d] = %v, want %v", i, j, gotVec[j], want[j])
+			}
+		}
+	}
+
+	// Usage falls back to first embedding's tokenCount when present.
+	if got.Usage == nil || got.Usage.PromptTokens != 3 || got.Usage.TotalTokens != 3 {
+		t.Fatalf("usage = %#v, want prompt/total 3 from first embedding statistics", got.Usage)
 	}
 }

--- a/core/providers/vertex/embedding_test.go
+++ b/core/providers/vertex/embedding_test.go
@@ -82,12 +82,8 @@ func TestToVertexGeminiEmbedContentRequest_FullyQualifiedModel(t *testing.T) {
 		t.Fatal("expected non-nil embedContent request")
 	}
 
-	wantModel := "projects/my-project/locations/eu/publishers/google/models/gemini-embedding-2"
-	if embedReq.Model != wantModel {
-		t.Fatalf("model = %q, want %q", embedReq.Model, wantModel)
-	}
-	if strings.Contains(embedReq.Model, "models/models/") {
-		t.Fatalf("double models/ prefix: %q", embedReq.Model)
+	if embedReq.Model != "" {
+		t.Fatalf("model must be omitted from body (URL carries identity), got %q", embedReq.Model)
 	}
 	if embedReq.Content == nil || len(embedReq.Content.Parts) != 1 || embedReq.Content.Parts[0].Text != text {
 		t.Fatalf("content = %#v", embedReq.Content)
@@ -104,7 +100,10 @@ func TestToVertexGeminiEmbedContentRequest_FullyQualifiedModel(t *testing.T) {
 	if strings.Contains(s, `"instances"`) || strings.Contains(s, `"requests"`) {
 		t.Fatalf("single embedContent body must not wrap instances/requests: %s", s)
 	}
-	if !strings.Contains(s, `"content"`) || !strings.Contains(s, wantModel) {
+	if strings.Contains(s, `"model"`) {
+		t.Fatalf("body must not set model (Vertex oneof with URL): %s", s)
+	}
+	if !strings.Contains(s, `"content"`) {
 		t.Fatalf("body = %s", s)
 	}
 }

--- a/core/providers/vertex/embedding_test.go
+++ b/core/providers/vertex/embedding_test.go
@@ -63,13 +63,12 @@ func TestUsesGeminiEmbedContentAPI(t *testing.T) {
 	}
 }
 
-func TestToVertexGeminiBatchEmbeddingRequest_FullyQualifiedModel(t *testing.T) {
+func TestToVertexGeminiEmbedContentRequest_FullyQualifiedModel(t *testing.T) {
 	t.Parallel()
 
 	text := "Hello world"
 	dims := 768
 	req := &schemas.BifrostEmbeddingRequest{
-		// Client may pass models/…; URL + body must both use the bare id.
 		Model: "models/gemini-embedding-2",
 		Input: &schemas.EmbeddingInput{Text: &text},
 		Params: &schemas.EmbeddingParameters{
@@ -78,52 +77,41 @@ func TestToVertexGeminiBatchEmbeddingRequest_FullyQualifiedModel(t *testing.T) {
 	}
 	modelID := canonicalVertexModelID(req.Model)
 
-	batch := ToVertexGeminiBatchEmbeddingRequest(req, "my-project", "europe-west1", modelID)
-	if batch == nil {
-		t.Fatal("expected non-nil batch request")
-	}
-	if len(batch.Requests) != 1 {
-		t.Fatalf("requests len = %d, want 1", len(batch.Requests))
+	embedReq := ToVertexGeminiEmbedContentRequest(req, text, "my-project", "eu", modelID)
+	if embedReq == nil {
+		t.Fatal("expected non-nil embedContent request")
 	}
 
-	wantModel := "projects/my-project/locations/europe-west1/publishers/google/models/gemini-embedding-2"
-	if batch.Requests[0].Model != wantModel {
-		t.Fatalf("model = %q, want %q", batch.Requests[0].Model, wantModel)
+	wantModel := "projects/my-project/locations/eu/publishers/google/models/gemini-embedding-2"
+	if embedReq.Model != wantModel {
+		t.Fatalf("model = %q, want %q", embedReq.Model, wantModel)
 	}
-	if strings.Contains(batch.Requests[0].Model, "models/models/") {
-		t.Fatalf("double models/ prefix in FQ model: %q", batch.Requests[0].Model)
+	if strings.Contains(embedReq.Model, "models/models/") {
+		t.Fatalf("double models/ prefix: %q", embedReq.Model)
 	}
-	if batch.Requests[0].Content == nil || len(batch.Requests[0].Content.Parts) != 1 {
-		t.Fatalf("expected one content part, got %#v", batch.Requests[0].Content)
+	if embedReq.Content == nil || len(embedReq.Content.Parts) != 1 || embedReq.Content.Parts[0].Text != text {
+		t.Fatalf("content = %#v", embedReq.Content)
 	}
-	if batch.Requests[0].Content.Parts[0].Text != text {
-		t.Fatalf("text = %q, want %q", batch.Requests[0].Content.Parts[0].Text, text)
-	}
-	if batch.Requests[0].OutputDimensionality == nil || *batch.Requests[0].OutputDimensionality != dims {
-		t.Fatalf("outputDimensionality = %#v, want %d", batch.Requests[0].OutputDimensionality, dims)
+	if embedReq.OutputDimensionality == nil || *embedReq.OutputDimensionality != dims {
+		t.Fatalf("outputDimensionality = %#v", embedReq.OutputDimensionality)
 	}
 
-	// Wire shape must not use legacy instances/parameters.
-	raw, err := json.Marshal(batch)
+	raw, err := json.Marshal(embedReq)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
 	s := string(raw)
-	if strings.Contains(s, `"instances"`) {
-		t.Fatalf("batch body must not contain instances: %s", s)
+	if strings.Contains(s, `"instances"`) || strings.Contains(s, `"requests"`) {
+		t.Fatalf("single embedContent body must not wrap instances/requests: %s", s)
 	}
-	if !strings.Contains(s, `"requests"`) {
-		t.Fatalf("batch body must contain requests: %s", s)
-	}
-	if !strings.Contains(s, wantModel) {
-		t.Fatalf("batch body missing FQ model: %s", s)
+	if !strings.Contains(s, `"content"`) || !strings.Contains(s, wantModel) {
+		t.Fatalf("body = %s", s)
 	}
 }
 
-func TestGeminiBatchEmbeddingURL_UsesCanonicalModelID(t *testing.T) {
+func TestGeminiEmbedContentURL_UsesCanonicalModelID(t *testing.T) {
 	t.Parallel()
 
-	// Mirrors Embedding(): both URL path and body FQ name use the same modelID.
 	for _, clientModel := range []string{
 		"gemini-embedding-2",
 		"models/gemini-embedding-2",
@@ -131,25 +119,17 @@ func TestGeminiBatchEmbeddingURL_UsesCanonicalModelID(t *testing.T) {
 	} {
 		modelID := canonicalVertexModelID(clientModel)
 		url := getVertexModelAwarePublisherModelURL(
-			"europe-west1", "v1", "proj", "google", modelID, ":batchEmbedContents",
+			"eu", "v1", "proj", "google", modelID, ":embedContent",
 			false, nil,
 		)
-		if !strings.HasSuffix(url, "/publishers/google/models/gemini-embedding-2:batchEmbedContents") {
-			t.Fatalf("clientModel=%q modelID=%q URL=%q", clientModel, modelID, url)
+		if !strings.HasSuffix(url, "/publishers/google/models/gemini-embedding-2:embedContent") {
+			t.Fatalf("clientModel=%q URL=%q", clientModel, url)
 		}
 		if strings.Contains(url, "/models/models/") {
-			t.Fatalf("double models/ in URL for clientModel=%q: %q", clientModel, url)
+			t.Fatalf("double models/ in URL: %q", url)
 		}
-
-		text := "x"
-		req := &schemas.BifrostEmbeddingRequest{
-			Model: clientModel,
-			Input: &schemas.EmbeddingInput{Text: &text},
-		}
-		batch := ToVertexGeminiBatchEmbeddingRequest(req, "proj", "europe-west1", modelID)
-		wantFQ := "projects/proj/locations/europe-west1/publishers/google/models/gemini-embedding-2"
-		if batch.Requests[0].Model != wantFQ {
-			t.Fatalf("clientModel=%q body model=%q want %q", clientModel, batch.Requests[0].Model, wantFQ)
+		if strings.Contains(url, "batchEmbedContents") {
+			t.Fatalf("must use :embedContent not batch: %q", url)
 		}
 	}
 }
@@ -181,17 +161,12 @@ func TestToVertexEmbeddingRequest_LegacyInstancesShape(t *testing.T) {
 func TestGetVertexEmbeddingURL_MethodByModel(t *testing.T) {
 	t.Parallel()
 
-	// URL helpers used by Embedding(): gemini-embedding-* → :batchEmbedContents,
-	// legacy → :predict (via getCompleteURLForGeminiEndpoint).
 	geminiURL := getVertexModelAwarePublisherModelURL(
-		"europe-west1", "v1", "proj", "google", "gemini-embedding-2", ":batchEmbedContents",
+		"eu", "v1", "proj", "google", "gemini-embedding-2", ":embedContent",
 		false, nil,
 	)
-	if !strings.HasSuffix(geminiURL, "/publishers/google/models/gemini-embedding-2:batchEmbedContents") {
+	if !strings.HasSuffix(geminiURL, "/publishers/google/models/gemini-embedding-2:embedContent") {
 		t.Fatalf("gemini URL = %q", geminiURL)
-	}
-	if !strings.Contains(geminiURL, "aiplatform") {
-		t.Fatalf("gemini URL missing aiplatform host: %q", geminiURL)
 	}
 
 	legacyURL := getCompleteURLForGeminiEndpoint("text-embedding-004", "europe-west1", "proj", "", ":predict")
@@ -200,82 +175,94 @@ func TestGetVertexEmbeddingURL_MethodByModel(t *testing.T) {
 	}
 }
 
-// TestGeminiBatchEmbedContentsResponse_PreservesOrder is a fixture regression
-// for the new :batchEmbedContents response path (CodeRabbit nit on #6016).
-// Each embeddings[] item must map to BifrostEmbeddingResponse.Data in source
-// order with values and indexes preserved.
-func TestGeminiBatchEmbedContentsResponse_PreservesOrder(t *testing.T) {
+// TestGeminiEmbedContentResponse_PreservesValues is a fixture regression for the
+// Vertex :embedContent response path (live shape: embedding.values).
+func TestGeminiEmbedContentResponse_PreservesValues(t *testing.T) {
 	t.Parallel()
 
-	// Wire fixture matching Vertex/Google AI Studio batchEmbedContents JSON.
+	// Live Vertex response for gemini-embedding-2:embedContent (trimmed).
 	const fixture = `{
-  "embeddings": [
-    {
-      "values": [0.11, 0.22, 0.33],
-      "statistics": { "tokenCount": 3 }
-    },
-    {
-      "values": [0.44, 0.55],
-      "statistics": { "tokenCount": 2 }
-    },
-    {
-      "values": [0.66]
-    }
-  ],
-  "metadata": {
-    "billableCharacterCount": 12
+  "embedding": {
+    "values": [0.11, 0.22, 0.33]
+  },
+  "usageMetadata": {
+    "promptTokenCount": 2,
+    "totalTokenCount": 2
   }
 }`
 
-	var geminiResp gemini.GeminiEmbeddingResponse
-	if err := json.Unmarshal([]byte(fixture), &geminiResp); err != nil {
+	var embedResp gemini.GeminiEmbedContentResponse
+	if err := json.Unmarshal([]byte(fixture), &embedResp); err != nil {
 		t.Fatalf("unmarshal fixture: %v", err)
 	}
-	if len(geminiResp.Embeddings) != 3 {
-		t.Fatalf("fixture embeddings len = %d, want 3", len(geminiResp.Embeddings))
+	if len(embedResp.Embedding.Values) != 3 {
+		t.Fatalf("values len = %d", len(embedResp.Embedding.Values))
 	}
 
-	// Same converter used by VertexProvider.Embedding for the Gemini branch.
-	got := gemini.ToBifrostEmbeddingResponse(&geminiResp, "gemini-embedding-2")
+	got := bifrostEmbeddingFromGeminiEmbedContent(&embedResp, "gemini-embedding-2", 0)
 	if got == nil {
-		t.Fatal("ToBifrostEmbeddingResponse returned nil")
+		t.Fatal("nil conversion")
 	}
-	if got.Model != "gemini-embedding-2" {
-		t.Fatalf("model = %q", got.Model)
+	if got.Model != "gemini-embedding-2" || len(got.Data) != 1 {
+		t.Fatalf("got = %#v", got)
 	}
-	if got.Object != "list" {
-		t.Fatalf("object = %q", got.Object)
+	if got.Data[0].Index != 0 {
+		t.Fatalf("index = %d", got.Data[0].Index)
 	}
-	if len(got.Data) != 3 {
-		t.Fatalf("Data len = %d, want 3", len(got.Data))
+	want := []float64{0.11, 0.22, 0.33}
+	for i, v := range want {
+		if got.Data[0].Embedding.EmbeddingArray[i] != v {
+			t.Fatalf("values[%d] = %v, want %v", i, got.Data[0].Embedding.EmbeddingArray[i], v)
+		}
 	}
+}
 
-	wantVectors := [][]float64{
-		{0.11, 0.22, 0.33},
-		{0.44, 0.55},
-		{0.66},
-	}
-	for i, want := range wantVectors {
-		item := got.Data[i]
-		if item.Index != i {
-			t.Fatalf("Data[%d].Index = %d, want %d", i, item.Index, i)
-		}
-		if item.Object != "embedding" {
-			t.Fatalf("Data[%d].Object = %q", i, item.Object)
-		}
-		gotVec := item.Embedding.EmbeddingArray
-		if len(gotVec) != len(want) {
-			t.Fatalf("Data[%d] len = %d, want %d (%v)", i, len(gotVec), len(want), gotVec)
-		}
-		for j := range want {
-			if gotVec[j] != want[j] {
-				t.Fatalf("Data[%d][%d] = %v, want %v", i, j, gotVec[j], want[j])
-			}
-		}
-	}
+func TestMergeBifrostEmbeddingResponses_OrderAndUsage(t *testing.T) {
+	t.Parallel()
 
-	// Usage falls back to first embedding's tokenCount when present.
-	if got.Usage == nil || got.Usage.PromptTokens != 3 || got.Usage.TotalTokens != 3 {
-		t.Fatalf("usage = %#v, want prompt/total 3 from first embedding statistics", got.Usage)
+	p0 := bifrostEmbeddingFromGeminiEmbedContent(&gemini.GeminiEmbedContentResponse{
+		Embedding: gemini.GeminiEmbedding{
+			Values:     []float64{1, 2},
+			Statistics: &gemini.ContentEmbeddingStatistics{TokenCount: 3},
+		},
+	}, "gemini-embedding-2", 0)
+	p1 := bifrostEmbeddingFromGeminiEmbedContent(&gemini.GeminiEmbedContentResponse{
+		Embedding: gemini.GeminiEmbedding{
+			Values:     []float64{3, 4, 5},
+			Statistics: &gemini.ContentEmbeddingStatistics{TokenCount: 4},
+		},
+	}, "gemini-embedding-2", 1)
+
+	got := mergeBifrostEmbeddingResponses([]*schemas.BifrostEmbeddingResponse{p0, p1}, "gemini-embedding-2")
+	if got == nil || len(got.Data) != 2 {
+		t.Fatalf("got = %#v", got)
+	}
+	if got.Data[0].Index != 0 || got.Data[1].Index != 1 {
+		t.Fatalf("indexes = %d,%d", got.Data[0].Index, got.Data[1].Index)
+	}
+	if len(got.Data[0].Embedding.EmbeddingArray) != 2 || len(got.Data[1].Embedding.EmbeddingArray) != 3 {
+		t.Fatalf("vector lens wrong: %#v", got.Data)
+	}
+	if got.Usage == nil || got.Usage.PromptTokens != 7 || got.Usage.TotalTokens != 7 {
+		t.Fatalf("usage = %#v", got.Usage)
+	}
+}
+
+// Ensure unmarshaling the batch-shaped response into EmbedContentResponse fails
+// loudly (documents why we must not call :batchEmbedContents on Vertex).
+func TestGeminiEmbedContentResponse_RejectsBatchShape(t *testing.T) {
+	t.Parallel()
+
+	const batchFixture = `{"embeddings":[{"values":[0.1,0.2]}]}`
+	var embedResp gemini.GeminiEmbedContentResponse
+	if err := json.Unmarshal([]byte(batchFixture), &embedResp); err != nil {
+		t.Fatalf("unexpected unmarshal err: %v", err)
+	}
+	// JSON ignores unknown "embeddings" key — Values stays empty.
+	if len(embedResp.Embedding.Values) != 0 {
+		t.Fatalf("expected empty values when given batch shape, got %v", embedResp.Embedding.Values)
+	}
+	if bifrostEmbeddingFromGeminiEmbedContent(&embedResp, "m", 0) != nil {
+		t.Fatal("batch-shaped body must not convert to a Bifrost embedding")
 	}
 }

--- a/core/providers/vertex/embedding_test.go
+++ b/core/providers/vertex/embedding_test.go
@@ -1,0 +1,135 @@
+package vertex
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestUsesGeminiEmbedContentAPI(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		model string
+		want  bool
+	}{
+		{"gemini-embedding-2", true},
+		{"gemini-embedding-001", true},
+		{"Gemini-Embedding-2", true},
+		{"models/gemini-embedding-2", true},
+		{"text-embedding-004", false},
+		{"text-embedding-005", false},
+		{"text-multilingual-embedding-002", false},
+		{"multimodalembedding@001", false},
+		{"gemini-2.5-flash", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.model, func(t *testing.T) {
+			t.Parallel()
+			if got := usesGeminiEmbedContentAPI(tc.model); got != tc.want {
+				t.Fatalf("usesGeminiEmbedContentAPI(%q) = %v, want %v", tc.model, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestToVertexGeminiBatchEmbeddingRequest_FullyQualifiedModel(t *testing.T) {
+	t.Parallel()
+
+	text := "Hello world"
+	dims := 768
+	req := &schemas.BifrostEmbeddingRequest{
+		Model: "gemini-embedding-2",
+		Input: &schemas.EmbeddingInput{Text: &text},
+		Params: &schemas.EmbeddingParameters{
+			Dimensions: &dims,
+		},
+	}
+
+	batch := ToVertexGeminiBatchEmbeddingRequest(req, "my-project", "europe-west1")
+	if batch == nil {
+		t.Fatal("expected non-nil batch request")
+	}
+	if len(batch.Requests) != 1 {
+		t.Fatalf("requests len = %d, want 1", len(batch.Requests))
+	}
+
+	wantModel := "projects/my-project/locations/europe-west1/publishers/google/models/gemini-embedding-2"
+	if batch.Requests[0].Model != wantModel {
+		t.Fatalf("model = %q, want %q", batch.Requests[0].Model, wantModel)
+	}
+	if batch.Requests[0].Content == nil || len(batch.Requests[0].Content.Parts) != 1 {
+		t.Fatalf("expected one content part, got %#v", batch.Requests[0].Content)
+	}
+	if batch.Requests[0].Content.Parts[0].Text != text {
+		t.Fatalf("text = %q, want %q", batch.Requests[0].Content.Parts[0].Text, text)
+	}
+	if batch.Requests[0].OutputDimensionality == nil || *batch.Requests[0].OutputDimensionality != dims {
+		t.Fatalf("outputDimensionality = %#v, want %d", batch.Requests[0].OutputDimensionality, dims)
+	}
+
+	// Wire shape must not use legacy instances/parameters.
+	raw, err := json.Marshal(batch)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(raw)
+	if strings.Contains(s, `"instances"`) {
+		t.Fatalf("batch body must not contain instances: %s", s)
+	}
+	if !strings.Contains(s, `"requests"`) {
+		t.Fatalf("batch body must contain requests: %s", s)
+	}
+	if !strings.Contains(s, wantModel) {
+		t.Fatalf("batch body missing FQ model: %s", s)
+	}
+}
+
+func TestToVertexEmbeddingRequest_LegacyInstancesShape(t *testing.T) {
+	t.Parallel()
+
+	text := "legacy"
+	req := &schemas.BifrostEmbeddingRequest{
+		Model: "text-embedding-004",
+		Input: &schemas.EmbeddingInput{Text: &text},
+	}
+	vertexReq := ToVertexEmbeddingRequest(req)
+	if vertexReq == nil {
+		t.Fatal("expected non-nil legacy request")
+	}
+	if len(vertexReq.Instances) != 1 || vertexReq.Instances[0].Content != text {
+		t.Fatalf("instances = %#v", vertexReq.Instances)
+	}
+	raw, err := json.Marshal(vertexReq)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(raw), `"instances"`) {
+		t.Fatalf("legacy body must contain instances: %s", raw)
+	}
+}
+
+func TestGetVertexEmbeddingURL_MethodByModel(t *testing.T) {
+	t.Parallel()
+
+	// URL helpers used by Embedding(): gemini-embedding-* → :batchEmbedContents,
+	// legacy → :predict (via getCompleteURLForGeminiEndpoint).
+	geminiURL := getVertexModelAwarePublisherModelURL(
+		"europe-west1", "v1", "proj", "google", "gemini-embedding-2", ":batchEmbedContents",
+		false, nil,
+	)
+	if !strings.HasSuffix(geminiURL, "/publishers/google/models/gemini-embedding-2:batchEmbedContents") {
+		t.Fatalf("gemini URL = %q", geminiURL)
+	}
+	if !strings.Contains(geminiURL, "aiplatform") {
+		t.Fatalf("gemini URL missing aiplatform host: %q", geminiURL)
+	}
+
+	legacyURL := getCompleteURLForGeminiEndpoint("text-embedding-004", "europe-west1", "proj", "", ":predict")
+	if !strings.HasSuffix(legacyURL, "/publishers/google/models/text-embedding-004:predict") {
+		t.Fatalf("legacy URL = %q", legacyURL)
+	}
+}

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -1728,6 +1728,13 @@ func (provider *VertexProvider) Embedding(ctx *schemas.BifrostContext, key schem
 
 // embeddingGeminiEmbedContent implements the Gemini-native Vertex embedding path
 // via :embedContent (see Embedding docs).
+//
+// Contract notes (multi-input /v1/embeddings):
+//   - Inputs are issued as sequential blocking :embedContent calls (no fan-out
+//     concurrency). Latency scales linearly with len(input).
+//   - Failure on input k aborts the whole request after k successful upstream
+//     calls may already have been billed (abort-on-first-failure).
+//   - Empty strings in Texts are skipped (see vertexGeminiEmbedTexts).
 func (provider *VertexProvider) embeddingGeminiEmbedContent(
 	ctx *schemas.BifrostContext,
 	key schemas.Key,
@@ -1742,7 +1749,6 @@ func (provider *VertexProvider) embeddingGeminiEmbedContent(
 	}
 
 	forceSingleRegion := resolveVertexForceSingleRegion(ctx, key)
-	effectiveRegion := getVertexEffectiveRegion(region, modelID, forceSingleRegion)
 
 	// Model-aware host so multi-region-only embedding models (e.g. on eu/us
 	// pools via rep.googleapis.com) are routed correctly when the key is
@@ -1781,8 +1787,9 @@ func (provider *VertexProvider) embeddingGeminiEmbedContent(
 	var lastRaw map[string]interface{}
 
 	for i, text := range texts {
-		embedReq := ToVertexGeminiEmbedContentRequest(request, text, projectID, effectiveRegion, modelID)
+		embedReq := ToVertexGeminiEmbedContentRequest(request, text)
 		if embedReq == nil {
+			// Should not happen after vertexGeminiEmbedTexts filters empties.
 			return nil, providerUtils.NewBifrostOperationError("failed to build embedContent request", fmt.Errorf("nil request for input %d", i))
 		}
 		jsonBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
@@ -1840,7 +1847,7 @@ func (provider *VertexProvider) embeddingGeminiEmbedContent(
 							}
 						}
 					}
-				} else if len(errBody) > 0 && errBody[0] == '<' {
+				} else if errBody[0] == '<' {
 					// HTML 404 body from missing Vertex endpoints (e.g. batchEmbedContents).
 					errorMessage = fmt.Sprintf("provider returned HTTP %d (non-JSON body)", resp.StatusCode())
 				}
@@ -1851,6 +1858,9 @@ func (provider *VertexProvider) embeddingGeminiEmbedContent(
 			return nil, providerUtils.EnrichError(ctx, providerUtils.NewProviderAPIError(errorMessage, nil, resp.StatusCode(), nil, nil), jsonBody, errBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 		}
 
+		// Embeddings are small fixed-size float arrays — never hand off a large
+		// response stream (that path would leak the connection while the loop
+		// continues and would inject empty vectors into the merged result).
 		responseBody, isLargeResp, decodeErr := providerUtils.FinalizeResponseWithLargeDetection(ctx, resp, provider.logger)
 		if decodeErr != nil {
 			wait()
@@ -1859,28 +1869,23 @@ func (provider *VertexProvider) embeddingGeminiEmbedContent(
 			return nil, providerUtils.EnrichError(ctx, decodeErr, jsonBody, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
 		}
 		if isLargeResp {
-			// Large response path: return metadata-only for this input (rare for embeddings).
 			wait()
 			fasthttp.ReleaseRequest(req)
-			// resp owned by large reader
-			parts = append(parts, &schemas.BifrostEmbeddingResponse{
-				Model: request.Model,
-				Data: []schemas.EmbeddingData{{
-					Object: "embedding",
-					Index:  i,
-				}},
-			})
-			continue
+			fasthttp.ReleaseResponse(resp)
+			return nil, providerUtils.NewBifrostOperationError(
+				"unexpected large response from embedContent",
+				fmt.Errorf("embedding responses are expected to be small; refusing large-response handoff for input %d", i),
+			)
 		}
 		wait()
 
-		var embedResp gemini.GeminiEmbedContentResponse
+		var embedResp vertexGeminiEmbedContentResponse
 		if err := sonic.Unmarshal(responseBody, &embedResp); err != nil {
 			fasthttp.ReleaseRequest(req)
 			fasthttp.ReleaseResponse(resp)
 			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err), jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
 		}
-		part := bifrostEmbeddingFromGeminiEmbedContent(&embedResp, request.Model, i)
+		part := bifrostEmbeddingFromVertexGeminiEmbedContent(&embedResp, request.Model, i)
 		if part == nil {
 			fasthttp.ReleaseRequest(req)
 			fasthttp.ReleaseResponse(resp)

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -1713,9 +1713,14 @@ func (provider *VertexProvider) Embedding(ctx *schemas.BifrostContext, key schem
 		return nil, providerUtils.NewConfigurationError("region is not set in key config")
 	}
 
-	useGeminiEmbedAPI := usesGeminiEmbedContentAPI(request.Model)
+	// One canonical model id for URL path, FQ resource name in the body, and
+	// multi-region host promotion. Stripping models/ here avoids
+	// …/models/models/gemini-embedding-2 when GenAI clients pass models/{id}.
+	modelID := canonicalVertexModelID(request.Model)
+	useGeminiEmbedAPI := usesGeminiEmbedContentAPI(modelID)
 	forceSingleRegion := resolveVertexForceSingleRegion(ctx, key)
-	effectiveRegion := getVertexEffectiveRegion(region, request.Model, forceSingleRegion)
+	// Host/region promotion keys off the bare model id (not models/…).
+	effectiveRegion := getVertexEffectiveRegion(region, modelID, forceSingleRegion)
 
 	var jsonBody []byte
 	var bifrostErr *schemas.BifrostError
@@ -1724,7 +1729,7 @@ func (provider *VertexProvider) Embedding(ctx *schemas.BifrostContext, key schem
 			ctx,
 			request,
 			func() (providerUtils.RequestBodyWithExtraParams, error) {
-				return ToVertexGeminiBatchEmbeddingRequest(request, projectID, effectiveRegion), nil
+				return ToVertexGeminiBatchEmbeddingRequest(request, projectID, effectiveRegion, modelID), nil
 			},
 		)
 	} else {
@@ -1742,7 +1747,7 @@ func (provider *VertexProvider) Embedding(ctx *schemas.BifrostContext, key schem
 
 	// For custom/fine-tuned models, validate projectNumber is set
 	projectNumber := resolveVertexProjectNumber(ctx, key)
-	if schemas.IsAllDigitsASCII(request.Model) && projectNumber == "" {
+	if schemas.IsAllDigitsASCII(modelID) && projectNumber == "" {
 		return nil, providerUtils.NewConfigurationError("project number is not set for fine-tuned models")
 	}
 
@@ -1758,11 +1763,11 @@ func (provider *VertexProvider) Embedding(ctx *schemas.BifrostContext, key schem
 		// configured with a single region such as europe-west1.
 		completeURL = getVertexModelAwarePublisherModelURL(
 			region, "v1", projectID, "google",
-			gemini.NormalizeModelName(request.Model), ":batchEmbedContents",
+			modelID, ":batchEmbedContents",
 			forceSingleRegion, provider.logger,
 		)
 	} else {
-		completeURL = getCompleteURLForGeminiEndpoint(request.Model, region, projectID, projectNumber, ":predict")
+		completeURL = getCompleteURLForGeminiEndpoint(modelID, region, projectID, projectNumber, ":predict")
 	}
 
 	// Create HTTP request for streaming

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -1695,9 +1695,12 @@ func (provider *VertexProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 //   - Legacy prediction embeddings (text-embedding-004, text-multilingual-*, …):
 //     POST …/models/{model}:predict with {instances, parameters}.
 //   - Gemini-native embeddings (gemini-embedding-*):
-//     POST …/models/{model}:batchEmbedContents with Gemini content.parts body.
+//     POST …/models/{model}:embedContent with Gemini content.parts body and
+//     response {"embedding":{"values":[…]}}.
 //     Using :predict for these models returns 400 "Precondition check failed"
-//     (https://github.com/maximhq/bifrost/issues/5003).
+//     (https://github.com/maximhq/bifrost/issues/5003). Vertex publisher APIs
+//     do not expose :batchEmbedContents for these models (HTML 404) — multi-
+//     input requests issue sequential :embedContent calls.
 //
 // GenAI :embedContent is classified as EmbeddingRequest by the transport and
 // therefore also flows through this method — fixing the branch above unblocks
@@ -1717,60 +1720,226 @@ func (provider *VertexProvider) Embedding(ctx *schemas.BifrostContext, key schem
 	// multi-region host promotion. Stripping models/ here avoids
 	// …/models/models/gemini-embedding-2 when GenAI clients pass models/{id}.
 	modelID := canonicalVertexModelID(request.Model)
-	useGeminiEmbedAPI := usesGeminiEmbedContentAPI(modelID)
+	if usesGeminiEmbedContentAPI(modelID) {
+		return provider.embeddingGeminiEmbedContent(ctx, key, request, projectID, region, modelID)
+	}
+	return provider.embeddingLegacyPredict(ctx, key, request, projectID, region, modelID)
+}
+
+// embeddingGeminiEmbedContent implements the Gemini-native Vertex embedding path
+// via :embedContent (see Embedding docs).
+func (provider *VertexProvider) embeddingGeminiEmbedContent(
+	ctx *schemas.BifrostContext,
+	key schemas.Key,
+	request *schemas.BifrostEmbeddingRequest,
+	projectID string,
+	region string,
+	modelID string,
+) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+	texts := vertexGeminiEmbedTexts(request)
+	if len(texts) == 0 {
+		return nil, providerUtils.NewBifrostOperationError("embedding input is empty", fmt.Errorf("no text inputs"))
+	}
+
 	forceSingleRegion := resolveVertexForceSingleRegion(ctx, key)
-	// Host/region promotion keys off the bare model id (not models/…).
 	effectiveRegion := getVertexEffectiveRegion(region, modelID, forceSingleRegion)
 
-	var jsonBody []byte
-	var bifrostErr *schemas.BifrostError
-	if useGeminiEmbedAPI {
-		jsonBody, bifrostErr = providerUtils.CheckContextAndGetRequestBody(
-			ctx,
-			request,
-			func() (providerUtils.RequestBodyWithExtraParams, error) {
-				return ToVertexGeminiBatchEmbeddingRequest(request, projectID, effectiveRegion, modelID), nil
-			},
-		)
-	} else {
-		jsonBody, bifrostErr = providerUtils.CheckContextAndGetRequestBody(
-			ctx,
-			request,
-			func() (providerUtils.RequestBodyWithExtraParams, error) {
-				return ToVertexEmbeddingRequest(request), nil
-			},
-		)
+	// Model-aware host so multi-region-only embedding models (e.g. on eu/us
+	// pools via rep.googleapis.com) are routed correctly when the key is
+	// configured with a single region such as europe-west1.
+	completeURL := getVertexModelAwarePublisherModelURL(
+		region, "v1", projectID, "google",
+		modelID, ":embedContent",
+		forceSingleRegion, provider.logger,
+	)
+
+	authQuery := ""
+	if key.Value.GetValue() != "" {
+		authQuery = fmt.Sprintf("key=%s", url.QueryEscape(key.Value.GetValue()))
 	}
+	requestURL := completeURL
+	if authQuery != "" {
+		requestURL = fmt.Sprintf("%s?%s", completeURL, authQuery)
+	}
+
+	var authHeader string
+	if authQuery == "" {
+		tokenSource, err := getAuthTokenSource(key)
+		if err != nil {
+			return nil, providerUtils.NewBifrostOperationError("error creating auth token source", err)
+		}
+		token, err := tokenSource.Token()
+		if err != nil {
+			return nil, providerUtils.NewBifrostOperationError("error getting token", err)
+		}
+		authHeader = "Bearer " + token.AccessToken
+	}
+
+	parts := make([]*schemas.BifrostEmbeddingResponse, 0, len(texts))
+	var totalLatency time.Duration
+	var lastHeaders map[string]string
+	var lastRaw map[string]interface{}
+
+	for i, text := range texts {
+		embedReq := ToVertexGeminiEmbedContentRequest(request, text, projectID, effectiveRegion, modelID)
+		if embedReq == nil {
+			return nil, providerUtils.NewBifrostOperationError("failed to build embedContent request", fmt.Errorf("nil request for input %d", i))
+		}
+		jsonBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+			ctx,
+			request,
+			func() (providerUtils.RequestBodyWithExtraParams, error) {
+				return embedReq, nil
+			},
+		)
+		if bifrostErr != nil {
+			return nil, bifrostErr
+		}
+
+		req := fasthttp.AcquireRequest()
+		resp := fasthttp.AcquireResponse()
+
+		req.Header.SetMethod(http.MethodPost)
+		req.Header.SetContentType("application/json")
+		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+		if authHeader != "" {
+			req.Header.Set("Authorization", authHeader)
+		}
+		req.SetRequestURI(requestURL)
+		req.SetBody(jsonBody)
+
+		activeClient := providerUtils.PrepareResponseStreaming(ctx, provider.client, resp)
+		latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, activeClient, req, resp)
+		totalLatency += latency
+		if bifrostErr != nil {
+			wait()
+			fasthttp.ReleaseRequest(req)
+			fasthttp.ReleaseResponse(resp)
+			return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, nil, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
+		}
+
+		lastHeaders = providerUtils.ExtractProviderResponseHeaders(resp)
+		ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, lastHeaders)
+
+		if resp.StatusCode() != fasthttp.StatusOK {
+			providerUtils.MaterializeStreamErrorBody(ctx, resp)
+			if resp.StatusCode() == fasthttp.StatusUnauthorized || resp.StatusCode() == fasthttp.StatusForbidden {
+				removeVertexClient(key.VertexKeyConfig.AuthCredentials.GetValue())
+			}
+			errBody := append([]byte(nil), resp.Body()...)
+			errorMessage := "Unknown error"
+			if len(errBody) > 0 {
+				var vertexError map[string]interface{}
+				if err := sonic.Unmarshal(errBody, &vertexError); err == nil {
+					if errorObj, exists := vertexError["error"]; exists {
+						if errorMap, ok := errorObj.(map[string]interface{}); ok {
+							if message, exists := errorMap["message"]; exists {
+								if msgStr, ok := message.(string); ok {
+									errorMessage = msgStr
+								}
+							}
+						}
+					}
+				} else if len(errBody) > 0 && errBody[0] == '<' {
+					// HTML 404 body from missing Vertex endpoints (e.g. batchEmbedContents).
+					errorMessage = fmt.Sprintf("provider returned HTTP %d (non-JSON body)", resp.StatusCode())
+				}
+			}
+			wait()
+			fasthttp.ReleaseRequest(req)
+			fasthttp.ReleaseResponse(resp)
+			return nil, providerUtils.EnrichError(ctx, providerUtils.NewProviderAPIError(errorMessage, nil, resp.StatusCode(), nil, nil), jsonBody, errBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
+		}
+
+		responseBody, isLargeResp, decodeErr := providerUtils.FinalizeResponseWithLargeDetection(ctx, resp, provider.logger)
+		if decodeErr != nil {
+			wait()
+			fasthttp.ReleaseRequest(req)
+			fasthttp.ReleaseResponse(resp)
+			return nil, providerUtils.EnrichError(ctx, decodeErr, jsonBody, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+		}
+		if isLargeResp {
+			// Large response path: return metadata-only for this input (rare for embeddings).
+			wait()
+			fasthttp.ReleaseRequest(req)
+			// resp owned by large reader
+			parts = append(parts, &schemas.BifrostEmbeddingResponse{
+				Model: request.Model,
+				Data: []schemas.EmbeddingData{{
+					Object: "embedding",
+					Index:  i,
+				}},
+			})
+			continue
+		}
+		wait()
+
+		var embedResp gemini.GeminiEmbedContentResponse
+		if err := sonic.Unmarshal(responseBody, &embedResp); err != nil {
+			fasthttp.ReleaseRequest(req)
+			fasthttp.ReleaseResponse(resp)
+			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err), jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
+		}
+		part := bifrostEmbeddingFromGeminiEmbedContent(&embedResp, request.Model, i)
+		if part == nil {
+			fasthttp.ReleaseRequest(req)
+			fasthttp.ReleaseResponse(resp)
+			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, fmt.Errorf("empty embedding in embedContent response for input %d", i)), jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
+		}
+		if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+			var rawResponseMap map[string]interface{}
+			if err := sonic.Unmarshal(responseBody, &rawResponseMap); err == nil {
+				lastRaw = rawResponseMap
+			}
+		}
+		parts = append(parts, part)
+		fasthttp.ReleaseRequest(req)
+		fasthttp.ReleaseResponse(resp)
+	}
+
+	bifrostResponse := mergeBifrostEmbeddingResponses(parts, request.Model)
+	if bifrostResponse == nil {
+		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, fmt.Errorf("failed to build embedding response"))
+	}
+	bifrostResponse.ExtraFields.Latency = totalLatency.Milliseconds()
+	bifrostResponse.ExtraFields.ProviderResponseHeaders = lastHeaders
+	if lastRaw != nil {
+		bifrostResponse.ExtraFields.RawResponse = lastRaw
+	}
+	return bifrostResponse, nil
+}
+
+// embeddingLegacyPredict implements the classic Vertex :predict embedding path.
+func (provider *VertexProvider) embeddingLegacyPredict(
+	ctx *schemas.BifrostContext,
+	key schemas.Key,
+	request *schemas.BifrostEmbeddingRequest,
+	projectID string,
+	region string,
+	modelID string,
+) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+	jsonBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToVertexEmbeddingRequest(request), nil
+		},
+	)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
 
-	// For custom/fine-tuned models, validate projectNumber is set
 	projectNumber := resolveVertexProjectNumber(ctx, key)
 	if schemas.IsAllDigitsASCII(modelID) && projectNumber == "" {
 		return nil, providerUtils.NewConfigurationError("project number is not set for fine-tuned models")
 	}
 
-	// Build the native Vertex embedding API endpoint
 	authQuery := ""
 	if key.Value.GetValue() != "" {
 		authQuery = fmt.Sprintf("key=%s", url.QueryEscape(key.Value.GetValue()))
 	}
-	var completeURL string
-	if useGeminiEmbedAPI {
-		// Model-aware host so multi-region-only embedding models (e.g. on eu/us
-		// pools via rep.googleapis.com) are routed correctly when the key is
-		// configured with a single region such as europe-west1.
-		completeURL = getVertexModelAwarePublisherModelURL(
-			region, "v1", projectID, "google",
-			modelID, ":batchEmbedContents",
-			forceSingleRegion, provider.logger,
-		)
-	} else {
-		completeURL = getCompleteURLForGeminiEndpoint(modelID, region, projectID, projectNumber, ":predict")
-	}
+	completeURL := getCompleteURLForGeminiEndpoint(modelID, region, projectID, projectNumber, ":predict")
 
-	// Create HTTP request for streaming
 	req := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
 	defer fasthttp.ReleaseRequest(req)
@@ -1783,12 +1952,8 @@ func (provider *VertexProvider) Embedding(ctx *schemas.BifrostContext, key schem
 
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
-
-	// Set any extra headers from network config
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	// If auth query is set, add it to the URL
-	// Otherwise, get the oauth2 token and set the Authorization header
 	if authQuery != "" {
 		completeURL = fmt.Sprintf("%s?%s", completeURL, authQuery)
 	} else {
@@ -1804,13 +1969,11 @@ func (provider *VertexProvider) Embedding(ctx *schemas.BifrostContext, key schem
 	}
 
 	req.SetRequestURI(completeURL)
-
 	usedLargePayloadBody := providerUtils.ApplyLargePayloadRequestBody(ctx, req)
 	if !usedLargePayloadBody {
 		req.SetBody(jsonBody)
 	}
 
-	// Make the request with optional large response streaming
 	activeClient := providerUtils.PrepareResponseStreaming(ctx, provider.client, resp)
 	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, activeClient, req, resp)
 	defer wait()
@@ -1824,22 +1987,16 @@ func (provider *VertexProvider) Embedding(ctx *schemas.BifrostContext, key schem
 
 	if resp.StatusCode() != fasthttp.StatusOK {
 		providerUtils.MaterializeStreamErrorBody(ctx, resp)
-		// Remove client from pool for authentication/authorization errors
 		if resp.StatusCode() == fasthttp.StatusUnauthorized || resp.StatusCode() == fasthttp.StatusForbidden {
 			removeVertexClient(key.VertexKeyConfig.AuthCredentials.GetValue())
 		}
-
 		errBody := resp.Body()
-
-		// Extract error message from Vertex's error format
 		errorMessage := "Unknown error"
 		if len(errBody) > 0 {
-			// Try to parse Vertex's error format
 			var vertexError map[string]interface{}
 			if err := sonic.Unmarshal(errBody, &vertexError); err != nil {
 				return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err), jsonBody, errBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 			}
-
 			if errorObj, exists := vertexError["error"]; exists {
 				if errorMap, ok := errorObj.(map[string]interface{}); ok {
 					if message, exists := errorMap["message"]; exists {
@@ -1850,7 +2007,6 @@ func (provider *VertexProvider) Embedding(ctx *schemas.BifrostContext, key schem
 				}
 			}
 		}
-
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewProviderAPIError(errorMessage, nil, resp.StatusCode(), nil, nil), jsonBody, errBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 	}
 
@@ -1868,60 +2024,30 @@ func (provider *VertexProvider) Embedding(ctx *schemas.BifrostContext, key schem
 		}, nil
 	}
 
-	var bifrostResponse *schemas.BifrostEmbeddingResponse
-	if useGeminiEmbedAPI {
-		// Gemini :batchEmbedContents response shape (embeddings[]), same as Google AI Studio.
-		var geminiResponse gemini.GeminiEmbeddingResponse
-		pt, ph := providerUtils.StartResponseParseSpan(ctx)
-		umErr := sonic.Unmarshal(responseBody, &geminiResponse)
-		if pt != nil {
-			if umErr != nil {
-				pt.EndSpan(ph, schemas.SpanStatusError, "response parse failed")
-			} else {
-				pt.EndSpan(ph, schemas.SpanStatusOk, "")
-			}
-		}
+	// Legacy :predict response shape (predictions[].embeddings).
+	var vertexResponse VertexEmbeddingResponse
+	pt, ph := providerUtils.StartResponseParseSpan(ctx)
+	umErr := sonic.Unmarshal(responseBody, &vertexResponse)
+	if pt != nil {
 		if umErr != nil {
-			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, umErr), jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
-		}
-		ct, ch := providerUtils.StartResponseConvertorSpan(ctx)
-		bifrostResponse = gemini.ToBifrostEmbeddingResponse(&geminiResponse, request.Model)
-		if ct != nil {
-			ct.EndSpan(ch, schemas.SpanStatusOk, "")
-		}
-		if bifrostResponse == nil {
-			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, fmt.Errorf("failed to convert Gemini embedding response to Bifrost format")), jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
-		}
-	} else {
-		// Legacy :predict response shape (predictions[].embeddings).
-		var vertexResponse VertexEmbeddingResponse
-		pt, ph := providerUtils.StartResponseParseSpan(ctx)
-		umErr := sonic.Unmarshal(responseBody, &vertexResponse)
-		if pt != nil {
-			if umErr != nil {
-				pt.EndSpan(ph, schemas.SpanStatusError, "response parse failed")
-			} else {
-				pt.EndSpan(ph, schemas.SpanStatusOk, "")
-			}
-		}
-		if umErr != nil {
-			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, umErr), jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
-		}
-		ct, ch := providerUtils.StartResponseConvertorSpan(ctx)
-		bifrostResponse = vertexResponse.ToBifrostEmbeddingResponse()
-		if ct != nil {
-			ct.EndSpan(ch, schemas.SpanStatusOk, "")
-		}
-		if bifrostResponse == nil {
-			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, fmt.Errorf("failed to convert Vertex embedding response to Bifrost format")), jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
+			pt.EndSpan(ph, schemas.SpanStatusError, "response parse failed")
+		} else {
+			pt.EndSpan(ph, schemas.SpanStatusOk, "")
 		}
 	}
-
-	// Set ExtraFields
+	if umErr != nil {
+		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, umErr), jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+	ct, ch := providerUtils.StartResponseConvertorSpan(ctx)
+	bifrostResponse := vertexResponse.ToBifrostEmbeddingResponse()
+	if ct != nil {
+		ct.EndSpan(ch, schemas.SpanStatusOk, "")
+	}
+	if bifrostResponse == nil {
+		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, fmt.Errorf("failed to convert Vertex embedding response to Bifrost format")), jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
 	bifrostResponse.ExtraFields.ProviderResponseHeaders = providerUtils.ExtractProviderResponseHeaders(resp)
-
-	// Set raw response if enabled
 	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
 		var rawResponseMap map[string]interface{}
 		if err := sonic.Unmarshal(responseBody, &rawResponseMap); err != nil {
@@ -1929,7 +2055,6 @@ func (provider *VertexProvider) Embedding(ctx *schemas.BifrostContext, key schem
 		}
 		bifrostResponse.ExtraFields.RawResponse = rawResponseMap
 	}
-
 	return bifrostResponse, nil
 }
 

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -1690,8 +1690,18 @@ func (provider *VertexProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 }
 
 // Embedding generates embeddings for the given input text(s) using Vertex AI.
-// All Vertex AI embedding models use the same response format regardless of the model type.
-// Returns a BifrostResponse containing the embedding(s) and any error that occurred.
+//
+// Two upstream contracts are supported:
+//   - Legacy prediction embeddings (text-embedding-004, text-multilingual-*, …):
+//     POST …/models/{model}:predict with {instances, parameters}.
+//   - Gemini-native embeddings (gemini-embedding-*):
+//     POST …/models/{model}:batchEmbedContents with Gemini content.parts body.
+//     Using :predict for these models returns 400 "Precondition check failed"
+//     (https://github.com/maximhq/bifrost/issues/5003).
+//
+// GenAI :embedContent is classified as EmbeddingRequest by the transport and
+// therefore also flows through this method — fixing the branch above unblocks
+// both /v1/embeddings and /genai/…:embedContent for gemini-embedding-*.
 func (provider *VertexProvider) Embedding(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
 	projectID := resolveVertexProjectID(ctx, key)
 	if projectID == "" {
@@ -1703,13 +1713,29 @@ func (provider *VertexProvider) Embedding(ctx *schemas.BifrostContext, key schem
 		return nil, providerUtils.NewConfigurationError("region is not set in key config")
 	}
 
-	jsonBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
-		ctx,
-		request,
-		func() (providerUtils.RequestBodyWithExtraParams, error) {
-			return ToVertexEmbeddingRequest(request), nil
-		},
-	)
+	useGeminiEmbedAPI := usesGeminiEmbedContentAPI(request.Model)
+	forceSingleRegion := resolveVertexForceSingleRegion(ctx, key)
+	effectiveRegion := getVertexEffectiveRegion(region, request.Model, forceSingleRegion)
+
+	var jsonBody []byte
+	var bifrostErr *schemas.BifrostError
+	if useGeminiEmbedAPI {
+		jsonBody, bifrostErr = providerUtils.CheckContextAndGetRequestBody(
+			ctx,
+			request,
+			func() (providerUtils.RequestBodyWithExtraParams, error) {
+				return ToVertexGeminiBatchEmbeddingRequest(request, projectID, effectiveRegion), nil
+			},
+		)
+	} else {
+		jsonBody, bifrostErr = providerUtils.CheckContextAndGetRequestBody(
+			ctx,
+			request,
+			func() (providerUtils.RequestBodyWithExtraParams, error) {
+				return ToVertexEmbeddingRequest(request), nil
+			},
+		)
+	}
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -1725,7 +1751,19 @@ func (provider *VertexProvider) Embedding(ctx *schemas.BifrostContext, key schem
 	if key.Value.GetValue() != "" {
 		authQuery = fmt.Sprintf("key=%s", url.QueryEscape(key.Value.GetValue()))
 	}
-	completeURL := getCompleteURLForGeminiEndpoint(request.Model, region, projectID, projectNumber, ":predict")
+	var completeURL string
+	if useGeminiEmbedAPI {
+		// Model-aware host so multi-region-only embedding models (e.g. on eu/us
+		// pools via rep.googleapis.com) are routed correctly when the key is
+		// configured with a single region such as europe-west1.
+		completeURL = getVertexModelAwarePublisherModelURL(
+			region, "v1", projectID, "google",
+			gemini.NormalizeModelName(request.Model), ":batchEmbedContents",
+			forceSingleRegion, provider.logger,
+		)
+	} else {
+		completeURL = getCompleteURLForGeminiEndpoint(request.Model, region, projectID, projectNumber, ":predict")
+	}
 
 	// Create HTTP request for streaming
 	req := fasthttp.AcquireRequest()
@@ -1825,26 +1863,53 @@ func (provider *VertexProvider) Embedding(ctx *schemas.BifrostContext, key schem
 		}, nil
 	}
 
-	// Parse Vertex's native embedding response using typed response
-	var vertexResponse VertexEmbeddingResponse
-	pt, ph := providerUtils.StartResponseParseSpan(ctx)
-	umErr := sonic.Unmarshal(responseBody, &vertexResponse)
-	if pt != nil {
-		if umErr != nil {
-			pt.EndSpan(ph, schemas.SpanStatusError, "response parse failed")
-		} else {
-			pt.EndSpan(ph, schemas.SpanStatusOk, "")
+	var bifrostResponse *schemas.BifrostEmbeddingResponse
+	if useGeminiEmbedAPI {
+		// Gemini :batchEmbedContents response shape (embeddings[]), same as Google AI Studio.
+		var geminiResponse gemini.GeminiEmbeddingResponse
+		pt, ph := providerUtils.StartResponseParseSpan(ctx)
+		umErr := sonic.Unmarshal(responseBody, &geminiResponse)
+		if pt != nil {
+			if umErr != nil {
+				pt.EndSpan(ph, schemas.SpanStatusError, "response parse failed")
+			} else {
+				pt.EndSpan(ph, schemas.SpanStatusOk, "")
+			}
 		}
-	}
-	if umErr != nil {
-		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, umErr), jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
-	}
-
-	// Use centralized Vertex converter
-	ct, ch := providerUtils.StartResponseConvertorSpan(ctx)
-	bifrostResponse := vertexResponse.ToBifrostEmbeddingResponse()
-	if ct != nil {
-		ct.EndSpan(ch, schemas.SpanStatusOk, "")
+		if umErr != nil {
+			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, umErr), jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
+		}
+		ct, ch := providerUtils.StartResponseConvertorSpan(ctx)
+		bifrostResponse = gemini.ToBifrostEmbeddingResponse(&geminiResponse, request.Model)
+		if ct != nil {
+			ct.EndSpan(ch, schemas.SpanStatusOk, "")
+		}
+		if bifrostResponse == nil {
+			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, fmt.Errorf("failed to convert Gemini embedding response to Bifrost format")), jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
+		}
+	} else {
+		// Legacy :predict response shape (predictions[].embeddings).
+		var vertexResponse VertexEmbeddingResponse
+		pt, ph := providerUtils.StartResponseParseSpan(ctx)
+		umErr := sonic.Unmarshal(responseBody, &vertexResponse)
+		if pt != nil {
+			if umErr != nil {
+				pt.EndSpan(ph, schemas.SpanStatusError, "response parse failed")
+			} else {
+				pt.EndSpan(ph, schemas.SpanStatusOk, "")
+			}
+		}
+		if umErr != nil {
+			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, umErr), jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
+		}
+		ct, ch := providerUtils.StartResponseConvertorSpan(ctx)
+		bifrostResponse = vertexResponse.ToBifrostEmbeddingResponse()
+		if ct != nil {
+			ct.EndSpan(ch, schemas.SpanStatusOk, "")
+		}
+		if bifrostResponse == nil {
+			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, fmt.Errorf("failed to convert Vertex embedding response to Bifrost format")), jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
+		}
 	}
 
 	// Set ExtraFields
@@ -1854,8 +1919,8 @@ func (provider *VertexProvider) Embedding(ctx *schemas.BifrostContext, key schem
 	// Set raw response if enabled
 	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
 		var rawResponseMap map[string]interface{}
-		if err := sonic.Unmarshal(resp.Body(), &rawResponseMap); err != nil {
-			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderRawResponseUnmarshal, err), jsonBody, resp.Body(), provider.sendBackRawRequest, provider.sendBackRawResponse)
+		if err := sonic.Unmarshal(responseBody, &rawResponseMap); err != nil {
+			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderRawResponseUnmarshal, err), jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
 		}
 		bifrostResponse.ExtraFields.RawResponse = rawResponseMap
 	}


### PR DESCRIPTION
## Summary
Fixes https://github.com/maximhq/bifrost/issues/5003.

Vertex `Embedding` always called the legacy prediction API:

- URL: `…/models/{model}:predict`
- Body: `{ "instances": [ { "content": "…" } ], "parameters": … }`

That works for `text-embedding-004` / multilingual embedding models, but **Gemini-native** embedding models (`gemini-embedding-001`, `gemini-embedding-2`, …) expect the Generative Language embedding surface:

- URL: `…/models/{model}:batchEmbedContents`
- Body: `{ "requests": [ { "model": "projects/…/locations/…/publishers/google/models/…", "content": { "parts": […] } } ] }`

Calling them with `:predict` returns **400 Precondition check failed**.

This also breaks GenAI `POST /genai/v1beta/models/{model}:embedContent`, because the transport classifies `:embedContent` as `EmbeddingRequest` and routes through the same Vertex `Embedding` method (it does **not** stay on raw passthrough).

## Change
- Detect `gemini-embedding*` models (`usesGeminiEmbedContentAPI`)
- For those models:
  - build Gemini batch body (reuse `gemini.ToGeminiEmbeddingRequest`)
  - rewrite each request's `model` to a **fully-qualified** Vertex publisher resource name
  - call `:batchEmbedContents` via model-aware publisher URL (supports `rep.googleapis.com` multi-region promotion)
  - parse `gemini.GeminiEmbeddingResponse` → Bifrost embedding response
- Leave legacy `:predict` path unchanged for all other embedding models

## Test plan
- [x] Unit tests: model detection, FQ model in batch body, legacy instances shape, URL method suffix
- [x] `go test ./providers/vertex/`
- [ ] Live: `POST /v1/embeddings` with `model=gemini-embedding-2`
- [ ] Live: GenAI `…/models/gemini-embedding-2:embedContent` with `x-model-provider: vertex`
- [ ] Regression: `text-embedding-004` still works via `:predict`
