### PR TITLE
fix: force TCP for postgres pg_isready checks

### DIFF
--- a/.github/workflows/configs/docker-compose.yml
+++ b/.github/workflows/configs/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U bifrost -d bifrost"]
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U bifrost -d bifrost"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/.github/workflows/scripts/cost-accuracy-test.sh
+++ b/.github/workflows/scripts/cost-accuracy-test.sh
@@ -118,7 +118,13 @@ start_postgres() {
   container="$(docker_compose -p "${COMPOSE_PROJECT}" -f "${COMPOSE_FILE}" ps -q postgres)"
   local pg_ready=0
   for _ in $(seq 1 60); do
-    if docker exec "${container}" pg_isready -U "${POSTGRES_USER}" -d bifrost >/dev/null 2>&1; then
+    # -h forces a TCP check instead of the default Unix socket: on a fresh
+    # volume, Postgres runs a temporary init server that only listens on the
+    # socket (listen_addresses=''), so a socket-based check can report ready
+    # against that server right as it shuts down, killing the next
+    # connection with "terminating connection due to administrator command".
+    # TCP only comes up once the real server starts.
+    if docker exec "${container}" pg_isready -h 127.0.0.1 -U "${POSTGRES_USER}" -d bifrost >/dev/null 2>&1; then
       log "Postgres is ready"
       pg_ready=1
       break


### PR DESCRIPTION
## Summary

Fixes a race condition in CI where the Postgres readiness check could falsely report success against the temporary init server that PostgreSQL spins up during volume initialization, causing subsequent connections to fail with `terminating connection due to administrator command`.

## Changes

- Added `-h 127.0.0.1` to `pg_isready` calls in both the Docker Compose healthcheck and the `start_postgres` script function. This forces a TCP-based check instead of a Unix socket check. The temporary init server only listens on the Unix socket (`listen_addresses=''`), so a socket-based check can incorrectly report ready before the real server has started. TCP connectivity only becomes available once the real Postgres server is fully up.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the cost accuracy test workflow in CI, particularly on a fresh Postgres volume where the init server race condition is most likely to occur. The test should no longer intermittently fail with `terminating connection due to administrator command` errors during startup.

```sh
# Trigger the cost-accuracy-test workflow in CI and observe Postgres startup logs
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable