### PR TITLE
feat: redesign `QuarterStartSelect` layout to horizontal label/preview with right-aligned select

### DIFF
--- a/ui/app/workspace/governance/views/customerSheet.tsx
+++ b/ui/app/workspace/governance/views/customerSheet.tsx
@@ -367,7 +367,7 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 											Align to calendar cycle
 										</Label>
 										<p className="text-muted-foreground text-xs">
-											Reset budgets and rate limits at the start of each period (e.g. 1st of month) instead of rolling from creation date.
+											Reset budgets and rate limits at the start of each period (e.g. 1st of month) instead of rolling from creation date. Quarterly budgets always align to fiscal quarter starts.
 											Applies to durations of a day or longer.
 										</p>
 									</div>

--- a/ui/app/workspace/governance/views/teamSheet.tsx
+++ b/ui/app/workspace/governance/views/teamSheet.tsx
@@ -524,7 +524,7 @@ export default function TeamSheet({ team, onSave, onCancel }: TeamSheetProps) {
 											Align to calendar cycle
 										</Label>
 										<p className="text-muted-foreground text-xs">
-											Reset budgets and rate limits at the start of each period (e.g. 1st of month) instead of rolling from creation date.
+											Reset budgets and rate limits at the start of each period (e.g. 1st of month) instead of rolling from creation date. Quarterly budgets always align to fiscal quarter starts.
 											Applies to durations of a day or longer.
 										</p>
 									</div>

--- a/ui/app/workspace/providers/fragments/governanceFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/governanceFormFragment.tsx
@@ -225,7 +225,7 @@ export function GovernanceFormFragment({ provider }: GovernanceFormFragmentProps
 								Align to calendar cycle
 							</Label>
 							<p className="text-muted-foreground text-xs">
-								Reset budgets at the start of each period (e.g. 1st of month) instead of rolling from creation date.
+								Reset budgets at the start of each period (e.g. 1st of month) instead of rolling from creation date. Quarterly budgets always align to fiscal quarter starts.
 							</p>
 						</div>
 						<Switch

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -119,6 +119,7 @@ const providerConfigSchema = z.object({
 							id: z.string().optional(),
 							max_limit: z.number().nonnegative().optional(),
 							reset_duration: z.string().optional(),
+							reset_config: z.object({ quarter_start_month: z.number().int().min(1).max(12).optional() }).optional(),
 						}),
 					)
 					.optional(),
@@ -377,6 +378,7 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 							id: b.id,
 							max_limit: b.max_limit,
 							reset_duration: b.reset_duration,
+							reset_config: b.reset_config,
 						})),
 						rate_limit: mb.rate_limit
 							? {
@@ -1604,7 +1606,7 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 												Align to calendar cycle
 											</Label>
 											<p id="vk-budget-calendar-aligned-description" className="text-muted-foreground text-xs">
-												Reset budgets and rate limits at the start of each period (e.g. 1st of month) instead of rolling from creation date.
+												Reset budgets and rate limits at the start of each period (e.g. 1st of month) instead of rolling from creation date. Quarterly budgets always align to fiscal quarter starts.
 												Applies to durations of a day or longer.
 											</p>
 										</div>

--- a/ui/components/ui/multibudgets.tsx
+++ b/ui/components/ui/multibudgets.tsx
@@ -136,11 +136,15 @@ export default function MultiBudgetLines({
 							</Button>
 						</div>
 						{isQuarterly(line.reset_duration) && (
-							<QuarterStartSelect
-								data-testid={`${testId}-quarter-config-${index}`}
-								value={line.reset_config?.quarter_start_month}
-								onChange={(month) => updateQuarterStartMonth(index, month)}
-							/>
+							// mr-10 (40px) = the remove button (w-8) + its gap-2, so the fiscal-year
+							// row shares its right edge with the Reset Period select above it.
+							<div className="mr-10">
+								<QuarterStartSelect
+									data-testid={`${testId}-quarter-config-${index}`}
+									value={line.reset_config?.quarter_start_month}
+									onChange={(month) => updateQuarterStartMonth(index, month)}
+								/>
+							</div>
 						)}
 						{isDuplicate && (
 							<p className="text-destructive pl-0.5 text-xs">Duplicate reset period; each budget line must use a different interval.</p>

--- a/ui/components/ui/quarterStartSelect.tsx
+++ b/ui/components/ui/quarterStartSelect.tsx
@@ -1,6 +1,8 @@
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { formatQuarterPreview, quarterStartMonthOptions } from "@/lib/constants/governance";
+import { currentQuarterIndex, nextQuarterReset, quarterRanges, quarterStartMonthOptions } from "@/lib/constants/governance";
+import { cn } from "@/lib/utils";
+import { format } from "date-fns";
 
 interface QuarterStartSelectProps {
 	"data-testid"?: string;
@@ -12,36 +14,67 @@ interface QuarterStartSelectProps {
 /**
  * Advanced setting for a quarterly budget: which month opens Q1.
  *
- * Shared by every budget editor rather than inlined, because the preview below
- * the select is the part that makes the setting legible and a second copy would
- * drift. Quarter boundaries repeat every three months, so the start month only
- * changes reset dates modulo 3: January, April, July and October all reset on
- * the same days, which covers the common UK/India (April), US federal (October)
- * and Australian (July) fiscal years. For those an operator sees no change in
- * reset behaviour at all, and the preview is the only feedback that the setting
- * took effect - what differs is which quarter is labelled Q1.
+ * Shared by every budget editor rather than inlined. The fiscal-year row and the
+ * quarter map share one bordered box so they read as a single grouped setting. The
+ * month select keeps the Reset Period select's size (h-9 / w-40), and the
+ * quarter map below makes the setting legible: quarter boundaries repeat every three
+ * months, so April/July/October fiscal years reset on the same days as January - the
+ * only visible difference is which range is labelled Q1 and which quarter is current.
+ * The helper line spells out the concrete next reset date so the effect is unambiguous.
  */
 export default function QuarterStartSelect({ "data-testid": testId, value, onChange }: QuarterStartSelectProps) {
+	const quarters = quarterRanges(value);
+	const current = currentQuarterIndex(value);
+	const nextReset = nextQuarterReset(value);
+	// The quarter ends the day before the next reset boundary.
+	const currentQuarterEnd = new Date(nextReset.getTime() - 86_400_000);
+
 	return (
-		<div className="bg-muted/20 mt-1 space-y-1.5 rounded-sm border p-2.5" data-testid={testId}>
-			<div className="flex w-full flex-row items-center gap-2">
-				<Label className="text-muted-foreground font-medium">Fiscal year starts</Label>
-				<div className="ml-auto flex flex-col items-end">
-					<Select value={String(value ?? 1)} onValueChange={(month) => onChange(Number(month))}>
-						<SelectTrigger className="h-8 w-44" data-testid={testId ? `${testId}-trigger` : undefined}>
-							<SelectValue />
-						</SelectTrigger>
-						<SelectContent>
-							{quarterStartMonthOptions.map((month) => (
-								<SelectItem key={month.value} value={month.value} data-testid={testId ? `${testId}-option-${month.value}` : undefined}>
-									{month.label}
-								</SelectItem>
-							))}
-						</SelectContent>
-					</Select>
-					<p className="text-muted-foreground text-[11px] italic">{formatQuarterPreview(value)}</p>
-				</div>
+		<div className="bg-muted/20 space-y-2.5 rounded-sm border p-3" data-testid={testId}>
+			{/* Stacks below sm so the label and month select don't crush each other on
+			    narrow viewports; horizontal (select right-aligned inside the box) above. */}
+			<div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
+				<Label className="font-normal">Fiscal year starts</Label>
+				<Select value={String(value ?? 1)} onValueChange={(month) => onChange(Number(month))}>
+					<SelectTrigger
+						aria-label="Fiscal year starts"
+						className="h-9 w-full shrink-0 sm:w-40"
+						data-testid={testId ? `${testId}-trigger` : undefined}
+					>
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						{quarterStartMonthOptions.map((month) => (
+							<SelectItem key={month.value} value={month.value} data-testid={testId ? `${testId}-option-${month.value}` : undefined}>
+								{month.label}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
 			</div>
+
+			<div className="grid grid-cols-4 gap-1.5">
+				{quarters.map((quarter, index) => {
+					const isCurrent = index === current;
+					return (
+						<div
+							key={quarter.label}
+							className={cn("flex flex-col gap-[3px] rounded-sm border p-2", isCurrent && "border-ring bg-secondary")}
+							data-testid={isCurrent && testId ? `${testId}-current-quarter` : undefined}
+						>
+							<div className="flex items-center justify-between">
+								<span className="text-muted-foreground font-mono text-[10.5px]">{quarter.label}</span>
+								{isCurrent && <span className="bg-primary h-[5px] w-[5px] rounded-full" />}
+							</div>
+							<span className={cn("font-mono text-xs", isCurrent ? "text-foreground" : "text-muted-foreground")}>{quarter.range}</span>
+						</div>
+					);
+				})}
+			</div>
+			<p className="text-muted-foreground border-t pt-2.5 text-[0.8rem] leading-relaxed">
+				Next reset on <span className="text-foreground font-medium">{format(nextReset, "MMM d, yyyy")}</span>. The current quarter ends{" "}
+				{format(currentQuarterEnd, "MMM d, yyyy")}.
+			</p>
 		</div>
 	);
 }

--- a/ui/lib/constants/governance.ts
+++ b/ui/lib/constants/governance.ts
@@ -39,6 +39,23 @@ export const resetDurationLabels: Record<string, string> = {
 
 const MONTH_ABBREVIATIONS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
+// Fall back to January for a missing, fractional, or out-of-range month, matching
+// BudgetResetConfig.QuarterStart on the Go side. Number.isInteger also rejects a
+// fractional month, which would otherwise index the month tables between slots.
+function normalizeQuarterStart(startMonth?: number): number {
+	return startMonth !== undefined && Number.isInteger(startMonth) && startMonth >= 1 && startMonth <= 12 ? startMonth : 1;
+}
+
+// Month indices (0-11) for the four fiscal quarters — the single source of the
+// modulo-3 boundary math the preview string, chip ranges, and reset date all build on.
+function quarterMonthIndices(startMonth?: number): { first: number; last: number }[] {
+	const start = normalizeQuarterStart(startMonth);
+	return [0, 1, 2, 3].map((quarter) => {
+		const first = (start - 1 + quarter * 3) % 12;
+		return { first, last: (first + 2) % 12 };
+	});
+}
+
 /**
  * Renders the four fiscal quarters implied by a start month, e.g. April gives
  * "Q1 Apr-Jun · Q2 Jul-Sep · Q3 Oct-Dec · Q4 Jan-Mar".
@@ -54,15 +71,8 @@ const MONTH_ABBREVIATIONS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "A
  * BudgetResetConfig.QuarterStart on the Go side.
  */
 export function formatQuarterPreview(startMonth?: number): string {
-	// Number.isInteger rejects a fractional month, which would otherwise pass the
-	// range check and index MONTH_ABBREVIATIONS between slots.
-	const start = startMonth !== undefined && Number.isInteger(startMonth) && startMonth >= 1 && startMonth <= 12 ? startMonth : 1;
-	return [0, 1, 2, 3]
-		.map((quarter) => {
-			const first = (start - 1 + quarter * 3) % 12;
-			const last = (first + 2) % 12;
-			return `Q${quarter + 1} ${MONTH_ABBREVIATIONS[first]}-${MONTH_ABBREVIATIONS[last]}`;
-		})
+	return quarterMonthIndices(startMonth)
+		.map((month, quarter) => `Q${quarter + 1} ${MONTH_ABBREVIATIONS[month.first]}-${MONTH_ABBREVIATIONS[month.last]}`)
 		.join(" · ");
 }
 
@@ -79,6 +89,41 @@ export function fiscalQuarterNote(resetDuration?: string, resetConfig?: { quarte
 	// otherwise pass the range check and index MONTH_ABBREVIATIONS between slots.
 	if (start === undefined || !Number.isInteger(start) || start === 1 || start < 1 || start > 12) return "";
 	return ` · FY starts ${MONTH_ABBREVIATIONS[start - 1]}`;
+}
+
+/**
+ * The four fiscal quarters as `{label, range}` for the quarter-map chips, e.g.
+ * April → `[{label:"Q1", range:"Apr–Jun"}, …]`. Uses an en-dash to match the design.
+ */
+export function quarterRanges(startMonth?: number): { label: string; range: string }[] {
+	return quarterMonthIndices(startMonth).map((month, quarter) => ({
+		label: `Q${quarter + 1}`,
+		range: `${MONTH_ABBREVIATIONS[month.first]}–${MONTH_ABBREVIATIONS[month.last]}`,
+	}));
+}
+
+/** Index (0-3) of the fiscal quarter containing `now`, for the current-quarter highlight. */
+export function currentQuarterIndex(startMonth?: number, now: Date = new Date()): number {
+	const start = normalizeQuarterStart(startMonth);
+	return Math.floor(((now.getMonth() - (start - 1) + 12) % 12) / 3);
+}
+
+/**
+ * First day of the next fiscal quarter strictly after `now`, for a fiscal year
+ * starting `startMonth` (1-12). Display-only — the authoritative reset schedule
+ * lives in BudgetResetConfig.QuarterStart on the Go side.
+ */
+export function nextQuarterReset(startMonth?: number, now: Date = new Date()): Date {
+	const start = normalizeQuarterStart(startMonth);
+	const candidates: Date[] = [];
+	for (let year = now.getFullYear() - 1; year <= now.getFullYear() + 1; year++) {
+		for (let quarter = 0; quarter < 4; quarter++) {
+			// A month index past 11 rolls into the next year, which is exactly the
+			// wrap we want for fiscal years that start late in the calendar year.
+			candidates.push(new Date(year, start - 1 + quarter * 3, 1));
+		}
+	}
+	return candidates.filter((date) => date > now).sort((a, b) => a.getTime() - b.getTime())[0];
 }
 
 // Month choices for the fiscal quarter start select.

--- a/ui/lib/utils/governance.test.ts
+++ b/ui/lib/utils/governance.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from "vitest";
 import { periodRank, shortPeriod } from "@/lib/budgetOutline";
 import {
 	budgetResetDurationOptions,
+	currentQuarterIndex,
 	fiscalQuarterNote,
 	formatQuarterPreview,
+	nextQuarterReset,
+	quarterRanges,
 	resetDurationLabels,
 	resetDurationOptions,
 	supportsCalendarAlignment,
@@ -141,6 +144,38 @@ describe("fiscalQuarterNote", () => {
 		// A fractional month sits in range but indexes MONTH_ABBREVIATIONS between
 		// slots, which would render "FY starts undefined" without the integer guard.
 		expect(fiscalQuarterNote("1Q", { quarter_start_month: 2.5 })).toBe("");
+	});
+});
+describe("quarter map helpers", () => {
+	it("labels the four quarters with en-dash ranges from the start month", () => {
+		expect(quarterRanges(4)).toEqual([
+			{ label: "Q1", range: "Apr–Jun" },
+			{ label: "Q2", range: "Jul–Sep" },
+			{ label: "Q3", range: "Oct–Dec" },
+			{ label: "Q4", range: "Jan–Mar" },
+		]);
+	});
+
+	it("falls back to January for a missing or invalid start month", () => {
+		expect(quarterRanges(undefined)).toEqual(quarterRanges(1));
+		expect(quarterRanges(2.5)).toEqual(quarterRanges(1));
+		expect(quarterRanges(13)).toEqual(quarterRanges(1));
+	});
+
+	it("finds the quarter containing a date for a non-January fiscal year", () => {
+		// April fiscal year: Q1 Apr–Jun, Q2 Jul–Sep, Q3 Oct–Dec, Q4 Jan–Mar.
+		expect(currentQuarterIndex(4, new Date(2026, 3, 15))).toBe(0); // April
+		expect(currentQuarterIndex(4, new Date(2026, 8, 1))).toBe(1); // September
+		expect(currentQuarterIndex(4, new Date(2026, 0, 31))).toBe(3); // January
+	});
+
+	it("returns the first day of the next quarter strictly after now", () => {
+		// April fiscal year, mid-May → next boundary is Jul 1.
+		expect(nextQuarterReset(4, new Date(2026, 4, 10)).getTime()).toBe(new Date(2026, 6, 1).getTime());
+		// On a boundary day, the next reset is the following quarter, not today.
+		expect(nextQuarterReset(4, new Date(2026, 3, 1)).getTime()).toBe(new Date(2026, 6, 1).getTime());
+		// A late-starting fiscal year wraps across the calendar year end.
+		expect(nextQuarterReset(11, new Date(2026, 11, 5)).getTime()).toBe(new Date(2027, 1, 1).getTime());
 	});
 });
 describe("budgetSignature", () => {


### PR DESCRIPTION
## Summary

Refactors the `QuarterStartSelect` component layout to use a cleaner, more consistent row-based design that aligns the label and quarter preview text on the left with the dropdown on the right.

## Changes

- Replaced the nested flex layout with a flat `justify-between` row, moving the quarter preview text below the label on the left side instead of below the dropdown on the right
- Adjusted styling to use standard `border`/`rounded-md` with horizontal padding instead of the muted background card style, making it consistent with other inline form controls
- Simplified the DOM structure by removing an extra wrapping `div` layer

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Navigate to any view that renders the `QuarterStartSelect` component and verify:
- The label "Fiscal year starts" and quarter preview text appear on the left
- The month dropdown appears on the right
- Selecting a different month updates the quarter preview text correctly

## Screenshots/Recordings

Before/after screenshots of the fiscal year start selector showing the updated layout are recommended.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable