### PR TITLE
docs: update docs for DD env var references

### DIFF
--- a/docs/features/observability/datadog.mdx
+++ b/docs/features/observability/datadog.mdx
@@ -63,16 +63,16 @@ Datadog officially supports agentless submission for [LLM Observability](https:/
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `service_name` | `string` | No | `bifrost` | Service name displayed in Datadog APM |
-| `ml_app` | `string` | No | (uses `service_name`) | ML application name for LLM Observability grouping |
+| `service_name` | `string` | No | `bifrost` | Service name displayed in Datadog APM (supports `env.VAR_NAME`) |
+| `ml_app` | `string` | No | (uses `service_name`) | ML application name for LLM Observability grouping (supports `env.VAR_NAME`) |
 | `agent_addr` | `string` | No | `localhost:8126` | Datadog Agent address as combined `host:port` (agent mode only, supports `env.VAR_NAME`). Overridden by `agent_host` when set |
 | `agent_host` | `string` | No | - | Datadog Agent host, set separately from the port (agent mode only, supports `env.VAR_NAME`). Takes precedence over `agent_addr` |
 | `agent_port` | `string` | No | `8126` | Datadog Agent port, used with `agent_host` (agent mode only, supports `env.VAR_NAME`) |
 | `dogstatsd_addr` | `string` | No | `localhost:8125` | DogStatsD server address as combined `host:port` (agent mode only, supports `env.VAR_NAME`). Overridden by `dogstatsd_host` when set |
 | `dogstatsd_host` | `string` | No | - | DogStatsD server host, set separately from the port (agent mode only, supports `env.VAR_NAME`). Takes precedence over `dogstatsd_addr` |
 | `dogstatsd_port` | `string` | No | `8125` | DogStatsD server port, used with `dogstatsd_host` (agent mode only, supports `env.VAR_NAME`) |
-| `env` | `string` | No | - | Environment tag (e.g., `production`, `staging`) |
-| `version` | `string` | No | - | Service version tag |
+| `env` | `string` | No | - | Environment tag (e.g., `production`, `staging`) (supports `env.VAR_NAME`) |
+| `version` | `string` | No | - | Service version tag (supports `env.VAR_NAME`) |
 | `custom_tags` | `object` | No | - | Additional tags for all traces and metrics |
 | `enable_metrics` | `bool` | No | `true` | Enable metrics emission |
 | `enable_traces` | `bool` | No | `true` | Enable APM traces |
@@ -86,10 +86,13 @@ Datadog officially supports agentless submission for [LLM Observability](https:/
 
 ### Environment Variable Substitution
 
-The `api_key`, `agent_addr`, `agent_host`, `agent_port`, `dogstatsd_addr`, `dogstatsd_host`, `dogstatsd_port`, and `custom_tags` fields support environment variable substitution using the `env.` prefix:
+The `service_name`, `ml_app`, `env`, `version`, `api_key`, `agent_addr`, `agent_host`, `agent_port`, `dogstatsd_addr`, `dogstatsd_host`, `dogstatsd_port`, and `custom_tags` fields support environment variable substitution using the `env.` prefix:
 
 ```json
 {
+  "service_name": "env.BIFROST_DD_SERVICE",
+  "env": "env.BIFROST_DD_ENV",
+  "version": "env.BIFROST_DD_VERSION",
   "api_key": "env.DD_API_KEY",
   "agent_addr": "env.DD_AGENT_ADDR",
   "dogstatsd_addr": "env.DD_DOGSTATSD_ADDR",

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -12,6 +12,7 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
 
 - Added `traces_enabled` to OTEL config (single-profile and `profiles[*]`). When `false`, no traces are exported and `collector_url` is not required, giving a metrics-only profile. Renders into `traces_enabled`; defaults to `true`.
 - Added `trace_headers` and `metrics_headers` to OTEL config (single-profile and `profiles[*]`). Common `headers` still go to both endpoints; these are overlaid on top for the trace / metrics endpoint respectively (same key wins), e.g. a Databricks table name required only on metrics. Render into `trace_headers` / `metrics_headers`.
+- - Documented `env.VAR_NAME` support for the Datadog plugin service-identity fields `bifrost.plugins.datadog.config.service_name`, `ml_app`, `env`, and `version` (render into `service_name`, `ml_app`, `env`, `version`). Values already passed through; this only adds the env-reference guidance to `values.yaml` comments and `values.schema.json` descriptions.
 
 
 ### 2.1.34

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -2673,12 +2673,12 @@
                   "properties": {
                     "service_name": {
                       "type": "string",
-                      "description": "Name of the service to report to Datadog (supports env.VAR_NAME references)",
+                      "description": "Name of the service to report to Datadog (can use env. prefix)",
                       "default": "bifrost"
                     },
                     "ml_app": {
                       "type": "string",
-                      "description": "ML application name for LLM Observability grouping (defaults to service_name, supports env.VAR_NAME references)"
+                      "description": "ML application name for LLM Observability grouping (defaults to service_name, can use env. prefix)"
                     },
                     "agent_addr": {
                       "type": "string",
@@ -2710,11 +2710,11 @@
                     },
                     "env": {
                       "type": "string",
-                      "description": "Environment tag (e.g., production or staging; supports env.VAR_NAME references)"
+                      "description": "Environment tag (e.g., production, staging, can use env. prefix)"
                     },
                     "version": {
                       "type": "string",
-                      "description": "Service version tag (supports env.VAR_NAME references)"
+                      "description": "Service version tag (can use env. prefix)"
                     },
                     "custom_tags": {
                       "type": "object",


### PR DESCRIPTION
## Summary

Extends environment variable substitution support to the `service_name`, `ml_app`, `env`, and `version` fields in the Datadog integration configuration, allowing these values to be sourced dynamically from environment variables at runtime.

## Changes

- Added `env.VAR_NAME` support notation to the `service_name`, `ml_app`, `env`, and `version` fields in the configuration reference table
- Updated the Environment Variable Substitution section to include `service_name`, `ml_app`, `env`, and `version` in the list of supported fields
- Added example usage of `env.BIFROST_DD_SERVICE`, `env.BIFROST_DD_ENV`, and `env.BIFROST_DD_VERSION` in the JSON code snippet

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the updated Datadog observability documentation to confirm the configuration table and environment variable substitution section accurately reflect the supported fields and example usage.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. This change only updates documentation to reflect existing or newly supported environment variable substitution behavior, which helps avoid hardcoding sensitive or environment-specific values in configuration files.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable