### PR TITLE
fix(ui): improve ModelMultiselect empty and error states

### DIFF
--- a/ui/components/ui/modelMultiselect.tsx
+++ b/ui/components/ui/modelMultiselect.tsx
@@ -82,8 +82,9 @@ export function ModelMultiselect(props: ModelMultiselectProps) {
 	} = props;
 	const isSingleSelect = props.isSingleSelect === true;
 
-	const [getModels, { data: modelsData, isLoading }] = useLazyGetModelsQuery();
-	const [getBaseModels, { data: baseModelsData, isLoading: isLoadingBaseModels }] = useLazyGetBaseModelsQuery();
+	const [getModels, { data: modelsData, isFetching, isError }] = useLazyGetModelsQuery();
+	const [getBaseModels, { data: baseModelsData, isFetching: isFetchingBaseModels, isError: isBaseModelsError }] =
+		useLazyGetBaseModelsQuery();
 	const [inputValue, setInputValue] = useState("");
 	const inputValueRef = useRef("");
 
@@ -256,6 +257,10 @@ export function ModelMultiselect(props: ModelMultiselectProps) {
 	}, [modelsData, baseModelsData, shouldUseBaseModels, allowAllOption]);
 
 	const shouldBeDisabled = disabled || (!provider && !shouldLoadOnEmpty);
+	const modelsQueryEnabled = !!provider || shouldLoadOnEmpty;
+	const activeIsFetching = shouldUseBaseModels ? isFetchingBaseModels : modelsQueryEnabled ? isFetching : false;
+	const activeIsError = shouldUseBaseModels ? isBaseModelsError : modelsQueryEnabled ? isError : false;
+	const modelLoadError = !activeIsFetching && activeIsError;
 
 	return (
 		<AsyncMultiSelect<ModelOption>
@@ -273,7 +278,7 @@ export function ModelMultiselect(props: ModelMultiselectProps) {
 			dynamicOptionCreation={true}
 			createOptionText={"Press enter to add new model"}
 			defaultOptions={defaultOptions.length > 0 ? defaultOptions : ([] as Option<ModelOption>[])}
-			isLoading={shouldUseBaseModels ? isLoadingBaseModels : isLoading}
+			isLoading={activeIsFetching}
 			placeholder={placeholder}
 			disabled={shouldBeDisabled}
 			className={cn("!min-h-9 w-full", className)}
@@ -287,8 +292,10 @@ export function ModelMultiselect(props: ModelMultiselectProps) {
 			menuListClassName="mx-1"
 			inputValue={inputValue}
 			onInputChange={handleInputChange}
-			noResultsFoundPlaceholder="No models found"
-			emptyResultPlaceholder={provider || shouldLoadOnEmpty ? "Start typing to search models..." : "Please select a provider first"}
+			noResultsFoundPlaceholder={modelLoadError ? "Couldn’t load models." : "No matching models."}
+			emptyResultPlaceholder={
+				modelLoadError ? "Couldn’t load models." : provider ? "No models available for this provider." : shouldLoadOnEmpty ? "No models available." : "Select a provider first."
+			}
 			views={{
 				dropdownIndicator: isSingleSelect ? undefined : () => <></>,
 				singleValue: isSingleSelect


### PR DESCRIPTION
## Summary

Improves the placeholder messages shown in the model multiselect dropdown to better reflect the actual state of the component, including distinguishing between load errors, empty results, and missing provider selection.

## Changes

- Tracks `isFetching` and `isError` states from both `useLazyGetModelsQuery` and `useLazyGetBaseModelsQuery`
- Introduces a `modelLoadError` flag that is true when a fetch has completed with an error (and is not currently re-fetching)
- Replaces generic placeholder strings with context-aware messages:
  - On error: `"Couldn't load models."`
  - On empty results with a provider selected: `"No models available for this provider."`
  - On empty results with no provider: `"Select a provider first."`
  - On empty results when loading on empty is enabled: `"No models available."`
  - When no results match a search: `"No matching models."`
- Adds a trailing newline to the end of the file

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Open a form that includes the model multiselect component.
2. Select a provider and observe the placeholder before typing — it should read `"No models available for this provider."` if no models are returned.
3. Clear the provider selection and confirm the placeholder reads `"Select a provider first."`
4. Simulate a network error (e.g., disable the API or use devtools to block the request) and confirm the placeholder reads `"Couldn't load models."`
5. Type a search term that returns no results and confirm the placeholder reads `"No matching models."`

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before:
- `noResultsFoundPlaceholder`: `"No models found"`
- `emptyResultPlaceholder`: `"Start typing to search models..."` / `"Please select a provider first"`

After:
- `noResultsFoundPlaceholder`: `"No matching models."` / `"Couldn't load models."`
- `emptyResultPlaceholder`: `"Couldn't load models."` / `"No models available for this provider."` / `"No models available."` / `"Select a provider first."`

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable