### PR TITLE
fix: guard response.create input

### DIFF
--- a/transports/bifrost-http/handlers/realtime_logging_test.go
+++ b/transports/bifrost-http/handlers/realtime_logging_test.go
@@ -10,6 +10,77 @@ import (
 	bfws "github.com/maximhq/bifrost/transports/bifrost-http/websocket"
 )
 
+func TestBuildRealtimeTurnPreRequestIncludesResponseCreateContent(t *testing.T) {
+	t.Parallel()
+
+	event := &schemas.BifrostRealtimeEvent{
+		Type: schemas.RTEventResponseCreate,
+		ExtraParams: map[string]json.RawMessage{
+			"response": json.RawMessage(`{
+				"instructions":"one line on war in english",
+				"input":[{"type":"message","role":"user","content":"inline input"}],
+				"tools":[{"type":"function","name":"lookup","description":"look something up","parameters":{"type":"object"}}]
+			}`),
+		},
+	}
+
+	req := buildRealtimeTurnPreRequest(schemas.OpenAI, "gpt-realtime", nil, nil, event)
+	if req.ResponsesRequest == nil || req.ResponsesRequest.Params == nil {
+		t.Fatal("expected response.create parameters in realtime pre-hook request")
+	}
+	instructions := req.ResponsesRequest.Params.Instructions
+	if instructions == nil || *instructions != "one line on war in english" {
+		t.Fatalf("unexpected instructions: %#v", instructions)
+	}
+	if len(req.ResponsesRequest.Input) != 1 {
+		t.Fatalf("input length = %d, want 1", len(req.ResponsesRequest.Input))
+	}
+	if len(req.ResponsesRequest.Params.Tools) != 1 || req.ResponsesRequest.Params.Tools[0].Name == nil || *req.ResponsesRequest.Params.Tools[0].Name != "lookup" {
+		t.Fatalf("unexpected tools: %#v", req.ResponsesRequest.Params.Tools)
+	}
+}
+
+func TestBuildRealtimeTurnPreRequestCombinesConversationAndResponseInput(t *testing.T) {
+	t.Parallel()
+
+	event := &schemas.BifrostRealtimeEvent{
+		Type: schemas.RTEventResponseCreate,
+		ExtraParams: map[string]json.RawMessage{
+			"response": json.RawMessage(`{"input":[{"type":"message","role":"user","content":"inline input"}]}`),
+		},
+	}
+	turnInputs := []bfws.RealtimeTurnInput{{Role: string(schemas.ChatMessageRoleUser), Summary: "conversation input"}}
+
+	req := buildRealtimeTurnPreRequest(schemas.OpenAI, "gpt-realtime", turnInputs, nil, event)
+	if len(req.ResponsesRequest.Input) != 2 {
+		t.Fatalf("input length = %d, want 2", len(req.ResponsesRequest.Input))
+	}
+}
+
+// TestBuildRealtimeTurnPreRequestPreservesEmptyResponseTools verifies an explicit empty tool list overrides session tools.
+func TestBuildRealtimeTurnPreRequestPreservesEmptyResponseTools(t *testing.T) {
+	t.Parallel()
+
+	event := &schemas.BifrostRealtimeEvent{
+		Type: schemas.RTEventResponseCreate,
+		ExtraParams: map[string]json.RawMessage{
+			"response": json.RawMessage(`{"tools":[]}`),
+		},
+	}
+	sessionTools := json.RawMessage(`[{"type":"function","name":"lookup","parameters":{"type":"object"}}]`)
+
+	req := buildRealtimeTurnPreRequest(schemas.OpenAI, "gpt-realtime", nil, sessionTools, event)
+	if req.ResponsesRequest == nil || req.ResponsesRequest.Params == nil {
+		t.Fatal("expected explicit empty response tools to preserve response parameters")
+	}
+	if req.ResponsesRequest.Params.Tools == nil {
+		t.Fatal("expected explicit empty response tools to remain non-nil")
+	}
+	if len(req.ResponsesRequest.Params.Tools) != 0 {
+		t.Fatalf("tools = %#v, want explicit empty list", req.ResponsesRequest.Params.Tools)
+	}
+}
+
 func TestShouldAccumulateRealtimeOutput(t *testing.T) {
 	provider := &openai.OpenAIProvider{}
 	if !provider.ShouldAccumulateRealtimeOutput(schemas.RTEventResponseTextDelta) {

--- a/transports/bifrost-http/handlers/realtime_turn_pipeline.go
+++ b/transports/bifrost-http/handlers/realtime_turn_pipeline.go
@@ -196,7 +196,33 @@ func updateRealtimeSessionFromEvent(session *bfws.Session, event *schemas.Bifros
 	}
 }
 
-func buildRealtimeTurnPreRequest(provider schemas.ModelProvider, model string, turnInputs []bfws.RealtimeTurnInput, sessionTools json.RawMessage) *schemas.BifrostRequest {
+// realtimeResponseCreateParams contains response-level content that must be visible
+// to turn pre-hooks before a response.create event reaches the provider.
+type realtimeResponseCreateParams struct {
+	Instructions *string                    `json:"instructions,omitempty"`
+	Input        []schemas.ResponsesMessage `json:"input,omitempty"`
+	Tools        *[]schemas.ResponsesTool   `json:"tools,omitempty"`
+}
+
+// realtimeResponseCreateParamsFromEvent extracts guardrail-relevant response.create fields.
+func realtimeResponseCreateParamsFromEvent(event *schemas.BifrostRealtimeEvent) realtimeResponseCreateParams {
+	if event == nil || event.Type != schemas.RTEventResponseCreate || event.ExtraParams == nil {
+		return realtimeResponseCreateParams{}
+	}
+	responseRaw := event.ExtraParams["response"]
+	if len(responseRaw) == 0 || string(responseRaw) == "null" {
+		return realtimeResponseCreateParams{}
+	}
+	var params realtimeResponseCreateParams
+	if json.Unmarshal(responseRaw, &params) != nil {
+		return realtimeResponseCreateParams{}
+	}
+	return params
+}
+
+// buildRealtimeTurnPreRequest builds the normalized request inspected by turn pre-hooks.
+func buildRealtimeTurnPreRequest(provider schemas.ModelProvider, model string, turnInputs []bfws.RealtimeTurnInput, sessionTools json.RawMessage, startEvent *schemas.BifrostRealtimeEvent) *schemas.BifrostRequest {
+	responseParams := realtimeResponseCreateParamsFromEvent(startEvent)
 	input := make([]schemas.ResponsesMessage, 0, len(turnInputs))
 	for _, turnInput := range turnInputs {
 		summary := strings.TrimSpace(turnInput.Summary)
@@ -224,12 +250,19 @@ func buildRealtimeTurnPreRequest(provider schemas.ModelProvider, model string, t
 		}
 	}
 
-	var params *schemas.ResponsesParameters
-	if len(sessionTools) > 0 {
+	input = append(input, responseParams.Input...)
+
+	params := &schemas.ResponsesParameters{Instructions: responseParams.Instructions}
+	if responseParams.Tools != nil {
+		params.Tools = *responseParams.Tools
+	} else if len(sessionTools) > 0 {
 		var tools []schemas.ResponsesTool
-		if json.Unmarshal(sessionTools, &tools) == nil && len(tools) > 0 {
-			params = &schemas.ResponsesParameters{Tools: tools}
+		if json.Unmarshal(sessionTools, &tools) == nil {
+			params.Tools = tools
 		}
+	}
+	if params.Instructions == nil && responseParams.Tools == nil && len(params.Tools) == 0 {
+		params = nil
 	}
 
 	return &schemas.BifrostRequest{
@@ -597,7 +630,7 @@ func startRealtimeTurnHooks(
 	provider schemas.ModelProvider,
 	model string,
 	key *schemas.Key,
-	startEventType schemas.RealtimeEventType,
+	startEvent *schemas.BifrostRealtimeEvent,
 ) *schemas.BifrostError {
 	if client == nil || session == nil {
 		return &schemas.BifrostError{
@@ -627,6 +660,10 @@ func startRealtimeTurnHooks(
 	}()
 
 	startedAt := time.Now()
+	startEventType := schemas.RealtimeEventType("")
+	if startEvent != nil {
+		startEventType = startEvent.Type
+	}
 	storeRaw := shouldStoreRealtimeRawPayloads(baseCtx)
 	turnCtx := newRealtimeTurnContext(baseCtx, "", session.ID(), session.ProviderSessionID(), realtimeTurnSourceEI, startEventType, key)
 	applyRealtimeRawStorageContext(turnCtx, storeRaw)
@@ -634,7 +671,7 @@ func startRealtimeTurnHooks(
 		turnCtx.SetValue(schemas.BifrostContextKeyRealtimeVoice, voice)
 	}
 	setRealtimeTurnStreamContext(turnCtx, startedAt, false)
-	req := buildRealtimeTurnPreRequest(provider, model, session.PeekRealtimeTurnInputs(), session.RealtimeSessionTools())
+	req := buildRealtimeTurnPreRequest(provider, model, session.PeekRealtimeTurnInputs(), session.RealtimeSessionTools(), startEvent)
 	hooks, bifrostErr := client.RunRealtimeTurnPreHooks(turnCtx, req)
 	if bifrostErr != nil {
 		// RunRealtimeTurnPreHooks already executed post-hooks and flushed the trace
@@ -708,7 +745,7 @@ func finalizeRealtimeTurnHooks(
 	preCtx := newRealtimeTurnContext(baseCtx, "", session.ID(), session.ProviderSessionID(), realtimeTurnSourceEI, "", key)
 	applyRealtimeRawStorageContext(preCtx, storeRaw)
 	setRealtimeTurnStreamContext(preCtx, startedAt, false)
-	preReq := buildRealtimeTurnPreRequest(provider, model, turnInputs, session.RealtimeSessionTools())
+	preReq := buildRealtimeTurnPreRequest(provider, model, turnInputs, session.RealtimeSessionTools(), nil)
 	hooks, bifrostErr := client.RunRealtimeTurnPreHooks(preCtx, preReq)
 	if bifrostErr != nil {
 		return bifrostErr
@@ -794,7 +831,7 @@ func finalizeRealtimeTurnHooksWithError(
 	preCtx := newRealtimeTurnContext(baseCtx, "", session.ID(), session.ProviderSessionID(), realtimeTurnSourceEI, "", key)
 	applyRealtimeRawStorageContext(preCtx, storeRaw)
 	setRealtimeTurnStreamContext(preCtx, startedAt, false)
-	preReq := buildRealtimeTurnPreRequest(provider, model, turnInputs, session.RealtimeSessionTools())
+	preReq := buildRealtimeTurnPreRequest(provider, model, turnInputs, session.RealtimeSessionTools(), nil)
 	hooks, hookPreErr := client.RunRealtimeTurnPreHooks(preCtx, preReq)
 	if hookPreErr != nil {
 		return hookPreErr

--- a/transports/bifrost-http/handlers/webrtc_realtime.go
+++ b/transports/bifrost-http/handlers/webrtc_realtime.go
@@ -835,7 +835,7 @@ func (r *webrtcRealtimeRelay) handleDownstreamMessage(msg webrtc.DataChannelMess
 			r.sendDownstream(newRealtimeTurnErrorEventPayload(newRealtimeWireBifrostError(400, "invalid_request_error", "Conversation already has an active response in progress.")), true)
 			return
 		}
-		if bifrostErr := startRealtimeTurnHooks(r.client, r.bifrostCtx, r.session, r.provider, r.providerKey, r.model, r.key, event.Type); bifrostErr != nil {
+		if bifrostErr := startRealtimeTurnHooks(r.client, r.bifrostCtx, r.session, r.provider, r.providerKey, r.model, r.key, event); bifrostErr != nil {
 			r.closeWithErrorEvent(newRealtimeTurnErrorEventPayload(bifrostErr))
 			return
 		}
@@ -908,7 +908,7 @@ func (r *webrtcRealtimeRelay) handleUpstreamMessage(msg webrtc.DataChannelMessag
 			r.session.AppendRealtimeOutputText(event.Delta.Transcript)
 		}
 		if r.provider.ShouldStartRealtimeTurn(event) && r.session.PeekRealtimeTurnHooks() == nil {
-			if bifrostErr := startRealtimeTurnHooks(r.client, r.bifrostCtx, r.session, r.provider, r.providerKey, r.model, r.key, event.Type); bifrostErr != nil {
+			if bifrostErr := startRealtimeTurnHooks(r.client, r.bifrostCtx, r.session, r.provider, r.providerKey, r.model, r.key, event); bifrostErr != nil {
 				r.closeWithErrorEvent(newRealtimeTurnErrorEventPayload(bifrostErr))
 				return
 			}

--- a/transports/bifrost-http/handlers/wsrealtime.go
+++ b/transports/bifrost-http/handlers/wsrealtime.go
@@ -393,7 +393,7 @@ func (h *WSRealtimeHandler) relayClientToRealtimeProvider(
 			if inputSummary != "" {
 				session.RecordRealtimeInput(inputItemID, inputSummary, string(message))
 			}
-			if bifrostErr := startRealtimeTurnHooks(h.client, bifrostCtx, session, provider, providerKey, model, &key, event.Type); bifrostErr != nil {
+			if bifrostErr := startRealtimeTurnHooks(h.client, bifrostCtx, session, provider, providerKey, model, &key, event); bifrostErr != nil {
 				clientConn.writeRealtimeError(bifrostErr)
 				return nil
 			}
@@ -525,7 +525,7 @@ func (h *WSRealtimeHandler) relayRealtimeProviderToClient(
 					session.AppendRealtimeOutputText(event.Delta.Transcript)
 				}
 				if provider.ShouldStartRealtimeTurn(event) && session.PeekRealtimeTurnHooks() == nil {
-					if bifrostErr := startRealtimeTurnHooks(h.client, bifrostCtx, session, provider, providerKey, model, &key, event.Type); bifrostErr != nil {
+					if bifrostErr := startRealtimeTurnHooks(h.client, bifrostCtx, session, provider, providerKey, model, &key, event); bifrostErr != nil {
 						clientConn.writeRealtimeError(bifrostErr)
 						return nil
 					}


### PR DESCRIPTION
## Summary

Fix Realtime input guardrails so they inspect prompt content supplied directly
in a valid `response.create` event.

Previously, Realtime pre-hooks only received conversation items accumulated
before the turn. A request that placed its prompt in `response.instructions` or
`response.input` was forwarded to the provider correctly, but those fields were
absent from the normalized request evaluated by guardrails. This caused
equivalent non-Realtime requests to be blocked while valid Realtime requests
could pass.

## Changes

- Pass the complete turn-start event into the Realtime pre-hook pipeline for
  both WebSocket and WebRTC transports.
- Extract `response.instructions`, `response.input`, and response-level
  `response.tools` from `response.create`.
- Combine inline response input with previously accumulated conversation input
  before running pre-hooks.
- Prefer response-level tools for that turn, falling back to session-level tools
  when no response-level tools are supplied.
- Preserve the existing behavior for turn starts that do not carry a `response`
  payload.
- Add regression tests for direct `response.create` content and mixed
  conversation/inline input.

### Before

A valid request could send all prompt content in `response.create`:

```json
{
  "type": "response.create",
  "response": {
    "output_modalities": ["text"],
    "instructions": "<some stuff that should be flagged>"
  }
}
```

The provider received the instructions, but the guardrail request was
effectively empty:

```text
response.create
  ├── response.instructions ───────────────► provider
  └── accumulated conversation (empty) ───► input guardrails

Result: the model generated a response even when the same prompt was blocked through the Responses API.
```

### After

The turn-start event is now included while constructing the request inspected by
pre-hooks:

```text
response.create
  ├── accumulated conversation ─┐
  ├── response.input ────────────┼──► normalized Realtime request ──► input guardrails
  ├── response.instructions ─────┤
  └── response.tools ────────────┘
                                      │
                                      ├── allowed ─► provider
                                      └── blocked ─► error returned; event is not forwarded
```

This also supports combining conversational and response-specific input:

```json
// Earlier event
{
  "type": "conversation.item.create",
  "item": {
    "type": "message",
    "role": "user",
    "content": [{ "type": "input_text", "text": "conversation context" }]
  }
}

// Turn-start event
{
  "type": "response.create",
  "response": {
    "instructions": "answer in one sentence",
    "input": [
      {
        "type": "message",
        "role": "user",
        "content": "inline request"
      }
    ]
  }
}
```

Both `conversation context` and `inline request`, together with the
instructions, are now visible to the input guardrail pipeline.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the focused regression tests:

```sh
go test ./transports/bifrost-http/handlers -run 'TestBuildRealtimeTurnPreRequest|TestPendingRealtimeInputUpdate'
```

Expected outcome: the tests pass and confirm that:

- `response.instructions`, inline `response.input`, and response-level tools are
  present in the pre-hook request;
- accumulated conversation input and inline response input are combined.

Run the complete handler test package:

```sh
go test ./transports/bifrost-http/handlers
```

Expected outcome: all handler tests pass.

No new configuration or environment variables are required.

## Screenshots/Recordings

Not applicable; this change affects Realtime request processing.

## Breaking changes

- [ ] Yes
- [x] No

Existing conversation-item flows continue to work. Valid `response.create`
prompt fields now receive the same input guardrail coverage.

## Related issues

No linked issue.

## Security considerations

This closes a guardrail coverage gap. Prompt content sent through
`response.create` is now evaluated before the event is forwarded to the Realtime
provider. No secrets, authentication behavior, or stored data formats are
changed.

This change concerns input enforcement only; it does not alter the existing
post-turn behavior of Realtime output guardrails.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed (not required for this internal
      behavior fix)
- [x] I verified builds succeed (Go and UI) (affected Go handler package
      verified; UI not affected)
- [x] I verified the CI pipeline passes locally if applicable (focused and
      complete handler tests pass)
