### PR TITLE
chore: adds otel logs setting in helm

### DIFF
--- a/examples/configs/withobservability/config.json
+++ b/examples/configs/withobservability/config.json
@@ -30,7 +30,9 @@
           "service_name": "bifrost",
           "collector_url": "http://localhost:4318/v1/traces",
           "trace_type": "genai_extension",
-          "protocol": "http"
+          "protocol": "http",
+          "logs_enabled": true,
+          "logs_endpoint": "http://localhost:4318/v1/logs"
         }
       }
     ]

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -6,6 +6,10 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
 
 **Latest Version:** 2.1.39
 
+### Upcoming
+
+- Added OTEL log export (GenAI events): `bifrost.plugins.otel.config.logs_enabled`, `logs_endpoint` (required when enabled), and `logs_disable_content_logging`, available on both the flat profile and each entry of `bifrost.plugins.otel.config.profiles[]`. These render into `logs_enabled`, `logs_endpoint`, and `logs_disable_content_logging` on the otel plugin config.
+
 ## Changelog
 
 ### 2.1.39
@@ -51,7 +55,6 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
 - Documented `endpoints` on the `bedrock` and `bedrock_mantle` key examples (AWS PrivateLink interface VPC endpoint hosts: `runtime`, `control_plane`, `mantle`, `agent_runtime`, `s3`). Passes through into `bedrock_key_config.endpoints` / `bedrock_mantle_key_config.endpoints`.
 - Extended `bifrost.governance.budgets[]` with quarterly resets (`reset_duration: "1Q"`) and `reset_config.quarter_start_month` (1–12, sets the fiscal Q1 month). Passes through into `budgets[].reset_config`.
 - Added `target` (`llm` default, or `mcp`) to `bifrost.governance` guardrail rules to select the rule's execution target. Passes through into the rule's `target`.
-
 
 ### 2.1.34
 

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -1580,6 +1580,15 @@ false
 {{- if $inputConfig.metrics_push_interval }}
 {{- $_ := set $otelConfig "metrics_push_interval" $inputConfig.metrics_push_interval }}
 {{- end }}
+{{- if hasKey $inputConfig "logs_enabled" }}
+{{- $_ := set $otelConfig "logs_enabled" $inputConfig.logs_enabled }}
+{{- end }}
+{{- if $inputConfig.logs_endpoint }}
+{{- $_ := set $otelConfig "logs_endpoint" $inputConfig.logs_endpoint }}
+{{- end }}
+{{- if hasKey $inputConfig "logs_disable_content_logging" }}
+{{- $_ := set $otelConfig "logs_disable_content_logging" $inputConfig.logs_disable_content_logging }}
+{{- end }}
 {{- if $inputConfig.headers }}
 {{- $_ := set $otelConfig "headers" $inputConfig.headers }}
 {{- end }}
@@ -2203,6 +2212,9 @@ Call this template at the beginning of deployment/stateful templates
 {{- if and $profile.metrics_enabled (not $profile.metrics_endpoint) }}
 {{- fail (printf "ERROR: bifrost.plugins.otel.config.profiles[%d].metrics_endpoint is required when metrics_enabled is true." $idx) }}
 {{- end }}
+{{- if and $profile.logs_enabled (not $profile.logs_endpoint) }}
+{{- fail (printf "ERROR: bifrost.plugins.otel.config.profiles[%d].logs_endpoint is required when logs_enabled is true." $idx) }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- else }}
@@ -2223,6 +2235,9 @@ Call this template at the beginning of deployment/stateful templates
 {{- end }}
 {{- if and $otelInputConfig.metrics_enabled (not $otelInputConfig.metrics_endpoint) }}
 {{- fail "ERROR: bifrost.plugins.otel.config.metrics_endpoint is required when metrics_enabled is true." }}
+{{- end }}
+{{- if and $otelInputConfig.logs_enabled (not $otelInputConfig.logs_endpoint) }}
+{{- fail "ERROR: bifrost.plugins.otel.config.logs_endpoint is required when logs_enabled is true." }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -5613,6 +5613,20 @@
           "minimum": 1,
           "maximum": 300
         },
+        "logs_enabled": {
+          "type": "boolean",
+          "description": "Enable OTLP log export of GenAI events. One gen_ai.client.inference.operation.details log record is emitted per LLM call, correlated with its span via trace_id/span_id.",
+          "default": false
+        },
+        "logs_endpoint": {
+          "$ref": "#/$defs/otelEndpoint",
+          "description": "OTLP logs endpoint URL (e.g., http://otel-collector:4318/v1/logs for HTTP or otel-collector:4317 for gRPC)"
+        },
+        "logs_disable_content_logging": {
+          "type": "boolean",
+          "description": "When true, message content, instructions, and tool payloads are dropped from exported log records; the events are still emitted with metadata only. Independent of disable_content_logging, which gates the same content on exported spans.",
+          "default": false
+        },
         "export_timeout": {
           "type": "integer",
           "description": "Maximum time in seconds for a single trace export. Bounds how long a slow or unreachable collector can hold an export goroutine; gRPC exports have no other timeout.",
@@ -5736,6 +5750,19 @@
           "then": {
             "required": ["metrics_endpoint", "protocol"]
           }
+        },
+        {
+          "if": {
+            "properties": {
+              "logs_enabled": {
+                "const": true
+              }
+            },
+            "required": ["logs_enabled"]
+          },
+          "then": {
+            "required": ["logs_endpoint"]
+          }
         }
       ],
       "additionalProperties": false
@@ -5794,6 +5821,18 @@
           "minimum": 1,
           "maximum": 300,
           "description": "Deprecated in the profiles wrapper; configure metrics_push_interval per profile instead."
+        },
+        "logs_enabled": {
+          "type": "boolean",
+          "description": "Deprecated in the profiles wrapper; configure logs_enabled per profile instead."
+        },
+        "logs_endpoint": {
+          "$ref": "#/$defs/otelEndpoint",
+          "description": "Deprecated in the profiles wrapper; configure logs_endpoint per profile instead."
+        },
+        "logs_disable_content_logging": {
+          "type": "boolean",
+          "description": "Deprecated in the profiles wrapper; configure logs_disable_content_logging per profile instead."
         },
         "export_timeout": {
           "type": "integer",

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -663,6 +663,9 @@ bifrost:
         #     headers: {}             # Sent to both endpoints (supports env.VAR_NAME prefix)
         #     trace_headers: {}       # Sent only to the trace endpoint, on top of headers (same key overrides)
         #     metrics_headers: {}     # Sent only to the metrics endpoint, on top of headers (e.g. a Databricks table name)
+        #     logs_enabled: false     # Export GenAI events (one OTLP log record per LLM call) correlated with the spans
+        #     logs_endpoint: ""       # Required when logs_enabled; e.g., http://otel-collector:4318/v1/logs (HTTP) or otel-collector:4317 (gRPC)
+        #     logs_disable_content_logging: false # Drop message content from exported logs only (independent of disable_content_logging, which gates spans)
         #     tls_ca_cert: ""         # Path to TLS CA certificate file
         #     insecure: true          # Skip TLS verification (ignored if tls_ca_cert is set)
         #     disable_content_logging: false
@@ -685,6 +688,13 @@ bifrost:
         metrics_enabled: false
         metrics_endpoint: "" # e.g., http://otel-collector:4318/v1/metrics (HTTP) or otel-collector:4317 (gRPC)
         metrics_push_interval: 15 # Push interval in seconds (1-300)
+        # Log export of GenAI events: one OTLP log record per LLM call, correlated with the
+        # exported trace via trace_id/span_id. logs_endpoint is required when enabled.
+        logs_enabled: false
+        logs_endpoint: "" # e.g., http://otel-collector:4318/v1/logs (HTTP) or otel-collector:4317 (gRPC)
+        # Drop message content from exported logs only. Independent of disable_content_logging below,
+        # which gates the same content on exported spans.
+        # logs_disable_content_logging: false
         # Custom headers sent to both the trace and metrics endpoints (supports env.VAR_NAME prefix)
         headers: {}
         # Extra headers sent only to the trace endpoint, on top of headers (same key overrides)


### PR DESCRIPTION
## Summary

Adds OTEL log export support for GenAI events to the Bifrost OTEL plugin. When enabled, one `gen_ai.client.inference.operation.details` OTLP log record is emitted per LLM call, correlated with its corresponding span via `trace_id`/`span_id`.

## Changes

- Added `logs_enabled`, `logs_endpoint`, and `logs_disable_content_logging` fields to the OTEL plugin configuration, available on both the flat profile and each entry of `profiles[]`.
- `logs_endpoint` is required when `logs_enabled` is `true`; Helm validation fails with a descriptive error if it is missing.
- `logs_disable_content_logging` independently gates content (message body, instructions, tool payloads) from exported log records, separate from `disable_content_logging` which gates the same content on spans.
- Updated the example observability config to demonstrate the new fields.
- Updated Helm schema, helpers, and values to render the new fields into the OTEL plugin config.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Enable log export in your OTEL plugin config and verify log records appear in your collector:

```json
{
  "logs_enabled": true,
  "logs_endpoint": "http://localhost:4318/v1/logs"
}
```

Or via Helm values:

```yaml
bifrost:
  plugins:
    otel:
      config:
        logs_enabled: true
        logs_endpoint: "http://otel-collector:4318/v1/logs"
        logs_disable_content_logging: false
```

Verify that:
- One log record is emitted per LLM call in the collector UI (e.g., Jaeger, Grafana).
- The log record is correlated with its span via `trace_id`/`span_id`.
- Setting `logs_disable_content_logging: true` drops message content from log records while still emitting metadata.
- Omitting `logs_endpoint` when `logs_enabled: true` causes Helm template rendering to fail with a clear error message.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

`logs_disable_content_logging` provides a mechanism to prevent PII or sensitive prompt/response content from being exported in OTLP log records. This is independent of the existing `disable_content_logging` flag, which only gates span content. Users handling sensitive data should evaluate both flags independently.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable