### PR TITLE
chore: release Bifrost Helm chart v2.1.35 with MCP OAuth, setup token, and governance enhancements

### DIFF
--- a/.github/workflows/scripts/schemasync/main.go
+++ b/.github/workflows/scripts/schemasync/main.go
@@ -95,6 +95,27 @@ var ignoreGoFields = map[string]string{
 	// populated on GET from the oauth_configs table, never accepted as config.json input.
 	"/properties/mcp/properties/client_configs/items|oauth_client_id":     "response-only; populated on GET from oauth_configs, not user-configurable via config.json",
 	"/properties/mcp/properties/client_configs/items|oauth_client_secret": "response-only; populated on GET from oauth_configs, not user-configurable via config.json",
+	// oauth_authorize_url / oauth_token_url / oauth_registration_url / oauth_scopes /
+	// oauth_resource are the remaining response-only OAuth fields on MCPClientConfig:
+	// populated on GET (not stored here) so the full oauth_config can be reviewed/edited,
+	// never accepted as config.json input. Inline OAuth input goes through oauth_config.
+	"/properties/mcp/properties/client_configs/items|oauth_authorize_url":    "response-only; populated on GET (not stored here), not user-configurable via config.json",
+	"/properties/mcp/properties/client_configs/items|oauth_token_url":        "response-only; populated on GET (not stored here), not user-configurable via config.json",
+	"/properties/mcp/properties/client_configs/items|oauth_registration_url": "response-only; populated on GET (not stored here), not user-configurable via config.json",
+	"/properties/mcp/properties/client_configs/items|oauth_scopes":           "response-only; populated on GET (not stored here), not user-configurable via config.json",
+	"/properties/mcp/properties/client_configs/items|oauth_resource":         "response-only; populated on GET (not stored here), not user-configurable via config.json",
+	// oauth_config_id is a server-managed reference to the oauth_configs row, minted by the
+	// admin verification flow; config.go clears any value supplied via config.json.
+	"/properties/mcp/properties/client_configs/items|oauth_config_id": "server-managed oauth_configs reference; config.go clears any config.json-supplied value",
+	// The inline oauth_config block (schemas.OAuth2Config) carries five fields beyond the
+	// user-facing set the UI form / config.schema.json document (client_id, client_secret,
+	// authorize_url, token_url, registration_url, scopes). These five are managed / derived /
+	// deprecated and are never authored in the inline config.json oauth_config block.
+	"/properties/mcp/properties/client_configs/items/properties/oauth_config|id":            "server-generated oauth_configs row id; not authored in the inline oauth_config block",
+	"/properties/mcp/properties/client_configs/items/properties/oauth_config|redirect_uri":  "computed by Bifrost (MCP OAuth callback URI); not authored in config.json",
+	"/properties/mcp/properties/client_configs/items/properties/oauth_config|server_url":    "derived from the client connection_string for OAuth discovery; not authored in config.json",
+	"/properties/mcp/properties/client_configs/items/properties/oauth_config|resource":      "RFC 8707 resource indicator; not part of the user-facing inline oauth_config block",
+	"/properties/mcp/properties/client_configs/items/properties/oauth_config|use_discovery": "deprecated; discovery is automatic when URLs are missing",
 	// source_id is a stable external identifier for teams provisioned by an
 	// integrating system (PR #3395). It is assigned through the API by that
 	// system, never authored in config.json.

--- a/docs/changelogs/helm-v2.1.35.mdx
+++ b/docs/changelogs/helm-v2.1.35.mdx
@@ -1,0 +1,22 @@
+---
+title: "v2.1.35"
+description: "Helm v2.1.35 changelog - 2026-08-13"
+---
+
+<Update label="Bifrost Helm" description="v2.1.35">
+
+## Changelog
+
+- Added `bifrost.plugins.otel.config.traces_enabled` (and `profiles[*].traces_enabled`, default `true`) — set `false` for a metrics-only profile where no traces are sent and `collector_url` is not required. Renders into `traces_enabled`.
+- Added `bifrost.plugins.otel.config.trace_headers` and `metrics_headers` (and their `profiles[*]` forms) — extra headers sent only to the trace or metrics endpoint, overlaid on the shared `headers` (same key wins), e.g. a Databricks table name required only on metrics. Render into `trace_headers` / `metrics_headers`.
+- Added top-level `bifrost.setupToken` — the operator-provisioned bootstrap secret required to create the first admin account when none exists (supports `env.`/`vault.` prefixes and the `BIFROST_SETUP_TOKEN` env var). Renders into `setup_token`.
+- Added `bifrost.server.pluginDownloadPrivateAllowlist` (array of hostnames/IPs/CIDRs) to let custom plugin (`.so`) downloads reach trusted internal hosts that resolve to private/loopback/link-local/CGNAT addresses, blocked by default to prevent SSRF. Renders into `server.plugin_download_private_allowlist`.
+- Added `http2_ping_interval_in_seconds` (0–3600, `0` disables) to provider `network_config` — sends a client-initiated HTTP/2 keepalive PING after that many idle seconds; only applies when `enforce_http2` is set. Renders into `network_config.http2_ping_interval_in_seconds`.
+- Added inline `oauthConfig` to `bifrost.mcp.clientConfigs[]` (`clientId`, `clientSecret`, `authorizeUrl`, `tokenUrl`, `registrationUrl`, `scopes`; all optional) for `authType` `oauth`/`per_user_oauth`, so OAuth can be declared inline instead of pre-creating a config — missing URLs and client IDs are discovered/registered during admin verification. Renders into `oauth_config`. (`oauthConfigId` is now Bifrost-managed and is no longer emitted.)
+- Added `tokenExchange` to `bifrost.mcp.clientConfigs[]` (`audience`, `useIdpCredentials`, `clientId`, `clientSecret`, `authorizationServerUrl`, `scopes`) for the new `token_exchange` auth type (Enterprise builds), exchanging each caller's IDP token for a short-lived token scoped to the server's audience. Renders into `token_exchange`.
+- Added `needsSessionStickiness` to `bifrost.mcp.clientConfigs[]` (HTTP servers only) to choose one persistent connection reused across callers (`true`) or a fresh connection per call (`false`, default). Renders into `needs_session_stickiness`.
+- Documented `endpoints` on the `bedrock` and `bedrock_mantle` key examples (AWS PrivateLink interface VPC endpoint hosts: `runtime`, `control_plane`, `mantle`, `agent_runtime`, `s3`). Passes through into `bedrock_key_config.endpoints` / `bedrock_mantle_key_config.endpoints`.
+- Extended `bifrost.governance.budgets[]` with quarterly resets (`reset_duration: "1Q"`) and `reset_config.quarter_start_month` (1–12, sets the fiscal Q1 month). Passes through into `budgets[].reset_config`.
+- Added `target` (`llm` default, or `mcp`) to `bifrost.governance` guardrail rules to select the rule's execution target. Passes through into the rule's `target`.
+
+</Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2078,6 +2078,7 @@
             "item": "Helm",
             "icon": "box",
             "pages": [
+              "changelogs/helm-v2.1.35",
               "changelogs/helm-v2.1.34",
               {
                 "group": "July 2026",

--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.34
+version: 2.1.35
 appVersion: "1.5.12"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,15 +4,23 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.1.34
+**Latest Version:** 2.1.35
 
 ## Changelog
 
 ### 2.1.35
 
-- Added `traces_enabled` to OTEL config (single-profile and `profiles[*]`). When `false`, no traces are exported and `collector_url` is not required, giving a metrics-only profile. Renders into `traces_enabled`; defaults to `true`.
-- Added `trace_headers` and `metrics_headers` to OTEL config (single-profile and `profiles[*]`). Common `headers` still go to both endpoints; these are overlaid on top for the trace / metrics endpoint respectively (same key wins), e.g. a Databricks table name required only on metrics. Render into `trace_headers` / `metrics_headers`.
-- - Documented `env.VAR_NAME` support for the Datadog plugin service-identity fields `bifrost.plugins.datadog.config.service_name`, `ml_app`, `env`, and `version` (render into `service_name`, `ml_app`, `env`, `version`). Values already passed through; this only adds the env-reference guidance to `values.yaml` comments and `values.schema.json` descriptions.
+- Added `bifrost.plugins.otel.config.traces_enabled` (and `profiles[*].traces_enabled`, default `true`) — set `false` for a metrics-only profile where no traces are sent and `collector_url` is not required. Renders into `traces_enabled`.
+- Added `bifrost.plugins.otel.config.trace_headers` and `metrics_headers` (and their `profiles[*]` forms) — extra headers sent only to the trace or metrics endpoint, overlaid on the shared `headers` (same key wins), e.g. a Databricks table name required only on metrics. Render into `trace_headers` / `metrics_headers`.
+- Added top-level `bifrost.setupToken` — the operator-provisioned bootstrap secret required to create the first admin account when none exists (supports `env.`/`vault.` prefixes and the `BIFROST_SETUP_TOKEN` env var). Renders into `setup_token`.
+- Added `bifrost.server.pluginDownloadPrivateAllowlist` (array of hostnames/IPs/CIDRs) to let custom plugin (`.so`) downloads reach trusted internal hosts that resolve to private/loopback/link-local/CGNAT addresses, blocked by default to prevent SSRF. Renders into `server.plugin_download_private_allowlist`.
+- Added `http2_ping_interval_in_seconds` (0–3600, `0` disables) to provider `network_config` — sends a client-initiated HTTP/2 keepalive PING after that many idle seconds; only applies when `enforce_http2` is set. Renders into `network_config.http2_ping_interval_in_seconds`.
+- Added inline `oauthConfig` to `bifrost.mcp.clientConfigs[]` (`clientId`, `clientSecret`, `authorizeUrl`, `tokenUrl`, `registrationUrl`, `scopes`; all optional) for `authType` `oauth`/`per_user_oauth`, so OAuth can be declared inline instead of pre-creating a config — missing URLs and client IDs are discovered/registered during admin verification. Renders into `oauth_config`. (`oauthConfigId` is now Bifrost-managed and is no longer emitted.)
+- Added `tokenExchange` to `bifrost.mcp.clientConfigs[]` (`audience`, `useIdpCredentials`, `clientId`, `clientSecret`, `authorizationServerUrl`, `scopes`) for the new `token_exchange` auth type (Enterprise builds), exchanging each caller's IDP token for a short-lived token scoped to the server's audience. Renders into `token_exchange`.
+- Added `needsSessionStickiness` to `bifrost.mcp.clientConfigs[]` (HTTP servers only) to choose one persistent connection reused across callers (`true`) or a fresh connection per call (`false`, default). Renders into `needs_session_stickiness`.
+- Documented `endpoints` on the `bedrock` and `bedrock_mantle` key examples (AWS PrivateLink interface VPC endpoint hosts: `runtime`, `control_plane`, `mantle`, `agent_runtime`, `s3`). Passes through into `bedrock_key_config.endpoints` / `bedrock_mantle_key_config.endpoints`.
+- Extended `bifrost.governance.budgets[]` with quarterly resets (`reset_duration: "1Q"`) and `reset_config.quarter_start_month` (1–12, sets the fiscal Q1 month). Passes through into `budgets[].reset_config`.
+- Added `target` (`llm` default, or `mcp`) to `bifrost.governance` guardrail rules to select the rule's execution target. Passes through into the rule's `target`.
 
 
 ### 2.1.34

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -211,6 +211,9 @@ false
 {{- if .Values.bifrost.envLabel }}
 {{- $_ := set $config "env_label" .Values.bifrost.envLabel }}
 {{- end }}
+{{- if .Values.bifrost.setupToken }}
+{{- $_ := set $config "setup_token" .Values.bifrost.setupToken }}
+{{- end }}
 {{- if .Values.bifrost.client }}
 {{- $client := dict }}
 {{- if hasKey .Values.bifrost.client "dropExcessRequests" }}
@@ -360,6 +363,9 @@ false
 {{- if .Values.bifrost.server.readBufferSize }}
 {{- $_ := set $server "read_buffer_size" .Values.bifrost.server.readBufferSize }}
 {{- end }}
+{{- if .Values.bifrost.server.pluginDownloadPrivateAllowlist }}
+{{- $_ := set $server "plugin_download_private_allowlist" .Values.bifrost.server.pluginDownloadPrivateAllowlist }}
+{{- end }}
 {{- if $server }}
 {{- $_ := set $config "server" $server }}
 {{- end }}
@@ -443,6 +449,9 @@ false
 {{- end }}
 {{- if hasKey $providerConfig.network_config "enforce_http2" }}
 {{- $_ := set $networkConfig "enforce_http2" $providerConfig.network_config.enforce_http2 }}
+{{- end }}
+{{- if hasKey $providerConfig.network_config "http2_ping_interval_in_seconds" }}
+{{- $_ := set $networkConfig "http2_ping_interval_in_seconds" $providerConfig.network_config.http2_ping_interval_in_seconds }}
 {{- end }}
 {{- if $providerConfig.network_config.beta_header_overrides }}
 {{- $_ := set $networkConfig "beta_header_overrides" $providerConfig.network_config.beta_header_overrides }}
@@ -1172,13 +1181,33 @@ false
 {{- else if hasKey $client "authType" }}
 {{- $_ := set $cc "auth_type" $client.authType }}
 {{- end }}
-{{- if hasKey $client "oauth_config_id" }}
-{{- $_ := set $cc "oauth_config_id" $client.oauth_config_id }}
-{{- else if hasKey $client "oauthConfigId" }}
-{{- $_ := set $cc "oauth_config_id" $client.oauthConfigId }}
+{{- /* Inline OAuth provider config for auth_type "oauth"/"per_user_oauth". oauth_config_id is Bifrost-managed (minted by the admin verification flow) and is ignored when supplied via config.json, so it is not rendered here. */ -}}
+{{- if $client.oauthConfig }}
+{{- $oauthCfg := dict }}
+{{- with $client.oauthConfig.clientId }}{{- $_ := set $oauthCfg "client_id" . }}{{- end }}
+{{- with $client.oauthConfig.clientSecret }}{{- $_ := set $oauthCfg "client_secret" . }}{{- end }}
+{{- with $client.oauthConfig.authorizeUrl }}{{- $_ := set $oauthCfg "authorize_url" . }}{{- end }}
+{{- with $client.oauthConfig.tokenUrl }}{{- $_ := set $oauthCfg "token_url" . }}{{- end }}
+{{- with $client.oauthConfig.registrationUrl }}{{- $_ := set $oauthCfg "registration_url" . }}{{- end }}
+{{- with $client.oauthConfig.scopes }}{{- $_ := set $oauthCfg "scopes" . }}{{- end }}
+{{- $_ := set $cc "oauth_config" $oauthCfg }}
+{{- end }}
+{{- /* Delegated token-exchange config for auth_type "token_exchange" (Enterprise builds only). */ -}}
+{{- if $client.tokenExchange }}
+{{- $te := dict }}
+{{- with $client.tokenExchange.audience }}{{- $_ := set $te "audience" . }}{{- end }}
+{{- if hasKey $client.tokenExchange "useIdpCredentials" }}{{- $_ := set $te "use_idp_credentials" $client.tokenExchange.useIdpCredentials }}{{- end }}
+{{- with $client.tokenExchange.clientId }}{{- $_ := set $te "client_id" . }}{{- end }}
+{{- with $client.tokenExchange.clientSecret }}{{- $_ := set $te "client_secret" . }}{{- end }}
+{{- with $client.tokenExchange.authorizationServerUrl }}{{- $_ := set $te "authorization_server_url" . }}{{- end }}
+{{- with $client.tokenExchange.scopes }}{{- $_ := set $te "scopes" . }}{{- end }}
+{{- $_ := set $cc "token_exchange" $te }}
 {{- end }}
 {{- if hasKey $client "isPingAvailable" }}
 {{- $_ := set $cc "is_ping_available" $client.isPingAvailable }}
+{{- end }}
+{{- if hasKey $client "needsSessionStickiness" }}
+{{- $_ := set $cc "needs_session_stickiness" $client.needsSessionStickiness }}
 {{- end }}
 {{- if $client.clientId }}
 {{- $_ := set $cc "client_id" $client.clientId }}

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -1190,7 +1190,10 @@ false
 {{- with $client.oauthConfig.tokenUrl }}{{- $_ := set $oauthCfg "token_url" . }}{{- end }}
 {{- with $client.oauthConfig.registrationUrl }}{{- $_ := set $oauthCfg "registration_url" . }}{{- end }}
 {{- with $client.oauthConfig.scopes }}{{- $_ := set $oauthCfg "scopes" . }}{{- end }}
+{{- /* Only emit oauth_config when at least one field resolved; an all-empty block would render "oauth_config": {} instead of relying on discovery. */ -}}
+{{- if $oauthCfg }}
 {{- $_ := set $cc "oauth_config" $oauthCfg }}
+{{- end }}
 {{- end }}
 {{- /* Delegated token-exchange config for auth_type "token_exchange" (Enterprise builds only). */ -}}
 {{- if $client.tokenExchange }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -303,6 +303,10 @@
           "description": "Short label (max 10 characters) displayed in the management UI sidebar to identify the environment (e.g. \"staging\", \"prod\"). Written into config.json as env_label.",
           "maxLength": 10
         },
+        "setupToken": {
+          "type": "string",
+          "description": "Operator-provisioned bootstrap secret required to create the very first admin account when none exists yet. Identical across every node so any node can authorize first-admin creation. Never persisted or logged; also read from the BIFROST_SETUP_TOKEN env var. Supports env.<ENV_VAR_NAME> and vault.<path> references. Renders into config.json setup_token."
+        },
         "schemaUrl": {
           "type": "string",
           "default": "",
@@ -618,6 +622,13 @@
               "type": "integer",
               "description": "Read buffer size in bytes. This controls the size of the buffer used for reading HTTP headers.",
               "default": 65536
+            },
+            "pluginDownloadPrivateAllowlist": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Hostnames, IP addresses, or CIDR ranges that custom plugin (.so) downloads are allowed to reach even when they resolve to a private/loopback/link-local/CGNAT address (blocked by default to prevent SSRF). Deploy-time only. Renders into server.plugin_download_private_allowlist."
             }
           },
           "additionalProperties": false
@@ -5953,12 +5964,82 @@
         },
         "authType": {
           "type": "string",
-          "enum": ["none", "headers", "oauth", "per_user_oauth", "per_user_headers"],
-          "description": "Authentication type for MCP connection"
+          "enum": ["none", "headers", "oauth", "per_user_oauth", "per_user_headers", "token_exchange"],
+          "description": "Authentication type for MCP connection. 'token_exchange' is only honored on Enterprise builds."
+        },
+        "oauthConfig": {
+          "type": "object",
+          "description": "Inline OAuth provider configuration for authType 'oauth' or 'per_user_oauth'. All fields are optional — omitted URLs are resolved via RFC 8414 discovery from the connection string and a missing clientId triggers RFC 7591 dynamic client registration at admin-verification time. Renders into oauth_config.",
+          "properties": {
+            "clientId": {
+              "type": "string",
+              "description": "OAuth client ID (optional — Dynamic Client Registration is used when omitted; can use env./vault. prefix). Renders into client_id."
+            },
+            "clientSecret": {
+              "type": "string",
+              "description": "OAuth client secret (optional — omit for PKCE public clients or DCR; can use env./vault. prefix). Renders into client_secret."
+            },
+            "authorizeUrl": {
+              "type": "string",
+              "description": "Provider authorize endpoint (optional — discovered when omitted). Renders into authorize_url."
+            },
+            "tokenUrl": {
+              "type": "string",
+              "description": "Provider token endpoint (optional — discovered when omitted). Renders into token_url."
+            },
+            "registrationUrl": {
+              "type": "string",
+              "description": "Dynamic Client Registration endpoint (optional — discovered when omitted). Renders into registration_url."
+            },
+            "scopes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "OAuth scopes to request."
+            }
+          },
+          "additionalProperties": false
+        },
+        "tokenExchange": {
+          "type": "object",
+          "description": "Delegated token-exchange configuration for authType 'token_exchange' (Enterprise builds only). Each caller's identity-provider token is exchanged at runtime for a short-lived token scoped to this server's audience. Renders into token_exchange.",
+          "properties": {
+            "audience": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Resource identifier the exchanged token is scoped to at the identity provider (e.g. 'api://jira-mcp'). Required."
+            },
+            "useIdpCredentials": {
+              "type": "boolean",
+              "description": "When true, performs the exchange as the SSO login application itself instead of clientId/clientSecret (which are then ignored). Renders into use_idp_credentials."
+            },
+            "clientId": {
+              "type": "string",
+              "description": "Identity-provider application authorized to perform exchanges for this audience. Required unless useIdpCredentials is true. Can use env./vault. prefix. Renders into client_id."
+            },
+            "clientSecret": {
+              "type": "string",
+              "description": "Secret for the exchange application; omit for public clients. Ignored when useIdpCredentials is true. Can use env./vault. prefix. Renders into client_secret."
+            },
+            "authorizationServerUrl": {
+              "type": "string",
+              "description": "Overrides where the exchange request is sent, for providers that bind an audience to a specific authorization server (e.g. Okta Custom Authorization Servers). Renders into authorization_server_url."
+            },
+            "scopes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Optional scopes to request on the exchanged token. Include 'offline_access' where supported so exchanges issue refresh tokens."
+            }
+          },
+          "required": ["audience"],
+          "additionalProperties": false
         },
         "oauthConfigId": {
           "type": "string",
-          "description": "OAuth config ID reference"
+          "description": "OAuth config ID reference. Bifrost-managed (minted by the admin verification flow); ignored when supplied via config.json. Prefer oauthConfig for inline OAuth setup."
         },
         "headers": {
           "type": "object",
@@ -6033,6 +6114,10 @@
         "isPingAvailable": {
           "type": "boolean",
           "description": "Whether the MCP server supports ping"
+        },
+        "needsSessionStickiness": {
+          "type": "boolean",
+          "description": "Only meaningful for connectionType 'http': true keeps one persistent connection reused across every caller; false (the default for new clients) connects fresh per call. SSE and STDIO always behave as sticky regardless. Renders into needs_session_stickiness."
         },
         "toolPricing": {
           "type": "object",

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -626,7 +626,8 @@
             "pluginDownloadPrivateAllowlist": {
               "type": "array",
               "items": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               },
               "description": "Hostnames, IP addresses, or CIDR ranges that custom plugin (.so) downloads are allowed to reach even when they resolve to a private/loopback/link-local/CGNAT address (blocked by default to prevent SSRF). Deploy-time only. Renders into server.plugin_download_private_allowlist."
             }
@@ -1512,6 +1513,19 @@
                     "type": "boolean",
                     "description": "Snap budget reset windows to calendar boundaries",
                     "default": false
+                  },
+                  "reset_config": {
+                    "type": "object",
+                    "description": "Window settings the reset duration cannot express. Only valid when reset_duration is quarterly (\"1Q\").",
+                    "properties": {
+                      "quarter_start_month": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 12,
+                        "description": "First month of Q1 as 1-12 (e.g. 4 = fiscal year starting April). Omitted or 0 means January."
+                      }
+                    },
+                    "additionalProperties": false
                   },
                   "current_usage": {
                     "type": "number"

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -217,6 +217,13 @@ bifrost:
   logStyle: json
   # envLabel: staging  # Short label (max 10 chars) shown in the UI sidebar to identify the environment
 
+  # Operator-provisioned bootstrap secret required to create the very first admin account
+  # when none exists yet. Identical across every node so any node can authorize first-admin
+  # creation. Never persisted or logged. Also read from the BIFROST_SETUP_TOKEN env var.
+  # Whitespace-only values are rejected. Use env.<ENV_VAR_NAME> or vault.<path> for indirection.
+  # Renders into config.json `setup_token`.
+  # setupToken: "env.BIFROST_SETUP_TOKEN"
+
   # Schema location written to config.json $schema and exported as BIFROST_SCHEMA_URL.
   # Leave empty to use the default (https://www.getbifrost.ai/schema); set it only for
   # isolated deployments that mirror the schema internally. When empty, the env var is
@@ -341,6 +348,13 @@ bifrost:
   # Server configuration
   server:
     readBufferSize: 65536 # Read buffer size in bytes for reading HTTP headers (default: 64 KiB)
+    # Hostnames, IPs, or CIDR ranges that custom plugin (.so) downloads may reach even when they
+    # resolve to a private/loopback/link-local/CGNAT address (blocked by default to prevent SSRF).
+    # Deploy-time only — read at startup, never settable via the plugin admin API.
+    # Renders into config.json `server.plugin_download_private_allowlist`.
+    # pluginDownloadPrivateAllowlist:
+    #   - "artifacts.internal.corp"
+    #   - "10.0.0.0/8"
 
   # Framework configuration
   framework:
@@ -391,6 +405,7 @@ bifrost:
     #     keep_alive_timeout_in_seconds: 30             # Idle keep-alive for pooled connections; set below the upstream's keep-alive (default: 30)
     #     max_conns_per_host: 5000                      # Max TCP connections per host (default: 5000)
     #     enforce_http2: false                           # Force HTTP/2 on provider connections (e.g. Bedrock)
+    #     http2_ping_interval_in_seconds: 0              # Idle seconds before a client-initiated HTTP/2 keepalive PING (0 = disabled; only when enforce_http2). Max 3600.
     #     insecure_skip_verify: false                   # Disable TLS certificate verification (last resort)
     #     ca_cert_pem: ""                               # PEM-encoded CA cert for self-signed/private CA
     #     allow_private_network: false                  # Allow connections to RFC 1918 private IPs (k8s pod network, LAN, VPC)
@@ -526,14 +541,41 @@ bifrost:
       # - name: "example-oauth-mcp"
       #   connectionType: "http"
       #   connectionString: "https://my-mcp.corp/mcp"
-      #   # authType "oauth": shared OAuth token; provide oauthConfigId referencing an existing oauth_config.
-      #   # authType "per_user_oauth": each user authenticates individually via OAuth flow;
-      #   #   oauth_config is registered via the API (POST /api/mcp/clients), not configured here.
+      #   # authType "oauth": shared inline OAuth. authType "per_user_oauth": each user authenticates
+      #   # individually. In both cases the client boots into `pending_verification`; an admin runs the
+      #   # verification flow once from the MCP Gateway UI. (oauth_config_id is minted by that flow and
+      #   # is Bifrost-managed — it cannot be set here and is ignored if supplied via config.json.)
       #   authType: "oauth"
-      #   oauthConfigId: "my-oauth-config-id"   # ID of the OAuth config created in Bifrost
+      #   # Inline OAuth provider config. All fields optional — omitted URLs are discovered from the
+      #   # connection_string (RFC 8414) and a missing clientId triggers dynamic client registration
+      #   # (RFC 7591) at admin-click time. Omit the whole block to rely entirely on discovery.
+      #   oauthConfig:
+      #     clientId: "env.MY_MCP_OAUTH_CLIENT_ID"       # optional (can use env./vault. prefix)
+      #     clientSecret: "env.MY_MCP_OAUTH_CLIENT_SECRET"  # optional (omit for PKCE/DCR public clients)
+      #     authorizeUrl: ""                             # optional — discovered when omitted
+      #     tokenUrl: ""                                 # optional — discovered when omitted
+      #     registrationUrl: ""                          # optional — discovered when omitted
+      #     scopes: []                                   # OAuth scopes to request
+      #   # Only meaningful for connectionType "http": true keeps one persistent connection reused
+      #   # across every caller; false (default for new clients) connects fresh per call.
+      #   needsSessionStickiness: false
       #   # When true, this MCP server is accessible to all virtual keys without explicit per-key assignment.
       #   # If a virtual key has an explicit MCP config for this server, that config takes precedence.
       #   allowOnAllVirtualKeys: false
+      #
+      # - name: "example-token-exchange-mcp"
+      #   connectionType: "http"
+      #   connectionString: "https://my-mcp.corp/mcp"
+      #   # authType "token_exchange" (Enterprise builds only): each caller's IdP token is exchanged at
+      #   # runtime for a short-lived token scoped to this server's audience. Requires user-identity auth.
+      #   authType: "token_exchange"
+      #   tokenExchange:
+      #     audience: "api://jira-mcp"                   # required — resource the exchanged token is scoped to
+      #     useIdpCredentials: false                     # true = exchange as the SSO login app (ignores clientId/secret)
+      #     clientId: "env.MY_EXCHANGE_CLIENT_ID"        # required unless useIdpCredentials is true (env./vault. prefix)
+      #     clientSecret: "env.MY_EXCHANGE_CLIENT_SECRET"  # omit for public clients
+      #     authorizationServerUrl: ""                   # optional — override exchange endpoint (e.g. Okta custom AS)
+      #     scopes: []                                   # optional; include 'offline_access' for refresh tokens
     # toolSyncInterval: "10m"   # Global tool sync interval (Go duration string, e.g. "10m", "1h", "0s")
     # Assign groups of MCP tools to virtual keys / access profiles.
     # toolGroups:
@@ -780,8 +822,11 @@ bifrost:
     budgets: []
       # - id: "budget-1"
       #   max_limit: 100
-      #   reset_duration: "1M"     # Supports: 30s, 5m, 1h, 1d, 1w, 1M, 1Y
+      #   reset_duration: "1M"     # Supports: 30s, 5m, 1h, 1d, 1w, 1M, 1Q, 1Y
       #   calendar_aligned: false  # Snap reset to calendar boundaries (e.g. 1M resets on the 1st)
+      #   # reset_config only applies to quarterly ("1Q") budgets:
+      #   reset_config:
+      #     quarter_start_month: 4  # First month of Q1 as 1-12 (e.g. 4 = fiscal year starting April). 0/omitted = January.
     rateLimits: []
       # - id: "rate-limit-1"
       #   token_max_limit: 100000

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -549,13 +549,16 @@ bifrost:
       #   # Inline OAuth provider config. All fields optional — omitted URLs are discovered from the
       #   # connection_string (RFC 8414) and a missing clientId triggers dynamic client registration
       #   # (RFC 7591) at admin-click time. Omit the whole block to rely entirely on discovery.
+      #   # Omit any field to have it discovered/registered during admin verification.
+      #   # Leaving every field blank is the same as omitting oauthConfig entirely (full discovery);
+      #   # blank/empty values are dropped, not written as an empty oauth_config block.
       #   oauthConfig:
       #     clientId: "env.MY_MCP_OAUTH_CLIENT_ID"       # optional (can use env./vault. prefix)
       #     clientSecret: "env.MY_MCP_OAUTH_CLIENT_SECRET"  # optional (omit for PKCE/DCR public clients)
-      #     authorizeUrl: ""                             # optional — discovered when omitted
-      #     tokenUrl: ""                                 # optional — discovered when omitted
-      #     registrationUrl: ""                          # optional — discovered when omitted
-      #     scopes: []                                   # OAuth scopes to request
+      #     # authorizeUrl: "https://idp.corp/oauth2/authorize"   # optional — discovered when omitted
+      #     # tokenUrl: "https://idp.corp/oauth2/token"           # optional — discovered when omitted
+      #     # registrationUrl: "https://idp.corp/oauth2/register" # optional — discovered when omitted
+      #     # scopes: ["read", "write"]                           # optional — OAuth scopes to request
       #   # Only meaningful for connectionType "http": true keeps one persistent connection reused
       #   # across every caller; false (default for new clients) connects fresh per call.
       #   needsSessionStickiness: false


### PR DESCRIPTION
## Summary

Extends the Bifrost Helm chart with several new configuration capabilities: a bootstrap `setupToken` for first-admin creation, inline OAuth provider config (`oauthConfig`) and delegated token-exchange auth (`tokenExchange`) for MCP clients, HTTP/2 keepalive ping support for provider network configs, a `pluginDownloadPrivateAllowlist` for SSRF-safe custom plugin downloads, `needsSessionStickiness` for HTTP MCP connections, and quarterly budget reset support with a configurable fiscal quarter start month.

## Changes

- **`setupToken`**: Adds a top-level `bifrost.setupToken` field that renders into `config.json` as `setup_token`. Used to bootstrap the first admin account; never persisted or logged. Supports `env.<VAR>` and `vault.<path>` indirection.

- **Inline OAuth config (`oauthConfig`)**: Replaces the previous `oauth_config_id` passthrough (which was Bifrost-managed and ignored at config load time anyway) with a proper `oauthConfig` block supporting `clientId`, `clientSecret`, `authorizeUrl`, `tokenUrl`, `registrationUrl`, and `scopes`. Omitted URLs are resolved via RFC 8414 discovery; a missing `clientId` triggers RFC 7591 dynamic client registration at admin-verification time.

- **Token-exchange auth (`tokenExchange`)**: Adds a new `authType: token_exchange` (Enterprise only) and a corresponding `tokenExchange` config block. Each caller's IdP token is exchanged at runtime for a short-lived token scoped to the configured `audience`. Supports `useIdpCredentials`, `clientId`/`clientSecret`, `authorizationServerUrl`, and `scopes`.

- **`needsSessionStickiness`**: New boolean field for HTTP MCP clients. When `true`, a single persistent connection is reused across all callers; when `false` (default), a fresh connection is made per call. SSE and STDIO always behave as sticky regardless.

- **`http2_ping_interval_in_seconds`**: Adds support for client-initiated HTTP/2 keepalive PINGs on provider network configs. Only active when `enforce_http2` is enabled. Max value 3600; 0 disables.

- **`pluginDownloadPrivateAllowlist`**: New `server`-level list of hostnames, IPs, or CIDR ranges that custom plugin (`.so`) downloads are permitted to reach even when they resolve to private/loopback/link-local/CGNAT addresses (blocked by default to prevent SSRF). Read at startup only.

- **Quarterly budget resets**: Updates budget `reset_duration` docs to include `1Q` and adds a `reset_config.quarter_start_month` field (1–12) to define the fiscal year start for quarterly budget alignment.

- The `oauthConfigId` schema field is retained but clarified as Bifrost-managed and deprecated in favor of `oauthConfig`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Validate Helm rendering with the new fields:

```sh
# Render the chart with a test values file that exercises the new fields
helm template bifrost ./helm-charts/bifrost -f test-values.yaml

# Confirm setup_token appears in the rendered config.json
helm template bifrost ./helm-charts/bifrost --set bifrost.setupToken="env.BIFROST_SETUP_TOKEN" \
  | grep setup_token

# Confirm oauthConfig renders correctly for an MCP client
helm template bifrost ./helm-charts/bifrost -f test-values.yaml \
  | grep -A 10 oauth_config

# Confirm token_exchange renders correctly
helm template bifrost ./helm-charts/bifrost -f test-values.yaml \
  | grep -A 10 token_exchange

# Confirm plugin_download_private_allowlist renders
helm template bifrost ./helm-charts/bifrost \
  --set 'bifrost.server.pluginDownloadPrivateAllowlist[0]=10.0.0.0/8' \
  | grep plugin_download_private_allowlist

# Validate schema
helm lint ./helm-charts/bifrost -f test-values.yaml
```

New configuration fields:

| Field | Config key | Notes |
|---|---|---|
| `bifrost.setupToken` | `setup_token` | Also read from `BIFROST_SETUP_TOKEN` env var |
| `bifrost.server.pluginDownloadPrivateAllowlist` | `server.plugin_download_private_allowlist` | Deploy-time only |
| `bifrost.mcpGateway.clients[].oauthConfig` | `oauth_config` | Replaces `oauth_config_id` for inline setup |
| `bifrost.mcpGateway.clients[].tokenExchange` | `token_exchange` | Enterprise only |
| `bifrost.mcpGateway.clients[].needsSessionStickiness` | `needs_session_stickiness` | HTTP clients only |
| `network_config.http2_ping_interval_in_seconds` | same | Requires `enforce_http2: true` |

## Breaking changes

- [x] Yes
- [ ] No

The `oauthConfigId` / `oauth_config_id` field on MCP clients is no longer rendered into `config.json` (it was already ignored by Bifrost at config load time, but callers relying on it being present in the rendered output should migrate to `oauthConfig`).

## Security considerations

- `setupToken` is explicitly never persisted or logged; it is also readable from an environment variable to avoid embedding secrets in values files.
- `pluginDownloadPrivateAllowlist` is a deploy-time-only safeguard against SSRF via custom plugin downloads; it cannot be modified at runtime through the plugin admin API.
- `tokenExchange` `clientId`/`clientSecret` fields support `env.`/`vault.` indirection to avoid embedding credentials directly in Helm values.
- `oauthConfig` `clientId`/`clientSecret` likewise support `env.`/`vault.` indirection.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable