### PR TITLE
chore: adds e2e ui tests for otel logs support

### DIFF
--- a/tests/e2e/features/observability/observability.spec.ts
+++ b/tests/e2e/features/observability/observability.spec.ts
@@ -58,6 +58,21 @@ test.describe('Observability', () => {
       expect(hasMetrics).toBe(true)
     })
 
+    test('should reveal logs endpoint when log export is enabled', async ({ observabilityPage }) => {
+      await observabilityPage.selectConnector('otel')
+
+      // The logs endpoint field only exists once "Enable Log Export" is on.
+      expect(await observabilityPage.getLogsEndpointPlaceholder()).toBeNull()
+
+      await observabilityPage.enableLogExport()
+      const placeholder = await observabilityPage.getLogsEndpointPlaceholder()
+      expect(placeholder).not.toBeNull()
+      expect(placeholder).toMatch(/v1\/logs|OTEL_LOGS_ENDPOINT/i)
+
+      // The logs-only content switch appears alongside it.
+      await expect(observabilityPage.page.getByTestId('otel-profile-0-logs-disable-content-toggle')).toBeVisible()
+    })
+
     test('should toggle OTel connector', async ({ observabilityPage }) => {
       await observabilityPage.selectConnector('otel')
 

--- a/tests/e2e/features/observability/pages/observability.page.ts
+++ b/tests/e2e/features/observability/pages/observability.page.ts
@@ -194,6 +194,30 @@ export class ObservabilityPage extends BasePage {
   }
 
   /**
+   * Enable Log Export (GenAI events). Uses the first profile's toggle.
+   */
+  async enableLogExport(): Promise<void> {
+    await this.selectConnector('otel')
+    const switch_ = this.page.getByTestId('otel-profile-0-logs-export-toggle')
+    await switch_.waitFor({ state: 'visible', timeout: 5000 })
+    const checked = await switch_.getAttribute('data-state') === 'checked'
+    if (!checked) {
+      await switch_.click()
+      await this.page.waitForTimeout(400)
+    }
+  }
+
+  /**
+   * Get the logs endpoint placeholder, which is only in the DOM once log export is on.
+   */
+  async getLogsEndpointPlaceholder(): Promise<string | null> {
+    const logsInput = this.page.getByPlaceholder(/v1\/logs|OTEL_LOGS_ENDPOINT/i).first()
+    const isVisible = await logsInput.isVisible().catch(() => false)
+    if (!isVisible) return null
+    return await logsInput.getAttribute('placeholder')
+  }
+
+  /**
    * Configure OTel endpoint
    */
   async configureOtelEndpoint(endpoint: string): Promise<void> {


### PR DESCRIPTION
## Summary

Adds E2E test coverage for the OTel log export feature, verifying that the logs endpoint field and the logs-only content toggle are conditionally revealed in the UI only after "Enable Log Export" is turned on.

## Changes

- Added `enableLogExport()` helper to `ObservabilityPage` that locates the `otel-profile-0-logs-export-toggle` switch and clicks it if not already enabled.
- Added `getLogsEndpointPlaceholder()` helper that returns the placeholder text of the logs endpoint input field, or `null` if the field is not yet present in the DOM.
- Added a new E2E test `should reveal logs endpoint when log export is enabled` that asserts the logs endpoint field is absent before enabling log export, appears with the expected placeholder after enabling it, and that the `otel-profile-0-logs-disable-content-toggle` switch becomes visible alongside it.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd tests/e2e
pnpm test -- --grep "should reveal logs endpoint when log export is enabled"
```

The test should pass with the OTel connector selected, confirming that the logs endpoint field and content toggle are hidden by default and visible after enabling log export.

## Screenshots/Recordings

N/A — no UI changes, test-only additions.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None. Changes are limited to test helpers and assertions.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable