### PR TITLE
fix: normalize Together provider for pricing lookup

### DIFF
--- a/framework/modelcatalog/datasheet/cost.go
+++ b/framework/modelcatalog/datasheet/cost.go
@@ -1211,6 +1211,7 @@ func populateOutputImageCount(imageUsage *schemas.ImageUsage, dataLen int) {
 // applies.
 func (s *Store) resolvePricing(routingInfo schemas.RoutingInfo, requestType schemas.RequestType, scopes LookupScopes) *configstoreTables.TableModelPricing {
 	provider := string(routingInfo.Provider)
+	catalogProvider := normalizeProvider(provider)
 	var aliasModelID, aliasModelName string
 	if rka := routingInfo.ResolvedKeyAlias; rka != nil {
 		aliasModelID = rka.ModelID
@@ -1239,7 +1240,7 @@ func (s *Store) resolvePricing(routingInfo schemas.RoutingInfo, requestType sche
 		if candidate == "" {
 			continue
 		}
-		base, exists := s.getBasePricing(candidate, provider, requestType)
+		base, exists := s.getBasePricing(candidate, catalogProvider, requestType)
 		if exists && base != nil {
 			result, _ := s.applyPricingOverrides(overrideKey, requestType, *base, scopes)
 			return &result

--- a/framework/modelcatalog/datasheet/cost_test.go
+++ b/framework/modelcatalog/datasheet/cost_test.go
@@ -1921,6 +1921,31 @@ func TestGetPricing_DirectLookup(t *testing.T) {
 	assert.Equal(t, 0.000005, derefF(p.InputCostPerToken))
 }
 
+func TestCalculateCost_TogetherAliasUsesTogetherAIPricingWithCache(t *testing.T) {
+	const model = "zai-org/GLM-5.2"
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey(model, "together_ai", "chat"): {
+			Model:                   model,
+			Provider:                "together_ai",
+			Mode:                    "chat",
+			InputCostPerToken:       bifrost.Ptr(1.40 / 1_000_000),
+			CacheReadInputTokenCost: bifrost.Ptr(0.26 / 1_000_000),
+			OutputCostPerToken:      bifrost.Ptr(4.40 / 1_000_000),
+		},
+	})
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     36_807_862,
+		CompletionTokens: 54_932,
+		TotalTokens:      36_862_794,
+		PromptTokensDetails: &schemas.ChatPromptTokensDetails{
+			CachedReadTokens: 33_829_760,
+		},
+	}
+
+	cost := s.CalculateCost(makeChatResponse("together", model, usage), nil)
+	assert.InDelta(t, 13.2067812, cost, 1e-9)
+}
+
 func TestGetPricing_GeminiFallsBackToVertex(t *testing.T) {
 	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
 		makeKey("gemini-2.0-flash", "vertex", "chat"): {

--- a/framework/modelcatalog/datasheet/types.go
+++ b/framework/modelcatalog/datasheet/types.go
@@ -349,10 +349,12 @@ func makeKey(model, provider, mode string) string {
 	return model + "|" + provider + "|" + mode
 }
 
-// normalizeProvider folds upstream-datasheet provider name variants
-// (vertex_ai, google-vertex, etc.) onto bifrost's canonical provider names.
+// normalizeProvider folds equivalent provider identifiers onto the canonical
+// provider name used by the pricing catalog.
 func normalizeProvider(p string) string {
 	switch {
+	case p == "together":
+		return "together_ai"
 	case strings.Contains(p, "vertex_ai") || p == "google-vertex":
 		return string(schemas.Vertex)
 	case strings.Contains(p, "bedrock"):


### PR DESCRIPTION
## Summary

- normalize the runtime custom-provider name `together` to the pricing catalog's canonical `together_ai` identifier
- apply provider normalization consistently when resolving catalog pricing, while preserving the runtime provider name for routing, metrics, and scoped overrides
- add an end-to-end cost regression using real GLM-5.2 token counts and cached-input pricing

## Root cause

Pricing rows are normalized when the hosted datasheet is ingested, but the runtime provider identifier was used verbatim during cost lookup. A custom OpenAI-compatible provider named `together` therefore could not match rows stored under `together_ai`; cost calculation returned zero even when the catalog contained the model.

The hosted catalog still needs a direct Together GLM-5.2 row. That data request is tracked in #6036. Once present, this change lets existing `together` deployments consume it without renaming a DB-backed provider.

## Validation

- `go test ./modelcatalog/datasheet -run 'TestCalculateCost_TogetherAliasUsesTogetherAIPricingWithCache|TestGetPricing_' -count=1`
- `go test ./modelcatalog/datasheet -count=1`
- the regression calculates `$13.2067812` from 36,807,862 input tokens, including 33,829,760 cached tokens, and 54,932 output tokens
