### PR TITLE
[fix]: azure responses - fill empty tool descriptions in additional_tools items

### DIFF
--- a/core/providers/openai/emptytooldescription6047_test.go
+++ b/core/providers/openai/emptytooldescription6047_test.go
@@ -1,0 +1,108 @@
+package openai_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/providers/openai"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// buildResponsesInput decodes a raw input array into ResponsesMessages,
+// exercising the same verbatim-preservation path as the HTTP transport.
+func buildResponsesInput(t *testing.T, raw string) []schemas.ResponsesMessage {
+	t.Helper()
+	var input []schemas.ResponsesMessage
+	require.NoError(t, json.Unmarshal([]byte(raw), &input))
+	return input
+}
+
+// wireInput converts the request for provider and returns the marshalled
+// `input` array as it would reach the upstream wire.
+func wireInput(t *testing.T, provider schemas.ModelProvider, input []schemas.ResponsesMessage) gjson.Result {
+	t.Helper()
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	oaReq := openai.ToOpenAIResponsesRequest(ctx, &schemas.BifrostResponsesRequest{
+		Provider: provider,
+		Model:    "gpt-5.6",
+		Input:    input,
+	})
+	require.NotNil(t, oaReq)
+	wire, err := json.Marshal(oaReq)
+	require.NoError(t, err)
+	return gjson.GetBytes(wire, "input")
+}
+
+const codexAdditionalToolsInput = `[
+	{
+		"type": "additional_tools",
+		"role": "developer",
+		"tools": [
+			{
+				"type": "namespace",
+				"name": "functions",
+				"description": "",
+				"tools": [
+					{"type": "function", "name": "get_weather", "description": "  ", "parameters": {"type": "object"}},
+					{"type": "function", "name": "described", "description": "Already documented", "parameters": {"type": "object"}}
+				]
+			},
+			{"type": "function", "name": "no_description_key", "parameters": {"type": "object"}}
+		]
+	},
+	{"role": "user", "content": "hi"}
+]`
+
+// Regression for #6047: Codex CLI 0.147.0 emits additional_tools entries with
+// empty descriptions, which Azure Responses rejects with HTTP 400 ("Expected a
+// string with minimum length 1"). For providers flagged with
+// EmptyToolDescription: false, the preserved item must be forwarded with
+// deterministic fallback descriptions instead.
+func TestAdditionalToolsEmptyDescriptionFilledForAzure(t *testing.T) {
+	input := wireInput(t, schemas.Azure, buildResponsesInput(t, codexAdditionalToolsInput))
+
+	item := input.Get("0")
+	assert.Equal(t, "additional_tools", item.Get("type").String())
+	assert.Equal(t, "Tools in the functions namespace", item.Get("tools.0.description").String(),
+		"empty namespace description must get the deterministic fallback")
+	assert.Equal(t, "The get_weather tool", item.Get("tools.0.tools.0.description").String(),
+		"whitespace-only descriptions on nested tools must be filled too")
+	assert.Equal(t, "Already documented", item.Get("tools.0.tools.1.description").String(),
+		"non-empty descriptions must remain unchanged")
+	assert.False(t, item.Get("tools.1.description").Exists(),
+		"absent description keys must stay absent; only empty strings are rejected upstream")
+
+	// The rest of the preserved item must survive byte-level rewriting.
+	assert.Equal(t, "developer", item.Get("role").String())
+	assert.Equal(t, "object", item.Get("tools.0.tools.0.parameters.type").String())
+	assert.Equal(t, "hi", input.Get("1.content").String())
+}
+
+// OpenAI proper accepts the empty description, so the item must keep
+// round-tripping byte-for-byte (the #5103 preservation contract).
+func TestAdditionalToolsEmptyDescriptionVerbatimForOpenAI(t *testing.T) {
+	input := wireInput(t, schemas.OpenAI, buildResponsesInput(t, codexAdditionalToolsInput))
+
+	item := input.Get("0")
+	assert.Equal(t, "", item.Get("tools.0.description").String())
+	assert.True(t, item.Get("tools.0.description").Exists())
+	assert.Equal(t, "  ", item.Get("tools.0.tools.0.description").String())
+}
+
+// A fully-described additional_tools item routed to Azure must not be
+// rewritten at all.
+func TestAdditionalToolsNonEmptyDescriptionsUntouchedForAzure(t *testing.T) {
+	raw := `[
+		{
+			"type": "additional_tools",
+			"role": "developer",
+			"tools": [{"type": "namespace", "name": "functions", "description": "All functions", "tools": []}]
+		}
+	]`
+	input := wireInput(t, schemas.Azure, buildResponsesInput(t, raw))
+	assert.Equal(t, "All functions", input.Get("0.tools.0.description").String())
+}

--- a/core/providers/openai/emptytooldescription6047_test.go
+++ b/core/providers/openai/emptytooldescription6047_test.go
@@ -1,6 +1,7 @@
 package openai_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 	"time"
@@ -88,6 +89,12 @@ func TestAdditionalToolsEmptyDescriptionVerbatimForOpenAI(t *testing.T) {
 	input := wireInput(t, schemas.OpenAI, buildResponsesInput(t, codexAdditionalToolsInput))
 
 	item := input.Get("0")
+	// encoding/json compacts MarshalJSON output when embedding, so the wire is
+	// the preserved bytes minus insignificant whitespace: compare against the
+	// compacted original to pin key order, unasserted fields, and escaping.
+	var expected bytes.Buffer
+	require.NoError(t, json.Compact(&expected, []byte(gjson.Parse(codexAdditionalToolsInput).Get("0").Raw)))
+	assert.Equal(t, expected.String(), item.Raw, "OpenAI must preserve additional_tools bytes verbatim")
 	assert.Equal(t, "", item.Get("tools.0.description").String())
 	assert.True(t, item.Get("tools.0.description").Exists())
 	assert.Equal(t, "  ", item.Get("tools.0.tools.0.description").String())

--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -2,7 +2,11 @@ package openai
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 
 	"github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -46,18 +50,27 @@ type ResponsesFeatureSupport struct {
 	// ContextManagement reports whether the backend accepts the context_management
 	// Responses body field.
 	ContextManagement bool
+	// EmptyToolDescription reports whether the backend accepts an empty (or
+	// whitespace-only) `description` string on tools carried by
+	// additional_tools items; when false those descriptions are replaced with
+	// a deterministic fallback before forwarding.
+	EmptyToolDescription bool
 }
 
 // ProviderFeatures maps each OpenAI-compatible provider to its supported
 // Responses wire extensions. Only providers with a known deviation are listed.
 var ProviderFeatures = map[schemas.ModelProvider]ResponsesFeatureSupport{
-	schemas.OpenAI: {AdditionalToolsItem: true, ContextManagement: true},
+	schemas.OpenAI: {AdditionalToolsItem: true, ContextManagement: true, EmptyToolDescription: true},
 	// Bedrock Mantle validates `input` against the standard union and rejects
 	// additional_tools with "Invalid 'input': value did not match any expected
 	// variant", but accepts the same tools at the top level. It also rejects
 	// context_management outright as an unknown parameter.
-	schemas.Bedrock:       {AdditionalToolsItem: false, ContextManagement: false},
-	schemas.BedrockMantle: {AdditionalToolsItem: false, ContextManagement: false},
+	schemas.Bedrock:       {AdditionalToolsItem: false, ContextManagement: false, EmptyToolDescription: true},
+	schemas.BedrockMantle: {AdditionalToolsItem: false, ContextManagement: false, EmptyToolDescription: true},
+	// Azure keeps additional_tools items but validates tool descriptions with
+	// a minimum length of 1 ("Invalid 'input[0].tools[0].description': empty
+	// string."), which rejects the empty description Codex CLI 0.147.0 emits.
+	schemas.Azure: {AdditionalToolsItem: true, ContextManagement: true, EmptyToolDescription: false},
 }
 
 // supportsAdditionalToolsItem reports whether provider accepts codex
@@ -68,6 +81,82 @@ func supportsAdditionalToolsItem(provider schemas.ModelProvider) bool {
 		return true
 	}
 	return features.AdditionalToolsItem
+}
+
+// supportsEmptyToolDescription reports whether provider accepts empty tool
+// description strings inside additional_tools items. Unlisted providers are
+// assumed to.
+func supportsEmptyToolDescription(provider schemas.ModelProvider) bool {
+	features, ok := ProviderFeatures[provider]
+	if !ok {
+		return true
+	}
+	return features.EmptyToolDescription
+}
+
+// toolDescriptionFallback builds the deterministic description used in place
+// of an empty one. Namespace tools describe the tools they group; anything
+// else falls back to its name.
+func toolDescriptionFallback(toolType, name string) string {
+	if toolType == "namespace" && name != "" {
+		return "Tools in the " + name + " namespace"
+	}
+	if name != "" {
+		return "The " + name + " tool"
+	}
+	return "No description provided"
+}
+
+// fillEmptyToolDescriptions rewrites every tools[] entry under base (recursing
+// into nested namespace tools[].tools[]) whose `description` is present but
+// empty or whitespace-only, leaving all other bytes untouched. Descriptions
+// that are absent stay absent: strict upstreams reject the empty string, not
+// the missing key.
+func fillEmptyToolDescriptions(raw []byte, base string) ([]byte, bool) {
+	changed := false
+	tools := gjson.GetBytes(raw, base)
+	if !tools.IsArray() {
+		return raw, false
+	}
+	for i := range tools.Array() {
+		entry := base + "." + strconv.Itoa(i)
+		if desc := gjson.GetBytes(raw, entry+".description"); desc.Type == gjson.String && strings.TrimSpace(desc.String()) == "" {
+			fallback := toolDescriptionFallback(
+				gjson.GetBytes(raw, entry+".type").String(),
+				gjson.GetBytes(raw, entry+".name").String(),
+			)
+			if updated, err := sjson.SetBytes(raw, entry+".description", fallback); err == nil {
+				raw = updated
+				changed = true
+			}
+		}
+		if nested, nestedChanged := fillEmptyToolDescriptions(raw, entry+".tools"); nestedChanged {
+			raw = nested
+			changed = true
+		}
+	}
+	return raw, changed
+}
+
+// normalizeAdditionalToolsDescriptions returns message with empty tool
+// descriptions replaced (see fillEmptyToolDescriptions). The item is preserved
+// as raw bytes, so it is re-marshalled (which emits those bytes verbatim),
+// rewritten, and decoded again to re-preserve the corrected bytes. On any
+// error the original message is returned unchanged.
+func normalizeAdditionalToolsDescriptions(message schemas.ResponsesMessage) schemas.ResponsesMessage {
+	raw, err := json.Marshal(message)
+	if err != nil {
+		return message
+	}
+	rewritten, changed := fillEmptyToolDescriptions(raw, "tools")
+	if !changed {
+		return message
+	}
+	var normalized schemas.ResponsesMessage
+	if err := schemas.Unmarshal(rewritten, &normalized); err != nil {
+		return message
+	}
+	return normalized
 }
 
 // hoistAdditionalTools decodes the tools carried by a codex additional_tools item.
@@ -102,11 +191,16 @@ func ToOpenAIResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.B
 	// Tools lifted out of codex additional_tools items for providers that reject them.
 	var hoistedTools []schemas.ResponsesTool
 	keepAdditionalTools := supportsAdditionalToolsItem(bifrostReq.Provider)
+	fillDescriptions := !supportsEmptyToolDescription(bifrostReq.Provider)
 	for _, message := range bifrostReq.Input {
-		if !keepAdditionalTools && message.Type != nil &&
-			*message.Type == schemas.ResponsesMessageTypeAdditionalTools {
-			hoistedTools = append(hoistedTools, hoistAdditionalTools(message)...)
-			continue
+		if message.Type != nil && *message.Type == schemas.ResponsesMessageTypeAdditionalTools {
+			if !keepAdditionalTools {
+				hoistedTools = append(hoistedTools, hoistAdditionalTools(message)...)
+				continue
+			}
+			if fillDescriptions {
+				message = normalizeAdditionalToolsDescriptions(message)
+			}
 		}
 		// First, check if message has compaction/fallback content blocks and rewrite them
 		if message.Content != nil && len(message.Content.ContentBlocks) > 0 {


### PR DESCRIPTION
…ools items

## Summary

Codex CLI 0.147.0 sends Responses `additional_tools` input items containing a namespace tool with `description:""`.  Bifrost preserves these Codex-specific items verbatim by design (#5103), which is correct for OpenAI — but Azure Responses validates tool descriptions with a minimum length of 1 and rejects the request with HTTP 400 (`Invalid 'input[0].tools[0].description': empty string.`) before inference. Every Codex request routed to an Azure Responses upstream fails.

## Changes

- `core/providers/openai/responses.go`:
  - Added `EmptyToolDescription` to the existing `ResponsesFeatureSupport` matrix (same pattern as `AdditionalToolsItem`); Azure is listed as not accepting empty descriptions, existing entries are explicit, unlisted providers keep the assume-supported default — nobody else's wire changes.
  - For flagged providers, preserved `additional_tools` items are re-marshalled (emitting the verbatim bytes), rewritten with gjson/sjson, and re-decoded so the corrected bytes become the preserved payload. Only `description` keys that are present but empty/whitespace change; recursion covers nested `tools[].tools[]`; absent keys stay absent (Azure rejects the empty string, not the missing key). Fallbacks are deterministic: `"Tools in the <name> namespace"` for namespace tools, `"The <name> tool"` otherwise.
- `core/providers/openai/emptytooldescription6047_test.go` (new): Azure fills empty + whitespace descriptions (nested included) while role, parameters, non-empty text, and absent keys survive untouched; OpenAI keeps the item byte-for-byte (the #5103 contract); fully-described items to Azure are not rewritten.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
cd core
go test ./providers/openai/ -run 'AdditionalTools' -count=1 -v
go test ./providers/openai/ -count=1
```

The Azure test fails on dev (empty description forwarded verbatim) and passes with the fix. Manual: send the issue's sanitized request shape through an Azure Responses provider; the forwarded item now carries "description": "Tools in the functions namespace" and Azure accepts the request.


## Breaking changes

- [x] No


## Related issues

Closes #6047 

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable


