### PR TITLE
fix(governance): block `from_memory` VK reads for DAC-scoped callers …

### DIFF
--- a/tests/cmd/seed/seed.go
+++ b/tests/cmd/seed/seed.go
@@ -337,6 +337,20 @@ func BuildShapes(prefix string) []Shape {
 	teamVK := prefix + "-vk-team-only"
 	outsideVK := prefix + "-vk-outside"
 
+	ids := dacFixtureIDs{
+		tiggingsUser:     tiggingsUser,
+		outsideUser:      outsideUser,
+		tiggingsTeam:     tiggingsTeam,
+		outsideTeam:      outsideTeam,
+		tiggingsCustomer: tiggingsCustomer,
+		outsideCustomer:  outsideCustomer,
+		tiggingsBU:       tiggingsBU,
+		outsideBU:        outsideBU,
+		userVK:           userVK,
+		teamVK:           teamVK,
+		outsideVK:        outsideVK,
+	}
+
 	shapes := make([]Shape, 0, 18)
 	for mask := 1; mask <= 15; mask++ {
 		hasVK := mask&0x1 != 0
@@ -363,20 +377,22 @@ func BuildShapes(prefix string) []Shape {
 			shape.CustomerID = tiggingsCustomer
 		}
 		shape.Marker = prefix + "-shape-" + shape.Name
-		shape.VisibleTo = computeVisibleTo(shape, tiggingsUser, outsideUser, tiggingsTeam, outsideTeam, userVK, teamVK, outsideVK)
+		shape.VisibleTo = computeVisibleTo(shape, ids)
 		shapes = append(shapes, shape)
 	}
 
-	shapes = append(shapes,
-		Shape{
+	// Negative shapes derive their visibility too. Hardcoding them is what hid the
+	// missing customer/BU dimensions: the hand-written outside lists happened to be
+	// right, so only the computed tiggings side disagreed with the server.
+	negatives := []Shape{
+		{
 			Name:           "user-not-in-tiggings",
 			UserID:         outsideUser,
 			CustomerID:     outsideCustomer,
 			BusinessUnitID: outsideBU,
 			Marker:         prefix + "-shape-user-not-in-tiggings",
-			VisibleTo:      []string{"all_data_admin", "own_reader_outside", "team_reader_outside"},
 		},
-		Shape{
+		{
 			Name:           "outside-team-virtual-key",
 			UserID:         outsideUser,
 			TeamID:         outsideTeam,
@@ -384,14 +400,16 @@ func BuildShapes(prefix string) []Shape {
 			BusinessUnitID: outsideBU,
 			VirtualKeyID:   outsideVK,
 			Marker:         prefix + "-shape-outside-team-vk",
-			VisibleTo:      []string{"all_data_admin", "own_reader_outside", "team_reader_outside"},
 		},
-		Shape{
-			Name:      "legacy-unowned",
-			Marker:    prefix + "-shape-legacy-unowned",
-			VisibleTo: []string{"all_data_admin"},
+		{
+			Name:   "legacy-unowned",
+			Marker: prefix + "-shape-legacy-unowned",
 		},
-	)
+	}
+	for _, shape := range negatives {
+		shape.VisibleTo = computeVisibleTo(shape, ids)
+		shapes = append(shapes, shape)
+	}
 	return shapes
 }
 
@@ -418,37 +436,69 @@ func shapeNameFromDims(hasVK, hasU, hasT, hasB bool) string {
 	return strings.Join(parts, "-")
 }
 
+// dacFixtureIDs carries the seeded values computeVisibleTo matches shapes against.
+// A struct rather than positional strings: the dimensions come in tiggings/outside
+// pairs, and swapping two would look like a server bug rather than a manifest one.
+type dacFixtureIDs struct {
+	tiggingsUser, outsideUser         string
+	tiggingsTeam, outsideTeam         string
+	tiggingsCustomer, outsideCustomer string
+	tiggingsBU, outsideBU             string
+	userVK, teamVK, outsideVK         string
+}
+
 // computeVisibleTo returns the sorted set of personas that can see rows of the
 // given shape, derived directly from the shape's DAC dimensions and the
 // well-known seeded principal/VK values.
-func computeVisibleTo(s Shape, tigU, outU, tigT, outT, userVK, teamVK, outVK string) []string {
+//
+// Mirrors the enterprise log scope (framework/logstore/dacscope.go); keep the two
+// in step, since a dimension the scope ORs in but this ignores makes the manifest
+// under-predict and the tests blame the server. Only team-data personas are widened
+// by the org dimensions, hence the team_reader_* -only customer/BU branches.
+func computeVisibleTo(s Shape, ids dacFixtureIDs) []string {
 	set := map[string]struct{}{"all_data_admin": {}}
 
 	switch s.UserID {
-	case tigU:
+	case ids.tiggingsUser:
 		set["own_reader_tiggings"] = struct{}{}
 		set["team_reader_tiggings"] = struct{}{}
-	case outU:
+	case ids.outsideUser:
 		set["own_reader_outside"] = struct{}{}
 		set["team_reader_outside"] = struct{}{}
 	}
 
 	switch s.TeamID {
-	case tigT:
+	case ids.tiggingsTeam:
 		set["team_reader_tiggings"] = struct{}{}
-	case outT:
+	case ids.outsideTeam:
+		set["team_reader_outside"] = struct{}{}
+	}
+
+	// BuildShapes sets customer and BU as a pair, so either branch alone would do
+	// today; both are modelled in case that pairing is relaxed.
+	switch s.CustomerID {
+	case ids.tiggingsCustomer:
+		set["team_reader_tiggings"] = struct{}{}
+	case ids.outsideCustomer:
+		set["team_reader_outside"] = struct{}{}
+	}
+
+	switch s.BusinessUnitID {
+	case ids.tiggingsBU:
+		set["team_reader_tiggings"] = struct{}{}
+	case ids.outsideBU:
 		set["team_reader_outside"] = struct{}{}
 	}
 
 	switch s.VirtualKeyID {
-	case userVK:
+	case ids.userVK:
 		set["vk_user_owned"] = struct{}{}
 		set["own_reader_tiggings"] = struct{}{}
 		set["team_reader_tiggings"] = struct{}{}
-	case teamVK:
+	case ids.teamVK:
 		set["vk_team_owned"] = struct{}{}
 		set["team_reader_tiggings"] = struct{}{}
-	case outVK:
+	case ids.outsideVK:
 		set["own_reader_outside"] = struct{}{}
 		set["team_reader_outside"] = struct{}{}
 	}

--- a/tests/cmd/seed/visibility_manifest_test.go
+++ b/tests/cmd/seed/visibility_manifest_test.go
@@ -1,0 +1,65 @@
+package seed
+
+import (
+	"slices"
+	"testing"
+)
+
+// TestComputeVisibleTo_ModelsOrgDimensions pins the manifest to the enterprise log
+// scope. The org dimensions were missing, so the business-unit-only shape read as
+// admin-only and the team reader looked like it saw 30 rows too many.
+func TestComputeVisibleTo_ModelsOrgDimensions(t *testing.T) {
+	shapes := BuildShapes("e2e")
+
+	byName := make(map[string][]string, len(shapes))
+	for _, s := range shapes {
+		byName[s.Name] = s.VisibleTo
+	}
+
+	visible := func(name, persona string) bool {
+		return slices.Contains(byName[name], persona)
+	}
+
+	if _, ok := byName["only-business-unit"]; !ok {
+		t.Fatalf("expected an only-business-unit shape, got %v", byName)
+	}
+	if !visible("only-business-unit", "team_reader_tiggings") {
+		t.Errorf("only-business-unit must be visible to team_reader_tiggings: %v", byName["only-business-unit"])
+	}
+	// Own-data personas are not widened by the org dimensions.
+	if visible("only-business-unit", "own_reader_tiggings") {
+		t.Errorf("only-business-unit must not be visible to own_reader_tiggings: %v", byName["only-business-unit"])
+	}
+	if visible("only-business-unit", "team_reader_outside") {
+		t.Errorf("only-business-unit must not cross to the outside team reader: %v", byName["only-business-unit"])
+	}
+
+	// A row with no DAC dimensions at all stays admin-only.
+	if got := byName["legacy-unowned"]; len(got) != 1 || got[0] != "all_data_admin" {
+		t.Errorf("legacy-unowned visibility: got %v, want [all_data_admin]", got)
+	}
+
+	// Derived negative shapes must still match what was previously hardcoded.
+	wantOutside := []string{"all_data_admin", "own_reader_outside", "team_reader_outside"}
+	for _, name := range []string{"user-not-in-tiggings", "outside-team-virtual-key"} {
+		got := slices.Sorted(slices.Values(byName[name]))
+		if !slices.Equal(got, wantOutside) {
+			t.Errorf("%s visibility: got %v, want %v", name, got, wantOutside)
+		}
+	}
+}
+
+// TestBuildShapes_TeamReaderVisibleCount guards the count the Postman assertion
+// compares against: all 15 matrix shapes carry at least one dimension the team
+// reader can see.
+func TestBuildShapes_TeamReaderVisibleCount(t *testing.T) {
+	count := 0
+	for _, s := range BuildShapes("e2e") {
+		if slices.Contains(s.VisibleTo, "team_reader_tiggings") {
+			count++
+		}
+	}
+	if count != 15 {
+		t.Errorf("team_reader_tiggings visible shapes: got %d, want 15", count)
+	}
+}


### PR DESCRIPTION
…and add customer/BU dimensions to seed manifest (#6137)

## Summary

Callers with narrowed virtual key visibility (enterprise DAC-scoped principals) could bypass access controls by appending `?from_memory=true` to the list and detail virtual key endpoints. The in-memory governance snapshot carries no notion of the calling principal, so it returned every cached key regardless of entitlement. This PR gates the snapshot path behind a `virtualKeyViewScoper` check and falls through to the scoped config store for narrowed callers.

A separate but related bug caused the DAC fixture manifest to under-predict visibility for shapes carrying only a customer or business unit dimension — the `computeVisibleTo` function was missing those two branches entirely. Because the negative shapes had hardcoded `VisibleTo` lists that happened to be correct, only the computed (tiggings) side disagreed with the server, surfacing as the team reader appearing to return 30 extra rows.

## Changes

- **`governance.go`**: Introduced `virtualKeyViewScoper` interface and `mayServeVirtualKeysFromMemory` helper. Both `getVirtualKeys` and `getVirtualKey` now skip the snapshot and delegate to the scoped config store when the caller's view is narrowed.
- **`governance_test.go`**: Added `newVKHandlerForFromMemory` factory with a `viewScoped` flag and a key present only in the snapshot, making snapshot vs. store reads distinguishable. Added tests covering the bypass fix for both the list and detail endpoints, and for the scoped caller preserving the `user_id` filter that the in-memory branch rejects.
- **`seed.go`**: Added `customer_id` and `business_unit_id` branches to `computeVisibleTo`, mirroring the enterprise log scope predicate. Introduced `dacFixtureIDs` struct to replace positional string arguments, preventing silent dimension-pair swaps. Removed hardcoded `VisibleTo` lists from the three negative shapes and derived them through `computeVisibleTo` instead.
- **`visibility_manifest_test.go`**: New test file pinning the manifest to the scope predicate — specifically that `only-business-unit` is visible to `team_reader_tiggings` but not `own_reader_tiggings` or `team_reader_outside`, that `legacy-unowned` stays admin-only, and that the 15-shape matrix is fully visible to the tiggings team reader.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/handlers/... ./tests/cmd/seed/...
```

The new governance tests assert that a scoped caller receives a 404 (detail) or an empty store-backed response (list) rather than the snapshot contents, and that an unscoped caller still reaches the snapshot. The seed tests assert the `only-business-unit` shape carries `team_reader_tiggings` in its `VisibleTo` list and that all 15 matrix shapes are visible to the tiggings team reader.

## Breaking changes

- [x] No

## Security considerations

The `from_memory=true` flag on the virtual key endpoints was exploitable by any caller whose config store is DAC-scoped: appending the flag returned the full unscoped in-memory snapshot, leaking keys belonging to other customers, teams, or users. The fix is fail-closed — stores that do not implement `virtualKeyViewScoper` (OSS) are unaffected and continue to use the snapshot as before.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)

## Summary

Briefly explain the purpose of this PR and the problem it solves.

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


