### PR TITLE
feat: add additional metadata in S3 log export

### DIFF
--- a/framework/logstore/payload.go
+++ b/framework/logstore/payload.go
@@ -2,6 +2,7 @@ package logstore
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 	"unicode/utf8"
 
@@ -56,7 +57,7 @@ var payloadFields = []string{
 // ExtractPayload reads the serialized TEXT payload fields from a Log into a map.
 // The map keys are the DB column names.
 func ExtractPayload(l *Log) map[string]string {
-	m := make(map[string]string, len(payloadFields)+1)
+	m := make(map[string]string, len(payloadFields)+25)
 	m["input_history"] = l.InputHistory
 	m["responses_input_history"] = l.ResponsesInputHistory
 	m["output_message"] = l.OutputMessage
@@ -101,7 +102,43 @@ func ExtractPayload(l *Log) map[string]string {
 	if l.Metadata != nil && *l.Metadata != "" {
 		m["metadata"] = *l.Metadata
 	}
+	m["provider"] = l.Provider
+	m["model"] = l.Model
+	m["status"] = l.Status
+	m["timestamp"] = l.Timestamp.Format(time.RFC3339Nano)
+	m["selected_key_id"] = l.SelectedKeyID
+	m["selected_key_name"] = l.SelectedKeyName
+	putIfPresent(m, "virtual_key_id", l.VirtualKeyID)
+	putIfPresent(m, "virtual_key_name", l.VirtualKeyName)
+	putIfPresent(m, "user_id", l.UserID)
+	putIfPresent(m, "user_name", l.UserName)
+	putIfPresent(m, "team_id", l.TeamID)
+	putIfPresent(m, "team_name", l.TeamName)
+	putIfPresent(m, "team_ids", l.TeamIDs)
+	putIfPresent(m, "team_names", l.TeamNames)
+	putIfPresent(m, "customer_id", l.CustomerID)
+	putIfPresent(m, "customer_name", l.CustomerName)
+	putIfPresent(m, "customer_ids", l.CustomerIDs)
+	putIfPresent(m, "customer_names", l.CustomerNames)
+	putIfPresent(m, "business_unit_id", l.BusinessUnitID)
+	putIfPresent(m, "business_unit_name", l.BusinessUnitName)
+	putIfPresent(m, "business_unit_ids", l.BusinessUnitIDs)
+	putIfPresent(m, "business_unit_names", l.BusinessUnitNames)
+	if l.Cost != nil {
+		m["cost"] = strconv.FormatFloat(*l.Cost, 'f', -1, 64)
+	}
+	if l.Latency != nil {
+		m["latency"] = strconv.FormatFloat(*l.Latency, 'f', -1, 64)
+	}
 	return m
+}
+
+// putIfPresent sets the key only when v is non-nil and non-empty, so absent
+// attribution stays absent rather than becoming an empty string.
+func putIfPresent(m map[string]string, key string, v *string) {
+	if v != nil && *v != "" {
+		m[key] = *v
+	}
 }
 
 // ClearPayload zeros out both the TEXT payload columns and the Parsed virtual


### PR DESCRIPTION
## Summary

Extends `ExtractPayload` to include attribution and request metadata fields in the log payload map, making them available for downstream storage and processing alongside the existing text payload fields.

## Changes

- Added `provider`, `model`, `status`, `timestamp`, `selected_key_id`, and `selected_key_name` as always-present fields in the extracted payload map.
- Added optional attribution fields (`virtual_key_id/name`, `user_id/name`, `team_id/name`, `team_ids/names`, `customer_id/name`, `customer_ids/names`, `business_unit_id/name`, `business_unit_ids/names`) using a new `putIfPresent` helper that omits nil or empty pointer values rather than writing empty strings.
- Added `cost` and `latency` as float fields, serialized only when non-nil.
- Introduced the `putIfPresent` helper to keep absent attribution data absent in the map, avoiding empty-string pollution in downstream storage.
- Increased the initial map capacity from `len(payloadFields)+1` to `len(payloadFields)+25` to accommodate the new fields without reallocation.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/logstore/...
```

Verify that a `Log` struct with populated attribution fields produces a payload map containing the expected keys and values, and that nil or empty pointer fields are absent from the resulting map.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

Attribution fields such as `user_id`, `customer_id`, and `team_id` are now included in the payload map. Ensure downstream consumers of this map handle these identifiers appropriately and do not expose them in unintended contexts.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable