### PR TITLE
fix: update custom pricing docs URL

### DIFF
--- a/tests/e2e/api/collections/bifrost-api-management.postman_collection.json
+++ b/tests/e2e/api/collections/bifrost-api-management.postman_collection.json
@@ -4333,7 +4333,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\"client_id\": \"{{mcp_client_id}}\", \"name\": \"TestMCPClient\", \"connection_type\": \"http\", \"connection_string\": {\"value\": \"http://localhost:3001/\", \"env_var\": \"\", \"from_env\": false}, \"auth_type\": \"none\", \"is_ping_available\": false}"
+              "raw": "{\"client_id\": \"{{mcp_client_id}}\", \"name\": \"TestMCPClient\", \"connection_type\": \"http\", \"connection_string\": {\"value\": \"http://localhost:3001/\", \"env_var\": \"\", \"from_env\": false}, \"auth_type\": \"none\", \"is_ping_available\": false, \"needs_session_stickiness\": true}"
             },
             "url": {
               "raw": "{{base_url}}/api/mcp/client",

--- a/ui/app/workspace/custom-pricing/overrides/pricingOverridesEmptyState.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/pricingOverridesEmptyState.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { ArrowUpRight, SlidersHorizontal } from "lucide-react";
 
-const PRICING_OVERRIDES_DOCS_URL = "https://docs.getbifrost.ai/features/governance/custom-pricing";
+const PRICING_OVERRIDES_DOCS_URL = "https://docs.getbifrost.ai/providers/custom-pricing";
 
 interface PricingOverridesEmptyStateProps {
 	onCreateClick: () => void;


### PR DESCRIPTION
## Summary

Updates the documentation URL for custom pricing overrides to reflect the correct path in the docs site.

## Changes

- Updated `PRICING_OVERRIDES_DOCS_URL` from `https://docs.getbifrost.ai/features/governance/custom-pricing` to `https://docs.getbifrost.ai/providers/custom-pricing` to point to the accurate documentation location.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Navigate to the custom pricing overrides empty state in the UI and click the documentation link. Verify it redirects to `https://docs.getbifrost.ai/providers/custom-pricing`.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable