### PR TITLE
test: add `needs_session_stickiness` to MCP client e2e collection

### DIFF
--- a/tests/e2e/api/collections/bifrost-api-management.postman_collection.json
+++ b/tests/e2e/api/collections/bifrost-api-management.postman_collection.json
@@ -4333,7 +4333,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\"client_id\": \"{{mcp_client_id}}\", \"name\": \"TestMCPClient\", \"connection_type\": \"http\", \"connection_string\": {\"value\": \"http://localhost:3001/\", \"env_var\": \"\", \"from_env\": false}, \"auth_type\": \"none\", \"is_ping_available\": false}"
+              "raw": "{\"client_id\": \"{{mcp_client_id}}\", \"name\": \"TestMCPClient\", \"connection_type\": \"http\", \"connection_string\": {\"value\": \"http://localhost:3001/\", \"env_var\": \"\", \"from_env\": false}, \"auth_type\": \"none\", \"is_ping_available\": false, \"needs_session_stickiness\": true}"
             },
             "url": {
               "raw": "{{base_url}}/api/mcp/client",


### PR DESCRIPTION
## Summary

Adds `needs_session_stickiness: true` to the MCP client creation request in the end-to-end API test collection, ensuring the test accurately reflects the expected payload for MCP clients that require session stickiness.

## Changes

- Added `needs_session_stickiness: true` to the raw request body in the `bifrost-api-management` Postman collection for the MCP client creation endpoint.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the Postman collection against a running Bifrost instance and verify the MCP client creation request succeeds with the `needs_session_stickiness` field included.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. This change only adds a session stickiness flag to a test request payload.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable