### PR TITLE
test: add e2e tests for virtual key budget override set/remove

### DIFF
--- a/tests/e2e/api/collections/bifrost-api-management.postman_collection.json
+++ b/tests/e2e/api/collections/bifrost-api-management.postman_collection.json
@@ -1936,6 +1936,16 @@
       "key": "webhook_name",
       "value": "",
       "type": "string"
+    },
+    {
+      "key": "vk_budget_id",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "vk_budget_max_limit",
+      "value": "",
+      "type": "string"
     }
   ],
   "item": [
@@ -3176,6 +3186,8 @@
                   "        pm.expect(vk.budgets).to.be.an('array').with.length.greaterThan(0);",
                   "        pm.expect(vk.rate_limit).to.be.an('object');",
                   "        pm.expect(vk.provider_configs).to.be.an('array').with.length.greaterThan(0);",
+                  "        pm.collectionVariables.set('vk_budget_id', String(vk.budgets[0].id));",
+                  "        pm.collectionVariables.set('vk_budget_max_limit', String(vk.budgets[0].max_limit));",
                   "    });",
                   "}"
                 ],
@@ -3363,6 +3375,138 @@
                 "governance",
                 "virtual-keys",
                 "{{vk_id}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Set Virtual Key Budget Override",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "// This mutates a real budget, so it must never fall back to placeholder ids:",
+                  "// skip unless the create above captured the VK and its budget.",
+                  "var missing = ['vk_id', 'vk_budget_id', 'vk_budget_max_limit'].filter(function (key) {",
+                  "  return !pm.collectionVariables.get(key);",
+                  "});",
+                  "if (missing.length && typeof pm.execution !== 'undefined' && pm.execution.skipRequest) {",
+                  "  pm.execution.skipRequest();",
+                  "}",
+                  "pm.collectionVariables.set('vk_override_amount', '7.5');",
+                  "pm.request.body.raw = JSON.stringify({ amount: 7.5, mode: 'forever' });"
+                ],
+                "type": "text/javascript"
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Virtual key budget override is applied', function () {",
+                  "    pm.expect(pm.response.code, pm.response.text().slice(0, 300)).to.be.within(200, 299);",
+                  "    var body = pm.response.json();",
+                  "    pm.expect(body).to.have.property('budget');",
+                  "    pm.expect(body.budget.override_mode).to.equal('forever');",
+                  "    pm.expect(Number(body.budget.override_amount)).to.equal(7.5);",
+                  "});",
+                  "",
+                  "pm.test('Override raises the effective limit above the base budget', function () {",
+                  "    var body = pm.response.json();",
+                  "    var base = Number(pm.collectionVariables.get('vk_budget_max_limit'));",
+                  "    pm.expect(Number(body.effective_max_limit)).to.be.above(base);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk_id}}/budgets/{{vk_budget_id}}/override",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk_id}}",
+                "budgets",
+                "{{vk_budget_id}}",
+                "override"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Remove Virtual Key Budget Override",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "// Mirrors the guard on the Set request: no placeholder ids reach a real budget.",
+                  "var missing = ['vk_id', 'vk_budget_id', 'vk_budget_max_limit'].filter(function (key) {",
+                  "  return !pm.collectionVariables.get(key);",
+                  "});",
+                  "if (missing.length && typeof pm.execution !== 'undefined' && pm.execution.skipRequest) {",
+                  "  pm.execution.skipRequest();",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Virtual key budget override is cleared', function () {",
+                  "    pm.expect(pm.response.code, pm.response.text().slice(0, 300)).to.be.within(200, 299);",
+                  "    var body = pm.response.json();",
+                  "    pm.expect(body).to.have.property('budget');",
+                  "    pm.expect(body.budget.override_mode || '').to.equal('');",
+                  "    pm.expect(Number(body.budget.override_amount || 0)).to.equal(0);",
+                  "});",
+                  "",
+                  "pm.test('Effective limit falls back to the base budget', function () {",
+                  "    var body = pm.response.json();",
+                  "    var base = Number(pm.collectionVariables.get('vk_budget_max_limit'));",
+                  "    pm.expect(Number(body.effective_max_limit)).to.equal(base);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk_id}}/budgets/{{vk_budget_id}}/override",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk_id}}",
+                "budgets",
+                "{{vk_budget_id}}",
+                "override"
               ]
             }
           }

--- a/tests/e2e/api/collections/collection-scripts.test.mjs
+++ b/tests/e2e/api/collections/collection-scripts.test.mjs
@@ -209,6 +209,62 @@ test("webhook capture still records the id on success", () => {
   assert.strictEqual(ctx.vars.webhook_id, "wh-1");
 });
 
+// ── Governance / Virtual key budget override ──────────────────────────────────
+// These two requests mutate a real budget, so they must not run against fallback
+// placeholder ids. A non-empty collection-variable default defeats a `!get(...)`
+// skip guard, which would send the override to a made-up budget instead of skipping.
+function collectionVariable(key) {
+  const entry = (collection.variable || []).find((v) => v.key === key);
+  assert.ok(entry, `collection variable not declared: ${key}`);
+  return entry.value;
+}
+
+for (const key of ["vk_budget_id", "vk_budget_max_limit"]) {
+  test(`${key} defaults to empty so the skip guard can fire`, () => {
+    assert.strictEqual(
+      collectionVariable(key),
+      "",
+      "a non-empty default makes the guard's truthiness check always pass",
+    );
+  });
+}
+
+const OVERRIDE_REQUESTS = [
+  "Governance - Virtual Keys / Set Virtual Key Budget Override",
+  "Governance - Virtual Keys / Remove Virtual Key Budget Override",
+];
+
+for (const path of OVERRIDE_REQUESTS) {
+  const prerequest = scriptFor(path, "prerequest");
+  const captured = {
+    vk_id: "vk-real",
+    vk_budget_id: "budget-real",
+    vk_budget_max_limit: "100",
+  };
+
+  for (const missing of ["vk_id", "vk_budget_id", "vk_budget_max_limit"]) {
+    test(`${path.split(" / ")[1]} skips when ${missing} was not captured`, () => {
+      const ctx = run(prerequest, {
+        variables: { ...captured, [missing]: "" },
+      });
+      assert.strictEqual(ctx.state.skipped, true, `expected skipRequest() with no ${missing}`);
+    });
+  }
+
+  test(`${path.split(" / ")[1]} runs when every id was captured`, () => {
+    const ctx = run(prerequest, { variables: { ...captured } });
+    assert.strictEqual(ctx.state.skipped, false, "should not skip a fully captured run");
+  });
+}
+
+test("Set Virtual Key Budget Override still builds its request body", () => {
+  const ctx = run(scriptFor(OVERRIDE_REQUESTS[0], "prerequest"), {
+    variables: { vk_id: "vk-real", vk_budget_id: "budget-real", vk_budget_max_limit: "100" },
+  });
+  assert.deepStrictEqual(JSON.parse(ctx.pm.request.body.raw), { amount: 7.5, mode: "forever" });
+  assert.strictEqual(ctx.vars.vk_override_amount, "7.5");
+});
+
 // ── Collection-level status gate ──────────────────────────────────────────────
 // README.md documents which statuses this gate lets through, including the named
 // requests that are allowed a non-2xx without a "(Coverage Probe)" suffix. Pin


### PR DESCRIPTION
## Summary

Adds end-to-end API tests for the virtual key budget override endpoints, covering both applying and removing a budget override on a virtual key.

## Changes

- Added `vk_budget_id` and `vk_budget_max_limit` as collection variables, populated dynamically from the first budget returned when fetching a virtual key.
- Added a **Set Virtual Key Budget Override** test (`PUT /api/governance/virtual-keys/{vk_id}/budgets/{vk_budget_id}/override`) that applies an override of `7.5` with mode `forever` and asserts the response contains the correct `override_mode`, `override_amount`, and that the `effective_max_limit` is raised above the base budget.
- Added a **Remove Virtual Key Budget Override** test (`DELETE /api/governance/virtual-keys/{vk_id}/budgets/{vk_budget_id}/override`) that clears the override and asserts `override_mode` and `override_amount` are empty/zero, and that `effective_max_limit` falls back to the original base budget value.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the Postman collection against a running Bifrost instance:

```sh
newman run tests/e2e/api/collections/bifrost-api-management.postman_collection.json \
  --env-var base_url=http://localhost:8080
```

The **Set Virtual Key Budget Override** and **Remove Virtual Key Budget Override** requests will execute after the virtual key fetch step, which populates `vk_budget_id` and `vk_budget_max_limit`. Both requests will be skipped automatically if no budget ID is available.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. Tests exercise existing governance endpoints using collection-scoped variables only.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable