### PR TITLE
fix: add per-alias override to decouple canonical-model resolution from adaptive-thinking preference

### DIFF
--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -697,7 +697,9 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 				}
 			} else if reasoningParams.Effort != nil && *reasoningParams.Effort != "none" {
 				effort := MapBifrostEffortToAnthropic(*reasoningParams.Effort)
-				if caps.SupportsAdaptiveThinking(DefaultSupportsAdaptiveThinking(caps.Model())) {
+				if schemas.ShouldUseAdaptiveThinking(ctx,
+					caps.SupportsAdaptiveThinking(DefaultSupportsAdaptiveThinking(caps.Model())),
+					caps.AdaptiveOnlyThinking(DefaultAdaptiveOnlyThinking(caps.Model()))) {
 					// Opus 4.6+ and Opus 4.7+: adaptive thinking + native effort
 					anthropicReq.Thinking = &AnthropicThinking{Type: "adaptive"}
 					setEffortOnOutputConfig(anthropicReq, effort)

--- a/core/providers/anthropic/chat_test.go
+++ b/core/providers/anthropic/chat_test.go
@@ -1173,7 +1173,7 @@ func TestToAnthropicChatRequest_NonOpus47_ReasoningMaxTokens_EnabledWithBudget(t
 // The wire model id is opaque (mirroring the incident); capModel is resolved
 // from the alias ModelName.
 func TestToAnthropicChatRequest_ForceFixedBudgetThinkingOverride(t *testing.T) {
-	const wireModelID = "v9xyf4o111s5" // opaque resource id, like the incident alias's model_id
+	const wireModelID = "a1b2c3d4e5f6" // opaque resource id, like the incident alias's model_id
 
 	tests := []struct {
 		name         string

--- a/core/providers/anthropic/chat_test.go
+++ b/core/providers/anthropic/chat_test.go
@@ -1168,6 +1168,96 @@ func TestToAnthropicChatRequest_NonOpus47_ReasoningMaxTokens_EnabledWithBudget(t
 	}
 }
 
+// TestToAnthropicChatRequest_ForceFixedBudgetThinkingOverride verifies the
+// per-alias ForceFixedBudgetThinking override on the direct Anthropic chat path.
+// The wire model id is opaque (mirroring the incident); capModel is resolved
+// from the alias ModelName.
+func TestToAnthropicChatRequest_ForceFixedBudgetThinkingOverride(t *testing.T) {
+	const wireModelID = "v9xyf4o111s5" // opaque resource id, like the incident alias's model_id
+
+	tests := []struct {
+		name         string
+		modelName    string
+		force        *bool
+		expectedType string
+		expectBudget bool
+		expectEffort bool
+	}{
+		{
+			name:         "Sonnet4.6_NoOverride_UsesAdaptive_Regression",
+			modelName:    "claude-sonnet-4-6",
+			force:        nil,
+			expectedType: "adaptive",
+			expectBudget: false,
+			expectEffort: true,
+		},
+		{
+			name:         "Sonnet4.6_OverrideTrue_UsesBudgetTokens_NewBehavior",
+			modelName:    "claude-sonnet-4-6",
+			force:        schemas.Ptr(true),
+			expectedType: "enabled",
+			expectBudget: true,
+			expectEffort: false,
+		},
+		{
+			name:         "Sonnet5_AdaptiveOnly_OverrideTrue_IgnoredStaysAdaptive",
+			modelName:    "claude-sonnet-5",
+			force:        schemas.Ptr(true),
+			expectedType: "adaptive",
+			expectBudget: false,
+			expectEffort: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bifrostReq := &schemas.BifrostChatRequest{
+				Provider: schemas.Anthropic,
+				Model:    wireModelID,
+				Input: []schemas.ChatMessage{
+					{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("think")}},
+				},
+				Params: &schemas.ChatParameters{
+					MaxCompletionTokens: schemas.Ptr(8192),
+					Reasoning:           &schemas.ChatReasoning{Effort: schemas.Ptr("high")},
+				},
+			}
+
+			ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+			defer cancel()
+			ctx.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{
+				Key: "best-claude",
+				Config: &schemas.AliasConfig{
+					ModelID:                  wireModelID,
+					ModelName:                schemas.Ptr(tt.modelName),
+					ForceFixedBudgetThinking: tt.force,
+				},
+			})
+
+			result, err := ToAnthropicChatRequest(ctx, bifrostReq)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Thinking == nil {
+				t.Fatal("expected Thinking to be set")
+			}
+			if result.Thinking.Type != tt.expectedType {
+				t.Errorf("thinking.type: got %q, want %q", result.Thinking.Type, tt.expectedType)
+			}
+			if tt.expectBudget && result.Thinking.BudgetTokens == nil {
+				t.Error("expected BudgetTokens to be set for budget_tokens wire shape")
+			}
+			if !tt.expectBudget && result.Thinking.BudgetTokens != nil {
+				t.Errorf("expected no BudgetTokens for adaptive wire shape, got %v", *result.Thinking.BudgetTokens)
+			}
+			hasEffort := result.OutputConfig != nil && result.OutputConfig.Effort != nil
+			if hasEffort != tt.expectEffort {
+				t.Errorf("output_config.effort presence: got %v, want %v", hasEffort, tt.expectEffort)
+			}
+		})
+	}
+}
+
 func TestToAnthropicChatRequest_Opus47_ReasoningEffort_AdaptiveWithEffort(t *testing.T) {
 	effort := "high"
 

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -4219,7 +4219,9 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 					if *bifrostReq.Params.Reasoning.Effort != "none" {
 						effort := MapBifrostEffortToAnthropic(*bifrostReq.Params.Reasoning.Effort)
 
-						if caps.SupportsAdaptiveThinking(DefaultSupportsAdaptiveThinking(caps.Model())) {
+						if schemas.ShouldUseAdaptiveThinking(ctx,
+							caps.SupportsAdaptiveThinking(DefaultSupportsAdaptiveThinking(caps.Model())),
+							caps.AdaptiveOnlyThinking(DefaultAdaptiveOnlyThinking(caps.Model()))) {
 							// Opus 4.6+ and Opus 4.7+: adaptive thinking + native effort
 							anthropicReq.Thinking = &AnthropicThinking{Type: "adaptive"}
 							setEffortOnOutputConfig(anthropicReq, effort)

--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -3625,7 +3625,7 @@ func TestAnthropicForceFixedBudgetThinkingOverride(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			const wireModelID = "v9xyf4o111s5" // opaque Bedrock resource id (like the incident)
+			const wireModelID = "a1b2c3d4e5f6" // opaque Bedrock resource id (like the incident)
 			bifrostReq := &schemas.BifrostChatRequest{
 				Model: wireModelID,
 				Input: []schemas.ChatMessage{

--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -3573,6 +3573,107 @@ func TestAnthropicReasoningConfigUsesThinkingField(t *testing.T) {
 	}
 }
 
+// TestAnthropicForceFixedBudgetThinkingOverride verifies the per-alias
+// ForceFixedBudgetThinking override decouples "attach a canonical model_name to
+// an alias" (for cachePoint/pricing) from "opt into the adaptive-thinking wire
+// shape". The wire model id stays opaque (mirroring the Bedrock resource id from
+// the incident); capModel is resolved from the alias ModelName.
+func TestAnthropicForceFixedBudgetThinkingOverride(t *testing.T) {
+	tests := []struct {
+		name               string
+		modelName          string // alias ModelName → resolves capModel for capability gating
+		force              *bool  // ForceFixedBudgetThinking override
+		expectedType       string // expected thinking.type
+		expectBudgetTokens bool
+	}{
+		{
+			name:               "Sonnet4.6_NoOverride_UsesAdaptive_Regression",
+			modelName:          "claude-sonnet-4-6",
+			force:              nil,
+			expectedType:       "adaptive",
+			expectBudgetTokens: false,
+		},
+		{
+			name:               "Sonnet4.6_OverrideFalse_UsesAdaptive",
+			modelName:          "claude-sonnet-4-6",
+			force:              schemas.Ptr(false),
+			expectedType:       "adaptive",
+			expectBudgetTokens: false,
+		},
+		{
+			name:               "Sonnet4.6_OverrideTrue_UsesBudgetTokens_NewBehavior",
+			modelName:          "claude-sonnet-4-6",
+			force:              schemas.Ptr(true),
+			expectedType:       "enabled",
+			expectBudgetTokens: true,
+		},
+		{
+			name:               "Sonnet5_AdaptiveOnly_OverrideTrue_IgnoredStaysAdaptive",
+			modelName:          "claude-sonnet-5",
+			force:              schemas.Ptr(true),
+			expectedType:       "adaptive",
+			expectBudgetTokens: false,
+		},
+		{
+			name:               "Sonnet3.5_NoAdaptiveSupport_OverrideTrue_UsesBudgetTokens",
+			modelName:          "claude-3-5-sonnet",
+			force:              schemas.Ptr(true),
+			expectedType:       "enabled",
+			expectBudgetTokens: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const wireModelID = "v9xyf4o111s5" // opaque Bedrock resource id (like the incident)
+			bifrostReq := &schemas.BifrostChatRequest{
+				Model: wireModelID,
+				Input: []schemas.ChatMessage{
+					{
+						Role: schemas.ChatMessageRoleUser,
+						Content: &schemas.ChatMessageContent{
+							ContentStr: schemas.Ptr("Hello"),
+						},
+					},
+				},
+				Params: &schemas.ChatParameters{
+					Reasoning: &schemas.ChatReasoning{Effort: schemas.Ptr("high")},
+				},
+			}
+
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			ctx.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{
+				Key: "best-claude",
+				Config: &schemas.AliasConfig{
+					ModelID:                  wireModelID,
+					ModelName:                schemas.Ptr(tt.modelName),
+					ForceFixedBudgetThinking: tt.force,
+				},
+			})
+
+			result, err := bedrock.ToBedrockChatCompletionRequest(ctx, bifrostReq)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.NotNil(t, result.AdditionalModelRequestFields)
+
+			thinkingConfig, hasThinking := result.AdditionalModelRequestFields.Get("thinking")
+			require.True(t, hasThinking, "expected thinking field in AdditionalModelRequestFields")
+
+			configMap, ok := thinkingConfig.(map[string]any)
+			require.True(t, ok, "thinking config should be map[string]any, got %T", thinkingConfig)
+			assert.Equal(t, tt.expectedType, configMap["type"], "thinking.type mismatch")
+
+			_, hasBudget := configMap["budget_tokens"]
+			assert.Equal(t, tt.expectBudgetTokens, hasBudget, "budget_tokens presence mismatch")
+
+			// The adaptive branch pairs thinking:{type:"adaptive"} with
+			// output_config.effort; the budget_tokens branch must not emit it.
+			_, hasOutputConfig := result.AdditionalModelRequestFields.Get("output_config")
+			assert.Equal(t, tt.expectedType == "adaptive", hasOutputConfig, "output_config presence should track adaptive shape")
+		})
+	}
+}
+
 func TestAnthropicOrderedOutputConfigRoundTripsReasoning(t *testing.T) {
 	request := &bedrock.BedrockConverseRequest{
 		ModelID: "anthropic.claude-opus-4-6-v1",

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -2497,7 +2497,9 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 
 						bedrockReq.AdditionalModelRequestFields.Set("reasoningConfig", config)
 					} else if schemas.IsAnthropicModelFamily(ctx, bifrostReq.Model) {
-						if caps.SupportsAdaptiveThinking(anthropic.DefaultSupportsAdaptiveThinking(caps.Model())) {
+						if schemas.ShouldUseAdaptiveThinking(ctx,
+							caps.SupportsAdaptiveThinking(anthropic.DefaultSupportsAdaptiveThinking(caps.Model())),
+							caps.AdaptiveOnlyThinking(anthropic.DefaultAdaptiveOnlyThinking(caps.Model()))) {
 							// Opus 4.6+: adaptive thinking + output_config.effort
 							effort := anthropic.MapBifrostEffortToAnthropic(*bifrostReq.Params.Reasoning.Effort)
 							thinkingConfig := map[string]any{

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -561,7 +561,9 @@ func convertChatParameters(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifr
 
 				bedrockReq.AdditionalModelRequestFields.Set("reasoningConfig", config)
 			} else if schemas.IsAnthropicModelFamily(ctx, bifrostReq.Model) {
-				if caps.SupportsAdaptiveThinking(anthropic.DefaultSupportsAdaptiveThinking(caps.Model())) {
+				if schemas.ShouldUseAdaptiveThinking(ctx,
+					caps.SupportsAdaptiveThinking(anthropic.DefaultSupportsAdaptiveThinking(caps.Model())),
+					caps.AdaptiveOnlyThinking(anthropic.DefaultAdaptiveOnlyThinking(caps.Model()))) {
 					// Opus 4.6+: adaptive thinking + output_config.effort
 					effort := anthropic.MapBifrostEffortToAnthropic(*bifrostReq.Params.Reasoning.Effort)
 					thinkingConfig := map[string]any{

--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -233,6 +233,28 @@ type AliasConfig struct {
 	ProjectID             *SecretVar `json:"project_id,omitempty"`
 	UseAnthropicEndpoints *bool      `json:"use_anthropic_endpoints,omitempty"` // Whether to use anthropic endpoints for this alias
 
+	// ForceFixedBudgetThinking, when true, pins Anthropic reasoning requests for
+	// this alias to the classic thinking:{type:"enabled",budget_tokens:N} wire
+	// shape even when the resolved canonical model (ModelName/ModelID; see
+	// ResolveCanonicalModel) supports the newer adaptive-thinking surface
+	// (thinking:{type:"adaptive"} + output_config.effort).
+	//
+	// Use this when adding ModelName/ModelID metadata to an alias for an
+	// unrelated reason (e.g. enabling Bedrock cachePoint via
+	// BedrockModelSupportsCachePoints, which also needs the canonical model to
+	// be resolvable) and you do NOT want to also opt into the adaptive-thinking
+	// behavior that resolving the canonical model incidentally unlocks —
+	// adaptive thinking removes the budget_tokens cap that previously bounded
+	// generation length under a given effort level, which can materially
+	// change latency/token-usage characteristics for existing callers tuned
+	// against the budget_tokens behavior.
+	//
+	// Has no effect on adaptive-ONLY models (Opus 4.7+, Sonnet 5+, Fable/Mythos
+	// — see IsAdaptiveOnlyThinkingModel in the anthropic package) since those
+	// reject budget_tokens outright; the override is silently ignored for
+	// those models and adaptive thinking is used regardless.
+	ForceFixedBudgetThinking *bool `json:"force_fixed_budget_thinking,omitempty"`
+
 	*AzureAliasCfg
 	*VertexAliasCfg
 	*BedrockAliasCfg
@@ -250,6 +272,7 @@ func (ac AliasConfig) isLegacyShape() bool {
 		ac.Region == nil &&
 		ac.ProjectID == nil &&
 		ac.UseAnthropicEndpoints == nil &&
+		ac.ForceFixedBudgetThinking == nil &&
 		ac.AzureAliasCfg == nil &&
 		ac.VertexAliasCfg == nil &&
 		ac.BedrockAliasCfg == nil &&
@@ -460,6 +483,35 @@ func ResolveCanonicalModel(ctx *BifrostContext, fallbackModel string) string {
 		}
 	}
 	return fallbackModel
+}
+
+// ShouldUseAdaptiveThinking reports whether reasoning requests for the current
+// attempt should use Anthropic's adaptive-thinking wire shape
+// (thinking:{type:"adaptive"}) instead of the classic budget_tokens shape.
+//
+// Callers first determine model capability via
+// anthropic.SupportsAdaptiveThinking(capModel) and
+// anthropic.IsAdaptiveOnlyThinkingModel(capModel) (capModel from
+// ResolveCanonicalModel) and pass the results in here — this package cannot
+// import the anthropic package directly (would create an import cycle), so it
+// only adds the per-alias ForceFixedBudgetThinking override on top of the
+// capability check the caller already computed.
+//
+// adaptiveOnly must be true for models where budget_tokens is rejected
+// outright (Opus 4.7+, Sonnet 5+, Fable/Mythos); the override never applies to
+// those regardless of alias config.
+func ShouldUseAdaptiveThinking(ctx *BifrostContext, supportsAdaptive bool, adaptiveOnly bool) bool {
+	if !supportsAdaptive {
+		return false
+	}
+	if adaptiveOnly {
+		return true
+	}
+	if ra := GetResolvedAlias(ctx); ra != nil && ra.Config != nil &&
+		ra.Config.ForceFixedBudgetThinking != nil && *ra.Config.ForceFixedBudgetThinking {
+		return false
+	}
+	return true
 }
 
 // ResolveBaseProvider returns the built-in provider that actually served this

--- a/core/schemas/account_test.go
+++ b/core/schemas/account_test.go
@@ -666,6 +666,89 @@ func TestResolveCanonicalModelPrecedence(t *testing.T) {
 	}
 }
 
+func TestShouldUseAdaptiveThinking(t *testing.T) {
+	// Helper to build a BifrostContext carrying a ResolvedAlias (nil ra => no alias).
+	withAlias := func(ra *ResolvedAlias) *BifrostContext {
+		bc := NewBifrostContext(nil, NoDeadline)
+		if ra != nil {
+			bc.SetValue(BifrostContextKeyResolvedAlias, ra)
+		}
+		return bc
+	}
+	forced := func(v bool) *ResolvedAlias {
+		return &ResolvedAlias{Key: "best-claude", Config: &AliasConfig{
+			ModelID:                  "claude-sonnet-4-6",
+			ForceFixedBudgetThinking: Ptr(v),
+		}}
+	}
+
+	cases := []struct {
+		name             string
+		ra               *ResolvedAlias
+		supportsAdaptive bool
+		adaptiveOnly     bool
+		want             bool
+	}{
+		{
+			name:             "adaptive-capable, no override: adaptive used (regression baseline)",
+			ra:               nil,
+			supportsAdaptive: true,
+			adaptiveOnly:     false,
+			want:             true,
+		},
+		{
+			name:             "adaptive-capable, override nil: adaptive used",
+			ra:               &ResolvedAlias{Key: "best-claude", Config: &AliasConfig{ModelID: "claude-sonnet-4-6"}},
+			supportsAdaptive: true,
+			adaptiveOnly:     false,
+			want:             true,
+		},
+		{
+			name:             "adaptive-capable, override false: adaptive used",
+			ra:               forced(false),
+			supportsAdaptive: true,
+			adaptiveOnly:     false,
+			want:             true,
+		},
+		{
+			name:             "adaptive-capable NOT adaptive-only, override true: budget_tokens (new behavior)",
+			ra:               forced(true),
+			supportsAdaptive: true,
+			adaptiveOnly:     false,
+			want:             false,
+		},
+		{
+			name:             "adaptive-ONLY, override true: override ignored, adaptive used",
+			ra:               forced(true),
+			supportsAdaptive: true,
+			adaptiveOnly:     true,
+			want:             true,
+		},
+		{
+			name:             "does not support adaptive, override true: budget_tokens (unaffected, no panic)",
+			ra:               forced(true),
+			supportsAdaptive: false,
+			adaptiveOnly:     false,
+			want:             false,
+		},
+		{
+			name:             "override true but nil Config: defensive, adaptive used",
+			ra:               &ResolvedAlias{Key: "best-claude", Config: nil},
+			supportsAdaptive: true,
+			adaptiveOnly:     false,
+			want:             true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ShouldUseAdaptiveThinking(withAlias(c.ra), c.supportsAdaptive, c.adaptiveOnly)
+			if got != c.want {
+				t.Fatalf("ShouldUseAdaptiveThinking: got %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
 func TestModelFamilyIsValid(t *testing.T) {
 	valid := []ModelFamily{
 		ModelFamilyAnthropic, ModelFamilyOpenAI, ModelFamilyMistral,


### PR DESCRIPTION
## Summary

Fixes #6084. Adds an opt-in, per-alias override that decouples "give this alias a canonical `model_name` for capability gating (cachePoint, pricing, logging, ...)" from "opt this alias into Anthropic's adaptive-thinking wire shape."

## Problem

`ResolveCanonicalModel()` resolves a single `capModel` string (`AliasConfig.ModelName → ModelID → fallback`) that many *unrelated* capability gates read off of — including both `BedrockModelSupportsCachePoints(capModel)` and `anthropic.SupportsAdaptiveThinking(capModel)`. Attaching `model_name` to an alias purely to fix cachePoint eligibility for an opaque wire ID (e.g. a Bedrock Application Inference Profile ID with no model string in it) has the side effect of also flipping reasoning requests from the classic `thinking:{type:"enabled",budget_tokens:N}` shape to `thinking:{type:"adaptive"}`+`output_config.effort` for any model where `SupportsAdaptiveThinking(capModel)` is true — even for models that are adaptive-*capable* but not adaptive-*only* (e.g. Claude Sonnet 4.6, which still accepts `budget_tokens` — see `IsAdaptiveOnlyThinkingModel`'s test cases), with no way to opt out.

This changes real generation-length/latency characteristics for existing callers tuned against the `budget_tokens` behavior (adaptive thinking has no equivalent to the ~20%-of-`max_output_tokens` reserve that `GetBudgetTokensFromReasoningEffort()` guarantees for the final answer under a fixed budget). See #6084 for the full writeup and a production incident this caused.

## Fix

- `core/schemas/account.go`: new `AliasConfig.ForceFixedBudgetThinking *bool` (opt-in, `omitempty`, default unset = 100% unchanged behavior), plus a `ShouldUseAdaptiveThinking(ctx, supportsAdaptive, adaptiveOnly bool) bool` helper that layers the override on top of the existing capability checks. The override is a no-op when `adaptiveOnly` is true (Opus 4.7+, Sonnet 5+, Fable/Mythos reject `budget_tokens` outright, so there is no "fixed budget" mode to fall back to for those).
- Swapped the 4 call sites that use `SupportsAdaptiveThinking(capModel)` as the adaptive-vs-fixed-budget preference branch to go through the new helper instead:
  - `core/providers/bedrock/utils.go`
  - `core/providers/bedrock/responses.go`
  - `core/providers/anthropic/chat.go`
  - `core/providers/anthropic/responses.go`
  
  (Every other `SupportsAdaptiveThinking`/`IsAdaptiveOnlyThinkingModel` call — e.g. the `display` field default, Fable-family special-casing — is untouched.)
- `isLegacyShape()` updated to account for the new field so an alias with only `ForceFixedBudgetThinking` set doesn't get mis-marshaled as the legacy string-valued shape.

## Example

```json
{
  "aliases": {
    "my-sonnet-4-6": {
      "model_id": "<opaque-wire-id>",
      "model_name": "claude-sonnet-4-6",
      "force_fixed_budget_thinking": true
    }
  }
}
```

`cachePoint`/pricing/logging keep resolving off `model_name` as before; reasoning requests for this alias keep using `thinking:{type:"enabled",budget_tokens:N}` instead of switching to adaptive.

## Testing

- `go build`, `go vet`, and `gofmt -l` are clean on all touched packages.
- New unit tests cover: default (unset override) behavior is unchanged for adaptive-capable models (regression); `ForceFixedBudgetThinking: true` forces `budget_tokens` for an adaptive-capable-but-not-adaptive-only model; the override is ignored (adaptive still used) for an adaptive-only model; and the helper directly, in isolation.
- **Local Docker verification** (built the real release image via `transports/Dockerfile.local`, booted it with a `config.json` containing a Bedrock alias with `force_fixed_budget_thinking: true` alongside a control alias without it, both pointed at the same non-production Bedrock inference-profile id):
  - `GET /api/providers/bedrock/keys` confirms the field round-trips correctly through the JSON config → config-store → admin API path.
  - Sent live, SigV4-signed requests to AWS Bedrock (`reasoning.effort: "high"`) through both aliases and inspected the raw outgoing request body (via `send_back_raw_request: true`) that bifrost actually put on the wire:
    - override alias → `"additionalModelRequestFields":{"thinking":{"budget_tokens":1804,"type":"enabled"}}` (`budget_tokens` matches `GetBudgetTokensFromReasoningEffort`'s formula for `effort=high`, `max_output_tokens=2000`: `1024 + 0.80×(2000−1024) = 1804`)
    - control alias → `"additionalModelRequestFields":{"thinking":{"type":"adaptive"},"output_config":{"effort":"high"}}`
  - Both requests reached Bedrock and were authenticated successfully (no credential/signing errors); Bedrock itself rejected the specific inference-profile id with `ValidationException: The provided model identifier is invalid`, which is an AWS-side resource/permission-scoping issue for the ad-hoc test principal used, unrelated to this change — the two `additionalModelRequestFields.thinking` payloads above are the literal bytes bifrost constructed and signed for delivery, which is exactly what this PR changes.

## Breaking changes

None. The new field is optional and unset by default; all existing aliases and callers keep their current behavior byte-for-byte.
