### PR TITLE
feat(ui): show overridden pricing in the model catalog

### DIFF
--- a/ui/app/workspace/custom-pricing/overrides/pricingFields.test.ts
+++ b/ui/app/workspace/custom-pricing/overrides/pricingFields.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import { PRICING_FIELDS, pricingFieldUnit } from "./pricingFields";
+
+describe("pricingFieldUnit", () => {
+	// Character-priced fields carry a "/ character" label, so rendering them
+	// with the token formatter's "/ 1M tokens" suffix names the wrong unit.
+	it("classifies character-priced fields separately from token-priced ones", () => {
+		expect(pricingFieldUnit("input_cost_per_character")).toBe("character");
+	});
+
+	it("classifies token-priced fields, including cache and modality-specific ones", () => {
+		for (const key of [
+			"input_cost_per_token",
+			"output_cost_per_token",
+			"cache_read_input_token_cost",
+			"cache_creation_input_token_cost",
+			"cache_creation_input_audio_token_cost",
+			"cache_read_input_image_token_cost",
+			"input_cost_per_audio_token",
+			"output_cost_per_audio_token",
+			"input_cost_per_image_token",
+			"output_cost_per_image_token",
+		]) {
+			expect(pricingFieldUnit(key), key).toBe("token");
+		}
+	});
+
+	it("keeps the token unit across context-tier and service-tier suffixes", () => {
+		for (const key of [
+			"input_cost_per_token_above_128k_tokens",
+			"cache_read_input_token_cost_above_200k_tokens",
+			"cache_read_input_token_cost_above_200k_tokens_priority",
+			"cache_creation_input_token_cost_above_1hr_fast",
+			"cache_read_input_token_cost_flex_above_272k_tokens",
+		]) {
+			expect(pricingFieldUnit(key), key).toBe("token");
+		}
+	});
+
+	// The trap: these price per second/image/video, but their context-tier
+	// suffix mentions tokens. A bare "contains token" rule gets them wrong.
+	it("does not treat a tokens-based context tier as a token-priced unit", () => {
+		for (const key of [
+			"input_cost_per_audio_per_second_above_128k_tokens",
+			"input_cost_per_image_above_128k_tokens",
+			"input_cost_per_video_per_second_above_128k_tokens",
+		]) {
+			expect(pricingFieldUnit(key), key).toBe("currency");
+		}
+	});
+
+	it("classifies the geo multiplier as a multiplier, not currency", () => {
+		expect(pricingFieldUnit("inference_geo_us_multiplier")).toBe("multiplier");
+	});
+
+	it("classifies flat and per-unit costs as currency", () => {
+		for (const key of [
+			"cost_per_request",
+			"input_cost_per_second",
+			"output_cost_per_pixel",
+			"input_cost_per_image",
+			"ocr_cost_per_page",
+			"annotation_cost_per_page",
+			"search_context_cost_per_query",
+			"code_interpreter_cost_per_session",
+			"output_cost_per_image_high_quality",
+		]) {
+			expect(pricingFieldUnit(key), key).toBe("currency");
+		}
+	});
+
+	// Guards future additions: every catalogued field must resolve to a unit,
+	// and only the one known multiplier may be non-currency/non-token.
+	it("resolves a unit for every catalogued pricing field", () => {
+		const byUnit: Record<string, string[]> = { token: [], currency: [], multiplier: [], character: [] };
+		for (const field of PRICING_FIELDS) {
+			const unit = pricingFieldUnit(field.key);
+			expect(byUnit[unit], `${field.key} resolved to unexpected unit ${unit}`).toBeDefined();
+			byUnit[unit].push(field.key);
+		}
+		expect(PRICING_FIELDS).toHaveLength(77);
+		expect(byUnit.multiplier).toEqual(["inference_geo_us_multiplier"]);
+		expect(byUnit.character).toEqual(["input_cost_per_character"]);
+		// Sanity: the split is real, not everything collapsing into one bucket.
+		expect(byUnit.token.length).toBeGreaterThan(20);
+		expect(byUnit.currency.length).toBeGreaterThan(20);
+	});
+});

--- a/ui/app/workspace/custom-pricing/overrides/pricingFields.ts
+++ b/ui/app/workspace/custom-pricing/overrides/pricingFields.ts
@@ -511,6 +511,28 @@ export const PRICING_FIELDS = [
 	},
 ] as const;
 
+/** What a pricing field's number means, which decides how it is rendered. */
+export type PricingFieldUnit = "token" | "character" | "currency" | "multiplier";
+
+/**
+ * Classifies a pricing field key by unit.
+ *
+ * Note the `_above_NNNk_tokens` strip: those suffixes name the *context tier* a
+ * rate applies above, not the unit being priced. Without removing them first,
+ * fields like `input_cost_per_audio_per_second_above_128k_tokens` and
+ * `input_cost_per_image_above_128k_tokens` look token-priced when they are
+ * priced per second and per image.
+ */
+export function pricingFieldUnit(key: string): PricingFieldUnit {
+	if (key.endsWith("_multiplier")) return "multiplier";
+	const withoutContextTier = key.replace(/_above_\d+k_tokens/g, "");
+	// Before the token check: character-priced fields are scaled per 1M like
+	// token pricing, but naming their unit "tokens" contradicts their label.
+	if (withoutContextTier.includes("_per_character")) return "character";
+	if (withoutContextTier.includes("token")) return "token";
+	return "currency";
+}
+
 export type PricingFieldKey = (typeof PRICING_FIELDS)[number]["key"];
 
 export const fieldLabelByKey = Object.fromEntries(PRICING_FIELDS.map((field) => [field.key, field.label])) as Record<

--- a/ui/app/workspace/model-catalog/views/attributeSheet.tsx
+++ b/ui/app/workspace/model-catalog/views/attributeSheet.tsx
@@ -1,3 +1,4 @@
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -5,19 +6,44 @@ import { DottedSeparator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Textarea } from "@/components/ui/textarea";
 import { RenderProviderIcon } from "@/lib/constants/icons";
-import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
-import { getErrorMessage, ModelDetails, useGetCoreConfigQuery, useUpsertModelCatalogEntriesMutation } from "@/lib/store";
+import { ProviderLabels, ProviderName, RequestTypeLabels } from "@/lib/constants/logs";
+import {
+	getErrorMessage,
+	ModelDetails,
+	ModelPricingOverrideSummary,
+	useGetCoreConfigQuery,
+	useUpsertModelCatalogEntriesMutation,
+} from "@/lib/store";
 import { KnownProvider } from "@/lib/types/config";
-import { formatTokenPriceFull } from "@/lib/utils/numbers";
+import { PricingOverrideScopeKind } from "@/lib/types/governance";
+import { formatCharacterPriceFull, formatTokenPriceFull } from "@/lib/utils/numbers";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { Link } from "@tanstack/react-router";
 import { ExternalLink, Plus, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
+import { fieldLabelByKey, PricingFieldKey, pricingFieldUnit } from "../../custom-pricing/overrides/pricingFields";
+import OverriddenPrice from "./overriddenPrice";
 
 const DEFAULT_PRICING_SOURCE_URL = "https://getbifrost.ai/datasheet";
 
+// Scopes whose overrides can't be resolved from the model catalog alone — they
+// only apply to requests carrying the matching virtual key, user, or provider
+// key, so they are listed here but never change the displayed price.
+const SCOPE_CAVEATS: Partial<Record<PricingOverrideScopeKind, string>> = {
+	provider_key: "Applies only to requests routed through the matching provider key.",
+	virtual_key: "Applies only to requests using the matching virtual key.",
+	virtual_key_provider: "Applies only to requests using the matching virtual key and provider.",
+	virtual_key_provider_key: "Applies only to requests using the matching virtual key and provider key.",
+	user: "Applies only to requests from the matching user.",
+	user_provider: "Applies only to requests from the matching user and provider.",
+	user_provider_key: "Applies only to requests from the matching user and provider key.",
+};
+
 interface AttributeSheetProps {
 	model: ModelDetails;
+	/** Overrides referenced by `model.pricing_override_ids`, keyed by ID. */
+	overrides?: Record<string, ModelPricingOverrideSummary>;
 	onClose: () => void;
 }
 
@@ -58,7 +84,24 @@ function getPricingSourceUrl(configuredUrl: string | undefined, modelName: strin
 	return url.toString();
 }
 
-export default function AttributeSheet({ model, onClose }: AttributeSheetProps) {
+// formatPatchValue renders a patch value in its field's own unit: the way the
+// pricing table does for token-priced fields, as a bare multiplier for the geo
+// multiplier, and as a plain dollar amount for everything else (per-image,
+// per-second, per-page, …).
+function formatPatchValue(key: string, value: number): string {
+	switch (pricingFieldUnit(key)) {
+		case "token":
+			return formatTokenPriceFull(value);
+		case "character":
+			return formatCharacterPriceFull(value);
+		case "multiplier":
+			return `${value}×`;
+		default:
+			return `$${value}`;
+	}
+}
+
+export default function AttributeSheet({ model, overrides, onClose }: AttributeSheetProps) {
 	const [isOpen, setIsOpen] = useState(true);
 	const hasUpdateAccess = useRbac(RbacResource.ModelProvider, RbacOperation.Update);
 	const { data: bifrostConfig } = useGetCoreConfigQuery({ fromDB: true });
@@ -67,6 +110,14 @@ export default function AttributeSheet({ model, onClose }: AttributeSheetProps) 
 
 	const initialDescription = model.additional_attributes?.description ?? "";
 	const [description, setDescription] = useState(initialDescription);
+
+	// Overrides arrive as IDs into a response-level index; skip any that went
+	// missing (e.g. deleted in another tab before this list refreshed).
+	const matchingOverrides = useMemo(
+		() => (model.pricing_override_ids ?? []).map((id) => overrides?.[id]).filter((o): o is ModelPricingOverrideSummary => !!o),
+		[model.pricing_override_ids, overrides],
+	);
+	const appliedOverrideName = model.applied_override_id ? overrides?.[model.applied_override_id]?.name : undefined;
 
 	const initialRows = useMemo(() => rowsFromAttributes(model.additional_attributes), [model.additional_attributes]);
 	const stripIds = (rows: AttributeRow[]) => rows.map(({ key, value }) => ({ key, value }));
@@ -198,29 +249,109 @@ export default function AttributeSheet({ model, onClose }: AttributeSheetProps) 
 								<div className="bg-muted/30 rounded-sm border px-3 py-2">
 									<p className="text-muted-foreground text-xs">Input</p>
 									<p className="mt-1 font-mono text-sm" data-testid="model-catalog-input-cost">
-										{formatTokenPriceFull(model.input_cost_per_token)}
+										<OverriddenPrice
+											variant="full"
+											base={model.input_cost_per_token}
+											override={model.overridden_pricing?.input_cost_per_token}
+											overrideName={appliedOverrideName}
+										/>
 									</p>
 								</div>
 								<div className="bg-muted/30 rounded-sm border px-3 py-2">
 									<p className="text-muted-foreground text-xs">Output</p>
 									<p className="mt-1 font-mono text-sm" data-testid="model-catalog-output-cost">
-										{formatTokenPriceFull(model.output_cost_per_token)}
+										<OverriddenPrice
+											variant="full"
+											base={model.output_cost_per_token}
+											override={model.overridden_pricing?.output_cost_per_token}
+											overrideName={appliedOverrideName}
+										/>
 									</p>
 								</div>
 								<div className="bg-muted/30 rounded-sm border px-3 py-2">
 									<p className="text-muted-foreground text-xs">Cache Write</p>
 									<p className="mt-1 font-mono text-sm" data-testid="model-catalog-cache-write-cost">
-										{formatTokenPriceFull(model.cache_creation_input_token_cost)}
+										<OverriddenPrice
+											variant="full"
+											base={model.cache_creation_input_token_cost}
+											override={model.overridden_pricing?.cache_creation_input_token_cost}
+											overrideName={appliedOverrideName}
+										/>
 									</p>
 								</div>
 								<div className="bg-muted/30 rounded-sm border px-3 py-2">
 									<p className="text-muted-foreground text-xs">Cache Read</p>
 									<p className="mt-1 font-mono text-sm" data-testid="model-catalog-cache-read-cost">
-										{formatTokenPriceFull(model.cache_read_input_token_cost)}
+										<OverriddenPrice
+											variant="full"
+											base={model.cache_read_input_token_cost}
+											override={model.overridden_pricing?.cache_read_input_token_cost}
+											overrideName={appliedOverrideName}
+										/>
 									</p>
 								</div>
 							</div>
 						</div>
+
+						{matchingOverrides.length > 0 && (
+							<>
+								<DottedSeparator />
+
+								{/* Pricing overrides */}
+								<div className="space-y-3" data-testid="model-catalog-pricing-overrides">
+									<div className="flex items-center justify-between gap-3">
+										<Label className="text-sm font-medium">Pricing overrides</Label>
+										<Link
+											to="/workspace/custom-pricing/overrides"
+											className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs"
+										>
+											Manage
+											<ExternalLink className="h-3 w-3" />
+										</Link>
+									</div>
+									{matchingOverrides.map((override) => {
+										const caveat = SCOPE_CAVEATS[override.scope_kind];
+										const patchEntries = Object.entries(override.patch).filter(([, value]) => value !== undefined && value !== null);
+										return (
+											<div
+												key={override.id}
+												className="bg-muted/30 space-y-2 rounded-sm border px-3 py-2"
+												data-testid={`model-catalog-pricing-override-${override.id}`}
+											>
+												<div className="flex flex-wrap items-center gap-2">
+													<span className="text-sm font-medium">{override.name || override.id}</span>
+													<Badge variant="secondary">{override.scope_kind}</Badge>
+													{override.id === model.applied_override_id && <Badge variant="outline">Applied</Badge>}
+												</div>
+												<p className="text-muted-foreground font-mono text-xs">
+													{override.match_type === "wildcard" ? "Matches" : "Exact"} {override.pattern}
+												</p>
+												{caveat && <p className="text-muted-foreground text-xs">{caveat}</p>}
+												{override.request_types && override.request_types.length > 0 && (
+													<div className="flex flex-wrap gap-1">
+														{override.request_types.map((rt) => (
+															<Badge key={rt} variant="outline" className="text-[10px]">
+																{RequestTypeLabels[rt as keyof typeof RequestTypeLabels] ?? rt}
+															</Badge>
+														))}
+													</div>
+												)}
+												{patchEntries.length > 0 && (
+													<div className="space-y-1">
+														{patchEntries.map(([key, value]) => (
+															<div key={key} className="flex items-baseline justify-between gap-3 text-xs">
+																<span className="text-muted-foreground">{fieldLabelByKey[key as PricingFieldKey] || key}</span>
+																<span className="font-mono">{formatPatchValue(key, value as number)}</span>
+															</div>
+														))}
+													</div>
+												)}
+											</div>
+										);
+									})}
+								</div>
+							</>
+						)}
 
 						<DottedSeparator />
 

--- a/ui/app/workspace/model-catalog/views/attributesTab.tsx
+++ b/ui/app/workspace/model-catalog/views/attributesTab.tsx
@@ -10,11 +10,11 @@ import { RenderProviderIcon } from "@/lib/constants/icons";
 import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
 import { ModelDetails, useGetModelDetailsQuery, useGetProvidersQuery } from "@/lib/store";
 import { KnownProvider } from "@/lib/types/config";
-import { formatTokenPriceCompact } from "@/lib/utils/numbers";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { ChevronLeft, ChevronRight, Edit, Search } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import AttributeSheet from "./attributeSheet";
+import OverriddenPrice from "./overriddenPrice";
 
 const PAGE_SIZE = 25;
 
@@ -74,6 +74,7 @@ export default function AttributesTab({ hasAccess }: AttributesTabProps) {
 
 	const models = data?.models ?? [];
 	const totalCount = data?.total ?? 0;
+	const overridesById = useMemo(() => data?.pricing_overrides ?? {}, [data?.pricing_overrides]);
 
 	// Snap offset back when total shrinks past current page
 	useEffect(() => {
@@ -106,7 +107,7 @@ export default function AttributesTab({ hasAccess }: AttributesTabProps) {
 
 	return (
 		<>
-			{editing && <AttributeSheet model={editing} onClose={() => setEditing(null)} />}
+			{editing && <AttributeSheet model={editing} overrides={overridesById} onClose={() => setEditing(null)} />}
 
 			<div className="flex min-h-0 w-full grow flex-col overflow-hidden">
 				<div className="mb-4 flex shrink-0 items-center justify-between">
@@ -149,13 +150,13 @@ export default function AttributesTab({ hasAccess }: AttributesTabProps) {
 							<TableRow className="hover:bg-transparent">
 								<TableHead className="w-[116px] font-medium">Provider</TableHead>
 								<TableHead className="font-medium">Model</TableHead>
-								<TableHead className="w-[72px] px-2 text-right font-medium">Input</TableHead>
-								<TableHead className="w-[76px] px-2 text-right font-medium">Output</TableHead>
-								<TableHead className="w-[86px] px-2 text-right font-medium">Cache Write</TableHead>
-								<TableHead className="w-[80px] px-2 text-right font-medium">Cache Read</TableHead>
+								<TableHead className="w-[104px] px-2 text-right font-medium">Input</TableHead>
+								<TableHead className="w-[104px] px-2 text-right font-medium">Output</TableHead>
+								<TableHead className="w-[112px] px-2 text-right font-medium">Cache Write</TableHead>
+								<TableHead className="w-[108px] px-2 text-right font-medium">Cache Read</TableHead>
 								<TableHead className="font-medium">Description</TableHead>
 								<TableHead className="w-[68px] font-medium">Other</TableHead>
-								<TableHead className="w-[40px] px-1"></TableHead>
+								<TableHead className="w-[80px] px-1"></TableHead>
 							</TableRow>
 						</TableHeader>
 						<TableBody>
@@ -172,6 +173,8 @@ export default function AttributesTab({ hasAccess }: AttributesTabProps) {
 									const attrs = m.additional_attributes ?? {};
 									const extraKeys = Object.keys(attrs).filter((k) => k !== "description");
 									const testKey = `${toTestIdPart(m.name)}-${toTestIdPart(m.provider)}`;
+									const overrideName = m.applied_override_id ? overridesById[m.applied_override_id]?.name : undefined;
+									const overrideCount = m.pricing_override_ids?.length ?? 0;
 									return (
 										<TableRow key={`${m.provider}|${m.name}`} data-testid={`model-catalog-row-${testKey}`}>
 											<TableCell className="py-3">
@@ -184,34 +187,63 @@ export default function AttributesTab({ hasAccess }: AttributesTabProps) {
 												{m.name}
 											</TableCell>
 											<TableCell className="px-2 py-3 text-right font-mono text-sm">
-												{formatTokenPriceCompact(m.input_cost_per_token)}
+												<OverriddenPrice
+													variant="compact"
+													base={m.input_cost_per_token}
+													override={m.overridden_pricing?.input_cost_per_token}
+													overrideName={overrideName}
+												/>
 											</TableCell>
 											<TableCell className="px-2 py-3 text-right font-mono text-sm">
-												{formatTokenPriceCompact(m.output_cost_per_token)}
+												<OverriddenPrice
+													variant="compact"
+													base={m.output_cost_per_token}
+													override={m.overridden_pricing?.output_cost_per_token}
+													overrideName={overrideName}
+												/>
 											</TableCell>
 											<TableCell className="px-2 py-3 text-right font-mono text-sm">
-												{formatTokenPriceCompact(m.cache_creation_input_token_cost)}
+												<OverriddenPrice
+													variant="compact"
+													base={m.cache_creation_input_token_cost}
+													override={m.overridden_pricing?.cache_creation_input_token_cost}
+													overrideName={overrideName}
+												/>
 											</TableCell>
 											<TableCell className="px-2 py-3 text-right font-mono text-sm">
-												{formatTokenPriceCompact(m.cache_read_input_token_cost)}
+												<OverriddenPrice
+													variant="compact"
+													base={m.cache_read_input_token_cost}
+													override={m.overridden_pricing?.cache_read_input_token_cost}
+													overrideName={overrideName}
+												/>
 											</TableCell>
 											<TableCell className="py-3">
 												<DescriptionCell description={attrs.description} />
 											</TableCell>
 											<TableCell className="py-3">
-												{extraKeys.length === 0 ? (
+												{extraKeys.length === 0 && !overrideCount ? (
 													<span className="text-muted-foreground text-sm">—</span>
 												) : (
-													<Badge variant="secondary">
-														{extraKeys.length} {extraKeys.length === 1 ? "attribute" : "attributes"}
-													</Badge>
+													<div className="flex flex-wrap gap-1 pr-4">
+														{extraKeys.length > 0 && (
+															<Badge variant="secondary">
+																{extraKeys.length} {extraKeys.length === 1 ? "attribute" : "attributes"}
+															</Badge>
+														)}
+														{overrideCount > 0 && (
+															<Badge variant="outline" data-testid={`model-catalog-override-badge-${testKey}`}>
+																{overrideCount} {overrideCount === 1 ? "override" : "overrides"}
+															</Badge>
+														)}
+													</div>
 												)}
 											</TableCell>
 											<TableCell className="px-1 py-3">
 												<Button
 													variant="ghost"
 													size="icon"
-													className="h-7 w-7"
+													className="ml-6 h-7 w-7"
 													disabled={!hasUpdateAccess}
 													onClick={() => setEditing(m)}
 													aria-label={`Edit attributes for ${m.name}`}

--- a/ui/app/workspace/model-catalog/views/overriddenPrice.tsx
+++ b/ui/app/workspace/model-catalog/views/overriddenPrice.tsx
@@ -1,0 +1,53 @@
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { formatTokenPriceCompact, formatTokenPriceFull } from "@/lib/utils/numbers";
+
+interface OverriddenPriceProps {
+	/** Catalog price from governance_model_pricing. */
+	base?: number;
+	/** Post-override price. Undefined means this field is not overridden. */
+	override?: number;
+	variant: "compact" | "full";
+	/** Name of the override that produced `override`, shown in the tooltip. */
+	overrideName?: string;
+	testId?: string;
+}
+
+/**
+ * Renders a catalog price, striking it through and showing the effective price
+ * beside it when a pricing override changes that field. With no override it
+ * renders exactly what the plain formatter would, so unaffected rows are
+ * visually unchanged.
+ */
+export default function OverriddenPrice({ base, override, variant, overrideName, testId }: OverriddenPriceProps) {
+	const format = variant === "compact" ? formatTokenPriceCompact : formatTokenPriceFull;
+
+	if (override === undefined || override === null) {
+		return <span data-testid={testId}>{format(base)}</span>;
+	}
+
+	return (
+		<TooltipProvider>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					{/* Focusable so keyboard users can reach the tooltip naming the override. */}
+					<span
+						tabIndex={0}
+						className="focus-visible:ring-ring/50 inline-flex flex-wrap items-baseline justify-end gap-x-1.5 rounded-sm focus-visible:ring-[3px] focus-visible:outline-none"
+						data-testid={testId}
+					>
+						{/* The strikethrough is visual only, so name each value for screen readers. */}
+						<span className="text-muted-foreground text-xs line-through" data-testid={testId ? `${testId}-original` : undefined}>
+							<span className="sr-only">Original price: </span>
+							{format(base)}
+						</span>
+						<span data-testid={testId ? `${testId}-override` : undefined}>
+							<span className="sr-only">Effective price: </span>
+							{format(override)}
+						</span>
+					</span>
+				</TooltipTrigger>
+				<TooltipContent>{overrideName ? `Overridden by "${overrideName}"` : "Overridden by a custom pricing override"}</TooltipContent>
+			</Tooltip>
+		</TooltipProvider>
+	);
+}

--- a/ui/lib/store/apis/providersApi.ts
+++ b/ui/lib/store/apis/providersApi.ts
@@ -9,7 +9,7 @@ import {
 	UpdateProviderRequest,
 	UpdateProviderKeyRequest,
 } from "@/lib/types/config";
-import { DBKey } from "@/lib/types/governance";
+import { DBKey, PricingOverrideMatchType, PricingOverridePatch, PricingOverrideScopeKind } from "@/lib/types/governance";
 import { baseApi } from "./baseApi";
 
 function sortProviders(a: ModelProvider, b: ModelProvider) {
@@ -49,11 +49,46 @@ export interface ModelDetails {
 	architecture?: unknown;
 	additional_attributes?: Record<string, string>;
 	accessible_by_keys?: string[];
+	// Post-override value of each displayed cost, present only for the fields
+	// the applied override actually changes — render those struck through.
+	overridden_pricing?: ModelOverriddenPricing;
+	// Which override produced overridden_pricing.
+	applied_override_id?: string;
+	// Every override matching this model, including virtual-key/user/provider-key
+	// scoped ones that do NOT affect overridden_pricing (shown informationally).
+	// Resolve against ListModelDetailsResponse.pricing_overrides.
+	pricing_override_ids?: string[];
+}
+
+export interface ModelOverriddenPricing {
+	input_cost_per_token?: number;
+	output_cost_per_token?: number;
+	cache_creation_input_token_cost?: number;
+	cache_read_input_token_cost?: number;
+}
+
+// ModelPricingOverrideSummary mirrors PricingOverride but carries the patch
+// already parsed — /api/models/details returns an object where the governance
+// API returns a JSON string.
+export interface ModelPricingOverrideSummary {
+	id: string;
+	name: string;
+	scope_kind: PricingOverrideScopeKind;
+	user_id?: string;
+	virtual_key_id?: string;
+	provider_id?: string;
+	provider_key_id?: string;
+	match_type: PricingOverrideMatchType;
+	pattern: string;
+	request_types?: string[];
+	patch: PricingOverridePatch;
 }
 
 export interface ListModelDetailsResponse {
 	models: ModelDetails[];
 	total: number;
+	// Overrides referenced by any row, keyed by ID and deduplicated.
+	pricing_overrides?: Record<string, ModelPricingOverrideSummary>;
 }
 
 // ModelPricingAttributesEntry is the body element for PUT /api/models/catalog.
@@ -109,7 +144,9 @@ export interface ListBaseModelsResponse {
 	total: number;
 }
 
-type UpdateProviderMutationArg = UpdateProviderRequest & { name: ModelProviderName };
+type UpdateProviderMutationArg = UpdateProviderRequest & {
+	name: ModelProviderName;
+};
 
 const DEFAULT_MODEL_PARAMETERS: ModelDatasheetResponse = {
 	mode: "chat",
@@ -267,7 +304,11 @@ export const providersApi = baseApi.injectEndpoints({
 						providersApi.util.updateQueryData("getAllKeys", undefined, (draft) => {
 							const index = draft.findIndex((k) => k.key_id === keyId);
 							if (index !== -1) {
-								draft[index] = { ...draft[index], name: updatedKey.name, models: updatedKey.models ?? [] };
+								draft[index] = {
+									...draft[index],
+									name: updatedKey.name,
+									models: updatedKey.models ?? [],
+								};
 							}
 						}),
 					);
@@ -442,7 +483,13 @@ export const providersApi = baseApi.injectEndpoints({
 		// size (under 1500 rows).
 		getModelDetails: builder.query<
 			ListModelDetailsResponse,
-			{ query?: string; provider?: string; limit?: number; offset?: number; unfiltered?: boolean }
+			{
+				query?: string;
+				provider?: string;
+				limit?: number;
+				offset?: number;
+				unfiltered?: boolean;
+			}
 		>({
 			query: ({ query, provider, limit, offset, unfiltered }) => {
 				const params = new URLSearchParams();

--- a/ui/lib/utils/numbers.ts
+++ b/ui/lib/utils/numbers.ts
@@ -43,3 +43,9 @@ export function formatTokenPriceFull(cost?: number): string {
 	if (cost === undefined || cost === null) return "Not available";
 	return `${formatTokenPriceValue(cost)} / 1M tokens`;
 }
+
+/** Per-1M like token pricing, but for fields priced per character. */
+export function formatCharacterPriceFull(cost?: number): string {
+	if (cost === undefined || cost === null) return "Not available";
+	return `${formatTokenPriceValue(cost)} / 1M characters`;
+}


### PR DESCRIPTION
## Summary

Surfaces custom pricing overrides in the model catalog UI. When a pricing override is applied to a model, the catalog table and detail sheet now show the original price struck through alongside the effective overridden price, and the detail sheet lists every override that matches the model with its scope, pattern, patch values, and any applicable caveats.

## Changes

- Added a new `OverriddenPrice` component that renders a base price normally when no override is active, or shows the original price struck through with the effective price beside it and a tooltip naming the override that produced it.
- Replaced all plain `formatTokenPriceCompact` / `formatTokenPriceFull` calls in the catalog table and attribute sheet with `OverriddenPrice`, so overridden fields are visually distinguished without affecting unoverridden rows.
- Added a "Pricing overrides" section to `AttributeSheet` that lists every override matching the model (including virtual-key, user, and provider-key scoped ones that don't change the displayed price), showing scope kind, match pattern, request type badges, patch field values, and a caveat explaining when context-dependent overrides apply.
- Added an "overrides" badge to the "Other" column in the catalog table showing how many overrides match each model.
- Extended `ModelDetails` with `overridden_pricing`, `applied_override_id`, and `pricing_override_ids` fields, and added `ModelOverriddenPricing` and `ModelPricingOverrideSummary` types to the store.
- Extended `ListModelDetailsResponse` with a `pricing_overrides` index (keyed by ID) that the attributes tab resolves override IDs against, skipping any that were deleted between fetches.
- Added `formatPatchValue` to render per-token/per-character patch values with the full token price formatter and all other fields as plain dollar amounts.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Configure at least one custom pricing override that matches a model in the catalog (e.g. a global override reducing input cost).
2. Open the Model Catalog tab and confirm the affected model's input/output/cache columns show the original price struck through with the new price beside it.
3. Hover the overridden price and confirm the tooltip names the override.
4. Click the edit icon for that model and confirm the "Pricing overrides" section appears in the sheet, listing the override with its scope badge, pattern, patch values, and (for virtual-key/user/provider-key scopes) the contextual caveat.
5. Confirm models with no overrides render identically to before.
6. Confirm the "Other" column shows an "overrides" badge for models with matching overrides.

```sh
cd ui
pnpm i
pnpm build
```

## Screenshots/Recordings

_Add before/after screenshots showing the struck-through price in the table and the overrides section in the detail sheet.  
_![image.png](https://app.graphite.com/user-attachments/assets/524b122b-0fec-47a2-96c4-07974dffe847.png)

![image.png](https://app.graphite.com/user-attachments/assets/52c48e10-137a-459d-8576-cd8723c71c3c.png)



## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new auth surfaces. Override data is already gated by RBAC on the model provider resource; the UI reads it from the same endpoint and does not expose any new write paths.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable