### PR TITLE
feat(logstore): fan out team/customer/BU dimension reads to JSON-array columns on all dialects

### DIFF
--- a/framework/logstore/dialectsql.go
+++ b/framework/logstore/dialectsql.go
@@ -25,3 +25,115 @@ func unixBucketExpr(dialect string, bucketSizeSeconds int64) string {
 		return fmt.Sprintf("CAST(FLOOR(EXTRACT(EPOCH FROM timestamp) / %d) * %d AS BIGINT)", bucketSizeSeconds, bucketSizeSeconds)
 	}
 }
+
+// fanoutDimensionColumns maps a scalar dimension id column to its JSON-array
+// id/name columns and its scalar name column. The org-hierarchy dimensions are
+// single-valued on the scalar column (set by the VK path and by pre-migration
+// rows) and multi-valued on the JSON-array column (set by the enterprise
+// user/AP path, which is the only writer that knows a request's full hierarchy).
+// ok is false for dimensions that have no array column at all (user, virtual
+// key, provider, app, user agent) — those keep plain scalar attribution.
+func fanoutDimensionColumns(idCol string) (arrIDs, arrNames, scalarName string, ok bool) {
+	switch idCol {
+	case "team_id":
+		return "team_ids", "team_names", "team_name", true
+	case "business_unit_id":
+		return "business_unit_ids", "business_unit_names", "business_unit_name", true
+	case "customer_id":
+		return "customer_ids", "customer_names", "customer_name", true
+	}
+	return "", "", "", false
+}
+
+// dimensionFanoutFrom returns a FROM subquery, aliased AS logs, that fans each
+// log row out to one row per associated dimension value, exposing derived
+// `dim_id` / `dim_name` columns alongside all original log columns (l.*) so DAC
+// scope and the regular filter predicates still resolve. Rows whose JSON-array
+// column is set are unnested with the id and name aligned by position; rows
+// without it (pre-upgrade rows, or the VK path, which only writes the scalar)
+// fall back to the scalar id/name. The two branches are mutually exclusive, so
+// no row is counted twice for the same dimension value.
+//
+// Returns ("", false) when the dimension has no array column, or when the
+// dialect has no fan-out implementation — callers then read the scalar column
+// exactly as before. No bind args: every identifier is an internal constant.
+func dimensionFanoutFrom(dialect, idCol string) (string, bool) {
+	arrIDs, arrNames, scalarName, ok := fanoutDimensionColumns(idCol)
+	if !ok {
+		return "", false
+	}
+	switch dialect {
+	case "postgres":
+		// Delegated so the Postgres text stays byte-identical to what the
+		// filter matviews were built from (see teamOrBUFanoutFrom).
+		return teamOrBUFanoutFrom(idCol)
+	case "sqlite":
+		return sqliteDimensionFanoutFrom(arrIDs, arrNames, idCol, scalarName), true
+	case "clickhouse":
+		return clickhouseDimensionFanoutFrom(arrIDs, arrNames, idCol, scalarName), true
+	}
+	return "", false
+}
+
+// sqliteDimensionFanoutFrom builds the SQLite fan-out subquery using the JSON1
+// extension (always compiled in: the bundled mattn/go-sqlite3 amalgamation
+// registers json_each unconditionally, and JSON has been on by default since
+// SQLite 3.38).
+//
+// Two details are load-bearing:
+//
+//   - json_each() raises "malformed JSON" on a non-JSON argument, and SQLite
+//     gives no guarantee that the branch's WHERE runs before the table-valued
+//     function is invoked for the row. Rewriting the argument to '[]' via CASE
+//     makes the array branch yield zero rows for NULL/garbage/non-array values
+//     instead of failing the whole query, which is what keeps the two branches
+//     mutually exclusive without depending on evaluation order.
+//   - the name is read positionally with json_extract(names, '$[<key>]')
+//     rather than a second json_each in a LEFT JOIN, because json_each sets
+//     `key` to the 0-based array index and json_extract accepts a runtime-built
+//     path. An id with no matching name yields NULL -> ''.
+//
+// json_valid must precede json_type in both guards: json_type() throws on
+// malformed input and SQLite evaluates AND left to right.
+func sqliteDimensionFanoutFrom(arrIDs, arrNames, idCol, scalarName string) string {
+	isArray := func(col string) string {
+		return fmt.Sprintf("l.%[1]s IS NOT NULL AND json_valid(l.%[1]s) AND json_type(l.%[1]s) = 'array'", col)
+	}
+	// Rewrites a possibly-NULL / non-array column to a safe JSON array literal.
+	safeArray := func(col string) string {
+		return fmt.Sprintf("CASE WHEN %s THEN l.%s ELSE '[]' END", isArray(col), col)
+	}
+	return fmt.Sprintf(`(
+	SELECT l.*, t.value AS dim_id, COALESCE(json_extract(%[2]s, '$[' || t.key || ']'), '') AS dim_name
+	FROM logs l
+	JOIN json_each(%[1]s) t
+	UNION ALL
+	SELECT l.*, COALESCE(l.%[3]s, '') AS dim_id, COALESCE(l.%[4]s, '') AS dim_name
+	FROM logs l
+	WHERE NOT (%[5]s)
+) AS logs`, safeArray(arrIDs), safeArray(arrNames), idCol, scalarName, isArray(arrIDs))
+}
+
+// clickhouseDimensionFanoutFrom builds the ClickHouse fan-out subquery. The
+// array columns are Nullable(String) holding the same JSON text as the other
+// backends, so every JSON function is guarded with ifNull.
+//
+// A single ARRAY JOIN over an if() replaces the UNION ALL used elsewhere: the
+// array branch and the scalar branch are mutually exclusive by construction, so
+// a row can never be counted twice. Plain ARRAY JOIN (not LEFT ARRAY JOIN) drops
+// rows whose array is empty, which reproduces the Postgres lateral's semantics.
+// arrayEnumerate yields 1-based indices matching ClickHouse array indexing, and
+// the length guard is the equivalent of the Postgres LEFT JOIN ON ordinality.
+func clickhouseDimensionFanoutFrom(arrIDs, arrNames, idCol, scalarName string) string {
+	ids := fmt.Sprintf("JSONExtract(ifNull(l.%s, ''), 'Array(String)')", arrIDs)
+	names := fmt.Sprintf("JSONExtract(ifNull(l.%s, ''), 'Array(String)')", arrNames)
+	return fmt.Sprintf(`(
+	SELECT l.*, fan.1 AS dim_id, fan.2 AS dim_name
+	FROM logs AS l
+	ARRAY JOIN if(
+		isValidJSON(ifNull(l.%[3]s, '')) AND JSONType(ifNull(l.%[3]s, '')) = 'Array',
+		arrayMap(i -> (%[1]s[i], if(i <= length(%[2]s), %[2]s[i], '')), arrayEnumerate(%[1]s)),
+		[(ifNull(l.%[4]s, ''), ifNull(l.%[5]s, ''))]
+	) AS fan
+) AS logs`, ids, names, arrIDs, idCol, scalarName)
+}

--- a/framework/logstore/dimension_fanout_test.go
+++ b/framework/logstore/dimension_fanout_test.go
@@ -1,0 +1,391 @@
+package logstore
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// TestDimensionFanoutFrom_PerDialect pins the dispatcher: Postgres must delegate
+// to teamOrBUFanoutFrom byte-for-byte (the filter matviews are built from that
+// exact text, and drift makes repairMatViewShapes drop them on boot), the other
+// supported dialects must produce their own array-or-scalar subquery, and every
+// unsupported (dialect, dimension) pair must fall back to the scalar path.
+func TestDimensionFanoutFrom_PerDialect(t *testing.T) {
+	for _, idCol := range []string{"team_id", "customer_id", "business_unit_id"} {
+		pgWant, ok := teamOrBUFanoutFrom(idCol)
+		require.True(t, ok)
+		pgGot, ok := dimensionFanoutFrom("postgres", idCol)
+		require.True(t, ok)
+		assert.Equal(t, pgWant, pgGot, "postgres text is pinned by the filter matview DDL for %s", idCol)
+	}
+
+	// Every fan-out dimension must be wired on every dialect: a column-mapping
+	// slip (e.g. business unit reading the team arrays) is invisible unless each
+	// dimension is asserted against its own columns.
+	for _, idCol := range []string{"team_id", "customer_id", "business_unit_id"} {
+		arrIDs, arrNames, scalarName, ok := fanoutDimensionColumns(idCol)
+		require.True(t, ok)
+
+		sqliteSQL, ok := dimensionFanoutFrom("sqlite", idCol)
+		require.Truef(t, ok, "sqlite fan-out missing for %s", idCol)
+		assert.Contains(t, sqliteSQL, "JOIN json_each(")
+		assert.Contains(t, sqliteSQL, "json_extract(", "names are read positionally")
+		assert.Contains(t, sqliteSQL, "json_valid(l."+arrIDs+")")
+		assert.Contains(t, sqliteSQL, "json_valid(l."+arrNames+")")
+		assert.Contains(t, sqliteSQL, "ELSE '[]' END", "non-array values must not reach json_each")
+		assert.Contains(t, sqliteSQL, "UNION ALL")
+		assert.Contains(t, sqliteSQL, "COALESCE(l."+idCol+", '') AS dim_id", "scalar fallback branch")
+		assert.Contains(t, sqliteSQL, "COALESCE(l."+scalarName+", '') AS dim_name")
+		assert.Contains(t, sqliteSQL, ") AS logs", "aliased AS logs so scope/filters resolve")
+
+		chSQL, ok := dimensionFanoutFrom("clickhouse", idCol)
+		require.Truef(t, ok, "clickhouse fan-out missing for %s", idCol)
+		assert.Contains(t, chSQL, "ARRAY JOIN if(")
+		assert.Contains(t, chSQL, "JSONExtract(ifNull(l."+arrIDs+", ''), 'Array(String)')")
+		assert.Contains(t, chSQL, "JSONExtract(ifNull(l."+arrNames+", ''), 'Array(String)')")
+		assert.Contains(t, chSQL, "arrayEnumerate(")
+		assert.Contains(t, chSQL, "[(ifNull(l."+idCol+", ''), ifNull(l."+scalarName+", ''))]", "scalar fallback branch")
+		assert.Contains(t, chSQL, ") AS logs")
+
+		// No dimension may read another's columns.
+		for _, other := range []string{"team_ids", "customer_ids", "business_unit_ids"} {
+			if other == arrIDs {
+				continue
+			}
+			assert.NotContainsf(t, sqliteSQL, "l."+other, "sqlite %s must not read %s", idCol, other)
+			assert.NotContainsf(t, chSQL, "l."+other, "clickhouse %s must not read %s", idCol, other)
+		}
+	}
+
+	// Dimensions with no array column keep plain scalar attribution.
+	for _, idCol := range []string{"user_id", "virtual_key_id", "provider", "app"} {
+		_, ok := dimensionFanoutFrom("postgres", idCol)
+		assert.Falsef(t, ok, "%s has no array column", idCol)
+		_, ok = dimensionFanoutFrom("sqlite", idCol)
+		assert.Falsef(t, ok, "%s has no array column", idCol)
+	}
+	// Dialects without an implementation fall back rather than emitting bad SQL.
+	_, mysqlOK := dimensionFanoutFrom("mysql", "team_id")
+	assert.False(t, mysqlOK)
+}
+
+// newFanoutTestStore returns an empty in-memory SQLite store. Fan-out rows are
+// inserted with insertFanoutLog so the raw JSON-array columns can hold values
+// (including malformed ones) that the Go writer would never produce.
+func newFanoutTestStore(t *testing.T) (*RDBLogStore, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&Log{}))
+	return &RDBLogStore{db: db, logger: bifrost.NewDefaultLogger(schemas.LogLevelInfo)}, db
+}
+
+// insertDimensionLog writes one log row with the scalar and/or JSON-array
+// columns of the given dimension set. Raw SQL (not the Go writer) so the array
+// columns can hold values the writer would never produce, e.g. malformed JSON.
+// Empty-string args are stored as NULL so the array-vs-scalar branch selection
+// is exercised faithfully.
+func insertDimensionLog(t *testing.T, db *gorm.DB, idCol, id string, ts time.Time, scalarID, scalarName, arrayIDs, arrayNames string) {
+	t.Helper()
+	arrIDsCol, arrNamesCol, scalarNameCol, ok := fanoutDimensionColumns(idCol)
+	require.Truef(t, ok, "%s is not a fan-out dimension", idCol)
+	nz := func(s string) any {
+		if s == "" {
+			return nil
+		}
+		return s
+	}
+	err := db.Exec(fmt.Sprintf(`
+		INSERT INTO logs (id, timestamp, object_type, provider, model, status,
+			%s, %s, %s, %s,
+			created_at, latency, cost, prompt_tokens, completion_tokens, total_tokens)
+		VALUES (?, ?, 'chat_completion', 'openai', 'gpt-4', 'success',
+			?, ?, ?, ?, ?, 100, 0.01, 10, 5, 15)
+	`, idCol, scalarNameCol, arrIDsCol, arrNamesCol),
+		id, ts, nz(scalarID), nz(scalarName), nz(arrayIDs), nz(arrayNames), ts).Error
+	require.NoError(t, err, "failed to insert fan-out test log")
+}
+
+// insertFanoutLog is the customer-dimension shorthand for insertDimensionLog.
+func insertFanoutLog(t *testing.T, db *gorm.DB, id string, ts time.Time, customerID, customerName, customerIDs, customerNames string) {
+	t.Helper()
+	insertDimensionLog(t, db, "customer_id", id, ts, customerID, customerName, customerIDs, customerNames)
+}
+
+func fanoutWindow(now time.Time) SearchFilters {
+	start := now.Add(-time.Hour)
+	end := now.Add(time.Hour)
+	return SearchFilters{StartTime: &start, EndTime: &end}
+}
+
+// TestDimensionRankings_SQLiteArrayFanout is the regression for the reported
+// bug: the enterprise user/AP path records a request's customers only in the
+// JSON-array columns, leaving the scalar customer_id NULL, so scalar-only
+// rankings reported every request as "Unassigned". Each id on the row must now
+// be credited in full, with the scalar column still covering rows that have no
+// array.
+func TestDimensionRankings_SQLiteArrayFanout(t *testing.T) {
+	s, db := newFanoutTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	// Row 1: array-only multi-customer request, scalar NULL (enterprise path).
+	insertFanoutLog(t, db, "log-1", now, "", "", `["c-a","c-b"]`, `["Customer A","Customer B"]`)
+	// Row 2: scalar-only request (VK path / pre-migration row).
+	insertFanoutLog(t, db, "log-2", now, "c-a", "Customer A", "", "")
+	// Row 3: no owner at all -> Unassigned.
+	insertFanoutLog(t, db, "log-3", now, "", "", "", "")
+
+	res, err := s.GetDimensionRankings(ctx, fanoutWindow(now), RankingDimensionCustomer)
+	require.NoError(t, err)
+
+	requests := make(map[string]int64, len(res.Rankings))
+	names := make(map[string]string, len(res.Rankings))
+	cost := make(map[string]float64, len(res.Rankings))
+	var summed int64
+	for _, r := range res.Rankings {
+		requests[r.ID] = r.TotalRequests
+		names[r.ID] = r.Name
+		cost[r.ID] = r.TotalCost
+		summed += r.TotalRequests
+	}
+
+	assert.Equal(t, int64(2), requests["c-a"], "credited its own scalar row plus the array row it appears in")
+	assert.Equal(t, int64(1), requests["c-b"], "array-only customer is now credited instead of being lost")
+	assert.Equal(t, int64(1), requests[unassignedDimensionID], "rows with neither array nor scalar owner")
+	assert.Equal(t, "Customer B", names["c-b"], "name read positionally from customer_names")
+	assert.Equal(t, unassignedDimensionName, names[unassignedDimensionID])
+	assert.InDelta(t, 0.01, cost["c-b"], 1e-9, "fan-out credits the full cost to each customer, it does not split it")
+
+	assert.Equal(t, int64(3), res.TotalActualRequests, "actual counts each request once, including Unassigned")
+	assert.Equal(t, int64(4), res.TotalAttributedRequests, "the two-customer request is attributed twice")
+	assert.Equal(t, res.TotalAttributedRequests, summed, "rows sum to attributed, not actual")
+}
+
+// TestDimensionRankings_SQLiteFanoutAllDimensions runs the same array /
+// scalar-fallback / Unassigned contract over every fan-out dimension, so a
+// column-mapping slip in one of them (business unit reading the team arrays,
+// say) cannot hide behind the customer coverage above.
+func TestDimensionRankings_SQLiteFanoutAllDimensions(t *testing.T) {
+	cases := []struct {
+		dimension RankingDimension
+		idCol     string
+	}{
+		{RankingDimensionTeam, "team_id"},
+		{RankingDimensionCustomer, "customer_id"},
+		{RankingDimensionBusinessUnit, "business_unit_id"},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.dimension), func(t *testing.T) {
+			s, db := newFanoutTestStore(t)
+			ctx := context.Background()
+			now := time.Now().UTC()
+
+			// Array-only multi-entity row, scalar-only row, and an owner-less row.
+			insertDimensionLog(t, db, tc.idCol, "log-1", now, "", "", `["e-a","e-b"]`, `["Entity A","Entity B"]`)
+			insertDimensionLog(t, db, tc.idCol, "log-2", now, "e-a", "Entity A", "", "")
+			insertDimensionLog(t, db, tc.idCol, "log-3", now, "", "", "", "")
+
+			res, err := s.GetDimensionRankings(ctx, fanoutWindow(now), tc.dimension)
+			require.NoError(t, err)
+
+			requests := make(map[string]int64, len(res.Rankings))
+			names := make(map[string]string, len(res.Rankings))
+			for _, r := range res.Rankings {
+				requests[r.ID] = r.TotalRequests
+				names[r.ID] = r.Name
+			}
+			assert.Equal(t, int64(2), requests["e-a"], "scalar row plus the array row it appears in")
+			assert.Equal(t, int64(1), requests["e-b"], "array-only entity is credited, not lost")
+			assert.Equal(t, "Entity B", names["e-b"], "name aligned positionally with the id")
+			assert.Equal(t, int64(1), requests[unassignedDimensionID])
+			assert.Equal(t, unassignedDimensionName, names[unassignedDimensionID])
+			assert.Equal(t, int64(3), res.TotalActualRequests)
+			assert.Equal(t, int64(4), res.TotalAttributedRequests)
+		})
+	}
+}
+
+// TestDimensionRankings_FanoutDimensionsAreIndependent pins that each fan-out
+// dimension reads only its own columns: a row carrying every hierarchy array
+// must produce exactly that dimension's entities, with no bleed between them.
+func TestDimensionRankings_FanoutDimensionsAreIndependent(t *testing.T) {
+	s, db := newFanoutTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	require.NoError(t, db.Exec(`
+		INSERT INTO logs (id, timestamp, object_type, provider, model, status,
+			team_ids, team_names, customer_ids, customer_names, business_unit_ids, business_unit_names,
+			created_at, latency, cost, prompt_tokens, completion_tokens, total_tokens)
+		VALUES ('log-1', ?, 'chat_completion', 'openai', 'gpt-4', 'success',
+			'["t-1"]', '["Team One"]', '["c-1","c-2"]', '["Cust One","Cust Two"]', '["b-1"]', '["BU One"]',
+			?, 100, 0.01, 10, 5, 15)
+	`, now, now).Error)
+
+	expected := map[RankingDimension][]string{
+		RankingDimensionTeam:         {"t-1"},
+		RankingDimensionCustomer:     {"c-1", "c-2"},
+		RankingDimensionBusinessUnit: {"b-1"},
+	}
+	for dim, wantIDs := range expected {
+		res, err := s.GetDimensionRankings(ctx, fanoutWindow(now), dim)
+		require.NoError(t, err)
+		gotIDs := make([]string, 0, len(res.Rankings))
+		for _, r := range res.Rankings {
+			gotIDs = append(gotIDs, r.ID)
+		}
+		sort.Strings(gotIDs)
+		assert.Equalf(t, wantIDs, gotIDs, "%s must read only its own array columns", dim)
+	}
+}
+
+// TestDimensionRankings_SQLiteMalformedArray pins the guards around json_each:
+// it raises on non-JSON input, so a row whose array column holds garbage (or a
+// JSON object rather than an array) must fall to the scalar branch instead of
+// failing the whole query.
+func TestDimensionRankings_SQLiteMalformedArray(t *testing.T) {
+	s, db := newFanoutTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	insertFanoutLog(t, db, "log-1", now, "c-a", "Customer A", "not json", "")
+	insertFanoutLog(t, db, "log-2", now, "c-b", "Customer B", `{"a":1}`, `{"a":1}`)
+	insertFanoutLog(t, db, "log-3", now, "", "", `["c-c"]`, `["Customer C"]`)
+
+	res, err := s.GetDimensionRankings(ctx, fanoutWindow(now), RankingDimensionCustomer)
+	require.NoError(t, err, "malformed JSON must not fail the query")
+
+	requests := make(map[string]int64, len(res.Rankings))
+	for _, r := range res.Rankings {
+		requests[r.ID] = r.TotalRequests
+	}
+	assert.Equal(t, int64(1), requests["c-a"], "garbage array falls back to the scalar owner")
+	assert.Equal(t, int64(1), requests["c-b"], "a JSON object is not an array; scalar owner wins")
+	assert.Equal(t, int64(1), requests["c-c"])
+	assert.Equal(t, int64(3), res.TotalActualRequests)
+	assert.Equal(t, int64(3), res.TotalAttributedRequests, "no row fanned out to more than one customer")
+}
+
+// TestDimensionRankings_SingleOwnerDimensionsUnchanged pins that dimensions with
+// no array column keep exactly their previous behaviour: one owner per request,
+// owner-less rows bucketed, and attributed == actual.
+func TestDimensionRankings_SingleOwnerDimensionsUnchanged(t *testing.T) {
+	s, db := newFanoutTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	require.NoError(t, db.Exec(`
+		INSERT INTO logs (id, timestamp, object_type, provider, model, status,
+			virtual_key_id, virtual_key_name, customer_ids, created_at, latency, cost,
+			prompt_tokens, completion_tokens, total_tokens)
+		VALUES ('log-1', ?, 'chat_completion', 'openai', 'gpt-4', 'success',
+			'vk-1', 'Prod Key', '["c-a","c-b"]', ?, 100, 0.01, 10, 5, 15)
+	`, now, now).Error)
+	insertFanoutLog(t, db, "log-2", now, "", "", "", "")
+
+	res, err := s.GetDimensionRankings(ctx, fanoutWindow(now), RankingDimensionVirtualKey)
+	require.NoError(t, err)
+
+	requests := make(map[string]int64, len(res.Rankings))
+	for _, r := range res.Rankings {
+		requests[r.ID] = r.TotalRequests
+	}
+	assert.Equal(t, int64(1), requests["vk-1"], "the customer array must not fan out the virtual-key rollup")
+	assert.Equal(t, int64(1), requests[unassignedDimensionID])
+	assert.Equal(t, int64(2), res.TotalActualRequests)
+	assert.Equal(t, res.TotalActualRequests, res.TotalAttributedRequests, "single-owner dimension stays additive")
+}
+
+// TestDimensionHistograms_SQLiteArrayFanout pins that the cost / token / latency
+// by-dimension histograms use the same attribution as the rankings shown beside
+// them: each customer on the row gets the full value, and owner-less rows land
+// in the Unassigned bucket (which the latency histogram never had before).
+func TestDimensionHistograms_SQLiteArrayFanout(t *testing.T) {
+	s, db := newFanoutTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	insertFanoutLog(t, db, "log-1", now, "", "", `["c-a","c-b"]`, `["Customer A","Customer B"]`)
+	insertFanoutLog(t, db, "log-2", now, "", "", "", "")
+	filters := fanoutWindow(now)
+
+	costRes, err := s.GetDimensionCostHistogram(ctx, filters, 3600, DimensionCustomer)
+	require.NoError(t, err)
+	costByDim := map[string]float64{}
+	for _, b := range costRes.Buckets {
+		for dim, v := range b.ByDimension {
+			costByDim[dim] += v
+		}
+	}
+	assert.InDelta(t, 0.01, costByDim["c-a"], 1e-9)
+	assert.InDelta(t, 0.01, costByDim["c-b"], 1e-9, "full cost credited to each customer")
+	assert.InDelta(t, 0.01, costByDim[unassignedDimensionID], 1e-9)
+
+	tokenRes, err := s.GetDimensionTokenHistogram(ctx, filters, 3600, DimensionCustomer)
+	require.NoError(t, err)
+	tokensByDim := map[string]int64{}
+	for _, b := range tokenRes.Buckets {
+		for dim, v := range b.ByDimension {
+			tokensByDim[dim] += v.TotalTokens
+		}
+	}
+	assert.Equal(t, int64(15), tokensByDim["c-a"])
+	assert.Equal(t, int64(15), tokensByDim["c-b"])
+	assert.Equal(t, int64(15), tokensByDim[unassignedDimensionID])
+
+	latencyRes, err := s.GetDimensionLatencyHistogram(ctx, filters, 3600, DimensionCustomer)
+	require.NoError(t, err)
+	latencyDims := map[string]bool{}
+	for _, b := range latencyRes.Buckets {
+		for dim := range b.ByDimension {
+			latencyDims[dim] = true
+		}
+	}
+	assert.True(t, latencyDims["c-a"])
+	assert.True(t, latencyDims["c-b"], "latency must fan out like cost and tokens")
+	assert.True(t, latencyDims[unassignedDimensionID], "latency must bucket owner-less rows, not key them on ''")
+	assert.False(t, latencyDims[""], "no empty-string dimension key")
+}
+
+// TestDimensionRankings_FanoutTrendUsesFanoutRelation pins that the previous
+// period is measured on the same relation as the current one. Reading the
+// previous period from the scalar column would leave an array-only entity with
+// no baseline and report it as brand-new traffic.
+func TestDimensionRankings_FanoutTrendUsesFanoutRelation(t *testing.T) {
+	s, db := newFanoutTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	// One request this hour, one in the previous hour, both array-only.
+	insertFanoutLog(t, db, "log-now", now.Add(-5*time.Minute), "", "", `["c-a"]`, `["Customer A"]`)
+	insertFanoutLog(t, db, "log-prev", now.Add(-90*time.Minute), "", "", `["c-a"]`, `["Customer A"]`)
+
+	start := now.Add(-time.Hour)
+	res, err := s.GetDimensionRankings(ctx, SearchFilters{StartTime: &start, EndTime: &now}, RankingDimensionCustomer)
+	require.NoError(t, err)
+
+	var found bool
+	for _, r := range res.Rankings {
+		if r.ID != "c-a" {
+			continue
+		}
+		found = true
+		assert.True(t, r.Trend.HasPreviousPeriod, "the previous period must be read from the fan-out relation too")
+		assert.Zero(t, r.Trend.RequestsTrend, "one request in each period is flat, not a spike")
+	}
+	assert.True(t, found, "expected a ranking row for c-a")
+}

--- a/framework/logstore/logstoreparity_test.go
+++ b/framework/logstore/logstoreparity_test.go
@@ -13,10 +13,13 @@ package logstore
 //
 // The Postgres store is built bare (no ensureMatViews), so matViewsReady stays
 // false and Postgres deterministically takes the same raw-table path the
-// matviews approximate. Known, deliberate divergences are NOT asserted here:
-// multi-value team_ids array matching and team/BU dimension fan-out
-// (postgres-only features; fixtures carry scalar ids only - the fan-out's
-// attributed-totals metadata is excluded from the contract), ILIKE
+// matviews approximate. Team / customer / business-unit dimension fan-out IS
+// part of the contract (the fixtures carry array-only and scalar-only hierarchy
+// rows for all three, and every backend has its own fan-out SQL, so a
+// column-mapping or dialect-SQL defect in any one of them fails here). Known,
+// deliberate divergences are NOT
+// asserted here: multi-value team_ids array *filtering* (postgres-only; the
+// other backends match the scalar column), ILIKE
 // case-insensitivity (fixtures use exact case), FTS-vs-LIKE content search
 // semantics (the fixture term matches under all three), and inc_number
 // (Postgres-assigned; NULL elsewhere - excluded from projections).
@@ -102,6 +105,11 @@ type parityLogSpec struct {
 	customerID   *string
 	buID         *string
 	userID       *string
+	// JSON-array hierarchy columns (enterprise user/AP path). Set without the
+	// scalar ids to exercise the dimension fan-out on every backend.
+	teamIDs, teamNames         *string
+	customerIDs, customerNames *string
+	buIDs, buNames             *string
 	cost         *float64
 	latency      *float64
 	tokens       [3]int // prompt, completion, total
@@ -134,6 +142,12 @@ func (s parityLogSpec) toLog(base time.Time) *Log {
 		CustomerID:            s.customerID,
 		BusinessUnitID:        s.buID,
 		UserID:                s.userID,
+		TeamIDs:               s.teamIDs,
+		TeamNames:             s.teamNames,
+		CustomerIDs:           s.customerIDs,
+		CustomerNames:         s.customerNames,
+		BusinessUnitIDs:       s.buIDs,
+		BusinessUnitNames:     s.buNames,
 		Cost:                  s.cost,
 		Latency:               s.latency,
 		PromptTokens:          s.tokens[0],
@@ -191,6 +205,24 @@ func paritySpecs() []parityLogSpec {
 		{id: "p10", offsetSec: 10, object: "chat.completion", provider: "openai", model: "gpt-4o", status: "success",
 			cost: f64PtrP(2.0), latency: f64PtrP(110), tokens: [3]int{80, 40, 120},
 			nodeID: strPtrP("pnode"), budgetIDs: strPtrP(`["bud1","bud2"]`), rateLimitIDs: strPtrP(`["rl1"]`)},
+		// Enterprise user/AP path: the hierarchy lives in the JSON arrays and the
+		// scalar ids stay NULL, so the dimension readers must fan out. p11 spans
+		// two teams / two customers, p12 a single one, and p13 carries a scalar
+		// id with no array (the fan-out's fallback branch). Every dialect's
+		// fan-out SQL is exercised here.
+		{id: "p11", offsetSec: 15, object: "chat.completion", provider: "openai", model: "gpt-4o", status: "success",
+			userID: strPtrP("u5"), cost: f64PtrP(4.0), latency: f64PtrP(140), tokens: [3]int{60, 30, 90},
+			teamIDs: strPtrP(`["t4","t5"]`), teamNames: strPtrP(`["Team Four","Team Five"]`),
+			customerIDs: strPtrP(`["c3","c4"]`), customerNames: strPtrP(`["Cust Three","Cust Four"]`),
+			buIDs: strPtrP(`["b3","b4"]`), buNames: strPtrP(`["BU Three","BU Four"]`)},
+		{id: "p12", offsetSec: 14, object: "chat.completion", provider: "anthropic", model: "claude-3", status: "success",
+			userID: strPtrP("u5"), cost: f64PtrP(0.25), latency: f64PtrP(160), tokens: [3]int{20, 10, 30},
+			teamIDs: strPtrP(`["t4"]`), teamNames: strPtrP(`["Team Four"]`),
+			customerIDs: strPtrP(`["c3"]`), customerNames: strPtrP(`["Cust Three"]`),
+			buIDs: strPtrP(`["b3"]`), buNames: strPtrP(`["BU Three"]`)},
+		{id: "p13", offsetSec: 13, object: "chat.completion", provider: "openai", model: "gpt-4o-mini", status: "success",
+			teamID: strPtrP("t4"), customerID: strPtrP("c3"), buID: strPtrP("b3"), userID: strPtrP("u6"),
+			cost: f64PtrP(0.1), latency: f64PtrP(35), tokens: [3]int{5, 5, 10}},
 	}
 }
 
@@ -615,6 +647,21 @@ func TestLogStoreParity(t *testing.T) {
 		"dimension_latency": func(ctx context.Context, s LogStore) (any, error) {
 			return s.GetDimensionLatencyHistogram(ctx, window, 60, DimensionProvider)
 		},
+		// The fan-out dimensions: the fixtures carry both array-only and
+		// scalar-only hierarchy rows, so each backend's fan-out SQL and its
+		// scalar fallback must agree.
+		"dimension_cost_team": func(ctx context.Context, s LogStore) (any, error) {
+			return s.GetDimensionCostHistogram(ctx, window, 60, DimensionTeam)
+		},
+		"dimension_tokens_customer": func(ctx context.Context, s LogStore) (any, error) {
+			return s.GetDimensionTokenHistogram(ctx, window, 60, DimensionCustomer)
+		},
+		"dimension_latency_team": func(ctx context.Context, s LogStore) (any, error) {
+			return s.GetDimensionLatencyHistogram(ctx, window, 60, DimensionTeam)
+		},
+		"dimension_cost_business_unit": func(ctx context.Context, s LogStore) (any, error) {
+			return s.GetDimensionCostHistogram(ctx, window, 60, DimensionBusinessUnit)
+		},
 		// Filter on the same column the SELECT aliases (SUM(cost) AS cost):
 		// without prefer_column_name_to_alias=1 ClickHouse resolves the WHERE
 		// identifier to the aggregate alias and errors (code 184).
@@ -649,19 +696,20 @@ func TestLogStoreParity(t *testing.T) {
 			return s.GetDimensionRankings(ctx, window, RankingDimensionVirtualKey)
 		})
 	})
-	t.Run("Rankings/dimension_team", func(t *testing.T) {
-		// Fixtures carry scalar team_id only, so the Postgres fan-out's scalar
-		// fallback and the other backends' plain group-by must agree on the
-		// rankings. TotalActual/AttributedRequests are documented as
-		// fan-out-only (Postgres) metadata and excluded from the contract.
-		assertParity(t, stores, 1e-6, func(ctx context.Context, s LogStore) (any, error) {
-			r, err := s.GetDimensionRankings(ctx, window, RankingDimensionTeam)
-			if err != nil {
-				return nil, err
-			}
-			return map[string]any{"rankings": r.Rankings, "dimension": r.Dimension}, nil
+	// The fixtures carry both scalar-only and array-only hierarchy rows, so these
+	// exercise each backend's fan-out SQL and its scalar fallback — including the
+	// attributed-vs-actual totals, which every dialect must now agree on.
+	for name, dim := range map[string]RankingDimension{
+		"dimension_team":          RankingDimensionTeam,
+		"dimension_customer":      RankingDimensionCustomer,
+		"dimension_business_unit": RankingDimensionBusinessUnit,
+	} {
+		t.Run("Rankings/"+name, func(t *testing.T) {
+			assertParity(t, stores, 1e-6, func(ctx context.Context, s LogStore) (any, error) {
+				return s.GetDimensionRankings(ctx, window, dim)
+			})
 		})
-	})
+	}
 
 	t.Run("Distinct", func(t *testing.T) {
 		sorted := func(v []string, err error) (any, error) {

--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -179,8 +179,10 @@ type filterMatViewDef struct {
 // dimension is single-valued on the scalar column (old / pre-migration rows and
 // the VK-team path) and multi-valued on the JSON-array column (the enterprise
 // user/AP path). It reuses teamOrBUFanoutFrom — the same fan-out the ranking /
-// histogram readers use — so a team / business unit that only ever appears in
-// the JSON array still surfaces in the filter dropdown. The fanned-out
+// histogram readers reach through dimensionFanoutFrom — so a team / business
+// unit that only ever appears in the JSON array still surfaces in the filter
+// dropdown. The emitted body text is pinned: repairMatViewShapes treats a
+// change as drift and drops the views on boot. The fanned-out
 // dim_id/dim_name become the dropdown id/name; the visibility columns
 // (scopeProjection) come from the original log row (exposed via l.* by the
 // fan-out subquery) so DAC scope still applies — including the scalar

--- a/framework/logstore/multi_team_matview_test.go
+++ b/framework/logstore/multi_team_matview_test.go
@@ -91,31 +91,33 @@ func TestFilterBusinessUnitMatView_CollectsScalarAndArray(t *testing.T) {
 	assert.Equal(t, "BU One", byID["bu-arr1"], "array-only business unit must now appear")
 }
 
-// TestDimensionRankings_SingleOwnerAdditive pins the additive attribution
-// semantics for the org-rollup dimensions: each request is credited to exactly
-// one owner — the scalar team_id — and requests with no scalar owner (e.g. the
-// enterprise user/AP path that only populates the JSON array) fall into a
-// synthetic "Unassigned" bucket rather than being fanned out to every team they
-// touch. This keeps the per-team spend additive so the Teams tab reconciles to
-// the org total, and TotalActualRequests == TotalAttributedRequests.
-func TestDimensionRankings_SingleOwnerAdditive(t *testing.T) {
+// TestDimensionRankings_ArrayFanout pins the attribution semantics for the org
+// dimensions that carry a JSON-array column. The enterprise user/AP path records
+// a request's full hierarchy in team_ids and leaves the scalar team_id NULL, so
+// each id on the row must be credited in full; the scalar column still covers
+// rows written without an array. The rollup is deliberately not additive —
+// TotalAttributedRequests exceeds TotalActualRequests when a request spans
+// several teams — and only rows with neither array nor scalar owner are
+// Unassigned.
+func TestDimensionRankings_ArrayFanout(t *testing.T) {
 	store, db := setupPerfTestDB(t)
 	ctx := context.Background()
 	now := time.Now().UTC()
 
-	// Row 1: array-only multi-team request with no scalar owner -> Unassigned.
+	// Row 1: array-only multi-team request -> credited to both teams.
 	// Row 2: single-team request with a scalar owner -> t-a.
-	// Additive: 2 requests total, each counted once.
+	// Row 3: no owner at all -> Unassigned.
 	insertTeamBULog(t, db, now, "u-1", "", "", `["t-a","t-b"]`, `["Team A","Team B"]`, "", "", "", "")
 	insertTeamBULog(t, db, now, "u-1", "t-a", "Team A", "", "", "", "", "", "")
+	insertTeamBULog(t, db, now, "u-1", "", "", "", "", "", "", "", "")
 
 	start := now.Add(-time.Hour)
 	end := now.Add(time.Hour)
 	res, err := store.GetDimensionRankings(ctx, SearchFilters{StartTime: &start, EndTime: &end}, RankingDimensionTeam)
 	require.NoError(t, err)
 
-	assert.Equal(t, int64(2), res.TotalActualRequests, "actual counts every terminal request, including Unassigned")
-	assert.Equal(t, int64(2), res.TotalAttributedRequests, "single-owner attribution is additive: attributed == actual")
+	assert.Equal(t, int64(3), res.TotalActualRequests, "actual counts every terminal request once, including Unassigned")
+	assert.Equal(t, int64(4), res.TotalAttributedRequests, "the two-team request is attributed to both teams")
 
 	requestsByID := make(map[string]int64, len(res.Rankings))
 	namesByID := make(map[string]string, len(res.Rankings))
@@ -125,12 +127,12 @@ func TestDimensionRankings_SingleOwnerAdditive(t *testing.T) {
 		namesByID[r.ID] = r.Name
 		summedRequests += r.TotalRequests
 	}
-	assert.Equal(t, int64(1), requestsByID["t-a"], "t-a owns exactly its one scalar-attributed request")
-	assert.Equal(t, int64(1), requestsByID[unassignedDimensionID], "the array-only request with no scalar owner is Unassigned")
+	assert.Equal(t, int64(2), requestsByID["t-a"], "t-a is credited its scalar row plus the array row it appears in")
+	assert.Equal(t, int64(1), requestsByID["t-b"], "an array-only team is credited rather than lost to Unassigned")
+	assert.Equal(t, "Team B", namesByID["t-b"], "name aligned with the id by ordinality")
+	assert.Equal(t, int64(1), requestsByID[unassignedDimensionID], "only the request with no owner at all is Unassigned")
 	assert.Equal(t, unassignedDimensionName, namesByID[unassignedDimensionID], "the unassigned bucket gets a stable display name")
-	_, hasTB := requestsByID["t-b"]
-	assert.False(t, hasTB, "no fan-out: t-b is never credited a request it doesn't scalar-own")
-	assert.Equal(t, res.TotalActualRequests, summedRequests, "rows must sum to the org total (additive rollup)")
+	assert.Equal(t, res.TotalAttributedRequests, summedRequests, "rows sum to attributed, not actual")
 }
 
 // TestDimensionRankings_VirtualKeyUnassigned pins that the Unassigned bucket now

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -129,27 +129,26 @@ func multiValueDimensionFilterSQL(scalarCol, arrayCol string, ids []string) (str
 	return sql, args
 }
 
-// teamOrBUFanoutFrom returns a Postgres FROM subquery (aliased AS logs) that fans
-// each log row out to one row per associated team / business unit, exposing
-// derived `dim_id` and `dim_name` columns alongside all original log columns
-// (l.*) so DAC scope and filters still resolve. Rows with the JSON-array column
-// set are unnested (id+name aligned by ordinality); rows without it (pre-upgrade
-// or VK-team logs) fall back to the scalar id/name — so historical logs keep
+// teamOrBUFanoutFrom is the Postgres implementation behind dimensionFanoutFrom
+// (dialectsql.go): a FROM subquery (aliased AS logs) that fans each log row out
+// to one row per associated team / business unit / customer, exposing derived
+// `dim_id` and `dim_name` columns alongside all original log columns (l.*) so
+// DAC scope and filters still resolve. Rows with the JSON-array column set are
+// unnested (id+name aligned by ordinality); rows without it (pre-upgrade or
+// VK-team logs) fall back to the scalar id/name — so historical logs keep
 // contributing. The two branches are mutually exclusive, so no row is counted
 // twice for the same dimension value. Returns ("", false) for non-fan-out
 // dimensions. idCol is the scalar id column ("team_id" / "business_unit_id"),
 // which both the ranking and histogram dimensions resolve to. No bind args: all
 // identifiers are internal constants.
+//
+// The emitted text is pinned: the filter matviews are built from it
+// (multiValueFilterMatViewBody), and repairMatViewShapes treats a changed body
+// as drift and drops the views on boot. Change it only when a rebuild is
+// intended.
 func teamOrBUFanoutFrom(idCol string) (string, bool) {
-	var arrIDs, arrNames, scalarName string
-	switch idCol {
-	case "team_id":
-		arrIDs, arrNames, scalarName = "team_ids", "team_names", "team_name"
-	case "business_unit_id":
-		arrIDs, arrNames, scalarName = "business_unit_ids", "business_unit_names", "business_unit_name"
-	case "customer_id":
-		arrIDs, arrNames, scalarName = "customer_ids", "customer_names", "customer_name"
-	default:
+	arrIDs, arrNames, scalarName, ok := fanoutDimensionColumns(idCol)
+	if !ok {
 		return "", false
 	}
 	return fmt.Sprintf(`(
@@ -168,27 +167,30 @@ func teamOrBUFanoutFrom(idCol string) (string, bool) {
 }
 
 // Rollup dimensions (team / business unit / customer / user / virtual key)
-// attribute each request to exactly ONE owner — the scalar id column — so that
-// per-dimension spend sums to the org total (an additive finance rollup).
-// Requests with no owner are grouped under a synthetic "Unassigned" entry
-// rather than dropped, so the rollup still reconciles to total spend.
+// group owner-less traffic under a synthetic "Unassigned" entry rather than
+// dropping it, so the rollup still reconciles to total spend.
 //
-// This deliberately replaces the multi-value fan-out (teamOrBUFanoutFrom) for
-// the *aggregate* readers (rankings + cost/token histograms): fan-out credited a
-// request to every team it touched, which double-counted shared requests and
-// made the tab non-additive (a user in N overlapping IdP groups inflated every
-// group to the same total). Fan-out is still used for filter dropdowns, where
-// listing every team a request touches is the correct behaviour.
+// How a request is attributed depends on whether the dimension has a
+// multi-value column. Team / business unit / customer do: the enterprise
+// user/AP path is the only writer that knows a request's full hierarchy, and it
+// records it in the JSON-array columns (team_ids, customer_ids, ...) while
+// leaving the scalar column NULL. The aggregate readers therefore fan those
+// rows out to every id they carry (dimensionFanoutFrom), falling back to the
+// scalar column for rows that have no array — otherwise all enterprise traffic
+// collapses into "Unassigned". A request touching N teams is credited in full
+// to each, so the per-dimension breakdown is NOT additive: it answers "what did
+// this team consume", not "how does org spend divide". DimensionRankingResult
+// reports TotalActualRequests alongside TotalAttributedRequests so the UI can
+// show both. User and virtual key have no array column and stay single-owner.
 const (
 	unassignedDimensionID   = "unassigned"
 	unassignedDimensionName = "Unassigned"
 )
 
 // isBucketedDimension reports whether a scalar id column is a rollup dimension
-// that uses single-owner attribution with an Unassigned bucket: each request is
-// credited to exactly one owner (the scalar id), and rows with no owner collapse
-// into a synthetic "Unassigned" entry so the per-dimension rollup stays additive
-// and reconciles to the org total. idCol is an internal constant.
+// that uses the Unassigned bucket: rows with no owner collapse into a synthetic
+// "Unassigned" entry instead of being dropped, so the rollup reconciles to
+// total spend. idCol is an internal constant.
 func isBucketedDimension(idCol string) bool {
 	switch idCol {
 	case "team_id", "business_unit_id", "customer_id", "user_id", "virtual_key_id":
@@ -203,6 +205,71 @@ func isBucketedDimension(idCol string) bool {
 // internal constant, so the interpolation carries no user input.
 func bucketedIDExpr(idCol string) string {
 	return fmt.Sprintf("COALESCE(NULLIF(%s, ''), '%s')", idCol, unassignedDimensionID)
+}
+
+// dimensionReadSource describes how the aggregate dimension readers (rankings +
+// the cost / token / latency histograms) must read the logs table for one
+// dimension: which relation to select from, which expression yields the
+// dimension id, and which column holds its display name.
+type dimensionReadSource struct {
+	// FromSQL is the fan-out subquery to read from, or "" to read the logs
+	// table directly.
+	FromSQL string
+	// IDExpr is the expression to group and order on.
+	IDExpr string
+	// NameCol holds the display name, or "" when the dimension has none.
+	NameCol string
+	// Bucketed reports that owner-less rows collapse into unassignedDimensionID.
+	Bucketed bool
+	// FannedOut reports that FromSQL emits one row per (request, dimension
+	// value) pair, so attributed requests may exceed actual requests.
+	FannedOut bool
+}
+
+// dimensionReadSourceFor resolves how to read a dimension. Team / customer /
+// business unit fan out to every id in their JSON-array column when the dialect
+// supports it, falling back to the scalar column for rows without an array;
+// user / virtual key have no array column and keep single-owner scalar
+// attribution with an Unassigned bucket; every other dimension (provider, app,
+// user agent) reads its scalar column with no bucket. idCol / nameCol come from
+// DimensionColumnDef or histogramDimensionColumn and are internal constants.
+func (s *RDBLogStore) dimensionReadSourceFor(idCol, nameCol string) dimensionReadSource {
+	src := dimensionReadSource{NameCol: nameCol, Bucketed: isBucketedDimension(idCol)}
+	if !src.Bucketed {
+		src.IDExpr = idCol
+		return src
+	}
+	if from, ok := dimensionFanoutFrom(s.db.Dialector.Name(), idCol); ok {
+		src.FromSQL = from
+		src.FannedOut = true
+		src.IDExpr = bucketedIDExpr("dim_id")
+		if nameCol != "" {
+			src.NameCol = "dim_name"
+		}
+		return src
+	}
+	src.IDExpr = bucketedIDExpr(idCol)
+	return src
+}
+
+// base starts a query against the resolved relation. db must already be
+// ScopedDB(ctx) when row visibility matters — the fan-out subquery re-exposes
+// every log column via l.*, so scope and filter predicates resolve against the
+// source row exactly as they do on the base table.
+//
+// The subquery already carries its own `AS logs` alias (the filter matviews are
+// built from that same text), so it is passed as a bind expression rather than
+// wrapped again: inlining it into Table() would also make GORM's leftmost-match
+// table regexp latch onto the "AS dim_id" inside the SQL. The statement table is
+// set explicitly because that regexp cannot see through the bind — it must stay
+// "logs", which is the alias applyRootsOnlyFilter correlates against.
+func (src dimensionReadSource) base(db *gorm.DB) *gorm.DB {
+	if src.FromSQL == "" {
+		return db.Model(&Log{})
+	}
+	tx := db.Table("?", gorm.Expr(src.FromSQL))
+	tx.Statement.Table = "logs"
+	return tx
 }
 
 // applyFilters applies search filters to a GORM query. Callers are
@@ -2599,31 +2666,28 @@ func (s *RDBLogStore) GetDimensionRankings(ctx context.Context, filters SearchFi
 		return nil, fmt.Errorf("invalid ranking dimension: %s", dimension)
 	}
 
-	// Every rollup dimension (team / business unit / customer / user / virtual
-	// key) attributes each request to a single owner — the scalar id column — and
-	// buckets owner-less traffic under a synthetic "Unassigned" entry, so
-	// per-dimension spend is additive and reconciles to the org total.
-	bucketed := isBucketedDimension(idCol)
-	groupExpr := idCol
-	if bucketed {
-		groupExpr = bucketedIDExpr(idCol)
-	}
-	baseTable := func(q *gorm.DB) *gorm.DB { return q.Model(&Log{}) }
+	// Team / customer / business unit fan out to every id on the row (the
+	// enterprise user/AP path records the full hierarchy in the JSON-array
+	// columns and leaves the scalar NULL); user / virtual key stay single-owner.
+	// Owner-less rows bucket under a synthetic "Unassigned" entry either way.
+	src := s.dimensionReadSourceFor(idCol, nameCol)
+	groupExpr := src.IDExpr
 
 	// Fresh-aggregate gate (not bare canUseMatView): short windows go to the
 	// raw table because mv_logs_hourly rounds the window out to full hour
 	// buckets, which visibly inflates rankings against the raw-path stats and
 	// cost-histogram totals shown on the same dashboard. Bucketed dimensions
-	// always use the raw path — the matview reader has no Unassigned bucket.
-	if !bucketed && s.db.Dialector.Name() == "postgres" && s.canUseMatViewForFreshAggregate(filters) {
+	// always use the raw path — the matview reader has neither an Unassigned
+	// bucket nor the array columns the fan-out needs.
+	if !src.Bucketed && s.db.Dialector.Name() == "postgres" && s.canUseMatViewForFreshAggregate(filters) {
 		if res, err := s.getDimensionRankingsFromMatView(ctx, filters, dimension); !s.fallBackToRaw(err) {
 			return res, err
 		}
 	}
 
 	var nameExpr string
-	if nameCol != "" {
-		nameExpr = fmt.Sprintf("MAX(%s) as name", nameCol)
+	if src.NameCol != "" {
+		nameExpr = fmt.Sprintf("MAX(%s) as name", src.NameCol)
 	} else {
 		nameExpr = "'' as name"
 	}
@@ -2636,10 +2700,10 @@ func (s *RDBLogStore) GetDimensionRankings(ctx context.Context, filters SearchFi
 		COALESCE(SUM(cost), 0) as total_cost
 	`, groupExpr, nameExpr)
 
-	currentQuery := baseTable(s.ScopedDB(ctx))
+	currentQuery := src.base(s.ScopedDB(ctx))
 	currentQuery = s.applyFilters(currentQuery, filters)
 	currentQuery = currentQuery.Where("status IN ?", terminalLogStatuses)
-	if !bucketed {
+	if !src.Bucketed {
 		currentQuery = currentQuery.Where(fmt.Sprintf("%s IS NOT NULL AND %s != ''", idCol, idCol))
 	}
 
@@ -2670,15 +2734,19 @@ func (s *RDBLogStore) GetDimensionRankings(ctx context.Context, filters SearchFi
 		}, nil
 	}
 
-	// Single-owner attribution is additive, so attributed == actual. Report the
-	// real total request count (including the Unassigned bucket) so the UI's
-	// totals reconcile to org-wide traffic.
+	// Actual is the real request count over the window (including the Unassigned
+	// bucket) so the UI reconciles to org-wide traffic; it must be counted on the
+	// raw table, never the fan-out relation, or a multi-team request would be
+	// counted once per team. Attributed counts the (request, dimension value)
+	// pairs the rankings are built from, so for a fanned-out dimension it equals
+	// the sum of every ranking row and can exceed actual. Single-owner dimensions
+	// have nothing to fan out, so the two are equal and one count suffices.
 	var requestCounts struct {
 		ActualRequests     int64 `gorm:"column:actual_requests"`
 		AttributedRequests int64 `gorm:"column:attributed_requests"`
 	}
-	if bucketed {
-		countQuery := baseTable(s.ScopedDB(ctx))
+	if src.Bucketed {
+		countQuery := s.ScopedDB(ctx).Model(&Log{})
 		countQuery = s.applyFilters(countQuery, filters)
 		countQuery = countQuery.Where("status IN ?", terminalLogStatuses)
 		var total int64
@@ -2687,6 +2755,17 @@ func (s *RDBLogStore) GetDimensionRankings(ctx context.Context, filters SearchFi
 		}
 		requestCounts.ActualRequests = total
 		requestCounts.AttributedRequests = total
+
+		if src.FannedOut {
+			attributedQuery := src.base(s.ScopedDB(ctx))
+			attributedQuery = s.applyFilters(attributedQuery, filters)
+			attributedQuery = attributedQuery.Where("status IN ?", terminalLogStatuses)
+			var attributed int64
+			if err := attributedQuery.Count(&attributed).Error; err != nil {
+				return nil, fmt.Errorf("failed to get attributed dimension ranking totals for %s: %w", dimension, err)
+			}
+			requestCounts.AttributedRequests = attributed
+		}
 	}
 
 	prevMap := make(map[string]DimensionRankingEntry)
@@ -2699,10 +2778,13 @@ func (s *RDBLogStore) GetDimensionRankings(ctx context.Context, filters SearchFi
 		prevFilters.StartTime = &prevStart
 		prevFilters.EndTime = &prevEnd
 
-		prevQuery := baseTable(s.ScopedDB(ctx))
+		// Same relation as the current period: comparing a fanned-out current
+		// period against a scalar previous period would show a fake spike on
+		// every entity that only appears in the array columns.
+		prevQuery := src.base(s.ScopedDB(ctx))
 		prevQuery = s.applyFilters(prevQuery, prevFilters)
 		prevQuery = prevQuery.Where("status IN ?", terminalLogStatuses)
-		if !bucketed {
+		if !src.Bucketed {
 			prevQuery = prevQuery.Where(fmt.Sprintf("%s IS NOT NULL AND %s != ''", idCol, idCol))
 		}
 
@@ -2750,7 +2832,7 @@ func (s *RDBLogStore) GetDimensionRankings(ctx context.Context, filters SearchFi
 		name := r.Name
 		// Owner-less rows collapse into the synthetic unassigned bucket, whose
 		// scalar name column is empty; give it a stable display label.
-		if bucketed && r.ID == unassignedDimensionID {
+		if src.Bucketed && r.ID == unassignedDimensionID {
 			name = unassignedDimensionName
 		}
 		entry := DimensionRankingEntry{
@@ -3356,24 +3438,23 @@ func (s *RDBLogStore) GetDimensionCostHistogram(ctx context.Context, filters Sea
 		bucketSizeSeconds = 3600
 	}
 	dialect := s.db.Dialector.Name()
-	// Rollup dimensions (team / business unit / customer / user / virtual key)
-	// attribute each request to a single owner and bucket owner-less traffic as
-	// "unassigned", so the per-dimension breakdown is additive and the bucket
-	// totals reconcile to org spend. Bucketed dimensions use the raw path — the
-	// matview reader has no unassigned bucket.
-	bucketed := isBucketedDimension(dimCol)
-	dimValueExpr := fmt.Sprintf("COALESCE(%s, '')", dimCol)
-	groupCol := dimCol
-	if bucketed {
-		dimValueExpr = bucketedIDExpr(dimCol)
-		groupCol = dimValueExpr
+	// Rollup dimensions bucket owner-less traffic as "unassigned"; team /
+	// customer / business unit additionally fan out to every id the row carries.
+	// Both force the raw path — the matview reader has neither the unassigned
+	// bucket nor the array columns.
+	src := s.dimensionReadSourceFor(dimCol, "")
+	dimValueExpr := src.IDExpr
+	groupCol := dimValueExpr
+	if !src.Bucketed {
+		dimValueExpr = fmt.Sprintf("COALESCE(%s, '')", dimCol)
+		groupCol = dimCol
 	}
-	if !bucketed && dialect == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
+	if !src.Bucketed && dialect == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
 		if res, err := s.getDimensionCostHistogramFromMatView(ctx, filters, bucketSizeSeconds, dimension); !s.fallBackToRaw(err) {
 			return res, err
 		}
 	}
-	baseQuery := s.ScopedDB(ctx).Model(&Log{})
+	baseQuery := src.base(s.ScopedDB(ctx))
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
 	baseQuery = baseQuery.Where("cost IS NOT NULL AND cost > 0")
@@ -3459,23 +3540,23 @@ func (s *RDBLogStore) GetDimensionTokenHistogram(ctx context.Context, filters Se
 		bucketSizeSeconds = 3600
 	}
 	dialect := s.db.Dialector.Name()
-	// Internal org-rollup dimensions (team / business unit / customer) attribute
-	// each request to a single owner and bucket owner-less traffic as
-	// "unassigned", so the per-dimension breakdown is additive. Bucketed
-	// dimensions use the raw path — the matview reader has no unassigned bucket.
-	bucketed := isBucketedDimension(dimCol)
-	dimValueExpr := fmt.Sprintf("COALESCE(%s, '')", dimCol)
-	groupCol := dimCol
-	if bucketed {
-		dimValueExpr = bucketedIDExpr(dimCol)
-		groupCol = dimValueExpr
+	// Rollup dimensions bucket owner-less traffic as "unassigned"; team /
+	// customer / business unit additionally fan out to every id the row carries.
+	// Both force the raw path — the matview reader has neither the unassigned
+	// bucket nor the array columns.
+	src := s.dimensionReadSourceFor(dimCol, "")
+	dimValueExpr := src.IDExpr
+	groupCol := dimValueExpr
+	if !src.Bucketed {
+		dimValueExpr = fmt.Sprintf("COALESCE(%s, '')", dimCol)
+		groupCol = dimCol
 	}
-	if !bucketed && dialect == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
+	if !src.Bucketed && dialect == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
 		if res, err := s.getDimensionTokenHistogramFromMatView(ctx, filters, bucketSizeSeconds, dimension); !s.fallBackToRaw(err) {
 			return res, err
 		}
 	}
-	baseQuery := s.ScopedDB(ctx).Model(&Log{})
+	baseQuery := src.base(s.ScopedDB(ctx))
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
 
@@ -3581,13 +3662,24 @@ func (s *RDBLogStore) GetDimensionLatencyHistogram(ctx context.Context, filters 
 	if bucketSizeSeconds <= 0 {
 		bucketSizeSeconds = 3600
 	}
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
+	// Rollup dimensions bucket owner-less traffic as "unassigned"; team /
+	// customer / business unit additionally fan out to every id the row carries.
+	// Both force the raw path — the matview reader has neither the unassigned
+	// bucket nor the array columns.
+	src := s.dimensionReadSourceFor(dimCol, "")
+	dimValueExpr := src.IDExpr
+	groupCol := dimValueExpr
+	if !src.Bucketed {
+		dimValueExpr = fmt.Sprintf("COALESCE(%s, '')", dimCol)
+		groupCol = dimCol
+	}
+	if !src.Bucketed && s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
 		if res, err := s.getDimensionLatencyHistogramFromMatView(ctx, filters, bucketSizeSeconds, dimension); !s.fallBackToRaw(err) {
 			return res, err
 		}
 	}
 	dialect := s.db.Dialector.Name()
-	baseQuery := s.ScopedDB(ctx).Model(&Log{})
+	baseQuery := src.base(s.ScopedDB(ctx))
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
 	baseQuery = baseQuery.Where("latency IS NOT NULL")
@@ -3602,11 +3694,11 @@ func (s *RDBLogStore) GetDimensionLatencyHistogram(ctx context.Context, filters 
 	}
 	if err := baseQuery.Select(fmt.Sprintf(`
 		%s AS bucket_timestamp,
-		COALESCE(%s, '') AS dim_value,
+		%s AS dim_value,
 		COALESCE(AVG(latency), 0) AS avg_lat,
 		COUNT(*) AS total_requests
-	`, bucketExpr, dimCol)).
-		Group(fmt.Sprintf("bucket_timestamp, %s", dimCol)).
+	`, bucketExpr, dimValueExpr)).
+		Group(fmt.Sprintf("bucket_timestamp, %s", groupCol)).
 		Order("bucket_timestamp ASC").
 		Find(&results).Error; err != nil {
 		return nil, err

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -1940,11 +1940,16 @@ type DimensionRankingResult struct {
 	Rankings  []DimensionRankingWithTrend `json:"rankings"`
 	Dimension RankingDimension            `json:"dimension"`
 	// TotalActualRequests / TotalAttributedRequests are set for every rollup
-	// dimension (team / business unit / customer / user / virtual key). These use
-	// single-owner attribution (one request → one owner, with owner-less traffic
-	// in an "Unassigned" bucket), so the rollup is additive and the two counts
-	// are equal — both report the real total request count over the window,
-	// including Unassigned.
+	// dimension (team / business unit / customer / user / virtual key), and both
+	// include the "Unassigned" bucket that owner-less traffic falls into.
+	//
+	// TotalActualRequests is the real number of requests in the window.
+	// TotalAttributedRequests is the sum of every ranking row. For team /
+	// customer / business unit a request is credited to every entity it carries
+	// (the enterprise user/AP path records the full hierarchy), so attributed
+	// can exceed actual and the rankings are NOT an additive split of org
+	// traffic. User and virtual key have a single owner per request, so for them
+	// the two counts are equal.
 	TotalActualRequests     int64 `json:"total_actual_requests,omitempty"`
 	TotalAttributedRequests int64 `json:"total_attributed_requests,omitempty"`
 }


### PR DESCRIPTION
## Summary

The enterprise user/AP path records a request's full org hierarchy (teams, customers, business units) in JSON-array columns (`team_ids`, `customer_ids`, `business_unit_ids`) and leaves the scalar id columns NULL. Previously, the aggregate dimension readers (rankings, cost/token/latency histograms) only read the scalar columns, so all enterprise-path traffic collapsed into "Unassigned" instead of being credited to the teams and customers it actually touched.

This PR extends the aggregate readers to fan out each log row to one row per associated dimension value, using the JSON-array columns when present and falling back to the scalar column for pre-migration and VK-path rows. The fan-out is implemented for all three backends (Postgres, SQLite, ClickHouse) and is exercised by the cross-backend parity test suite.

## Changes

- **`dialectsql.go`**: Adds `fanoutDimensionColumns`, `dimensionFanoutFrom`, `sqliteDimensionFanoutFrom`, and `clickhouseDimensionFanoutFrom`. The SQLite implementation uses `json_each` with `CASE`-guarded safe-array rewrites to prevent `json_each` from raising on malformed input. The ClickHouse implementation uses `ARRAY JOIN if(...)` to unify the array and scalar branches without a `UNION ALL`. Postgres delegates to the existing `teamOrBUFanoutFrom`, whose emitted text is pinned because the filter matviews are built from it.

- **`rdb.go`**: Introduces `dimensionReadSource` and `dimensionReadSourceFor` to centralize how each dimension is read (fan-out subquery vs. plain table, bucketed vs. unbucketed, `dim_id`/`dim_name` vs. scalar columns). All four aggregate readers (`GetDimensionRankings`, `GetDimensionCostHistogram`, `GetDimensionTokenHistogram`, `GetDimensionLatencyHistogram`) now go through this resolved source. The actual-vs-attributed request count split is made explicit: actual is always counted on the raw table (never the fan-out relation) so a multi-team request is not counted once per team; attributed counts fan-out rows and can exceed actual for team/customer/BU dimensions. The previous-period trend query uses the same fan-out relation as the current period to avoid reporting fake spikes on array-only entities.

- **`tables.go`**: Updates the `DimensionRankingResult` doc comment to reflect that `TotalActualRequests` and `TotalAttributedRequests` are no longer guaranteed equal — for team/customer/BU a request touching N entities is credited to each, making the breakdown non-additive.

- **`matviews.go`**: Clarifies that `teamOrBUFanoutFrom`'s emitted text is pinned and that `repairMatViewShapes` treats a changed body as drift.

- **Tests**: Adds `dimension_fanout_test.go` with SQLite integration tests covering array fan-out, malformed JSON fallback, single-owner dimension stability, histogram fan-out, and trend correctness. Updates `logstoreparity_test.go` to include array-only and scalar-only hierarchy fixtures (`p11`–`p13`) and adds fan-out histogram and ranking cases to the cross-backend parity assertions. Updates `multi_team_matview_test.go` to reflect the new fan-out semantics (array-only teams are now credited rather than collapsed into Unassigned).

## Type of change

- [x] Bug fix
- [x] Feature

## Affected areas

- [x] Core (Go)

## How to test

```sh
go test ./framework/logstore/... -run TestDimensionRankings
go test ./framework/logstore/... -run TestDimensionHistograms
go test ./framework/logstore/... -run TestDimensionFanoutFrom
go test ./framework/logstore/... -run TestLogStoreParity
go test ./framework/logstore/...
```

Expected: all tests pass. Specifically:
- `TestDimensionRankings_SQLiteArrayFanout`: `c-b` (array-only customer) receives `TotalRequests == 1` instead of being lost to Unassigned.
- `TestDimensionRankings_SQLiteMalformedArray`: queries with garbage JSON in array columns do not fail and fall back to the scalar owner.
- `TestLogStoreParity`: the `Rankings/dimension_team` and `Rankings/dimension_customer` cases now include attributed totals in the contract and all three backends agree.

## Breaking changes

- [x] Yes

`DimensionRankingResult.TotalAttributedRequests` can now exceed `TotalActualRequests` for team, customer, and business unit dimensions. Any UI or downstream consumer that assumed these two fields were always equal must be updated to display them separately.

## Security considerations

No auth, secrets, PII, or sandboxing changes. The fan-out subqueries use only internal column name constants — no user-supplied identifiers are interpolated into SQL.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable