### PR TITLE
[DO-NOT-MERGE-YET] complexity session route observations

### DIFF
--- a/plugins/governance/complexitysession.go
+++ b/plugins/governance/complexitysession.go
@@ -37,11 +37,13 @@ var (
 // complexity-routed session. It deliberately carries no switching thresholds
 // or other policy; callers apply the current session config to these facts.
 type SessionRouteObservation struct {
-	// CachedReadTokens is the cached input-token count most recently reported by
-	// the provider for this route.
+	// CachedReadTokens is the positive cached input-token count most recently
+	// observed for this route. Zero carries no cache-presence claim.
 	CachedReadTokens int `json:"cached_read_tokens"`
-	// CacheObserved distinguishes a provider-reported zero from a response that
-	// did not include cache telemetry at all.
+	// CacheObserved is true only when the normalized response proves cache reuse.
+	// False means unknown: the provider may have omitted cache telemetry, or it may
+	// have reported a zero that the normalized usage type cannot distinguish from
+	// an absent field.
 	CacheObserved bool `json:"cache_observed"`
 	// LastSeenAt is when this route most recently produced the observation.
 	LastSeenAt time.Time `json:"last_seen_at"`

--- a/plugins/governance/complexitysessionroute.go
+++ b/plugins/governance/complexitysessionroute.go
@@ -1,9 +1,12 @@
 package governance
 
 import (
+	"errors"
 	"time"
 
+	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/plugins/governance/complexity"
 )
@@ -12,6 +15,24 @@ import (
 // without virtual keys. Callers in this scope must provide globally unique
 // session IDs because no narrower ownership boundary is available.
 const complexitySessionGlobalScope = "global"
+
+// complexitySessionContextKey carries the resolved session across the request so
+// the response path can record what the provider reported without repeating
+// identity resolution and key derivation.
+const complexitySessionContextKey schemas.BifrostContextKey = "bf-governance-complexity-session"
+
+const (
+	// maxSessionRouteObservations bounds retained per-route history. A session
+	// that cycles through fallbacks would otherwise grow this map without limit,
+	// and the whole record is rewritten — and replicated — on every write.
+	maxSessionRouteObservations = 8
+	// sessionObservationChangeRatio is how much the cached-token count must move
+	// before it is worth a write. Cache sizes drift a little every turn, and
+	// persisting each drift would put a cluster broadcast back on every request.
+	sessionObservationChangeRatio = 0.1
+)
+
+var errSessionRouteObservationUnchanged = errors.New("complexity session route observation unchanged")
 
 // complexitySessionState is the per-request session context, resolved once
 // before routing so both the routing engine and the classification closure work
@@ -23,6 +44,8 @@ type complexitySessionState struct {
 	Source string
 	// Key is the tenant-namespaced store key, empty when ID is empty.
 	Key string
+	// Mode is the normalized session mode captured at request start.
+	Mode string
 	// TTL is the sliding idle window from configuration.
 	TTL time.Duration
 }
@@ -69,7 +92,204 @@ func (p *GovernancePlugin) resolveComplexitySessionState(
 		return nil
 	}
 
-	return &complexitySessionState{ID: sessionID, Source: source, Key: key, TTL: ttl}
+	state := &complexitySessionState{ID: sessionID, Source: source, Key: key, Mode: config.Mode, TTL: ttl}
+	// Carried on the context because the response path cannot redo this: identity
+	// resolution reads the request body, which is gone by then.
+	ctx.SetValue(complexitySessionContextKey, state)
+	return state
+}
+
+// recordSessionRouteObservation stores cache-reuse evidence for the route that
+// actually served this turn. Cache-aware switching decides whether discarding a
+// warm cache is worth it, which is unanswerable without these facts.
+//
+// It records nothing on non-final chunks: usage generally only arrives with the
+// last one, so recording earlier would persist useless unknown observations and
+// add replication traffic to streamed requests.
+func (p *GovernancePlugin) recordSessionRouteObservation(
+	ctx *schemas.BifrostContext,
+	result *schemas.BifrostResponse,
+	provider schemas.ModelProvider,
+	model string,
+	isFinalChunk bool,
+) {
+	if !isFinalChunk || result == nil {
+		return
+	}
+	state, _ := ctx.Value(complexitySessionContextKey).(*complexitySessionState)
+	if state == nil || state.Mode != configstore.ComplexitySessionModeCacheAware {
+		return
+	}
+	stored := p.complexitySessionStore.Load()
+	if stored == nil {
+		return
+	}
+	store := *stored
+
+	routeID := effectiveSessionRouteIdentity(ctx, provider, model)
+	if routeID == "" {
+		return
+	}
+	cachedTokens, cacheObserved := sessionCachedReadTokens(result)
+	observation := SessionRouteObservation{
+		CachedReadTokens: cachedTokens,
+		CacheObserved:    cacheObserved,
+		LastSeenAt:       time.Now(),
+	}
+
+	// The comparison belongs inside Update. A separate Get followed by Update can
+	// make its decision from a stale record and let an older response overwrite a
+	// newer observation. Returning the private sentinel aborts both the write and
+	// its replication event when this turn adds no information.
+	_, _, err := store.Update(ctx, state.Key, state.TTL, func(current *SessionComplexityRecord) error {
+		if !applySessionRouteObservation(current, routeID, observation, state.TTL) {
+			return errSessionRouteObservationUnchanged
+		}
+		return nil
+	})
+	if err != nil && !errors.Is(err, errSessionRouteObservationUnchanged) && p.logger != nil {
+		p.logger.Debug("[Governance] Could not record complexity session route observation: %v", err)
+	}
+}
+
+// applySessionRouteObservation conditionally applies observation to the latest
+// record owned by SessionStore.Update. It returns false for stale or immaterial
+// observations so the caller can abort the write and avoid replication.
+func applySessionRouteObservation(
+	record *SessionComplexityRecord,
+	routeID string,
+	observation SessionRouteObservation,
+	ttl time.Duration,
+) bool {
+	previous := record.RouteObservations[routeID]
+	if !sessionObservationNeedsUpdate(
+		previous,
+		observation.CachedReadTokens,
+		observation.CacheObserved,
+		observation.LastSeenAt,
+		ttl,
+	) {
+		return false
+	}
+	if record.RouteObservations == nil {
+		record.RouteObservations = make(map[string]SessionRouteObservation, 1)
+	}
+	record.RouteObservations[routeID] = observation
+	boundSessionRouteObservations(record.RouteObservations, maxSessionRouteObservations)
+	return true
+}
+
+// sessionObservationNeedsUpdate decides whether this turn told us anything the
+// stored observation does not already say.
+func sessionObservationNeedsUpdate(
+	previous SessionRouteObservation,
+	cachedTokens int,
+	cacheObserved bool,
+	observedAt time.Time,
+	ttl time.Duration,
+) bool {
+	// Never seen this route.
+	if previous.LastSeenAt.IsZero() {
+		return true
+	}
+	// A response that completed earlier must never overwrite a later observation,
+	// even when its cache count differs enough that it would otherwise be useful.
+	if !observedAt.After(previous.LastSeenAt) {
+		return false
+	}
+	// Whether the normalized response proves cache reuse is a different fact from
+	// how many tokens it proves, and it changes how the number should be read.
+	if previous.CacheObserved != cacheObserved {
+		return true
+	}
+	if cacheObserved && sessionCachedTokensMateriallyChanged(previous.CachedReadTokens, cachedTokens) {
+		return true
+	}
+	// Otherwise refresh on the same cadence as the read path, so LastSeenAt stays
+	// roughly current without a write per turn.
+	return observedAt.Sub(previous.LastSeenAt) >= complexitySessionRefreshInterval(ttl)
+}
+
+// sessionCachedTokensMateriallyChanged treats any crossing of zero as material.
+// The current response path never marks an ambiguous zero as observed, but
+// replicated records or a future presence-aware writer may carry an observed
+// zero, so the comparison remains complete for every valid record.
+func sessionCachedTokensMateriallyChanged(previous, next int) bool {
+	if previous == next {
+		return false
+	}
+	if previous == 0 || next == 0 {
+		return true
+	}
+	delta := next - previous
+	if delta < 0 {
+		delta = -delta
+	}
+	return float64(delta) > float64(previous)*sessionObservationChangeRatio
+}
+
+// boundSessionRouteObservations evicts the least recently seen routes until the
+// map fits. Recency is the right axis: a route not seen for a while is not the
+// one a switch would be giving up.
+func boundSessionRouteObservations(observations map[string]SessionRouteObservation, limit int) {
+	for len(observations) > limit {
+		oldestKey := ""
+		var oldestSeen time.Time
+		for key, observation := range observations {
+			if oldestKey == "" || observation.LastSeenAt.Before(oldestSeen) {
+				oldestKey, oldestSeen = key, observation.LastSeenAt
+			}
+		}
+		delete(observations, oldestKey)
+	}
+}
+
+// effectiveSessionRouteIdentity identifies the route that actually served, which
+// is not necessarily the one routing selected: a fallback changes provider and
+// model, and key rotation changes which cache is warm. The value is hashed
+// because callers only ever compare identities, and the record replicates.
+func effectiveSessionRouteIdentity(ctx *schemas.BifrostContext, provider schemas.ModelProvider, model string) string {
+	keyID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedKeyID)
+	if provider == "" && model == "" && keyID == "" {
+		return ""
+	}
+	return complexitySessionHash(string(provider) + "\x00" + model + "\x00" + keyID)
+}
+
+// sessionCachedReadTokens reports positive evidence of provider cache reuse.
+// The normalized usage structs do not preserve whether a zero-valued cache field
+// was present, and their detail blocks may exist only for modality accounting.
+// Ambiguous zero is therefore treated as unobserved rather than as a cold cache.
+// The chat and responses APIs carry the same fact under different types, so each
+// is unwrapped on its own rather than through a shared usage value.
+func sessionCachedReadTokens(result *schemas.BifrostResponse) (int, bool) {
+	switch {
+	case result.ChatResponse != nil && result.ChatResponse.Usage != nil:
+		return chatCachedReadTokens(result.ChatResponse.Usage)
+	case result.TextCompletionResponse != nil && result.TextCompletionResponse.Usage != nil:
+		return chatCachedReadTokens(result.TextCompletionResponse.Usage)
+	case result.ResponsesResponse != nil && result.ResponsesResponse.Usage != nil:
+		return responsesCachedReadTokens(result.ResponsesResponse.Usage)
+	case result.ResponsesStreamResponse != nil &&
+		result.ResponsesStreamResponse.Response != nil &&
+		result.ResponsesStreamResponse.Response.Usage != nil:
+		return responsesCachedReadTokens(result.ResponsesStreamResponse.Response.Usage)
+	}
+	return 0, false
+}
+
+func chatCachedReadTokens(usage *schemas.BifrostLLMUsage) (int, bool) {
+	if usage.PromptTokensDetails == nil || usage.PromptTokensDetails.CachedReadTokens <= 0 {
+		return 0, false
+	}
+	return usage.PromptTokensDetails.CachedReadTokens, true
+}
+
+func responsesCachedReadTokens(usage *schemas.ResponsesResponseUsage) (int, bool) {
+	if usage.InputTokensDetails == nil || usage.InputTokensDetails.CachedReadTokens <= 0 {
+		return 0, false
+	}
+	return usage.InputTokensDetails.CachedReadTokens, true
 }
 
 // publishSessionKeyAffinity hands the resolved conversation identity to the

--- a/plugins/governance/complexitysessionroute_test.go
+++ b/plugins/governance/complexitysessionroute_test.go
@@ -52,6 +52,12 @@ func enabledSessionConfig() *configstore.ComplexitySessionConfig {
 	}
 }
 
+func cacheAwareSessionConfig() *configstore.ComplexitySessionConfig {
+	config := enabledSessionConfig()
+	config.Mode = configstore.ComplexitySessionModeCacheAware
+	return config
+}
+
 // The second argument is a deadline, not a timestamp. It has to be in the
 // future: an expired context makes every store call fail validation, which the
 // session path deliberately degrades to plain classification — so the tests
@@ -353,4 +359,258 @@ func TestWithComplexitySessionPassesThroughWhenDisabled(t *testing.T) {
 		require.NotNil(t, wrapped())
 	}
 	assert.Equal(t, 3, classifyCalls, "classification was suppressed with session behaviour off")
+}
+
+func chatResponseWithCacheDetails(cached int, includeDetails bool) *schemas.BifrostResponse {
+	usage := &schemas.BifrostLLMUsage{TotalTokens: 100}
+	if includeDetails {
+		usage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{CachedReadTokens: cached}
+	}
+	return &schemas.BifrostResponse{ChatResponse: &schemas.BifrostChatResponse{Usage: usage}}
+}
+
+func sessionWithObservations(t *testing.T) (*GovernancePlugin, *kvSessionStore, *complexitySessionState, *schemas.BifrostContext) {
+	t.Helper()
+	sessionStore, _ := newTestKVSessionStore(t)
+	p := sessionRoutePlugin(t, sessionStore, cacheAwareSessionConfig())
+	ctx := sessionTestContext(t, "session-abc")
+	state := p.resolveComplexitySessionState(ctx, nil)
+	require.NotNil(t, state)
+	_, err := sessionStore.Create(context.Background(), state.Key, &SessionComplexityRecord{Tier: "COMPLEX"}, state.TTL)
+	require.NoError(t, err)
+	return p, sessionStore, state, ctx
+}
+
+// Pinned mode never consumes route observations, so recording them would add a
+// response-side store operation and occasional cluster broadcast for no benefit.
+func TestRecordSessionRouteObservationSkipsPinnedMode(t *testing.T) {
+	sessionStore, store := newTestKVSessionStore(t)
+	_, targetKV := newTestKVSessionStore(t)
+	p := sessionRoutePlugin(t, sessionStore, enabledSessionConfig())
+	ctx := sessionTestContext(t, "session-abc")
+	state := p.resolveComplexitySessionState(ctx, nil)
+	require.NotNil(t, state)
+	_, err := sessionStore.Create(context.Background(), state.Key, &SessionComplexityRecord{Tier: "COMPLEX"}, state.TTL)
+	require.NoError(t, err)
+
+	delegate := &forwardingKVDelegate{target: targetKV}
+	store.SetDelegate(delegate)
+	p.recordSessionRouteObservation(ctx, chatResponseWithCacheDetails(4096, true), schemas.OpenAI, "gpt-4o", true)
+
+	record, found, err := sessionStore.Get(context.Background(), state.Key, state.TTL)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Empty(t, record.RouteObservations)
+	assert.Zero(t, delegate.Sets(), "pinned mode wrote an unused route observation")
+}
+
+// The observation is the input cache-aware switching reasons about, so the
+// provider's reported cache size has to reach the record.
+func TestRecordSessionRouteObservationStoresCacheSize(t *testing.T) {
+	p, sessionStore, state, ctx := sessionWithObservations(t)
+
+	p.recordSessionRouteObservation(ctx, chatResponseWithCacheDetails(4096, true), schemas.OpenAI, "gpt-4o", true)
+
+	record, found, err := sessionStore.Get(context.Background(), state.Key, state.TTL)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Len(t, record.RouteObservations, 1)
+	for _, observation := range record.RouteObservations {
+		assert.Equal(t, 4096, observation.CachedReadTokens)
+		assert.True(t, observation.CacheObserved)
+		assert.False(t, observation.LastSeenAt.IsZero())
+	}
+}
+
+// A modality breakdown can create prompt-token details without saying anything
+// about cache reuse. Treating that shape as a cold cache would make a downgrade
+// discard cache state that is actually unknown.
+func TestRecordSessionRouteObservationTreatsAmbiguousZeroAsUnknown(t *testing.T) {
+	p, sessionStore, state, ctx := sessionWithObservations(t)
+	response := &schemas.BifrostResponse{ChatResponse: &schemas.BifrostChatResponse{Usage: &schemas.BifrostLLMUsage{
+		TotalTokens:         100,
+		PromptTokensDetails: &schemas.ChatPromptTokensDetails{TextTokens: 100},
+	}}}
+
+	p.recordSessionRouteObservation(ctx, response, schemas.Gemini, "gemini-2.5-pro", true)
+
+	record, found, err := sessionStore.Get(context.Background(), state.Key, state.TTL)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Len(t, record.RouteObservations, 1)
+	for _, observation := range record.RouteObservations {
+		assert.Zero(t, observation.CachedReadTokens)
+		assert.False(t, observation.CacheObserved, "modality details were recorded as proof of a cold cache")
+	}
+}
+
+// Usage arrives with the final chunk. Recording earlier persists zeros and reads
+// as "no cache worth keeping" on every streamed request.
+func TestRecordSessionRouteObservationIgnoresNonFinalChunks(t *testing.T) {
+	p, sessionStore, state, ctx := sessionWithObservations(t)
+
+	p.recordSessionRouteObservation(ctx, chatResponseWithCacheDetails(4096, true), schemas.OpenAI, "gpt-4o", false)
+
+	record, found, err := sessionStore.Get(context.Background(), state.Key, state.TTL)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Empty(t, record.RouteObservations)
+}
+
+// Recording an unchanged observation every turn would put a cluster broadcast
+// back on every request, undoing the read-path work.
+func TestRecordSessionRouteObservationDoesNotWriteWhenUnchanged(t *testing.T) {
+	sessionStore, store := newTestKVSessionStore(t)
+	_, targetKV := newTestKVSessionStore(t)
+	p := sessionRoutePlugin(t, sessionStore, cacheAwareSessionConfig())
+	ctx := sessionTestContext(t, "session-abc")
+	state := p.resolveComplexitySessionState(ctx, nil)
+	require.NotNil(t, state)
+	_, err := sessionStore.Create(context.Background(), state.Key, &SessionComplexityRecord{Tier: "COMPLEX"}, state.TTL)
+	require.NoError(t, err)
+
+	response := chatResponseWithCacheDetails(4096, true)
+	p.recordSessionRouteObservation(ctx, response, schemas.OpenAI, "gpt-4o", true)
+
+	// Attached after the first observation so only the repeats are counted.
+	delegate := &forwardingKVDelegate{target: targetKV}
+	store.SetDelegate(delegate)
+	for i := 0; i < 25; i++ {
+		p.recordSessionRouteObservation(ctx, response, schemas.OpenAI, "gpt-4o", true)
+	}
+	assert.Zero(t, delegate.Sets(), "an unchanged observation was written on every turn")
+
+	// A materially different cache size is still worth recording.
+	p.recordSessionRouteObservation(ctx, chatResponseWithCacheDetails(8192, true), schemas.OpenAI, "gpt-4o", true)
+	assert.NotZero(t, delegate.Sets(), "a materially changed cache size was never recorded")
+}
+
+// Fallbacks and key rotation change which cache is warm, so each effective route
+// is tracked separately rather than overwriting one another.
+func TestRecordSessionRouteObservationSeparatesRoutes(t *testing.T) {
+	p, sessionStore, state, ctx := sessionWithObservations(t)
+
+	p.recordSessionRouteObservation(ctx, chatResponseWithCacheDetails(4096, true), schemas.OpenAI, "gpt-4o", true)
+	p.recordSessionRouteObservation(ctx, chatResponseWithCacheDetails(128, true), schemas.Anthropic, "claude-3-5-sonnet", true)
+
+	record, found, err := sessionStore.Get(context.Background(), state.Key, state.TTL)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Len(t, record.RouteObservations, 2)
+}
+
+// The updater executes against the latest store value. A response that finished
+// earlier must not replace a newer observation merely because its cache count is
+// materially different.
+func TestApplySessionRouteObservationRejectsStaleObservation(t *testing.T) {
+	now := time.Now()
+	record := &SessionComplexityRecord{RouteObservations: map[string]SessionRouteObservation{
+		"route": {
+			CachedReadTokens: 4096,
+			CacheObserved:    true,
+			LastSeenAt:       now,
+		},
+	}}
+
+	changed := applySessionRouteObservation(record, "route", SessionRouteObservation{
+		CachedReadTokens: 128,
+		CacheObserved:    true,
+		LastSeenAt:       now.Add(-time.Second),
+	}, time.Hour)
+	assert.False(t, changed)
+	assert.Equal(t, 4096, record.RouteObservations["route"].CachedReadTokens)
+	assert.Equal(t, now, record.RouteObservations["route"].LastSeenAt)
+
+	changed = applySessionRouteObservation(record, "route", SessionRouteObservation{
+		CachedReadTokens: 8192,
+		CacheObserved:    true,
+		LastSeenAt:       now.Add(time.Second),
+	}, time.Hour)
+	assert.True(t, changed)
+	assert.Equal(t, 8192, record.RouteObservations["route"].CachedReadTokens)
+	assert.Equal(t, now.Add(time.Second), record.RouteObservations["route"].LastSeenAt)
+}
+
+func TestSessionCachedReadTokensRequiresPositiveEvidence(t *testing.T) {
+	tests := []struct {
+		name         string
+		response     *schemas.BifrostResponse
+		wantTokens   int
+		wantObserved bool
+	}{
+		{
+			name:     "chat details absent",
+			response: chatResponseWithCacheDetails(0, false),
+		},
+		{
+			name:     "chat details contain ambiguous zero",
+			response: chatResponseWithCacheDetails(0, true),
+		},
+		{
+			name: "chat details contain only modality usage",
+			response: &schemas.BifrostResponse{ChatResponse: &schemas.BifrostChatResponse{Usage: &schemas.BifrostLLMUsage{
+				PromptTokensDetails: &schemas.ChatPromptTokensDetails{TextTokens: 100},
+			}}},
+		},
+		{
+			name:         "chat reports positive cache reuse",
+			response:     chatResponseWithCacheDetails(128, true),
+			wantTokens:   128,
+			wantObserved: true,
+		},
+		{
+			name: "responses details contain ambiguous zero",
+			response: &schemas.BifrostResponse{ResponsesResponse: &schemas.BifrostResponsesResponse{Usage: &schemas.ResponsesResponseUsage{
+				InputTokensDetails: &schemas.ResponsesResponseInputTokens{},
+			}}},
+		},
+		{
+			name: "responses report positive cache reuse",
+			response: &schemas.BifrostResponse{ResponsesResponse: &schemas.BifrostResponsesResponse{Usage: &schemas.ResponsesResponseUsage{
+				InputTokensDetails: &schemas.ResponsesResponseInputTokens{CachedReadTokens: 256},
+			}}},
+			wantTokens:   256,
+			wantObserved: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tokens, observed := sessionCachedReadTokens(tt.response)
+			assert.Equal(t, tt.wantTokens, tokens)
+			assert.Equal(t, tt.wantObserved, observed)
+		})
+	}
+}
+
+// A long session cycling through fallbacks must not grow the map without limit:
+// the whole record is rewritten, and replicated, on every write.
+func TestBoundSessionRouteObservationsEvictsLeastRecent(t *testing.T) {
+	now := time.Now()
+	observations := map[string]SessionRouteObservation{}
+	for i := 0; i < maxSessionRouteObservations+4; i++ {
+		observations[string(rune('a'+i))] = SessionRouteObservation{
+			CachedReadTokens: i,
+			CacheObserved:    true,
+			LastSeenAt:       now.Add(time.Duration(i) * time.Minute),
+		}
+	}
+
+	boundSessionRouteObservations(observations, maxSessionRouteObservations)
+
+	require.Len(t, observations, maxSessionRouteObservations)
+	// The four oldest went; the most recent survived.
+	assert.NotContains(t, observations, "a")
+	assert.Contains(t, observations, string(rune('a'+maxSessionRouteObservations+3)))
+}
+
+func TestSessionCachedTokensMateriallyChanged(t *testing.T) {
+	// Crossing zero flips whether there is a cache to protect at all.
+	assert.True(t, sessionCachedTokensMateriallyChanged(0, 10))
+	assert.True(t, sessionCachedTokensMateriallyChanged(4096, 0))
+	// Ordinary drift is not worth a cluster message.
+	assert.False(t, sessionCachedTokensMateriallyChanged(4096, 4096))
+	assert.False(t, sessionCachedTokensMateriallyChanged(4096, 4200))
+	// A large move is.
+	assert.True(t, sessionCachedTokensMateriallyChanged(4096, 8192))
 }

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -1557,6 +1557,11 @@ func (p *GovernancePlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 	// CalculateCost call (and every later post-hook, e.g. telemetry) sees it.
 	stampRoutingDebug(ctx, result, requestType, isFinalChunk)
 
+	// Record what this turn revealed about the served route's cache. Only
+	// cache-aware switching reads it, but it has to be gathered while the
+	// response is in hand.
+	p.recordSessionRouteObservation(ctx, result, provider, requestedModel, isFinalChunk)
+
 	// Build pricing scopes from context using the governance VK ID (not the raw VK token)
 	pricingScopes := modelcatalog.PricingLookupScopesFromContext(ctx, string(provider))
 


### PR DESCRIPTION
## Summary

Adds per-route cache observation recording to the complexity session system. When a provider responds, the governance plugin now captures how many cached tokens were read and whether the provider reported cache telemetry at all. This data is what cache-aware route switching needs to decide whether discarding a warm cache is worth a fallback — a question that cannot be answered without knowing the current cache state per route.

## Changes

- After each final response chunk, `recordSessionRouteObservation` reads the provider's cached-input token count from the response and persists it to the session store under a hashed route identity (provider + model + key ID). This identity accounts for fallbacks and key rotation, both of which change which cache is warm.
- The resolved session state is stored on the request context during `resolveComplexitySessionState` so the response path can access it without re-running identity resolution, which requires the request body that is no longer available at that point.
- A distinction is made between a provider that reports zero cached tokens and one that reports no cache telemetry at all. Collapsing these two cases would cause a switch to treat a silent provider as having a cold cache and discard a warm one unnecessarily.
- Writes are suppressed when the observation has not materially changed. A change is considered material if the cached token count crosses zero (the boundary between "cache exists" and "cache does not"), or if it moves by more than 10% from the stored value. This avoids a cluster broadcast on every request for sessions where the cache is stable.
- The per-session route observation map is bounded to `maxSessionRouteObservations` (8) entries, evicting the least recently seen route. The entire record is rewritten and replicated on every write, so unbounded growth would be expensive.
- Non-final stream chunks are skipped entirely; usage data only arrives with the last chunk, so recording earlier would persist zeros.
- `recordSessionRouteObservation` is called from `PostLLMHook` while the response is still in hand.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/...
```

Key scenarios covered by the new tests:
- `TestRecordSessionRouteObservationStoresCacheSize` — verifies the cached token count reaches the store.
- `TestRecordSessionRouteObservationDistinguishesUnreportedFromZero` — verifies a silent provider is not recorded as a cold cache.
- `TestRecordSessionRouteObservationIgnoresNonFinalChunks` — verifies intermediate stream chunks produce no write.
- `TestRecordSessionRouteObservationDoesNotWriteWhenUnchanged` — verifies stable observations do not produce repeated writes.
- `TestRecordSessionRouteObservationSeparatesRoutes` — verifies different provider/model pairs are tracked independently.
- `TestBoundSessionRouteObservationsEvictsLeastRecent` — verifies the map cap evicts the oldest routes.
- `TestSessionCachedTokensMateriallyChanged` — verifies the materiality threshold and zero-crossing logic.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Route identity values are hashed before being stored as map keys, so provider names, model names, and key IDs are not persisted in plaintext within the replicated session record.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable