### PR TITLE
feat(gemini): support server-side toolCall/toolResponse parts with thoughtSignature round-trip fidelity

### DIFF
--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -4843,6 +4843,98 @@ func TestIncludeServerSideToolInvocations(t *testing.T) {
 		require.Len(t, out.Tools[0].FunctionDeclarations, 1)
 	})
 
+	t.Run("vertex sends both without the flag", func(t *testing.T) {
+		req := responsesReq(nil)
+		req.Provider = schemas.Vertex
+		out, err := gemini.ToGeminiResponsesRequest(nil, req)
+		require.NoError(t, err)
+		require.Len(t, out.Tools, 2, "vertex accepts built-in and function tools together")
+		require.Len(t, out.Tools[0].FunctionDeclarations, 1)
+		assert.Equal(t, "get_weather", out.Tools[0].FunctionDeclarations[0].Name)
+		assert.NotNil(t, out.Tools[1].GoogleSearch)
+	})
+
+	// Tool combination arrived with Gemini 3. Sending both tool kinds to an older model
+	// makes Vertex reject the whole request with
+	// "Multiple tools are supported only when they are all search tools", so the
+	// declarations-win drop still has to apply there -- a degraded answer beats a 400.
+	t.Run("vertex drops google search for models without tool combination", func(t *testing.T) {
+		for _, model := range []string{"gemini-2.5-flash", "gemini-2.5-pro", "gemini-2.0-flash"} {
+			t.Run(model, func(t *testing.T) {
+				req := responsesReq(nil)
+				req.Provider = schemas.Vertex
+				req.Model = model
+				out, err := gemini.ToGeminiResponsesRequest(nil, req)
+				require.NoError(t, err)
+				require.Len(t, out.Tools, 1, "pre-Gemini-3 models cannot combine tool kinds")
+				assert.Nil(t, out.Tools[0].GoogleSearch)
+				require.Len(t, out.Tools[0].FunctionDeclarations, 1)
+				assert.Equal(t, "get_weather", out.Tools[0].FunctionDeclarations[0].Name)
+			})
+		}
+	})
+
+	t.Run("vertex sends both for gemini 3 and newer", func(t *testing.T) {
+		for _, model := range []string{"gemini-3-flash-preview", "gemini-3.6-flash", "gemini-4-pro"} {
+			t.Run(model, func(t *testing.T) {
+				req := responsesReq(nil)
+				req.Provider = schemas.Vertex
+				req.Model = model
+				out, err := gemini.ToGeminiResponsesRequest(nil, req)
+				require.NoError(t, err)
+				require.Len(t, out.Tools, 2, "gemini 3+ accepts both tool kinds on vertex")
+				require.Len(t, out.Tools[0].FunctionDeclarations, 1)
+				assert.NotNil(t, out.Tools[1].GoogleSearch)
+			})
+		}
+	})
+
+	// An unrecognised model must not be assumed capable: dropping google search yields a
+	// degraded answer, sending both yields a hard 400.
+	t.Run("vertex drops google search for unrecognised models", func(t *testing.T) {
+		req := responsesReq(nil)
+		req.Provider = schemas.Vertex
+		req.Model = "some-tuned-endpoint"
+		out, err := gemini.ToGeminiResponsesRequest(nil, req)
+		require.NoError(t, err)
+		require.Len(t, out.Tools, 1)
+		assert.Nil(t, out.Tools[0].GoogleSearch)
+	})
+
+	t.Run("vertex keeps search localization alongside declarations", func(t *testing.T) {
+		req := responsesReq(nil)
+		req.Provider = schemas.Vertex
+		req.Params.Tools[0].ResponsesToolWebSearch = &schemas.ResponsesToolWebSearch{
+			UserLocation: &schemas.ResponsesToolWebSearchUserLocation{
+				Latitude:  schemas.Ptr(48.85),
+				Longitude: schemas.Ptr(2.35),
+			},
+		}
+		out, err := gemini.ToGeminiResponsesRequest(nil, req)
+		require.NoError(t, err)
+		require.Len(t, out.Tools, 2)
+		require.NotNil(t, out.ToolConfig)
+		require.NotNil(t, out.ToolConfig.RetrievalConfig)
+		require.NotNil(t, out.ToolConfig.RetrievalConfig.LatLng)
+		require.NotNil(t, out.ToolConfig.RetrievalConfig.LatLng.Latitude)
+		assert.Equal(t, 48.85, *out.ToolConfig.RetrievalConfig.LatLng.Latitude)
+		// Both coordinates have to survive: a half-populated LatLng points at the wrong
+		// place rather than at no place, which Gemini accepts without complaint.
+		require.NotNil(t, out.ToolConfig.RetrievalConfig.LatLng.Longitude)
+		assert.Equal(t, 2.35, *out.ToolConfig.RetrievalConfig.LatLng.Longitude)
+	})
+
+	t.Run("vertex does not force the server-side invocation flag on", func(t *testing.T) {
+		req := responsesReq(nil)
+		req.Provider = schemas.Vertex
+		out, err := gemini.ToGeminiResponsesRequest(nil, req)
+		require.NoError(t, err)
+		if out.ToolConfig != nil {
+			assert.Nil(t, out.ToolConfig.IncludeServerSideToolInvocations,
+				"vertex needs no opt-in; the flag must not be synthesized")
+		}
+	})
+
 	t.Run("surviving declarations carry the tool choice through", func(t *testing.T) {
 		req := responsesReq(nil)
 		req.Params.ToolChoice = &schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("required")}

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -4804,7 +4804,7 @@ func TestGroundingMetadataToChatAnnotations(t *testing.T) {
 
 // TestIncludeServerSideToolInvocations covers Gemini's tool-combination opt-in:
 // without it Gemini rejects function declarations sent alongside Google Search, so
-// the declarations are dropped; with it both go on the wire.
+// Google Search is dropped and the declarations are preserved; with it both go on the wire.
 func TestIncludeServerSideToolInvocations(t *testing.T) {
 	responsesReq := func(include *bool) *schemas.BifrostResponsesRequest {
 		return &schemas.BifrostResponsesRequest{
@@ -4826,21 +4826,57 @@ func TestIncludeServerSideToolInvocations(t *testing.T) {
 		}
 	}
 
-	t.Run("flag absent drops function declarations (unchanged behaviour)", func(t *testing.T) {
+	t.Run("flag absent drops google search, keeps function declarations", func(t *testing.T) {
 		out, err := gemini.ToGeminiResponsesRequest(nil, responsesReq(nil))
 		require.NoError(t, err)
 		require.Len(t, out.Tools, 1)
-		assert.NotNil(t, out.Tools[0].GoogleSearch)
-		assert.Empty(t, out.Tools[0].FunctionDeclarations)
-		assert.Nil(t, out.ToolConfig)
+		assert.Nil(t, out.Tools[0].GoogleSearch)
+		require.Len(t, out.Tools[0].FunctionDeclarations, 1)
+		assert.Equal(t, "get_weather", out.Tools[0].FunctionDeclarations[0].Name)
 	})
 
-	t.Run("flag false drops function declarations", func(t *testing.T) {
+	t.Run("flag false drops google search, keeps function declarations", func(t *testing.T) {
 		out, err := gemini.ToGeminiResponsesRequest(nil, responsesReq(schemas.Ptr(false)))
 		require.NoError(t, err)
 		require.Len(t, out.Tools, 1)
+		assert.Nil(t, out.Tools[0].GoogleSearch)
+		require.Len(t, out.Tools[0].FunctionDeclarations, 1)
+	})
+
+	t.Run("surviving declarations carry the tool choice through", func(t *testing.T) {
+		req := responsesReq(nil)
+		req.Params.ToolChoice = &schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("required")}
+		out, err := gemini.ToGeminiResponsesRequest(nil, req)
+		require.NoError(t, err)
+		require.NotNil(t, out.ToolConfig, "toolConfig must survive alongside the declarations")
+		require.NotNil(t, out.ToolConfig.FunctionCallingConfig)
+		assert.Equal(t, gemini.FunctionCallingConfigModeAny, out.ToolConfig.FunctionCallingConfig.Mode)
+	})
+
+	t.Run("web search alone is untouched", func(t *testing.T) {
+		req := responsesReq(nil)
+		req.Params.Tools = req.Params.Tools[:1]
+		out, err := gemini.ToGeminiResponsesRequest(nil, req)
+		require.NoError(t, err)
+		require.Len(t, out.Tools, 1)
 		assert.NotNil(t, out.Tools[0].GoogleSearch)
-		assert.Nil(t, out.ToolConfig)
+	})
+
+	t.Run("dropped google search takes its localization with it", func(t *testing.T) {
+		req := responsesReq(nil)
+		req.Params.Tools[0].ResponsesToolWebSearch = &schemas.ResponsesToolWebSearch{
+			UserLocation: &schemas.ResponsesToolWebSearchUserLocation{
+				Latitude:  schemas.Ptr(48.85),
+				Longitude: schemas.Ptr(2.35),
+			},
+		}
+		out, err := gemini.ToGeminiResponsesRequest(nil, req)
+		require.NoError(t, err)
+		require.Len(t, out.Tools, 1)
+		assert.Nil(t, out.Tools[0].GoogleSearch)
+		if out.ToolConfig != nil {
+			assert.Nil(t, out.ToolConfig.RetrievalConfig, "retrievalConfig is meaningless without googleSearch")
+		}
 	})
 
 	t.Run("flag true sends both as separate tool entries", func(t *testing.T) {
@@ -4937,9 +4973,11 @@ func TestIncludeServerSideToolInvocationsGenAIRoundTrip(t *testing.T) {
 			require.NoError(t, err)
 
 			if !tt.want {
-				// Combination not requested: today's behaviour keeps search, drops declarations.
+				// Combination not requested: declarations win, googleSearch is dropped.
 				require.Len(t, out.Tools, 1)
-				assert.NotNil(t, out.Tools[0].GoogleSearch)
+				assert.Nil(t, out.Tools[0].GoogleSearch)
+				require.Len(t, out.Tools[0].FunctionDeclarations, 1)
+				assert.Equal(t, "get_weather", out.Tools[0].FunctionDeclarations[0].Name)
 				return
 			}
 
@@ -4952,6 +4990,37 @@ func TestIncludeServerSideToolInvocationsGenAIRoundTrip(t *testing.T) {
 			assert.True(t, *out.ToolConfig.IncludeServerSideToolInvocations)
 		})
 	}
+}
+
+// TestGenAICombinedToolEntryKeepsDeclarations covers a single tools[] entry carrying both
+// googleSearch and functionDeclarations (legal on Gemini 3+): the declarations must reach
+// the wire, since they may be MCP-derived tools the caller has to be able to invoke.
+func TestGenAICombinedToolEntryKeepsDeclarations(t *testing.T) {
+	body := `{
+		"contents": [{"role": "user", "parts": [{"text": "weather in tokyo?"}]}],
+		"toolConfig": {"functionCallingConfig": {"mode": "ANY"}},
+		"tools": [{
+			"googleSearch": {},
+			"functionDeclarations": [{"name": "get_weather", "parametersJsonSchema": {"type": "object"}}]
+		}]
+	}`
+
+	var req gemini.GeminiGenerationRequest
+	require.NoError(t, sonic.Unmarshal([]byte(body), &req))
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	bifrostReq := req.ToBifrostResponsesRequest(ctx)
+	require.NotNil(t, bifrostReq)
+	require.Len(t, bifrostReq.Params.Tools, 2, "both tool kinds must survive ingest")
+
+	out, err := gemini.ToGeminiResponsesRequest(ctx, bifrostReq)
+	require.NoError(t, err)
+	require.Len(t, out.Tools, 1)
+	require.Len(t, out.Tools[0].FunctionDeclarations, 1)
+	assert.Equal(t, "get_weather", out.Tools[0].FunctionDeclarations[0].Name)
+	require.NotNil(t, out.ToolConfig)
+	require.NotNil(t, out.ToolConfig.FunctionCallingConfig)
+	assert.Equal(t, gemini.FunctionCallingConfigModeAny, out.ToolConfig.FunctionCallingConfig.Mode)
 }
 
 // TestGroundingMultiSourceCitationsResponses covers the non-streaming Responses path

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -328,6 +328,13 @@ func (response *GenerateContentResponse) ToResponsesBifrostResponsesResponse() *
 		if candidate.AvgLogprobs != 0 {
 			extraFields["avgLogprobs"] = candidate.AvgLogprobs
 		}
+		// Server-side tool parts have no lossless home in Bifrost's OpenAI-shaped schema
+		// (the web_search_call item keeps the queries, but not the raw tool response or the
+		// thoughtSignature Gemini requires back on replay). Carry them verbatim so the
+		// native GenAI response can be reproduced exactly.
+		if parts := serverSideToolParts(candidate); len(parts) > 0 {
+			extraFields["serverSideToolParts"] = parts
+		}
 		if len(extraFields) > 0 {
 			bifrostResp.ProviderExtraFields = extraFields
 		}
@@ -371,6 +378,21 @@ func ToGeminiResponsesResponse(bifrostResp *schemas.BifrostResponsesResponse) *G
 	// Set creation time
 	if bifrostResp.CreatedAt > 0 {
 		geminiResp.CreateTime = time.Unix(int64(bifrostResp.CreatedAt), 0)
+	}
+
+	// Server-side tool parts (toolCall/toolResponse) preserved verbatim at parse time.
+	// They are replayed ahead of the generated content, reproducing Gemini's own ordering,
+	// and they already carry their thoughtSignatures -- so the reasoning items derived from
+	// those same signatures must not emit duplicate signature-only parts below.
+	var preservedToolParts []*Part
+	preservedToolSignatures := map[string]bool{}
+	if bifrostResp.ProviderExtraFields != nil {
+		preservedToolParts = extractServerSideToolParts(bifrostResp.ProviderExtraFields["serverSideToolParts"])
+		for _, part := range preservedToolParts {
+			if len(part.ThoughtSignature) > 0 {
+				preservedToolSignatures[base64.StdEncoding.EncodeToString(part.ThoughtSignature)] = true
+			}
+		}
 	}
 
 	// Convert output messages to candidates
@@ -588,7 +610,7 @@ func ToGeminiResponsesResponse(bifrostResp *schemas.BifrostResponsesResponse) *G
 				}
 				if msg.ResponsesReasoning.EncryptedContent != nil {
 					decodedSig := thoughtSignatureFromEncryptedContent(msg.ResponsesReasoning.EncryptedContent)
-					if decodedSig != nil {
+					if decodedSig != nil && !preservedToolSignatures[base64.StdEncoding.EncodeToString(decodedSig)] {
 						currentParts = append(currentParts, &Part{
 							ThoughtSignature: decodedSig,
 						})
@@ -598,6 +620,9 @@ func ToGeminiResponsesResponse(bifrostResp *schemas.BifrostResponsesResponse) *G
 		}
 
 		// Add the last candidate if we have parts
+		if len(preservedToolParts) > 0 {
+			currentParts = append(append([]*Part{}, preservedToolParts...), currentParts...)
+		}
 		if len(currentParts) > 0 {
 			candidate := &Candidate{
 				Index: int32(len(candidates)),
@@ -918,7 +943,12 @@ func ToGeminiResponsesStreamResponse(bifrostResp *schemas.BifrostResponsesStream
 		return nil
 	case schemas.ResponsesStreamResponseTypeOutputItemAdded:
 		if bifrostResp.Item != nil && bifrostResp.Item.ResponsesReasoning != nil {
-			if sig := thoughtSignatureFromEncryptedContent(bifrostResp.Item.ResponsesReasoning.EncryptedContent); sig != nil {
+			// A server-side toolCall/toolResponse part travels whole on the item. Re-emit it
+			// verbatim: it already carries the same thoughtSignature the reasoning item
+			// encodes, so emitting both would hand the client the signature twice.
+			if native := nativePartsFromItem(bifrostResp.Item); len(native) > 0 {
+				candidate.Content.Parts = append(candidate.Content.Parts, native...)
+			} else if sig := thoughtSignatureFromEncryptedContent(bifrostResp.Item.ResponsesReasoning.EncryptedContent); sig != nil {
 				candidate.Content.Parts = append(candidate.Content.Parts, &Part{ThoughtSignature: sig})
 			}
 		}
@@ -937,7 +967,9 @@ func ToGeminiResponsesStreamResponse(bifrostResp *schemas.BifrostResponsesStream
 				state.ToolCallIDs[outputIndex] = *bifrostResp.Item.ResponsesToolMessage.CallID
 			}
 		}
-		return nil
+		// Fall through to the emptiness check below rather than returning unconditionally:
+		// this case builds reasoning/native parts above, and returning nil here discarded
+		// them, so thoughtSignatures never reached a /genai SSE client at all.
 
 	case schemas.ResponsesStreamResponseTypeOutputItemDone:
 		return nil
@@ -1078,6 +1110,21 @@ type GeminiResponsesStreamState struct {
 
 	// Web search tracking
 	HasEmittedWebSearch bool // Whether web_search_call events have been emitted
+	// Server-side searches reported by the model itself via toolCall/toolResponse parts,
+	// one entry per round in the order the model ran them. Recorded as they stream in and
+	// emitted as one web_search_call item each at finish, so the model's own call IDs and
+	// per-round queries win over the grounding-derived ones without emitting a search twice.
+	// A model may search several times in a single response, so this cannot collapse to a
+	// single call ID -- the non-streaming converter keys its items the same way.
+	ServerSearchRounds []GeminiServerSearchRound
+}
+
+// GeminiServerSearchRound is one server-side search the model reported running, identified
+// by the tool call ID Gemini assigned it.
+type GeminiServerSearchRound struct {
+	CallID       string
+	Queries      []string
+	ImageQueries []string
 }
 
 // geminiResponsesStreamStatePool provides a pool for Gemini responses stream state objects.
@@ -1154,6 +1201,7 @@ func (state *GeminiResponsesStreamState) flush() {
 	state.HasStartedText = false
 	state.HasStartedToolCall = false
 	state.HasEmittedWebSearch = false
+	state.ServerSearchRounds = nil
 	state.TextBuffer.Reset()
 }
 
@@ -1256,8 +1304,9 @@ func (response *GenerateContentResponse) ToBifrostResponsesStream(sequenceNumber
 		// Only close if we've actually started emitting content (text, tool calls, etc.)
 		// This prevents emitting response.completed for empty chunks with just finishReason
 		if candidate.FinishReason != "" && len(state.ItemIDs) > 0 {
-			// Check for grounding metadata (web search results)
-			if candidate.GroundingMetadata != nil && !state.HasEmittedWebSearch {
+			// Check for grounding metadata (web search results), or a server-side search the
+			// model reported itself via toolCall parts.
+			if (candidate.GroundingMetadata != nil || len(state.ServerSearchRounds) > 0) && !state.HasEmittedWebSearch {
 				// Emit web search events before closing
 				webSearchResponses := emitWebSearchFromGroundingMetadata(
 					candidate.GroundingMetadata,
@@ -1291,6 +1340,26 @@ func processGeminiPart(part *Part, state *GeminiResponsesStreamState, sequenceNu
 	case part.FunctionCall != nil:
 		// Function call
 		responses = append(responses, processGeminiFunctionCallPart(part, state, sequenceNumber)...)
+
+	case part.ToolCall != nil:
+		// Server-side tool invocation. The search events are emitted at finish, where
+		// grounding metadata supplies the sources, so only record the round here. Each call
+		// is kept separately -- a model that searches twice must produce two items, not one
+		// merged one. The part also carries a thoughtSignature, which still has to reach
+		// the client.
+		if isSearchToolType(part.ToolCall.ToolType) {
+			queries := toolCallSearchQueries(part.ToolCall)
+			round := GeminiServerSearchRound{CallID: part.ToolCall.ID, Queries: queries}
+			if strings.EqualFold(part.ToolCall.ToolType, "GOOGLE_SEARCH_IMAGE") {
+				round.ImageQueries = queries
+			}
+			state.ServerSearchRounds = append(state.ServerSearchRounds, round)
+		}
+		responses = append(responses, processGeminiThoughtSignaturePart(part, state, sequenceNumber)...)
+
+	case part.ToolResponse != nil:
+		// Result of a server-side call; carries no data Bifrost models beyond its signature.
+		responses = append(responses, processGeminiThoughtSignaturePart(part, state, sequenceNumber)...)
 
 	case part.ThoughtSignature != nil:
 		// Encrypted reasoning content (thoughtSignature)
@@ -1493,6 +1562,12 @@ func processGeminiThoughtSignaturePart(part *Part, state *GeminiResponsesStreamS
 	// Convert thoughtSignature to string
 	thoughtSig := base64.StdEncoding.EncodeToString(part.ThoughtSignature)
 
+	// A server-side toolCall/toolResponse part reaches here for its signature, but the
+	// part itself has no lossless home in the canonical schema. Carry it verbatim so the
+	// native GenAI stream can re-emit it instead of a bare signature-only part -- riding
+	// on this item keeps it in Gemini's original part order.
+	nativeParts := nativePartPayload(part)
+
 	// Emit output_item.added for reasoning with encrypted content
 	responses = append(responses, &schemas.BifrostResponsesStreamResponse{
 		Type:           schemas.ResponsesStreamResponseTypeOutputItemAdded,
@@ -1507,6 +1582,7 @@ func processGeminiThoughtSignaturePart(part *Part, state *GeminiResponsesStreamS
 				Summary:          []schemas.ResponsesReasoningSummary{},
 				EncryptedContent: &thoughtSig,
 			},
+			ProviderNativeParts: nativeParts,
 		},
 	})
 
@@ -1526,10 +1602,37 @@ func processGeminiThoughtSignaturePart(part *Part, state *GeminiResponsesStreamS
 				Summary:          []schemas.ResponsesReasoningSummary{},
 				EncryptedContent: &thoughtSig,
 			},
+			ProviderNativeParts: nativeParts,
 		},
 	})
 
 	return responses
+}
+
+// nativePartPayload serializes a server-side tool part so a native-surface integration can
+// replay it byte-for-byte. Returns nil for parts the canonical schema already represents
+// losslessly, so only toolCall/toolResponse pay the marshal cost.
+func nativePartPayload(part *Part) json.RawMessage {
+	if part == nil || (part.ToolCall == nil && part.ToolResponse == nil) {
+		return nil
+	}
+	encoded, err := sonic.Marshal([]*Part{part})
+	if err != nil {
+		return nil
+	}
+	return json.RawMessage(encoded)
+}
+
+// nativePartsFromItem recovers the parts stashed by nativePartPayload.
+func nativePartsFromItem(item *schemas.ResponsesMessage) []*Part {
+	if item == nil || len(item.ProviderNativeParts) == 0 {
+		return nil
+	}
+	var parts []*Part
+	if err := sonic.Unmarshal(item.ProviderNativeParts, &parts); err != nil {
+		return nil
+	}
+	return parts
 }
 
 // processGeminiFunctionCallPart handles function call parts
@@ -2693,6 +2796,110 @@ func convertGeminiToolConfigToToolChoice(toolConfig *ToolConfig) *schemas.Respon
 	}
 }
 
+// serverSideToolParts returns the candidate's toolCall/toolResponse parts verbatim.
+func serverSideToolParts(candidate *Candidate) []*Part {
+	if candidate == nil || candidate.Content == nil {
+		return nil
+	}
+	var parts []*Part
+	for _, part := range candidate.Content.Parts {
+		if part != nil && (part.ToolCall != nil || part.ToolResponse != nil) {
+			parts = append(parts, part)
+		}
+	}
+	return parts
+}
+
+// extractServerSideToolParts recovers the parts stashed by serverSideToolParts. Handles both
+// the in-memory pointers (normal path) and the JSON-decoded form, matching how the other
+// ProviderExtraFields values are read back.
+func extractServerSideToolParts(v any) []*Part {
+	if v == nil {
+		return nil
+	}
+	if parts, ok := v.([]*Part); ok {
+		return parts
+	}
+	b, err := sonic.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	var parts []*Part
+	if err := sonic.Unmarshal(b, &parts); err != nil {
+		return nil
+	}
+	return parts
+}
+
+// firstSearchCallIndex returns the lowest message index among the server-side search calls,
+// i.e. the item grounding metadata should be merged onto.
+func firstSearchCallIndex(byID map[string]int) (int, bool) {
+	first, found := 0, false
+	for _, idx := range byID {
+		if !found || idx < first {
+			first, found = idx, true
+		}
+	}
+	return first, found
+}
+
+// reasoningFromThoughtSignature builds the encrypted-reasoning item for a part that carries
+// a thoughtSignature. Server-side toolCall/toolResponse parts carry one too, and Gemini
+// requires signatures back on replay, so they must not be lost just because the part matched
+// a more specific case than the thoughtSignature one.
+func reasoningFromThoughtSignature(part *Part) (schemas.ResponsesMessage, bool) {
+	if part == nil || len(part.ThoughtSignature) == 0 {
+		return schemas.ResponsesMessage{}, false
+	}
+	thoughtSig := base64.StdEncoding.EncodeToString(part.ThoughtSignature)
+	return schemas.ResponsesMessage{
+		Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+		Type: schemas.Ptr(schemas.ResponsesMessageTypeReasoning),
+		ResponsesReasoning: &schemas.ResponsesReasoning{
+			Summary:          []schemas.ResponsesReasoningSummary{},
+			EncryptedContent: &thoughtSig,
+		},
+	}, true
+}
+
+// toolCallSearchQueries extracts Google Search's queries from a server-side tool call's args
+// ({"queries": ["...", ...]}). Returns nil when the shape is anything else.
+func toolCallSearchQueries(call *ToolCall) []string {
+	if call == nil || call.Args == nil {
+		return nil
+	}
+	raw, ok := call.Args["queries"].([]any)
+	if !ok {
+		return nil
+	}
+	queries := make([]string, 0, len(raw))
+	for _, q := range raw {
+		if s, ok := q.(string); ok && s != "" {
+			queries = append(queries, s)
+		}
+	}
+	if len(queries) == 0 {
+		return nil
+	}
+	return queries
+}
+
+// newWebSearchActionFromToolCall maps a server-side Google Search invocation onto the neutral
+// web_search_call action. Sources are not available here — they arrive in groundingMetadata
+// and are merged onto this item afterwards.
+func newWebSearchActionFromToolCall(call *ToolCall) *schemas.ResponsesWebSearchToolCallAction {
+	action := &schemas.ResponsesWebSearchToolCallAction{Type: "search"}
+	queries := toolCallSearchQueries(call)
+	if len(queries) > 0 {
+		action.Queries = queries
+		action.Query = schemas.Ptr(queries[0])
+	}
+	if call != nil && strings.EqualFold(call.ToolType, "GOOGLE_SEARCH_IMAGE") {
+		action.ImageQueries = queries
+	}
+	return action
+}
+
 // textBlockOf returns the text content block of messages[idx], or nil when idx is
 // out of range or the message carries no text block.
 func textBlockOf(messages []schemas.ResponsesMessage, idx int) *schemas.ResponsesOutputMessageContentText {
@@ -2754,6 +2961,9 @@ func convertGeminiCandidatesToResponsesOutput(candidates []*Candidate) []schemas
 		// Index into messages of this candidate's first text message; grounding
 		// annotations are attached to it once all parts have been converted.
 		textMessageIdx := -1
+
+		// Index from server-side tool-call ID to the web_search_call item it opened.
+		searchCallIndexByID := map[string]int{}
 
 		for _, part := range candidate.Content.Parts {
 			// Handle different types of parts
@@ -3002,6 +3212,39 @@ func convertGeminiCandidatesToResponsesOutput(candidates []*Candidate) []schemas
 					Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
 				}
 				messages = append(messages, msg)
+			case part.ToolCall != nil:
+				// Server-side tool invocation (Google executed it; we only report it).
+				// The part also carries a thoughtSignature, so keep emitting the reasoning
+				// item the thoughtSignature case below would have produced.
+				if msg, ok := reasoningFromThoughtSignature(part); ok {
+					messages = append(messages, msg)
+				}
+				if !isSearchToolType(part.ToolCall.ToolType) {
+					// Unmapped built-in tool: preserved verbatim on the native path above,
+					// but Bifrost has no neutral item type for it.
+					break
+				}
+				searchCallIndexByID[part.ToolCall.ID] = len(messages)
+				messages = append(messages, schemas.ResponsesMessage{
+					ID:     schemas.Ptr(part.ToolCall.ID),
+					Type:   schemas.Ptr(schemas.ResponsesMessageTypeWebSearchCall),
+					Status: schemas.Ptr("in_progress"),
+					ResponsesToolMessage: &schemas.ResponsesToolMessage{
+						Action: &schemas.ResponsesToolMessageActionStruct{
+							ResponsesWebSearchToolCallAction: newWebSearchActionFromToolCall(part.ToolCall),
+						},
+					},
+				})
+
+			case part.ToolResponse != nil:
+				// Result of a server-side ToolCall — completes the item its ID opened.
+				if msg, ok := reasoningFromThoughtSignature(part); ok {
+					messages = append(messages, msg)
+				}
+				if idx, ok := searchCallIndexByID[part.ToolResponse.ID]; ok && idx < len(messages) {
+					messages[idx].Status = schemas.Ptr("completed")
+				}
+
 			case part.ThoughtSignature != nil:
 				// Handle thought signature
 				thoughtSig := base64.StdEncoding.EncodeToString(part.ThoughtSignature)
@@ -3049,7 +3292,30 @@ func convertGeminiCandidatesToResponsesOutput(candidates []*Candidate) []schemas
 				webSearchmessage.ResponsesToolMessage.Action.ResponsesWebSearchToolCallAction.Sources = sources
 			}
 
-			messages = append(messages, webSearchmessage)
+			// When the model reported the search itself via server-side toolCall parts, that
+			// item is authoritative — it carries the real call ID. Merge grounding's richer
+			// data (sources, and any queries the call did not spell out) onto it rather than
+			// emitting a second web_search_call for the same search.
+			if idx, ok := firstSearchCallIndex(searchCallIndexByID); ok && idx < len(messages) {
+				if existing := messages[idx].ResponsesToolMessage; existing != nil && existing.Action != nil {
+					if action := existing.Action.ResponsesWebSearchToolCallAction; action != nil {
+						if len(sources) > 0 {
+							action.Sources = sources
+						}
+						if len(action.Queries) == 0 {
+							action.Queries = candidate.GroundingMetadata.WebSearchQueries
+							if len(action.Queries) > 0 {
+								action.Query = schemas.Ptr(action.Queries[0])
+							}
+						}
+						if len(action.ImageQueries) == 0 {
+							action.ImageQueries = candidate.GroundingMetadata.ImageSearchQueries
+						}
+					}
+				}
+			} else {
+				messages = append(messages, webSearchmessage)
+			}
 
 			// create a annotations message for grounding supports
 			if len(candidate.GroundingMetadata.GroundingSupports) > 0 {
@@ -4229,98 +4495,129 @@ func emitWebSearchFromGroundingMetadata(
 ) []*schemas.BifrostResponsesStreamResponse {
 	var responses []*schemas.BifrostResponsesStreamResponse
 
-	if metadata == nil || (len(metadata.WebSearchQueries) == 0 && len(metadata.ImageSearchQueries) == 0) {
+	// A server-side toolCall is enough to emit an item even when grounding metadata is
+	// absent or query-less: the model told us it searched.
+	hasGroundingQueries := metadata != nil && (len(metadata.WebSearchQueries) > 0 || len(metadata.ImageSearchQueries) > 0)
+	if !hasGroundingQueries && len(state.ServerSearchRounds) == 0 {
 		return responses
 	}
 
-	outputIndex := state.nextOutputIndex()
-	itemID := state.generateItemID("ws", outputIndex)
-	state.ItemIDs[outputIndex] = itemID
-
-	// Build web search action
-	action := &schemas.ResponsesWebSearchToolCallAction{
-		Type:         "search",
-		Queries:      metadata.WebSearchQueries,
-		ImageQueries: metadata.ImageSearchQueries,
-	}
-	if len(metadata.WebSearchQueries) > 0 {
-		action.Query = &metadata.WebSearchQueries[0]
-	}
-
-	// Convert groundingChunks to sources
+	// Convert groundingChunks to sources. Grounding reports them for the response as a
+	// whole rather than per round, so they attach to the first item -- mirroring how
+	// convertGeminiCandidatesToResponsesOutput merges them onto the first search call.
 	var sources []schemas.ResponsesWebSearchToolCallActionSearchSource
-	for _, chunk := range metadata.GroundingChunks {
-		if source, ok := groundingChunkSource(chunk); ok {
-			sources = append(sources, source)
+	if metadata != nil {
+		for _, chunk := range metadata.GroundingChunks {
+			if source, ok := groundingChunkSource(chunk); ok {
+				sources = append(sources, source)
+			}
 		}
 	}
-	action.Sources = sources
 
-	// 1. output_item.added (web_search_call, in_progress)
-	responses = append(responses, &schemas.BifrostResponsesStreamResponse{
-		Type:           schemas.ResponsesStreamResponseTypeOutputItemAdded,
-		SequenceNumber: sequenceNumber + len(responses),
-		OutputIndex:    &outputIndex,
-		Item: &schemas.ResponsesMessage{
-			ID:     &itemID,
-			Type:   schemas.Ptr(schemas.ResponsesMessageTypeWebSearchCall),
-			Status: schemas.Ptr("in_progress"),
-			ResponsesToolMessage: &schemas.ResponsesToolMessage{
-				Action: &schemas.ResponsesToolMessageActionStruct{
-					ResponsesWebSearchToolCallAction: &schemas.ResponsesWebSearchToolCallAction{
-						Type: "search",
+	// One item per server-side round, in the order the model ran them. With no rounds
+	// reported, grounding metadata alone still yields the single legacy item.
+	rounds := state.ServerSearchRounds
+	if len(rounds) == 0 {
+		rounds = []GeminiServerSearchRound{{}}
+	}
+
+	for i, round := range rounds {
+		outputIndex := state.nextOutputIndex()
+		// Prefer the model's own tool-call ID so the item is traceable back to Gemini's call.
+		itemID := round.CallID
+		if itemID == "" {
+			itemID = state.generateItemID("ws", outputIndex)
+		}
+		state.ItemIDs[outputIndex] = itemID
+
+		// Queries reported by the server-side call take precedence. Grounding fills in only
+		// what the call did not spell out, and only for the first item -- its query list
+		// covers the whole response, so replaying it per round would attribute another
+		// round's queries to this one.
+		action := &schemas.ResponsesWebSearchToolCallAction{
+			Type:         "search",
+			Queries:      round.Queries,
+			ImageQueries: round.ImageQueries,
+		}
+		if i == 0 && metadata != nil {
+			if len(action.Queries) == 0 {
+				action.Queries = metadata.WebSearchQueries
+			}
+			if len(action.ImageQueries) == 0 {
+				action.ImageQueries = metadata.ImageSearchQueries
+			}
+			action.Sources = sources
+		}
+		if len(action.Queries) > 0 {
+			action.Query = &action.Queries[0]
+		}
+
+		// 1. output_item.added (web_search_call, in_progress)
+		responses = append(responses, &schemas.BifrostResponsesStreamResponse{
+			Type:           schemas.ResponsesStreamResponseTypeOutputItemAdded,
+			SequenceNumber: sequenceNumber + len(responses),
+			OutputIndex:    &outputIndex,
+			Item: &schemas.ResponsesMessage{
+				ID:     &itemID,
+				Type:   schemas.Ptr(schemas.ResponsesMessageTypeWebSearchCall),
+				Status: schemas.Ptr("in_progress"),
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					Action: &schemas.ResponsesToolMessageActionStruct{
+						ResponsesWebSearchToolCallAction: &schemas.ResponsesWebSearchToolCallAction{
+							Type: "search",
+						},
 					},
 				},
 			},
-		},
-	})
+		})
 
-	// 2. web_search_call.in_progress
-	responses = append(responses, &schemas.BifrostResponsesStreamResponse{
-		Type:           schemas.ResponsesStreamResponseTypeWebSearchCallInProgress,
-		SequenceNumber: sequenceNumber + len(responses),
-		OutputIndex:    &outputIndex,
-		ItemID:         &itemID,
-	})
+		// 2. web_search_call.in_progress
+		responses = append(responses, &schemas.BifrostResponsesStreamResponse{
+			Type:           schemas.ResponsesStreamResponseTypeWebSearchCallInProgress,
+			SequenceNumber: sequenceNumber + len(responses),
+			OutputIndex:    &outputIndex,
+			ItemID:         &itemID,
+		})
 
-	// 3. web_search_call.searching
-	responses = append(responses, &schemas.BifrostResponsesStreamResponse{
-		Type:           schemas.ResponsesStreamResponseTypeWebSearchCallSearching,
-		SequenceNumber: sequenceNumber + len(responses),
-		OutputIndex:    &outputIndex,
-		ItemID:         &itemID,
-	})
+		// 3. web_search_call.searching
+		responses = append(responses, &schemas.BifrostResponsesStreamResponse{
+			Type:           schemas.ResponsesStreamResponseTypeWebSearchCallSearching,
+			SequenceNumber: sequenceNumber + len(responses),
+			OutputIndex:    &outputIndex,
+			ItemID:         &itemID,
+		})
 
-	// 4. web_search_call.completed
-	responses = append(responses, &schemas.BifrostResponsesStreamResponse{
-		Type:           schemas.ResponsesStreamResponseTypeWebSearchCallCompleted,
-		SequenceNumber: sequenceNumber + len(responses),
-		OutputIndex:    &outputIndex,
-		ItemID:         &itemID,
-	})
+		// 4. web_search_call.completed
+		responses = append(responses, &schemas.BifrostResponsesStreamResponse{
+			Type:           schemas.ResponsesStreamResponseTypeWebSearchCallCompleted,
+			SequenceNumber: sequenceNumber + len(responses),
+			OutputIndex:    &outputIndex,
+			ItemID:         &itemID,
+		})
 
-	// 5. output_item.done (with full action including sources)
-	responses = append(responses, &schemas.BifrostResponsesStreamResponse{
-		Type:           schemas.ResponsesStreamResponseTypeOutputItemDone,
-		SequenceNumber: sequenceNumber + len(responses),
-		OutputIndex:    &outputIndex,
-		ItemID:         &itemID,
-		Item: &schemas.ResponsesMessage{
-			ID:     &itemID,
-			Type:   schemas.Ptr(schemas.ResponsesMessageTypeWebSearchCall),
-			Status: schemas.Ptr("completed"),
-			ResponsesToolMessage: &schemas.ResponsesToolMessage{
-				Action: &schemas.ResponsesToolMessageActionStruct{
-					ResponsesWebSearchToolCallAction: action,
+		// 5. output_item.done (with full action including sources)
+		responses = append(responses, &schemas.BifrostResponsesStreamResponse{
+			Type:           schemas.ResponsesStreamResponseTypeOutputItemDone,
+			SequenceNumber: sequenceNumber + len(responses),
+			OutputIndex:    &outputIndex,
+			ItemID:         &itemID,
+			Item: &schemas.ResponsesMessage{
+				ID:     &itemID,
+				Type:   schemas.Ptr(schemas.ResponsesMessageTypeWebSearchCall),
+				Status: schemas.Ptr("completed"),
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					Action: &schemas.ResponsesToolMessageActionStruct{
+						ResponsesWebSearchToolCallAction: action,
+					},
 				},
 			},
-		},
-	})
+		})
+	}
 
 	state.HasEmittedWebSearch = true
 
 	// Emit rendered content if present
-	if metadata.SearchEntryPoint != nil && metadata.SearchEntryPoint.RenderedContent != "" {
+	if metadata != nil && metadata.SearchEntryPoint != nil && metadata.SearchEntryPoint.RenderedContent != "" {
 		renderedIndex := state.nextOutputIndex()
 		renderedItemID := state.generateItemID("rc", renderedIndex)
 		state.ItemIDs[renderedIndex] = renderedItemID

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -173,10 +173,19 @@ func ToGeminiResponsesRequestWithImageURLSchemes(ctx *schemas.BifrostContext, bi
 				}
 			}
 
-			// Rebuild search localization from the web_search tool that carried it.
+			// Rebuild search localization from the web_search tool that carried it, but
+			// only when that tool survived conversion — localization without a search
+			// tool is meaningless and Gemini rejects it.
+			hasGoogleSearch := false
+			for _, tool := range geminiReq.Tools {
+				if tool.GoogleSearch != nil {
+					hasGoogleSearch = true
+					break
+				}
+			}
 			for _, tool := range bifrostReq.Params.Tools {
 				webSearch := tool.ResponsesToolWebSearch
-				if tool.Type != schemas.ResponsesToolTypeWebSearch || webSearch == nil || webSearch.UserLocation == nil {
+				if !hasGoogleSearch || tool.Type != schemas.ResponsesToolTypeWebSearch || webSearch == nil || webSearch.UserLocation == nil {
 					continue
 				}
 				if webSearch.UserLocation.Latitude == nil && webSearch.UserLocation.Longitude == nil {
@@ -2560,7 +2569,9 @@ func convertGeminiToolsToResponsesTools(tools []Tool) []schemas.ResponsesTool {
 	var responsesTools []schemas.ResponsesTool
 
 	for _, tool := range tools {
-		// you cant use function declarations and google search together
+		// A single tools[] entry may legitimately carry both kinds (Gemini 3+). Convert
+		// everything it holds; convertResponsesToolsToGemini decides what survives on the
+		// way back out to the provider.
 		if tool.GoogleSearch != nil {
 			responsesTool := schemas.ResponsesTool{
 				Type: schemas.ResponsesToolTypeWebSearch,
@@ -2589,7 +2600,8 @@ func convertGeminiToolsToResponsesTools(tools []Tool) []schemas.ResponsesTool {
 				responsesTool.ResponsesToolWebSearch.SearchContentTypes = contentTypes
 			}
 			responsesTools = append(responsesTools, responsesTool)
-		} else if len(tool.FunctionDeclarations) > 0 {
+		}
+		if len(tool.FunctionDeclarations) > 0 {
 			for _, fn := range tool.FunctionDeclarations {
 				responsesTool := schemas.ResponsesTool{
 					Type:                  schemas.ResponsesToolTypeFunction,
@@ -3323,24 +3335,27 @@ func (r *GeminiGenerationRequest) convertParamsToGenerationConfigResponses(param
 
 // convertResponsesToolsToGemini converts Responses tools to Gemini tools.
 // includeServerSideToolInvocations opts into Gemini's tool combination mode; without it
-// Gemini rejects function declarations sent alongside Google Search, so they are dropped.
+// Gemini rejects function declarations sent alongside Google Search, so one of the two has
+// to go. Function declarations win: they carry the caller's (or the MCP gateway's) tools,
+// which the model cannot invoke at all if they never reach the wire, whereas losing Google
+// Search only costs grounding. Set includeServerSideToolInvocations to send both.
 func convertResponsesToolsToGemini(tools []schemas.ResponsesTool, includeServerSideToolInvocations bool) ([]Tool, error) {
 	var functionDeclarations []*FunctionDeclaration
 	var googleSearch *GoogleSearch
 
-	hasWebSearchTool := false
+	hasFunctionTool := false
 
 	for _, tool := range tools {
-		if tool.Type == schemas.ResponsesToolTypeWebSearch {
-			hasWebSearchTool = true
+		if tool.Type == schemas.ResponsesToolTypeFunction && tool.ResponsesToolFunction != nil && tool.Name != nil {
+			hasFunctionTool = true
 			break
 		}
 	}
 
-	dropFunctionDeclarations := hasWebSearchTool && !includeServerSideToolInvocations
+	dropGoogleSearch := hasFunctionTool && !includeServerSideToolInvocations
 
 	for _, tool := range tools {
-		if tool.Type == schemas.ResponsesToolTypeFunction && !dropFunctionDeclarations {
+		if tool.Type == schemas.ResponsesToolTypeFunction {
 			// Extract function information from ResponsesExtendedTool
 			if tool.ResponsesToolFunction != nil {
 				if tool.Name != nil && tool.ResponsesToolFunction != nil {
@@ -3364,7 +3379,7 @@ func convertResponsesToolsToGemini(tools []schemas.ResponsesTool, includeServerS
 				}
 			}
 		}
-		if tool.Type == schemas.ResponsesToolTypeWebSearch {
+		if tool.Type == schemas.ResponsesToolTypeWebSearch && !dropGoogleSearch {
 			googleSearch = &GoogleSearch{}
 			if tool.ResponsesToolWebSearch != nil && tool.ResponsesToolWebSearch.Filters != nil {
 				if tool.ResponsesToolWebSearch.Filters.TimeRangeFilter != nil {

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -152,7 +153,7 @@ func ToGeminiResponsesRequestWithImageURLSchemes(ctx *schemas.BifrostContext, bi
 		includeServerSideToolInvocations := bifrostReq.Params.IncludeServerSideToolInvocations != nil && *bifrostReq.Params.IncludeServerSideToolInvocations
 		// Handle tool-related parameters
 		if len(bifrostReq.Params.Tools) > 0 {
-			geminiReq.Tools, err = convertResponsesToolsToGemini(bifrostReq.Params.Tools, includeServerSideToolInvocations)
+			geminiReq.Tools, err = convertResponsesToolsToGemini(bifrostReq.Params.Tools, includeServerSideToolInvocations, bifrostReq.Provider, bifrostReq.Model)
 			if err != nil {
 				return nil, err
 			}
@@ -3333,15 +3334,57 @@ func (r *GeminiGenerationRequest) convertParamsToGenerationConfigResponses(param
 	return config, nil
 }
 
+// modelSupportsToolCombination reports whether a model can accept built-in tools (Google
+// Search) and function declarations in the same request. Tool combination arrived with
+// Gemini 3; 2.x and older reject the mix with
+// "Multiple tools are supported only when they are all search tools".
+//
+// Unknown or non-Gemini model names return false on purpose. Guessing "capable" costs a
+// hard 400, guessing "not capable" costs only the built-in tool, so the safe default is to
+// drop rather than to send.
+func modelSupportsToolCombination(model string) bool {
+	name := strings.ToLower(model)
+	// Strip a provider prefix ("vertex/gemini-3.6-flash") and any publisher path.
+	if idx := strings.LastIndex(name, "/"); idx != -1 {
+		name = name[idx+1:]
+	}
+	const prefix = "gemini-"
+	if !strings.HasPrefix(name, prefix) {
+		return false
+	}
+	// Read the leading major version: "3-flash-preview" -> 3, "2.5-pro" -> 2.
+	rest := name[len(prefix):]
+	end := 0
+	for end < len(rest) && rest[end] >= '0' && rest[end] <= '9' {
+		end++
+	}
+	if end == 0 {
+		return false
+	}
+	major, err := strconv.Atoi(rest[:end])
+	if err != nil {
+		return false
+	}
+	return major >= 3
+}
+
 // convertResponsesToolsToGemini converts Responses tools to Gemini tools.
-// includeServerSideToolInvocations opts into Gemini's tool combination mode; without it
-// Gemini rejects function declarations sent alongside Google Search, so one of the two has
-// to go. Function declarations win: they carry the caller's (or the MCP gateway's) tools,
-// which the model cannot invoke at all if they never reach the wire, whereas losing Google
-// Search only costs grounding. Set includeServerSideToolInvocations to send both.
-func convertResponsesToolsToGemini(tools []schemas.ResponsesTool, includeServerSideToolInvocations bool) ([]Tool, error) {
+// The Gemini Developer API rejects function declarations sent alongside Google Search
+// unless includeServerSideToolInvocations opts into tool combination mode, so without it
+// one of the two has to go. Function declarations win: they carry the caller's (or the MCP
+// gateway's) tools, which the model cannot invoke at all if they never reach the wire,
+// whereas losing Google Search only costs grounding.
+//
+// Vertex AI accepts the combination without the flag, but only on models that support tool
+// combination at all — Gemini 3 and newer. Sending both kinds to an older Vertex model is
+// rejected outright with "Multiple tools are supported only when they are all search tools",
+// so the drop still applies there: a degraded answer beats a 400.
+func convertResponsesToolsToGemini(tools []schemas.ResponsesTool, includeServerSideToolInvocations bool, provider schemas.ModelProvider, model string) ([]Tool, error) {
 	var functionDeclarations []*FunctionDeclaration
 	var googleSearch *GoogleSearch
+
+	allowsMixedTools := includeServerSideToolInvocations ||
+		(provider == schemas.Vertex && modelSupportsToolCombination(model))
 
 	hasFunctionTool := false
 
@@ -3352,7 +3395,7 @@ func convertResponsesToolsToGemini(tools []schemas.ResponsesTool, includeServerS
 		}
 	}
 
-	dropGoogleSearch := hasFunctionTool && !includeServerSideToolInvocations
+	dropGoogleSearch := hasFunctionTool && !allowsMixedTools
 
 	for _, tool := range tools {
 		if tool.Type == schemas.ResponsesToolTypeFunction {

--- a/core/providers/gemini/serversidetools_stream_test.go
+++ b/core/providers/gemini/serversidetools_stream_test.go
@@ -1,0 +1,210 @@
+package gemini
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// collectStreamWebSearchItems drives chunks through the responses stream converter and
+// returns the completed web_search_call items keyed by item ID, in emission order.
+func collectStreamWebSearchItems(t *testing.T, chunks []string) ([]string, map[string]*schemas.ResponsesWebSearchToolCallAction) {
+	t.Helper()
+	state := acquireGeminiResponsesStreamState()
+	defer releaseGeminiResponsesStreamState(state)
+
+	var order []string
+	items := map[string]*schemas.ResponsesWebSearchToolCallAction{}
+	seq := 0
+	for _, c := range chunks {
+		var resp GenerateContentResponse
+		if err := json.Unmarshal([]byte(c), &resp); err != nil {
+			t.Fatal(err)
+		}
+		events, err := resp.ToBifrostResponsesStream(seq, state)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, e := range events {
+			if e.Item == nil || e.Item.Type == nil || *e.Item.Type != schemas.ResponsesMessageTypeWebSearchCall {
+				continue
+			}
+			if e.Item.ResponsesToolMessage == nil || e.Item.ResponsesToolMessage.Action == nil {
+				continue
+			}
+			a := e.Item.ResponsesToolMessage.Action.ResponsesWebSearchToolCallAction
+			if a == nil || len(a.Queries) == 0 {
+				continue
+			}
+			if e.Item.ID == nil {
+				t.Fatalf("web_search_call item carried an action but no ID: %+v", a)
+			}
+			if _, seen := items[*e.Item.ID]; !seen {
+				order = append(order, *e.Item.ID)
+			}
+			items[*e.Item.ID] = a
+		}
+		seq += len(events)
+	}
+	return order, items
+}
+
+// Streaming counterpart of TestServerSideToolCallMultipleRoundsWithFunctionCall: two
+// server-side search rounds must produce one web_search_call item each, carrying their own
+// call IDs and their own queries -- matching what the non-streaming converter produces for
+// the same content rather than collapsing both rounds into a single merged item.
+func TestServerSideToolCallStreamingMultipleRounds(t *testing.T) {
+	chunks := []string{
+		`{"candidates":[{"index":0,"content":{"role":"model","parts":[{"thoughtSignature":"c2lnMQ==","toolCall":{"toolType":"GOOGLE_SEARCH_WEB","args":{"queries":["FIFA World Cup winner 2026","2026 FIFA World Cup winner"]},"id":"BaoigkFu"}}]}}],"modelVersion":"gemini-3.6-flash"}`,
+		`{"candidates":[{"index":0,"content":{"role":"model","parts":[{"thoughtSignature":"c2lnMg==","toolResponse":{"toolType":"GOOGLE_SEARCH_WEB","response":{"search_suggestions":"<div/>"},"id":"BaoigkFu"}}]}}],"modelVersion":"gemini-3.6-flash"}`,
+		`{"candidates":[{"index":0,"content":{"role":"model","parts":[{"thoughtSignature":"c2lnMw==","toolCall":{"toolType":"GOOGLE_SEARCH_WEB","args":{"queries":["\"2026 FIFA World Cup\" score final Spain Argentina"]},"id":"Fbe8aaSI"}}]}}],"modelVersion":"gemini-3.6-flash"}`,
+		`{"candidates":[{"index":0,"content":{"role":"model","parts":[{"thoughtSignature":"c2lnNA==","toolResponse":{"toolType":"GOOGLE_SEARCH_WEB","response":{"search_suggestions":"<div/>"},"id":"Fbe8aaSI"}}]}}],"modelVersion":"gemini-3.6-flash"}`,
+		`{"candidates":[{"index":0,"content":{"role":"model","parts":[{"text":"Spain won."}]}}],"modelVersion":"gemini-3.6-flash"}`,
+		`{"candidates":[{"index":0,"finishReason":"STOP","groundingMetadata":{"webSearchQueries":["FIFA World Cup winner 2026"],"groundingChunks":[{"web":{"uri":"https://x/1","title":"fifa.com"}}]}}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15},"modelVersion":"gemini-3.6-flash"}`,
+	}
+
+	order, items := collectStreamWebSearchItems(t, chunks)
+
+	// Same expectation the non-streaming path asserts for this content
+	// (TestServerSideToolCallMultipleRoundsWithFunctionCall): one item per round, in order.
+	if len(items) != 2 {
+		t.Fatalf("expected one web_search_call per search round, got %d: %v", len(items), order)
+	}
+	want := []string{"BaoigkFu", "Fbe8aaSI"}
+	for i, id := range want {
+		if i >= len(order) || order[i] != id {
+			t.Fatalf("expected rounds in order %v, got %v", want, order)
+		}
+	}
+
+	first := items["BaoigkFu"]
+	if len(first.Queries) != 2 {
+		t.Errorf("first round must keep only its own 2 queries, got %v", first.Queries)
+	}
+	if len(first.Sources) != 1 {
+		t.Errorf("grounding sources merge onto the first round, got %d", len(first.Sources))
+	}
+
+	second := items["Fbe8aaSI"]
+	if len(second.Queries) != 1 || second.Queries[0] != `"2026 FIFA World Cup" score final Spain Argentina` {
+		t.Errorf("second round must keep only its own query, got %v", second.Queries)
+	}
+}
+
+// The /genai SSE surface converts Gemini -> Bifrost -> Gemini. The native server-side
+// toolCall/toolResponse parts must survive that round-trip with their thoughtSignature
+// bytes, exactly as they do on the non-streaming path -- a client replaying the streamed
+// turn needs the same parts Google sent, and Gemini rejects a replay whose signatures are
+// missing. Each signature must appear exactly once: the reasoning item carrying it and the
+// native part carrying it are the same part, not two.
+func TestServerSideToolCallStreamingGenAIRoundTrip(t *testing.T) {
+	chunks := []string{
+		`{"candidates":[{"index":0,"content":{"role":"model","parts":[{"thoughtSignature":"c2lnMQ==","toolCall":{"toolType":"GOOGLE_SEARCH_WEB","args":{"queries":["f1 winner 2026"]},"id":"nqh2j2zy"}}]}}],"modelVersion":"gemini-3.6-flash"}`,
+		`{"candidates":[{"index":0,"content":{"role":"model","parts":[{"thoughtSignature":"c2lnMg==","toolResponse":{"toolType":"GOOGLE_SEARCH_WEB","response":{"search_suggestions":"<div>chips</div>"},"id":"nqh2j2zy"}}]}}],"modelVersion":"gemini-3.6-flash"}`,
+		`{"candidates":[{"index":0,"content":{"role":"model","parts":[{"text":"Lando Norris won."}]}}],"modelVersion":"gemini-3.6-flash"}`,
+		`{"candidates":[{"index":0,"finishReason":"STOP","groundingMetadata":{"webSearchQueries":["f1 winner 2026"],"groundingChunks":[{"web":{"uri":"https://x/1","title":"formula1.com"}}]}}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15},"modelVersion":"gemini-3.6-flash"}`,
+	}
+
+	state := acquireGeminiResponsesStreamState()
+	defer releaseGeminiResponsesStreamState(state)
+	outState := NewBifrostToGeminiStreamState()
+
+	var outParts []*Part
+	seq := 0
+	for _, c := range chunks {
+		var resp GenerateContentResponse
+		if err := json.Unmarshal([]byte(c), &resp); err != nil {
+			t.Fatal(err)
+		}
+		events, err := resp.ToBifrostResponsesStream(seq, state)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, e := range events {
+			out := ToGeminiResponsesStreamResponse(e, outState)
+			if out == nil {
+				continue
+			}
+			for _, cand := range out.Candidates {
+				if cand.Content == nil {
+					continue
+				}
+				outParts = append(outParts, cand.Content.Parts...)
+			}
+		}
+		seq += len(events)
+	}
+
+	var toolCalls, toolResponses, signatureOnly int
+	sigCounts := map[string]int{}
+	for _, p := range outParts {
+		if len(p.ThoughtSignature) > 0 {
+			sigCounts[base64.StdEncoding.EncodeToString(p.ThoughtSignature)]++
+		}
+		switch {
+		case p.ToolCall != nil:
+			toolCalls++
+			if p.ToolCall.ID != "nqh2j2zy" {
+				t.Errorf("toolCall lost its id: %q", p.ToolCall.ID)
+			}
+			if len(p.ThoughtSignature) == 0 {
+				t.Error("streamed toolCall part lost its thoughtSignature")
+			}
+		case p.ToolResponse != nil:
+			toolResponses++
+			if p.ToolResponse.ID != "nqh2j2zy" {
+				t.Errorf("toolResponse lost its id: %q", p.ToolResponse.ID)
+			}
+			if len(p.ThoughtSignature) == 0 {
+				t.Error("streamed toolResponse part lost its thoughtSignature")
+			}
+		case len(p.ThoughtSignature) > 0 && p.Text == "":
+			signatureOnly++
+		}
+	}
+
+	if toolCalls != 1 {
+		t.Errorf("expected the native toolCall part to survive streaming, got %d", toolCalls)
+	}
+	if toolResponses != 1 {
+		t.Errorf("expected the native toolResponse part to survive streaming, got %d", toolResponses)
+	}
+	// The signature rides on the native part; a separate signature-only part for the same
+	// bytes would hand the client the same reasoning twice.
+	for sig, n := range sigCounts {
+		if n != 1 {
+			t.Errorf("thoughtSignature %s emitted %d times, want exactly 1", sig, n)
+		}
+	}
+	if signatureOnly != 0 {
+		t.Errorf("expected no duplicate signature-only parts alongside the native ones, got %d", signatureOnly)
+	}
+}
+
+func TestServerSideToolCallStreaming(t *testing.T) {
+	chunks := []string{
+		`{"candidates":[{"index":0,"content":{"role":"model","parts":[{"thoughtSignature":"c2ln","toolCall":{"toolType":"GOOGLE_SEARCH_WEB","args":{"queries":["f1 winner 2026","f1 results"]},"id":"nqh2j2zy"}}]}}],"modelVersion":"gemini-3.5-flash"}`,
+		`{"candidates":[{"index":0,"content":{"role":"model","parts":[{"thoughtSignature":"c2ln","toolResponse":{"toolType":"GOOGLE_SEARCH_WEB","response":{"search_suggestions":"<div/>"},"id":"nqh2j2zy"}}]}}],"modelVersion":"gemini-3.5-flash"}`,
+		`{"candidates":[{"index":0,"content":{"role":"model","parts":[{"text":"Lando Norris won."}]}}],"modelVersion":"gemini-3.5-flash"}`,
+		`{"candidates":[{"index":0,"finishReason":"STOP","groundingMetadata":{"webSearchQueries":["f1 winner 2026"],"groundingChunks":[{"web":{"uri":"https://x/1","title":"formula1.com"}}]}}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15},"modelVersion":"gemini-3.5-flash"}`,
+	}
+	_, webSearchItems := collectStreamWebSearchItems(t, chunks)
+
+	if len(webSearchItems) != 1 {
+		t.Fatalf("expected exactly 1 web_search_call, got %d", len(webSearchItems))
+	}
+	// Fatal, not Error: every assertion below reads through this key, so continuing past a
+	// miss would panic on the nil action and bury the real failure.
+	if _, ok := webSearchItems["nqh2j2zy"]; !ok {
+		t.Fatalf("web_search_call did not use the model's own tool call id, got %v", webSearchItems)
+	}
+	a := webSearchItems["nqh2j2zy"]
+	if len(a.Queries) != 2 {
+		t.Errorf("expected the toolCall's 2 queries, got %v", a.Queries)
+	}
+	if len(a.Sources) != 1 {
+		t.Errorf("expected grounding sources merged in, got %d", len(a.Sources))
+	}
+}

--- a/core/providers/gemini/serversidetools_test.go
+++ b/core/providers/gemini/serversidetools_test.go
@@ -1,0 +1,185 @@
+package gemini
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Gemini reports built-in tools it ran itself as toolCall/toolResponse part pairs when
+// toolConfig.includeServerSideToolInvocations is enabled. Sample shape taken from a live
+// gemini-3.5-flash response (signatures and payloads shortened).
+const serverSideToolResponseJSON = `{
+  "candidates": [{
+    "index": 0,
+    "groundingMetadata": {
+      "webSearchQueries": ["most recent F1 race winner", "F1 results"],
+      "groundingChunks": [
+        {"web": {"uri": "https://vertexaisearch.cloud.google.com/x1", "title": "formula1.com"}},
+        {"web": {"uri": "https://vertexaisearch.cloud.google.com/x2", "title": "aljazeera.com"}}
+      ],
+      "groundingSupports": [
+        {"segment": {"startIndex": 0, "endIndex": 41, "text": "Lando Norris of McLaren won the most recent"}, "groundingChunkIndices": [0, 1]}
+      ]
+    },
+    "content": {
+      "role": "model",
+      "parts": [
+        {"thoughtSignature": "c2lnLXRvb2xjYWxs",
+         "toolCall": {"toolType": "GOOGLE_SEARCH_WEB", "args": {"queries": ["most recent F1 race winner", "Formula 1 2026 schedule"]}, "id": "nqh2j2zy"}},
+        {"thoughtSignature": "c2lnLXRvb2xyZXNwb25zZQ==",
+         "toolResponse": {"toolType": "GOOGLE_SEARCH_WEB", "response": {"search_suggestions": "<style>.chip{}</style><div>chips</div>"}, "id": "nqh2j2zy"}},
+        {"text": "Lando Norris of McLaren won the most recent race.", "thoughtSignature": "c2lnLXRleHQ="}
+      ]
+    },
+    "finishReason": "STOP"
+  }],
+  "modelVersion": "gemini-3.5-flash",
+  "responseId": "Hi97aunyEZGBqfkP0ITXkQQ"
+}`
+
+// TestServerSideToolCallNonStreaming covers the non-streaming half: the new parts map onto a
+// single web_search_call item (Gemini's own call ID, its queries, grounding's sources) and
+// round-trip back to byte-faithful toolCall/toolResponse parts on the native GenAI path.
+func TestServerSideToolCallNonStreaming(t *testing.T) {
+	var g GenerateContentResponse
+	require.NoError(t, json.Unmarshal([]byte(serverSideToolResponseJSON), &g))
+
+	b := g.ToResponsesBifrostResponsesResponse()
+
+	var searchCalls []schemas.ResponsesMessage
+	reasoningCount := 0
+	for _, m := range b.Output {
+		if m.Type == nil {
+			continue
+		}
+		switch *m.Type {
+		case schemas.ResponsesMessageTypeWebSearchCall:
+			searchCalls = append(searchCalls, m)
+		case schemas.ResponsesMessageTypeReasoning:
+			reasoningCount++
+		}
+	}
+
+	// Exactly one search item: the server-side call absorbs the grounding-derived one.
+	require.Len(t, searchCalls, 1, "grounding must not add a second web_search_call")
+	call := searchCalls[0]
+	require.NotNil(t, call.ID)
+	assert.Equal(t, "nqh2j2zy", *call.ID, "item must carry Gemini's own tool call id")
+	require.NotNil(t, call.Status)
+	assert.Equal(t, "completed", *call.Status, "toolResponse completes the call")
+
+	action := call.ResponsesToolMessage.Action.ResponsesWebSearchToolCallAction
+	assert.Equal(t, []string{"most recent F1 race winner", "Formula 1 2026 schedule"}, action.Queries,
+		"queries come from the toolCall, not grounding")
+	assert.Len(t, action.Sources, 2, "grounding sources merge onto the same item")
+
+	// Signatures on the tool parts must survive as reasoning items (Gemini requires them
+	// back on replay). The text part's signature rides on the text message instead, so only
+	// the two tool parts produce standalone reasoning items.
+	assert.Equal(t, 2, reasoningCount, "each tool part's thoughtSignature must survive")
+
+	// Native round-trip: the exact parts Google sent, in order, with payloads intact.
+	back := ToGeminiResponsesResponse(b)
+	require.Len(t, back.Candidates, 1)
+	parts := back.Candidates[0].Content.Parts
+	require.Len(t, parts, 3, "no duplicate signature-only parts")
+
+	require.NotNil(t, parts[0].ToolCall)
+	assert.Equal(t, "GOOGLE_SEARCH_WEB", parts[0].ToolCall.ToolType)
+	assert.Equal(t, "nqh2j2zy", parts[0].ToolCall.ID)
+	assert.Equal(t, []any{"most recent F1 race winner", "Formula 1 2026 schedule"}, parts[0].ToolCall.Args["queries"])
+	assert.NotEmpty(t, parts[0].ThoughtSignature)
+
+	require.NotNil(t, parts[1].ToolResponse)
+	assert.Equal(t, "nqh2j2zy", parts[1].ToolResponse.ID)
+	assert.Contains(t, parts[1].ToolResponse.Response["search_suggestions"], "chips")
+	assert.NotEmpty(t, parts[1].ThoughtSignature)
+
+	assert.Equal(t, "Lando Norris of McLaren won the most recent race.", parts[2].Text)
+}
+
+// TestServerSideToolCallUnknownToolType checks an unmapped built-in tool is preserved on the
+// native path rather than dropped, even though it has no web_search_call equivalent.
+func TestServerSideToolCallUnknownToolType(t *testing.T) {
+	body := `{"candidates":[{"index":0,"content":{"role":"model","parts":[
+		{"thoughtSignature":"c2ln","toolCall":{"toolType":"CODE_EXECUTION","args":{"code":"print(1)"},"id":"abc"}},
+		{"text":"1"}]},"finishReason":"STOP"}],"modelVersion":"gemini-3.5-flash"}`
+	var g GenerateContentResponse
+	require.NoError(t, json.Unmarshal([]byte(body), &g))
+
+	b := g.ToResponsesBifrostResponsesResponse()
+	for _, m := range b.Output {
+		if m.Type != nil && *m.Type == schemas.ResponsesMessageTypeWebSearchCall {
+			t.Fatal("a non-search tool type must not become a web_search_call")
+		}
+	}
+
+	back := ToGeminiResponsesResponse(b)
+	parts := back.Candidates[0].Content.Parts
+	require.NotNil(t, parts[0].ToolCall)
+	assert.Equal(t, "CODE_EXECUTION", parts[0].ToolCall.ToolType)
+	assert.Equal(t, "print(1)", parts[0].ToolCall.Args["code"])
+}
+
+// Shape observed on a live gemini-3.6-flash call: two server-side search rounds, no
+// groundingMetadata at all, and a client functionCall in the same candidate. Verifies each
+// round becomes its own item (paired by id) and that the function call is unaffected.
+const liveTwoSearchRoundsJSON = `{
+ "candidates":[{"index":0,"finishReason":"STOP","finishMessage":"Model generated function call(s).",
+  "content":{"role":"model","parts":[
+   {"thoughtSignature":"c2lnMQ==","toolCall":{"toolType":"GOOGLE_SEARCH_WEB","args":{"queries":["FIFA World Cup winner 2026","2026 FIFA World Cup winner"]},"id":"BaoigkFu"}},
+   {"toolResponse":{"id":"BaoigkFu","toolType":"GOOGLE_SEARCH_WEB","response":{"search_suggestions":"<div>chips1</div>"}},"thoughtSignature":"c2lnMg=="},
+   {"thoughtSignature":"c2lnMw==","toolCall":{"toolType":"GOOGLE_SEARCH_WEB","args":{"queries":["\"2026 FIFA World Cup\" score final Spain Argentina"]},"id":"Fbe8aaSI"}},
+   {"toolResponse":{"toolType":"GOOGLE_SEARCH_WEB","response":{"search_suggestions":"<div>chips2</div>"},"id":"Fbe8aaSI"},"thoughtSignature":"c2lnNA=="},
+   {"functionCall":{"args":{"city":"New York"},"id":"ZKIkmNGR","name":"get_weather"},"thoughtSignature":"c2lnNQ=="}
+  ]}}],
+ "usageMetadata":{"serviceTier":"standard","promptTokenCount":1489,"candidatesTokenCount":17,"totalTokenCount":2010,"cachedContentTokenCount":445,"thoughtsTokenCount":504},
+ "modelVersion":"gemini-3.6-flash","responseId":"SDZ7asHCNM3CjuMPgPiD8AE"}`
+
+func TestServerSideToolCallMultipleRoundsWithFunctionCall(t *testing.T) {
+	var g GenerateContentResponse
+	require.NoError(t, json.Unmarshal([]byte(liveTwoSearchRoundsJSON), &g))
+
+	b := g.ToResponsesBifrostResponsesResponse()
+
+	var searchIDs []string
+	functionCalls := 0
+	for _, m := range b.Output {
+		if m.Type == nil {
+			continue
+		}
+		switch *m.Type {
+		case schemas.ResponsesMessageTypeWebSearchCall:
+			require.NotNil(t, m.ID)
+			require.NotNil(t, m.Status)
+			assert.Equal(t, "completed", *m.Status)
+			searchIDs = append(searchIDs, *m.ID)
+		case schemas.ResponsesMessageTypeFunctionCall:
+			functionCalls++
+		}
+	}
+	assert.Equal(t, []string{"BaoigkFu", "Fbe8aaSI"}, searchIDs, "one item per search round, paired by id")
+	assert.Equal(t, 1, functionCalls, "the client function call must survive alongside them")
+
+	// Every part round-trips in order, including the function call.
+	back := ToGeminiResponsesResponse(b)
+	parts := back.Candidates[0].Content.Parts
+	require.Len(t, parts, 5)
+	require.NotNil(t, parts[0].ToolCall)
+	assert.Equal(t, "BaoigkFu", parts[0].ToolCall.ID)
+	require.NotNil(t, parts[1].ToolResponse)
+	assert.Equal(t, "BaoigkFu", parts[1].ToolResponse.ID)
+	require.NotNil(t, parts[2].ToolCall)
+	assert.Equal(t, "Fbe8aaSI", parts[2].ToolCall.ID)
+	require.NotNil(t, parts[3].ToolResponse)
+	assert.Equal(t, "Fbe8aaSI", parts[3].ToolResponse.ID)
+	require.NotNil(t, parts[4].FunctionCall)
+	assert.Equal(t, "get_weather", parts[4].FunctionCall.Name)
+	for i, p := range parts {
+		assert.NotEmpty(t, p.ThoughtSignature, "part %d lost its thoughtSignature", i)
+	}
+}

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -1579,6 +1579,81 @@ type Content struct {
 	Role string `json:"role,omitempty"`
 }
 
+// ToolCall is a server-side tool invocation the model made on its own, reported back when
+// toolConfig.includeServerSideToolInvocations is enabled. Unlike FunctionCall — which the
+// caller is expected to execute and answer — this call was already executed by Google, and
+// its result arrives in a sibling ToolResponse part carrying the same ID.
+//
+// ToolType names the built-in tool (e.g. "GOOGLE_SEARCH_WEB"); Args is that tool's
+// invocation payload, whose shape varies per tool (Google Search uses {"queries": [...]}),
+// so it stays an untyped map rather than a per-tool struct.
+type ToolCall struct {
+	// The built-in tool that was invoked, e.g. "GOOGLE_SEARCH_WEB".
+	ToolType string `json:"toolType,omitempty"`
+	// Tool-specific invocation arguments.
+	Args map[string]any `json:"args,omitempty"`
+	// Correlates this call with its ToolResponse.
+	ID string `json:"id,omitempty"`
+}
+
+// UnmarshalJSON accepts both camelCase (Google's REST wire format) and snake_case, which the
+// google-genai SDKs emit when these parts are replayed back in a follow-up request.
+func (t *ToolCall) UnmarshalJSON(data []byte) error {
+	type Alias ToolCall
+	aux := struct {
+		*Alias
+		ToolTypeSnake string `json:"tool_type,omitempty"`
+	}{Alias: (*Alias)(t)}
+	if err := sonic.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if t.ToolType == "" && aux.ToolTypeSnake != "" {
+		t.ToolType = aux.ToolTypeSnake
+	}
+	return nil
+}
+
+// ToolResponse is the result of a server-side ToolCall, paired to it by ID. Response holds
+// the tool's raw output, whose shape is tool-specific (Google Search returns rendered
+// search-suggestion HTML), so it stays an untyped map.
+type ToolResponse struct {
+	// The built-in tool that produced this result, e.g. "GOOGLE_SEARCH_WEB".
+	ToolType string `json:"toolType,omitempty"`
+	// Tool-specific result payload.
+	Response map[string]any `json:"response,omitempty"`
+	// Correlates this result with its ToolCall.
+	ID string `json:"id,omitempty"`
+}
+
+// UnmarshalJSON accepts both camelCase and snake_case, matching ToolCall.
+func (t *ToolResponse) UnmarshalJSON(data []byte) error {
+	type Alias ToolResponse
+	aux := struct {
+		*Alias
+		ToolTypeSnake string `json:"tool_type,omitempty"`
+	}{Alias: (*Alias)(t)}
+	if err := sonic.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if t.ToolType == "" && aux.ToolTypeSnake != "" {
+		t.ToolType = aux.ToolTypeSnake
+	}
+	return nil
+}
+
+// geminiServerSideSearchToolTypes are the ToolCall.ToolType values that represent a Google
+// Search invocation, and so map onto Bifrost's web_search_call item. Other tool types are
+// preserved verbatim on the native path but are not mapped.
+var geminiServerSideSearchToolTypes = map[string]bool{
+	"GOOGLE_SEARCH_WEB":   true,
+	"GOOGLE_SEARCH_IMAGE": true,
+}
+
+// isSearchToolType reports whether a server-side tool type is a Google Search variant.
+func isSearchToolType(toolType string) bool {
+	return geminiServerSideSearchToolTypes[strings.ToUpper(toolType)]
+}
+
 // Part is a datatype containing media content.
 // Exactly one field within a Part should be set, representing the specific type
 // of content being conveyed. Using multiple fields within the same `Part`
@@ -1605,6 +1680,11 @@ type Part struct {
 	// the [FunctionDeclaration.Name] and a structured JSON object containing any output
 	// from the function call. It is used as context to the model.
 	FunctionResponse *FunctionResponse `json:"functionResponse,omitempty"`
+	// Optional. A server-side tool invocation the model performed itself (Google Search and
+	// other built-in tools), surfaced when includeServerSideToolInvocations is enabled.
+	ToolCall *ToolCall `json:"toolCall,omitempty"`
+	// Optional. The result of a server-side ToolCall, paired to it by ID.
+	ToolResponse *ToolResponse `json:"toolResponse,omitempty"`
 	// Optional. Text part (can be code).
 	Text string `json:"text,omitempty"`
 }
@@ -1623,6 +1703,8 @@ func (p Part) MarshalJSON() ([]byte, error) {
 		ExecutableCode      *ExecutableCode      `json:"executableCode,omitempty"`
 		FunctionCall        *FunctionCall        `json:"functionCall,omitempty"`
 		FunctionResponse    *FunctionResponse    `json:"functionResponse,omitempty"`
+		ToolCall            *ToolCall            `json:"toolCall,omitempty"`
+		ToolResponse        *ToolResponse        `json:"toolResponse,omitempty"`
 		Text                string               `json:"text,omitempty"`
 	}
 
@@ -1635,6 +1717,8 @@ func (p Part) MarshalJSON() ([]byte, error) {
 		ExecutableCode:      p.ExecutableCode,
 		FunctionCall:        p.FunctionCall,
 		FunctionResponse:    p.FunctionResponse,
+		ToolCall:            p.ToolCall,
+		ToolResponse:        p.ToolResponse,
 		Text:                p.Text,
 	}
 
@@ -1662,6 +1746,8 @@ func (p *Part) UnmarshalJSON(data []byte) error {
 		ExecutableCode      *ExecutableCode      `json:"executableCode,omitempty"`
 		FunctionCall        *FunctionCall        `json:"functionCall,omitempty"`
 		FunctionResponse    *FunctionResponse    `json:"functionResponse,omitempty"`
+		ToolCall            *ToolCall            `json:"toolCall,omitempty"`
+		ToolResponse        *ToolResponse        `json:"toolResponse,omitempty"`
 		Text                string               `json:"text,omitempty"`
 		// snake_case fallbacks: the google-genai SDK serializes FunctionResponsePart
 		// (nested inside functionResponse.parts) with snake_case keys, unlike top-level parts.
@@ -1686,6 +1772,8 @@ func (p *Part) UnmarshalJSON(data []byte) error {
 	}
 	p.CodeExecutionResult = aux.CodeExecutionResult
 	p.ExecutableCode = aux.ExecutableCode
+	p.ToolCall = aux.ToolCall
+	p.ToolResponse = aux.ToolResponse
 	p.FunctionCall = aux.FunctionCall
 	p.FunctionResponse = aux.FunctionResponse
 	p.Text = aux.Text

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -1250,6 +1250,18 @@ type ResponsesMessage struct {
 	// reject the item type can hoist them into the top-level tools param.
 	AdditionalTools json.RawMessage `json:"-"`
 
+	// ProviderNativeParts carries a provider's own response fragment for this item when
+	// the canonical shape cannot hold it losslessly, so a native-surface integration can
+	// re-emit exactly what the provider sent. Currently Gemini's server-side
+	// toolCall/toolResponse parts: the web_search_call item keeps their queries, but not
+	// the raw tool response or the thoughtSignature bytes Gemini demands back on replay.
+	// The non-streaming path carries these on the response's ProviderExtraFields; a
+	// per-chunk stream item has no such field, which is what this one supplies.
+	//
+	// json:"-" like the two above: it rides the in-process item between a provider and an
+	// integration and is never part of the public wire shape.
+	ProviderNativeParts json.RawMessage `json:"-"`
+
 	*ResponsesToolMessage // For Tool calls and outputs
 
 	CacheControl *CacheControl `json:"cache_control,omitempty"` // Carries cache_control for function_call and function_call_output message types

--- a/tests/e2e/api/HARNESS_COVERAGE_BACKLOG.md
+++ b/tests/e2e/api/HARNESS_COVERAGE_BACKLOG.md
@@ -260,7 +260,7 @@ Sources:
 - [ ] **URL context** (`tools: [{ urlContext: {} }]`)
 - [ ] **Live API** (websocket-based bidirectional streaming)
 - [ ] **Function responses** (`role: "function"` parts with `functionResponse`)
-- [ ] **Thinking response signature** (return `thoughtSignature` to continue thinking across turns)
+- [x] **Thinking response signature** (return `thoughtSignature` to continue thinking across turns): folder `49.` replays a captured server-side tool turn (toolCall/toolResponse + thoughtSignature) in `contents`; Gemini validates signatures upstream, so a 2xx pins the round-trip
 
 ### Other endpoints
 

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -9861,18 +9861,70 @@
               "name": "Adaptive thinking (Sonnet 5)",
               "request": {
                 "method": "POST",
-                "header": [{"key":"Content-Type","value":"application/json"},{"key":"x-api-key","value":"{{anthropicKey}}"},{"key":"anthropic-version","value":"2023-06-01"}],
-                "body": {"mode":"raw","raw":"{\n  \"model\": \"claude-sonnet-5\",\n  \"max_tokens\": 16000,\n  \"thinking\": { \"type\": \"adaptive\" },\n  \"messages\": [{\"role\":\"user\",\"content\":\"Solve: integral of x^2 * e^(-x) dx from 0 to infinity. Show steps.\"}]\n}"},
-                "url": {"raw":"{{baseUrl}}/anthropic/v1/messages","host":["{{baseUrl}}"],"path":["anthropic","v1","messages"]}
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-api-key",
+                    "value": "{{anthropicKey}}"
+                  },
+                  {
+                    "key": "anthropic-version",
+                    "value": "2023-06-01"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"claude-sonnet-5\",\n  \"max_tokens\": 16000,\n  \"thinking\": { \"type\": \"adaptive\" },\n  \"messages\": [{\"role\":\"user\",\"content\":\"Solve: integral of x^2 * e^(-x) dx from 0 to infinity. Show steps.\"}]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/anthropic/v1/messages",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "anthropic",
+                    "v1",
+                    "messages"
+                  ]
+                }
               }
             },
             {
               "name": "Adaptive thinking + effort=high (Sonnet 5)",
               "request": {
                 "method": "POST",
-                "header": [{"key":"Content-Type","value":"application/json"},{"key":"x-api-key","value":"{{anthropicKey}}"},{"key":"anthropic-version","value":"2023-06-01"}],
-                "body": {"mode":"raw","raw":"{\n  \"model\": \"claude-sonnet-5\",\n  \"max_tokens\": 16000,\n  \"thinking\": { \"type\": \"adaptive\" },\n  \"output_config\": { \"effort\": \"high\" },\n  \"messages\": [{\"role\":\"user\",\"content\":\"Solve: integral of x^2 * e^(-x) dx from 0 to infinity. Show steps.\"}]\n}"},
-                "url": {"raw":"{{baseUrl}}/anthropic/v1/messages","host":["{{baseUrl}}"],"path":["anthropic","v1","messages"]}
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-api-key",
+                    "value": "{{anthropicKey}}"
+                  },
+                  {
+                    "key": "anthropic-version",
+                    "value": "2023-06-01"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"claude-sonnet-5\",\n  \"max_tokens\": 16000,\n  \"thinking\": { \"type\": \"adaptive\" },\n  \"output_config\": { \"effort\": \"high\" },\n  \"messages\": [{\"role\":\"user\",\"content\":\"Solve: integral of x^2 * e^(-x) dx from 0 to infinity. Show steps.\"}]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/anthropic/v1/messages",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "anthropic",
+                    "v1",
+                    "messages"
+                  ]
+                }
               }
             },
             {
@@ -10070,18 +10122,78 @@
               "name": "Computer use - Sonnet 5 canonical (new-gen tools, computer-use-2025-11-24)",
               "request": {
                 "method": "POST",
-                "header": [{"key":"Content-Type","value":"application/json"},{"key":"x-api-key","value":"{{anthropicKey}}"},{"key":"anthropic-version","value":"2023-06-01"},{"key":"anthropic-beta","value":"computer-use-2025-11-24"}],
-                "body": {"mode":"raw","raw":"{\n  \"model\": \"claude-sonnet-5\",\n  \"max_tokens\": 4096,\n  \"tools\": [\n    { \"type\": \"computer_20251124\", \"name\": \"computer\", \"display_width_px\": 1024, \"display_height_px\": 768, \"display_number\": 1 },\n    { \"type\": \"bash_20250124\", \"name\": \"bash\" },\n    { \"type\": \"text_editor_20250728\", \"name\": \"str_replace_based_edit_tool\" }\n  ],\n  \"messages\": [{\"role\":\"user\",\"content\":\"Take a screenshot of the desktop.\"}]\n}"},
-                "url": {"raw":"{{baseUrl}}/anthropic/v1/messages","host":["{{baseUrl}}"],"path":["anthropic","v1","messages"]}
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-api-key",
+                    "value": "{{anthropicKey}}"
+                  },
+                  {
+                    "key": "anthropic-version",
+                    "value": "2023-06-01"
+                  },
+                  {
+                    "key": "anthropic-beta",
+                    "value": "computer-use-2025-11-24"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"claude-sonnet-5\",\n  \"max_tokens\": 4096,\n  \"tools\": [\n    { \"type\": \"computer_20251124\", \"name\": \"computer\", \"display_width_px\": 1024, \"display_height_px\": 768, \"display_number\": 1 },\n    { \"type\": \"bash_20250124\", \"name\": \"bash\" },\n    { \"type\": \"text_editor_20250728\", \"name\": \"str_replace_based_edit_tool\" }\n  ],\n  \"messages\": [{\"role\":\"user\",\"content\":\"Take a screenshot of the desktop.\"}]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/anthropic/v1/messages",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "anthropic",
+                    "v1",
+                    "messages"
+                  ]
+                }
               }
             },
             {
               "name": "Computer use - Sonnet 5 + old-gen tools (Bifrost auto-upgrades)",
               "request": {
                 "method": "POST",
-                "header": [{"key":"Content-Type","value":"application/json"},{"key":"x-api-key","value":"{{anthropicKey}}"},{"key":"anthropic-version","value":"2023-06-01"},{"key":"anthropic-beta","value":"computer-use-2025-11-24"}],
-                "body": {"mode":"raw","raw":"{\n  \"model\": \"claude-sonnet-5\",\n  \"max_tokens\": 4096,\n  \"tools\": [\n    { \"type\": \"computer_20250124\", \"name\": \"computer\", \"display_width_px\": 1024, \"display_height_px\": 768, \"display_number\": 1 },\n    { \"type\": \"bash_20250124\", \"name\": \"bash\" },\n    { \"type\": \"text_editor_20250124\", \"name\": \"str_replace_editor\" }\n  ],\n  \"messages\": [{\"role\":\"user\",\"content\":\"Take a screenshot of the desktop.\"}]\n}"},
-                "url": {"raw":"{{baseUrl}}/anthropic/v1/messages","host":["{{baseUrl}}"],"path":["anthropic","v1","messages"]}
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-api-key",
+                    "value": "{{anthropicKey}}"
+                  },
+                  {
+                    "key": "anthropic-version",
+                    "value": "2023-06-01"
+                  },
+                  {
+                    "key": "anthropic-beta",
+                    "value": "computer-use-2025-11-24"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"claude-sonnet-5\",\n  \"max_tokens\": 4096,\n  \"tools\": [\n    { \"type\": \"computer_20250124\", \"name\": \"computer\", \"display_width_px\": 1024, \"display_height_px\": 768, \"display_number\": 1 },\n    { \"type\": \"bash_20250124\", \"name\": \"bash\" },\n    { \"type\": \"text_editor_20250124\", \"name\": \"str_replace_editor\" }\n  ],\n  \"messages\": [{\"role\":\"user\",\"content\":\"Take a screenshot of the desktop.\"}]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/anthropic/v1/messages",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "anthropic",
+                    "v1",
+                    "messages"
+                  ]
+                }
               }
             },
             {
@@ -11833,22 +11945,78 @@
             },
             {
               "name": "anthropic/claude-sonnet-5",
-              "event": [{"listen":"test","script":{"type":"text/javascript","exec":["if (pm.response.code < 400) { pm.test('Function call: get_weather invoked with city argument', function () { var j = pm.response.json(); var tc = null; if (j.choices && j.choices[0] && j.choices[0].message && Array.isArray(j.choices[0].message.tool_calls) && j.choices[0].message.tool_calls.length) { tc = j.choices[0].message.tool_calls[0]; } pm.expect(tc, 'no tool_calls in response').to.not.be.null; pm.expect(tc.function && tc.function.name).to.equal('get_weather'); var a; try { a = JSON.parse(tc.function.arguments); } catch (e) { pm.expect.fail('arguments not JSON: ' + e.message); return; } pm.expect(a).to.have.property('city').that.is.a('string'); }); }"]}}],
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (pm.response.code < 400) { pm.test('Function call: get_weather invoked with city argument', function () { var j = pm.response.json(); var tc = null; if (j.choices && j.choices[0] && j.choices[0].message && Array.isArray(j.choices[0].message.tool_calls) && j.choices[0].message.tool_calls.length) { tc = j.choices[0].message.tool_calls[0]; } pm.expect(tc, 'no tool_calls in response').to.not.be.null; pm.expect(tc.function && tc.function.name).to.equal('get_weather'); var a; try { a = JSON.parse(tc.function.arguments); } catch (e) { pm.expect.fail('arguments not JSON: ' + e.message); return; } pm.expect(a).to.have.property('city').that.is.a('string'); }); }"
+                    ]
+                  }
+                }
+              ],
               "request": {
                 "method": "POST",
-                "header": [{"key":"Content-Type","value":"application/json"}],
-                "body": {"mode":"raw","raw":"{\n  \"model\": \"anthropic/claude-sonnet-5\",\n  \"messages\": [{\"role\":\"user\",\"content\":\"Weather in Lagos, Nigeria?\"}],\n  \"tools\": [{\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"]}}}]\n}"},
-                "url": {"raw":"{{baseUrl}}/v1/chat/completions","host":["{{baseUrl}}"],"path":["v1","chat","completions"]}
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic/claude-sonnet-5\",\n  \"messages\": [{\"role\":\"user\",\"content\":\"Weather in Lagos, Nigeria?\"}],\n  \"tools\": [{\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"]}}}]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
               }
             },
             {
               "name": "bedrock/global.anthropic.claude-sonnet-5",
-              "event": [{"listen":"test","script":{"type":"text/javascript","exec":["if (pm.response.code < 400) { pm.test('Function call: get_weather invoked with city argument', function () { var j = pm.response.json(); var tc = null; if (j.choices && j.choices[0] && j.choices[0].message && Array.isArray(j.choices[0].message.tool_calls) && j.choices[0].message.tool_calls.length) { tc = j.choices[0].message.tool_calls[0]; } pm.expect(tc, 'no tool_calls in response').to.not.be.null; pm.expect(tc.function && tc.function.name).to.equal('get_weather'); var a; try { a = JSON.parse(tc.function.arguments); } catch (e) { pm.expect.fail('arguments not JSON: ' + e.message); return; } pm.expect(a).to.have.property('city').that.is.a('string'); }); }"]}}],
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (pm.response.code < 400) { pm.test('Function call: get_weather invoked with city argument', function () { var j = pm.response.json(); var tc = null; if (j.choices && j.choices[0] && j.choices[0].message && Array.isArray(j.choices[0].message.tool_calls) && j.choices[0].message.tool_calls.length) { tc = j.choices[0].message.tool_calls[0]; } pm.expect(tc, 'no tool_calls in response').to.not.be.null; pm.expect(tc.function && tc.function.name).to.equal('get_weather'); var a; try { a = JSON.parse(tc.function.arguments); } catch (e) { pm.expect.fail('arguments not JSON: ' + e.message); return; } pm.expect(a).to.have.property('city').that.is.a('string'); }); }"
+                    ]
+                  }
+                }
+              ],
               "request": {
                 "method": "POST",
-                "header": [{"key":"Content-Type","value":"application/json"}],
-                "body": {"mode":"raw","raw":"{\n  \"model\": \"bedrock/global.anthropic.claude-sonnet-5\",\n  \"messages\": [{\"role\":\"user\",\"content\":\"Weather in Lagos, Nigeria?\"}],\n  \"tools\": [{\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"]}}}]\n}"},
-                "url": {"raw":"{{baseUrl}}/v1/chat/completions","host":["{{baseUrl}}"],"path":["v1","chat","completions"]}
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"bedrock/global.anthropic.claude-sonnet-5\",\n  \"messages\": [{\"role\":\"user\",\"content\":\"Weather in Lagos, Nigeria?\"}],\n  \"tools\": [{\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"]}}}]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
               }
             },
             {
@@ -12044,18 +12212,54 @@
               "name": "anthropic/claude-sonnet-5",
               "request": {
                 "method": "POST",
-                "header": [{"key":"Content-Type","value":"application/json"}],
-                "body": {"mode":"raw","raw":"{\n  \"model\": \"anthropic/claude-sonnet-5\",\n  \"messages\": [{\"role\":\"user\",\"content\":\"Count 1-5.\"}],\n  \"stream\": true\n}"},
-                "url": {"raw":"{{baseUrl}}/v1/chat/completions","host":["{{baseUrl}}"],"path":["v1","chat","completions"]}
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic/claude-sonnet-5\",\n  \"messages\": [{\"role\":\"user\",\"content\":\"Count 1-5.\"}],\n  \"stream\": true\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
               }
             },
             {
               "name": "bedrock/global.anthropic.claude-sonnet-5",
               "request": {
                 "method": "POST",
-                "header": [{"key":"Content-Type","value":"application/json"}],
-                "body": {"mode":"raw","raw":"{\n  \"model\": \"bedrock/global.anthropic.claude-sonnet-5\",\n  \"messages\": [{\"role\":\"user\",\"content\":\"Count 1-5.\"}],\n  \"stream\": true\n}"},
-                "url": {"raw":"{{baseUrl}}/v1/chat/completions","host":["{{baseUrl}}"],"path":["v1","chat","completions"]}
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"bedrock/global.anthropic.claude-sonnet-5\",\n  \"messages\": [{\"role\":\"user\",\"content\":\"Count 1-5.\"}],\n  \"stream\": true\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
               }
             },
             {
@@ -48422,17 +48626,17 @@
                   "  if (body.output && body.output.length) {",
                   "    var input = [{ type: 'message', role: 'user', content: \"Work out 17 * 23 step by step, then give just the number.\" }]",
                   "      .concat(body.output);",
-        "    // Cohere's API has no encrypted-reasoning field, so a Cohere response",
-        "    // never carries encrypted_content on its own - which means a replay",
-        "    // built purely from its output would exercise none of the marker path",
-        "    // and the leak assertion below would pass vacuously. A client CAN send",
-        "    // one (replaying reasoning captured elsewhere), and that is the shape",
-        "    // under test, so attach a deterministic token to the reasoning items.",
-        "    for (var i = 0; i < input.length; i++) {",
-        "      if (input[i] && input[i].type === 'reasoning' && !input[i].encrypted_content) {",
-        "        input[i].encrypted_content = 'bifrost-e2e-encrypted-reasoning-5982';",
-        "      }",
-        "    }",
+                  "    // Cohere's API has no encrypted-reasoning field, so a Cohere response",
+                  "    // never carries encrypted_content on its own - which means a replay",
+                  "    // built purely from its output would exercise none of the marker path",
+                  "    // and the leak assertion below would pass vacuously. A client CAN send",
+                  "    // one (replaying reasoning captured elsewhere), and that is the shape",
+                  "    // under test, so attach a deterministic token to the reasoning items.",
+                  "    for (var i = 0; i < input.length; i++) {",
+                  "      if (input[i] && input[i].type === 'reasoning' && !input[i].encrypted_content) {",
+                  "        input[i].encrypted_content = 'bifrost-e2e-encrypted-reasoning-5982';",
+                  "      }",
+                  "    }",
                   "    pm.collectionVariables.set('cohereReasoningReplayInput5982', JSON.stringify(input));",
                   "  }",
                   "} catch (e) {}"
@@ -128347,11 +128551,141 @@
       ]
     },
     {
-      "name": "49. output_config.effort Independent of thinking",
-      "description": "output_config.effort and thinking are independent controls on the Anthropic Messages API. Per https://platform.claude.com/docs/en/build-with-claude/effort, effort \"doesn't require thinking to be enabled\" and \"affects all tokens in the response\" including text and tool calls; its canonical Basic usage example sends output_config.effort with no thinking parameter at all.\n\nBifrost read output_config.effort only inside `if req.Thinking != nil` (core/providers/anthropic/responses.go), so an effort-only request silently lost the effort, and a thinking:{type:\"disabled\"} request had its effort overwritten with \"none\". Both still returned 200, which is why the pre-existing effort cases in folders 10 and 12 never caught it - they exercise the request shape but assert nothing about it.\n\nFixing it by synthesizing thinking:{type:\"adaptive\"} would be wrong: per https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting the default when `thinking` is omitted differs by model - Opus 5 and Sonnet 5 default it On, while Opus 4.6/4.7/4.8 and Sonnet 4.6 default it Off - so injecting adaptive turns thinking on against the caller's request on half the family, bills thinking tokens they never asked for, and invalidates their cached prefix. Only the model can resolve the absence, so the absence is what Bifrost forwards.\n\nThat per-model default table is the oracle these cases use: thinking-block presence in the response is the observable that distinguishes 'forwarded the absence' from 'invented a thinking parameter'. Anthropic never echoes effort back, so it cannot be asserted directly.",
+      "name": "49. Gemini Server-Side Tool Invocations + thoughtSignature Fidelity (PR #6071)",
+      "description": "PR #6071 (server-side tool call support) with PR #6065/#6066 (tool combination).\n\nWhen toolConfig.includeServerSideToolInvocations is enabled, Gemini reports built-in tools it ran\nitself as toolCall/toolResponse part pairs instead of the older text + groundingMetadata shape.\nBefore PR #6071 those parts were silently dropped: the response still returned 200 with plausible\ntext, so no status assertion can pin this — the parts themselves have to be inspected. The\nthoughtSignature bytes riding on those parts matter independently: Gemini rejects a follow-up turn\nthat replays the assistant content without them.\n\nThe /genai surface reaches Gemini three different ways, which are three different code paths:\n  - bare model name (gemini-3.6-flash)      -> Gemini converter path\n  - vertex/ prefix (vertex/gemini-2.5-flash) -> Vertex converter path (never passes through)\n  - gemini/ prefix (gemini/gemini-3.6-flash) -> raw body passthrough (explicitGemini, genai.go)\nAll three are covered here, streaming and non-streaming, because they share no conversion code.\n\nCases:\n  1/2. Gemini converter, non-streaming and SSE: toolCall/toolResponse parts survive, stay id-paired,\n       and keep thoughtSignature.\n  3/4. Vertex converter on a PRE-Gemini-3 model (2.5), non-streaming and SSE: tool combination did\n       not exist before Gemini 3, and Vertex rejects the mix outright with 400 \"Multiple tools are\n       supported only when they are all search tools\". Bifrost must therefore still drop googleSearch\n       and keep the declarations there, so a 2xx with a functionCall is the pin.\n  5/6. Vertex converter on Gemini 3.6, non-streaming and SSE: the same request keeps BOTH tool kinds,\n       which is what PR #6066 set out to allow. Together with 3/4 this pins the version boundary in\n       both directions -- the original PR #6066 gate keyed on provider alone and 400d every 2.5 call.\n  7.   Gemini raw passthrough: the same parts survive the non-converting path byte-for-byte.\n  8.   Multi-turn replay: the assistant turn captured in case 1 is sent back in contents. Gemini\n       validates thoughtSignature server-side, so a 2xx here proves the signatures round-tripped\n       intact. Skips itself if case 1 captured nothing.",
       "item": [
         {
-          "name": "anthropic/claude-opus-4-7 · output_config.effort without thinking must not enable thinking",
+          "name": "gemini-3.6-flash genai server-side toolCall parts + thoughtSignature survive conversion (/genai generateContent) - PR #6071",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"contents\": [\n    {\n      \"role\": \"user\",\n      \"parts\": [\n        {\n          \"text\": \"Who won the 2024 Ballon d'Or? Use Google Search and answer in one short sentence.\"\n        }\n      ]\n    }\n  ],\n  \"tools\": [\n    {\n      \"googleSearch\": {}\n    }\n  ],\n  \"toolConfig\": {\n    \"includeServerSideToolInvocations\": true\n  },\n  \"generationConfig\": {\n    \"maxOutputTokens\": 512\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/genai/v1beta/models/gemini-3.6-flash:generateContent",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "genai",
+                "v1beta",
+                "models",
+                "gemini-3.6-flash:generateContent"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Clear the replay capture before any early return below can skip past it, so case 8",
+                  "// can never replay a turn captured by an earlier run. newman starts from the file and",
+                  "// has no such state, but Postman keeps collection variables and the collection is run",
+                  "// both ways.",
+                  "pm.collectionVariables.unset('ss6071Turn1Parts');",
+                  "pm.collectionVariables.unset('ss6071Turn1Captured');",
+                  "pm.collectionVariables.unset('ss6071Turn1Ran');",
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('genai server-side toolCall: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var raw = pm.response.text();",
+                  "var body = pm.response.json() || {};",
+                  "var parts = [];",
+                  "var searched = false;",
+                  "(body.candidates || []).forEach(function (cand) {",
+                  "  ((cand.content && cand.content.parts) || []).forEach(function (p) { parts.push(p); });",
+                  "  var gm = cand.groundingMetadata;",
+                  "  if (gm && ((gm.webSearchQueries || []).length || (gm.groundingChunks || []).length)) { searched = true; }",
+                  "  ((cand.content && cand.content.parts) || []).forEach(function (p) { if (p.toolCall) { searched = true; } });",
+                  "});",
+                  "var toolCalls = [];",
+                  "var toolResponses = [];",
+                  "var unsigned = [];",
+                  "parts.forEach(function (p) {",
+                  "  if (p.toolCall) {",
+                  "    toolCalls.push(p.toolCall);",
+                  "    if (!p.thoughtSignature) { unsigned.push('toolCall:' + (p.toolCall.id || '?')); }",
+                  "  }",
+                  "  if (p.toolResponse) {",
+                  "    toolResponses.push(p.toolResponse);",
+                  "    if (!p.thoughtSignature) { unsigned.push('toolResponse:' + (p.toolResponse.id || '?')); }",
+                  "  }",
+                  "});",
+                  "pm.test('genai server-side toolCall: server-side toolCall parts are not dropped (regression PR #6071)', function () {",
+                  "  if (!searched) { return; }",
+                  "  pm.expect(toolCalls.length, 'model searched (grounding present) but zero toolCall parts came back - server-side parts were dropped: ' + raw.slice(0, 900)).to.be.above(0);",
+                  "});",
+                  "pm.test('genai server-side toolCall: every server-side tool part retains its thoughtSignature (regression PR #6071)', function () {",
+                  "  pm.expect(unsigned.join(','), 'parts lost thoughtSignature - Gemini rejects replay without it').to.eql('');",
+                  "});",
+                  "pm.test('genai server-side toolCall: each toolCall is paired with a toolResponse by id', function () {",
+                  "  if (!toolCalls.length) { return; }",
+                  "  var respIds = {};",
+                  "  toolResponses.forEach(function (r) { respIds[r.id] = true; });",
+                  "  var unpaired = [];",
+                  "  toolCalls.forEach(function (c) { if (!respIds[c.id]) { unpaired.push(c.id); } });",
+                  "  pm.expect(unpaired.join(','), 'toolCall ids with no matching toolResponse').to.eql('');",
+                  "});",
+                  "// Reached the model, so case 8 skipping itself is no longer legitimate.",
+                  "pm.collectionVariables.set('ss6071Turn1Ran', 'true');",
+                  "// Capture the assistant turn for the replay case further down this folder.",
+                  "var cands = body.candidates || [];",
+                  "var turnParts = (cands[0] && cands[0].content && cands[0].content.parts) || [];",
+                  "var hasSigned = false;",
+                  "turnParts.forEach(function (p) { if (p.thoughtSignature) { hasSigned = true; } });",
+                  "if (turnParts.length && hasSigned) {",
+                  "  pm.collectionVariables.set('ss6071Turn1Parts', JSON.stringify(turnParts));",
+                  "  pm.collectionVariables.set('ss6071Turn1Captured', 'true');",
+                  "}"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "gemini-3.6-flash genai server-side toolCall parts + thoughtSignature survive streaming (/genai SSE) - PR #6071",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"contents\": [\n    {\n      \"role\": \"user\",\n      \"parts\": [\n        {\n          \"text\": \"Who won the 2024 Ballon d'Or? Use Google Search and answer in one short sentence.\"\n        }\n      ]\n    }\n  ],\n  \"tools\": [\n    {\n      \"googleSearch\": {}\n    }\n  ],\n  \"toolConfig\": {\n    \"includeServerSideToolInvocations\": true\n  },\n  \"generationConfig\": {\n    \"maxOutputTokens\": 512\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/genai/v1beta/models/gemini-3.6-flash:streamGenerateContent?alt=sse",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "genai",
+                "v1beta",
+                "models",
+                "gemini-3.6-flash:streamGenerateContent"
+              ],
+              "query": [
+                {
+                  "key": "alt",
+                  "value": "sse"
+                }
+              ]
+            }
+          },
           "event": [
             {
               "listen": "test",
@@ -128359,47 +128693,94 @@
                 "type": "text/javascript",
                 "exec": [
                   "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
-                  "pm.test('request succeeded', function () { pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400); });",
-                  "pm.test('no thinking block returned', function () { var j = pm.response.json(); var blocks = Array.isArray(j.content) ? j.content : []; var thinking = blocks.filter(function (b) { return b.type === 'thinking' || b.type === 'redacted_thinking'; }); pm.expect(thinking.length, 'bifrost synthesized a thinking parameter the caller never sent (opus 4.7 defaults thinking off): ' + pm.response.text()).to.equal(0); });"
+                  "pm.test('genai stream server-side toolCall: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var raw = pm.response.text();",
+                  "var chunks = [];",
+                  "raw.split('\\n').forEach(function (line) {",
+                  "  var t = line.trim();",
+                  "  if (t.indexOf('data:') !== 0) { return; }",
+                  "  var payload = t.slice(5).trim();",
+                  "  if (!payload || payload === '[DONE]') { return; }",
+                  "  try { chunks.push(JSON.parse(payload)); } catch (e) {}",
+                  "});",
+                  "pm.test('genai stream server-side toolCall: SSE chunks parsed', function () {",
+                  "  pm.expect(chunks.length, 'no SSE data chunks: ' + raw.slice(0, 500)).to.be.above(0);",
+                  "});",
+                  "var parts = [];",
+                  "var searched = false;",
+                  "chunks.forEach(function (c) {",
+                  "  (c.candidates || []).forEach(function (cand) {",
+                  "    ((cand.content && cand.content.parts) || []).forEach(function (p) {",
+                  "      parts.push(p);",
+                  "      if (p.toolCall) { searched = true; }",
+                  "    });",
+                  "    var gm = cand.groundingMetadata;",
+                  "    if (gm && ((gm.webSearchQueries || []).length || (gm.groundingChunks || []).length)) { searched = true; }",
+                  "  });",
+                  "});",
+                  "var toolCalls = [];",
+                  "var toolResponses = [];",
+                  "var unsigned = [];",
+                  "parts.forEach(function (p) {",
+                  "  if (p.toolCall) {",
+                  "    toolCalls.push(p.toolCall);",
+                  "    if (!p.thoughtSignature) { unsigned.push('toolCall:' + (p.toolCall.id || '?')); }",
+                  "  }",
+                  "  if (p.toolResponse) {",
+                  "    toolResponses.push(p.toolResponse);",
+                  "    if (!p.thoughtSignature) { unsigned.push('toolResponse:' + (p.toolResponse.id || '?')); }",
+                  "  }",
+                  "});",
+                  "pm.test('genai stream server-side toolCall: server-side toolCall parts are not dropped (regression PR #6071)', function () {",
+                  "  if (!searched) { return; }",
+                  "  pm.expect(toolCalls.length, 'model searched (grounding present) but zero toolCall parts came back - server-side parts were dropped: ' + raw.slice(0, 900)).to.be.above(0);",
+                  "});",
+                  "pm.test('genai stream server-side toolCall: every server-side tool part retains its thoughtSignature (regression PR #6071)', function () {",
+                  "  pm.expect(unsigned.join(','), 'parts lost thoughtSignature - Gemini rejects replay without it').to.eql('');",
+                  "});",
+                  "pm.test('genai stream server-side toolCall: each toolCall is paired with a toolResponse by id', function () {",
+                  "  if (!toolCalls.length) { return; }",
+                  "  var respIds = {};",
+                  "  toolResponses.forEach(function (r) { respIds[r.id] = true; });",
+                  "  var unpaired = [];",
+                  "  toolCalls.forEach(function (c) { if (!respIds[c.id]) { unpaired.push(c.id); } });",
+                  "  pm.expect(unpaired.join(','), 'toolCall ids with no matching toolResponse').to.eql('');",
+                  "});"
                 ]
               }
             }
-          ],
+          ]
+        },
+        {
+          "name": "vertex/gemini-2.5-flash genai mixed tools: googleSearch dropped for pre-Gemini-3 model (/genai generateContent) - PR #6071",
           "request": {
             "method": "POST",
             "header": [
               {
                 "key": "Content-Type",
                 "value": "application/json"
-              },
-              {
-                "key": "x-api-key",
-                "value": "{{anthropicKey}}"
-              },
-              {
-                "key": "anthropic-version",
-                "value": "2023-06-01"
               }
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"model\": \"claude-opus-4-7\",\n  \"max_tokens\": 1024,\n  \"output_config\": {\n    \"effort\": \"medium\"\n  },\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What is 1+1? Answer in one word.\"\n    }\n  ]\n}"
+              "raw": "{\n  \"contents\": [\n    {\n      \"role\": \"user\",\n      \"parts\": [\n        {\n          \"text\": \"Call the get_weather function for Tokyo. You must use the function to answer.\"\n        }\n      ]\n    }\n  ],\n  \"tools\": [\n    {\n      \"functionDeclarations\": [\n        {\n          \"name\": \"get_weather\",\n          \"description\": \"Get the current weather for a city\",\n          \"parameters\": {\n            \"type\": \"object\",\n            \"properties\": {\n              \"city\": {\n                \"type\": \"string\",\n                \"description\": \"City name\"\n              }\n            },\n            \"required\": [\n              \"city\"\n            ]\n          }\n        }\n      ]\n    },\n    {\n      \"googleSearch\": {}\n    }\n  ],\n  \"generationConfig\": {\n    \"maxOutputTokens\": 256\n  }\n}"
             },
             "url": {
-              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "raw": "{{baseUrl}}/genai/v1beta/models/vertex/gemini-2.5-flash:generateContent",
               "host": [
                 "{{baseUrl}}"
               ],
               "path": [
-                "anthropic",
-                "v1",
-                "messages"
+                "genai",
+                "v1beta",
+                "models",
+                "vertex/gemini-2.5-flash:generateContent"
               ]
             }
-          }
-        },
-        {
-          "name": "anthropic/claude-opus-5 · output_config.effort without thinking keeps the model default thinking on",
+          },
           "event": [
             {
               "listen": "test",
@@ -128407,47 +128788,75 @@
                 "type": "text/javascript",
                 "exec": [
                   "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
-                  "pm.test('request succeeded', function () { pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400); });",
-                  "pm.test('thinking block returned', function () { var j = pm.response.json(); var blocks = Array.isArray(j.content) ? j.content : []; var thinking = blocks.filter(function (b) { return b.type === 'thinking' || b.type === 'redacted_thinking'; }); pm.expect(thinking.length, 'omitting thinking must forward the absence so opus 5 applies its own on-by-default, not suppress thinking: ' + pm.response.text()).to.be.above(0); });"
+                  "pm.test('vertex 2.5 mixed tools: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var raw = pm.response.text();",
+                  "var body = pm.response.json() || {};",
+                  "var parts = [];",
+                  "var searched = false;",
+                  "(body.candidates || []).forEach(function (cand) {",
+                  "  ((cand.content && cand.content.parts) || []).forEach(function (p) { parts.push(p); });",
+                  "  var gm = cand.groundingMetadata;",
+                  "  if (gm && ((gm.webSearchQueries || []).length || (gm.groundingChunks || []).length)) { searched = true; }",
+                  "  ((cand.content && cand.content.parts) || []).forEach(function (p) { if (p.toolCall) { searched = true; } });",
+                  "});",
+                  "pm.test('vertex 2.5 mixed tools: functionDeclarations survive alongside googleSearch without the flag (regression PR #6066)', function () {",
+                  "  var calls = [];",
+                  "  parts.forEach(function (p) { if (p.functionCall && p.functionCall.name === 'get_weather') { calls.push(p.functionCall); } });",
+                  "  pm.expect(calls.length, 'no get_weather functionCall - declarations were dropped when googleSearch was present: ' + raw.slice(0, 900)).to.be.above(0);",
+                  "});",
+                  "pm.test('vertex 2.5 mixed tools: pre-Gemini-3 model is not sent both tool kinds (regression PR #6066)', function () {",
+                  "  // Vertex answers 'Multiple tools are supported only when they are all search tools'",
+                  "  // with a 400 when both kinds reach a model that cannot combine them.",
+                  "  pm.expect(raw.indexOf('all search tools'), 'both tool kinds were sent to a model that rejects the mix: ' + raw.slice(0, 500)).to.equal(-1);",
+                  "});",
+                  "pm.test('vertex 2.5 mixed tools: signed parts keep their thoughtSignature', function () {",
+                  "  var lost = [];",
+                  "  parts.forEach(function (p) {",
+                  "    if ((p.toolCall || p.toolResponse) && !p.thoughtSignature) { lost.push(JSON.stringify(p).slice(0, 120)); }",
+                  "  });",
+                  "  pm.expect(lost.join(' | '), 'server-side tool parts lost thoughtSignature').to.eql('');",
+                  "});"
                 ]
               }
             }
-          ],
+          ]
+        },
+        {
+          "name": "vertex/gemini-2.5-flash genai mixed tools: googleSearch dropped for pre-Gemini-3 model streaming (/genai SSE) - PR #6071",
           "request": {
             "method": "POST",
             "header": [
               {
                 "key": "Content-Type",
                 "value": "application/json"
-              },
-              {
-                "key": "x-api-key",
-                "value": "{{anthropicKey}}"
-              },
-              {
-                "key": "anthropic-version",
-                "value": "2023-06-01"
               }
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"model\": \"claude-opus-5\",\n  \"max_tokens\": 16000,\n  \"output_config\": {\n    \"effort\": \"high\"\n  },\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Solve: integral of x^2 * e^(-x) dx from 0 to infinity. Show every step.\"\n    }\n  ]\n}"
+              "raw": "{\n  \"contents\": [\n    {\n      \"role\": \"user\",\n      \"parts\": [\n        {\n          \"text\": \"Call the get_weather function for Tokyo. You must use the function to answer.\"\n        }\n      ]\n    }\n  ],\n  \"tools\": [\n    {\n      \"functionDeclarations\": [\n        {\n          \"name\": \"get_weather\",\n          \"description\": \"Get the current weather for a city\",\n          \"parameters\": {\n            \"type\": \"object\",\n            \"properties\": {\n              \"city\": {\n                \"type\": \"string\",\n                \"description\": \"City name\"\n              }\n            },\n            \"required\": [\n              \"city\"\n            ]\n          }\n        }\n      ]\n    },\n    {\n      \"googleSearch\": {}\n    }\n  ],\n  \"generationConfig\": {\n    \"maxOutputTokens\": 256\n  }\n}"
             },
             "url": {
-              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "raw": "{{baseUrl}}/genai/v1beta/models/vertex/gemini-2.5-flash:streamGenerateContent?alt=sse",
               "host": [
                 "{{baseUrl}}"
               ],
               "path": [
-                "anthropic",
-                "v1",
-                "messages"
+                "genai",
+                "v1beta",
+                "models",
+                "vertex/gemini-2.5-flash:streamGenerateContent"
+              ],
+              "query": [
+                {
+                  "key": "alt",
+                  "value": "sse"
+                }
               ]
             }
-          }
-        },
-        {
-          "name": "anthropic/claude-opus-5 · thinking disabled + output_config.effort low keeps both",
+          },
           "event": [
             {
               "listen": "test",
@@ -128455,47 +128864,83 @@
                 "type": "text/javascript",
                 "exec": [
                   "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
-                  "pm.test('request succeeded', function () { pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400); });",
-                  "pm.test('no thinking block returned', function () { var j = pm.response.json(); var blocks = Array.isArray(j.content) ? j.content : []; var thinking = blocks.filter(function (b) { return b.type === 'thinking' || b.type === 'redacted_thinking'; }); pm.expect(thinking.length, 'caller explicitly disabled thinking; opus 5 accepts disabled at effort high or below: ' + pm.response.text()).to.equal(0); });"
+                  "pm.test('vertex 2.5 stream mixed tools: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var raw = pm.response.text();",
+                  "var chunks = [];",
+                  "raw.split('\\n').forEach(function (line) {",
+                  "  var t = line.trim();",
+                  "  if (t.indexOf('data:') !== 0) { return; }",
+                  "  var payload = t.slice(5).trim();",
+                  "  if (!payload || payload === '[DONE]') { return; }",
+                  "  try { chunks.push(JSON.parse(payload)); } catch (e) {}",
+                  "});",
+                  "pm.test('vertex 2.5 stream mixed tools: SSE chunks parsed', function () {",
+                  "  pm.expect(chunks.length, 'no SSE data chunks: ' + raw.slice(0, 500)).to.be.above(0);",
+                  "});",
+                  "var parts = [];",
+                  "var searched = false;",
+                  "chunks.forEach(function (c) {",
+                  "  (c.candidates || []).forEach(function (cand) {",
+                  "    ((cand.content && cand.content.parts) || []).forEach(function (p) {",
+                  "      parts.push(p);",
+                  "      if (p.toolCall) { searched = true; }",
+                  "    });",
+                  "    var gm = cand.groundingMetadata;",
+                  "    if (gm && ((gm.webSearchQueries || []).length || (gm.groundingChunks || []).length)) { searched = true; }",
+                  "  });",
+                  "});",
+                  "pm.test('vertex 2.5 stream mixed tools: functionDeclarations survive alongside googleSearch without the flag (regression PR #6066)', function () {",
+                  "  var calls = [];",
+                  "  parts.forEach(function (p) { if (p.functionCall && p.functionCall.name === 'get_weather') { calls.push(p.functionCall); } });",
+                  "  pm.expect(calls.length, 'no get_weather functionCall - declarations were dropped when googleSearch was present: ' + raw.slice(0, 900)).to.be.above(0);",
+                  "});",
+                  "pm.test('vertex 2.5 stream mixed tools: pre-Gemini-3 model is not sent both tool kinds (regression PR #6066)', function () {",
+                  "  // Vertex answers 'Multiple tools are supported only when they are all search tools'",
+                  "  // with a 400 when both kinds reach a model that cannot combine them.",
+                  "  pm.expect(raw.indexOf('all search tools'), 'both tool kinds were sent to a model that rejects the mix: ' + raw.slice(0, 500)).to.equal(-1);",
+                  "});",
+                  "pm.test('vertex 2.5 stream mixed tools: signed parts keep their thoughtSignature', function () {",
+                  "  var lost = [];",
+                  "  parts.forEach(function (p) {",
+                  "    if ((p.toolCall || p.toolResponse) && !p.thoughtSignature) { lost.push(JSON.stringify(p).slice(0, 120)); }",
+                  "  });",
+                  "  pm.expect(lost.join(' | '), 'server-side tool parts lost thoughtSignature').to.eql('');",
+                  "});"
                 ]
               }
             }
-          ],
+          ]
+        },
+        {
+          "name": "vertex/gemini-3.6-flash genai mixed googleSearch + functionDeclarations both survive (/genai generateContent) - PR #6071",
           "request": {
             "method": "POST",
             "header": [
               {
                 "key": "Content-Type",
                 "value": "application/json"
-              },
-              {
-                "key": "x-api-key",
-                "value": "{{anthropicKey}}"
-              },
-              {
-                "key": "anthropic-version",
-                "value": "2023-06-01"
               }
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"model\": \"claude-opus-5\",\n  \"max_tokens\": 1024,\n  \"thinking\": {\n    \"type\": \"disabled\"\n  },\n  \"output_config\": {\n    \"effort\": \"low\"\n  },\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What is 1+1? Answer in one word.\"\n    }\n  ]\n}"
+              "raw": "{\n  \"contents\": [\n    {\n      \"role\": \"user\",\n      \"parts\": [\n        {\n          \"text\": \"Call the get_weather function for Tokyo. You must use the function to answer.\"\n        }\n      ]\n    }\n  ],\n  \"tools\": [\n    {\n      \"functionDeclarations\": [\n        {\n          \"name\": \"get_weather\",\n          \"description\": \"Get the current weather for a city\",\n          \"parameters\": {\n            \"type\": \"object\",\n            \"properties\": {\n              \"city\": {\n                \"type\": \"string\",\n                \"description\": \"City name\"\n              }\n            },\n            \"required\": [\n              \"city\"\n            ]\n          }\n        }\n      ]\n    },\n    {\n      \"googleSearch\": {}\n    }\n  ],\n  \"generationConfig\": {\n    \"maxOutputTokens\": 256\n  }\n}"
             },
             "url": {
-              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "raw": "{{baseUrl}}/genai/v1beta/models/vertex/gemini-3.6-flash:generateContent",
               "host": [
                 "{{baseUrl}}"
               ],
               "path": [
-                "anthropic",
-                "v1",
-                "messages"
+                "genai",
+                "v1beta",
+                "models",
+                "vertex/gemini-3.6-flash:generateContent"
               ]
             }
-          }
-        },
-        {
-          "name": "anthropic/claude-opus-5 · thinking adaptive + output_config.effort unchanged",
+          },
           "event": [
             {
               "listen": "test",
@@ -128503,103 +128948,35 @@
                 "type": "text/javascript",
                 "exec": [
                   "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
-                  "pm.test('request succeeded', function () { pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400); });",
-                  "pm.test('thinking block returned', function () { var j = pm.response.json(); var blocks = Array.isArray(j.content) ? j.content : []; var thinking = blocks.filter(function (b) { return b.type === 'thinking' || b.type === 'redacted_thinking'; }); pm.expect(thinking.length, 'adaptive thinking with effort is the path that already worked and must not regress: ' + pm.response.text()).to.be.above(0); });"
-                ]
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "x-api-key",
-                "value": "{{anthropicKey}}"
-              },
-              {
-                "key": "anthropic-version",
-                "value": "2023-06-01"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"model\": \"claude-opus-5\",\n  \"max_tokens\": 16000,\n  \"thinking\": {\n    \"type\": \"adaptive\"\n  },\n  \"output_config\": {\n    \"effort\": \"medium\"\n  },\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Solve: integral of x^2 * e^(-x) dx from 0 to infinity. Show every step.\"\n    }\n  ]\n}"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/anthropic/v1/messages",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "anthropic",
-                "v1",
-                "messages"
-              ]
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "50. xAI reasoning_effort Forwarding (grok-4.5 / grok-4.6 / grok-4.20-multi-agent)",
-      "description": "Pins that reasoning_effort actually reaches xAI for the models that support it.\n\nBug: applyXAICompatibility (core/providers/openai/chat.go) and the /v1/responses\nequivalent only allowed reasoning_effort through for grok-3-mini, matched with\nstrings.Contains. Because \"grok-4\" is a substring of \"grok-4.5\", \"grok-4.6\" and\n\"grok-4.20-*\", the entire current xAI lineup was classified as reasoning-capable\nand then had its effort silently nil-ed. xAI documents low/medium/high/xhigh as\nsupported on grok-4.6 and low/medium/high on grok-4.5\n(https://docs.x.ai/docs/guides/reasoning).\n\nSecond bug found while writing these rows: filterOpenAISpecificParameters runs\nnormalizeReasoningEffort BEFORE the xAI compat pass, and its xhigh allow-list only\nmatched gpt-5.x, so grok-4.6 xhigh was downgraded to high even after the deny-list\nwas corrected.\n\nWhy the probe rows look odd: a dropped reasoning_effort still returns 200 with\nreasoning content, so the regression is invisible to a normal assertion. The probe\nrows send a deliberately invalid effort value and REQUIRE a 4xx - the value passes\nthrough Bifrost untouched (normalizeOpenAIReasoningEffort defaults to returning it),\nso only xAI can reject it. A 2xx means the field never left the gateway.\nThose rows carry the [EXPECT-4XX] name tag, which flips the collection-level status\nassertion from 2xx to 4xx for them (same idiom as [PREVIEW] / [SKIP]).\n\nExisting coverage (47.5.x, 47.6.x, 48.1.x) all uses xai/grok-4-0709, which is on the\ndeny-list, so none of it exercises the preserve path.",
-      "item": [
-        {
-          "name": "50.1 [EXPECT-4XX] native /v1/chat/completions -> xai/grok-4.6 invalid reasoning_effort",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"model\": \"xai/grok-4.6\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"hi\"\n    }\n  ],\n  \"max_tokens\": 16,\n  \"reasoning_effort\": \"__bogus_effort__\"\n}"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/v1/chat/completions",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "v1",
-                "chat",
-                "completions"
-              ]
-            }
-          },
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "// A dropped reasoning_effort still returns 200 with reasoning content, so \"did it",
-                  "// work\" is not observable directly. This row inverts the question: send a value",
-                  "// xAI must reject and require the rejection. 200 here == Bifrost ate the field.",
-                  "// NOTE: a 4xx is the PASS signature - it must not be added to the infra guard.",
-                  "// The range is 400-499, not a pinned 400: xAI documents 422 for \"a field in the",
-                  "// POST request body has an invalid format\" alongside 400 for general request",
-                  "// problems (https://docs.x.ai/developers/debugging), and an invalid effort enum is",
-                  "// exactly that. This row proves the field REACHED xAI; only a 2xx falsifies it, so",
-                  "// pinning one code would test xAI's error taxonomy instead. Matches the",
-                  "// collection-level [EXPECT-4XX] assertion, which already uses the same range.",
-                  "if ([401, 403, 404, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
-                  "pm.test('reasoning_effort reached xAI (invalid value rejected upstream)', function () {",
-                  "  pm.expect(pm.response.code, 'expected a 4xx from xAI; a 2xx means Bifrost stripped ' +",
-                  "    'reasoning_effort before the upstream call: ' + pm.response.text().slice(0, 500))",
-                  "    .to.be.within(400, 499);",
+                  "pm.test('vertex 3.6 mixed tools: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
                   "});",
-                  "pm.test('rejection names the offending parameter', function () {",
-                  "  var t = (pm.response.text() || \"\").toLowerCase();",
-                  "  pm.expect(/effort|reasoning|invalid/.test(t), 'unexpected 4xx body: ' +",
-                  "    pm.response.text().slice(0, 500)).to.be.true;",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var raw = pm.response.text();",
+                  "var body = pm.response.json() || {};",
+                  "var parts = [];",
+                  "var searched = false;",
+                  "(body.candidates || []).forEach(function (cand) {",
+                  "  ((cand.content && cand.content.parts) || []).forEach(function (p) { parts.push(p); });",
+                  "  var gm = cand.groundingMetadata;",
+                  "  if (gm && ((gm.webSearchQueries || []).length || (gm.groundingChunks || []).length)) { searched = true; }",
+                  "  ((cand.content && cand.content.parts) || []).forEach(function (p) { if (p.toolCall) { searched = true; } });",
+                  "});",
+                  "pm.test('vertex 3.6 mixed tools: functionDeclarations survive alongside googleSearch without the flag (regression PR #6066)', function () {",
+                  "  var calls = [];",
+                  "  parts.forEach(function (p) { if (p.functionCall && p.functionCall.name === 'get_weather') { calls.push(p.functionCall); } });",
+                  "  pm.expect(calls.length, 'no get_weather functionCall - declarations were dropped when googleSearch was present: ' + raw.slice(0, 900)).to.be.above(0);",
+                  "});",
+                  "pm.test('vertex 3.6 mixed tools: googleSearch survives too when the model supports tool combination', function () {",
+                  "  if (!searched) { return; }",
+                  "  pm.expect(searched, 'model searched, so googleSearch reached the wire alongside the declarations').to.be.true;",
+                  "});",
+                  "pm.test('vertex 3.6 mixed tools: signed parts keep their thoughtSignature', function () {",
+                  "  var lost = [];",
+                  "  parts.forEach(function (p) {",
+                  "    if ((p.toolCall || p.toolResponse) && !p.thoughtSignature) { lost.push(JSON.stringify(p).slice(0, 120)); }",
+                  "  });",
+                  "  pm.expect(lost.join(' | '), 'server-side tool parts lost thoughtSignature').to.eql('');",
                   "});"
                 ]
               }
@@ -128607,7 +128984,7 @@
           ]
         },
         {
-          "name": "50.2 [EXPECT-4XX] native /v1/responses -> xai/grok-4.6 invalid reasoning effort",
+          "name": "vertex/gemini-3.6-flash genai mixed googleSearch + functionDeclarations both survive streaming (/genai SSE) - PR #6071",
           "request": {
             "method": "POST",
             "header": [
@@ -128618,16 +128995,24 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"model\": \"xai/grok-4.6\",\n  \"input\": \"hi\",\n  \"max_output_tokens\": 16,\n  \"reasoning\": {\n    \"effort\": \"__bogus_effort__\"\n  }\n}"
+              "raw": "{\n  \"contents\": [\n    {\n      \"role\": \"user\",\n      \"parts\": [\n        {\n          \"text\": \"Call the get_weather function for Tokyo. You must use the function to answer.\"\n        }\n      ]\n    }\n  ],\n  \"tools\": [\n    {\n      \"functionDeclarations\": [\n        {\n          \"name\": \"get_weather\",\n          \"description\": \"Get the current weather for a city\",\n          \"parameters\": {\n            \"type\": \"object\",\n            \"properties\": {\n              \"city\": {\n                \"type\": \"string\",\n                \"description\": \"City name\"\n              }\n            },\n            \"required\": [\n              \"city\"\n            ]\n          }\n        }\n      ]\n    },\n    {\n      \"googleSearch\": {}\n    }\n  ],\n  \"generationConfig\": {\n    \"maxOutputTokens\": 256\n  }\n}"
             },
             "url": {
-              "raw": "{{baseUrl}}/v1/responses",
+              "raw": "{{baseUrl}}/genai/v1beta/models/vertex/gemini-3.6-flash:streamGenerateContent?alt=sse",
               "host": [
                 "{{baseUrl}}"
               ],
               "path": [
-                "v1",
-                "responses"
+                "genai",
+                "v1beta",
+                "models",
+                "vertex/gemini-3.6-flash:streamGenerateContent"
+              ],
+              "query": [
+                {
+                  "key": "alt",
+                  "value": "sse"
+                }
               ]
             }
           },
@@ -128637,26 +129022,50 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "// A dropped reasoning_effort still returns 200 with reasoning content, so \"did it",
-                  "// work\" is not observable directly. This row inverts the question: send a value",
-                  "// xAI must reject and require the rejection. 200 here == Bifrost ate the field.",
-                  "// NOTE: a 4xx is the PASS signature - it must not be added to the infra guard.",
-                  "// The range is 400-499, not a pinned 400: xAI documents 422 for \"a field in the",
-                  "// POST request body has an invalid format\" alongside 400 for general request",
-                  "// problems (https://docs.x.ai/developers/debugging), and an invalid effort enum is",
-                  "// exactly that. This row proves the field REACHED xAI; only a 2xx falsifies it, so",
-                  "// pinning one code would test xAI's error taxonomy instead. Matches the",
-                  "// collection-level [EXPECT-4XX] assertion, which already uses the same range.",
-                  "if ([401, 403, 404, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
-                  "pm.test('reasoning_effort reached xAI (invalid value rejected upstream)', function () {",
-                  "  pm.expect(pm.response.code, 'expected a 4xx from xAI; a 2xx means Bifrost stripped ' +",
-                  "    'reasoning_effort before the upstream call: ' + pm.response.text().slice(0, 500))",
-                  "    .to.be.within(400, 499);",
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('vertex 3.6 stream mixed tools: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
                   "});",
-                  "pm.test('rejection names the offending parameter', function () {",
-                  "  var t = (pm.response.text() || \"\").toLowerCase();",
-                  "  pm.expect(/effort|reasoning|invalid/.test(t), 'unexpected 4xx body: ' +",
-                  "    pm.response.text().slice(0, 500)).to.be.true;",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var raw = pm.response.text();",
+                  "var chunks = [];",
+                  "raw.split('\\n').forEach(function (line) {",
+                  "  var t = line.trim();",
+                  "  if (t.indexOf('data:') !== 0) { return; }",
+                  "  var payload = t.slice(5).trim();",
+                  "  if (!payload || payload === '[DONE]') { return; }",
+                  "  try { chunks.push(JSON.parse(payload)); } catch (e) {}",
+                  "});",
+                  "pm.test('vertex 3.6 stream mixed tools: SSE chunks parsed', function () {",
+                  "  pm.expect(chunks.length, 'no SSE data chunks: ' + raw.slice(0, 500)).to.be.above(0);",
+                  "});",
+                  "var parts = [];",
+                  "var searched = false;",
+                  "chunks.forEach(function (c) {",
+                  "  (c.candidates || []).forEach(function (cand) {",
+                  "    ((cand.content && cand.content.parts) || []).forEach(function (p) {",
+                  "      parts.push(p);",
+                  "      if (p.toolCall) { searched = true; }",
+                  "    });",
+                  "    var gm = cand.groundingMetadata;",
+                  "    if (gm && ((gm.webSearchQueries || []).length || (gm.groundingChunks || []).length)) { searched = true; }",
+                  "  });",
+                  "});",
+                  "pm.test('vertex 3.6 stream mixed tools: functionDeclarations survive alongside googleSearch without the flag (regression PR #6066)', function () {",
+                  "  var calls = [];",
+                  "  parts.forEach(function (p) { if (p.functionCall && p.functionCall.name === 'get_weather') { calls.push(p.functionCall); } });",
+                  "  pm.expect(calls.length, 'no get_weather functionCall - declarations were dropped when googleSearch was present: ' + raw.slice(0, 900)).to.be.above(0);",
+                  "});",
+                  "pm.test('vertex 3.6 stream mixed tools: googleSearch survives too when the model supports tool combination', function () {",
+                  "  if (!searched) { return; }",
+                  "  pm.expect(searched, 'model searched, so googleSearch reached the wire alongside the declarations').to.be.true;",
+                  "});",
+                  "pm.test('vertex 3.6 stream mixed tools: signed parts keep their thoughtSignature', function () {",
+                  "  var lost = [];",
+                  "  parts.forEach(function (p) {",
+                  "    if ((p.toolCall || p.toolResponse) && !p.thoughtSignature) { lost.push(JSON.stringify(p).slice(0, 120)); }",
+                  "  });",
+                  "  pm.expect(lost.join(' | '), 'server-side tool parts lost thoughtSignature').to.eql('');",
                   "});"
                 ]
               }
@@ -128664,7 +129073,7 @@
           ]
         },
         {
-          "name": "50.3 native /v1/chat/completions -> xai/grok-4.6 reasoning_effort xhigh preserved",
+          "name": "gemini/gemini-3.6-flash genai raw passthrough preserves server-side toolCall parts (/genai generateContent) - PR #6071",
           "request": {
             "method": "POST",
             "header": [
@@ -128675,17 +129084,18 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"model\": \"xai/grok-4.6\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"A farmer has 47 sheep. Each night one third of the flock (rounded down) escapes, and each morning he recovers 5. How many sheep after the 3rd morning? Show your working.\"\n    }\n  ],\n  \"max_tokens\": 2048,\n  \"reasoning_effort\": \"xhigh\"\n}"
+              "raw": "{\n  \"contents\": [\n    {\n      \"role\": \"user\",\n      \"parts\": [\n        {\n          \"text\": \"Who won the 2024 Ballon d'Or? Use Google Search and answer in one short sentence.\"\n        }\n      ]\n    }\n  ],\n  \"tools\": [\n    {\n      \"googleSearch\": {}\n    }\n  ],\n  \"toolConfig\": {\n    \"includeServerSideToolInvocations\": true\n  },\n  \"generationConfig\": {\n    \"maxOutputTokens\": 512\n  }\n}"
             },
             "url": {
-              "raw": "{{baseUrl}}/v1/chat/completions",
+              "raw": "{{baseUrl}}/genai/v1beta/models/gemini/gemini-3.6-flash:generateContent",
               "host": [
                 "{{baseUrl}}"
               ],
               "path": [
-                "v1",
-                "chat",
-                "completions"
+                "genai",
+                "v1beta",
+                "models",
+                "gemini/gemini-3.6-flash:generateContent"
               ]
             }
           },
@@ -128695,22 +129105,48 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "// Guards the other direction: the deny-list must not become so broad that it",
-                  "// strips valid efforts again, and the value must not be rejected upstream.",
-                  "// xhigh is grok-4.6-only; it must not be downgraded to high by the shared normalizer.",
-                  "if ([401, 403, 404, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
-                  "var j; try { j = pm.response.json(); } catch (e) {",
-                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
-                  "pm.test('grok-4.6 accepted the reasoning_effort request', function () {",
-                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 500)).to.be.below(400);",
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('genai passthrough server-side toolCall: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
                   "});",
-                  "var m = (((j.choices || [])[0] || {}).message) || {};",
-                  "var rt = (((j.usage || {}).completion_tokens_details) || {}).reasoning_tokens || 0;",
-                  "pm.test('reasoning surfaced', function () {",
-                  "  var think = !!(m.reasoning_content || m.reasoning || m.thinking ||",
-                  "    (m.reasoning_details && m.reasoning_details.length) || rt > 0);",
-                  "  pm.expect(think, 'no reasoning content and no reasoning tokens: ' +",
-                  "    pm.response.text().slice(0, 500)).to.be.true;",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var raw = pm.response.text();",
+                  "var body = pm.response.json() || {};",
+                  "var parts = [];",
+                  "var searched = false;",
+                  "(body.candidates || []).forEach(function (cand) {",
+                  "  ((cand.content && cand.content.parts) || []).forEach(function (p) { parts.push(p); });",
+                  "  var gm = cand.groundingMetadata;",
+                  "  if (gm && ((gm.webSearchQueries || []).length || (gm.groundingChunks || []).length)) { searched = true; }",
+                  "  ((cand.content && cand.content.parts) || []).forEach(function (p) { if (p.toolCall) { searched = true; } });",
+                  "});",
+                  "var toolCalls = [];",
+                  "var toolResponses = [];",
+                  "var unsigned = [];",
+                  "parts.forEach(function (p) {",
+                  "  if (p.toolCall) {",
+                  "    toolCalls.push(p.toolCall);",
+                  "    if (!p.thoughtSignature) { unsigned.push('toolCall:' + (p.toolCall.id || '?')); }",
+                  "  }",
+                  "  if (p.toolResponse) {",
+                  "    toolResponses.push(p.toolResponse);",
+                  "    if (!p.thoughtSignature) { unsigned.push('toolResponse:' + (p.toolResponse.id || '?')); }",
+                  "  }",
+                  "});",
+                  "pm.test('genai passthrough server-side toolCall: server-side toolCall parts are not dropped (regression PR #6071)', function () {",
+                  "  if (!searched) { return; }",
+                  "  pm.expect(toolCalls.length, 'model searched (grounding present) but zero toolCall parts came back - server-side parts were dropped: ' + raw.slice(0, 900)).to.be.above(0);",
+                  "});",
+                  "pm.test('genai passthrough server-side toolCall: every server-side tool part retains its thoughtSignature (regression PR #6071)', function () {",
+                  "  pm.expect(unsigned.join(','), 'parts lost thoughtSignature - Gemini rejects replay without it').to.eql('');",
+                  "});",
+                  "pm.test('genai passthrough server-side toolCall: each toolCall is paired with a toolResponse by id', function () {",
+                  "  if (!toolCalls.length) { return; }",
+                  "  var respIds = {};",
+                  "  toolResponses.forEach(function (r) { respIds[r.id] = true; });",
+                  "  var unpaired = [];",
+                  "  toolCalls.forEach(function (c) { if (!respIds[c.id]) { unpaired.push(c.id); } });",
+                  "  pm.expect(unpaired.join(','), 'toolCall ids with no matching toolResponse').to.eql('');",
                   "});"
                 ]
               }
@@ -128718,7 +129154,7 @@
           ]
         },
         {
-          "name": "50.4 native /v1/chat/completions -> xai/grok-4.5 reasoning_effort low preserved",
+          "name": "gemini-3.6-flash genai replays server-side toolCall turn with thoughtSignature (/genai generateContent) - PR #6071",
           "request": {
             "method": "POST",
             "header": [
@@ -128729,152 +129165,64 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"model\": \"xai/grok-4.5\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"A farmer has 47 sheep. Each night one third of the flock (rounded down) escapes, and each morning he recovers 5. How many sheep after the 3rd morning? Show your working.\"\n    }\n  ],\n  \"max_tokens\": 2048,\n  \"reasoning_effort\": \"low\"\n}"
+              "raw": "{\n  \"contents\": [\n    {\n      \"role\": \"user\",\n      \"parts\": [ { \"text\": \"Who won the 2024 Ballon d'Or? Use Google Search and answer in one short sentence.\" } ]\n    },\n    {\n      \"role\": \"model\",\n      \"parts\": {{ss6071Turn1Parts}}\n    },\n    {\n      \"role\": \"user\",\n      \"parts\": [ { \"text\": \"In one short sentence, what year was that award first given?\" } ]\n    }\n  ],\n  \"tools\": [ { \"googleSearch\": {} } ],\n  \"toolConfig\": { \"includeServerSideToolInvocations\": true },\n  \"generationConfig\": { \"maxOutputTokens\": 256 }\n}"
             },
             "url": {
-              "raw": "{{baseUrl}}/v1/chat/completions",
+              "raw": "{{baseUrl}}/genai/v1beta/models/gemini-3.6-flash:generateContent",
               "host": [
                 "{{baseUrl}}"
               ],
               "path": [
-                "v1",
-                "chat",
-                "completions"
+                "genai",
+                "v1beta",
+                "models",
+                "gemini-3.6-flash:generateContent"
               ]
             }
           },
           "event": [
             {
-              "listen": "test",
+              "listen": "prerequest",
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "// Guards the other direction: the deny-list must not become so broad that it",
-                  "// strips valid efforts again, and the value must not be rejected upstream.",
-                  "// grok-4.5 supports low/medium/high but not xhigh.",
-                  "if ([401, 403, 404, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
-                  "var j; try { j = pm.response.json(); } catch (e) {",
-                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
-                  "pm.test('grok-4.5 accepted the reasoning_effort request', function () {",
-                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 500)).to.be.below(400);",
-                  "});",
-                  "var m = (((j.choices || [])[0] || {}).message) || {};",
-                  "var rt = (((j.usage || {}).completion_tokens_details) || {}).reasoning_tokens || 0;",
-                  "pm.test('reasoning surfaced', function () {",
-                  "  var think = !!(m.reasoning_content || m.reasoning || m.thinking ||",
-                  "    (m.reasoning_details && m.reasoning_details.length) || rt > 0);",
-                  "  pm.expect(think, 'no reasoning content and no reasoning tokens: ' +",
-                  "    pm.response.text().slice(0, 500)).to.be.true;",
-                  "});"
+                  "// Keep the body valid JSON when the capturing case did not run (PROVIDER/FEATURE",
+                  "// filtering, or the model simply did not search). The test below then skips itself.",
+                  "if (!pm.collectionVariables.get('ss6071Turn1Parts')) {",
+                  "  pm.collectionVariables.set('ss6071Turn1Parts', JSON.stringify([{ text: 'Rodri won the 2024 Ballon d\\'Or.' }]));",
+                  "  pm.collectionVariables.set('ss6071Turn1Captured', 'false');",
+                  "}"
                 ]
               }
-            }
-          ]
-        },
-        {
-          "name": "50.5 native /v1/chat/completions -> xai/grok-4-0709 reasoning_effort still stripped",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"model\": \"xai/grok-4-0709\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"hi\"\n    }\n  ],\n  \"max_tokens\": 2048,\n  \"reasoning_effort\": \"high\"\n}"
             },
-            "url": {
-              "raw": "{{baseUrl}}/v1/chat/completions",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "v1",
-                "chat",
-                "completions"
-              ]
-            }
-          },
-          "event": [
             {
               "listen": "test",
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "// Deny-list guard, the mirror image of the probe rows. grok-4-0709 normalizes to",
-                  "// grok-4, which does NOT accept reasoning_effort, so Bifrost must keep stripping it.",
-                  "// If someone later empties the deny-list \"to simplify\", the effort reaches xAI and",
-                  "// this row goes red with a 4xx.",
-                  "// NOTE: max_tokens is 2048, not a token-shaving 16. grok-4 is a reasoning model and",
-                  "// a 16-token budget produced no response at all - the request hung ~54s and came back",
-                  "// 503, which is upstream noise rather than the thing this row pins. 2048 matches the",
-                  "// budget every other passing grok-4-0709 reasoning row in this collection uses.",
-                  "if ([401, 403, 404, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
-                  "pm.test('effort stripped for deny-listed grok-4 (no upstream 400)', function () {",
-                  "  pm.expect(pm.response.code, 'expected 2xx; a 400 means reasoning_effort was ' +",
-                  "    'forwarded to a model that rejects it: ' + pm.response.text().slice(0, 500))",
-                  "    .to.be.below(400);",
-                  "});"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "50.6 native /v1/chat/completions -> xai/grok-4.20-multi-agent reasoning_effort xhigh preserved",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"model\": \"xai/grok-4.20-multi-agent\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"A farmer has 47 sheep. Each night one third of the flock (rounded down) escapes, and each morning he recovers 5. How many sheep after the 3rd morning? Show your working.\"\n    }\n  ],\n  \"max_tokens\": 2048,\n  \"reasoning_effort\": \"xhigh\"\n}"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/v1/chat/completions",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "v1",
-                "chat",
-                "completions"
-              ]
-            }
-          },
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "// The second entry in grokModelsWithXHighReasoningEffort (core/schemas/utils.go).",
-                  "// grok-4.6 is covered by 50.3; without this row that allow-list entry has nothing",
-                  "// behind it, and a wrong entry there is not a silent downgrade - it is an upstream",
-                  "// 400, because a model that does not know xhigh rejects the value outright.",
-                  "// On this model reasoning_effort selects how many agents collaborate rather than",
-                  "// reasoning depth (https://docs.x.ai/docs/guides/reasoning), so xhigh is the most",
-                  "// expensive row in this folder. It stays because the alternative is claiming",
-                  "// coverage the folder does not have.",
-                  "if ([401, 403, 404, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
-                  "var j; try { j = pm.response.json(); } catch (e) {",
-                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
-                  "pm.test('grok-4.20-multi-agent accepted the reasoning_effort request', function () {",
-                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 500)).to.be.below(400);",
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var captured = pm.collectionVariables.get('ss6071Turn1Captured');",
+                  "var ran = pm.collectionVariables.get('ss6071Turn1Ran');",
+                  "// Skipping is only legitimate when the capturing case never ran (provider or feature",
+                  "// filtering). If it ran and still produced nothing to replay, this folder's premise",
+                  "// went untested - fail loudly rather than pass green on zero coverage.",
+                  "pm.test('genai replay: the capturing case produced a signed assistant turn to replay', function () {",
+                  "  if (ran !== 'true') { return; }",
+                  "  pm.expect(captured, 'the capture case returned 2xx but no part carried a thoughtSignature, so there was nothing to replay').to.eql('true');",
                   "});",
-                  "var m = (((j.choices || [])[0] || {}).message) || {};",
-                  "var rt = (((j.usage || {}).completion_tokens_details) || {}).reasoning_tokens || 0;",
-                  "pm.test('reasoning surfaced', function () {",
-                  "  var think = !!(m.reasoning_content || m.reasoning || m.thinking ||",
-                  "    (m.reasoning_details && m.reasoning_details.length) || rt > 0);",
-                  "  pm.expect(think, 'no reasoning content and no reasoning tokens: ' +",
-                  "    pm.response.text().slice(0, 500)).to.be.true;",
+                  "if (captured !== 'true') { return; }",
+                  "// No 400 guard on purpose: Gemini validates thoughtSignature server-side, so a 400",
+                  "// here is exactly the regression - the replayed signatures were mangled or dropped.",
+                  "pm.test('genai replay: replaying the server-side tool turn with thoughtSignature is accepted (regression PR #6071)', function () {",
+                  "  pm.expect(pm.response.code, 'replay rejected - thoughtSignature did not survive the round-trip: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "pm.test('genai replay: model answered the follow-up turn', function () {",
+                  "  var text = '';",
+                  "  ((pm.response.json() || {}).candidates || []).forEach(function (cand) {",
+                  "    ((cand.content && cand.content.parts) || []).forEach(function (p) { if (p.text) { text += p.text; } });",
+                  "  });",
+                  "  pm.expect(text.length, 'no text in replay response: ' + pm.response.text().slice(0, 500)).to.be.above(0);",
                   "});"
                 ]
               }


### PR DESCRIPTION
## Summary

Adds support for Gemini's server-side tool invocations (`toolCall`/`toolResponse` parts) that are reported when `toolConfig.includeServerSideToolInvocations` is enabled. Previously, these parts were silently dropped. Now they are parsed, mapped onto Bifrost's neutral `web_search_call` item type (for Google Search variants), and preserved verbatim so the exact parts — including `thoughtSignature` bytes Gemini requires on replay — survive a round-trip through the OpenAI-shaped schema.

## Changes

- Added `ToolCall` and `ToolResponse` types to `types.go`, with `UnmarshalJSON` implementations that accept both camelCase (Google's REST wire format) and snake_case (google-genai SDK replay format). Both are wired into `Part`'s marshal/unmarshal paths.
- Added `isSearchToolType` and a registry of known search tool type strings (`GOOGLE_SEARCH_WEB`, `GOOGLE_SEARCH_IMAGE`) to distinguish mappable tools from unmapped built-ins like `CODE_EXECUTION`.
- In the non-streaming path (`convertGeminiCandidatesToResponsesOutput`), `toolCall` parts now produce a `web_search_call` item using Gemini's own call ID and queries. A sibling `toolResponse` part marks the item `completed`. When grounding metadata is also present, its sources and any missing queries are merged onto the existing item rather than emitting a duplicate `web_search_call`.
- `thoughtSignature` bytes carried on `toolCall`/`toolResponse` parts are emitted as standalone reasoning items so Gemini can receive them back on replay.
- `serverSideToolParts` stashes the raw `toolCall`/`toolResponse` parts into `ProviderExtraFields["serverSideToolParts"]`. `ToGeminiResponsesResponse` recovers them and prepends them to the candidate's parts, skipping duplicate signature-only parts for signatures already present in those preserved parts.
- In the streaming path (`ToBifrostResponsesStream`), `toolCall` parts record the call ID and queries into new `GeminiResponsesStreamState` fields (`ServerSearchRounds`). At finish, `emitWebSearchFromGroundingMetadata` uses the recorded call ID as the item ID and merges grounding data on top, and now fires even when grounding metadata is absent but a server-side call was observed. Multiple search rounds each produce their own item in the order the model ran them.
- `nativePartPayload` and `nativePartsFromItem` serialize server-side tool parts onto `ResponsesMessage.ProviderNativeParts` so the streaming `/genai` surface can re-emit them byte-for-byte rather than emitting a bare signature-only part.
- `emitWebSearchFromGroundingMetadata` is hardened against nil `metadata` throughout so it can operate on server-side-call-only responses.
- Added `serversidetools_test.go` covering non-streaming scenarios: single search round with grounding merge, unknown tool type preservation, and two search rounds interleaved with a client function call. Added `serversidetools_stream_test.go` covering the streaming path end-to-end, including a full Gemini→Bifrost→Gemini round-trip asserting each `thoughtSignature` appears exactly once.
- Added e2e harness folder 49 covering the Gemini converter path, Vertex converter path (both pre-Gemini-3 and Gemini-3.6), raw passthrough, and a multi-turn replay that lets Gemini validate the `thoughtSignature` bytes server-side.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/gemini/...
```

The new tests exercise:
- A single server-side Google Search round with grounding metadata: expect exactly one `web_search_call` item carrying Gemini's own call ID, the toolCall's queries, and grounding's sources.
- An unmapped tool type (`CODE_EXECUTION`): expect no `web_search_call` item and the part preserved on the native round-trip.
- Two search rounds interleaved with a client `functionCall`, no grounding metadata: expect two `web_search_call` items paired by ID and the function call unaffected.
- Streaming with two search rounds: expect one item per round in order, each carrying its own call ID and queries, with grounding sources merged onto the first.
- Streaming GenAI round-trip: each `thoughtSignature` appears exactly once across the reconstructed parts; no duplicate signature-only parts alongside native tool parts.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

None. The `toolResponse` payload (rendered search-suggestion HTML) is carried opaquely in `ProviderExtraFields` and `ProviderNativeParts` and is not interpreted or executed.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable