### PR TITLE
[DO-NOT-MERGE-YET] fix: use correct "latest" route when fallbacks are configured

### DIFF
--- a/plugins/governance/complexitysession.go
+++ b/plugins/governance/complexitysession.go
@@ -38,6 +38,11 @@ var (
 // complexity-routed session. It deliberately carries no switching thresholds
 // or other policy; callers apply the current session config to these facts.
 type SessionRouteObservation struct {
+	// Tier is the complexity tier the session was published on when this route
+	// served. Cache evidence is only meaningful against the tier that produced
+	// it: a warm cache built while the session was on COMPLEX is not at risk when
+	// moving MEDIUM to SIMPLE, so a decision must not weigh it.
+	Tier string `json:"tier"`
 	// CachedReadTokens is the positive cached input-token count most recently
 	// observed for this route. Zero carries no cache-presence claim.
 	CachedReadTokens int `json:"cached_read_tokens"`
@@ -475,7 +480,7 @@ func updateSessionTierRecord(
 		return unswitchedSessionTierDecision(record, sessionTierReasonDowngradePending, recordChanged)
 	}
 
-	observation, ok := latestUsableSessionRouteObservation(record, now, config.TTL)
+	observation, ok := heldTierCacheEvidence(record, now, config.TTL)
 	if !ok || !observation.CacheObserved || observation.CachedReadTokens <= 0 {
 		return unswitchedSessionTierDecision(record, sessionTierReasonCacheStateUnknown, recordChanged)
 	}
@@ -549,32 +554,50 @@ func advancePendingSessionTier(record *SessionComplexityRecord, tier string, sco
 	return changed
 }
 
-// latestUsableSessionRouteObservation returns the freshest route fact that is
-// no newer than now and still within the session observation window. We use the
-// latest served route because tier selection happens before routing, so the
-// destination route for a proposed tier is not known yet.
+// heldTierCacheEvidence returns the strongest cache fact recorded for the tier
+// the session currently holds, ignoring facts that are stale, dated in the
+// future, or attributed to a tier the session has already left.
+//
+// It cannot simply ask about the route a switch would leave, because tier
+// selection happens before routing: the destination route for a proposed tier is
+// not known yet. What it can do is bound the question to the evidence that is
+// actually at risk.
 //
 // A stale fact is unknown, not cold: session TTL is not proof of a provider's
 // prompt-cache TTL, and guessing expiry could discard a still-warm cache.
-func latestUsableSessionRouteObservation(
+func heldTierCacheEvidence(
 	record *SessionComplexityRecord,
 	now time.Time,
 	ttl time.Duration,
 ) (SessionRouteObservation, bool) {
-	if record == nil || now.IsZero() || ttl <= 0 {
+	if record == nil || now.IsZero() || ttl <= 0 || record.Tier == "" {
 		return SessionRouteObservation{}, false
 	}
 
-	var latest SessionRouteObservation
+	// Two filters, and both are load-bearing.
+	//
+	// Only the held tier's observations count, because only that tier's cache is
+	// at risk from the move being considered. A warm cache recorded before an
+	// earlier switch belongs to a tier the session has already left.
+	//
+	// Within the tier the strongest evidence wins rather than the newest. A
+	// fallback that served one turn is the most recent observation and is cold by
+	// construction, so taking the newest would let a transient detour mask the
+	// primary route's warm cache and license a downgrade that discards it.
+	var strongest SessionRouteObservation
+	found := false
 	for _, observation := range record.RouteObservations {
-		if observation.LastSeenAt.After(latest.LastSeenAt) {
-			latest = observation
+		if observation.Tier != record.Tier {
+			continue
+		}
+		if observation.LastSeenAt.IsZero() || observation.LastSeenAt.After(now) || now.Sub(observation.LastSeenAt) > ttl {
+			continue
+		}
+		if !found || observation.CachedReadTokens > strongest.CachedReadTokens {
+			strongest, found = observation, true
 		}
 	}
-	if latest.LastSeenAt.IsZero() || latest.LastSeenAt.After(now) || now.Sub(latest.LastSeenAt) > ttl {
-		return SessionRouteObservation{}, false
-	}
-	return latest, true
+	return strongest, found
 }
 
 func switchedSessionTierDecision(

--- a/plugins/governance/complexitysession_test.go
+++ b/plugins/governance/complexitysession_test.go
@@ -768,6 +768,7 @@ func TestUpdateSessionTierRecordRequiresSustainedDowngrade(t *testing.T) {
 	config := sessionTierTestConfig()
 	record := sessionTierTestRecord(now)
 	record.RouteObservations["current-route"] = SessionRouteObservation{
+		Tier:             complexity.TierComplex,
 		CachedReadTokens: 128,
 		CacheObserved:    true,
 		LastSeenAt:       now.Add(-time.Minute),
@@ -820,6 +821,7 @@ func TestUpdateSessionTierRecordDowngradeCacheGate(t *testing.T) {
 		{
 			name: "ambiguous zero is unknown",
 			observed: map[string]SessionRouteObservation{"route": {
+				Tier:          complexity.TierComplex,
 				CacheObserved: true,
 				LastSeenAt:    now.Add(-time.Minute),
 			}},
@@ -828,6 +830,7 @@ func TestUpdateSessionTierRecordDowngradeCacheGate(t *testing.T) {
 		{
 			name: "stale observation is unknown without provider cache ttl",
 			observed: map[string]SessionRouteObservation{"route": {
+				Tier:             complexity.TierComplex,
 				CachedReadTokens: 128,
 				CacheObserved:    true,
 				LastSeenAt:       now.Add(-2 * time.Hour),
@@ -837,6 +840,7 @@ func TestUpdateSessionTierRecordDowngradeCacheGate(t *testing.T) {
 		{
 			name: "future observation is unknown",
 			observed: map[string]SessionRouteObservation{"route": {
+				Tier:             complexity.TierComplex,
 				CachedReadTokens: 128,
 				CacheObserved:    true,
 				LastSeenAt:       now.Add(time.Minute),
@@ -846,6 +850,7 @@ func TestUpdateSessionTierRecordDowngradeCacheGate(t *testing.T) {
 		{
 			name: "large cache holds tier",
 			observed: map[string]SessionRouteObservation{"route": {
+				Tier:             complexity.TierComplex,
 				CachedReadTokens: 4096,
 				CacheObserved:    true,
 				LastSeenAt:       now.Add(-time.Minute),
@@ -855,6 +860,7 @@ func TestUpdateSessionTierRecordDowngradeCacheGate(t *testing.T) {
 		{
 			name: "small positive cache permits downgrade",
 			observed: map[string]SessionRouteObservation{"route": {
+				Tier:             complexity.TierComplex,
 				CachedReadTokens: 128,
 				CacheObserved:    true,
 				LastSeenAt:       now.Add(-time.Minute),
@@ -863,21 +869,40 @@ func TestUpdateSessionTierRecordDowngradeCacheGate(t *testing.T) {
 			wantSwitch: true,
 		},
 		{
-			name: "freshest route observation wins",
+			// A fallback that served one turn is the newest observation and is
+			// cold by construction. Taking the newest let a transient detour mask
+			// the primary route's warm cache and license a downgrade that would
+			// discard it, so the strongest evidence in the tier wins instead.
+			name: "warm route outweighs a fresher cold fallback",
 			observed: map[string]SessionRouteObservation{
-				"older-warm": {
+				"primary-warm": {
+					Tier:             complexity.TierComplex,
 					CachedReadTokens: 4096,
 					CacheObserved:    true,
 					LastSeenAt:       now.Add(-2 * time.Minute),
 				},
-				"newer-small": {
+				"fallback-cold": {
+					Tier:             complexity.TierComplex,
 					CachedReadTokens: 128,
 					CacheObserved:    true,
 					LastSeenAt:       now.Add(-time.Minute),
 				},
 			},
-			wantReason: sessionTierReasonDowngraded,
-			wantSwitch: true,
+			wantReason: sessionTierReasonCacheWorthHolding,
+		},
+		{
+			// Cache built before an earlier switch belongs to a tier the session
+			// has left, and is not at risk from the move being considered.
+			name: "observation from a tier the session left is ignored",
+			observed: map[string]SessionRouteObservation{
+				"left-tier-warm": {
+					Tier:             complexity.TierSimple,
+					CachedReadTokens: 4096,
+					CacheObserved:    true,
+					LastSeenAt:       now.Add(-time.Minute),
+				},
+			},
+			wantReason: sessionTierReasonCacheStateUnknown,
 		},
 	}
 
@@ -911,6 +936,7 @@ func TestUpdateSessionTierRecordAvoidsRepeatedCacheHoldWrites(t *testing.T) {
 	record.PendingTurns = 2
 	record.PendingMinScore = 0.9
 	record.RouteObservations["route"] = SessionRouteObservation{
+		Tier:             complexity.TierComplex,
 		CachedReadTokens: 4096,
 		CacheObserved:    true,
 		LastSeenAt:       now.Add(-time.Minute),

--- a/plugins/governance/complexitysessionroute.go
+++ b/plugins/governance/complexitysessionroute.go
@@ -133,12 +133,20 @@ func (p *GovernancePlugin) recordSessionRouteObservation(
 	}
 	store := *stored
 
-	routeID := effectiveSessionRouteIdentity(ctx, provider, model)
+	// The tier this turn was published on. Without it the observation cannot be
+	// attributed, and an unattributed one is worse than none: it would be weighed
+	// against a tier it says nothing about.
+	tier := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceComplexityTier)
+	if tier == "" {
+		return
+	}
+	routeID := effectiveSessionRouteIdentity(ctx, tier, provider, model)
 	if routeID == "" {
 		return
 	}
 	cachedTokens, cacheObserved := sessionCachedReadTokens(result)
 	observation := SessionRouteObservation{
+		Tier:             tier,
 		CachedReadTokens: cachedTokens,
 		CacheObserved:    cacheObserved,
 		LastSeenAt:       time.Now(),
@@ -182,7 +190,7 @@ func applySessionRouteObservation(
 		record.RouteObservations = make(map[string]SessionRouteObservation, 1)
 	}
 	record.RouteObservations[routeID] = observation
-	boundSessionRouteObservations(record.RouteObservations, maxSessionRouteObservations)
+	boundSessionRouteObservations(record.RouteObservations, maxSessionRouteObservations, record.Tier)
 	return true
 }
 
@@ -235,19 +243,30 @@ func sessionCachedTokensMateriallyChanged(previous, next int) bool {
 	return float64(delta) > float64(previous)*sessionObservationChangeRatio
 }
 
-// boundSessionRouteObservations evicts the least recently seen routes until the
-// map fits. Recency is the right axis: a route not seen for a while is not the
-// one a switch would be giving up.
-func boundSessionRouteObservations(observations map[string]SessionRouteObservation, limit int) {
+// boundSessionRouteObservations evicts observations until the map fits, taking
+// the least recently seen first within whichever group is evictable.
+//
+// heldTier is the tier the session is currently on. Its observations are evicted
+// last: they are the only ones a switch decision reads, so dropping them to make
+// room for a tier the session has already left would blind the very decision
+// this history exists to inform. Scoping identities by tier multiplies the key
+// space, which makes reaching the limit realistic rather than theoretical.
+func boundSessionRouteObservations(observations map[string]SessionRouteObservation, limit int, heldTier string) {
 	for len(observations) > limit {
-		oldestKey := ""
-		var oldestSeen time.Time
+		evictKey := ""
+		var evictSeen time.Time
+		evictingHeld := true
 		for key, observation := range observations {
-			if oldestKey == "" || observation.LastSeenAt.Before(oldestSeen) {
-				oldestKey, oldestSeen = key, observation.LastSeenAt
+			isHeld := observation.Tier == heldTier
+			// Prefer any non-held observation over every held one, and among
+			// equals take the least recently seen.
+			if evictKey == "" ||
+				(evictingHeld && !isHeld) ||
+				(evictingHeld == isHeld && observation.LastSeenAt.Before(evictSeen)) {
+				evictKey, evictSeen, evictingHeld = key, observation.LastSeenAt, isHeld
 			}
 		}
-		delete(observations, oldestKey)
+		delete(observations, evictKey)
 	}
 }
 
@@ -255,12 +274,17 @@ func boundSessionRouteObservations(observations map[string]SessionRouteObservati
 // is not necessarily the one routing selected: a fallback changes provider and
 // model, and key rotation changes which cache is warm. The value is hashed
 // because callers only ever compare identities, and the record replicates.
-func effectiveSessionRouteIdentity(ctx *schemas.BifrostContext, provider schemas.ModelProvider, model string) string {
+//
+// The tier is part of the identity, not just a field on the observation. Nothing
+// stops two tiers resolving to the same provider and model, and sharing a key
+// would let the later tier's observation overwrite the earlier one's — silently
+// attributing one tier's cache evidence to another.
+func effectiveSessionRouteIdentity(ctx *schemas.BifrostContext, tier string, provider schemas.ModelProvider, model string) string {
 	keyID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedKeyID)
 	if provider == "" && model == "" && keyID == "" {
 		return ""
 	}
-	return complexitySessionHash(string(provider) + "\x00" + model + "\x00" + keyID)
+	return complexitySessionHash(tier + "\x00" + string(provider) + "\x00" + model + "\x00" + keyID)
 }
 
 // sessionCachedReadTokens reports positive evidence of provider cache reuse.

--- a/plugins/governance/complexitysessionroute_test.go
+++ b/plugins/governance/complexitysessionroute_test.go
@@ -273,6 +273,7 @@ func TestWithComplexitySessionCacheAwareRequiresSustainedDowngrade(t *testing.T)
 		Tier:      complexity.TierComplex,
 		DecidedAt: time.Now().Add(-time.Minute),
 		RouteObservations: map[string]SessionRouteObservation{"route": {
+			Tier:             complexity.TierComplex,
 			CachedReadTokens: 128,
 			CacheObserved:    true,
 			LastSeenAt:       time.Now(),
@@ -629,8 +630,13 @@ func sessionWithObservations(t *testing.T) (*GovernancePlugin, *kvSessionStore, 
 	ctx := sessionTestContext(t, "session-abc")
 	state := p.resolveComplexitySessionState(ctx, nil)
 	require.NotNil(t, state)
-	_, err := sessionStore.Create(context.Background(), state.Key, &SessionComplexityRecord{Tier: "COMPLEX"}, state.Config.TTL)
+	_, err := sessionStore.Create(context.Background(), state.Key, &SessionComplexityRecord{Tier: complexity.TierComplex}, state.Config.TTL)
 	require.NoError(t, err)
+	// The tier this turn published. The request path sets it before the response
+	// hook runs; an observation that cannot be attributed to a tier is dropped,
+	// because weighing it against a tier it says nothing about is worse than
+	// having no observation at all.
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexityTier, complexity.TierComplex)
 	return p, sessionStore, state, ctx
 }
 
@@ -719,8 +725,9 @@ func TestRecordSessionRouteObservationDoesNotWriteWhenUnchanged(t *testing.T) {
 	ctx := sessionTestContext(t, "session-abc")
 	state := p.resolveComplexitySessionState(ctx, nil)
 	require.NotNil(t, state)
-	_, err := sessionStore.Create(context.Background(), state.Key, &SessionComplexityRecord{Tier: "COMPLEX"}, state.Config.TTL)
+	_, err := sessionStore.Create(context.Background(), state.Key, &SessionComplexityRecord{Tier: complexity.TierComplex}, state.Config.TTL)
 	require.NoError(t, err)
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexityTier, complexity.TierComplex)
 
 	response := chatResponseWithCacheDetails(4096, true)
 	p.recordSessionRouteObservation(ctx, response, schemas.OpenAI, "gpt-4o", true)
@@ -849,12 +856,40 @@ func TestBoundSessionRouteObservationsEvictsLeastRecent(t *testing.T) {
 		}
 	}
 
-	boundSessionRouteObservations(observations, maxSessionRouteObservations)
+	boundSessionRouteObservations(observations, maxSessionRouteObservations, "")
 
 	require.Len(t, observations, maxSessionRouteObservations)
 	// The four oldest went; the most recent survived.
 	assert.NotContains(t, observations, "a")
 	assert.Contains(t, observations, string(rune('a'+maxSessionRouteObservations+3)))
+}
+
+// Only the held tier's observations are ever read by a switch decision, so
+// evicting them to make room for a tier the session has already left would blind
+// the decision this history exists to inform.
+func TestBoundSessionRouteObservationsKeepsHeldTierLast(t *testing.T) {
+	now := time.Now()
+	observations := map[string]SessionRouteObservation{}
+	// The held tier's entries are the oldest, so plain LRU would evict them first.
+	for i := 0; i < 3; i++ {
+		observations["held-"+string(rune('a'+i))] = SessionRouteObservation{
+			Tier:       complexity.TierComplex,
+			LastSeenAt: now.Add(time.Duration(i) * time.Minute),
+		}
+	}
+	for i := 0; i < maxSessionRouteObservations; i++ {
+		observations["left-"+string(rune('a'+i))] = SessionRouteObservation{
+			Tier:       complexity.TierSimple,
+			LastSeenAt: now.Add(time.Duration(100+i) * time.Minute),
+		}
+	}
+
+	boundSessionRouteObservations(observations, maxSessionRouteObservations, complexity.TierComplex)
+
+	require.Len(t, observations, maxSessionRouteObservations)
+	for i := 0; i < 3; i++ {
+		assert.Contains(t, observations, "held-"+string(rune('a'+i)), "an observation for the held tier was evicted")
+	}
 }
 
 func TestSessionCachedTokensMateriallyChanged(t *testing.T) {
@@ -866,4 +901,59 @@ func TestSessionCachedTokensMateriallyChanged(t *testing.T) {
 	assert.False(t, sessionCachedTokensMateriallyChanged(4096, 4200))
 	// A large move is.
 	assert.True(t, sessionCachedTokensMateriallyChanged(4096, 8192))
+}
+
+// Two tiers can resolve to the same provider and model, so the tier has to be
+// part of the observation key. Sharing one would let the later tier's cache
+// evidence silently overwrite the earlier tier's.
+func TestEffectiveSessionRouteIdentitySeparatesTiers(t *testing.T) {
+	ctx := sessionTestContext(t, "session-abc")
+
+	complexRoute := effectiveSessionRouteIdentity(ctx, complexity.TierComplex, schemas.OpenAI, "gpt-4o")
+	mediumRoute := effectiveSessionRouteIdentity(ctx, complexity.TierMedium, schemas.OpenAI, "gpt-4o")
+
+	require.NotEmpty(t, complexRoute)
+	assert.NotEqual(t, complexRoute, mediumRoute, "one route served two tiers under a single key")
+}
+
+// An observation recorded while the session was on a different tier describes a
+// cache that the move under consideration would not discard, so it must not
+// keep the session where it is.
+func TestRecordSessionRouteObservationAttributesTheHeldTier(t *testing.T) {
+	p, sessionStore, state, ctx := sessionWithObservations(t)
+
+	p.recordSessionRouteObservation(ctx, chatResponseWithCacheDetails(4096, true), schemas.OpenAI, "gpt-4o", true)
+
+	record, found, err := sessionStore.Get(context.Background(), state.Key, state.Config.TTL)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Len(t, record.RouteObservations, 1)
+	for _, observation := range record.RouteObservations {
+		assert.Equal(t, complexity.TierComplex, observation.Tier, "the observation was stored without a tier to attribute it to")
+	}
+
+	// The same route observed while the session sits on a lower tier is a
+	// separate fact, not an overwrite of the one above.
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexityTier, complexity.TierMedium)
+	p.recordSessionRouteObservation(ctx, chatResponseWithCacheDetails(64, true), schemas.OpenAI, "gpt-4o", true)
+
+	record, found, err = sessionStore.Get(context.Background(), state.Key, state.Config.TTL)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Len(t, record.RouteObservations, 2, "a second tier's observation overwrote the first")
+}
+
+// A turn that published no tier cannot be attributed, and an unattributed
+// observation is worse than none: it would be weighed against a tier it says
+// nothing about.
+func TestRecordSessionRouteObservationSkipsUnattributedTurns(t *testing.T) {
+	p, sessionStore, state, ctx := sessionWithObservations(t)
+	ctx.ClearValue(schemas.BifrostContextKeyGovernanceComplexityTier)
+
+	p.recordSessionRouteObservation(ctx, chatResponseWithCacheDetails(4096, true), schemas.OpenAI, "gpt-4o", true)
+
+	record, found, err := sessionStore.Get(context.Background(), state.Key, state.Config.TTL)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Empty(t, record.RouteObservations)
 }


### PR DESCRIPTION
## Summary

Cache evidence recorded while a session was on one complexity tier was being weighed against decisions about a different tier. This meant a warm cache built on COMPLEX could be ignored when the session moved to MEDIUM, or a cold fallback observation on the same tier could mask a primary route's warm cache and license a downgrade that would discard it.

## Changes

- Added a `Tier` field to `SessionRouteObservation` so every cache fact is attributed to the tier the session held when it was recorded.
- Replaced `latestUsableSessionRouteObservation` with `heldTierCacheEvidence`, which filters to only the current tier's observations and selects the strongest (highest cached token count) rather than the newest. The newest observation is often a cold fallback by construction, and taking it would let a transient detour mask the primary route's warm cache.
- Made `effectiveSessionRouteIdentity` include the tier in the hash key. Two tiers can resolve to the same provider and model; sharing a key would let the later tier's observation silently overwrite the earlier one's.
- Dropped observations that carry no tier attribution at the recording site. An unattributed observation is worse than none — it would be weighed against a tier it says nothing about.
- Updated `boundSessionRouteObservations` to evict non-held-tier observations before held-tier ones. Tier-scoped keys multiply the key space, making the limit realistic, and evicting held-tier observations to make room for a tier the session has already left would blind the switch decision this history exists to inform.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/...
```

New and updated test cases cover:
- `TestBoundSessionRouteObservationsKeepsHeldTierLast` — held-tier observations survive eviction when non-held ones are available.
- `TestEffectiveSessionRouteIdentitySeparatesTiers` — the same provider/model on two tiers produces distinct keys.
- `TestRecordSessionRouteObservationAttributesTheHeldTier` — observations from two tiers are stored as separate facts rather than overwriting each other.
- `TestRecordSessionRouteObservationSkipsUnattributedTurns` — turns with no tier in context produce no observation.
- The renamed `warm route outweighs a fresher cold fallback` case replaces the previous `freshest route observation wins` case, which encoded the incorrect behaviour.
- A new `observation from a tier the session left is ignored` case confirms cross-tier evidence does not gate a downgrade.

## Breaking changes

- [x] Yes
- [ ] No

`SessionRouteObservation` gains a required `Tier` field. Any persisted session records that predate this change will have observations with an empty tier, which `heldTierCacheEvidence` will filter out as unattributable. Affected sessions will treat cache state as unknown for one TTL window and then rebuild attribution normally. No migration is required.

## Security considerations

None beyond the existing session store access patterns.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable