### PR TITLE
fix: skip list models call for budgets and rate-limits

### DIFF
--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -960,8 +960,18 @@ func (p *GovernancePlugin) EvaluateGovernanceRequest(ctx *schemas.BifrostContext
 	}
 	p.cfgMutex.RUnlock()
 
+	// Read-only metadata calls (e.g. list models) set this flag to skip budget/rate-limit
+	// checks while still enforcing VK identity (existence, active status, provider/model filtering).
+	skipBudgetsAndRateLimits := bifrost.GetBoolFromContext(ctx, schemas.BifrostContextKeySkipBudgetAndRateLimits)
+
 	// First evaluate model and provider checks (applies even when virtual keys are disabled or not present)
-	result := p.resolver.EvaluateModelAndProviderRequest(ctx, evaluationRequest.Provider, evaluationRequest.Model)
+	result := &EvaluationResult{
+		Decision: DecisionAllow,
+		Reason:   "Provider-level and model-level checks skipped for read-only request",
+	}
+	if !skipBudgetsAndRateLimits {
+		result = p.resolver.EvaluateModelAndProviderRequest(ctx, evaluationRequest.Provider, evaluationRequest.Model)
+	}
 
 	// The flow for governance checks is:
 	//   VK (identity + VK-level budget/rate-limit) -> Customer -> Team -> User
@@ -978,10 +988,6 @@ func (p *GovernancePlugin) EvaluateGovernanceRequest(ctx *schemas.BifrostContext
 			hierarchyVK = vk
 		}
 	}
-
-	// Read-only metadata calls (e.g. list models) set this flag to skip budget/rate-limit
-	// checks while still enforcing VK identity (existence, active status, provider/model filtering).
-	skipBudgetsAndRateLimits := bifrost.GetBoolFromContext(ctx, schemas.BifrostContextKeySkipBudgetAndRateLimits)
 
 	// Step 1: Evaluate virtual key (identity + VK-level budget/rate-limit hierarchy).
 	// Short-circuits with VirtualKeyBlocked / ProviderBlocked / ModelBlocked before

--- a/plugins/governance/modelprovidergovernance_test.go
+++ b/plugins/governance/modelprovidergovernance_test.go
@@ -1075,6 +1075,69 @@ func TestResolver_EvaluateModelAndProviderRequest_ProviderOnly_NoModel(t *testin
 	assertDecision(t, DecisionAllow, result)
 }
 
+// TestGovernancePlugin_EvaluateGovernanceRequest_SkipFlagBypassesProviderBudget pins the
+// read-only exemption for list models: an exhausted provider budget blocks inference but
+// must not block the metadata call, which consumes no quota.
+func TestGovernancePlugin_EvaluateGovernanceRequest_SkipFlagBypassesProviderBudget(t *testing.T) {
+	logger := NewMockLogger()
+	budget := buildBudgetWithUsage("budget1", 100.0, 100.0, "1h") // At limit
+	provider := buildProviderWithGovernance("openai", budget, nil)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		Providers: []configstoreTables.TableProvider{*provider},
+		Budgets:   []configstoreTables.TableBudget{*budget},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin := &GovernancePlugin{store: store, resolver: NewBudgetResolver(store, nil, logger, nil)}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	_, bifrostErr := plugin.EvaluateGovernanceRequest(ctx, &EvaluationRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4",
+	}, schemas.ChatCompletionRequest)
+	require.NotNil(t, bifrostErr)
+	require.NotNil(t, bifrostErr.StatusCode)
+	assert.Equal(t, 402, *bifrostErr.StatusCode)
+
+	ctx.SetValue(schemas.BifrostContextKeySkipBudgetAndRateLimits, true)
+	result, bifrostErr := plugin.EvaluateGovernanceRequest(ctx, &EvaluationRequest{
+		Provider: schemas.OpenAI,
+	}, schemas.ListModelsRequest)
+	require.Nil(t, bifrostErr)
+	assertDecision(t, DecisionAllow, result)
+}
+
+// TestGovernancePlugin_EvaluateGovernanceRequest_SkipFlagBypassesProviderRateLimit is the
+// rate-limit counterpart to the provider-budget exemption above.
+func TestGovernancePlugin_EvaluateGovernanceRequest_SkipFlagBypassesProviderRateLimit(t *testing.T) {
+	logger := NewMockLogger()
+	rateLimit := buildRateLimitWithUsage("rl1", 10000, 10000, 1000, 0) // Tokens at max
+	provider := buildProviderWithGovernance("openai", nil, rateLimit)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		Providers:  []configstoreTables.TableProvider{*provider},
+		RateLimits: []configstoreTables.TableRateLimit{*rateLimit},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin := &GovernancePlugin{store: store, resolver: NewBudgetResolver(store, nil, logger, nil)}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	_, bifrostErr := plugin.EvaluateGovernanceRequest(ctx, &EvaluationRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4",
+	}, schemas.ChatCompletionRequest)
+	require.NotNil(t, bifrostErr)
+	require.NotNil(t, bifrostErr.StatusCode)
+	assert.Equal(t, 429, *bifrostErr.StatusCode)
+
+	ctx.SetValue(schemas.BifrostContextKeySkipBudgetAndRateLimits, true)
+	result, bifrostErr := plugin.EvaluateGovernanceRequest(ctx, &EvaluationRequest{
+		Provider: schemas.OpenAI,
+	}, schemas.ListModelsRequest)
+	require.Nil(t, bifrostErr)
+	assertDecision(t, DecisionAllow, result)
+}
+
 func TestResolver_EvaluateModelAndProviderRequest_ModelOnly_NoProvider(t *testing.T) {
 	logger := NewMockLogger()
 	budget := buildBudget("budget1", 100.0, "1h")


### PR DESCRIPTION
## Summary

Read-only metadata requests (e.g. list models) should not be blocked by exhausted provider budgets or rate limits, since they consume no quota. Previously, the `skipBudgetsAndRateLimits` flag only bypassed VK-level and hierarchy checks, but provider-level budget and rate-limit evaluation still ran unconditionally. This PR ensures that when the skip flag is set, provider/model governance checks are also bypassed, while VK identity enforcement (existence, active status) remains intact.

## Changes

- Moved the `skipBudgetsAndRateLimits` flag read to before the `EvaluateModelAndProviderRequest` call so it can gate that evaluation.
- When `skipBudgetsAndRateLimits` is `true`, `EvaluateModelAndProviderRequest` is skipped entirely and the result defaults to `DecisionAllow`, preventing exhausted provider budgets or rate limits from blocking metadata-only calls.
- Added two tests pinning this behavior: one for an exhausted provider budget (expects 402 on inference, allow on list models) and one for an exhausted provider rate limit (expects 429 on inference, allow on list models).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/... -run TestGovernancePlugin_EvaluateGovernanceRequest_SkipFlagBypasses
```

Expected: both `TestGovernancePlugin_EvaluateGovernanceRequest_SkipFlagBypassesProviderBudget` and `TestGovernancePlugin_EvaluateGovernanceRequest_SkipFlagBypassesProviderRateLimit` pass, confirming that list-models requests are allowed even when the provider budget is exhausted (402) or rate limit is maxed (429).

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The skip flag only bypasses budget and rate-limit enforcement. VK identity checks (existence and active status) continue to run regardless, so unauthenticated or inactive keys cannot exploit this path to enumerate models.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable