### PR TITLE
fix(gemini): prefer function declarations over google search when tool combination is disabled

### DIFF
--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -4804,7 +4804,7 @@ func TestGroundingMetadataToChatAnnotations(t *testing.T) {
 
 // TestIncludeServerSideToolInvocations covers Gemini's tool-combination opt-in:
 // without it Gemini rejects function declarations sent alongside Google Search, so
-// the declarations are dropped; with it both go on the wire.
+// Google Search is dropped and the declarations are preserved; with it both go on the wire.
 func TestIncludeServerSideToolInvocations(t *testing.T) {
 	responsesReq := func(include *bool) *schemas.BifrostResponsesRequest {
 		return &schemas.BifrostResponsesRequest{
@@ -4826,21 +4826,57 @@ func TestIncludeServerSideToolInvocations(t *testing.T) {
 		}
 	}
 
-	t.Run("flag absent drops function declarations (unchanged behaviour)", func(t *testing.T) {
+	t.Run("flag absent drops google search, keeps function declarations", func(t *testing.T) {
 		out, err := gemini.ToGeminiResponsesRequest(nil, responsesReq(nil))
 		require.NoError(t, err)
 		require.Len(t, out.Tools, 1)
-		assert.NotNil(t, out.Tools[0].GoogleSearch)
-		assert.Empty(t, out.Tools[0].FunctionDeclarations)
-		assert.Nil(t, out.ToolConfig)
+		assert.Nil(t, out.Tools[0].GoogleSearch)
+		require.Len(t, out.Tools[0].FunctionDeclarations, 1)
+		assert.Equal(t, "get_weather", out.Tools[0].FunctionDeclarations[0].Name)
 	})
 
-	t.Run("flag false drops function declarations", func(t *testing.T) {
+	t.Run("flag false drops google search, keeps function declarations", func(t *testing.T) {
 		out, err := gemini.ToGeminiResponsesRequest(nil, responsesReq(schemas.Ptr(false)))
 		require.NoError(t, err)
 		require.Len(t, out.Tools, 1)
+		assert.Nil(t, out.Tools[0].GoogleSearch)
+		require.Len(t, out.Tools[0].FunctionDeclarations, 1)
+	})
+
+	t.Run("surviving declarations carry the tool choice through", func(t *testing.T) {
+		req := responsesReq(nil)
+		req.Params.ToolChoice = &schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("required")}
+		out, err := gemini.ToGeminiResponsesRequest(nil, req)
+		require.NoError(t, err)
+		require.NotNil(t, out.ToolConfig, "toolConfig must survive alongside the declarations")
+		require.NotNil(t, out.ToolConfig.FunctionCallingConfig)
+		assert.Equal(t, gemini.FunctionCallingConfigModeAny, out.ToolConfig.FunctionCallingConfig.Mode)
+	})
+
+	t.Run("web search alone is untouched", func(t *testing.T) {
+		req := responsesReq(nil)
+		req.Params.Tools = req.Params.Tools[:1]
+		out, err := gemini.ToGeminiResponsesRequest(nil, req)
+		require.NoError(t, err)
+		require.Len(t, out.Tools, 1)
 		assert.NotNil(t, out.Tools[0].GoogleSearch)
-		assert.Nil(t, out.ToolConfig)
+	})
+
+	t.Run("dropped google search takes its localization with it", func(t *testing.T) {
+		req := responsesReq(nil)
+		req.Params.Tools[0].ResponsesToolWebSearch = &schemas.ResponsesToolWebSearch{
+			UserLocation: &schemas.ResponsesToolWebSearchUserLocation{
+				Latitude:  schemas.Ptr(48.85),
+				Longitude: schemas.Ptr(2.35),
+			},
+		}
+		out, err := gemini.ToGeminiResponsesRequest(nil, req)
+		require.NoError(t, err)
+		require.Len(t, out.Tools, 1)
+		assert.Nil(t, out.Tools[0].GoogleSearch)
+		if out.ToolConfig != nil {
+			assert.Nil(t, out.ToolConfig.RetrievalConfig, "retrievalConfig is meaningless without googleSearch")
+		}
 	})
 
 	t.Run("flag true sends both as separate tool entries", func(t *testing.T) {
@@ -4937,9 +4973,11 @@ func TestIncludeServerSideToolInvocationsGenAIRoundTrip(t *testing.T) {
 			require.NoError(t, err)
 
 			if !tt.want {
-				// Combination not requested: today's behaviour keeps search, drops declarations.
+				// Combination not requested: declarations win, googleSearch is dropped.
 				require.Len(t, out.Tools, 1)
-				assert.NotNil(t, out.Tools[0].GoogleSearch)
+				assert.Nil(t, out.Tools[0].GoogleSearch)
+				require.Len(t, out.Tools[0].FunctionDeclarations, 1)
+				assert.Equal(t, "get_weather", out.Tools[0].FunctionDeclarations[0].Name)
 				return
 			}
 
@@ -4952,6 +4990,37 @@ func TestIncludeServerSideToolInvocationsGenAIRoundTrip(t *testing.T) {
 			assert.True(t, *out.ToolConfig.IncludeServerSideToolInvocations)
 		})
 	}
+}
+
+// TestGenAICombinedToolEntryKeepsDeclarations covers a single tools[] entry carrying both
+// googleSearch and functionDeclarations (legal on Gemini 3+): the declarations must reach
+// the wire, since they may be MCP-derived tools the caller has to be able to invoke.
+func TestGenAICombinedToolEntryKeepsDeclarations(t *testing.T) {
+	body := `{
+		"contents": [{"role": "user", "parts": [{"text": "weather in tokyo?"}]}],
+		"toolConfig": {"functionCallingConfig": {"mode": "ANY"}},
+		"tools": [{
+			"googleSearch": {},
+			"functionDeclarations": [{"name": "get_weather", "parametersJsonSchema": {"type": "object"}}]
+		}]
+	}`
+
+	var req gemini.GeminiGenerationRequest
+	require.NoError(t, sonic.Unmarshal([]byte(body), &req))
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	bifrostReq := req.ToBifrostResponsesRequest(ctx)
+	require.NotNil(t, bifrostReq)
+	require.Len(t, bifrostReq.Params.Tools, 2, "both tool kinds must survive ingest")
+
+	out, err := gemini.ToGeminiResponsesRequest(ctx, bifrostReq)
+	require.NoError(t, err)
+	require.Len(t, out.Tools, 1)
+	require.Len(t, out.Tools[0].FunctionDeclarations, 1)
+	assert.Equal(t, "get_weather", out.Tools[0].FunctionDeclarations[0].Name)
+	require.NotNil(t, out.ToolConfig)
+	require.NotNil(t, out.ToolConfig.FunctionCallingConfig)
+	assert.Equal(t, gemini.FunctionCallingConfigModeAny, out.ToolConfig.FunctionCallingConfig.Mode)
 }
 
 // TestGroundingMultiSourceCitationsResponses covers the non-streaming Responses path

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -173,10 +173,19 @@ func ToGeminiResponsesRequestWithImageURLSchemes(ctx *schemas.BifrostContext, bi
 				}
 			}
 
-			// Rebuild search localization from the web_search tool that carried it.
+			// Rebuild search localization from the web_search tool that carried it, but
+			// only when that tool survived conversion — localization without a search
+			// tool is meaningless and Gemini rejects it.
+			hasGoogleSearch := false
+			for _, tool := range geminiReq.Tools {
+				if tool.GoogleSearch != nil {
+					hasGoogleSearch = true
+					break
+				}
+			}
 			for _, tool := range bifrostReq.Params.Tools {
 				webSearch := tool.ResponsesToolWebSearch
-				if tool.Type != schemas.ResponsesToolTypeWebSearch || webSearch == nil || webSearch.UserLocation == nil {
+				if !hasGoogleSearch || tool.Type != schemas.ResponsesToolTypeWebSearch || webSearch == nil || webSearch.UserLocation == nil {
 					continue
 				}
 				if webSearch.UserLocation.Latitude == nil && webSearch.UserLocation.Longitude == nil {
@@ -2560,7 +2569,9 @@ func convertGeminiToolsToResponsesTools(tools []Tool) []schemas.ResponsesTool {
 	var responsesTools []schemas.ResponsesTool
 
 	for _, tool := range tools {
-		// you cant use function declarations and google search together
+		// A single tools[] entry may legitimately carry both kinds (Gemini 3+). Convert
+		// everything it holds; convertResponsesToolsToGemini decides what survives on the
+		// way back out to the provider.
 		if tool.GoogleSearch != nil {
 			responsesTool := schemas.ResponsesTool{
 				Type: schemas.ResponsesToolTypeWebSearch,
@@ -2589,7 +2600,8 @@ func convertGeminiToolsToResponsesTools(tools []Tool) []schemas.ResponsesTool {
 				responsesTool.ResponsesToolWebSearch.SearchContentTypes = contentTypes
 			}
 			responsesTools = append(responsesTools, responsesTool)
-		} else if len(tool.FunctionDeclarations) > 0 {
+		}
+		if len(tool.FunctionDeclarations) > 0 {
 			for _, fn := range tool.FunctionDeclarations {
 				responsesTool := schemas.ResponsesTool{
 					Type:                  schemas.ResponsesToolTypeFunction,
@@ -3323,24 +3335,27 @@ func (r *GeminiGenerationRequest) convertParamsToGenerationConfigResponses(param
 
 // convertResponsesToolsToGemini converts Responses tools to Gemini tools.
 // includeServerSideToolInvocations opts into Gemini's tool combination mode; without it
-// Gemini rejects function declarations sent alongside Google Search, so they are dropped.
+// Gemini rejects function declarations sent alongside Google Search, so one of the two has
+// to go. Function declarations win: they carry the caller's (or the MCP gateway's) tools,
+// which the model cannot invoke at all if they never reach the wire, whereas losing Google
+// Search only costs grounding. Set includeServerSideToolInvocations to send both.
 func convertResponsesToolsToGemini(tools []schemas.ResponsesTool, includeServerSideToolInvocations bool) ([]Tool, error) {
 	var functionDeclarations []*FunctionDeclaration
 	var googleSearch *GoogleSearch
 
-	hasWebSearchTool := false
+	hasFunctionTool := false
 
 	for _, tool := range tools {
-		if tool.Type == schemas.ResponsesToolTypeWebSearch {
-			hasWebSearchTool = true
+		if tool.Type == schemas.ResponsesToolTypeFunction && tool.ResponsesToolFunction != nil && tool.Name != nil {
+			hasFunctionTool = true
 			break
 		}
 	}
 
-	dropFunctionDeclarations := hasWebSearchTool && !includeServerSideToolInvocations
+	dropGoogleSearch := hasFunctionTool && !includeServerSideToolInvocations
 
 	for _, tool := range tools {
-		if tool.Type == schemas.ResponsesToolTypeFunction && !dropFunctionDeclarations {
+		if tool.Type == schemas.ResponsesToolTypeFunction {
 			// Extract function information from ResponsesExtendedTool
 			if tool.ResponsesToolFunction != nil {
 				if tool.Name != nil && tool.ResponsesToolFunction != nil {
@@ -3364,7 +3379,7 @@ func convertResponsesToolsToGemini(tools []schemas.ResponsesTool, includeServerS
 				}
 			}
 		}
-		if tool.Type == schemas.ResponsesToolTypeWebSearch {
+		if tool.Type == schemas.ResponsesToolTypeWebSearch && !dropGoogleSearch {
 			googleSearch = &GoogleSearch{}
 			if tool.ResponsesToolWebSearch != nil && tool.ResponsesToolWebSearch.Filters != nil {
 				if tool.ResponsesToolWebSearch.Filters.TimeRangeFilter != nil {


### PR DESCRIPTION
## Summary

When Gemini receives both function declarations and a Google Search tool in the same request without the `includeServerSideToolInvocations` opt-in, it rejects the combination. Previously, the resolution was to drop function declarations and keep Google Search. This PR inverts that priority: function declarations now win because they carry caller- or MCP-derived tools that the model cannot invoke at all if they never reach the wire, whereas dropping Google Search only costs grounding. Setting `includeServerSideToolInvocations` continues to send both.

## Changes

- `convertResponsesToolsToGemini` now detects the presence of function tools (rather than web search tools) as the deciding factor, drops Google Search instead of function declarations when the opt-in flag is absent, and preserves `ToolConfig` alongside the surviving declarations.
- `convertGeminiToolsToResponsesTools` changed the `else if` for function declarations to a standalone `if`, so a single `tools[]` entry carrying both `googleSearch` and `functionDeclarations` (valid on Gemini 3+) converts both kinds into the internal representation rather than skipping declarations.
- Search localization (`retrievalConfig`) is now only emitted when a Google Search tool actually survived conversion, preventing Gemini from rejecting a request with localization but no search tool.
- Tests updated to reflect the new priority: flag-absent and flag-false cases now assert that Google Search is nil and function declarations are present. New test cases cover tool choice surviving alongside declarations, web-search-only requests remaining untouched, localization being dropped with its search tool, and a round-trip for a combined single-entry `tools[]` payload.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
go test ./core/providers/gemini/...
```

The updated and new test cases in `gemini_test.go` cover the inverted drop priority, tool choice propagation, web-search-only passthrough, localization cleanup, and the combined single-entry round-trip.

## Breaking changes

- [x] Yes

Callers who relied on Google Search being preserved (and function declarations being dropped) when mixing both tool types without `includeServerSideToolInvocations` will now see the opposite: function declarations are preserved and Google Search is dropped. To restore the previous behaviour — sending both — set `includeServerSideToolInvocations` to `true`.

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable