### PR TITLE
feat(modelcatalog): resolve pricing overrides for catalog rows

### DIFF
--- a/framework/modelcatalog/config.go
+++ b/framework/modelcatalog/config.go
@@ -67,6 +67,8 @@ type (
 	ScopeKind           = datasheet.ScopeKind
 	MatchType           = datasheet.MatchType
 
+	CatalogPricingOverrides = datasheet.CatalogPricingOverrides
+
 	KeyConfigEntry = keyconfig.KeyEntry
 	AliasOwner     = keyconfig.AliasOwner
 )

--- a/framework/modelcatalog/datasheet/overrides.go
+++ b/framework/modelcatalog/datasheet/overrides.go
@@ -3,6 +3,8 @@ package datasheet
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"slices"
 	"sort"
 	"strings"
 
@@ -162,20 +164,75 @@ func (e *customPricingEntry) matchesMode(mode string) bool {
 	return ok
 }
 
+// matchesCatalogProvider reports whether the entry could ever apply to a model
+// served by provider. Weaker than matchesScope on purpose: the management
+// catalog has no virtual-key/user/selected-key context, so those scopes can
+// never satisfy matchesScope there, yet they still deserve to be listed
+// informationally. Entries whose scope pins a provider must match it;
+// provider_key-scoped entries carry no provider_id, so they always pass.
+func (e *customPricingEntry) matchesCatalogProvider(provider string) bool {
+	return e.providerID == "" || e.providerID == provider
+}
+
+// matchesModel reports whether the entry's pattern covers model.
+func (e *customPricingEntry) matchesModel(model string) bool {
+	if e.wildcard {
+		return strings.HasPrefix(model, e.pattern)
+	}
+	return e.pattern == model
+}
+
+// catalogScopeRank orders scope kinds most-specific-first for display. Mirrors
+// scopePriorityOrder's ranking but is independent of runtime identifiers,
+// which the management catalog does not have.
+func catalogScopeRank(k ScopeKind) int {
+	switch k {
+	case ScopeKindVirtualKeyProviderKey:
+		return 0
+	case ScopeKindVirtualKeyProvider:
+		return 1
+	case ScopeKindVirtualKey:
+		return 2
+	case ScopeKindUserProviderKey:
+		return 3
+	case ScopeKindUserProvider:
+		return 4
+	case ScopeKindUser:
+		return 5
+	case ScopeKindProviderKey:
+		return 6
+	case ScopeKindProvider:
+		return 7
+	case ScopeKindGlobal:
+		return 8
+	}
+	return 9
+}
+
 // resolve walks the 9-scope priority hierarchy and returns the first matching
 // pricing patch for the given model, mode, and runtime scopes.
 func (c *customPricingData) resolve(model, mode string, scopes LookupScopes) *Options {
+	if e := c.resolveEntry(model, mode, scopes); e != nil {
+		return &e.options
+	}
+	return nil
+}
+
+// resolveEntry is resolve's implementation, returning the winning entry itself
+// so callers that need the override's identity (not just its patch) can
+// recover it without duplicating the precedence walk.
+func (c *customPricingData) resolveEntry(model, mode string, scopes LookupScopes) *customPricingEntry {
 	for _, scopeKind := range scopePriorityOrder(scopes) {
 		for i := range c.exact[model] {
 			e := &c.exact[model][i]
 			if e.scopeKind == scopeKind && e.matchesScope(scopes) && e.matchesMode(mode) {
-				return &e.options
+				return e
 			}
 		}
 		for i := range c.wildcard {
 			e := &c.wildcard[i]
 			if e.scopeKind == scopeKind && e.matchesScope(scopes) && strings.HasPrefix(model, e.pattern) && e.matchesMode(mode) {
-				return &e.options
+				return e
 			}
 		}
 	}
@@ -283,6 +340,130 @@ func (s *Store) applyPricingOverrides(model string, requestType schemas.RequestT
 		return patchPricing(pricing, *patch), true
 	}
 	return pricing, false
+}
+
+// cloneOptions returns a copy of o in which every non-nil pointer field
+// addresses a fresh value.
+//
+// buildCustomPricingData stores Options by value, so a runtime entry shares
+// every pointer with the override it came from. Options is nothing but pointer
+// fields, so copying the struct alone still lets a caller reach through and
+// repricing live requests. Reflection rather than field-by-field assignment
+// keeps this correct as Options gains fields — a missed field would fail
+// silently. Only the management catalog path pays for this; the request path
+// dereferences through resolve() and never hands pointers out.
+func cloneOptions(o Options) Options {
+	out := o
+	v := reflect.ValueOf(&out).Elem()
+	for _, f := range v.Fields() {
+		if f.Kind() != reflect.Pointer || f.IsNil() || !f.CanSet() {
+			continue
+		}
+		fresh := reflect.New(f.Type().Elem())
+		fresh.Elem().Set(f.Elem())
+		f.Set(fresh)
+	}
+	return out
+}
+
+// cloneOverride returns a copy of o sharing no mutable state with it.
+func cloneOverride(o Override) Override {
+	out := o
+	out.UserID = cloneStringPtr(o.UserID)
+	out.VirtualKeyID = cloneStringPtr(o.VirtualKeyID)
+	out.ProviderID = cloneStringPtr(o.ProviderID)
+	out.ProviderKeyID = cloneStringPtr(o.ProviderKeyID)
+	out.RequestTypes = slices.Clone(o.RequestTypes)
+	out.Options = cloneOptions(o.Options)
+	return out
+}
+
+func cloneStringPtr(s *string) *string {
+	if s == nil {
+		return nil
+	}
+	v := *s
+	return &v
+}
+
+// CatalogPricingOverrides summarizes how scoped overrides affect one
+// (model, provider) row of the management model catalog.
+type CatalogPricingOverrides struct {
+	// AppliedID is the override that wins under the global/provider scopes
+	// only — the scopes that apply to every request regardless of caller.
+	// Empty when nothing global/provider-scoped matches.
+	AppliedID string
+	// AppliedPatch is that winner's option patch; nil when AppliedID is empty.
+	AppliedPatch *Options
+	// Matching lists every override matching (model, provider) regardless of
+	// scope or mode, most-specific-first, for informational display. Includes
+	// the applied one.
+	Matching []Override
+}
+
+// CatalogPricingOverrides returns the overrides relevant to one management
+// catalog row. mode is the pricing mode of the base row being displayed
+// ("chat", "embedding", …).
+//
+// The management catalog has no virtual-key/user/selected-key context, so
+// AppliedPatch is resolved with only the provider set — scopePriorityOrder
+// then naturally yields [provider, global], the two scopes that hold for
+// every caller. Overrides in the virtual-key/user/provider-key families are
+// still returned in Matching so the UI can show them as informational.
+func (s *Store) CatalogPricingOverrides(model string, provider schemas.ModelProvider, mode string) CatalogPricingOverrides {
+	s.overridesMu.RLock()
+	custom := s.customPricing
+	raw := s.rawOverrides
+	s.overridesMu.RUnlock()
+
+	if custom == nil || len(raw) == 0 {
+		return CatalogPricingOverrides{}
+	}
+
+	var out CatalogPricingOverrides
+	if e := custom.resolveEntry(model, mode, LookupScopes{Provider: string(provider)}); e != nil {
+		patch := cloneOptions(e.options)
+		out.AppliedID = e.id
+		out.AppliedPatch = &patch
+	}
+
+	matched := make(map[string]struct{})
+	collect := func(entries []customPricingEntry) {
+		for i := range entries {
+			e := &entries[i]
+			if e.matchesModel(model) && e.matchesCatalogProvider(string(provider)) {
+				matched[e.id] = struct{}{}
+			}
+		}
+	}
+	collect(custom.exact[model])
+	collect(custom.wildcard)
+	if len(matched) == 0 {
+		return out
+	}
+
+	out.Matching = make([]Override, 0, len(matched))
+	for i := range raw {
+		if _, ok := matched[raw[i].ID]; ok {
+			out.Matching = append(out.Matching, cloneOverride(raw[i]))
+		}
+	}
+	sort.SliceStable(out.Matching, func(i, j int) bool {
+		a, b := out.Matching[i], out.Matching[j]
+		if ra, rb := catalogScopeRank(a.ScopeKind), catalogScopeRank(b.ScopeKind); ra != rb {
+			return ra < rb
+		}
+		// Exact patterns are more specific than wildcards; among wildcards the
+		// longer prefix wins, matching buildCustomPricingData's ordering.
+		if av, bv := a.MatchType == MatchTypeWildcard, b.MatchType == MatchTypeWildcard; av != bv {
+			return !av
+		}
+		if len(a.Pattern) != len(b.Pattern) {
+			return len(a.Pattern) > len(b.Pattern)
+		}
+		return a.ID < b.ID
+	})
+	return out
 }
 
 // patchPricing returns a copy of pricing with override fields applied. Nil

--- a/framework/modelcatalog/datasheet/overrides_test.go
+++ b/framework/modelcatalog/datasheet/overrides_test.go
@@ -728,3 +728,234 @@ func TestOverrideIsValid_UserScopeKind(t *testing.T) {
 	userProviderKeyWithVK.VirtualKeyID = &vkID
 	require.ErrorContains(t, userProviderKeyWithVK.IsValid(), "does not support virtual_key_id")
 }
+
+func TestCatalogPricingOverrides_ProviderBeatsGlobal(t *testing.T) {
+	s := newTestStore()
+	providerID := "openai"
+
+	require.NoError(t, s.SetOverrides([]configstoreTables.TablePricingOverride{
+		{
+			ID:               "global",
+			Name:             "Global",
+			ScopeKind:        string(ScopeKindGlobal),
+			MatchType:        string(MatchTypeExact),
+			Pattern:          "gpt-4o",
+			RequestTypes:     []schemas.RequestType{schemas.ChatCompletionRequest},
+			PricingPatchJSON: `{"input_cost_per_token":2}`,
+		},
+		{
+			ID:               "provider",
+			Name:             "Provider",
+			ScopeKind:        string(ScopeKindProvider),
+			ProviderID:       &providerID,
+			MatchType:        string(MatchTypeExact),
+			Pattern:          "gpt-4o",
+			RequestTypes:     []schemas.RequestType{schemas.ChatCompletionRequest},
+			PricingPatchJSON: `{"input_cost_per_token":3}`,
+		},
+	}))
+
+	result := s.CatalogPricingOverrides("gpt-4o", schemas.OpenAI, "chat")
+	assert.Equal(t, "provider", result.AppliedID)
+	require.NotNil(t, result.AppliedPatch)
+	require.NotNil(t, result.AppliedPatch.InputCostPerToken)
+	assert.Equal(t, 3.0, *result.AppliedPatch.InputCostPerToken)
+
+	require.Len(t, result.Matching, 2)
+	assert.Equal(t, "provider", result.Matching[0].ID, "provider scope sorts before global")
+	assert.Equal(t, "global", result.Matching[1].ID)
+}
+
+func TestCatalogPricingOverrides_IgnoresMismatchedProvider(t *testing.T) {
+	s := newTestStore()
+	anthropicID := "anthropic"
+
+	require.NoError(t, s.SetOverrides([]configstoreTables.TablePricingOverride{
+		{
+			ID:               "anthropic-only",
+			ScopeKind:        string(ScopeKindProvider),
+			ProviderID:       &anthropicID,
+			MatchType:        string(MatchTypeExact),
+			Pattern:          "gpt-4o",
+			RequestTypes:     []schemas.RequestType{schemas.ChatCompletionRequest},
+			PricingPatchJSON: `{"input_cost_per_token":3}`,
+		},
+	}))
+
+	result := s.CatalogPricingOverrides("gpt-4o", schemas.OpenAI, "chat")
+	assert.Empty(t, result.AppliedID)
+	assert.Nil(t, result.AppliedPatch)
+	assert.Empty(t, result.Matching)
+}
+
+func TestCatalogPricingOverrides_NonGlobalScopesAreInformationalOnly(t *testing.T) {
+	s := newTestStore()
+	providerID := "openai"
+	providerKeyID := "provider-key-1"
+	virtualKeyID := "virtual-key-1"
+	userID := "user-1"
+
+	require.NoError(t, s.SetOverrides([]configstoreTables.TablePricingOverride{
+		{
+			ID:               "virtual-key",
+			ScopeKind:        string(ScopeKindVirtualKey),
+			VirtualKeyID:     &virtualKeyID,
+			MatchType:        string(MatchTypeExact),
+			Pattern:          "gpt-4o",
+			RequestTypes:     []schemas.RequestType{schemas.ChatCompletionRequest},
+			PricingPatchJSON: `{"input_cost_per_token":5}`,
+		},
+		{
+			ID:               "user-provider",
+			ScopeKind:        string(ScopeKindUserProvider),
+			UserID:           &userID,
+			ProviderID:       &providerID,
+			MatchType:        string(MatchTypeExact),
+			Pattern:          "gpt-4o",
+			RequestTypes:     []schemas.RequestType{schemas.ChatCompletionRequest},
+			PricingPatchJSON: `{"input_cost_per_token":7}`,
+		},
+		{
+			// provider_key scope carries no provider_id, so it can't be
+			// provider-filtered — it must still surface informationally.
+			ID:               "provider-key",
+			ScopeKind:        string(ScopeKindProviderKey),
+			ProviderKeyID:    &providerKeyID,
+			MatchType:        string(MatchTypeExact),
+			Pattern:          "gpt-4o",
+			RequestTypes:     []schemas.RequestType{schemas.ChatCompletionRequest},
+			PricingPatchJSON: `{"input_cost_per_token":4}`,
+		},
+	}))
+
+	result := s.CatalogPricingOverrides("gpt-4o", schemas.OpenAI, "chat")
+	assert.Empty(t, result.AppliedID, "no global/provider scoped override exists")
+	assert.Nil(t, result.AppliedPatch)
+
+	ids := make([]string, 0, len(result.Matching))
+	for _, o := range result.Matching {
+		ids = append(ids, o.ID)
+	}
+	assert.Equal(t, []string{"virtual-key", "user-provider", "provider-key"}, ids)
+}
+
+func TestCatalogPricingOverrides_WildcardLongestPrefixWins(t *testing.T) {
+	s := newTestStore()
+
+	require.NoError(t, s.SetOverrides([]configstoreTables.TablePricingOverride{
+		{
+			ID:               "broad",
+			ScopeKind:        string(ScopeKindGlobal),
+			MatchType:        string(MatchTypeWildcard),
+			Pattern:          "gpt-*",
+			RequestTypes:     []schemas.RequestType{schemas.ChatCompletionRequest},
+			PricingPatchJSON: `{"input_cost_per_token":1}`,
+		},
+		{
+			ID:               "narrow",
+			ScopeKind:        string(ScopeKindGlobal),
+			MatchType:        string(MatchTypeWildcard),
+			Pattern:          "gpt-4*",
+			RequestTypes:     []schemas.RequestType{schemas.ChatCompletionRequest},
+			PricingPatchJSON: `{"input_cost_per_token":2}`,
+		},
+	}))
+
+	result := s.CatalogPricingOverrides("gpt-4o", schemas.OpenAI, "chat")
+	assert.Equal(t, "narrow", result.AppliedID)
+	require.Len(t, result.Matching, 2)
+	assert.Equal(t, "narrow", result.Matching[0].ID)
+	assert.Equal(t, "gpt-4*", result.Matching[0].Pattern, "un-stripped pattern is reported")
+
+	// A model only the broad pattern covers.
+	other := s.CatalogPricingOverrides("gpt-5-nano", schemas.OpenAI, "chat")
+	assert.Equal(t, "broad", other.AppliedID)
+	require.Len(t, other.Matching, 1)
+}
+
+func TestCatalogPricingOverrides_ModeFilteringAppliesToWinnerOnly(t *testing.T) {
+	s := newTestStore()
+
+	require.NoError(t, s.SetOverrides([]configstoreTables.TablePricingOverride{
+		{
+			ID:               "embedding-only",
+			ScopeKind:        string(ScopeKindGlobal),
+			MatchType:        string(MatchTypeExact),
+			Pattern:          "gpt-4o",
+			RequestTypes:     []schemas.RequestType{schemas.EmbeddingRequest},
+			PricingPatchJSON: `{"input_cost_per_token":9}`,
+		},
+	}))
+
+	chat := s.CatalogPricingOverrides("gpt-4o", schemas.OpenAI, "chat")
+	assert.Empty(t, chat.AppliedID)
+	assert.Nil(t, chat.AppliedPatch)
+	require.Len(t, chat.Matching, 1, "listed informationally even though the mode differs")
+	assert.Equal(t, "embedding-only", chat.Matching[0].ID)
+
+	embedding := s.CatalogPricingOverrides("gpt-4o", schemas.OpenAI, "embedding")
+	assert.Equal(t, "embedding-only", embedding.AppliedID)
+	require.NotNil(t, embedding.AppliedPatch)
+}
+
+func TestCatalogPricingOverrides_EmptyStore(t *testing.T) {
+	s := newTestStore()
+	assert.Equal(t, CatalogPricingOverrides{}, s.CatalogPricingOverrides("gpt-4o", schemas.OpenAI, "chat"))
+
+	require.NoError(t, s.SetOverrides(nil))
+	assert.Equal(t, CatalogPricingOverrides{}, s.CatalogPricingOverrides("gpt-4o", schemas.OpenAI, "chat"))
+}
+
+// Callers must not be able to reach through the returned result into the
+// pointers the runtime lookup structure prices requests with.
+func TestCatalogPricingOverrides_ReturnsDeepCopies(t *testing.T) {
+	s := newTestStore()
+	providerID := "openai"
+
+	require.NoError(t, s.SetOverrides([]configstoreTables.TablePricingOverride{
+		{
+			ID:               "provider",
+			Name:             "Provider",
+			ScopeKind:        string(ScopeKindProvider),
+			ProviderID:       &providerID,
+			MatchType:        string(MatchTypeExact),
+			Pattern:          "gpt-4o",
+			RequestTypes:     []schemas.RequestType{schemas.ChatCompletionRequest},
+			PricingPatchJSON: `{"input_cost_per_token":3}`,
+		},
+	}))
+
+	result := s.CatalogPricingOverrides("gpt-4o", schemas.OpenAI, "chat")
+	require.NotNil(t, result.AppliedPatch)
+	require.NotNil(t, result.AppliedPatch.InputCostPerToken)
+	require.Len(t, result.Matching, 1)
+	require.NotNil(t, result.Matching[0].ProviderID)
+	require.Len(t, result.Matching[0].RequestTypes, 1)
+	require.NotNil(t, result.Matching[0].Options.InputCostPerToken)
+
+	// A caller mutating what it was handed.
+	*result.AppliedPatch.InputCostPerToken = 999
+	*result.Matching[0].Options.InputCostPerToken = 999
+	*result.Matching[0].ProviderID = "mutated"
+	result.Matching[0].RequestTypes[0] = schemas.EmbeddingRequest
+
+	fresh := s.CatalogPricingOverrides("gpt-4o", schemas.OpenAI, "chat")
+	require.NotNil(t, fresh.AppliedPatch)
+	require.NotNil(t, fresh.AppliedPatch.InputCostPerToken)
+	assert.Equal(t, 3.0, *fresh.AppliedPatch.InputCostPerToken, "applied patch must survive a caller mutating a prior result")
+	require.Len(t, fresh.Matching, 1)
+	require.NotNil(t, fresh.Matching[0].Options.InputCostPerToken)
+	assert.Equal(t, 3.0, *fresh.Matching[0].Options.InputCostPerToken)
+	require.NotNil(t, fresh.Matching[0].ProviderID)
+	assert.Equal(t, "openai", *fresh.Matching[0].ProviderID)
+	assert.Equal(t, []schemas.RequestType{schemas.ChatCompletionRequest}, fresh.Matching[0].RequestTypes)
+
+	// The request-pricing path reads the same entries the catalog view exposed.
+	// Scope with a literal, not providerID — the override holds &providerID, so
+	// the mutation above would otherwise rewrite this lookup's own input.
+	priced, ok := s.applyPricingOverrides("gpt-4o", schemas.ChatCompletionRequest,
+		configstoreTables.TableModelPricing{}, LookupScopes{Provider: "openai"})
+	require.True(t, ok)
+	require.NotNil(t, priced.InputCostPerToken)
+	assert.Equal(t, 3.0, *priced.InputCostPerToken, "runtime pricing must survive a caller mutating a catalog result")
+}

--- a/framework/modelcatalog/pricing.go
+++ b/framework/modelcatalog/pricing.go
@@ -16,6 +16,14 @@ func (mc *ModelCatalog) GetModelCapabilityEntryForModel(model string, provider s
 	return mc.datasheet.GetCapabilityEntry(model, provider)
 }
 
+// GetCatalogPricingOverrides returns the scoped pricing overrides relevant to
+// a management-catalog row: the global/provider-scope winner for mode (the
+// pricing the UI shows as overridden) plus every override matching
+// (model, provider) for informational display.
+func (mc *ModelCatalog) GetCatalogPricingOverrides(model string, provider schemas.ModelProvider, mode string) CatalogPricingOverrides {
+	return mc.datasheet.CatalogPricingOverrides(model, provider, mode)
+}
+
 // IsRequestTypeSupported preserves the historical (model, provider,
 // requestType) signature; provider is ignored (the underlying datasheet
 // index is keyed by model only).


### PR DESCRIPTION
## Summary

Adds a `CatalogPricingOverrides` API to the model catalog's pricing override system, enabling the management UI to display which pricing overrides apply to a given model/provider row and which are present informationally (e.g. virtual-key or user-scoped overrides that can't be evaluated without a request context).

## Changes

- Introduced `CatalogPricingOverrides` struct with two distinct fields: `AppliedID`/`AppliedPatch` (the winning override under global/provider scopes only) and `Matching` (all overrides touching the model+provider, sorted most-specific-first, for informational display).
- Refactored `customPricingData.resolve` into a thin wrapper over a new `resolveEntry` method, which returns the winning `customPricingEntry` directly so callers can recover the override's identity without duplicating the precedence walk.
- Added `matchesCatalogProvider` and `matchesModel` helpers on `customPricingEntry` to support catalog-context filtering, where virtual-key/user/provider-key scopes have no runtime identifiers but should still surface informationally. Provider-key-scoped entries carry no `provider_id` and always pass the provider filter.
- Added `catalogScopeRank` to order scope kinds most-specific-first for display, independent of runtime identifiers.
- Exposed `Store.CatalogPricingOverrides` and `ModelCatalog.GetCatalogPricingOverrides` as the public entry points.
- Re-exported `CatalogPricingOverrides` from the `modelcatalog` package via the existing type alias block.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/modelcatalog/... ./framework/modelcatalog/datasheet/...
```

Key scenarios covered by the new tests:

- Provider-scoped override beats global-scoped override (`TestCatalogPricingOverrides_ProviderBeatsGlobal`)
- Overrides for a different provider are excluded entirely (`TestCatalogPricingOverrides_IgnoresMismatchedProvider`)
- Virtual-key, user, and provider-key scoped overrides appear in `Matching` but never in `AppliedID` (`TestCatalogPricingOverrides_NonGlobalScopesAreInformationalOnly`)
- Wildcard longest-prefix wins in both `AppliedID` and `Matching` ordering (`TestCatalogPricingOverrides_WildcardLongestPrefixWins`)
- Mode filtering applies to `AppliedID` resolution but not to `Matching` listing (`TestCatalogPricingOverrides_ModeFilteringAppliesToWinnerOnly`)
- Empty/nil override store returns a zero-value result (`TestCatalogPricingOverrides_EmptyStore`)

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new auth surfaces or secrets handling. The new method reads from the existing in-memory override store under the existing read lock (`overridesMu.RLock`).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable