### PR TITLE
[DO-NOT-MERGE-YET] complexity session routing and store readiness

### DIFF
--- a/framework/configstore/complexityconfig.go
+++ b/framework/configstore/complexityconfig.go
@@ -355,7 +355,6 @@ const (
 // on the exemplar set's score distribution, so it ships unset (no gating).
 const (
 	DefaultComplexitySessionTTL                   = time.Hour
-	DefaultComplexitySessionReleaseAfterFailures  = 3
 	DefaultComplexitySessionDowngradeAfterNTurns  = 2
 	DefaultComplexitySessionMinCachedTokensToHold = 1024
 )
@@ -381,9 +380,6 @@ type ComplexitySessionConfig struct {
 	// session ID, tried in the constant order above regardless of the order
 	// given here.
 	IdentitySources []string `json:"identity_sources,omitempty"`
-	// ReleaseAfterFailures releases a pin after this many consecutive upstream
-	// failures, on the assumption that the pinned tier is implicated.
-	ReleaseAfterFailures int `json:"release_after_failures,omitempty"`
 
 	// SwitchMinSimilarity is the confidence a classification must reach before
 	// it may change session state, forming hysteresis with the semantic
@@ -501,7 +497,6 @@ func (c *ComplexitySessionConfig) normalized() *ComplexitySessionConfig {
 		Mode:                  strings.ToLower(strings.TrimSpace(c.Mode)),
 		TTL:                   c.TTL,
 		IdentitySources:       normalizeComplexitySessionIdentitySources(c.IdentitySources),
-		ReleaseAfterFailures:  c.ReleaseAfterFailures,
 		SwitchMinSimilarity:   c.SwitchMinSimilarity,
 		DowngradeAfterNTurns:  c.DowngradeAfterNTurns,
 		MinCachedTokensToHold: c.MinCachedTokensToHold,
@@ -516,9 +511,6 @@ func (c *ComplexitySessionConfig) normalized() *ComplexitySessionConfig {
 	}
 	if len(out.IdentitySources) == 0 {
 		out.IdentitySources = DefaultComplexitySessionIdentitySources()
-	}
-	if out.ReleaseAfterFailures == 0 {
-		out.ReleaseAfterFailures = DefaultComplexitySessionReleaseAfterFailures
 	}
 	if out.DowngradeAfterNTurns == 0 {
 		out.DowngradeAfterNTurns = DefaultComplexitySessionDowngradeAfterNTurns
@@ -594,9 +586,6 @@ func (c *ComplexitySessionConfig) Validate() error {
 	// MinSimilarity treatment: a misconfiguration, not "never switch".
 	if c.SwitchMinSimilarity < 0 || c.SwitchMinSimilarity >= 1 {
 		return fmt.Errorf("session switch_min_similarity must be at least 0 and less than 1, got %v", c.SwitchMinSimilarity)
-	}
-	if c.ReleaseAfterFailures < 1 {
-		return fmt.Errorf("session release_after_failures must be at least 1, got %d", c.ReleaseAfterFailures)
 	}
 	if c.DowngradeAfterNTurns < 1 {
 		return fmt.Errorf("session downgrade_after_n_turns must be at least 1, got %d", c.DowngradeAfterNTurns)

--- a/framework/configstore/complexityconfig_test.go
+++ b/framework/configstore/complexityconfig_test.go
@@ -476,7 +476,6 @@ func TestComplexitySessionConfigNormalizedDefaults(t *testing.T) {
 
 	assert.Equal(t, DefaultComplexitySessionTTL, normalized.TTL)
 	assert.Equal(t, DefaultComplexitySessionIdentitySources(), normalized.IdentitySources)
-	assert.Equal(t, DefaultComplexitySessionReleaseAfterFailures, normalized.ReleaseAfterFailures)
 	assert.Equal(t, DefaultComplexitySessionDowngradeAfterNTurns, normalized.DowngradeAfterNTurns)
 	assert.Equal(t, DefaultComplexitySessionMinCachedTokensToHold, normalized.MinCachedTokensToHold)
 	// Ships unset: no sensible absolute default exists until the exemplar set's

--- a/plugins/governance/complexity/config.go
+++ b/plugins/governance/complexity/config.go
@@ -42,6 +42,12 @@ const (
 const (
 	MechanismSemantic = "semantic"
 	MechanismSkipped  = "skipped"
+	// MechanismSession means the tier was reused from session state rather than
+	// classified for this request. It is a distinct value rather than reporting
+	// the mechanism that originally decided it: the whole point of the pin is
+	// that no classifier ran for this turn, and recording "semantic" would make
+	// a log of held turns indistinguishable from a log of embedded ones.
+	MechanismSession = "session"
 )
 
 // Default boundaries are retained for the dormant lexical analyzer and its

--- a/plugins/governance/complexitysession.go
+++ b/plugins/governance/complexitysession.go
@@ -60,6 +60,10 @@ type SessionComplexityRecord struct {
 	RuleID string `json:"rule_id"`
 	// SwitchCount is the number of tier changes made during this session.
 	SwitchCount int `json:"switch_count,omitempty"`
+	// RefreshedAt is when the sliding expiration was last extended. It exists so
+	// reads can tell whether the window actually needs sliding: refreshing on
+	// every read makes each read a write, and each write a cluster broadcast.
+	RefreshedAt time.Time `json:"refreshed_at"`
 
 	// PendingTier is the lower tier currently being considered for a sustained
 	// downgrade. Empty means that no downgrade is pending.
@@ -71,9 +75,6 @@ type SessionComplexityRecord struct {
 	// pending sequence.
 	PendingMinScore float64 `json:"pending_min_score,omitempty"`
 
-	// ConsecutiveFailures counts upstream failures associated with the current
-	// pin and is reset after a successful pinned attempt.
-	ConsecutiveFailures int `json:"consecutive_failures,omitempty"`
 	// RouteObservations is keyed by a stable, opaque effective-route identity.
 	// It is a map so primary, fallback, and destination warmth remain separate.
 	// Writers are responsible for bounding retained history.
@@ -81,18 +82,23 @@ type SessionComplexityRecord struct {
 }
 
 // SessionStoreStatus describes the guarantees of the active session-state
-// backend. Multi-replica session routing is safe only when both
-// SharedAcrossReplicas and AtomicUpdates are true.
+// backend. It reports what the storage layer can prove about itself, never
+// whether a given deployment is safe: that also depends on how many replicas
+// are running, which this layer cannot observe.
 type SessionStoreStatus struct {
 	// Backend is a diagnostic name for the active implementation. Callers must
 	// use the capability fields, not this label, when deciding readiness.
 	Backend string `json:"backend"`
-	// SharedAcrossReplicas reports whether all replicas observe the same logical
-	// session records.
-	SharedAcrossReplicas bool `json:"shared_across_replicas"`
-	// AtomicUpdates reports whether concurrent updates to one session are
-	// serialized across every replica that shares the backend.
-	AtomicUpdates bool `json:"atomic_updates"`
+	// ReplicationConfigured reports whether local mutations are forwarded to
+	// other nodes. It is deliberately named for the configuration rather than
+	// the outcome: forwarding is fire-and-forget, so a delegate being installed
+	// says nothing about whether peers are connected, reachable, or converged.
+	ReplicationConfigured bool `json:"replication_configured"`
+	// AtomicAcrossReplicas reports whether concurrent updates to one session are
+	// serialized across everything sharing this backend. A single node holding
+	// the only copy satisfies this through its own lock; gossip replication does
+	// not, because it resolves conflicts by last-write-wins after the fact.
+	AtomicAcrossReplicas bool `json:"atomic_across_replicas"`
 }
 
 // SessionRecordUpdater mutates a caller-owned copy of the current session
@@ -105,9 +111,16 @@ type SessionRecordUpdater func(*SessionComplexityRecord) error
 // contract. Implementations must be safe for concurrent use and must not expose
 // shared record pointers or RouteObservations maps to callers.
 type SessionStore interface {
-	// Get atomically reads a record and refreshes its sliding expiration to ttl.
-	// The returned record is caller-owned. found is false, with a nil error, when
-	// the key is absent or expired. ttl must be positive.
+	// Get reads a record and keeps its sliding expiration at least ttl away. The
+	// returned record is caller-owned. found is false, with a nil error, when the
+	// key is absent or expired. ttl must be positive.
+	//
+	// The refresh is coarse rather than per-read: an implementation may leave the
+	// expiry untouched while the window is still comfortably in the future. A
+	// record therefore survives at least ttl of idleness, and may survive somewhat
+	// longer. This is deliberate — sliding on literally every read turns a read
+	// path into a write path, which on a replicated backend means a cluster
+	// message per request.
 	Get(ctx context.Context, key string, ttl time.Duration) (record *SessionComplexityRecord, found bool, err error)
 	// Create atomically stores a caller-owned snapshot only when key is absent or
 	// expired. created is false, with a nil error, when another caller already
@@ -160,21 +173,74 @@ func (s *kvSessionStore) Get(ctx context.Context, key string, ttl time.Duration)
 		return nil, false, err
 	}
 
-	value, found, err := s.store.UpdateWithTTL(key, ttl, func(current any) (any, error) {
-		return complexitySessionRecordFromValue(current)
-	})
-	if err != nil {
-		return nil, found, fmt.Errorf("refresh complexity session %q: %w", key, err)
-	}
-	if !found {
+	// The read-only path first. kvstore.Get takes a read lock and notifies no
+	// delegate, so a held turn costs nothing beyond a map lookup.
+	value, err := s.store.Get(key)
+	if errors.Is(err, kvstore.ErrNotFound) {
 		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("read complexity session %q: %w", key, err)
 	}
 
 	record, err := complexitySessionRecordFromValue(value)
 	if err != nil {
 		return nil, true, fmt.Errorf("read complexity session %q: %w", key, err)
 	}
-	return record, true, nil
+
+	// Still comfortably inside the window, so leave the expiry alone.
+	if time.Since(record.RefreshedAt) < complexitySessionRefreshInterval(ttl) {
+		return record, true, nil
+	}
+
+	refreshedAt := time.Now()
+	value, found, err := s.store.UpdateWithTTL(key, complexitySessionStoredTTL(ttl), func(current any) (any, error) {
+		refreshed, err := complexitySessionRecordFromValue(current)
+		if err != nil {
+			return nil, err
+		}
+		refreshed.RefreshedAt = refreshedAt
+		return refreshed, nil
+	})
+	if err != nil {
+		return nil, true, fmt.Errorf("refresh complexity session %q: %w", key, err)
+	}
+	if !found {
+		// Expired between the read and the refresh. The record we hold is already
+		// gone, so report it as absent rather than serving a tier the store no
+		// longer has.
+		return nil, false, nil
+	}
+
+	refreshed, err := complexitySessionRecordFromValue(value)
+	if err != nil {
+		return nil, true, fmt.Errorf("read refreshed complexity session %q: %w", key, err)
+	}
+	return refreshed, true, nil
+}
+
+// complexitySessionRefreshInterval is how much of the idle window may elapse
+// before a read slides the expiry. A quarter keeps writes to roughly four per
+// window however chatty the conversation is, while staying frequent enough that
+// the stored expiry never drifts far from the truth.
+func complexitySessionRefreshInterval(ttl time.Duration) time.Duration {
+	interval := ttl / 4
+	if interval <= 0 {
+		// A ttl too short to quarter refreshes on every read, which is correct:
+		// there is no amplification to avoid at that scale.
+		return 0
+	}
+	return interval
+}
+
+// complexitySessionStoredTTL is the expiry actually written to the backend. It
+// carries one refresh interval of headroom so a coarse refresh can never expire
+// a session earlier than the configured idle window: the worst case is a read
+// that declines to slide just before the caller goes idle, and the headroom
+// covers exactly that gap. The cost is that an abandoned session lingers up to
+// one interval longer than configured.
+func complexitySessionStoredTTL(ttl time.Duration) time.Duration {
+	return ttl + complexitySessionRefreshInterval(ttl)
 }
 
 // Create stores a detached record snapshot when key is currently absent or
@@ -187,7 +253,13 @@ func (s *kvSessionStore) Create(ctx context.Context, key string, record *Session
 		return false, errNilComplexitySessionRecord
 	}
 
-	created, err := s.store.SetNXWithTTL(key, cloneSessionComplexityRecord(record), ttl)
+	// The store owns the refresh clock, not the caller: a record created with a
+	// zero or stale RefreshedAt would slide its expiry on the very next read,
+	// which is the write-per-read this exists to avoid.
+	stored := cloneSessionComplexityRecord(record)
+	stored.RefreshedAt = time.Now()
+
+	created, err := s.store.SetNXWithTTL(key, stored, complexitySessionStoredTTL(ttl))
 	if err != nil {
 		return false, fmt.Errorf("create complexity session %q: %w", key, err)
 	}
@@ -204,7 +276,11 @@ func (s *kvSessionStore) Update(ctx context.Context, key string, ttl time.Durati
 		return nil, false, errNilComplexitySessionUpdater
 	}
 
-	value, found, err := s.store.UpdateWithTTL(key, ttl, func(current any) (any, error) {
+	// An update is already a write, so it slides the window too — leaving it on
+	// the old expiry would make a just-modified session expire sooner than a
+	// merely-read one.
+	refreshedAt := time.Now()
+	value, found, err := s.store.UpdateWithTTL(key, complexitySessionStoredTTL(ttl), func(current any) (any, error) {
 		record, err := complexitySessionRecordFromValue(current)
 		if err != nil {
 			return nil, err
@@ -212,6 +288,8 @@ func (s *kvSessionStore) Update(ctx context.Context, key string, ttl time.Durati
 		if err := update(record); err != nil {
 			return nil, err
 		}
+		// Stamped after the updater so a caller cannot rewind the refresh clock.
+		record.RefreshedAt = refreshedAt
 		return cloneSessionComplexityRecord(record), nil
 	})
 	if err != nil {
@@ -252,11 +330,16 @@ func (s *kvSessionStore) Status(ctx context.Context) (SessionStoreStatus, error)
 		return SessionStoreStatus{}, err
 	}
 
-	sharedAcrossReplicas := s.store.HasSyncDelegate()
+	replicationConfigured := s.store.HasSyncDelegate()
 	return SessionStoreStatus{
-		Backend:              complexitySessionStoreBackendKV,
-		SharedAcrossReplicas: sharedAcrossReplicas,
-		AtomicUpdates:        !sharedAcrossReplicas,
+		Backend:               complexitySessionStoreBackendKV,
+		ReplicationConfigured: replicationConfigured,
+		// Inverted deliberately. With no delegate this process holds the only
+		// copy and its own lock serializes every update, so updates are atomic
+		// across the one replica that exists. Once replication is configured the
+		// lock is local to each node while the records are shared, which is the
+		// combination that lets two nodes decide different tiers for one session.
+		AtomicAcrossReplicas: !replicationConfigured,
 	}, nil
 }
 

--- a/plugins/governance/complexitysession_test.go
+++ b/plugins/governance/complexitysession_test.go
@@ -281,14 +281,13 @@ func TestKVSessionStoreRoundTripAndOwnership(t *testing.T) {
 	decidedAt := time.Date(2026, time.August, 10, 12, 0, 0, 0, time.UTC)
 	lastSeenAt := decidedAt.Add(time.Minute)
 	record := &SessionComplexityRecord{
-		Tier:                "complex",
-		DecidedAt:           decidedAt,
-		RuleID:              "rule-1",
-		SwitchCount:         2,
-		PendingTier:         "medium",
-		PendingTurns:        1,
-		PendingMinScore:     0.91,
-		ConsecutiveFailures: 1,
+		Tier:            "complex",
+		DecidedAt:       decidedAt,
+		RuleID:          "rule-1",
+		SwitchCount:     2,
+		PendingTier:     "medium",
+		PendingTurns:    1,
+		PendingMinScore: 0.91,
 		RouteObservations: map[string]SessionRouteObservation{
 			"route-1": {
 				CachedReadTokens: 4096,
@@ -310,6 +309,10 @@ func TestKVSessionStoreRoundTripAndOwnership(t *testing.T) {
 	got, found, err := sessionStore.Get(context.Background(), key, time.Hour)
 	require.NoError(t, err)
 	require.True(t, found)
+	// The store stamps RefreshedAt itself, so it is asserted separately and
+	// cleared before the structural comparison.
+	assert.False(t, got.RefreshedAt.IsZero(), "Create should stamp the refresh clock")
+	got.RefreshedAt = time.Time{}
 	assert.Equal(t, want, got)
 
 	// Mutating a returned record must not mutate stored state either.
@@ -319,6 +322,7 @@ func TestKVSessionStoreRoundTripAndOwnership(t *testing.T) {
 	gotAgain, found, err := sessionStore.Get(context.Background(), key, time.Hour)
 	require.NoError(t, err)
 	require.True(t, found)
+	gotAgain.RefreshedAt = time.Time{}
 	assert.Equal(t, want, gotAgain)
 }
 
@@ -448,10 +452,59 @@ func TestKVSessionStoreSlidingTTL(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, found, "successful Get should extend the deadline")
 
-	time.Sleep(300 * time.Millisecond)
+	// Expiry is ttl plus one refresh interval of headroom, so an abandoned
+	// session lingers a little past the configured window rather than expiring
+	// early — the direction that matters, since expiring early would drop a live
+	// conversation's tier mid-way.
+	time.Sleep(ttl + complexitySessionRefreshInterval(ttl) + 100*time.Millisecond)
 	_, found, err = sessionStore.Get(context.Background(), key, ttl)
 	require.NoError(t, err)
-	assert.False(t, found, "record should expire when its TTL is no longer refreshed")
+	assert.False(t, found, "record should expire once its TTL is no longer refreshed")
+}
+
+// The refresh is coarse on purpose: sliding the expiry on every read makes each
+// read a write, and on a replicated backend each write is a cluster broadcast.
+// A chatty conversation must not cost one broadcast per turn.
+func TestKVSessionStoreGetDoesNotWriteOnEveryRead(t *testing.T) {
+	sessionStore, store := newTestKVSessionStore(t)
+	_, targetKV := newTestKVSessionStore(t)
+	delegate := &forwardingKVDelegate{target: targetKV}
+
+	key := testComplexitySessionKey(t, "tenant", "read-amplification")
+	_, err := sessionStore.Create(context.Background(), key, &SessionComplexityRecord{Tier: "complex"}, time.Hour)
+	require.NoError(t, err)
+
+	// Attached after Create so only the reads below are counted.
+	store.SetDelegate(delegate)
+	for i := 0; i < 50; i++ {
+		_, found, err := sessionStore.Get(context.Background(), key, time.Hour)
+		require.NoError(t, err)
+		require.True(t, found)
+	}
+
+	assert.Zero(t, delegate.Sets(), "reads inside the refresh interval must not replicate")
+}
+
+// The window must still slide for a long-lived conversation, or a session that
+// stays busy past its ttl would expire underneath itself.
+func TestKVSessionStoreGetRefreshesOnceTheIntervalElapses(t *testing.T) {
+	sessionStore, _ := newTestKVSessionStore(t)
+	key := testComplexitySessionKey(t, "tenant", "interval-elapsed")
+	const ttl = 400 * time.Millisecond
+
+	_, err := sessionStore.Create(context.Background(), key, &SessionComplexityRecord{Tier: "complex"}, ttl)
+	require.NoError(t, err)
+
+	before, found, err := sessionStore.Get(context.Background(), key, ttl)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	// Past one refresh interval (ttl/4 = 100ms), so the next read slides it.
+	time.Sleep(complexitySessionRefreshInterval(ttl) + 50*time.Millisecond)
+	after, found, err := sessionStore.Get(context.Background(), key, ttl)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.True(t, after.RefreshedAt.After(before.RefreshedAt), "the window never slid")
 }
 
 func TestKVSessionStoreRegistersReplicationDecoder(t *testing.T) {
@@ -480,6 +533,8 @@ func TestKVSessionStoreRegistersReplicationDecoder(t *testing.T) {
 	got, found, err := target.Get(context.Background(), key, time.Hour)
 	require.NoError(t, err)
 	require.True(t, found)
+	assert.False(t, got.RefreshedAt.IsZero(), "the replicated record should carry the refresh clock")
+	got.RefreshedAt = time.Time{}
 	assert.Equal(t, want, got)
 }
 
@@ -529,9 +584,9 @@ func TestKVSessionStoreStatus(t *testing.T) {
 	status, err := sessionStore.Status(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, SessionStoreStatus{
-		Backend:              complexitySessionStoreBackendKV,
-		SharedAcrossReplicas: false,
-		AtomicUpdates:        true,
+		Backend:               complexitySessionStoreBackendKV,
+		ReplicationConfigured: false,
+		AtomicAcrossReplicas:  true,
 	}, status)
 
 	_, targetKV := newTestKVSessionStore(t)
@@ -539,9 +594,9 @@ func TestKVSessionStoreStatus(t *testing.T) {
 	status, err = sessionStore.Status(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, SessionStoreStatus{
-		Backend:              complexitySessionStoreBackendKV,
-		SharedAcrossReplicas: true,
-		AtomicUpdates:        false,
+		Backend:               complexitySessionStoreBackendKV,
+		ReplicationConfigured: true,
+		AtomicAcrossReplicas:  false,
 	}, status)
 }
 
@@ -568,10 +623,22 @@ type forwardingKVDelegate struct {
 	target *kvstore.Store
 	mu     sync.Mutex
 	err    error
+	sets   int
 }
 
 func (d *forwardingKVDelegate) OnSet(key string, valueJSON []byte, writtenAt int64, expiresAt int64) {
+	d.mu.Lock()
+	d.sets++
+	d.mu.Unlock()
 	d.recordError(d.target.SetRemote(key, valueJSON, writtenAt, expiresAt))
+}
+
+// Sets reports how many replication messages this delegate has been asked to
+// send, which is the cost a read path must not incur per request.
+func (d *forwardingKVDelegate) Sets() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.sets
 }
 
 func (d *forwardingKVDelegate) OnDelete(key string, deletedAt int64) {

--- a/plugins/governance/complexitysessionroute.go
+++ b/plugins/governance/complexitysessionroute.go
@@ -1,0 +1,191 @@
+package governance
+
+import (
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/plugins/governance/complexity"
+)
+
+// complexitySessionGlobalScope namespaces sessions on deployments that route
+// without virtual keys. Callers in this scope must provide globally unique
+// session IDs because no narrower ownership boundary is available.
+const complexitySessionGlobalScope = "global"
+
+// complexitySessionState is the per-request session context, resolved once
+// before routing so both the routing engine and the classification closure work
+// from the same identity.
+type complexitySessionState struct {
+	// ID is the resolved conversation identity, empty when nothing identified it.
+	ID string
+	// Source names which rung of the identity ladder produced ID.
+	Source string
+	// Key is the tenant-namespaced store key, empty when ID is empty.
+	Key string
+	// TTL is the sliding idle window from configuration.
+	TTL time.Duration
+}
+
+// resolveComplexitySessionState resolves the conversation identity for this
+// request. It returns nil when session behaviour is off, when no store is
+// attached, or when nothing identified the conversation — all of which mean
+// "classify this turn normally", the pre-session behaviour.
+//
+// Resolution runs eagerly because the routing engine needs the ID to make target
+// selection sticky, and the ladder only reads request context. The store lookup
+// stays lazy: it happens inside the classification closure, so a request whose
+// rules never mention complexity never touches the store at all.
+func (p *GovernancePlugin) resolveComplexitySessionState(
+	ctx *schemas.BifrostContext,
+	virtualKey *configstoreTables.TableVirtualKey,
+) *complexitySessionState {
+	config := p.complexitySessionConfig.Load()
+	if config == nil || p.complexitySessionStore.Load() == nil {
+		return nil
+	}
+
+	sessionID, source, ok := resolveSessionID(ctx, config.IdentitySources)
+	if !ok {
+		return nil
+	}
+
+	// Sessions are namespaced per virtual key so one tenant's conversation can
+	// never adopt another's pinned tier, even if both present the same id.
+	scopeID := complexitySessionGlobalScope
+	if virtualKey != nil && virtualKey.ID != "" {
+		scopeID = virtualKey.ID
+	}
+	key, ok := buildComplexitySessionKey(scopeID, sessionID)
+	if !ok {
+		return nil
+	}
+
+	ttl := config.TTL
+	if ttl <= 0 {
+		// Normalization fills this in, so reaching here means a record was
+		// written by an older build or hand-edited. A non-positive ttl is
+		// rejected by the store, which would disable sessions silently.
+		return nil
+	}
+
+	return &complexitySessionState{ID: sessionID, Source: source, Key: key, TTL: ttl}
+}
+
+// publishSessionKeyAffinity hands the resolved conversation identity to the
+// core's API-key stickiness.
+//
+// Without this the feature protects the wrong layer. A provider's prompt cache
+// is keyed per API key, so holding a conversation on one tier while its key
+// rotates between turns discards the cache anyway — the pin would do the
+// bookkeeping and deliver none of the benefit.
+//
+// It is safe to publish unconditionally here because state is only non-nil when
+// session behaviour is switched on and something identified the conversation.
+// That matters: core activates stickiness on any non-empty session id, so
+// writing a derived id outside those conditions would silently pin API keys for
+// callers who never asked for it.
+func (p *GovernancePlugin) publishSessionKeyAffinity(ctx *schemas.BifrostContext, state *complexitySessionState) {
+	if state == nil {
+		return
+	}
+	// A header-sourced ID is already here and this rewrites the same value; a
+	// harness-native one is new, which is the whole point.
+	ctx.SetValue(schemas.BifrostContextKeySessionID, state.ID)
+
+	// Align the two lifetimes. Core otherwise falls back to its own one-hour
+	// default, so a shorter configured session would release its tier while the
+	// key stayed pinned — or a longer one would keep classifying against a key
+	// that had already rotated. An explicit per-request ttl still wins: the
+	// caller asked for it by name.
+	if existing, ok := ctx.Value(schemas.BifrostContextKeySessionTTL).(time.Duration); !ok || existing <= 0 {
+		ctx.SetValue(schemas.BifrostContextKeySessionTTL, state.TTL)
+	}
+}
+
+// withComplexitySession wraps the lazy classification closure so an established
+// session reuses its tier instead of classifying again. That reuse is the point
+// of the feature: it keeps the provider's prompt cache warm and skips the
+// per-turn embedding call.
+//
+// It deliberately wraps rather than running ahead of classification. The inner
+// closure is only invoked when a routing rule references complexity_tier, so
+// wrapping inherits that condition for free and a request that never routes on
+// complexity performs no session reads.
+func (p *GovernancePlugin) withComplexitySession(
+	ctx *schemas.BifrostContext,
+	state *complexitySessionState,
+	classify func() *complexity.ComplexityResult,
+) func() *complexity.ComplexityResult {
+	if state == nil || classify == nil {
+		return classify
+	}
+	stored := p.complexitySessionStore.Load()
+	if stored == nil {
+		return classify
+	}
+	store := *stored
+
+	return func() *complexity.ComplexityResult {
+		// A store that cannot be read is not a reason to fail the request: fall
+		// through and classify, which is exactly the pre-session behaviour.
+		record, found, err := store.Get(ctx, state.Key, state.TTL)
+		if err != nil {
+			if p.logger != nil {
+				p.logger.Warn("[Governance] Complexity session lookup failed, classifying this turn: %v", err)
+			}
+		} else if found && record != nil && record.Tier != "" {
+			p.publishSessionTier(ctx, state, record)
+			return &complexity.ComplexityResult{Tier: record.Tier}
+		}
+
+		result := classify()
+		// Only a real tier is worth remembering. Persisting a failed or rejected
+		// classification would pin the session to "no tier" for the whole ttl,
+		// turning one bad turn into a session-long outage of complexity routing.
+		if result == nil || result.Tier == "" {
+			return result
+		}
+
+		// RuleID is deliberately left unset. The tier is classifier memory about
+		// the conversation, not state owned by whichever rule happened to consult
+		// it first — binding them would let an unrelated rule edit drop every
+		// live session's tier.
+		created, err := store.Create(ctx, state.Key, &SessionComplexityRecord{
+			Tier:      result.Tier,
+			DecidedAt: time.Now(),
+		}, state.TTL)
+		if err != nil && p.logger != nil {
+			p.logger.Warn("[Governance] Failed to persist complexity session tier, the next turn will classify again: %v", err)
+		}
+		if created {
+			ctx.AppendRoutingEngineLog(
+				schemas.RoutingEngineRoutingRule,
+				schemas.LogLevelInfo,
+				"Complexity session established: tier="+result.Tier+" identity="+state.Source,
+			)
+		}
+		return result
+	}
+}
+
+// publishSessionTier records a held tier the same way a fresh classification is
+// recorded, so downstream logging sees a tier rather than a gap — with a
+// mechanism that says it was reused, not embedded.
+func (p *GovernancePlugin) publishSessionTier(
+	ctx *schemas.BifrostContext,
+	state *complexitySessionState,
+	record *SessionComplexityRecord,
+) {
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexityTier, record.Tier)
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexityMechanism, complexity.MechanismSession)
+	if p.logger != nil {
+		p.logger.Debug("[Governance] Complexity session hit: tier=%s identity=%s", record.Tier, state.Source)
+	}
+	ctx.AppendRoutingEngineLog(
+		schemas.RoutingEngineRoutingRule,
+		schemas.LogLevelInfo,
+		"Complexity tier held from session: tier="+record.Tier+" identity="+state.Source+
+			" (no classification ran for this turn)",
+	)
+}

--- a/plugins/governance/complexitysessionroute_test.go
+++ b/plugins/governance/complexitysessionroute_test.go
@@ -1,0 +1,356 @@
+package governance
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/plugins/governance/complexity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// failingSessionStore reports an error from every read so tests can prove a
+// broken backend degrades to classification rather than failing the request.
+type failingSessionStore struct {
+	SessionStore
+	getErr    error
+	createErr error
+	creates   int
+}
+
+func (f *failingSessionStore) Get(context.Context, string, time.Duration) (*SessionComplexityRecord, bool, error) {
+	return nil, false, f.getErr
+}
+
+func (f *failingSessionStore) Create(context.Context, string, *SessionComplexityRecord, time.Duration) (bool, error) {
+	f.creates++
+	return false, f.createErr
+}
+
+func sessionRoutePlugin(t *testing.T, store SessionStore, sessionConfig *configstore.ComplexitySessionConfig) *GovernancePlugin {
+	t.Helper()
+	p := &GovernancePlugin{logger: NewMockLogger()}
+	if store != nil {
+		p.complexitySessionStore.Store(&store)
+	}
+	if sessionConfig != nil {
+		p.complexitySessionConfig.Store(sessionConfig)
+	}
+	return p
+}
+
+func enabledSessionConfig() *configstore.ComplexitySessionConfig {
+	return &configstore.ComplexitySessionConfig{
+		Mode:            configstore.ComplexitySessionModePinned,
+		TTL:             time.Hour,
+		IdentitySources: configstore.DefaultComplexitySessionIdentitySources(),
+	}
+}
+
+// The second argument is a deadline, not a timestamp. It has to be in the
+// future: an expired context makes every store call fail validation, which the
+// session path deliberately degrades to plain classification — so the tests
+// would pass their assertions about fallback and silently prove nothing about
+// the reuse path.
+func sessionTestContext(t *testing.T, sessionID string) *schemas.BifrostContext {
+	t.Helper()
+	ctx := schemas.NewBifrostContext(context.Background(), time.Now().Add(time.Minute))
+	if sessionID != "" {
+		ctx.SetValue(schemas.BifrostContextKeySessionID, sessionID)
+	}
+	return ctx
+}
+
+// The first turn classifies and remembers; every later turn reuses the tier
+// without running the classifier again. Skipping that call is the entire point:
+// it is what keeps the provider's prompt cache warm and avoids a per-turn
+// embedding.
+func TestWithComplexitySessionReusesTierAfterFirstTurn(t *testing.T) {
+	sessionStore, _ := newTestKVSessionStore(t)
+	p := sessionRoutePlugin(t, sessionStore, enabledSessionConfig())
+	ctx := sessionTestContext(t, "session-abc")
+
+	state := p.resolveComplexitySessionState(ctx, nil)
+	require.NotNil(t, state)
+
+	classifyCalls := 0
+	classify := func() *complexity.ComplexityResult {
+		classifyCalls++
+		return &complexity.ComplexityResult{Tier: "COMPLEX"}
+	}
+
+	first := p.withComplexitySession(ctx, state, classify)()
+	require.NotNil(t, first)
+	assert.Equal(t, "COMPLEX", first.Tier)
+	assert.Equal(t, 1, classifyCalls)
+
+	for i := 0; i < 5; i++ {
+		held := p.withComplexitySession(ctx, state, classify)()
+		require.NotNil(t, held)
+		assert.Equal(t, "COMPLEX", held.Tier)
+	}
+	assert.Equal(t, 1, classifyCalls, "classifier ran again for an established session")
+}
+
+// A held turn must report that it was held. Recording "semantic" would make a
+// log of reused turns indistinguishable from a log of embedded ones.
+func TestWithComplexitySessionPublishesSessionMechanism(t *testing.T) {
+	sessionStore, _ := newTestKVSessionStore(t)
+	p := sessionRoutePlugin(t, sessionStore, enabledSessionConfig())
+	ctx := sessionTestContext(t, "session-abc")
+	state := p.resolveComplexitySessionState(ctx, nil)
+	require.NotNil(t, state)
+
+	classify := func() *complexity.ComplexityResult { return &complexity.ComplexityResult{Tier: "MEDIUM"} }
+	p.withComplexitySession(ctx, state, classify)()
+
+	held := sessionTestContext(t, "session-abc")
+	result := p.withComplexitySession(held, state, classify)()
+	require.NotNil(t, result)
+
+	tier, _ := held.Value(schemas.BifrostContextKeyGovernanceComplexityTier).(string)
+	mechanism, _ := held.Value(schemas.BifrostContextKeyGovernanceComplexityMechanism).(string)
+	assert.Equal(t, "MEDIUM", tier)
+	assert.Equal(t, complexity.MechanismSession, mechanism)
+}
+
+// A failed or rejected classification must not be stored. Pinning "no tier"
+// would turn one bad turn into a session-long outage of complexity routing.
+func TestWithComplexitySessionDoesNotStoreAbsentTier(t *testing.T) {
+	sessionStore, _ := newTestKVSessionStore(t)
+	p := sessionRoutePlugin(t, sessionStore, enabledSessionConfig())
+	ctx := sessionTestContext(t, "session-abc")
+	state := p.resolveComplexitySessionState(ctx, nil)
+	require.NotNil(t, state)
+
+	classifyCalls := 0
+	failing := func() *complexity.ComplexityResult {
+		classifyCalls++
+		return nil
+	}
+
+	require.Nil(t, p.withComplexitySession(ctx, state, failing)())
+	require.Nil(t, p.withComplexitySession(ctx, state, failing)())
+	assert.Equal(t, 2, classifyCalls, "a failed classification was pinned instead of retried")
+
+	// A later success still establishes the session.
+	result := p.withComplexitySession(ctx, state, func() *complexity.ComplexityResult {
+		return &complexity.ComplexityResult{Tier: "SIMPLE"}
+	})()
+	require.NotNil(t, result)
+	record, found, err := sessionStore.Get(context.Background(), state.Key, time.Hour)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "SIMPLE", record.Tier)
+}
+
+// An unreadable store is not a reason to fail a request: it degrades to the
+// behaviour that predates session state.
+func TestWithComplexitySessionFallsBackWhenStoreFails(t *testing.T) {
+	broken := &failingSessionStore{getErr: errors.New("backend down"), createErr: errors.New("backend down")}
+	p := sessionRoutePlugin(t, broken, enabledSessionConfig())
+	ctx := sessionTestContext(t, "session-abc")
+	state := p.resolveComplexitySessionState(ctx, nil)
+	require.NotNil(t, state)
+
+	classifyCalls := 0
+	result := p.withComplexitySession(ctx, state, func() *complexity.ComplexityResult {
+		classifyCalls++
+		return &complexity.ComplexityResult{Tier: "COMPLEX"}
+	})()
+
+	require.NotNil(t, result)
+	assert.Equal(t, "COMPLEX", result.Tier)
+	assert.Equal(t, 1, classifyCalls)
+	assert.Equal(t, 1, broken.creates, "a failed write should not stop the request")
+}
+
+// The tier belongs to the conversation, not to whichever rule consulted it
+// first. Binding them would let an unrelated rule edit drop every live session.
+func TestWithComplexitySessionDoesNotBindTierToARule(t *testing.T) {
+	sessionStore, _ := newTestKVSessionStore(t)
+	p := sessionRoutePlugin(t, sessionStore, enabledSessionConfig())
+	ctx := sessionTestContext(t, "session-abc")
+	state := p.resolveComplexitySessionState(ctx, nil)
+	require.NotNil(t, state)
+
+	p.withComplexitySession(ctx, state, func() *complexity.ComplexityResult {
+		return &complexity.ComplexityResult{Tier: "COMPLEX"}
+	})()
+
+	record, found, err := sessionStore.Get(context.Background(), state.Key, time.Hour)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Empty(t, record.RuleID)
+	assert.False(t, record.DecidedAt.IsZero())
+}
+
+// Sessions are namespaced per virtual key, so the same id presented by two
+// tenants must never share a pinned tier.
+func TestResolveComplexitySessionStateNamespacesByVirtualKey(t *testing.T) {
+	sessionStore, _ := newTestKVSessionStore(t)
+	p := sessionRoutePlugin(t, sessionStore, enabledSessionConfig())
+	ctx := sessionTestContext(t, "shared-session-id")
+
+	first := p.resolveComplexitySessionState(ctx, &configstoreTables.TableVirtualKey{ID: "vk-1"})
+	second := p.resolveComplexitySessionState(ctx, &configstoreTables.TableVirtualKey{ID: "vk-2"})
+	global := p.resolveComplexitySessionState(ctx, nil)
+
+	require.NotNil(t, first)
+	require.NotNil(t, second)
+	require.NotNil(t, global)
+	assert.NotEqual(t, first.Key, second.Key)
+	assert.NotEqual(t, first.Key, global.Key)
+}
+
+// Every "session behaviour does not apply" path must yield nil, which the caller
+// reads as "classify this turn normally".
+func TestResolveComplexitySessionStateDisabledPaths(t *testing.T) {
+	sessionStore, _ := newTestKVSessionStore(t)
+
+	t.Run("mode off", func(t *testing.T) {
+		p := sessionRoutePlugin(t, sessionStore, nil)
+		assert.Nil(t, p.resolveComplexitySessionState(sessionTestContext(t, "session-abc"), nil))
+	})
+
+	t.Run("no store attached", func(t *testing.T) {
+		p := sessionRoutePlugin(t, nil, enabledSessionConfig())
+		assert.Nil(t, p.resolveComplexitySessionState(sessionTestContext(t, "session-abc"), nil))
+	})
+
+	t.Run("nothing identifies the conversation", func(t *testing.T) {
+		p := sessionRoutePlugin(t, sessionStore, enabledSessionConfig())
+		assert.Nil(t, p.resolveComplexitySessionState(sessionTestContext(t, ""), nil))
+	})
+
+	t.Run("non-positive ttl", func(t *testing.T) {
+		config := enabledSessionConfig()
+		config.TTL = 0
+		p := sessionRoutePlugin(t, sessionStore, config)
+		assert.Nil(t, p.resolveComplexitySessionState(sessionTestContext(t, "session-abc"), nil))
+	})
+}
+
+// A harness-derived identity has to reach core's key stickiness, or the API key
+// rotates between turns and discards the provider cache the pinned tier exists
+// to protect.
+func TestPublishSessionKeyAffinityBridgesHarnessIdentity(t *testing.T) {
+	sessionStore, _ := newTestKVSessionStore(t)
+	config := enabledSessionConfig()
+	config.TTL = 30 * time.Minute
+	p := sessionRoutePlugin(t, sessionStore, config)
+
+	// No x-bf-session-id: the identity comes from the harness rung, so nothing
+	// has published a session id for key selection yet.
+	ctx := sessionTestContext(t, "")
+	ctx.SetValue(schemas.BifrostContextKeyRequestHeaders, map[string]string{
+		"user-agent":              "claude-cli/1.0.0",
+		claudeCodeSessionIDHeader: "harness-session-1",
+	})
+
+	state := p.resolveComplexitySessionState(ctx, nil)
+	require.NotNil(t, state, "harness identity should resolve")
+	p.publishSessionKeyAffinity(ctx, state)
+
+	published, _ := ctx.Value(schemas.BifrostContextKeySessionID).(string)
+	assert.Equal(t, state.ID, published, "core key stickiness cannot see the derived identity")
+
+	// Both lifetimes must agree, or the tier releases while the key stays pinned.
+	ttl, _ := ctx.Value(schemas.BifrostContextKeySessionTTL).(time.Duration)
+	assert.Equal(t, 30*time.Minute, ttl)
+}
+
+// Session behaviour off must leave key selection exactly as it was: core
+// activates stickiness on any non-empty id, so publishing one here would pin API
+// keys for callers who never enabled the feature.
+func TestPublishSessionKeyAffinityIsInertWhenDisabled(t *testing.T) {
+	p := sessionRoutePlugin(t, nil, nil)
+	ctx := sessionTestContext(t, "")
+	ctx.SetValue(schemas.BifrostContextKeyRequestHeaders, map[string]string{
+		"user-agent":              "claude-cli/1.0.0",
+		claudeCodeSessionIDHeader: "harness-session-1",
+	})
+
+	state := p.resolveComplexitySessionState(ctx, nil)
+	require.Nil(t, state)
+	p.publishSessionKeyAffinity(ctx, state)
+
+	published, _ := ctx.Value(schemas.BifrostContextKeySessionID).(string)
+	assert.Empty(t, published, "a derived session id leaked into key selection with the feature off")
+	ttl, _ := ctx.Value(schemas.BifrostContextKeySessionTTL).(time.Duration)
+	assert.Zero(t, ttl)
+}
+
+// An explicit per-request ttl was asked for by name and must outrank the
+// configured session window.
+func TestPublishSessionKeyAffinityKeepsExplicitTTL(t *testing.T) {
+	sessionStore, _ := newTestKVSessionStore(t)
+	p := sessionRoutePlugin(t, sessionStore, enabledSessionConfig())
+	ctx := sessionTestContext(t, "session-abc")
+	ctx.SetValue(schemas.BifrostContextKeySessionTTL, 5*time.Minute)
+
+	state := p.resolveComplexitySessionState(ctx, nil)
+	require.NotNil(t, state)
+	p.publishSessionKeyAffinity(ctx, state)
+
+	ttl, _ := ctx.Value(schemas.BifrostContextKeySessionTTL).(time.Duration)
+	assert.Equal(t, 5*time.Minute, ttl)
+}
+
+// Switching the mode off needs no record cleanup: the stored pins become
+// unreachable on the next request and expire on their own ttl. This pins that
+// claim, because the alternative — records that keep being honoured after the
+// feature is switched off — would be a silent routing bug.
+func TestModeOffStopsHonouringExistingPins(t *testing.T) {
+	sessionStore, _ := newTestKVSessionStore(t)
+	p := sessionRoutePlugin(t, sessionStore, enabledSessionConfig())
+	ctx := sessionTestContext(t, "session-abc")
+
+	state := p.resolveComplexitySessionState(ctx, nil)
+	require.NotNil(t, state)
+	classifyCalls := 0
+	classify := func() *complexity.ComplexityResult {
+		classifyCalls++
+		return &complexity.ComplexityResult{Tier: "COMPLEX"}
+	}
+	p.withComplexitySession(ctx, state, classify)()
+	require.Equal(t, 1, classifyCalls)
+
+	// The record still exists...
+	record, found, err := sessionStore.Get(context.Background(), state.Key, time.Hour)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "COMPLEX", record.Tier)
+
+	// ...but with the mode off nothing resolves a session, so it is never read
+	// and every turn classifies again.
+	p.complexitySessionConfig.Store(nil)
+	offState := p.resolveComplexitySessionState(ctx, nil)
+	require.Nil(t, offState)
+	p.withComplexitySession(ctx, offState, classify)()
+	assert.Equal(t, 2, classifyCalls, "a pin was still honoured after session behaviour was switched off")
+}
+
+// With no session state the closure must be returned untouched, so the
+// pre-session path keeps classifying exactly as before.
+func TestWithComplexitySessionPassesThroughWhenDisabled(t *testing.T) {
+	p := sessionRoutePlugin(t, nil, nil)
+	ctx := sessionTestContext(t, "session-abc")
+
+	classifyCalls := 0
+	classify := func() *complexity.ComplexityResult {
+		classifyCalls++
+		return &complexity.ComplexityResult{Tier: "SIMPLE"}
+	}
+
+	wrapped := p.withComplexitySession(ctx, nil, classify)
+	for i := 0; i < 3; i++ {
+		require.NotNil(t, wrapped())
+	}
+	assert.Equal(t, 3, classifyCalls, "classification was suppressed with session behaviour off")
+}

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -97,10 +97,14 @@ type GovernancePlugin struct {
 
 	complexityAnalyzer atomic.Pointer[complexity.ComplexityAnalyzer]
 	semanticClassifier *complexity.SemanticClassifier
-	// complexitySessionEnabled mirrors the analyzer config's session mode so the
-	// request path can gate session behaviour without holding the config. Kept in
-	// step by storeComplexityAnalyzerConfig, so it follows live reloads.
-	complexitySessionEnabled atomic.Bool
+	// complexitySessionConfig mirrors the analyzer config's session block so the
+	// request path can read mode, ttl, and identity sources without holding the
+	// whole config. Kept in step by storeComplexityAnalyzerConfig, so it follows
+	// live reloads. Nil means session behaviour is off.
+	complexitySessionConfig atomic.Pointer[configstore.ComplexitySessionConfig]
+	// complexitySessionStore is attached after construction and may stay nil when
+	// no kv store is available. Atomic because status reads can race attachment.
+	complexitySessionStore atomic.Pointer[SessionStore]
 
 	// embeddingRequestExecutor is wired by the HTTP server after the bifrost
 	// client exists (post-Init) via SetEmbeddingRequestExecutor; nil until
@@ -399,6 +403,39 @@ func (p *GovernancePlugin) ComplexitySemanticStatus() complexity.SemanticStatusI
 	return p.semanticClassifier.Status()
 }
 
+// SetComplexitySessionKVStore installs the backing store for session state.
+//
+// It is a setter rather than an Init parameter so the store can be attached
+// after the plugin exists, matching how the cluster controller and node id are
+// already wired. Attachment time does not affect what Status reports: the
+// backend's guarantees are read at call time, so a replication delegate
+// installed later is picked up without re-registering anything here.
+func (p *GovernancePlugin) SetComplexitySessionKVStore(store *kvstore.Store) error {
+	sessionStore, err := newKVSessionStore(store)
+	if err != nil {
+		return err
+	}
+	var asInterface SessionStore = sessionStore
+	p.complexitySessionStore.Store(&asInterface)
+	return nil
+}
+
+// ComplexitySessionStoreStatus reports what the session-state backend can
+// guarantee, or nil when no store is attached. Callers must not read a nil
+// result as "unsafe": it means session state has no backing store at all, which
+// is the normal case while session routing is switched off.
+func (p *GovernancePlugin) ComplexitySessionStoreStatus(ctx context.Context) (*SessionStoreStatus, error) {
+	stored := p.complexitySessionStore.Load()
+	if stored == nil {
+		return nil, nil
+	}
+	status, err := (*stored).Status(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &status, nil
+}
+
 func (p *GovernancePlugin) storeComplexityAnalyzerConfig(config *complexity.AnalyzerConfig) {
 	resolved, err := complexity.ValidateAndNormalize(config)
 	if err != nil {
@@ -409,7 +446,14 @@ func (p *GovernancePlugin) storeComplexityAnalyzerConfig(config *complexity.Anal
 		resolved = &defaults
 	}
 	p.complexityAnalyzer.Store(complexity.NewComplexityAnalyzerWithConfig(resolved))
-	p.complexitySessionEnabled.Store(resolved.Session.Enabled())
+	// Only a session block that is actually switched on is published: the request
+	// path then treats "no config" and "mode off" identically without repeating
+	// the mode check at every read.
+	if resolved.Session.Enabled() {
+		p.complexitySessionConfig.Store(resolved.Session)
+	} else {
+		p.complexitySessionConfig.Store(nil)
+	}
 	if p.semanticClassifier != nil {
 		p.semanticClassifier.Configure(resolved)
 	}
@@ -744,6 +788,15 @@ func (p *GovernancePlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *s
 	headers, _ := ctx.Value(schemas.BifrostContextKeyRequestHeaders).(map[string]string)
 	queryParams, _ := ctx.Value(schemas.BifrostContextKeyRequestQuery).(map[string]string)
 
+	// Resolved before the routing context is built because target stickiness
+	// needs the same identity the tier is stored under. Nil means classify
+	// normally, which is the behaviour that predates session state.
+	sessionState := p.resolveComplexitySessionState(ctx, virtualKey)
+	// Published before key selection runs so the conversation keeps one API key
+	// as well as one tier; a rotating key would discard the provider cache the
+	// pinned tier exists to protect.
+	p.publishSessionKeyAffinity(ctx, sessionState)
+
 	// Set up lazy complexity computation; only runs if a rule references complexity_tier.
 	var computeComplexity func() *complexity.ComplexityResult
 	if p.complexityAnalyzer.Load() != nil {
@@ -856,6 +909,20 @@ func (p *GovernancePlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *s
 		}
 	}
 
+	// Session state short-circuits classification for an established conversation.
+	// Wrapping keeps that inside the lazy closure, so a request whose rules never
+	// mention complexity_tier still performs no session work.
+	computeComplexity = p.withComplexitySession(ctx, sessionState, computeComplexity)
+
+	// Target stickiness keys on the resolved identity, not the raw header, so a
+	// harness-native id pins targets the same way an explicit header does. With
+	// session behaviour off, sessionState is nil and this falls back to the header
+	// read that predates it — which the stickiness gate ignores anyway.
+	sessionID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySessionID)
+	if sessionState != nil {
+		sessionID = sessionState.ID
+	}
+
 	routingCtx := &RoutingContext{
 		VirtualKey:               virtualKey,
 		UserID:                   bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyUserID),
@@ -866,8 +933,8 @@ func (p *GovernancePlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *s
 		QueryParams:              queryParams,
 		BudgetAndRateLimitStatus: p.store.GetBudgetAndRateLimitStatus(ctx, model, provider, virtualKey, nil, nil, nil),
 		computeComplexity:        computeComplexity,
-		SessionID:                bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySessionID),
-		SessionComplexityEnabled: p.complexitySessionEnabled.Load(),
+		SessionID:                sessionID,
+		SessionComplexityEnabled: sessionState != nil,
 	}
 
 	p.logger.Debug("[PreRequestHook] Built routing context: provider=%s, model=%s, requestType=%s, vk=%v",

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -107,6 +107,20 @@ type complexitySemanticStatusProvider interface {
 	GetComplexitySemanticStatus(ctx context.Context) (complexity.SemanticStatusInfo, error)
 }
 
+// complexitySessionStoreStatusProvider is separate from the semantic provider so
+// a build that exposes one but not the other still serves what it has.
+type complexitySessionStoreStatusProvider interface {
+	GetComplexitySessionStoreStatus(ctx context.Context) (*governance.SessionStoreStatus, error)
+}
+
+// complexityStatusResponse is the analyzer status payload. SemanticStatusInfo is
+// embedded rather than nested so every field clients already read stays at the
+// top level; session_store is additive and omitted when no store is attached.
+type complexityStatusResponse struct {
+	complexity.SemanticStatusInfo
+	SessionStore *governance.SessionStoreStatus `json:"session_store,omitempty"`
+}
+
 // GovernanceHandler manages HTTP requests for governance operations
 // ScopeNameResolver returns the human-readable name for a non-global model
 // config scope target (e.g. a virtual key's Name given its ID). The second
@@ -1471,7 +1485,21 @@ func (h *GovernanceHandler) getComplexitySemanticStatus(ctx *fasthttp.RequestCtx
 		SendError(ctx, fasthttp.StatusServiceUnavailable, fmt.Sprintf("failed to get semantic complexity status: %v", err))
 		return
 	}
-	SendJSON(ctx, status)
+
+	response := complexityStatusResponse{SemanticStatusInfo: status}
+	// The session store is reported alongside the classifier rather than behind
+	// its own endpoint, but it must not be able to fail the whole response: a
+	// classifier that is ready is still worth reporting when the session backend
+	// cannot describe itself.
+	if sessionProvider, ok := h.governanceManager.(complexitySessionStoreStatusProvider); ok {
+		sessionStatus, sessionErr := sessionProvider.GetComplexitySessionStoreStatus(ctx)
+		if sessionErr != nil {
+			logger.Warn("failed to get complexity session store status: %v", sessionErr)
+		} else {
+			response.SessionStore = sessionStatus
+		}
+	}
+	SendJSON(ctx, response)
 }
 
 // Virtual Key CRUD Operations

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -274,6 +274,8 @@ type mockComplexityGovernanceManager struct {
 	validationErr  error
 	semanticStatus complexity.SemanticStatusInfo
 	semanticErr    error
+	sessionStatus  *governance.SessionStoreStatus
+	sessionErr     error
 }
 
 func (m *mockComplexityGovernanceManager) ReloadComplexityAnalyzerConfig(_ context.Context, config *complexity.AnalyzerConfig) error {
@@ -292,6 +294,103 @@ func (m *mockComplexityGovernanceManager) ValidateComplexityAnalyzerConfig(_ con
 // non-persisted semantic classifier state.
 func (m *mockComplexityGovernanceManager) GetComplexitySemanticStatus(_ context.Context) (complexity.SemanticStatusInfo, error) {
 	return m.semanticStatus, m.semanticErr
+}
+
+// GetComplexitySessionStoreStatus lets the same tests emulate the session
+// backend's reported guarantees.
+func (m *mockComplexityGovernanceManager) GetComplexitySessionStoreStatus(_ context.Context) (*governance.SessionStoreStatus, error) {
+	return m.sessionStatus, m.sessionErr
+}
+
+// The session block is additive: it must not move or drop any field an existing
+// client already reads off this endpoint.
+func TestComplexityStatusReportsSessionStoreAlongsideSemanticFields(t *testing.T) {
+	SetLogger(&mockLogger{})
+	handler := &GovernanceHandler{
+		configStore: setupPricingOverrideHandlerStore(t),
+		governanceManager: &mockComplexityGovernanceManager{
+			semanticStatus: complexity.SemanticStatusInfo{
+				State:  complexity.SemanticStatusReady,
+				Loaded: 12,
+				Total:  12,
+			},
+			sessionStatus: &governance.SessionStoreStatus{
+				Backend:               "kvstore",
+				ReplicationConfigured: true,
+				AtomicAcrossReplicas:  false,
+			},
+		},
+	}
+
+	ctx := newTestRequestCtx("")
+	handler.getComplexitySemanticStatus(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(ctx.Response.Body(), &body); err != nil {
+		t.Fatalf("decode status response: %v", err)
+	}
+	// Top-level shape is the contract existing clients depend on.
+	for field, want := range map[string]any{"state": "ready", "loaded": float64(12), "total": float64(12)} {
+		if body[field] != want {
+			t.Fatalf("expected %s=%v at the top level, got %v: %s", field, want, body[field], string(ctx.Response.Body()))
+		}
+	}
+
+	sessionStore, ok := body["session_store"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected a session_store object, got %s", string(ctx.Response.Body()))
+	}
+	if sessionStore["replication_configured"] != true || sessionStore["atomic_across_replicas"] != false {
+		t.Fatalf("expected the replicated-but-not-atomic pair, got %v", sessionStore)
+	}
+}
+
+// No attached store is the normal case with session routing off, so the field is
+// omitted rather than reported as a backend with no guarantees — which would
+// render as the alarming state in the UI.
+func TestComplexityStatusOmitsSessionStoreWhenUnattached(t *testing.T) {
+	SetLogger(&mockLogger{})
+	handler := &GovernanceHandler{
+		configStore:       setupPricingOverrideHandlerStore(t),
+		governanceManager: &mockComplexityGovernanceManager{semanticStatus: complexity.SemanticStatusInfo{State: complexity.SemanticStatusDisabled}},
+	}
+
+	ctx := newTestRequestCtx("")
+	handler.getComplexitySemanticStatus(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+	if strings.Contains(string(ctx.Response.Body()), "session_store") {
+		t.Fatalf("expected session_store to be omitted, got %s", string(ctx.Response.Body()))
+	}
+}
+
+// A session backend that cannot describe itself must not take the classifier's
+// readiness down with it.
+func TestComplexityStatusSurvivesSessionStoreError(t *testing.T) {
+	SetLogger(&mockLogger{})
+	handler := &GovernanceHandler{
+		configStore: setupPricingOverrideHandlerStore(t),
+		governanceManager: &mockComplexityGovernanceManager{
+			semanticStatus: complexity.SemanticStatusInfo{State: complexity.SemanticStatusReady, Loaded: 3, Total: 3},
+			sessionErr:     errors.New("store unavailable"),
+		},
+	}
+
+	ctx := newTestRequestCtx("")
+	handler.getComplexitySemanticStatus(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected status 200 despite the session error, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+	if !strings.Contains(string(ctx.Response.Body()), `"state":"ready"`) {
+		t.Fatalf("expected the classifier state to still be reported, got %s", string(ctx.Response.Body()))
+	}
 }
 
 func testComplexityAnalyzerPayload(t *testing.T, cfg complexity.AnalyzerConfig) string {
@@ -382,7 +481,6 @@ func TestComplexityAnalyzerConfigPutRoundTripsSessionBlock(t *testing.T) {
 	cfg.Session = &configstore.ComplexitySessionConfig{
 		Mode:                  configstore.ComplexitySessionModePinned,
 		TTL:                   30 * time.Minute,
-		ReleaseAfterFailures:  5,
 		MaxSwitchesPerSession: 2,
 	}
 
@@ -405,9 +503,6 @@ func TestComplexityAnalyzerConfigPutRoundTripsSessionBlock(t *testing.T) {
 	}
 	if stored.Session.TTL != 30*time.Minute {
 		t.Fatalf("expected ttl 30m, got %s", stored.Session.TTL)
-	}
-	if stored.Session.ReleaseAfterFailures != 5 {
-		t.Fatalf("expected release_after_failures 5, got %d", stored.Session.ReleaseAfterFailures)
 	}
 	if stored.Session.MaxSwitchesPerSession != 2 {
 		t.Fatalf("expected max_switches_per_session 2, got %d", stored.Session.MaxSwitchesPerSession)
@@ -887,7 +982,6 @@ func TestComplexityAnalyzerConfigResetPreservesSessionBlock(t *testing.T) {
 	custom.Session = &configstore.ComplexitySessionConfig{
 		Mode:                 configstore.ComplexitySessionModePinned,
 		TTL:                  45 * time.Minute,
-		ReleaseAfterFailures: 7,
 	}
 	if err := store.UpdateComplexityAnalyzerConfig(context.Background(), &custom); err != nil {
 		t.Fatalf("seed custom config: %v", err)
@@ -912,9 +1006,6 @@ func TestComplexityAnalyzerConfigResetPreservesSessionBlock(t *testing.T) {
 	}
 	if stored.Session.TTL != 45*time.Minute {
 		t.Fatalf("expected ttl preserved, got %s", stored.Session.TTL)
-	}
-	if stored.Session.ReleaseAfterFailures != 7 {
-		t.Fatalf("expected release_after_failures preserved, got %d", stored.Session.ReleaseAfterFailures)
 	}
 	// The phrase lists are what reset actually owns.
 	if slices.Contains(stored.Keywords.SimpleKeywords, "only phrase the operator wrote") {

--- a/transports/bifrost-http/server/plugins.go
+++ b/transports/bifrost-http/server/plugins.go
@@ -94,9 +94,20 @@ func loadBuiltinPlugin(ctx context.Context, name string, pluginConfig any, bifro
 			return nil, fmt.Errorf("failed to marshal governance plugin config: %w", err)
 		}
 		inMemoryStore := &GovernanceInMemoryStore{Config: bifrostConfig}
-		return governance.Init(ctx, governanceConfig, logger, bifrostConfig.ConfigStore,
+		governancePlugin, err := governance.Init(ctx, governanceConfig, logger, bifrostConfig.ConfigStore,
 			bifrostConfig.GovernanceConfig, bifrostConfig.ModelCatalog,
 			bifrostConfig.MCPCatalog, inMemoryStore)
+		if err != nil {
+			return nil, err
+		}
+		// Session state is optional: without a kv store the plugin simply reports
+		// no session backend, which is the honest answer rather than a failure.
+		if kvStore := bifrostConfig.GetKVStore(); kvStore != nil {
+			if err := governancePlugin.SetComplexitySessionKVStore(kvStore); err != nil {
+				logger.Warn("failed to attach complexity session store, session routing will be unavailable: %v", err)
+			}
+		}
+		return governancePlugin, nil
 
 	case maxim.PluginName:
 		maximConfig, err := MarshalPluginConfig[maxim.Config](pluginConfig)

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1073,6 +1073,24 @@ func (s *BifrostHTTPServer) GetComplexitySemanticStatus(ctx context.Context) (co
 	return provider.ComplexitySemanticStatus(), nil
 }
 
+// GetComplexitySessionStoreStatus returns what the session-state backend can
+// guarantee, or nil when no store is attached. A nil result is not an error: it
+// means session state has no backing store, which is normal when session
+// routing is off.
+func (s *BifrostHTTPServer) GetComplexitySessionStoreStatus(ctx context.Context) (*governance.SessionStoreStatus, error) {
+	governancePlugin, err := s.getGovernancePlugin()
+	if err != nil {
+		return nil, fmt.Errorf("governance plugin not found: %w", err)
+	}
+	provider, ok := governancePlugin.(interface {
+		ComplexitySessionStoreStatus(ctx context.Context) (*governance.SessionStoreStatus, error)
+	})
+	if !ok {
+		return nil, fmt.Errorf("governance plugin does not expose session store status")
+	}
+	return provider.ComplexitySessionStoreStatus(ctx)
+}
+
 // ReloadRoutingRule reloads a routing rule from the database into the governance store
 func (s *BifrostHTTPServer) ReloadRoutingRule(ctx context.Context, id string) error {
 	governancePluginName := governance.PluginName

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -3742,11 +3742,6 @@
           "minItems": 1,
           "uniqueItems": true
         },
-        "release_after_failures": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Release the pin after this many consecutive upstream failures, on the assumption that the pinned tier is implicated (default: 3)"
-        },
         "switch_min_similarity": {
           "type": "number",
           "minimum": 0,

--- a/ui/app/workspace/complexity-router/formSchema.ts
+++ b/ui/app/workspace/complexity-router/formSchema.ts
@@ -61,10 +61,6 @@ const sessionSchema = z.object({
 	// The server rejects an empty ladder, and with nothing able to identify a
 	// session the feature silently does nothing.
 	identity_sources: z.array(z.enum(["header", "harness"])).min(1, "Select at least one way to identify a session"),
-	release_after_failures: z
-		.number({ error: "Enter a whole number of failures" })
-		.int("Must be a whole number")
-		.min(1, "Must be at least 1"),
 	switch_min_similarity: z.number({ error: "Enter a number between 0 and 1" }).min(0, "Must be 0 or greater").lt(1, "Must be less than 1"),
 	downgrade_after_n_turns: z.number({ error: "Enter a whole number of turns" }).int("Must be a whole number").min(1, "Must be at least 1"),
 	min_cached_tokens_to_hold: z
@@ -164,7 +160,6 @@ export const DEFAULT_SESSION_FORM_VALUES: SessionFormValues = {
 	mode: DEFAULT_SESSION_CONFIG.mode,
 	ttl: DEFAULT_SESSION_CONFIG.ttl ?? "60m",
 	identity_sources: [...DEFAULT_SESSION_IDENTITY_SOURCES],
-	release_after_failures: DEFAULT_SESSION_CONFIG.release_after_failures ?? 3,
 	switch_min_similarity: DEFAULT_SESSION_CONFIG.switch_min_similarity ?? 0,
 	downgrade_after_n_turns: DEFAULT_SESSION_CONFIG.downgrade_after_n_turns ?? 2,
 	min_cached_tokens_to_hold: DEFAULT_SESSION_CONFIG.min_cached_tokens_to_hold ?? 1024,
@@ -226,7 +221,6 @@ export function toFormValues(config: AnalyzerConfig): AnalyzerFormValues {
 						savedSession.identity_sources && savedSession.identity_sources.length > 0
 							? savedSession.identity_sources
 							: DEFAULT_SESSION_FORM_VALUES.identity_sources,
-					release_after_failures: savedSession.release_after_failures ?? DEFAULT_SESSION_FORM_VALUES.release_after_failures,
 					switch_min_similarity: savedSession.switch_min_similarity ?? 0,
 					downgrade_after_n_turns: savedSession.downgrade_after_n_turns ?? DEFAULT_SESSION_FORM_VALUES.downgrade_after_n_turns,
 					min_cached_tokens_to_hold: savedSession.min_cached_tokens_to_hold ?? DEFAULT_SESSION_FORM_VALUES.min_cached_tokens_to_hold,

--- a/ui/app/workspace/complexity-router/page.tsx
+++ b/ui/app/workspace/complexity-router/page.tsx
@@ -106,8 +106,12 @@ export default function ComplexityRouterPage() {
 	// that had already recovered. It polls slowly because it is waiting on a
 	// human, where warming is polled fast to keep the progress bar moving.
 	const [statusPollInterval, setStatusPollInterval] = useState(0);
+	// Also fetched when only session behavior is configured: the same endpoint now
+	// carries the session store's guarantees, and skipping on the classifier alone
+	// left the session sheet with nothing to report on a deployment that had
+	// enabled sessions without configuring embeddings.
 	const { data: semanticStatus, isLoading: statusLoading } = useGetComplexitySemanticStatusQuery(undefined, {
-		skip: !data?.semantic,
+		skip: !data?.semantic && !data?.session,
 		pollingInterval: statusPollInterval,
 	});
 	useEffect(() => {
@@ -621,6 +625,8 @@ export default function ComplexityRouterPage() {
 				session={liveSession}
 				canUpdate={canUpdate}
 				isClassifierConfigured={isClassifierConfigured}
+				storeStatus={semanticStatus?.session_store}
+				storeStatusLoading={statusLoading}
 				canSave={canSave}
 				isSaving={isSaving}
 				onSave={() => void submit()}

--- a/ui/app/workspace/complexity-router/views/sessionConfigSheet.tsx
+++ b/ui/app/workspace/complexity-router/views/sessionConfigSheet.tsx
@@ -6,13 +6,38 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Switch } from "@/components/ui/switch";
-import { SESSION_IDENTITY_SOURCE_OPTIONS, SESSION_MODE_OPTIONS, SessionIdentitySource } from "@/lib/types/complexityRouter";
+import {
+	SESSION_IDENTITY_SOURCE_OPTIONS,
+	SESSION_MODE_OPTIONS,
+	SessionIdentitySource,
+	sessionStoreReadiness,
+	SessionStoreReadiness,
+	SessionStoreStatus,
+} from "@/lib/types/complexityRouter";
 import { cn } from "@/lib/utils";
 import { Info, LoaderCircle, Save, TriangleAlert } from "lucide-react";
 import { Controller, type Control, type FieldErrors, type UseFormRegister } from "react-hook-form";
 import type { AnalyzerFormValues, SessionFormValues } from "../formSchema";
 import { sessionTtlFieldValue } from "../formSchema";
 import { FieldLabel } from "./formPrimitives";
+
+// Each state names the guarantee and the consequence. The middle one is the
+// case that matters: it is what a replicated deployment reports today, and it is
+// the one a single "replicated ✓" boolean would have rendered as reassuring.
+const READINESS_COPY: Record<SessionStoreReadiness, { title: string; body: string }> = {
+	"node-local": {
+		title: "Session state is node-local.",
+		body: "Each gateway holds its own copy. That is fine on a single replica; if you run more than one, a conversation is tracked separately on each and can be pinned to a different tier on each.",
+	},
+	"replicated-not-atomic": {
+		title: "Replicated, but not atomic.",
+		body: "Records reach other replicas, but concurrent updates to one conversation are not serialized across them. Two replicas handling turns at the same time can decide different tiers, and the later write wins. Use load-balancer session affinity if you need this to hold.",
+	},
+	"shared-atomic": {
+		title: "Shared and atomic.",
+		body: "Every replica sees the same session records and concurrent updates to one conversation are serialized across them.",
+	},
+};
 
 interface Props {
 	open: boolean;
@@ -26,6 +51,10 @@ interface Props {
 	// on the tier the classifier produces, so with no classifier there is nothing
 	// to pin and these settings sit inert.
 	isClassifierConfigured: boolean;
+	// What the session backend reports about itself. Undefined means no store is
+	// attached, which is not the same as an unsafe one.
+	storeStatus: SessionStoreStatus | undefined;
+	storeStatusLoading: boolean;
 	canSave: boolean;
 	isSaving: boolean;
 	onSave: () => void;
@@ -46,11 +75,14 @@ export default function SessionConfigSheet({
 	session,
 	canUpdate,
 	isClassifierConfigured,
+	storeStatus,
+	storeStatusLoading,
 	canSave,
 	isSaving,
 	onSave,
 }: Props) {
 	const mode = session?.mode ?? "off";
+	const readiness = sessionStoreReadiness(storeStatus);
 	const isEnabled = mode === "pinned" || mode === "cache_aware";
 	const isCacheAware = mode === "cache_aware";
 	const fieldsDisabled = !canUpdate || !isEnabled;
@@ -103,16 +135,17 @@ export default function SessionConfigSheet({
 						</p>
 					</div>
 
-					{/* Session state is held per node. Track A's readiness probe will
-					    replace this with the live backend's guarantees; until then the
-					    caveat is stated unconditionally rather than implied, because a
-					    silent split across replicas looks like the feature working. */}
-					{isEnabled && (
-						<Alert variant="warning" data-testid="complexity-router-session-replica-warning">
-							<TriangleAlert className="h-4 w-4" />
+					{/* The backend can only describe itself — it cannot see how many
+					    replicas are running — so none of these three say "safe". They
+					    say what the storage guarantees and leave the topology to the
+					    operator, who is the only one who knows it. */}
+					{isEnabled && !storeStatusLoading && readiness && (
+						<Alert variant={readiness === "shared-atomic" ? "info" : "warning"} data-testid="complexity-router-session-store-readiness">
+							{readiness === "shared-atomic" ? <Info className="h-4 w-4" /> : <TriangleAlert className="h-4 w-4" />}
 							<AlertDescription>
-								Session state is held in each gateway&apos;s own memory. If you run more than one replica, turns handled by different
-								replicas resolve their tiers independently, so a conversation can be pinned to two different tiers at once.
+								<span>
+									<span className="font-medium">{READINESS_COPY[readiness].title}</span> {READINESS_COPY[readiness].body}
+								</span>
 							</AlertDescription>
 						</Alert>
 					)}
@@ -151,29 +184,6 @@ export default function SessionConfigSheet({
 							) : (
 								<p className="text-muted-foreground text-xs leading-relaxed">How long an idle conversation keeps its tier.</p>
 							)}
-						</div>
-
-						<div className="space-y-2">
-							<FieldLabel
-								htmlFor="session-release-after-failures"
-								tooltip="After this many consecutive upstream failures the pin is dropped and the next turn is classified fresh, on the assumption that the pinned tier is the thing failing."
-							>
-								Release after failures
-							</FieldLabel>
-							<Input
-								id="session-release-after-failures"
-								data-testid="complexity-router-session-release-input"
-								type="number"
-								min={1}
-								step={1}
-								disabled={fieldsDisabled}
-								aria-invalid={errors?.release_after_failures ? true : undefined}
-								className={cn("font-mono", errors?.release_after_failures && "border-destructive focus-visible:ring-destructive")}
-								{...register("session.release_after_failures", {
-									valueAsNumber: true,
-								})}
-							/>
-							{errors?.release_after_failures && <p className="text-destructive text-xs">{errors.release_after_failures.message}</p>}
 						</div>
 					</div>
 

--- a/ui/lib/types/complexityRouter.ts
+++ b/ui/lib/types/complexityRouter.ts
@@ -25,6 +25,17 @@ export interface SemanticConfig {
 	vector_store?: SemanticVectorStore;
 }
 
+// What the session-state backend can prove about itself. Absent when no store is
+// attached, which is the normal case with session routing off.
+export interface SessionStoreStatus {
+	backend: string;
+	// Named for the configuration, not the outcome: replication is
+	// fire-and-forget, so this says a delegate is installed, not that peers are
+	// connected or converged.
+	replication_configured: boolean;
+	atomic_across_replicas: boolean;
+}
+
 export interface SemanticStatusInfo {
 	state: "disabled" | "warming" | "ready" | "failed";
 	loaded: number;
@@ -37,6 +48,19 @@ export interface SemanticStatusInfo {
 	// unchanged. Reuse cannot be inferred from the persisted config alone; zero
 	// means the next save re-embeds every phrase regardless of what changed.
 	cached_phrases?: number;
+	session_store?: SessionStoreStatus;
+}
+
+// The three states an operator can actually be in. Derived from the two
+// booleans rather than reported directly, because the storage layer can only
+// describe itself — it cannot see how many replicas are running, so it can never
+// say "safe" on its own.
+export type SessionStoreReadiness = "node-local" | "replicated-not-atomic" | "shared-atomic";
+
+export function sessionStoreReadiness(status: SessionStoreStatus | undefined): SessionStoreReadiness | undefined {
+	if (!status) return undefined;
+	if (!status.replication_configured) return "node-local";
+	return status.atomic_across_replicas ? "shared-atomic" : "replicated-not-atomic";
 }
 
 // Mirrors ComplexitySessionMode* in framework/configstore. "off" is a real
@@ -53,7 +77,6 @@ export interface SessionConfig {
 	mode: SessionMode;
 	ttl?: string;
 	identity_sources?: SessionIdentitySource[];
-	release_after_failures?: number;
 	// cache_aware only, from here down.
 	switch_min_similarity?: number;
 	downgrade_after_n_turns?: number;
@@ -83,7 +106,10 @@ export const LEGACY_COMPLEXITY_TIER_VALUES = ["REASONING"] as const;
 // LEGACY_COMPLEXITY_TIER_VALUES): the complexity_mechanism column ships with the
 // semantic classifier, so no row was ever written with the retired "lexical"
 // mechanism and filtering on it could only ever return nothing.
-export const COMPLEXITY_MECHANISM_VALUES = ["semantic", "skipped"] as const;
+// "session" means the tier was reused from session state and no classifier ran
+// for that turn, which is the difference between a held conversation and a
+// freshly embedded one.
+export const COMPLEXITY_MECHANISM_VALUES = ["semantic", "session", "skipped"] as const;
 
 // Labels cover "lexical" even though nothing filters on it. Rows predating the
 // structured columns record their decision only in the prose routing log, and
@@ -92,6 +118,7 @@ export const COMPLEXITY_MECHANISM_VALUES = ["semantic", "skipped"] as const;
 export const COMPLEXITY_MECHANISM_LABELS: Record<string, string> = {
 	lexical: "Lexical",
 	semantic: "Semantic",
+	session: "Session",
 	skipped: "Skipped",
 };
 
@@ -193,7 +220,6 @@ export function formatSemanticTimeout(milliseconds: number): string {
 
 // Mirrors DefaultComplexitySession* in framework/configstore.
 export const DEFAULT_SESSION_TTL_MINUTES = 60;
-export const DEFAULT_SESSION_RELEASE_AFTER_FAILURES = 3;
 export const DEFAULT_SESSION_DOWNGRADE_AFTER_N_TURNS = 2;
 export const DEFAULT_SESSION_MIN_CACHED_TOKENS_TO_HOLD = 1024;
 
@@ -206,7 +232,6 @@ export const DEFAULT_SESSION_CONFIG: SessionConfig = {
 	mode: "off",
 	ttl: `${DEFAULT_SESSION_TTL_MINUTES}m`,
 	identity_sources: DEFAULT_SESSION_IDENTITY_SOURCES,
-	release_after_failures: DEFAULT_SESSION_RELEASE_AFTER_FAILURES,
 	switch_min_similarity: 0,
 	downgrade_after_n_turns: DEFAULT_SESSION_DOWNGRADE_AFTER_N_TURNS,
 	min_cached_tokens_to_hold: DEFAULT_SESSION_MIN_CACHED_TOKENS_TO_HOLD,


### PR DESCRIPTION
## Summary

This PR wires up the complexity session store to the routing engine, making session-based tier pinning functional end-to-end. It also removes the `release_after_failures` mechanism (which released a pin after consecutive upstream errors) in favour of a coarser, write-efficient refresh strategy for the session store's sliding TTL.

## Changes

- **Removed `release_after_failures`** from `ComplexitySessionConfig`, its default constant, normalization, validation, schema, UI form, and all tests. The field was intended to drop a pin when the pinned tier appeared to be failing upstream, but this heuristic was removed as part of simplifying the session contract.

- **Added `MechanismSession`** (`"session"`) to the complexity mechanism vocabulary. A held turn now reports a distinct mechanism rather than inheriting `"semantic"`, making replayed turns distinguishable in logs and analytics from freshly embedded ones.

- **Introduced coarse TTL refresh on reads.** Previously every `Get` call on the session store triggered a write to slide the expiry, turning a read-heavy path into a write-per-request and a cluster broadcast per turn on replicated backends. The store now stamps `RefreshedAt` on each record and only writes when more than one quarter of the TTL has elapsed since the last refresh. The stored TTL carries one refresh interval of headroom so a session that goes idle just before a refresh is due never expires earlier than configured.

- **Extracted session routing logic into `complexitysessionroute.go`.** `resolveComplexitySessionState`, `publishSessionKeyAffinity`, `withComplexitySession`, and `publishSessionTier` are now in a dedicated file. `withComplexitySession` wraps the lazy classification closure so session reads only happen when a routing rule actually references `complexity_tier`.

- **Replaced `complexitySessionEnabled atomic.Bool` with `complexitySessionConfig atomic.Pointer`.** The request path now reads mode, TTL, and identity sources from a single atomic pointer rather than holding the whole config or repeating the mode check at every read. Nil means session behaviour is off.

- **Renamed `SessionStoreStatus` fields** from `SharedAcrossReplicas`/`AtomicUpdates` to `ReplicationConfigured`/`AtomicAcrossReplicas` with updated comments that distinguish configuration from outcome (replication is fire-and-forget; a delegate being installed says nothing about peer connectivity or convergence).

- **Wired `SetComplexitySessionKVStore` in the HTTP server plugin loader.** The governance plugin now receives the KV store after construction if one is available. If attachment fails, a warning is logged and session routing is simply unavailable rather than blocking startup.

- **Exposed `ComplexitySessionStoreStatus` on the HTTP server** and merged it into the existing `/complexity/semantic/status` response as an optional `session_store` field. The classifier's readiness is never taken down by a session backend error.

- **Updated the UI** to remove the `release_after_failures` field, add `SessionStoreStatus` and `SessionStoreReadiness` types, derive a three-state readiness label (`node-local`, `replicated-not-atomic`, `shared-atomic`) from the two backend booleans, and replace the unconditional replica warning in the session config sheet with a live, backend-reported readiness banner. The status query now also fires when only session behaviour is configured (not only when the semantic classifier is configured).

- **Added `"session"` to `COMPLEXITY_MECHANISM_VALUES` and `COMPLEXITY_MECHANISM_LABELS`** in the UI type definitions.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./plugins/governance/... ./framework/configstore/... ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm build
```

- Enable session routing (`mode: pinned`) in the complexity analyzer config and send several turns with the same `x-bf-session-id`. Confirm the classifier runs only on the first turn and subsequent turns report `mechanism: session`.
- Confirm the `/complexity/semantic/status` response includes a `session_store` object when a KV store is attached, and omits it when none is attached.
- On a single-replica deployment, confirm the session store status reports `atomic_across_replicas: true` and `replication_configured: false`, and the UI shows the `node-local` banner.
- On a replicated deployment (delegate attached), confirm `replication_configured: true`, `atomic_across_replicas: false`, and the UI shows the `replicated-not-atomic` warning.
- Send 50 rapid turns on an established session and confirm the delegate's `Sets()` counter is well below 50 (at most ~4 refreshes per TTL window).

## Breaking changes

- [x] Yes
- [ ] No

`release_after_failures` is removed from `ComplexitySessionConfig`. Any stored configuration or API payload that includes this field will have it silently ignored after normalization (the field no longer exists). Operators who relied on the pin-release-on-failure behaviour must remove the field from their configs; no migration of stored session records is required.

`SessionStoreStatus` fields `SharedAcrossReplicas` and `AtomicUpdates` are renamed to `ReplicationConfigured` and `AtomicAcrossReplicas`. Any client reading the raw JSON from the status endpoint must update its field names.

## Related issues

## Security considerations

Session keys are namespaced per virtual key tenant so one tenant's pinned tier cannot be adopted by another, even when both present the same session identifier.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable