### PR TITLE
feat: adds row in logs sheet to render batch pricing information

### DIFF
--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -3423,7 +3423,7 @@ func (provider *VertexProvider) batchResultsByKey(ctx *schemas.BifrostContext, k
 			if line.Response != nil {
 				item.Response = &schemas.BatchResultResponse{
 					StatusCode: 200,
-					Body:       line.Response,
+					Body:       vertexNormalizeBatchUsage(line.Response),
 				}
 			} else {
 				item.Error = &schemas.BatchResultError{Message: line.Status}
@@ -3440,6 +3440,33 @@ func (provider *VertexProvider) batchResultsByKey(ctx *schemas.BifrostContext, k
 			Latency: time.Since(startTime).Milliseconds(),
 		},
 	}, nil
+}
+
+func vertexNormalizeBatchUsage(body map[string]any) map[string]any {
+	raw, ok := body["usageMetadata"]
+	if !ok {
+		return body
+	}
+	metaBytes, err := sonic.Marshal(raw)
+	if err != nil {
+		return body
+	}
+	var meta gemini.GenerateContentResponseUsageMetadata
+	if err := sonic.Unmarshal(metaBytes, &meta); err != nil {
+		return body
+	}
+	usage := map[string]any{
+		"prompt_tokens":     meta.PromptTokenCount,
+		"completion_tokens": meta.CandidatesTokenCount,
+		"total_tokens":      meta.TotalTokenCount,
+	}
+	if meta.CachedContentTokenCount > 0 {
+		usage["prompt_tokens_details"] = map[string]any{
+			"cached_tokens": meta.CachedContentTokenCount,
+		}
+	}
+	body["usage"] = usage
+	return body
 }
 
 // gcsListAllObjects lists every object under a prefix, following pagination.
@@ -3530,7 +3557,6 @@ const (
 	gcsStorageBase = "https://storage.googleapis.com/storage/v1"
 	gcsUploadBase  = "https://storage.googleapis.com/upload/storage/v1"
 )
-
 
 // --- GCS helpers ---
 

--- a/core/schemas/batch.go
+++ b/core/schemas/batch.go
@@ -63,7 +63,21 @@ func (c BatchRequestCounts) IsZero() bool {
 // request addressed, how the provider reported its progress, and — on the
 // aggregate cost row only — how settlement priced it.
 type BifrostBatchDebug struct {
-	BatchID       string                `json:"batch_id,omitempty"`
+	BatchID string `json:"batch_id,omitempty"`
+	// Status is the provider's batch lifecycle status (BatchStatus, e.g.
+	// "in_progress" or "completed") as last known when this row was written. On a
+	// batch_create/batch_retrieve row it is that call's own response status. On the
+	// aggregate cost row it is the status settlement observed (always a terminal
+	// one, since settlement only runs once the batch completed) — a later /results
+	// fetch of the same batch mirrors this value rather than re-deriving it, so it
+	// can go stale relative to the provider if queried long after settlement.
+	Status string `json:"status,omitempty"`
+	// Endpoint is the batch's provider endpoint (/v1/embeddings, /v1/chat/completions,
+	// …). The row's Object column is always "batch_results", which carries no modality,
+	// so without this a later repricing pass cannot tell an embeddings batch from a
+	// chat one and would look the wrong catalog rates up. Empty on rows written before
+	// this field existed; callers must keep a fallback for them.
+	Endpoint      string                `json:"endpoint,omitempty"`
 	RequestCounts *BatchRequestCounts   `json:"request_counts,omitempty"`
 	Accounting    *BatchAccountingDebug `json:"accounting,omitempty"` // Set only on the aggregate cost row
 }
@@ -74,14 +88,28 @@ func (d *BifrostBatchDebug) IsZero() bool {
 	if d == nil {
 		return true
 	}
-	return d.BatchID == "" && d.RequestCounts == nil && d.Accounting == nil
+	return d.BatchID == "" && d.Status == "" && d.Endpoint == "" && d.RequestCounts == nil && d.Accounting == nil
 }
 
-// BatchAccountingDebug records how a settled batch was priced. It rides on the
-// aggregate cost row, whose cost and token_usage columns hold the row-level
-// totals ModelBreakdowns breaks down.
+// BatchAccountingDebug records how a settled batch was priced. On the aggregate
+// cost row (the one CreateIfNotExists writes once), the row's own cost and
+// token_usage columns hold the row-level totals ModelBreakdowns breaks down.
+// A repeated /results fetch after the batch already settled gets its own,
+// separate log row for that HTTP call — Cost on THAT row is a read-only echo
+// of the aggregate row's price so the caller can display it too; see Cost below.
 type BatchAccountingDebug struct {
 	ModelBreakdowns map[string]BatchModelBreakdown `json:"model_breakdowns,omitempty"`
+	Cost            *float64                       `json:"cost,omitempty"`
+	// ParseErrorCount is how many result rows the provider returned that could not
+	// be parsed at all. Their usage is unrecoverable — the raw results are not
+	// persisted — so the count is kept as the record of how much the row omits.
+	ParseErrorCount int `json:"parse_error_count,omitempty"`
+	// Incomplete marks a total that is known to under-state the batch: some
+	// usage-bearing row failed to price, or rows were lost to parse errors. It is
+	// only ever set, never cleared by a repricing pass — usage that never reached
+	// ModelBreakdowns (a row with no model at all, or a parse error) cannot be
+	// recovered by repricing the breakdowns that did land.
+	Incomplete bool `json:"incomplete,omitempty"`
 }
 
 // BatchModelBreakdown is the per-model slice of a settled batch's usage and

--- a/framework/batchaccounting/accounting.go
+++ b/framework/batchaccounting/accounting.go
@@ -1,0 +1,1058 @@
+package batchaccounting
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/google/uuid"
+	"github.com/maximhq/bifrost/core/schemas"
+	cstables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/logstore"
+	"github.com/maximhq/bifrost/framework/modelcatalog"
+)
+
+const (
+	defaultClaimTTL = 5 * time.Minute
+
+	UnpriceableReasonNoResults           = "no_results"
+	UnpriceableReasonNoUsage             = "no_usage"
+	UnpriceableReasonMissingModel        = "missing_model"
+	UnpriceableReasonMissingBatchPricing = "missing_batch_pricing"
+	UnpriceableReasonMaxPollAttempts     = "max_poll_attempts"
+	UnpriceableReasonResultParseErrors   = "result_parse_errors"
+)
+
+// BatchJobStore is the mutable coordination-state store for delayed batch
+// accounting. It is satisfied by configstore.ConfigStore (the batch lifecycle is
+// a state machine, which belongs in the relational config store rather than the
+// append-only log store). Ownership is fenced on a runner id.
+type BatchJobStore interface {
+	UpsertBatchJob(ctx context.Context, job *cstables.TableBatchJob) error
+	GetBatchJob(ctx context.Context, jobID string) (*cstables.TableBatchJob, error)
+	// ClaimBatchJob fences the job on runnerID. allowUnpriceable relaxes the
+	// terminal-state guard to admit "unpriceable" jobs: that state means "stop
+	// polling", not "refuse money", so a caller that actually holds results may
+	// re-drive one. Only settlement paths with results in hand pass true — the
+	// sweeper's poll loop must keep skipping unpriceable jobs (it does, via
+	// ListDueBatchJobs). "accounted" is terminal forever either way.
+	ClaimBatchJob(ctx context.Context, jobID, runnerID string, staleBefore time.Time, allowUnpriceable bool) (bool, error)
+	MarkBatchJobAggregateLogWritten(ctx context.Context, jobID, runnerID string) error
+	MarkBatchJobGovernanceReported(ctx context.Context, jobID, runnerID string) error
+	CompleteBatchJob(ctx context.Context, jobID, runnerID string) error
+	MarkBatchJobUnpriceable(ctx context.Context, jobID, runnerID, reason string, err error) error
+	FailBatchJob(ctx context.Context, jobID, runnerID string, err error) error
+}
+
+// AggregateLogStore writes the append-only aggregate batch cost record. It is
+// satisfied by logstore.LogStore — the cost record lives in the log store next to
+// every other request cost row.
+type AggregateLogStore interface {
+	CreateIfNotExists(ctx context.Context, entry *logstore.Log) error
+	// FindByID reads the aggregate cost row back, keyed by the same deterministic
+	// id CreateIfNotExists wrote it under. Used only to mirror an already-settled
+	// batch's price onto a caller that did not win this call's settlement claim
+	// (see the !claimed branch in AccountBatchResults) — never to drive a write.
+	FindByID(ctx context.Context, id string) (*logstore.Log, error)
+}
+
+type AggregateLogEmitter interface {
+	EmitBatchAggregateLog(ctx context.Context, entry *logstore.Log)
+}
+
+// UsageReporter receives the settled usage/cost for a batch so it can be billed.
+//
+// Implementations MUST be idempotent on BatchUsageReport.RequestID: settlement is
+// at-least-once, so the same report can be delivered more than once when the
+// durable "reported" marker fails to persist after a successful report. See the
+// package doc for the exact window and its limits.
+type UsageReporter interface {
+	ReportBatchUsage(ctx context.Context, usage BatchUsageReport) error
+}
+
+type BatchUsageReport struct {
+	RequestID    string
+	Provider     schemas.ModelProvider
+	Model        string
+	Cost         float64
+	TokensUsed   int64
+	BudgetIDs    []string
+	RateLimitIDs []string
+}
+
+type PricingManager interface {
+	CalculateBatchCostDetailsForUsage(usage *schemas.BifrostLLMUsage, provider schemas.ModelProvider, model string, requestType schemas.RequestType, scopes *modelcatalog.PricingLookupScopes) modelcatalog.BatchCostDetails
+}
+
+type Request struct {
+	Provider      schemas.ModelProvider
+	BatchID       string
+	FallbackModel string
+	Endpoint      schemas.BatchEndpoint
+	Results       []schemas.BatchResultItem
+	ParseErrors   []schemas.BatchError
+	RequestCounts *schemas.BatchRequestCounts
+	BatchJob      *cstables.TableBatchJob
+	BaseLog       *logstore.Log
+	Emitter       AggregateLogEmitter
+	UsageReporter UsageReporter
+	ClaimedBy     string
+	Scopes        *modelcatalog.PricingLookupScopes
+	Now           time.Time
+}
+
+type Summary struct {
+	JobID           string                    `json:"job_id"`
+	LogID           string                    `json:"log_id"`
+	Provider        schemas.ModelProvider     `json:"provider"`
+	BatchID         string                    `json:"batch_id"`
+	Cost            float64                   `json:"cost"`
+	Usage           schemas.BifrostLLMUsage   `json:"usage"`
+	ModelBreakdowns map[string]ModelBreakdown `json:"model_breakdowns"`
+	PricedCount     int                       `json:"priced_count"`
+	UnpricedCount   int                       `json:"unpriced_count"`
+	FailedCount     int                       `json:"failed_count"`
+	// UnpricedModel names the model behind wholly-unpriced usage when it is
+	// unambiguous, so the logged row is attributable (and therefore backfillable).
+	// Empty when the usage spans several models or carried no model at all.
+	UnpricedModel string `json:"unpriced_model,omitempty"`
+	// Status is the provider's batch lifecycle status as of this settlement attempt
+	// (from req.BatchJob.ProviderStatus when claimed, or mirrored from the
+	// already-written aggregate row otherwise). See BifrostBatchDebug.Status.
+	Status string `json:"status,omitempty"`
+	// Complete reports that every usage-bearing row priced, so Cost is the batch's
+	// real total. When false the batch consumed tokens we could not price and Cost
+	// is only the known part — it must never be persisted as the row's cost, and
+	// governance must not be told the batch settled for it.
+	Complete          bool   `json:"complete"`
+	Accounted         bool   `json:"accounted"`
+	Claimed           bool   `json:"claimed"`
+	UnpriceableReason string `json:"unpriceable_reason,omitempty"`
+}
+
+// ModelBreakdown is the per-model slice of a settled batch's usage and cost.
+//
+// It is an alias rather than a local type because the breakdown is persisted on
+// the aggregate log row (schemas.BifrostBatchDebug), and logstore cannot import
+// this package — batchaccounting already imports logstore.
+type ModelBreakdown = schemas.BatchModelBreakdown
+
+type extractedUsage struct {
+	model        string
+	usage        *schemas.BifrostLLMUsage
+	hasUsage     bool
+	missingModel bool
+}
+
+// AccountBatchResults settles a completed batch: it advances the coordination
+// state in stateStore (configstore) and writes the append-only aggregate cost row
+// via logStore (logstore). Ownership is fenced on req.ClaimedBy (the runner id).
+func AccountBatchResults(ctx context.Context, stateStore BatchJobStore, logStore AggregateLogStore, pricing PricingManager, req Request) (*Summary, error) {
+	if stateStore == nil {
+		return nil, fmt.Errorf("batch accounting state store is nil")
+	}
+	if logStore == nil {
+		return nil, fmt.Errorf("batch accounting log store is nil")
+	}
+	if pricing == nil {
+		return nil, fmt.Errorf("batch accounting pricing manager is nil")
+	}
+	if req.Provider == "" || req.BatchID == "" {
+		return nil, nil
+	}
+
+	now := req.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	job := req.BatchJob
+	if job == nil {
+		job = &cstables.TableBatchJob{
+			Provider:         string(req.Provider),
+			BatchID:          req.BatchID,
+			Model:            req.FallbackModel,
+			Endpoint:         string(req.Endpoint),
+			AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		}
+	}
+	if job.Endpoint == "" && req.Endpoint != "" {
+		job.Endpoint = string(req.Endpoint)
+	}
+	if job.ID == "" {
+		job.ID = cstables.BatchJobID(string(req.Provider), req.BatchID)
+	}
+	if err := stateStore.UpsertBatchJob(ctx, job); err != nil {
+		return nil, err
+	}
+
+	summary := &Summary{
+		JobID:    job.ID,
+		LogID:    AccountingLogID(req.Provider, req.BatchID),
+		Provider: req.Provider,
+		BatchID:  req.BatchID,
+	}
+
+	runnerID := req.ClaimedBy
+	// Holding results is what earns the right to re-drive an unpriceable job: the
+	// state was reached by giving up on polling (max attempts, a terminal status
+	// with nothing to fetch, unpriceable rows), and none of those reasons survive
+	// a caller arriving with the actual rows. Without results there is nothing new
+	// to say, so the terminal guard stands.
+	claimed, err := stateStore.ClaimBatchJob(ctx, job.ID, runnerID, now.Add(-defaultClaimTTL), len(req.Results) > 0)
+	if err != nil {
+		return nil, err
+	}
+	summary.Claimed = claimed
+	if !claimed {
+		// This call did not settle the batch — either it was already settled by an
+		// earlier call, or another runner is settling it right now. Either way, the
+		// caller (e.g. a repeated /v1/batches/.../results fetch) still wants to show
+		// a price if one already exists, so mirror the already-written aggregate row
+		// for display. This never writes anything: no job transition, no governance
+		// report, no count change — a losing claim earns a read, nothing more.
+		populateSummaryFromExistingLog(ctx, logStore, summary)
+		return summary, nil
+	}
+	// The persisted row carries the only record of how far a previous attempt got
+	// (AggregateLogWrittenAt / GovernanceReportedAt). Callers may hand us a
+	// freshly-built job with those markers unset, so if this read fails we cannot
+	// tell a partially-settled batch from a new one — proceeding would re-report
+	// usage that already landed. Fail closed, releasing the claim so a later
+	// attempt can retry cleanly rather than waiting out the claim TTL.
+	persisted, err := stateStore.GetBatchJob(ctx, job.ID)
+	if err != nil {
+		_ = stateStore.FailBatchJob(ctx, job.ID, runnerID, err)
+		return nil, err
+	}
+	if persisted != nil {
+		mergeBatchJobHints(job, persisted)
+	}
+	req.BatchJob = job
+	if req.FallbackModel == "" {
+		req.FallbackModel = job.Model
+	}
+	if req.Endpoint == "" {
+		req.Endpoint = schemas.BatchEndpoint(job.Endpoint)
+	}
+	req.Scopes = pricingScopesForBatchJob(req.Scopes, req.Provider, job)
+	// job.ProviderStatus is fixed for the rest of this call — the caller set it
+	// before invoking AccountBatchResults (from the just-fetched retrieve response,
+	// or hardcoded to "completed" on the inline /results path) and nothing here
+	// advances it. Every aggregate-log write below reads it via summary.Status.
+	summary.Status = job.ProviderStatus
+
+	// Malformed rows are no longer a reason to abandon the batch. One bad JSONL line
+	// used to discard every correctly parsed row's tokens and cost, permanently — the
+	// raw provider results are not persisted anywhere else, so what is not priced here
+	// is lost for good. The parsed rows are priced normally and the count of rows we
+	// could not read is carried onto the aggregate row (parse_error_count) together
+	// with the incomplete marker, so the total is recorded as under-stating rather than
+	// silently pretending to be whole.
+	computed, err := summarizeResults(pricing, req)
+	if err != nil {
+		_ = stateStore.FailBatchJob(ctx, job.ID, runnerID, err)
+		return nil, err
+	}
+	if computed == nil || computed.PricedCount == 0 {
+		reason := UnpriceableReasonNoUsage
+		if computed != nil && computed.UnpriceableReason != "" {
+			reason = computed.UnpriceableReason
+		}
+		// Parse errors only become the headline reason when they are the sole cause.
+		// If rows did parse and carried usage we simply could not price, that is the
+		// more specific and more actionable diagnosis.
+		var reasonErr error
+		if len(req.ParseErrors) > 0 && (reason == UnpriceableReasonNoResults || reason == UnpriceableReasonNoUsage) {
+			reason = UnpriceableReasonResultParseErrors
+			reasonErr = fmt.Errorf("batch result contained %d malformed row(s)", len(req.ParseErrors))
+		}
+		summary.UnpriceableReason = reason
+		if computed != nil {
+			summary.Usage = computed.Usage
+			summary.ModelBreakdowns = computed.ModelBreakdowns
+			summary.UnpricedCount = computed.UnpricedCount
+			summary.FailedCount = computed.FailedCount
+		}
+		// The batch ran and consumed tokens we simply could not price (typically the
+		// catalog has no batch rates for the model yet). Log the row with an unknown
+		// cost rather than dropping it: this mirrors the synchronous path, which
+		// always writes the row and leaves cost NULL, and it puts the row in reach of
+		// the existing missing-cost backfill (SearchFilters.MissingCostOnly selects
+		// `cost IS NULL OR cost <= 0`, and recalculation re-derives cost from the
+		// row's stored usage). Skipping the write would lose the usage for good — the
+		// raw provider results are not persisted anywhere else.
+		if computed != nil && summary.Usage.TotalTokens > 0 && job.AggregateLogWrittenAt == nil {
+			entry := buildAggregateLog(req, summary, now)
+			// Unknown, not zero — a zero cost would read as "this batch was free".
+			entry.Cost = nil
+			if computed.UnpricedModel != "" {
+				entry.Model = computed.UnpricedModel
+			} else if len(computed.ModelBreakdowns) == 1 {
+				// buildAggregateLog names the row after a single ModelBreakdown entry,
+				// but UnpricedModel was deliberately left blank — the only way that
+				// happens with exactly one breakdown is a missing-model row mixed in
+				// (see summarizeResults), meaning Usage is a mixture that must not be
+				// attributed to the one named model.
+				entry.Model = "mixed"
+			}
+			if err := logStore.CreateIfNotExists(ctx, entry); err != nil {
+				_ = stateStore.FailBatchJob(ctx, job.ID, runnerID, err)
+				return nil, err
+			}
+			if err := stateStore.MarkBatchJobAggregateLogWritten(ctx, job.ID, runnerID); err != nil {
+				_ = stateStore.FailBatchJob(ctx, job.ID, runnerID, err)
+				return nil, err
+			}
+			if req.Emitter != nil {
+				req.Emitter.EmitBatchAggregateLog(ctx, entry)
+			}
+		}
+		if err := stateStore.MarkBatchJobUnpriceable(ctx, job.ID, runnerID, reason, reasonErr); err != nil {
+			return nil, err
+		}
+		return summary, nil
+	}
+
+	summary.Cost = computed.Cost
+	summary.Usage = computed.Usage
+	summary.ModelBreakdowns = computed.ModelBreakdowns
+	summary.PricedCount = computed.PricedCount
+	summary.UnpricedCount = computed.UnpricedCount
+	summary.FailedCount = computed.FailedCount
+	summary.Complete = computed.Complete
+
+	entry := buildAggregateLog(req, summary, now)
+	if !summary.Complete {
+		// Some usage priced and some did not. summary.Cost is therefore only the known
+		// part of the bill, and persisting it as the row's cost would be a lie with
+		// consequences: a positive cost puts the row outside the missing-cost backfill
+		// (`cost IS NULL OR cost <= 0`), so the unpriced share could never be recovered
+		// through the designed recovery path, and governance would be told a partial
+		// number is the batch's final bill. Write the row with an unknown cost instead —
+		// the full usage and the per-model breakdowns (with the known costs) are all on
+		// it, so a later recalculation can complete it — and leave the job re-drivable
+		// rather than marking it accounted.
+		entry.Cost = nil
+	}
+	if job.AggregateLogWrittenAt == nil {
+		if err := logStore.CreateIfNotExists(ctx, entry); err != nil {
+			_ = stateStore.FailBatchJob(ctx, job.ID, runnerID, err)
+			return nil, err
+		}
+		if err := stateStore.MarkBatchJobAggregateLogWritten(ctx, job.ID, runnerID); err != nil {
+			_ = stateStore.FailBatchJob(ctx, job.ID, runnerID, err)
+			return nil, err
+		}
+		if req.Emitter != nil {
+			req.Emitter.EmitBatchAggregateLog(ctx, entry)
+		}
+	}
+	if !summary.Complete {
+		// Neither report nor complete: governance would receive a total that is known
+		// to be short, and "accounted" is terminal forever. Park the job unpriceable —
+		// which stops polling but stays claimable by a settlement holding results (see
+		// ClaimBatchJob's allowUnpriceable) — so recalculation plus a re-drive remain
+		// the recovery path.
+		summary.UnpriceableReason = computed.UnpriceableReason
+		if summary.UnpriceableReason == "" {
+			summary.UnpriceableReason = UnpriceableReasonMissingBatchPricing
+		}
+		if err := stateStore.MarkBatchJobUnpriceable(ctx, job.ID, runnerID, summary.UnpriceableReason, nil); err != nil {
+			return nil, err
+		}
+		return summary, nil
+	}
+	if req.UsageReporter != nil && job.GovernanceReportedAt == nil {
+		if err := req.UsageReporter.ReportBatchUsage(ctx, batchUsageReportFromLog(req.Provider, entry)); err != nil {
+			_ = stateStore.FailBatchJob(ctx, job.ID, runnerID, err)
+			return nil, err
+		}
+		if err := stateStore.MarkBatchJobGovernanceReported(ctx, job.ID, runnerID); err != nil {
+			_ = stateStore.FailBatchJob(ctx, job.ID, runnerID, err)
+			return nil, err
+		}
+	}
+	if err := stateStore.CompleteBatchJob(ctx, job.ID, runnerID); err != nil {
+		_ = stateStore.FailBatchJob(ctx, job.ID, runnerID, err)
+		return nil, err
+	}
+	summary.Accounted = true
+	return summary, nil
+}
+
+// populateSummaryFromExistingLog fills summary from the aggregate log row
+// already written for it, if any, so a caller that lost the settlement claim
+// can still display the batch's price. summary.LogID is deterministic
+// (AccountingLogID) and set unconditionally before the claim attempt, so this
+// looks up the same row settlement would have written — nothing here writes.
+//
+// A missing row (job never reached a write, or is still being settled by
+// another runner) leaves summary at its zero value: nothing to show yet, which
+// is the correct display for "not priced".
+func populateSummaryFromExistingLog(ctx context.Context, logStore AggregateLogStore, summary *Summary) {
+	entry, err := logStore.FindByID(ctx, summary.LogID)
+	if err != nil || entry == nil {
+		return
+	}
+	if entry.TokenUsageParsed != nil {
+		summary.Usage = *entry.TokenUsageParsed
+	}
+	if entry.Cost != nil {
+		summary.Cost = *entry.Cost
+		// buildAggregateLog only ever leaves Cost nil for an incomplete total (see
+		// the !summary.Complete branch in AccountBatchResults) — a non-nil Cost on
+		// the persisted row means every usage-bearing result priced when it was
+		// written.
+		summary.Complete = true
+	}
+	if entry.BatchDebugParsed != nil {
+		summary.Status = entry.BatchDebugParsed.Status
+		if entry.BatchDebugParsed.Accounting != nil {
+			summary.ModelBreakdowns = entry.BatchDebugParsed.Accounting.ModelBreakdowns
+		}
+	}
+}
+
+func mergeBatchJobHints(dst *cstables.TableBatchJob, src *cstables.TableBatchJob) {
+	if dst == nil || src == nil {
+		return
+	}
+	if dst.Model == "" {
+		dst.Model = src.Model
+	}
+	if dst.Endpoint == "" {
+		dst.Endpoint = src.Endpoint
+	}
+	dst.AggregateLogWrittenAt = src.AggregateLogWrittenAt
+	dst.GovernanceReportedAt = src.GovernanceReportedAt
+	if dst.SelectedKeyID == "" {
+		dst.SelectedKeyID = src.SelectedKeyID
+	}
+	if dst.VirtualKeyID == nil {
+		dst.VirtualKeyID = src.VirtualKeyID
+	}
+	if dst.BudgetIDs == nil {
+		dst.BudgetIDs = src.BudgetIDs
+	}
+	if dst.RateLimitIDs == nil {
+		dst.RateLimitIDs = src.RateLimitIDs
+	}
+}
+
+func pricingScopesForBatchJob(scopes *modelcatalog.PricingLookupScopes, provider schemas.ModelProvider, job *cstables.TableBatchJob) *modelcatalog.PricingLookupScopes {
+	if scopes == nil {
+		scopes = &modelcatalog.PricingLookupScopes{}
+	} else {
+		copied := *scopes
+		scopes = &copied
+	}
+	if scopes.Provider == "" {
+		scopes.Provider = string(provider)
+	}
+	if job == nil {
+		return scopes
+	}
+	if scopes.SelectedKeyID == "" {
+		scopes.SelectedKeyID = job.SelectedKeyID
+	}
+	if scopes.VirtualKeyID == "" && job.VirtualKeyID != nil {
+		scopes.VirtualKeyID = *job.VirtualKeyID
+	}
+	return scopes
+}
+
+func batchUsageReportFromLog(provider schemas.ModelProvider, entry *logstore.Log) BatchUsageReport {
+	report := BatchUsageReport{
+		RequestID:    entry.ID,
+		Provider:     provider,
+		Model:        entry.Model,
+		TokensUsed:   int64(entry.TotalTokens),
+		BudgetIDs:    stringSliceFromParsedOrJSON(entry.BudgetIDsParsed, entry.BudgetIDs),
+		RateLimitIDs: stringSliceFromParsedOrJSON(entry.RateLimitIDsParsed, entry.RateLimitIDs),
+	}
+	if entry.Cost != nil {
+		report.Cost = *entry.Cost
+	}
+	return report
+}
+
+func stringSliceFromParsedOrJSON(parsed []string, raw *string) []string {
+	if len(parsed) > 0 {
+		return parsed
+	}
+	if raw == nil || *raw == "" {
+		return nil
+	}
+	var values []string
+	if err := sonic.Unmarshal([]byte(*raw), &values); err != nil {
+		return nil
+	}
+	return values
+}
+
+// accountingLogNamespace is the UUIDv5 namespace for aggregate cost log ids.
+//
+// It must never change. The derived id is both the idempotency key for the
+// aggregate write and the governance dedupe key, so a new namespace would make
+// every already-settled batch look unsettled and re-report its usage.
+var accountingLogNamespace = uuid.MustParse("90a2f576-5276-481f-a753-2c78ccf97607")
+
+// AccountingLogID derives the id of the aggregate cost log for a batch.
+//
+// The id is deterministic by design: CreateIfNotExists keys on it so a replayed
+// settlement is a no-op, and it is reused as BatchUsageReport.RequestID so the
+// governance reporter can dedupe. UUIDv5 gives that determinism while keeping the
+// id a plain UUID like every other log id — ids travel back to the store through
+// URL path parameters, and anything needing percent-encoding does not survive
+// that round trip cleanly.
+func AccountingLogID(provider schemas.ModelProvider, batchID string) string {
+	return uuid.NewSHA1(accountingLogNamespace, []byte(string(provider)+":"+batchID)).String()
+}
+
+func summarizeResults(pricing PricingManager, req Request) (*Summary, error) {
+	if len(req.Results) == 0 {
+		return &Summary{UnpriceableReason: UnpriceableReasonNoResults}, nil
+	}
+
+	breakdowns := make(map[string]ModelBreakdown)
+	// Every usage-bearing row lands here, priced or not — including rows with no
+	// model at all, which get no breakdown entry and would otherwise be dropped
+	// entirely. The row-level usage is a record of what the batch consumed; leaving
+	// the unpriced share out of it would silently shrink the batch and put the
+	// missing tokens beyond the reach of any later repricing.
+	totalUsage := schemas.BifrostLLMUsage{}
+	unpricedModels := make(map[string]struct{})
+	totalCost := 0.0
+	usageSeen := false
+	missingModelSeen := false
+	missingPricingSeen := false
+	pricedCount := 0
+	unpricedCount := 0
+	failedCount := 0
+
+	for _, item := range req.Results {
+		if item.Failed() {
+			failedCount++
+			continue
+		}
+		extracted, err := extractUsage(req.Provider, req.FallbackModel, item)
+		if err != nil {
+			return nil, err
+		}
+		if !extracted.hasUsage {
+			unpricedCount++
+			continue
+		}
+		usageSeen = true
+		if merged := schemas.MergeBifrostLLMUsage(&totalUsage, extracted.usage); merged != nil {
+			totalUsage = *merged
+		}
+		if extracted.missingModel {
+			missingModelSeen = true
+			unpricedCount++
+			continue
+		}
+
+		// Every known model gets a breakdown entry regardless of pricing outcome —
+		// missing-batch-pricing rows included — so a later recalculation can reprice
+		// this model from its Usage once rates land, instead of the usage only
+		// surviving as an anonymous blob nothing can ever re-attribute.
+		breakdown := breakdowns[extracted.model]
+		breakdown.Model = extracted.model
+		breakdown.RequestCount++
+		if merged := schemas.MergeBifrostLLMUsage(&breakdown.Usage, extracted.usage); merged != nil {
+			breakdown.Usage = *merged
+		}
+		breakdowns[extracted.model] = breakdown
+
+		costDetails := pricing.CalculateBatchCostDetailsForUsage(extracted.usage, req.Provider, extracted.model, BatchRequestType(req.Endpoint), req.Scopes)
+		if !costDetails.Priced {
+			missingPricingSeen = true
+			unpricedCount++
+			unpricedModels[extracted.model] = struct{}{}
+			continue
+		}
+
+		// breakdown.Cost is nil until a result for this model actually prices — a
+		// model that never leaves the unpriced branch above keeps Cost nil, matching
+		// the row-level "nil means not priced yet, not $0" convention.
+		modelCost := costDetails.Cost
+		if breakdown.Cost != nil {
+			modelCost += *breakdown.Cost
+		}
+		breakdown.Cost = &modelCost
+		breakdowns[extracted.model] = breakdown
+
+		totalCost += costDetails.Cost
+		pricedCount++
+	}
+
+	// breakdowns is no longer a reliable "was anything priced" signal — it now
+	// gets an entry for every known model, priced or not — so the unpriceable
+	// decision keys on pricedCount instead.
+	if pricedCount == 0 {
+		reason := UnpriceableReasonNoUsage
+		switch {
+		case missingModelSeen:
+			reason = UnpriceableReasonMissingModel
+		case usageSeen && missingPricingSeen:
+			reason = UnpriceableReasonMissingBatchPricing
+		}
+		// Carry the unpriced usage, counts, and per-model breakdowns out rather than
+		// reporting only the reason: the caller logs this usage with an unknown cost
+		// so it stays recoverable instead of being silently dropped.
+		// Attribute the row-level model only when every unpriced token demonstrably
+		// belongs to one model. Missing-model rows contribute usage but no model, so
+		// if any are present the total is a mixture and naming the one known model
+		// would let backfill price those orphan tokens as it — leave it unattributed
+		// instead. This does not affect ModelBreakdowns itself: each entry there is
+		// keyed by its own real model name and carries only that model's usage, so
+		// per-model attribution stays unambiguous even when the row-level label isn't.
+		unpricedModel := ""
+		if !missingModelSeen && len(unpricedModels) == 1 {
+			for model := range unpricedModels {
+				unpricedModel = model
+			}
+		}
+		return &Summary{
+			Provider:          req.Provider,
+			BatchID:           req.BatchID,
+			Usage:             totalUsage,
+			ModelBreakdowns:   breakdowns,
+			UnpricedModel:     unpricedModel,
+			UnpricedCount:     unpricedCount,
+			FailedCount:       failedCount,
+			UnpriceableReason: reason,
+		}, nil
+	}
+
+	// Some usage priced, so the batch settles — but only as "complete" if nothing
+	// usage-bearing was left unpriced. When it was, name the reason too: it is the
+	// same diagnosis a wholly-unpriced batch would carry, and the caller parks the
+	// job under it rather than closing it out on a partial total.
+	summary := &Summary{
+		Provider:        req.Provider,
+		BatchID:         req.BatchID,
+		Cost:            totalCost,
+		Usage:           totalUsage,
+		ModelBreakdowns: breakdowns,
+		PricedCount:     pricedCount,
+		UnpricedCount:   unpricedCount,
+		FailedCount:     failedCount,
+		Complete:        !missingModelSeen && !missingPricingSeen,
+	}
+	if !summary.Complete {
+		if missingModelSeen {
+			summary.UnpriceableReason = UnpriceableReasonMissingModel
+		} else {
+			summary.UnpriceableReason = UnpriceableReasonMissingBatchPricing
+		}
+	}
+	return summary, nil
+}
+
+// BatchRequestType maps a batch endpoint to the request type its results price
+// under. Exported because the aggregate row records only the endpoint (its Object
+// column is always "batch_results"), so a later repricing pass outside this package
+// must reach the same modality settlement used.
+func BatchRequestType(endpoint schemas.BatchEndpoint) schemas.RequestType {
+	switch endpoint {
+	case schemas.BatchEndpointEmbeddings:
+		return schemas.EmbeddingRequest
+	case schemas.BatchEndpointCompletions:
+		return schemas.TextCompletionRequest
+	case schemas.BatchEndpointResponses:
+		return schemas.ResponsesRequest
+	case schemas.BatchEndpointChatCompletions, schemas.BatchEndpointMessages:
+		return schemas.ChatCompletionRequest
+	default:
+		return schemas.BatchResultsRequest
+	}
+}
+
+type usageExtractor func(fallbackModel string, item schemas.BatchResultItem) (extractedUsage, error)
+
+var usageExtractors = map[schemas.ModelProvider]usageExtractor{
+	schemas.OpenAI:    extractResponseBodyUsage,
+	schemas.Azure:     extractResponseBodyUsage,
+	schemas.Bedrock:   extractResponseBodyUsage,
+	schemas.Gemini:    extractResponseBodyUsage,
+	schemas.Vertex:    extractResponseBodyUsage,
+	schemas.Anthropic: extractAnthropicUsage,
+}
+
+func IsProviderSupported(provider schemas.ModelProvider) bool {
+	_, ok := usageExtractors[provider]
+	return ok
+}
+
+func extractUsage(provider schemas.ModelProvider, fallbackModel string, item schemas.BatchResultItem) (extractedUsage, error) {
+	extractor, ok := usageExtractors[provider]
+	if !ok {
+		return extractedUsage{}, nil
+	}
+	return extractor(fallbackModel, item)
+}
+
+func extractResponseBodyUsage(fallbackModel string, item schemas.BatchResultItem) (extractedUsage, error) {
+	if item.Response == nil || item.Response.StatusCode >= 400 || item.Response.Body == nil {
+		return extractedUsage{}, nil
+	}
+	usageValue, ok := item.Response.Body["usage"]
+	if !ok || usageValue == nil {
+		return extractedUsage{}, nil
+	}
+	usage, err := usageFromValue(usageValue)
+	if err != nil {
+		return extractedUsage{}, err
+	}
+	if usage.TotalTokens == 0 {
+		usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
+	}
+	if usage.TotalTokens == 0 {
+		return extractedUsage{}, nil
+	}
+	model, _ := item.Response.Body["model"].(string)
+	if model == "" {
+		model = fallbackModel
+	}
+	if model == "" {
+		return extractedUsage{usage: usage, hasUsage: true, missingModel: true}, nil
+	}
+	return extractedUsage{model: model, usage: usage, hasUsage: true}, nil
+}
+
+func extractAnthropicUsage(fallbackModel string, item schemas.BatchResultItem) (extractedUsage, error) {
+	if item.Result == nil || item.Result.Type != "succeeded" || item.Result.Message == nil {
+		return extractedUsage{}, nil
+	}
+	usageValue, ok := item.Result.Message["usage"]
+	if !ok || usageValue == nil {
+		return extractedUsage{}, nil
+	}
+	usage, err := anthropicUsageFromValue(usageValue)
+	if err != nil {
+		return extractedUsage{}, err
+	}
+	if usage.TotalTokens == 0 {
+		return extractedUsage{}, nil
+	}
+	model, _ := item.Result.Message["model"].(string)
+	if model == "" {
+		model = fallbackModel
+	}
+	if model == "" {
+		return extractedUsage{usage: usage, hasUsage: true, missingModel: true}, nil
+	}
+	return extractedUsage{model: model, usage: usage, hasUsage: true}, nil
+}
+
+func anthropicUsageFromValue(value interface{}) (*schemas.BifrostLLMUsage, error) {
+	bytes, err := sonic.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	var usage struct {
+		InputTokens              int `json:"input_tokens"`
+		CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+		CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+		CacheCreation            struct {
+			Ephemeral5mInputTokens int `json:"ephemeral_5m_input_tokens"`
+			Ephemeral1hInputTokens int `json:"ephemeral_1h_input_tokens"`
+		} `json:"cache_creation"`
+		OutputTokens int `json:"output_tokens"`
+	}
+	if err := sonic.Unmarshal(bytes, &usage); err != nil {
+		return nil, err
+	}
+	promptTokens := usage.InputTokens + usage.CacheCreationInputTokens + usage.CacheReadInputTokens
+	totalTokens := promptTokens + usage.OutputTokens
+	if totalTokens == 0 {
+		return &schemas.BifrostLLMUsage{}, nil
+	}
+	out := &schemas.BifrostLLMUsage{
+		PromptTokens:     promptTokens,
+		CompletionTokens: usage.OutputTokens,
+		TotalTokens:      totalTokens,
+	}
+	if usage.CacheCreationInputTokens > 0 || usage.CacheReadInputTokens > 0 {
+		out.PromptTokensDetails = &schemas.ChatPromptTokensDetails{
+			CachedReadTokens:  usage.CacheReadInputTokens,
+			CachedWriteTokens: usage.CacheCreationInputTokens,
+		}
+		if usage.CacheCreation.Ephemeral5mInputTokens > 0 || usage.CacheCreation.Ephemeral1hInputTokens > 0 {
+			out.PromptTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{
+				CachedWriteTokens5m: usage.CacheCreation.Ephemeral5mInputTokens,
+				CachedWriteTokens1h: usage.CacheCreation.Ephemeral1hInputTokens,
+			}
+		}
+	}
+	return out, nil
+}
+
+func usageFromValue(value interface{}) (*schemas.BifrostLLMUsage, error) {
+	bytes, err := sonic.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	var usage struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+		TotalTokens      int `json:"total_tokens"`
+
+		InputTokensSnake  int `json:"input_tokens"`
+		OutputTokensSnake int `json:"output_tokens"`
+
+		InputTokensCamel  int `json:"inputTokens"`
+		OutputTokensCamel int `json:"outputTokens"`
+		TotalTokensCamel  int `json:"totalTokens"`
+
+		CacheCreationInputTokens  int `json:"cache_creation_input_tokens"`
+		CacheReadInputTokens      int `json:"cache_read_input_tokens"`
+		CacheReadInputTokensCamel int `json:"cacheReadInputTokens"`
+		CacheWriteInputTokens     int `json:"cacheWriteInputTokens"`
+		CacheCreation             struct {
+			Ephemeral5mInputTokens int `json:"ephemeral_5m_input_tokens"`
+			Ephemeral1hInputTokens int `json:"ephemeral_1h_input_tokens"`
+		} `json:"cache_creation"`
+		CacheDetails []struct {
+			InputTokens int    `json:"inputTokens"`
+			TTL         string `json:"ttl"`
+		} `json:"cacheDetails"`
+		// OpenAI (and Gemini, which we normalize into the same shape) report
+		// cached input as a breakdown of prompt_tokens rather than as a separate
+		// bucket — see the inclusive/exclusive note below.
+		PromptTokensDetails struct {
+			CachedTokens int `json:"cached_tokens"`
+		} `json:"prompt_tokens_details"`
+		Cost *schemas.BifrostCost `json:"cost,omitempty"`
+	}
+	if err := sonic.Unmarshal(bytes, &usage); err != nil {
+		return nil, err
+	}
+	cacheWriteTokens := usage.CacheCreationInputTokens + usage.CacheWriteInputTokens
+	cacheWrite5m := usage.CacheCreation.Ephemeral5mInputTokens
+	cacheWrite1h := usage.CacheCreation.Ephemeral1hInputTokens
+	cacheDetailsWriteTokens := 0
+	for _, detail := range usage.CacheDetails {
+		cacheDetailsWriteTokens += detail.InputTokens
+		switch detail.TTL {
+		case "5m":
+			cacheWrite5m += detail.InputTokens
+		case "1h":
+			cacheWrite1h += detail.InputTokens
+		}
+	}
+	if cacheWriteTokens == 0 {
+		cacheWriteTokens = cacheDetailsWriteTokens
+	}
+	// Two wire conventions, keyed by field name, and the distinction is load-bearing:
+	//   - Anthropic/Bedrock (cache_read_input_tokens, cacheReadInputTokens, ...) report
+	//     cache tokens EXCLUSIVE of the base input count, so they are added in below to
+	//     normalize into our internal convention (PromptTokens is inclusive of cache).
+	//   - OpenAI/Gemini (prompt_tokens_details.cached_tokens) report cached input as a
+	//     BREAKDOWN of prompt_tokens, which already includes it — adding it would
+	//     double-count. It is only surfaced on PromptTokensDetails so the cache-read
+	//     discount applies at pricing time.
+	// A provider emits one convention or the other, never both.
+	cacheReadTokens := usage.CacheReadInputTokens + usage.CacheReadInputTokensCamel
+	inclusiveCacheReadTokens := usage.PromptTokensDetails.CachedTokens
+
+	promptTokens := firstNonZero(usage.PromptTokens, usage.InputTokensSnake, usage.InputTokensCamel) + cacheReadTokens + cacheWriteTokens
+	completionTokens := firstNonZero(usage.CompletionTokens, usage.OutputTokensSnake, usage.OutputTokensCamel)
+	computedTotal := promptTokens + completionTokens
+	totalTokens := firstNonZero(usage.TotalTokens, usage.TotalTokensCamel)
+	if totalTokens == 0 || totalTokens < computedTotal {
+		totalTokens = computedTotal
+	}
+	out := &schemas.BifrostLLMUsage{
+		PromptTokens:     promptTokens,
+		CompletionTokens: completionTokens,
+		TotalTokens:      totalTokens,
+		Cost:             usage.Cost,
+	}
+	totalCacheReadTokens := cacheReadTokens + inclusiveCacheReadTokens
+	if totalCacheReadTokens > 0 || cacheWriteTokens > 0 {
+		out.PromptTokensDetails = &schemas.ChatPromptTokensDetails{
+			CachedReadTokens:  totalCacheReadTokens,
+			CachedWriteTokens: cacheWriteTokens,
+		}
+		if cacheWrite5m > 0 || cacheWrite1h > 0 {
+			out.PromptTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{
+				CachedWriteTokens5m: cacheWrite5m,
+				CachedWriteTokens1h: cacheWrite1h,
+			}
+		}
+	}
+	return out, nil
+}
+
+func firstNonZero(values ...int) int {
+	for _, value := range values {
+		if value != 0 {
+			return value
+		}
+	}
+	return 0
+}
+
+func buildAggregateLog(req Request, summary *Summary, now time.Time) *logstore.Log {
+	model := req.FallbackModel
+	if len(summary.ModelBreakdowns) == 1 {
+		for key := range summary.ModelBreakdowns {
+			model = key
+		}
+	} else if len(summary.ModelBreakdowns) > 1 {
+		model = "mixed"
+	}
+	if model == "" {
+		model = "mixed"
+	}
+
+	// The provider is already a column on the row, and applyLogAttribution sets
+	// ParentRequestID for the source request, so neither is repeated here.
+	batchDebug := &schemas.BifrostBatchDebug{
+		BatchID:  req.BatchID,
+		Status:   summary.Status,
+		Endpoint: string(req.Endpoint),
+		Accounting: &schemas.BatchAccountingDebug{
+			ModelBreakdowns: summary.ModelBreakdowns,
+			ParseErrorCount: len(req.ParseErrors),
+			// Two different ways to under-state, one marker: usage that failed to price,
+			// and rows that never parsed. Parse errors are unrecoverable (the raw results
+			// are not kept), so unlike unpriced usage they do not hold the settlement back
+			// — the batch still settles, it just settles on record as short.
+			Incomplete: !summary.Complete || len(req.ParseErrors) > 0,
+		},
+	}
+	if requestCounts := requestCountsForAggregateLog(req); !requestCounts.IsZero() {
+		batchDebug.RequestCounts = &requestCounts
+	}
+
+	entry := &logstore.Log{
+		ID:               summary.LogID,
+		Timestamp:        now,
+		Object:           string(schemas.BatchResultsRequest),
+		Provider:         string(req.Provider),
+		Model:            model,
+		Status:           "success",
+		Cost:             &summary.Cost,
+		TokenUsageParsed: &summary.Usage,
+		PromptTokens:     summary.Usage.PromptTokens,
+		CompletionTokens: summary.Usage.CompletionTokens,
+		TotalTokens:      summary.Usage.TotalTokens,
+		CreatedAt:        now,
+		BatchDebugParsed: batchDebug,
+	}
+	// Attribution must not depend on who happens to settle the batch first. The
+	// sweeper reaches here with only the job; a /results call reaches here with the
+	// caller's log entry too — and copying that wholesale meant the same batch billed
+	// the creator's budgets or the fetcher's depending on a race, so an admin reading
+	// someone else's results absorbed the entire bill. The batch job's create-time
+	// attribution is the one identity that does not move, so it wins whenever it
+	// exists; BaseLog only fills the display/denormalization fields the job does not
+	// persist, and only when it is demonstrably the same virtual key (otherwise the
+	// row would carry one identity's ids under another's names). A batch first seen at
+	// /results has no create-time attribution to prefer, so it keeps using BaseLog.
+	if req.BatchJob != nil && hasBatchJobAttribution(req.BatchJob) {
+		applyBatchJobAttribution(entry, req.BatchJob)
+		if req.BaseLog != nil {
+			// Provenance, not attribution: which request triggered this settlement.
+			if req.BaseLog.ID != "" {
+				entry.ParentRequestID = &req.BaseLog.ID
+			}
+			if sameVirtualKey(req.BatchJob.VirtualKeyID, req.BaseLog.VirtualKeyID) {
+				applyLogDenormalizations(entry, req.BaseLog)
+			}
+		}
+		return entry
+	}
+	if req.BaseLog != nil {
+		applyLogAttribution(entry, req.BaseLog)
+		return entry
+	}
+	if req.BatchJob != nil {
+		applyBatchJobAttribution(entry, req.BatchJob)
+	}
+	return entry
+}
+
+// hasBatchJobAttribution reports whether the job captured who to bill at create
+// time. Batches created outside Bifrost (first seen at /results) carry none.
+func hasBatchJobAttribution(job *cstables.TableBatchJob) bool {
+	if job.SelectedKeyID != "" || (job.VirtualKeyID != nil && *job.VirtualKeyID != "") {
+		return true
+	}
+	return (job.BudgetIDs != nil && *job.BudgetIDs != "") || (job.RateLimitIDs != nil && *job.RateLimitIDs != "")
+}
+
+// sameVirtualKey treats nil and "" alike: neither side claiming a virtual key is
+// not a conflict of identity, only a mismatch between two named ones is.
+func sameVirtualKey(a, b *string) bool {
+	left := ""
+	if a != nil {
+		left = *a
+	}
+	right := ""
+	if b != nil {
+		right = *b
+	}
+	return left == right
+}
+
+func requestCountsForAggregateLog(req Request) schemas.BatchRequestCounts {
+	if req.RequestCounts != nil && !req.RequestCounts.IsZero() {
+		return *req.RequestCounts
+	}
+	return schemas.BatchRequestCountsFromResults(req.Results)
+}
+
+func applyLogAttribution(entry *logstore.Log, source *logstore.Log) {
+	if source.ID != "" {
+		entry.ParentRequestID = &source.ID
+	}
+	entry.SelectedKeyID = source.SelectedKeyID
+	entry.VirtualKeyID = source.VirtualKeyID
+	entry.BudgetIDsParsed = source.BudgetIDsParsed
+	entry.RateLimitIDsParsed = source.RateLimitIDsParsed
+	applyLogDenormalizations(entry, source)
+}
+
+// applyLogDenormalizations copies the display and grouping fields a log row
+// carries but batch_jobs does not persist. Deliberately excludes the ids the
+// batch job owns (selected key, virtual key, budgets, rate limits): those decide
+// who is billed, and mixing them with another request's would reintroduce exactly
+// the attribution race this split exists to remove.
+func applyLogDenormalizations(entry *logstore.Log, source *logstore.Log) {
+	entry.SelectedKeyName = source.SelectedKeyName
+	entry.VirtualKeyName = source.VirtualKeyName
+	entry.RoutingRuleID = source.RoutingRuleID
+	entry.RoutingRuleName = source.RoutingRuleName
+	entry.UserID = source.UserID
+	entry.UserName = source.UserName
+	entry.TeamID = source.TeamID
+	entry.TeamName = source.TeamName
+	entry.CustomerID = source.CustomerID
+	entry.CustomerName = source.CustomerName
+	entry.BusinessUnitID = source.BusinessUnitID
+	entry.BusinessUnitName = source.BusinessUnitName
+	entry.TeamIDsParsed = source.TeamIDsParsed
+	entry.TeamNamesParsed = source.TeamNamesParsed
+	entry.CustomerIDsParsed = source.CustomerIDsParsed
+	entry.CustomerNamesParsed = source.CustomerNamesParsed
+	entry.BusinessUnitIDsParsed = source.BusinessUnitIDsParsed
+	entry.BusinessUnitNamesParsed = source.BusinessUnitNamesParsed
+	entry.ClusterNodeID = source.ClusterNodeID
+	entry.Alias = source.Alias
+	entry.CanonicalModelName = source.CanonicalModelName
+	entry.AliasModelFamily = source.AliasModelFamily
+}
+
+func applyBatchJobAttribution(entry *logstore.Log, job *cstables.TableBatchJob) {
+	entry.SelectedKeyID = job.SelectedKeyID
+	entry.VirtualKeyID = job.VirtualKeyID
+	entry.BudgetIDs = job.BudgetIDs
+	entry.RateLimitIDs = job.RateLimitIDs
+}

--- a/framework/batchaccounting/accounting_test.go
+++ b/framework/batchaccounting/accounting_test.go
@@ -1,0 +1,1742 @@
+package batchaccounting
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	cstables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/logstore"
+	"github.com/maximhq/bifrost/framework/modelcatalog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeAccountingStore struct {
+	logs             map[string]*logstore.Log
+	jobs             map[string]*cstables.TableBatchJob
+	failCompleteOnce bool
+	// failCompleteAlways models a settlement that keeps failing (a wedged store, a
+	// deleted budget), which is what the accounting retry budget has to bound.
+	failCompleteAlways bool
+	failGetOnce        bool
+}
+
+func newFakeAccountingStore() *fakeAccountingStore {
+	return &fakeAccountingStore{
+		logs: make(map[string]*logstore.Log),
+		jobs: make(map[string]*cstables.TableBatchJob),
+	}
+}
+
+func (s *fakeAccountingStore) CreateIfNotExists(ctx context.Context, entry *logstore.Log) error {
+	if _, ok := s.logs[entry.ID]; ok {
+		return nil
+	}
+	copied := *entry
+	s.logs[entry.ID] = &copied
+	return nil
+}
+
+func (s *fakeAccountingStore) FindByID(ctx context.Context, id string) (*logstore.Log, error) {
+	entry, ok := s.logs[id]
+	if !ok {
+		return nil, logstore.ErrNotFound
+	}
+	copied := *entry
+	return &copied, nil
+}
+
+func (s *fakeAccountingStore) UpsertBatchJob(ctx context.Context, job *cstables.TableBatchJob) error {
+	if job.ID == "" {
+		job.ID = cstables.BatchJobID(job.Provider, job.BatchID)
+	}
+	existing, ok := s.jobs[job.ID]
+	if !ok {
+		copied := *job
+		if copied.AccountingStatus == "" {
+			copied.AccountingStatus = cstables.BatchJobAccountingStatusPending
+		}
+		s.jobs[job.ID] = &copied
+		return nil
+	}
+	if job.ProviderStatus != "" {
+		existing.ProviderStatus = job.ProviderStatus
+	}
+	if job.OutputFileID != nil {
+		existing.OutputFileID = job.OutputFileID
+	}
+	if job.NextCheckAt != nil {
+		existing.NextCheckAt = job.NextCheckAt
+	}
+	if job.PollAttempts > 0 {
+		existing.PollAttempts = job.PollAttempts
+	}
+	// Refresh updated_at like the real store does. This is deliberately unfenced,
+	// which is exactly why claim staleness must not be measured on it.
+	existing.UpdatedAt = time.Now().UTC()
+	return nil
+}
+
+func (s *fakeAccountingStore) GetBatchJob(ctx context.Context, jobID string) (*cstables.TableBatchJob, error) {
+	if s.failGetOnce {
+		s.failGetOnce = false
+		return nil, errors.New("transient read failure")
+	}
+	job, ok := s.jobs[jobID]
+	if !ok {
+		return nil, errors.New("missing batch job")
+	}
+	copied := *job
+	return &copied, nil
+}
+
+func (s *fakeAccountingStore) ListDueBatchJobs(ctx context.Context, provider string, now time.Time, limit int) ([]*cstables.TableBatchJob, error) {
+	var jobs []*cstables.TableBatchJob
+	for _, job := range s.jobs {
+		if provider != "" && job.Provider != provider {
+			continue
+		}
+		if job.NextCheckAt == nil || job.NextCheckAt.After(now) {
+			continue
+		}
+		if job.AccountingStatus == cstables.BatchJobAccountingStatusAccounted || job.AccountingStatus == cstables.BatchJobAccountingStatusUnpriceable {
+			continue
+		}
+		// Hand back a detached copy: a real store returns rows, not live pointers.
+		// Returning the map pointer would let sweeper mutations persist without an
+		// UpsertBatchJob and hide missing-write bugs.
+		copied := *job
+		jobs = append(jobs, &copied)
+		if limit > 0 && len(jobs) >= limit {
+			break
+		}
+	}
+	return jobs, nil
+}
+
+func (s *fakeAccountingStore) ClaimBatchJob(ctx context.Context, jobID, runnerID string, staleBefore time.Time, allowUnpriceable bool) (bool, error) {
+	entry, ok := s.jobs[jobID]
+	if !ok {
+		return false, errors.New("missing batch job")
+	}
+	if entry.AccountingStatus == cstables.BatchJobAccountingStatusAccounted {
+		return false, nil
+	}
+	// "unpriceable" is a stop-polling marker, not a refusal of money: a caller
+	// holding real results may re-drive it. Mirrors the real store's allowUnpriceable.
+	if entry.AccountingStatus == cstables.BatchJobAccountingStatusUnpriceable && !allowUnpriceable {
+		return false, nil
+	}
+	// Staleness reads claimed_at, never updated_at — mirroring the real store, where
+	// updated_at is refreshed by the unfenced UpsertBatchJob and so cannot be trusted
+	// to represent claim age.
+	if entry.AccountingStatus == cstables.BatchJobAccountingStatusProcessing &&
+		entry.ClaimedAt != nil && entry.ClaimedAt.After(staleBefore) {
+		return false, nil
+	}
+	now := time.Now().UTC()
+	rid := runnerID
+	entry.AccountingStatus = cstables.BatchJobAccountingStatusProcessing
+	entry.RunnerID = &rid
+	entry.ClaimedAt = &now
+	entry.LastError = nil
+	entry.UpdatedAt = now
+	return true, nil
+}
+
+func (s *fakeAccountingStore) ownedJob(id, runnerID string) (*cstables.TableBatchJob, error) {
+	entry, ok := s.jobs[id]
+	if !ok {
+		return nil, errors.New("missing batch job")
+	}
+	if entry.RunnerID == nil || *entry.RunnerID != runnerID {
+		return nil, errors.New("stale runner")
+	}
+	return entry, nil
+}
+
+func (s *fakeAccountingStore) MarkBatchJobAggregateLogWritten(ctx context.Context, id, runnerID string) error {
+	entry, err := s.ownedJob(id, runnerID)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	entry.AggregateLogWrittenAt = &now
+	return nil
+}
+
+func (s *fakeAccountingStore) MarkBatchJobGovernanceReported(ctx context.Context, id, runnerID string) error {
+	entry, err := s.ownedJob(id, runnerID)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	entry.GovernanceReportedAt = &now
+	return nil
+}
+
+func (s *fakeAccountingStore) CompleteBatchJob(ctx context.Context, id, runnerID string) error {
+	entry, err := s.ownedJob(id, runnerID)
+	if err != nil {
+		return err
+	}
+	if s.failCompleteOnce {
+		s.failCompleteOnce = false
+		return errors.New("complete failed")
+	}
+	if s.failCompleteAlways {
+		return errors.New("complete failed")
+	}
+	entry.AccountingStatus = cstables.BatchJobAccountingStatusAccounted
+	entry.RunnerID = nil
+	entry.ClaimedAt = nil
+	return nil
+}
+
+func (s *fakeAccountingStore) MarkBatchJobUnpriceable(ctx context.Context, id, runnerID, reason string, err error) error {
+	entry, ownErr := s.ownedJob(id, runnerID)
+	if ownErr != nil {
+		return ownErr
+	}
+	entry.AccountingStatus = cstables.BatchJobAccountingStatusUnpriceable
+	entry.UnpriceableReason = &reason
+	entry.RunnerID = nil
+	entry.ClaimedAt = nil
+	return nil
+}
+
+func (s *fakeAccountingStore) FailBatchJob(ctx context.Context, id, runnerID string, err error) error {
+	// Fenced on runnerID like the real finishBatchJob: a stale runner must not be
+	// able to release another runner's live claim.
+	entry, ownErr := s.ownedJob(id, runnerID)
+	if ownErr != nil {
+		return ownErr
+	}
+	entry.AccountingStatus = cstables.BatchJobAccountingStatusError
+	entry.RunnerID = nil
+	entry.ClaimedAt = nil
+	return nil
+}
+
+type fakeBatchPricing struct{}
+
+func (fakeBatchPricing) CalculateBatchCostDetailsForUsage(usage *schemas.BifrostLLMUsage, provider schemas.ModelProvider, model string, requestType schemas.RequestType, scopes *modelcatalog.PricingLookupScopes) modelcatalog.BatchCostDetails {
+	if usage == nil || requestType != schemas.BatchResultsRequest {
+		return modelcatalog.BatchCostDetails{}
+	}
+	if usage.Cost != nil {
+		return modelcatalog.BatchCostDetails{Cost: usage.Cost.TotalCost, Priced: true, ProviderCostUsed: true}
+	}
+	inputRate := 0.00001
+	outputRate := 0.00002
+	switch model {
+	case "gpt-4o-mini":
+		inputRate = 0.000005
+		outputRate = 0.000010
+	case "gpt-4o":
+	case "claude-3-5-haiku":
+	case "amazon.nova-lite-v1:0":
+	case "gemini-2.0-flash":
+	default:
+		return modelcatalog.BatchCostDetails{}
+	}
+	return modelcatalog.BatchCostDetails{
+		Cost:                      float64(usage.PromptTokens)*inputRate + float64(usage.CompletionTokens)*outputRate,
+		Priced:                    true,
+		InputCostPerTokenBatches:  &inputRate,
+		OutputCostPerTokenBatches: &outputRate,
+	}
+}
+
+type fakeAggregateLogWriter struct {
+	emitted []*logstore.Log
+}
+
+func (w *fakeAggregateLogWriter) EmitBatchAggregateLog(ctx context.Context, entry *logstore.Log) {
+	copied := *entry
+	w.emitted = append(w.emitted, &copied)
+}
+
+type fakeUsageReporter struct {
+	reports []BatchUsageReport
+}
+
+type requestTypePricing struct {
+	requestTypes []schemas.RequestType
+}
+
+func (p *requestTypePricing) CalculateBatchCostDetailsForUsage(usage *schemas.BifrostLLMUsage, provider schemas.ModelProvider, model string, requestType schemas.RequestType, scopes *modelcatalog.PricingLookupScopes) modelcatalog.BatchCostDetails {
+	p.requestTypes = append(p.requestTypes, requestType)
+	return modelcatalog.BatchCostDetails{Cost: float64(usage.PromptTokens), Priced: true}
+}
+
+func (r *fakeUsageReporter) ReportBatchUsage(ctx context.Context, report BatchUsageReport) error {
+	r.reports = append(r.reports, report)
+	return nil
+}
+
+func TestAccountBatchResults_OpenAIAggregatesAndWritesOnce(t *testing.T) {
+	store := newFakeAccountingStore()
+	baseLog := &logstore.Log{
+		ID:              "request-1",
+		Provider:        string(schemas.OpenAI),
+		Model:           "gpt-4o-mini",
+		SelectedKeyID:   "key-1",
+		SelectedKeyName: "primary",
+	}
+
+	req := Request{
+		Provider:      schemas.OpenAI,
+		BatchID:       "batch_123",
+		FallbackModel: "gpt-4o-mini",
+		BaseLog:       baseLog,
+		ClaimedBy:     "test-node",
+		Now:           time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC),
+		RequestCounts: &schemas.BatchRequestCounts{Total: 3, Completed: 2, Failed: 1},
+		Results: []schemas.BatchResultItem{
+			openAIResult(200, "gpt-4o-mini", 18, 9),
+			openAIResult(200, "gpt-4o", 20, 5),
+			openAIResult(500, "gpt-4o-mini", 100, 100),
+		},
+	}
+
+	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, req)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.True(t, summary.Accounted)
+	assert.Equal(t, 38, summary.Usage.PromptTokens)
+	assert.Equal(t, 14, summary.Usage.CompletionTokens)
+	assert.Equal(t, 52, summary.Usage.TotalTokens)
+	assert.InDelta(t, 0.00048, summary.Cost, 1e-12)
+	require.Len(t, store.logs, 1)
+
+	logEntry := store.logs[AccountingLogID(schemas.OpenAI, "batch_123")]
+	require.NotNil(t, logEntry)
+	assert.Equal(t, "request-1", *logEntry.ParentRequestID)
+	assert.Equal(t, string(schemas.BatchResultsRequest), logEntry.Object)
+	assert.Equal(t, "mixed", logEntry.Model)
+	assert.Equal(t, summary.Cost, *logEntry.Cost)
+	assert.Equal(t, "key-1", logEntry.SelectedKeyID)
+	require.NotNil(t, logEntry.BatchDebugParsed)
+	require.NotNil(t, logEntry.BatchDebugParsed.Accounting)
+	assert.Equal(t, "batch_123", logEntry.BatchDebugParsed.BatchID)
+	assert.Nil(t, logEntry.MetadataParsed, "batch detail belongs in batch_debug, not the caller-owned metadata bag")
+	require.NotNil(t, logEntry.BatchDebugParsed.RequestCounts)
+	assert.Equal(t, schemas.BatchRequestCounts{Total: 3, Completed: 2, Failed: 1}, *logEntry.BatchDebugParsed.RequestCounts)
+	breakdown := logEntry.BatchDebugParsed.Accounting.ModelBreakdowns
+	require.Contains(t, breakdown, "gpt-4o-mini")
+	assert.Equal(t, 1, breakdown["gpt-4o-mini"].RequestCount, "the 500-status gpt-4o-mini result is failed, not priced")
+	assert.Equal(t, 18, breakdown["gpt-4o-mini"].Usage.PromptTokens)
+	assert.Equal(t, 9, breakdown["gpt-4o-mini"].Usage.CompletionTokens)
+	require.NotNil(t, breakdown["gpt-4o-mini"].Cost)
+	assert.InDelta(t, 0.00018, *breakdown["gpt-4o-mini"].Cost, 1e-12)
+	require.Contains(t, breakdown, "gpt-4o")
+	assert.Equal(t, 1, breakdown["gpt-4o"].RequestCount)
+
+	// A repeat call (e.g. a second /results fetch) does not win the claim and
+	// writes nothing new, but still mirrors the already-settled price so the
+	// caller can display it.
+	second, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, req)
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	assert.False(t, second.Claimed)
+	assert.False(t, second.Accounted)
+	assert.Len(t, store.logs, 1)
+	assert.Equal(t, summary.Cost, second.Cost)
+	assert.True(t, second.Complete)
+	assert.Equal(t, summary.Usage, second.Usage)
+	assert.Equal(t, summary.ModelBreakdowns, second.ModelBreakdowns)
+}
+
+func TestAccountBatchResults_MissingModelMarksUnpriceable(t *testing.T) {
+	store := newFakeAccountingStore()
+	result := openAIResult(200, "", 18, 9)
+
+	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, Request{
+		Provider:  schemas.OpenAI,
+		BatchID:   "batch_missing_model",
+		ClaimedBy: "test-node",
+		Results:   []schemas.BatchResultItem{result},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.False(t, summary.Accounted)
+	assert.Equal(t, UnpriceableReasonMissingModel, summary.UnpriceableReason)
+
+	job := store.jobs[cstables.BatchJobID(string(schemas.OpenAI), "batch_missing_model")]
+	require.NotNil(t, job)
+	assert.Equal(t, cstables.BatchJobAccountingStatusUnpriceable, job.AccountingStatus)
+	require.NotNil(t, job.UnpriceableReason)
+	assert.Equal(t, UnpriceableReasonMissingModel, *job.UnpriceableReason)
+
+	// Tokens were consumed, so the row is still logged rather than dropped. Unlike
+	// the missing-rates case this one is not backfillable — there is no model to
+	// look up — so the row is a record of the usage, not a recoverable cost.
+	require.Len(t, store.logs, 1)
+	logged := store.logs[AccountingLogID(schemas.OpenAI, "batch_missing_model")]
+	require.NotNil(t, logged)
+	assert.Nil(t, logged.Cost)
+	assert.Equal(t, 18, logged.PromptTokens)
+	assert.Equal(t, 9, logged.CompletionTokens)
+}
+
+func TestAccountBatchResults_MissingBatchPricingMarksUnpriceable(t *testing.T) {
+	store := newFakeAccountingStore()
+
+	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, Request{
+		Provider: schemas.OpenAI,
+		BatchID:  "batch_missing_pricing",
+		Results:  []schemas.BatchResultItem{openAIResult(200, "unknown-model", 18, 9)},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.False(t, summary.Accounted)
+	assert.Equal(t, UnpriceableReasonMissingBatchPricing, summary.UnpriceableReason)
+
+	job := store.jobs[cstables.BatchJobID(string(schemas.OpenAI), "batch_missing_pricing")]
+	require.NotNil(t, job)
+	assert.Equal(t, cstables.BatchJobAccountingStatusUnpriceable, job.AccountingStatus)
+	require.NotNil(t, job.UnpriceableReason)
+	assert.Equal(t, UnpriceableReasonMissingBatchPricing, *job.UnpriceableReason)
+
+	// The model is known, only its batch rates are missing — so the row is logged
+	// with an unknown cost and stays attributable, which is exactly what the
+	// missing-cost backfill needs to price it once rates are added.
+	require.Len(t, store.logs, 1, "usage we could not price must still be logged, not dropped")
+	logged := store.logs[AccountingLogID(schemas.OpenAI, "batch_missing_pricing")]
+	require.NotNil(t, logged)
+	assert.Nil(t, logged.Cost, "cost must be unknown (nil), not zero")
+	assert.Equal(t, "unknown-model", logged.Model)
+	assert.Equal(t, 18, logged.PromptTokens)
+	assert.Equal(t, 9, logged.CompletionTokens)
+
+	// The unpriced model still gets a ModelBreakdown entry (Cost nil, Usage set)
+	// so a later cost-recalculation pass can reprice it once rates land, instead
+	// of its usage only surviving as an anonymous row-level blob.
+	require.NotNil(t, logged.BatchDebugParsed)
+	require.NotNil(t, logged.BatchDebugParsed.Accounting)
+	breakdown, ok := logged.BatchDebugParsed.Accounting.ModelBreakdowns["unknown-model"]
+	require.True(t, ok)
+	assert.Equal(t, 1, breakdown.RequestCount)
+	assert.Equal(t, 18, breakdown.Usage.PromptTokens)
+	assert.Equal(t, 9, breakdown.Usage.CompletionTokens)
+	assert.Nil(t, breakdown.Cost, "cost must be unknown (nil), not zero, matching the row-level cost")
+}
+
+func TestAccountBatchResults_ProviderCostPassthrough(t *testing.T) {
+	store := newFakeAccountingStore()
+	result := openAIResult(200, "unknown-provider-priced-model", 18, 9)
+	result.Response.Body["usage"].(map[string]interface{})["cost"] = map[string]interface{}{
+		"total_cost": 0.123,
+	}
+
+	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, Request{
+		Provider:  schemas.OpenAI,
+		BatchID:   "batch_provider_cost",
+		ClaimedBy: "test-node",
+		Results:   []schemas.BatchResultItem{result},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.True(t, summary.Accounted)
+	assert.InDelta(t, 0.123, summary.Cost, 1e-12)
+
+	breakdown := summary.ModelBreakdowns["unknown-provider-priced-model"]
+	require.NotNil(t, breakdown.Cost, "provider-supplied cost must still land in the per-model breakdown")
+	assert.InDelta(t, 0.123, *breakdown.Cost, 1e-12)
+}
+
+func TestAccountBatchResults_ZeroProviderCostIsStillPriced(t *testing.T) {
+	store := newFakeAccountingStore()
+	result := openAIResult(200, "unknown-provider-priced-model", 18, 9)
+	result.Response.Body["usage"].(map[string]interface{})["cost"] = map[string]interface{}{
+		"total_cost": 0.0,
+	}
+
+	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, Request{
+		Provider: schemas.OpenAI,
+		BatchID:  "batch_zero_cost",
+		Results:  []schemas.BatchResultItem{result},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.True(t, summary.Accounted)
+	assert.Equal(t, 1, summary.PricedCount)
+	assert.Equal(t, 0.0, summary.Cost)
+}
+
+func TestAccountBatchResults_AnthropicAggregatesUsage(t *testing.T) {
+	store := newFakeAccountingStore()
+
+	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, Request{
+		Provider: schemas.Anthropic,
+		BatchID:  "anthropic_batch",
+		Results: []schemas.BatchResultItem{
+			anthropicResult("claude-3-5-haiku", 10, 2, 3, 5),
+			anthropicResult("claude-3-5-haiku", 7, 0, 0, 4),
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.True(t, summary.Accounted)
+	assert.Equal(t, 22, summary.Usage.PromptTokens)
+	assert.Equal(t, 9, summary.Usage.CompletionTokens)
+	assert.Equal(t, 31, summary.Usage.TotalTokens)
+	assert.InDelta(t, 0.00040, summary.Cost, 1e-12)
+}
+
+func TestAccountBatchResults_BedrockAggregatesUsageFromResponseBody(t *testing.T) {
+	store := newFakeAccountingStore()
+
+	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, Request{
+		Provider:      schemas.Bedrock,
+		BatchID:       "bedrock_batch",
+		FallbackModel: "amazon.nova-lite-v1:0",
+		Results: []schemas.BatchResultItem{
+			bedrockResult("", 12, 6),
+			bedrockResult("amazon.nova-lite-v1:0", 8, 2),
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.True(t, summary.Accounted)
+	assert.Equal(t, 20, summary.Usage.PromptTokens)
+	assert.Equal(t, 8, summary.Usage.CompletionTokens)
+	assert.Equal(t, 28, summary.Usage.TotalTokens)
+	assert.InDelta(t, 0.00036, summary.Cost, 1e-12)
+}
+
+func TestAccountBatchResults_BedrockIncludesCacheDetailsInPromptUsage(t *testing.T) {
+	store := newFakeAccountingStore()
+
+	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, Request{
+		Provider:      schemas.Bedrock,
+		BatchID:       "bedrock_cache_batch",
+		FallbackModel: "amazon.nova-lite-v1:0",
+		Results: []schemas.BatchResultItem{
+			{
+				CustomID: "custom-id",
+				Response: &schemas.BatchResultResponse{
+					StatusCode: 200,
+					Body: map[string]interface{}{
+						"usage": map[string]interface{}{
+							"inputTokens":  12,
+							"outputTokens": 6,
+							"totalTokens":  18,
+							"cacheDetails": []map[string]interface{}{
+								{"inputTokens": 4, "ttl": "5m"},
+								{"inputTokens": 3, "ttl": "1h"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.True(t, summary.Accounted)
+	assert.Equal(t, 19, summary.Usage.PromptTokens)
+	assert.Equal(t, 6, summary.Usage.CompletionTokens)
+	assert.Equal(t, 25, summary.Usage.TotalTokens)
+	require.NotNil(t, summary.Usage.PromptTokensDetails)
+	assert.Equal(t, 7, summary.Usage.PromptTokensDetails.CachedWriteTokens)
+	require.NotNil(t, summary.Usage.PromptTokensDetails.CachedWriteTokenDetails)
+	assert.Equal(t, 4, summary.Usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m)
+	assert.Equal(t, 3, summary.Usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h)
+	assert.InDelta(t, 0.00031, summary.Cost, 1e-12)
+}
+
+func TestAccountBatchResults_GeminiAggregatesUsageFromResponseBody(t *testing.T) {
+	store := newFakeAccountingStore()
+
+	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, Request{
+		Provider:      schemas.Gemini,
+		BatchID:       "gemini_batch",
+		FallbackModel: "gemini-2.0-flash",
+		Results: []schemas.BatchResultItem{
+			geminiResult(11, 3),
+			geminiResult(7, 2),
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.True(t, summary.Accounted)
+	assert.Equal(t, 18, summary.Usage.PromptTokens)
+	assert.Equal(t, 5, summary.Usage.CompletionTokens)
+	assert.Equal(t, 23, summary.Usage.TotalTokens)
+	assert.InDelta(t, 0.00028, summary.Cost, 1e-12)
+}
+
+func TestAccountBatchResults_UsesAggregateWriterAndUsageReporter(t *testing.T) {
+	store := newFakeAccountingStore()
+	writer := &fakeAggregateLogWriter{}
+	reporter := &fakeUsageReporter{}
+
+	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, Request{
+		Provider:      schemas.OpenAI,
+		BatchID:       "batch_writer",
+		FallbackModel: "gpt-4o-mini",
+		Emitter:       writer,
+		UsageReporter: reporter,
+		Results:       []schemas.BatchResultItem{openAIResult(200, "gpt-4o-mini", 18, 9)},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.True(t, summary.Accounted)
+	require.Len(t, store.logs, 1)
+	require.Len(t, writer.emitted, 1)
+	require.Len(t, reporter.reports, 1)
+	assert.Equal(t, AccountingLogID(schemas.OpenAI, "batch_writer"), reporter.reports[0].RequestID)
+	assert.Equal(t, int64(27), reporter.reports[0].TokensUsed)
+}
+
+func TestAccountBatchResults_RetryAfterCompleteFailureDoesNotReportGovernanceTwice(t *testing.T) {
+	store := newFakeAccountingStore()
+	store.failCompleteOnce = true
+	writer := &fakeAggregateLogWriter{}
+	reporter := &fakeUsageReporter{}
+
+	req := Request{
+		Provider:      schemas.OpenAI,
+		BatchID:       "batch_retry_governance",
+		FallbackModel: "gpt-4o-mini",
+		Emitter:       writer,
+		UsageReporter: reporter,
+		Results:       []schemas.BatchResultItem{openAIResult(200, "gpt-4o-mini", 18, 9)},
+	}
+
+	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, req)
+	require.Error(t, err)
+	require.Nil(t, summary)
+	require.Len(t, writer.emitted, 1)
+	require.Len(t, reporter.reports, 1)
+
+	summary, err = AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, req)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.True(t, summary.Accounted)
+	require.Len(t, store.logs, 1)
+	require.Len(t, writer.emitted, 1)
+	require.Len(t, reporter.reports, 1)
+}
+
+func TestAccountBatchResults_RecordsPartialPricingMetadata(t *testing.T) {
+	store := newFakeAccountingStore()
+	reporter := &fakeUsageReporter{}
+
+	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, Request{
+		Provider: schemas.OpenAI,
+		BatchID:  "batch_partial",
+		Results: []schemas.BatchResultItem{
+			openAIResult(200, "gpt-4o-mini", 10, 5),
+			openAIResult(200, "", 10, 5),
+			openAIResult(200, "unknown-model", 10, 5),
+			{CustomID: "failed", Error: &schemas.BatchResultError{Code: "bad_request"}},
+			{CustomID: "http-failed", Response: &schemas.BatchResultResponse{StatusCode: 400}},
+			{CustomID: "anthropic-failed", Result: &schemas.BatchResultData{Type: "errored"}},
+		},
+		UsageReporter: reporter,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	// One model priced and two rows' tokens did not, so the batch is settled-as-short
+	// rather than accounted: closing it out would present a partial total as the bill.
+	assert.False(t, summary.Accounted)
+	assert.False(t, summary.Complete)
+	assert.Empty(t, reporter.reports, "governance must not be told a partial total is the batch's cost")
+	assert.Equal(t, 1, summary.PricedCount)
+	assert.Equal(t, 2, summary.UnpricedCount)
+	assert.Equal(t, 3, summary.FailedCount)
+	// Every usage-bearing row is in the row total, including the one whose model the
+	// provider never named — that usage has nowhere else to survive.
+	assert.Equal(t, 30, summary.Usage.PromptTokens)
+	assert.Equal(t, 15, summary.Usage.CompletionTokens)
+
+	// "" has no model at all, so it can never get a breakdown entry — its usage
+	// only survives in the aggregate unpriced blob. "unknown-model" is a known
+	// model that just failed to price, so it still gets an entry (Cost nil) next
+	// to the priced "gpt-4o-mini" one (Cost set) — that's what lets a later
+	// recalculation target exactly the models still needing a rate.
+	require.Len(t, summary.ModelBreakdowns, 2)
+	require.Contains(t, summary.ModelBreakdowns, "gpt-4o-mini")
+	require.NotNil(t, summary.ModelBreakdowns["gpt-4o-mini"].Cost)
+	assert.InDelta(t, 0.0001, *summary.ModelBreakdowns["gpt-4o-mini"].Cost, 1e-12)
+	require.Contains(t, summary.ModelBreakdowns, "unknown-model")
+	assert.Nil(t, summary.ModelBreakdowns["unknown-model"].Cost)
+	assert.Equal(t, 10, summary.ModelBreakdowns["unknown-model"].Usage.PromptTokens)
+
+	logEntry := store.logs[AccountingLogID(schemas.OpenAI, "batch_partial")]
+	require.NotNil(t, logEntry)
+	require.NotNil(t, logEntry.BatchDebugParsed)
+	require.NotNil(t, logEntry.BatchDebugParsed.Accounting)
+	assert.Nil(t, logEntry.Cost, "a partial total must not be persisted as the row's cost")
+	assert.True(t, logEntry.BatchDebugParsed.Accounting.Incomplete)
+	assert.Equal(t, 30, logEntry.PromptTokens)
+	assert.Equal(t, 15, logEntry.CompletionTokens)
+}
+
+type fakeBatchResultFetcher struct {
+	retrieveCalls int
+	resultsCalls  int
+	retrieveResp  *schemas.BifrostBatchRetrieveResponse
+	resultsResp   *schemas.BifrostBatchResultsResponse
+}
+
+func (f *fakeBatchResultFetcher) RetrieveBatch(ctx context.Context, job *cstables.TableBatchJob) (*schemas.BifrostBatchRetrieveResponse, error) {
+	f.retrieveCalls++
+	return f.retrieveResp, nil
+}
+
+func (f *fakeBatchResultFetcher) FetchBatchResults(ctx context.Context, job *cstables.TableBatchJob) (*schemas.BifrostBatchResultsResponse, error) {
+	f.resultsCalls++
+	return f.resultsResp, nil
+}
+
+type fakeKVStore struct {
+	setNXAllowed bool
+	setNXCalls   int
+	deleteCalls  int
+}
+
+func (s *fakeKVStore) Get(key string) (any, error) {
+	return nil, nil
+}
+
+func (s *fakeKVStore) SetWithTTL(key string, value any, ttl time.Duration) error {
+	return nil
+}
+
+func (s *fakeKVStore) SetNXWithTTL(key string, value any, ttl time.Duration) (bool, error) {
+	s.setNXCalls++
+	return s.setNXAllowed, nil
+}
+
+func (s *fakeKVStore) Delete(key string) (bool, error) {
+	s.deleteCalls++
+	return true, nil
+}
+
+func TestSweeper_AccountsCompletedOpenAIJob(t *testing.T) {
+	store := newFakeAccountingStore()
+	now := time.Now().UTC().Add(-time.Minute)
+	job := &cstables.TableBatchJob{
+		ID:               cstables.BatchJobID(string(schemas.OpenAI), "batch_sweep"),
+		Provider:         string(schemas.OpenAI),
+		BatchID:          "batch_sweep",
+		Model:            "gpt-4o-mini",
+		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		NextCheckAt:      &now,
+	}
+	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+
+	fetcher := &fakeBatchResultFetcher{
+		retrieveResp: &schemas.BifrostBatchRetrieveResponse{
+			ID:     "batch_sweep",
+			Status: schemas.BatchStatusCompleted,
+		},
+		resultsResp: &schemas.BifrostBatchResultsResponse{
+			BatchID: "batch_sweep",
+			Results: []schemas.BatchResultItem{
+				openAIResult(200, "gpt-4o-mini", 18, 9),
+			},
+		},
+	}
+	sweeper := NewSweeper(store, store, fakeBatchPricing{}, fetcher, nil, nil, SweeperConfig{
+		Provider: schemas.OpenAI,
+		Limit:    10,
+	})
+
+	sweeper.SweepOnce(context.Background())
+
+	assert.Equal(t, 1, fetcher.retrieveCalls)
+	assert.Equal(t, 1, fetcher.resultsCalls)
+	accounted := store.jobs[cstables.BatchJobID(string(schemas.OpenAI), "batch_sweep")]
+	require.NotNil(t, accounted)
+	assert.Equal(t, cstables.BatchJobAccountingStatusAccounted, accounted.AccountingStatus)
+	assert.Len(t, store.logs, 1)
+}
+
+func TestSweeper_AccountsCompletedAnthropicJob(t *testing.T) {
+	store := newFakeAccountingStore()
+	now := time.Now().UTC().Add(-time.Minute)
+	job := &cstables.TableBatchJob{
+		ID:               cstables.BatchJobID(string(schemas.Anthropic), "anthropic_sweep"),
+		Provider:         string(schemas.Anthropic),
+		BatchID:          "anthropic_sweep",
+		Model:            "claude-3-5-haiku",
+		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		NextCheckAt:      &now,
+	}
+	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+
+	fetcher := &fakeBatchResultFetcher{
+		retrieveResp: &schemas.BifrostBatchRetrieveResponse{
+			ID:     "anthropic_sweep",
+			Status: schemas.BatchStatusCompleted,
+		},
+		resultsResp: &schemas.BifrostBatchResultsResponse{
+			BatchID: "anthropic_sweep",
+			Results: []schemas.BatchResultItem{
+				anthropicResult("claude-3-5-haiku", 10, 0, 0, 5),
+			},
+		},
+	}
+	sweeper := NewSweeper(store, store, fakeBatchPricing{}, fetcher, nil, nil, SweeperConfig{
+		Limit: 10,
+	})
+
+	sweeper.SweepOnce(context.Background())
+
+	assert.Equal(t, 1, fetcher.retrieveCalls)
+	assert.Equal(t, 1, fetcher.resultsCalls)
+	accounted := store.jobs[cstables.BatchJobID(string(schemas.Anthropic), "anthropic_sweep")]
+	require.NotNil(t, accounted)
+	assert.Equal(t, cstables.BatchJobAccountingStatusAccounted, accounted.AccountingStatus)
+}
+
+func TestSweeper_AccountsCompletedGeminiJob(t *testing.T) {
+	store := newFakeAccountingStore()
+	now := time.Now().UTC().Add(-time.Minute)
+	job := &cstables.TableBatchJob{
+		ID:               cstables.BatchJobID(string(schemas.Gemini), "gemini_sweep"),
+		Provider:         string(schemas.Gemini),
+		BatchID:          "gemini_sweep",
+		Model:            "gemini-2.0-flash",
+		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		NextCheckAt:      &now,
+	}
+	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+
+	fetcher := &fakeBatchResultFetcher{
+		retrieveResp: &schemas.BifrostBatchRetrieveResponse{
+			ID:     "gemini_sweep",
+			Status: schemas.BatchStatusCompleted,
+		},
+		resultsResp: &schemas.BifrostBatchResultsResponse{
+			BatchID: "gemini_sweep",
+			Results: []schemas.BatchResultItem{
+				geminiResult(10, 5),
+			},
+		},
+	}
+	sweeper := NewSweeper(store, store, fakeBatchPricing{}, fetcher, nil, nil, SweeperConfig{
+		Limit: 10,
+	})
+
+	sweeper.SweepOnce(context.Background())
+
+	assert.Equal(t, 1, fetcher.retrieveCalls)
+	assert.Equal(t, 1, fetcher.resultsCalls)
+	accounted := store.jobs[cstables.BatchJobID(string(schemas.Gemini), "gemini_sweep")]
+	require.NotNil(t, accounted)
+	assert.Equal(t, cstables.BatchJobAccountingStatusAccounted, accounted.AccountingStatus)
+}
+
+func TestSweeper_SkipsProviderPollWhenKVLeaseIsHeld(t *testing.T) {
+	store := newFakeAccountingStore()
+	now := time.Now().UTC().Add(-time.Minute)
+	job := &cstables.TableBatchJob{
+		ID:               cstables.BatchJobID(string(schemas.OpenAI), "batch_sweep_lease"),
+		Provider:         string(schemas.OpenAI),
+		BatchID:          "batch_sweep_lease",
+		Model:            "gpt-4o-mini",
+		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		NextCheckAt:      &now,
+	}
+	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+
+	fetcher := &fakeBatchResultFetcher{}
+	kv := &fakeKVStore{setNXAllowed: false}
+	sweeper := NewSweeper(store, store, fakeBatchPricing{}, fetcher, nil, nil, SweeperConfig{
+		Provider: schemas.OpenAI,
+		Limit:    10,
+		KVStore:  kv,
+	})
+
+	sweeper.SweepOnce(context.Background())
+
+	assert.Equal(t, 1, kv.setNXCalls)
+	assert.Zero(t, kv.deleteCalls)
+	assert.Zero(t, fetcher.retrieveCalls)
+	assert.Zero(t, fetcher.resultsCalls)
+}
+
+func TestSweeper_ReleasesProviderPollLeaseAfterSuccessfulPoll(t *testing.T) {
+	store := newFakeAccountingStore()
+	now := time.Now().UTC().Add(-time.Minute)
+	job := &cstables.TableBatchJob{
+		ID:               cstables.BatchJobID(string(schemas.OpenAI), "batch_release_lease"),
+		Provider:         string(schemas.OpenAI),
+		BatchID:          "batch_release_lease",
+		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		NextCheckAt:      &now,
+	}
+	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+
+	fetcher := &fakeBatchResultFetcher{retrieveResp: &schemas.BifrostBatchRetrieveResponse{
+		ID:     job.BatchID,
+		Status: schemas.BatchStatusInProgress,
+	}}
+	kv := &fakeKVStore{setNXAllowed: true}
+	sweeper := NewSweeper(store, store, fakeBatchPricing{}, fetcher, nil, nil, SweeperConfig{
+		Provider: schemas.OpenAI,
+		Limit:    10,
+		KVStore:  kv,
+	})
+
+	sweeper.SweepOnce(context.Background())
+
+	assert.Equal(t, 1, kv.setNXCalls)
+	assert.Equal(t, 1, kv.deleteCalls)
+}
+
+func TestSweeper_RescheduleUsesBackoffAndJitter(t *testing.T) {
+	store := newFakeAccountingStore()
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	job := &cstables.TableBatchJob{
+		ID:               cstables.BatchJobID(string(schemas.OpenAI), "batch_backoff"),
+		Provider:         string(schemas.OpenAI),
+		BatchID:          "batch_backoff",
+		Model:            "gpt-4o-mini",
+		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		PollAttempts:     9,
+		NextCheckAt:      &now,
+	}
+	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+
+	fetcher := &fakeBatchResultFetcher{
+		retrieveResp: &schemas.BifrostBatchRetrieveResponse{
+			ID:     "batch_backoff",
+			Status: schemas.BatchStatusInProgress,
+		},
+	}
+	sweeper := NewSweeper(store, store, fakeBatchPricing{}, fetcher, nil, nil, SweeperConfig{
+		Interval: time.Minute,
+		Limit:    10,
+	})
+
+	sweeper.sweepJob(context.Background(), job, now)
+
+	updated := store.jobs[job.ID]
+	require.NotNil(t, updated)
+	assert.Equal(t, 10, updated.PollAttempts)
+	require.NotNil(t, updated.NextCheckAt)
+	assert.True(t, updated.NextCheckAt.After(now.Add(5*time.Minute-time.Second)))
+	assert.True(t, updated.NextCheckAt.Before(now.Add(6*time.Minute+time.Second)))
+}
+
+// An expired batch is not an empty one: the provider bills the requests that
+// finished before the window closed, and their rows are still in the output file.
+func TestSweeper_ExpiredBatchSettlesTheRowsThatCompleted(t *testing.T) {
+	store := newFakeAccountingStore()
+	due := time.Now().UTC().Add(-time.Minute)
+	jobID := cstables.BatchJobID(string(schemas.OpenAI), "batch_expired")
+	require.NoError(t, store.UpsertBatchJob(context.Background(), &cstables.TableBatchJob{
+		ID:               jobID,
+		Provider:         string(schemas.OpenAI),
+		BatchID:          "batch_expired",
+		Model:            "gpt-4o-mini",
+		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		NextCheckAt:      &due,
+	}))
+
+	fetcher := &fakeBatchResultFetcher{
+		retrieveResp: &schemas.BifrostBatchRetrieveResponse{
+			ID:     "batch_expired",
+			Status: schemas.BatchStatusExpired,
+		},
+		resultsResp: &schemas.BifrostBatchResultsResponse{
+			BatchID: "batch_expired",
+			Results: []schemas.BatchResultItem{openAIResult(200, "gpt-4o-mini", 18, 9)},
+		},
+	}
+	sweeper := NewSweeper(store, store, fakeBatchPricing{}, fetcher, nil, nil, SweeperConfig{Limit: 10})
+
+	sweeper.SweepOnce(context.Background())
+
+	assert.Equal(t, 1, fetcher.resultsCalls, "a terminal batch must still be asked for its results")
+	require.Len(t, store.logs, 1)
+	assert.Equal(t, cstables.BatchJobAccountingStatusAccounted, store.jobs[jobID].AccountingStatus)
+}
+
+// With nothing to fetch, the terminal batch ends where it always did.
+func TestSweeper_ExpiredBatchWithoutResultsIsTerminalWithoutResults(t *testing.T) {
+	store := newFakeAccountingStore()
+	due := time.Now().UTC().Add(-time.Minute)
+	jobID := cstables.BatchJobID(string(schemas.OpenAI), "batch_expired_empty")
+	require.NoError(t, store.UpsertBatchJob(context.Background(), &cstables.TableBatchJob{
+		ID:               jobID,
+		Provider:         string(schemas.OpenAI),
+		BatchID:          "batch_expired_empty",
+		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		NextCheckAt:      &due,
+	}))
+
+	fetcher := &fakeBatchResultFetcher{
+		retrieveResp: &schemas.BifrostBatchRetrieveResponse{
+			ID:     "batch_expired_empty",
+			Status: schemas.BatchStatusExpired,
+		},
+		resultsResp: &schemas.BifrostBatchResultsResponse{BatchID: "batch_expired_empty"},
+	}
+	sweeper := NewSweeper(store, store, fakeBatchPricing{}, fetcher, nil, nil, SweeperConfig{Limit: 10})
+
+	sweeper.SweepOnce(context.Background())
+
+	assert.Empty(t, store.logs)
+	job := store.jobs[jobID]
+	require.NotNil(t, job)
+	assert.Equal(t, cstables.BatchJobAccountingStatusUnpriceable, job.AccountingStatus)
+	require.NotNil(t, job.UnpriceableReason)
+	assert.Equal(t, "terminal_without_results", *job.UnpriceableReason)
+}
+
+// A deleted batch has nothing left to read, so it must not cost a provider call.
+func TestSweeper_DeletedBatchDoesNotFetchResults(t *testing.T) {
+	store := newFakeAccountingStore()
+	due := time.Now().UTC().Add(-time.Minute)
+	require.NoError(t, store.UpsertBatchJob(context.Background(), &cstables.TableBatchJob{
+		ID:               cstables.BatchJobID(string(schemas.OpenAI), "batch_deleted"),
+		Provider:         string(schemas.OpenAI),
+		BatchID:          "batch_deleted",
+		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		NextCheckAt:      &due,
+	}))
+
+	fetcher := &fakeBatchResultFetcher{retrieveResp: &schemas.BifrostBatchRetrieveResponse{
+		ID:     "batch_deleted",
+		Status: schemas.BatchStatusDeleted,
+	}}
+	sweeper := NewSweeper(store, store, fakeBatchPricing{}, fetcher, nil, nil, SweeperConfig{Limit: 10})
+
+	sweeper.SweepOnce(context.Background())
+
+	assert.Zero(t, fetcher.resultsCalls)
+}
+
+// A settlement that keeps failing used to re-download the whole results payload and
+// re-fail every sweep, forever: FailBatchJob left next_check_at in the past and never
+// advanced poll_attempts. It has to consume the same retry budget as any other failure.
+func TestSweeper_ReschedulesAfterSettlementFailure(t *testing.T) {
+	store := newFakeAccountingStore()
+	store.failCompleteAlways = true
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	jobID := cstables.BatchJobID(string(schemas.OpenAI), "batch_settle_fail")
+	job := &cstables.TableBatchJob{
+		ID:               jobID,
+		Provider:         string(schemas.OpenAI),
+		BatchID:          "batch_settle_fail",
+		Model:            "gpt-4o-mini",
+		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		PollAttempts:     9,
+		NextCheckAt:      &now,
+	}
+	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+
+	fetcher := &fakeBatchResultFetcher{
+		retrieveResp: &schemas.BifrostBatchRetrieveResponse{
+			ID:     "batch_settle_fail",
+			Status: schemas.BatchStatusCompleted,
+		},
+		resultsResp: &schemas.BifrostBatchResultsResponse{
+			BatchID: "batch_settle_fail",
+			Results: []schemas.BatchResultItem{openAIResult(200, "gpt-4o-mini", 18, 9)},
+		},
+	}
+	sweeper := NewSweeper(store, store, fakeBatchPricing{}, fetcher, nil, nil, SweeperConfig{
+		Interval: time.Minute,
+		Limit:    10,
+	})
+
+	sweeper.sweepJob(context.Background(), job, now)
+
+	updated := store.jobs[jobID]
+	require.NotNil(t, updated)
+	assert.Equal(t, 10, updated.PollAttempts, "an accounting failure must consume an attempt")
+	require.NotNil(t, updated.NextCheckAt)
+	assert.True(t, updated.NextCheckAt.After(now), "next_check_at must move forward, not stay past-due")
+}
+
+// The attempt cap is what eventually stops a settlement that can never succeed —
+// and it parks the job somewhere a later /results call can still re-drive it.
+func TestSweeper_SettlementFailureHitsPollAttemptCap(t *testing.T) {
+	store := newFakeAccountingStore()
+	store.failCompleteAlways = true
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	jobID := cstables.BatchJobID(string(schemas.OpenAI), "batch_settle_cap")
+	job := &cstables.TableBatchJob{
+		ID:               jobID,
+		Provider:         string(schemas.OpenAI),
+		BatchID:          "batch_settle_cap",
+		Model:            "gpt-4o-mini",
+		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		PollAttempts:     maxPollAttempts - 1,
+		NextCheckAt:      &now,
+	}
+	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+
+	fetcher := &fakeBatchResultFetcher{
+		retrieveResp: &schemas.BifrostBatchRetrieveResponse{
+			ID:     "batch_settle_cap",
+			Status: schemas.BatchStatusCompleted,
+		},
+		resultsResp: &schemas.BifrostBatchResultsResponse{
+			BatchID: "batch_settle_cap",
+			Results: []schemas.BatchResultItem{openAIResult(200, "gpt-4o-mini", 18, 9)},
+		},
+	}
+	sweeper := NewSweeper(store, store, fakeBatchPricing{}, fetcher, nil, nil, SweeperConfig{
+		Interval: time.Minute,
+		Limit:    10,
+	})
+
+	sweeper.sweepJob(context.Background(), job, now)
+
+	updated := store.jobs[jobID]
+	require.NotNil(t, updated)
+	assert.Equal(t, cstables.BatchJobAccountingStatusUnpriceable, updated.AccountingStatus)
+	require.NotNil(t, updated.UnpriceableReason)
+	assert.Equal(t, UnpriceableReasonMaxPollAttempts, *updated.UnpriceableReason)
+}
+
+func openAIResult(status int, model string, promptTokens int, completionTokens int) schemas.BatchResultItem {
+	return schemas.BatchResultItem{
+		CustomID: "custom-id",
+		Response: &schemas.BatchResultResponse{
+			StatusCode: status,
+			Body: map[string]interface{}{
+				"model": model,
+				"usage": map[string]interface{}{
+					"prompt_tokens":     promptTokens,
+					"completion_tokens": completionTokens,
+					"total_tokens":      promptTokens + completionTokens,
+				},
+			},
+		},
+	}
+}
+
+func anthropicResult(model string, inputTokens int, cacheReadTokens int, cacheWriteTokens int, outputTokens int) schemas.BatchResultItem {
+	return schemas.BatchResultItem{
+		CustomID: "custom-id",
+		Result: &schemas.BatchResultData{
+			Type: "succeeded",
+			Message: map[string]interface{}{
+				"model": model,
+				"usage": map[string]interface{}{
+					"input_tokens":                inputTokens,
+					"cache_read_input_tokens":     cacheReadTokens,
+					"cache_creation_input_tokens": cacheWriteTokens,
+					"output_tokens":               outputTokens,
+					"cache_creation":              map[string]interface{}{"ephemeral_5m_input_tokens": cacheWriteTokens},
+				},
+			},
+		},
+	}
+}
+
+func bedrockResult(model string, promptTokens int, completionTokens int) schemas.BatchResultItem {
+	body := map[string]interface{}{
+		"usage": map[string]interface{}{
+			"inputTokens":  promptTokens,
+			"outputTokens": completionTokens,
+			"totalTokens":  promptTokens + completionTokens,
+		},
+	}
+	if model != "" {
+		body["model"] = model
+	}
+	return schemas.BatchResultItem{
+		CustomID: "custom-id",
+		Response: &schemas.BatchResultResponse{
+			StatusCode: 200,
+			Body:       body,
+		},
+	}
+}
+
+func geminiResult(promptTokens int, completionTokens int) schemas.BatchResultItem {
+	return schemas.BatchResultItem{
+		CustomID: "custom-id",
+		Response: &schemas.BatchResultResponse{
+			StatusCode: 200,
+			Body: map[string]interface{}{
+				"usage": map[string]interface{}{
+					"prompt_tokens":     promptTokens,
+					"completion_tokens": completionTokens,
+					"total_tokens":      promptTokens + completionTokens,
+				},
+			},
+		},
+	}
+}
+
+func TestAccountBatchResults_ExternalBatchWithoutRow(t *testing.T) {
+	store := newFakeAccountingStore()
+	writer := &fakeAggregateLogWriter{}
+	reporter := &fakeUsageReporter{}
+
+	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, Request{
+		Provider:      schemas.OpenAI,
+		BatchID:       "ext-batch-no-job",
+		FallbackModel: "gpt-4o-mini",
+		Results: []schemas.BatchResultItem{
+			openAIResult(200, "gpt-4o-mini", 10, 5),
+		},
+		Emitter:       writer,
+		UsageReporter: reporter,
+		ClaimedBy:     "test",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.True(t, summary.Accounted)
+	assert.Greater(t, summary.Cost, 0.0)
+
+	jobID := cstables.BatchJobID(string(schemas.OpenAI), "ext-batch-no-job")
+	job, ok := store.jobs[jobID]
+	require.True(t, ok, "batch_jobs row should be created for externally-created batch")
+	assert.Equal(t, cstables.BatchJobAccountingStatusAccounted, job.AccountingStatus)
+}
+
+func TestAccountBatchResults_EmbeddingEndpointUsesEmbeddingPricing(t *testing.T) {
+	store := newFakeAccountingStore()
+	pricing := &requestTypePricing{}
+	summary, err := AccountBatchResults(context.Background(), store, store, pricing, Request{
+		Provider:      schemas.OpenAI,
+		BatchID:       "embedding-batch",
+		FallbackModel: "text-embedding-3-small",
+		Endpoint:      schemas.BatchEndpointEmbeddings,
+		Results: []schemas.BatchResultItem{
+			openAIResult(200, "text-embedding-3-small", 25, 0),
+		},
+		ClaimedBy: "test",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.True(t, summary.Accounted)
+	require.Equal(t, []schemas.RequestType{schemas.EmbeddingRequest}, pricing.requestTypes)
+
+	// The row's Object is "batch_results" for every batch, so the endpoint is the
+	// only thing that lets a later repricing pass reach these same embedding rates.
+	logged := store.logs[AccountingLogID(schemas.OpenAI, "embedding-batch")]
+	require.NotNil(t, logged)
+	require.NotNil(t, logged.BatchDebugParsed)
+	assert.Equal(t, string(schemas.BatchEndpointEmbeddings), logged.BatchDebugParsed.Endpoint)
+}
+
+// The two cache-token wire conventions must normalize to the same internal shape:
+// OpenAI/Gemini report cached input as a breakdown of an already-inclusive
+// prompt_tokens, while Anthropic/Bedrock report it exclusive of the base count.
+// Getting this wrong either double-counts prompt tokens or drops the cache discount.
+func TestUsageFromValue_CacheTokenConventions(t *testing.T) {
+	t.Run("openai cached_tokens is inclusive of prompt_tokens", func(t *testing.T) {
+		usage, err := usageFromValue(map[string]interface{}{
+			"prompt_tokens":         1000, // already includes the 400 cached
+			"completion_tokens":     50,
+			"total_tokens":          1050,
+			"prompt_tokens_details": map[string]interface{}{"cached_tokens": 400},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1000, usage.PromptTokens, "cached tokens must not be added again")
+		require.NotNil(t, usage.PromptTokensDetails, "cache details must be surfaced for the discount")
+		assert.Equal(t, 400, usage.PromptTokensDetails.CachedReadTokens)
+	})
+
+	t.Run("anthropic cache_read_input_tokens is exclusive of input_tokens", func(t *testing.T) {
+		usage, err := usageFromValue(map[string]interface{}{
+			"input_tokens":            600, // excludes the 400 cached
+			"output_tokens":           50,
+			"cache_read_input_tokens": 400,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1000, usage.PromptTokens, "exclusive cache tokens must be added in")
+		require.NotNil(t, usage.PromptTokensDetails)
+		assert.Equal(t, 400, usage.PromptTokensDetails.CachedReadTokens)
+	})
+}
+
+// When unpriced usage mixes a missing-model row with a known model, the row must
+// NOT be attributed to that known model: the logged usage is a blend, and naming
+// one model would let backfill price the orphan tokens as it.
+func TestAccountBatchResults_MixedMissingModelIsNotAttributed(t *testing.T) {
+	store := newFakeAccountingStore()
+
+	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, Request{
+		Provider: schemas.OpenAI,
+		BatchID:  "batch_mixed_unpriced",
+		Results: []schemas.BatchResultItem{
+			openAIResult(200, "", 10, 5),              // missing model: 15 tokens, unattributable
+			openAIResult(200, "unknown-model", 20, 8), // known model, no batch rates
+		},
+		ClaimedBy: "test",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.False(t, summary.Accounted)
+
+	require.Len(t, store.logs, 1, "the usage must still be logged")
+	logged := store.logs[AccountingLogID(schemas.OpenAI, "batch_mixed_unpriced")]
+	require.NotNil(t, logged)
+	assert.Nil(t, logged.Cost)
+	// Both rows' tokens are present, so the row cannot claim to be one model.
+	assert.Equal(t, 30, logged.PromptTokens)
+	assert.Equal(t, 13, logged.CompletionTokens)
+	assert.NotEqual(t, "unknown-model", logged.Model,
+		"usage blended with missing-model rows must not be attributed to the one known model")
+}
+
+// ClaimedBy becomes the runner id every ownership fence keys on, so two sweepers
+// that both omit it must not end up indistinguishable.
+func TestNewSweeperDefaultsToDistinctRunnerIDs(t *testing.T) {
+	store := newFakeAccountingStore()
+	cfg := SweeperConfig{Interval: time.Minute}
+
+	a := NewSweeper(store, store, fakeBatchPricing{}, &fakeBatchResultFetcher{}, nil, nil, cfg)
+	b := NewSweeper(store, store, fakeBatchPricing{}, &fakeBatchResultFetcher{}, nil, nil, cfg)
+
+	assert.NotEmpty(t, a.config.ClaimedBy)
+	assert.NotEqual(t, a.config.ClaimedBy, b.config.ClaimedBy,
+		"two sweepers defaulting ClaimedBy must not share a runner identity")
+
+	// An explicit id is still honored untouched.
+	explicit := NewSweeper(store, store, fakeBatchPricing{}, &fakeBatchResultFetcher{}, nil, nil,
+		SweeperConfig{Interval: time.Minute, ClaimedBy: "node-7"})
+	assert.Equal(t, "node-7", explicit.config.ClaimedBy)
+}
+
+// A failed refresh of the persisted job must fail closed: the markers it carries
+// are the only record of a partially-settled batch, so settling on top of unknown
+// markers could re-report usage that already landed.
+func TestAccountBatchResults_PersistedJobReadFailureFailsClosed(t *testing.T) {
+	store := newFakeAccountingStore()
+	reporter := &fakeUsageReporter{}
+	store.failGetOnce = true
+
+	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, Request{
+		Provider:      schemas.OpenAI,
+		BatchID:       "read-failure",
+		FallbackModel: "gpt-4o-mini",
+		Results: []schemas.BatchResultItem{
+			openAIResult(200, "gpt-4o-mini", 10, 5),
+		},
+		UsageReporter: reporter,
+		ClaimedBy:     "test",
+	})
+
+	require.Error(t, err, "a failed persisted-job read must surface, not be swallowed")
+	assert.Nil(t, summary)
+	assert.Empty(t, store.logs, "no aggregate log should be written")
+	assert.Empty(t, reporter.reports, "no usage should be reported")
+
+	// The claim is released so a later attempt can retry without waiting out the TTL.
+	job := store.jobs[cstables.BatchJobID(string(schemas.OpenAI), "read-failure")]
+	require.NotNil(t, job)
+	assert.Equal(t, cstables.BatchJobAccountingStatusError, job.AccountingStatus)
+	assert.Nil(t, job.RunnerID)
+}
+
+// A malformed row costs the batch that row, not every other row. The raw provider
+// results are not persisted anywhere else, so abandoning the batch on the first bad
+// JSONL line lost the parsed rows' money permanently.
+func TestAccountBatchResults_ParseErrorsStillPriceTheParsedRows(t *testing.T) {
+	store := newFakeAccountingStore()
+	reporter := &fakeUsageReporter{}
+	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, Request{
+		Provider:      schemas.OpenAI,
+		BatchID:       "malformed-results",
+		FallbackModel: "gpt-4o-mini",
+		Results: []schemas.BatchResultItem{
+			openAIResult(200, "gpt-4o-mini", 10, 5),
+			openAIResult(200, "gpt-4o-mini", 20, 4),
+		},
+		ParseErrors:   []schemas.BatchError{{Code: "parse_error", Message: "invalid JSONL"}},
+		UsageReporter: reporter,
+		ClaimedBy:     "test",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.True(t, summary.Accounted)
+	assert.Equal(t, 2, summary.PricedCount)
+	assert.Equal(t, 30, summary.Usage.PromptTokens)
+	assert.Equal(t, 9, summary.Usage.CompletionTokens)
+
+	job := store.jobs[cstables.BatchJobID(string(schemas.OpenAI), "malformed-results")]
+	require.NotNil(t, job)
+	assert.Equal(t, cstables.BatchJobAccountingStatusAccounted, job.AccountingStatus)
+
+	logged := store.logs[AccountingLogID(schemas.OpenAI, "malformed-results")]
+	require.NotNil(t, logged)
+	require.NotNil(t, logged.Cost)
+	assert.InDelta(t, 0.00024, *logged.Cost, 1e-12)
+	require.NotNil(t, logged.BatchDebugParsed)
+	require.NotNil(t, logged.BatchDebugParsed.Accounting)
+	// The count is the record of what the row omits; the marker says the total is
+	// short. Neither is recoverable — the unparsed rows are gone — so both are kept.
+	assert.Equal(t, 1, logged.BatchDebugParsed.Accounting.ParseErrorCount)
+	assert.True(t, logged.BatchDebugParsed.Accounting.Incomplete)
+
+	require.Len(t, reporter.reports, 1, "priced rows must still be billed")
+	assert.InDelta(t, 0.00024, reporter.reports[0].Cost, 1e-12)
+}
+
+// When the parse errors are the only thing that went wrong — nothing parsed at all —
+// they stay the reason the batch is unpriceable.
+func TestAccountBatchResults_AllRowsUnparseableMarksUnpriceable(t *testing.T) {
+	store := newFakeAccountingStore()
+	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, Request{
+		Provider:      schemas.OpenAI,
+		BatchID:       "all-malformed",
+		FallbackModel: "gpt-4o-mini",
+		ParseErrors: []schemas.BatchError{
+			{Code: "parse_error", Message: "invalid JSONL"},
+			{Code: "parse_error", Message: "invalid JSONL"},
+		},
+		ClaimedBy: "test",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.False(t, summary.Accounted)
+	assert.Equal(t, UnpriceableReasonResultParseErrors, summary.UnpriceableReason)
+	job := store.jobs[cstables.BatchJobID(string(schemas.OpenAI), "all-malformed")]
+	require.NotNil(t, job)
+	assert.Equal(t, cstables.BatchJobAccountingStatusUnpriceable, job.AccountingStatus)
+	require.NotNil(t, job.UnpriceableReason)
+	assert.Equal(t, UnpriceableReasonResultParseErrors, *job.UnpriceableReason)
+	assert.Empty(t, store.logs)
+}
+
+// Two models, one of them absent from the catalog: the row must carry the whole
+// batch's usage with an unknown cost, so the missing-cost backfill can still select
+// it, and governance must not be handed the half of the bill that did price.
+func TestAccountBatchResults_PartiallyPricedBatchKeepsCostUnknown(t *testing.T) {
+	store := newFakeAccountingStore()
+	reporter := &fakeUsageReporter{}
+
+	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, Request{
+		Provider: schemas.OpenAI,
+		BatchID:  "batch_half_priced",
+		Results: []schemas.BatchResultItem{
+			openAIResult(200, "gpt-4o-mini", 10, 5),
+			openAIResult(200, "unknown-model", 20, 8),
+		},
+		UsageReporter: reporter,
+		ClaimedBy:     "test",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.False(t, summary.Accounted)
+	assert.False(t, summary.Complete)
+	assert.Equal(t, UnpriceableReasonMissingBatchPricing, summary.UnpriceableReason)
+	assert.Empty(t, reporter.reports)
+
+	logged := store.logs[AccountingLogID(schemas.OpenAI, "batch_half_priced")]
+	require.NotNil(t, logged)
+	assert.Nil(t, logged.Cost, "cost must be unknown, not the priced half")
+	assert.Equal(t, 30, logged.PromptTokens, "the unpriced model's tokens belong in the row total")
+	assert.Equal(t, 13, logged.CompletionTokens)
+	require.NotNil(t, logged.BatchDebugParsed.Accounting)
+	assert.True(t, logged.BatchDebugParsed.Accounting.Incomplete)
+
+	// What did price is still recorded per model, so a recalculation only has to
+	// find the rate that was missing.
+	breakdowns := logged.BatchDebugParsed.Accounting.ModelBreakdowns
+	require.NotNil(t, breakdowns["gpt-4o-mini"].Cost)
+	assert.InDelta(t, 0.0001, *breakdowns["gpt-4o-mini"].Cost, 1e-12)
+	assert.Nil(t, breakdowns["unknown-model"].Cost)
+
+	// Parked, not closed: the job stops being polled but stays re-drivable.
+	job := store.jobs[cstables.BatchJobID(string(schemas.OpenAI), "batch_half_priced")]
+	require.NotNil(t, job)
+	assert.Equal(t, cstables.BatchJobAccountingStatusUnpriceable, job.AccountingStatus)
+	require.NotNil(t, job.UnpriceableReason)
+	assert.Equal(t, UnpriceableReasonMissingBatchPricing, *job.UnpriceableReason)
+}
+
+// The batch's create-time attribution is the one identity that does not depend on
+// who happens to settle first — a /results call by a different key must not move
+// the bill onto that key's budgets.
+func TestAccountBatchResults_PrefersBatchJobAttributionOverFetcher(t *testing.T) {
+	store := newFakeAccountingStore()
+	reporter := &fakeUsageReporter{}
+	creatorVK := "vk-creator"
+	creatorBudgets := `["budget-creator"]`
+	fetcherVK := "vk-fetcher"
+
+	job := &cstables.TableBatchJob{
+		ID:               cstables.BatchJobID(string(schemas.OpenAI), "batch_attribution"),
+		Provider:         string(schemas.OpenAI),
+		BatchID:          "batch_attribution",
+		Model:            "gpt-4o-mini",
+		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		SelectedKeyID:    "key-creator",
+		VirtualKeyID:     &creatorVK,
+		BudgetIDs:        &creatorBudgets,
+	}
+	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+
+	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, Request{
+		Provider:      schemas.OpenAI,
+		BatchID:       "batch_attribution",
+		FallbackModel: "gpt-4o-mini",
+		BatchJob:      job,
+		BaseLog: &logstore.Log{
+			ID:              "results-request",
+			SelectedKeyID:   "key-fetcher",
+			SelectedKeyName: "fetcher key",
+			VirtualKeyID:    &fetcherVK,
+			VirtualKeyName:  strPtr("fetcher vk"),
+			TeamID:          strPtr("team-fetcher"),
+			BudgetIDsParsed: []string{"budget-fetcher"},
+		},
+		Results:       []schemas.BatchResultItem{openAIResult(200, "gpt-4o-mini", 10, 5)},
+		UsageReporter: reporter,
+		ClaimedBy:     "test",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.True(t, summary.Accounted)
+
+	logged := store.logs[AccountingLogID(schemas.OpenAI, "batch_attribution")]
+	require.NotNil(t, logged)
+	assert.Equal(t, "key-creator", logged.SelectedKeyID)
+	require.NotNil(t, logged.VirtualKeyID)
+	assert.Equal(t, creatorVK, *logged.VirtualKeyID)
+	require.NotNil(t, logged.BudgetIDs)
+	assert.Equal(t, creatorBudgets, *logged.BudgetIDs)
+	assert.Empty(t, logged.BudgetIDsParsed, "the fetcher's budgets must not ride along")
+	// A mismatched virtual key means the fetcher's names describe a different
+	// identity, so they are left off rather than mixed into the creator's row.
+	assert.Nil(t, logged.VirtualKeyName)
+	assert.Nil(t, logged.TeamID)
+	// The triggering request is still recorded as provenance.
+	require.NotNil(t, logged.ParentRequestID)
+	assert.Equal(t, "results-request", *logged.ParentRequestID)
+
+	require.Len(t, reporter.reports, 1)
+	assert.Equal(t, []string{"budget-creator"}, reporter.reports[0].BudgetIDs)
+}
+
+// Same virtual key on both sides: the job still owns the billing ids, but the log
+// entry's denormalized names are safe to copy because they describe that same key.
+func TestAccountBatchResults_FillsNamesFromMatchingVirtualKey(t *testing.T) {
+	store := newFakeAccountingStore()
+	sharedVK := "vk-shared"
+
+	job := &cstables.TableBatchJob{
+		ID:               cstables.BatchJobID(string(schemas.OpenAI), "batch_same_vk"),
+		Provider:         string(schemas.OpenAI),
+		BatchID:          "batch_same_vk",
+		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		SelectedKeyID:    "key-1",
+		VirtualKeyID:     &sharedVK,
+	}
+	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+
+	_, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, Request{
+		Provider:      schemas.OpenAI,
+		BatchID:       "batch_same_vk",
+		FallbackModel: "gpt-4o-mini",
+		BatchJob:      job,
+		BaseLog: &logstore.Log{
+			ID:             "results-request",
+			VirtualKeyID:   &sharedVK,
+			VirtualKeyName: strPtr("shared vk"),
+			TeamID:         strPtr("team-1"),
+		},
+		Results:   []schemas.BatchResultItem{openAIResult(200, "gpt-4o-mini", 10, 5)},
+		ClaimedBy: "test",
+	})
+	require.NoError(t, err)
+
+	logged := store.logs[AccountingLogID(schemas.OpenAI, "batch_same_vk")]
+	require.NotNil(t, logged)
+	require.NotNil(t, logged.VirtualKeyName)
+	assert.Equal(t, "shared vk", *logged.VirtualKeyName)
+	require.NotNil(t, logged.TeamID)
+	assert.Equal(t, "team-1", *logged.TeamID)
+}
+
+// A batch created outside Bifrost has no create-time attribution to prefer, so the
+// /results caller's remains the only identity available — unchanged behavior.
+func TestAccountBatchResults_WithoutJobAttributionUsesBaseLog(t *testing.T) {
+	store := newFakeAccountingStore()
+	reporter := &fakeUsageReporter{}
+	fetcherVK := "vk-fetcher"
+
+	_, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, Request{
+		Provider:      schemas.OpenAI,
+		BatchID:       "batch_external",
+		FallbackModel: "gpt-4o-mini",
+		BaseLog: &logstore.Log{
+			ID:              "results-request",
+			SelectedKeyID:   "key-fetcher",
+			SelectedKeyName: "fetcher key",
+			VirtualKeyID:    &fetcherVK,
+			BudgetIDsParsed: []string{"budget-fetcher"},
+		},
+		Results:       []schemas.BatchResultItem{openAIResult(200, "gpt-4o-mini", 10, 5)},
+		UsageReporter: reporter,
+		ClaimedBy:     "test",
+	})
+	require.NoError(t, err)
+
+	logged := store.logs[AccountingLogID(schemas.OpenAI, "batch_external")]
+	require.NotNil(t, logged)
+	assert.Equal(t, "key-fetcher", logged.SelectedKeyID)
+	assert.Equal(t, "fetcher key", logged.SelectedKeyName)
+	require.NotNil(t, logged.VirtualKeyID)
+	assert.Equal(t, fetcherVK, *logged.VirtualKeyID)
+	require.Len(t, reporter.reports, 1)
+	assert.Equal(t, []string{"budget-fetcher"}, reporter.reports[0].BudgetIDs)
+}
+
+// "unpriceable" means stop polling, not refuse money. A caller arriving with real
+// results answers every reason the job reached that state, so it must be able to
+// re-drive it — otherwise a slow batch that outran the poll budget loses its bill
+// permanently.
+func TestAccountBatchResults_ReclaimsUnpriceableJobWhenResultsArrive(t *testing.T) {
+	store := newFakeAccountingStore()
+	jobID := cstables.BatchJobID(string(schemas.OpenAI), "batch_reclaim")
+	reason := UnpriceableReasonMaxPollAttempts
+	require.NoError(t, store.UpsertBatchJob(context.Background(), &cstables.TableBatchJob{
+		ID:                jobID,
+		Provider:          string(schemas.OpenAI),
+		BatchID:           "batch_reclaim",
+		Model:             "gpt-4o-mini",
+		AccountingStatus:  cstables.BatchJobAccountingStatusUnpriceable,
+		UnpriceableReason: &reason,
+	}))
+
+	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, Request{
+		Provider:      schemas.OpenAI,
+		BatchID:       "batch_reclaim",
+		FallbackModel: "gpt-4o-mini",
+		Results:       []schemas.BatchResultItem{openAIResult(200, "gpt-4o-mini", 10, 5)},
+		ClaimedBy:     "test",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.True(t, summary.Claimed)
+	assert.True(t, summary.Accounted)
+	assert.Equal(t, cstables.BatchJobAccountingStatusAccounted, store.jobs[jobID].AccountingStatus)
+	assert.Len(t, store.logs, 1)
+}
+
+// A losing claim against a job another runner is mid-settling (fresh claimed_at,
+// no aggregate row written yet) has nothing to mirror. The summary must come back
+// zero-valued rather than erroring, so a caller displays "not priced yet".
+func TestAccountBatchResults_LosingClaimWithNoExistingLogMirrorsNothing(t *testing.T) {
+	store := newFakeAccountingStore()
+	jobID := cstables.BatchJobID(string(schemas.OpenAI), "batch_in_flight")
+	now := time.Now().UTC()
+	store.jobs[jobID] = &cstables.TableBatchJob{
+		ID:               jobID,
+		Provider:         string(schemas.OpenAI),
+		BatchID:          "batch_in_flight",
+		Model:            "gpt-4o-mini",
+		AccountingStatus: cstables.BatchJobAccountingStatusProcessing,
+		RunnerID:         schemas.Ptr("other-node"),
+		ClaimedAt:        &now,
+	}
+
+	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, Request{
+		Provider:      schemas.OpenAI,
+		BatchID:       "batch_in_flight",
+		FallbackModel: "gpt-4o-mini",
+		Results:       []schemas.BatchResultItem{openAIResult(200, "gpt-4o-mini", 10, 5)},
+		ClaimedBy:     "test",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.False(t, summary.Claimed)
+	assert.Zero(t, summary.Cost)
+	assert.False(t, summary.Complete)
+	assert.Nil(t, summary.ModelBreakdowns)
+	assert.Empty(t, store.logs)
+}
+
+// The provider's batch lifecycle status flows onto the aggregate row at
+// settlement and is mirrored (not re-derived) on a repeat call that loses the
+// claim — the display must reflect what settlement actually observed, not
+// silently relabel it "completed" just because it settled.
+func TestAccountBatchResults_StatusPersistsAndMirrorsOnRepeatCall(t *testing.T) {
+	store := newFakeAccountingStore()
+	req := Request{
+		Provider:      schemas.OpenAI,
+		BatchID:       "batch_status",
+		FallbackModel: "gpt-4o-mini",
+		BatchJob: &cstables.TableBatchJob{
+			Provider:       string(schemas.OpenAI),
+			BatchID:        "batch_status",
+			Model:          "gpt-4o-mini",
+			ProviderStatus: string(schemas.BatchStatusEnded),
+		},
+		Results:   []schemas.BatchResultItem{openAIResult(200, "gpt-4o-mini", 10, 5)},
+		ClaimedBy: "test",
+	}
+
+	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, req)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.True(t, summary.Accounted)
+	assert.Equal(t, string(schemas.BatchStatusEnded), summary.Status)
+
+	logged := store.logs[AccountingLogID(schemas.OpenAI, "batch_status")]
+	require.NotNil(t, logged)
+	require.NotNil(t, logged.BatchDebugParsed)
+	assert.Equal(t, string(schemas.BatchStatusEnded), logged.BatchDebugParsed.Status)
+
+	// A repeat call loses the claim; it must mirror the persisted status rather
+	// than re-deriving it from this call's own (possibly different) BatchJob hint.
+	second, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, req)
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	assert.False(t, second.Claimed)
+	assert.Equal(t, string(schemas.BatchStatusEnded), second.Status)
+}
+
+// Without results there is nothing new to say about an unpriceable job, and an
+// accounted one is closed forever either way.
+func TestAccountBatchResults_TerminalJobsStayClosedWithoutResults(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status string
+	}{
+		{"unpriceable without results", cstables.BatchJobAccountingStatusUnpriceable},
+		{"accounted", cstables.BatchJobAccountingStatusAccounted},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newFakeAccountingStore()
+			jobID := cstables.BatchJobID(string(schemas.OpenAI), "batch_closed")
+			require.NoError(t, store.UpsertBatchJob(context.Background(), &cstables.TableBatchJob{
+				ID:               jobID,
+				Provider:         string(schemas.OpenAI),
+				BatchID:          "batch_closed",
+				AccountingStatus: tc.status,
+			}))
+
+			results := []schemas.BatchResultItem{openAIResult(200, "gpt-4o-mini", 10, 5)}
+			if tc.status == cstables.BatchJobAccountingStatusUnpriceable {
+				results = nil
+			}
+			summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, Request{
+				Provider:  schemas.OpenAI,
+				BatchID:   "batch_closed",
+				Results:   results,
+				ClaimedBy: "test",
+			})
+			require.NoError(t, err)
+			require.NotNil(t, summary)
+			assert.False(t, summary.Claimed)
+			assert.Empty(t, store.logs)
+		})
+	}
+}
+
+func strPtr(v string) *string {
+	return &v
+}

--- a/framework/batchaccounting/batchpricing_test.go
+++ b/framework/batchaccounting/batchpricing_test.go
@@ -1,0 +1,290 @@
+package batchaccounting
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	cstables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/logstore"
+	"github.com/maximhq/bifrost/framework/modelcatalog"
+	"github.com/maximhq/bifrost/framework/modelcatalog/datasheet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func loadPricingFromFile(t *testing.T) *modelcatalog.ModelCatalog {
+	t.Helper()
+	abs, err := filepath.Abs("testdata/pricing.json")
+	require.NoError(t, err, "resolve testdata/pricing.json path")
+	ds := datasheet.New(nil, bifrost.NewNoOpLogger(), datasheet.Config{URL: "file://" + abs})
+	require.NoError(t, ds.LoadFromURLIntoMemory(context.Background()), "failed to load pricing datasheet")
+	return modelcatalog.NewTestCatalogWithDatasheet(ds)
+}
+
+func assertSweeperAccountsBatchWithPricing(t *testing.T, mc *modelcatalog.ModelCatalog, job *cstables.TableBatchJob, results []schemas.BatchResultItem, expectedCost float64) {
+	t.Helper()
+	store := newFakeAccountingStore()
+	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+
+	fetcher := &fakeBatchResultFetcher{
+		retrieveResp: &schemas.BifrostBatchRetrieveResponse{
+			ID:     job.BatchID,
+			Status: schemas.BatchStatusCompleted,
+		},
+		resultsResp: &schemas.BifrostBatchResultsResponse{
+			BatchID: job.BatchID,
+			Results: results,
+		},
+	}
+	emitter := &fakeAggregateLogWriter{}
+	reporter := &fakeUsageReporter{}
+
+	kv := &fakeKVStore{setNXAllowed: true}
+	sweeper := NewSweeper(store, store, mc, fetcher, emitter, reporter, SweeperConfig{
+		Interval: time.Minute,
+		Limit:    10,
+		KVStore:  kv,
+	})
+
+	sweeper.SweepOnce(context.Background())
+
+	accounted := store.jobs[job.ID]
+	require.NotNil(t, accounted, "batch job should exist in store")
+	assert.Equal(t, cstables.BatchJobAccountingStatusAccounted, accounted.AccountingStatus,
+		"batch job should be accounted, got status=%s", accounted.AccountingStatus)
+
+	assert.Len(t, store.logs, 1, "one aggregate log should be written")
+	logEntry := store.logs[AccountingLogID(schemas.ModelProvider(job.Provider), job.BatchID)]
+	require.NotNil(t, logEntry, "aggregate log entry should exist")
+	require.NotNil(t, logEntry.Cost, "log entry should have a cost")
+	assert.InDelta(t, expectedCost, *logEntry.Cost, 1e-12,
+		"cost mismatch for %s/%s: expected %.12f got %.12f",
+		job.Provider, job.Model, expectedCost, *logEntry.Cost)
+
+	assert.Len(t, emitter.emitted, 1, "one emit should fire")
+	require.Len(t, reporter.reports, 1, "one governance report should fire")
+	assert.Equal(t, *logEntry.Cost, reporter.reports[0].Cost, "governance cost should match log cost")
+}
+
+func TestBatchPricing_ClaudeSonnet5_Anthropic(t *testing.T) {
+	mc := loadPricingFromFile(t)
+	now := time.Now().UTC().Add(-time.Minute)
+	job := &cstables.TableBatchJob{
+		ID:               cstables.BatchJobID(string(schemas.Anthropic), "batch_claude_sonnet_5"),
+		Provider:         string(schemas.Anthropic),
+		BatchID:          "batch_claude_sonnet_5",
+		Model:            "claude-sonnet-5",
+		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		NextCheckAt:      &now,
+	}
+	results := []schemas.BatchResultItem{
+		anthropicResult("claude-sonnet-5", 500, 0, 0, 200),
+	}
+	assertSweeperAccountsBatchWithPricing(t, mc, job, results, 500*1.5e-06+200*7.5e-06)
+}
+
+func TestBatchPricing_Gemini25Flash(t *testing.T) {
+	mc := loadPricingFromFile(t)
+	now := time.Now().UTC().Add(-time.Minute)
+	job := &cstables.TableBatchJob{
+		ID:               cstables.BatchJobID(string(schemas.Gemini), "batch_gemini_25_flash"),
+		Provider:         string(schemas.Gemini),
+		BatchID:          "batch_gemini_25_flash",
+		Model:            "gemini-2.5-flash",
+		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		NextCheckAt:      &now,
+	}
+	results := []schemas.BatchResultItem{
+		geminiResult(300, 150),
+	}
+	assertSweeperAccountsBatchWithPricing(t, mc, job, results, 300*1.5e-07+150*1.25e-06)
+}
+
+func TestBatchPricing_ClaudeSonnet46_Bedrock(t *testing.T) {
+	mc := loadPricingFromFile(t)
+	now := time.Now().UTC().Add(-time.Minute)
+	job := &cstables.TableBatchJob{
+		ID:               cstables.BatchJobID(string(schemas.Bedrock), "batch_claude_sonnet_46"),
+		Provider:         string(schemas.Bedrock),
+		BatchID:          "batch_claude_sonnet_46",
+		Model:            "anthropic.claude-sonnet-4-6",
+		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		NextCheckAt:      &now,
+	}
+	results := []schemas.BatchResultItem{
+		bedrockResult("anthropic.claude-sonnet-4-6", 400, 100),
+	}
+	assertSweeperAccountsBatchWithPricing(t, mc, job, results, 400*1.5e-06+100*7.5e-06)
+}
+
+func TestBatchPricing_GlobalClaudeSonnet46_Bedrock(t *testing.T) {
+	mc := loadPricingFromFile(t)
+	now := time.Now().UTC().Add(-time.Minute)
+	job := &cstables.TableBatchJob{
+		ID:               cstables.BatchJobID(string(schemas.Bedrock), "batch_global_claude_sonnet_46"),
+		Provider:         string(schemas.Bedrock),
+		BatchID:          "batch_global_claude_sonnet_46",
+		Model:            "global.anthropic.claude-sonnet-4-6",
+		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		NextCheckAt:      &now,
+	}
+	results := []schemas.BatchResultItem{
+		bedrockResult("global.anthropic.claude-sonnet-4-6", 250, 75),
+	}
+	assertSweeperAccountsBatchWithPricing(t, mc, job, results, 250*1.5e-06+75*7.5e-06)
+}
+
+// TestBatchPricing_ClaudeHaiku45_DefaultsToHalfStandardRate covers a model
+// with standard chat pricing (input_cost_per_token: 8e-07, output: 4e-06 in
+// testdata/pricing.json) but no batch-specific rate. Rather than going
+// unpriceable, it prices at defaultBatchPricingRatio (0.5) of the standard
+// rate: 100*4e-07 + 50*2e-06 = 0.00014.
+func TestBatchPricing_ClaudeHaiku45_DefaultsToHalfStandardRate(t *testing.T) {
+	mc := loadPricingFromFile(t)
+	now := time.Now().UTC().Add(-time.Minute)
+	job := &cstables.TableBatchJob{
+		ID:               cstables.BatchJobID(string(schemas.Anthropic), "batch_haiku_45"),
+		Provider:         string(schemas.Anthropic),
+		BatchID:          "batch_haiku_45",
+		Model:            "claude-haiku-4-5",
+		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		NextCheckAt:      &now,
+	}
+	results := []schemas.BatchResultItem{
+		anthropicResult("claude-haiku-4-5", 100, 0, 0, 50),
+	}
+	assertSweeperAccountsBatchWithPricing(t, mc, job, results, 100*4e-07+50*2e-06)
+}
+
+// TestBatchPricing_UnknownModel_StillUnpriceable covers a model with no
+// pricing at all — not even a standard rate to default 50% of — which must
+// still go unpriceable rather than silently pricing at zero.
+func TestBatchPricing_UnknownModel_StillUnpriceable(t *testing.T) {
+	mc := loadPricingFromFile(t)
+	now := time.Now().UTC().Add(-time.Minute)
+	job := &cstables.TableBatchJob{
+		ID:               cstables.BatchJobID(string(schemas.Anthropic), "batch_unknown_model"),
+		Provider:         string(schemas.Anthropic),
+		BatchID:          "batch_unknown_model",
+		Model:            "totally-unknown-model-xyz",
+		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		NextCheckAt:      &now,
+	}
+
+	store := newFakeAccountingStore()
+	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+
+	fetcher := &fakeBatchResultFetcher{
+		retrieveResp: &schemas.BifrostBatchRetrieveResponse{
+			ID:     "batch_unknown_model",
+			Status: schemas.BatchStatusCompleted,
+		},
+		resultsResp: &schemas.BifrostBatchResultsResponse{
+			BatchID: "batch_unknown_model",
+			Results: []schemas.BatchResultItem{
+				anthropicResult("totally-unknown-model-xyz", 100, 0, 0, 50),
+			},
+		},
+	}
+
+	kv := &fakeKVStore{setNXAllowed: true}
+	sweeper := NewSweeper(store, store, mc, fetcher, nil, nil, SweeperConfig{
+		Interval: time.Minute,
+		Limit:    10,
+		KVStore:  kv,
+	})
+
+	sweeper.SweepOnce(context.Background())
+
+	unpriced := store.jobs[job.ID]
+	require.NotNil(t, unpriced)
+	assert.Equal(t, cstables.BatchJobAccountingStatusUnpriceable, unpriced.AccountingStatus,
+		"batch with no pricing at all should be marked unpriceable")
+	require.NotNil(t, unpriced.UnpriceableReason)
+	assert.Equal(t, UnpriceableReasonMissingBatchPricing, *unpriced.UnpriceableReason,
+		"reason should be missing_batch_pricing")
+
+	// The batch really ran and consumed tokens; we just have no pricing for the
+	// model at all. The row is still written with an unknown cost so the usage is
+	// not lost and the missing-cost backfill can price it once rates land — the
+	// same treatment a synchronous call gets.
+	require.Len(t, store.logs, 1, "an unpriceable batch with real usage must still be logged")
+	var logged *logstore.Log
+	for _, entry := range store.logs {
+		logged = entry
+	}
+	require.NotNil(t, logged)
+	assert.Nil(t, logged.Cost, "cost must be unknown (nil), not zero")
+	assert.Equal(t, "totally-unknown-model-xyz", logged.Model,
+		"row must stay attributable to its model so backfill can resolve it")
+	assert.Equal(t, 100, logged.PromptTokens, "usage must be preserved for later recalculation")
+	assert.Equal(t, 50, logged.CompletionTokens)
+	assert.Equal(t, 150, logged.TotalTokens)
+}
+
+func TestBatchPricing_MultiModel(t *testing.T) {
+	mc := loadPricingFromFile(t)
+	now := time.Now().UTC().Add(-time.Minute)
+	job := &cstables.TableBatchJob{
+		ID:               cstables.BatchJobID(string(schemas.Bedrock), "batch_multimodel"),
+		Provider:         string(schemas.Bedrock),
+		BatchID:          "batch_multimodel",
+		Model:            "anthropic.claude-sonnet-4-6",
+		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		NextCheckAt:      &now,
+	}
+
+	store := newFakeAccountingStore()
+	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+
+	fetcher := &fakeBatchResultFetcher{
+		retrieveResp: &schemas.BifrostBatchRetrieveResponse{
+			ID:     "batch_multimodel",
+			Status: schemas.BatchStatusCompleted,
+		},
+		resultsResp: &schemas.BifrostBatchResultsResponse{
+			BatchID: "batch_multimodel",
+			Results: []schemas.BatchResultItem{
+				bedrockResult("anthropic.claude-sonnet-4-6", 200, 50),
+				bedrockResult("global.anthropic.claude-sonnet-4-6", 150, 30),
+			},
+		},
+	}
+
+	kv := &fakeKVStore{setNXAllowed: true}
+	sweeper := NewSweeper(store, store, mc, fetcher, nil, nil, SweeperConfig{
+		Interval: time.Minute,
+		Limit:    10,
+		KVStore:  kv,
+	})
+
+	sweeper.SweepOnce(context.Background())
+
+	accounted := store.jobs[job.ID]
+	require.NotNil(t, accounted)
+	assert.Equal(t, cstables.BatchJobAccountingStatusAccounted, accounted.AccountingStatus)
+
+	require.Len(t, store.logs, 1)
+	logEntry := store.logs[AccountingLogID(schemas.Bedrock, "batch_multimodel")]
+	require.NotNil(t, logEntry)
+	require.NotNil(t, logEntry.Cost, "accounted batch should have a cost")
+
+	expectedCost := (200+150)*1.5e-06 + (50+30)*7.5e-06
+	assert.InDelta(t, expectedCost, *logEntry.Cost, 1e-12)
+	assert.Equal(t, "mixed", logEntry.Model, "mixed-model batch should have model='mixed'")
+
+	require.NotNil(t, logEntry.BatchDebugParsed)
+	require.NotNil(t, logEntry.BatchDebugParsed.Accounting)
+	breakdown := logEntry.BatchDebugParsed.Accounting.ModelBreakdowns
+	require.Contains(t, breakdown, "anthropic.claude-sonnet-4-6")
+	require.Contains(t, breakdown, "global.anthropic.claude-sonnet-4-6")
+
+	require.NotNil(t, breakdown["anthropic.claude-sonnet-4-6"].Cost)
+	assert.InDelta(t, 200*1.5e-06+50*7.5e-06, *breakdown["anthropic.claude-sonnet-4-6"].Cost, 1e-12)
+	require.NotNil(t, breakdown["global.anthropic.claude-sonnet-4-6"].Cost)
+	assert.InDelta(t, 150*1.5e-06+30*7.5e-06, *breakdown["global.anthropic.claude-sonnet-4-6"].Cost, 1e-12)
+}

--- a/framework/batchaccounting/doc.go
+++ b/framework/batchaccounting/doc.go
@@ -1,0 +1,70 @@
+// Package batchaccounting settles usage and cost for provider batch jobs after
+// they complete, out of band from the original request.
+//
+// # Two stores, by design
+//
+// A batch job's lifecycle is split across two stores whose lifecycles are
+// deliberately opposite:
+//
+//   - Coordination state (BatchJobStore, backed by the config store) is a mutable
+//     state machine — pending → processing → accounted/unpriceable/error — that is
+//     UPDATE-d in place many times (poll rescheduling, ownership claims, settlement
+//     markers). It belongs in the relational config store alongside the sidekiq and
+//     dlock tables, not in the append-only log store (whose ClickHouse backend is a
+//     poor fit for in-place mutation).
+//   - The cost record (AggregateLogStore, backed by the log store) is written once,
+//     append-only, as a single aggregate row in the logs table — the durable
+//     financial artifact, sitting next to every other request cost row.
+//
+// Because the two stores may be different physical databases, the aggregate-log
+// write and the state markers are not transactional together; idempotency instead
+// relies on CreateIfNotExists plus the AggregateLogWrittenAt / GovernanceReportedAt
+// markers, so a retry after a partial settlement resumes rather than redoing work.
+//
+// # Settlement is at-least-once, not exactly-once
+//
+// The aggregate cost log is genuinely idempotent: CreateIfNotExists keys on a
+// deterministic id, so replaying it is a no-op.
+//
+// Governance reporting is not, and the gap is deliberate. If ReportBatchUsage
+// succeeds but the GovernanceReportedAt marker write then fails, the job is left
+// retryable with the report already applied. Two things narrow this, neither
+// closes it:
+//
+//   - The reporter is expected to dedupe on BatchUsageReport.RequestID (a stable
+//     per-batch id). The governance plugin does, but only within one process.
+//   - Governance budget bumps are in-memory deltas flushed periodically, so a
+//     crash inside the window usually loses the bump too, making the replay a
+//     correction rather than a double-count.
+//
+// The uncovered case is a marker failure WITHOUT a crash: the original node
+// flushes its delta, and a later sweep on a DIFFERENT node retries with an empty
+// dedupe set, double-counting that batch against one budget. This is accepted:
+// the window requires a marker write to fail, the impact is bounded to one
+// batch, and the synchronous request path alongside it is strictly less durable
+// (it has no marker at all and simply under-counts on any crash). Closing it
+// properly needs either a durable dedupe key persisted with the usage mutation,
+// or marker-before-bump ordering (which trades double-count for under-count).
+//
+// Governance sees a batch's usage only at settlement: cost recalculation is
+// reporting-only and never re-reports to budgets, the same platform-wide invariant
+// that holds for recalculating any ordinary request row.
+//
+// # Ownership fencing
+//
+// Delayed accounting can run concurrently across nodes (the sweeper on one node,
+// a user-triggered /results call on another). ClaimBatchJob transitions a job to
+// "processing" under a runner id; every subsequent advance/complete is fenced on
+// that runner id, and a job stuck in "processing" past a stale threshold can be
+// re-claimed. This mirrors the sidekiq job runner rather than using a separate
+// claim token.
+//
+// # Entry points
+//
+//   - AccountBatchResults settles one completed batch: claim → price → write the
+//     aggregate cost log → report governance usage → complete. It is idempotent and
+//     safe to call from both the sweeper and request post-hooks.
+//   - Sweeper polls due jobs (ListDueBatchJobs), retrieves provider status, and
+//     invokes AccountBatchResults once a batch completes, rescheduling with capped
+//     retries and deterministic backoff/jitter until then.
+package batchaccounting

--- a/framework/batchaccounting/sweeper.go
+++ b/framework/batchaccounting/sweeper.go
@@ -1,0 +1,394 @@
+package batchaccounting
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"hash/fnv"
+	"strconv"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	cstables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/modelcatalog"
+)
+
+const (
+	defaultSweepInterval = time.Minute
+	defaultSweepLimit    = 50
+	defaultKVLeaseTTL    = 5 * time.Minute
+	maxPollAttempts      = 120
+	// defaultProviderPollTimeout bounds a single provider call. The sweep is
+	// serial, so without it one hung provider stalls every remaining due job
+	// indefinitely — the sweeper's context is long-lived and has no deadline of its
+	// own. Sized to the KV poll lease: past that window another worker may take the
+	// job anyway, so there is nothing to gain by waiting longer. Generous enough for
+	// a large results download.
+	defaultProviderPollTimeout = 5 * time.Minute
+)
+
+type SweepStore interface {
+	BatchJobStore
+	ListDueBatchJobs(ctx context.Context, provider string, now time.Time, limit int) ([]*cstables.TableBatchJob, error)
+}
+
+type BatchResultFetcher interface {
+	RetrieveBatch(ctx context.Context, job *cstables.TableBatchJob) (*schemas.BifrostBatchRetrieveResponse, error)
+	FetchBatchResults(ctx context.Context, job *cstables.TableBatchJob) (*schemas.BifrostBatchResultsResponse, error)
+}
+
+type SweeperConfig struct {
+	Interval   time.Duration
+	Limit      int
+	ClaimedBy  string
+	Provider   schemas.ModelProvider
+	Scopes     *modelcatalog.PricingLookupScopes
+	KVStore    schemas.KVStore
+	KVLeaseTTL time.Duration
+	Logger     schemas.Logger
+}
+
+type Sweeper struct {
+	store         SweepStore
+	logStore      AggregateLogStore
+	pricing       PricingManager
+	fetcher       BatchResultFetcher
+	emitter       AggregateLogEmitter
+	usageReporter UsageReporter
+	config        SweeperConfig
+}
+
+func NewSweeper(store SweepStore, logStore AggregateLogStore, pricing PricingManager, fetcher BatchResultFetcher, emitter AggregateLogEmitter, usageReporter UsageReporter, config SweeperConfig) *Sweeper {
+	if config.Interval <= 0 {
+		config.Interval = defaultSweepInterval
+	}
+	if config.Limit <= 0 {
+		config.Limit = defaultSweepLimit
+	}
+	if config.ClaimedBy == "" {
+		// Never default to a bare constant: ClaimedBy becomes the runner id that
+		// ClaimBatchJob and every ownership fence key on, so two sweepers sharing a
+		// database and a default would be indistinguishable — each able to advance
+		// the other's in-flight job. Callers should pass a stable per-node id; if
+		// they don't, a per-instance id at least keeps the fence meaningful.
+		config.ClaimedBy = "batch-sweeper:" + newSweeperInstanceID()
+	}
+	if config.KVLeaseTTL <= 0 {
+		config.KVLeaseTTL = defaultKVLeaseTTL
+	}
+	return &Sweeper{
+		store:         store,
+		logStore:      logStore,
+		pricing:       pricing,
+		fetcher:       fetcher,
+		emitter:       emitter,
+		usageReporter: usageReporter,
+		config:        config,
+	}
+}
+
+// retrieveBatch and fetchBatchResults wrap the provider calls in a bounded context.
+// The sweep is serial and the sweeper's own context is long-lived with no deadline,
+// so an unbounded provider call would stall every remaining due job. The timeout is
+// derived from the parent, so shutdown cancellation still propagates.
+func (s *Sweeper) retrieveBatch(ctx context.Context, job *cstables.TableBatchJob) (*schemas.BifrostBatchRetrieveResponse, error) {
+	callCtx, cancel := context.WithTimeout(ctx, defaultProviderPollTimeout)
+	defer cancel()
+	return s.fetcher.RetrieveBatch(callCtx, job)
+}
+
+func (s *Sweeper) fetchBatchResults(ctx context.Context, job *cstables.TableBatchJob) (*schemas.BifrostBatchResultsResponse, error) {
+	callCtx, cancel := context.WithTimeout(ctx, defaultProviderPollTimeout)
+	defer cancel()
+	return s.fetcher.FetchBatchResults(callCtx, job)
+}
+
+// newSweeperInstanceID returns a random id distinguishing this sweeper from any
+// other sharing the same database. Random rather than PID-based: sweepers on
+// different hosts can share a PID, and this value is what keeps their claims apart.
+func newSweeperInstanceID() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return strconv.FormatInt(time.Now().UnixNano(), 36)
+	}
+	return hex.EncodeToString(b[:])
+}
+
+func (s *Sweeper) Run(ctx context.Context) {
+	if s == nil {
+		return
+	}
+	ticker := time.NewTicker(s.config.Interval)
+	defer ticker.Stop()
+	for {
+		s.SweepOnce(ctx)
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func (s *Sweeper) SweepOnce(ctx context.Context) {
+	if s == nil || s.store == nil || s.logStore == nil || s.pricing == nil || s.fetcher == nil {
+		return
+	}
+	now := time.Now().UTC()
+	jobs, err := s.store.ListDueBatchJobs(ctx, string(s.config.Provider), now, s.config.Limit)
+	if err != nil {
+		s.warn("batch accounting sweeper failed to find due jobs: %v", err)
+		return
+	}
+	for _, job := range jobs {
+		// Stop promptly on shutdown rather than working through the remaining
+		// jobs firing provider calls that are already doomed to fail.
+		if ctx.Err() != nil {
+			return
+		}
+		s.sweepJob(ctx, job, now)
+	}
+}
+
+func (s *Sweeper) sweepJob(ctx context.Context, job *cstables.TableBatchJob, now time.Time) {
+	if job == nil || !IsProviderSupported(schemas.ModelProvider(job.Provider)) {
+		return
+	}
+	locked, err := s.acquireProviderPollLease(job)
+	if err != nil {
+		s.warn("batch accounting sweeper failed to acquire poll lease provider=%s batch_id=%s job_id=%s: %v", job.Provider, job.BatchID, job.ID, err)
+		return
+	}
+	if !locked {
+		return
+	}
+	defer s.deletePollLease(job)
+	retrieved, err := s.retrieveBatch(ctx, job)
+	if err != nil || retrieved == nil {
+		if err != nil {
+			s.warn("batch accounting sweeper retrieve failed provider=%s batch_id=%s job_id=%s: %v", job.Provider, job.BatchID, job.ID, err)
+		} else {
+			s.warn("batch accounting sweeper retrieve returned nil response provider=%s batch_id=%s job_id=%s", job.Provider, job.BatchID, job.ID)
+		}
+		s.reschedule(ctx, job, now)
+		return
+	}
+	if retrieved.ID != "" && retrieved.ID != job.BatchID {
+		s.warn("batch accounting sweeper retrieve returned mismatched batch id job_id=%s", job.ID)
+		s.reschedule(ctx, job, now)
+		return
+	}
+	latest := batchJobFromRetrieve(job, retrieved)
+	if err := s.store.UpsertBatchJob(ctx, latest); err != nil {
+		s.warn("batch accounting sweeper failed to upsert retrieved batch provider=%s batch_id=%s job_id=%s: %v", latest.Provider, latest.BatchID, latest.ID, err)
+		return
+	}
+	if retrieved.Status != schemas.BatchStatusCompleted && retrieved.Status != schemas.BatchStatusEnded {
+		if isTerminalStatus(retrieved.Status) {
+			// An expired or cancelled batch is not an empty one: the provider bills the
+			// requests that did finish before the window closed, and their rows are in
+			// the output file. Treating the status alone as "no results" silently threw
+			// that usage away. Try the fetch, settle whatever came back, and only fall
+			// through to the give-up path when there is genuinely nothing to price.
+			if terminalMayHaveResults(retrieved.Status, latest) {
+				if results, ok := s.fetchResultsForSettlement(ctx, latest); ok && len(results.Results) > 0 {
+					s.settle(ctx, latest, retrieved, results, now)
+					return
+				}
+			}
+			s.markTerminalWithoutResults(ctx, latest)
+			return
+		}
+		s.reschedule(ctx, latest, now)
+		return
+	}
+
+	results, ok := s.fetchResultsForSettlement(ctx, latest)
+	if !ok {
+		s.reschedule(ctx, latest, now)
+		return
+	}
+	s.settle(ctx, latest, retrieved, results, now)
+}
+
+// terminalMayHaveResults reports whether a terminal provider status can still have
+// completed rows worth fetching. Expired and cancelled batches keep the rows that
+// finished; a failed batch only has an output file when the provider says so; a
+// deleted batch has nothing left to read.
+func terminalMayHaveResults(status schemas.BatchStatus, job *cstables.TableBatchJob) bool {
+	switch status {
+	case schemas.BatchStatusExpired, schemas.BatchStatusCancelled:
+		return true
+	case schemas.BatchStatusFailed:
+		return (job.OutputFileID != nil && *job.OutputFileID != "") || (job.ResultsURL != nil && *job.ResultsURL != "")
+	default:
+		return false
+	}
+}
+
+// fetchResultsForSettlement returns the batch's results, or ok=false when they
+// could not be obtained. What that means is the caller's to decide: a live batch
+// retries later, a terminal one gives up.
+func (s *Sweeper) fetchResultsForSettlement(ctx context.Context, job *cstables.TableBatchJob) (*schemas.BifrostBatchResultsResponse, bool) {
+	results, err := s.fetchBatchResults(ctx, job)
+	if err != nil || results == nil {
+		if err != nil {
+			s.warn("batch accounting sweeper results fetch failed provider=%s batch_id=%s job_id=%s: %v", job.Provider, job.BatchID, job.ID, err)
+		} else {
+			s.warn("batch accounting sweeper results fetch returned no response provider=%s batch_id=%s job_id=%s", job.Provider, job.BatchID, job.ID)
+		}
+		return nil, false
+	}
+	if results.BatchID != "" && results.BatchID != job.BatchID {
+		s.warn("batch accounting sweeper results returned mismatched batch id job_id=%s", job.ID)
+		return nil, false
+	}
+	return results, true
+}
+
+func (s *Sweeper) settle(ctx context.Context, latest *cstables.TableBatchJob, retrieved *schemas.BifrostBatchRetrieveResponse, results *schemas.BifrostBatchResultsResponse, now time.Time) {
+	endpoint := schemas.BatchEndpoint(latest.Endpoint)
+	if results.Endpoint != "" {
+		endpoint = results.Endpoint
+	}
+	if _, err := AccountBatchResults(ctx, s.store, s.logStore, s.pricing, Request{
+		Provider:      schemas.ModelProvider(latest.Provider),
+		BatchID:       latest.BatchID,
+		FallbackModel: latest.Model,
+		Endpoint:      endpoint,
+		Results:       results.Results,
+		ParseErrors:   results.ExtraFields.ParseErrors,
+		RequestCounts: &retrieved.RequestCounts,
+		BatchJob:      latest,
+		Emitter:       s.emitter,
+		UsageReporter: s.usageReporter,
+		ClaimedBy:     s.config.ClaimedBy,
+		Scopes:        s.config.Scopes,
+		Now:           now,
+	}); err != nil {
+		s.warn("batch accounting sweeper accounting failed provider=%s batch_id=%s job_id=%s: %v", latest.Provider, latest.BatchID, latest.ID, err)
+		// Settlement failures were the one retry path with no budget: next_check_at
+		// stayed in the past and poll_attempts never moved, so every sweep re-downloaded
+		// the entire results payload and re-failed, forever. Reschedule like any other
+		// retry so backoff, jitter, and the attempt cap apply here too.
+		s.reschedule(ctx, latest, now)
+	}
+}
+
+func (s *Sweeper) reschedule(ctx context.Context, job *cstables.TableBatchJob, now time.Time) {
+	job.PollAttempts++
+	if job.PollAttempts >= maxPollAttempts {
+		s.markTerminalAsUnpriceable(ctx, job, UnpriceableReasonMaxPollAttempts)
+		return
+	}
+	next := s.nextCheckAt(job, now)
+	job.NextCheckAt = &next
+	if err := s.store.UpsertBatchJob(ctx, job); err != nil {
+		s.warn("batch accounting sweeper failed to reschedule provider=%s batch_id=%s job_id=%s: %v", job.Provider, job.BatchID, job.ID, err)
+		return
+	}
+}
+
+func (s *Sweeper) markTerminalAsUnpriceable(ctx context.Context, job *cstables.TableBatchJob, reason string) {
+	runnerID := s.config.ClaimedBy
+	// allowUnpriceable=false: this path is giving up on a job, not settling one, so
+	// it has no business re-opening one that already reached that state.
+	claimed, err := s.store.ClaimBatchJob(ctx, job.ID, runnerID, time.Now().UTC().Add(-defaultClaimTTL), false)
+	if err != nil || !claimed {
+		if err != nil {
+			s.warn("batch accounting sweeper failed to claim for unpriceable provider=%s batch_id=%s job_id=%s reason=%s: %v", job.Provider, job.BatchID, job.ID, reason, err)
+		}
+		return
+	}
+	if err := s.store.MarkBatchJobUnpriceable(ctx, job.ID, runnerID, reason, nil); err != nil {
+		s.warn("batch accounting sweeper failed to mark unpriceable batch provider=%s batch_id=%s job_id=%s reason=%s: %v", job.Provider, job.BatchID, job.ID, reason, err)
+	}
+}
+
+func (s *Sweeper) markTerminalWithoutResults(ctx context.Context, job *cstables.TableBatchJob) {
+	s.markTerminalAsUnpriceable(ctx, job, "terminal_without_results")
+}
+
+func batchJobFromRetrieve(existing *cstables.TableBatchJob, retrieved *schemas.BifrostBatchRetrieveResponse) *cstables.TableBatchJob {
+	job := *existing
+	job.ProviderStatus = string(retrieved.Status)
+	if retrieved.Endpoint != "" {
+		job.Endpoint = retrieved.Endpoint
+	}
+	job.InputFileID = retrieved.InputFileID
+	job.OutputFileID = retrieved.OutputFileID
+	job.ErrorFileID = retrieved.ErrorFileID
+	job.ResultsURL = retrieved.ResultsURL
+	return &job
+}
+
+func isTerminalStatus(status schemas.BatchStatus) bool {
+	switch status {
+	case schemas.BatchStatusCompleted, schemas.BatchStatusFailed, schemas.BatchStatusExpired, schemas.BatchStatusCancelled, schemas.BatchStatusEnded, schemas.BatchStatusDeleted:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *Sweeper) acquireProviderPollLease(job *cstables.TableBatchJob) (bool, error) {
+	if s.config.KVStore == nil {
+		return true, nil
+	}
+	key := fmt.Sprintf("batch-accounting:poll:%s:%s", job.Provider, job.BatchID)
+	value := map[string]string{
+		"claimed_by": s.config.ClaimedBy,
+		"job_id":     job.ID,
+	}
+	return s.config.KVStore.SetNXWithTTL(key, value, s.config.KVLeaseTTL)
+}
+
+func (s *Sweeper) deletePollLease(job *cstables.TableBatchJob) {
+	if s.config.KVStore == nil {
+		return
+	}
+	key := fmt.Sprintf("batch-accounting:poll:%s:%s", job.Provider, job.BatchID)
+	if _, err := s.config.KVStore.Delete(key); err != nil {
+		s.warn("batch accounting sweeper failed to release poll lease provider=%s batch_id=%s job_id=%s: %v", job.Provider, job.BatchID, job.ID, err)
+	}
+}
+
+func (s *Sweeper) nextCheckAt(job *cstables.TableBatchJob, now time.Time) time.Time {
+	delay := s.config.Interval
+	switch {
+	case job.PollAttempts >= 30:
+		delay = maxDuration(delay, 15*time.Minute)
+	case job.PollAttempts >= 10:
+		delay = maxDuration(delay, 5*time.Minute)
+	case job.PollAttempts >= 5:
+		delay = maxDuration(delay, 2*time.Minute)
+	}
+	return now.Add(delay + deterministicJitter(job.ID, job.PollAttempts, delay))
+}
+
+func deterministicJitter(jobID string, attempts int, delay time.Duration) time.Duration {
+	if delay <= 0 {
+		return 0
+	}
+	jitterCap := min(time.Minute, delay/5)
+	if jitterCap <= 0 {
+		return 0
+	}
+	h := fnv.New32a()
+	_, _ = fmt.Fprintf(h, "%s:%d", jobID, attempts)
+	return time.Duration(h.Sum32()%uint32(jitterCap/time.Second+1)) * time.Second
+}
+
+func maxDuration(a, b time.Duration) time.Duration {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func (s *Sweeper) warn(msg string, args ...any) {
+	if s.config.Logger != nil {
+		s.config.Logger.Warn(msg, args...)
+	}
+}

--- a/framework/batchaccounting/testdata/pricing.json
+++ b/framework/batchaccounting/testdata/pricing.json
@@ -1,0 +1,40 @@
+{
+  "claude-sonnet-5": {
+    "input_cost_per_token": 3e-06,
+    "input_cost_per_token_batches": 1.5e-06,
+    "output_cost_per_token": 1.5e-05,
+    "output_cost_per_token_batches": 7.5e-06,
+    "provider": "anthropic",
+    "mode": "chat"
+  },
+  "gemini-2.5-flash": {
+    "input_cost_per_token": 3e-07,
+    "input_cost_per_token_batches": 1.5e-07,
+    "output_cost_per_token": 2.5e-06,
+    "output_cost_per_token_batches": 1.25e-06,
+    "provider": "gemini",
+    "mode": "chat"
+  },
+  "anthropic.claude-sonnet-4-6": {
+    "input_cost_per_token": 3e-06,
+    "input_cost_per_token_batches": 1.5e-06,
+    "output_cost_per_token": 1.5e-05,
+    "output_cost_per_token_batches": 7.5e-06,
+    "provider": "bedrock",
+    "mode": "chat"
+  },
+  "global.anthropic.claude-sonnet-4-6": {
+    "input_cost_per_token": 3e-06,
+    "input_cost_per_token_batches": 1.5e-06,
+    "output_cost_per_token": 1.5e-05,
+    "output_cost_per_token_batches": 7.5e-06,
+    "provider": "bedrock",
+    "mode": "chat"
+  },
+  "claude-haiku-4-5": {
+    "input_cost_per_token": 8e-07,
+    "output_cost_per_token": 4e-06,
+    "provider": "anthropic",
+    "mode": "chat"
+  }
+}

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -1320,8 +1320,9 @@ var billingPayloadColumns = map[string][]string{
 }
 
 // billingScalarColumns is every non-payload column cost recomputation reads, and
-// nothing else. Traced from calculateCostForLog, pricingScopesForLog,
-// servedTierFromLog, isKnownZeroCostLog, and the recalc job's cursor bookkeeping.
+// nothing else. Traced from calculateCostForLog, calculateBatchAggregateCost,
+// pricingScopesForLog, servedTierFromLog, isKnownZeroCostLog, and the recalc
+// job's cursor bookkeeping.
 //
 // Deliberately NOT built on listSelectColumns: that projection serves /api/logs and
 // carries message previews, content summaries, metadata and every denormalized
@@ -1339,6 +1340,10 @@ var billingScalarColumns = []string{
 	"token_usage", "prompt_tokens", "completion_tokens", "total_tokens", "cached_read_tokens",
 	// Semantic-cache billing.
 	"cache_debug",
+	// Per-model usage for a batch aggregate row (object_type=batch_results) whose
+	// own Model is "mixed" and token_usage is one blended total — without this,
+	// calculateBatchAggregateCost has nothing to reprice a mixed-model batch from.
+	"batch_debug",
 	// Whether the payload was offloaded, and whether it can ever be fetched back.
 	"has_object", "content_hidden",
 	// Served tier: scales every token rate.

--- a/plugins/governance/accounting_test.go
+++ b/plugins/governance/accounting_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/batchaccounting"
 	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/stretchr/testify/assert"
@@ -18,6 +19,26 @@ import (
 type accountingFixture struct {
 	store   GovernanceStore
 	tracker *UsageTracker
+}
+
+func TestReportBatchUsage_IdempotentPerAggregateAndTarget(t *testing.T) {
+	f := newAccountingFixture(t)
+	plugin := &GovernancePlugin{store: f.store, tracker: f.tracker}
+	report := batchaccounting.BatchUsageReport{
+		RequestID:    "batch-cost:openai:batch-1",
+		Provider:     schemas.OpenAI,
+		Model:        "gpt-4o-mini",
+		Cost:         12.5,
+		TokensUsed:   123,
+		BudgetIDs:    []string{"budget1"},
+		RateLimitIDs: []string{"rl1"},
+	}
+
+	require.NoError(t, plugin.ReportBatchUsage(context.Background(), report))
+	require.NoError(t, plugin.ReportBatchUsage(context.Background(), report))
+	assert.Equal(t, 12.5, f.cost())
+	assert.Equal(t, int64(123), f.tokens())
+	assert.Equal(t, int64(1), f.requests())
 }
 
 func newAccountingFixture(t *testing.T) *accountingFixture {

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/batchaccounting"
 	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/mcpcatalog"
@@ -1100,19 +1101,19 @@ func (p *GovernancePlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 	}
 	// If effectiveVK is empty, it will be passed as empty string to postHookWorker
 	// The tracker will handle empty virtual keys gracefully by only updating provider-level and model-level usage
-	if requestedModel != "" {
-		// Collect the affected budget and rate-limit IDs synchronously (fast in-memory
-		// lookups) and attach them to the context. The logging plugin reads these keys
-		// when building the log entry, enabling ghost-node usage reconciliation to
-		// attribute cost/tokens to the correct governance entities.
-		budgetIDs, rateLimitIDs := p.store.CollectApplicableGovernanceIDs(ctx, effectiveVK, userID, provider, requestedModel)
-		if len(budgetIDs) > 0 {
-			ctx.SetValue(schemas.BifrostContextKeyGovernanceBudgetIDs, budgetIDs)
-		}
-		if len(rateLimitIDs) > 0 {
-			ctx.SetValue(schemas.BifrostContextKeyGovernanceRateLimitIDs, rateLimitIDs)
-		}
+	// Collect the affected budget and rate-limit IDs synchronously (fast in-memory
+	// lookups) and attach them to the context. Batch-create requests commonly omit
+	// a top-level model because each input-file row carries its own model; the
+	// store still returns provider/VK hierarchy IDs when requestedModel is empty.
+	budgetIDs, rateLimitIDs := p.store.CollectApplicableGovernanceIDs(ctx, effectiveVK, userID, provider, requestedModel)
+	if len(budgetIDs) > 0 {
+		ctx.SetValue(schemas.BifrostContextKeyGovernanceBudgetIDs, budgetIDs)
+	}
+	if len(rateLimitIDs) > 0 {
+		ctx.SetValue(schemas.BifrostContextKeyGovernanceRateLimitIDs, rateLimitIDs)
+	}
 
+	if requestedModel != "" {
 		// Attempt number distinguishes physical provider calls within one
 		// logical request so each token-consuming attempt bills exactly once.
 		// Set by core on every retry iteration.
@@ -1479,6 +1480,42 @@ func (p *GovernancePlugin) postHookWorker(result *schemas.BifrostResponse, bifro
 // GetGovernanceStore returns the governance store
 func (p *GovernancePlugin) GetGovernanceStore() GovernanceStore {
 	return p.store
+}
+
+func (p *GovernancePlugin) ReportBatchUsage(ctx context.Context, usage batchaccounting.BatchUsageReport) error {
+	var errs []error
+
+	if usage.Cost > 0 {
+		for _, budgetID := range usage.BudgetIDs {
+			billingKey := fmt.Sprintf("%s:budget:%s", usage.RequestID, budgetID)
+			if usage.RequestID != "" && !p.tracker.tryClaimBatchBilling(billingKey) {
+				continue
+			}
+			if err := p.store.BumpBudgetUsage(ctx, budgetID, usage.Cost); err != nil {
+				p.tracker.releaseBatchBilling(billingKey)
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	for _, rateLimitID := range usage.RateLimitIDs {
+		billingKey := fmt.Sprintf("%s:rate-limit:%s", usage.RequestID, rateLimitID)
+		if usage.RequestID != "" && !p.tracker.tryClaimBatchBilling(billingKey) {
+			continue
+		}
+		// BumpRateLimitUsage (not ...UsageBy) because it resets an expired window
+		// before adding, the way BumpBudgetUsage does. A batch can settle hours
+		// after it was created, so its window may well have rolled over in the
+		// meantime; without the reset the usage lands on the stale window and is
+		// then wiped by the reset worker. It adds tokensUsed and one request,
+		// which is exactly what a settled batch contributes.
+		if err := p.store.BumpRateLimitUsage(ctx, rateLimitID, usage.TokensUsed, true, true); err != nil {
+			p.tracker.releaseBatchBilling(billingKey)
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 // GenerateVirtualKey is a helper function

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -120,12 +120,14 @@ type GovernanceStore interface {
 	// use it for every config publish (fresh load or admin edit) so a concurrent
 	// BumpBudgetUsage increment is never clobbered.
 	LoadBudget(ctx context.Context, budgetID string) *configstoreTables.TableBudget
+	BumpBudgetUsage(ctx context.Context, budgetID string, cost float64) error
 	UpsertBudgetConfig(ctx context.Context, budgetID string, config *configstoreTables.TableBudget)
 	DeleteBudget(ctx context.Context, budgetID string)
 	// Rate limit crud. UpsertRateLimitConfig carries in-memory counter state
 	// (token + request CurrentUsage/LastReset) forward across replacements —
 	// same rationale as UpsertBudgetConfig.
 	LoadRateLimit(ctx context.Context, rateLimitID string) *configstoreTables.TableRateLimit
+	BumpRateLimitUsage(ctx context.Context, rateLimitID string, tokensUsed int64, shouldUpdateTokens, shouldUpdateRequests bool) error
 	UpsertRateLimitConfig(ctx context.Context, rateLimitID string, config *configstoreTables.TableRateLimit)
 	DeleteRateLimit(ctx context.Context, rateLimitID string)
 	// Provider-level governance checks

--- a/plugins/governance/tracker.go
+++ b/plugins/governance/tracker.go
@@ -60,6 +60,19 @@ type UsageTracker struct {
 	// by a TTL sweep on the existing resetWorker tick (no extra goroutine).
 	billedMu sync.Mutex
 	billed   map[string]time.Time
+	// batchBilled tracks each durable batch aggregate's individual governance
+	// target. Reporting may be retried after a database marker failure, so the
+	// target-level key prevents budgets or rate limits that already succeeded
+	// from being incremented again while allowing failed targets to retry.
+	//
+	// This is process-local and therefore best-effort: it makes batch reporting
+	// idempotent within one process, not across a restart or another node. A
+	// batch whose report succeeded but whose durable marker write failed stays
+	// retryable, and a retry elsewhere has an empty map and will bill it again.
+	// That gap is accepted — see framework/batchaccounting's package doc for why
+	// and what closing it would cost. Note the synchronous path's `billed` map
+	// above has the same property with no durable marker at all.
+	batchBilled map[string]time.Time
 }
 
 const (
@@ -68,6 +81,10 @@ const (
 	// lifetime of a single logical request (max retries × backoff + stream idle
 	// timeout); 5 minutes is well beyond any real request.
 	billedEntryTTL = 5 * time.Minute
+	// Batch settlement retries can outlive a normal request by hours. Keep the
+	// stable aggregate-log keys long enough for the durable reported marker to
+	// be written and observed by every local retry path.
+	batchBilledEntryTTL = 7 * 24 * time.Hour
 )
 
 // NewUsageTracker creates a new usage tracker for the hierarchical budget system
@@ -79,6 +96,7 @@ func NewUsageTracker(ctx context.Context, store GovernanceStore, resolver *Budge
 		logger:      logger,
 		done:        make(chan struct{}),
 		billed:      make(map[string]time.Time),
+		batchBilled: make(map[string]time.Time),
 	}
 
 	// Start background workers for business logic
@@ -305,7 +323,9 @@ func (t *UsageTracker) tryClaimBilling(update *UsageUpdate) bool {
 // sweepBilled drops idempotency keys older than billedEntryTTL, bounding the
 // map to roughly the requests seen within the TTL window.
 func (t *UsageTracker) sweepBilled() {
-	cutoff := time.Now().Add(-billedEntryTTL)
+	now := time.Now()
+	cutoff := now.Add(-billedEntryTTL)
+	batchCutoff := now.Add(-batchBilledEntryTTL)
 	t.billedMu.Lock()
 	defer t.billedMu.Unlock()
 	for k, at := range t.billed {
@@ -313,6 +333,33 @@ func (t *UsageTracker) sweepBilled() {
 			delete(t.billed, k)
 		}
 	}
+	for k, at := range t.batchBilled {
+		if at.Before(batchCutoff) {
+			delete(t.batchBilled, k)
+		}
+	}
+}
+
+func (t *UsageTracker) tryClaimBatchBilling(key string) bool {
+	if key == "" {
+		return true
+	}
+	t.billedMu.Lock()
+	defer t.billedMu.Unlock()
+	if _, seen := t.batchBilled[key]; seen {
+		return false
+	}
+	t.batchBilled[key] = time.Now()
+	return true
+}
+
+func (t *UsageTracker) releaseBatchBilling(key string) {
+	if key == "" {
+		return
+	}
+	t.billedMu.Lock()
+	delete(t.batchBilled, key)
+	t.billedMu.Unlock()
 }
 
 // Public methods for monitoring and admin operations

--- a/plugins/logging/cleanup_test.go
+++ b/plugins/logging/cleanup_test.go
@@ -64,7 +64,7 @@ func makeTestLog(id string) *logstore.Log {
 // recover and persist all of them.
 func TestCleanupDrainsRecoveredBatchNoDrops(t *testing.T) {
 	rec := &recordingStore{LogStore: newTestStore(t)}
-	plugin, err := Init(context.Background(), &Config{}, testLogger{}, rec, nil, nil)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, rec, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}
@@ -106,7 +106,7 @@ func TestCleanupDrainsCombinedQueueAndBatchNoDrops(t *testing.T) {
 		LogStore: newTestStore(t),
 		delay:    25 * time.Millisecond, // slow store keeps batchWriter busy so the channel buffer fills
 	}
-	plugin, err := Init(context.Background(), &Config{}, testLogger{}, rec, nil, nil)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, rec, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}
@@ -141,7 +141,7 @@ func TestCleanupDrainsCombinedQueueAndBatchNoDrops(t *testing.T) {
 // subsequent enqueues are dropped at the source and do not panic.
 func TestCleanupRejectsNewSendsAfterClosed(t *testing.T) {
 	rec := &recordingStore{LogStore: newTestStore(t)}
-	plugin, err := Init(context.Background(), &Config{}, testLogger{}, rec, nil, nil)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, rec, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}
@@ -178,7 +178,7 @@ func TestCleanupRejectsNewSendsAfterClosed(t *testing.T) {
 // call must be a no-op rather than re-cancelling, re-closing channels, or
 // panicking.
 func TestCleanupIsIdempotent(t *testing.T) {
-	plugin, err := Init(context.Background(), &Config{}, testLogger{}, newTestStore(t), nil, nil)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, newTestStore(t), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}
@@ -191,7 +191,7 @@ func TestCleanupIsIdempotent(t *testing.T) {
 }
 
 func TestWriterConfigDefaultsAndInitOverrides(t *testing.T) {
-	plugin, err := Init(context.Background(), &Config{}, testLogger{}, newTestStore(t), nil, nil)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, newTestStore(t), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}
@@ -215,7 +215,7 @@ func TestWriterConfigDefaultsAndInitOverrides(t *testing.T) {
 		WriteQueueCapacity:       11,
 		DeferredUsageConcurrency: 2,
 	}
-	plugin, err = Init(context.Background(), &Config{Writer: writer}, testLogger{}, newTestStore(t), nil, nil)
+	plugin, err = Init(context.Background(), &Config{Writer: writer}, testLogger{}, newTestStore(t), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Init() with writer error = %v", err)
 	}

--- a/plugins/logging/costfidelity_test.go
+++ b/plugins/logging/costfidelity_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
@@ -948,4 +949,284 @@ func TestRecalculateCostsBackfillsRecoveredUsageSoSecondRunSkipsObjectStore(t *t
 	assert.Equal(t, 1, store.fetches,
 		"the second pass must be served entirely from the database; fetches should still be 1")
 	assertCostsEqual(t, "recompute after backfill", store.costs["backfill-1"], firstCost)
+}
+
+// These tests cover calculateBatchAggregateCost and its wiring into
+// RecalculateCosts: a batch aggregate row (object=batch_results) spanning more
+// than one model has Model="mixed" and one blended token_usage, so the generic
+// calculateCostForLog path can never price it — "mixed" has no catalog entry.
+// calculateBatchAggregateCost reprices per model_breakdown entry instead, the
+// same way settlement originally priced each result item.
+
+func batchModelBreakdown(promptTokens, completionTokens int) schemas.BatchModelBreakdown {
+	return schemas.BatchModelBreakdown{
+		RequestCount: 1,
+		Usage: schemas.BifrostLLMUsage{
+			PromptTokens:     promptTokens,
+			CompletionTokens: completionTokens,
+			TotalTokens:      promptTokens + completionTokens,
+		},
+	}
+}
+
+// TestCalculateBatchAggregateCost_MultiModel prices two models in one row —
+// gpt-4o (1.25e-06/5e-06 batch rate) and gpt-4o-mini (7.5e-08/3e-07) in
+// testdata/pricing.json. A batch is inherently single-provider (one provider's
+// batch API), so both models share the row's Provider; the defaultBatchPricingRatio
+// fallback itself is already covered directly at the pricing-engine level
+// (TestCalculateCostForUsage_BatchResultsDefaultsToHalfStandardRate) and at the
+// settlement level (TestBatchPricing_ClaudeHaiku45_DefaultsToHalfStandardRate) —
+// this test's job is the multi-model loop and per-model write-back, not re-proving
+// that math. Both models' costs must land in the summed total and in their own
+// ModelBreakdown entry.
+func TestCalculateBatchAggregateCost_MultiModel(t *testing.T) {
+	plugin := newCostFidelityPlugin(t)
+
+	entry := &logstore.Log{
+		ID:       "batch-multi",
+		Object:   string(schemas.BatchResultsRequest),
+		Provider: string(schemas.OpenAI),
+		Model:    "mixed",
+		BatchDebugParsed: &schemas.BifrostBatchDebug{
+			BatchID: "batch_multi",
+			Accounting: &schemas.BatchAccountingDebug{
+				ModelBreakdowns: map[string]schemas.BatchModelBreakdown{
+					"gpt-4o":      batchModelBreakdown(1000, 200),
+					"gpt-4o-mini": batchModelBreakdown(500, 100),
+				},
+			},
+		},
+	}
+
+	cost, batchDebugJSON, err := plugin.calculateBatchAggregateCost(entry)
+	require.NoError(t, err)
+	assert.NotEmpty(t, batchDebugJSON)
+
+	wantGPT4o := 1000*1.25e-06 + 200*5e-06
+	wantGPT4oMini := 500*7.5e-08 + 100*3e-07
+	assertCostsEqual(t, "batch multi-model total", cost, wantGPT4o+wantGPT4oMini)
+
+	breakdowns := entry.BatchDebugParsed.Accounting.ModelBreakdowns
+	require.NotNil(t, breakdowns["gpt-4o"].Cost)
+	assertCostsEqual(t, "gpt-4o breakdown cost", *breakdowns["gpt-4o"].Cost, wantGPT4o)
+	require.NotNil(t, breakdowns["gpt-4o-mini"].Cost)
+	assertCostsEqual(t, "gpt-4o-mini breakdown cost", *breakdowns["gpt-4o-mini"].Cost, wantGPT4oMini)
+
+	// The returned JSON is what gets persisted to batch_debug — it must reflect
+	// the same mutated breakdowns, not a stale pre-pricing snapshot.
+	var roundTripped schemas.BifrostBatchDebug
+	require.NoError(t, sonic.UnmarshalString(batchDebugJSON, &roundTripped))
+	require.NotNil(t, roundTripped.Accounting.ModelBreakdowns["gpt-4o"].Cost)
+	assertCostsEqual(t, "round-tripped gpt-4o cost", *roundTripped.Accounting.ModelBreakdowns["gpt-4o"].Cost, wantGPT4o)
+}
+
+// TestCalculateBatchAggregateCost_PartiallyUnpriced covers a batch where one
+// model prices and another has no catalog entry at all (not even a standard
+// rate to default from): the total must reflect only the priced model, and the
+// unpriced model's breakdown Cost must stay nil rather than being reported as a
+// real (and wrong) zero.
+func TestCalculateBatchAggregateCost_PartiallyUnpriced(t *testing.T) {
+	plugin := newCostFidelityPlugin(t)
+
+	entry := &logstore.Log{
+		ID:       "batch-partial",
+		Object:   string(schemas.BatchResultsRequest),
+		Provider: string(schemas.OpenAI),
+		Model:    "mixed",
+		BatchDebugParsed: &schemas.BifrostBatchDebug{
+			BatchID: "batch_partial",
+			Accounting: &schemas.BatchAccountingDebug{
+				ModelBreakdowns: map[string]schemas.BatchModelBreakdown{
+					"gpt-4o":                batchModelBreakdown(1000, 200),
+					"totally-unknown-model": batchModelBreakdown(300, 50),
+				},
+			},
+		},
+	}
+
+	cost, _, err := plugin.calculateBatchAggregateCost(entry)
+	require.NoError(t, err)
+	assertCostsEqual(t, "partially-unpriced batch total", cost, 1000*1.25e-06+200*5e-06)
+
+	breakdowns := entry.BatchDebugParsed.Accounting.ModelBreakdowns
+	require.NotNil(t, breakdowns["gpt-4o"].Cost)
+	assert.Nil(t, breakdowns["totally-unknown-model"].Cost,
+		"a model with no pricing at all must stay nil, not be reported as free")
+}
+
+// TestCalculateBatchAggregateCost_EmbeddingEndpointUsesEmbeddingRates covers the
+// modality the row itself cannot express: Object is "batch_results" for every
+// batch and normalizes to "chat", so an embeddings batch used to look for chat
+// rates on an embedding-only model and could never reprice at all. The endpoint
+// settlement recorded in batch_debug is what makes the lookup land.
+func TestCalculateBatchAggregateCost_EmbeddingEndpointUsesEmbeddingRates(t *testing.T) {
+	plugin := newCostFidelityPlugin(t)
+
+	newEntry := func(endpoint string) *logstore.Log {
+		return &logstore.Log{
+			ID:       "batch-embeddings",
+			Object:   string(schemas.BatchResultsRequest),
+			Provider: string(schemas.OpenAI),
+			Model:    "text-embedding-3-small",
+			BatchDebugParsed: &schemas.BifrostBatchDebug{
+				BatchID:  "batch_embeddings",
+				Endpoint: endpoint,
+				Accounting: &schemas.BatchAccountingDebug{
+					ModelBreakdowns: map[string]schemas.BatchModelBreakdown{
+						"text-embedding-3-small": batchModelBreakdown(1000, 0),
+					},
+				},
+			},
+		}
+	}
+
+	cost, _, err := plugin.calculateBatchAggregateCost(newEntry(string(schemas.BatchEndpointEmbeddings)))
+	require.NoError(t, err)
+	// testdata input_cost_per_token_batches for text-embedding-3-small: 1e-08.
+	assertCostsEqual(t, "embeddings batch total", cost, 1000*1e-08)
+
+	// Rows written before the endpoint was persisted keep the old behavior rather
+	// than being guessed at — for an embedding-only model that still means unpriceable.
+	_, _, err = plugin.calculateBatchAggregateCost(newEntry(""))
+	require.ErrorIs(t, err, errPricingInputsUnavailable)
+}
+
+// TestCalculateBatchAggregateCost_PartialRepriceMarksIncomplete pins the agreement
+// between settlement and recalculation: recovering some of a batch's cost is worth
+// persisting, but the total must not present itself as whole while a model is still
+// rateless. The flag is the durable record that it under-states.
+func TestCalculateBatchAggregateCost_PartialRepriceMarksIncomplete(t *testing.T) {
+	plugin := newCostFidelityPlugin(t)
+
+	entry := &logstore.Log{
+		ID:       "batch-still-partial",
+		Object:   string(schemas.BatchResultsRequest),
+		Provider: string(schemas.OpenAI),
+		Model:    "mixed",
+		BatchDebugParsed: &schemas.BifrostBatchDebug{
+			BatchID: "batch_still_partial",
+			Accounting: &schemas.BatchAccountingDebug{
+				ModelBreakdowns: map[string]schemas.BatchModelBreakdown{
+					"gpt-4o":                batchModelBreakdown(1000, 200),
+					"totally-unknown-model": batchModelBreakdown(300, 50),
+				},
+			},
+		},
+	}
+
+	_, batchDebugJSON, err := plugin.calculateBatchAggregateCost(entry)
+	require.NoError(t, err)
+	assert.True(t, entry.BatchDebugParsed.Accounting.Incomplete)
+
+	var roundTripped schemas.BifrostBatchDebug
+	require.NoError(t, sonic.UnmarshalString(batchDebugJSON, &roundTripped))
+	assert.True(t, roundTripped.Accounting.Incomplete,
+		"the flag must survive into the persisted batch_debug, not just the in-memory copy")
+}
+
+// TestCalculateBatchAggregateCost_IncompleteIsNeverCleared: the flag can stand for
+// usage that is not in ModelBreakdowns at all — rows whose model the provider never
+// named, rows lost to parse errors — and repricing the breakdowns that did land says
+// nothing about those. A pass that priced everything it can see must not close it.
+func TestCalculateBatchAggregateCost_IncompleteIsNeverCleared(t *testing.T) {
+	plugin := newCostFidelityPlugin(t)
+
+	entry := &logstore.Log{
+		ID:       "batch-parse-errors",
+		Object:   string(schemas.BatchResultsRequest),
+		Provider: string(schemas.OpenAI),
+		Model:    "gpt-4o",
+		BatchDebugParsed: &schemas.BifrostBatchDebug{
+			BatchID: "batch_parse_errors",
+			Accounting: &schemas.BatchAccountingDebug{
+				ModelBreakdowns: map[string]schemas.BatchModelBreakdown{
+					"gpt-4o": batchModelBreakdown(1000, 200),
+				},
+				ParseErrorCount: 3,
+				Incomplete:      true,
+			},
+		},
+	}
+
+	_, _, err := plugin.calculateBatchAggregateCost(entry)
+	require.NoError(t, err)
+	assert.True(t, entry.BatchDebugParsed.Accounting.Incomplete,
+		"unparseable rows are gone for good; a successful reprice does not recover them")
+	assert.Equal(t, 3, entry.BatchDebugParsed.Accounting.ParseErrorCount)
+}
+
+// TestCalculateBatchAggregateCost_AllUnpriced covers a batch where nothing can
+// price: it must report errPricingInputsUnavailable, the same sentinel every
+// other genuinely-unpriceable row reports, so the recalc job's Unpriceable
+// counter (not just Skipped) reflects it.
+func TestCalculateBatchAggregateCost_AllUnpriced(t *testing.T) {
+	plugin := newCostFidelityPlugin(t)
+
+	entry := &logstore.Log{
+		ID:       "batch-none",
+		Object:   string(schemas.BatchResultsRequest),
+		Provider: string(schemas.OpenAI),
+		Model:    "totally-unknown-model",
+		BatchDebugParsed: &schemas.BifrostBatchDebug{
+			BatchID: "batch_none",
+			Accounting: &schemas.BatchAccountingDebug{
+				ModelBreakdowns: map[string]schemas.BatchModelBreakdown{
+					"totally-unknown-model": batchModelBreakdown(300, 50),
+				},
+			},
+		},
+	}
+
+	_, _, err := plugin.calculateBatchAggregateCost(entry)
+	require.ErrorIs(t, err, errPricingInputsUnavailable)
+}
+
+// TestRecalculateCostsReprisesMixedModelBatchRow is the end-to-end regression
+// test: a real "mixed"-model batch row, stuck with cost=nil because Model="mixed"
+// has no catalog entry, must come out of RecalculateCosts with both the row's
+// cost and its batch_debug model_breakdowns correctly populated — not just one
+// of the two, which would leave them permanently disagreeing.
+func TestRecalculateCostsReprisesMixedModelBatchRow(t *testing.T) {
+	plugin := newCostFidelityPlugin(t)
+	store := plugin.store
+
+	entry := &logstore.Log{
+		ID:        "batch-e2e-mixed",
+		Timestamp: time.Now().UTC(),
+		Object:    string(schemas.BatchResultsRequest),
+		Provider:  string(schemas.OpenAI),
+		Model:     "mixed",
+		Status:    "success",
+		Cost:      nil,
+		BatchDebugParsed: &schemas.BifrostBatchDebug{
+			BatchID: "batch_e2e_mixed",
+			Accounting: &schemas.BatchAccountingDebug{
+				ModelBreakdowns: map[string]schemas.BatchModelBreakdown{
+					"gpt-4o":      batchModelBreakdown(1000, 200),
+					"gpt-4o-mini": batchModelBreakdown(500, 100),
+				},
+			},
+		},
+	}
+	require.NoError(t, store.Create(context.Background(), entry))
+
+	result, err := plugin.RecalculateCosts(context.Background(), logstore.SearchFilters{}, 10)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Updated)
+
+	logged, err := store.FindByID(context.Background(), "batch-e2e-mixed")
+	require.NoError(t, err)
+	require.NotNil(t, logged.Cost)
+
+	wantGPT4o := 1000*1.25e-06 + 200*5e-06
+	wantGPT4oMini := 500*7.5e-08 + 100*3e-07
+	assertCostsEqual(t, "e2e mixed-model row cost", *logged.Cost, wantGPT4o+wantGPT4oMini)
+
+	require.NotNil(t, logged.BatchDebugParsed)
+	require.NotNil(t, logged.BatchDebugParsed.Accounting)
+	breakdowns := logged.BatchDebugParsed.Accounting.ModelBreakdowns
+	require.NotNil(t, breakdowns["gpt-4o"].Cost)
+	assertCostsEqual(t, "e2e gpt-4o breakdown cost", *breakdowns["gpt-4o"].Cost, wantGPT4o)
+	require.NotNil(t, breakdowns["gpt-4o-mini"].Cost)
+	assertCostsEqual(t, "e2e gpt-4o-mini breakdown cost", *breakdowns["gpt-4o-mini"].Cost, wantGPT4oMini)
 }

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -5,8 +5,11 @@ package logging
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -16,6 +19,7 @@ import (
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/mcp"
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/batchaccounting"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/framework/mcpcatalog"
@@ -324,6 +328,197 @@ func (p *LoggerPlugin) sleepCtx(d time.Duration) bool {
 	}
 }
 
+// batchAccountingTimeout bounds inline batch settlement on the /results response
+// path so a stalled store or reporter cannot hang the caller. Anything that times
+// out is not lost: the job stays due and the sweeper re-drives it.
+const batchAccountingTimeout = 30 * time.Second
+
+// batchRunnerProcessID distinguishes this process when no cluster node id is set.
+// Deliberately random rather than PID-based: two replicas on different hosts can
+// share a PID, and this identity is what keeps their batch claims apart.
+var batchRunnerProcessID = newBatchRunnerProcessID()
+
+func newBatchRunnerProcessID() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand is effectively infallible here; a time-based value still
+		// separates processes far better than a shared constant would.
+		return strconv.FormatInt(time.Now().UnixNano(), 36)
+	}
+	return hex.EncodeToString(b[:])
+}
+
+// batchRunnerID builds the ownership-fence identity for a batch accounting worker.
+//
+// Batch claims are fenced on this value, so it must differ between workers that
+// could contend for the same job. SetClusterNodeID supplies a stable id in
+// clustered deployments, but it is never called in OSS — so without the
+// per-process fallback every replica sharing a database would present the same
+// identity ("logging" / "batch-sweeper") and the fence would not tell them apart.
+// A per-process id is the right granularity: the fence only needs to separate
+// live workers, and a restarted process should not inherit its predecessor's
+// claims — those are recovered through the staleness path instead.
+func (p *LoggerPlugin) batchRunnerID(prefix string) string {
+	if nodeID, _ := p.clusterNodeID.Load().(string); nodeID != "" {
+		return prefix + ":" + nodeID
+	}
+	return prefix + ":" + batchRunnerProcessID
+}
+
+func (p *LoggerPlugin) accountBatchResults(entry *logstore.Log, result *schemas.BifrostResponse, pricingScopes *modelcatalog.PricingLookupScopes) {
+	if result == nil || result.BatchResultsResponse == nil || entry == nil || p.pricingManager == nil || p.batchStore == nil {
+		return
+	}
+	batchResp := result.BatchResultsResponse
+	if batchResp.BatchID == "" {
+		return
+	}
+
+	// This runs inline on the /results response path, and settlement touches the
+	// config store, the log store and the governance reporter. p.ctx is the
+	// plugin's lifetime context and has no deadline, so any one of those stalling
+	// would hang the caller's HTTP response indefinitely. Bound the whole
+	// settlement instead; the sweeper re-drives anything that times out, since a
+	// job left un-accounted stays due.
+	ctx, cancel := context.WithTimeout(p.ctx, batchAccountingTimeout)
+	defer cancel()
+
+	claimedBy := p.batchRunnerID("logging")
+	p.mu.Lock()
+	usageReporter := p.batchUsageReporter
+	p.mu.Unlock()
+
+	summary, err := batchaccounting.AccountBatchResults(ctx, p.batchStore, p.store, p.pricingManager, batchaccounting.Request{
+		Provider:      schemas.ModelProvider(entry.Provider),
+		BatchID:       batchResp.BatchID,
+		FallbackModel: entry.Model,
+		Endpoint:      batchResp.Endpoint,
+		Results:       batchResp.Results,
+		ParseErrors:   batchResp.ExtraFields.ParseErrors,
+		BatchJob:      batchJobFromEntry(entry, batchResp.BatchID, entry.Model, string(batchResp.Endpoint), string(schemas.BatchStatusCompleted)),
+		BaseLog:       entry,
+		Emitter:       p,
+		UsageReporter: usageReporter,
+		ClaimedBy:     claimedBy,
+		Scopes:        pricingScopes,
+	})
+	if err != nil {
+		p.logger.Warn("failed to account batch results for provider=%s batch_id=%s: %v", entry.Provider, batchResp.BatchID, err)
+		return
+	}
+	if summary != nil && summary.Accounted {
+		p.logger.Info("accounted batch results for provider=%s batch_id=%s cost=%f log_id=%s", entry.Provider, batchResp.BatchID, summary.Cost, summary.LogID)
+	}
+	attachBatchResultsDisplay(entry, batchResp, summary)
+}
+
+func attachBatchResultsDisplay(entry *logstore.Log, batchResp *schemas.BifrostBatchResultsResponse, summary *batchaccounting.Summary) {
+	debug := &schemas.BifrostBatchDebug{BatchID: batchResp.BatchID}
+	if counts := schemas.BatchRequestCountsFromResults(batchResp.Results); !counts.IsZero() {
+		debug.RequestCounts = &counts
+	}
+	if summary != nil {
+		debug.Status = summary.Status
+		if summary.Complete || len(summary.ModelBreakdowns) > 0 {
+			accounting := &schemas.BatchAccountingDebug{
+				ModelBreakdowns: summary.ModelBreakdowns,
+				Incomplete:      !summary.Complete,
+			}
+			if summary.Complete {
+				cost := summary.Cost
+				accounting.Cost = &cost
+			}
+			debug.Accounting = accounting
+		}
+	}
+	if debug.IsZero() {
+		return
+	}
+	entry.BatchDebugParsed = debug
+}
+
+func (p *LoggerPlugin) EmitBatchAggregateLog(ctx context.Context, entry *logstore.Log) {
+	p.makePostWriteCallback(nil)(entry)
+}
+
+func (p *LoggerPlugin) recordBatchJobLifecycle(entry *logstore.Log, result *schemas.BifrostResponse) {
+	if entry == nil || result == nil || p.batchStore == nil {
+		return
+	}
+
+	var job *tables.TableBatchJob
+	now := time.Now().UTC()
+	switch {
+	case result.BatchCreateResponse != nil:
+		resp := result.BatchCreateResponse
+		job = batchJobFromEntry(entry, resp.ID, entry.Model, resp.Endpoint, string(resp.Status))
+		job.InputFileID = resp.InputFileID
+		job.OutputFileID = resp.OutputFileID
+		job.ErrorFileID = resp.ErrorFileID
+		job.ResultsURL = resp.ResultsURL
+		addBatchDetailToLog(entry, resp.ID, string(resp.Status), resp.RequestCounts)
+	case result.BatchRetrieveResponse != nil:
+		resp := result.BatchRetrieveResponse
+		job = batchJobFromEntry(entry, resp.ID, entry.Model, resp.Endpoint, string(resp.Status))
+		job.InputFileID = resp.InputFileID
+		job.OutputFileID = resp.OutputFileID
+		job.ErrorFileID = resp.ErrorFileID
+		job.ResultsURL = resp.ResultsURL
+		addBatchDetailToLog(entry, resp.ID, string(resp.Status), resp.RequestCounts)
+	default:
+		return
+	}
+
+	if job.BatchID == "" {
+		return
+	}
+	if !tables.IsTerminalBatchProviderStatus(job.ProviderStatus) {
+		next := now.Add(time.Minute)
+		job.NextCheckAt = &next
+	} else if job.ProviderStatus == string(schemas.BatchStatusCompleted) ||
+		job.ProviderStatus == string(schemas.BatchStatusEnded) {
+		job.NextCheckAt = &now
+	}
+	if err := p.batchStore.UpsertBatchJob(p.ctx, job); err != nil {
+		p.logger.Warn("failed to record batch job lifecycle for provider=%s batch_id=%s: %v", job.Provider, job.BatchID, err)
+	}
+}
+
+// addBatchDetailToLog records which batch a batch_create / batch_retrieve row
+// addressed and the provider's progress counts for it.
+func addBatchDetailToLog(entry *logstore.Log, batchID string, status string, counts schemas.BatchRequestCounts) {
+	if entry == nil {
+		return
+	}
+	debug := &schemas.BifrostBatchDebug{BatchID: batchID, Status: status}
+	if !counts.IsZero() {
+		debug.RequestCounts = &counts
+	}
+	if debug.IsZero() {
+		return
+	}
+	entry.BatchDebugParsed = debug
+}
+
+func batchJobFromEntry(entry *logstore.Log, batchID string, model string, endpoint string, status string) *tables.TableBatchJob {
+	job := &tables.TableBatchJob{
+		Provider:         entry.Provider,
+		BatchID:          batchID,
+		Model:            model,
+		Endpoint:         endpoint,
+		ProviderStatus:   status,
+		AccountingStatus: tables.BatchJobAccountingStatusPending,
+		SelectedKeyID:    entry.SelectedKeyID,
+		VirtualKeyID:     entry.VirtualKeyID,
+		BudgetIDs:        stringSlicePtr(entry.BudgetIDsParsed),
+		RateLimitIDs:     stringSlicePtr(entry.RateLimitIDsParsed),
+	}
+	if job.ID == "" && job.Provider != "" && job.BatchID != "" {
+		job.ID = tables.BatchJobID(job.Provider, job.BatchID)
+	}
+	return job
+}
+
 func (p *LoggerPlugin) scheduleDeferredUsageUpdate(ctx *schemas.BifrostContext, requestID string, usageAlreadyPresent bool) {
 	if usageAlreadyPresent || ctx == nil {
 		return
@@ -552,6 +747,7 @@ type compiledUserAgentMapping struct {
 type LoggerPlugin struct {
 	ctx                          context.Context
 	store                        logstore.LogStore
+	batchStore                   batchaccounting.SweepStore // configstore-backed mutable batch coordination state (nil disables batch accounting)
 	disableContentLogging        *bool
 	retainContentInObjectStorage *bool     // Pointer to live config value; when true, content-disabled requests are stored hidden instead of dropped
 	objectStorageEnabled         bool      // Log store offloads payloads to object storage; required for retain_content_in_object_storage
@@ -565,6 +761,7 @@ type LoggerPlugin struct {
 	wg                           sync.WaitGroup
 	logger                       schemas.Logger
 	logCallback                  LogCallback
+	batchUsageReporter           batchaccounting.UsageReporter
 	mcpToolLogCallback           MCPToolLogCallback // Callback for MCP tool log entries
 	droppedRequests              atomic.Int64
 	cleanupTicker                *time.Ticker          // Ticker for cleaning up old processing logs
@@ -582,14 +779,17 @@ type LoggerPlugin struct {
 	clusterNodeID                atomic.Value          // Cluster node ID (string) for log attribution in clustered deployments
 	batchCtx                     context.Context       // Cancelled by Cleanup to stop the batchWriter goroutine before any further DB work
 	batchCancel                  context.CancelFunc    // Cancels batchCtx
+	batchSweeperCancel           context.CancelFunc    // Cancels the batch accounting sweeper, when enabled
 	batchWriterDone              chan struct{}         // Closed by batchWriter on exit; receiving from it transfers writeQueue ownership to Cleanup
 	recoveredBatch               []*writeQueueEntry    // batchWriter parks its in-memory batch here before exiting; safe to read after batchWriterDone closes (happens-before)
 	userAgentMappings            atomic.Value          // []compiledUserAgentMapping, read from request hot paths
 	userAgentMappingMu           sync.Mutex            // serializes user-agent mapping write+reload sequences to keep the cache consistent
 }
 
-// Init creates new logger plugin with given log store
-func Init(ctx context.Context, config *Config, logger schemas.Logger, logsStore logstore.LogStore, pricingManager *modelcatalog.ModelCatalog, mcpCatalog *mcpcatalog.MCPCatalog) (*LoggerPlugin, error) {
+// Init creates new logger plugin with given log store. batchStore is the
+// configstore-backed coordination store for delayed batch accounting; it may be
+// nil, which disables batch accounting.
+func Init(ctx context.Context, config *Config, logger schemas.Logger, logsStore logstore.LogStore, batchStore batchaccounting.SweepStore, pricingManager *modelcatalog.ModelCatalog, mcpCatalog *mcpcatalog.MCPCatalog) (*LoggerPlugin, error) {
 	if config == nil {
 		return nil, fmt.Errorf("config is required")
 	}
@@ -619,6 +819,7 @@ func Init(ctx context.Context, config *Config, logger schemas.Logger, logsStore 
 	plugin := &LoggerPlugin{
 		ctx:                          ctx,
 		store:                        logsStore,
+		batchStore:                   batchStore,
 		pricingManager:               pricingManager,
 		mcpCatalog:                   mcpCatalog,
 		disableContentLogging:        config.DisableContentLogging,
@@ -766,6 +967,58 @@ func (p *LoggerPlugin) SetLogCallback(callback LogCallback) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.logCallback = callback
+}
+
+func (p *LoggerPlugin) SetBatchUsageReporter(reporter batchaccounting.UsageReporter) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.batchUsageReporter = reporter
+}
+
+func (p *LoggerPlugin) StartBatchAccountingSweeper(fetcher batchaccounting.BatchResultFetcher, interval time.Duration, kvStore schemas.KVStore) context.CancelFunc {
+	if fetcher == nil || p.store == nil || p.batchStore == nil || p.pricingManager == nil {
+		if p.logger != nil {
+			p.logger.Warn("batch accounting sweeper not started: missing fetcher, store, batch store, or pricing manager")
+		}
+		return func() {}
+	}
+	if kvStore == nil && p.logger != nil {
+		p.logger.Debug("batch accounting sweeper starting without KV store")
+	}
+	ctx, cancel := context.WithCancel(p.ctx)
+	p.mu.Lock()
+	// Cleanup sets p.closed and cancels the sweeper under this same lock before it
+	// reaches p.wg.Wait(), so checking it here is what keeps the wg.Add below from
+	// racing that Wait — a reload wiring a sweeper onto an instance already shutting
+	// down would otherwise violate the WaitGroup contract and start a goroutine
+	// writing through a closed plugin.
+	if p.closed.Load() {
+		p.mu.Unlock()
+		cancel()
+		if p.logger != nil {
+			p.logger.Warn("batch accounting sweeper not started: logging plugin is shutting down")
+		}
+		return func() {}
+	}
+	if p.batchSweeperCancel != nil {
+		p.batchSweeperCancel()
+	}
+	p.batchSweeperCancel = cancel
+	usageReporter := p.batchUsageReporter
+	p.mu.Unlock()
+	claimedBy := p.batchRunnerID("batch-sweeper")
+	sweeper := batchaccounting.NewSweeper(p.batchStore, p.store, p.pricingManager, fetcher, p, usageReporter, batchaccounting.SweeperConfig{
+		Interval:  interval,
+		ClaimedBy: claimedBy,
+		KVStore:   kvStore,
+		Logger:    p.logger,
+	})
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		sweeper.Run(ctx)
+	}()
+	return cancel
 }
 
 // GetName returns the name of the plugin
@@ -1550,6 +1803,9 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 		}
 	}
 	applyLargePayloadPreviewsToEntry(ctx, entry, contentLoggingEnabled)
+	if bifrostErr == nil && (requestType == schemas.BatchCreateRequest || requestType == schemas.BatchRetrieveRequest) {
+		p.recordBatchJobLifecycle(entry, result)
+	}
 
 	// Calculate cost
 	var cacheDebug *schemas.BifrostCacheDebug
@@ -1561,6 +1817,12 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 		pricingScopes := modelcatalog.PricingLookupScopesFromContext(ctx, string(entry.Provider))
 		if cost := p.pricingManager.CalculateCost(result, pricingScopes); cost > 0 {
 			entry.Cost = &cost
+		}
+		if bifrostErr == nil &&
+			requestType == schemas.BatchResultsRequest &&
+			result != nil &&
+			result.BatchResultsResponse != nil {
+			p.accountBatchResults(entry, result, pricingScopes)
 		}
 	}
 
@@ -1596,15 +1858,25 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 // cannot wedge the server's overall 30s shutdown budget.
 func (p *LoggerPlugin) Cleanup() error {
 	p.cleanupOnce.Do(func() {
+		p.mu.Lock()
+		// Under the same lock as the sweeper cancel, and before anything below can
+		// reach p.wg.Wait(): StartBatchAccountingSweeper reads this flag while holding
+		// p.mu, so once it is set no further wg.Add can slip in behind the Wait.
+		p.closed.Store(true)
+		if p.batchSweeperCancel != nil {
+			p.batchSweeperCancel()
+			p.batchSweeperCancel = nil
+		}
+		p.mu.Unlock()
 		if p.cleanupTicker != nil {
 			p.cleanupTicker.Stop()
 		}
 		// Signal the cleanup worker to stop.
 		close(p.done)
-		// Stop new producers before killing batchWriter so the channel does
-		// not grow further while we drain it ourselves. Any producer that raced
-		// past this check is absorbed by the enqueue recover path.
-		p.closed.Store(true)
+		// p.closed was already set above (it doubles as the sweeper-start guard),
+		// which is what stops new producers before we kill batchWriter so the queue
+		// does not grow while we drain it. Any producer that raced past that check is
+		// absorbed by the enqueue recover path.
 		// Kill batchWriter. Its current in-memory batch is handed back via
 		// p.recoveredBatch; it does not issue any further DB writes.
 		p.batchCancel()

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytedance/sonic"
 	"github.com/google/uuid"
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/batchaccounting"
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
 	"github.com/maximhq/bifrost/framework/streaming"
@@ -1532,6 +1533,7 @@ func (p *LoggerPlugin) RecalculateCostsWithProgress(ctx context.Context, filters
 		}
 
 		costUpdates := make(map[string]float64, len(searchResult.Logs))
+		batchDebugUpdated := 0
 		stillMissingInBatch := 0
 
 		for i := range searchResult.Logs {
@@ -1558,6 +1560,20 @@ func (p *LoggerPlugin) RecalculateCostsWithProgress(ctx context.Context, filters
 				stillMissingInBatch++
 				continue
 			}
+			if outcomes[i].batchDebugUpdate != "" {
+				// A repriced batch aggregate row needs cost and batch_debug written
+				// together so model_breakdowns never disagrees with the row's own
+				// cost — BulkUpdateCost only ever writes the cost column, so this one
+				// row goes through a dedicated update instead of the bulk path below.
+				if err := p.store.Update(ctx, logEntry.ID, map[string]any{
+					"cost":        cost,
+					"batch_debug": outcomes[i].batchDebugUpdate,
+				}); err != nil {
+					return nil, fmt.Errorf("failed to update batch cost for log %s: %w", logEntry.ID, err)
+				}
+				batchDebugUpdated++
+				continue
+			}
 			costUpdates[logEntry.ID] = cost
 		}
 
@@ -1567,6 +1583,7 @@ func (p *LoggerPlugin) RecalculateCostsWithProgress(ctx context.Context, filters
 			}
 			result.Updated += len(costUpdates)
 		}
+		result.Updated += batchDebugUpdated
 
 		if filters.MissingCostOnly {
 			// Updated rows drop out of the result set, so only advance past rows
@@ -1634,6 +1651,12 @@ type billingOutcome struct {
 	// is derived from CacheDebugParsed and ReleaseBillingPayloads clears that. Callers
 	// run after the release, so they cannot re-derive it.
 	knownZeroCost bool
+	// batchDebugUpdate is the serialized batch_debug JSON to persist alongside cost,
+	// set only for a batch aggregate row repriced via calculateBatchAggregateCost.
+	// BulkUpdateCost only ever touches the cost column, so without this the row's
+	// model_breakdowns would stay stuck showing the pre-recalculation (unpriced)
+	// state even after cost is fixed.
+	batchDebugUpdate string
 }
 
 // priceLogsInChunks hydrates and prices a batch a few rows at a time, releasing each
@@ -1693,7 +1716,11 @@ func (p *LoggerPlugin) priceLogsInChunks(ctx context.Context, batch []logstore.L
 				outcomes[i].err = fmt.Errorf("%w: log %s", errPricingInputsUnavailable, batch[i].ID)
 				continue
 			}
-			outcomes[i].cost, outcomes[i].err = p.calculateCostForLog(&batch[i])
+			if isBatchAggregateRow(&batch[i]) {
+				outcomes[i].cost, outcomes[i].batchDebugUpdate, outcomes[i].err = p.calculateBatchAggregateCost(&batch[i])
+			} else {
+				outcomes[i].cost, outcomes[i].err = p.calculateCostForLog(&batch[i])
+			}
 			// Must be read here, before the release below drops cache_debug.
 			outcomes[i].knownZeroCost = isKnownZeroCostLog(&batch[i])
 			// Pricing metadata belongs in the log store even when request/response
@@ -1720,6 +1747,90 @@ func (p *LoggerPlugin) priceLogsInChunks(ctx context.Context, batch []logstore.L
 	}
 
 	return outcomes, nil
+}
+
+// isBatchAggregateRow reports whether logEntry is a batch settlement row with
+// per-model usage to reprice from. AfterFind deserializes BatchDebug on every
+// load, so BatchDebugParsed is normally already populated; the direct-field
+// check here is a cheap defensive fallback, not the primary path.
+func isBatchAggregateRow(logEntry *logstore.Log) bool {
+	if logEntry.BatchDebugParsed == nil && logEntry.BatchDebug != "" {
+		if err := logEntry.DeserializeFields(); err != nil {
+			return false
+		}
+	}
+	return logEntry.Object == string(schemas.BatchResultsRequest) &&
+		logEntry.BatchDebugParsed != nil &&
+		logEntry.BatchDebugParsed.Accounting != nil &&
+		len(logEntry.BatchDebugParsed.Accounting.ModelBreakdowns) > 0
+}
+
+// calculateBatchAggregateCost reprices a batch aggregate row from its per-model
+// breakdowns rather than the row's single blended token_usage. A batch can span
+// multiple models, and the row's own Model field is "mixed" in that case —
+// pricing that literal string against the catalog never finds an entry, so the
+// row prices at zero forever through the generic calculateCostForLog path.
+// Repricing per model, the same way settlement (batchaccounting.summarizeResults)
+// originally priced each result item, is the only way a mixed-model batch — or a
+// single-model batch whose rate only arrived after settlement — can recover a
+// cost here.
+//
+// Mutates logEntry.BatchDebugParsed.Accounting.ModelBreakdowns in place (each
+// entry's Cost refreshed, nil if that model still has no rate) and returns the
+// row's total cost — the sum of every model that priced this time — plus the
+// batch_debug JSON to persist alongside it, since BulkUpdateCost only ever
+// writes the cost column and would otherwise leave model_breakdowns stuck
+// showing the pre-recalculation state.
+func (p *LoggerPlugin) calculateBatchAggregateCost(logEntry *logstore.Log) (float64, string, error) {
+	accounting := logEntry.BatchDebugParsed.Accounting
+	scopes := pricingScopesForLog(logEntry)
+	// The row's Object is always "batch_results", which normalizes to "chat" — so
+	// repricing by it alone charged every batch at chat rates and could never find
+	// an embedding model's catalog entry at all. Settlement now records the batch's
+	// endpoint, so use the same endpoint→request-type mapping it priced with. Rows
+	// written before that field existed have no endpoint; they keep the old behavior
+	// rather than being guessed at.
+	requestType := schemas.RequestType(logEntry.Object)
+	if endpoint := logEntry.BatchDebugParsed.Endpoint; endpoint != "" {
+		requestType = batchaccounting.BatchRequestType(schemas.BatchEndpoint(endpoint))
+	}
+
+	var total float64
+	priced := 0
+	for model, breakdown := range accounting.ModelBreakdowns {
+		usage := breakdown.Usage
+		details := p.pricingManager.CalculateBatchCostDetailsForUsage(&usage, schemas.ModelProvider(logEntry.Provider), model, requestType, &scopes)
+		if details.Priced {
+			cost := details.Cost
+			breakdown.Cost = &cost
+			total += cost
+			priced++
+		} else {
+			breakdown.Cost = nil
+		}
+		accounting.ModelBreakdowns[model] = breakdown
+	}
+	if priced == 0 {
+		return 0, "", fmt.Errorf("%w: log %s", errPricingInputsUnavailable, logEntry.ID)
+	}
+	// Recovering some of the cost is worth persisting — refusing to write anything
+	// would leave the operator with nothing — but the total must not present itself
+	// as whole while models are still rateless. Settlement uses the same flag for
+	// the same reason, so the two agree on what the number means.
+	//
+	// Only ever set, never cleared: the flag can also stand for usage that is not in
+	// ModelBreakdowns at all (rows whose model the provider never named, rows lost to
+	// parse errors), and repricing the breakdowns that did land says nothing about
+	// those. Clearing it here would close a gap this pass cannot see.
+	if priced < len(accounting.ModelBreakdowns) {
+		accounting.Incomplete = true
+	}
+
+	batchDebugJSON, err := sonic.Marshal(logEntry.BatchDebugParsed)
+	if err != nil {
+		return 0, "", fmt.Errorf("failed to serialize batch_debug for log %s: %w", logEntry.ID, err)
+	}
+	return total, string(batchDebugJSON), nil
 }
 
 func isKnownZeroCostLog(logEntry *logstore.Log) bool {

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/batchaccounting"
+	cstables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
 	"github.com/maximhq/bifrost/framework/modelcatalog/datasheet"
@@ -27,6 +29,146 @@ func (testLogger) SetLevel(schemas.LogLevel)              {}
 func (testLogger) SetOutputType(schemas.LoggerOutputType) {}
 func (testLogger) LogHTTPRequest(schemas.LogLevel, string) schemas.LogEventBuilder {
 	return schemas.NoopLogEvent
+}
+
+// fakeBatchStore is an in-memory batchaccounting.SweepStore for logging tests.
+type fakeBatchStore struct {
+	jobs map[string]*cstables.TableBatchJob
+}
+
+func newFakeBatchStore() *fakeBatchStore {
+	return &fakeBatchStore{jobs: make(map[string]*cstables.TableBatchJob)}
+}
+
+func (s *fakeBatchStore) UpsertBatchJob(ctx context.Context, job *cstables.TableBatchJob) error {
+	if job.ID == "" {
+		job.ID = cstables.BatchJobID(job.Provider, job.BatchID)
+	}
+	existing, ok := s.jobs[job.ID]
+	if !ok {
+		copied := *job
+		if copied.AccountingStatus == "" {
+			copied.AccountingStatus = cstables.BatchJobAccountingStatusPending
+		}
+		s.jobs[job.ID] = &copied
+		return nil
+	}
+	if job.Model != "" {
+		existing.Model = job.Model
+	}
+	if job.ProviderStatus != "" {
+		existing.ProviderStatus = job.ProviderStatus
+	}
+	if job.InputFileID != "" {
+		existing.InputFileID = job.InputFileID
+	}
+	if job.OutputFileID != nil {
+		existing.OutputFileID = job.OutputFileID
+	}
+	if job.NextCheckAt != nil {
+		existing.NextCheckAt = job.NextCheckAt
+	}
+	if cstables.IsTerminalBatchProviderStatus(job.ProviderStatus) &&
+		job.ProviderStatus != string(schemas.BatchStatusCompleted) &&
+		job.ProviderStatus != string(schemas.BatchStatusEnded) {
+		existing.NextCheckAt = nil
+	}
+	return nil
+}
+
+func (s *fakeBatchStore) GetBatchJob(ctx context.Context, jobID string) (*cstables.TableBatchJob, error) {
+	job, ok := s.jobs[jobID]
+	if !ok {
+		return nil, errors.New("missing batch job")
+	}
+	copied := *job
+	return &copied, nil
+}
+
+func (s *fakeBatchStore) ListDueBatchJobs(ctx context.Context, provider string, now time.Time, limit int) ([]*cstables.TableBatchJob, error) {
+	var jobs []*cstables.TableBatchJob
+	for _, job := range s.jobs {
+		if provider != "" && job.Provider != provider {
+			continue
+		}
+		if job.NextCheckAt == nil || job.NextCheckAt.After(now) {
+			continue
+		}
+		if job.AccountingStatus == cstables.BatchJobAccountingStatusAccounted || job.AccountingStatus == cstables.BatchJobAccountingStatusUnpriceable {
+			continue
+		}
+		jobs = append(jobs, job)
+	}
+	return jobs, nil
+}
+
+func (s *fakeBatchStore) ClaimBatchJob(ctx context.Context, jobID, runnerID string, staleBefore time.Time, allowUnpriceable bool) (bool, error) {
+	entry, ok := s.jobs[jobID]
+	if !ok {
+		return false, errors.New("missing batch job")
+	}
+	if entry.AccountingStatus == cstables.BatchJobAccountingStatusAccounted || entry.AccountingStatus == cstables.BatchJobAccountingStatusUnpriceable {
+		return false, nil
+	}
+	// Claim staleness reads claimed_at, not updated_at — updated_at is refreshed by
+	// the unfenced UpsertBatchJob, so it cannot represent claim age.
+	if entry.AccountingStatus == cstables.BatchJobAccountingStatusProcessing &&
+		entry.ClaimedAt != nil && entry.ClaimedAt.After(staleBefore) {
+		return false, nil
+	}
+	now := time.Now().UTC()
+	rid := runnerID
+	entry.AccountingStatus = cstables.BatchJobAccountingStatusProcessing
+	entry.RunnerID = &rid
+	entry.ClaimedAt = &now
+	entry.UpdatedAt = now
+	return true, nil
+}
+
+func (s *fakeBatchStore) markTerminal(id, status, reason string) error {
+	entry, ok := s.jobs[id]
+	if !ok {
+		return errors.New("missing batch job")
+	}
+	entry.AccountingStatus = status
+	entry.RunnerID = nil
+	entry.ClaimedAt = nil
+	if reason != "" {
+		entry.UnpriceableReason = &reason
+	}
+	return nil
+}
+
+func (s *fakeBatchStore) MarkBatchJobAggregateLogWritten(ctx context.Context, id, runnerID string) error {
+	entry, ok := s.jobs[id]
+	if !ok {
+		return errors.New("missing batch job")
+	}
+	now := time.Now().UTC()
+	entry.AggregateLogWrittenAt = &now
+	return nil
+}
+
+func (s *fakeBatchStore) MarkBatchJobGovernanceReported(ctx context.Context, id, runnerID string) error {
+	entry, ok := s.jobs[id]
+	if !ok {
+		return errors.New("missing batch job")
+	}
+	now := time.Now().UTC()
+	entry.GovernanceReportedAt = &now
+	return nil
+}
+
+func (s *fakeBatchStore) CompleteBatchJob(ctx context.Context, id, runnerID string) error {
+	return s.markTerminal(id, cstables.BatchJobAccountingStatusAccounted, "")
+}
+
+func (s *fakeBatchStore) MarkBatchJobUnpriceable(ctx context.Context, id, runnerID, reason string, err error) error {
+	return s.markTerminal(id, cstables.BatchJobAccountingStatusUnpriceable, reason)
+}
+
+func (s *fakeBatchStore) FailBatchJob(ctx context.Context, id, runnerID string, err error) error {
+	return s.markTerminal(id, cstables.BatchJobAccountingStatusError, "")
 }
 
 func newTestStore(t *testing.T) logstore.LogStore {
@@ -103,7 +245,7 @@ func TestUserAgentFromContextFallsBackToUserAgentKey(t *testing.T) {
 func TestPreLLMHookSetsAppContextFromDetectedApp(t *testing.T) {
 	store := newTestStore(t)
 	defer store.Close(context.Background())
-	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}
@@ -145,7 +287,7 @@ func TestPreLLMHookSetsAppContextFromDetectedApp(t *testing.T) {
 func TestPreLLMHookContextKeyComesFromUserAgentNotAgentHeader(t *testing.T) {
 	store := newTestStore(t)
 	defer store.Close(context.Background())
-	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}
@@ -184,7 +326,7 @@ func TestPreLLMHookContextKeyComesFromUserAgentNotAgentHeader(t *testing.T) {
 func TestCustomUserAgentMappingOverridesBuiltInDetection(t *testing.T) {
 	store := newTestStore(t)
 	defer store.Close(context.Background())
-	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}
@@ -212,7 +354,7 @@ func TestCustomUserAgentMappingOverridesBuiltInDetection(t *testing.T) {
 func TestPreLLMHookSetsAppContextFromCustomMapping(t *testing.T) {
 	store := newTestStore(t)
 	defer store.Close(context.Background())
-	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}
@@ -255,7 +397,7 @@ func TestPreLLMHookSetsAppContextFromCustomMapping(t *testing.T) {
 func TestPostLLMHookNoPendingErrorPreservesMetadata(t *testing.T) {
 	store := newTestStore(t)
 	loggingHeaders := []string{"x-custom-log"}
-	plugin, err := Init(context.Background(), &Config{LoggingHeaders: &loggingHeaders}, testLogger{}, store, nil, nil)
+	plugin, err := Init(context.Background(), &Config{LoggingHeaders: &loggingHeaders}, testLogger{}, store, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}
@@ -316,10 +458,35 @@ func TestPostLLMHookNoPendingErrorPreservesMetadata(t *testing.T) {
 	}
 }
 
+func TestEmitBatchAggregateLogRunsCallback(t *testing.T) {
+	store := newTestStore(t)
+	plugin := &LoggerPlugin{
+		ctx:   context.Background(),
+		store: store,
+	}
+	callbacks := 0
+	plugin.SetLogCallback(func(ctx context.Context, logEntry *logstore.Log) {
+		callbacks++
+	})
+
+	entry := &logstore.Log{
+		ID:        "batch-cost:openai:callback",
+		Timestamp: time.Now().UTC(),
+		Object:    string(schemas.BatchResultsRequest),
+		Provider:  string(schemas.OpenAI),
+		Model:     "gpt-4o-mini",
+		Status:    "success",
+	}
+	plugin.EmitBatchAggregateLog(context.Background(), entry)
+	if callbacks != 1 {
+		t.Fatalf("callback count after emit = %d, want 1", callbacks)
+	}
+}
+
 func TestPostLLMHookStreamingErrorPreservesHeaderMetadata(t *testing.T) {
 	store := newTestStore(t)
 	loggingHeaders := []string{"x-custom-log"}
-	plugin, err := Init(context.Background(), &Config{LoggingHeaders: &loggingHeaders}, testLogger{}, store, nil, nil)
+	plugin, err := Init(context.Background(), &Config{LoggingHeaders: &loggingHeaders}, testLogger{}, store, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}
@@ -414,7 +581,7 @@ func TestPostLLMHookCancelledStreamLogsCost(t *testing.T) {
 	}
 	pricingManager := modelcatalog.NewTestCatalogWithDatasheet(ds)
 
-	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, pricingManager, nil)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, pricingManager, nil)
 	if err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}
@@ -518,7 +685,7 @@ func TestPostLLMHookCancelledStreamLogsCost(t *testing.T) {
 
 func TestPostLLMHookContextTimeoutLogsCancelledStatus(t *testing.T) {
 	store := newTestStore(t)
-	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}
@@ -571,7 +738,7 @@ func TestPostLLMHookContextTimeoutLogsCancelledStatus(t *testing.T) {
 
 func TestPostLLMHookProviderTimeoutRemainsErrorStatus(t *testing.T) {
 	store := newTestStore(t)
-	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}
@@ -719,7 +886,7 @@ func newTestPricingManager(t *testing.T) *modelcatalog.ModelCatalog {
 // already-parsed token counters must be left untouched (not double-applied).
 func TestApplyErrorBillingFromBilledUsage_ComputesCostWhenTokensAlreadyParsed(t *testing.T) {
 	store := newTestStore(t)
-	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, newTestPricingManager(t), nil)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, newTestPricingManager(t), nil)
 	if err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}
@@ -760,7 +927,7 @@ func TestApplyErrorBillingFromBilledUsage_ComputesCostWhenTokensAlreadyParsed(t 
 // backfilled from BilledUsage.
 func TestApplyErrorBillingFromBilledUsage_FillsTokensAndCostWhenUnparsed(t *testing.T) {
 	store := newTestStore(t)
-	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, newTestPricingManager(t), nil)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, newTestPricingManager(t), nil)
 	if err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}
@@ -1070,7 +1237,7 @@ func TestBuildLogEntriesOmitEmptyUserAgent(t *testing.T) {
 // snapshot accumulated before logging's post-hook runs.
 func TestMCPHooksPersistPluginLogs(t *testing.T) {
 	store := newTestStore(t)
-	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}
@@ -1180,7 +1347,7 @@ func TestMCPHooksPersistPluginLogs(t *testing.T) {
 // created without a pending pre-hook entry still carry DAC ownership fields.
 func TestPostMCPHookFallbackStampsGovernanceFields(t *testing.T) {
 	store := newTestStore(t)
-	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}
@@ -1224,7 +1391,7 @@ func TestPostMCPHookFallbackStampsGovernanceFields(t *testing.T) {
 // MCP logs are committed as terminal errors instead of being silently dropped.
 func TestCleanupStalePendingMCPLogsPersistsErrorFallback(t *testing.T) {
 	store := newTestStore(t)
-	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}
@@ -1283,7 +1450,7 @@ func TestCleanupStalePendingMCPLogsPersistsErrorFallback(t *testing.T) {
 // older than the TTL but whose LastActivity is recent must NOT be reaped.
 func TestActiveStreamSurvivesCleanup(t *testing.T) {
 	store := newTestStore(t)
-	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}
@@ -1318,7 +1485,7 @@ func TestActiveStreamSurvivesCleanup(t *testing.T) {
 // TTL (no chunk activity for the whole idle window) must be deleted.
 func TestIdlePendingEntryEvicted(t *testing.T) {
 	store := newTestStore(t)
-	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}
@@ -1352,7 +1519,7 @@ func TestIdlePendingEntryEvicted(t *testing.T) {
 // would silently skip and leave the pending row to expire as a fake TTL error.
 func TestPreMCPHookSkipsPrefixedCodemodeTool(t *testing.T) {
 	store := newTestStore(t)
-	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}
@@ -2426,5 +2593,347 @@ func TestGuardrailDebugForLogReadsContextWithoutResponse(t *testing.T) {
 	}
 	if debug.JudgeCalls[0] != requireCall {
 		t.Fatalf("guardrail call = %#v; want %#v", debug.JudgeCalls[0], requireCall)
+	}
+}
+
+// Batch claims are fenced on the runner id, so it must differ between workers
+// that could contend for the same job. In OSS SetClusterNodeID is never called,
+// so the per-process fallback is what keeps replicas sharing a database apart.
+func TestBatchRunnerID(t *testing.T) {
+	plugin := &LoggerPlugin{}
+
+	t.Run("falls back to a per-process id when no cluster node is set", func(t *testing.T) {
+		id := plugin.batchRunnerID("logging")
+		if id == "logging" || id == "logging:" {
+			t.Fatalf("runner id must not collapse to a shared constant, got %q", id)
+		}
+		if !strings.HasPrefix(id, "logging:") {
+			t.Fatalf("expected a logging: prefix, got %q", id)
+		}
+		// Distinct roles in the same process must not collide either.
+		if other := plugin.batchRunnerID("batch-sweeper"); other == id {
+			t.Fatalf("distinct prefixes produced the same runner id: %q", id)
+		}
+	})
+
+	t.Run("prefers the cluster node id when present", func(t *testing.T) {
+		clustered := &LoggerPlugin{}
+		clustered.clusterNodeID.Store("node-7")
+		if got := clustered.batchRunnerID("logging"); got != "logging:node-7" {
+			t.Fatalf("expected logging:node-7, got %q", got)
+		}
+	})
+}
+
+func TestRecordBatchJobLifecycle_CompletedSetsNextCheckAt(t *testing.T) {
+	store := newTestStore(t)
+	bs := newFakeBatchStore()
+	plugin := &LoggerPlugin{
+		ctx:        context.Background(),
+		store:      store,
+		batchStore: bs,
+		logger:     testLogger{},
+	}
+
+	tests := []struct {
+		name       string
+		status     string
+		wantNow    bool
+		wantMinute bool
+		wantNil    bool
+	}{
+		{name: "in_progress", status: string(schemas.BatchStatusInProgress), wantMinute: true},
+		{name: "validating", status: string(schemas.BatchStatusValidating), wantMinute: true},
+		{name: "finalizing", status: string(schemas.BatchStatusFinalizing), wantMinute: true},
+		{name: "completed", status: string(schemas.BatchStatusCompleted), wantNow: true},
+		// Anthropic reports "ended"; it takes the same immediate-accounting branch.
+		{name: "ended", status: string(schemas.BatchStatusEnded), wantNow: true},
+		{name: "failed", status: string(schemas.BatchStatusFailed), wantNil: true},
+		{name: "cancelled", status: string(schemas.BatchStatusCancelled), wantNil: true},
+		{name: "expired", status: string(schemas.BatchStatusExpired), wantNil: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			batchID := "batch-" + tt.name
+			entry := &logstore.Log{
+				Provider: string(schemas.OpenAI),
+				Model:    "gpt-4o-mini",
+			}
+			retrieveResp := &schemas.BifrostBatchRetrieveResponse{
+				ID:       batchID,
+				Endpoint: string(schemas.BatchEndpointChatCompletions),
+				Status:   schemas.BatchStatus(tt.status),
+			}
+			result := &schemas.BifrostResponse{
+				BatchRetrieveResponse: retrieveResp,
+			}
+			plugin.recordBatchJobLifecycle(entry, result)
+
+			job, err := bs.GetBatchJob(context.Background(), cstables.BatchJobID("openai", batchID))
+			if err != nil {
+				t.Fatalf("GetBatchJob() error = %v", err)
+			}
+			if job.BatchID != batchID {
+				t.Fatalf("expected batch_id %s, got %s", batchID, job.BatchID)
+			}
+			if job.ProviderStatus != tt.status {
+				t.Fatalf("expected status %s, got %s", tt.status, job.ProviderStatus)
+			}
+
+			switch {
+			case tt.wantNow:
+				if job.NextCheckAt == nil {
+					t.Fatal("expected NextCheckAt to be set")
+				}
+				if job.NextCheckAt.After(time.Now().UTC().Add(2 * time.Second)) {
+					t.Fatalf("expected NextCheckAt to be now, got %v", job.NextCheckAt)
+				}
+			case tt.wantMinute:
+				if job.NextCheckAt == nil {
+					t.Fatal("expected NextCheckAt to be set")
+				}
+				if job.NextCheckAt.Before(time.Now().UTC().Add(50*time.Second)) ||
+					job.NextCheckAt.After(time.Now().UTC().Add(70*time.Second)) {
+					t.Fatalf("expected NextCheckAt ~1min from now, got %v (now=%v)", job.NextCheckAt, time.Now().UTC())
+				}
+			case tt.wantNil:
+				if job.NextCheckAt != nil {
+					t.Fatalf("expected NextCheckAt to be nil, got %v", *job.NextCheckAt)
+				}
+			}
+		})
+	}
+}
+
+func TestRecordBatchJobLifecycle_CreatePersistsModel(t *testing.T) {
+	store := newTestStore(t)
+	bs := newFakeBatchStore()
+	plugin := &LoggerPlugin{
+		ctx:        context.Background(),
+		store:      store,
+		batchStore: bs,
+		logger:     testLogger{},
+	}
+
+	entry := &logstore.Log{
+		ID:       "req-create-batch",
+		Provider: string(schemas.OpenAI),
+		Model:    "gpt-4o",
+	}
+	createResp := &schemas.BifrostBatchCreateResponse{
+		ID:          "batch-create-123",
+		Status:      schemas.BatchStatusValidating,
+		InputFileID: "file-abc",
+	}
+	result := &schemas.BifrostResponse{
+		BatchCreateResponse: createResp,
+	}
+	plugin.recordBatchJobLifecycle(entry, result)
+
+	job, err := bs.GetBatchJob(context.Background(), cstables.BatchJobID("openai", "batch-create-123"))
+	if err != nil {
+		t.Fatalf("GetBatchJob() error = %v", err)
+	}
+	if job.Model != "gpt-4o" {
+		t.Fatalf("expected model %s, got %s", "gpt-4o", job.Model)
+	}
+	if job.InputFileID != "file-abc" {
+		t.Fatalf("expected input_file_id %s, got %s", "file-abc", job.InputFileID)
+	}
+	if job.AccountingStatus != cstables.BatchJobAccountingStatusPending {
+		t.Fatalf("expected accounting_status %s, got %s", cstables.BatchJobAccountingStatusPending, job.AccountingStatus)
+	}
+}
+
+func TestAccountBatchResults_NonResultsResponseIsNoop(t *testing.T) {
+	store := newTestStore(t)
+	bs := newFakeBatchStore()
+	plugin := &LoggerPlugin{
+		ctx:        context.Background(),
+		store:      store,
+		batchStore: bs,
+		logger:     testLogger{},
+		// Pricing must be set or accountBatchResults returns on the nil-pricing
+		// guard and this test passes without ever reaching the check it covers.
+		pricingManager: newTestPricingManager(t),
+	}
+
+	entry := &logstore.Log{
+		ID:       "req-no-results",
+		Provider: string(schemas.OpenAI),
+		Model:    "gpt-4o-mini",
+	}
+	nonResultsResult := &schemas.BifrostResponse{
+		ListModelsResponse: &schemas.BifrostListModelsResponse{},
+	}
+	// accountBatchResults with no BatchResultsResponse should be a no-op
+	plugin.accountBatchResults(entry, nonResultsResult, nil)
+
+	// Verify no batch_jobs rows were created
+	jobs, err := bs.ListDueBatchJobs(context.Background(), "openai", time.Now().UTC().Add(time.Hour), 100)
+	if err != nil {
+		t.Fatalf("ListDueBatchJobs() error = %v", err)
+	}
+	if len(jobs) > 0 {
+		t.Fatalf("expected no batch jobs from non-batch-response, got %d", len(jobs))
+	}
+}
+
+func TestAccountBatchResults_EmptyResultsMarksUnpriceable(t *testing.T) {
+	store := newTestStore(t)
+	bs := newFakeBatchStore()
+	plugin := &LoggerPlugin{
+		ctx:            context.Background(),
+		store:          store,
+		batchStore:     bs,
+		logger:         testLogger{},
+		pricingManager: newTestPricingManager(t),
+	}
+
+	entry := &logstore.Log{
+		ID:       "req-empty-batch-results",
+		Provider: string(schemas.OpenAI),
+		Model:    "gpt-4o-mini",
+	}
+	result := &schemas.BifrostResponse{
+		BatchResultsResponse: &schemas.BifrostBatchResultsResponse{
+			BatchID: "batch-empty-results",
+			Results: nil,
+		},
+	}
+
+	plugin.accountBatchResults(entry, result, nil)
+
+	job, err := bs.GetBatchJob(context.Background(), cstables.BatchJobID("openai", "batch-empty-results"))
+	if err != nil {
+		t.Fatalf("GetBatchJob() error = %v", err)
+	}
+	if job.AccountingStatus != cstables.BatchJobAccountingStatusUnpriceable {
+		t.Fatalf("expected accounting_status %s, got %s", cstables.BatchJobAccountingStatusUnpriceable, job.AccountingStatus)
+	}
+	if job.UnpriceableReason == nil || *job.UnpriceableReason != batchaccounting.UnpriceableReasonNoResults {
+		t.Fatalf("expected unpriceable_reason %s, got %#v", batchaccounting.UnpriceableReasonNoResults, job.UnpriceableReason)
+	}
+}
+
+func TestAccountBatchResults_RepeatedFetchDisplaysPriceWithoutBilling(t *testing.T) {
+	store := newTestStore(t)
+	bs := newFakeBatchStore()
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, bs, newTestPricingManager(t), nil)
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	newResult := func() *schemas.BifrostResponse {
+		return &schemas.BifrostResponse{
+			BatchResultsResponse: &schemas.BifrostBatchResultsResponse{
+				BatchID: "batch-repeat-fetch",
+				Results: []schemas.BatchResultItem{{
+					CustomID: "custom-1",
+					Response: &schemas.BatchResultResponse{
+						StatusCode: 200,
+						Body: map[string]interface{}{
+							"model": "gpt-4o",
+							"usage": map[string]interface{}{
+								"prompt_tokens":     100,
+								"completion_tokens": 50,
+								"total_tokens":      150,
+							},
+						},
+					},
+				}},
+			},
+		}
+	}
+
+	first := &logstore.Log{ID: "req-fetch-1", Provider: string(schemas.OpenAI), Model: "gpt-4o"}
+	plugin.accountBatchResults(first, newResult(), nil)
+
+	if first.BatchDebugParsed == nil || first.BatchDebugParsed.Accounting == nil || first.BatchDebugParsed.Accounting.Cost == nil {
+		t.Fatalf("expected first call's own row to show the settled price, got %#v", first.BatchDebugParsed)
+	}
+	wantCost := *first.BatchDebugParsed.Accounting.Cost
+	if wantCost <= 0 {
+		t.Fatalf("expected a positive settled cost, got %v", wantCost)
+	}
+	if first.Cost != nil {
+		t.Fatalf("entry.Cost must stay nil on a batch_results row, got %v", *first.Cost)
+	}
+	if first.BatchDebugParsed.Status != string(schemas.BatchStatusCompleted) {
+		t.Fatalf("expected status %q, got %q", schemas.BatchStatusCompleted, first.BatchDebugParsed.Status)
+	}
+
+	second := &logstore.Log{ID: "req-fetch-2", Provider: string(schemas.OpenAI), Model: "gpt-4o"}
+	plugin.accountBatchResults(second, newResult(), nil)
+
+	if second.BatchDebugParsed == nil || second.BatchDebugParsed.Accounting == nil || second.BatchDebugParsed.Accounting.Cost == nil {
+		t.Fatalf("expected the repeat fetch's own row to also show the settled price, got %#v", second.BatchDebugParsed)
+	}
+	if diff := *second.BatchDebugParsed.Accounting.Cost - wantCost; diff < -1e-12 || diff > 1e-12 {
+		t.Fatalf("repeat fetch price %v does not match originally settled price %v", *second.BatchDebugParsed.Accounting.Cost, wantCost)
+	}
+	if second.BatchDebugParsed.Accounting.Incomplete {
+		t.Fatal("repeat fetch must not show incomplete once the batch fully priced")
+	}
+	if second.Cost != nil {
+		t.Fatalf("entry.Cost must stay nil on the repeat fetch's row too, got %v", *second.Cost)
+	}
+	if second.BatchDebugParsed.Status != string(schemas.BatchStatusCompleted) {
+		t.Fatalf("expected mirrored status %q, got %q", schemas.BatchStatusCompleted, second.BatchDebugParsed.Status)
+	}
+
+	logs, err := store.SearchLogs(context.Background(), logstore.SearchFilters{}, logstore.PaginationOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("SearchLogs() error = %v", err)
+	}
+	aggregateRows := 0
+	for _, l := range logs.Logs {
+		if l.ID == batchaccounting.AccountingLogID(schemas.OpenAI, "batch-repeat-fetch") {
+			aggregateRows++
+		}
+	}
+	if aggregateRows != 1 {
+		t.Fatalf("expected exactly 1 aggregate cost row, got %d", aggregateRows)
+	}
+}
+
+// noopBatchFetcher satisfies batchaccounting.BatchResultFetcher without touching a
+// provider: the point of the test below is that it is never reached.
+type noopBatchFetcher struct{}
+
+func (noopBatchFetcher) RetrieveBatch(context.Context, *cstables.TableBatchJob) (*schemas.BifrostBatchRetrieveResponse, error) {
+	return nil, nil
+}
+
+func (noopBatchFetcher) FetchBatchResults(context.Context, *cstables.TableBatchJob) (*schemas.BifrostBatchResultsResponse, error) {
+	return nil, nil
+}
+
+// A plugin reload can call the wiring against an instance that is already shutting
+// down. Cleanup sets the shutdown flag and cancels the sweeper under p.mu before it
+// reaches p.wg.Wait(), so a start arriving afterwards must decline rather than run
+// wg.Add concurrently with that Wait — which is a WaitGroup contract violation and
+// would leave a sweeper writing through a closed plugin.
+func TestStartBatchAccountingSweeperAfterCleanupIsRefused(t *testing.T) {
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, newTestStore(t), newFakeBatchStore(), newTestPricingManager(t), nil)
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	if err := plugin.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	cancel := plugin.StartBatchAccountingSweeper(noopBatchFetcher{}, time.Minute, nil)
+	if cancel == nil {
+		t.Fatal("StartBatchAccountingSweeper must always return a cancel func")
+	}
+	cancel() // must be safe to call on the refused path
+
+	plugin.mu.Lock()
+	registered := plugin.batchSweeperCancel
+	plugin.mu.Unlock()
+	if registered != nil {
+		t.Fatal("no sweeper should be registered after Cleanup")
 	}
 }

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bytedance/sonic"
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/logstore"
@@ -906,4 +907,15 @@ func formatRoutingEngineLogs(logs []schemas.RoutingEngineLogEntry) string {
 		sb.WriteString(fmt.Sprintf("[%d] [%s] - %s\n", log.Timestamp, log.Engine, log.Message))
 	}
 	return sb.String()
+}
+
+func stringSlicePtr(values []string) *string {
+	if len(values) == 0 {
+		return nil
+	}
+	out, err := sonic.MarshalString(values)
+	if err != nil {
+		return nil
+	}
+	return &out
 }

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -3344,9 +3344,24 @@ func (h *CompletionHandler) batchCreate(ctx *fasthttp.RequestCtx) {
 		logger.Warn("Failed to extract extra params: %v", err)
 	}
 
+	// Model is optional at the batch level per OpenAI spec — it lives inside
+	// each JSONL request body. When absent, lift it from the first inline request
+	// so the sweeper has a fallback model for pricing lookups.
+	//
+	// Taking Requests[0] is deliberate, not a mixed-model hazard. It is only ever
+	// a fallback: accounting prefers the model echoed on each result row, and the
+	// providers where the fallback actually decides pricing run one model per job
+	// anyway — Gemini carries it in the URL (models/%s:batchGenerateContent) and
+	// Bedrock requires a job-level model. Leaving it unset when inline models
+	// differ would break Bedrock batch creation and make Gemini silently run its
+	// default model.
 	var model *string
 	if modelName != "" {
 		model = schemas.Ptr(modelName)
+	} else if len(req.Requests) > 0 && req.Requests[0].Body != nil {
+		if m, ok := req.Requests[0].Body["model"].(string); ok && m != "" {
+			model = schemas.Ptr(m)
+		}
 	}
 
 	// Build Bifrost batch create request

--- a/transports/bifrost-http/server/batch_accounting.go
+++ b/transports/bifrost-http/server/batch_accounting.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/batchaccounting"
+	cstables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/plugins/governance"
+	"github.com/maximhq/bifrost/plugins/logging"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+)
+
+type bifrostBatchResultFetcher struct {
+	client *bifrost.Bifrost
+}
+
+func (f *bifrostBatchResultFetcher) RetrieveBatch(ctx context.Context, job *cstables.TableBatchJob) (*schemas.BifrostBatchRetrieveResponse, error) {
+	if f == nil || f.client == nil {
+		return nil, fmt.Errorf("bifrost client is nil")
+	}
+	if job == nil {
+		return nil, fmt.Errorf("batch job is nil")
+	}
+	resp, bifrostErr := f.client.BatchRetrieveRequest(internalBatchContext(ctx), &schemas.BifrostBatchRetrieveRequest{
+		Provider: schemas.ModelProvider(job.Provider),
+		Model:    modelPtr(job.Model),
+		BatchID:  job.BatchID,
+	})
+	if bifrostErr != nil {
+		return nil, fmt.Errorf("%s", bifrostErr.GetErrorString())
+	}
+	return resp, nil
+}
+
+func (f *bifrostBatchResultFetcher) FetchBatchResults(ctx context.Context, job *cstables.TableBatchJob) (*schemas.BifrostBatchResultsResponse, error) {
+	if f == nil || f.client == nil {
+		return nil, fmt.Errorf("bifrost client is nil")
+	}
+	if job == nil {
+		return nil, fmt.Errorf("batch job is nil")
+	}
+	resp, bifrostErr := f.client.BatchResultsRequest(internalBatchContext(ctx), &schemas.BifrostBatchResultsRequest{
+		Provider: schemas.ModelProvider(job.Provider),
+		Model:    modelPtr(job.Model),
+		BatchID:  job.BatchID,
+	})
+	if bifrostErr != nil {
+		return nil, fmt.Errorf("%s", bifrostErr.GetErrorString())
+	}
+	return resp, nil
+}
+
+func internalBatchContext(parent context.Context) *schemas.BifrostContext {
+	ctx := schemas.NewBifrostContext(parent, schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyRequestID, uuid.NewString())
+	ctx.SetValue(schemas.BifrostContextKeySkipPluginPipeline, true)
+	ctx.SetValue(schemas.BifrostContextKeySkipBudgetAndRateLimits, true)
+	return ctx
+}
+
+func modelPtr(model string) *string {
+	if model == "" {
+		return nil
+	}
+	return &model
+}
+
+func (s *BifrostHTTPServer) WireBatchAccountingSweeper() {
+	if s == nil || s.Client == nil || s.Config == nil {
+		return
+	}
+	loggerPlugin, err := lib.FindPluginAs[*logging.LoggerPlugin](s.Config, logging.PluginName)
+	if err != nil || loggerPlugin == nil {
+		logger.Warn("batch accounting sweeper not wired: logging plugin not found (err=%v)", err)
+		return
+	}
+	// The reporter must be cleared, not just left alone, when governance is gone:
+	// this runs on reload, and a stale reporter keeps the logging plugin (and the
+	// sweeper it is about to start, which snapshots it) reporting batch usage
+	// through a torn-down plugin instance.
+	var usageReporter batchaccounting.UsageReporter
+	if governancePlugin, govErr := lib.FindPluginAs[governance.BaseGovernancePlugin](s.Config, s.getGovernancePluginName()); govErr == nil && governancePlugin != nil {
+		if reporter, ok := governancePlugin.(batchaccounting.UsageReporter); ok {
+			usageReporter = reporter
+		}
+	}
+	loggerPlugin.SetBatchUsageReporter(usageReporter)
+	loggerPlugin.StartBatchAccountingSweeper(&bifrostBatchResultFetcher{client: s.Client}, time.Minute, s.Config.KVStore)
+}

--- a/transports/bifrost-http/server/plugins.go
+++ b/transports/bifrost-http/server/plugins.go
@@ -87,7 +87,7 @@ func loadBuiltinPlugin(ctx context.Context, name string, pluginConfig any, bifro
 				bifrostConfig.LogsStoreConfig.ObjectStorage != nil
 		}
 		return logging.Init(ctx, loggingConfig, logger, bifrostConfig.LogsStore,
-			bifrostConfig.ModelCatalog, bifrostConfig.MCPCatalog)
+			bifrostConfig.ConfigStore, bifrostConfig.ModelCatalog, bifrostConfig.MCPCatalog)
 
 	case governance.PluginName:
 		governanceConfig, err := MarshalPluginConfig[governance.Config](pluginConfig)

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1929,6 +1929,14 @@ func (s *BifrostHTTPServer) SyncLoadedPlugin(ctx context.Context, name string, p
 	if _, ok := plugin.(schemas.ObservabilityPlugin); ok {
 		s.reloadObservabilityPlugins()
 	}
+	// 4b. Batch accounting is wired at bootstrap against the live logging and
+	// governance plugins. Reloading either swaps the instance — which cancels the
+	// old sweeper and leaves the sweeper holding a torn-down usage reporter — so
+	// it must be rewired here or batch accounting silently stops until restart.
+	// Safe to re-run: StartBatchAccountingSweeper cancels any prior sweeper.
+	if plugin.GetName() == logging.PluginName || plugin.GetName() == s.getGovernancePluginName() {
+		s.WireBatchAccountingSweeper()
+	}
 	// 5. Update plugin status
 	s.Config.UpdatePluginOverallStatus(plugin.GetName(), name, schemas.PluginStatusActive,
 		[]string{fmt.Sprintf("plugin %s reloaded successfully", name)}, InferPluginTypes(plugin))
@@ -2516,6 +2524,7 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	}
 	logger.Info("models added to catalog")
 	s.Config.SetBifrostClient(s.Client)
+	s.WireBatchAccountingSweeper()
 	// Initialize routes
 	s.Router = router.New()
 	// Save the matched route template on each request

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -38,7 +38,7 @@ import {
 	RoutingEngineUsedLabels,
 	Status,
 } from "@/lib/constants/logs";
-import { ContentBlock, LogEntry, ResponsesMessage } from "@/lib/types/logs";
+import { BatchRequestCounts, ContentBlock, LogEntry, ResponsesMessage } from "@/lib/types/logs";
 import { useGetUserAgentMappingsQuery } from "@/lib/store";
 import { cn } from "@/lib/utils";
 import { downloadAsJson } from "@/lib/utils/browser-download";
@@ -365,6 +365,25 @@ const formatToolChoice = (value: unknown): string => {
 	}
 };
 
+// batchRequestStates lists the provider's per-state request tallies as discrete
+// label/count pairs. Total, Completed, and Failed are universal (every provider
+// sets them, and a 0 is a real, useful count — e.g. "no failures yet"), so they
+// always render. The remaining states are Anthropic-specific and simply absent
+// for other providers, so those are dropped when not reported.
+const batchRequestStates = (counts: BatchRequestCounts): [string, number][] => {
+	const optional: [string, number | undefined][] = [
+		["Succeeded", counts.succeeded],
+		["Expired", counts.expired],
+		["Canceled", counts.canceled],
+		["Pending", counts.pending],
+	];
+	return [
+		["Completed", counts.completed],
+		["Failed", counts.failed],
+		...optional.filter((entry): entry is [string, number] => Boolean(entry[1])),
+	];
+};
+
 // Helper to detect passthrough operations
 const isPassthroughOperation = (object: string) => object === "passthrough" || object === "passthrough_stream";
 
@@ -396,6 +415,16 @@ const statusDotStyles: Record<string, string> = {
 	processing: "bg-blue-500",
 	cancelled: "bg-gray-400",
 };
+
+const batchStatusBadgeStyles: Record<string, string> = {
+	completed: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+	ended: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+	failed: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+	expired: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300",
+	cancelled: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300",
+	deleted: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300",
+};
+const batchStatusBadgeDefault = "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200";
 
 function StatusPill({ status }: { status: Status }) {
 	return (
@@ -670,6 +699,7 @@ export function LogDetailView({
 	const showTabs = !isContainer;
 	const isPassthrough = isPassthroughOperation(log.object);
 	const isRealtimeTurn = log.object === "realtime.turn";
+	const batchDebug = log.batch_debug;
 	const passthroughParams = isPassthrough
 		? (log.params as {
 				method?: string;
@@ -885,6 +915,17 @@ export function LogDetailView({
 									className="rounded-sm border-amber-300 bg-amber-50 px-2 py-0.5 font-medium text-amber-700 dark:border-amber-600 dark:bg-amber-950 dark:text-amber-300"
 								>
 									{log.metadata.realtime_voice}
+								</Badge>
+							)}
+							{batchDebug?.status && (
+								<Badge
+									variant="outline"
+									className={cn(
+										"rounded-sm px-2 py-0.5 font-medium uppercase",
+										batchStatusBadgeStyles[batchDebug.status] ?? batchStatusBadgeDefault,
+									)}
+								>
+									{batchDebug.status.replace(/_/g, " ")}
 								</Badge>
 							)}
 						</div>
@@ -1613,6 +1654,40 @@ export function LogDetailView({
 									</>
 								);
 							})()}
+							{batchDebug && (
+								<>
+									<DottedSeparator />
+									<div className="space-y-4">
+										<BlockHeader title="Batch Details" />
+										<div className="grid w-full grid-cols-3 md:grid-cols-1 items-start justify-between gap-4">
+											{batchDebug.batch_id && (
+												<LogEntryDetailsView
+													className="w-full"
+													label="Batch ID"
+													value={
+														<span className="flex items-center gap-1">
+															<code className="font-mono text-xs">{batchDebug.batch_id}</code>
+															<CopyInlineButton text={batchDebug.batch_id} testId="logdetails-copy-batch-id-button" />
+														</span>
+													}
+												/>
+											)}
+											{batchDebug.request_counts && (
+												<>
+													<LogEntryDetailsView className="w-full" label="Total Requests" value={String(batchDebug.request_counts.total)} />
+													{batchRequestStates(batchDebug.request_counts).map(([label, count]) => (
+														<LogEntryDetailsView key={label} className="w-full" label={label} value={String(count)} />
+													))}
+												</>
+											)}
+											{batchDebug.accounting?.cost != null && (
+												<LogEntryDetailsView className="w-full" label="Batch Cost" value={formatCost(batchDebug.accounting.cost)} />
+											)}
+										</div>
+									</div>
+								</>
+							)}
+
 							{log.cache_debug && (
 								<>
 									<DottedSeparator />

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -446,6 +446,40 @@ export interface CacheDebug {
 	similarity?: number;
 }
 
+export interface BatchRequestCounts {
+	total: number;
+	completed: number;
+	failed: number;
+	succeeded?: number; // Anthropic-specific
+	expired?: number; // Anthropic-specific
+	canceled?: number; // Anthropic-specific
+	pending?: number; // Anthropic-specific
+}
+
+export interface BatchModelBreakdown {
+	model: string;
+	request_count: number;
+	usage: LLMUsage;
+	cost?: number; // Absent when this model hasn't priced yet (e.g. no batch rate at settlement time)
+}
+
+export interface BatchAccountingDebug {
+	model_breakdowns?: Record<string, BatchModelBreakdown>;
+	cost?: number; // Mirrors the settled price on a row that isn't itself the aggregate cost row
+	parse_error_count?: number; // Result rows the provider returned that could not be parsed; their usage is not in this row
+	incomplete?: boolean; // The row's total is known to under-state the batch (unpriced usage and/or parse errors)
+}
+
+// Batch detail for batch rows. `accounting` is present only on the aggregate
+// cost row written when a settled batch is priced.
+export interface BatchDebug {
+	batch_id?: string;
+	status?: string; // Provider batch lifecycle status, e.g. "in_progress" / "completed"
+	endpoint?: string; // Provider batch endpoint the batch ran against; absent on rows written before it was persisted
+	request_counts?: BatchRequestCounts;
+	accounting?: BatchAccountingDebug;
+}
+
 export interface GuardrailJudgeCall {
 	phase?: string;
 	rule_id?: number;
@@ -604,6 +638,7 @@ export interface LogEntry {
 	overhead_latency?: number; // Bifrost overhead (total minus upstream), ms
 	token_usage?: LLMUsage;
 	cache_debug?: CacheDebug;
+	batch_debug?: BatchDebug;
 	guardrail_debug?: GuardrailDebug;
 	cost?: number; // Cost in dollars (total cost of the request - includes cache lookup cost and also guardrail judge calls)
 	// Served billing tier, denormalized onto the log row so cost recomputation can reprice


### PR DESCRIPTION
## Summary

Adds a "Batch Details" section to the log detail view that surfaces batch-specific metadata — including the provider batch ID, per-state request counts, and accounting breakdowns — when a log entry contains `batch_debug` data.

## Changes

- Introduced `BatchRequestCounts`, `BatchModelBreakdown`, `BatchAccountingDebug`, and `BatchDebug` TypeScript interfaces to model batch metadata returned on log entries.
- Added `batch_debug` as an optional field on `LogEntry`.
- Added a `batchRequestStates` helper that filters provider-reported per-state request tallies (completed, succeeded, failed, expired, canceled, pending), omitting states not reported by the provider. `total` is always rendered separately.
- Rendered a "Batch Details" block in `LogDetailView` when `batch_debug` is present, showing the batch ID (with a copy button), total and per-state request counts, and accounting figures (priced, unpriced, failed).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Navigate to a log entry associated with a batch operation. Verify that the "Batch Details" section appears below the existing log details, showing:
- The provider batch ID with a working copy button.
- Total request count and any non-zero per-state counts (e.g., completed, failed).
- Priced, unpriced, and failed accounting counts if accounting data is present.

For log entries without `batch_debug`, confirm the section does not appear.

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

_Add before/after screenshots of the log detail panel for a batch log entry._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new auth, secrets, or PII concerns. The batch ID is already stored server-side and is only surfaced to users who already have access to the log entry.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable