### PR TITLE
chore: update docs for otel logs support

### DIFF
--- a/docs/deployment-guides/config-json/plugins.mdx
+++ b/docs/deployment-guides/config-json/plugins.mdx
@@ -133,6 +133,9 @@ Exports distributed traces to any OTel-compatible collector (Jaeger, Zipkin, Tem
 | `config.metrics_enabled` | No | `false` | Enable push-based OTLP metrics export |
 | `config.metrics_endpoint` | Yes (if `metrics_enabled`) | - | OTLP metrics endpoint URL |
 | `config.metrics_push_interval` | No | `15` | Metrics push interval in seconds |
+| `config.logs_enabled` | No | `false` | Export GenAI events as OTLP log records, one per LLM call |
+| `config.logs_endpoint` | No | - | OTLP logs endpoint URL (required when `logs_enabled`) |
+| `config.logs_disable_content_logging` | No | `false` | Drop message content from exported log records only |
 | `config.headers` | No | - | Custom headers sent to both the trace and metrics endpoints (supports `env.` prefix) |
 | `config.trace_headers` | No | - | Extra headers sent only to the trace endpoint, overlaid on `headers` (supports `env.` prefix) |
 | `config.metrics_headers` | No | - | Extra headers sent only to the metrics endpoint, overlaid on `headers` (supports `env.` prefix) |
@@ -199,6 +202,28 @@ Exports distributed traces to any OTel-compatible collector (Jaeger, Zipkin, Tem
   ]
 }
 ```
+
+**With GenAI event (log) export:**
+
+```json
+{
+  "plugins": [
+    {
+      "name": "otel",
+      "enabled": true,
+      "config": {
+        "collector_url": "http://otel-collector:4318/v1/traces",
+        "trace_type": "genai_extension",
+        "protocol": "http",
+        "logs_enabled": true,
+        "logs_endpoint": "http://otel-collector:4318/v1/logs"
+      }
+    }
+  ]
+}
+```
+
+See [Log Export (GenAI Events)](/features/observability/otel#log-export-genai-events) for what each event carries.
 
 </Tab>
 

--- a/docs/deployment-guides/helm/plugins.mdx
+++ b/docs/deployment-guides/helm/plugins.mdx
@@ -263,6 +263,9 @@ Sends distributed traces and push-based metrics to any OTLP-compatible collector
 | `bifrost.plugins.otel.config.metrics_enabled` | Enable OTLP push-based metrics | `false` |
 | `bifrost.plugins.otel.config.metrics_endpoint` | OTLP metrics endpoint; required when `metrics_enabled` | `""` |
 | `bifrost.plugins.otel.config.metrics_push_interval` | Push interval in seconds | `15` |
+| `bifrost.plugins.otel.config.logs_enabled` | Export GenAI events as OTLP log records, one per LLM call | `false` |
+| `bifrost.plugins.otel.config.logs_endpoint` | OTLP logs endpoint (required when `logs_enabled`) | `""` |
+| `bifrost.plugins.otel.config.logs_disable_content_logging` | Drop message content from exported log records only | `false` |
 | `bifrost.plugins.otel.config.headers` | Custom headers sent to both the trace and metrics endpoints | `{}` |
 | `bifrost.plugins.otel.config.trace_headers` | Extra headers sent only to the trace endpoint, overlaid on `headers` | `{}` |
 | `bifrost.plugins.otel.config.metrics_headers` | Extra headers sent only to the metrics endpoint, overlaid on `headers` | `{}` |
@@ -287,6 +290,9 @@ bifrost:
         metrics_enabled: true
         metrics_endpoint: "otel-collector.observability.svc.cluster.local:4317"
         metrics_push_interval: 15
+        # GenAI events as OTLP logs, correlated with the exported spans
+        logs_enabled: true
+        logs_endpoint: "otel-collector.observability.svc.cluster.local:4317"
         headers:
           x-honeycomb-team: "env.HONEYCOMB_API_KEY"
 ```

--- a/docs/features/observability/otel.mdx
+++ b/docs/features/observability/otel.mdx
@@ -46,11 +46,14 @@ The plugin supports multiple trace formats to match your observability platform:
 | `group_traces_by_session` | `boolean` | ❌ No | Group requests sharing the same `x-bf-session-id` into one trace (default: `false`). See [Grouping Traces by Session](#grouping-traces-by-session) |
 | `disable_content_logging` | `boolean` | ❌ No | Drop message content from exported spans (default: `false`). See [Controlling Exported Content](#controlling-exported-content) |
 | `disable_root_span_content` | `boolean` | ❌ No | Drop content from the **root span only**, keeping it on child spans (default: `false`). Overridden by `disable_content_logging`, which drops content from every span. See [Controlling Exported Content](#controlling-exported-content) |
+| `logs_enabled` | `boolean` | ❌ No | Export GenAI events as OTLP log records, one per LLM call (default: `false`). See [Log Export (GenAI Events)](#log-export-genai-events) |
+| `logs_endpoint` | `string \| EnvVar` | ✅ Yes (if `logs_enabled`) | OTLP logs endpoint URL — supports `env.VAR_NAME` |
+| `logs_disable_content_logging` | `boolean` | ❌ No | Drop message content from exported **log records** only (default: `false`). Independent of `disable_content_logging`, which gates spans. See [Controlling Exported Content](#controlling-exported-content) |
 | `request_headers` | `string[]` | ❌ No | Request-header name patterns whose values are attached to the root span as `http.request.header.*` attributes. Supports exact names and wildcards (`x-custom-*`, `*`) |
 
 ### Environment Variable Substitution
 
-`collector_url`, `metrics_endpoint`, and individual values in `headers`, `trace_headers`, and `metrics_headers` all support the `env.` prefix to read from environment variables at runtime. This keeps sensitive URLs and credentials out of stored configuration.
+`collector_url`, `metrics_endpoint`, `logs_endpoint`, and individual values in `headers`, `trace_headers`, and `metrics_headers` all support the `env.` prefix to read from environment variables at runtime. This keeps sensitive URLs and credentials out of stored configuration.
 
 ```json
 {
@@ -783,12 +786,22 @@ When Enterprise guardrail redaction is enabled, Bifrost applies trace redaction 
 
 ### Controlling Exported Content
 
-Two profile-level flags control how much message content leaves Bifrost:
+Three profile-level flags control how much message content leaves Bifrost:
 
 | Flag | Effect |
 |------|--------|
 | `disable_content_logging` | Drops input/output message content, prompt and instructions, model reasoning, tool definitions, and tool call arguments/results from **every** exported span. Metadata is still exported, including model, provider, tokens, cost, latency, status, and governance attribution. |
 | `disable_root_span_content` | When used alone, drops content from the **root span only**. Bifrost duplicates input/output onto the root span for trace-level display; this removes that duplication while child spans keep full content. Useful when your backend indexes root-span attributes and you want to limit the blast radius without losing detail. `disable_content_logging` takes precedence: when it is enabled, child spans lose their content too. |
+| `logs_disable_content_logging` | Drops the same content from exported **log records** (GenAI events) only. The events are still emitted, carrying metadata alone. Applies only when `logs_enabled` is set. |
+
+`disable_content_logging` gates **traces**; `logs_disable_content_logging` gates **logs**. Because the two are independent, all four capture modes are available:
+
+| `disable_content_logging` | `logs_disable_content_logging` | Result |
+|---|---|---|
+| `false` | `false` | Content on spans **and** events (default) |
+| `true` | `false` | Content on events only — keeps payloads in the log pipeline, with its own retention and access control |
+| `false` | `true` | Content on spans only |
+| `true` | `true` | No content on either signal |
 
 ```json
 {
@@ -1122,6 +1135,98 @@ service:
 | Cluster aggregation | Query-side `sum()` | Collector handles it |
 
 For **single-node deployments**, pull-based `/metrics` scraping works well. For **multi-node clusters**, push-based metrics ensures all nodes are captured.
+
+---
+
+## Log Export (GenAI Events)
+
+<Note>
+**Development stability**: GenAI events follow the OpenTelemetry [GenAI semantic conventions](https://github.com/open-telemetry/semantic-conventions-genai), which are still marked Development. Attribute names may change with future semconv releases.
+</Note>
+
+Beyond traces and metrics, a profile can export **GenAI events** as OTLP log records. Each event is a `gen_ai.client.inference.operation.details` log record describing one call to one model: the chat history, system instructions, tool definitions, request parameters, and usage. Retries and fallbacks each produce their own event, matching their own `llm.call` span.
+
+This is the signal to enable when your backend ingests logs rather than spans (Loki, OpenSearch, a SIEM), or when you want prompt/response payloads to live in a log pipeline with its own retention and access control instead of on your traces.
+
+### Correlation
+
+Every log record carries the `trace_id` and `span_id` of the `llm.call` span it describes, so log-to-trace navigation works out of the box in Grafana, Datadog, and anything else that reads OTLP correlation fields. Records also carry `session.id`, `bifrost.request.id`, instance attributes, and any captured request headers, so a log-only backend can filter by tenant without joining back to the trace.
+
+Records are emitted at `INFO` severity, or `ERROR` when the call failed (the event then carries `error.type`).
+
+### Configuration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `logs_enabled` | `boolean` | ❌ No | Enable GenAI event export (default: `false`) |
+| `logs_endpoint` | `string \| EnvVar` | ✅ Yes (if enabled) | OTLP logs endpoint URL — supports `env.VAR_NAME` |
+| `logs_disable_content_logging` | `boolean` | ❌ No | Drop message content from exported log records (default: `false`) |
+
+Logs reuse the profile's `protocol`, `headers`, `tls_ca_cert`, `insecure`, and `export_timeout`, but dial their own endpoint. For `protocol: http` give the full OTLP logs URL (`http://collector:4318/v1/logs`); for `grpc` give `host:port`.
+
+```json
+{
+  "plugins": [
+    {
+      "enabled": true,
+      "name": "otel",
+      "config": {
+        "service_name": "bifrost",
+        "collector_url": "http://otel-collector:4318/v1/traces",
+        "trace_type": "genai_extension",
+        "protocol": "http",
+        "logs_enabled": true,
+        "logs_endpoint": "http://otel-collector:4318/v1/logs"
+      }
+    }
+  ]
+}
+```
+
+Log export is its own failure domain: it has a separate client and circuit breaker, so an unreachable logs endpoint never suppresses trace or metrics export (and vice versa).
+
+### Event Content
+
+Content attributes are recorded in **structured form** (nested attribute values, not JSON strings), following the semconv message schemas:
+
+| Attribute | Contents |
+|-----------|----------|
+| `gen_ai.input.messages` | `[{role, parts}]` — `text`, `tool_call` (with parsed arguments), `tool_call_response`, `reasoning`, and `refusal` parts |
+| `gen_ai.output.messages` | The same shape, plus `finish_reason` per message |
+| `gen_ai.system_instructions` | `[{type: "text", content}]` |
+| `gen_ai.tool.definitions` | `[{type, name, description}]` — tool names and descriptions only, per semconv guidance against expanding parameter schemas |
+
+Alongside these, each event carries the request/response metadata from its span: `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.response.model`, request parameters, `gen_ai.response.finish_reasons`, token usage, cost, and Bifrost governance attributes.
+
+<Warning>
+Unlike the semantic conventions — which recommend capturing content only on explicit opt-in — Bifrost exports content by default once log export is enabled, matching the existing span behavior. Set `logs_disable_content_logging: true` to emit metadata-only events.
+</Warning>
+
+### Collector Configuration
+
+Add a `logs` pipeline to the collector receiving the export:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+exporters:
+  debug:
+    verbosity: detailed
+  # loki, opensearch, datadog, ... whichever backend consumes the events
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+```
 
 ---
 


### PR DESCRIPTION
## Summary

Documents the new OTLP log export feature for the OTel plugin, which allows Bifrost to emit GenAI events as OTLP log records — one per LLM call — alongside existing trace and metrics export.

## Changes

- Added `logs_enabled`, `logs_endpoint`, and `logs_disable_content_logging` configuration fields to the OTel plugin reference tables in both the `config.json` and Helm deployment guides
- Added a new **Log Export (GenAI Events)** section to the OTel observability feature page covering:
  - What each `gen_ai.client.inference.operation.details` log record contains (chat history, system instructions, tool definitions, request parameters, usage)
  - Trace/log correlation via `trace_id` and `span_id` on every record
  - Severity behavior (`INFO` on success, `ERROR` on failure)
  - A configuration example for HTTP log export
  - Structured event content attribute reference (`gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.system_instructions`, `gen_ai.tool.definitions`)
  - A sample collector YAML pipeline for receiving the log signal
- Expanded the **Controlling Exported Content** section to document `logs_disable_content_logging` as independent of `disable_content_logging`, with a truth table covering all four capture modes (content on both, content on logs only, content on spans only, no content on either)
- Updated the environment variable substitution note to include `logs_endpoint` alongside `collector_url` and `metrics_endpoint`
- Added a cross-reference from the `config.json` plugin example to the new Log Export section

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation for:
- Correct field names and defaults in the config reference tables (`logs_enabled: false`, `logs_endpoint: ""`, `logs_disable_content_logging: false`)
- The truth table in **Controlling Exported Content** rendering as a valid Markdown table
- The JSON and YAML examples being syntactically valid
- The cross-reference link `[Log Export (GenAI Events)](/features/observability/otel#log-export-genai-events)` resolving to the new section anchor

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The `logs_disable_content_logging` flag and its interaction with `disable_content_logging` are documented explicitly. Operators who want to prevent prompt/response payloads from entering a log pipeline must set `logs_disable_content_logging: true` independently of `disable_content_logging`, as the two flags gate separate signals. This distinction is called out in both the content-control table and the Warning admonition in the new Log Export section.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable