### PR TITLE
chore: update helm-charts doc for env var reference fixes for Datadog

### DIFF
--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -12,6 +12,7 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
 
 - Added `traces_enabled` to OTEL config (single-profile and `profiles[*]`). When `false`, no traces are exported and `collector_url` is not required, giving a metrics-only profile. Renders into `traces_enabled`; defaults to `true`.
 - Added `trace_headers` and `metrics_headers` to OTEL config (single-profile and `profiles[*]`). Common `headers` still go to both endpoints; these are overlaid on top for the trace / metrics endpoint respectively (same key wins), e.g. a Databricks table name required only on metrics. Render into `trace_headers` / `metrics_headers`.
+- - Documented `env.VAR_NAME` support for the Datadog plugin service-identity fields `bifrost.plugins.datadog.config.service_name`, `ml_app`, `env`, and `version` (render into `service_name`, `ml_app`, `env`, `version`). Values already passed through; this only adds the env-reference guidance to `values.yaml` comments and `values.schema.json` descriptions.
 
 
 ### 2.1.34

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -2673,12 +2673,12 @@
                   "properties": {
                     "service_name": {
                       "type": "string",
-                      "description": "Name of the service to report to Datadog (supports env.VAR_NAME references)",
+                      "description": "Name of the service to report to Datadog (can use env. prefix)",
                       "default": "bifrost"
                     },
                     "ml_app": {
                       "type": "string",
-                      "description": "ML application name for LLM Observability grouping (defaults to service_name, supports env.VAR_NAME references)"
+                      "description": "ML application name for LLM Observability grouping (defaults to service_name, can use env. prefix)"
                     },
                     "agent_addr": {
                       "type": "string",
@@ -2710,11 +2710,11 @@
                     },
                     "env": {
                       "type": "string",
-                      "description": "Environment tag (e.g., production or staging; supports env.VAR_NAME references)"
+                      "description": "Environment tag (e.g., production, staging, can use env. prefix)"
                     },
                     "version": {
                       "type": "string",
-                      "description": "Service version tag (supports env.VAR_NAME references)"
+                      "description": "Service version tag (can use env. prefix)"
                     },
                     "custom_tags": {
                       "type": "object",


### PR DESCRIPTION
## Summary

Documents `env.VAR_NAME` substitution support for the Datadog plugin's service-identity fields (`service_name`, `ml_app`, `env`, `version`). These fields already supported environment variable references at runtime; this PR makes that capability visible through inline comments in `values.yaml` and descriptions in both `values.schema.json` and `transports/config.schema.json`.

## Changes

- Added `env.VAR_NAME` guidance to `values.yaml` comments for `service_name`, `env`, `version`, and `ml_app` Datadog config fields
- Added or updated `description` fields in `values.schema.json` for `service_name`, `env`, and `version` to document env-reference support (matching the existing pattern already used for `agent_addr`, `dogstatsd_host`, etc.)
- Updated `transports/config.schema.json` descriptions for `service_name`, `ml_app`, `env`, and `version` to note the `env.` prefix capability
- Added an `Upcoming` changelog entry in `README.md` describing the documentation addition

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

No behavioral changes were made. To validate:

1. Confirm Helm schema validation still passes with existing and new `values.yaml` configurations.
2. Set a Datadog plugin field using the `env.VAR_NAME` pattern (e.g. `service_name: "env.BIFROST_DD_SERVICE"`) and verify the value resolves correctly at runtime as it did before this change.

```sh
helm lint helm-charts/bifrost
helm template bifrost helm-charts/bifrost --values helm-charts/bifrost/values.yaml
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. No new secrets, auth flows, or PII handling introduced.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable