### PR TITLE
fix: Helm chart - map perUserHeaderKeys into rendered config.json

### DIFF
--- a/.github/workflows/scripts/validate-helm-config-fields.sh
+++ b/.github/workflows/scripts/validate-helm-config-fields.sh
@@ -806,6 +806,12 @@ bifrost:
         connectionType: "websocket"
         websocketConfig:
           url: "wss://mcp.example.com/ws"
+      - name: "per-user-headers-server"
+        connectionType: "http"
+        httpConfig:
+          url: "https://mcp.example.com/headers"
+        authType: "per_user_headers"
+        perUserHeaderKeys: ["Authorization", "X-Api-Key"]
     toolManagerConfig:
       toolExecutionTimeout: 60
       maxAgentDepth: 5
@@ -831,6 +837,11 @@ assert_field_value 'mcp client[1] connection_string' '.mcp.client_configs.[1].co
 assert_field_value 'mcp client[2] name' '.mcp.client_configs.[2].name' '"ws-server"'
 assert_field_value 'mcp client[2] connection_type (ws->sse)' '.mcp.client_configs.[2].connection_type' '"sse"'
 assert_field_value 'mcp client[2] connection_string' '.mcp.client_configs.[2].connection_string' '"wss://mcp.example.com/ws"'
+
+# per_user_headers client
+assert_field_value 'mcp client[3] auth_type' '.mcp.client_configs.[3].auth_type' '"per_user_headers"'
+assert_field_value 'mcp client[3] per_user_header_keys[0]' '.mcp.client_configs.[3].per_user_header_keys.[0]' '"Authorization"'
+assert_field_value 'mcp client[3] per_user_header_keys[1]' '.mcp.client_configs.[3].per_user_header_keys.[1]' '"X-Api-Key"'
 
 # Tool manager config
 assert_field_value 'mcp tool_manager_config.tool_execution_timeout' '.mcp.tool_manager_config.tool_execution_timeout' '60'

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -61,6 +61,7 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
 - Documented `endpoints` on the `bedrock` and `bedrock_mantle` key examples (AWS PrivateLink interface VPC endpoint hosts: `runtime`, `control_plane`, `mantle`, `agent_runtime`, `s3`). Passes through into `bedrock_key_config.endpoints` / `bedrock_mantle_key_config.endpoints`.
 - Extended `bifrost.governance.budgets[]` with quarterly resets (`reset_duration: "1Q"`) and `reset_config.quarter_start_month` (1–12, sets the fiscal Q1 month). Passes through into `budgets[].reset_config`.
 - Added `target` (`llm` default, or `mcp`) to `bifrost.governance` guardrail rules to select the rule's execution target. Passes through into the rule's `target`.
+- Added `mcp.clientConfigs[].perUserHeaderKeys` — the header names each caller must individually supply under `authType: per_user_headers` (e.g. `["Authorization"]`). This field already existed in `transports/config.schema.json` and the per-user-headers auth flow, but was never mapped through `_helpers.tpl`, so it silently dropped out of the rendered `config.json` and `authType: per_user_headers` clients could not be fully configured via Helm. Renders into `per_user_header_keys`.
 
 
 ### 2.1.34

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -1347,6 +1347,9 @@ false
 {{- if $client.allowedExtraHeaders }}
 {{- $_ := set $cc "allowed_extra_headers" $client.allowedExtraHeaders }}
 {{- end }}
+{{- if $client.perUserHeaderKeys }}
+{{- $_ := set $cc "per_user_header_keys" $client.perUserHeaderKeys }}
+{{- end }}
 {{- /* allowByDefault supersedes allowOnAllVirtualKeys. Emit exactly one key so the backend's
        ResolveAllowByDefault sees an unambiguous declaration: the current key when it is given,
        otherwise the deprecated one passed through untranslated. */ -}}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -6988,6 +6988,13 @@
           },
           "description": "Allowlist of request-level headers that callers may forward to this MCP server. Use ['*'] to allow all headers."
         },
+        "perUserHeaderKeys": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Header names each caller must individually supply when authType is 'per_user_headers' (e.g. ['Authorization']). Required (non-empty) for that auth type; ignored otherwise."
+        },
         "allowOnAllVirtualKeys": {
           "type": "boolean",
           "deprecated": true,

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -6991,7 +6991,8 @@
         "perUserHeaderKeys": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "pattern": "\\S"
           },
           "description": "Header names each caller must individually supply when authType is 'per_user_headers' (e.g. ['Authorization']). Required (non-empty) for that auth type; ignored otherwise."
         },
@@ -7076,6 +7077,24 @@
           },
           "then": {
             "required": ["connectionString"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "authType": {
+                "const": "per_user_headers"
+              }
+            },
+            "required": ["authType"]
+          },
+          "then": {
+            "required": ["perUserHeaderKeys"],
+            "properties": {
+              "perUserHeaderKeys": {
+                "minItems": 1
+              }
+            }
           }
         }
       ]

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -555,7 +555,8 @@ bifrost:
       #     scopes: []                                   # optional; include 'offline_access' for refresh tokens
       # - name: "example-per-user-headers-mcp"
       #   connectionType: "http"
-      #   connectionString: "https://my-mcp.corp/mcp"
+      #   httpConfig:
+      #     url: "https://my-mcp.corp/mcp"
       #   # authType "per_user_headers": each caller submits their own header values (API keys,
       #   # signed tokens) through the Bifrost auth flow; perUserHeaderKeys declares which header
       #   # names are required. Values are collected and stored per-identity by Bifrost, not here.

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -553,6 +553,14 @@ bifrost:
       #     clientSecret: "env.MY_EXCHANGE_CLIENT_SECRET"  # omit for public clients
       #     authorizationServerUrl: ""                   # optional — override exchange endpoint (e.g. Okta custom AS)
       #     scopes: []                                   # optional; include 'offline_access' for refresh tokens
+      # - name: "example-per-user-headers-mcp"
+      #   connectionType: "http"
+      #   connectionString: "https://my-mcp.corp/mcp"
+      #   # authType "per_user_headers": each caller submits their own header values (API keys,
+      #   # signed tokens) through the Bifrost auth flow; perUserHeaderKeys declares which header
+      #   # names are required. Values are collected and stored per-identity by Bifrost, not here.
+      #   authType: "per_user_headers"
+      #   perUserHeaderKeys: ["Authorization"]
     # toolSyncInterval: "10m"   # Global tool sync interval (Go duration string, e.g. "10m", "1h", "0s")
     # Virtual MCPs: bundle tools from one or more MCP clients into a single endpoint
     # served at /mcp/<endpointSlug> and attach it to virtual keys.


### PR DESCRIPTION
## Summary

Fixes #6033.

`MCPClientConfig.PerUserHeaderKeys` (`per_user_header_keys` in `transports/config.schema.json`) is required (non-empty) for `authType: per_user_headers` MCP clients — it declares the header names each caller must individually supply (e.g. `Authorization`). It's fully wired through the Go core, config store, and API (credential store, client manager, MCP handlers, reconciliation hash), but the Helm chart never mapped it: `_helpers.tpl`'s `clientConfigs` → `config.json` loop explicitly copies each field one at a time, and there was no case for `perUserHeaderKeys`. `values.schema.json` also never declared the property. So setting it under `bifrost.mcp.clientConfigs[]` in Helm values was silently dropped, even though `authType: per_user_headers` itself renders fine.

## Changes

- `helm-charts/bifrost/values.schema.json` — added `perUserHeaderKeys` (array of strings) to `mcpClientConfig`, matching the existing `allowedExtraHeaders` shape.
- `helm-charts/bifrost/templates/_helpers.tpl` — maps `perUserHeaderKeys` → `per_user_header_keys` in rendered `config.json`, same pattern as the adjacent `allowedExtraHeaders` mapping.
- `helm-charts/bifrost/values.yaml` — added a commented `per_user_headers` example next to the existing `oauth`/`oauthConfigId` example.
- `helm-charts/bifrost/README.md` — documented under `### Upcoming`.
- `.github/workflows/scripts/validate-helm-config-fields.sh` — added a fourth MCP test client (`per-user-headers-server`) asserting `auth_type` and `per_user_header_keys[0..1]` render correctly.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs (Helm chart + CI script)

## How to test

```sh
bash .github/workflows/scripts/validate-helm-templates.sh
bash .github/workflows/scripts/validate-helm-config-fields.sh
bash .github/workflows/scripts/validate-helm-schema.sh
helm lint helm-charts/bifrost
```

All pass locally, including the new MCP assertions for `per_user_header_keys`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes #6033

## Security considerations

None — this only affects which header *names* an admin declares as required; header *values* continue to be collected and stored per-identity through the existing per-user-headers submission flow, never through this static config.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI) — N/A, Helm-only change
- [x] I verified the CI pipeline passes locally if applicable