### PR TITLE
fix(test): move misplaced budget override validity anchor tests to correct describe block

### DIFF
--- a/ui/lib/utils/governance.test.ts
+++ b/ui/lib/utils/governance.test.ts
@@ -48,6 +48,21 @@ describe("budget overrides", () => {
 			getBudgetOverrideValidUntil({ max_limit: 100, last_reset: "2026-01-01T00:00:00.000Z", reset_duration: "1M" }, 2, true)?.toISOString(),
 		).toBe("2026-03-01T00:00:00.000Z");
 	});
+
+	it("anchors calendar-aligned validity to the current period boundary", () => {
+		expect(
+			getBudgetOverrideValidUntil({ max_limit: 100, last_reset: "2026-08-03T08:59:52.077Z", reset_duration: "1M" }, 1, true)?.toISOString(),
+		).toBe("2026-09-01T00:00:00.000Z");
+		expect(
+			getBudgetOverrideValidUntil({ max_limit: 100, last_reset: "2026-08-05T08:59:52.077Z", reset_duration: "1w" }, 1, true)?.toISOString(),
+		).toBe("2026-08-10T00:00:00.000Z");
+		expect(
+			getBudgetOverrideValidUntil({ max_limit: 100, last_reset: "2026-08-03T08:59:52.077Z", reset_duration: "1d" }, 1, true)?.toISOString(),
+		).toBe("2026-08-04T00:00:00.000Z");
+		expect(
+			getBudgetOverrideValidUntil({ max_limit: 100, last_reset: "2026-08-03T08:59:52.077Z", reset_duration: "1Y" }, 1, true)?.toISOString(),
+		).toBe("2027-01-01T00:00:00.000Z");
+	});
 });
 describe("quarterly budgets", () => {
 	it("offers Quarterly on budgets but not on rate limits", () => {
@@ -180,36 +195,5 @@ describe("budgetSignature without ids", () => {
 			reset_config: b.reset_config,
 		}));
 		expect(budgetSignature(stripped)).toBe(budgetSignature(row(4)));
-
-		it("anchors calendar-aligned validity to the current period boundary", () => {
-			expect(
-				getBudgetOverrideValidUntil(
-					{ max_limit: 100, last_reset: "2026-08-03T08:59:52.077Z", reset_duration: "1M" },
-					1,
-					true,
-				)?.toISOString(),
-			).toBe("2026-09-01T00:00:00.000Z");
-			expect(
-				getBudgetOverrideValidUntil(
-					{ max_limit: 100, last_reset: "2026-08-05T08:59:52.077Z", reset_duration: "1w" },
-					1,
-					true,
-				)?.toISOString(),
-			).toBe("2026-08-10T00:00:00.000Z");
-			expect(
-				getBudgetOverrideValidUntil(
-					{ max_limit: 100, last_reset: "2026-08-03T08:59:52.077Z", reset_duration: "1d" },
-					1,
-					true,
-				)?.toISOString(),
-			).toBe("2026-08-04T00:00:00.000Z");
-			expect(
-				getBudgetOverrideValidUntil(
-					{ max_limit: 100, last_reset: "2026-08-03T08:59:52.077Z", reset_duration: "1Y" },
-					1,
-					true,
-				)?.toISOString(),
-			).toBe("2027-01-01T00:00:00.000Z");
-		});
 	});
 });


### PR DESCRIPTION
## Summary

A test for calendar-aligned budget override validity was accidentally nested inside an unrelated `it` block in the `budgetSignature without ids` describe block, causing it to never actually run. This PR moves the test to the correct location within the `budget overrides` describe block.

## Changes

- Removed the misplaced `it("anchors calendar-aligned validity to the current period boundary", ...)` block that was nested inside the `budgetSignature without ids` test, where it would never execute
- Added the same test cases correctly at the top level of the `budget overrides` describe block, where they are properly registered and run

## Type of change

- [x] Bug fix

## Affected areas

- [x] UI (React)

## How to test

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
```

The previously dormant test cases for `getBudgetOverrideValidUntil` with monthly, weekly, daily, and yearly reset durations should now execute and pass.

## Breaking changes

- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable