### PR TITLE
feat(api): expose pricing overrides on /api/models/details

### DIFF
--- a/framework/modelcatalog/config.go
+++ b/framework/modelcatalog/config.go
@@ -67,6 +67,8 @@ type (
 	ScopeKind           = datasheet.ScopeKind
 	MatchType           = datasheet.MatchType
 
+	CatalogPricingOverrides = datasheet.CatalogPricingOverrides
+
 	KeyConfigEntry = keyconfig.KeyEntry
 	AliasOwner     = keyconfig.AliasOwner
 )

--- a/framework/modelcatalog/datasheet/overrides.go
+++ b/framework/modelcatalog/datasheet/overrides.go
@@ -3,6 +3,8 @@ package datasheet
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"slices"
 	"sort"
 	"strings"
 
@@ -162,20 +164,75 @@ func (e *customPricingEntry) matchesMode(mode string) bool {
 	return ok
 }
 
+// matchesCatalogProvider reports whether the entry could ever apply to a model
+// served by provider. Weaker than matchesScope on purpose: the management
+// catalog has no virtual-key/user/selected-key context, so those scopes can
+// never satisfy matchesScope there, yet they still deserve to be listed
+// informationally. Entries whose scope pins a provider must match it;
+// provider_key-scoped entries carry no provider_id, so they always pass.
+func (e *customPricingEntry) matchesCatalogProvider(provider string) bool {
+	return e.providerID == "" || e.providerID == provider
+}
+
+// matchesModel reports whether the entry's pattern covers model.
+func (e *customPricingEntry) matchesModel(model string) bool {
+	if e.wildcard {
+		return strings.HasPrefix(model, e.pattern)
+	}
+	return e.pattern == model
+}
+
+// catalogScopeRank orders scope kinds most-specific-first for display. Mirrors
+// scopePriorityOrder's ranking but is independent of runtime identifiers,
+// which the management catalog does not have.
+func catalogScopeRank(k ScopeKind) int {
+	switch k {
+	case ScopeKindVirtualKeyProviderKey:
+		return 0
+	case ScopeKindVirtualKeyProvider:
+		return 1
+	case ScopeKindVirtualKey:
+		return 2
+	case ScopeKindUserProviderKey:
+		return 3
+	case ScopeKindUserProvider:
+		return 4
+	case ScopeKindUser:
+		return 5
+	case ScopeKindProviderKey:
+		return 6
+	case ScopeKindProvider:
+		return 7
+	case ScopeKindGlobal:
+		return 8
+	}
+	return 9
+}
+
 // resolve walks the 9-scope priority hierarchy and returns the first matching
 // pricing patch for the given model, mode, and runtime scopes.
 func (c *customPricingData) resolve(model, mode string, scopes LookupScopes) *Options {
+	if e := c.resolveEntry(model, mode, scopes); e != nil {
+		return &e.options
+	}
+	return nil
+}
+
+// resolveEntry is resolve's implementation, returning the winning entry itself
+// so callers that need the override's identity (not just its patch) can
+// recover it without duplicating the precedence walk.
+func (c *customPricingData) resolveEntry(model, mode string, scopes LookupScopes) *customPricingEntry {
 	for _, scopeKind := range scopePriorityOrder(scopes) {
 		for i := range c.exact[model] {
 			e := &c.exact[model][i]
 			if e.scopeKind == scopeKind && e.matchesScope(scopes) && e.matchesMode(mode) {
-				return &e.options
+				return e
 			}
 		}
 		for i := range c.wildcard {
 			e := &c.wildcard[i]
 			if e.scopeKind == scopeKind && e.matchesScope(scopes) && strings.HasPrefix(model, e.pattern) && e.matchesMode(mode) {
-				return &e.options
+				return e
 			}
 		}
 	}
@@ -283,6 +340,130 @@ func (s *Store) applyPricingOverrides(model string, requestType schemas.RequestT
 		return patchPricing(pricing, *patch), true
 	}
 	return pricing, false
+}
+
+// cloneOptions returns a copy of o in which every non-nil pointer field
+// addresses a fresh value.
+//
+// buildCustomPricingData stores Options by value, so a runtime entry shares
+// every pointer with the override it came from. Options is nothing but pointer
+// fields, so copying the struct alone still lets a caller reach through and
+// repricing live requests. Reflection rather than field-by-field assignment
+// keeps this correct as Options gains fields — a missed field would fail
+// silently. Only the management catalog path pays for this; the request path
+// dereferences through resolve() and never hands pointers out.
+func cloneOptions(o Options) Options {
+	out := o
+	v := reflect.ValueOf(&out).Elem()
+	for _, f := range v.Fields() {
+		if f.Kind() != reflect.Pointer || f.IsNil() || !f.CanSet() {
+			continue
+		}
+		fresh := reflect.New(f.Type().Elem())
+		fresh.Elem().Set(f.Elem())
+		f.Set(fresh)
+	}
+	return out
+}
+
+// cloneOverride returns a copy of o sharing no mutable state with it.
+func cloneOverride(o Override) Override {
+	out := o
+	out.UserID = cloneStringPtr(o.UserID)
+	out.VirtualKeyID = cloneStringPtr(o.VirtualKeyID)
+	out.ProviderID = cloneStringPtr(o.ProviderID)
+	out.ProviderKeyID = cloneStringPtr(o.ProviderKeyID)
+	out.RequestTypes = slices.Clone(o.RequestTypes)
+	out.Options = cloneOptions(o.Options)
+	return out
+}
+
+func cloneStringPtr(s *string) *string {
+	if s == nil {
+		return nil
+	}
+	v := *s
+	return &v
+}
+
+// CatalogPricingOverrides summarizes how scoped overrides affect one
+// (model, provider) row of the management model catalog.
+type CatalogPricingOverrides struct {
+	// AppliedID is the override that wins under the global/provider scopes
+	// only — the scopes that apply to every request regardless of caller.
+	// Empty when nothing global/provider-scoped matches.
+	AppliedID string
+	// AppliedPatch is that winner's option patch; nil when AppliedID is empty.
+	AppliedPatch *Options
+	// Matching lists every override matching (model, provider) regardless of
+	// scope or mode, most-specific-first, for informational display. Includes
+	// the applied one.
+	Matching []Override
+}
+
+// CatalogPricingOverrides returns the overrides relevant to one management
+// catalog row. mode is the pricing mode of the base row being displayed
+// ("chat", "embedding", …).
+//
+// The management catalog has no virtual-key/user/selected-key context, so
+// AppliedPatch is resolved with only the provider set — scopePriorityOrder
+// then naturally yields [provider, global], the two scopes that hold for
+// every caller. Overrides in the virtual-key/user/provider-key families are
+// still returned in Matching so the UI can show them as informational.
+func (s *Store) CatalogPricingOverrides(model string, provider schemas.ModelProvider, mode string) CatalogPricingOverrides {
+	s.overridesMu.RLock()
+	custom := s.customPricing
+	raw := s.rawOverrides
+	s.overridesMu.RUnlock()
+
+	if custom == nil || len(raw) == 0 {
+		return CatalogPricingOverrides{}
+	}
+
+	var out CatalogPricingOverrides
+	if e := custom.resolveEntry(model, mode, LookupScopes{Provider: string(provider)}); e != nil {
+		patch := cloneOptions(e.options)
+		out.AppliedID = e.id
+		out.AppliedPatch = &patch
+	}
+
+	matched := make(map[string]struct{})
+	collect := func(entries []customPricingEntry) {
+		for i := range entries {
+			e := &entries[i]
+			if e.matchesModel(model) && e.matchesCatalogProvider(string(provider)) {
+				matched[e.id] = struct{}{}
+			}
+		}
+	}
+	collect(custom.exact[model])
+	collect(custom.wildcard)
+	if len(matched) == 0 {
+		return out
+	}
+
+	out.Matching = make([]Override, 0, len(matched))
+	for i := range raw {
+		if _, ok := matched[raw[i].ID]; ok {
+			out.Matching = append(out.Matching, cloneOverride(raw[i]))
+		}
+	}
+	sort.SliceStable(out.Matching, func(i, j int) bool {
+		a, b := out.Matching[i], out.Matching[j]
+		if ra, rb := catalogScopeRank(a.ScopeKind), catalogScopeRank(b.ScopeKind); ra != rb {
+			return ra < rb
+		}
+		// Exact patterns are more specific than wildcards; among wildcards the
+		// longer prefix wins, matching buildCustomPricingData's ordering.
+		if av, bv := a.MatchType == MatchTypeWildcard, b.MatchType == MatchTypeWildcard; av != bv {
+			return !av
+		}
+		if len(a.Pattern) != len(b.Pattern) {
+			return len(a.Pattern) > len(b.Pattern)
+		}
+		return a.ID < b.ID
+	})
+	return out
 }
 
 // patchPricing returns a copy of pricing with override fields applied. Nil

--- a/framework/modelcatalog/datasheet/overrides_test.go
+++ b/framework/modelcatalog/datasheet/overrides_test.go
@@ -728,3 +728,234 @@ func TestOverrideIsValid_UserScopeKind(t *testing.T) {
 	userProviderKeyWithVK.VirtualKeyID = &vkID
 	require.ErrorContains(t, userProviderKeyWithVK.IsValid(), "does not support virtual_key_id")
 }
+
+func TestCatalogPricingOverrides_ProviderBeatsGlobal(t *testing.T) {
+	s := newTestStore()
+	providerID := "openai"
+
+	require.NoError(t, s.SetOverrides([]configstoreTables.TablePricingOverride{
+		{
+			ID:               "global",
+			Name:             "Global",
+			ScopeKind:        string(ScopeKindGlobal),
+			MatchType:        string(MatchTypeExact),
+			Pattern:          "gpt-4o",
+			RequestTypes:     []schemas.RequestType{schemas.ChatCompletionRequest},
+			PricingPatchJSON: `{"input_cost_per_token":2}`,
+		},
+		{
+			ID:               "provider",
+			Name:             "Provider",
+			ScopeKind:        string(ScopeKindProvider),
+			ProviderID:       &providerID,
+			MatchType:        string(MatchTypeExact),
+			Pattern:          "gpt-4o",
+			RequestTypes:     []schemas.RequestType{schemas.ChatCompletionRequest},
+			PricingPatchJSON: `{"input_cost_per_token":3}`,
+		},
+	}))
+
+	result := s.CatalogPricingOverrides("gpt-4o", schemas.OpenAI, "chat")
+	assert.Equal(t, "provider", result.AppliedID)
+	require.NotNil(t, result.AppliedPatch)
+	require.NotNil(t, result.AppliedPatch.InputCostPerToken)
+	assert.Equal(t, 3.0, *result.AppliedPatch.InputCostPerToken)
+
+	require.Len(t, result.Matching, 2)
+	assert.Equal(t, "provider", result.Matching[0].ID, "provider scope sorts before global")
+	assert.Equal(t, "global", result.Matching[1].ID)
+}
+
+func TestCatalogPricingOverrides_IgnoresMismatchedProvider(t *testing.T) {
+	s := newTestStore()
+	anthropicID := "anthropic"
+
+	require.NoError(t, s.SetOverrides([]configstoreTables.TablePricingOverride{
+		{
+			ID:               "anthropic-only",
+			ScopeKind:        string(ScopeKindProvider),
+			ProviderID:       &anthropicID,
+			MatchType:        string(MatchTypeExact),
+			Pattern:          "gpt-4o",
+			RequestTypes:     []schemas.RequestType{schemas.ChatCompletionRequest},
+			PricingPatchJSON: `{"input_cost_per_token":3}`,
+		},
+	}))
+
+	result := s.CatalogPricingOverrides("gpt-4o", schemas.OpenAI, "chat")
+	assert.Empty(t, result.AppliedID)
+	assert.Nil(t, result.AppliedPatch)
+	assert.Empty(t, result.Matching)
+}
+
+func TestCatalogPricingOverrides_NonGlobalScopesAreInformationalOnly(t *testing.T) {
+	s := newTestStore()
+	providerID := "openai"
+	providerKeyID := "provider-key-1"
+	virtualKeyID := "virtual-key-1"
+	userID := "user-1"
+
+	require.NoError(t, s.SetOverrides([]configstoreTables.TablePricingOverride{
+		{
+			ID:               "virtual-key",
+			ScopeKind:        string(ScopeKindVirtualKey),
+			VirtualKeyID:     &virtualKeyID,
+			MatchType:        string(MatchTypeExact),
+			Pattern:          "gpt-4o",
+			RequestTypes:     []schemas.RequestType{schemas.ChatCompletionRequest},
+			PricingPatchJSON: `{"input_cost_per_token":5}`,
+		},
+		{
+			ID:               "user-provider",
+			ScopeKind:        string(ScopeKindUserProvider),
+			UserID:           &userID,
+			ProviderID:       &providerID,
+			MatchType:        string(MatchTypeExact),
+			Pattern:          "gpt-4o",
+			RequestTypes:     []schemas.RequestType{schemas.ChatCompletionRequest},
+			PricingPatchJSON: `{"input_cost_per_token":7}`,
+		},
+		{
+			// provider_key scope carries no provider_id, so it can't be
+			// provider-filtered — it must still surface informationally.
+			ID:               "provider-key",
+			ScopeKind:        string(ScopeKindProviderKey),
+			ProviderKeyID:    &providerKeyID,
+			MatchType:        string(MatchTypeExact),
+			Pattern:          "gpt-4o",
+			RequestTypes:     []schemas.RequestType{schemas.ChatCompletionRequest},
+			PricingPatchJSON: `{"input_cost_per_token":4}`,
+		},
+	}))
+
+	result := s.CatalogPricingOverrides("gpt-4o", schemas.OpenAI, "chat")
+	assert.Empty(t, result.AppliedID, "no global/provider scoped override exists")
+	assert.Nil(t, result.AppliedPatch)
+
+	ids := make([]string, 0, len(result.Matching))
+	for _, o := range result.Matching {
+		ids = append(ids, o.ID)
+	}
+	assert.Equal(t, []string{"virtual-key", "user-provider", "provider-key"}, ids)
+}
+
+func TestCatalogPricingOverrides_WildcardLongestPrefixWins(t *testing.T) {
+	s := newTestStore()
+
+	require.NoError(t, s.SetOverrides([]configstoreTables.TablePricingOverride{
+		{
+			ID:               "broad",
+			ScopeKind:        string(ScopeKindGlobal),
+			MatchType:        string(MatchTypeWildcard),
+			Pattern:          "gpt-*",
+			RequestTypes:     []schemas.RequestType{schemas.ChatCompletionRequest},
+			PricingPatchJSON: `{"input_cost_per_token":1}`,
+		},
+		{
+			ID:               "narrow",
+			ScopeKind:        string(ScopeKindGlobal),
+			MatchType:        string(MatchTypeWildcard),
+			Pattern:          "gpt-4*",
+			RequestTypes:     []schemas.RequestType{schemas.ChatCompletionRequest},
+			PricingPatchJSON: `{"input_cost_per_token":2}`,
+		},
+	}))
+
+	result := s.CatalogPricingOverrides("gpt-4o", schemas.OpenAI, "chat")
+	assert.Equal(t, "narrow", result.AppliedID)
+	require.Len(t, result.Matching, 2)
+	assert.Equal(t, "narrow", result.Matching[0].ID)
+	assert.Equal(t, "gpt-4*", result.Matching[0].Pattern, "un-stripped pattern is reported")
+
+	// A model only the broad pattern covers.
+	other := s.CatalogPricingOverrides("gpt-5-nano", schemas.OpenAI, "chat")
+	assert.Equal(t, "broad", other.AppliedID)
+	require.Len(t, other.Matching, 1)
+}
+
+func TestCatalogPricingOverrides_ModeFilteringAppliesToWinnerOnly(t *testing.T) {
+	s := newTestStore()
+
+	require.NoError(t, s.SetOverrides([]configstoreTables.TablePricingOverride{
+		{
+			ID:               "embedding-only",
+			ScopeKind:        string(ScopeKindGlobal),
+			MatchType:        string(MatchTypeExact),
+			Pattern:          "gpt-4o",
+			RequestTypes:     []schemas.RequestType{schemas.EmbeddingRequest},
+			PricingPatchJSON: `{"input_cost_per_token":9}`,
+		},
+	}))
+
+	chat := s.CatalogPricingOverrides("gpt-4o", schemas.OpenAI, "chat")
+	assert.Empty(t, chat.AppliedID)
+	assert.Nil(t, chat.AppliedPatch)
+	require.Len(t, chat.Matching, 1, "listed informationally even though the mode differs")
+	assert.Equal(t, "embedding-only", chat.Matching[0].ID)
+
+	embedding := s.CatalogPricingOverrides("gpt-4o", schemas.OpenAI, "embedding")
+	assert.Equal(t, "embedding-only", embedding.AppliedID)
+	require.NotNil(t, embedding.AppliedPatch)
+}
+
+func TestCatalogPricingOverrides_EmptyStore(t *testing.T) {
+	s := newTestStore()
+	assert.Equal(t, CatalogPricingOverrides{}, s.CatalogPricingOverrides("gpt-4o", schemas.OpenAI, "chat"))
+
+	require.NoError(t, s.SetOverrides(nil))
+	assert.Equal(t, CatalogPricingOverrides{}, s.CatalogPricingOverrides("gpt-4o", schemas.OpenAI, "chat"))
+}
+
+// Callers must not be able to reach through the returned result into the
+// pointers the runtime lookup structure prices requests with.
+func TestCatalogPricingOverrides_ReturnsDeepCopies(t *testing.T) {
+	s := newTestStore()
+	providerID := "openai"
+
+	require.NoError(t, s.SetOverrides([]configstoreTables.TablePricingOverride{
+		{
+			ID:               "provider",
+			Name:             "Provider",
+			ScopeKind:        string(ScopeKindProvider),
+			ProviderID:       &providerID,
+			MatchType:        string(MatchTypeExact),
+			Pattern:          "gpt-4o",
+			RequestTypes:     []schemas.RequestType{schemas.ChatCompletionRequest},
+			PricingPatchJSON: `{"input_cost_per_token":3}`,
+		},
+	}))
+
+	result := s.CatalogPricingOverrides("gpt-4o", schemas.OpenAI, "chat")
+	require.NotNil(t, result.AppliedPatch)
+	require.NotNil(t, result.AppliedPatch.InputCostPerToken)
+	require.Len(t, result.Matching, 1)
+	require.NotNil(t, result.Matching[0].ProviderID)
+	require.Len(t, result.Matching[0].RequestTypes, 1)
+	require.NotNil(t, result.Matching[0].Options.InputCostPerToken)
+
+	// A caller mutating what it was handed.
+	*result.AppliedPatch.InputCostPerToken = 999
+	*result.Matching[0].Options.InputCostPerToken = 999
+	*result.Matching[0].ProviderID = "mutated"
+	result.Matching[0].RequestTypes[0] = schemas.EmbeddingRequest
+
+	fresh := s.CatalogPricingOverrides("gpt-4o", schemas.OpenAI, "chat")
+	require.NotNil(t, fresh.AppliedPatch)
+	require.NotNil(t, fresh.AppliedPatch.InputCostPerToken)
+	assert.Equal(t, 3.0, *fresh.AppliedPatch.InputCostPerToken, "applied patch must survive a caller mutating a prior result")
+	require.Len(t, fresh.Matching, 1)
+	require.NotNil(t, fresh.Matching[0].Options.InputCostPerToken)
+	assert.Equal(t, 3.0, *fresh.Matching[0].Options.InputCostPerToken)
+	require.NotNil(t, fresh.Matching[0].ProviderID)
+	assert.Equal(t, "openai", *fresh.Matching[0].ProviderID)
+	assert.Equal(t, []schemas.RequestType{schemas.ChatCompletionRequest}, fresh.Matching[0].RequestTypes)
+
+	// The request-pricing path reads the same entries the catalog view exposed.
+	// Scope with a literal, not providerID — the override holds &providerID, so
+	// the mutation above would otherwise rewrite this lookup's own input.
+	priced, ok := s.applyPricingOverrides("gpt-4o", schemas.ChatCompletionRequest,
+		configstoreTables.TableModelPricing{}, LookupScopes{Provider: "openai"})
+	require.True(t, ok)
+	require.NotNil(t, priced.InputCostPerToken)
+	assert.Equal(t, 3.0, *priced.InputCostPerToken, "runtime pricing must survive a caller mutating a catalog result")
+}

--- a/framework/modelcatalog/pricing.go
+++ b/framework/modelcatalog/pricing.go
@@ -16,6 +16,14 @@ func (mc *ModelCatalog) GetModelCapabilityEntryForModel(model string, provider s
 	return mc.datasheet.GetCapabilityEntry(model, provider)
 }
 
+// GetCatalogPricingOverrides returns the scoped pricing overrides relevant to
+// a management-catalog row: the global/provider-scope winner for mode (the
+// pricing the UI shows as overridden) plus every override matching
+// (model, provider) for informational display.
+func (mc *ModelCatalog) GetCatalogPricingOverrides(model string, provider schemas.ModelProvider, mode string) CatalogPricingOverrides {
+	return mc.datasheet.CatalogPricingOverrides(model, provider, mode)
+}
+
 // IsRequestTypeSupported preserves the historical (model, provider,
 // requestType) signature; provider is ignored (the underlying datasheet
 // index is keyed by model only).

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -668,12 +668,55 @@ type ModelDetailsResponse struct {
 	IsDeprecated         bool                  `json:"is_deprecated,omitempty"`
 	AdditionalAttributes map[string]string     `json:"additional_attributes,omitempty"`
 	AccessibleByKeys     []string              `json:"accessible_by_keys,omitempty"`
+
+	// OverriddenPricing carries the post-override value of each cost field the
+	// UI displays, and only for fields the applied override actually changes —
+	// the client strikes through exactly the fields present here. Nil when no
+	// global/provider-scoped override applies.
+	OverriddenPricing *ModelOverriddenPricing `json:"overridden_pricing,omitempty"`
+	// AppliedOverrideID identifies which override produced OverriddenPricing.
+	AppliedOverrideID string `json:"applied_override_id,omitempty"`
+	// PricingOverrideIDs lists every override matching this model, including
+	// virtual-key/user/provider-key scoped ones that do NOT affect
+	// OverriddenPricing and are shown informationally. Resolve against
+	// ListModelDetailsResponse.PricingOverrides.
+	PricingOverrideIDs []string `json:"pricing_override_ids,omitempty"`
+}
+
+// ModelOverriddenPricing carries the post-override value of each displayed
+// cost field. A field is non-nil only when the applied override changes it.
+type ModelOverriddenPricing struct {
+	InputCostPerToken  *float64 `json:"input_cost_per_token,omitempty"`
+	OutputCostPerToken *float64 `json:"output_cost_per_token,omitempty"`
+	CacheWriteCost     *float64 `json:"cache_creation_input_token_cost,omitempty"`
+	CacheReadCost      *float64 `json:"cache_read_input_token_cost,omitempty"`
+}
+
+// ModelPricingOverrideSummary describes one pricing override referenced by a
+// model row.
+type ModelPricingOverrideSummary struct {
+	ID            string                      `json:"id"`
+	Name          string                      `json:"name"`
+	ScopeKind     modelcatalog.ScopeKind      `json:"scope_kind"`
+	UserID        *string                     `json:"user_id,omitempty"`
+	VirtualKeyID  *string                     `json:"virtual_key_id,omitempty"`
+	ProviderID    *string                     `json:"provider_id,omitempty"`
+	ProviderKeyID *string                     `json:"provider_key_id,omitempty"`
+	MatchType     modelcatalog.MatchType      `json:"match_type"`
+	Pattern       string                      `json:"pattern"`
+	RequestTypes  []schemas.RequestType       `json:"request_types,omitempty"`
+	Patch         modelcatalog.PricingOptions `json:"patch"`
 }
 
 // ListModelDetailsResponse represents the response for listing detailed models.
 type ListModelDetailsResponse struct {
 	Models []ModelDetailsResponse `json:"models"`
 	Total  int                    `json:"total"`
+	// PricingOverrides indexes every override referenced by any row, keyed by
+	// ID. Deduplicated here rather than inlined per row: a single global
+	// wildcard override would otherwise be serialized once for every model on
+	// the page.
+	PricingOverrides map[string]ModelPricingOverrideSummary `json:"pricing_overrides,omitempty"`
 }
 
 type modelListQuery struct {
@@ -768,6 +811,7 @@ func (h *ProviderHandler) listModelDetails(ctx *fasthttp.RequestCtx) {
 	}
 
 	responseModels := make([]ModelDetailsResponse, 0, len(allModels))
+	overrideIndex := map[string]ModelPricingOverrideSummary{}
 	for _, model := range allModels {
 		details := ModelDetailsResponse{
 			Name:     model.Name,
@@ -776,7 +820,8 @@ func (h *ProviderHandler) listModelDetails(ctx *fasthttp.RequestCtx) {
 		if len(model.AccessibleByKeys) > 0 {
 			details.AccessibleByKeys = model.AccessibleByKeys
 		}
-		if capabilities := modelCatalog.GetModelCapabilityEntryForModel(model.Name, model.Provider); capabilities != nil {
+		capabilities := modelCatalog.GetModelCapabilityEntryForModel(model.Name, model.Provider)
+		if capabilities != nil {
 			details.ContextLength = capabilities.ContextLength
 			details.MaxInputTokens = capabilities.MaxInputTokens
 			details.MaxOutputTokens = capabilities.MaxOutputTokens
@@ -788,13 +833,98 @@ func (h *ProviderHandler) listModelDetails(ctx *fasthttp.RequestCtx) {
 			details.IsDeprecated = capabilities.IsDeprecated
 			details.AdditionalAttributes = capabilities.AdditionalAttributes
 		}
+
+		// Resolve overrides against the mode the displayed base row came from
+		// (usually chat, but embedding/responses for those models) so an
+		// override scoped to a different mode never strikes this row's price.
+		mode := defaultCatalogPricingMode
+		if capabilities != nil && capabilities.Mode != "" {
+			mode = capabilities.Mode
+		}
+		overrides := modelCatalog.GetCatalogPricingOverrides(model.Name, model.Provider, mode)
+		if len(overrides.Matching) > 0 {
+			details.PricingOverrideIDs = make([]string, 0, len(overrides.Matching))
+			for _, o := range overrides.Matching {
+				details.PricingOverrideIDs = append(details.PricingOverrideIDs, o.ID)
+				if _, seen := overrideIndex[o.ID]; !seen {
+					overrideIndex[o.ID] = toPricingOverrideSummary(o)
+				}
+			}
+		}
+		if overrides.AppliedPatch != nil {
+			if overridden := buildOverriddenPricing(capabilities, overrides.AppliedPatch); overridden != nil {
+				details.OverriddenPricing = overridden
+				details.AppliedOverrideID = overrides.AppliedID
+			}
+		}
+
 		responseModels = append(responseModels, details)
 	}
 
-	SendJSON(ctx, ListModelDetailsResponse{
+	response := ListModelDetailsResponse{
 		Models: responseModels,
 		Total:  total,
-	})
+	}
+	if len(overrideIndex) > 0 {
+		response.PricingOverrides = overrideIndex
+	}
+	SendJSON(ctx, response)
+}
+
+// defaultCatalogPricingMode is the pricing mode used to resolve overrides for
+// a catalog row with no base pricing entry to read a mode from.
+const defaultCatalogPricingMode = "chat"
+
+// changedCost returns patched only when it differs from base, so the UI never
+// strikes a price through with the identical number.
+func changedCost(base, patched *float64) *float64 {
+	if patched == nil {
+		return nil
+	}
+	if base != nil && *base == *patched {
+		return nil
+	}
+	return patched
+}
+
+// buildOverriddenPricing projects the four displayed costs through the applied
+// patch. base may be nil (an override priced a model absent from the catalog).
+// Returns nil when the patch changes none of the displayed fields.
+func buildOverriddenPricing(base *modelcatalog.PricingEntry, patch *modelcatalog.PricingOptions) *ModelOverriddenPricing {
+	if patch == nil {
+		return nil
+	}
+	var baseOptions modelcatalog.PricingOptions
+	if base != nil {
+		baseOptions = base.Options
+	}
+	overridden := ModelOverriddenPricing{
+		InputCostPerToken:  changedCost(baseOptions.InputCostPerToken, patch.InputCostPerToken),
+		OutputCostPerToken: changedCost(baseOptions.OutputCostPerToken, patch.OutputCostPerToken),
+		CacheWriteCost:     changedCost(baseOptions.CacheCreationInputTokenCost, patch.CacheCreationInputTokenCost),
+		CacheReadCost:      changedCost(baseOptions.CacheReadInputTokenCost, patch.CacheReadInputTokenCost),
+	}
+	if overridden.InputCostPerToken == nil && overridden.OutputCostPerToken == nil &&
+		overridden.CacheWriteCost == nil && overridden.CacheReadCost == nil {
+		return nil
+	}
+	return &overridden
+}
+
+func toPricingOverrideSummary(o modelcatalog.PricingOverride) ModelPricingOverrideSummary {
+	return ModelPricingOverrideSummary{
+		ID:            o.ID,
+		Name:          o.Name,
+		ScopeKind:     o.ScopeKind,
+		UserID:        o.UserID,
+		VirtualKeyID:  o.VirtualKeyID,
+		ProviderID:    o.ProviderID,
+		ProviderKeyID: o.ProviderKeyID,
+		MatchType:     o.MatchType,
+		Pattern:       o.Pattern,
+		RequestTypes:  o.RequestTypes,
+		Patch:         o.Options,
+	}
 }
 
 func (h *ProviderHandler) isModelDeprecated(model string, provider schemas.ModelProvider) bool {

--- a/transports/bifrost-http/handlers/providers_test.go
+++ b/transports/bifrost-http/handlers/providers_test.go
@@ -899,6 +899,307 @@ func TestListModelDetails_IncludesPricing(t *testing.T) {
 	}
 }
 
+// gpt4oPricingJSON is the base catalog fixture shared by the override tests.
+const gpt4oPricingJSON = `{
+	"gpt-4o": {
+		"provider": "openai",
+		"mode": "chat",
+		"input_cost_per_token": 0.0000025,
+		"output_cost_per_token": 0.00001
+	},
+	"gpt-4o-mini": {
+		"provider": "openai",
+		"mode": "chat",
+		"input_cost_per_token": 0.0000001,
+		"output_cost_per_token": 0.0000004
+	}
+}`
+
+// listModelDetailsForTest issues the details request and decodes the response,
+// also returning the raw body so tests can assert on omitted JSON keys.
+func listModelDetailsForTest(t *testing.T, h *ProviderHandler, uri string) (ListModelDetailsResponse, string) {
+	t.Helper()
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.SetRequestURI(uri)
+
+	h.listModelDetails(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+	body := string(ctx.Response.Body())
+	var resp ListModelDetailsResponse
+	if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	return resp, body
+}
+
+func TestListModelDetails_AppliesGlobalOverrideWithoutMutatingBase(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := providerHandlerForTest(schemas.OpenAI, []schemas.Key{{ID: "key-a"}}, []string{"gpt-4o"}, []string{"gpt-4o"})
+	h.inMemoryStore.ModelCatalog = modelCatalogForPricingJSON(t, []byte(gpt4oPricingJSON))
+	if err := h.inMemoryStore.ModelCatalog.SetPricingOverrides([]configstoreTables.TablePricingOverride{{
+		ID:               "global-1",
+		Name:             "Negotiated rate",
+		ScopeKind:        string(modelcatalog.ScopeKindGlobal),
+		MatchType:        string(modelcatalog.MatchTypeExact),
+		Pattern:          "gpt-4o",
+		RequestTypes:     []schemas.RequestType{schemas.ChatCompletionRequest},
+		PricingPatchJSON: `{"input_cost_per_token":0.000001}`,
+	}}); err != nil {
+		t.Fatalf("seed overrides: %v", err)
+	}
+
+	resp, _ := listModelDetailsForTest(t, h, "/api/models/details?provider=openai&limit=100")
+
+	if len(resp.Models) != 1 {
+		t.Fatalf("expected one model, got %#v", resp.Models)
+	}
+	m := resp.Models[0]
+	if m.InputCostPerToken == nil || *m.InputCostPerToken != 0.0000025 {
+		t.Fatalf("base input cost must stay unchanged, got %#v", m.InputCostPerToken)
+	}
+	if m.OverriddenPricing == nil || m.OverriddenPricing.InputCostPerToken == nil ||
+		*m.OverriddenPricing.InputCostPerToken != 0.000001 {
+		t.Fatalf("expected overridden input cost 0.000001, got %#v", m.OverriddenPricing)
+	}
+	if m.OverriddenPricing.OutputCostPerToken != nil {
+		t.Fatalf("output cost was not patched, expected nil, got %#v", m.OverriddenPricing.OutputCostPerToken)
+	}
+	if m.AppliedOverrideID != "global-1" {
+		t.Fatalf("expected applied override global-1, got %q", m.AppliedOverrideID)
+	}
+	if len(m.PricingOverrideIDs) != 1 || m.PricingOverrideIDs[0] != "global-1" {
+		t.Fatalf("expected one referenced override, got %#v", m.PricingOverrideIDs)
+	}
+	summary, ok := resp.PricingOverrides["global-1"]
+	if !ok {
+		t.Fatalf("override index missing global-1: %#v", resp.PricingOverrides)
+	}
+	if summary.Name != "Negotiated rate" || summary.Pattern != "gpt-4o" {
+		t.Fatalf("unexpected override summary %#v", summary)
+	}
+	if summary.Patch.InputCostPerToken == nil || *summary.Patch.InputCostPerToken != 0.000001 {
+		t.Fatalf("expected patch in summary, got %#v", summary.Patch)
+	}
+}
+
+func TestListModelDetails_OverrideIndexIsDeduplicated(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := providerHandlerForTest(
+		schemas.OpenAI,
+		[]schemas.Key{{ID: "key-a"}},
+		[]string{"gpt-4o", "gpt-4o-mini"},
+		[]string{"gpt-4o", "gpt-4o-mini"},
+	)
+	h.inMemoryStore.ModelCatalog = modelCatalogForPricingJSON(t, []byte(gpt4oPricingJSON))
+	if err := h.inMemoryStore.ModelCatalog.SetPricingOverrides([]configstoreTables.TablePricingOverride{{
+		ID:               "wildcard-1",
+		Name:             "All GPT models",
+		ScopeKind:        string(modelcatalog.ScopeKindGlobal),
+		MatchType:        string(modelcatalog.MatchTypeWildcard),
+		Pattern:          "gpt-*",
+		RequestTypes:     []schemas.RequestType{schemas.ChatCompletionRequest},
+		PricingPatchJSON: `{"input_cost_per_token":0.000002}`,
+	}}); err != nil {
+		t.Fatalf("seed overrides: %v", err)
+	}
+
+	resp, _ := listModelDetailsForTest(t, h, "/api/models/details?provider=openai&limit=100")
+
+	if len(resp.Models) != 2 {
+		t.Fatalf("expected two models, got %#v", resp.Models)
+	}
+	if len(resp.PricingOverrides) != 1 {
+		t.Fatalf("expected the shared override serialized once, got %#v", resp.PricingOverrides)
+	}
+	for _, m := range resp.Models {
+		if m.AppliedOverrideID != "wildcard-1" {
+			t.Fatalf("model %s missing applied override, got %q", m.Name, m.AppliedOverrideID)
+		}
+	}
+}
+
+func TestListModelDetails_NoOverridesOmitsNewFields(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := providerHandlerForTest(schemas.OpenAI, []schemas.Key{{ID: "key-a"}}, []string{"gpt-4o"}, []string{"gpt-4o"})
+	h.inMemoryStore.ModelCatalog = modelCatalogForPricingJSON(t, []byte(gpt4oPricingJSON))
+
+	_, body := listModelDetailsForTest(t, h, "/api/models/details?provider=openai&limit=100")
+
+	for _, key := range []string{"overridden_pricing", "applied_override_id", "pricing_override_ids", "pricing_overrides"} {
+		if strings.Contains(body, key) {
+			t.Fatalf("expected %q to be omitted when no overrides exist: %s", key, body)
+		}
+	}
+}
+
+func TestListModelDetails_PatchToSameValueIsNotMarkedOverridden(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := providerHandlerForTest(schemas.OpenAI, []schemas.Key{{ID: "key-a"}}, []string{"gpt-4o"}, []string{"gpt-4o"})
+	h.inMemoryStore.ModelCatalog = modelCatalogForPricingJSON(t, []byte(gpt4oPricingJSON))
+	if err := h.inMemoryStore.ModelCatalog.SetPricingOverrides([]configstoreTables.TablePricingOverride{{
+		ID:               "noop-1",
+		ScopeKind:        string(modelcatalog.ScopeKindGlobal),
+		MatchType:        string(modelcatalog.MatchTypeExact),
+		Pattern:          "gpt-4o",
+		RequestTypes:     []schemas.RequestType{schemas.ChatCompletionRequest},
+		PricingPatchJSON: `{"input_cost_per_token":0.0000025}`,
+	}}); err != nil {
+		t.Fatalf("seed overrides: %v", err)
+	}
+
+	resp, _ := listModelDetailsForTest(t, h, "/api/models/details?provider=openai&limit=100")
+
+	m := resp.Models[0]
+	if m.OverriddenPricing != nil {
+		t.Fatalf("a patch matching the base value must not render as overridden, got %#v", m.OverriddenPricing)
+	}
+	if m.AppliedOverrideID != "" {
+		t.Fatalf("expected no applied override id, got %q", m.AppliedOverrideID)
+	}
+	// The override still matched the model, so it stays listed for the sheet.
+	if len(m.PricingOverrideIDs) != 1 {
+		t.Fatalf("expected the override to remain listed, got %#v", m.PricingOverrideIDs)
+	}
+}
+
+func TestListModelDetails_OverrideWithoutBaseCatalogRow(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := providerHandlerForTest(
+		schemas.OpenAI,
+		[]schemas.Key{{ID: "key-a"}},
+		[]string{"custom-model"},
+		[]string{"custom-model"},
+	)
+	h.inMemoryStore.ModelCatalog = modelCatalogForPricingJSON(t, []byte(gpt4oPricingJSON))
+	if err := h.inMemoryStore.ModelCatalog.SetPricingOverrides([]configstoreTables.TablePricingOverride{{
+		ID:               "custom-1",
+		ScopeKind:        string(modelcatalog.ScopeKindGlobal),
+		MatchType:        string(modelcatalog.MatchTypeExact),
+		Pattern:          "custom-model",
+		RequestTypes:     []schemas.RequestType{schemas.ChatCompletionRequest},
+		PricingPatchJSON: `{"input_cost_per_token":0.000009}`,
+	}}); err != nil {
+		t.Fatalf("seed overrides: %v", err)
+	}
+
+	resp, _ := listModelDetailsForTest(t, h, "/api/models/details?provider=openai&limit=100")
+
+	m := resp.Models[0]
+	if m.InputCostPerToken != nil {
+		t.Fatalf("expected no base pricing, got %#v", m.InputCostPerToken)
+	}
+	if m.OverriddenPricing == nil || m.OverriddenPricing.InputCostPerToken == nil ||
+		*m.OverriddenPricing.InputCostPerToken != 0.000009 {
+		t.Fatalf("expected override-only pricing, got %#v", m.OverriddenPricing)
+	}
+}
+
+func TestListModelDetails_VirtualKeyScopedOverrideIsInformationalOnly(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	vkID := "vk-1"
+	h := providerHandlerForTest(schemas.OpenAI, []schemas.Key{{ID: "key-a"}}, []string{"gpt-4o"}, []string{"gpt-4o"})
+	h.inMemoryStore.ModelCatalog = modelCatalogForPricingJSON(t, []byte(gpt4oPricingJSON))
+	if err := h.inMemoryStore.ModelCatalog.SetPricingOverrides([]configstoreTables.TablePricingOverride{{
+		ID:               "vk-scoped",
+		ScopeKind:        string(modelcatalog.ScopeKindVirtualKey),
+		VirtualKeyID:     &vkID,
+		MatchType:        string(modelcatalog.MatchTypeExact),
+		Pattern:          "gpt-4o",
+		RequestTypes:     []schemas.RequestType{schemas.ChatCompletionRequest},
+		PricingPatchJSON: `{"input_cost_per_token":0.000001}`,
+	}}); err != nil {
+		t.Fatalf("seed overrides: %v", err)
+	}
+
+	resp, _ := listModelDetailsForTest(t, h, "/api/models/details?provider=openai&limit=100")
+
+	m := resp.Models[0]
+	if m.OverriddenPricing != nil || m.AppliedOverrideID != "" {
+		t.Fatalf("virtual-key scoped overrides must not change the displayed price, got %#v", m.OverriddenPricing)
+	}
+	if len(m.PricingOverrideIDs) != 1 || m.PricingOverrideIDs[0] != "vk-scoped" {
+		t.Fatalf("expected the override listed informationally, got %#v", m.PricingOverrideIDs)
+	}
+}
+
+// Provider scope is the only non-global scope that changes the displayed price,
+// so it is the only case that pins the provider argument threaded into
+// GetCatalogPricingOverrides. The global-scope tests above would pass even if
+// that argument were wrong. The mismatched anthropic override must not surface
+// at all — not even informationally.
+func TestListModelDetails_AppliesProviderScopedOverride(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	openaiID := "openai"
+	anthropicID := "anthropic"
+	h := providerHandlerForTest(schemas.OpenAI, []schemas.Key{{ID: "key-a"}}, []string{"gpt-4o"}, []string{"gpt-4o"})
+	h.inMemoryStore.ModelCatalog = modelCatalogForPricingJSON(t, []byte(gpt4oPricingJSON))
+	if err := h.inMemoryStore.ModelCatalog.SetPricingOverrides([]configstoreTables.TablePricingOverride{
+		{
+			ID:               "provider-openai",
+			Name:             "OpenAI rate",
+			ScopeKind:        string(modelcatalog.ScopeKindProvider),
+			ProviderID:       &openaiID,
+			MatchType:        string(modelcatalog.MatchTypeExact),
+			Pattern:          "gpt-4o",
+			RequestTypes:     []schemas.RequestType{schemas.ChatCompletionRequest},
+			PricingPatchJSON: `{"input_cost_per_token":0.000002}`,
+		},
+		{
+			ID:               "provider-anthropic",
+			Name:             "Anthropic rate",
+			ScopeKind:        string(modelcatalog.ScopeKindProvider),
+			ProviderID:       &anthropicID,
+			MatchType:        string(modelcatalog.MatchTypeExact),
+			Pattern:          "gpt-4o",
+			RequestTypes:     []schemas.RequestType{schemas.ChatCompletionRequest},
+			PricingPatchJSON: `{"input_cost_per_token":0.000009}`,
+		},
+	}); err != nil {
+		t.Fatalf("seed overrides: %v", err)
+	}
+
+	resp, _ := listModelDetailsForTest(t, h, "/api/models/details?provider=openai&limit=100")
+
+	if len(resp.Models) != 1 {
+		t.Fatalf("expected one model, got %#v", resp.Models)
+	}
+	m := resp.Models[0]
+	if m.InputCostPerToken == nil || *m.InputCostPerToken != 0.0000025 {
+		t.Fatalf("base input cost must stay unchanged, got %#v", m.InputCostPerToken)
+	}
+	if m.OverriddenPricing == nil || m.OverriddenPricing.InputCostPerToken == nil ||
+		*m.OverriddenPricing.InputCostPerToken != 0.000002 {
+		t.Fatalf("expected provider-scoped override to set input cost 0.000002, got %#v", m.OverriddenPricing)
+	}
+	if m.AppliedOverrideID != "provider-openai" {
+		t.Fatalf("expected applied override provider-openai, got %q", m.AppliedOverrideID)
+	}
+	if len(m.PricingOverrideIDs) != 1 || m.PricingOverrideIDs[0] != "provider-openai" {
+		t.Fatalf("anthropic-scoped override must not surface for an openai model, got %#v", m.PricingOverrideIDs)
+	}
+	if _, ok := resp.PricingOverrides["provider-anthropic"]; ok {
+		t.Fatalf("override index must not carry the mismatched provider: %#v", resp.PricingOverrides)
+	}
+	summary, ok := resp.PricingOverrides["provider-openai"]
+	if !ok {
+		t.Fatalf("override index missing provider-openai: %#v", resp.PricingOverrides)
+	}
+	if summary.Name != "OpenAI rate" {
+		t.Fatalf("unexpected override summary %#v", summary)
+	}
+}
+
 // --- VK-based filtering tests ---
 
 // TestParseVKValueFromRequest verifies that the VK value is extracted from each


### PR DESCRIPTION
## Summary

Exposes pricing override information in the `listModelDetails` API response so the UI can display which models have negotiated or custom rates applied, and strike through only the specific cost fields that differ from the catalog baseline.

## Changes

- Added `OverriddenPricing`, `AppliedOverrideID`, and `PricingOverrideIDs` fields to `ModelDetailsResponse`. `OverriddenPricing` carries post-override values only for fields the applied override actually changes; unaffected fields are omitted so the client knows exactly which prices to strike through.
- Added `ModelOverriddenPricing` struct holding the four displayed cost fields (`input_cost_per_token`, `output_cost_per_token`, `cache_creation_input_token_cost`, `cache_read_input_token_cost`) as nullable pointers.
- Added `ModelPricingOverrideSummary` struct and a top-level `PricingOverrides` map on `ListModelDetailsResponse`. Overrides are deduplicated at the response level rather than inlined per row — a single wildcard override matching every model is serialized once regardless of page size.
- Only global and provider-scoped overrides populate `OverriddenPricing`/`AppliedOverrideID`; virtual-key, user, and provider-key scoped overrides appear in `PricingOverrideIDs` for informational display only.
- A patch that sets a cost field to its existing catalog value is not treated as an override (no strike-through for identical numbers).
- Override resolution uses the model's catalog pricing mode (defaulting to `"chat"`) so an override scoped to a different mode never affects the displayed row.
- Added `buildOverriddenPricing`, `changedCost`, and `toPricingOverrideSummary` helpers to keep the handler loop readable.
- Added six focused tests covering: global override application without mutating base pricing, deduplication of the override index across multiple models, omission of new fields when no overrides exist, no-op patches that match the base value, overrides on models absent from the catalog, and virtual-key scoped overrides being informational only.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/handlers/... -run TestListModelDetails
```

Expected: all six new `TestListModelDetails_*` tests pass alongside the existing pricing tests.

To validate end-to-end, seed a global pricing override via the config store and call `GET /api/models/details?provider=openai`. Confirm:
- `overridden_pricing` appears only on models matched by the override and only for fields with a changed value.
- `pricing_overrides` at the response root contains one entry per unique override ID, not one per model row.
- Virtual-key scoped overrides appear in `pricing_override_ids` but do not set `overridden_pricing` or `applied_override_id`.

## Breaking changes

- [ ] Yes
- [x] No

New fields are additive and omitempty; existing consumers are unaffected.

## Security considerations

Override data returned is read-only metadata already accessible to authenticated callers of the model details endpoint. No new secrets or PII are introduced; virtual key IDs and user IDs present in override summaries are already stored in the config store and gated by existing auth middleware.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable