### PR TITLE
feat(anthropic): synthesize missing terminal text suffix from output_text.done

### DIFF
--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -180,10 +180,11 @@ type anthropicToResponsesStreamState struct {
 	nextBlockIndex   int
 	blockIndexByItem map[string]int
 
-	// emittedTextByBlock holds bounded progress for text actually emitted to a
-	// normalized Anthropic client. Responses output_text.done is cumulative, so
-	// this lets the converter recover only its missing suffix without retaining a
-	// second full copy of the streamed response.
+	// emittedTextByBlock holds bounded progress for text that actually reached a
+	// normalized Anthropic client. Responses output_text.done is cumulative, while
+	// Anthropic clients assemble incremental content_block_delta events, so the
+	// converter needs this state to recover only a verified missing suffix without
+	// retaining a second full copy of the streamed response.
 	emittedTextByBlock map[int]*emittedTextProgress
 
 	// blockIndexMisses records non-empty item keys for which blockIndexFor was
@@ -247,13 +248,17 @@ type anthropicToResponsesStreamState struct {
 	codeExecServerClosedByItem map[string]bool
 }
 
-// emittedTextProgress records the byte length and SHA-256 state of one emitted text prefix.
+// emittedTextProgress records one Anthropic text block's wire-visible prefix.
+// emittedBytes locates the possible terminal suffix, while prefixHasher proves
+// that output_text.done still extends the exact bytes already sent. Keeping only
+// the count and digest makes the bookkeeping bounded regardless of output size.
 type emittedTextProgress struct {
 	emittedBytes int
 	prefixHasher hash.Hash
 }
 
-// recordEmittedText advances one block's bounded text progress.
+// recordEmittedText advances one block's bounded progress after a text delta is
+// known to be client-visible.
 func (s *anthropicToResponsesStreamState) recordEmittedText(blockIndex int, text string) {
 	if text == "" {
 		return
@@ -270,7 +275,9 @@ func (s *anthropicToResponsesStreamState) recordEmittedText(blockIndex int, text
 	progress.emittedBytes += len(text)
 }
 
-// recordEmittedTextEvents tracks text deltas that survived protocol validation and will reach the client.
+// recordEmittedTextEvents tracks only text deltas that survived protocol
+// validation and will reach the normalized client. Raw passthrough frames remain
+// authoritative, so the converter must neither track nor later supplement them.
 func (s *anthropicToResponsesStreamState) recordEmittedTextEvents(events []*AnthropicStreamEvent) {
 	if s.passthrough {
 		return
@@ -284,7 +291,11 @@ func (s *anthropicToResponsesStreamState) recordEmittedTextEvents(events []*Anth
 	}
 }
 
-// missingTerminalText returns the append-only suffix absent from prior emitted deltas.
+// missingTerminalText returns the append-only suffix not present in prior
+// client-visible deltas. Responses output_text.done carries cumulative text, so
+// the emitted prefix must match byte-for-byte before the remainder can safely be
+// converted into an Anthropic delta; a shorter or divergent aggregate is rejected
+// instead of duplicating or guessing client-visible content.
 func (s *anthropicToResponsesStreamState) missingTerminalText(blockIndex int, aggregate string) (string, bool) {
 	emittedBytes := 0
 	if progress := s.emittedTextByBlock[blockIndex]; progress != nil {
@@ -301,7 +312,8 @@ func (s *anthropicToResponsesStreamState) missingTerminalText(blockIndex int, ag
 	return missing, missing != ""
 }
 
-// clearEmittedTextProgress releases one content block's terminal-text bookkeeping.
+// clearEmittedTextProgress releases terminal-text bookkeeping once
+// output_item.done closes the corresponding Anthropic content block.
 func (s *anthropicToResponsesStreamState) clearEmittedTextProgress(key string) {
 	if key == "" || s.blockIndexByItem == nil || s.emittedTextByBlock == nil {
 		return
@@ -3316,6 +3328,10 @@ func toAnthropicResponsesStreamEvents(ctx *schemas.BifrostContext, bifrostResp *
 		}
 
 	case schemas.ResponsesStreamResponseTypeOutputTextDone:
+		// Runtime redaction may hold every output_text.delta and release the safe
+		// cumulative text only in output_text.done. Anthropic has no equivalent
+		// cumulative text event, so emit only the verified suffix before the block
+		// closes; passthrough streams keep their raw upstream frames authoritative.
 		state := getOrCreateAnthropicToResponsesStreamState(ctx)
 		if state.passthrough || bifrostResp.Text == nil || *bifrostResp.Text == "" {
 			return nil

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -1,10 +1,12 @@
 package anthropic
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"hash"
 	"maps"
 	"math"
 	"strings"
@@ -178,6 +180,12 @@ type anthropicToResponsesStreamState struct {
 	nextBlockIndex   int
 	blockIndexByItem map[string]int
 
+	// emittedTextByBlock holds bounded progress for text actually emitted to a
+	// normalized Anthropic client. Responses output_text.done is cumulative, so
+	// this lets the converter recover only its missing suffix without retaining a
+	// second full copy of the streamed response.
+	emittedTextByBlock map[int]*emittedTextProgress
+
 	// blockIndexMisses records non-empty item keys for which blockIndexFor was
 	// asked for an index that allocBlockIndex never assigned — i.e. a
 	// content_block_stop/_delta referencing a block whose content_block_start was
@@ -237,6 +245,70 @@ type anthropicToResponsesStreamState struct {
 	// Code can't carry and never spawns nested blocks, so it is left open here and
 	// closed at output_item.done from the verbatim carry input instead.
 	codeExecServerClosedByItem map[string]bool
+}
+
+// emittedTextProgress records the byte length and SHA-256 state of one emitted text prefix.
+type emittedTextProgress struct {
+	emittedBytes int
+	prefixHasher hash.Hash
+}
+
+// recordEmittedText advances one block's bounded text progress.
+func (s *anthropicToResponsesStreamState) recordEmittedText(blockIndex int, text string) {
+	if text == "" {
+		return
+	}
+	if s.emittedTextByBlock == nil {
+		s.emittedTextByBlock = make(map[int]*emittedTextProgress)
+	}
+	progress := s.emittedTextByBlock[blockIndex]
+	if progress == nil {
+		progress = &emittedTextProgress{prefixHasher: sha256.New()}
+		s.emittedTextByBlock[blockIndex] = progress
+	}
+	_, _ = progress.prefixHasher.Write([]byte(text))
+	progress.emittedBytes += len(text)
+}
+
+// recordEmittedTextEvents tracks text deltas that survived protocol validation and will reach the client.
+func (s *anthropicToResponsesStreamState) recordEmittedTextEvents(events []*AnthropicStreamEvent) {
+	if s.passthrough {
+		return
+	}
+	for _, event := range events {
+		if event == nil || event.Type != AnthropicStreamEventTypeContentBlockDelta || event.Index == nil ||
+			event.Delta == nil || event.Delta.Type != AnthropicStreamDeltaTypeText || event.Delta.Text == nil {
+			continue
+		}
+		s.recordEmittedText(*event.Index, *event.Delta.Text)
+	}
+}
+
+// missingTerminalText returns the append-only suffix absent from prior emitted deltas.
+func (s *anthropicToResponsesStreamState) missingTerminalText(blockIndex int, aggregate string) (string, bool) {
+	emittedBytes := 0
+	if progress := s.emittedTextByBlock[blockIndex]; progress != nil {
+		emittedBytes = progress.emittedBytes
+		if emittedBytes > len(aggregate) {
+			return "", false
+		}
+		aggregatePrefixHash := sha256.Sum256([]byte(aggregate[:emittedBytes]))
+		if !bytes.Equal(progress.prefixHasher.Sum(nil), aggregatePrefixHash[:]) {
+			return "", false
+		}
+	}
+	missing := aggregate[emittedBytes:]
+	return missing, missing != ""
+}
+
+// clearEmittedTextProgress releases one content block's terminal-text bookkeeping.
+func (s *anthropicToResponsesStreamState) clearEmittedTextProgress(key string) {
+	if key == "" || s.blockIndexByItem == nil || s.emittedTextByBlock == nil {
+		return
+	}
+	if blockIndex, ok := s.blockIndexByItem[key]; ok {
+		delete(s.emittedTextByBlock, blockIndex)
+	}
 }
 
 // allocBlockIndex assigns and returns the next Anthropic content-block index. A
@@ -549,8 +621,8 @@ func anthropicNativeEffortFrom(ctx *schemas.BifrostContext) (anthropicNativeEffo
 
 // SetResponsesStreamPassthrough marks this request's Anthropic reverse stream
 // conversion as running on the Claude Code passthrough path (raw upstream frames
-// interleaved with converted ones). The converter reads state.passthrough only for
-// collapsed server-tool result blocks that must still consume an upstream index.
+// interleaved with converted ones). The converter keeps raw upstream text
+// authoritative while still consuming indices for collapsed server-tool results.
 func SetResponsesStreamPassthrough(ctx *schemas.BifrostContext) {
 	getOrCreateAnthropicToResponsesStreamState(ctx).passthrough = true
 }
@@ -2784,7 +2856,10 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 	if len(events) == 0 || ctx == nil {
 		return events
 	}
-	return enforceStreamBlockTypes(getOrCreateAnthropicToResponsesStreamState(ctx), events)
+	state := getOrCreateAnthropicToResponsesStreamState(ctx)
+	events = enforceStreamBlockTypes(state, events)
+	state.recordEmittedTextEvents(events)
+	return events
 }
 
 // enforceStreamBlockTypes tracks the type each content_block_start opens and drops
@@ -3240,6 +3315,26 @@ func toAnthropicResponsesStreamEvents(ctx *schemas.BifrostContext, bifrostResp *
 			}
 		}
 
+	case schemas.ResponsesStreamResponseTypeOutputTextDone:
+		state := getOrCreateAnthropicToResponsesStreamState(ctx)
+		if state.passthrough || bifrostResp.Text == nil || *bifrostResp.Text == "" {
+			return nil
+		}
+		blockIndex, ok := state.blockIndexByItem[reverseStreamItemKey(bifrostResp)]
+		if !ok || state.blockType(blockIndex) != AnthropicContentBlockTypeText {
+			return nil
+		}
+		missing, ok := state.missingTerminalText(blockIndex, *bifrostResp.Text)
+		if !ok {
+			return nil
+		}
+		streamResp.Type = AnthropicStreamEventTypeContentBlockDelta
+		streamResp.Index = schemas.Ptr(blockIndex)
+		streamResp.Delta = &AnthropicStreamDelta{
+			Type: AnthropicStreamDeltaTypeText,
+			Text: schemas.Ptr(missing),
+		}
+
 	case schemas.ResponsesStreamResponseTypeFunctionCallArgumentsDelta:
 		// Skip WebSearch tool argument deltas - they will be sent synthetically in output_item.done
 		if bifrostResp.ItemID != nil {
@@ -3314,6 +3409,7 @@ func toAnthropicResponsesStreamEvents(ctx *schemas.BifrostContext, bifrostResp *
 		return nil
 
 	case schemas.ResponsesStreamResponseTypeOutputItemDone:
+		getOrCreateAnthropicToResponsesStreamState(ctx).clearEmittedTextProgress(reverseStreamItemKey(bifrostResp))
 		// Handle WebSearch tool completion with sanitization and synthetic delta generation
 		if bifrostResp.Item != nil &&
 			bifrostResp.Item.Type != nil &&

--- a/core/providers/anthropic/terminaltextstream_test.go
+++ b/core/providers/anthropic/terminaltextstream_test.go
@@ -1,0 +1,195 @@
+package anthropic
+
+import (
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// terminalTextItemAdded builds a text output-item start for reverse stream conversion.
+func terminalTextItemAdded(itemID string, outputIndex int) *schemas.BifrostResponsesStreamResponse {
+	return &schemas.BifrostResponsesStreamResponse{
+		Type:        schemas.ResponsesStreamResponseTypeOutputItemAdded,
+		OutputIndex: schemas.Ptr(outputIndex),
+		Item: &schemas.ResponsesMessage{
+			ID:   schemas.Ptr(itemID),
+			Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+		},
+	}
+}
+
+// terminalTextDelta builds one normalized output-text delta.
+func terminalTextDelta(itemID string, outputIndex int, text string) *schemas.BifrostResponsesStreamResponse {
+	return &schemas.BifrostResponsesStreamResponse{
+		Type:        schemas.ResponsesStreamResponseTypeOutputTextDelta,
+		ItemID:      schemas.Ptr(itemID),
+		OutputIndex: schemas.Ptr(outputIndex),
+		Delta:       schemas.Ptr(text),
+	}
+}
+
+// terminalTextDone builds the cumulative normalized output-text terminal event.
+func terminalTextDone(itemID string, outputIndex int, text string) *schemas.BifrostResponsesStreamResponse {
+	return &schemas.BifrostResponsesStreamResponse{
+		Type:        schemas.ResponsesStreamResponseTypeOutputTextDone,
+		ItemID:      schemas.Ptr(itemID),
+		OutputIndex: schemas.Ptr(outputIndex),
+		Text:        schemas.Ptr(text),
+	}
+}
+
+// terminalTextItemDone builds the output-item terminal event that closes the Anthropic block.
+func terminalTextItemDone(itemID string, outputIndex int) *schemas.BifrostResponsesStreamResponse {
+	return &schemas.BifrostResponsesStreamResponse{
+		Type:        schemas.ResponsesStreamResponseTypeOutputItemDone,
+		OutputIndex: schemas.Ptr(outputIndex),
+		Item: &schemas.ResponsesMessage{
+			ID:   schemas.Ptr(itemID),
+			Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+		},
+	}
+}
+
+// convertTerminalTextEvents runs normalized events through the Bifrost-to-Anthropic converter.
+func convertTerminalTextEvents(ctx *schemas.BifrostContext, responses ...*schemas.BifrostResponsesStreamResponse) []*AnthropicStreamEvent {
+	var events []*AnthropicStreamEvent
+	for _, response := range responses {
+		events = append(events, ToAnthropicResponsesStreamResponse(ctx, response)...)
+	}
+	return events
+}
+
+// terminalTextDeltas reconstructs client-visible text from Anthropic text deltas only.
+func terminalTextDeltas(events []*AnthropicStreamEvent) string {
+	var text string
+	for _, event := range events {
+		if event.Type == AnthropicStreamEventTypeContentBlockDelta &&
+			event.Delta != nil && event.Delta.Type == AnthropicStreamDeltaTypeText && event.Delta.Text != nil {
+			text += *event.Delta.Text
+		}
+	}
+	return text
+}
+
+// TestTerminalTextStreamEmitsOnlyMissingSuffix verifies held and partially released output is completed once.
+func TestTerminalTextStreamEmitsOnlyMissingSuffix(t *testing.T) {
+	tests := []struct {
+		name         string
+		deltas       []string
+		aggregate    string
+		want         string
+		wantTerminal string
+	}{
+		{name: "short held reply", deltas: []string{"", ""}, aggregate: "OK", want: "OK", wantTerminal: "OK"},
+		{name: "partially released reply", deltas: []string{"First sentence. "}, aggregate: "First sentence. Final sentence.", want: "First sentence. Final sentence.", wantTerminal: "Final sentence."},
+		{name: "normal stream", deltas: []string{"O", "K"}, aggregate: "OK", want: "OK", wantTerminal: ""},
+		{name: "redaction changes byte length", deltas: []string{"Contact [EMAIL]. "}, aggregate: "Contact [EMAIL]. Done.", want: "Contact [EMAIL]. Done.", wantTerminal: "Done."},
+		{name: "unicode prefix", deltas: []string{"Hello 世界. "}, aggregate: "Hello 世界. Done.", want: "Hello 世界. Done.", wantTerminal: "Done."},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := schemas.NewBifrostContext(nil, time.Time{})
+			responses := []*schemas.BifrostResponsesStreamResponse{terminalTextItemAdded("msg_1", 0)}
+			for _, delta := range test.deltas {
+				responses = append(responses, terminalTextDelta("msg_1", 0, delta))
+			}
+
+			beforeTerminal := convertTerminalTextEvents(ctx, responses...)
+			terminalEvents := convertTerminalTextEvents(ctx, terminalTextDone("msg_1", 0, test.aggregate))
+			allEvents := append(beforeTerminal, terminalEvents...)
+			if got := terminalTextDeltas(allEvents); got != test.want {
+				t.Fatalf("reconstructed text = %q, want %q", got, test.want)
+			}
+			if got := terminalTextDeltas(terminalEvents); got != test.wantTerminal {
+				t.Fatalf("terminal text delta = %q, want %q", got, test.wantTerminal)
+			}
+		})
+	}
+}
+
+// TestTerminalTextStreamTracksBlocksIndependently verifies interleaved text items do not share progress.
+func TestTerminalTextStreamTracksBlocksIndependently(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	events := convertTerminalTextEvents(ctx,
+		terminalTextItemAdded("msg_1", 0),
+		terminalTextDelta("msg_1", 0, "First "),
+		terminalTextItemAdded("msg_2", 1),
+		terminalTextDelta("msg_2", 1, "Second "),
+		terminalTextDone("msg_1", 0, "First done."),
+		terminalTextDone("msg_2", 1, "Second done."),
+	)
+
+	wantByBlock := map[int]string{0: "First done.", 1: "Second done."}
+	gotByBlock := make(map[int]string)
+	for _, event := range events {
+		if event.Type == AnthropicStreamEventTypeContentBlockDelta && event.Index != nil &&
+			event.Delta != nil && event.Delta.Type == AnthropicStreamDeltaTypeText && event.Delta.Text != nil {
+			gotByBlock[*event.Index] += *event.Delta.Text
+		}
+	}
+	for index, want := range wantByBlock {
+		if got := gotByBlock[index]; got != want {
+			t.Errorf("block %d text = %q, want %q", index, got, want)
+		}
+	}
+}
+
+// TestTerminalTextStreamRejectsNonAppendOnlyAggregate verifies unsafe terminal aggregates never synthesize guessed text.
+func TestTerminalTextStreamRejectsNonAppendOnlyAggregate(t *testing.T) {
+	tests := []struct {
+		name      string
+		aggregate string
+	}{
+		{name: "shorter", aggregate: "Fir"},
+		{name: "prefix mismatch", aggregate: "Changed sentence. Final."},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := schemas.NewBifrostContext(nil, time.Time{})
+			convertTerminalTextEvents(ctx,
+				terminalTextItemAdded("msg_1", 0),
+				terminalTextDelta("msg_1", 0, "First sentence. "),
+			)
+			if events := convertTerminalTextEvents(ctx, terminalTextDone("msg_1", 0, test.aggregate)); len(events) != 0 {
+				t.Fatalf("unsafe aggregate emitted events: %#v", events)
+			}
+		})
+	}
+
+	t.Run("unopened block", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+		if events := convertTerminalTextEvents(ctx, terminalTextDone("msg_missing", 0, "OK")); len(events) != 0 {
+			t.Fatalf("unopened block emitted events: %#v", events)
+		}
+	})
+}
+
+// TestTerminalTextStreamPassthroughNeverSynthesizes verifies raw Claude Code frames remain authoritative.
+func TestTerminalTextStreamPassthroughNeverSynthesizes(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	SetResponsesStreamPassthrough(ctx)
+	convertTerminalTextEvents(ctx, terminalTextItemAdded("msg_1", 0))
+
+	if events := convertTerminalTextEvents(ctx, terminalTextDone("msg_1", 0, "OK")); len(events) != 0 {
+		t.Fatalf("passthrough output_text.done synthesized events: %#v", events)
+	}
+}
+
+// TestTerminalTextStreamDeltaPrecedesStop verifies the recovered suffix is emitted before its block closes.
+func TestTerminalTextStreamDeltaPrecedesStop(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	convertTerminalTextEvents(ctx, terminalTextItemAdded("msg_1", 0))
+	terminalEvents := convertTerminalTextEvents(ctx, terminalTextDone("msg_1", 0, "OK"))
+	stopEvents := convertTerminalTextEvents(ctx, terminalTextItemDone("msg_1", 0))
+	events := append(terminalEvents, stopEvents...)
+
+	if len(events) != 2 || events[0].Type != AnthropicStreamEventTypeContentBlockDelta || events[1].Type != AnthropicStreamEventTypeContentBlockStop {
+		t.Fatalf("terminal event order = %#v, want text delta then block stop", events)
+	}
+	if progress := getOrCreateAnthropicToResponsesStreamState(ctx).emittedTextByBlock; len(progress) != 0 {
+		t.Fatalf("emitted text progress leaked after block stop: %#v", progress)
+	}
+}


### PR DESCRIPTION
## Summary

When the Responses API streams text, the `output_text.done` event carries the full cumulative text for a block. If some deltas were held back or never emitted (e.g. due to redaction or buffering), the terminal event contains text the Anthropic client never received. This PR recovers that missing suffix by tracking exactly how many bytes — and a rolling SHA-256 of those bytes — were actually emitted per content block, then synthesizing a final `content_block_delta` for the append-only remainder at `output_text.done` time.

## Changes

- Added `emittedTextProgress` per content block, storing the byte count and an incremental SHA-256 hasher of all text deltas that survived protocol validation and reached the client.
- `recordEmittedTextEvents` is called after `enforceStreamBlockTypes` in `ToAnthropicResponsesStreamResponse` to track only deltas that were actually forwarded.
- `missingTerminalText` computes the suffix absent from prior emitted deltas by verifying the aggregate's prefix hash matches the recorded hash before slicing — rejecting any aggregate that is shorter or has a mismatched prefix.
- `output_text.done` now synthesizes a `content_block_delta` carrying only the missing suffix, guarded by passthrough mode, block-type checks, and hash validation.
- `clearEmittedTextProgress` is called on `output_item.done` to release per-block bookkeeping once the block is closed.
- Passthrough mode (Claude Code raw frames) skips all synthesis, keeping upstream frames authoritative.
- Added `terminaltextstream_test.go` covering: held replies, partially released replies, normal streams, unicode prefixes, independent multi-block tracking, non-append-only aggregate rejection, passthrough suppression, and correct delta-before-stop ordering.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/anthropic/... -run TestTerminalText
```

The new tests cover:
- `TestTerminalTextStreamEmitsOnlyMissingSuffix` — held and partially released text is completed exactly once without duplication.
- `TestTerminalTextStreamTracksBlocksIndependently` — interleaved blocks do not share progress state.
- `TestTerminalTextStreamRejectsNonAppendOnlyAggregate` — shorter or prefix-mismatched aggregates emit no events.
- `TestTerminalTextStreamPassthroughNeverSynthesizes` — passthrough mode suppresses all synthesis.
- `TestTerminalTextStreamDeltaPrecedesStop` — the recovered suffix delta is emitted before `content_block_stop`, and progress is cleaned up afterward.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The SHA-256 prefix check ensures the converter never synthesizes text based on a mutated or truncated aggregate — if the upstream `output_text.done` value does not extend the already-emitted prefix byte-for-byte, no delta is produced. This prevents accidental injection of content that was not part of the original stream.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable