### PR TITLE
chore: release Bifrost Helm chart v2.1.35 with MCP OAuth, setup token, and governance enhancements

### DIFF
--- a/docs/changelogs/helm-v2.1.35.mdx
+++ b/docs/changelogs/helm-v2.1.35.mdx
@@ -1,0 +1,22 @@
+---
+title: "v2.1.35"
+description: "Helm v2.1.35 changelog - 2026-08-13"
+---
+
+<Update label="Bifrost Helm" description="v2.1.35">
+
+## Changelog
+
+- **OTEL metrics-only profiles.** Set `traces_enabled: false` on an OTEL profile (or the single-profile config) to export metrics without traces — `collector_url` is no longer required in that case.
+- **Per-signal OTEL headers.** New `trace_headers` and `metrics_headers` are overlaid on the shared `headers` for the trace and metrics endpoints respectively, so you can send a header (e.g. a Databricks table name) to only one endpoint.
+- **First-admin bootstrap token.** New `bifrost.setupToken` provisions the secret required to create the very first admin account. Supports `env.`/`vault.` references and the `BIFROST_SETUP_TOKEN` environment variable.
+- **Trusted internal plugin hosts.** New `bifrost.server.pluginDownloadPrivateAllowlist` lets custom plugin (`.so`) downloads reach trusted internal hosts that resolve to private/loopback addresses, which are blocked by default to prevent SSRF.
+- **HTTP/2 keepalive for providers.** New per-provider `network_config.http2_ping_interval_in_seconds` sends keepalive PINGs on idle HTTP/2 streams (applies only when `enforce_http2` is set).
+- **Inline OAuth for MCP servers.** MCP client configs now accept an inline `oauthConfig` block (client ID/secret, authorize/token/registration URLs, scopes) for the `oauth` and `per_user_oauth` auth types — you no longer need to pre-create an OAuth config and reference it. Any missing values are auto-discovered during admin verification. (`oauthConfigId` is now managed by Bifrost and no longer set here.)
+- **Delegated token exchange for MCP servers (Enterprise).** The new `token_exchange` auth type with a `tokenExchange` block exchanges each caller's identity-provider token for a short-lived token scoped to the MCP server's audience.
+- **Per-caller vs shared MCP connections.** New `needsSessionStickiness` (HTTP servers only) chooses between one persistent connection reused across callers and a fresh connection per call.
+- **AWS PrivateLink for Bedrock.** The `bedrock` and `bedrock_mantle` key examples now document `endpoints` for routing through interface VPC endpoints.
+- **Quarterly budgets.** Governance budgets now support quarterly resets (`reset_duration: "1Q"`) with `reset_config.quarter_start_month` to align to a fiscal year.
+- **Guardrail execution target.** Governance guardrail rules now accept a `target` (`llm`, the default, or `mcp`).
+
+</Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2078,6 +2078,7 @@
             "item": "Helm",
             "icon": "box",
             "pages": [
+              "changelogs/helm-v2.1.35",
               "changelogs/helm-v2.1.34",
               {
                 "group": "July 2026",

--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.34
+version: 2.1.35
 appVersion: "1.5.12"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,15 +4,23 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.1.34
+**Latest Version:** 2.1.35
 
 ## Changelog
 
 ### 2.1.35
 
-- Added `traces_enabled` to OTEL config (single-profile and `profiles[*]`). When `false`, no traces are exported and `collector_url` is not required, giving a metrics-only profile. Renders into `traces_enabled`; defaults to `true`.
-- Added `trace_headers` and `metrics_headers` to OTEL config (single-profile and `profiles[*]`). Common `headers` still go to both endpoints; these are overlaid on top for the trace / metrics endpoint respectively (same key wins), e.g. a Databricks table name required only on metrics. Render into `trace_headers` / `metrics_headers`.
-- - Documented `env.VAR_NAME` support for the Datadog plugin service-identity fields `bifrost.plugins.datadog.config.service_name`, `ml_app`, `env`, and `version` (render into `service_name`, `ml_app`, `env`, `version`). Values already passed through; this only adds the env-reference guidance to `values.yaml` comments and `values.schema.json` descriptions.
+- Added `bifrost.plugins.otel.config.traces_enabled` (and `profiles[*].traces_enabled`, default `true`) — set `false` for a metrics-only profile where no traces are sent and `collector_url` is not required. Renders into `traces_enabled`.
+- Added `bifrost.plugins.otel.config.trace_headers` and `metrics_headers` (and their `profiles[*]` forms) — extra headers sent only to the trace or metrics endpoint, overlaid on the shared `headers` (same key wins), e.g. a Databricks table name required only on metrics. Render into `trace_headers` / `metrics_headers`.
+- Added top-level `bifrost.setupToken` — the operator-provisioned bootstrap secret required to create the first admin account when none exists (supports `env.`/`vault.` prefixes and the `BIFROST_SETUP_TOKEN` env var). Renders into `setup_token`.
+- Added `bifrost.server.pluginDownloadPrivateAllowlist` (array of hostnames/IPs/CIDRs) to let custom plugin (`.so`) downloads reach trusted internal hosts that resolve to private/loopback/link-local/CGNAT addresses, blocked by default to prevent SSRF. Renders into `server.plugin_download_private_allowlist`.
+- Added `http2_ping_interval_in_seconds` (0–3600, `0` disables) to provider `network_config` — sends a client-initiated HTTP/2 keepalive PING after that many idle seconds; only applies when `enforce_http2` is set. Renders into `network_config.http2_ping_interval_in_seconds`.
+- Added inline `oauthConfig` to `bifrost.mcp.clientConfigs[]` (`clientId`, `clientSecret`, `authorizeUrl`, `tokenUrl`, `registrationUrl`, `scopes`; all optional) for `authType` `oauth`/`per_user_oauth`, so OAuth can be declared inline instead of pre-creating a config — missing URLs and client IDs are discovered/registered during admin verification. Renders into `oauth_config`. (`oauthConfigId` is now Bifrost-managed and is no longer emitted.)
+- Added `tokenExchange` to `bifrost.mcp.clientConfigs[]` (`audience`, `useIdpCredentials`, `clientId`, `clientSecret`, `authorizationServerUrl`, `scopes`) for the new `token_exchange` auth type (Enterprise builds), exchanging each caller's IDP token for a short-lived token scoped to the server's audience. Renders into `token_exchange`.
+- Added `needsSessionStickiness` to `bifrost.mcp.clientConfigs[]` (HTTP servers only) to choose one persistent connection reused across callers (`true`) or a fresh connection per call (`false`, default). Renders into `needs_session_stickiness`.
+- Documented `endpoints` on the `bedrock` and `bedrock_mantle` key examples (AWS PrivateLink interface VPC endpoint hosts: `runtime`, `control_plane`, `mantle`, `agent_runtime`, `s3`). Passes through into `bedrock_key_config.endpoints` / `bedrock_mantle_key_config.endpoints`.
+- Extended `bifrost.governance.budgets[]` with quarterly resets (`reset_duration: "1Q"`) and `reset_config.quarter_start_month` (1–12, sets the fiscal Q1 month). Passes through into `budgets[].reset_config`.
+- Added `target` (`llm` default, or `mcp`) to `bifrost.governance` guardrail rules to select the rule's execution target. Passes through into the rule's `target`.
 
 
 ### 2.1.34


### PR DESCRIPTION
## Summary

Bumps the Bifrost Helm chart to version 2.1.35, introducing several new configuration options across OTEL observability, MCP client auth, governance budgets, provider networking, and security controls.

## Changes

- `traces_enabled: false` can now be set on an OTEL profile to export metrics without traces, making `collector_url` optional in that case.
- Added `trace_headers` and `metrics_headers` to OTEL config, overlaid on the shared `headers` field, allowing endpoint-specific headers (e.g. a Databricks table name sent only to the metrics endpoint).
- Added `bifrost.setupToken` to provision the secret required to create the first admin account, supporting `env.`/`vault.` references and the `BIFROST_SETUP_TOKEN` environment variable.
- Added `bifrost.server.pluginDownloadPrivateAllowlist` to permit custom plugin (`.so`) downloads from trusted internal hosts that resolve to private or loopback addresses, which are otherwise blocked to prevent SSRF.
- Added per-provider `network_config.http2_ping_interval_in_seconds` to send keepalive PINGs on idle HTTP/2 streams when `enforce_http2` is enabled.
- MCP client configs now accept an inline `oauthConfig` block (client ID/secret, authorize/token/registration URLs, scopes) for `oauth` and `per_user_oauth` auth types, removing the need to pre-create and reference a separate OAuth config. `oauthConfigId` is now managed by Bifrost.
- MCP client configs now support a `token_exchange` auth type (Enterprise) with a `tokenExchange` block for delegated short-lived token exchange scoped to the MCP server's audience.
- Added `needsSessionStickiness` to MCP client configs (HTTP servers only) to control whether a persistent connection is reused across callers or a fresh connection is created per call.
- Documented `endpoints` on `bedrock` and `bedrock_mantle` key examples for routing through AWS PrivateLink interface VPC endpoints.
- Governance budgets now support quarterly resets (`reset_duration: "1Q"`) with `reset_config.quarter_start_month` for fiscal-year alignment.
- Added `target` (`llm` or `mcp`) to governance guardrail rules.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Validate the updated Helm chart renders correctly with the new fields:

```sh
helm lint helm-charts/bifrost
helm template bifrost helm-charts/bifrost --values helm-charts/bifrost/values.yaml
```

New config fields to verify in rendered output:
- `traces_enabled`, `trace_headers`, `metrics_headers` under OTEL config
- `setupToken` under `bifrost`
- `pluginDownloadPrivateAllowlist` under `bifrost.server`
- `http2_ping_interval_in_seconds` under provider `network_config`
- Inline `oauthConfig` and `token_exchange` blocks under MCP client configs
- `needsSessionStickiness` under MCP client configs
- `reset_duration: "1Q"` and `quarter_start_month` under governance budgets
- `target` under governance guardrail rules

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

- `pluginDownloadPrivateAllowlist` explicitly controls which internal hosts are permitted for plugin downloads, mitigating SSRF risk from arbitrary private-address resolution.
- `setupToken` provisions the initial admin secret and supports secure `env.`/`vault.` references to avoid hardcoding credentials.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable