### PR TITLE
docs: document passthrough/passthrough_stream as independent allowed_requests flags

### DIFF
--- a/docs/providers/custom-providers.mdx
+++ b/docs/providers/custom-providers.mdx
@@ -245,6 +245,12 @@ Available operations:
 - **`transcription`**: Speech-to-text conversion
 - **`transcription_stream`**: Streaming speech-to-text
 - **`rerank`**: Document reranking via `/v1/rerank` (OpenAI-compatible base only)
+- **`passthrough`**: Byte-preserving requests via `/passthrough/<provider>/...`
+- **`passthrough_stream`**: Streaming byte-preserving requests via the same route
+
+<Info>
+`passthrough` and `passthrough_stream` are independent flags, just like the `_stream` suffix on every other operation above. Enabling only `passthrough` lets non-streaming clients through but a streaming client hitting the same `/passthrough/<provider>/...` route will get `passthrough_stream is not supported by <provider> provider` until `passthrough_stream` is enabled too. A quick non-streaming smoke test won't catch a missing `passthrough_stream` -- test with a real streaming client, or enable both together if you don't know in advance which your clients will send.
+</Info>
 
 ### Base Provider Types
 


### PR DESCRIPTION
Closes #6118.

Neither `passthrough` nor `passthrough_stream` was listed in the "Available operations" section of the custom-providers docs at all, despite being real `AllowedRequests` fields (`core/schemas/provider.go`). We hit this directly: enabled `passthrough`, smoke-tested with a non-streaming curl, shipped it, then a real streaming client 400'd with `passthrough_stream is not supported by <provider> provider` -- the two flags gate unary vs. streaming passthrough independently, same as every other `_stream` suffix already in that list, but nothing said so for these two specifically.

Small, additive doc change: adds both to the operations list and a short `<Info>` callout explaining they're independent and why a non-streaming smoke test won't catch a missing `passthrough_stream`.