### PR TITLE
[DO-NOT-MERGE-YET] complexity cache-aware session routing integration

### DIFF
--- a/framework/configstore/complexityconfig.go
+++ b/framework/configstore/complexityconfig.go
@@ -335,8 +335,8 @@ func (c *ComplexitySemanticConfig) Validate() error {
 // an explicit "off" are equivalent at runtime; use Enabled to test either.
 //
 // "pinned" classifies once per session and reuses the tier until the pin is
-// released. "cache_aware" classifies every request and gates tier changes; it
-// cannot skip classification because it needs the proposal to decide.
+// released. "cache_aware" classifies every turn whose routing rules consult
+// complexity and gates tier changes; it needs that proposal to decide.
 const (
 	ComplexitySessionModeOff        = "off"
 	ComplexitySessionModePinned     = "pinned"

--- a/plugins/governance/complexity/config.go
+++ b/plugins/governance/complexity/config.go
@@ -42,11 +42,10 @@ const (
 const (
 	MechanismSemantic = "semantic"
 	MechanismSkipped  = "skipped"
-	// MechanismSession means the tier was reused from session state rather than
-	// classified for this request. It is a distinct value rather than reporting
-	// the mechanism that originally decided it: the whole point of the pin is
-	// that no classifier ran for this turn, and recording "semantic" would make
-	// a log of held turns indistinguishable from a log of embedded ones.
+	// MechanismSession means pinned mode reused a tier without classifying this
+	// request. Cache-aware mode deliberately keeps MechanismSemantic or
+	// MechanismSkipped because its classifier runs before session policy decides
+	// whether to hold or switch the tier.
 	MechanismSession = "session"
 )
 

--- a/plugins/governance/complexitysessionroute.go
+++ b/plugins/governance/complexitysessionroute.go
@@ -2,6 +2,7 @@ package governance
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	bifrost "github.com/maximhq/bifrost/core"
@@ -32,7 +33,10 @@ const (
 	sessionObservationChangeRatio = 0.1
 )
 
-var errSessionRouteObservationUnchanged = errors.New("complexity session route observation unchanged")
+var (
+	errSessionRouteObservationUnchanged = errors.New("complexity session route observation unchanged")
+	errSessionTierDecisionUnchanged     = errors.New("complexity session tier decision unchanged")
+)
 
 // complexitySessionState is the per-request session context, resolved once
 // before routing so both the routing engine and the classification closure work
@@ -44,10 +48,9 @@ type complexitySessionState struct {
 	Source string
 	// Key is the tenant-namespaced store key, empty when ID is empty.
 	Key string
-	// Mode is the normalized session mode captured at request start.
-	Mode string
-	// TTL is the sliding idle window from configuration.
-	TTL time.Duration
+	// Config is the normalized session-policy snapshot captured at request start.
+	// Keeping one value avoids mixing thresholds from a concurrent config reload.
+	Config configstore.ComplexitySessionConfig
 }
 
 // resolveComplexitySessionState resolves the conversation identity for this
@@ -92,7 +95,7 @@ func (p *GovernancePlugin) resolveComplexitySessionState(
 		return nil
 	}
 
-	state := &complexitySessionState{ID: sessionID, Source: source, Key: key, Mode: config.Mode, TTL: ttl}
+	state := &complexitySessionState{ID: sessionID, Source: source, Key: key, Config: *config}
 	// Carried on the context because the response path cannot redo this: identity
 	// resolution reads the request body, which is gone by then.
 	ctx.SetValue(complexitySessionContextKey, state)
@@ -117,7 +120,7 @@ func (p *GovernancePlugin) recordSessionRouteObservation(
 		return
 	}
 	state, _ := ctx.Value(complexitySessionContextKey).(*complexitySessionState)
-	if state == nil || state.Mode != configstore.ComplexitySessionModeCacheAware {
+	if state == nil || state.Config.Mode != configstore.ComplexitySessionModeCacheAware {
 		return
 	}
 	stored := p.complexitySessionStore.Load()
@@ -141,8 +144,8 @@ func (p *GovernancePlugin) recordSessionRouteObservation(
 	// make its decision from a stale record and let an older response overwrite a
 	// newer observation. Returning the private sentinel aborts both the write and
 	// its replication event when this turn adds no information.
-	_, _, err := store.Update(ctx, state.Key, state.TTL, func(current *SessionComplexityRecord) error {
-		if !applySessionRouteObservation(current, routeID, observation, state.TTL) {
+	_, _, err := store.Update(ctx, state.Key, state.Config.TTL, func(current *SessionComplexityRecord) error {
+		if !applySessionRouteObservation(current, routeID, observation, state.Config.TTL) {
 			return errSessionRouteObservationUnchanged
 		}
 		return nil
@@ -319,14 +322,14 @@ func (p *GovernancePlugin) publishSessionKeyAffinity(ctx *schemas.BifrostContext
 	// that had already rotated. An explicit per-request ttl still wins: the
 	// caller asked for it by name.
 	if existing, ok := ctx.Value(schemas.BifrostContextKeySessionTTL).(time.Duration); !ok || existing <= 0 {
-		ctx.SetValue(schemas.BifrostContextKeySessionTTL, state.TTL)
+		ctx.SetValue(schemas.BifrostContextKeySessionTTL, state.Config.TTL)
 	}
 }
 
-// withComplexitySession wraps the lazy classification closure so an established
-// session reuses its tier instead of classifying again. That reuse is the point
-// of the feature: it keeps the provider's prompt cache warm and skips the
-// per-turn embedding call.
+// withComplexitySession wraps the lazy classification closure with the selected
+// session policy. Pinned mode reuses an established tier without classifying;
+// cache-aware mode classifies each relevant turn and decides atomically whether
+// the session may move.
 //
 // It deliberately wraps rather than running ahead of classification. The inner
 // closure is only invoked when a routing rule references complexity_tier, so
@@ -346,53 +349,127 @@ func (p *GovernancePlugin) withComplexitySession(
 	}
 	store := *stored
 
-	return func() *complexity.ComplexityResult {
-		// A store that cannot be read is not a reason to fail the request: fall
-		// through and classify, which is exactly the pre-session behaviour.
-		record, found, err := store.Get(ctx, state.Key, state.TTL)
-		if err != nil {
-			if p.logger != nil {
-				p.logger.Warn("[Governance] Complexity session lookup failed, classifying this turn: %v", err)
-			}
-		} else if found && record != nil && record.Tier != "" {
-			p.publishSessionTier(ctx, state, record)
-			return &complexity.ComplexityResult{Tier: record.Tier}
+	switch state.Config.Mode {
+	case configstore.ComplexitySessionModePinned:
+		return func() *complexity.ComplexityResult {
+			return p.classifyWithPinnedSession(ctx, store, state, classify)
 		}
-
-		result := classify()
-		// Only a real tier is worth remembering. Persisting a failed or rejected
-		// classification would pin the session to "no tier" for the whole ttl,
-		// turning one bad turn into a session-long outage of complexity routing.
-		if result == nil || result.Tier == "" {
-			return result
+	case configstore.ComplexitySessionModeCacheAware:
+		return func() *complexity.ComplexityResult {
+			return p.classifyWithCacheAwareSession(ctx, store, state, classify)
 		}
-
-		// RuleID is deliberately left unset. The tier is classifier memory about
-		// the conversation, not state owned by whichever rule happened to consult
-		// it first — binding them would let an unrelated rule edit drop every
-		// live session's tier.
-		created, err := store.Create(ctx, state.Key, &SessionComplexityRecord{
-			Tier:      result.Tier,
-			DecidedAt: time.Now(),
-		}, state.TTL)
-		if err != nil && p.logger != nil {
-			p.logger.Warn("[Governance] Failed to persist complexity session tier, the next turn will classify again: %v", err)
-		}
-		if created {
-			ctx.AppendRoutingEngineLog(
-				schemas.RoutingEngineRoutingRule,
-				schemas.LogLevelInfo,
-				"Complexity session established: tier="+result.Tier+" identity="+state.Source,
-			)
-		}
-		return result
+	default:
+		return classify
 	}
 }
 
-// publishSessionTier records a held tier the same way a fresh classification is
-// recorded, so downstream logging sees a tier rather than a gap — with a
-// mechanism that says it was reused, not embedded.
-func (p *GovernancePlugin) publishSessionTier(
+func (p *GovernancePlugin) classifyWithPinnedSession(
+	ctx *schemas.BifrostContext,
+	store SessionStore,
+	state *complexitySessionState,
+	classify func() *complexity.ComplexityResult,
+) *complexity.ComplexityResult {
+	// A store that cannot be read is not a reason to fail the request: fall
+	// through and classify, which is exactly the pre-session behaviour.
+	record, found, err := store.Get(ctx, state.Key, state.Config.TTL)
+	if err != nil {
+		if p.logger != nil {
+			p.logger.Warn("[Governance] Complexity session lookup failed, classifying this turn: %v", err)
+		}
+	} else if found && record != nil && record.Tier != "" {
+		p.publishPinnedSessionTier(ctx, state, record)
+		return &complexity.ComplexityResult{Tier: record.Tier}
+	}
+
+	result := classify()
+	p.persistInitialSessionTier(ctx, store, state, result)
+	return result
+}
+
+func (p *GovernancePlugin) classifyWithCacheAwareSession(
+	ctx *schemas.BifrostContext,
+	store SessionStore,
+	state *complexitySessionState,
+	classify func() *complexity.ComplexityResult,
+) *complexity.ComplexityResult {
+	proposed := classify()
+	var decision sessionTierDecision
+	decisionTime := time.Now()
+	_, found, err := store.Update(ctx, state.Key, state.Config.TTL, func(current *SessionComplexityRecord) error {
+		decision = updateSessionTierRecord(current, proposed, &state.Config, decisionTime)
+		if decision.Reason == sessionTierReasonInvalidState {
+			return errInvalidComplexitySession
+		}
+		if !decision.RecordChanged {
+			return errSessionTierDecisionUnchanged
+		}
+		return nil
+	})
+	if errors.Is(err, errSessionTierDecisionUnchanged) {
+		// Aborting Update avoids a replicated write, but also leaves the expiry
+		// untouched. Get performs the store's coarse sliding-TTL refresh without
+		// changing the decision, which was already made from the locked record.
+		if _, _, refreshErr := store.Get(ctx, state.Key, state.Config.TTL); refreshErr != nil && p.logger != nil {
+			p.logger.Debug("[Governance] Could not refresh held complexity session: %v", refreshErr)
+		}
+		err = nil
+	}
+	if err != nil {
+		if p.logger != nil {
+			p.logger.Warn("[Governance] Complexity session update failed, using this turn's classification: %v", err)
+		}
+		return proposed
+	}
+	if !found {
+		// Update found no live record. Treat this request as a new session rather
+		// than trying to apply switching policy without a held tier.
+		p.persistInitialSessionTier(ctx, store, state, proposed)
+		return proposed
+	}
+
+	p.publishCacheAwareSessionTier(ctx, state, proposed, decision)
+	return complexityResultForSessionDecision(proposed, decision)
+}
+
+// persistInitialSessionTier records the first accepted tier for either session
+// mode. A failed or rejected classification is never persisted: pinning "no
+// tier" would turn one bad turn into a session-long routing outage.
+func (p *GovernancePlugin) persistInitialSessionTier(
+	ctx *schemas.BifrostContext,
+	store SessionStore,
+	state *complexitySessionState,
+	result *complexity.ComplexityResult,
+) {
+	if result == nil || result.Tier == "" {
+		return
+	}
+
+	// RuleID is deliberately left unset. The tier is classifier memory about
+	// the conversation, not state owned by whichever rule happened to consult
+	// it first — binding them would let an unrelated rule edit drop every live
+	// session's tier.
+	created, err := store.Create(ctx, state.Key, &SessionComplexityRecord{
+		Tier:      result.Tier,
+		DecidedAt: time.Now(),
+	}, state.Config.TTL)
+	if err != nil {
+		if p.logger != nil {
+			p.logger.Warn("[Governance] Failed to persist complexity session tier; session policy will retry later: %v", err)
+		}
+		return
+	}
+	if created {
+		ctx.AppendRoutingEngineLog(
+			schemas.RoutingEngineRoutingRule,
+			schemas.LogLevelInfo,
+			"Complexity session established: tier="+result.Tier+" identity="+state.Source,
+		)
+	}
+}
+
+// publishPinnedSessionTier records a reused tier with a mechanism that makes it
+// explicit that no classifier or embedding ran for this turn.
+func (p *GovernancePlugin) publishPinnedSessionTier(
 	ctx *schemas.BifrostContext,
 	state *complexitySessionState,
 	record *SessionComplexityRecord,
@@ -408,4 +485,47 @@ func (p *GovernancePlugin) publishSessionTier(
 		"Complexity tier held from session: tier="+record.Tier+" identity="+state.Source+
 			" (no classification ran for this turn)",
 	)
+}
+
+// publishCacheAwareSessionTier publishes the policy's final tier while leaving
+// the classifier mechanism intact: semantic means an embedding produced a
+// proposal, and skipped means it produced no tier. A held tier must not retain
+// a score calculated for a different proposed tier.
+func (p *GovernancePlugin) publishCacheAwareSessionTier(
+	ctx *schemas.BifrostContext,
+	state *complexitySessionState,
+	proposed *complexity.ComplexityResult,
+	decision sessionTierDecision,
+) {
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexityTier, decision.Tier)
+	if proposed == nil || proposed.Tier != decision.Tier {
+		ctx.ClearValue(schemas.BifrostContextKeyGovernanceComplexityScore)
+	}
+
+	proposedTier := "none"
+	if proposed != nil && proposed.Tier != "" {
+		proposedTier = proposed.Tier
+	}
+	message := fmt.Sprintf(
+		"Cache-aware complexity session: tier=%s proposed=%s switched=%t reason=%s identity=%s",
+		decision.Tier,
+		proposedTier,
+		decision.Switched,
+		decision.Reason,
+		state.Source,
+	)
+	if p.logger != nil {
+		p.logger.Debug("[Governance] %s", message)
+	}
+	ctx.AppendRoutingEngineLog(schemas.RoutingEngineRoutingRule, schemas.LogLevelInfo, message)
+}
+
+func complexityResultForSessionDecision(
+	proposed *complexity.ComplexityResult,
+	decision sessionTierDecision,
+) *complexity.ComplexityResult {
+	if proposed != nil && proposed.Tier == decision.Tier {
+		return proposed
+	}
+	return &complexity.ComplexityResult{Tier: decision.Tier}
 }

--- a/plugins/governance/complexitysessionroute_test.go
+++ b/plugins/governance/complexitysessionroute_test.go
@@ -32,6 +32,22 @@ func (f *failingSessionStore) Create(context.Context, string, *SessionComplexity
 	return false, f.createErr
 }
 
+type failingUpdateSessionStore struct {
+	SessionStore
+	err     error
+	updates int
+}
+
+func (f *failingUpdateSessionStore) Update(
+	context.Context,
+	string,
+	time.Duration,
+	SessionRecordUpdater,
+) (*SessionComplexityRecord, bool, error) {
+	f.updates++
+	return nil, true, f.err
+}
+
 func sessionRoutePlugin(t *testing.T, store SessionStore, sessionConfig *configstore.ComplexitySessionConfig) *GovernancePlugin {
 	t.Helper()
 	p := &GovernancePlugin{logger: NewMockLogger()}
@@ -56,6 +72,13 @@ func cacheAwareSessionConfig() *configstore.ComplexitySessionConfig {
 	config := enabledSessionConfig()
 	config.Mode = configstore.ComplexitySessionModeCacheAware
 	return config
+}
+
+func semanticSessionProposal(ctx *schemas.BifrostContext, tier string, score float64) *complexity.ComplexityResult {
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexityTier, tier)
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexityScore, score)
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexityMechanism, complexity.MechanismSemantic)
+	return &complexity.ComplexityResult{Tier: tier, Score: score}
 }
 
 // The second argument is a deadline, not a timestamp. It has to be in the
@@ -123,6 +146,182 @@ func TestWithComplexitySessionPublishesSessionMechanism(t *testing.T) {
 	mechanism, _ := held.Value(schemas.BifrostContextKeyGovernanceComplexityMechanism).(string)
 	assert.Equal(t, "MEDIUM", tier)
 	assert.Equal(t, complexity.MechanismSession, mechanism)
+}
+
+// Cache-aware mode pays for a proposal on every relevant turn, but an unchanged
+// decision must not turn that read path into one replicated write per request.
+func TestWithComplexitySessionCacheAwareClassifiesEveryTurnWithoutWritingUnchangedTier(t *testing.T) {
+	sessionStore, store := newTestKVSessionStore(t)
+	_, targetKV := newTestKVSessionStore(t)
+	p := sessionRoutePlugin(t, sessionStore, cacheAwareSessionConfig())
+	ctx := sessionTestContext(t, "session-abc")
+	state := p.resolveComplexitySessionState(ctx, nil)
+	require.NotNil(t, state)
+
+	classifyCalls := 0
+	classify := func() *complexity.ComplexityResult {
+		classifyCalls++
+		return semanticSessionProposal(ctx, complexity.TierComplex, 0.95)
+	}
+	first := p.withComplexitySession(ctx, state, classify)()
+	require.NotNil(t, first)
+	require.Equal(t, complexity.TierComplex, first.Tier)
+
+	// Count only established-session decisions. The initial Create is expected
+	// to write; equal-tier decisions after it are not.
+	delegate := &forwardingKVDelegate{target: targetKV}
+	store.SetDelegate(delegate)
+	for range 5 {
+		result := p.withComplexitySession(ctx, state, classify)()
+		require.NotNil(t, result)
+		assert.Equal(t, complexity.TierComplex, result.Tier)
+	}
+
+	assert.Equal(t, 6, classifyCalls)
+	assert.Zero(t, delegate.Sets(), "an unchanged cache-aware tier was replicated on every turn")
+}
+
+func TestWithComplexitySessionCacheAwareEscalatesAndKeepsSemanticMechanism(t *testing.T) {
+	config := cacheAwareSessionConfig()
+	config.SwitchMinSimilarity = 0.8
+	sessionStore, _ := newTestKVSessionStore(t)
+	p := sessionRoutePlugin(t, sessionStore, config)
+	ctx := sessionTestContext(t, "session-abc")
+	state := p.resolveComplexitySessionState(ctx, nil)
+	require.NotNil(t, state)
+	created, err := sessionStore.Create(context.Background(), state.Key, &SessionComplexityRecord{
+		Tier:      complexity.TierSimple,
+		DecidedAt: time.Now().Add(-time.Minute),
+	}, state.Config.TTL)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	result := p.withComplexitySession(ctx, state, func() *complexity.ComplexityResult {
+		return semanticSessionProposal(ctx, complexity.TierComplex, 0.93)
+	})()
+	require.NotNil(t, result)
+	assert.Equal(t, complexity.TierComplex, result.Tier)
+	assert.Equal(t, complexity.MechanismSemantic, ctx.Value(schemas.BifrostContextKeyGovernanceComplexityMechanism))
+	assert.Equal(t, 0.93, ctx.Value(schemas.BifrostContextKeyGovernanceComplexityScore))
+
+	record, found, err := sessionStore.Get(context.Background(), state.Key, state.Config.TTL)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, complexity.TierComplex, record.Tier)
+	assert.Equal(t, 1, record.SwitchCount)
+	assert.False(t, record.DecidedAt.IsZero())
+}
+
+func TestWithComplexitySessionCacheAwareRequiresSustainedDowngrade(t *testing.T) {
+	config := cacheAwareSessionConfig()
+	config.SwitchMinSimilarity = 0.8
+	config.DowngradeAfterNTurns = 2
+	config.MinCachedTokensToHold = 1024
+	sessionStore, _ := newTestKVSessionStore(t)
+	p := sessionRoutePlugin(t, sessionStore, config)
+	ctx := sessionTestContext(t, "session-abc")
+	state := p.resolveComplexitySessionState(ctx, nil)
+	require.NotNil(t, state)
+	created, err := sessionStore.Create(context.Background(), state.Key, &SessionComplexityRecord{
+		Tier:      complexity.TierComplex,
+		DecidedAt: time.Now().Add(-time.Minute),
+		RouteObservations: map[string]SessionRouteObservation{"route": {
+			CachedReadTokens: 128,
+			CacheObserved:    true,
+			LastSeenAt:       time.Now(),
+		}},
+	}, state.Config.TTL)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	first := p.withComplexitySession(ctx, state, func() *complexity.ComplexityResult {
+		return semanticSessionProposal(ctx, complexity.TierMedium, 0.93)
+	})()
+	require.NotNil(t, first)
+	assert.Equal(t, complexity.TierComplex, first.Tier)
+	assert.Equal(t, complexity.TierComplex, ctx.Value(schemas.BifrostContextKeyGovernanceComplexityTier))
+	assert.Equal(t, complexity.MechanismSemantic, ctx.Value(schemas.BifrostContextKeyGovernanceComplexityMechanism))
+	_, hasScore := ctx.Value(schemas.BifrostContextKeyGovernanceComplexityScore).(float64)
+	assert.False(t, hasScore, "a held tier kept the score calculated for a different proposal")
+
+	record, found, err := sessionStore.Get(context.Background(), state.Key, state.Config.TTL)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, complexity.TierComplex, record.Tier)
+	assert.Equal(t, complexity.TierMedium, record.PendingTier)
+	assert.Equal(t, 1, record.PendingTurns)
+
+	second := p.withComplexitySession(ctx, state, func() *complexity.ComplexityResult {
+		return semanticSessionProposal(ctx, complexity.TierMedium, 0.91)
+	})()
+	require.NotNil(t, second)
+	assert.Equal(t, complexity.TierMedium, second.Tier)
+	assert.Equal(t, 0.91, ctx.Value(schemas.BifrostContextKeyGovernanceComplexityScore))
+
+	record, found, err = sessionStore.Get(context.Background(), state.Key, state.Config.TTL)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, complexity.TierMedium, record.Tier)
+	assert.Equal(t, 1, record.SwitchCount)
+	assert.Empty(t, record.PendingTier)
+	assert.Zero(t, record.PendingTurns)
+}
+
+func TestWithComplexitySessionCacheAwareHoldsWhenClassificationHasNoTier(t *testing.T) {
+	sessionStore, _ := newTestKVSessionStore(t)
+	p := sessionRoutePlugin(t, sessionStore, cacheAwareSessionConfig())
+	ctx := sessionTestContext(t, "session-abc")
+	state := p.resolveComplexitySessionState(ctx, nil)
+	require.NotNil(t, state)
+	created, err := sessionStore.Create(context.Background(), state.Key, &SessionComplexityRecord{
+		Tier:            complexity.TierComplex,
+		PendingTier:     complexity.TierMedium,
+		PendingTurns:    1,
+		PendingMinScore: 0.9,
+	}, state.Config.TTL)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	result := p.withComplexitySession(ctx, state, func() *complexity.ComplexityResult {
+		ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexityMechanism, complexity.MechanismSkipped)
+		return nil
+	})()
+	require.NotNil(t, result)
+	assert.Equal(t, complexity.TierComplex, result.Tier)
+	assert.Equal(t, complexity.TierComplex, ctx.Value(schemas.BifrostContextKeyGovernanceComplexityTier))
+	assert.Equal(t, complexity.MechanismSkipped, ctx.Value(schemas.BifrostContextKeyGovernanceComplexityMechanism))
+
+	record, found, err := sessionStore.Get(context.Background(), state.Key, state.Config.TTL)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Empty(t, record.PendingTier)
+	assert.Zero(t, record.PendingTurns)
+}
+
+func TestWithComplexitySessionCacheAwareFallsBackWhenUpdateFails(t *testing.T) {
+	sessionStore, _ := newTestKVSessionStore(t)
+	broken := &failingUpdateSessionStore{SessionStore: sessionStore, err: errors.New("backend down")}
+	p := sessionRoutePlugin(t, broken, cacheAwareSessionConfig())
+	ctx := sessionTestContext(t, "session-abc")
+	state := p.resolveComplexitySessionState(ctx, nil)
+	require.NotNil(t, state)
+	created, err := sessionStore.Create(context.Background(), state.Key, &SessionComplexityRecord{
+		Tier: complexity.TierSimple,
+	}, state.Config.TTL)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	result := p.withComplexitySession(ctx, state, func() *complexity.ComplexityResult {
+		return semanticSessionProposal(ctx, complexity.TierComplex, 0.95)
+	})()
+	require.NotNil(t, result)
+	assert.Equal(t, complexity.TierComplex, result.Tier)
+	assert.Equal(t, 1, broken.updates)
+
+	record, found, err := sessionStore.Get(context.Background(), state.Key, state.Config.TTL)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, complexity.TierSimple, record.Tier, "a failed update mutated the stored tier")
 }
 
 // A failed or rejected classification must not be stored. Pinning "no tier"
@@ -376,7 +575,7 @@ func sessionWithObservations(t *testing.T) (*GovernancePlugin, *kvSessionStore, 
 	ctx := sessionTestContext(t, "session-abc")
 	state := p.resolveComplexitySessionState(ctx, nil)
 	require.NotNil(t, state)
-	_, err := sessionStore.Create(context.Background(), state.Key, &SessionComplexityRecord{Tier: "COMPLEX"}, state.TTL)
+	_, err := sessionStore.Create(context.Background(), state.Key, &SessionComplexityRecord{Tier: "COMPLEX"}, state.Config.TTL)
 	require.NoError(t, err)
 	return p, sessionStore, state, ctx
 }
@@ -390,14 +589,14 @@ func TestRecordSessionRouteObservationSkipsPinnedMode(t *testing.T) {
 	ctx := sessionTestContext(t, "session-abc")
 	state := p.resolveComplexitySessionState(ctx, nil)
 	require.NotNil(t, state)
-	_, err := sessionStore.Create(context.Background(), state.Key, &SessionComplexityRecord{Tier: "COMPLEX"}, state.TTL)
+	_, err := sessionStore.Create(context.Background(), state.Key, &SessionComplexityRecord{Tier: "COMPLEX"}, state.Config.TTL)
 	require.NoError(t, err)
 
 	delegate := &forwardingKVDelegate{target: targetKV}
 	store.SetDelegate(delegate)
 	p.recordSessionRouteObservation(ctx, chatResponseWithCacheDetails(4096, true), schemas.OpenAI, "gpt-4o", true)
 
-	record, found, err := sessionStore.Get(context.Background(), state.Key, state.TTL)
+	record, found, err := sessionStore.Get(context.Background(), state.Key, state.Config.TTL)
 	require.NoError(t, err)
 	require.True(t, found)
 	assert.Empty(t, record.RouteObservations)
@@ -411,7 +610,7 @@ func TestRecordSessionRouteObservationStoresCacheSize(t *testing.T) {
 
 	p.recordSessionRouteObservation(ctx, chatResponseWithCacheDetails(4096, true), schemas.OpenAI, "gpt-4o", true)
 
-	record, found, err := sessionStore.Get(context.Background(), state.Key, state.TTL)
+	record, found, err := sessionStore.Get(context.Background(), state.Key, state.Config.TTL)
 	require.NoError(t, err)
 	require.True(t, found)
 	require.Len(t, record.RouteObservations, 1)
@@ -434,7 +633,7 @@ func TestRecordSessionRouteObservationTreatsAmbiguousZeroAsUnknown(t *testing.T)
 
 	p.recordSessionRouteObservation(ctx, response, schemas.Gemini, "gemini-2.5-pro", true)
 
-	record, found, err := sessionStore.Get(context.Background(), state.Key, state.TTL)
+	record, found, err := sessionStore.Get(context.Background(), state.Key, state.Config.TTL)
 	require.NoError(t, err)
 	require.True(t, found)
 	require.Len(t, record.RouteObservations, 1)
@@ -451,7 +650,7 @@ func TestRecordSessionRouteObservationIgnoresNonFinalChunks(t *testing.T) {
 
 	p.recordSessionRouteObservation(ctx, chatResponseWithCacheDetails(4096, true), schemas.OpenAI, "gpt-4o", false)
 
-	record, found, err := sessionStore.Get(context.Background(), state.Key, state.TTL)
+	record, found, err := sessionStore.Get(context.Background(), state.Key, state.Config.TTL)
 	require.NoError(t, err)
 	require.True(t, found)
 	assert.Empty(t, record.RouteObservations)
@@ -466,7 +665,7 @@ func TestRecordSessionRouteObservationDoesNotWriteWhenUnchanged(t *testing.T) {
 	ctx := sessionTestContext(t, "session-abc")
 	state := p.resolveComplexitySessionState(ctx, nil)
 	require.NotNil(t, state)
-	_, err := sessionStore.Create(context.Background(), state.Key, &SessionComplexityRecord{Tier: "COMPLEX"}, state.TTL)
+	_, err := sessionStore.Create(context.Background(), state.Key, &SessionComplexityRecord{Tier: "COMPLEX"}, state.Config.TTL)
 	require.NoError(t, err)
 
 	response := chatResponseWithCacheDetails(4096, true)
@@ -493,7 +692,7 @@ func TestRecordSessionRouteObservationSeparatesRoutes(t *testing.T) {
 	p.recordSessionRouteObservation(ctx, chatResponseWithCacheDetails(4096, true), schemas.OpenAI, "gpt-4o", true)
 	p.recordSessionRouteObservation(ctx, chatResponseWithCacheDetails(128, true), schemas.Anthropic, "claude-3-5-sonnet", true)
 
-	record, found, err := sessionStore.Get(context.Background(), state.Key, state.TTL)
+	record, found, err := sessionStore.Get(context.Background(), state.Key, state.Config.TTL)
 	require.NoError(t, err)
 	require.True(t, found)
 	assert.Len(t, record.RouteObservations, 2)

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -909,9 +909,10 @@ func (p *GovernancePlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *s
 		}
 	}
 
-	// Session state short-circuits classification for an established conversation.
-	// Wrapping keeps that inside the lazy closure, so a request whose rules never
-	// mention complexity_tier still performs no session work.
+	// Session policy stays inside the lazy closure: pinned mode can short-circuit
+	// classification, while cache-aware mode classifies and gates a tier change.
+	// A request whose rules never mention complexity_tier still performs neither
+	// classification nor session-store work.
 	computeComplexity = p.withComplexitySession(ctx, sessionState, computeComplexity)
 
 	// Target stickiness keys on the resolved identity, not the raw header, so a

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -3711,15 +3711,15 @@
     },
     "complexity_session_config": {
       "type": "object",
-      "description": "Session state settings. When enabled, a conversation's complexity tier is resolved once and reused for later turns instead of being reclassified every turn, which keeps the provider-side prompt cache intact and skips the per-turn embedding call. Session state is node-local unless a shared backend is configured, so on multi-replica deployments turns handled by different replicas may resolve tiers independently.",
+      "description": "Session state settings. Pinned mode resolves a conversation's complexity tier once and reuses it, preserving the provider-side prompt cache and skipping later embedding calls. Cache-aware mode reclassifies every turn that uses complexity routing, then gates tier changes to avoid discarding valuable cache state. Session state is node-local unless a shared backend is configured, so on multi-replica deployments turns handled by different replicas may resolve tiers independently.",
       "properties": {
         "mode": {
           "type": "string",
           "enum": ["off", "pinned", "cache_aware"],
-          "description": "'off' disables session state and classifies every turn (default). 'pinned' classifies turn 1 and holds that tier for the session. 'cache_aware' additionally allows tier switches when the classifier is confident enough and the cache being protected is small enough to be worth discarding."
+          "description": "'off' disables session state and classifies every turn (default). 'pinned' classifies turn 1 and holds that tier for the session. 'cache_aware' classifies every complexity-routed turn (including its embedding cost), then switches only when the classifier is confident enough and the cache being protected is small enough to discard."
         },
         "ttl": {
-          "description": "How long a session record survives without traffic (duration string like '1h' or '30m', or milliseconds as a number; default: 1h). The window slides on every read, so it measures idle time rather than total session age.",
+          "description": "How long a session record stays active without traffic (duration string like '1h' or '30m', or milliseconds as a number; default: 1h). Reads keep the session alive using a throttled refresh, so the setting measures idle time rather than total session age.",
           "oneOf": [
             {
               "type": "string",

--- a/ui/app/workspace/complexity-router/page.tsx
+++ b/ui/app/workspace/complexity-router/page.tsx
@@ -465,11 +465,10 @@ export default function ComplexityRouterPage() {
 								}
 							/>
 
-							{/* Without this the phrase lists read as governing every request. Under
-							    session behavior they govern the first turn of each conversation and
-							    nothing after it, which is invisible from the lists themselves: an
-							    operator tuning phrases here would watch later turns ignore the
-							    tuning and have nothing on screen to explain why. */}
+							{/* Session mode changes when these phrases affect routing. Pinned mode
+							    consults them only on the first turn; cache-aware mode consults them
+							    on every relevant turn but may hold the existing tier. That distinction
+							    is otherwise invisible while an operator tunes the phrase lists. */}
 							{isSessionEnabled && (
 								<Alert variant="info" data-testid="complexity-router-session-scope-callout">
 									<Info className="h-4 w-4" />
@@ -478,11 +477,10 @@ export default function ComplexityRouterPage() {
 									    among the text broke it across three lines. */}
 									<AlertDescription>
 										<span>
-											Session behavior is set to <span className="font-medium">{SESSION_MODE_LABELS[sessionMode]}</span>, so these phrases
-											classify the first turn of a conversation
+											Session behavior is set to <span className="font-medium">{SESSION_MODE_LABELS[sessionMode]}</span>, so
 											{sessionMode === "pinned"
-												? ". Later turns keep that tier without being classified again."
-												: ", and later turns only when a classification is confident enough to move the session."}
+												? " these phrases classify the first turn. Later turns keep that tier without being classified again."
+												: " these phrases classify every complexity-routed turn, using one embedding each time. A new tier applies only when confidence and cache conditions allow it."}
 										</span>
 									</AlertDescription>
 								</Alert>

--- a/ui/app/workspace/complexity-router/views/sessionConfigSheet.tsx
+++ b/ui/app/workspace/complexity-router/views/sessionConfigSheet.tsx
@@ -93,7 +93,7 @@ export default function SessionConfigSheet({
 				<SheetHeader className="flex flex-col items-start gap-1 px-6 py-4" headerClassName="bg-card z-10 mb-0 border-b">
 					<SheetTitle>Session behavior</SheetTitle>
 					<SheetDescription className="text-xs">
-						Whether a conversation is classified once and held at that tier, or reclassified on every turn.
+						Whether a conversation keeps its first tier or reclassifies each turn and gates changes to protect its prompt cache.
 					</SheetDescription>
 				</SheetHeader>
 
@@ -154,7 +154,7 @@ export default function SessionConfigSheet({
 						<div className="space-y-2">
 							<FieldLabel
 								htmlFor="session-ttl"
-								tooltip="Measured from the last turn, not from the start of the conversation: the window slides on every request, so an active session never expires."
+								tooltip="Measured from the last turn, not from the start of the conversation. Activity keeps the session alive, so it expires only after an idle period."
 							>
 								Session timeout (minutes)
 							</FieldLabel>

--- a/ui/lib/types/complexityRouter.ts
+++ b/ui/lib/types/complexityRouter.ts
@@ -259,7 +259,8 @@ export const SESSION_MODE_OPTIONS: Array<{
 	{
 		value: "cache_aware",
 		label: "Cache aware",
-		description: "Like Pinned, but a confident enough classification can still move the session when little cache would be lost.",
+		description:
+			"Reclassifies every complexity-routed turn (one embedding each time), then moves the session only when confidence and cache conditions allow.",
 	},
 ];
 


### PR DESCRIPTION
## Summary

Cache-aware session mode previously shared a single code path with pinned mode, which meant it could not correctly handle per-turn classification, atomic tier-change decisions, or the distinction between a held tier and a freshly classified one. This PR splits the two modes into separate implementations so each behaves correctly and independently.

## Changes

- Extracted `classifyWithPinnedSession` and `classifyWithCacheAwareSession` from the single `withComplexitySession` closure, replacing a mode-conditional branch inside one function with two dedicated paths dispatched by a `switch` on `state.Config.Mode`.
- Cache-aware mode now classifies on every relevant turn, then calls `store.Update` atomically to decide whether the session may move. An unchanged decision aborts the replicated write and falls back to a coarse `Get` to slide the TTL, avoiding one write per request when the tier is stable.
- Pinned mode retains its original behaviour: look up the stored tier, return it if found, classify and persist only on the first turn.
- Replaced the two separate `Mode` and `TTL` fields on `complexitySessionState` with a single `Config configstore.ComplexitySessionConfig` snapshot, so both paths read from the same policy values captured at request start and cannot mix thresholds from a concurrent config reload.
- Added `publishCacheAwareSessionTier` to log the policy decision (tier, proposed tier, switched flag, reason, identity) and clear the score from context when the held tier differs from the proposal, preventing a score calculated for one tier from being attributed to another.
- Added `persistInitialSessionTier` as a shared helper used by both modes when writing the first record for a new session.
- Added `errSessionTierDecisionUnchanged` sentinel so `Update` can abort without a replicated write while still allowing the caller to distinguish a no-op from a real error.
- Added `failingUpdateSessionStore` test double and five new test cases covering: no replicated write on an unchanged cache-aware tier, escalation with semantic mechanism preserved, sustained-downgrade gating, hold when classification produces no tier, and fallback to the proposal when `Update` fails.
- Updated schema descriptions, UI copy, and comments throughout to accurately describe what each mode does, particularly that cache-aware mode pays an embedding cost on every complexity-routed turn.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./plugins/governance/... -run TestWithComplexitySession
go test ./plugins/governance/... -run TestRecordSessionRouteObservation
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm build || npm run build
```

Validate cache-aware behaviour end-to-end by configuring a session with `mode: cache_aware`, sending several turns with the same session identity, and confirming via routing engine logs that:
- Every complexity-routed turn shows a `Cache-aware complexity session` log entry with `switched=false` when the tier is stable.
- No replicated store write occurs on unchanged decisions (observable via store metrics or delegate counters in tests).
- A turn whose classifier proposes a higher tier and meets the confidence threshold shows `switched=true` and the new tier takes effect immediately.
- A downgrade proposal accumulates `pending_turns` until `downgrade_after_n_turns` is satisfied before switching.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No auth, secrets, PII, or sandboxing changes. Session keys remain tenant-namespaced and TTL-bounded as before.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable