### PR TITLE
encrypted content patch for encrytped content could not be verified

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -559,6 +559,23 @@ Only `framework/vectorstore` needs any of this. Every other framework package pa
 
 Before writing a fix, add (or extend) a test that reproduces the bug and confirm it fails for the expected reason — a wrong assertion, not a compile error or an unrelated panic. Only then implement the fix, and confirm the same test now passes. For bugs reachable through `make run-provider-harness-test`, add the harness regression case (see `.claude/skills/harness-test-writer/SKILL.md`) alongside Go-level tests: Go tests give a fast, free red/green loop while coding; the harness case is the live end-to-end pin, expected red pre-fix and green post-fix, validated structurally (`augment-provider-harness.mjs` / `filter-collection.mjs`) without needing a live paid run during development.
 
+### Every `core/` change ships with a provider-harness case
+
+Any change under `core/` that a client can observe on the wire must land together with a case in `tests/e2e/api/collections/provider-harness.json` (see `.claude/skills/harness-test-writer/SKILL.md`). This covers new features and refactors, not only bug fixes — the rule in the previous section is the narrower instance of this one.
+
+`core/` is the only layer every transport, integration and provider funnels through, so its behaviour is what the harness exists to pin. A Go unit test proves the function does what you meant; only the harness proves the bytes a real client sends still come back correct through the whole stack. The gap between those two is where regressions live: a fail-soft that fires on one request shape and silently skips a sibling shape passes every unit test it has.
+
+Write the case so it is **red before the change and green after**, and validate it structurally while developing — no live paid run needed:
+
+```bash
+node tests/e2e/api/runners/augment-provider-harness.mjs --source tests/e2e/api/collections/provider-harness.json --out tmp/harness-augmented.json
+node tests/e2e/api/runners/filter-collection.mjs --source tmp/harness-augmented.json --out tmp/filtered.json --feature "<keyword>"
+```
+
+Insert into the collection surgically (a script that splices the new object in, never a whole-file reserialize) — the file is ~50k lines and a reformat buries the actual change.
+
+The narrow exemptions: changes with no wire-visible effect (comments, internal renames, log lines) and behaviour no HTTP request can reach. If a change is exempt, say so explicitly in the PR rather than leaving the omission unexplained.
+
 ### Always prefer `make test-core` over raw `go test` for provider-level tests
 
 The `make test-core` target is the canonical harness for provider tests — it wires up env vars from `.env` (provider API keys), invokes the per-provider `{provider}_test.go` entrypoint in `core/providers/<provider>/`, and routes through the shared `core/internal/llmtests/` scenario suite that validates end-to-end behavior (including streaming).

--- a/core/encryptedreasoning.go
+++ b/core/encryptedreasoning.go
@@ -47,9 +47,37 @@ func isEncryptedReasoningRejection(err *schemas.BifrostError) bool {
 		(strings.Contains(message, "invalid `data`") && strings.Contains(message, "`redacted_thinking` block"))
 }
 
+// encryptedReasoningCarriers returns the input array and raw body of the request
+// shape that replays reasoning items, or nils when this request carries none.
+//
+// Three endpoints replay the same []ResponsesMessage and all three reach the
+// provider through the retry loop that calls the strip: /v1/responses, its
+// token-counting twin, and /v1/responses/compact. The last one is a separate
+// top-level request rather than a flag on the first, and a coding CLI resuming a
+// session hits it with the entire prior transcript -- the exact payload most likely
+// to be refused. Keying the strip off one shape would hand that 400 straight to
+// the client, so the shapes are resolved here and rewritten by one code path.
+//
+// Pointers are returned rather than values because both branches write back.
+func encryptedReasoningCarriers(req *schemas.BifrostRequest) (input *[]schemas.ResponsesMessage, rawBody *[]byte) {
+	if req == nil {
+		return nil, nil
+	}
+	switch {
+	case req.ResponsesRequest != nil:
+		return &req.ResponsesRequest.Input, &req.ResponsesRequest.RawRequestBody
+	case req.CountTokensRequest != nil:
+		return &req.CountTokensRequest.Input, &req.CountTokensRequest.RawRequestBody
+	case req.CompactionRequest != nil:
+		return &req.CompactionRequest.Input, &req.CompactionRequest.RawRequestBody
+	default:
+		return nil, nil
+	}
+}
+
 // stripResponsesEncryptedContent removes encrypted_content from every reasoning item
-// in a Responses request, reporting whether anything changed. Reasoning items left
-// with nothing to say -- no summary and no content blocks -- are dropped entirely
+// in a Responses-shaped request, reporting whether anything changed. Reasoning items
+// left with nothing to say -- no summary and no content blocks -- are dropped entirely
 // rather than forwarded as bare ids the upstream never issued.
 //
 // Summaries, ids, and every other item are preserved: the model loses the verbatim
@@ -70,7 +98,8 @@ func isEncryptedReasoningRejection(err *schemas.BifrostError) bool {
 // body streams straight from a reader that core never parsed and cannot rewrite, so
 // claiming a change would buy a second identical upstream call.
 func stripResponsesEncryptedContent(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) bool {
-	if req == nil || req.ResponsesRequest == nil {
+	inputRef, rawBodyRef := encryptedReasoningCarriers(req)
+	if inputRef == nil {
 		return false
 	}
 	if ctx != nil {
@@ -78,15 +107,15 @@ func stripResponsesEncryptedContent(ctx *schemas.BifrostContext, req *schemas.Bi
 			return false
 		}
 		if useRawBody, ok := ctx.Value(schemas.BifrostContextKeyUseRawRequestBody).(bool); ok && useRawBody {
-			return stripRawResponsesEncryptedContent(req.ResponsesRequest)
+			return stripRawResponsesEncryptedContent(rawBodyRef)
 		}
 	}
 
-	if len(req.ResponsesRequest.Input) == 0 {
+	if len(*inputRef) == 0 {
 		return false
 	}
 
-	input := req.ResponsesRequest.Input
+	input := *inputRef
 	stripped := make([]schemas.ResponsesMessage, 0, len(input))
 	changed := false
 
@@ -112,7 +141,7 @@ func stripResponsesEncryptedContent(ctx *schemas.BifrostContext, req *schemas.Bi
 		return false
 	}
 
-	req.ResponsesRequest.Input = stripped
+	*inputRef = stripped
 	return true
 }
 
@@ -120,8 +149,11 @@ func stripResponsesEncryptedContent(ctx *schemas.BifrostContext, req *schemas.Bi
 // body, which is what reaches the provider when the caller opted into passthrough.
 // Each surviving item keeps its original bytes (minus the deleted field) so fields
 // Bifrost's schema does not model are not lost on the way through.
-func stripRawResponsesEncryptedContent(req *schemas.BifrostResponsesRequest) bool {
-	body := req.RawRequestBody
+func stripRawResponsesEncryptedContent(rawBody *[]byte) bool {
+	if rawBody == nil {
+		return false
+	}
+	body := *rawBody
 	if len(body) == 0 {
 		return false
 	}
@@ -158,6 +190,6 @@ func stripRawResponsesEncryptedContent(req *schemas.BifrostResponsesRequest) boo
 	if err != nil {
 		return false
 	}
-	req.RawRequestBody = updated
+	*rawBody = updated
 	return true
 }

--- a/core/encryptedreasoning_test.go
+++ b/core/encryptedreasoning_test.go
@@ -41,6 +41,21 @@ func newEncryptedReasoningRequest(encrypted string) *schemas.BifrostRequest {
 	}
 }
 
+// newEncryptedReasoningCompactionRequest builds the /v1/responses/compact counterpart
+// of newEncryptedReasoningRequest. Codex sends its remote compaction over this shape,
+// replaying the same reasoning items the Responses turns carried.
+func newEncryptedReasoningCompactionRequest(encrypted string) *schemas.BifrostRequest {
+	responses := newEncryptedReasoningRequest(encrypted).ResponsesRequest
+	return &schemas.BifrostRequest{
+		RequestType: schemas.CompactionRequest,
+		CompactionRequest: &schemas.BifrostCompactionRequest{
+			Provider: schemas.OpenAI,
+			Model:    responses.Model,
+			Input:    responses.Input,
+		},
+	}
+}
+
 func encryptedContentError() *schemas.BifrostError {
 	return &schemas.BifrostError{
 		StatusCode: schemas.Ptr(400),
@@ -361,6 +376,42 @@ func TestStripResponsesEncryptedContent(t *testing.T) {
 
 		if stripResponsesEncryptedContent(nil, req) {
 			t.Error("expected no change to be reported")
+		}
+	})
+
+	// Codex's remote compaction replays the same reasoning items over
+	// /v1/responses/compact, which Bifrost models as its own request shape. The
+	// upstream rejects an unverifiable payload there exactly as it does on a normal
+	// turn, so the strip has to reach it or the 400 is handed straight to the client.
+	t.Run("strips a compaction request", func(t *testing.T) {
+		req := newEncryptedReasoningCompactionRequest("ciphertext")
+
+		if !stripResponsesEncryptedContent(nil, req) {
+			t.Fatal("expected the strip to report a change on a compaction request")
+		}
+		if len(req.CompactionRequest.Input) != 2 {
+			t.Fatalf("expected the summarised reasoning item to survive, got %d items", len(req.CompactionRequest.Input))
+		}
+		if req.CompactionRequest.Input[1].ResponsesReasoning.EncryptedContent != nil {
+			t.Error("expected encrypted_content to be cleared on the compaction input")
+		}
+	})
+
+	t.Run("rewrites a compaction raw body under passthrough", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+
+		req := newEncryptedReasoningCompactionRequest("ciphertext")
+		req.CompactionRequest.RawRequestBody = []byte(`{"model":"gpt-5.6-sol","input":[` +
+			`{"type":"message","role":"user","content":"run the tests"},` +
+			`{"type":"reasoning","id":"rs_1","summary":[{"type":"summary_text","text":"planning"}],"encrypted_content":"cipher"}` +
+			`]}`)
+
+		if !stripResponsesEncryptedContent(ctx, req) {
+			t.Fatal("expected the compaction raw body to be rewritten")
+		}
+		if body := string(req.CompactionRequest.RawRequestBody); strings.Contains(body, "encrypted_content") {
+			t.Errorf("expected encrypted_content to be gone, got %s", body)
 		}
 	})
 

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -49732,6 +49732,108 @@
           }
         }
       ]
+    },
+    {
+      "name": "45. Encrypted Reasoning Fail-Soft on Compaction (/v1/responses/compact degrades instead of 400)",
+      "description": "Bifrost's encrypted-reasoning fail-soft (core/encryptedreasoning.go) also has to reach /v1/responses/compact.\nCodex's remote compaction replays the entire prior transcript in one request, so it is the call most likely to\ncarry reasoning items minted under a different key or org - exactly the payload the upstream refuses with 400\ninvalid_encrypted_content.\n\nCompaction is a separate top-level request shape in Bifrost (schemas.BifrostRequest.CompactionRequest, its own Input and\nRawRequestBody), not a flag on the Responses request. The strip originally keyed off ResponsesRequest alone and returned\nfalse for compaction, so the detector matched, the retry never fired, and the raw 400 reached the client - Codex surfaced\nit as \"Error running remote compact task\" and retried the identical body forever.\n\nFIXTURE CONSTRAINT - the two cases cover both strip outcomes and must not be collapsed: the first reasoning item keeps a\nsummary so the stripped item survives the retry, the second has none so the item is dropped entirely rather than sent as a\nbare id the upstream never issued. A synthetic unverifiable blob is used rather than a captured one: the upstream refuses any\npayload it cannot verify identically, and this keeps each case self-contained.",
+      "item": [
+        {
+          "name": "openai/gpt-5-mini /openai/v1/responses/compact unverifiable encrypted reasoning degrades - failsoft",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('compaction with unverifiable encrypted reasoning degrades instead of 400ing', function () {",
+                  "  var body = pm.response.text() || '';",
+                  "  pm.expect(body, 'upstream rejection reached the client; the fail-soft does not cover the compaction request shape').to.not.include('invalid_encrypted_content');",
+                  "  pm.expect(pm.response.code, 'compaction failed: ' + body).to.be.below(400);",
+                  "  var j = pm.response.json();",
+                  "  pm.expect(j.object, 'compaction did not complete after the stripped retry').to.equal('response.compaction');",
+                  "  pm.expect(j.output, 'no output returned after the stripped retry').to.be.an('array').that.is.not.empty;",
+                  "  pm.expect(j.output[j.output.length - 1].type, 'compaction item missing from the output').to.equal('compaction');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"openai/gpt-5-mini\",\"input\":[{\"role\":\"user\",\"content\":\"What is the capital of France?\"},{\"type\":\"reasoning\",\"id\":\"rs_bfharness0000000000000000000000000000000000002\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"Recalling what the user asked about France.\"}],\"encrypted_content\":\"gAAAAABqdgntZpz92rFHmQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvgAAAAABqdgntZpz92rFHmQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvgAAAAABqdgntZpz92rFHmQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvgAAAAABqdgntZpz92rFHmQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvgAAAAABqdgntZpz92rFHmQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvgAAAAABqdgntZpz92rFHmQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0Iv\"},{\"type\":\"message\",\"id\":\"msg_bfharness02\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"The capital of France is Paris.\"}]},{\"role\":\"user\",\"content\":\"What is it known for?\"},{\"type\":\"message\",\"id\":\"msg_bfharness03\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"The Eiffel Tower, the Louvre, and its cuisine.\"}]}]}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/openai/v1/responses/compact",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "openai",
+                "v1",
+                "responses",
+                "compact"
+              ]
+            }
+          }
+        },
+        {
+          "name": "openai/gpt-5-mini /openai/v1/responses/compact summary-less reasoning item is dropped - failsoft",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('compaction with unverifiable encrypted reasoning degrades instead of 400ing', function () {",
+                  "  var body = pm.response.text() || '';",
+                  "  pm.expect(body, 'upstream rejection reached the client; the fail-soft does not cover the compaction request shape').to.not.include('invalid_encrypted_content');",
+                  "  pm.expect(pm.response.code, 'compaction failed: ' + body).to.be.below(400);",
+                  "  var j = pm.response.json();",
+                  "  pm.expect(j.object, 'compaction did not complete after the stripped retry').to.equal('response.compaction');",
+                  "  pm.expect(j.output, 'no output returned after the stripped retry').to.be.an('array').that.is.not.empty;",
+                  "  pm.expect(body, 'the emptied reasoning item was forwarded as a bare id instead of being dropped').to.not.include('rs_bfharness0000000000000000000000000000000000002');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"openai/gpt-5-mini\",\"input\":[{\"role\":\"user\",\"content\":\"What is the capital of France?\"},{\"type\":\"reasoning\",\"id\":\"rs_bfharness0000000000000000000000000000000000002\",\"summary\":[],\"encrypted_content\":\"gAAAAABqdgntZpz92rFHmQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvgAAAAABqdgntZpz92rFHmQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvgAAAAABqdgntZpz92rFHmQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvgAAAAABqdgntZpz92rFHmQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvgAAAAABqdgntZpz92rFHmQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0IvgAAAAABqdgntZpz92rFHmQx7Kd3vTn8LpWs2Yb6Hj9Rf4Mc1Ae5Gu0Iv\"},{\"type\":\"message\",\"id\":\"msg_bfharness02\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"The capital of France is Paris.\"}]},{\"role\":\"user\",\"content\":\"What is it known for?\"},{\"type\":\"message\",\"id\":\"msg_bfharness03\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"The Eiffel Tower, the Louvre, and its cuisine.\"}]}]}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/openai/v1/responses/compact",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "openai",
+                "v1",
+                "responses",
+                "compact"
+              ]
+            }
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

The encrypted-reasoning fail-soft that strips `encrypted_content` from reasoning items before retrying a rejected request only covered `ResponsesRequest`. Bifrost models `/v1/responses/compact` as a separate top-level request shape (`CompactionRequest` with its own `Input` and `RawRequestBody`), so the strip returned `false` for compaction requests, the retry never fired, and the raw `400 invalid_encrypted_content` was handed straight to the client. Codex surfaced this as "Error running remote compact task" and retried the identical body indefinitely.

## Changes

- Introduced `encryptedReasoningCarriers`, which resolves the `Input` and `RawRequestBody` pointers for whichever of the three Responses-shaped request types (`ResponsesRequest`, `CountTokensRequest`, `CompactionRequest`) is present on a given `BifrostRequest`. This lets a single code path in `stripResponsesEncryptedContent` and `stripRawResponsesEncryptedContent` cover all three shapes without duplicating logic.
- `stripResponsesEncryptedContent` now keys off the resolved pointers rather than a hard check for `ResponsesRequest != nil`, so compaction and token-counting requests are rewritten on the same retry path.
- `stripRawResponsesEncryptedContent` now accepts a `*[]byte` instead of a `*schemas.BifrostResponsesRequest`, removing the coupling to one specific request type.
- Added unit tests covering the compaction strip path for both the structured and raw-body (passthrough) cases, and for the drop-on-empty-summary behaviour on compaction input.
- Added two provider-harness cases under entry 45 that pin the end-to-end behaviour: one where the stripped reasoning item survives (it has a summary), and one where it is dropped entirely (empty summary) rather than forwarded as a bare id the upstream never issued.
- Updated `AGENTS.md` to make explicit that any wire-visible change under `core/` must ship with a provider-harness case, not only bug fixes, and documents the structural validation workflow and the narrow exemptions.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)

## How to test

```sh
# Unit tests — fast red/green loop
go test ./core/... -run TestStripResponsesEncryptedContent

# Structural harness validation — no live API key needed
node tests/e2e/api/runners/augment-provider-harness.mjs \
  --source tests/e2e/api/collections/provider-harness.json \
  --out tmp/harness-augmented.json

node tests/e2e/api/runners/filter-collection.mjs \
  --source tmp/harness-augmented.json \
  --out tmp/filtered.json \
  --feature "Encrypted Reasoning Fail-Soft on Compaction"
```

The two new harness cases (`openai/gpt-5-mini /openai/v1/responses/compact unverifiable encrypted reasoning degrades` and the summary-less drop variant) should pass structurally. Against a live endpoint they verify that the compaction response returns `object: "response.compaction"` with a non-empty `output` array and no `invalid_encrypted_content` in the body.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

No auth, secrets, or PII implications. The strip removes `encrypted_content` blobs that the upstream has already refused; no key material is logged or forwarded.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable