### PR TITLE
enterprise core version update

### DIFF
--- a/docs/changelogs/ent-v1.5.9.mdx
+++ b/docs/changelogs/ent-v1.5.9.mdx
@@ -91,7 +91,7 @@ require (
 	github.com/hashicorp/memberlist v0.5.4
 	github.com/hashicorp/vault/api v1.23.0
 	github.com/klauspost/compress v1.18.6
-	github.com/maximhq/bifrost/core v1.7.7
+	github.com/maximhq/bifrost/core v1.7.8
 	github.com/maximhq/bifrost/framework v1.5.7
 	github.com/maximhq/bifrost/plugins/governance v1.6.11
 	github.com/maximhq/bifrost/plugins/logging v1.6.7


### PR DESCRIPTION
## Summary

Bumps the `github.com/maximhq/bifrost/core` dependency from `v1.7.7` to `v1.7.8` in the enterprise v1.5.9 changelog.

## Changes

- Updated `github.com/maximhq/bifrost/core` to `v1.7.8` to pick up the latest patch release.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go version
go test ./...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable