### PR TITLE
feat: expose `resource` (RFC 8707) in `oauth_config` schema and mark flattened `oauth_*` response fields as excluded from config sync

### DIFF
--- a/.github/workflows/configs/docker-compose.yml
+++ b/.github/workflows/configs/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U bifrost -d bifrost"]
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U bifrost -d bifrost"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/.github/workflows/scripts/cost-accuracy-test.sh
+++ b/.github/workflows/scripts/cost-accuracy-test.sh
@@ -118,7 +118,13 @@ start_postgres() {
   container="$(docker_compose -p "${COMPOSE_PROJECT}" -f "${COMPOSE_FILE}" ps -q postgres)"
   local pg_ready=0
   for _ in $(seq 1 60); do
-    if docker exec "${container}" pg_isready -U "${POSTGRES_USER}" -d bifrost >/dev/null 2>&1; then
+    # -h forces a TCP check instead of the default Unix socket: on a fresh
+    # volume, Postgres runs a temporary init server that only listens on the
+    # socket (listen_addresses=''), so a socket-based check can report ready
+    # against that server right as it shuts down, killing the next
+    # connection with "terminating connection due to administrator command".
+    # TCP only comes up once the real server starts.
+    if docker exec "${container}" pg_isready -h 127.0.0.1 -U "${POSTGRES_USER}" -d bifrost >/dev/null 2>&1; then
       log "Postgres is ready"
       pg_ready=1
       break

--- a/.github/workflows/scripts/run-migration-tests.sh
+++ b/.github/workflows/scripts/run-migration-tests.sh
@@ -2079,6 +2079,9 @@ append_dynamic_columns_postgres() {
     echo "UPDATE logs SET redaction_mapping = '' WHERE id = 'log-migration-test-001';" >> "$output_file"
     echo "UPDATE logs SET redaction_mapping = '' WHERE id = 'log-migration-test-002';" >> "$output_file"
     echo "UPDATE logs SET redaction_mapping = '' WHERE id = 'log-migration-test-003';" >> "$output_file"
+  fi
+
+  # -------------------------------------------------------------------------
   # v1.6.3 columns - config store tables
   # -------------------------------------------------------------------------
 
@@ -2164,6 +2167,9 @@ append_dynamic_columns_postgres() {
     echo "UPDATE logs SET server_side_fallback_model = NULL WHERE id = 'log-migration-test-001';" >> "$output_file"
     echo "UPDATE logs SET server_side_fallback_model = 'gpt-4-turbo' WHERE id = 'log-migration-test-002';" >> "$output_file"
     echo "UPDATE logs SET server_side_fallback_model = NULL WHERE id = 'log-migration-test-003';" >> "$output_file"
+  fi
+
+  # -------------------------------------------------------------------------
   # v1.6.4 columns
   # -------------------------------------------------------------------------
 
@@ -2243,6 +2249,13 @@ append_dynamic_columns_postgres() {
   if column_exists_postgres "governance_budgets" "override_anchor_reset"; then
     echo "UPDATE governance_budgets SET override_anchor_reset = $now WHERE id = 'budget-migration-test-1';" >> "$output_file"
     echo "UPDATE governance_budgets SET override_anchor_reset = NULL WHERE id = 'budget-migration-test-2';" >> "$output_file"
+  fi
+
+  # governance_budgets.reset_config_json (added via migrationAddBudgetResetConfigColumn -
+  # nullable text, JSON reset config; '' when unset, e.g. '{"quarter_start_month":4}' for quarterly resets)
+  if column_exists_postgres "governance_budgets" "reset_config_json"; then
+    echo "UPDATE governance_budgets SET reset_config_json = '{\"quarter_start_month\":4}' WHERE id = 'budget-migration-test-1';" >> "$output_file"
+    echo "UPDATE governance_budgets SET reset_config_json = '' WHERE id = 'budget-migration-test-2';" >> "$output_file"
   fi
 
   # governance_pricing_overrides.user_id (added via add_pricing_override_user_id_column)
@@ -3471,12 +3484,6 @@ append_dynamic_columns_sqlite() {
     echo "UPDATE logs SET redaction_mapping = '' WHERE id = 'log-migration-test-001';" >> "$output_file"
     echo "UPDATE logs SET redaction_mapping = '' WHERE id = 'log-migration-test-002';" >> "$output_file"
     echo "UPDATE logs SET redaction_mapping = '' WHERE id = 'log-migration-test-003';" >> "$output_file"
-  # logs.redaction_mapping (added in v1.6.4 via logs_add_redaction_mapping_column -
-  # nullable text, stores the encrypted reversible redaction mapping)
-  if column_exists_sqlite "$logs_db" "logs" "redaction_mapping"; then
-    echo "UPDATE logs SET redaction_mapping = NULL WHERE id = 'log-migration-test-001';" >> "$output_file"
-    echo "UPDATE logs SET redaction_mapping = NULL WHERE id = 'log-migration-test-002';" >> "$output_file"
-    echo "UPDATE logs SET redaction_mapping = NULL WHERE id = 'log-migration-test-003';" >> "$output_file"
   fi
 
   # -------------------------------------------------------------------------
@@ -3570,6 +3577,13 @@ append_dynamic_columns_sqlite() {
   if column_exists_sqlite "$config_db" "governance_budgets" "override_anchor_reset"; then
     echo "UPDATE governance_budgets SET override_anchor_reset = $now WHERE id = 'budget-migration-test-1';" >> "$output_file"
     echo "UPDATE governance_budgets SET override_anchor_reset = NULL WHERE id = 'budget-migration-test-2';" >> "$output_file"
+  fi
+
+  # governance_budgets.reset_config_json (added via migrationAddBudgetResetConfigColumn -
+  # nullable text, JSON reset config; '' when unset, e.g. '{"quarter_start_month":4}' for quarterly resets)
+  if column_exists_sqlite "$config_db" "governance_budgets" "reset_config_json"; then
+    echo "UPDATE governance_budgets SET reset_config_json = '{\"quarter_start_month\":4}' WHERE id = 'budget-migration-test-1';" >> "$output_file"
+    echo "UPDATE governance_budgets SET reset_config_json = '' WHERE id = 'budget-migration-test-2';" >> "$output_file"
   fi
 
   # governance_pricing_overrides.user_id (added via add_pricing_override_user_id_column)

--- a/.github/workflows/scripts/schemasync/main.go
+++ b/.github/workflows/scripts/schemasync/main.go
@@ -107,14 +107,13 @@ var ignoreGoFields = map[string]string{
 	// oauth_config_id is a server-managed reference to the oauth_configs row, minted by the
 	// admin verification flow; config.go clears any value supplied via config.json.
 	"/properties/mcp/properties/client_configs/items|oauth_config_id": "server-managed oauth_configs reference; config.go clears any config.json-supplied value",
-	// The inline oauth_config block (schemas.OAuth2Config) carries five fields beyond the
+	// The inline oauth_config block (schemas.OAuth2Config) carries four fields beyond the
 	// user-facing set the UI form / config.schema.json document (client_id, client_secret,
-	// authorize_url, token_url, registration_url, scopes). These five are managed / derived /
-	// deprecated and are never authored in the inline config.json oauth_config block.
+	// authorize_url, token_url, registration_url, scopes, resource). These four are managed /
+	// derived / deprecated and are never authored in the inline config.json oauth_config block.
 	"/properties/mcp/properties/client_configs/items/properties/oauth_config|id":            "server-generated oauth_configs row id; not authored in the inline oauth_config block",
 	"/properties/mcp/properties/client_configs/items/properties/oauth_config|redirect_uri":  "computed by Bifrost (MCP OAuth callback URI); not authored in config.json",
 	"/properties/mcp/properties/client_configs/items/properties/oauth_config|server_url":    "derived from the client connection_string for OAuth discovery; not authored in config.json",
-	"/properties/mcp/properties/client_configs/items/properties/oauth_config|resource":      "RFC 8707 resource indicator; not part of the user-facing inline oauth_config block",
 	"/properties/mcp/properties/client_configs/items/properties/oauth_config|use_discovery": "deprecated; discovery is automatic when URLs are missing",
 	// source_id is a stable external identifier for teams provisioned by an
 	// integrating system (PR #3395). It is assigned through the API by that

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -2320,6 +2320,8 @@ func TestApplyNonStreamingOutputToEntryVideoOutputs(t *testing.T) {
 			t.Error("expected VideoGenerationOutputParsed to be nil when contentLoggingEnabled=false")
 		}
 	})
+}
+
 // TestGuardrailDebugForLogReadsContextWithoutResponse verifies input blocks remain observable.
 func TestGuardrailDebugForLogReadsContextWithoutResponse(t *testing.T) {
 	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -17989,20 +17989,25 @@ var excludedGoFields = map[string]map[string]bool{
 		"tool_sync_interval": true, // Internal
 	},
 	"schemas.MCPClientConfig": {
-		"client_id":             true, // Internal ID
-		"state":                 true, // Runtime state
-		"is_code_mode_client":   true, // Internal
-		"auth_type":             true, // Internal
-		"oauth_config_id":       true, // Internal
-		"oauth_client_id":       true, // Response-only: populated on GET from oauth config, not stored
-		"oauth_client_secret":   true, // Response-only: populated on GET from oauth config, not stored
-		"is_ping_available":     true, // Runtime state
-		"tool_sync_interval":    true, // Internal
-		"tool_pricing":          true, // Internal
-		"tools_to_auto_execute": true, // Internal
-		"tools_to_execute":      true, // Moved to VK MCP config
-		"connection_string":     true, // Use specific config types instead
-		"headers":               true, // Internal
+		"client_id":              true, // Internal ID
+		"state":                  true, // Runtime state
+		"is_code_mode_client":    true, // Internal
+		"auth_type":              true, // Internal
+		"oauth_config_id":        true, // Internal
+		"oauth_client_id":        true, // Response-only: populated on GET from oauth config, not stored
+		"oauth_client_secret":    true, // Response-only: populated on GET from oauth config, not stored
+		"oauth_authorize_url":    true, // Response-only: populated on GET from oauth config, not stored
+		"oauth_token_url":        true, // Response-only: populated on GET from oauth config, not stored
+		"oauth_registration_url": true, // Response-only: populated on GET from oauth config, not stored
+		"oauth_scopes":           true, // Response-only: populated on GET from oauth config, not stored
+		"oauth_resource":         true, // Response-only: populated on GET from oauth config, not stored
+		"is_ping_available":      true, // Runtime state
+		"tool_sync_interval":     true, // Internal
+		"tool_pricing":           true, // Internal
+		"tools_to_auto_execute":  true, // Internal
+		"tools_to_execute":       true, // Moved to VK MCP config
+		"connection_string":      true, // Use specific config types instead
+		"headers":                true, // Internal
 	},
 	"schemas.MCPToolManagerConfig": {
 		"code_mode_binding_level": true, // Internal

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -5025,6 +5025,10 @@
                 "type": "string"
               },
               "description": "OAuth scopes to request"
+            },
+            "resource": {
+              "type": "string",
+              "description": "OAuth resource indicator, RFC 8707 (optional: discovered from the MCP server's protected resource metadata when omitted)"
             }
           },
           "additionalProperties": false

--- a/transports/schema_test/config_schema_test.go
+++ b/transports/schema_test/config_schema_test.go
@@ -847,7 +847,9 @@ func TestSchemaMCPClientConfigFields(t *testing.T) {
 		"is_code_mode_client",
 		"connection_string",
 		"auth_type",
-		"oauth_config_id",
+		// config.json declares OAuth inline via `oauth_config`; the
+		// `oauth_config_id` FK is assigned server-side and is not settable here.
+		"oauth_config",
 		"headers",
 		"tools_to_execute",
 		"tools_to_auto_execute",


### PR DESCRIPTION
## Summary

Exposes the `resource` field (RFC 8707 OAuth resource indicator) in the user-facing `oauth_config` inline block within `config.schema.json`, making it configurable by users rather than treating it as a server-managed field. Previously, `resource` was excluded from the schema and listed as an ignored field; it is now a first-class, optional config.json-authored field with discovery fallback when omitted.

## Changes

- Added `resource` to `config.schema.json` under the `oauth_config` inline block, with a description noting it is optional and can be discovered from the MCP server's protected resource metadata.
- Removed `resource` from the `ignoreGoFields` map in the schemasync script, reducing the count of ignored fields from five to four and updating the associated comment accordingly.
- Added `oauth_authorize_url`, `oauth_token_url`, `oauth_registration_url`, `oauth_scopes`, and `oauth_resource` to the `excludedGoFields` map in `config_test.go` for `schemas.MCPClientConfig`, marking them as response-only fields populated on GET from the OAuth config but not stored directly.
- Updated `TestSchemaMCPClientConfigFields` to expect `oauth_config` (the inline block) instead of `oauth_config_id` (the server-assigned FK), reflecting that config.json authors use the inline form while the FK is assigned server-side.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/lib/...
go test ./transports/schema_test/...
```

Verify that a `config.json` with an inline `oauth_config` block containing a `resource` field passes schema validation and that the value is used as the RFC 8707 resource indicator during OAuth flows. Omitting `resource` should result in automatic discovery from the MCP server's protected resource metadata.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The `resource` field is an OAuth 2.0 resource indicator (RFC 8707) used to scope token requests to a specific protected resource. It does not introduce new secret handling but should be validated to prevent open-redirect or token-confusion attacks if the value influences authorization request construction.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable