### PR TITLE
feat(ui): add `contentClassName` prop to `EntitySelector` for popover width override

### DIFF
--- a/ui/components/entitySelectors/entitySelector.tsx
+++ b/ui/components/entitySelectors/entitySelector.tsx
@@ -84,6 +84,11 @@ export interface EntitySelectorCommonProps {
 	 * Single mode only.
 	 */
 	triggerClassName?: string;
+	/**
+	 * Overrides the popover width, which otherwise matches the trigger. For a
+	 * narrow trigger whose options need more room than it has. Single/add only.
+	 */
+	contentClassName?: string;
 	/** Ids to omit from the results — e.g. entities already added to a list. */
 	excludeIds?: string[];
 	/**
@@ -181,6 +186,7 @@ export function EntitySelector(props: EntitySelectorProps) {
 		fallbackOptions,
 		noPortal = true,
 		triggerClassName,
+		contentClassName,
 		excludeIds,
 		trigger,
 	} = props;
@@ -417,10 +423,11 @@ export function EntitySelector(props: EntitySelectorProps) {
 				emptyMessage={emptyMessage}
 				disabled={disabled}
 				// A compact trigger shouldn't dictate the popover width, so add
-				// mode keeps SearchSelect's own fixed width.
+				// mode keeps SearchSelect's own fixed width. Either default gives
+				// way to an explicit contentClassName.
 				align={isAdd ? "end" : "start"}
 				className={isAdd ? undefined : "w-full"}
-				contentClassName={isAdd ? undefined : "w-(--radix-popover-trigger-width)"}
+				contentClassName={contentClassName ?? (isAdd ? undefined : "w-(--radix-popover-trigger-width)")}
 				noPortal={noPortal}
 			/>
 		</div>


### PR DESCRIPTION
## Summary

Adds a `contentClassName` prop to `EntitySelector` that allows callers to override the popover width independently of the trigger width. This is useful when the trigger is narrow but the dropdown options need more horizontal space to display properly.

## Changes

- Added `contentClassName` to `EntitySelectorCommonProps` with documentation noting it applies to single/add mode only.
- Wired `contentClassName` through to `SearchSelect`, where it takes precedence over the default `contentClassName` logic (trigger-width matching for single mode, `undefined` for add mode).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Render an `EntitySelector` in single mode with a narrow trigger and pass a `contentClassName` with an explicit width (e.g. `w-80`). Confirm the popover opens at the specified width rather than matching the trigger width.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable