### PR TITLE
feat: add otlp log export of genai events to otel plugin

### DIFF
--- a/.github/workflows/configs/withobservability/config.json
+++ b/.github/workflows/configs/withobservability/config.json
@@ -22,7 +22,9 @@
           "service_name": "bifrost",
           "collector_url": "http://localhost:4318/v1/traces",
           "trace_type": "genai_extension",
-          "protocol": "http"
+          "protocol": "http",
+          "logs_enabled": true,
+          "logs_endpoint": "http://localhost:4318/v1/logs"
         }
       }
     ]

--- a/framework/tracing/llmspan.go
+++ b/framework/tracing/llmspan.go
@@ -1417,6 +1417,10 @@ type MessageSummary struct {
 	ReasoningDetails []ReasoningDetailSummary `json:"reasoning_details,omitempty"`
 	Audio            *AudioSummary            `json:"audio,omitempty"`
 	Refusal          string                   `json:"refusal,omitempty"`
+	// ToolCallID links a role:"tool" message back to the assistant tool call it answers.
+	// Required to render a tool_call_response part when re-encoding these summaries into
+	// GenAI semconv event payloads (the OTEL plugin's log export).
+	ToolCallID string `json:"tool_call_id,omitempty"`
 }
 
 // ToolCallSummary represents a summarized tool call for tracing
@@ -1480,6 +1484,12 @@ func extractMessageSummary(msg *schemas.ChatMessage) MessageSummary {
 
 	if msg.Role != "" {
 		summary.Role = string(msg.Role)
+	}
+
+	// Extract tool-result linkage (role: "tool") so the message can be paired with the
+	// assistant tool call it responds to.
+	if msg.ChatToolMessage != nil && msg.ChatToolMessage.ToolCallID != nil {
+		summary.ToolCallID = *msg.ChatToolMessage.ToolCallID
 	}
 
 	// Extract assistant-specific fields

--- a/plugins/otel/logclient.go
+++ b/plugins/otel/logclient.go
@@ -1,0 +1,147 @@
+package otel
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	collectorlogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
+)
+
+// OtelLogClient ships OTLP log records (GenAI events) to a collector. It mirrors
+// OtelClient rather than reusing it because logs go to their own endpoint and use the
+// logs service, but the transport behaviour (timeout, TLS, headers) is identical.
+type OtelLogClient interface {
+	EmitLogs(ctx context.Context, logs []*ResourceLog) error
+	Close() error
+}
+
+// OtelLogClientHTTP exports log records over OTLP/HTTP (protobuf).
+type OtelLogClientHTTP struct {
+	client   *http.Client
+	endpoint string
+	headers  map[string]string
+}
+
+// NewOtelLogClientHTTP creates a new OTLP logs client for HTTP.
+// timeout bounds a single export; it comes from the profile's export_timeout and is
+// also applied as a per-export context deadline by the caller.
+func NewOtelLogClientHTTP(endpoint string, headers map[string]string, tlsCACert string, insecureMode bool, timeout time.Duration) (*OtelLogClientHTTP, error) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConns = 100
+	transport.MaxIdleConnsPerHost = 10
+	transport.IdleConnTimeout = 120 * time.Second
+
+	tlsConfig, err := buildTLSConfig(tlsCACert, insecureMode)
+	if err != nil {
+		return nil, err
+	}
+	transport.TLSClientConfig = tlsConfig
+
+	return &OtelLogClientHTTP{client: &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+	}, endpoint: endpoint, headers: headers}, nil
+}
+
+// EmitLogs sends log records to the OpenTelemetry collector
+func (c *OtelLogClientHTTP) EmitLogs(ctx context.Context, logs []*ResourceLog) error {
+	payload, err := proto.Marshal(&collectorlogspb.ExportLogsServiceRequest{ResourceLogs: logs})
+	if err != nil {
+		logger.Error("[otel] failed to marshal logs: %v", err)
+		return err
+	}
+	var body bytes.Buffer
+	body.Write(payload)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, &body)
+	if err != nil {
+		logger.Error("[otel] failed to create logs request: %v", err)
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	if c.headers != nil {
+		for key, value := range c.headers {
+			if strings.ToLower(key) == "content-type" {
+				continue
+			}
+			req.Header.Set(key, value)
+		}
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		logger.Error("[otel] failed to send logs request to %s: %v", c.endpoint, err)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		// Discard the body to avoid leaking memory
+		_, _ = io.Copy(io.Discard, resp.Body)
+		logger.Error("[otel] collector at %s returned status %s for logs", c.endpoint, resp.Status)
+		return fmt.Errorf("collector returned %s", resp.Status)
+	}
+	logger.Debug("[otel] successfully sent logs to %s, status: %s", c.endpoint, resp.Status)
+	return nil
+}
+
+// Close closes the HTTP client
+func (c *OtelLogClientHTTP) Close() error {
+	if c.client != nil {
+		c.client.CloseIdleConnections()
+	}
+	return nil
+}
+
+// OtelLogClientGRPC exports log records over OTLP/gRPC.
+type OtelLogClientGRPC struct {
+	client  collectorlogspb.LogsServiceClient
+	conn    *grpc.ClientConn
+	headers map[string]string
+}
+
+// NewOtelLogClientGRPC creates a new OTLP logs client for gRPC
+func NewOtelLogClientGRPC(endpoint string, headers map[string]string, tlsCACert string, insecureMode bool) (*OtelLogClientGRPC, error) {
+	var creds credentials.TransportCredentials
+
+	// gRPC insecure mode uses plaintext (no TLS at all), not just skip-verify.
+	// buildTLSConfig is bypassed here to preserve that behaviour.
+	if tlsCACert == "" && insecureMode {
+		creds = insecure.NewCredentials()
+	} else {
+		tlsConfig, err := buildTLSConfig(tlsCACert, false)
+		if err != nil {
+			return nil, err
+		}
+		creds = credentials.NewTLS(tlsConfig)
+	}
+	conn, err := grpc.NewClient(endpoint, grpc.WithTransportCredentials(creds))
+	if err != nil {
+		return nil, err
+	}
+	return &OtelLogClientGRPC{client: collectorlogspb.NewLogsServiceClient(conn), conn: conn, headers: headers}, nil
+}
+
+// EmitLogs sends log records to the OpenTelemetry collector
+func (c *OtelLogClientGRPC) EmitLogs(ctx context.Context, logs []*ResourceLog) error {
+	if c.headers != nil {
+		ctx = metadata.NewOutgoingContext(ctx, metadata.New(c.headers))
+	}
+	_, err := c.client.Export(ctx, &collectorlogspb.ExportLogsServiceRequest{ResourceLogs: logs})
+	return err
+}
+
+// Close closes the gRPC connection
+func (c *OtelLogClientGRPC) Close() error {
+	if c.conn != nil {
+		return c.conn.Close()
+	}
+	return nil
+}

--- a/plugins/otel/logconverter.go
+++ b/plugins/otel/logconverter.go
@@ -1,0 +1,418 @@
+package otel
+
+import (
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/tracing"
+	logspb "go.opentelemetry.io/proto/otlp/logs/v1"
+	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+)
+
+// GenAI events semantic conventions.
+// Source: https://github.com/open-telemetry/semantic-conventions-genai (docs/gen-ai/gen-ai-events.md).
+// Everything below is Development stability — attribute names may change with semconv releases.
+const (
+	// EventNameInferenceDetails is the single event emitted per inference operation. It
+	// replaces the removed per-message events (gen_ai.system.message, gen_ai.choice, ...).
+	EventNameInferenceDetails = "gen_ai.client.inference.operation.details"
+
+	// Event-only attribute names. Everything else is copied from the span verbatim.
+	attrSystemInstructions = "gen_ai.system_instructions"
+	attrToolDefinitions    = "gen_ai.tool.definitions"
+	attrConversationID     = "gen_ai.conversation.id"
+
+	// Semconv message part types.
+	partTypeText             = "text"
+	partTypeToolCall         = "tool_call"
+	partTypeToolCallResponse = "tool_call_response"
+	partTypeReasoning        = "reasoning"
+	partTypeRefusal          = "refusal"
+)
+
+// logRecordFlagsSampled is the W3C "sampled" bit within LOG_RECORD_FLAGS_TRACE_FLAGS_MASK.
+// Bifrost hands completed traces to connectors only for requests it already decided to
+// record, so every emitted event is sampled.
+const logRecordFlagsSampled uint32 = 0x01
+
+// contentAttrsHandledStructurally are the content attributes the event carries in
+// structured form under a semconv name, so the generic attribute copy must skip them.
+var contentAttrsHandledStructurally = map[string]struct{}{
+	schemas.AttrInputMessages:  {},
+	schemas.AttrOutputMessages: {},
+	schemas.AttrInstructions:   {},
+	schemas.AttrTools:          {},
+	schemas.AttrRespTools:      {},
+}
+
+// convertTraceToResourceLogs builds the GenAI events for one completed trace: one
+// gen_ai.client.inference.operation.details log record per exported llm.call span,
+// correlated to that span via trace_id/span_id. Returns nil when the trace holds no
+// exportable LLM span, so the caller can skip the export entirely.
+func (p *OtelPlugin) convertTraceToResourceLogs(serviceName string, trace *schemas.Trace, target *otelTarget) *ResourceLog {
+	if trace == nil {
+		return nil
+	}
+
+	sessionID := getStringAttr(trace.Attributes, schemas.TraceAttrSessionID)
+
+	// Use the same trace ID the span exporter would use, so events and spans agree even
+	// when requests are grouped into a session-derived trace.
+	traceID := trace.TraceID
+	if target.groupTracesBySession && sessionID != "" && trace.RootSpan != nil && trace.RootSpan.ParentID == "" {
+		traceID = sessionTraceID(sessionID)
+	}
+
+	// Attributes that only ever live on the root span (or the trace) are copied onto every
+	// event, so each log record is self-describing for backends that only ingest logs.
+	sharedAttrs := p.buildSharedLogAttrs(trace, target, sessionID)
+
+	observedTime := uint64(time.Now().UnixNano())
+	records := make([]*LogRecord, 0, len(trace.Spans))
+	for _, span := range trace.Spans {
+		if span == nil || span.Kind != schemas.SpanKindLLMCall {
+			continue
+		}
+		if !p.pluginSpanFilter.ShouldExportSpan(span) {
+			continue
+		}
+		records = append(records, buildInferenceEvent(traceID, span, target, sharedAttrs, observedTime))
+	}
+	if len(records) == 0 {
+		return nil
+	}
+
+	return &ResourceLog{
+		Resource: &resourcepb.Resource{
+			Attributes: p.getResourceAttributes(serviceName),
+		},
+		ScopeLogs: []*ScopeLog{{
+			Scope:      p.getInstrumentationScope(serviceName),
+			LogRecords: records,
+		}},
+	}
+}
+
+// buildSharedLogAttrs collects the trace/root-level enrichment attached to every event:
+// session and request identity, instance attributes, and captured request headers.
+func (p *OtelPlugin) buildSharedLogAttrs(trace *schemas.Trace, target *otelTarget, sessionID string) []*KeyValue {
+	attrs := make([]*KeyValue, 0, 8)
+	if sessionID != "" {
+		attrs = append(attrs, kvStr("session.id", sessionID))
+		// Only a caller-supplied x-bf-session-id counts as a conversation; Bifrost never
+		// synthesizes one.
+		attrs = append(attrs, kvStr(attrConversationID, sessionID))
+	}
+	if requestID := trace.GetRequestID(); requestID != "" {
+		attrs = append(attrs, kvStr(schemas.AttrBifrostRequestID, requestID))
+	}
+	attrs = append(attrs, p.instanceAttrs...)
+	for k, v := range schemas.FilterHeaders(trace.RequestHeaders, target.requestHeaders) {
+		attrs = append(attrs, kvStr("http.request.header."+k, v))
+	}
+	return attrs
+}
+
+// buildInferenceEvent converts one llm.call span into a GenAI inference event.
+func buildInferenceEvent(traceID string, span *schemas.Span, target *otelTarget, sharedAttrs []*KeyValue, observedTime uint64) *LogRecord {
+	timestamp := observedTime
+	if !span.EndTime.IsZero() {
+		timestamp = uint64(span.EndTime.UnixNano())
+	}
+
+	record := &LogRecord{
+		TimeUnixNano:         timestamp,
+		ObservedTimeUnixNano: observedTime,
+		EventName:            EventNameInferenceDetails,
+		TraceId:              hexToBytes(traceID, 16),
+		SpanId:               hexToBytes(span.SpanID, 8),
+		Flags:                logRecordFlagsSampled,
+		Attributes:           buildEventAttributes(span, target, sharedAttrs),
+		// Body stays unset: the convention carries everything in attributes.
+	}
+
+	// A failed call is an ERROR-severity event so log backends can alert on it without
+	// parsing attributes.
+	if getStringAttr(span.Attributes, schemas.AttrErrorTypeSpec) != "" {
+		record.SeverityNumber = logspb.SeverityNumber_SEVERITY_NUMBER_ERROR
+		record.SeverityText = "ERROR"
+	} else {
+		record.SeverityNumber = logspb.SeverityNumber_SEVERITY_NUMBER_INFO
+		record.SeverityText = "INFO"
+	}
+
+	return record
+}
+
+// buildEventAttributes assembles the event's attributes: every span attribute (metadata
+// plus Bifrost extras) verbatim, with the content attributes re-encoded into the
+// structured semconv shapes. Content is dropped entirely when the profile sets
+// logs_disable_content_logging — note this is the logs-specific switch; the trace-level
+// disable_content_logging continues to gate spans only.
+func buildEventAttributes(span *schemas.Span, target *otelTarget, sharedAttrs []*KeyValue) []*KeyValue {
+	attrs := span.Attributes
+	kvs := make([]*KeyValue, 0, len(attrs)+len(sharedAttrs))
+
+	for k, v := range attrs {
+		// Overhead is computed for the logs DB only; it never rides an export.
+		if k == schemas.AttrBifrostOverheadDurationMs {
+			continue
+		}
+		if _, structured := contentAttrsHandledStructurally[k]; structured {
+			continue
+		}
+		if target.logsDisableContentLogging && schemas.IsContentAttribute(k) {
+			continue
+		}
+		if kv := anyToKeyValue(k, v); kv != nil {
+			kvs = append(kvs, kv)
+		}
+	}
+
+	if !target.logsDisableContentLogging {
+		kvs = append(kvs, buildContentAttributes(attrs)...)
+	}
+
+	return append(kvs, sharedAttrs...)
+}
+
+// buildContentAttributes re-encodes the span's JSON-string content attributes into the
+// structured (nested AnyValue) form events require. Anything that fails to parse falls
+// back to the raw value as a plain attribute — an event with degraded content beats no
+// event at all.
+func buildContentAttributes(attrs map[string]any) []*KeyValue {
+	out := make([]*KeyValue, 0, 4)
+
+	if raw, ok := attrs[schemas.AttrInputMessages]; ok {
+		out = appendContentAttr(out, schemas.AttrInputMessages, raw, messagesToAnyValue(raw, nil))
+	}
+	if raw, ok := attrs[schemas.AttrOutputMessages]; ok {
+		out = appendContentAttr(out, schemas.AttrOutputMessages, raw, messagesToAnyValue(raw, finishReasonsFromAttrs(attrs)))
+	}
+	if instructions := getStringAttr(attrs, schemas.AttrInstructions); instructions != "" {
+		// System instructions are a list of message parts, not a bare string.
+		out = append(out, kvAny(attrSystemInstructions, arrValue(
+			listValue(kvStr("type", partTypeText), kvStr("content", instructions)),
+		)))
+	}
+	// The Responses API echoes the tool set back on the response; either source describes
+	// the same definitions, so whichever is present wins (request first).
+	toolsRaw, ok := attrs[schemas.AttrTools]
+	if !ok {
+		toolsRaw, ok = attrs[schemas.AttrRespTools]
+	}
+	if ok {
+		out = appendContentAttr(out, attrToolDefinitions, toolsRaw, toolDefinitionsToAnyValue(toolsRaw))
+	}
+
+	return out
+}
+
+// appendContentAttr appends the structured encoding under key, falling back to the raw
+// span value when structured encoding was not possible.
+func appendContentAttr(out []*KeyValue, key string, raw any, structured *AnyValue) []*KeyValue {
+	if structured != nil {
+		return append(out, kvAny(key, structured))
+	}
+	if kv := anyToKeyValue(key, raw); kv != nil {
+		return append(out, kv)
+	}
+	return out
+}
+
+// finishReasonsFromAttrs reads the response finish reasons, preferring the array form and
+// falling back to the singular attribute.
+func finishReasonsFromAttrs(attrs map[string]any) []string {
+	if reasons := getStringSliceAttr(attrs, schemas.AttrFinishReasons); len(reasons) > 0 {
+		return reasons
+	}
+	if reason := getStringAttr(attrs, schemas.AttrFinishReason); reason != "" {
+		return []string{reason}
+	}
+	return nil
+}
+
+// messagesToAnyValue converts a span's JSON-string message summary into the semconv
+// message schema: a list of {role, parts[, finish_reason]}. finishReasons is non-nil for
+// output messages and is applied positionally. Returns nil when the value is not a
+// parseable message list, letting the caller fall back to the raw attribute.
+func messagesToAnyValue(raw any, finishReasons []string) *AnyValue {
+	jsonStr, ok := raw.(string)
+	if !ok || jsonStr == "" {
+		return nil
+	}
+	var messages []tracing.MessageSummary
+	if err := sonic.UnmarshalString(jsonStr, &messages); err != nil || len(messages) == 0 {
+		return nil
+	}
+
+	values := make([]*AnyValue, 0, len(messages))
+	for i, msg := range messages {
+		fields := []*KeyValue{kvStr("role", messageRole(msg, finishReasons != nil))}
+		fields = append(fields, kvAny("parts", arrValue(messageParts(msg)...)))
+		if i < len(finishReasons) && finishReasons[i] != "" {
+			fields = append(fields, kvStr("finish_reason", finishReasons[i]))
+		}
+		values = append(values, listValue(fields...))
+	}
+	return arrValue(values...)
+}
+
+// messageRole returns the message's role, defaulting to "assistant" for output messages
+// and "user" for input messages when the summary carries none.
+func messageRole(msg tracing.MessageSummary, isOutput bool) string {
+	if msg.Role != "" {
+		return msg.Role
+	}
+	if isOutput {
+		return string(schemas.ChatMessageRoleAssistant)
+	}
+	return string(schemas.ChatMessageRoleUser)
+}
+
+// messageParts maps one MessageSummary onto the semconv message-part list.
+func messageParts(msg tracing.MessageSummary) []*AnyValue {
+	parts := make([]*AnyValue, 0, 2+len(msg.ToolCalls)+len(msg.ReasoningDetails))
+
+	if msg.Content != "" {
+		if msg.Role == string(schemas.ChatMessageRoleTool) {
+			// A tool message's content is the result of an earlier tool call, not free text.
+			fields := []*KeyValue{kvStr("type", partTypeToolCallResponse), kvStr("response", msg.Content)}
+			if msg.ToolCallID != "" {
+				fields = append(fields, kvStr("id", msg.ToolCallID))
+			}
+			parts = append(parts, listValue(fields...))
+		} else {
+			parts = append(parts, textPart(msg.Content))
+		}
+	}
+
+	if msg.Reasoning != "" {
+		parts = append(parts, listValue(kvStr("type", partTypeReasoning), kvStr("content", msg.Reasoning)))
+	}
+	for _, detail := range msg.ReasoningDetails {
+		if detail.Text == "" {
+			continue
+		}
+		parts = append(parts, listValue(kvStr("type", partTypeReasoning), kvStr("content", detail.Text)))
+	}
+
+	for _, tc := range msg.ToolCalls {
+		fields := []*KeyValue{kvStr("type", partTypeToolCall)}
+		if tc.ID != "" {
+			fields = append(fields, kvStr("id", tc.ID))
+		}
+		if tc.Name != "" {
+			fields = append(fields, kvStr("name", tc.Name))
+		}
+		if tc.Args != "" {
+			// Arguments are a provider-supplied JSON string; keep them structured when they
+			// parse, and as the raw string when they do not (models emit invalid JSON).
+			if parsed := jsonToAnyValue(tc.Args); parsed != nil {
+				fields = append(fields, kvAny("arguments", parsed))
+			} else {
+				fields = append(fields, kvStr("arguments", tc.Args))
+			}
+		}
+		parts = append(parts, listValue(fields...))
+	}
+
+	// Refusal has no dedicated part type in the schema; the schema permits arbitrary types.
+	if msg.Refusal != "" {
+		parts = append(parts, listValue(kvStr("type", partTypeRefusal), kvStr("content", msg.Refusal)))
+	}
+	if msg.Audio != nil && msg.Audio.Transcript != "" {
+		parts = append(parts, textPart(msg.Audio.Transcript))
+	}
+
+	return parts
+}
+
+// textPart builds a {type: "text", content: ...} message part.
+func textPart(content string) *AnyValue {
+	return listValue(kvStr("type", partTypeText), kvStr("content", content))
+}
+
+// toolDefinitionsToAnyValue converts the span's JSON-string tool list into the semconv
+// gen_ai.tool.definitions shape. Bifrost records name/description only; per semconv it is
+// NOT RECOMMENDED to expand parameter schemas, so nothing more is added here. Returns nil
+// when the value cannot be parsed.
+func toolDefinitionsToAnyValue(raw any) *AnyValue {
+	jsonStr, ok := raw.(string)
+	if !ok || jsonStr == "" {
+		return nil
+	}
+	var tools []struct {
+		Name        string `json:"name"`
+		Description string `json:"description,omitempty"`
+	}
+	if err := sonic.UnmarshalString(jsonStr, &tools); err != nil || len(tools) == 0 {
+		return nil
+	}
+	values := make([]*AnyValue, 0, len(tools))
+	for _, tool := range tools {
+		fields := []*KeyValue{kvStr("type", "function"), kvStr("name", tool.Name)}
+		if tool.Description != "" {
+			fields = append(fields, kvStr("description", tool.Description))
+		}
+		values = append(values, listValue(fields...))
+	}
+	return arrValue(values...)
+}
+
+// jsonToAnyValue parses a JSON document into a nested AnyValue tree. Returns nil when the
+// input is not valid JSON, so callers can fall back to the raw string.
+func jsonToAnyValue(raw string) *AnyValue {
+	if raw == "" {
+		return nil
+	}
+	var generic any
+	if err := sonic.UnmarshalString(raw, &generic); err != nil {
+		return nil
+	}
+	return anyToAnyValue(generic)
+}
+
+// anyToAnyValue recursively converts a decoded JSON value into an OTEL AnyValue. Unlike
+// anyToKeyValue it preserves empty strings and empty containers, since dropping them from
+// a structured payload would silently change the message shape.
+func anyToAnyValue(value any) *AnyValue {
+	switch v := value.(type) {
+	case nil:
+		return &AnyValue{}
+	case string:
+		return &AnyValue{Value: &StringValue{StringValue: v}}
+	case bool:
+		return &AnyValue{Value: &BoolValue{BoolValue: v}}
+	case float64:
+		// JSON has one number type; keep integral values as integers so backends do not
+		// render token counts and ids as floats.
+		if v == float64(int64(v)) {
+			return &AnyValue{Value: &IntValue{IntValue: int64(v)}}
+		}
+		return &AnyValue{Value: &DoubleValue{DoubleValue: v}}
+	case int64:
+		return &AnyValue{Value: &IntValue{IntValue: v}}
+	case int:
+		return &AnyValue{Value: &IntValue{IntValue: int64(v)}}
+	case []any:
+		vals := make([]*AnyValue, 0, len(v))
+		for _, item := range v {
+			vals = append(vals, anyToAnyValue(item))
+		}
+		return arrValue(vals...)
+	case map[string]any:
+		kvs := make([]*KeyValue, 0, len(v))
+		for k, item := range v {
+			kvs = append(kvs, kvAny(k, anyToAnyValue(item)))
+		}
+		return listValue(kvs...)
+	default:
+		// Anything else came from a Go value rather than JSON; reuse the span encoder.
+		if kv := anyToKeyValue("_", v); kv != nil {
+			return kv.Value
+		}
+		return &AnyValue{}
+	}
+}

--- a/plugins/otel/logconverter_test.go
+++ b/plugins/otel/logconverter_test.go
@@ -1,0 +1,410 @@
+package otel
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	logspb "go.opentelemetry.io/proto/otlp/logs/v1"
+)
+
+// logTestTarget builds a target with log export enabled and the given content switches.
+func logTestTarget(disableSpanContent, disableLogContent bool) *otelTarget {
+	return &otelTarget{
+		serviceName:               "svc",
+		logsURL:                   "http://collector:4318/v1/logs",
+		logClient:                 &fakeLogClient{},
+		disableContentLogging:     disableSpanContent,
+		logsDisableContentLogging: disableLogContent,
+	}
+}
+
+// chatTrace builds a root + one llm.call span carrying a realistic chat payload:
+// a system/user/tool conversation in, one assistant message with a tool call out.
+func chatTrace() *schemas.Trace {
+	root := makeSpan("aaaa", "", "request", schemas.SpanKindInternal)
+	root.Attributes = map[string]any{schemas.AttrRequestModel: "gpt-4o-mini"}
+	child := makeSpan("bbbb", "aaaa", "chat", schemas.SpanKindLLMCall)
+	child.EndTime = time.Unix(1700000000, 500)
+	child.Attributes = map[string]any{
+		schemas.AttrOperationName: "chat",
+		schemas.AttrProviderName:  "openai",
+		schemas.AttrRequestModel:  "gpt-4o-mini",
+		schemas.AttrResponseModel: "gpt-4o-mini-2024-07-18",
+		schemas.AttrInputTokens:   12,
+		schemas.AttrOutputTokens:  7,
+		schemas.AttrFinishReasons: []string{"tool_calls"},
+		schemas.AttrInputMessages: `[
+			{"role":"system","content":"be terse"},
+			{"role":"user","content":"weather in paris?"},
+			{"role":"tool","content":"{\"temp\":21}","tool_call_id":"call_1"}
+		]`,
+		schemas.AttrOutputMessages: `[{"role":"assistant","content":"looking it up","reasoning":"need the tool",` +
+			`"tool_calls":[{"id":"call_2","type":"function","name":"get_weather","args":"{\"city\":\"paris\",\"days\":3}"}]}]`,
+		schemas.AttrTools: `[{"name":"get_weather","description":"Look up weather"}]`,
+	}
+	return &schemas.Trace{
+		TraceID:  "0123456789abcdef0123456789abcdef",
+		RootSpan: root,
+		Spans:    []*schemas.Span{root, child},
+	}
+}
+
+// TestConvertTraceToResourceLogs_EventShape asserts the core record fields: one event per
+// llm.call span, the semconv event name, correlation with the exported span's trace/span
+// ids, INFO severity, an unset body, and the sampled flag.
+func TestConvertTraceToResourceLogs_EventShape(t *testing.T) {
+	p := &OtelPlugin{bifrostVersion: "1.0.0"}
+	rl := p.convertTraceToResourceLogs("svc", chatTrace(), logTestTarget(false, false))
+	if rl == nil {
+		t.Fatal("expected a ResourceLog for a trace with an llm.call span")
+	}
+	if len(rl.ScopeLogs) != 1 || len(rl.ScopeLogs[0].LogRecords) != 1 {
+		t.Fatalf("expected exactly 1 log record (one per llm.call span), got %d scope logs", len(rl.ScopeLogs))
+	}
+	rec := rl.ScopeLogs[0].LogRecords[0]
+
+	if rec.EventName != EventNameInferenceDetails {
+		t.Errorf("event_name = %q, want %q", rec.EventName, EventNameInferenceDetails)
+	}
+	// Correlation: same ids the span exporter writes for this span.
+	if !bytes.Equal(rec.TraceId, hexToBytes("0123456789abcdef0123456789abcdef", 16)) {
+		t.Errorf("trace_id = %x, want the trace's id", rec.TraceId)
+	}
+	if !bytes.Equal(rec.SpanId, hexToBytes("bbbb", 8)) {
+		t.Errorf("span_id = %x, want the llm.call span id", rec.SpanId)
+	}
+	if rec.TimeUnixNano != uint64(time.Unix(1700000000, 500).UnixNano()) {
+		t.Errorf("time_unix_nano = %d, want the span end time", rec.TimeUnixNano)
+	}
+	if rec.ObservedTimeUnixNano == 0 {
+		t.Error("observed_time_unix_nano should be stamped at conversion time")
+	}
+	if rec.SeverityNumber != logspb.SeverityNumber_SEVERITY_NUMBER_INFO {
+		t.Errorf("severity = %v, want INFO for a successful call", rec.SeverityNumber)
+	}
+	if rec.Body != nil {
+		t.Error("body must stay unset; the convention puts everything in attributes")
+	}
+	if rec.Flags != logRecordFlagsSampled {
+		t.Errorf("flags = %d, want the sampled bit %d", rec.Flags, logRecordFlagsSampled)
+	}
+	// Resource/scope are shared with the trace exporter.
+	if kvMap(rl.Resource.Attributes)["service.name"].GetStringValue() != "svc" {
+		t.Error("resource service.name should match the profile service name")
+	}
+	if rl.ScopeLogs[0].Scope.GetName() != "svc" {
+		t.Error("instrumentation scope should match the trace exporter's")
+	}
+}
+
+// TestConvertTraceToResourceLogs_StructuredMessages asserts the semconv requirement that
+// content on events is recorded in structured form: nested AnyValue trees, not JSON
+// strings — including tool_call parts with parsed arguments and a tool_call_response part
+// carrying its tool_call_id.
+func TestConvertTraceToResourceLogs_StructuredMessages(t *testing.T) {
+	p := &OtelPlugin{}
+	rl := p.convertTraceToResourceLogs("svc", chatTrace(), logTestTarget(false, false))
+	attrs := kvMap(rl.ScopeLogs[0].LogRecords[0].Attributes)
+
+	input := attrs[schemas.AttrInputMessages]
+	if input.GetArrayValue() == nil {
+		t.Fatalf("gen_ai.input.messages must be structured, got %v", input)
+	}
+	messages := input.GetArrayValue().Values
+	if len(messages) != 3 {
+		t.Fatalf("input messages = %d, want 3", len(messages))
+	}
+
+	// Message 0: a plain system message → one text part.
+	sys := kvMap(messages[0].GetKvlistValue().Values)
+	if got := sys["role"].GetStringValue(); got != "system" {
+		t.Errorf("message 0 role = %q, want system", got)
+	}
+	sysParts := sys["parts"].GetArrayValue().Values
+	if len(sysParts) != 1 {
+		t.Fatalf("system message parts = %d, want 1", len(sysParts))
+	}
+	part := kvMap(sysParts[0].GetKvlistValue().Values)
+	if part["type"].GetStringValue() != partTypeText || part["content"].GetStringValue() != "be terse" {
+		t.Errorf("system part = %v, want a text part with the message content", part)
+	}
+
+	// Message 2: a tool result → tool_call_response part linked by tool_call_id.
+	toolMsg := kvMap(messages[2].GetKvlistValue().Values)
+	toolParts := toolMsg["parts"].GetArrayValue().Values
+	if len(toolParts) != 1 {
+		t.Fatalf("tool message parts = %d, want 1", len(toolParts))
+	}
+	toolPart := kvMap(toolParts[0].GetKvlistValue().Values)
+	if got := toolPart["type"].GetStringValue(); got != partTypeToolCallResponse {
+		t.Errorf("tool message part type = %q, want %q", got, partTypeToolCallResponse)
+	}
+	if got := toolPart["id"].GetStringValue(); got != "call_1" {
+		t.Errorf("tool_call_response id = %q, want call_1 (from MessageSummary.ToolCallID)", got)
+	}
+	if got := toolPart["response"].GetStringValue(); got != `{"temp":21}` {
+		t.Errorf("tool_call_response response = %q, want the tool output", got)
+	}
+
+	// Output: one assistant message with finish_reason, text, reasoning and a tool call
+	// whose arguments are structured rather than a JSON string.
+	output := attrs[schemas.AttrOutputMessages]
+	outMessages := output.GetArrayValue().Values
+	if len(outMessages) != 1 {
+		t.Fatalf("output messages = %d, want 1", len(outMessages))
+	}
+	out := kvMap(outMessages[0].GetKvlistValue().Values)
+	if got := out["finish_reason"].GetStringValue(); got != "tool_calls" {
+		t.Errorf("finish_reason = %q, want tool_calls", got)
+	}
+	outParts := out["parts"].GetArrayValue().Values
+	if len(outParts) != 3 {
+		t.Fatalf("output parts = %d, want text + reasoning + tool_call", len(outParts))
+	}
+	byType := make(map[string]map[string]*AnyValue, len(outParts))
+	for _, p := range outParts {
+		fields := kvMap(p.GetKvlistValue().Values)
+		byType[fields["type"].GetStringValue()] = fields
+	}
+	if byType[partTypeReasoning]["content"].GetStringValue() != "need the tool" {
+		t.Error("reasoning part missing or wrong")
+	}
+	call := byType[partTypeToolCall]
+	if call == nil {
+		t.Fatal("tool_call part missing from the output message")
+	}
+	if got := call["name"].GetStringValue(); got != "get_weather" {
+		t.Errorf("tool_call name = %q, want get_weather", got)
+	}
+	args := call["arguments"].GetKvlistValue()
+	if args == nil {
+		t.Fatalf("tool_call arguments must be structured, got %v", call["arguments"])
+	}
+	argMap := kvMap(args.Values)
+	if got := argMap["city"].GetStringValue(); got != "paris" {
+		t.Errorf("arguments.city = %q, want paris", got)
+	}
+	if got := argMap["days"].GetIntValue(); got != 3 {
+		t.Errorf("arguments.days = %d, want 3 (integral JSON numbers stay ints)", got)
+	}
+
+	// Tool definitions come from the span's request tools, renamed to the semconv key.
+	tools := attrs[attrToolDefinitions].GetArrayValue()
+	if tools == nil || len(tools.Values) != 1 {
+		t.Fatalf("gen_ai.tool.definitions = %v, want one structured definition", attrs[attrToolDefinitions])
+	}
+	def := kvMap(tools.Values[0].GetKvlistValue().Values)
+	if def["name"].GetStringValue() != "get_weather" || def["type"].GetStringValue() != "function" {
+		t.Errorf("tool definition = %v, want {type:function, name:get_weather}", def)
+	}
+	if _, ok := attrs[schemas.AttrTools]; ok {
+		t.Error("the raw gen_ai.request.tools string should not ride the event alongside the structured form")
+	}
+}
+
+// TestConvertTraceToResourceLogs_MalformedContentFallsBack asserts that unparseable
+// content degrades to a plain string attribute rather than dropping the event.
+func TestConvertTraceToResourceLogs_MalformedContentFallsBack(t *testing.T) {
+	p := &OtelPlugin{}
+	trace := chatTrace()
+	llm := trace.Spans[1]
+	llm.Attributes[schemas.AttrInputMessages] = "not json at all"
+	llm.Attributes[schemas.AttrOutputMessages] = `[{"role":"assistant","content":"hi","tool_calls":[{"id":"c","name":"f","args":"{oops"}]}]`
+
+	rl := p.convertTraceToResourceLogs("svc", trace, logTestTarget(false, false))
+	if rl == nil {
+		t.Fatal("a malformed content attribute must not drop the event")
+	}
+	attrs := kvMap(rl.ScopeLogs[0].LogRecords[0].Attributes)
+	if got := attrs[schemas.AttrInputMessages].GetStringValue(); got != "not json at all" {
+		t.Errorf("unparseable input messages = %v, want the raw string preserved", attrs[schemas.AttrInputMessages])
+	}
+	// The message list still parses, so only the tool-call arguments fall back.
+	outParts := kvMap(attrs[schemas.AttrOutputMessages].GetArrayValue().Values[0].GetKvlistValue().Values)["parts"].GetArrayValue().Values
+	for _, part := range outParts {
+		fields := kvMap(part.GetKvlistValue().Values)
+		if fields["type"].GetStringValue() != partTypeToolCall {
+			continue
+		}
+		if got := fields["arguments"].GetStringValue(); got != "{oops" {
+			t.Errorf("invalid tool-call arguments = %v, want the raw string preserved", fields["arguments"])
+		}
+	}
+}
+
+// TestConvertTraceToResourceLogs_ContentGatingIsPerSignal covers all four capture modes:
+// span content and event content are gated by independent switches, so operators can put
+// content on spans only, events only, both, or neither.
+func TestConvertTraceToResourceLogs_ContentGatingIsPerSignal(t *testing.T) {
+	p := &OtelPlugin{}
+	contentKeys := []string{schemas.AttrInputMessages, schemas.AttrOutputMessages, attrToolDefinitions}
+
+	cases := []struct {
+		name             string
+		disableSpan      bool
+		disableLog       bool
+		wantSpanContent  bool
+		wantEventContent bool
+	}{
+		{name: "SPAN_AND_EVENT", wantSpanContent: true, wantEventContent: true},
+		{name: "EVENT_ONLY", disableSpan: true, wantEventContent: true},
+		{name: "SPAN_ONLY", disableLog: true, wantSpanContent: true},
+		{name: "NO_CONTENT", disableSpan: true, disableLog: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			target := logTestTarget(tc.disableSpan, tc.disableLog)
+			rl := p.convertTraceToResourceLogs("svc", chatTrace(), target)
+			if rl == nil {
+				t.Fatal("events are emitted even without content, for correlation and audit")
+			}
+			eventAttrs := kvMap(rl.ScopeLogs[0].LogRecords[0].Attributes)
+			for _, key := range contentKeys {
+				if _, ok := eventAttrs[key]; ok != tc.wantEventContent {
+					t.Errorf("event attribute %q present = %v, want %v", key, ok, tc.wantEventContent)
+				}
+			}
+			// Metadata always survives, so the event stays useful with content off.
+			if got := eventAttrs[schemas.AttrRequestModel].GetStringValue(); got != "gpt-4o-mini" {
+				t.Errorf("event gen_ai.request.model = %q, want it kept regardless of content gating", got)
+			}
+			if got := eventAttrs[schemas.AttrInputTokens].GetIntValue(); got != 12 {
+				t.Errorf("event input tokens = %d, want 12", got)
+			}
+
+			// The span export is gated by the other switch, from the same trace.
+			rs := p.convertTraceToResourceSpan("svc", chatTrace(), nil, target.disableContentLogging, false, false)
+			var llmSpan *Span
+			for _, s := range rs.ScopeSpans[0].Spans {
+				if bytes.Equal(s.SpanId, hexToBytes("bbbb", 8)) {
+					llmSpan = s
+				}
+			}
+			if got := attrString(llmSpan, schemas.AttrInputMessages) != ""; got != tc.wantSpanContent {
+				t.Errorf("span content present = %v, want %v", got, tc.wantSpanContent)
+			}
+		})
+	}
+}
+
+// TestConvertTraceToResourceLogs_ErrorSeverity asserts a failed call is recorded at ERROR
+// severity and carries error.type.
+func TestConvertTraceToResourceLogs_ErrorSeverity(t *testing.T) {
+	p := &OtelPlugin{}
+	trace := chatTrace()
+	trace.Spans[1].Status = schemas.SpanStatusError
+	trace.Spans[1].Attributes[schemas.AttrErrorTypeSpec] = "rate_limit_error"
+
+	rl := p.convertTraceToResourceLogs("svc", trace, logTestTarget(false, false))
+	rec := rl.ScopeLogs[0].LogRecords[0]
+	if rec.SeverityNumber != logspb.SeverityNumber_SEVERITY_NUMBER_ERROR {
+		t.Errorf("severity = %v, want ERROR for a failed call", rec.SeverityNumber)
+	}
+	if rec.SeverityText != "ERROR" {
+		t.Errorf("severity_text = %q, want ERROR", rec.SeverityText)
+	}
+	if got := kvMap(rec.Attributes)[schemas.AttrErrorTypeSpec].GetStringValue(); got != "rate_limit_error" {
+		t.Errorf("error.type = %q, want rate_limit_error", got)
+	}
+}
+
+// TestConvertTraceToResourceLogs_SharedAttrsOnEveryEvent asserts that root-only enrichment
+// (session, request id, instance attrs, captured headers) is copied onto each event, so a
+// log-only backend can filter by tenant without joining to the trace.
+func TestConvertTraceToResourceLogs_SharedAttrsOnEveryEvent(t *testing.T) {
+	p := &OtelPlugin{instanceAttrs: []*KeyValue{kvStr("service.instance.id", "pod-7")}}
+	trace := chatTrace()
+	trace.Attributes = map[string]any{schemas.TraceAttrSessionID: "sess-9"}
+	trace.RequestHeaders = map[string]string{"x-tenant": "acme"}
+	// A second attempt (retry/fallback) gets its own event.
+	second := makeSpan("cccc", "aaaa", "chat", schemas.SpanKindLLMCall)
+	second.Attributes = map[string]any{schemas.AttrRequestModel: "gpt-4o"}
+	trace.Spans = append(trace.Spans, second)
+
+	target := logTestTarget(false, false)
+	target.requestHeaders = []string{"x-tenant"}
+	rl := p.convertTraceToResourceLogs("svc", trace, target)
+	records := rl.ScopeLogs[0].LogRecords
+	if len(records) != 2 {
+		t.Fatalf("log records = %d, want one per llm.call span", len(records))
+	}
+	for i, rec := range records {
+		attrs := kvMap(rec.Attributes)
+		if got := attrs["session.id"].GetStringValue(); got != "sess-9" {
+			t.Errorf("record %d session.id = %q, want sess-9", i, got)
+		}
+		if got := attrs[attrConversationID].GetStringValue(); got != "sess-9" {
+			t.Errorf("record %d gen_ai.conversation.id = %q, want the caller-supplied session id", i, got)
+		}
+		if got := attrs["service.instance.id"].GetStringValue(); got != "pod-7" {
+			t.Errorf("record %d service.instance.id = %q, want pod-7", i, got)
+		}
+		if got := attrs["http.request.header.x-tenant"].GetStringValue(); got != "acme" {
+			t.Errorf("record %d captured header = %q, want acme", i, got)
+		}
+	}
+}
+
+// TestConvertTraceToResourceLogs_NoConversationIDWithoutSession asserts Bifrost never
+// synthesizes a conversation id: without an inbound x-bf-session-id there is none.
+func TestConvertTraceToResourceLogs_NoConversationIDWithoutSession(t *testing.T) {
+	p := &OtelPlugin{}
+	rl := p.convertTraceToResourceLogs("svc", chatTrace(), logTestTarget(false, false))
+	attrs := kvMap(rl.ScopeLogs[0].LogRecords[0].Attributes)
+	if _, ok := attrs[attrConversationID]; ok {
+		t.Error("gen_ai.conversation.id must be absent when the caller supplied no session id")
+	}
+}
+
+// TestConvertTraceToResourceLogs_SessionGroupingParity asserts events adopt the same
+// session-derived trace ID the span exporter uses, so logs and spans stay joinable.
+func TestConvertTraceToResourceLogs_SessionGroupingParity(t *testing.T) {
+	p := &OtelPlugin{}
+	trace := chatTrace()
+	trace.Attributes = map[string]any{schemas.TraceAttrSessionID: "user-42"}
+
+	target := logTestTarget(false, false)
+	target.groupTracesBySession = true
+	rl := p.convertTraceToResourceLogs("svc", trace, target)
+	want := hexToBytes(sessionTraceID("user-42"), 16)
+	if got := rl.ScopeLogs[0].LogRecords[0].TraceId; !bytes.Equal(got, want) {
+		t.Errorf("event trace_id = %x, want the session-derived trace id %x", got, want)
+	}
+
+	// Grouping off: the original trace ID, matching the span exporter.
+	target.groupTracesBySession = false
+	rl = p.convertTraceToResourceLogs("svc", trace, target)
+	want = hexToBytes(trace.TraceID, 16)
+	if got := rl.ScopeLogs[0].LogRecords[0].TraceId; !bytes.Equal(got, want) {
+		t.Errorf("event trace_id = %x, want the original trace id %x", got, want)
+	}
+}
+
+// TestConvertTraceToResourceLogs_NoLLMSpans asserts traces without an exportable llm.call
+// span produce nothing, so no empty export request is made.
+func TestConvertTraceToResourceLogs_NoLLMSpans(t *testing.T) {
+	p := &OtelPlugin{}
+	root := makeSpan("aaaa", "", "request", schemas.SpanKindInternal)
+	trace := &schemas.Trace{
+		TraceID:  "0000000000000000000000000000000b",
+		RootSpan: root,
+		Spans:    []*schemas.Span{root, makeSpan("bbbb", "aaaa", "plugin.logging.prehook", schemas.SpanKindPlugin)},
+	}
+	if rl := p.convertTraceToResourceLogs("svc", trace, logTestTarget(false, false)); rl != nil {
+		t.Error("a trace with no llm.call spans should produce no log export")
+	}
+}
+
+// TestConvertTraceToResourceLogs_HonoursSpanFilter asserts log export respects the same
+// plugin span filter as trace export.
+func TestConvertTraceToResourceLogs_HonoursSpanFilter(t *testing.T) {
+	p := &OtelPlugin{pluginSpanFilter: &PluginSpanFilter{
+		Mode:    PluginSpanFilterModeExclude,
+		Plugins: []string{"logging"},
+	}}
+	if rl := p.convertTraceToResourceLogs("svc", chatTrace(), logTestTarget(false, false)); rl == nil {
+		t.Fatal("an llm.call span is not filtered by a plugin exclusion")
+	}
+}

--- a/plugins/otel/logexport_test.go
+++ b/plugins/otel/logexport_test.go
@@ -1,0 +1,356 @@
+package otel
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bytedance/sonic"
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	collectorlogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+// fakeLogClient records what would have been exported, and can be made to fail.
+type fakeLogClient struct {
+	calls    atomic.Int64
+	fail     bool
+	lastLogs atomic.Value // []*ResourceLog
+}
+
+func (c *fakeLogClient) EmitLogs(_ context.Context, logs []*ResourceLog) error {
+	c.calls.Add(1)
+	c.lastLogs.Store(logs)
+	if c.fail {
+		return errors.New("logs collector unreachable")
+	}
+	return nil
+}
+func (c *fakeLogClient) Close() error { return nil }
+
+// recordingClient records successful trace exports.
+type recordingClient struct{ calls atomic.Int64 }
+
+func (c *recordingClient) Emit(_ context.Context, _ []*ResourceSpan) error {
+	c.calls.Add(1)
+	return nil
+}
+func (c *recordingClient) Close() error { return nil }
+
+// TestInject_LogFailuresDoNotSuppressTraces is the independent-failure-domain guarantee:
+// a permanently broken logs endpoint opens only the logs breaker, while traces keep
+// exporting on every request.
+func TestInject_LogFailuresDoNotSuppressTraces(t *testing.T) {
+	logger = bifrost.NewDefaultLogger(schemas.LogLevelError)
+
+	traceClient := &recordingClient{}
+	logClient := &fakeLogClient{fail: true}
+	target := &otelTarget{
+		serviceName:   "svc",
+		url:           "test://traces",
+		logsURL:       "test://logs",
+		client:        traceClient,
+		logClient:     logClient,
+		exportTimeout: time.Second,
+	}
+	plugin := &OtelPlugin{targets: []*otelTarget{target}}
+
+	const attempts = breakerFailureThreshold + 20
+	for range attempts {
+		if err := plugin.Inject(context.Background(), chatTrace()); err != nil {
+			t.Fatalf("Inject: %v", err)
+		}
+	}
+
+	if got := traceClient.calls.Load(); got != attempts {
+		t.Errorf("trace exports = %d, want %d — a failing logs endpoint must not suppress traces", got, attempts)
+	}
+	if got := logClient.calls.Load(); got > breakerFailureThreshold {
+		t.Errorf("log exports = %d, want the logs breaker to open at %d", got, breakerFailureThreshold)
+	}
+	if target.breakerOpen() {
+		t.Error("the trace breaker must stay closed while only logs are failing")
+	}
+	if target.logBreaker.suppressedExports.Load() == 0 {
+		t.Error("expected suppressed log exports once the logs breaker opened")
+	}
+}
+
+// TestInject_TraceFailuresDoNotSuppressLogs is the mirror case: an open trace breaker must
+// not stop GenAI events from reaching the logs pipeline.
+func TestInject_TraceFailuresDoNotSuppressLogs(t *testing.T) {
+	logger = bifrost.NewDefaultLogger(schemas.LogLevelError)
+
+	logClient := &fakeLogClient{}
+	target := &otelTarget{
+		serviceName:   "svc",
+		url:           "test://traces",
+		logsURL:       "test://logs",
+		client:        &failingClient{},
+		logClient:     logClient,
+		exportTimeout: time.Second,
+	}
+	plugin := &OtelPlugin{targets: []*otelTarget{target}}
+
+	const attempts = breakerFailureThreshold + 20
+	for range attempts {
+		if err := plugin.Inject(context.Background(), chatTrace()); err != nil {
+			t.Fatalf("Inject: %v", err)
+		}
+	}
+
+	if got := logClient.calls.Load(); got != attempts {
+		t.Errorf("log exports = %d, want %d — an open trace breaker must not suppress logs", got, attempts)
+	}
+}
+
+// TestInject_NoLogClientSkipsConversion asserts profiles without log export do no work.
+func TestInject_NoLogClientSkipsConversion(t *testing.T) {
+	logger = bifrost.NewDefaultLogger(schemas.LogLevelError)
+	target := &otelTarget{serviceName: "svc", url: "test://traces", client: &recordingClient{}, exportTimeout: time.Second}
+	plugin := &OtelPlugin{targets: []*otelTarget{target}}
+	if err := plugin.Inject(context.Background(), chatTrace()); err != nil {
+		t.Fatalf("Inject: %v", err)
+	}
+	if target.logBreaker.failedExports.Load() != 0 {
+		t.Error("a profile without log export should never touch the logs breaker")
+	}
+}
+
+// TestExportStats_ReportsLogsEndpointSeparately asserts logs health is visible under its
+// own endpoint, since it fails independently of traces.
+func TestExportStats_ReportsLogsEndpointSeparately(t *testing.T) {
+	target := &otelTarget{url: "http://collector:4318/v1/traces", logsURL: "http://collector:4318/v1/logs", logClient: &fakeLogClient{}}
+	target.tripBreaker()
+	target.logBreaker.tripBreaker()
+	target.logBreaker.tripBreaker()
+
+	stats := (&OtelPlugin{targets: []*otelTarget{target}}).ExportStats()
+	if got := stats["http://collector:4318/v1/traces"].Failed; got != 1 {
+		t.Errorf("trace failures = %d, want 1", got)
+	}
+	if got := stats["http://collector:4318/v1/logs"].Failed; got != 2 {
+		t.Errorf("log failures = %d, want 2", got)
+	}
+}
+
+// TestOtelLogClientHTTP_SendsValidExportRequest asserts the wire payload is a decodable
+// ExportLogsServiceRequest with the right content type and configured headers.
+func TestOtelLogClientHTTP_SendsValidExportRequest(t *testing.T) {
+	logger = bifrost.NewDefaultLogger(schemas.LogLevelError)
+
+	type captured struct {
+		contentType string
+		auth        string
+		req         *collectorlogspb.ExportLogsServiceRequest
+	}
+	got := make(chan captured, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		var decoded collectorlogspb.ExportLogsServiceRequest
+		if err := proto.Unmarshal(body, &decoded); err != nil {
+			t.Errorf("payload is not an ExportLogsServiceRequest: %v", err)
+		}
+		got <- captured{contentType: r.Header.Get("Content-Type"), auth: r.Header.Get("Authorization"), req: &decoded}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client, err := NewOtelLogClientHTTP(srv.URL, map[string]string{"Authorization": "Bearer t"}, "", true, 2*time.Second)
+	if err != nil {
+		t.Fatalf("NewOtelLogClientHTTP: %v", err)
+	}
+	defer client.Close()
+
+	rl := (&OtelPlugin{}).convertTraceToResourceLogs("svc", chatTrace(), logTestTarget(false, false))
+	if err := client.EmitLogs(context.Background(), []*ResourceLog{rl}); err != nil {
+		t.Fatalf("EmitLogs: %v", err)
+	}
+
+	c := <-got
+	if c.contentType != "application/x-protobuf" {
+		t.Errorf("Content-Type = %q, want application/x-protobuf", c.contentType)
+	}
+	if c.auth != "Bearer t" {
+		t.Errorf("Authorization = %q, want the configured header", c.auth)
+	}
+	records := c.req.ResourceLogs[0].ScopeLogs[0].LogRecords
+	if len(records) != 1 || records[0].EventName != EventNameInferenceDetails {
+		t.Errorf("decoded records = %v, want one inference-details event", records)
+	}
+}
+
+// TestOtelLogClientHTTP_NonOKIsAnError asserts a rejecting collector surfaces as an error
+// so the breaker can trip.
+func TestOtelLogClientHTTP_NonOKIsAnError(t *testing.T) {
+	logger = bifrost.NewDefaultLogger(schemas.LogLevelError)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	client, err := NewOtelLogClientHTTP(srv.URL, nil, "", true, 2*time.Second)
+	if err != nil {
+		t.Fatalf("NewOtelLogClientHTTP: %v", err)
+	}
+	defer client.Close()
+	if err := client.EmitLogs(context.Background(), []*ResourceLog{{}}); err == nil {
+		t.Error("expected an error when the collector rejects the export")
+	}
+}
+
+// TestOtelLogClientHTTP_HonoursTimeout covers the export bound on the logs path: a
+// black-holed endpoint must not hold the flush goroutine open.
+func TestOtelLogClientHTTP_HonoursTimeout(t *testing.T) {
+	addr, stop := blackholeListener(t)
+	defer stop()
+	logger = bifrost.NewDefaultLogger(schemas.LogLevelError)
+
+	const timeout = 400 * time.Millisecond
+	client, err := NewOtelLogClientHTTP("http://"+addr, nil, "", true, timeout)
+	if err != nil {
+		t.Fatalf("NewOtelLogClientHTTP: %v", err)
+	}
+	defer client.Close()
+
+	start := time.Now()
+	if err := client.EmitLogs(context.Background(), []*ResourceLog{{}}); err == nil {
+		t.Error("expected an error against a black-holed endpoint")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("EmitLogs took %v, expected it bounded near %v", elapsed, timeout)
+	}
+}
+
+// TestLogsConfigStorageRoundTrip asserts the new logs fields survive persistence,
+// including env-var indirection on the endpoint.
+func TestLogsConfigStorageRoundTrip(t *testing.T) {
+	t.Setenv("OTEL_LOGS_URL", "http://collector:4318/v1/logs")
+	raw := `{"profiles": [{
+		"service_name": "svc",
+		"collector_url": "http://collector:4318/v1/traces",
+		"trace_type": "genai_extension",
+		"protocol": "http",
+		"logs_enabled": true,
+		"logs_endpoint": "env.OTEL_LOGS_URL",
+		"logs_disable_content_logging": true
+	}]}`
+
+	var cfg Config
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	stored, err := cfg.MarshalForStorage()
+	if err != nil {
+		t.Fatalf("MarshalForStorage: %v", err)
+	}
+
+	var asMap map[string]any
+	if err := sonic.Unmarshal(stored, &asMap); err != nil {
+		t.Fatalf("stored not an object: %v", err)
+	}
+	profile := asMap["profiles"].([]any)[0].(map[string]any)
+	if got := profile["logs_endpoint"]; got != "env.OTEL_LOGS_URL" {
+		t.Errorf("stored logs_endpoint = %v, want the env reference flattened to a string", got)
+	}
+
+	var back Config
+	if err := json.Unmarshal(stored, &back); err != nil {
+		t.Fatalf("round-trip unmarshal: %v", err)
+	}
+	p := back.Profiles[0]
+	if !p.LogsEnabled {
+		t.Error("logs_enabled lost in round-trip")
+	}
+	if !p.LogsDisableContentLogging {
+		t.Error("logs_disable_content_logging lost in round-trip")
+	}
+	if got := p.LogsEndpoint.GetValue(); got != "http://collector:4318/v1/logs" {
+		t.Errorf("round-trip logs_endpoint = %q, want the resolved env value", got)
+	}
+
+	// Redaction keeps the env var name (so the UI can round-trip the edit) and hides the
+	// resolved value.
+	redacted := back.Redacted().Profiles[0]
+	if redacted.LogsEndpoint.GetValue() == "http://collector:4318/v1/logs" {
+		t.Error("redacted logs_endpoint still exposes the resolved env value")
+	}
+}
+
+// TestBuildTargetRequiresLogsEndpoint asserts logs_enabled without an endpoint is a
+// config error rather than a silently disabled signal, matching metrics_endpoint.
+func TestBuildTargetRequiresLogsEndpoint(t *testing.T) {
+	logger = testLogger{}
+	raw := `{"profiles": [{
+		"collector_url": "http://collector:4318/v1/traces",
+		"trace_type": "genai_extension",
+		"protocol": "http",
+		"logs_enabled": true
+	}]}`
+	var cfg Config
+	if err := sonic.Unmarshal([]byte(raw), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, err := Init(context.Background(), &cfg, testLogger{}, nil, ""); err == nil {
+		t.Error("expected an error when logs_enabled is set without logs_endpoint")
+	}
+}
+
+// TestInitBuildsLogClient asserts an enabled profile ends up with a live logs client
+// pointed at its own endpoint.
+func TestInitBuildsLogClient(t *testing.T) {
+	logger = testLogger{}
+	raw := `{"profiles": [{
+		"collector_url": "http://collector:4318/v1/traces",
+		"trace_type": "genai_extension",
+		"protocol": "http",
+		"logs_enabled": true,
+		"logs_endpoint": "http://collector:4318/v1/logs"
+	}]}`
+	var cfg Config
+	if err := sonic.Unmarshal([]byte(raw), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	plugin, err := Init(context.Background(), &cfg, testLogger{}, nil, "")
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	t.Cleanup(func() { _ = plugin.Cleanup() })
+	if plugin.targets[0].logClient == nil {
+		t.Fatal("logs_enabled profile has no logs client")
+	}
+	if got := plugin.targets[0].logsURL; got != "http://collector:4318/v1/logs" {
+		t.Errorf("logsURL = %q, want the configured endpoint", got)
+	}
+}
+
+// TestLogsDisabledByDefault asserts existing configs are untouched: no logs client unless
+// the profile opts in.
+func TestLogsDisabledByDefault(t *testing.T) {
+	logger = testLogger{}
+	var cfg Config
+	if err := sonic.Unmarshal([]byte(`{"profiles": [{"collector_url": "a:4317", "trace_type": "genai_extension", "protocol": "grpc"}]}`), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if cfg.Profiles[0].LogsEnabled {
+		t.Error("logs_enabled should default to false when omitted")
+	}
+	plugin, err := Init(context.Background(), &cfg, testLogger{}, nil, "")
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	t.Cleanup(func() { _ = plugin.Cleanup() })
+	if plugin.targets[0].logClient != nil {
+		t.Error("no logs client should be built for a profile that did not opt in")
+	}
+}

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -113,6 +113,18 @@ type Profile struct {
 	MetricsEndpoint     *schemas.SecretVar `json:"metrics_endpoint,omitempty"`
 	MetricsPushInterval int                `json:"metrics_push_interval,omitempty"` // in seconds, default 15
 
+	// Logs export configuration. When enabled, one OTLP log record per llm.call span is
+	// exported as a GenAI event (gen_ai.client.inference.operation.details), correlated
+	// with the exported trace via trace_id/span_id.
+	LogsEnabled  bool               `json:"logs_enabled"`
+	LogsEndpoint *schemas.SecretVar `json:"logs_endpoint,omitempty"` // required when LogsEnabled
+
+	// LogsDisableContentLogging strips message content, instructions, and tool payloads
+	// from exported log records only. It is independent of DisableContentLogging, which
+	// gates the same content on exported spans — so content can live on spans only, on
+	// events only, on both, or on neither.
+	LogsDisableContentLogging bool `json:"logs_disable_content_logging,omitempty"`
+
 	// RequestHeaders lists request-header name patterns (exact or wildcard like "x-custom-*"
 	// or "*") whose captured values are attached to the root span as attributes.
 	RequestHeaders []string `json:"request_headers,omitempty"`
@@ -272,25 +284,28 @@ func profileCarriers(data []byte) []spanFilterCarrier {
 // flattened to plain strings ("env.VAR_NAME" or the literal value) for DB/config-file
 // persistence.
 type profileForStorage struct {
-	Enabled                bool              `json:"enabled"`
-	TracesEnabled          bool              `json:"traces_enabled"`
-	ServiceName            string            `json:"service_name"`
-	CollectorURL           string            `json:"collector_url"`
-	Headers                map[string]string `json:"headers,omitempty"`
-	TraceHeaders           map[string]string `json:"trace_headers,omitempty"`
-	MetricsHeaders         map[string]string `json:"metrics_headers,omitempty"`
-	TraceType              TraceType         `json:"trace_type"`
-	Protocol               Protocol          `json:"protocol"`
-	TLSCACert              string            `json:"tls_ca_cert,omitempty"`
-	Insecure               bool              `json:"insecure"`
-	ExportTimeout          int               `json:"export_timeout,omitempty"`
-	MetricsEnabled         bool              `json:"metrics_enabled"`
-	MetricsEndpoint        string            `json:"metrics_endpoint,omitempty"`
-	MetricsPushInterval    int               `json:"metrics_push_interval,omitempty"`
-	RequestHeaders         []string          `json:"request_headers,omitempty"`
-	DisableContentLogging  bool              `json:"disable_content_logging,omitempty"`
-	GroupTracesBySession   bool              `json:"group_traces_by_session,omitempty"`
-	DisableRootSpanContent bool              `json:"disable_root_span_content,omitempty"`
+	Enabled                   bool              `json:"enabled"`
+	TracesEnabled             bool              `json:"traces_enabled"`
+	ServiceName               string            `json:"service_name"`
+	CollectorURL              string            `json:"collector_url"`
+	Headers                   map[string]string `json:"headers,omitempty"`
+	TraceHeaders              map[string]string `json:"trace_headers,omitempty"`
+	MetricsHeaders            map[string]string `json:"metrics_headers,omitempty"`
+	TraceType                 TraceType         `json:"trace_type"`
+	Protocol                  Protocol          `json:"protocol"`
+	TLSCACert                 string            `json:"tls_ca_cert,omitempty"`
+	Insecure                  bool              `json:"insecure"`
+	ExportTimeout             int               `json:"export_timeout,omitempty"`
+	MetricsEnabled            bool              `json:"metrics_enabled"`
+	MetricsEndpoint           string            `json:"metrics_endpoint,omitempty"`
+	MetricsPushInterval       int               `json:"metrics_push_interval,omitempty"`
+	LogsEnabled               bool              `json:"logs_enabled"`
+	LogsEndpoint              string            `json:"logs_endpoint,omitempty"`
+	LogsDisableContentLogging bool              `json:"logs_disable_content_logging,omitempty"`
+	RequestHeaders            []string          `json:"request_headers,omitempty"`
+	DisableContentLogging     bool              `json:"disable_content_logging,omitempty"`
+	GroupTracesBySession      bool              `json:"group_traces_by_session,omitempty"`
+	DisableRootSpanContent    bool              `json:"disable_root_span_content,omitempty"`
 }
 
 // configForStorage is the persisted wrapper shape.
@@ -315,32 +330,35 @@ func (c *Config) MarshalForStorage() ([]byte, error) {
 			continue
 		}
 		out.Profiles = append(out.Profiles, profileForStorage{
-			Enabled:                p.Enabled,
-			TracesEnabled:          p.TracesEnabled,
-			ServiceName:            p.ServiceName,
-			CollectorURL:           schemas.SecretVarAsString(p.CollectorURL),
-			Headers:                p.Headers,
-			TraceHeaders:           p.TraceHeaders,
-			MetricsHeaders:         p.MetricsHeaders,
-			TraceType:              p.TraceType,
-			Protocol:               p.Protocol,
-			TLSCACert:              p.TLSCACert,
-			Insecure:               p.Insecure,
-			ExportTimeout:          p.ExportTimeout,
-			MetricsEnabled:         p.MetricsEnabled,
-			MetricsEndpoint:        schemas.SecretVarAsString(p.MetricsEndpoint),
-			MetricsPushInterval:    p.MetricsPushInterval,
-			RequestHeaders:         p.RequestHeaders,
-			DisableContentLogging:  p.DisableContentLogging,
-			GroupTracesBySession:   p.GroupTracesBySession,
-			DisableRootSpanContent: p.DisableRootSpanContent,
+			Enabled:                   p.Enabled,
+			TracesEnabled:             p.TracesEnabled,
+			ServiceName:               p.ServiceName,
+			CollectorURL:              schemas.SecretVarAsString(p.CollectorURL),
+			Headers:                   p.Headers,
+			TraceHeaders:              p.TraceHeaders,
+			MetricsHeaders:            p.MetricsHeaders,
+			TraceType:                 p.TraceType,
+			Protocol:                  p.Protocol,
+			TLSCACert:                 p.TLSCACert,
+			Insecure:                  p.Insecure,
+			ExportTimeout:             p.ExportTimeout,
+			MetricsEnabled:            p.MetricsEnabled,
+			MetricsEndpoint:           schemas.SecretVarAsString(p.MetricsEndpoint),
+			MetricsPushInterval:       p.MetricsPushInterval,
+			LogsEnabled:               p.LogsEnabled,
+			LogsEndpoint:              schemas.SecretVarAsString(p.LogsEndpoint),
+			LogsDisableContentLogging: p.LogsDisableContentLogging,
+			RequestHeaders:            p.RequestHeaders,
+			DisableContentLogging:     p.DisableContentLogging,
+			GroupTracesBySession:      p.GroupTracesBySession,
+			DisableRootSpanContent:    p.DisableRootSpanContent,
 		})
 	}
 	return sonic.Marshal(out)
 }
 
 // Redacted returns a copy of the config with sensitive fields redacted for API responses.
-// URLs (CollectorURL, MetricsEndpoint) are not secrets and are returned unchanged so the UI
+// URLs (CollectorURL, MetricsEndpoint, LogsEndpoint) are not secrets and are returned unchanged so the UI
 // can display and re-submit them without failing URL validation. For env var references on
 // those fields, only the resolved value is hidden; the env_var name is preserved.
 // Header values may carry auth tokens, so literal values are masked while "env." references
@@ -360,6 +378,7 @@ func (c *Config) Redacted() *Config {
 			rp := *p
 			rp.CollectorURL = hideResolvedEnvValue(p.CollectorURL)
 			rp.MetricsEndpoint = hideResolvedEnvValue(p.MetricsEndpoint)
+			rp.LogsEndpoint = hideResolvedEnvValue(p.LogsEndpoint)
 			rp.Headers = redactHeaderMap(p.Headers)
 			rp.TraceHeaders = redactHeaderMap(p.TraceHeaders)
 			rp.MetricsHeaders = redactHeaderMap(p.MetricsHeaders)
@@ -416,13 +435,30 @@ type otelTarget struct {
 	groupTracesBySession   bool
 	disableRootSpanContent bool
 
+	// logClient is nil unless the profile enables log export. Logs ship over their own
+	// client to their own endpoint and carry their own breaker (see logExportState), so a
+	// broken logs pipeline can never suppress trace or metrics export.
+	logClient                 OtelLogClient
+	logsURL                   string
+	logsDisableContentLogging bool
+
 	// exportTimeout bounds a single Emit. See Profile.ExportTimeout.
 	exportTimeout time.Duration
 
-	// Circuit breaker. A misconfigured endpoint fails identically for every trace, so
-	// after breakerFailureThreshold consecutive failures the target stops dialling until
-	// breakerCooldown has elapsed. Without this, a permanently wrong endpoint costs a
-	// full exportTimeout on every single request forever.
+	// Trace-export breaker. Promoted, so tripBreaker/resetBreaker/breakerOpen on the
+	// target act on the trace signal.
+	exportBreaker
+
+	// logBreaker is the log-export breaker. Kept separate from the trace one so the two
+	// signals fail independently: a dead logs endpoint must not stop trace export.
+	logBreaker exportBreaker
+}
+
+// exportBreaker is a per-signal circuit breaker. A misconfigured endpoint fails
+// identically for every trace, so after breakerFailureThreshold consecutive failures
+// the signal stops dialling until breakerCooldown has elapsed. Without this, a
+// permanently wrong endpoint costs a full exportTimeout on every single request forever.
+type exportBreaker struct {
 	consecutiveFailures atomic.Int64
 	breakerOpenUntil    atomic.Int64 // UnixNano; exports are skipped until this instant
 	suppressedExports   atomic.Int64
@@ -431,7 +467,7 @@ type otelTarget struct {
 
 // tripBreaker records a failed export and opens the circuit once the failure threshold
 // is reached.
-func (t *otelTarget) tripBreaker() {
+func (t *exportBreaker) tripBreaker() {
 	t.failedExports.Add(1)
 	if t.consecutiveFailures.Add(1) >= breakerFailureThreshold {
 		t.breakerOpenUntil.Store(time.Now().Add(breakerCooldown).UnixNano())
@@ -439,18 +475,18 @@ func (t *otelTarget) tripBreaker() {
 }
 
 // resetBreaker records a successful export, closing the circuit.
-func (t *otelTarget) resetBreaker() {
+func (t *exportBreaker) resetBreaker() {
 	t.consecutiveFailures.Store(0)
 	t.breakerOpenUntil.Store(0)
 }
 
-// breakerOpen reports whether exports to this target are currently suppressed.
+// breakerOpen reports whether exports for this signal are currently suppressed.
 // Exactly one probe is allowed through once the cooldown expires: the goroutine that
 // wins the CAS pushes the window forward by another cooldown and dials for real, so
 // concurrent callers and anyone arriving while that probe is in flight stay suppressed.
 // The probe then resets the breaker on success or re-arms it on failure; if it somehow
 // does neither, the pushed-forward window expires on its own and the next caller probes.
-func (t *otelTarget) breakerOpen() bool {
+func (t *exportBreaker) breakerOpen() bool {
 	openUntil := t.breakerOpenUntil.Load()
 	if openUntil == 0 {
 		return false
@@ -569,9 +605,9 @@ func (p *OtelPlugin) buildTarget(index int, profile *Profile) (*otelTarget, erro
 		serviceName = "bifrost"
 	}
 
-	// Both traces and metrics dial with this protocol, so validate it once. A profile
-	// with neither enabled is a no-op, so skip the check.
-	if profile.TracesEnabled || profile.MetricsEnabled {
+	// Traces, metrics and logs all dial with this protocol, so validate it once. A profile
+	// with none of them enabled is a no-op, so skip the check.
+	if profile.TracesEnabled || profile.MetricsEnabled || profile.LogsEnabled {
 		switch profile.Protocol {
 		case ProtocolGRPC, ProtocolHTTP:
 		default:
@@ -583,6 +619,7 @@ func (p *OtelPlugin) buildTarget(index int, profile *Profile) (*otelTarget, erro
 	var (
 		traceHeaders   map[string]string
 		metricsHeaders map[string]string
+		logHeaders     map[string]string
 		err            error
 	)
 	if profile.TracesEnabled {
@@ -597,6 +634,12 @@ func (p *OtelPlugin) buildTarget(index int, profile *Profile) (*otelTarget, erro
 			return nil, fmt.Errorf("profile %d: %w", index, err)
 		}
 	}
+	if profile.LogsEnabled {
+		logHeaders, err = mergedResolvedHeaders(profile.Headers, nil)
+		if err != nil {
+			return nil, fmt.Errorf("profile %d: %w", index, err)
+		}
+	}
 
 	exportTimeout, err := resolveExportTimeout(profile.ExportTimeout)
 	if err != nil {
@@ -604,13 +647,14 @@ func (p *OtelPlugin) buildTarget(index int, profile *Profile) (*otelTarget, erro
 	}
 
 	target := &otelTarget{
-		serviceName:            serviceName,
-		traceType:              profile.TraceType,
-		requestHeaders:         slices.Clone(profile.RequestHeaders),
-		disableContentLogging:  profile.DisableContentLogging,
-		groupTracesBySession:   profile.GroupTracesBySession,
-		disableRootSpanContent: profile.DisableRootSpanContent,
-		exportTimeout:          exportTimeout,
+		serviceName:               serviceName,
+		traceType:                 profile.TraceType,
+		requestHeaders:            slices.Clone(profile.RequestHeaders),
+		disableContentLogging:     profile.DisableContentLogging,
+		groupTracesBySession:      profile.GroupTracesBySession,
+		disableRootSpanContent:    profile.DisableRootSpanContent,
+		logsDisableContentLogging: profile.LogsDisableContentLogging,
+		exportTimeout:             exportTimeout,
 	}
 
 	// Build the trace client only when traces are enabled; Inject skips a nil client.
@@ -670,6 +714,28 @@ func (p *OtelPlugin) buildTarget(index int, profile *Profile) (*otelTarget, erro
 		logger.Info("OTEL metrics push enabled for profile %d, pushing to %s every %d seconds", index, profile.MetricsEndpoint.GetValue(), pushInterval)
 	}
 
+	// Initialize the logs client if enabled. It reuses the profile's protocol, headers,
+	// TLS settings and export timeout, but dials its own endpoint.
+	if profile.LogsEnabled {
+		logsURL := profile.LogsEndpoint.GetValue()
+		if logsURL == "" {
+			target.closeClients()
+			return nil, fmt.Errorf("profile %d: logs_endpoint is required when logs_enabled is true", index)
+		}
+		target.logsURL = logsURL
+		switch profile.Protocol {
+		case ProtocolGRPC:
+			target.logClient, err = NewOtelLogClientGRPC(logsURL, logHeaders, profile.TLSCACert, profile.Insecure)
+		case ProtocolHTTP:
+			target.logClient, err = NewOtelLogClientHTTP(logsURL, logHeaders, profile.TLSCACert, profile.Insecure, exportTimeout)
+		}
+		if err != nil {
+			target.closeClients()
+			return nil, fmt.Errorf("profile %d: failed to initialize logs client: %w", index, err)
+		}
+		logger.Info("OTEL log export enabled for profile %d, exporting GenAI events to %s", index, logsURL)
+	}
+
 	return target, nil
 }
 
@@ -683,6 +749,28 @@ func mergedResolvedHeaders(common, overlay map[string]string) (map[string]string
 		return nil, err
 	}
 	return merged, nil
+}
+
+// closeClients releases every client this target has opened so far. Used to unwind a
+// partially built target when a later step of buildTarget fails, and by Cleanup.
+func (t *otelTarget) closeClients() error {
+	var firstErr error
+	if t.metricsExporter != nil {
+		if err := t.metricsExporter.Shutdown(context.Background()); err != nil {
+			logger.Error("failed to shutdown metrics exporter: %v", err)
+		}
+	}
+	if t.client != nil {
+		if err := t.client.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if t.logClient != nil {
+		if err := t.logClient.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
 // resolveExportTimeout validates a configured export_timeout (in seconds) and returns
@@ -868,6 +956,9 @@ func (p *OtelPlugin) Inject(ctx context.Context, trace *schemas.Trace) error {
 				p.recordMetricsFromTrace(ctx, t.metricsExporter, trace)
 				p.recordMCPMetricsFromTrace(ctx, t.metricsExporter, trace)
 			}
+			// Logs are a separate signal with their own client, endpoint and breaker, so
+			// they are emitted even when the trace client is missing or its breaker is open.
+			p.emitLogs(ctx, t, trace)
 			if t.client == nil || t.breakerOpen() {
 				return
 			}
@@ -890,15 +981,50 @@ func (p *OtelPlugin) Inject(ctx context.Context, trace *schemas.Trace) error {
 	return nil
 }
 
+// emitLogs converts the trace to GenAI event log records and ships them to the target's
+// logs endpoint. No-op when the profile has log export disabled, when the logs breaker is
+// open, or when the trace holds no exportable LLM spans.
+func (p *OtelPlugin) emitLogs(ctx context.Context, t *otelTarget, trace *schemas.Trace) {
+	if t.logClient == nil || t.logBreaker.breakerOpen() {
+		return
+	}
+	resourceLog := p.convertTraceToResourceLogs(t.serviceName, trace, t)
+	if resourceLog == nil {
+		return
+	}
+	emitCtx, cancel := context.WithTimeout(ctx, t.exportTimeout)
+	defer cancel()
+	if err := t.logClient.EmitLogs(emitCtx, []*ResourceLog{resourceLog}); err != nil {
+		t.logBreaker.tripBreaker()
+		if n := t.logBreaker.failedExports.Load(); n == 1 || n%exportLogThrottle == 0 {
+			logger.Error("failed to emit logs for trace %s to %s: %v (%d failed exports so far)", trace.TraceID, t.logsURL, err, n)
+		}
+		return
+	}
+	t.logBreaker.resetBreaker()
+}
+
 // ExportStats reports per-target export health: how many exports failed and how many
 // were suppressed by an open circuit breaker. A rising suppressed count means the
 // target's endpoint is being treated as dead — usually a misconfigured collector URL.
+// Logs, when enabled, are reported separately under their own endpoint since they fail
+// independently of traces.
 func (p *OtelPlugin) ExportStats() map[string]struct{ Failed, Suppressed int64 } {
 	stats := make(map[string]struct{ Failed, Suppressed int64 }, len(p.targets))
 	for _, t := range p.targets {
 		stats[t.url] = struct{ Failed, Suppressed int64 }{
 			Failed:     t.failedExports.Load(),
 			Suppressed: t.suppressedExports.Load(),
+		}
+		if t.logClient == nil {
+			continue
+		}
+		// A profile may point both signals at the same host:port (gRPC), so fold rather
+		// than overwrite when the keys collide.
+		prev := stats[t.logsURL]
+		stats[t.logsURL] = struct{ Failed, Suppressed int64 }{
+			Failed:     prev.Failed + t.logBreaker.failedExports.Load(),
+			Suppressed: prev.Suppressed + t.logBreaker.suppressedExports.Load(),
 		}
 	}
 	return stats
@@ -1318,23 +1444,16 @@ func (p *OtelPlugin) recordMetricsFromTrace(ctx context.Context, exporter *Metri
 }
 
 // Cleanup function for the OTEL plugin. It shuts down every profile's metrics exporter
-// and closes every trace client, returning the first client-close error encountered.
+// and closes every trace and logs client, returning the first client-close error
+// encountered.
 func (p *OtelPlugin) Cleanup() error {
 	if p.cancel != nil {
 		p.cancel()
 	}
 	var firstErr error
 	for _, t := range p.targets {
-		// Shutdown metrics exporter first
-		if t.metricsExporter != nil {
-			if err := t.metricsExporter.Shutdown(context.Background()); err != nil {
-				logger.Error("failed to shutdown metrics exporter: %v", err)
-			}
-		}
-		if t.client != nil {
-			if err := t.client.Close(); err != nil && firstErr == nil {
-				firstErr = err
-			}
+		if err := t.closeClients(); err != nil && firstErr == nil {
+			firstErr = err
 		}
 	}
 	return firstErr

--- a/plugins/otel/types.go
+++ b/plugins/otel/types.go
@@ -2,6 +2,7 @@ package otel
 
 import (
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	logspb "go.opentelemetry.io/proto/otlp/logs/v1"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
@@ -16,6 +17,18 @@ type Span = tracepb.Span
 
 // Event is an event in a span
 type Event = tracepb.Span_Event
+
+// ResourceLog is a set of log records for one resource in the OpenTelemetry format
+type ResourceLog = logspb.ResourceLogs
+
+// ScopeLog is a group of log records emitted by one instrumentation scope
+type ScopeLog = logspb.ScopeLogs
+
+// LogRecord is a single log record (a GenAI event, for this plugin) in the OpenTelemetry format
+type LogRecord = logspb.LogRecord
+
+// SeverityNumber is the numeric severity of a log record
+type SeverityNumber = logspb.SeverityNumber
 
 // KeyValue is a key-value pair in the OpenTelemetry format
 type KeyValue = commonpb.KeyValue

--- a/transports/bifrost-http/lib/validator_test.go
+++ b/transports/bifrost-http/lib/validator_test.go
@@ -1335,6 +1335,56 @@ func TestValidateConfigSchema_OtelPlugin_GrpcAddress(t *testing.T) {
 	}
 }
 
+func TestValidateConfigSchema_OtelPlugin_LogsEnabled(t *testing.T) {
+	// Log export opts in per profile and requires its own endpoint.
+	validConfig := `{
+		"plugins": [
+			{
+				"enabled": true,
+				"name": "otel",
+				"config": {
+					"profiles": [
+						{
+							"collector_url": "http://localhost:4318/v1/traces",
+							"trace_type": "genai_extension",
+							"protocol": "http",
+							"logs_enabled": true,
+							"logs_endpoint": "http://localhost:4318/v1/logs",
+							"logs_disable_content_logging": true
+						}
+					]
+				}
+			}
+		]
+	}`
+
+	if err := ValidateConfigSchema([]byte(validConfig), loadLocalSchema(t)); err != nil {
+		t.Errorf("expected OTEL config with log export to pass validation, got error: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_OtelPlugin_LogsEnabledMissingEndpoint(t *testing.T) {
+	// logs_enabled without logs_endpoint is a config error, mirroring metrics_endpoint.
+	invalidConfig := `{
+		"plugins": [
+			{
+				"enabled": true,
+				"name": "otel",
+				"config": {
+					"collector_url": "http://localhost:4318",
+					"trace_type": "genai_extension",
+					"protocol": "http",
+					"logs_enabled": true
+				}
+			}
+		]
+	}`
+
+	if err := ValidateConfigSchema([]byte(invalidConfig), loadLocalSchema(t)); err == nil {
+		t.Error("expected config with 'logs_enabled' but no 'logs_endpoint' to fail validation")
+	}
+}
+
 func TestValidateConfigSchema_OtelPlugin_MissingCollectorUrl(t *testing.T) {
 	// Missing required field: collector_url
 	invalidConfig := `{

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -3502,6 +3502,20 @@
           "minimum": 1,
           "maximum": 300
         },
+        "logs_enabled": {
+          "type": "boolean",
+          "description": "Enable OTLP log export of GenAI events. One gen_ai.client.inference.operation.details log record is emitted per LLM call, correlated with its span via trace_id/span_id.",
+          "default": false
+        },
+        "logs_endpoint": {
+          "$ref": "#/$defs/otel_endpoint",
+          "description": "OTLP logs endpoint URL (e.g., http://otel-collector:4318/v1/logs for HTTP or otel-collector:4317 for gRPC)"
+        },
+        "logs_disable_content_logging": {
+          "type": "boolean",
+          "description": "When true, message content, instructions, and tool payloads are dropped from exported log records; the events are still emitted with metadata only. Independent of disable_content_logging, which gates the same content on exported spans.",
+          "default": false
+        },
         "request_headers": {
           "type": "array",
           "items": {
@@ -3511,7 +3525,7 @@
         },
         "disable_content_logging": {
           "type": "boolean",
-          "description": "When true, message content (input/output messages, embeddings, tool definitions, and tool call arguments/results) is dropped from exported spans. Only metadata such as model, tokens, and latency is sent to the collector.",
+          "description": "When true, message content (input/output messages, embeddings, tool definitions, and tool call arguments/results) is dropped from exported spans. Only metadata such as model, tokens, and latency is sent to the collector. Exported logs are gated separately by logs_disable_content_logging.",
           "default": false
         },
         "group_traces_by_session": {
@@ -3599,6 +3613,19 @@
           },
           "then": {
             "required": ["metrics_endpoint", "protocol"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "logs_enabled": {
+                "const": true
+              }
+            },
+            "required": ["logs_enabled"]
+          },
+          "then": {
+            "required": ["logs_endpoint"]
           }
         }
       ],

--- a/ui/app/workspace/observability/fragments/otelFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/otelFormFragment.tsx
@@ -38,6 +38,9 @@ interface StoredOtelProfile {
 	metrics_enabled?: boolean;
 	metrics_endpoint?: string | SecretVar;
 	metrics_push_interval?: number;
+	logs_enabled?: boolean;
+	logs_endpoint?: string | SecretVar;
+	logs_disable_content_logging?: boolean;
 	export_timeout?: number;
 	request_headers?: string[];
 	disable_content_logging?: boolean;
@@ -106,6 +109,9 @@ const emptyProfile = (): ProfileForm => ({
 	metrics_enabled: false,
 	metrics_endpoint: emptySecretVar(),
 	metrics_push_interval: 15,
+	logs_enabled: false,
+	logs_endpoint: emptySecretVar(),
+	logs_disable_content_logging: false,
 	export_timeout: 5,
 	request_headers: [],
 	disable_content_logging: false,
@@ -129,6 +135,9 @@ const toProfileForm = (p?: StoredOtelProfile): ProfileForm => ({
 	metrics_enabled: p?.metrics_enabled ?? false,
 	metrics_endpoint: toSecretVarFormValue(p?.metrics_endpoint),
 	metrics_push_interval: p?.metrics_push_interval ?? 15,
+	logs_enabled: p?.logs_enabled ?? false,
+	logs_endpoint: toSecretVarFormValue(p?.logs_endpoint),
+	logs_disable_content_logging: p?.logs_disable_content_logging ?? false,
 	export_timeout: p?.export_timeout ?? 5,
 	request_headers: p?.request_headers ?? [],
 	disable_content_logging: p?.disable_content_logging ?? false,
@@ -327,20 +336,23 @@ function OtelProfileSection({ form, control, index, hasOtelAccess, canRemove, op
 	const protocol = form.watch(`${base}.protocol`);
 	const tracesEnabled = form.watch(`${base}.traces_enabled`);
 	const metricsEnabled = form.watch(`${base}.metrics_enabled`);
+	const logsEnabled = form.watch(`${base}.logs_enabled`);
 	const insecure = form.watch(`${base}.insecure`);
 	const enabled = form.watch(`${base}.enabled`);
 	const serviceName = form.watch(`${base}.service_name`);
 	const collectorUrl = form.watch(`${base}.collector_url`);
 
-	const [activeTab, setActiveTab] = useState<"traces" | "metrics">("traces");
+	const [activeTab, setActiveTab] = useState<"traces" | "metrics" | "logs">("traces");
 
 	// Surface which tab holds a validation error so it's findable without expanding every section.
 	const profileErrors = form.formState.errors?.profiles?.[index];
 	const hasError = Boolean(profileErrors);
 	const tracesFields = ["traces_enabled", "collector_url", "trace_type", "export_timeout", "request_headers"] as const;
 	const metricsFields = ["metrics_endpoint", "metrics_push_interval"] as const;
+	const logsFields = ["logs_endpoint"] as const;
 	const hasTracesError = tracesFields.some((f) => Boolean(profileErrors?.[f]));
 	const hasMetricsError = metricsFields.some((f) => Boolean(profileErrors?.[f]));
+	const hasLogsError = logsFields.some((f) => Boolean(profileErrors?.[f]));
 
 	const collectorPreview =
 		typeof collectorUrl === "string"
@@ -513,7 +525,7 @@ function OtelProfileSection({ form, control, index, hasOtelAccess, canRemove, op
 					</div>
 
 					{/* Traces and Metrics tabs, each independently enable-able */}
-					<Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as "traces" | "metrics")} className="border-t pt-4">
+					<Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as "traces" | "metrics" | "logs")} className="border-t pt-4">
 						<TabsList className="gap-2">
 							<TabsTrigger value="traces" className="px-2 py-1" data-testid={`otel-profile-${index}-tab-traces`}>
 								Traces
@@ -526,6 +538,14 @@ function OtelProfileSection({ form, control, index, hasOtelAccess, canRemove, op
 							<TabsTrigger value="metrics" className="px-2 py-1" data-testid={`otel-profile-${index}-tab-metrics`}>
 								Metrics
 								{hasMetricsError && (
+									<Badge variant="destructive" className="ml-1.5 px-1 py-0 text-[10px] leading-none">
+										!
+									</Badge>
+								)}
+							</TabsTrigger>
+							<TabsTrigger value="logs" className="px-2 py-1" data-testid={`otel-profile-${index}-tab-logs`}>
+								Logs
+								{hasLogsError && (
 									<Badge variant="destructive" className="ml-1.5 px-1 py-0 text-[10px] leading-none">
 										!
 									</Badge>
@@ -861,6 +881,90 @@ function OtelProfileSection({ form, control, index, hasOtelAccess, canRemove, op
 												</FormControl>
 												<FormDescription>How often to push metrics (1-300 seconds)</FormDescription>
 												<FormMessage />
+											</FormItem>
+										)}
+									/>
+								</div>
+							)}
+						</TabsContent>
+
+						{/* Logs tab: exports GenAI events as OTLP logs */}
+						<TabsContent value="logs" className="mt-2 space-y-4">
+							<FormField
+								control={control}
+								name={`${base}.logs_enabled`}
+								render={({ field }) => (
+									<FormItem className="flex flex-row items-center gap-2">
+										<div className="flex w-full flex-row items-center gap-2">
+											<div className="flex flex-col gap-1">
+												<h3 className="flex flex-row items-center gap-2 text-sm font-medium">
+													Enable Log Export <Badge variant="secondary">BETA</Badge>
+												</h3>
+												<p className="text-muted-foreground text-xs">
+													Export GenAI events (inputs, outputs, request details) as OTLP logs correlated with trace and span IDs
+												</p>
+											</div>
+											<div className="ml-auto">
+												<Switch
+													data-testid={`otel-profile-${index}-logs-export-toggle`}
+													checked={field.value}
+													onCheckedChange={field.onChange}
+													disabled={!hasOtelAccess}
+												/>
+											</div>
+										</div>
+									</FormItem>
+								)}
+							/>
+
+							{logsEnabled && (
+								<div className="border-muted flex flex-col gap-4">
+									<FormField
+										control={control}
+										name={`${base}.logs_endpoint`}
+										render={({ field }) => (
+											<FormItem className="w-full">
+												<FormLabel>Logs Endpoint</FormLabel>
+												<div className="text-muted-foreground text-xs">
+													<code>{protocol === "http" ? "http(s)://<host>:<port>/v1/logs" : "<host>:<port>"}</code>
+												</div>
+												<FormControl>
+													<SecretVarInput
+														placeholder={
+															protocol === "http"
+																? "https://otel-collector:4318/v1/logs or env.OTEL_LOGS_ENDPOINT"
+																: "otel-collector:4317 or env.OTEL_LOGS_ENDPOINT"
+														}
+														disabled={!hasOtelAccess}
+														{...field}
+													/>
+												</FormControl>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
+
+									<FormField
+										control={control}
+										name={`${base}.logs_disable_content_logging`}
+										render={({ field }) => (
+											<FormItem className="flex flex-row items-center justify-between">
+												<div className="space-y-0.5">
+													<FormLabel className="text-base">Disable Content Logging (Logs)</FormLabel>
+													<FormDescription>
+														Exclude message content, instructions, and tool payloads from exported logs. Independent of the
+														trace-level Disable Content Logging setting on the Traces tab, so content can be sent on spans only, on
+														events only, on both, or on neither.
+													</FormDescription>
+												</div>
+												<FormControl>
+													<Switch
+														checked={field.value}
+														onCheckedChange={field.onChange}
+														disabled={!hasOtelAccess}
+														data-testid={`otel-profile-${index}-logs-disable-content-toggle`}
+													/>
+												</FormControl>
 											</FormItem>
 										)}
 									/>

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -1067,6 +1067,12 @@ export const otelConfigSchema = z
 		metrics_enabled: z.boolean().default(false),
 		metrics_endpoint: secretVarSchema.optional(),
 		metrics_push_interval: z.number().int().min(1).max(300).default(15),
+		// Log export configuration. Emits GenAI events (one OTLP log record per LLM call)
+		// correlated with the exported spans.
+		logs_enabled: z.boolean().default(false),
+		logs_endpoint: secretVarSchema.optional(),
+		// Gates content on exported logs only; disable_content_logging gates spans.
+		logs_disable_content_logging: z.boolean().default(false),
 		request_headers: z.array(z.string()).default([]),
 		disable_content_logging: z.boolean().default(false),
 		group_traces_by_session: z.boolean().default(false),
@@ -1157,6 +1163,22 @@ export const otelConfigSchema = z
 				validateHttpUrl(metricsEndpoint, ["metrics_endpoint"]);
 			} else if (metricsEndpoint && (data.metrics_endpoint?.type === "plain_text" || !data.metrics_endpoint?.type) && protocol === "grpc") {
 				validateHostPort(metricsEndpoint, ["metrics_endpoint"], "otel-collector:4317");
+			}
+		}
+
+		// Validate logs_endpoint when logs_enabled is true
+		if (data.logs_enabled) {
+			const logsEndpoint = (data.logs_endpoint?.value || "").trim();
+			if (!isSecretVarSet(data.logs_endpoint)) {
+				ctx.addIssue({
+					code: "custom",
+					path: ["logs_endpoint"],
+					message: "Logs endpoint is required when log export is enabled",
+				});
+			} else if (logsEndpoint && (data.logs_endpoint?.type === "plain_text" || !data.logs_endpoint?.type) && protocol === "http") {
+				validateHttpUrl(logsEndpoint, ["logs_endpoint"]);
+			} else if (logsEndpoint && (data.logs_endpoint?.type === "plain_text" || !data.logs_endpoint?.type) && protocol === "grpc") {
+				validateHostPort(logsEndpoint, ["logs_endpoint"], "otel-collector:4317");
 			}
 		}
 	});


### PR DESCRIPTION
## Summary

Adds OTLP log export of GenAI events to the OTel plugin. When enabled, one `gen_ai.client.inference.operation.details` log record is emitted per `llm.call` span, correlated with the exported trace via `trace_id`/`span_id`. This follows the OpenTelemetry GenAI semantic conventions for event payloads, encoding message content, tool calls, reasoning, and tool results as structured nested `AnyValue` trees rather than raw JSON strings.

## Changes

- **`plugins/otel/logclient.go`**: New `OtelLogClient` interface with HTTP (`OtelLogClientHTTP`) and gRPC (`OtelLogClientGRPC`) implementations. Mirrors the existing trace client but dials the logs endpoint and uses the OTLP logs service. TLS, headers, and timeout behaviour are identical to the trace client.
- **`plugins/otel/logconverter.go`**: Converts a completed `schemas.Trace` into a `ResourceLog` containing one `gen_ai.client.inference.operation.details` event per exportable `llm.call` span. Message content is re-encoded from JSON strings into structured `AnyValue` trees (text, tool_call, tool_call_response, reasoning, refusal parts). Tool-call arguments are parsed into nested key-value structures when valid JSON; invalid JSON falls back to the raw string. Content can be stripped independently of the span-level `disable_content_logging` via a new `logs_disable_content_logging` flag.
- **`plugins/otel/main.go`**: Introduces a separate `exportBreaker` struct so the trace and logs signals each carry their own circuit breaker — a dead logs endpoint cannot suppress trace export and vice versa. Adds `logs_enabled`, `logs_endpoint`, and `logs_disable_content_logging` to `Profile` and `profileForStorage`. `buildTarget` initialises the log client when opted in, requiring `logs_endpoint` when `logs_enabled` is true. `Inject` calls `emitLogs` unconditionally before checking the trace breaker. `ExportStats` reports logs health under its own endpoint key. `Cleanup` is refactored into `closeClients` to handle trace, metrics, and log clients together.
- **`framework/tracing/llmspan.go`**: Adds `ToolCallID` to `MessageSummary` and populates it from `ChatToolMessage.ToolCallID`, so `role:"tool"` messages can be re-encoded as `tool_call_response` parts with the correct `id` linkage in log events.
- **`transports/config.schema.json`** and **`transports/bifrost-http/lib/validator_test.go`**: Schema gains `logs_enabled`, `logs_endpoint`, and `logs_disable_content_logging` fields with an `if/then` constraint requiring `logs_endpoint` when `logs_enabled` is true.
- **`ui/`**: The OTel profile form gains a "Logs" tab (behind a BETA badge) with an enable toggle, endpoint input, and a per-signal content-logging switch. The Zod schema validates the endpoint when log export is enabled.
- **`logconverter_test.go`** and **`logexport_test.go`**: Tests covering event shape, structured message encoding, malformed-content fallback, per-signal content gating, error severity, shared attribute propagation, session grouping parity, breaker independence, HTTP wire format, timeout enforcement, and config round-trip.
- **`.github/workflows/configs/withobservability/config.json`**: CI observability config updated to enable log export pointing at the local collector's `/v1/logs` endpoint.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./plugins/otel/... ./framework/tracing/... ./transports/bifrost-http/lib/...

# UI
cd ui
pnpm i
pnpm build
```

To validate end-to-end, enable log export in a profile pointing at a local OTel collector (e.g. `http://localhost:4318/v1/logs`) and confirm `gen_ai.client.inference.operation.details` log records appear in the collector's output, correlated with the exported spans by `trace_id` and `span_id`.

New profile config fields:

| Field | Type | Default | Description |
| --- | --- | --- | --- |
| `logs_enabled` | bool | `false` | Opt in to OTLP log export |
| `logs_endpoint` | SecretVar | — | Required when `logs_enabled` is true |
| `logs_disable_content_logging` | bool | `false` | Strip message content from log records only |

## Breaking changes

- [x] No

## Security considerations

- `logs_endpoint` follows the same `SecretVar` / env-var indirection as `collector_url` and `metrics_endpoint`. Resolved values are hidden in `Redacted()` responses; the env-var reference name is preserved for UI round-trips.
- `logs_disable_content_logging` gives operators independent control over PII in the logs pipeline without affecting span content, which may be subject to different retention or access policies.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable