### PR TITLE
fix: exclude PKCE/state/token_id columns from `oauth_configs` snapshot comparison and fix `isPayloadEmpty` to check only offloadable payload fields

### DIFF
--- a/.github/workflows/scripts/run-migration-tests.sh
+++ b/.github/workflows/scripts/run-migration-tests.sh
@@ -5192,6 +5192,15 @@ compare_postgres_snapshots() {
     if [ "$table" = "oauth_user_tokens" ]; then
       dropped_columns="$dropped_columns session_token session_token_hash"
     fi
+    # state, code_verifier, code_challenge, expires_at (dropped from oauth_configs by
+    # migrationDropOauthConfigPKCEColumns) and token_id (dropped by
+    # migrationDropOauthConfigTokenIDColumn). The CSRF-state / PKCE handshake and its
+    # token reference moved onto mcp_oauth_flows; nothing populates these on
+    # oauth_configs anymore, so they are dropped outright rather than left as dead
+    # NOT NULL columns that would break every future INSERT.
+    if [ "$table" = "oauth_configs" ]; then
+      dropped_columns="$dropped_columns state code_verifier code_challenge expires_at token_id"
+    fi
     # enable_litellm_fallbacks (dropped from config_client in latest cut - behavior moved elsewhere)
     # allow_direct_keys (dropped from config_client in v1.5.0 - direct-keys-only mode removed; HTTP header
     # pass-through is no longer accepted)

--- a/framework/logstore/hybrid.go
+++ b/framework/logstore/hybrid.go
@@ -155,12 +155,15 @@ func (h *HybridLogStore) processUpload(work *uploadWork) {
 	h.droppedUploads.Add(1)
 }
 
-// isPayloadEmpty returns true when every value in the payload map is empty.
-// Skipping uploads for empty payloads avoids wasted S3 PUTs (e.g. initial
-// "processing" entries that carry no input/output data yet).
+// isPayloadEmpty returns true when the payload carries no offloadable content.
+// Only the large TEXT payload fields count: metadata like provider, model,
+// status and timestamp is populated on every entry (see ExtractPayload), so
+// checking the whole map would never report empty and would defeat the skip
+// for initial "processing" rows that have no input/output data yet. Skipping
+// uploads for empty payloads avoids wasted S3 PUTs.
 func isPayloadEmpty(payload map[string]string) bool {
-	for _, v := range payload {
-		if v != "" {
+	for _, f := range payloadFields {
+		if payload[f] != "" {
 			return false
 		}
 	}


### PR DESCRIPTION
## Summary

This PR fixes two distinct bugs: a false-negative in the hybrid log store's payload-empty check that was causing unnecessary S3 uploads, and missing dropped-column exclusions in the migration test snapshot comparison for `oauth_configs`.

## Changes

- **`isPayloadEmpty` fix**: The previous implementation iterated over all keys in the payload map, but `ExtractPayload` always populates metadata fields (provider, model, status, timestamp), meaning the map was never considered empty. The check now only inspects the large TEXT payload fields (`payloadFields`) that represent actual offloadable content, correctly skipping S3 PUTs for initial "processing" rows that carry no input/output data.

- **Migration test snapshot exclusions**: Added `state`, `code_verifier`, `code_challenge`, `expires_at`, and `token_id` to the list of dropped columns for `oauth_configs` in the migration snapshot comparison script. These columns were removed by `migrationDropOauthConfigPKCEColumns` and `migrationDropOauthConfigTokenIDColumn` as the CSRF-state/PKCE handshake and token reference moved to `mcp_oauth_flows`. Without this exclusion, migration tests would fail when comparing pre/post snapshots.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/logstore/...
```

For the migration test fix, run the migration test suite and confirm snapshot comparisons for `oauth_configs` no longer fail due to the dropped PKCE/token columns.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The `oauth_configs` columns being dropped (`state`, `code_verifier`, `code_challenge`, `token_id`) are OAuth PKCE handshake fields. Their removal from `oauth_configs` and migration to `mcp_oauth_flows` should be reviewed to ensure no PKCE state is silently lost during upgrades.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable