### PR TITLE
feat: bedrock vpc endpoints support

### DIFF
--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -278,7 +278,7 @@ func (provider *BedrockProvider) completeRequest(ctx *schemas.BifrostContext, js
 	region := resolveBedrockRegion(ctx, key, model)
 
 	// Create the request with the JSON body
-	requestURL := fmt.Sprintf("https://bedrock-runtime.%s.amazonaws.com/model/%s", region, path)
+	requestURL := fmt.Sprintf("https://%s/model/%s", resolveBedrockHost(bedrockEndpoints(config), bedrockServiceRuntime, region), path)
 	req, err := http.NewRequestWithContext(ctx, "POST", requestURL, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return nil, 0, nil, &schemas.BifrostError{
@@ -394,7 +394,7 @@ func (provider *BedrockProvider) completeAgentRuntimeRequest(ctx *schemas.Bifros
 		region = config.Region.GetValue()
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("https://bedrock-agent-runtime.%s.amazonaws.com%s", region, path), bytes.NewBuffer(jsonData))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("https://%s%s", resolveBedrockHost(bedrockEndpoints(config), bedrockServiceAgentRuntime, region), path), bytes.NewBuffer(jsonData))
 	if err != nil {
 		return nil, 0, nil, &schemas.BifrostError{
 			IsBifrostError: true,
@@ -486,7 +486,7 @@ func (provider *BedrockProvider) makeStreamingRequest(ctx *schemas.BifrostContex
 	path, region := provider.getModelPathAndRegion(ctx, action, model, key)
 
 	// Create HTTP request for streaming
-	requestURL := fmt.Sprintf("https://bedrock-runtime.%s.amazonaws.com/model/%s", region, path)
+	requestURL := fmt.Sprintf("https://%s/model/%s", resolveBedrockHost(bedrockEndpoints(key.BedrockKeyConfig), bedrockServiceRuntime, region), path)
 	req, reqErr := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, bytes.NewReader(jsonData))
 	if reqErr != nil {
 		return nil, providerUtils.NewBifrostOperationError("error creating request", reqErr)
@@ -784,7 +784,7 @@ func signAWSRequest(
 // for this GET). Best-effort: returns nil on any failure so the foundation-model list is
 // still returned.
 func (provider *BedrockProvider) listMantleModels(ctx *schemas.BifrostContext, key schemas.Key, region string, unfiltered bool) *schemas.BifrostListModelsResponse {
-	mURL := mantleOpenAIURL(region, "", "models")
+	mURL := mantleOpenAIURL(bedrockEndpoints(key.BedrockKeyConfig), region, "", "models")
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, mURL, nil)
 	if err != nil {
 		provider.logger.Warn("failed to build mantle list-models request: %v", err)
@@ -848,7 +848,7 @@ func (provider *BedrockProvider) listModelsByKey(ctx *schemas.BifrostContext, ke
 	}
 
 	// List models endpoint uses the bedrock service (not bedrock-runtime)
-	url := fmt.Sprintf("https://bedrock.%s.amazonaws.com/foundation-models?%s", region, params.Encode())
+	url := fmt.Sprintf("https://%s/foundation-models?%s", resolveBedrockHost(bedrockEndpoints(config), bedrockServiceControlPlane, region), params.Encode())
 
 	// Create the GET request without a body
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -2545,7 +2545,7 @@ func (provider *BedrockProvider) FileUpload(ctx *schemas.BifrostContext, key sch
 
 	// Build S3 PUT request URL
 	// Escape each path segment individually to handle special characters while preserving "/"
-	reqURL := fmt.Sprintf("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, escapeS3KeyForURL(s3Key))
+	reqURL := fmt.Sprintf("https://%s.%s/%s", bucketName, resolveBedrockHost(bedrockEndpoints(key.BedrockKeyConfig), bedrockServiceS3, region), escapeS3KeyForURL(s3Key))
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPut, reqURL, bytes.NewReader(request.File))
 	if err != nil {
@@ -2678,7 +2678,7 @@ func (provider *BedrockProvider) FileList(ctx *schemas.BifrostContext, keys []sc
 		params.Set("continuation-token", nativeCursor)
 	}
 
-	requestURL := fmt.Sprintf("https://%s.s3.%s.amazonaws.com/?%s", bucketName, region, params.Encode())
+	requestURL := fmt.Sprintf("https://%s.%s/?%s", bucketName, resolveBedrockHost(bedrockEndpoints(key.BedrockKeyConfig), bedrockServiceS3, region), params.Encode())
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
 	if err != nil {
@@ -2788,7 +2788,7 @@ func (provider *BedrockProvider) FileRetrieve(ctx *schemas.BifrostContext, keys 
 
 		// Build S3 HEAD request
 		// Escape each path segment individually to handle special characters while preserving "/"
-		reqURL := fmt.Sprintf("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, escapeS3KeyForURL(s3Key))
+		reqURL := fmt.Sprintf("https://%s.%s/%s", bucketName, resolveBedrockHost(bedrockEndpoints(key.BedrockKeyConfig), bedrockServiceS3, region), escapeS3KeyForURL(s3Key))
 
 		httpReq, err := http.NewRequestWithContext(ctx, http.MethodHead, reqURL, nil)
 		if err != nil {
@@ -2886,7 +2886,7 @@ func (provider *BedrockProvider) FileDelete(ctx *schemas.BifrostContext, keys []
 
 		// Build S3 DELETE request
 		// Escape each path segment individually to handle special characters while preserving "/"
-		reqURL := fmt.Sprintf("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, escapeS3KeyForURL(s3Key))
+		reqURL := fmt.Sprintf("https://%s.%s/%s", bucketName, resolveBedrockHost(bedrockEndpoints(key.BedrockKeyConfig), bedrockServiceS3, region), escapeS3KeyForURL(s3Key))
 
 		httpReq, err := http.NewRequestWithContext(ctx, http.MethodDelete, reqURL, nil)
 		if err != nil {
@@ -2967,7 +2967,7 @@ func (provider *BedrockProvider) FileContent(ctx *schemas.BifrostContext, keys [
 
 		// Build S3 GET request
 		// Escape each path segment individually to handle special characters while preserving "/"
-		reqURL := fmt.Sprintf("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, escapeS3KeyForURL(s3Key))
+		reqURL := fmt.Sprintf("https://%s.%s/%s", bucketName, resolveBedrockHost(bedrockEndpoints(key.BedrockKeyConfig), bedrockServiceS3, region), escapeS3KeyForURL(s3Key))
 
 		httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 		if err != nil {
@@ -3179,7 +3179,7 @@ func (provider *BedrockProvider) BatchCreate(ctx *schemas.BifrostContext, key sc
 	}
 
 	// Create HTTP request
-	reqURL := fmt.Sprintf("https://bedrock.%s.amazonaws.com/model-invocation-job", region)
+	reqURL := fmt.Sprintf("https://%s/model-invocation-job", resolveBedrockHost(bedrockEndpoints(key.BedrockKeyConfig), bedrockServiceControlPlane, region))
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("error creating request", err), jsonData, nil, sendBackRawRequest, sendBackRawResponse)
@@ -3300,7 +3300,7 @@ func (provider *BedrockProvider) BatchList(ctx *schemas.BifrostContext, keys []s
 		params.Set("nextToken", nativeCursor)
 	}
 
-	reqURL := fmt.Sprintf("https://bedrock.%s.amazonaws.com/model-invocation-jobs", region)
+	reqURL := fmt.Sprintf("https://%s/model-invocation-jobs", resolveBedrockHost(bedrockEndpoints(key.BedrockKeyConfig), bedrockServiceControlPlane, region))
 	if len(params) > 0 {
 		reqURL += "?" + params.Encode()
 	}
@@ -3421,7 +3421,7 @@ func (provider *BedrockProvider) fetchBatchManifest(ctx *schemas.BifrostContext,
 	}
 
 	// Build S3 GET request
-	reqURL := fmt.Sprintf("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, escapeS3KeyForURL(manifestKey))
+	reqURL := fmt.Sprintf("https://%s.%s/%s", bucketName, resolveBedrockHost(bedrockEndpoints(key.BedrockKeyConfig), bedrockServiceS3, region), escapeS3KeyForURL(manifestKey))
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
@@ -3481,7 +3481,7 @@ func (provider *BedrockProvider) BatchRetrieve(ctx *schemas.BifrostContext, keys
 
 		// URL encode the job ARN
 		encodedJobArn := url.PathEscape(request.BatchID)
-		reqURL := fmt.Sprintf("https://bedrock.%s.amazonaws.com/model-invocation-job/%s", region, encodedJobArn)
+		reqURL := fmt.Sprintf("https://%s/model-invocation-job/%s", resolveBedrockHost(bedrockEndpoints(key.BedrockKeyConfig), bedrockServiceControlPlane, region), encodedJobArn)
 
 		httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 		if err != nil {
@@ -3625,7 +3625,7 @@ func (provider *BedrockProvider) BatchCancel(ctx *schemas.BifrostContext, keys [
 
 		// URL encode the job ARN
 		encodedJobArn := url.PathEscape(request.BatchID)
-		reqURL := fmt.Sprintf("https://bedrock.%s.amazonaws.com/model-invocation-job/%s/stop", region, encodedJobArn)
+		reqURL := fmt.Sprintf("https://%s/model-invocation-job/%s/stop", resolveBedrockHost(bedrockEndpoints(key.BedrockKeyConfig), bedrockServiceControlPlane, region), encodedJobArn)
 
 		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, nil)
 		if err != nil {

--- a/core/providers/bedrock/mantle.go
+++ b/core/providers/bedrock/mantle.go
@@ -57,12 +57,12 @@ func isMantleModel(ctx *schemas.BifrostContext, model string) bool {
 // (capability-resolved) model for correct path gating; the request body still carries the
 // wire request.Model. Frontier families (closed gpt-5.x, Gemma 4) live under the "openai/v1"
 // base path; gpt-oss uses the bare "v1" path.
-func mantleOpenAIURL(region, model, path string) string {
+func mantleOpenAIURL(endpoints *schemas.BedrockEndpoints, region, model, path string) string {
 	base := "v1"
 	if strings.Contains(model, "gpt-5") || strings.Contains(model, "gemma-4") {
 		base = "openai/v1"
 	}
-	return fmt.Sprintf("https://bedrock-mantle.%s.api.aws/%s/%s", region, base, path)
+	return fmt.Sprintf("https://%s/%s/%s", resolveBedrockHost(endpoints, bedrockServiceMantle, region), base, path)
 }
 
 // SignMantleV4Headers computes SigV4 auth headers for a mantle request by signing a dummy
@@ -140,7 +140,7 @@ func (provider *BedrockProvider) mantleChatCompletions(
 	request *schemas.BifrostChatRequest,
 ) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
 	region := resolveBedrockRegion(ctx, key, request.Model)
-	url := mantleOpenAIURL(region, schemas.ResolveCanonicalModel(ctx, request.Model), "chat/completions")
+	url := mantleOpenAIURL(bedrockEndpoints(key.BedrockKeyConfig), region, schemas.ResolveCanonicalModel(ctx, request.Model), "chat/completions")
 
 	// SigV4 (empty key value): sign the exact body the handler builds via a signer closure.
 	// Bearer (key has a value): no signer; auth flows through the Authorization header.
@@ -178,7 +178,7 @@ func (provider *BedrockProvider) mantleChatCompletionsStream(
 	request *schemas.BifrostChatRequest,
 ) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
 	region := resolveBedrockRegion(ctx, key, request.Model)
-	url := mantleOpenAIURL(region, schemas.ResolveCanonicalModel(ctx, request.Model), "chat/completions")
+	url := mantleOpenAIURL(bedrockEndpoints(key.BedrockKeyConfig), region, schemas.ResolveCanonicalModel(ctx, request.Model), "chat/completions")
 
 	// SigV4 (empty key value): sign the exact body the handler builds via a signer closure.
 	// Bearer (key has a value): no signer; auth flows through the Authorization header.
@@ -215,7 +215,7 @@ func (provider *BedrockProvider) mantleResponses(
 	request *schemas.BifrostResponsesRequest,
 ) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
 	region := resolveBedrockRegion(ctx, key, request.Model)
-	url := mantleOpenAIURL(region, schemas.ResolveCanonicalModel(ctx, request.Model), "responses")
+	url := mantleOpenAIURL(bedrockEndpoints(key.BedrockKeyConfig), region, schemas.ResolveCanonicalModel(ctx, request.Model), "responses")
 
 	// SigV4 (empty key value): sign the exact body the handler builds via a signer closure.
 	// Bearer (key has a value): no signer; auth flows through the Authorization header.
@@ -253,7 +253,7 @@ func (provider *BedrockProvider) mantleResponsesStream(
 	request *schemas.BifrostResponsesRequest,
 ) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
 	region := resolveBedrockRegion(ctx, key, request.Model)
-	url := mantleOpenAIURL(region, schemas.ResolveCanonicalModel(ctx, request.Model), "responses")
+	url := mantleOpenAIURL(bedrockEndpoints(key.BedrockKeyConfig), region, schemas.ResolveCanonicalModel(ctx, request.Model), "responses")
 
 	// SigV4 (empty key value): sign the exact body the handler builds via a signer closure.
 	// Bearer (key has a value): no signer; auth flows through the Authorization header.

--- a/core/providers/bedrock/mantle_test.go
+++ b/core/providers/bedrock/mantle_test.go
@@ -64,7 +64,7 @@ func TestMantleOpenAIURL(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := mantleOpenAIURL(tc.region, tc.model, tc.path); got != tc.want {
+			if got := mantleOpenAIURL(nil, tc.region, tc.model, tc.path); got != tc.want {
 				t.Errorf("mantleOpenAIURL(%q, %q, %q) = %q, want %q", tc.region, tc.model, tc.path, got, tc.want)
 			}
 		})

--- a/core/providers/bedrock/types.go
+++ b/core/providers/bedrock/types.go
@@ -20,6 +20,19 @@ const bedrockSigningService = "bedrock"
 // credential scope; using "bedrock" will cause signature verification failures.
 const bedrockMantleSigningService = "bedrock-mantle"
 
+// bedrockService identifies an AWS endpoint service Bifrost dials. The value doubles as the
+// host prefix of the public regional endpoint. It is distinct from the SigV4 signing service
+// above: bedrock-runtime and bedrock-agent-runtime both sign as "bedrock".
+type bedrockService string
+
+const (
+	bedrockServiceRuntime      bedrockService = "bedrock-runtime"
+	bedrockServiceControlPlane bedrockService = "bedrock"
+	bedrockServiceMantle       bedrockService = "bedrock-mantle"
+	bedrockServiceAgentRuntime bedrockService = "bedrock-agent-runtime"
+	bedrockServiceS3           bedrockService = "s3"
+)
+
 const MinimumReasoningMaxTokens = 1
 const DefaultCompletionMaxTokens = 4096 // Only used for relative reasoning max token calculation - not passed in body by default
 

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -78,6 +78,45 @@ func resolveBedrockRegion(ctx *schemas.BifrostContext, key schemas.Key, model st
 	return DefaultBedrockRegion
 }
 
+// resolveBedrockHost returns the host to dial for an AWS endpoint service: the configured VPC
+// endpoint override when set, otherwise the public regional host built from the region. The
+// returned value is a bare host, so callers keep ownership of the scheme and path — including
+// the bucket prefix S3's virtual-hosted URLs carry.
+func resolveBedrockHost(endpoints *schemas.BedrockEndpoints, service bedrockService, region string) string {
+	if endpoints != nil {
+		var override *schemas.SecretVar
+		switch service {
+		case bedrockServiceRuntime:
+			override = endpoints.Runtime
+		case bedrockServiceControlPlane:
+			override = endpoints.ControlPlane
+		case bedrockServiceMantle:
+			override = endpoints.Mantle
+		case bedrockServiceAgentRuntime:
+			override = endpoints.AgentRuntime
+		case bedrockServiceS3:
+			override = endpoints.S3
+		}
+		if host := schemas.NormalizeEndpointHost(override); host != "" {
+			return host
+		}
+	}
+	// Mantle is the odd one out: its public host lives under api.aws, not amazonaws.com.
+	if service == bedrockServiceMantle {
+		return fmt.Sprintf("%s.%s.api.aws", service, region)
+	}
+	return fmt.Sprintf("%s.%s.amazonaws.com", service, region)
+}
+
+// bedrockEndpoints returns the endpoint overrides on a key config, tolerating a nil config so
+// callers on the API-key auth path (where BedrockKeyConfig may be absent) need no guard.
+func bedrockEndpoints(cfg *schemas.BedrockKeyConfig) *schemas.BedrockEndpoints {
+	if cfg == nil {
+		return nil
+	}
+	return cfg.Endpoints
+}
+
 // resolveBedrockARN returns the inference-profile / resource ARN prepended
 // to the Bedrock URL path. Priority: alias-level BedrockAliasCfg
 // InferenceProfileARN > key-level BedrockKeyConfig.ARN. Returns empty when

--- a/core/providers/bedrock/vpcendpoints_test.go
+++ b/core/providers/bedrock/vpcendpoints_test.go
@@ -1,0 +1,128 @@
+package bedrock
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func secret(v string) *schemas.SecretVar {
+	return &schemas.SecretVar{Val: v}
+}
+
+func TestResolveBedrockHostDefaults(t *testing.T) {
+	cases := []struct {
+		service bedrockService
+		want    string
+	}{
+		{bedrockServiceRuntime, "bedrock-runtime.eu-west-2.amazonaws.com"},
+		{bedrockServiceControlPlane, "bedrock.eu-west-2.amazonaws.com"},
+		{bedrockServiceAgentRuntime, "bedrock-agent-runtime.eu-west-2.amazonaws.com"},
+		{bedrockServiceS3, "s3.eu-west-2.amazonaws.com"},
+		// Mantle is served from api.aws, not amazonaws.com.
+		{bedrockServiceMantle, "bedrock-mantle.eu-west-2.api.aws"},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.service), func(t *testing.T) {
+			// A nil endpoints struct and an empty one must both fall back to the public host.
+			assert.Equal(t, tc.want, resolveBedrockHost(nil, tc.service, "eu-west-2"))
+			assert.Equal(t, tc.want, resolveBedrockHost(&schemas.BedrockEndpoints{}, tc.service, "eu-west-2"))
+		})
+	}
+}
+
+func TestResolveBedrockHostOverridePerService(t *testing.T) {
+	endpoints := &schemas.BedrockEndpoints{
+		Runtime: secret("vpce-0abc123-x1y2z3.bedrock-runtime.eu-west-2.vpce.amazonaws.com"),
+	}
+
+	assert.Equal(t, "vpce-0abc123-x1y2z3.bedrock-runtime.eu-west-2.vpce.amazonaws.com",
+		resolveBedrockHost(endpoints, bedrockServiceRuntime, "eu-west-2"))
+
+	// An override for one service must not leak onto the others: a runtime VPC endpoint cannot
+	// serve control-plane or agent-runtime calls.
+	assert.Equal(t, "bedrock.eu-west-2.amazonaws.com", resolveBedrockHost(endpoints, bedrockServiceControlPlane, "eu-west-2"))
+	assert.Equal(t, "bedrock-agent-runtime.eu-west-2.amazonaws.com", resolveBedrockHost(endpoints, bedrockServiceAgentRuntime, "eu-west-2"))
+	assert.Equal(t, "s3.eu-west-2.amazonaws.com", resolveBedrockHost(endpoints, bedrockServiceS3, "eu-west-2"))
+	assert.Equal(t, "bedrock-mantle.eu-west-2.api.aws", resolveBedrockHost(endpoints, bedrockServiceMantle, "eu-west-2"))
+}
+
+func TestResolveBedrockHostNormalizesValue(t *testing.T) {
+	const host = "vpce-0abc123-x1y2z3.bedrock-runtime.eu-west-2.vpce.amazonaws.com"
+	cases := []struct {
+		name       string
+		configured string
+		want       string
+	}{
+		{"bare host", host, host},
+		{"with scheme", "https://" + host, host},
+		{"with scheme and trailing slash", "https://" + host + "/", host},
+		{"with scheme and path", "https://" + host + "/model/foo", host},
+		{"surrounding whitespace", "  " + host + "  ", host},
+		// An empty value must not shadow the public host.
+		{"empty", "", "bedrock-runtime.eu-west-2.amazonaws.com"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			endpoints := &schemas.BedrockEndpoints{Runtime: secret(tc.configured)}
+			assert.Equal(t, tc.want, resolveBedrockHost(endpoints, bedrockServiceRuntime, "eu-west-2"))
+		})
+	}
+}
+
+func TestBedrockEndpointsNilKeyConfig(t *testing.T) {
+	// The API-key auth path can reach URL construction with no BedrockKeyConfig at all.
+	assert.Nil(t, bedrockEndpoints(nil))
+	assert.Nil(t, bedrockEndpoints(&schemas.BedrockKeyConfig{}))
+}
+
+func TestMantleOpenAIURLHonoursEndpointOverride(t *testing.T) {
+	endpoints := &schemas.BedrockEndpoints{
+		Mantle: secret("vpce-0abc123-x1y2z3.bedrock-mantle.eu-west-2.vpce.amazonaws.com"),
+	}
+	assert.Equal(t,
+		"https://vpce-0abc123-x1y2z3.bedrock-mantle.eu-west-2.vpce.amazonaws.com/v1/chat/completions",
+		mantleOpenAIURL(endpoints, "eu-west-2", "gpt-oss-120b", "chat/completions"))
+	assert.Equal(t,
+		"https://vpce-0abc123-x1y2z3.bedrock-mantle.eu-west-2.vpce.amazonaws.com/openai/v1/responses",
+		mantleOpenAIURL(endpoints, "eu-west-2", "gpt-5", "responses"))
+}
+
+// A VPC endpoint host must sign correctly: SigV4 takes the host from the request URI but the
+// credential scope from the configured region, so the two stay independent.
+func TestSignAWSRequestWithVPCEndpointHost(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	defer ctx.Cancel()
+
+	keyCfg := &schemas.BedrockKeyConfig{
+		AccessKey: schemas.SecretVar{Val: "AKIAIOSFODNN7EXAMPLE"},
+		SecretKey: schemas.SecretVar{Val: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"},
+	}
+
+	const vpceHost = "vpce-0abc123-x1y2z3.bedrock-runtime.eu-west-2.vpce.amazonaws.com"
+	sign := func(host string) string {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://"+host+"/model/anthropic.claude-v2/converse", strings.NewReader(`{}`))
+		require.NoError(t, err)
+		require.Nil(t, signAWSRequest(ctx, req, keyCfg, "eu-west-2", bedrockSigningService))
+		return req.Header.Get("Authorization")
+	}
+
+	auth := sign(vpceHost)
+	require.NotEmpty(t, auth)
+
+	// The credential scope follows the configured region and service, not the hostname — a
+	// vpce- host still signs as bedrock/eu-west-2.
+	assert.Contains(t, auth, "/eu-west-2/bedrock/aws4_request")
+	// Host must be part of SignedHeaders, otherwise AWS rejects the request.
+	assert.Contains(t, auth, "SignedHeaders=")
+	assert.Contains(t, auth, "host")
+
+	// Signing the same request against the public host must produce a different signature,
+	// proving the endpoint host is actually covered by the canonical request.
+	assert.NotEqual(t, auth, sign("bedrock-runtime.eu-west-2.amazonaws.com"))
+}

--- a/core/providers/bedrockmantle/bedrockmantle.go
+++ b/core/providers/bedrockmantle/bedrockmantle.go
@@ -81,17 +81,37 @@ const defaultMantleRegion = "us-east-1"
 // model for correct path gating; the request body still carries the wire request.Model.
 // Frontier families (closed gpt-5.x, Gemma 4) live under the "openai/v1" base path; gpt-oss
 // uses the bare "v1" path.
-func mantleOpenAIURL(region, model, path string) string {
+func mantleOpenAIURL(endpoints *schemas.BedrockEndpoints, region, model, path string) string {
 	base := "v1"
 	if strings.Contains(model, "gpt-5") || strings.Contains(model, "gemma-4") {
 		base = "openai/v1"
 	}
-	return fmt.Sprintf("https://bedrock-mantle.%s.api.aws/%s/%s", region, base, path)
+	return fmt.Sprintf("https://%s/%s/%s", mantleHost(endpoints, region), base, path)
 }
 
 // mantleAnthropicURL builds the Bedrock Mantle native-Anthropic Messages endpoint URL.
-func mantleAnthropicURL(region string) string {
-	return fmt.Sprintf("https://bedrock-mantle.%s.api.aws/anthropic/v1/messages", region)
+func mantleAnthropicURL(endpoints *schemas.BedrockEndpoints, region string) string {
+	return fmt.Sprintf("https://%s/anthropic/v1/messages", mantleHost(endpoints, region))
+}
+
+// mantleHost returns the host to dial for Bedrock Mantle: the configured interface VPC endpoint
+// override when set, otherwise the public regional host.
+func mantleHost(endpoints *schemas.BedrockEndpoints, region string) string {
+	if endpoints != nil {
+		if host := schemas.NormalizeEndpointHost(endpoints.Mantle); host != "" {
+			return host
+		}
+	}
+	return fmt.Sprintf("bedrock-mantle.%s.api.aws", region)
+}
+
+// mantleEndpoints returns the endpoint overrides on a mantle key config, tolerating a nil config
+// so callers on the API-key auth path need no guard.
+func mantleEndpoints(cfg *schemas.BedrockMantleKeyConfig) *schemas.BedrockEndpoints {
+	if cfg == nil {
+		return nil
+	}
+	return cfg.Endpoints
 }
 
 // mantleSigner returns a BodySigner that SigV4-signs the request body for the bedrock-mantle
@@ -120,7 +140,7 @@ func (provider *BedrockMantleProvider) GetProviderKey() schemas.ModelProvider {
 // per-request extra headers consumed by the shared OpenAI list-models path.
 func (provider *BedrockMantleProvider) listModelsByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
 	region := provider.resolveRegion(ctx, key, "")
-	mURL := mantleOpenAIURL(region, "", "models")
+	mURL := mantleOpenAIURL(mantleEndpoints(key.BedrockMantleKeyConfig), region, "", "models")
 
 	// Scope the catalog to the configured project via the OpenAI-Project header (default project
 	// when unset). It is a plain header, so it does not need to be part of the SigV4 SignedHeaders.
@@ -171,7 +191,7 @@ func (provider *BedrockMantleProvider) ChatCompletion(ctx *schemas.BifrostContex
 	// Anthropic-family models (Claude) use the native Anthropic Messages surface; all other
 	// (OpenAI-family / Gemma) models use the OpenAI-compatible surface.
 	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
-		url := mantleAnthropicURL(region)
+		url := mantleAnthropicURL(mantleEndpoints(key.BedrockMantleKeyConfig), region)
 		_, bareModel := parseBedrockRegionAndModel(request.Model)
 		return anthropic.HandleAnthropicChatCompletionRequest(
 			ctx,
@@ -192,7 +212,7 @@ func (provider *BedrockMantleProvider) ChatCompletion(ctx *schemas.BifrostContex
 		)
 	}
 
-	url := mantleOpenAIURL(region, schemas.ResolveCanonicalModel(ctx, request.Model), "chat/completions")
+	url := mantleOpenAIURL(mantleEndpoints(key.BedrockMantleKeyConfig), region, schemas.ResolveCanonicalModel(ctx, request.Model), "chat/completions")
 	return openai.HandleOpenAIChatCompletionRequest(
 		ctx,
 		provider.mantleClient,
@@ -218,7 +238,7 @@ func (provider *BedrockMantleProvider) ChatCompletionStream(ctx *schemas.Bifrost
 	// Anthropic-family models (Claude) use the native Anthropic Messages surface; all other
 	// (OpenAI-family / Gemma) models use the OpenAI-compatible surface.
 	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
-		url := mantleAnthropicURL(region)
+		url := mantleAnthropicURL(mantleEndpoints(key.BedrockMantleKeyConfig), region)
 
 		_, bareModel := parseBedrockRegionAndModel(request.Model)
 		jsonData, bifrostErr := anthropic.BuildAnthropicChatRequestBody(ctx, request, anthropic.AnthropicRequestBuildConfig{
@@ -253,7 +273,7 @@ func (provider *BedrockMantleProvider) ChatCompletionStream(ctx *schemas.Bifrost
 		)
 	}
 
-	url := mantleOpenAIURL(region, schemas.ResolveCanonicalModel(ctx, request.Model), "chat/completions")
+	url := mantleOpenAIURL(mantleEndpoints(key.BedrockMantleKeyConfig), region, schemas.ResolveCanonicalModel(ctx, request.Model), "chat/completions")
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx, provider.mantleStreamingClient, url, request,
 		openai.BearerAuthHeader(key), bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleOpenAIProjectHeader, resolveProjectID(ctx, key)),
@@ -275,7 +295,7 @@ func (provider *BedrockMantleProvider) Responses(ctx *schemas.BifrostContext, ke
 	// Anthropic-family models (Claude) use the native Anthropic Messages surface; all other
 	// (OpenAI-family / Gemma) models use the OpenAI-compatible surface.
 	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
-		url := mantleAnthropicURL(region)
+		url := mantleAnthropicURL(mantleEndpoints(key.BedrockMantleKeyConfig), region)
 
 		_, bareModel := parseBedrockRegionAndModel(request.Model)
 		return anthropic.HandleAnthropicResponsesRequest(
@@ -298,7 +318,7 @@ func (provider *BedrockMantleProvider) Responses(ctx *schemas.BifrostContext, ke
 		)
 	}
 
-	url := mantleOpenAIURL(region, schemas.ResolveCanonicalModel(ctx, request.Model), "responses")
+	url := mantleOpenAIURL(mantleEndpoints(key.BedrockMantleKeyConfig), region, schemas.ResolveCanonicalModel(ctx, request.Model), "responses")
 	return openai.HandleOpenAIResponsesRequest(
 		ctx,
 		provider.mantleClient,
@@ -323,7 +343,7 @@ func (provider *BedrockMantleProvider) ResponsesStream(ctx *schemas.BifrostConte
 	// Anthropic-family models (Claude) use the native Anthropic Messages surface; all other
 	// (OpenAI-family / Gemma) models use the OpenAI-compatible surface.
 	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
-		url := mantleAnthropicURL(region)
+		url := mantleAnthropicURL(mantleEndpoints(key.BedrockMantleKeyConfig), region)
 
 		_, bareModel := parseBedrockRegionAndModel(request.Model)
 		jsonData, bifrostErr := anthropic.BuildAnthropicResponsesRequestBody(ctx, request, anthropic.AnthropicRequestBuildConfig{
@@ -359,7 +379,7 @@ func (provider *BedrockMantleProvider) ResponsesStream(ctx *schemas.BifrostConte
 		)
 	}
 
-	url := mantleOpenAIURL(region, schemas.ResolveCanonicalModel(ctx, request.Model), "responses")
+	url := mantleOpenAIURL(mantleEndpoints(key.BedrockMantleKeyConfig), region, schemas.ResolveCanonicalModel(ctx, request.Model), "responses")
 	return openai.HandleOpenAIResponsesStreaming(
 		ctx, provider.mantleStreamingClient, url, request,
 		openai.BearerAuthHeader(key), bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleOpenAIProjectHeader, resolveProjectID(ctx, key)),

--- a/core/providers/bedrockmantle/counttokens.go
+++ b/core/providers/bedrockmantle/counttokens.go
@@ -15,8 +15,8 @@ import (
 // bedrock-mantle host. This is the only token-counting path available for Claude models that
 // have no Region-specific bedrock-runtime endpoint (models launching cross-Region-inference
 // only), which is why it is not redundant with the bedrock provider's Converse count-tokens.
-func mantleAnthropicCountTokensURL(region string) string {
-	return fmt.Sprintf("https://bedrock-mantle.%s.api.aws/anthropic/v1/messages/count_tokens", region)
+func mantleAnthropicCountTokensURL(endpoints *schemas.BedrockEndpoints, region string) string {
+	return fmt.Sprintf("https://%s/anthropic/v1/messages/count_tokens", mantleHost(endpoints, region))
 }
 
 // CountTokens counts the input tokens a request would consume, using the native-Anthropic
@@ -39,7 +39,7 @@ func (provider *BedrockMantleProvider) CountTokens(ctx *schemas.BifrostContext, 
 	}
 
 	region := provider.resolveRegion(ctx, key, request.Model)
-	url := mantleAnthropicCountTokensURL(region)
+	url := mantleAnthropicCountTokensURL(mantleEndpoints(key.BedrockMantleKeyConfig), region)
 	// The region addresses the host, the bare id goes in the body.
 	_, bareModel := parseBedrockRegionAndModel(request.Model)
 

--- a/core/providers/bedrockmantle/counttokens_test.go
+++ b/core/providers/bedrockmantle/counttokens_test.go
@@ -27,13 +27,13 @@ func TestMantleAnthropicCountTokensURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.region, func(t *testing.T) {
-			got := mantleAnthropicCountTokensURL(tt.region)
+			got := mantleAnthropicCountTokensURL(nil, tt.region)
 			if got != tt.want {
 				t.Fatalf("mantleAnthropicCountTokensURL(%q) = %q, want %q", tt.region, got, tt.want)
 			}
 			// count_tokens must stay a suffix of the messages URL, so a future change to the
 			// messages host/path can't silently desync the two surfaces.
-			if want := mantleAnthropicURL(tt.region) + "/count_tokens"; got != want {
+			if want := mantleAnthropicURL(nil, tt.region) + "/count_tokens"; got != want {
 				t.Fatalf("count-tokens URL %q is not the messages URL + /count_tokens (%q)", got, want)
 			}
 		})
@@ -70,7 +70,7 @@ func TestCountTokensRegionResolution(t *testing.T) {
 			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 			defer ctx.Cancel()
 
-			got := mantleAnthropicCountTokensURL(provider.resolveRegion(ctx, tt.key, tt.model))
+			got := mantleAnthropicCountTokensURL(nil, provider.resolveRegion(ctx, tt.key, tt.model))
 			want := "https://bedrock-mantle." + tt.want + ".api.aws/anthropic/v1/messages/count_tokens"
 			if got != want {
 				t.Fatalf("count-tokens URL = %q, want %q", got, want)

--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -698,6 +698,43 @@ type BatchS3Config struct {
 	Buckets []S3BucketConfig `json:"buckets,omitempty"` // List of S3 bucket configurations
 }
 
+// BedrockEndpoints overrides the host Bifrost dials for each AWS endpoint service, so Bedrock
+// traffic can be routed through interface VPC endpoints (AWS PrivateLink) when private DNS is
+// not in effect. Each value is the endpoint's DNS name as listed in the VPC console, e.g.
+// "vpce-0abc123-x1y2z3.bedrock-runtime.eu-west-2.vpce.amazonaws.com". The endpoint ID alone is
+// not enough: AWS appends a random string to it that cannot be derived. Zonal names and custom
+// Route 53 aliases for the endpoint work here too. Region stays required either way, since it
+// sets the SigV4 credential scope independently of which host is dialled.
+//
+// S3 is the exception to the naming shape: its endpoint DNS is a wildcard whose leading label
+// selects the API surface, so the value must carry the literal "bucket." prefix. Bifrost prepends
+// the bucket name to whatever is set here, matching the virtual-hosted URL the AWS SDKs build.
+// An S3 Gateway endpoint needs no value at all — it routes via the route table under the public
+// S3 hostname and has no DNS name to configure.
+type BedrockEndpoints struct {
+	Runtime      *SecretVar `json:"runtime,omitempty"`       // com.amazonaws.{region}.bedrock-runtime — all inference
+	ControlPlane *SecretVar `json:"control_plane,omitempty"` // com.amazonaws.{region}.bedrock — model listing, batch jobs
+	Mantle       *SecretVar `json:"mantle,omitempty"`        // com.amazonaws.{region}.bedrock-mantle — mantle-routed models
+	AgentRuntime *SecretVar `json:"agent_runtime,omitempty"` // com.amazonaws.{region}.bedrock-agent-runtime — rerank
+	S3           *SecretVar `json:"s3,omitempty"`            // com.amazonaws.{region}.s3 — batch file I/O, "bucket."-prefixed
+}
+
+// NormalizeEndpointHost returns a configured endpoint value as a bare host, or "" when unset.
+// A value may be pasted with a scheme or a trailing path; both are stripped so callers can slot
+// the result straight into a URL template.
+func NormalizeEndpointHost(v *SecretVar) string {
+	if v == nil {
+		return ""
+	}
+	host := strings.TrimSpace(v.GetValue())
+	host = strings.TrimPrefix(host, "https://")
+	host = strings.TrimPrefix(host, "http://")
+	if i := strings.IndexByte(host, '/'); i >= 0 {
+		host = host[:i]
+	}
+	return host
+}
+
 // BedrockKeyConfig represents the AWS Bedrock-specific configuration.
 // It contains AWS-specific settings required for authentication and service access.
 type BedrockKeyConfig struct {
@@ -722,6 +759,9 @@ type BedrockKeyConfig struct {
 	ProjectID *SecretVar `json:"project_id,omitempty"`
 
 	BatchS3Config *BatchS3Config `json:"batch_s3_config,omitempty"` // S3 bucket configuration for batch operations
+
+	// Endpoints routes each AWS endpoint service through an interface VPC endpoint. See BedrockEndpoints.
+	Endpoints *BedrockEndpoints `json:"endpoints,omitempty"`
 }
 
 // NOTE: To use Bedrock IAM role authentication, set both AccessKey and SecretKey to empty strings.
@@ -747,6 +787,9 @@ type BedrockMantleKeyConfig struct {
 	// header on the native-Anthropic (Claude) surface. When empty, AWS routes to the account's
 	// default project.
 	ProjectID *SecretVar `json:"project_id,omitempty"`
+
+	// Endpoints routes each AWS endpoint service through an interface VPC endpoint. See BedrockEndpoints.
+	Endpoints *BedrockEndpoints `json:"endpoints,omitempty"`
 }
 
 // NOTE: To use Bedrock Mantle IAM role authentication, set both AccessKey and SecretKey to empty

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -609,6 +609,10 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 			if key.BedrockKeyConfig.BatchS3Config != nil {
 				bedrockConfig.BatchS3Config = key.BedrockKeyConfig.BatchS3Config
 			}
+			// VPC endpoint hosts are network addresses, not credentials — surface them in plaintext.
+			if key.BedrockKeyConfig.Endpoints != nil {
+				bedrockConfig.Endpoints = key.BedrockKeyConfig.Endpoints
+			}
 			redactedConfig.Keys[i].BedrockKeyConfig = bedrockConfig
 		}
 
@@ -635,6 +639,10 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 			// Project ID is an identifier, not a credential — surface it in plaintext.
 			if key.BedrockMantleKeyConfig.ProjectID != nil {
 				mantleConfig.ProjectID = key.BedrockMantleKeyConfig.ProjectID
+			}
+			// VPC endpoint hosts are network addresses, not credentials — surface them in plaintext.
+			if key.BedrockMantleKeyConfig.Endpoints != nil {
+				mantleConfig.Endpoints = key.BedrockMantleKeyConfig.Endpoints
 			}
 			redactedConfig.Keys[i].BedrockMantleKeyConfig = mantleConfig
 		}

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -466,6 +466,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_mcp_admin_auth_mode_indexes"}, run: migrationAddMCPAdminAuthModeIndexes},
 	{IDs: []string{"add_mcp_client_token_exchange_json_column"}, run: migrationAddMCPClientTokenExchangeJSONColumn},
 	{IDs: []string{"add_needs_session_stickiness_column"}, run: migrationAddNeedsSessionStickinessColumn},
+	{IDs: []string{"add_bedrock_endpoints_columns"}, run: migrationAddBedrockEndpointsColumns},
 }
 
 // quoteSQLiteIdentifier quotes a SQLite identifier, escaping any double quotes.
@@ -11854,4 +11855,40 @@ func migrationAddMCPAdminAuthModeIndexes(ctx context.Context, db *gorm.DB, logge
 			return nil
 		},
 	})
+}
+
+// migrationAddBedrockEndpointsColumns adds the bedrock_endpoints_json and
+// bedrock_mantle_endpoints_json columns to the config_keys table. They hold the interface VPC
+// endpoint hosts dialled in place of the public regional endpoints, serialized as
+// schemas.BedrockEndpoints.
+func migrationAddBedrockEndpointsColumns(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_bedrock_endpoints_columns"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	columns := []string{"bedrock_endpoints_json", "bedrock_mantle_endpoints_json"}
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			for _, column := range columns {
+				if err := addColumnIfNotExists(tx, logger, &tables.TableKey{}, column); err != nil {
+					return fmt.Errorf("failed to add %s column: %w", column, err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			for _, column := range columns {
+				if err := dropColumnIfExists(tx, logger, &tables.TableKey{}, column); err != nil {
+					return fmt.Errorf("failed to drop %s column: %w", column, err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running db migration: %s", err.Error())
+	}
+	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -227,6 +227,14 @@ func tableKeyFromSchemaKey(provider tables.TableProvider, key schemas.Key) (tabl
 			s := string(data)
 			dbKey.BedrockBatchS3ConfigJSON = &s
 		}
+		if key.BedrockKeyConfig.Endpoints != nil {
+			data, err := sonic.Marshal(key.BedrockKeyConfig.Endpoints)
+			if err != nil {
+				return tables.TableKey{}, err
+			}
+			s := string(data)
+			dbKey.BedrockEndpointsJSON = &s
+		}
 	}
 
 	return dbKey, nil
@@ -771,8 +779,17 @@ func (s *RDBConfigStore) UpdateProvidersConfig(ctx context.Context, providers ma
 					s := string(data)
 					dbKey.BedrockBatchS3ConfigJSON = &s
 				}
+				if key.BedrockKeyConfig.Endpoints != nil {
+					data, err := sonic.Marshal(key.BedrockKeyConfig.Endpoints)
+					if err != nil {
+						return err
+					}
+					s := string(data)
+					dbKey.BedrockEndpointsJSON = &s
+				}
 			} else {
 				dbKey.BedrockBatchS3ConfigJSON = nil
+				dbKey.BedrockEndpointsJSON = nil
 			}
 
 			dbKeys = append(dbKeys, dbKey)
@@ -1005,6 +1022,16 @@ func (s *RDBConfigStore) UpdateProvider(ctx context.Context, provider schemas.Mo
 			} else {
 				dbKey.BedrockBatchS3ConfigJSON = nil
 			}
+			if key.BedrockKeyConfig.Endpoints != nil {
+				data, err := sonic.Marshal(key.BedrockKeyConfig.Endpoints)
+				if err != nil {
+					return err
+				}
+				s := string(data)
+				dbKey.BedrockEndpointsJSON = &s
+			} else {
+				dbKey.BedrockEndpointsJSON = nil
+			}
 		}
 
 		// Check if this key already exists
@@ -1144,6 +1171,16 @@ func (s *RDBConfigStore) AddProvider(ctx context.Context, provider schemas.Model
 				dbKey.BedrockBatchS3ConfigJSON = &s
 			} else {
 				dbKey.BedrockBatchS3ConfigJSON = nil
+			}
+			if key.BedrockKeyConfig.Endpoints != nil {
+				data, err := sonic.Marshal(key.BedrockKeyConfig.Endpoints)
+				if err != nil {
+					return err
+				}
+				s := string(data)
+				dbKey.BedrockEndpointsJSON = &s
+			} else {
+				dbKey.BedrockEndpointsJSON = nil
 			}
 		}
 

--- a/framework/configstore/tables/encryption_test.go
+++ b/framework/configstore/tables/encryption_test.go
@@ -912,6 +912,95 @@ func TestTableKey_BedrockMantleProjectID_RoundTrip(t *testing.T) {
 	assert.Equal(t, "us-east-1", found.BedrockMantleKeyConfig.Region.GetValue())
 }
 
+// TestTableKey_BedrockEndpoints_RoundTrip verifies the VPC endpoint hosts survive a save/find
+// cycle on both Bedrock configs. The columns are the only persistence path: BedrockKeyConfig is
+// a virtual field, so an endpoint without a column is silently dropped on write.
+func TestTableKey_BedrockEndpoints_RoundTrip(t *testing.T) {
+	db := setupTestDB(t)
+
+	const runtimeHost = "vpce-0abc123-x1y2z3.bedrock-runtime.eu-west-2.vpce.amazonaws.com"
+	const mantleHost = "vpce-0abc123-x1y2z3.bedrock-mantle.eu-west-2.vpce.amazonaws.com"
+
+	key := &TableKey{
+		Name:       "bedrock-vpce-key",
+		ProviderID: 1,
+		Provider:   "bedrock",
+		KeyID:      "bedrock-vpce-uuid",
+		Value:      *schemas.NewSecretVar(""),
+		BedrockKeyConfig: &schemas.BedrockKeyConfig{
+			AccessKey: *schemas.NewSecretVar("AKIA-VPCE"),
+			SecretKey: *schemas.NewSecretVar("wJalr-VPCE"),
+			Region:    schemas.NewSecretVar("eu-west-2"),
+			Endpoints: &schemas.BedrockEndpoints{
+				Runtime: schemas.NewSecretVar(runtimeHost),
+			},
+		},
+		BedrockMantleKeyConfig: &schemas.BedrockMantleKeyConfig{
+			AccessKey: *schemas.NewSecretVar("AKIA-VPCE-MANTLE"),
+			SecretKey: *schemas.NewSecretVar("wJalr-VPCE-MANTLE"),
+			Region:    schemas.NewSecretVar("eu-west-2"),
+			Endpoints: &schemas.BedrockEndpoints{
+				Mantle: schemas.NewSecretVar(mantleHost),
+			},
+		},
+	}
+
+	require.NoError(t, db.Create(key).Error)
+
+	raw := rawRow(t, db, "config_keys", key.ID)
+	assert.Equal(t, "encrypted", raw["encryption_status"])
+	assert.NotContains(t, raw["bedrock_endpoints_json"], runtimeHost)
+	assert.NotContains(t, raw["bedrock_mantle_endpoints_json"], mantleHost)
+
+	var found TableKey
+	require.NoError(t, db.First(&found, key.ID).Error)
+
+	require.NotNil(t, found.BedrockKeyConfig)
+	require.NotNil(t, found.BedrockKeyConfig.Endpoints)
+	require.NotNil(t, found.BedrockKeyConfig.Endpoints.Runtime)
+	assert.Equal(t, runtimeHost, found.BedrockKeyConfig.Endpoints.Runtime.GetValue())
+	// Services the user left blank must stay unset so the public regional host is used.
+	assert.Nil(t, found.BedrockKeyConfig.Endpoints.ControlPlane)
+	assert.Nil(t, found.BedrockKeyConfig.Endpoints.S3)
+
+	require.NotNil(t, found.BedrockMantleKeyConfig)
+	require.NotNil(t, found.BedrockMantleKeyConfig.Endpoints)
+	require.NotNil(t, found.BedrockMantleKeyConfig.Endpoints.Mantle)
+	assert.Equal(t, mantleHost, found.BedrockMantleKeyConfig.Endpoints.Mantle.GetValue())
+}
+
+// TestTableKey_BedrockEndpointsCleared_RoundTrip verifies clearing the endpoints on an existing
+// key wipes the column, so a key edited back to the public endpoints stops dialling the VPCE.
+func TestTableKey_BedrockEndpointsCleared_RoundTrip(t *testing.T) {
+	db := setupTestDB(t)
+
+	key := &TableKey{
+		Name:       "bedrock-vpce-cleared-key",
+		ProviderID: 1,
+		Provider:   "bedrock",
+		KeyID:      "bedrock-vpce-cleared-uuid",
+		Value:      *schemas.NewSecretVar(""),
+		BedrockKeyConfig: &schemas.BedrockKeyConfig{
+			AccessKey: *schemas.NewSecretVar("AKIA-VPCE"),
+			SecretKey: *schemas.NewSecretVar("wJalr-VPCE"),
+			Region:    schemas.NewSecretVar("eu-west-2"),
+			Endpoints: &schemas.BedrockEndpoints{
+				Runtime: schemas.NewSecretVar("vpce-0abc123-x1y2z3.bedrock-runtime.eu-west-2.vpce.amazonaws.com"),
+			},
+		},
+	}
+	require.NoError(t, db.Create(key).Error)
+
+	key.BedrockKeyConfig.Endpoints = nil
+	require.NoError(t, db.Save(key).Error)
+
+	var found TableKey
+	require.NoError(t, db.First(&found, key.ID).Error)
+	require.NotNil(t, found.BedrockKeyConfig)
+	assert.Nil(t, found.BedrockKeyConfig.Endpoints)
+	assert.Equal(t, "eu-west-2", found.BedrockKeyConfig.Region.GetValue())
+}
+
 // ============================================================================
 // MCP — edge cases for connection string / headers combinations
 // ============================================================================

--- a/framework/configstore/tables/key.go
+++ b/framework/configstore/tables/key.go
@@ -58,6 +58,7 @@ type TableKey struct {
 	BedrockBatchRoleARN      *schemas.SecretVar `gorm:"type:text" json:"bedrock_batch_role_arn,omitempty"`
 	BedrockProjectID         *schemas.SecretVar `gorm:"type:text" json:"bedrock_project_id,omitempty"`
 	BedrockBatchS3ConfigJSON *string            `gorm:"type:text" json:"-"` // JSON serialized schemas.BatchS3Config
+	BedrockEndpointsJSON     *string            `gorm:"type:text" json:"-"` // JSON serialized schemas.BedrockEndpoints
 
 	// Bedrock Mantle config fields (embedded)
 	BedrockMantleAccessKey       *schemas.SecretVar `gorm:"type:text" json:"bedrock_mantle_access_key,omitempty"`
@@ -68,6 +69,7 @@ type TableKey struct {
 	BedrockMantleExternalID      *schemas.SecretVar `gorm:"type:text" json:"bedrock_mantle_external_id,omitempty"`
 	BedrockMantleRoleSessionName *schemas.SecretVar `gorm:"type:text" json:"bedrock_mantle_role_session_name,omitempty"`
 	BedrockMantleProjectID       *schemas.SecretVar `gorm:"type:text" json:"bedrock_mantle_project_id,omitempty"`
+	BedrockMantleEndpointsJSON   *string            `gorm:"type:text" json:"-"` // JSON serialized schemas.BedrockEndpoints
 
 	// VLLM config fields (embedded)
 	VLLMUrl       *schemas.SecretVar `gorm:"type:text" json:"vllm_url,omitempty"`
@@ -300,6 +302,16 @@ func (k *TableKey) BeforeSave(tx *gorm.DB) error {
 		} else {
 			k.BedrockBatchS3ConfigJSON = nil
 		}
+		if k.BedrockKeyConfig.Endpoints != nil {
+			data, err := sonic.Marshal(k.BedrockKeyConfig.Endpoints)
+			if err != nil {
+				return err
+			}
+			s := string(data)
+			k.BedrockEndpointsJSON = &s
+		} else {
+			k.BedrockEndpointsJSON = nil
+		}
 	} else {
 		k.BedrockAccessKey = nil
 		k.BedrockSecretKey = nil
@@ -312,6 +324,7 @@ func (k *TableKey) BeforeSave(tx *gorm.DB) error {
 		k.BedrockBatchRoleARN = nil
 		k.BedrockProjectID = nil
 		k.BedrockBatchS3ConfigJSON = nil
+		k.BedrockEndpointsJSON = nil
 	}
 
 	if k.BedrockMantleKeyConfig != nil {
@@ -364,6 +377,16 @@ func (k *TableKey) BeforeSave(tx *gorm.DB) error {
 		} else {
 			k.BedrockMantleProjectID = nil
 		}
+		if k.BedrockMantleKeyConfig.Endpoints != nil {
+			data, err := sonic.Marshal(k.BedrockMantleKeyConfig.Endpoints)
+			if err != nil {
+				return err
+			}
+			s := string(data)
+			k.BedrockMantleEndpointsJSON = &s
+		} else {
+			k.BedrockMantleEndpointsJSON = nil
+		}
 	} else {
 		k.BedrockMantleAccessKey = nil
 		k.BedrockMantleSecretKey = nil
@@ -373,6 +396,7 @@ func (k *TableKey) BeforeSave(tx *gorm.DB) error {
 		k.BedrockMantleExternalID = nil
 		k.BedrockMantleRoleSessionName = nil
 		k.BedrockMantleProjectID = nil
+		k.BedrockMantleEndpointsJSON = nil
 	}
 
 	if k.Aliases != nil {
@@ -502,6 +526,9 @@ func (k *TableKey) BeforeSave(tx *gorm.DB) error {
 		if err := encryptString(k.BedrockBatchS3ConfigJSON); err != nil {
 			return fmt.Errorf("failed to encrypt bedrock batch s3 config: %w", err)
 		}
+		if err := encryptString(k.BedrockEndpointsJSON); err != nil {
+			return fmt.Errorf("failed to encrypt bedrock endpoints: %w", err)
+		}
 		// Bedrock Mantle
 		if err := encryptSecretVarPtr(&k.BedrockMantleAccessKey); err != nil {
 			return fmt.Errorf("failed to encrypt bedrock mantle access key: %w", err)
@@ -526,6 +553,9 @@ func (k *TableKey) BeforeSave(tx *gorm.DB) error {
 		}
 		if err := encryptSecretVarPtr(&k.BedrockMantleProjectID); err != nil {
 			return fmt.Errorf("failed to encrypt bedrock mantle project id: %w", err)
+		}
+		if err := encryptString(k.BedrockMantleEndpointsJSON); err != nil {
+			return fmt.Errorf("failed to encrypt bedrock mantle endpoints: %w", err)
 		}
 		// Aliases
 		if err := encryptString(k.AliasesJSON); err != nil {
@@ -617,6 +647,9 @@ func (k *TableKey) AfterFind(tx *gorm.DB) error {
 		if err := decryptString(k.BedrockBatchS3ConfigJSON); err != nil {
 			return fmt.Errorf("failed to decrypt bedrock batch s3 config: %w", err)
 		}
+		if err := decryptString(k.BedrockEndpointsJSON); err != nil {
+			return fmt.Errorf("failed to decrypt bedrock endpoints: %w", err)
+		}
 		// Bedrock Mantle
 		if err := decryptSecretVarPtr(&k.BedrockMantleAccessKey); err != nil {
 			return fmt.Errorf("failed to decrypt bedrock mantle access key: %w", err)
@@ -641,6 +674,9 @@ func (k *TableKey) AfterFind(tx *gorm.DB) error {
 		}
 		if err := decryptSecretVarPtr(&k.BedrockMantleProjectID); err != nil {
 			return fmt.Errorf("failed to decrypt bedrock mantle project id: %w", err)
+		}
+		if err := decryptString(k.BedrockMantleEndpointsJSON); err != nil {
+			return fmt.Errorf("failed to decrypt bedrock mantle endpoints: %w", err)
 		}
 		// Aliases
 		if err := decryptString(k.AliasesJSON); err != nil {
@@ -728,7 +764,7 @@ func (k *TableKey) AfterFind(tx *gorm.DB) error {
 		k.VertexKeyConfig = config
 	}
 	// Reconstruct Bedrock config if fields are present
-	if k.BedrockAccessKey != nil || k.BedrockSecretKey != nil || k.BedrockSessionToken != nil || k.BedrockRegion != nil || k.BedrockARN != nil || k.BedrockRoleARN != nil || k.BedrockExternalID != nil || k.BedrockRoleSessionName != nil || k.BedrockBatchRoleARN != nil || k.BedrockProjectID != nil || (k.BedrockBatchS3ConfigJSON != nil && *k.BedrockBatchS3ConfigJSON != "") {
+	if k.BedrockAccessKey != nil || k.BedrockSecretKey != nil || k.BedrockSessionToken != nil || k.BedrockRegion != nil || k.BedrockARN != nil || k.BedrockRoleARN != nil || k.BedrockExternalID != nil || k.BedrockRoleSessionName != nil || k.BedrockBatchRoleARN != nil || k.BedrockProjectID != nil || (k.BedrockBatchS3ConfigJSON != nil && *k.BedrockBatchS3ConfigJSON != "") || (k.BedrockEndpointsJSON != nil && *k.BedrockEndpointsJSON != "") {
 		bedrockConfig := &schemas.BedrockKeyConfig{}
 
 		if k.BedrockAccessKey != nil {
@@ -756,10 +792,18 @@ func (k *TableKey) AfterFind(tx *gorm.DB) error {
 			bedrockConfig.BatchS3Config = &batchS3Config
 		}
 
+		if k.BedrockEndpointsJSON != nil && *k.BedrockEndpointsJSON != "" {
+			var endpoints schemas.BedrockEndpoints
+			if err := json.Unmarshal([]byte(*k.BedrockEndpointsJSON), &endpoints); err != nil {
+				return err
+			}
+			bedrockConfig.Endpoints = &endpoints
+		}
+
 		k.BedrockKeyConfig = bedrockConfig
 	}
 	// Reconstruct Bedrock Mantle config if fields are present
-	if k.BedrockMantleAccessKey != nil || k.BedrockMantleSecretKey != nil || k.BedrockMantleSessionToken != nil || k.BedrockMantleRegion != nil || k.BedrockMantleRoleARN != nil || k.BedrockMantleExternalID != nil || k.BedrockMantleRoleSessionName != nil || k.BedrockMantleProjectID != nil {
+	if k.BedrockMantleAccessKey != nil || k.BedrockMantleSecretKey != nil || k.BedrockMantleSessionToken != nil || k.BedrockMantleRegion != nil || k.BedrockMantleRoleARN != nil || k.BedrockMantleExternalID != nil || k.BedrockMantleRoleSessionName != nil || k.BedrockMantleProjectID != nil || (k.BedrockMantleEndpointsJSON != nil && *k.BedrockMantleEndpointsJSON != "") {
 		mantleConfig := &schemas.BedrockMantleKeyConfig{}
 		if k.BedrockMantleAccessKey != nil {
 			mantleConfig.AccessKey = *k.BedrockMantleAccessKey
@@ -773,6 +817,13 @@ func (k *TableKey) AfterFind(tx *gorm.DB) error {
 		mantleConfig.ExternalID = k.BedrockMantleExternalID
 		mantleConfig.RoleSessionName = k.BedrockMantleRoleSessionName
 		mantleConfig.ProjectID = k.BedrockMantleProjectID
+		if k.BedrockMantleEndpointsJSON != nil && *k.BedrockMantleEndpointsJSON != "" {
+			var endpoints schemas.BedrockEndpoints
+			if err := json.Unmarshal([]byte(*k.BedrockMantleEndpointsJSON), &endpoints); err != nil {
+				return err
+			}
+			mantleConfig.Endpoints = &endpoints
+		}
 		k.BedrockMantleKeyConfig = mantleConfig
 	}
 	// Reconstruct Aliases

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -5473,6 +5473,38 @@
                 }
               },
               "additionalProperties": false
+            },
+            "endpoints": {
+              "type": "object",
+              "description": "Interface VPC endpoint (AWS PrivateLink) hosts to dial instead of the public regional endpoints. Use the endpoint's DNS name from the VPC console, not the endpoint ID — AWS appends a random string that cannot be derived. Region is still required: it sets the SigV4 credential scope.",
+              "properties": {
+                "runtime": {
+                  "type": "string",
+                  "pattern": "\\.",
+                  "description": "Host for the bedrock-runtime service, which serves all inference (can use env. prefix)"
+                },
+                "control_plane": {
+                  "type": "string",
+                  "pattern": "\\.",
+                  "description": "Host for the bedrock service, which serves model listing and batch jobs (can use env. prefix)"
+                },
+                "mantle": {
+                  "type": "string",
+                  "pattern": "\\.",
+                  "description": "Host for the bedrock-mantle service, which serves mantle-routed models (can use env. prefix)"
+                },
+                "agent_runtime": {
+                  "type": "string",
+                  "pattern": "\\.",
+                  "description": "Host for the bedrock-agent-runtime service, which serves rerank (can use env. prefix)"
+                },
+                "s3": {
+                  "type": "string",
+                  "pattern": "\\.",
+                  "description": "Host for the s3 service, which serves batch file I/O. Must carry the literal \"bucket.\" prefix, since Bifrost prepends the bucket name to build the virtual-hosted URL. A Gateway endpoint needs no value here (can use env. prefix)"
+                }
+              },
+              "additionalProperties": false
             }
           },
           "required": ["region"],
@@ -5512,6 +5544,18 @@
             "project_id": {
               "type": "string",
               "description": "Bedrock project ID scoping the Mantle sub-surface (OpenAI-compatible gpt-*/Gemma routing) via the OpenAI-Project header. When empty, AWS routes to the account's default project. No effect on the Converse/bedrock-runtime paths (can use env. prefix)"
+            },
+            "endpoints": {
+              "type": "object",
+              "description": "Interface VPC endpoint (AWS PrivateLink) hosts to dial instead of the public regional endpoints. Use the endpoint's DNS name from the VPC console, not the endpoint ID — AWS appends a random string that cannot be derived. Region is still required: it sets the SigV4 credential scope.",
+              "properties": {
+                "mantle": {
+                  "type": "string",
+                  "pattern": "\\.",
+                  "description": "Host for the bedrock-mantle service (can use env. prefix)"
+                }
+              },
+              "additionalProperties": false
             }
           },
           "required": ["region"],
@@ -6412,6 +6456,38 @@
                         }
                       }
                     }
+                  },
+                  "endpoints": {
+                    "type": "object",
+                    "description": "Interface VPC endpoint (AWS PrivateLink) hosts to dial instead of the public regional endpoints. Use the endpoint's DNS name from the VPC console, not the endpoint ID — AWS appends a random string that cannot be derived. Region is still required: it sets the SigV4 credential scope.",
+                    "properties": {
+                      "runtime": {
+                        "type": "string",
+                        "pattern": "\\.",
+                        "description": "Host for the bedrock-runtime service, which serves all inference (can use env. prefix)"
+                      },
+                      "control_plane": {
+                        "type": "string",
+                        "pattern": "\\.",
+                        "description": "Host for the bedrock service, which serves model listing and batch jobs (can use env. prefix)"
+                      },
+                      "mantle": {
+                        "type": "string",
+                        "pattern": "\\.",
+                        "description": "Host for the bedrock-mantle service, which serves mantle-routed models (can use env. prefix)"
+                      },
+                      "agent_runtime": {
+                        "type": "string",
+                        "pattern": "\\.",
+                        "description": "Host for the bedrock-agent-runtime service, which serves rerank (can use env. prefix)"
+                      },
+                      "s3": {
+                        "type": "string",
+                        "pattern": "\\.",
+                        "description": "Host for the s3 service, which serves batch file I/O. Must carry the literal \"bucket.\" prefix, since Bifrost prepends the bucket name to build the virtual-hosted URL. A Gateway endpoint needs no value here (can use env. prefix)"
+                      }
+                    },
+                    "additionalProperties": false
                   }
                 },
                 "additionalProperties": false

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -452,6 +452,14 @@ bifrost:
   #         secret_key: "env.AWS_SECRET_ACCESS_KEY"
   #         # batch_role_arn: ""  # Optional: service role Bedrock assumes for batch S3 access; takes priority over role_arn sent in the request (can use env. prefix)
   #         project_id: ""  # Optional: Bedrock project ID scoping inference and model listing (can use env. prefix)
+  #         # Optional: route through interface VPC endpoints (AWS PrivateLink) instead of the public regional hosts.
+  #         # Use each endpoint's DNS name from the VPC console, not its ID. Region above still sets the SigV4 scope.
+  #         # endpoints:
+  #         #   runtime: "vpce-0abc123-x1y2z3.bedrock-runtime.us-east-1.vpce.amazonaws.com"        # All inference
+  #         #   control_plane: "vpce-0abc123-x1y2z3.bedrock.us-east-1.vpce.amazonaws.com"          # Model listing, batch jobs
+  #         #   mantle: "vpce-0abc123-x1y2z3.bedrock-mantle.us-east-1.vpce.amazonaws.com"          # Mantle-routed models
+  #         #   agent_runtime: "vpce-0abc123-x1y2z3.bedrock-agent-runtime.us-east-1.vpce.amazonaws.com"  # Rerank
+  #         #   s3: "bucket.vpce-0abc123-x1y2z3.s3.us-east-1.vpce.amazonaws.com"                   # Batch file I/O; needs the bucket. prefix
   #
   # # AWS Bedrock Mantle example (requires bedrock_mantle_key_config)
   # bedrock_mantle:
@@ -468,6 +476,9 @@ bifrost:
   #         # role_arn: ""                          # For AssumeRole
   #         # external_id: ""
   #         # session_name: ""
+  #         # Optional: route through an interface VPC endpoint (AWS PrivateLink) instead of the public regional host.
+  #         # endpoints:
+  #         #   mantle: "vpce-0abc123-x1y2z3.bedrock-mantle.us-east-1.vpce.amazonaws.com"
 
   # Provider secrets - use existing Kubernetes secrets for provider API keys
   # These will be injected as environment variables that can be referenced in providers config

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -4136,6 +4136,38 @@
                     }
                   },
                   "additionalProperties": false
+                },
+                "endpoints": {
+                  "type": "object",
+                  "description": "Interface VPC endpoint (AWS PrivateLink) hosts to dial instead of the public regional endpoints. Use the endpoint's DNS name from the VPC console, not the endpoint ID — AWS appends a random string that cannot be derived. Region is still required: it sets the SigV4 credential scope.",
+                  "properties": {
+                    "runtime": {
+                      "type": "string",
+                      "pattern": "\\.",
+                      "description": "Host for the bedrock-runtime service, which serves all inference (can use env. prefix)"
+                    },
+                    "control_plane": {
+                      "type": "string",
+                      "pattern": "\\.",
+                      "description": "Host for the bedrock service, which serves model listing and batch jobs (can use env. prefix)"
+                    },
+                    "mantle": {
+                      "type": "string",
+                      "pattern": "\\.",
+                      "description": "Host for the bedrock-mantle service, which serves mantle-routed models (can use env. prefix)"
+                    },
+                    "agent_runtime": {
+                      "type": "string",
+                      "pattern": "\\.",
+                      "description": "Host for the bedrock-agent-runtime service, which serves rerank (can use env. prefix)"
+                    },
+                    "s3": {
+                      "type": "string",
+                      "pattern": "\\.",
+                      "description": "Host for the s3 service, which serves batch file I/O. Must carry the literal \"bucket.\" prefix, since Bifrost prepends the bucket name to build the virtual-hosted URL. A Gateway endpoint needs no value here (can use env. prefix)"
+                    }
+                  },
+                  "additionalProperties": false
                 }
               },
               "required": ["region"],
@@ -4187,6 +4219,18 @@
                 "project_id": {
                   "type": "string",
                   "description": "Bedrock project ID scoping inference and model listing. Sent as the OpenAI-Project header on the OpenAI-compatible surface and the anthropic-workspace-id header on the native-Anthropic (Claude) surface. When empty, AWS routes to the account's default project (can use env. prefix)."
+                },
+                "endpoints": {
+                  "type": "object",
+                  "description": "Interface VPC endpoint (AWS PrivateLink) hosts to dial instead of the public regional endpoints. Use the endpoint's DNS name from the VPC console, not the endpoint ID — AWS appends a random string that cannot be derived. Region is still required: it sets the SigV4 credential scope.",
+                  "properties": {
+                    "mantle": {
+                      "type": "string",
+                      "pattern": "\\.",
+                      "description": "Host for the bedrock-mantle service (can use env. prefix)"
+                    }
+                  },
+                  "additionalProperties": false
                 }
               },
               "required": ["region"],

--- a/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
@@ -1,4 +1,5 @@
 import { SecretVarInput } from "@/components/ui/secretVarInput";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { ModelMultiselect } from "@/components/ui/modelMultiselect";
@@ -45,6 +46,92 @@ function BatchAPIFormField({ control }: { control: Control<any>; form: UseFormRe
 				</FormItem>
 			)}
 		/>
+	);
+}
+
+// AWS endpoint services Bifrost dials for Bedrock. `name` is the config field, `placeholder` the
+// DNS name shape for that service - S3 differs from the rest, so each is spelled out.
+const BEDROCK_VPC_ENDPOINT_SERVICES = [
+	{
+		name: "runtime",
+		label: "Runtime",
+		description: "Serves all inference.",
+		placeholder: "vpce-0abc123-x1y2z3.bedrock-runtime.us-east-1.vpce.amazonaws.com",
+	},
+	{
+		name: "control_plane",
+		label: "Control Plane",
+		description: "Serves model listing and batch jobs.",
+		placeholder: "vpce-0abc123-x1y2z3.bedrock.us-east-1.vpce.amazonaws.com",
+	},
+	{
+		name: "mantle",
+		label: "Mantle",
+		description: "Serves mantle-routed models.",
+		placeholder: "vpce-0abc123-x1y2z3.bedrock-mantle.us-east-1.vpce.amazonaws.com",
+	},
+	{
+		name: "agent_runtime",
+		label: "Agent Runtime",
+		description: "Serves rerank.",
+		placeholder: "vpce-0abc123-x1y2z3.bedrock-agent-runtime.us-east-1.vpce.amazonaws.com",
+	},
+	{
+		name: "s3",
+		label: "S3",
+		description: "Serves batch file I/O. Requires the bucket-prefixed endpoint name. A Gateway endpoint needs no value here.",
+		placeholder: "bucket.vpce-0abc123-x1y2z3.s3.us-east-1.vpce.amazonaws.com",
+	},
+];
+
+// VPC endpoint host overrides for AWS PrivateLink. Collapsed by default: most deployments reach
+// Bedrock over the public regional endpoints and never set these.
+function VPCEndpointsFormField({
+	control,
+	configKey,
+	services,
+}: {
+	control: Control<any>;
+	configKey: string;
+	services: typeof BEDROCK_VPC_ENDPOINT_SERVICES;
+}) {
+	return (
+		<Accordion type="single" collapsible className="w-full">
+			<AccordionItem value="vpc-endpoints" className="rounded-sm border px-2 last:border-b">
+				<AccordionTrigger className="py-2 hover:no-underline" data-testid="bedrock-vpc-endpoints-trigger">
+					<span className="block space-y-1.5 pr-2">
+						<span className="block text-sm leading-none font-medium">VPC Endpoints (Optional)</span>
+						<span className="text-muted-foreground block text-sm font-normal">
+							Route traffic through interface VPC endpoints instead of the public regional endpoints. Use each endpoint&apos;s DNS name from
+							the VPC console, not its ID. Region is still required — it sets the request signing scope.
+						</span>
+					</span>
+				</AccordionTrigger>
+				<AccordionContent className="space-y-4 pt-2 pb-3">
+					{services.map((service) => (
+						<FormField
+							key={service.name}
+							control={control}
+							name={`${configKey}.endpoints.${service.name}`}
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>{service.label}</FormLabel>
+									<FormDescription>{service.description}</FormDescription>
+									<FormControl>
+										<SecretVarInput
+											data-testid={`apikey-bedrock-endpoint-${service.name}-input`}
+											placeholder={service.placeholder}
+											{...field}
+										/>
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+					))}
+				</AccordionContent>
+			</AccordionItem>
+		</Accordion>
 	);
 }
 
@@ -1036,6 +1123,7 @@ export function ApiKeyFormFragment({ control, providerName, baseProviderType, fo
 						/>
 					)}
 					{supportsBatchAPI && <BatchAPIFormField control={control} form={form} />}
+					<VPCEndpointsFormField control={control} configKey="key.bedrock_key_config" services={BEDROCK_VPC_ENDPOINT_SERVICES} />
 				</div>
 			)}
 
@@ -1238,6 +1326,11 @@ export function ApiKeyFormFragment({ control, providerName, baseProviderType, fo
 							/>
 						</>
 					)}
+					<VPCEndpointsFormField
+						control={control}
+						configKey="key.bedrock_mantle_key_config"
+						services={BEDROCK_VPC_ENDPOINT_SERVICES.filter((s) => s.name === "mantle")}
+					/>
 				</div>
 			)}
 		</div>

--- a/ui/lib/schemas/providerForm.ts
+++ b/ui/lib/schemas/providerForm.ts
@@ -105,6 +105,22 @@ const BatchS3ConfigSchema = z.object({
 	buckets: z.array(S3BucketConfigSchema).optional(),
 });
 
+// A VPC endpoint value must be a DNS name, so it always contains a dot. The check exists to
+// catch a pasted endpoint ID, which resolves to nothing: AWS appends a random string to the ID
+// that the DNS name carries and the ID does not.
+const VPCEndpointHostSchema = z
+	.string()
+	.refine((v) => v.trim() === "" || v.includes("."), "Enter the endpoint's DNS name from the VPC console, not its ID")
+	.optional();
+
+const BedrockEndpointsSchema = z.object({
+	runtime: VPCEndpointHostSchema,
+	control_plane: VPCEndpointHostSchema,
+	mantle: VPCEndpointHostSchema,
+	agent_runtime: VPCEndpointHostSchema,
+	s3: VPCEndpointHostSchema,
+});
+
 const BedrockKeyConfigSchema = z
 	.object({
 		access_key: z.string(),
@@ -118,6 +134,7 @@ const BedrockKeyConfigSchema = z
 		arn: z.string().optional(),
 		project_id: z.string().optional(),
 		batch_s3_config: BatchS3ConfigSchema.optional(),
+		endpoints: BedrockEndpointsSchema.optional(),
 	})
 	.refine(
 		(data) => {
@@ -155,6 +172,7 @@ const BedrockMantleKeyConfigSchema = z
 		external_id: z.string().optional(),
 		session_name: z.string().optional(),
 		project_id: z.string().optional(),
+		endpoints: BedrockEndpointsSchema.optional(),
 	})
 	.refine(
 		(data) => {

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -120,6 +120,16 @@ export interface BatchS3Config {
 	buckets?: S3BucketConfig[];
 }
 
+// BedrockEndpoints matching Go's schemas.BedrockEndpoints. Each value is an interface VPC
+// endpoint's DNS name, dialled instead of the public regional host for that AWS service.
+export interface BedrockEndpoints {
+	runtime?: SecretVar;
+	control_plane?: SecretVar;
+	mantle?: SecretVar;
+	agent_runtime?: SecretVar;
+	s3?: SecretVar;
+}
+
 // BedrockKeyConfig matching Go's schemas.BedrockKeyConfig
 export interface BedrockKeyConfig {
 	access_key?: SecretVar;
@@ -129,6 +139,7 @@ export interface BedrockKeyConfig {
 	arn?: SecretVar;
 	project_id?: SecretVar;
 	batch_s3_config?: BatchS3Config;
+	endpoints?: BedrockEndpoints;
 }
 
 // Default BedrockKeyConfig
@@ -140,6 +151,7 @@ export const DefaultBedrockKeyConfig: BedrockKeyConfig = {
 	arn: { value: "", ref: "" },
 	project_id: { value: "", ref: "" },
 	batch_s3_config: undefined as unknown as BatchS3Config,
+	endpoints: undefined as unknown as BedrockEndpoints,
 } as const satisfies Required<BedrockKeyConfig>;
 
 // BedrockMantleKeyConfig matching Go's schemas.BedrockMantleKeyConfig
@@ -152,6 +164,7 @@ export interface BedrockMantleKeyConfig {
 	external_id?: SecretVar;
 	session_name?: SecretVar;
 	project_id?: SecretVar;
+	endpoints?: BedrockEndpoints;
 }
 
 // Default BedrockMantleKeyConfig
@@ -164,6 +177,7 @@ export const DefaultBedrockMantleKeyConfig: BedrockMantleKeyConfig = {
 	external_id: undefined as unknown as SecretVar,
 	session_name: undefined as unknown as SecretVar,
 	project_id: undefined as unknown as SecretVar,
+	endpoints: undefined as unknown as BedrockEndpoints,
 } as const satisfies Required<BedrockMantleKeyConfig>;
 
 // VLLMKeyConfig matching Go's schemas.VLLMKeyConfig

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -151,6 +151,15 @@ export const batchS3ConfigSchema = z.object({
 	buckets: z.array(s3BucketConfigSchema).optional(),
 });
 
+// Interface VPC endpoint hosts, one per AWS endpoint service Bifrost dials for Bedrock.
+export const bedrockEndpointsSchema = z.object({
+	runtime: secretVarSchema.optional(),
+	control_plane: secretVarSchema.optional(),
+	mantle: secretVarSchema.optional(),
+	agent_runtime: secretVarSchema.optional(),
+	s3: secretVarSchema.optional(),
+});
+
 // Bedrock key config schema
 export const bedrockKeyConfigSchema = z
 	.object({
@@ -166,6 +175,7 @@ export const bedrockKeyConfigSchema = z
 		arn: secretVarSchema.optional(),
 		project_id: secretVarSchema.optional(),
 		batch_s3_config: batchS3ConfigSchema.optional(),
+		endpoints: bedrockEndpointsSchema.optional(),
 	})
 	.refine(
 		(data) => {
@@ -207,6 +217,7 @@ export const bedrockMantleKeyConfigSchema = z
 		external_id: secretVarSchema.optional(),
 		session_name: secretVarSchema.optional(),
 		project_id: secretVarSchema.optional(),
+		endpoints: bedrockEndpointsSchema.optional(),
 	})
 	.refine((data) => isSecretVarSet(data.region), {
 		message: "Region is required",


### PR DESCRIPTION
## Summary

Adds support for routing AWS Bedrock traffic through interface VPC endpoints (AWS PrivateLink), allowing deployments where Bedrock services are accessed over private networking rather than the public regional endpoints. Each AWS endpoint service Bifrost dials (bedrock-runtime, bedrock, bedrock-mantle, bedrock-agent-runtime, s3) can be independently overridden with a VPC endpoint DNS name per key config.

## Changes

- Introduced `BedrockEndpoints` schema type holding per-service VPC endpoint host overrides for both `BedrockKeyConfig` and `BedrockMantleKeyConfig`.
- Added `resolveBedrockHost` utility that returns the configured VPC endpoint host when set, falling back to the public regional hostname. Mantle is handled as a special case since its public host lives under `api.aws` rather than `amazonaws.com`.
- Added `bedrockEndpoints` helper to safely extract endpoint config from a potentially nil `BedrockKeyConfig`.
- Replaced all hardcoded `fmt.Sprintf("https://bedrock-runtime.%s.amazonaws.com/...")` style URL construction across `bedrock.go`, `mantle.go`, and `bedrockmantle.go` with calls to `resolveBedrockHost`, covering inference, streaming, agent runtime, control plane, S3 file operations, and batch job endpoints.
- Updated `mantleOpenAIURL`, `mantleAnthropicURL`, and `mantleAnthropicCountTokensURL` to accept an `*schemas.BedrockEndpoints` argument so the override propagates through all Mantle call sites.
- Added `NormalizeEndpointHost` to strip scheme and path from a pasted endpoint value, so users can paste a full URL from the AWS console without breaking URL construction.
- Added `bedrockService` typed constants (`bedrockServiceRuntime`, `bedrockServiceControlPlane`, `bedrockServiceMantle`, `bedrockServiceAgentRuntime`, `bedrockServiceS3`) to make service identity explicit and avoid stringly-typed dispatch.
- Persisted `BedrockEndpoints` as encrypted JSON columns (`bedrock_endpoints_json`, `bedrock_mantle_endpoints_json`) in the `config_keys` table, with full `BeforeSave`/`AfterFind` encrypt/decrypt lifecycle and a database migration.
- Exposed VPC endpoint hosts in the redacted config view (they are network addresses, not credentials).
- Added a collapsible **VPC Endpoints** section to the Bedrock and Bedrock Mantle key forms in the UI, with per-service fields and a validation rule requiring a DNS name (containing a dot) rather than a bare endpoint ID.
- Updated `config.schema.json` with the `endpoints` object for both Bedrock and Bedrock Mantle key configs.
- Added `vpcendpoints_test.go` covering default host resolution, per-service override isolation, host normalization edge cases, and SigV4 signing correctness with a VPC endpoint host. Updated existing tests to pass `nil` endpoints where the new parameter was added.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./core/providers/bedrock/... ./core/providers/bedrockmantle/... ./framework/configstore/...

# UI
cd ui
pnpm i
pnpm build
```

To validate end-to-end, configure a Bedrock key with an `endpoints.runtime` value set to a VPC endpoint DNS name and confirm inference requests are directed to that host. Confirm that omitting the field falls back to the standard `bedrock-runtime.{region}.amazonaws.com` host. Confirm SigV4 signing still uses the configured region regardless of which host is dialled.

**New config fields (`BedrockKeyConfig.endpoints`):**

| Field | AWS endpoint service | Default public host |
|---|---|---|
| `runtime` | `bedrock-runtime` | `bedrock-runtime.{region}.amazonaws.com` |
| `control_plane` | `bedrock` | `bedrock.{region}.amazonaws.com` |
| `mantle` | `bedrock-mantle` | `bedrock-mantle.{region}.api.aws` |
| `agent_runtime` | `bedrock-agent-runtime` | `bedrock-agent-runtime.{region}.amazonaws.com` |
| `s3` | `s3` | `s3.{region}.amazonaws.com` |

Values accept the full DNS name from the VPC console (e.g. `vpce-0abc123-x1y2z3.bedrock-runtime.eu-west-2.vpce.amazonaws.com`), a URL with scheme, or a URL with a trailing path — all are normalized to a bare host.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

VPC endpoint hosts are stored encrypted at rest alongside other key config. They are surfaced in plaintext in the redacted config view because they are network addresses rather than credentials. SigV4 signing is unaffected: the credential scope continues to use the configured region, not the hostname, so a VPC endpoint host does not alter the signature scope.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable