### PR TITLE
refactor: move `PublishRoutingAllowlist` and `LoadBalanceProvider` from governance's `PreRequestHook` into the routing plugin so both run after rule evaluation on the post-rule model

### DIFF
--- a/plugins/governance/loadbalance_test.go
+++ b/plugins/governance/loadbalance_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newPreRequestRoutingPlugin(t *testing.T, vk *configstoreTables.TableVirtualKey) *GovernancePlugin {
+func newLoadBalanceTestPlugin(t *testing.T, vk *configstoreTables.TableVirtualKey) *GovernancePlugin {
 	t.Helper()
 	logger := NewMockLogger()
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
@@ -25,50 +25,72 @@ func newPreRequestRoutingPlugin(t *testing.T, vk *configstoreTables.TableVirtual
 	}
 }
 
-// TestRunPreRequestRouting_ExplicitProviderPrefixSkipsLoadBalancing covers the
-// large-payload path: metadata.Model arrives provider-prefixed and unparsed, and
+// loadBalance runs LoadBalanceProvider over a model string the way the routing plugin does for
+// large-payload requests, and returns the resolved model (provider-prefixed when a provider
+// was selected, plain model otherwise).
+func loadBalance(t *testing.T, p *GovernancePlugin, ctx *schemas.BifrostContext, modelIn string) (string, error) {
+	t.Helper()
+	providerIn, parsedModel := schemas.ParseModelString(modelIn, "")
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{Provider: providerIn, Model: parsedModel},
+	}
+	vkValue := "sk-bf-lb"
+	vk, _ := p.store.GetVirtualKey(ctx, vkValue)
+	if err := p.LoadBalanceProvider(ctx, req, vk); err != nil {
+		return modelIn, err
+	}
+	provider, model, _ := req.GetRequestFields()
+	if provider != "" {
+		return string(provider) + "/" + model, nil
+	}
+	return model, nil
+}
+
+// TestLoadBalanceProvider_ExplicitProviderPrefixSkipsLoadBalancing covers the
+// large-payload path, where metadata.Model arrives provider-prefixed and unparsed, and
 // the explicit prefix must win over VK load balancing even when multiple weighted
 // providers allow the model.
-func TestRunPreRequestRouting_ExplicitProviderPrefixSkipsLoadBalancing(t *testing.T) {
+func TestLoadBalanceProvider_ExplicitProviderPrefixSkipsLoadBalancing(t *testing.T) {
 	vk := buildVirtualKeyWithProviders("vk1", "sk-bf-lb", "LB VK", []configstoreTables.TableVirtualKeyProviderConfig{
 		buildProviderConfig("openai", []string{"*"}),
 		buildProviderConfig("anthropic", []string{"*"}),
 	})
-	p := newPreRequestRoutingPlugin(t, vk)
+	p := newLoadBalanceTestPlugin(t, vk)
 
 	for range 20 {
 		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-		got, err := p.runPreRequestRouting(ctx, vk, "openai/gpt-4o", schemas.ChatCompletionRequest)
+		got, err := loadBalance(t, p, ctx, "openai/gpt-4o")
 		require.NoError(t, err)
 		assert.Equal(t, "openai/gpt-4o", got)
 	}
 }
 
-// TestRunPreRequestRouting_UnprefixedModelLoadBalances verifies that a bare model
+// TestLoadBalanceProvider_UnprefixedModelLoadBalances verifies that a bare model
 // string still goes through VK load balancing and comes back provider-prefixed.
-func TestRunPreRequestRouting_UnprefixedModelLoadBalances(t *testing.T) {
+func TestLoadBalanceProvider_UnprefixedModelLoadBalances(t *testing.T) {
 	vk := buildVirtualKeyWithProviders("vk1", "sk-bf-lb", "LB VK", []configstoreTables.TableVirtualKeyProviderConfig{
 		buildProviderConfig("openai", []string{"*"}),
 	})
-	p := newPreRequestRoutingPlugin(t, vk)
+	p := newLoadBalanceTestPlugin(t, vk)
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
-	got, err := p.runPreRequestRouting(ctx, vk, "gpt-4o", schemas.ChatCompletionRequest)
+	got, err := loadBalance(t, p, ctx, "gpt-4o")
 	require.NoError(t, err)
 	assert.Equal(t, "openai/gpt-4o", got)
 }
 
-// TestRunPreRequestRouting_UnknownPrefixIsTreatedAsModelNamespace verifies that a
+// TestLoadBalanceProvider_UnknownPrefixIsTreatedAsModelNamespace verifies that a
 // "/" prefix that is not a known provider (e.g. a HuggingFace-style namespace) is
 // kept as part of the model name and load balancing still applies.
-func TestRunPreRequestRouting_UnknownPrefixIsTreatedAsModelNamespace(t *testing.T) {
+func TestLoadBalanceProvider_UnknownPrefixIsTreatedAsModelNamespace(t *testing.T) {
 	vk := buildVirtualKeyWithProviders("vk1", "sk-bf-lb", "LB VK", []configstoreTables.TableVirtualKeyProviderConfig{
 		buildProviderConfig("groq", []string{"*"}),
 	})
-	p := newPreRequestRoutingPlugin(t, vk)
+	p := newLoadBalanceTestPlugin(t, vk)
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
-	got, err := p.runPreRequestRouting(ctx, vk, "meta-llama/llama-3.1-8b-instant", schemas.ChatCompletionRequest)
+	got, err := loadBalance(t, p, ctx, "meta-llama/llama-3.1-8b-instant")
 	require.NoError(t, err)
 	assert.Equal(t, "groq/meta-llama/llama-3.1-8b-instant", got)
 }

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -53,6 +53,12 @@ type BaseGovernancePlugin interface {
 	PostMCPHook(ctx *schemas.BifrostContext, resp *schemas.BifrostMCPResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostMCPResponse, *schemas.BifrostError, error)
 	Cleanup() error
 	GetGovernanceStore() GovernanceStore
+	// Routing collaboration: the routing plugin calls these after evaluating routing rules,
+	// so the allowlist and the load balancer both act on the post-rule provider/model.
+	GetVirtualKey(ctx context.Context, vkValue string) (*configstoreTables.TableVirtualKey, bool)
+	GetBudgetAndRateLimitStatus(ctx context.Context, model string, provider schemas.ModelProvider, vk *configstoreTables.TableVirtualKey, budgetBaselines map[string]float64, tokenBaselines map[string]int64, requestBaselines map[string]int64) *BudgetAndRateLimitStatus
+	PublishRoutingAllowlist(ctx *schemas.BifrostContext, virtualKey *configstoreTables.TableVirtualKey, modelStr string)
+	LoadBalanceProvider(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, virtualKey *configstoreTables.TableVirtualKey) error
 }
 
 // GovernancePlugin implements the main governance plugin with hierarchical budget system
@@ -324,51 +330,6 @@ func (p *GovernancePlugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req
 	return nil, nil
 }
 
-// runPreRequestRouting wraps a model string in a synthetic BifrostRequest, runs the same
-// loadBalanceProvider helper used by the main PreRequestHook path, and returns the resolved
-// model (provider-prefixed when a provider was selected, plain model otherwise). Used by
-// PreRequestHook's large-payload branch where req.Model is empty because the body wasn't
-// parsed.
-func (p *GovernancePlugin) runPreRequestRouting(ctx *schemas.BifrostContext, virtualKey *configstoreTables.TableVirtualKey, modelIn string, requestType schemas.RequestType) (string, error) {
-	// Parse a provider-prefixed model string the same way the transport does for
-	// body-having requests, so an explicit prefix like "openai/gpt-4o" lands in
-	// ChatRequest.Provider and load balancing honors the caller's routing intent.
-	providerIn, parsedModel := schemas.ParseModelString(modelIn, "")
-	synthetic := &schemas.BifrostRequest{
-		RequestType: requestType,
-		ChatRequest: &schemas.BifrostChatRequest{Provider: providerIn, Model: parsedModel},
-	}
-
-	if virtualKey != nil {
-		if err := p.loadBalanceProvider(ctx, synthetic, virtualKey); err != nil {
-			return modelIn, err
-		}
-
-		// A caller-provided include-tools list can only narrow the virtual key's
-		// tool grant, never expand it — prune entries the key does not allow.
-		includeToolsProvided := p.pruneMCPIncludeToolsFromContext(ctx, virtualKey)
-
-		p.cfgMutex.RLock()
-		autoInjectDisabled := p.disableAutoToolInject != nil && *p.disableAutoToolInject
-		p.cfgMutex.RUnlock()
-		// An include-clients filter opts the request into tool injection even when
-		// auto-injection is disabled (see ParseAndAddToolsToRequest in core/mcp), so
-		// the key's allowlist must be stamped on every path where injection can run.
-		includeClientsPresent := ctx.Value(schemas.MCPContextKeyIncludeClients) != nil
-		if !includeToolsProvided && (!autoInjectDisabled || includeClientsPresent) {
-			if tools := p.computeMCPIncludeTools(virtualKey); tools != nil {
-				ctx.SetValue(schemas.MCPContextKeyIncludeTools, tools)
-			}
-		}
-	}
-
-	provider, model, _ := synthetic.GetRequestFields()
-	if provider != "" {
-		return string(provider) + "/" + model, nil
-	}
-	return model, nil
-}
-
 // HTTPTransportPostHook intercepts requests after they are processed (governance decision point)
 // It modifies the response in-place and returns nil to continue
 func (p *GovernancePlugin) HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error {
@@ -380,10 +341,26 @@ func (p *GovernancePlugin) HTTPTransportStreamChunkHook(ctx *schemas.BifrostCont
 	return chunk, nil
 }
 
-// loadBalanceProvider picks a weighted provider from the VK's configs for req.Model
+// GetVirtualKey resolves a virtual key by its value. Exposed so the routing plugin can build
+// the rule scope chain from the same key this plugin governs.
+func (p *GovernancePlugin) GetVirtualKey(ctx context.Context, vkValue string) (*configstoreTables.TableVirtualKey, bool) {
+	return p.store.GetVirtualKey(ctx, vkValue)
+}
+
+// GetBudgetAndRateLimitStatus reports live budget and rate limit usage for a provider/model
+// pair. Exposed so routing rules can test budget_used, tokens_used and request.
+func (p *GovernancePlugin) GetBudgetAndRateLimitStatus(ctx context.Context, model string, provider schemas.ModelProvider, vk *configstoreTables.TableVirtualKey, budgetBaselines map[string]float64, tokenBaselines map[string]int64, requestBaselines map[string]int64) *BudgetAndRateLimitStatus {
+	return p.store.GetBudgetAndRateLimitStatus(ctx, model, provider, vk, budgetBaselines, tokenBaselines, requestBaselines)
+}
+
+// LoadBalanceProvider picks a weighted provider from the VK's configs for req.Model
 // and mutates req.Provider/req.Model with the refined provider/model. Also populates req.Fallbacks
 // from the remaining weighted providers if no fallbacks were configured by the caller.
-func (p *GovernancePlugin) loadBalanceProvider(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, virtualKey *configstoreTables.TableVirtualKey) error {
+func (p *GovernancePlugin) LoadBalanceProvider(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, virtualKey *configstoreTables.TableVirtualKey) error {
+	if virtualKey == nil {
+		return nil
+	}
+
 	provider, modelStr, existingFallbacks := req.GetRequestFields()
 	if modelStr == "" {
 		return nil
@@ -562,7 +539,7 @@ func (p *GovernancePlugin) loadBalanceProvider(ctx *schemas.BifrostContext, req 
 	return nil
 }
 
-// publishRoutingAllowlist records, for downstream routing layers, which of the VK's configured
+// PublishRoutingAllowlist records, for downstream routing layers, which of the VK's configured
 // providers permit modelStr according to the VK's own allowed_models / blocked_models. It is a
 // coarse provider gate (BifrostContextKeyRoutingAllowedProviders) layered on top of the model
 // catalog checks those layers already run — its purpose is to stop a later routing layer (load
@@ -573,7 +550,7 @@ func (p *GovernancePlugin) loadBalanceProvider(ctx *schemas.BifrostContext, req 
 // Provider prefixes on the request model are already split into req.Provider + bare model at the
 // HTTP layer (resolveModelAndProvider), so VK allowed_models / blocked_models are matched against
 // bare names and plain membership checks are sufficient here.
-func (p *GovernancePlugin) publishRoutingAllowlist(ctx *schemas.BifrostContext, virtualKey *configstoreTables.TableVirtualKey, modelStr string) {
+func (p *GovernancePlugin) PublishRoutingAllowlist(ctx *schemas.BifrostContext, virtualKey *configstoreTables.TableVirtualKey, modelStr string) {
 	if virtualKey == nil {
 		return
 	}
@@ -993,13 +970,14 @@ func (p *GovernancePlugin) isMCPToolAllowedByVKWith(vk *configstoreTables.TableV
 	return false
 }
 
-// PreRequestHook is the per-request governance phase: it stamps the virtual key's scope on
-// ctx, publishes the key's provider allowlist, load balances across the key's provider
-// configs, and narrows the MCP tool list. It runs for both normal body-having requests
-// (routing on req.Model) and large-payload streaming requests (routing on
-// LargePayloadMetadata.Model from ctx — the body is opaque mid-stream, so routing is
-// constrained to same-protocol-family targets that the upstream provider can hydrate
-// from the rewritten metadata).
+// PreRequestHook is the per-request governance phase: it resolves the request's virtual key,
+// stamps the key's scope on ctx for downstream plugins, and narrows the MCP tool list to what
+// the key grants.
+//
+// It deliberately runs before the routing plugin so a routing rule evaluates against a fully
+// stamped context. The provider allowlist and load balancing that used to live here now run
+// from the routing plugin after rule evaluation, through PublishRoutingAllowlist and
+// LoadBalanceProvider, because both must act on the post-rule model.
 //
 // Realtime + generic streaming bypass handleRequest (see core/bifrost.go
 // RunRealtimeTurnPreHooks / RunStreamPreHooks) and are still handled at HTTPTransportPreHook.
@@ -1019,35 +997,6 @@ func (p *GovernancePlugin) PreRequestHook(ctx *schemas.BifrostContext, req *sche
 	}
 
 	stampGovernanceCtxFromVK(ctx, virtualKey)
-
-	// Large-payload mode: the body streams to the provider unparsed, so req.Model is
-	// empty for routes where the model lives in the body (OpenAI/Anthropic chat,
-	// responses, etc.). Route on LargePayloadMetadata.Model — the provider's
-	// streaming body rewriter (ApplyLargePayloadRequestBodyWithModelNormalization)
-	// reads metadata.Model when it rewrites the model field in the body prefix, so
-	// mutating it here is what propagates the routing decision to the upstream call.
-	if metadata, _ := ctx.Value(schemas.BifrostContextKeyLargePayloadMetadata).(*schemas.LargePayloadMetadata); metadata != nil && metadata.Model != "" {
-		newModel, err := p.runPreRequestRouting(ctx, virtualKey, metadata.Model, req.RequestType)
-		if err != nil {
-			return err
-		}
-		if newModel != "" && newModel != metadata.Model {
-			metadata.Model = newModel
-		}
-		_, routedModel := schemas.ParseModelString(metadata.Model, "")
-		p.publishRoutingAllowlist(ctx, virtualKey, routedModel)
-		return nil
-	}
-
-	// Publish the VK provider allowlist for the (post routing-rules) model so downstream routing
-	// layers (load balancing, model-catalog resolution) and core enforcement intersect their
-	// candidates with it — a later layer must not select a provider the VK forbids for this model.
-	_, routedModel, _ := req.GetRequestFields()
-	p.publishRoutingAllowlist(ctx, virtualKey, routedModel)
-
-	if err := p.loadBalanceProvider(ctx, req, virtualKey); err != nil {
-		return err
-	}
 
 	// A caller-provided include-tools list can only narrow the virtual key's
 	// tool grant, never expand it — prune entries the key does not allow.

--- a/plugins/routing/complexity/prerequesthook_test.go
+++ b/plugins/routing/complexity/prerequesthook_test.go
@@ -36,7 +36,7 @@ func TestPreRequestHook_ComplexityAnalyzerFeedsCELVariable(t *testing.T) {
 		Priority: 0,
 	}))
 
-	plugin, err := routing.InitFromStore(context.Background(), nil, logger, nil, ruleStore, rules.NewMockGovernanceStore())
+	plugin, err := routing.InitFromStore(context.Background(), nil, logger, nil, ruleStore, routing.NewMockGovernance())
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, plugin.Cleanup())
@@ -87,7 +87,7 @@ func TestPreRequestHook_ComplexitySkippedWhenNoRulesReferenceIt(t *testing.T) {
 		Priority: 0,
 	}))
 
-	plugin, err := routing.InitFromStore(context.Background(), nil, logger, nil, ruleStore, rules.NewMockGovernanceStore())
+	plugin, err := routing.InitFromStore(context.Background(), nil, logger, nil, ruleStore, routing.NewMockGovernance())
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, plugin.Cleanup())

--- a/plugins/routing/main.go
+++ b/plugins/routing/main.go
@@ -2,10 +2,11 @@
 // set, the compiled CEL programs behind each rule, and the request-complexity analyzer that
 // backs the complexity_tier variable.
 //
-// The plugin runs in PreRequestHook, ahead of the plugins that materialize a virtual key's
-// provider configuration, so a matched rule decides provider, model, fallback chain and key
-// pin before any load balancing happens. Requests with no rules configured pay a single map
-// check and return.
+// The plugin runs in PreRequestHook, after governance has resolved the request's virtual key
+// and stamped its scope on the context, and it drives the rest of the routing pipeline from
+// there: rules decide provider, model, fallback chain and key pin, and only then does the
+// virtual key's provider allowlist get published and its providers load balanced. Requests
+// with no rules configured pay a single map check before that materialization.
 package routing
 
 import (
@@ -25,6 +26,19 @@ import (
 
 // PluginName is the name of the routing plugin
 const PluginName = "routing"
+
+// Governance is what routing needs from the governance plugin. The two reads feed rule
+// evaluation; the two writes materialize the virtual key's provider choice for the model the
+// rules settled on, and run from the routing hook so they see post-rule values.
+//
+// It is satisfied by the registered governance plugin rather than by its store, so a
+// deployment that swaps in its own governance implementation supplies its own load balancing
+// through this same call.
+type Governance interface {
+	rules.GovernanceStore
+	PublishRoutingAllowlist(ctx *schemas.BifrostContext, virtualKey *configstoreTables.TableVirtualKey, modelStr string)
+	LoadBalanceProvider(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, virtualKey *configstoreTables.TableVirtualKey) error
+}
 
 const noComplexitySignalLog = "Complexity analysis skipped: no configured complexity signal matched the latest user message; continuing with existing routing path"
 
@@ -54,9 +68,10 @@ type RoutingPlugin struct {
 	engine             *rules.Engine
 	complexityAnalyzer atomic.Pointer[complexity.ComplexityAnalyzer]
 
-	// governance supplies the virtual key and its live budget/rate-limit usage. Required:
-	// rules address both, and the scope chain is built from the virtual key hierarchy.
-	governance  rules.GovernanceStore
+	// governance supplies the virtual key, its live budget/rate-limit usage, and the provider
+	// materialization that runs once rules have decided. Required: rules address budgets and
+	// rate limits, and the scope chain is built from the virtual key hierarchy.
+	governance  Governance
 	configStore configstore.ConfigStore
 	logger      schemas.Logger
 	cleanupOnce sync.Once
@@ -71,19 +86,19 @@ type RoutingPlugin struct {
 //   - config: plugin flags; may be nil, in which case defaults apply.
 //   - logger: logger used by the engine and the rule store.
 //   - configStore: configuration store rules are read from; may be nil.
-//   - governanceStore: virtual key and budget state provider; must not be nil.
+//   - governancePlugin: virtual key state and provider materialization; must not be nil.
 func Init(
 	ctx context.Context,
 	config *Config,
 	logger schemas.Logger,
 	configStore configstore.ConfigStore,
-	governanceStore rules.GovernanceStore,
+	governancePlugin Governance,
 ) (*RoutingPlugin, error) {
 	ruleStore, err := rules.NewLocalStore(ctx, logger, configStore)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize routing rule store: %w", err)
 	}
-	return InitFromStore(ctx, config, logger, configStore, ruleStore, governanceStore)
+	return InitFromStore(ctx, config, logger, configStore, ruleStore, governancePlugin)
 }
 
 // InitFromStore initializes and returns a routing plugin instance with a custom rule store.
@@ -97,7 +112,7 @@ func InitFromStore(
 	logger schemas.Logger,
 	configStore configstore.ConfigStore,
 	ruleStore rules.Store,
-	governanceStore rules.GovernanceStore,
+	governancePlugin Governance,
 ) (*RoutingPlugin, error) {
 	if logger == nil {
 		return nil, fmt.Errorf("logger cannot be nil")
@@ -108,7 +123,7 @@ func InitFromStore(
 
 	chainMaxDepth := config.chainMaxDepthOrDefault()
 
-	engine, err := rules.NewEngine(ruleStore, governanceStore, logger, chainMaxDepth)
+	engine, err := rules.NewEngine(ruleStore, governancePlugin, logger, chainMaxDepth)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize routing engine: %w", err)
 	}
@@ -116,7 +131,7 @@ func InitFromStore(
 	plugin := &RoutingPlugin{
 		rules:       ruleStore,
 		engine:      engine,
-		governance:  governanceStore,
+		governance:  governancePlugin,
 		configStore: configStore,
 		logger:      logger,
 	}
@@ -156,16 +171,20 @@ func (p *RoutingPlugin) storeComplexityAnalyzerConfig(config *complexity.Analyze
 	p.complexityAnalyzer.Store(complexity.NewComplexityAnalyzerWithConfig(resolved))
 }
 
-// PreRequestHook evaluates routing rules and applies the matched decision to the request.
+// PreRequestHook evaluates routing rules, then materializes the virtual key's provider choice
+// for whatever provider/model the rules settled on.
 //
-// It runs for both normal body-having requests (routing on req.Model) and large-payload
+// The order inside this hook is load bearing: a matched rule can rewrite provider, model and
+// fallbacks, so the virtual key's provider allowlist and its load balancer must both see the
+// post-rule values. Both of those belong to the governance plugin and are invoked from here
+// rather than from governance's own hook, which runs earlier so that rules evaluate against a
+// fully stamped context.
+//
+// It handles both normal body-having requests (routing on req.Model) and large-payload
 // streaming requests (routing on LargePayloadMetadata.Model from ctx, since the body is
-// opaque mid-stream). Requests with no rules configured return immediately.
+// opaque mid-stream).
 func (p *RoutingPlugin) PreRequestHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) error {
 	if req.RequestType == schemas.PassthroughRequest || req.RequestType == schemas.PassthroughStreamRequest {
-		return nil
-	}
-	if !p.rules.HasRules(ctx) {
 		return nil
 	}
 
@@ -194,11 +213,19 @@ func (p *RoutingPlugin) PreRequestHook(ctx *schemas.BifrostContext, req *schemas
 	if _, err := p.applyRoutingRules(ctx, req, virtualKey); err != nil {
 		return err
 	}
-	return nil
+
+	_, routedModel, _ := req.GetRequestFields()
+
+	// Downstream routing layers (load balancing, model-catalog resolution) and core
+	// enforcement intersect their candidates with this allowlist, so a later layer cannot
+	// select a provider the key forbids for the routed model. Without a virtual key there is
+	// nothing to allow or deny and the call is a no-op.
+	p.governance.PublishRoutingAllowlist(ctx, virtualKey, routedModel)
+	return p.governance.LoadBalanceProvider(ctx, req, virtualKey)
 }
 
 // routeLargePayloadModel wraps a model string in a synthetic BifrostRequest, runs the same
-// applyRoutingRules helper used by the main PreRequestHook path, and returns the resolved
+// rule evaluation and virtual key materialization as the main PreRequestHook path, and returns the resolved
 // model (provider-prefixed when a provider was selected, plain model otherwise). Used by the
 // large-payload branch where req.Model is empty because the body wasn't parsed.
 func (p *RoutingPlugin) routeLargePayloadModel(ctx *schemas.BifrostContext, virtualKey *configstoreTables.TableVirtualKey, modelIn string, requestType schemas.RequestType) (string, error) {
@@ -215,6 +242,18 @@ func (p *RoutingPlugin) routeLargePayloadModel(ctx *schemas.BifrostContext, virt
 		return modelIn, err
 	}
 
+	// Publish before load balancing, exactly as the body-having path does: the allowlist is
+	// matched against the key's allowed/blacklisted model patterns, which are written against
+	// caller-facing model names. Load balancing may replace the model with a provider-specific
+	// one (RefineModelForProvider), and an allowlist computed from that refined name can come
+	// back empty, which downstream layers read as "no provider permitted".
+	_, routedModel, _ := synthetic.GetRequestFields()
+	p.governance.PublishRoutingAllowlist(ctx, virtualKey, routedModel)
+
+	if err := p.governance.LoadBalanceProvider(ctx, synthetic, virtualKey); err != nil {
+		return modelIn, err
+	}
+
 	provider, model, _ := synthetic.GetRequestFields()
 	if provider != "" {
 		return string(provider) + "/" + model, nil
@@ -223,9 +262,14 @@ func (p *RoutingPlugin) routeLargePayloadModel(ctx *schemas.BifrostContext, virt
 }
 
 // applyRoutingRules evaluates routing rules against req and mutates
-// req.Provider/req.Model/req.Fallbacks when a rule matches. Returns the matched rules.Decision
-// (nil when no rule matched).
+// req.Provider/req.Model/req.Fallbacks when a rule matches, returning the matched
+// rules.Decision, or nil when no rule matched. A deployment with no rules configured pays a
+// single map check here and falls through to the virtual key's own provider selection.
 func (p *RoutingPlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, virtualKey *configstoreTables.TableVirtualKey) (*rules.Decision, error) {
+	if !p.rules.HasRules(ctx) {
+		return nil, nil
+	}
+
 	provider, model, _ := req.GetRequestFields()
 	if model == "" {
 		return nil, nil

--- a/plugins/routing/routingpin_test.go
+++ b/plugins/routing/routingpin_test.go
@@ -42,7 +42,7 @@ func TestApplyRoutingRules_PinnedKeyReachesContext(t *testing.T) {
 		Priority: 0,
 	}))
 
-	plugin, err := InitFromStore(context.Background(), nil, rules.NewMockLogger(), nil, store, rules.NewMockGovernanceStore())
+	plugin, err := InitFromStore(context.Background(), nil, rules.NewMockLogger(), nil, store, NewMockGovernance())
 	require.NoError(t, err)
 
 	req := &schemas.BifrostRequest{
@@ -64,4 +64,102 @@ func TestApplyRoutingRules_PinnedKeyReachesContext(t *testing.T) {
 	ctxKeyID, _ := root.Value(schemas.BifrostContextKeyRoutingPinnedAPIKeyID).(string)
 	assert.Equal(t, pinnedKeyID, ctxKeyID,
 		"routing-rule pinned key_id must reach BifrostContextKeyRoutingPinnedAPIKeyID that selectKeyFromProviderForModelWithPool reads")
+}
+
+// TestPreRequestHook_MaterializesVirtualKeyRoutingAfterRules pins the ordering this plugin
+// exists to guarantee: a matched rule rewrites the model, and both the provider allowlist and
+// the load balancer must then run against the rewritten model, not the one the caller sent.
+// Publishing the allowlist for the incoming model would prune providers the routed model is
+// actually allowed on.
+func TestPreRequestHook_MaterializesVirtualKeyRoutingAfterRules(t *testing.T) {
+	store, err := rules.NewLocalStore(context.Background(), rules.NewMockLogger(), nil)
+	require.NoError(t, err)
+	require.NoError(t, store.UpsertRule(context.Background(), &configstoreTables.TableRoutingRule{
+		ID:            "rewrite-1",
+		Name:          "Rewrite Model",
+		CelExpression: "model == 'gpt-4o'",
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("anthropic"), Model: bifrost.Ptr("claude-sonnet-4"), Weight: 1.0},
+		},
+		Enabled:  bifrost.Ptr(true),
+		Scope:    "global",
+		Priority: 0,
+	}))
+
+	vk := &configstoreTables.TableVirtualKey{ID: "vk-1", Name: "vk", Value: *schemas.NewSecretVar("sk-bf-test"), IsActive: bifrost.Ptr(true)}
+	governance := NewMockGovernance()
+	governance.VirtualKeys["sk-bf-test"] = vk
+
+	plugin, err := InitFromStore(context.Background(), nil, rules.NewMockLogger(), nil, store, governance)
+	require.NoError(t, err)
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{Provider: schemas.OpenAI, Model: "gpt-4o"},
+	}
+	ctx := schemas.NewBifrostContext(context.Background(), time.Now())
+	ctx.SetValue(schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
+
+	require.NoError(t, plugin.PreRequestHook(ctx, req))
+
+	_, model, _ := req.GetRequestFields()
+	assert.Equal(t, "claude-sonnet-4", model, "rule should have rewritten the model")
+	assert.Equal(t, []string{"claude-sonnet-4"}, governance.AllowlistModels,
+		"allowlist must be published for the routed model, not the incoming one")
+	assert.Equal(t, []string{"claude-sonnet-4"}, governance.LoadBalancedModels,
+		"load balancing must run after rules, on the routed model")
+}
+
+// TestPreRequestHook_LargePayloadPublishesAllowlistBeforeRefinement covers the large-payload
+// path, where the model is carried on LargePayloadMetadata instead of the request body. The
+// allowlist must be computed from the model the caller asked for (post-rule, pre-load-balance),
+// because a virtual key's allowed/blacklisted model patterns are written against caller-facing
+// names. Load balancing may rewrite the model to a provider-specific one, and an allowlist
+// derived from that name can come back empty, which downstream layers treat as "no provider
+// permitted".
+func TestPreRequestHook_LargePayloadPublishesAllowlistBeforeRefinement(t *testing.T) {
+	store, err := rules.NewLocalStore(context.Background(), rules.NewMockLogger(), nil)
+	require.NoError(t, err)
+	require.NoError(t, store.UpsertRule(context.Background(), &configstoreTables.TableRoutingRule{
+		ID:            "rewrite-lp",
+		Name:          "Rewrite Model",
+		CelExpression: "model == 'gpt-4o'",
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Model: bifrost.Ptr("gpt-4o-mini"), Weight: 1.0},
+		},
+		Enabled:  bifrost.Ptr(true),
+		Scope:    "global",
+		Priority: 0,
+	}))
+
+	vk := &configstoreTables.TableVirtualKey{ID: "vk-1", Name: "vk", Value: *schemas.NewSecretVar("sk-bf-test"), IsActive: bifrost.Ptr(true)}
+	governance := NewMockGovernance()
+	governance.VirtualKeys["sk-bf-test"] = vk
+	// Stand in for the real load balancer picking a provider and refining the model to that
+	// provider's deployment name.
+	governance.OnLoadBalance = func(req *schemas.BifrostRequest) {
+		req.SetProvider(schemas.Azure)
+		req.SetModel("azure-gpt-4o-mini-deployment")
+	}
+
+	plugin, err := InitFromStore(context.Background(), nil, rules.NewMockLogger(), nil, store, governance)
+	require.NoError(t, err)
+
+	metadata := &schemas.LargePayloadMetadata{Model: "gpt-4o"}
+	ctx := schemas.NewBifrostContext(context.Background(), time.Now())
+	ctx.SetValue(schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
+	ctx.SetValue(schemas.BifrostContextKeyLargePayloadMetadata, metadata)
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{},
+	}
+	require.NoError(t, plugin.PreRequestHook(ctx, req))
+
+	assert.Equal(t, []string{"gpt-4o-mini"}, governance.AllowlistModels,
+		"allowlist must be published for the routed model, before load balancing refines it")
+	assert.Equal(t, []string{"gpt-4o-mini"}, governance.LoadBalancedModels,
+		"load balancing must run on the routed model")
+	assert.Equal(t, "azure/azure-gpt-4o-mini-deployment", metadata.Model,
+		"the refined provider/model must be written back to the streamed metadata")
 }

--- a/plugins/routing/test_utils.go
+++ b/plugins/routing/test_utils.go
@@ -1,0 +1,41 @@
+package routing
+
+import (
+	"github.com/maximhq/bifrost/core/schemas"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/plugins/routing/rules"
+)
+
+// MockGovernance stands in for the governance plugin. It serves the canned virtual key and
+// usage state its embedded store provides, and records the provider materialization calls the
+// routing hook makes so tests can assert what model they were handed.
+type MockGovernance struct {
+	*rules.MockGovernanceStore
+
+	// AllowlistModels records the model passed to each PublishRoutingAllowlist call, in order.
+	AllowlistModels []string
+	// LoadBalancedModels records the model on the request at each LoadBalanceProvider call.
+	LoadBalancedModels []string
+	// LoadBalanceErr, when set, is returned by LoadBalanceProvider.
+	LoadBalanceErr error
+	// OnLoadBalance, when set, runs inside LoadBalanceProvider. Tests use it to stand in for
+	// the real load balancer's provider pick and model refinement.
+	OnLoadBalance func(req *schemas.BifrostRequest)
+}
+
+func NewMockGovernance() *MockGovernance {
+	return &MockGovernance{MockGovernanceStore: rules.NewMockGovernanceStore()}
+}
+
+func (m *MockGovernance) PublishRoutingAllowlist(_ *schemas.BifrostContext, _ *configstoreTables.TableVirtualKey, modelStr string) {
+	m.AllowlistModels = append(m.AllowlistModels, modelStr)
+}
+
+func (m *MockGovernance) LoadBalanceProvider(_ *schemas.BifrostContext, req *schemas.BifrostRequest, _ *configstoreTables.TableVirtualKey) error {
+	_, model, _ := req.GetRequestFields()
+	m.LoadBalancedModels = append(m.LoadBalancedModels, model)
+	if m.OnLoadBalance != nil {
+		m.OnLoadBalance(req)
+	}
+	return m.LoadBalanceErr
+}

--- a/transports/bifrost-http/handlers/realtime_client_secrets_test.go
+++ b/transports/bifrost-http/handlers/realtime_client_secrets_test.go
@@ -10,6 +10,7 @@ import (
 	bifrost "github.com/maximhq/bifrost/core"
 	openaiProvider "github.com/maximhq/bifrost/core/providers/openai"
 	"github.com/maximhq/bifrost/core/schemas"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/kvstore"
 	"github.com/maximhq/bifrost/plugins/governance"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
@@ -525,6 +526,21 @@ func (m *mockRealtimeMintingGovernancePlugin) Cleanup() error {
 }
 
 func (m *mockRealtimeMintingGovernancePlugin) GetGovernanceStore() governance.GovernanceStore {
+	return nil
+}
+
+func (m *mockRealtimeMintingGovernancePlugin) GetVirtualKey(_ context.Context, _ string) (*configstoreTables.TableVirtualKey, bool) {
+	return nil, false
+}
+
+func (m *mockRealtimeMintingGovernancePlugin) GetBudgetAndRateLimitStatus(_ context.Context, _ string, _ schemas.ModelProvider, _ *configstoreTables.TableVirtualKey, _ map[string]float64, _ map[string]int64, _ map[string]int64) *governance.BudgetAndRateLimitStatus {
+	return nil
+}
+
+func (m *mockRealtimeMintingGovernancePlugin) PublishRoutingAllowlist(_ *schemas.BifrostContext, _ *configstoreTables.TableVirtualKey, _ string) {
+}
+
+func (m *mockRealtimeMintingGovernancePlugin) LoadBalanceProvider(_ *schemas.BifrostContext, _ *schemas.BifrostRequest, _ *configstoreTables.TableVirtualKey) error {
 	return nil
 }
 

--- a/transports/bifrost-http/server/plugins.go
+++ b/transports/bifrost-http/server/plugins.go
@@ -110,8 +110,7 @@ func loadBuiltinPlugin(ctx context.Context, name string, pluginConfig any, bifro
 		if err != nil {
 			return nil, fmt.Errorf("routing plugin requires the governance plugin: %w", err)
 		}
-		return routing.Init(ctx, routingConfig, logger, bifrostConfig.ConfigStore,
-			governancePlugin.GetGovernanceStore())
+		return routing.Init(ctx, routingConfig, logger, bifrostConfig.ConfigStore, governancePlugin)
 
 	case maxim.PluginName:
 		maximConfig, err := MarshalPluginConfig[maxim.Config](pluginConfig)
@@ -228,7 +227,7 @@ func (s *BifrostHTTPServer) loadBuiltinPlugins(ctx context.Context) error {
 	}
 	s.Config.SetPluginOrderInfo(logging.PluginName, builtinPlacement, schemas.Ptr(3))
 
-	// 5. Governance (if enabled and not enterprise)
+	// 4. Governance (if enabled and not enterprise)
 	if ctx.Value(schemas.BifrostContextKeyIsEnterprise) == nil {
 		config := &governance.Config{
 			IsVkMandatory:         &s.Config.ClientConfig.EnforceAuthOnInference,
@@ -239,11 +238,11 @@ func (s *BifrostHTTPServer) loadBuiltinPlugins(ctx context.Context) error {
 	} else {
 		s.markPluginDisabled(governance.PluginName)
 	}
-	s.Config.SetPluginOrderInfo(governance.PluginName, builtinPlacement, schemas.Ptr(5))
+	s.Config.SetPluginOrderInfo(governance.PluginName, builtinPlacement, schemas.Ptr(4))
 
-	// 4. Routing rules (registered after governance because it reads the governance store,
-	// but ordered ahead of it: a matched rule decides provider/model/key before the virtual
-	// key's own provider configs are load balanced over).
+	// 5. Routing rules. Runs after governance so rules evaluate against a fully stamped
+	// context, and drives the rest of the routing pipeline itself: it publishes the virtual
+	// key's provider allowlist and load balances its providers once a rule has decided.
 	if s.Config.IsPluginLoaded(s.getGovernancePluginName()) {
 		config := &routing.Config{
 			ChainMaxDepth: &s.Config.ClientConfig.RoutingChainMaxDepth,
@@ -252,7 +251,7 @@ func (s *BifrostHTTPServer) loadBuiltinPlugins(ctx context.Context) error {
 	} else {
 		s.markPluginDisabled(routing.PluginName)
 	}
-	s.Config.SetPluginOrderInfo(routing.PluginName, builtinPlacement, schemas.Ptr(4))
+	s.Config.SetPluginOrderInfo(routing.PluginName, builtinPlacement, schemas.Ptr(5))
 
 	// 6. OTEL (if configured in PluginConfigs)
 	otelConfig := s.getPluginConfig(otel.PluginName)


### PR DESCRIPTION
## Summary

The governance and routing plugins previously ran in the wrong order relative to each other: routing ran first (priority 4) so that it could decide provider/model before load balancing, but this meant routing rules evaluated against an unstamped context. This PR inverts the execution order — governance now runs first (priority 4) to stamp the virtual key's scope on the context, and routing runs second (priority 5) to evaluate rules and then drive the rest of the provider materialization pipeline itself.

## Changes

- **Execution order swapped**: Governance is now priority 4 and routing is priority 5. Governance stamps the virtual key scope; routing evaluates rules against that fully stamped context.
- **Provider materialization moved to routing**: `PublishRoutingAllowlist` and `LoadBalanceProvider` were previously called inside `GovernancePlugin.PreRequestHook`. They are now called from `RoutingPlugin.PreRequestHook` after rule evaluation, so both always act on the post-rule provider/model rather than the incoming one. The large-payload path (`routeLargePayloadModel`) also calls them in the correct order: allowlist published before load balancing, since load balancing may refine the model to a provider-specific deployment name that would produce an empty allowlist.
- **`Governance` interface introduced in the routing package**: Routing now depends on a `Governance` interface (a superset of `rules.GovernanceStore`) that adds `PublishRoutingAllowlist` and `LoadBalanceProvider`. The concrete `GovernancePlugin` satisfies this interface. The server wires the governance plugin directly rather than passing its store.
- **`loadBalanceProvider` and `publishRoutingAllowlist` promoted to exported methods**: Renamed to `LoadBalanceProvider` and `PublishRoutingAllowlist` on `GovernancePlugin`, and added to `BaseGovernancePlugin`. `GetVirtualKey` and `GetBudgetAndRateLimitStatus` are also now exported on the interface for the same cross-plugin collaboration.
- **`runPreRequestRouting` removed from governance**: The helper that wrapped a model string in a synthetic request and ran load balancing is gone; the routing plugin's `routeLargePayloadModel` now owns that logic end-to-end.
- **`HasRules` guard moved into `applyRoutingRules`**: The early-return for deployments with no rules is now inside `applyRoutingRules` rather than `PreRequestHook`, so provider materialization still runs even when no rules are configured.
- **Test infrastructure updated**: `MockGovernance` added to the routing package, recording `AllowlistModels` and `LoadBalancedModels` per call so ordering can be asserted. Two new integration-style tests cover the body-having and large-payload paths. Load balance tests in the governance package are renamed to reflect they test `LoadBalanceProvider` directly.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/...
go test ./plugins/routing/...
go test ./transports/bifrost-http/...
```

The new tests in `plugins/routing/routingpin_test.go` assert that:
1. A matched rule rewrites the model and both the allowlist and load balancer receive the rewritten model, not the incoming one.
2. On the large-payload path, the allowlist is published for the post-rule model before load balancing refines it to a provider-specific deployment name.

## Breaking changes

- [x] Yes

`BaseGovernancePlugin` has four new required methods: `GetVirtualKey`, `GetBudgetAndRateLimitStatus`, `PublishRoutingAllowlist`, and `LoadBalanceProvider`. Any custom implementation of this interface must add these methods. The routing plugin's `Init` and `InitFromStore` signatures now accept a `Governance` interface instead of `rules.GovernanceStore`; callers passing a governance store directly must switch to passing the governance plugin.

## Security considerations

No new auth surfaces. The allowlist and load balancing logic is unchanged in behavior; only the call site moved. The ordering fix ensures a routing rule cannot select a provider that the virtual key forbids, which is a correctness improvement for the existing access control model.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable