### PR TITLE
[DO-NOT-MERGE-YET] complexity cache-aware session tier policy

### DIFF
--- a/plugins/governance/complexitysession.go
+++ b/plugins/governance/complexitysession.go
@@ -15,6 +15,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	"github.com/maximhq/bifrost/framework/kvstore"
+	"github.com/maximhq/bifrost/plugins/governance/complexity"
 )
 
 const (
@@ -81,6 +82,37 @@ type SessionComplexityRecord struct {
 	// It is a map so primary, fallback, and destination warmth remain separate.
 	// Writers are responsible for bounding retained history.
 	RouteObservations map[string]SessionRouteObservation `json:"route_observations,omitempty"`
+}
+
+// sessionTierDecisionReason is a stable, machine-readable explanation of a
+// cache-aware tier decision. The integration layer may turn it into a richer
+// routing log, but policy remains independent of logging and request state.
+type sessionTierDecisionReason string
+
+const (
+	sessionTierReasonInvalidState          sessionTierDecisionReason = "invalid_state"
+	sessionTierReasonInvalidProposal       sessionTierDecisionReason = "invalid_proposal"
+	sessionTierReasonNoProposal            sessionTierDecisionReason = "no_proposal"
+	sessionTierReasonSameTier              sessionTierDecisionReason = "same_tier"
+	sessionTierReasonBelowSwitchSimilarity sessionTierDecisionReason = "below_switch_similarity"
+	sessionTierReasonSwitchLimitReached    sessionTierDecisionReason = "switch_limit_reached"
+	sessionTierReasonEscalated             sessionTierDecisionReason = "escalated"
+	sessionTierReasonDowngradePending      sessionTierDecisionReason = "downgrade_pending"
+	sessionTierReasonCacheStateUnknown     sessionTierDecisionReason = "cache_state_unknown"
+	sessionTierReasonCacheWorthHolding     sessionTierDecisionReason = "cache_worth_holding"
+	sessionTierReasonDowngraded            sessionTierDecisionReason = "downgraded"
+)
+
+// sessionTierDecision is the result of applying cache-aware session policy.
+// Tier is the value to publish for this turn. Switched distinguishes a tier
+// move from a hold, while RecordChanged tells the caller whether persistence is
+// necessary even when the tier stayed put, such as while advancing a pending
+// downgrade.
+type sessionTierDecision struct {
+	Tier          string
+	Switched      bool
+	RecordChanged bool
+	Reason        sessionTierDecisionReason
 }
 
 // SessionStoreStatus describes the guarantees of the active session-state
@@ -383,6 +415,184 @@ func cloneSessionComplexityRecord(record *SessionComplexityRecord) *SessionCompl
 	cloned := *record
 	cloned.RouteObservations = maps.Clone(record.RouteObservations)
 	return &cloned
+}
+
+// updateSessionTierRecord applies cache-aware switching policy to record and
+// returns the tier to publish for this turn. It mutates only the supplied
+// caller-owned record and performs no I/O, logging, or store access.
+//
+// Callers must invoke it from inside SessionStore.Update so the decision and
+// its PendingTurns/SwitchCount mutations use the latest record atomically. A
+// false RecordChanged result lets the caller abort the write, avoiding an
+// unnecessary replication message for an ordinary held turn.
+func updateSessionTierRecord(
+	record *SessionComplexityRecord,
+	proposed *complexity.ComplexityResult,
+	config *configstore.ComplexitySessionConfig,
+	now time.Time,
+) sessionTierDecision {
+	if record == nil {
+		return sessionTierDecision{Reason: sessionTierReasonInvalidState}
+	}
+	if config == nil || config.Mode != configstore.ComplexitySessionModeCacheAware {
+		return sessionTierDecision{Tier: record.Tier, Reason: sessionTierReasonInvalidState}
+	}
+
+	currentRank, currentValid := sessionTierRank(record.Tier)
+	if !currentValid {
+		return sessionTierDecision{Tier: record.Tier, Reason: sessionTierReasonInvalidState}
+	}
+	if proposed == nil || proposed.Tier == "" {
+		return heldSessionTierDecision(record, sessionTierReasonNoProposal)
+	}
+
+	proposedRank, proposedValid := sessionTierRank(proposed.Tier)
+	if !proposedValid {
+		return heldSessionTierDecision(record, sessionTierReasonInvalidProposal)
+	}
+	if proposedRank == currentRank {
+		return heldSessionTierDecision(record, sessionTierReasonSameTier)
+	}
+
+	escalating := proposedRank > currentRank
+	if !meetsSessionSwitchSimilarity(proposed.Score, config.SwitchMinSimilarity) &&
+		!(escalating && config.AlwaysAllowEscalation) {
+		return heldSessionTierDecision(record, sessionTierReasonBelowSwitchSimilarity)
+	}
+	if config.MaxSwitchesPerSession > 0 && record.SwitchCount >= config.MaxSwitchesPerSession {
+		return heldSessionTierDecision(record, sessionTierReasonSwitchLimitReached)
+	}
+	if escalating {
+		return switchedSessionTierDecision(record, proposed.Tier, now, sessionTierReasonEscalated)
+	}
+
+	requiredTurns := config.DowngradeAfterNTurns
+	if requiredTurns < 1 {
+		requiredTurns = 1
+	}
+	recordChanged := advancePendingSessionTier(record, proposed.Tier, proposed.Score, requiredTurns)
+	if record.PendingTurns < requiredTurns {
+		return unswitchedSessionTierDecision(record, sessionTierReasonDowngradePending, recordChanged)
+	}
+
+	observation, ok := latestUsableSessionRouteObservation(record, now, config.TTL)
+	if !ok || !observation.CacheObserved || observation.CachedReadTokens <= 0 {
+		return unswitchedSessionTierDecision(record, sessionTierReasonCacheStateUnknown, recordChanged)
+	}
+	if observation.CachedReadTokens >= config.MinCachedTokensToHold {
+		return unswitchedSessionTierDecision(record, sessionTierReasonCacheWorthHolding, recordChanged)
+	}
+
+	return switchedSessionTierDecision(record, proposed.Tier, now, sessionTierReasonDowngraded)
+}
+
+func sessionTierRank(tier string) (int, bool) {
+	switch tier {
+	case complexity.TierSimple:
+		return 0, true
+	case complexity.TierMedium:
+		return 1, true
+	case complexity.TierComplex:
+		return 2, true
+	default:
+		return 0, false
+	}
+}
+
+func meetsSessionSwitchSimilarity(score, threshold float64) bool {
+	return threshold <= 0 || score >= threshold
+}
+
+func heldSessionTierDecision(record *SessionComplexityRecord, reason sessionTierDecisionReason) sessionTierDecision {
+	return unswitchedSessionTierDecision(record, reason, clearPendingSessionTier(record))
+}
+
+func unswitchedSessionTierDecision(
+	record *SessionComplexityRecord,
+	reason sessionTierDecisionReason,
+	recordChanged bool,
+) sessionTierDecision {
+	return sessionTierDecision{
+		Tier:          record.Tier,
+		RecordChanged: recordChanged,
+		Reason:        reason,
+	}
+}
+
+func clearPendingSessionTier(record *SessionComplexityRecord) bool {
+	if record.PendingTier == "" && record.PendingTurns == 0 && record.PendingMinScore == 0 {
+		return false
+	}
+	record.PendingTier = ""
+	record.PendingTurns = 0
+	record.PendingMinScore = 0
+	return true
+}
+
+func advancePendingSessionTier(record *SessionComplexityRecord, tier string, score float64, requiredTurns int) bool {
+	if record.PendingTier != tier || record.PendingTurns <= 0 {
+		record.PendingTier = tier
+		record.PendingTurns = 1
+		record.PendingMinScore = score
+		return true
+	}
+
+	changed := false
+	if record.PendingTurns < requiredTurns {
+		record.PendingTurns++
+		changed = true
+	}
+	if score < record.PendingMinScore {
+		record.PendingMinScore = score
+		changed = true
+	}
+	return changed
+}
+
+// latestUsableSessionRouteObservation returns the freshest route fact that is
+// no newer than now and still within the session observation window. We use the
+// latest served route because tier selection happens before routing, so the
+// destination route for a proposed tier is not known yet.
+//
+// A stale fact is unknown, not cold: session TTL is not proof of a provider's
+// prompt-cache TTL, and guessing expiry could discard a still-warm cache.
+func latestUsableSessionRouteObservation(
+	record *SessionComplexityRecord,
+	now time.Time,
+	ttl time.Duration,
+) (SessionRouteObservation, bool) {
+	if record == nil || now.IsZero() || ttl <= 0 {
+		return SessionRouteObservation{}, false
+	}
+
+	var latest SessionRouteObservation
+	for _, observation := range record.RouteObservations {
+		if observation.LastSeenAt.After(latest.LastSeenAt) {
+			latest = observation
+		}
+	}
+	if latest.LastSeenAt.IsZero() || latest.LastSeenAt.After(now) || now.Sub(latest.LastSeenAt) > ttl {
+		return SessionRouteObservation{}, false
+	}
+	return latest, true
+}
+
+func switchedSessionTierDecision(
+	record *SessionComplexityRecord,
+	tier string,
+	now time.Time,
+	reason sessionTierDecisionReason,
+) sessionTierDecision {
+	record.Tier = tier
+	record.DecidedAt = now
+	record.SwitchCount++
+	clearPendingSessionTier(record)
+	return sessionTierDecision{
+		Tier:          record.Tier,
+		Switched:      true,
+		RecordChanged: true,
+		Reason:        reason,
+	}
 }
 
 // resolveSessionID walks the enabled identity sources in their fixed precedence

--- a/plugins/governance/complexitysession_test.go
+++ b/plugins/governance/complexitysession_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	"github.com/maximhq/bifrost/framework/kvstore"
+	"github.com/maximhq/bifrost/plugins/governance/complexity"
 )
 
 func TestResolveSessionIDPrecedence(t *testing.T) {
@@ -598,6 +599,380 @@ func TestKVSessionStoreStatus(t *testing.T) {
 		ReplicationConfigured: true,
 		AtomicAcrossReplicas:  false,
 	}, status)
+}
+
+func TestSessionTierRank(t *testing.T) {
+	tests := []struct {
+		name     string
+		tier     string
+		wantRank int
+		wantOK   bool
+	}{
+		{name: "simple", tier: complexity.TierSimple, wantRank: 0, wantOK: true},
+		{name: "medium", tier: complexity.TierMedium, wantRank: 1, wantOK: true},
+		{name: "complex", tier: complexity.TierComplex, wantRank: 2, wantOK: true},
+		{name: "unknown", tier: "UNKNOWN", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rank, ok := sessionTierRank(tt.tier)
+			assert.Equal(t, tt.wantRank, rank)
+			assert.Equal(t, tt.wantOK, ok)
+		})
+	}
+}
+
+func TestUpdateSessionTierRecordClearsInterruptedDowngrade(t *testing.T) {
+	now := time.Date(2026, time.August, 11, 10, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		proposed   *complexity.ComplexityResult
+		configure  func(*configstore.ComplexitySessionConfig)
+		wantReason sessionTierDecisionReason
+	}{
+		{name: "no proposal", wantReason: sessionTierReasonNoProposal},
+		{
+			name:       "empty proposed tier",
+			proposed:   sessionTierProposal("", 0.95),
+			wantReason: sessionTierReasonNoProposal,
+		},
+		{
+			name:       "invalid proposed tier",
+			proposed:   sessionTierProposal("UNKNOWN", 0.95),
+			wantReason: sessionTierReasonInvalidProposal,
+		},
+		{
+			name:       "same tier",
+			proposed:   sessionTierProposal(complexity.TierComplex, 0.95),
+			wantReason: sessionTierReasonSameTier,
+		},
+		{
+			name:       "weak downgrade",
+			proposed:   sessionTierProposal(complexity.TierMedium, 0.5),
+			wantReason: sessionTierReasonBelowSwitchSimilarity,
+		},
+		{
+			name:       "switch limit",
+			proposed:   sessionTierProposal(complexity.TierMedium, 0.95),
+			configure:  func(config *configstore.ComplexitySessionConfig) { config.MaxSwitchesPerSession = 1 },
+			wantReason: sessionTierReasonSwitchLimitReached,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := sessionTierTestConfig()
+			if tt.configure != nil {
+				tt.configure(config)
+			}
+			record := sessionTierTestRecord(now)
+			record.SwitchCount = 1
+			record.PendingTier = complexity.TierMedium
+			record.PendingTurns = 1
+			record.PendingMinScore = 0.91
+
+			decision := updateSessionTierRecord(record, tt.proposed, config, now)
+
+			assert.Equal(t, complexity.TierComplex, decision.Tier)
+			assert.Equal(t, tt.wantReason, decision.Reason)
+			assert.True(t, decision.RecordChanged)
+			assert.False(t, decision.Switched)
+			assert.Empty(t, record.PendingTier)
+			assert.Zero(t, record.PendingTurns)
+			assert.Zero(t, record.PendingMinScore)
+			assert.Equal(t, 1, record.SwitchCount)
+		})
+	}
+
+	record := sessionTierTestRecord(now)
+	decision := updateSessionTierRecord(record, nil, sessionTierTestConfig(), now)
+	assert.False(t, decision.RecordChanged, "a repeated hold must not create a store write")
+}
+
+func TestUpdateSessionTierRecordEscalation(t *testing.T) {
+	now := time.Date(2026, time.August, 11, 10, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		score      float64
+		configure  func(*configstore.ComplexitySessionConfig)
+		wantReason sessionTierDecisionReason
+		wantSwitch bool
+	}{
+		{
+			name:       "strong proposal switches immediately",
+			score:      0.91,
+			wantReason: sessionTierReasonEscalated,
+			wantSwitch: true,
+		},
+		{
+			name:       "weak proposal is held",
+			score:      0.7,
+			wantReason: sessionTierReasonBelowSwitchSimilarity,
+		},
+		{
+			name:       "zero threshold disables similarity gate",
+			score:      0,
+			configure:  func(config *configstore.ComplexitySessionConfig) { config.SwitchMinSimilarity = 0 },
+			wantReason: sessionTierReasonEscalated,
+			wantSwitch: true,
+		},
+		{
+			name:       "always allow bypasses similarity",
+			score:      0.7,
+			configure:  func(config *configstore.ComplexitySessionConfig) { config.AlwaysAllowEscalation = true },
+			wantReason: sessionTierReasonEscalated,
+			wantSwitch: true,
+		},
+		{
+			name:  "switch cap remains absolute",
+			score: 0.91,
+			configure: func(config *configstore.ComplexitySessionConfig) {
+				config.AlwaysAllowEscalation = true
+				config.MaxSwitchesPerSession = 1
+			},
+			wantReason: sessionTierReasonSwitchLimitReached,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := sessionTierTestConfig()
+			if tt.configure != nil {
+				tt.configure(config)
+			}
+			record := sessionTierTestRecord(now)
+			record.Tier = complexity.TierMedium
+			if config.MaxSwitchesPerSession > 0 {
+				record.SwitchCount = config.MaxSwitchesPerSession
+			}
+
+			decision := updateSessionTierRecord(record, sessionTierProposal(complexity.TierComplex, tt.score), config, now)
+
+			assert.Equal(t, tt.wantReason, decision.Reason)
+			assert.Equal(t, tt.wantSwitch, decision.Switched)
+			assert.Equal(t, tt.wantSwitch, decision.RecordChanged)
+			if tt.wantSwitch {
+				assert.Equal(t, complexity.TierComplex, record.Tier)
+				assert.Equal(t, now, record.DecidedAt)
+				assert.Equal(t, 1, record.SwitchCount)
+			} else {
+				assert.Equal(t, complexity.TierMedium, record.Tier)
+			}
+		})
+	}
+}
+
+func TestUpdateSessionTierRecordRequiresSustainedDowngrade(t *testing.T) {
+	now := time.Date(2026, time.August, 11, 10, 0, 0, 0, time.UTC)
+	config := sessionTierTestConfig()
+	record := sessionTierTestRecord(now)
+	record.RouteObservations["current-route"] = SessionRouteObservation{
+		CachedReadTokens: 128,
+		CacheObserved:    true,
+		LastSeenAt:       now.Add(-time.Minute),
+	}
+
+	first := updateSessionTierRecord(record, sessionTierProposal(complexity.TierMedium, 0.93), config, now)
+	assert.Equal(t, sessionTierReasonDowngradePending, first.Reason)
+	assert.False(t, first.Switched)
+	assert.True(t, first.RecordChanged)
+	assert.Equal(t, complexity.TierMedium, record.PendingTier)
+	assert.Equal(t, 1, record.PendingTurns)
+	assert.Equal(t, 0.93, record.PendingMinScore)
+
+	restarted := updateSessionTierRecord(record, sessionTierProposal(complexity.TierSimple, 0.92), config, now.Add(time.Minute))
+	assert.Equal(t, sessionTierReasonDowngradePending, restarted.Reason)
+	assert.False(t, restarted.Switched)
+	assert.True(t, restarted.RecordChanged)
+	assert.Equal(t, complexity.TierSimple, record.PendingTier)
+	assert.Equal(t, 1, record.PendingTurns, "a different lower tier starts a new consecutive sequence")
+	assert.Equal(t, 0.92, record.PendingMinScore)
+
+	second := updateSessionTierRecord(record, sessionTierProposal(complexity.TierSimple, 0.9), config, now.Add(2*time.Minute))
+	assert.Equal(t, sessionTierReasonDowngraded, second.Reason)
+	assert.True(t, second.Switched)
+	assert.True(t, second.RecordChanged)
+	assert.Equal(t, complexity.TierSimple, record.Tier)
+	assert.Equal(t, now.Add(2*time.Minute), record.DecidedAt)
+	assert.Equal(t, 1, record.SwitchCount)
+	assert.Empty(t, record.PendingTier)
+	assert.Zero(t, record.PendingTurns)
+	assert.Zero(t, record.PendingMinScore)
+}
+
+func TestUpdateSessionTierRecordDowngradeCacheGate(t *testing.T) {
+	now := time.Date(2026, time.August, 11, 10, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		observed   map[string]SessionRouteObservation
+		wantReason sessionTierDecisionReason
+		wantSwitch bool
+	}{
+		{name: "missing telemetry is unknown", wantReason: sessionTierReasonCacheStateUnknown},
+		{
+			name: "unreported cache is unknown",
+			observed: map[string]SessionRouteObservation{"route": {
+				LastSeenAt: now.Add(-time.Minute),
+			}},
+			wantReason: sessionTierReasonCacheStateUnknown,
+		},
+		{
+			name: "ambiguous zero is unknown",
+			observed: map[string]SessionRouteObservation{"route": {
+				CacheObserved: true,
+				LastSeenAt:    now.Add(-time.Minute),
+			}},
+			wantReason: sessionTierReasonCacheStateUnknown,
+		},
+		{
+			name: "stale observation is unknown without provider cache ttl",
+			observed: map[string]SessionRouteObservation{"route": {
+				CachedReadTokens: 128,
+				CacheObserved:    true,
+				LastSeenAt:       now.Add(-2 * time.Hour),
+			}},
+			wantReason: sessionTierReasonCacheStateUnknown,
+		},
+		{
+			name: "future observation is unknown",
+			observed: map[string]SessionRouteObservation{"route": {
+				CachedReadTokens: 128,
+				CacheObserved:    true,
+				LastSeenAt:       now.Add(time.Minute),
+			}},
+			wantReason: sessionTierReasonCacheStateUnknown,
+		},
+		{
+			name: "large cache holds tier",
+			observed: map[string]SessionRouteObservation{"route": {
+				CachedReadTokens: 4096,
+				CacheObserved:    true,
+				LastSeenAt:       now.Add(-time.Minute),
+			}},
+			wantReason: sessionTierReasonCacheWorthHolding,
+		},
+		{
+			name: "small positive cache permits downgrade",
+			observed: map[string]SessionRouteObservation{"route": {
+				CachedReadTokens: 128,
+				CacheObserved:    true,
+				LastSeenAt:       now.Add(-time.Minute),
+			}},
+			wantReason: sessionTierReasonDowngraded,
+			wantSwitch: true,
+		},
+		{
+			name: "freshest route observation wins",
+			observed: map[string]SessionRouteObservation{
+				"older-warm": {
+					CachedReadTokens: 4096,
+					CacheObserved:    true,
+					LastSeenAt:       now.Add(-2 * time.Minute),
+				},
+				"newer-small": {
+					CachedReadTokens: 128,
+					CacheObserved:    true,
+					LastSeenAt:       now.Add(-time.Minute),
+				},
+			},
+			wantReason: sessionTierReasonDowngraded,
+			wantSwitch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			record := sessionTierTestRecord(now)
+			record.PendingTier = complexity.TierMedium
+			record.PendingTurns = 1
+			record.PendingMinScore = 0.95
+			record.RouteObservations = tt.observed
+
+			decision := updateSessionTierRecord(record, sessionTierProposal(complexity.TierMedium, 0.9), sessionTierTestConfig(), now)
+
+			assert.Equal(t, tt.wantReason, decision.Reason)
+			assert.Equal(t, tt.wantSwitch, decision.Switched)
+			assert.True(t, decision.RecordChanged)
+			if tt.wantSwitch {
+				assert.Equal(t, complexity.TierMedium, record.Tier)
+			} else {
+				assert.Equal(t, complexity.TierComplex, record.Tier)
+				assert.Equal(t, 2, record.PendingTurns)
+			}
+		})
+	}
+}
+
+func TestUpdateSessionTierRecordAvoidsRepeatedCacheHoldWrites(t *testing.T) {
+	now := time.Date(2026, time.August, 11, 10, 0, 0, 0, time.UTC)
+	record := sessionTierTestRecord(now)
+	record.PendingTier = complexity.TierMedium
+	record.PendingTurns = 2
+	record.PendingMinScore = 0.9
+	record.RouteObservations["route"] = SessionRouteObservation{
+		CachedReadTokens: 4096,
+		CacheObserved:    true,
+		LastSeenAt:       now.Add(-time.Minute),
+	}
+
+	decision := updateSessionTierRecord(record, sessionTierProposal(complexity.TierMedium, 0.91), sessionTierTestConfig(), now)
+
+	assert.Equal(t, sessionTierReasonCacheWorthHolding, decision.Reason)
+	assert.False(t, decision.Switched)
+	assert.False(t, decision.RecordChanged)
+	assert.Equal(t, 2, record.PendingTurns)
+}
+
+func TestUpdateSessionTierRecordRejectsInvalidState(t *testing.T) {
+	now := time.Date(2026, time.August, 11, 10, 0, 0, 0, time.UTC)
+	proposal := sessionTierProposal(complexity.TierComplex, 0.95)
+
+	decision := updateSessionTierRecord(nil, proposal, sessionTierTestConfig(), now)
+	assert.Equal(t, sessionTierReasonInvalidState, decision.Reason)
+	assert.False(t, decision.RecordChanged)
+
+	record := sessionTierTestRecord(now)
+	original := cloneSessionComplexityRecord(record)
+	decision = updateSessionTierRecord(record, proposal, nil, now)
+	assert.Equal(t, sessionTierReasonInvalidState, decision.Reason)
+	assert.Equal(t, original, record)
+
+	config := sessionTierTestConfig()
+	config.Mode = configstore.ComplexitySessionModePinned
+	decision = updateSessionTierRecord(record, proposal, config, now)
+	assert.Equal(t, sessionTierReasonInvalidState, decision.Reason)
+	assert.Equal(t, original, record)
+
+	record.Tier = "UNKNOWN"
+	original = cloneSessionComplexityRecord(record)
+	decision = updateSessionTierRecord(record, proposal, sessionTierTestConfig(), now)
+	assert.Equal(t, sessionTierReasonInvalidState, decision.Reason)
+	assert.Equal(t, "UNKNOWN", decision.Tier)
+	assert.Equal(t, original, record)
+}
+
+func sessionTierTestConfig() *configstore.ComplexitySessionConfig {
+	return &configstore.ComplexitySessionConfig{
+		Mode:                  configstore.ComplexitySessionModeCacheAware,
+		TTL:                   time.Hour,
+		SwitchMinSimilarity:   0.8,
+		DowngradeAfterNTurns:  2,
+		MinCachedTokensToHold: 1024,
+	}
+}
+
+func sessionTierProposal(tier string, score float64) *complexity.ComplexityResult {
+	return &complexity.ComplexityResult{Tier: tier, Score: score}
+}
+
+func sessionTierTestRecord(now time.Time) *SessionComplexityRecord {
+	return &SessionComplexityRecord{
+		Tier:              complexity.TierComplex,
+		DecidedAt:         now.Add(-time.Hour),
+		RuleID:            "rule-1",
+		RouteObservations: make(map[string]SessionRouteObservation),
+	}
 }
 
 func newTestKVSessionStore(t *testing.T) (*kvSessionStore, *kvstore.Store) {


### PR DESCRIPTION
## Summary

Adds `updateSessionTierRecord`, a pure, I/O-free function that applies cache-aware tier switching policy to a session complexity record. This centralises the decision logic for when to escalate, hold, or downgrade a session's complexity tier, including a multi-turn confirmation window and a prompt-cache gate that prevents downgrades while a provider cache is still warm enough to be worth preserving.

## Changes

- Introduced `updateSessionTierRecord` and its supporting helpers (`sessionTierRank`, `meetsSessionSwitchSimilarity`, `advancePendingSessionTier`, `clearPendingSessionTier`, `latestUsableSessionRouteObservation`, `switchedSessionTierDecision`, `heldSessionTierDecision`, `unswitchedSessionTierDecision`) to encapsulate all cache-aware session tier policy in one place with no side effects.
- Added `sessionTierDecision` as the structured return type, carrying the resolved tier, whether a switch occurred, whether the record was mutated (so callers can skip unnecessary store writes), and a stable machine-readable reason code.
- Added `sessionTierDecisionReason` constants covering every policy outcome: invalid state, no/invalid proposal, same tier, similarity gate, switch cap, escalation, pending downgrade, unknown cache state, cache worth holding, and downgrade.
- Downgrade logic requires `DowngradeAfterNTurns` consecutive turns proposing the same lower tier before consulting the cache gate; a different lower tier resets the counter. The cache gate then blocks the downgrade if the freshest in-window route observation reports cached read tokens at or above `MinCachedTokensToHold`.
- Escalations bypass the multi-turn window and can optionally bypass the similarity gate via `AlwaysAllowEscalation`, but the `MaxSwitchesPerSession` cap is always enforced.
- `RecordChanged` is set to `false` on repeated holds where no pending state exists, avoiding unnecessary replication writes.
- Added comprehensive table-driven tests covering tier ranking, escalation paths, sustained downgrade sequencing, cache gate scenarios (missing telemetry, stale observations, future timestamps, large vs. small cache, freshest-route selection), repeated cache-hold write avoidance, and invalid state rejection.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/... -run TestUpdateSessionTierRecord
go test ./plugins/governance/... -run TestSessionTierRank
go test ./plugins/governance/...
```

All new tests are self-contained and require no external dependencies or store setup.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No auth, secrets, or PII are involved. The function is pure and performs no I/O; all sensitive routing state remains within the existing session store access patterns.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable