### PR TITLE
fix: updates framework tests

### DIFF
--- a/framework/logstore/payload_test.go
+++ b/framework/logstore/payload_test.go
@@ -51,7 +51,9 @@ func TestExtractPayload_RoundTrip(t *testing.T) {
 	}
 
 	payload := ExtractPayload(log)
-	assert.Equal(t, len(payloadFields)+1, len(payload), "payload map should have all payload fields plus metadata")
+	// +1 for metadata, +6 for the always-present index fields (provider, model,
+	// status, timestamp, selected_key_id, selected_key_name) added in #6070.
+	assert.Equal(t, len(payloadFields)+1+6, len(payload), "payload map should have all payload fields plus metadata and index fields")
 	assert.Equal(t, `[{"role":"user","content":"hello"}]`, payload["input_history"])
 	assert.Equal(t, `{"role":"assistant","content":"world"}`, payload["output_message"])
 	assert.Equal(t, `{"judge_calls":[{"total_tokens":18}]}`, payload["guardrail_debug"])


### PR DESCRIPTION
## Summary

Updates the `TestExtractPayload_RoundTrip` test to account for six additional index fields (`provider`, `model`, `status`, `timestamp`, `selected_key_id`, `selected_key_name`) that are always present in the extracted payload, introduced in #6070.

## Changes

- The expected payload length in the round-trip test was updated from `len(payloadFields)+1` to `len(payloadFields)+1+6` to reflect the six always-present index fields added alongside the existing metadata field.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)

## How to test

```sh
go test ./framework/logstore/...
```

## Breaking changes

- [x] No

## Related issues

Related to #6070

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable