### PR TITLE
feat(routing): semantic classifier runtime and harness-aware input extraction

### DIFF
--- a/plugins/routing/complexity/extract.go
+++ b/plugins/routing/complexity/extract.go
@@ -1,17 +1,89 @@
 package complexity
 
 import (
+	"encoding/json"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-// BuildInput extracts text from normalized BifrostRequest values for
+type complexityHarness uint8
+
+const (
+	complexityHarnessUnknown complexityHarness = iota
+	complexityHarnessClaudeCode
+	complexityHarnessCodex
+)
+
+type complexityTextKind uint8
+
+const (
+	complexityTextInvalid complexityTextKind = iota
+	complexityTextHuman
+	// Context-only text can be ignored while an earlier human turn remains the
+	// routing subject for the current request.
+	complexityTextContextOnly
+	// Housekeeping text drives an internal request. When it is the newest
+	// relevant user turn, complexity routing must not inherit an older prompt.
+	complexityTextHousekeeping
+)
+
+type complexityTagPair struct {
+	open  string
+	close string
+}
+
+var (
+	// Claude Code emits these protocol wrappers as user-role text. Keep this
+	// list client-gated and explicit: arbitrary XML-like user text is valid.
+	claudeContextTags = [...]complexityTagPair{
+		{open: "<system-reminder>", close: "</system-reminder>"},
+	}
+	claudeHousekeepingTags = [...]complexityTagPair{
+		{open: "<local-command-caveat>", close: "</local-command-caveat>"},
+		{open: "<local-command-stdout>", close: "</local-command-stdout>"},
+		{open: "<local-command-stderr>", close: "</local-command-stderr>"},
+		{open: "<command-name>", close: "</command-name>"},
+		{open: "<command-message>", close: "</command-message>"},
+		{open: "<command-args>", close: "</command-args>"},
+	}
+	// These fixed pairs mirror Codex contextual user fragments. Dynamic
+	// <external_*> fragments are intentionally excluded to avoid stripping
+	// arbitrary caller-owned XML.
+	codexContextTags = [...]complexityTagPair{
+		{open: "# AGENTS.md instructions", close: "</INSTRUCTIONS>"},
+		{open: "<environment_context>", close: "</environment_context>"},
+		{open: "<skill>", close: "</skill>"},
+		{open: "<turn_aborted>", close: "</turn_aborted>"},
+		{open: "<subagent_notification>", close: "</subagent_notification>"},
+		{open: "<codex_internal_context", close: "</codex_internal_context>"},
+		{open: "<goal_context>", close: "</goal_context>"},
+		{open: "<recommended_plugins>", close: "</recommended_plugins>"},
+	}
+	codexHousekeepingTags = [...]complexityTagPair{
+		{open: "<user_shell_command>", close: "</user_shell_command>"},
+	}
+)
+
+const codexTurnMetadataHeader = "x-codex-turn-metadata"
+
+type codexTurnMetadata struct {
+	RequestKind string
+}
+
+// buildComplexityInput extracts text from normalized BifrostRequest values for
 // complexity_tier routing. It intentionally runs after the transport converters
-// have produced Bifrost's typed request shape, so this package does not duplicate
+// have produced Bifrost's typed request shape, so governance does not duplicate
 // provider-specific raw payload parsing.
-func BuildInput(req *schemas.BifrostRequest) (ComplexityInput, bool) {
+func BuildInput(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (ComplexityInput, bool) {
 	if req == nil {
+		return ComplexityInput{}, false
+	}
+
+	harness := detectComplexityHarness(ctx)
+	if harness == complexityHarnessCodex && isCodexBackgroundRequest(ctx) {
 		return ComplexityInput{}, false
 	}
 
@@ -20,7 +92,7 @@ func BuildInput(req *schemas.BifrostRequest) (ComplexityInput, bool) {
 		if req.ChatRequest == nil {
 			return ComplexityInput{}, false
 		}
-		return extractFromChatMessages(req.ChatRequest.Input)
+		return extractFromChatMessages(req.ChatRequest.Input, harness)
 	case schemas.TextCompletionRequest, schemas.TextCompletionStreamRequest:
 		if req.TextCompletionRequest == nil {
 			return ComplexityInput{}, false
@@ -30,7 +102,7 @@ func BuildInput(req *schemas.BifrostRequest) (ComplexityInput, bool) {
 		if req.ResponsesRequest == nil {
 			return ComplexityInput{}, false
 		}
-		return extractFromResponsesRequest(req.ResponsesRequest)
+		return extractFromResponsesRequest(req.ResponsesRequest, harness)
 	default:
 		return ComplexityInput{}, false
 	}
@@ -38,28 +110,40 @@ func BuildInput(req *schemas.BifrostRequest) (ComplexityInput, bool) {
 
 // extractFromChatMessages builds a complexity input from chat messages by
 // preserving system/developer context and tracking only text-only user turns.
-func extractFromChatMessages(messages []schemas.ChatMessage) (ComplexityInput, bool) {
+func extractFromChatMessages(messages []schemas.ChatMessage, harness complexityHarness) (ComplexityInput, bool) {
 	if len(messages) == 0 {
 		return ComplexityInput{}, false
 	}
 
 	var input ComplexityInput
 	var userTexts []string
+	lastRelevantUserKind := complexityTextInvalid
 
 	for _, msg := range messages {
 		switch msg.Role {
 		case schemas.ChatMessageRoleSystem, schemas.ChatMessageRoleDeveloper:
-			input.SystemText = appendText(input.SystemText, extractChatText(msg.Content))
+			input.SystemText = appendText(input.SystemText, sanitizeSystemText(extractChatText(msg.Content), harness))
 		case schemas.ChatMessageRoleUser:
 			text, ok := extractChatTextOnly(msg.Content)
-			if !ok || strings.TrimSpace(text) == "" {
+			if !ok {
 				return ComplexityInput{}, false
 			}
-			userTexts = append(userTexts, text)
+			text, kind := sanitizeUserText(text, harness)
+			switch kind {
+			case complexityTextHuman:
+				userTexts = append(userTexts, text)
+				lastRelevantUserKind = kind
+			case complexityTextContextOnly:
+				continue
+			case complexityTextHousekeeping:
+				lastRelevantUserKind = kind
+			default:
+				return ComplexityInput{}, false
+			}
 		}
 	}
 
-	if len(userTexts) == 0 {
+	if lastRelevantUserKind == complexityTextHousekeeping || len(userTexts) == 0 {
 		return ComplexityInput{}, false
 	}
 
@@ -84,17 +168,18 @@ func extractFromTextCompletionRequest(req *schemas.BifrostTextCompletionRequest)
 
 // extractFromResponsesRequest builds a complexity input from Responses API
 // messages while combining instructions with system/developer message text.
-func extractFromResponsesRequest(req *schemas.BifrostResponsesRequest) (ComplexityInput, bool) {
+func extractFromResponsesRequest(req *schemas.BifrostResponsesRequest, harness complexityHarness) (ComplexityInput, bool) {
 	if req == nil || len(req.Input) == 0 {
 		return ComplexityInput{}, false
 	}
 
 	var input ComplexityInput
 	if req.Params != nil && req.Params.Instructions != nil {
-		input.SystemText = *req.Params.Instructions
+		input.SystemText = sanitizeSystemText(*req.Params.Instructions, harness)
 	}
 
 	var userTexts []string
+	lastRelevantUserKind := complexityTextInvalid
 	for _, msg := range req.Input {
 		if msg.Role == nil {
 			continue
@@ -102,17 +187,28 @@ func extractFromResponsesRequest(req *schemas.BifrostResponsesRequest) (Complexi
 
 		switch *msg.Role {
 		case schemas.ResponsesInputMessageRoleSystem, schemas.ResponsesInputMessageRoleDeveloper:
-			input.SystemText = appendText(input.SystemText, extractResponsesText(msg.Content))
+			input.SystemText = appendText(input.SystemText, sanitizeSystemText(extractResponsesText(msg.Content), harness))
 		case schemas.ResponsesInputMessageRoleUser:
 			text, ok := extractResponsesTextOnly(msg.Content)
-			if !ok || strings.TrimSpace(text) == "" {
+			if !ok {
 				return ComplexityInput{}, false
 			}
-			userTexts = append(userTexts, text)
+			text, kind := sanitizeUserText(text, harness)
+			switch kind {
+			case complexityTextHuman:
+				userTexts = append(userTexts, text)
+				lastRelevantUserKind = kind
+			case complexityTextContextOnly:
+				continue
+			case complexityTextHousekeeping:
+				lastRelevantUserKind = kind
+			default:
+				return ComplexityInput{}, false
+			}
 		}
 	}
 
-	if len(userTexts) == 0 {
+	if lastRelevantUserKind == complexityTextHousekeeping || len(userTexts) == 0 {
 		return ComplexityInput{}, false
 	}
 
@@ -228,6 +324,179 @@ func isResponsesInputTextBlock(block schemas.ResponsesMessageContentBlock) bool 
 	return block.Type == "" ||
 		block.Type == schemas.ResponsesInputMessageContentBlockTypeText ||
 		block.Type == schemas.ResponsesOutputMessageContentTypeText
+}
+
+func detectComplexityHarness(ctx *schemas.BifrostContext) complexityHarness {
+	if ctx == nil {
+		return complexityHarnessUnknown
+	}
+
+	userAgent, _ := ctx.Value(schemas.BifrostContextKeyUserAgent).(string)
+	if strings.TrimSpace(userAgent) == "" {
+		headers, _ := ctx.Value(schemas.BifrostContextKeyRequestHeaders).(map[string]string)
+		userAgent = headers["user-agent"]
+	}
+
+	switch {
+	case schemas.ClaudeCLI.Matches(userAgent):
+		return complexityHarnessClaudeCode
+	case schemas.CodexCLI.Matches(userAgent), schemas.CodexDesktop.Matches(userAgent):
+		return complexityHarnessCodex
+	default:
+		return complexityHarnessUnknown
+	}
+}
+
+func isCodexBackgroundRequest(ctx *schemas.BifrostContext) bool {
+	metadata, ok := parseCodexTurnMetadata(ctx)
+	if !ok {
+		return false
+	}
+
+	switch strings.ToLower(strings.TrimSpace(metadata.RequestKind)) {
+	case "prewarm", "compaction", "memory":
+		return true
+	default:
+		return false
+	}
+}
+
+// parseCodexTurnMetadata decodes the structured metadata emitted by Codex.
+// Missing or structurally malformed metadata is unavailable rather than an
+// error so callers can preserve the existing fail-open request behavior.
+func parseCodexTurnMetadata(ctx *schemas.BifrostContext) (codexTurnMetadata, bool) {
+	if ctx == nil {
+		return codexTurnMetadata{}, false
+	}
+	headers, _ := ctx.Value(schemas.BifrostContextKeyRequestHeaders).(map[string]string)
+	rawMetadata := strings.TrimSpace(headers[codexTurnMetadataHeader])
+	if rawMetadata == "" {
+		return codexTurnMetadata{}, false
+	}
+
+	var fields struct {
+		RequestKind json.RawMessage `json:"request_kind"`
+	}
+	if err := json.Unmarshal([]byte(rawMetadata), &fields); err != nil {
+		return codexTurnMetadata{}, false
+	}
+
+	// Decode fields independently so an invalid new field cannot change the
+	// established behavior of another one.
+	var metadata codexTurnMetadata
+	if len(fields.RequestKind) > 0 {
+		_ = json.Unmarshal(fields.RequestKind, &metadata.RequestKind)
+	}
+	return metadata, true
+}
+
+func sanitizeUserText(text string, harness complexityHarness) (string, complexityTextKind) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return "", complexityTextContextOnly
+	}
+
+	switch harness {
+	case complexityHarnessClaudeCode:
+		cleaned, removedContext := stripComplexityTags(text, claudeContextTags[:])
+		cleaned, removedHousekeeping := stripComplexityTags(cleaned, claudeHousekeepingTags[:])
+		return classifySanitizedText(cleaned, removedContext, removedHousekeeping)
+	case complexityHarnessCodex:
+		cleaned, removedContext := stripComplexityTags(text, codexContextTags[:])
+		cleaned, removedHousekeeping := stripComplexityTags(cleaned, codexHousekeepingTags[:])
+		return classifySanitizedText(cleaned, removedContext, removedHousekeeping)
+	default:
+		return text, complexityTextHuman
+	}
+}
+
+func sanitizeSystemText(text string, harness complexityHarness) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+
+	switch harness {
+	case complexityHarnessClaudeCode:
+		text, _ = stripComplexityTags(text, claudeContextTags[:])
+		text, _ = stripComplexityTags(text, claudeHousekeepingTags[:])
+	case complexityHarnessCodex:
+		text, _ = stripComplexityTags(text, codexContextTags[:])
+		text, _ = stripComplexityTags(text, codexHousekeepingTags[:])
+	}
+	return strings.TrimSpace(text)
+}
+
+func classifySanitizedText(text string, removedContext, removedHousekeeping bool) (string, complexityTextKind) {
+	text = strings.TrimSpace(text)
+	if text != "" {
+		return text, complexityTextHuman
+	}
+	if removedHousekeeping {
+		return "", complexityTextHousekeeping
+	}
+	if removedContext {
+		return "", complexityTextContextOnly
+	}
+	return "", complexityTextInvalid
+}
+
+func stripComplexityTags(text string, tags []complexityTagPair) (string, bool) {
+	removedAny := false
+	for _, tag := range tags {
+		var cleaned strings.Builder
+		remaining := text
+		removedTag := false
+
+		// write appends a fragment, inserting one space when dropping a tag would
+		// otherwise merge the words that surrounded it.
+		write := func(fragment string) {
+			if fragment == "" {
+				return
+			}
+			if written := cleaned.String(); written != "" && !endsWithSpace(written) && !startsWithSpace(fragment) {
+				cleaned.WriteByte(' ')
+			}
+			cleaned.WriteString(fragment)
+		}
+
+		for {
+			start := strings.Index(remaining, tag.open)
+			if start < 0 {
+				write(remaining)
+				break
+			}
+
+			afterOpen := remaining[start+len(tag.open):]
+			closeOffset := strings.Index(afterOpen, tag.close)
+			if closeOffset < 0 {
+				// Preserve malformed/unclosed input instead of guessing where a
+				// client-owned fragment ends.
+				write(remaining)
+				break
+			}
+
+			write(remaining[:start])
+			remaining = afterOpen[closeOffset+len(tag.close):]
+			removedTag = true
+		}
+
+		if removedTag {
+			text = cleaned.String()
+			removedAny = true
+		}
+	}
+	return strings.TrimSpace(text), removedAny
+}
+
+func startsWithSpace(s string) bool {
+	r, _ := utf8.DecodeRuneInString(s)
+	return unicode.IsSpace(r)
+}
+
+func endsWithSpace(s string) bool {
+	r, _ := utf8.DecodeLastRuneInString(s)
+	return unicode.IsSpace(r)
 }
 
 // appendText joins adjacent text fragments with one separating space while

--- a/plugins/routing/complexity/extract_test.go
+++ b/plugins/routing/complexity/extract_test.go
@@ -1,7 +1,9 @@
 package complexity
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,7 +38,7 @@ func TestBuildComplexityInput_ChatTextMessages(t *testing.T) {
 		},
 	}
 
-	input, ok := BuildInput(req)
+	input, ok := BuildInput(nil, req)
 	require.True(t, ok)
 	assert.Equal(t, "Compare them to Lamport clocks", input.LastUserText)
 	assert.Equal(t, []string{"Explain vector clocks"}, input.PriorUserTexts)
@@ -52,7 +54,7 @@ func TestBuildComplexityInput_TextCompletionPrompt(t *testing.T) {
 		},
 	}
 
-	input, ok := BuildInput(req)
+	input, ok := BuildInput(nil, req)
 	require.True(t, ok)
 	assert.Equal(t, prompt, input.LastUserText)
 }
@@ -70,7 +72,7 @@ func TestBuildComplexityInput_TextCompletionPromptArraySkipped(t *testing.T) {
 		},
 	}
 
-	input, ok := BuildInput(req)
+	input, ok := BuildInput(nil, req)
 	require.False(t, ok)
 	assert.Empty(t, input.LastUserText)
 }
@@ -112,11 +114,64 @@ func TestBuildComplexityInput_ResponsesInputTextBlocks(t *testing.T) {
 		},
 	}
 
-	input, ok := BuildInput(req)
+	input, ok := BuildInput(nil, req)
 	require.True(t, ok)
 	assert.Equal(t, "Can you explain the changes?", input.LastUserText)
 	assert.Equal(t, []string{"I changed the retry policy and circuit breaker thresholds."}, input.PriorUserTexts)
 	assert.Equal(t, "Review carefully Be concise", input.SystemText)
+}
+
+func TestBuildComplexityInput_BlankUserTurns(t *testing.T) {
+	userRole := schemas.ResponsesInputMessageRoleUser
+	tests := []struct {
+		name         string
+		req          *schemas.BifrostRequest
+		wantOK       bool
+		wantLastUser string
+	}{
+		{
+			name: "chat trailing blank preserves prior human turn",
+			req: &schemas.BifrostRequest{
+				RequestType: schemas.ChatCompletionRequest,
+				ChatRequest: &schemas.BifrostChatRequest{Input: []schemas.ChatMessage{
+					{Role: schemas.ChatMessageRoleUser, Content: complexityChatString("Explain vector clocks")},
+					{Role: schemas.ChatMessageRoleUser, Content: complexityChatString("  ")},
+				}},
+			},
+			wantOK:       true,
+			wantLastUser: "Explain vector clocks",
+		},
+		{
+			name: "responses trailing blank preserves prior human turn",
+			req: &schemas.BifrostRequest{
+				RequestType: schemas.ResponsesRequest,
+				ResponsesRequest: &schemas.BifrostResponsesRequest{Input: []schemas.ResponsesMessage{
+					{Role: &userRole, Content: complexityResponsesString("Explain vector clocks")},
+					{Role: &userRole, Content: complexityResponsesString("  ")},
+				}},
+			},
+			wantOK:       true,
+			wantLastUser: "Explain vector clocks",
+		},
+		{
+			name: "all blank turns remain unavailable",
+			req: &schemas.BifrostRequest{
+				RequestType: schemas.ChatCompletionRequest,
+				ChatRequest: &schemas.BifrostChatRequest{Input: []schemas.ChatMessage{
+					{Role: schemas.ChatMessageRoleUser, Content: complexityChatString("")},
+					{Role: schemas.ChatMessageRoleUser, Content: complexityChatString("  ")},
+				}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, ok := BuildInput(nil, tt.req)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantLastUser, input.LastUserText)
+		})
+	}
 }
 
 func TestBuildComplexityInput_SupportsStreamingRequestTypes(t *testing.T) {
@@ -177,7 +232,7 @@ func TestBuildComplexityInput_SupportsStreamingRequestTypes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			input, ok := BuildInput(tt.req)
+			input, ok := BuildInput(nil, tt.req)
 			require.True(t, ok)
 			assert.Equal(t, tt.wantLastUser, input.LastUserText)
 			assert.Equal(t, tt.wantSystem, input.SystemText)
@@ -210,7 +265,7 @@ func TestBuildComplexityInput_ResponsesOutputTextTypedUserBlocks(t *testing.T) {
 		},
 	}
 
-	input, ok := BuildInput(req)
+	input, ok := BuildInput(nil, req)
 	require.True(t, ok)
 	assert.Equal(t, "Explain encryption", input.LastUserText)
 	assert.Equal(t, "You are a coding agent", input.SystemText)
@@ -232,7 +287,7 @@ func TestBuildComplexityInput_SkipsUnsupportedRequestTypesEvenWhenTextIsPresent(
 		},
 	}
 
-	input, ok := BuildInput(req)
+	input, ok := BuildInput(nil, req)
 	require.False(t, ok)
 	assert.Empty(t, input.LastUserText)
 }
@@ -285,7 +340,7 @@ func TestBuildComplexityInput_ExtractsTextFromMixedModalityUserContent(t *testin
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			input, ok := BuildInput(tt.req)
+			input, ok := BuildInput(nil, tt.req)
 			require.True(t, ok)
 			assert.Equal(t, tt.wantText, input.LastUserText)
 		})
@@ -335,11 +390,260 @@ func TestBuildComplexityInput_SkipsUserContentWithoutText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			input, ok := BuildInput(tt.req)
+			input, ok := BuildInput(nil, tt.req)
 			require.False(t, ok)
 			assert.Empty(t, input.LastUserText)
 		})
 	}
+}
+
+func TestSanitizeUserText_ClaudeCodeWrappers(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		wantText string
+		wantKind complexityTextKind
+	}{
+		{
+			name:     "system_reminder",
+			text:     "<system-reminder>Internal context</system-reminder>",
+			wantKind: complexityTextContextOnly,
+		},
+		{
+			name:     "local_command_caveat",
+			text:     "<local-command-caveat>Ignore local command messages</local-command-caveat>",
+			wantKind: complexityTextHousekeeping,
+		},
+		{
+			name:     "local_command_stdout",
+			text:     "<local-command-stdout>Compacted</local-command-stdout>",
+			wantKind: complexityTextHousekeeping,
+		},
+		{
+			name:     "local_command_stderr",
+			text:     "<local-command-stderr>command failed</local-command-stderr>",
+			wantKind: complexityTextHousekeeping,
+		},
+		{
+			name:     "command_name",
+			text:     "<command-name>/compact</command-name>",
+			wantKind: complexityTextHousekeeping,
+		},
+		{
+			name:     "command_message",
+			text:     "<command-message>compact</command-message>",
+			wantKind: complexityTextHousekeeping,
+		},
+		{
+			name:     "command_args",
+			text:     "<command-args>focus on routing</command-args>",
+			wantKind: complexityTextHousekeeping,
+		},
+		{
+			name:     "wrapper_with_human_text",
+			text:     "<local-command-stdout>build failed</local-command-stdout>\nWhy did the build fail?",
+			wantText: "Why did the build fail?",
+			wantKind: complexityTextHuman,
+		},
+		{
+			name:     "malformed_wrapper_is_preserved",
+			text:     "<local-command-stdout>build failed",
+			wantText: "<local-command-stdout>build failed",
+			wantKind: complexityTextHuman,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotText, gotKind := sanitizeUserText(tt.text, complexityHarnessClaudeCode)
+			assert.Equal(t, tt.wantText, gotText)
+			assert.Equal(t, tt.wantKind, gotKind)
+		})
+	}
+}
+
+func TestBuildComplexityInput_ClaudeCodeContextAndHousekeeping(t *testing.T) {
+	claudeCtx := complexityHarnessContext(schemas.ClaudeCLI.String(), nil)
+
+	tests := []struct {
+		name       string
+		messages   []schemas.ChatMessage
+		wantOK     bool
+		wantLast   string
+		wantPriors []string
+	}{
+		{
+			name: "trailing_context_reveals_previous_human_turn",
+			messages: []schemas.ChatMessage{
+				{Role: schemas.ChatMessageRoleUser, Content: complexityChatString("Explain vector clocks")},
+				{Role: schemas.ChatMessageRoleUser, Content: complexityChatString("<system-reminder>Use the repository instructions</system-reminder>")},
+			},
+			wantOK:   true,
+			wantLast: "Explain vector clocks",
+		},
+		{
+			name: "historical_command_is_not_conversation_context",
+			messages: []schemas.ChatMessage{
+				{Role: schemas.ChatMessageRoleUser, Content: complexityChatString("Explain vector clocks")},
+				{Role: schemas.ChatMessageRoleUser, Content: complexityChatString("<command-name>/plugin</command-name>")},
+				{Role: schemas.ChatMessageRoleUser, Content: complexityChatString("Compare them to Lamport clocks")},
+			},
+			wantOK:     true,
+			wantLast:   "Compare them to Lamport clocks",
+			wantPriors: []string{"Explain vector clocks"},
+		},
+		{
+			name: "newest_local_command_skips_request",
+			messages: []schemas.ChatMessage{
+				{Role: schemas.ChatMessageRoleUser, Content: complexityChatString("Explain vector clocks")},
+				{Role: schemas.ChatMessageRoleUser, Content: complexityChatString("<local-command-stdout>Compacted</local-command-stdout>")},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, ok := BuildInput(claudeCtx, &schemas.BifrostRequest{
+				RequestType: schemas.ChatCompletionRequest,
+				ChatRequest: &schemas.BifrostChatRequest{
+					Input: tt.messages,
+				},
+			})
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantLast, input.LastUserText)
+			assert.Equal(t, tt.wantPriors, input.PriorUserTexts)
+		})
+	}
+}
+
+func TestBuildComplexityInput_CodexContextAndSystemText(t *testing.T) {
+	codexCtx := complexityHarnessContext(schemas.CodexDesktop.String(), nil)
+	userRole := schemas.ResponsesInputMessageRoleUser
+	systemRole := schemas.ResponsesInputMessageRoleSystem
+	systemText := "Keep answers concise. <recommended_plugins>Plugin inventory</recommended_plugins>"
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ResponsesRequest,
+		ResponsesRequest: &schemas.BifrostResponsesRequest{
+			Input: []schemas.ResponsesMessage{
+				{Role: &systemRole, Content: complexityResponsesString(systemText)},
+				{Role: &userRole, Content: complexityResponsesString("<environment_context><cwd>/tmp/repo</cwd></environment_context>")},
+				{Role: &userRole, Content: complexityResponsesString("Fix the latest-message extractor")},
+			},
+		},
+	}
+
+	input, ok := BuildInput(codexCtx, req)
+	require.True(t, ok)
+	assert.Equal(t, "Fix the latest-message extractor", input.LastUserText)
+	assert.Empty(t, input.PriorUserTexts)
+	assert.Equal(t, "Keep answers concise.", input.SystemText)
+	assert.Equal(t, systemText, *req.ResponsesRequest.Input[0].Content.ContentStr, "classifier sanitization must not mutate the request")
+}
+
+func TestBuildComplexityInput_CodexNewestHousekeepingSkipsRequest(t *testing.T) {
+	codexCtx := complexityHarnessContext(schemas.CodexCLI.String(), nil)
+	userRole := schemas.ResponsesInputMessageRoleUser
+
+	tests := []struct {
+		name       string
+		latestText string
+	}{
+		{
+			name:       "local_shell_command",
+			latestText: "<user_shell_command><command>pwd</command><result>/tmp/repo</result></user_shell_command>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, ok := BuildInput(codexCtx, &schemas.BifrostRequest{
+				RequestType: schemas.ResponsesRequest,
+				ResponsesRequest: &schemas.BifrostResponsesRequest{
+					Input: []schemas.ResponsesMessage{
+						{Role: &userRole, Content: complexityResponsesString("Explain vector clocks")},
+						{Role: &userRole, Content: complexityResponsesString(tt.latestText)},
+					},
+				},
+			})
+			require.False(t, ok)
+			assert.Empty(t, input.LastUserText)
+		})
+	}
+}
+
+func TestBuildComplexityInput_CodexRequestKinds(t *testing.T) {
+	userRole := schemas.ResponsesInputMessageRoleUser
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ResponsesRequest,
+		ResponsesRequest: &schemas.BifrostResponsesRequest{
+			Input: []schemas.ResponsesMessage{
+				{Role: &userRole, Content: complexityResponsesString("Explain vector clocks")},
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		userAgent   string
+		requestKind string
+		rawMetadata string
+		wantOK      bool
+	}{
+		{name: "turn", userAgent: schemas.CodexCLI.String(), requestKind: "turn", wantOK: true},
+		{name: "prewarm", userAgent: schemas.CodexCLI.String(), requestKind: "prewarm"},
+		{name: "compaction", userAgent: schemas.CodexCLI.String(), requestKind: "compaction"},
+		{name: "memory", userAgent: schemas.CodexDesktop.String(), requestKind: "memory"},
+		{name: "unknown_kind_preserves_behavior", userAgent: schemas.CodexCLI.String(), requestKind: "future_kind", wantOK: true},
+		{name: "malformed_metadata_preserves_behavior", userAgent: schemas.CodexCLI.String(), rawMetadata: "{", wantOK: true},
+		{name: "non_codex_cannot_skip", userAgent: "generic-client/1.0", requestKind: "compaction", wantOK: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rawMetadata := tt.rawMetadata
+			if rawMetadata == "" {
+				rawMetadata = `{"request_kind":"` + tt.requestKind + `"}`
+			}
+			ctx := complexityHarnessContext("", map[string]string{
+				"user-agent":            tt.userAgent,
+				codexTurnMetadataHeader: rawMetadata,
+			})
+
+			input, ok := BuildInput(ctx, req)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, "Explain vector clocks", input.LastUserText)
+			}
+		})
+	}
+}
+
+func TestBuildComplexityInput_HarnessMarkersRequireMatchingUserAgent(t *testing.T) {
+	markerText := "<local-command-stdout>Compacted</local-command-stdout>"
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Input: []schemas.ChatMessage{
+				{Role: schemas.ChatMessageRoleUser, Content: complexityChatString(markerText)},
+			},
+		},
+	}
+
+	input, ok := BuildInput(complexityHarnessContext("generic-client/1.0", nil), req)
+	require.True(t, ok)
+	assert.Equal(t, markerText, input.LastUserText)
+}
+
+func complexityHarnessContext(userAgent string, headers map[string]string) *schemas.BifrostContext {
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	if userAgent != "" {
+		ctx.SetValue(schemas.BifrostContextKeyUserAgent, userAgent)
+	}
+	if headers != nil {
+		ctx.SetValue(schemas.BifrostContextKeyRequestHeaders, headers)
+	}
+	return ctx
 }
 
 func complexityChatString(text string) *schemas.ChatMessageContent {

--- a/plugins/routing/complexity/semanticclassifier.go
+++ b/plugins/routing/complexity/semanticclassifier.go
@@ -1,0 +1,1025 @@
+package complexity
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/vectorstore"
+)
+
+// SemanticVectorStoreNamespace is the prefix for immutable, fingerprinted
+// complexity-routing generations. It isolates routing exemplars from every
+// other VectorStore consumer, including the semantic cache plugin.
+const SemanticVectorStoreNamespace = "BifrostComplexityRouter"
+
+const (
+	semanticMetadataTier        = "tier"
+	semanticMetadataKind        = "kind"
+	semanticMetadataFingerprint = "fingerprint"
+	semanticMetadataKindExample = "example"
+	semanticMetadataKindMarker  = "marker"
+	semanticWarmupBatchSize     = 32
+)
+
+// SemanticStatus describes whether the semantic classifier can serve routing
+// requests for the current complexity configuration.
+type SemanticStatus string
+
+const (
+	// SemanticStatusDisabled means semantic routing is not configured.
+	SemanticStatusDisabled SemanticStatus = "disabled"
+	// SemanticStatusWarming means exemplar embeddings are being prepared.
+	SemanticStatusWarming SemanticStatus = "warming"
+	// SemanticStatusReady means semantic requests can query the current exemplars.
+	SemanticStatusReady SemanticStatus = "ready"
+	// SemanticStatusFailed means the desired generation failed to warm. The
+	// previous generation may still be serving when ServingPrevious is true.
+	SemanticStatusFailed SemanticStatus = "failed"
+)
+
+// SemanticStatusInfo is the safe runtime state exposed to Governance handlers
+// and UI clients; it never contains prompts, embeddings, or provider secrets.
+type SemanticStatusInfo struct {
+	State           SemanticStatus `json:"state"`
+	Loaded          int            `json:"loaded"`
+	Total           int            `json:"total"`
+	ServingPrevious bool           `json:"serving_previous,omitempty"`
+	Error           string         `json:"error,omitempty"`
+	// CachedPhrases is how many phrase vectors are currently held in process for
+	// the configured provider/model. Reuse cannot be inferred from the persisted
+	// config alone: the cache lives only in memory (vectors cannot be read back
+	// out of a VectorStore), so a restart empties it while the saved phrases look
+	// unchanged. Configuration clients estimating what a save will re-embed need
+	// this to tell a warm cache from a cold one; zero means the next save embeds
+	// every phrase regardless of what changed.
+	CachedPhrases int `json:"cached_phrases"`
+}
+
+// SemanticResult is the tier selected by the nearest labelled exemplar.
+// Score is the VectorStore backend's similarity value, not a lexical score.
+type SemanticResult struct {
+	Tier  string
+	Score float64
+	// MinSimilarity is the configured floor Score was tested against, echoed so
+	// callers can log a near miss without re-reading classifier state.
+	MinSimilarity float64
+	// Accepted reports whether Score cleared MinSimilarity. A rejected result
+	// still carries its tier and score for logging, but callers must not route
+	// on it — they publish no tier and record the request as "skipped".
+	Accepted bool
+	// MatchedExemplar is the tier phrase this request landed on. Tier and Score
+	// report what the classifier decided and how confidently; without the phrase
+	// itself a routing log cannot distinguish a sound match from an accidental
+	// one, which is the question anyone reading that log is actually asking.
+	// Empty when the serving generation carries no exemplar index or the backend
+	// returns a record ID it was not warmed with.
+	MatchedExemplar string
+}
+
+// EmbeddingFunc creates one embedding for semantic complexity classification.
+// The Governance package supplies the adapter so this package has no provider client.
+type EmbeddingFunc func(context.Context, *SemanticConfig, string) ([]float32, error)
+
+// BatchEmbeddingFunc creates one ordered embedding per input. Warmup uses it in
+// bounded batches when available and retains EmbeddingFunc as the compatibility
+// fallback for providers or models without true multi-input support.
+type BatchEmbeddingFunc func(context.Context, *SemanticConfig, []string) ([][]float32, error)
+
+// semanticGeneration is the immutable serving snapshot selected only after its
+// namespace has a completion marker. Its semantic config and measured vector
+// width must stay paired with the vectors produced by its provider and model.
+type semanticGeneration struct {
+	store     vectorstore.VectorStore
+	namespace string
+	semantic  *SemanticConfig
+	dimension int
+	embed     EmbeddingFunc
+	// exemplars maps this generation's record IDs back to the phrases they were
+	// built from. Keeping the index in process rather than as a fourth stored
+	// property preserves semanticVectorStoreProperties' rule that no phrase text
+	// reaches the backend, and costs no re-warm: the IDs derive from the same
+	// fingerprint the namespace does, so an already-warmed store stays valid.
+	// Published once with the generation and never mutated, so Classify may read
+	// it after releasing the mutex.
+	exemplars map[string]string
+}
+
+// SemanticClassifier embeds the shared tier phrase lists and classifies a
+// request against their exact nearest neighbour in an isolated VectorStore namespace.
+type SemanticClassifier struct {
+	ctx    context.Context
+	logger schemas.Logger
+
+	mu               sync.Mutex
+	configuredStore  vectorstore.VectorStore
+	ownedStore       vectorstore.VectorStore
+	embed            EmbeddingFunc
+	embedBatch       BatchEmbeddingFunc
+	config           *AnalyzerConfig
+	store            vectorstore.VectorStore
+	active           *semanticGeneration
+	status           SemanticStatusInfo
+	revision         uint64
+	warmCancel       context.CancelFunc
+	warming          bool
+	closed           bool
+	embeddedInFlight map[string]int
+	embeddingCache   *semanticEmbeddingCache
+	wg               sync.WaitGroup
+}
+
+// NewSemanticClassifier creates a disabled classifier. Callers configure it
+// and supply an embedding function independently because the Bifrost client is
+// wired after Governance construction.
+func NewSemanticClassifier(ctx context.Context, logger schemas.Logger) *SemanticClassifier {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return &SemanticClassifier{
+		ctx:            ctx,
+		logger:         logger,
+		status:         SemanticStatusInfo{State: SemanticStatusDisabled},
+		embeddingCache: newSemanticEmbeddingCache(),
+	}
+}
+
+// Configure snapshots the current analyzer configuration and starts a fresh
+// warmup when an embedding function and usable store are available.
+func (c *SemanticClassifier) Configure(config *AnalyzerConfig) {
+	c.mu.Lock()
+	c.config = cloneAnalyzerConfig(config)
+	c.revision++
+	c.resetForCurrentConfigLocked()
+	c.requestWarmupLocked()
+	c.mu.Unlock()
+}
+
+// SetConfiguredStore supplies Bifrost's configured shared VectorStore.
+// "embedded" mode ignores it; "vector_store" mode uses it when present and
+// falls back to the embedded store when it is nil.
+func (c *SemanticClassifier) SetConfiguredStore(store vectorstore.VectorStore) {
+	c.mu.Lock()
+	c.configuredStore = store
+	c.revision++
+	c.resetForCurrentConfigLocked()
+	c.requestWarmupLocked()
+	c.mu.Unlock()
+}
+
+// SetEmbeddingFunc supplies or clears the post-construction embedding adapter.
+// Changing it restarts preparation for the current configuration.
+func (c *SemanticClassifier) SetEmbeddingFunc(embed EmbeddingFunc) {
+	c.SetEmbeddingFunctions(embed, nil)
+}
+
+// SetEmbeddingFunctions supplies the request-time single-input adapter and the
+// optional warmup batch adapter in one state transition.
+func (c *SemanticClassifier) SetEmbeddingFunctions(embed EmbeddingFunc, embedBatch BatchEmbeddingFunc) {
+	c.mu.Lock()
+	c.embed = embed
+	c.embedBatch = embedBatch
+	c.revision++
+	c.resetForCurrentConfigLocked()
+	c.requestWarmupLocked()
+	c.mu.Unlock()
+}
+
+// RearmForProvider restarts preparation after the embedding provider's own
+// configuration changed — a key re-enabled, added, or its model allow-list
+// widened. Warmup is otherwise only ever started by a write to the complexity
+// configuration, so a classifier that failed because its provider could not
+// serve stayed failed even once the operator fixed the provider, with no way
+// back short of re-saving a configuration that had not changed.
+//
+// Two guards keep this from becoming an expensive reflex. Warmup re-embeds
+// every reference phrase, which costs real tokens:
+//
+//   - only the provider this classifier actually embeds through counts; edits
+//     to any other provider are irrelevant to it.
+//   - only a failed classifier re-arms. A ready one is serving correctly and
+//     has nothing to gain, and a warming one is already doing this work.
+func (c *SemanticClassifier) RearmForProvider(provider schemas.ModelProvider) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.config == nil || c.config.Semantic == nil {
+		return
+	}
+	if !strings.EqualFold(string(c.config.Semantic.Provider), string(provider)) {
+		return
+	}
+	if c.status.State != SemanticStatusFailed {
+		return
+	}
+	c.revision++
+	c.resetForCurrentConfigLocked()
+	c.requestWarmupLocked()
+}
+
+// ValidateConfig is the seam for checks that depend on live process state
+// rather than the payload alone, run before a handler persists a configuration.
+// No semantic setting needs one today: neither vector_store mode can fail, since
+// "vector_store" degrades to the embedded store when none is configured. Kept so
+// a future runtime-dependent setting has somewhere to go.
+func (c *SemanticClassifier) ValidateConfig(config *AnalyzerConfig) error {
+	_, err := ValidateAndNormalize(config)
+	return err
+}
+
+// Status returns a stable snapshot of the current semantic readiness state.
+func (c *SemanticClassifier) Status() SemanticStatusInfo {
+	c.mu.Lock()
+	status := c.status
+	cache := c.embeddingCache
+	c.mu.Unlock()
+	// Read the cache outside c.mu: it carries its own lock, and warmup holds that
+	// one while embedding.
+	status.CachedPhrases = cache.size()
+	return status
+}
+
+// Timeout returns the per-request embedding budget currently in force,
+// resolving an unset value the same way the embedding path does. Callers need
+// it to say what a classification ran out of: "timed out" without the budget
+// leaves an operator unable to tell a too-tight setting from a stalled provider.
+func (c *SemanticClassifier) Timeout() time.Duration {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.config == nil || c.config.Semantic == nil || c.config.Semantic.Timeout <= 0 {
+		return configstore.DefaultComplexitySemanticTimeout
+	}
+	return c.config.Semantic.Timeout
+}
+
+// IsConfigured reports whether semantic classification is enabled in the
+// current complexity configuration, independently from warmup readiness.
+func (c *SemanticClassifier) IsConfigured() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.config != nil && c.config.Semantic != nil
+}
+
+// SemanticInputText joins the most recent messageHistoryCount user turns into
+// the single text that gets embedded, oldest first so the latest message reads
+// last. Blank turns are skipped, and a request with fewer turns than requested
+// contributes what it has. Only user text is included: system prompts steer
+// every request in a deployment alike and would pull all of them toward the
+// same exemplar.
+func SemanticInputText(input ComplexityInput, messageHistoryCount int) string {
+	if messageHistoryCount < 1 {
+		messageHistoryCount = 1
+	}
+	texts := make([]string, 0, messageHistoryCount)
+	if priorCount := messageHistoryCount - 1; priorCount > 0 && len(input.PriorUserTexts) > 0 {
+		// Walk backwards so blank turns are skipped before the window is counted:
+		// slicing first would let blanks eat into the requested history count.
+		prior := make([]string, 0, priorCount)
+		for i := len(input.PriorUserTexts) - 1; i >= 0 && len(prior) < priorCount; i-- {
+			if strings.TrimSpace(input.PriorUserTexts[i]) != "" {
+				prior = append(prior, input.PriorUserTexts[i])
+			}
+		}
+		for i := len(prior) - 1; i >= 0; i-- {
+			texts = append(texts, prior[i])
+		}
+	}
+	if strings.TrimSpace(input.LastUserText) != "" {
+		texts = append(texts, input.LastUserText)
+	}
+	return strings.Join(texts, "\n")
+}
+
+// Classify embeds the configured slice of the request once and returns the tier
+// from the global nearest exemplar in the last completely warmed generation. A
+// newer desired generation can warm or fail without disrupting this serving
+// snapshot.
+func (c *SemanticClassifier) Classify(ctx context.Context, input ComplexityInput) (*SemanticResult, error) {
+	c.mu.Lock()
+	if c.config == nil || c.config.Semantic == nil || c.active == nil || c.active.embed == nil {
+		c.mu.Unlock()
+		return nil, nil
+	}
+	semantic := cloneSemanticConfig(c.active.semantic)
+	generation := c.active
+	dimension := generation.dimension
+	store := generation.store
+	namespace := generation.namespace
+	embed := generation.embed
+	exemplars := generation.exemplars
+	embeddedGeneration := c.isOwnedStoreLocked(store)
+	if embeddedGeneration {
+		if c.embeddedInFlight == nil {
+			c.embeddedInFlight = make(map[string]int)
+		}
+		c.embeddedInFlight[namespace]++
+	}
+	c.mu.Unlock()
+	if embeddedGeneration {
+		defer c.releaseGeneration(generation)
+	}
+
+	text := SemanticInputText(input, semantic.MessageHistoryCount)
+	if strings.TrimSpace(text) == "" {
+		return nil, nil
+	}
+	embedding, err := embed(ctx, semantic, text)
+	if err != nil {
+		return nil, fmt.Errorf("embed complexity input: %w", err)
+	}
+	if len(embedding) != dimension {
+		return nil, fmt.Errorf("embedding dimension %d does not match the active semantic generation dimension %d", len(embedding), dimension)
+	}
+
+	// MinSimilarity is deliberately not pushed into the query. Backends that
+	// filter server-side (Weaviate's certainty, Qdrant's score threshold) would
+	// drop the rejected candidate instead of returning it, and its score is
+	// exactly what makes a near miss diagnosable in the request log. Asking for
+	// a single result means the backend does the same work either way.
+	//
+	// The floor passed down is 0 rather than "no floor": a nearest exemplar with
+	// negative similarity points away from every tier, so it is never a
+	// defensible classification, and 0 is valid on every backend (Weaviate
+	// rejects a negative certainty).
+	results, err := store.GetNearest(ctx, namespace, embedding,
+		[]vectorstore.Query{{Field: semanticMetadataKind, Operator: vectorstore.QueryOperatorEqual, Value: semanticMetadataKindExample}},
+		[]string{semanticMetadataTier}, 0, 1)
+	if err != nil {
+		return nil, fmt.Errorf("query complexity exemplars: %w", err)
+	}
+	if len(results) == 0 || results[0].Score == nil {
+		return nil, nil
+	}
+	tier, ok := results[0].Properties[semanticMetadataTier].(string)
+	if !ok || !isComplexityTier(tier) {
+		return nil, fmt.Errorf("nearest complexity exemplar has invalid tier metadata")
+	}
+	score := *results[0].Score
+	return &SemanticResult{
+		Tier:            tier,
+		Score:           score,
+		MinSimilarity:   semantic.MinSimilarity,
+		Accepted:        semantic.MinSimilarity <= 0 || score >= semantic.MinSimilarity,
+		MatchedExemplar: exemplars[results[0].ID],
+	}, nil
+}
+
+// Close cancels active warmup and waits for the classifier's single worker to
+// exit. It only closes the embedded store owned by this classifier.
+func (c *SemanticClassifier) Close() error {
+	c.mu.Lock()
+	c.closed = true
+	if c.warmCancel != nil {
+		c.warmCancel()
+	}
+	ownedStore := c.ownedStore
+	c.mu.Unlock()
+	c.wg.Wait()
+	if ownedStore == nil {
+		return nil
+	}
+	return ownedStore.Close(context.Background(), SemanticVectorStoreNamespace)
+}
+
+// resetForCurrentConfigLocked recalculates readiness after a dependency or
+// configuration change. The caller must hold c.mu.
+func (c *SemanticClassifier) resetForCurrentConfigLocked() {
+	// A closed classifier must stay inert: recalculating readiness here would
+	// hand resolveStoreLocked the already-closed owned store.
+	if c.closed {
+		return
+	}
+	if c.warmCancel != nil {
+		c.warmCancel()
+		c.warmCancel = nil
+	}
+	c.store = nil
+	if c.config == nil || c.config.Semantic == nil {
+		previous := c.active
+		c.active = nil
+		c.status = SemanticStatusInfo{State: SemanticStatusDisabled}
+		if previous != nil {
+			c.cleanupEmbeddedNamespaceLocked(previous.store, previous.namespace)
+		}
+		return
+	}
+
+	semantic := c.config.Semantic
+	c.status = SemanticStatusInfo{
+		State:           SemanticStatusWarming,
+		Total:           len(semanticExemplars(c.config)),
+		ServingPrevious: c.active != nil,
+	}
+	// Governance dependencies are injected after plugin construction. Waiting
+	// for the embedding adapter prevents "vector_store" mode from creating an
+	// embedded store that is immediately superseded by the configured shared
+	// store once that arrives.
+	if c.embed == nil {
+		return
+	}
+	store, err := c.resolveStoreLocked(semantic)
+	if err != nil {
+		c.status.State = SemanticStatusFailed
+		c.status.Error = "semantic classifier is unavailable; check server logs"
+		c.logWarmupError(err)
+		return
+	}
+	c.store = store
+}
+
+// requestWarmupLocked starts the single serial warmup worker when the current
+// config can be embedded. The caller must hold c.mu.
+func (c *SemanticClassifier) requestWarmupLocked() {
+	if c.closed {
+		return
+	}
+	if c.config == nil || c.config.Semantic == nil || c.store == nil || c.embed == nil {
+		return
+	}
+	if c.warming {
+		return
+	}
+	c.warming = true
+	c.wg.Add(1)
+	go c.runWarmupWorker()
+}
+
+// runWarmupWorker serializes namespace mutation so cancelled generations cannot
+// write vectors into the namespace selected by a newer configuration.
+func (c *SemanticClassifier) runWarmupWorker() {
+	defer c.wg.Done()
+	for {
+		c.mu.Lock()
+		if c.config == nil || c.config.Semantic == nil || c.store == nil || c.embed == nil {
+			c.warming = false
+			c.mu.Unlock()
+			return
+		}
+		revision := c.revision
+		config := cloneAnalyzerConfig(c.config)
+		store := c.store
+		embed := c.embed
+		embedBatch := c.embedBatch
+		warmCtx, cancel := context.WithCancel(c.ctx)
+		c.warmCancel = cancel
+		c.status = SemanticStatusInfo{
+			State:           SemanticStatusWarming,
+			Total:           len(semanticExemplars(config)),
+			ServingPrevious: c.active != nil,
+		}
+		c.mu.Unlock()
+
+		loaded, namespace, dimension, err := warmSemanticExemplars(warmCtx, store, config, embed, embedBatch, c.embeddingCache)
+		cancel()
+
+		c.mu.Lock()
+		if c.revision != revision {
+			c.cleanupEmbeddedNamespaceLocked(store, namespace)
+			c.mu.Unlock()
+			continue
+		}
+		c.warmCancel = nil
+		c.warming = false
+		if err != nil {
+			c.status = SemanticStatusInfo{
+				State:           SemanticStatusFailed,
+				Loaded:          loaded,
+				Total:           len(semanticExemplars(config)),
+				ServingPrevious: c.active != nil,
+				Error:           "semantic warmup failed; check server logs",
+			}
+			c.logWarmupError(err)
+			c.cleanupEmbeddedNamespaceLocked(store, namespace)
+		} else {
+			previous := c.active
+			c.active = &semanticGeneration{
+				store:     store,
+				namespace: namespace,
+				semantic:  cloneSemanticConfig(config.Semantic),
+				dimension: dimension,
+				embed:     embed,
+				exemplars: semanticExemplarIndex(config, dimension),
+			}
+			c.status = SemanticStatusInfo{State: SemanticStatusReady, Loaded: loaded, Total: len(semanticExemplars(config))}
+			if previous != nil {
+				c.cleanupEmbeddedNamespaceLocked(previous.store, previous.namespace)
+			}
+		}
+		c.mu.Unlock()
+		return
+	}
+}
+
+// releaseGeneration drops the request's hold on an embedded generation. A
+// retired namespace is removed as soon as its final classification finishes.
+func (c *SemanticClassifier) releaseGeneration(generation *semanticGeneration) {
+	if generation == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.isOwnedStoreLocked(generation.store) {
+		return
+	}
+	if count := c.embeddedInFlight[generation.namespace]; count > 1 {
+		c.embeddedInFlight[generation.namespace] = count - 1
+		return
+	}
+	delete(c.embeddedInFlight, generation.namespace)
+	c.cleanupEmbeddedNamespaceLocked(generation.store, generation.namespace)
+}
+
+// cleanupEmbeddedNamespaceLocked removes a private Chromem generation only
+// when no request can still query it. Shared stores are intentionally retained:
+// another Bifrost replica may still serve the previous generation.
+func (c *SemanticClassifier) cleanupEmbeddedNamespaceLocked(store vectorstore.VectorStore, namespace string) {
+	if namespace == "" || !c.isOwnedStoreLocked(store) {
+		return
+	}
+	if c.active != nil && c.isOwnedStoreLocked(c.active.store) && c.active.namespace == namespace {
+		return
+	}
+	if c.embeddedInFlight[namespace] > 0 {
+		return
+	}
+	if err := c.ownedStore.DeleteNamespace(context.Background(), namespace); err != nil && c.logger != nil {
+		c.logger.Warn("[Governance] Failed to clean retired semantic complexity namespace %s: %v", namespace, err)
+	}
+	delete(c.embeddedInFlight, namespace)
+}
+
+func (c *SemanticClassifier) isOwnedStoreLocked(store vectorstore.VectorStore) bool {
+	return c.ownedStore != nil && store == c.ownedStore
+}
+
+// logWarmupError records provider and backend details without exposing them
+// through the public semantic classifier status endpoint.
+func (c *SemanticClassifier) logWarmupError(err error) {
+	if c.logger != nil {
+		c.logger.Error("[Governance] Semantic complexity warmup failed: %v", err)
+	}
+}
+
+// resolveStoreLocked selects the backing store without ever taking ownership of
+// Bifrost's configured shared store. The caller must hold c.mu.
+func (c *SemanticClassifier) resolveStoreLocked(semantic *SemanticConfig) (vectorstore.VectorStore, error) {
+	switch semantic.VectorStore {
+	case configstore.ComplexitySemanticVectorStoreEmbedded:
+		return c.embeddedStoreLocked()
+	case configstore.ComplexitySemanticVectorStoreConfigured:
+		// A missing vector store degrades to the embedded store rather than
+		// failing: storage choice should never be able to take semantic
+		// classification offline.
+		if c.configuredStore != nil {
+			return c.configuredStore, nil
+		}
+		return c.embeddedStoreLocked()
+	default:
+		return nil, fmt.Errorf("unsupported semantic vector_store %q", semantic.VectorStore)
+	}
+}
+
+// embeddedStoreLocked creates the private in-process Chromem store once. The
+// caller must hold c.mu.
+func (c *SemanticClassifier) embeddedStoreLocked() (vectorstore.VectorStore, error) {
+	if c.ownedStore != nil {
+		return c.ownedStore, nil
+	}
+	store, err := vectorstore.NewVectorStore(c.ctx, &vectorstore.Config{
+		Enabled: true,
+		Type:    vectorstore.VectorStoreTypeChromem,
+		Config:  vectorstore.ChromemConfig{},
+	}, c.logger)
+	if err != nil {
+		return nil, fmt.Errorf("create embedded semantic VectorStore: %w", err)
+	}
+	c.ownedStore = store
+	return store, nil
+}
+
+// warmSemanticExemplars ensures one complete labelled vector generation is
+// present before it writes the marker that permits a persistent store reuse.
+func warmSemanticExemplars(
+	ctx context.Context,
+	store vectorstore.VectorStore,
+	config *AnalyzerConfig,
+	embed EmbeddingFunc,
+	embedBatch BatchEmbeddingFunc,
+	cache *semanticEmbeddingCache,
+) (int, string, int, error) {
+	if config == nil || config.Semantic == nil {
+		return 0, "", 0, nil
+	}
+	exemplars := semanticExemplars(config)
+	if len(exemplars) == 0 {
+		return 0, "", 0, fmt.Errorf("semantic complexity classifier has no exemplars")
+	}
+
+	// Vectors are reused only for the same provider/model. Their common width is
+	// the runtime dimension for this generation, so no operator-entered width is
+	// needed in config.json or the management API.
+	cache.useIdentity(semanticEmbeddingIdentity(config.Semantic))
+	vectors := make([][]float32, len(exemplars))
+	pending := make([]int, 0, len(exemplars))
+	dimension := 0
+	for index, exemplar := range exemplars {
+		if vector, ok := cache.get(exemplar.Phrase); ok {
+			vectors[index] = vector
+			dimension = len(vector)
+			continue
+		}
+		pending = append(pending, index)
+	}
+	if dimension == 0 {
+		// Namespace creation needs a width. Prefer the first warmup batch so
+		// providers that support batching do not pay an extra single-input call.
+		if embedBatch != nil && len(pending) > 1 {
+			batchEnd := min(len(pending), semanticWarmupBatchSize)
+			batch := pending[:batchEnd]
+			phrases := make([]string, len(batch))
+			for index, exemplarIndex := range batch {
+				phrases[index] = exemplars[exemplarIndex].Phrase
+			}
+			embeddings, err := embedBatch(ctx, config.Semantic, phrases)
+			if err == nil && len(embeddings) != len(batch) {
+				err = fmt.Errorf("%w: expected %d vectors, got %d", ErrBatchEmbeddingsUnsupported, len(batch), len(embeddings))
+			}
+			if err != nil && !errors.Is(err, ErrBatchEmbeddingsUnsupported) {
+				return 0, "", 0, fmt.Errorf("detect semantic embedding dimension: %w", err)
+			}
+			if errors.Is(err, ErrBatchEmbeddingsUnsupported) {
+				embedBatch = nil
+			} else {
+				dimension = len(embeddings[0])
+				// A zero width would make the per-vector check below accept every
+				// empty vector, and with the whole list in one batch it would also
+				// leave pending empty for the scalar probe's pending[0] read.
+				if dimension == 0 {
+					return 0, "", 0, fmt.Errorf("detect semantic embedding dimension: %s exemplar %d returned an empty embedding", strings.ToLower(exemplars[batch[0]].Tier), batch[0]+1)
+				}
+				for index, exemplarIndex := range batch {
+					if len(embeddings[index]) != dimension {
+						return 0, "", dimension, fmt.Errorf("%s exemplar %d returned dimension %d, expected %d", strings.ToLower(exemplars[exemplarIndex].Tier), exemplarIndex+1, len(embeddings[index]), dimension)
+					}
+					vectors[exemplarIndex] = embeddings[index]
+					cache.put(exemplars[exemplarIndex].Phrase, embeddings[index])
+				}
+				pending = pending[batchEnd:]
+			}
+		}
+		if dimension == 0 {
+			// The scalar result is retained as useful warmup work rather than a
+			// throwaway probe request.
+			first := pending[0]
+			embedding, err := embed(ctx, config.Semantic, exemplars[first].Phrase)
+			if err != nil {
+				return 0, "", 0, fmt.Errorf("detect semantic embedding dimension: %w", err)
+			}
+			dimension = len(embedding)
+			vectors[first] = embedding
+			cache.put(exemplars[first].Phrase, embedding)
+			pending = pending[1:]
+		}
+	}
+	if dimension < 2 {
+		return 0, "", dimension, fmt.Errorf("semantic embedding dimension must be at least 2, got %d", dimension)
+	}
+
+	fingerprint := semanticFingerprint(config, exemplars, dimension)
+	namespace := semanticGenerationNamespace(fingerprint)
+	markerID := semanticMarkerID(fingerprint)
+	// Every VectorStore implementation treats CreateNamespace as idempotent.
+	// Creating first makes a brand-new generation work on Qdrant and Weaviate,
+	// whose reads return backend-specific errors for missing namespaces.
+	if err := store.CreateNamespace(ctx, namespace, dimension, semanticVectorStoreProperties); err != nil {
+		return 0, namespace, dimension, fmt.Errorf("create complexity generation namespace: %w", err)
+	}
+	markers, err := store.GetChunks(ctx, namespace, []string{markerID})
+	if err == nil && len(markers) > 0 {
+		if markers[0].Properties[semanticMetadataFingerprint] == fingerprint {
+			// This generation is already stored, so nothing below runs — but the
+			// cache can still be holding another generation's phrases (reverting to
+			// a previously warmed config lands here with the newer config's vectors
+			// resident). Prune here too, or those entries survive until the next
+			// warmup that actually embeds something.
+			cache.retain(exemplars)
+			return len(exemplars), namespace, dimension, nil
+		}
+	} else if err != nil && !errors.Is(err, vectorstore.ErrNotFound) {
+		return 0, namespace, dimension, fmt.Errorf("check complexity warmup marker: %w", err)
+	}
+
+	for batchStart := 0; batchStart < len(pending); batchStart += semanticWarmupBatchSize {
+		batchEnd := batchStart + semanticWarmupBatchSize
+		if batchEnd > len(pending) {
+			batchEnd = len(pending)
+		}
+		if err := ctx.Err(); err != nil {
+			return 0, namespace, dimension, err
+		}
+
+		batch := pending[batchStart:batchEnd]
+		var embeddings [][]float32
+		if embedBatch != nil && len(batch) > 1 {
+			phrases := make([]string, len(batch))
+			for index, exemplarIndex := range batch {
+				phrases[index] = exemplars[exemplarIndex].Phrase
+			}
+			var err error
+			embeddings, err = embedBatch(ctx, config.Semantic, phrases)
+			if err == nil && len(embeddings) != len(batch) {
+				err = fmt.Errorf("%w: expected %d vectors, got %d", ErrBatchEmbeddingsUnsupported, len(batch), len(embeddings))
+			}
+			if err != nil && !errors.Is(err, ErrBatchEmbeddingsUnsupported) {
+				return 0, namespace, dimension, fmt.Errorf("embed exemplar batch %d-%d: %w", batchStart+1, batchEnd, err)
+			}
+			if errors.Is(err, ErrBatchEmbeddingsUnsupported) {
+				// Do not retry later batches through a provider/model that has
+				// already demonstrated single-input-only behavior.
+				embedBatch = nil
+				embeddings = nil
+			}
+		}
+
+		if embedBatch == nil || len(batch) == 1 {
+			embeddings = make([][]float32, len(batch))
+			for index, exemplarIndex := range batch {
+				exemplar := exemplars[exemplarIndex]
+				embedding, err := embed(ctx, config.Semantic, exemplar.Phrase)
+				if err != nil {
+					return 0, namespace, dimension, fmt.Errorf("embed %s exemplar %d: %w", strings.ToLower(exemplar.Tier), exemplarIndex+1, err)
+				}
+				embeddings[index] = embedding
+			}
+		}
+
+		for index, exemplarIndex := range batch {
+			exemplar := exemplars[exemplarIndex]
+			embedding := embeddings[index]
+			if len(embedding) != dimension {
+				return 0, namespace, dimension, fmt.Errorf("%s exemplar %d returned dimension %d, expected %d", strings.ToLower(exemplar.Tier), exemplarIndex+1, len(embedding), dimension)
+			}
+			vectors[exemplarIndex] = embedding
+			// Cached only after the width check, so a provider that answered for
+			// the wrong model cannot poison later warmups.
+			cache.put(exemplar.Phrase, embedding)
+		}
+	}
+
+	var markerEmbedding []float32
+	for index, exemplar := range exemplars {
+		if err := ctx.Err(); err != nil {
+			return index, namespace, dimension, err
+		}
+		embedding := vectors[index]
+		if len(embedding) != dimension {
+			return index, namespace, dimension, fmt.Errorf("%s exemplar %d returned dimension %d, expected %d", strings.ToLower(exemplar.Tier), index+1, len(embedding), dimension)
+		}
+		if err := store.Add(ctx, namespace, semanticExemplarID(fingerprint, exemplar), embedding, map[string]interface{}{
+			semanticMetadataTier:        exemplar.Tier,
+			semanticMetadataKind:        semanticMetadataKindExample,
+			semanticMetadataFingerprint: fingerprint,
+		}); err != nil {
+			return index, namespace, dimension, fmt.Errorf("store %s exemplar %d: %w", strings.ToLower(exemplar.Tier), index+1, err)
+		}
+		markerEmbedding = embedding
+	}
+	if err := store.Add(ctx, namespace, markerID, markerEmbedding, map[string]interface{}{
+		semanticMetadataKind:        semanticMetadataKindMarker,
+		semanticMetadataFingerprint: fingerprint,
+	}); err != nil {
+		return len(exemplars), namespace, dimension, fmt.Errorf("store complexity warmup marker: %w", err)
+	}
+	cache.retain(exemplars)
+	return len(exemplars), namespace, dimension, nil
+}
+
+// semanticEmbeddingCache remembers the vector each exemplar phrase embedded to,
+// so editing the tier lists re-embeds only what actually changed.
+//
+// Generations stay immutable and content-addressed: adding one phrase still
+// mints a new fingerprint, a new namespace, and a new record id for every
+// exemplar. What changes is where those vectors come from. A stored vector
+// cannot be read back — vectorstore.SearchResult carries only an id, score, and
+// properties — so reuse has to be held in process.
+//
+// Entries are only valid for the provider and model that produced them;
+// switching either invalidates all of them at once. Warmup prunes the map to
+// the phrases it just embedded,
+// so a long-lived process editing its tier lists repeatedly does not accumulate
+// vectors for phrases nobody references any more.
+type semanticEmbeddingCache struct {
+	mu       sync.Mutex
+	identity string
+	vectors  map[string][]float32
+}
+
+func newSemanticEmbeddingCache() *semanticEmbeddingCache {
+	return &semanticEmbeddingCache{vectors: map[string][]float32{}}
+}
+
+// semanticEmbeddingIdentity names everything about a config that changes what a
+// phrase embeds to. Two configs sharing it can share vectors.
+func semanticEmbeddingIdentity(semantic *SemanticConfig) string {
+	if semantic == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s\x00%s", semantic.Provider, semantic.EmbeddingModel)
+}
+
+// useIdentity drops every cached vector when the embedding identity changes,
+// because a vector from another provider or model is not merely stale but
+// wrong: it would be stored as though it described this phrase under the new
+// model, and nothing downstream could tell.
+func (c *semanticEmbeddingCache) useIdentity(identity string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.identity != identity {
+		c.identity = identity
+		c.vectors = map[string][]float32{}
+	}
+}
+
+// size reports how many phrase vectors are currently held, which is what a
+// configuration client needs to tell a warm cache from one emptied by a restart
+// or an identity change.
+func (c *semanticEmbeddingCache) size() int {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.vectors)
+}
+
+func (c *semanticEmbeddingCache) get(phrase string) ([]float32, bool) {
+	if c == nil {
+		return nil, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	vector, ok := c.vectors[phrase]
+	return vector, ok
+}
+
+func (c *semanticEmbeddingCache) put(phrase string, vector []float32) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.vectors[phrase] = vector
+}
+
+// retain prunes the cache to the phrases a completed warmup actually used.
+func (c *semanticEmbeddingCache) retain(exemplars []semanticExemplar) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	keep := make(map[string][]float32, len(exemplars))
+	for _, exemplar := range exemplars {
+		if vector, ok := c.vectors[exemplar.Phrase]; ok {
+			keep[exemplar.Phrase] = vector
+		}
+	}
+	c.vectors = keep
+}
+
+// semanticExemplar binds one normalized shared tier phrase to its routing tier.
+type semanticExemplar struct {
+	Tier   string
+	Phrase string
+}
+
+// semanticExemplars converts the shared tier lists into labelled semantic examples.
+func semanticExemplars(config *AnalyzerConfig) []semanticExemplar {
+	if config == nil {
+		return nil
+	}
+	exemplars := make([]semanticExemplar, 0, len(config.Keywords.SimpleKeywords)+len(config.Keywords.MediumKeywords)+len(config.Keywords.ComplexKeywords))
+	appendTier := func(tier string, phrases []string) {
+		for _, phrase := range phrases {
+			exemplars = append(exemplars, semanticExemplar{Tier: tier, Phrase: phrase})
+		}
+	}
+	appendTier(TierSimple, config.Keywords.SimpleKeywords)
+	appendTier(TierMedium, config.Keywords.MediumKeywords)
+	appendTier(TierComplex, config.Keywords.ComplexKeywords)
+	return exemplars
+}
+
+// semanticFingerprint identifies the embeddings implied by one configuration.
+// Phrase order does not affect nearest-neighbour classification, so hash a
+// sorted copy to avoid creating a new generation when an admin only reorders
+// otherwise identical tier phrases.
+func semanticFingerprint(config *AnalyzerConfig, exemplars []semanticExemplar, dimension int) string {
+	canonical := append([]semanticExemplar(nil), exemplars...)
+	sort.Slice(canonical, func(i, j int) bool {
+		if canonical[i].Tier != canonical[j].Tier {
+			return canonical[i].Tier < canonical[j].Tier
+		}
+		return canonical[i].Phrase < canonical[j].Phrase
+	})
+
+	hash := sha256.New()
+	_, _ = fmt.Fprintf(hash, "semantic-router-v1\x00%s\x00%s\x00%d\x00", config.Semantic.Provider, config.Semantic.EmbeddingModel, dimension)
+	for _, exemplar := range canonical {
+		_, _ = fmt.Fprintf(hash, "%s\x00%s\x00", exemplar.Tier, exemplar.Phrase)
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+// semanticGenerationNamespace maps one embedding fingerprint to an immutable
+// namespace. The underscore + hexadecimal suffix is accepted by every current
+// backend, including Weaviate's class-name validation.
+func semanticGenerationNamespace(fingerprint string) string {
+	return SemanticVectorStoreNamespace + "_" + fingerprint
+}
+
+// semanticExemplarID deterministically identifies one labelled exemplar inside
+// the fingerprinted routing namespace with a UUID accepted by every backend.
+func semanticExemplarID(fingerprint string, exemplar semanticExemplar) string {
+	return semanticRecordID("example", fingerprint, exemplar.Tier, exemplar.Phrase)
+}
+
+// semanticExemplarIndex maps the record IDs one configuration implies back to
+// the phrases they were derived from. It repeats warmSemanticExemplars' own
+// exemplar and fingerprint derivation over the same config snapshot, so the two
+// agree by construction on every ID that warmup wrote.
+func semanticExemplarIndex(config *AnalyzerConfig, dimension int) map[string]string {
+	exemplars := semanticExemplars(config)
+	if len(exemplars) == 0 {
+		return nil
+	}
+	fingerprint := semanticFingerprint(config, exemplars, dimension)
+	index := make(map[string]string, len(exemplars))
+	for _, exemplar := range exemplars {
+		index[semanticExemplarID(fingerprint, exemplar)] = exemplar.Phrase
+	}
+	return index
+}
+
+// semanticMarkerID deterministically identifies one configuration generation
+// marker with a backend-compatible UUID.
+func semanticMarkerID(fingerprint string) string {
+	return semanticRecordID("marker", fingerprint)
+}
+
+// semanticRecordID derives a stable UUIDv5 from one namespaced routing record.
+func semanticRecordID(parts ...string) string {
+	return uuid.NewSHA1(uuid.NameSpaceURL, []byte(strings.Join(parts, "\x00"))).String()
+}
+
+// isComplexityTier reports whether tier is one of the supported routing values.
+func isComplexityTier(tier string) bool {
+	return tier == TierSimple || tier == TierMedium || tier == TierComplex
+}
+
+// cloneAnalyzerConfig copies the mutable slices and semantic settings used by
+// an asynchronous warmup so later handler writes cannot mutate its snapshot.
+func cloneAnalyzerConfig(config *AnalyzerConfig) *AnalyzerConfig {
+	if config == nil {
+		return nil
+	}
+	cloned := config.Normalized()
+	return &cloned
+}
+
+// cloneSemanticConfig copies the semantic settings used by one embedding call.
+func cloneSemanticConfig(config *SemanticConfig) *SemanticConfig {
+	if config == nil {
+		return nil
+	}
+	cloned := *config
+	return &cloned
+}
+
+// semanticVectorStoreProperties declares the minimal metadata schema needed by
+// semantic routing. It intentionally excludes prompts and embedding contents.
+var semanticVectorStoreProperties = map[string]vectorstore.VectorStoreProperties{
+	semanticMetadataTier: {
+		DataType:    vectorstore.VectorStorePropertyTypeString,
+		Description: "Complexity tier represented by this exemplar",
+	},
+	semanticMetadataKind: {
+		DataType:    vectorstore.VectorStorePropertyTypeString,
+		Description: "Semantic routing record kind: example or marker",
+	},
+	semanticMetadataFingerprint: {
+		DataType:    vectorstore.VectorStorePropertyTypeString,
+		Description: "Fingerprint of the semantic routing configuration",
+	},
+}

--- a/plugins/routing/complexity/semanticclassifier_test.go
+++ b/plugins/routing/complexity/semanticclassifier_test.go
@@ -1,0 +1,963 @@
+package complexity
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/vectorstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testSemanticDimension = 2
+
+// TestSemanticClassifierClassifiesNearestSharedTierPhrase verifies semantic
+// routing labels the existing tier lists instead of maintaining a second list.
+func TestSemanticClassifierClassifiesNearestSharedTierPhrase(t *testing.T) {
+	classifier := NewSemanticClassifier(context.Background(), bifrost.NewDefaultLogger(schemas.LogLevelError))
+	t.Cleanup(func() {
+		require.NoError(t, classifier.Close())
+	})
+	classifier.SetEmbeddingFunc(testSemanticEmbedding)
+	config := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreEmbedded)
+	classifier.Configure(&config)
+
+	require.Eventually(t, func() bool {
+		return classifier.Status().State == SemanticStatusReady
+	}, time.Second, 10*time.Millisecond, "semantic classifier did not finish warmup")
+
+	result, err := classifier.Classify(context.Background(), ComplexityInput{LastUserText: "simple request"})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, TierSimple, result.Tier)
+	assert.InDelta(t, 1, result.Score, 0.0001)
+	assert.Equal(t, "simple exemplar", result.MatchedExemplar, "a classification must name the phrase it matched")
+}
+
+// TestSemanticClassifierNamesMatchedExemplarFromReusedGeneration proves the
+// matched phrase comes from the in-process index rather than stored metadata:
+// a classifier that adopts an already-warmed namespace embeds nothing, yet must
+// still report which exemplar the request landed on.
+func TestSemanticClassifierNamesMatchedExemplarFromReusedGeneration(t *testing.T) {
+	store, err := vectorstore.NewVectorStore(context.Background(), &vectorstore.Config{
+		Enabled: true,
+		Type:    vectorstore.VectorStoreTypeChromem,
+		Config:  vectorstore.ChromemConfig{},
+	}, bifrost.NewDefaultLogger(schemas.LogLevelError))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close(context.Background(), SemanticVectorStoreNamespace))
+	})
+
+	config := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreConfigured)
+	_, _, _, err = warmSemanticExemplars(context.Background(), store, &config, testSemanticEmbedding, nil, nil)
+	require.NoError(t, err)
+
+	classifier := NewSemanticClassifier(context.Background(), bifrost.NewDefaultLogger(schemas.LogLevelError))
+	t.Cleanup(func() {
+		require.NoError(t, classifier.Close())
+	})
+	var exemplarEmbeddings atomic.Int32
+	classifier.SetEmbeddingFunc(func(ctx context.Context, semantic *SemanticConfig, text string) ([]float32, error) {
+		if text == "medium exemplar" {
+			exemplarEmbeddings.Add(1)
+		}
+		return testSemanticEmbedding(ctx, semantic, text)
+	})
+	classifier.SetConfiguredStore(store)
+	classifier.Configure(&config)
+
+	require.Eventually(t, func() bool {
+		return classifier.Status().State == SemanticStatusReady
+	}, time.Second, 10*time.Millisecond, "semantic classifier did not adopt the warmed generation")
+
+	result, err := classifier.Classify(context.Background(), ComplexityInput{LastUserText: "medium request"})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, TierMedium, result.Tier)
+	assert.Equal(t, "medium exemplar", result.MatchedExemplar)
+	assert.EqualValues(t, 0, exemplarEmbeddings.Load(), "adopting a warmed generation must not re-embed exemplars")
+}
+
+// TestSemanticInputTextAppliesMessageHistoryWindow covers how much of a
+// conversation reaches the embedding. The latest turn must always be last so
+// the text reads in conversation order, and a request with fewer turns than
+// configured must still classify on what it has.
+func TestSemanticInputTextAppliesMessageHistoryWindow(t *testing.T) {
+	input := ComplexityInput{
+		SystemText:     "you are a helpful assistant",
+		PriorUserTexts: []string{"first", "second", "third"},
+		LastUserText:   "latest",
+	}
+
+	tests := []struct {
+		name  string
+		count int
+		want  string
+	}{
+		{name: "zero falls back to the latest turn", count: 0, want: "latest"},
+		{name: "one embeds only the latest turn", count: 1, want: "latest"},
+		{name: "two adds the turn before it", count: 2, want: "third\nlatest"},
+		{name: "window spans oldest to newest", count: 3, want: "second\nthird\nlatest"},
+		{name: "count beyond history uses what exists", count: 25, want: "first\nsecond\nthird\nlatest"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, SemanticInputText(input, test.count))
+		})
+	}
+
+	// System text steers every request in a deployment alike, so including it
+	// would drag unrelated requests toward the same exemplar.
+	assert.NotContains(t, SemanticInputText(input, 10), "helpful assistant")
+
+	t.Run("blank turns are skipped", func(t *testing.T) {
+		sparse := ComplexityInput{PriorUserTexts: []string{"kept", "   ", ""}, LastUserText: "latest"}
+		assert.Equal(t, "kept\nlatest", SemanticInputText(sparse, 4))
+	})
+
+	// Blanks must not consume window slots: a request whose recent turns are
+	// blank still contributes the requested count of real turns.
+	t.Run("blank turns do not shrink the window", func(t *testing.T) {
+		sparse := ComplexityInput{PriorUserTexts: []string{"first", "second", "  ", ""}, LastUserText: "latest"}
+		assert.Equal(t, "first\nsecond\nlatest", SemanticInputText(sparse, 3))
+	})
+
+	t.Run("no user text yields nothing to embed", func(t *testing.T) {
+		assert.Empty(t, SemanticInputText(ComplexityInput{SystemText: "system only"}, 5))
+	})
+}
+
+// TestSemanticClassifierEmbedsConfiguredMessageWindow checks the classifier
+// reads the window from its own serving snapshot rather than the caller.
+func TestSemanticClassifierEmbedsConfiguredMessageWindow(t *testing.T) {
+	classifier := NewSemanticClassifier(context.Background(), bifrost.NewDefaultLogger(schemas.LogLevelError))
+	t.Cleanup(func() {
+		require.NoError(t, classifier.Close())
+	})
+
+	var embedded []string
+	classifier.SetEmbeddingFunc(func(ctx context.Context, semantic *SemanticConfig, text string) ([]float32, error) {
+		if vector, err := testSemanticEmbedding(ctx, semantic, text); err == nil {
+			return vector, nil
+		}
+		// Not an exemplar, so this is the classification call under test.
+		embedded = append(embedded, text)
+		return []float32{1, 0}, nil
+	})
+
+	config := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreEmbedded)
+	config.Semantic.MessageHistoryCount = 2
+	classifier.Configure(&config)
+	require.Eventually(t, func() bool {
+		return classifier.Status().State == SemanticStatusReady
+	}, time.Second, 10*time.Millisecond, "semantic classifier did not finish warmup")
+
+	_, err := classifier.Classify(context.Background(), ComplexityInput{
+		PriorUserTexts: []string{"older turn", "previous turn"},
+		LastUserText:   "current turn",
+	})
+	require.NoError(t, err)
+	require.Len(t, embedded, 1)
+	assert.Equal(t, "previous turn\ncurrent turn", embedded[0])
+}
+
+// TestSemanticClassifierAppliesMinSimilarity covers the floor that stops the
+// nearest exemplar from winning by default however unrelated it is. A rejected
+// match must still report its tier and score so the near miss is diagnosable.
+func TestSemanticClassifierAppliesMinSimilarity(t *testing.T) {
+	tests := []struct {
+		name          string
+		minSimilarity float64
+		wantAccepted  bool
+	}{
+		{name: "no floor accepts a weak match", minSimilarity: 0, wantAccepted: true},
+		{name: "floor below the score accepts", minSimilarity: 0.5, wantAccepted: true},
+		{name: "floor at the score accepts", minSimilarity: 0.7071068, wantAccepted: true},
+		{name: "floor above the score rejects", minSimilarity: 0.9, wantAccepted: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			classifier := NewSemanticClassifier(context.Background(), bifrost.NewDefaultLogger(schemas.LogLevelError))
+			t.Cleanup(func() {
+				require.NoError(t, classifier.Close())
+			})
+			classifier.SetEmbeddingFunc(testSemanticEmbedding)
+			config := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreEmbedded)
+			config.Semantic.MinSimilarity = test.minSimilarity
+			classifier.Configure(&config)
+
+			require.Eventually(t, func() bool {
+				return classifier.Status().State == SemanticStatusReady
+			}, time.Second, 10*time.Millisecond, "semantic classifier did not finish warmup")
+
+			result, err := classifier.Classify(context.Background(), ComplexityInput{LastUserText: "borderline request"})
+			require.NoError(t, err)
+			require.NotNil(t, result, "a rejected match must still be reported so callers can log the near miss")
+			assert.Equal(t, test.wantAccepted, result.Accepted)
+			assert.Equal(t, test.minSimilarity, result.MinSimilarity)
+			assert.InDelta(t, 0.7071068, result.Score, 0.001)
+			assert.True(t, isComplexityTier(result.Tier))
+		})
+	}
+}
+
+// TestSemanticClassifierFallsBackWhenNoStoreIsConfigured pins the one behavior
+// that makes "vector_store" safe to pick from the UI: selecting it on a
+// deployment that has no vector_store section must degrade to the embedded
+// store and keep serving, never fail the config or take classification offline.
+func TestSemanticClassifierFallsBackWhenNoStoreIsConfigured(t *testing.T) {
+	classifier := NewSemanticClassifier(context.Background(), bifrost.NewDefaultLogger(schemas.LogLevelError))
+	t.Cleanup(func() {
+		require.NoError(t, classifier.Close())
+	})
+	config := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreConfigured)
+	require.NoError(t, classifier.ValidateConfig(&config))
+
+	classifier.SetEmbeddingFunc(testSemanticEmbedding)
+	classifier.Configure(&config)
+	require.Eventually(t, func() bool {
+		return classifier.Status().State == SemanticStatusReady
+	}, time.Second, 10*time.Millisecond)
+
+	assert.NotNil(t, classifier.ownedStore, "a missing configured store must be replaced by the embedded one")
+	assert.Same(t, classifier.ownedStore, classifier.store)
+
+	result, err := classifier.Classify(context.Background(), ComplexityInput{LastUserText: "simple request"})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.Accepted)
+}
+
+// TestWarmSemanticExemplarsReusesMatchingMarker reuses a persisted generation
+// after one embedding establishes the model's runtime vector width.
+func TestWarmSemanticExemplarsReusesMatchingMarker(t *testing.T) {
+	store, err := vectorstore.NewVectorStore(context.Background(), &vectorstore.Config{
+		Enabled: true,
+		Type:    vectorstore.VectorStoreTypeChromem,
+		Config:  vectorstore.ChromemConfig{},
+	}, bifrost.NewDefaultLogger(schemas.LogLevelError))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close(context.Background(), SemanticVectorStoreNamespace))
+	})
+
+	config := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreEmbedded)
+	var embeddingCalls atomic.Int32
+	embed := func(ctx context.Context, semantic *SemanticConfig, text string) ([]float32, error) {
+		embeddingCalls.Add(1)
+		return testSemanticEmbedding(ctx, semantic, text)
+	}
+
+	loaded, _, _, err := warmSemanticExemplars(context.Background(), store, &config, embed, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, len(semanticExemplars(&config)), loaded)
+	assert.EqualValues(t, loaded, embeddingCalls.Load())
+
+	loaded, _, _, err = warmSemanticExemplars(context.Background(), store, &config, embed, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, len(semanticExemplars(&config)), loaded)
+	assert.EqualValues(t, loaded+1, embeddingCalls.Load(), "reusing a persisted generation needs one embedding to rediscover its width")
+}
+
+// TestWarmSemanticExemplarsUsesBackendCompatibleLifecycle proves warmup does
+// not depend on Chromem's missing-record error or an existing dimension.
+func TestWarmSemanticExemplarsUsesBackendCompatibleLifecycle(t *testing.T) {
+	backingStore, err := vectorstore.NewVectorStore(context.Background(), &vectorstore.Config{
+		Enabled: true,
+		Type:    vectorstore.VectorStoreTypeChromem,
+		Config:  vectorstore.ChromemConfig{},
+	}, bifrost.NewDefaultLogger(schemas.LogLevelError))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, backingStore.Close(context.Background(), SemanticVectorStoreNamespace))
+	})
+
+	store := &semanticLifecycleProbeStore{VectorStore: backingStore}
+	config := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreConfigured)
+
+	loaded, namespace, dimension, err := warmSemanticExemplars(context.Background(), store, &config, testSemanticEmbedding, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, len(semanticExemplars(&config)), loaded)
+	assert.True(t, store.createdBeforeRead, "a generation namespace must exist before its marker is read")
+	assert.False(t, store.deleted, "an older generation must not be deleted during warmup")
+	assert.Equal(t, semanticGenerationNamespace(semanticFingerprint(&config, semanticExemplars(&config), dimension)), namespace)
+	require.Len(t, store.markerIDs, 1)
+	markerID, err := uuid.Parse(store.markerIDs[0])
+	require.NoError(t, err)
+	assert.Equal(t, uuid.Version(5), markerID.Version())
+}
+
+func TestSemanticClassifierDefersStoreSelectionUntilDependenciesAreWired(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelError)
+	classifier := NewSemanticClassifier(context.Background(), logger)
+	config := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreConfigured)
+	classifier.Configure(&config)
+
+	assert.Nil(t, classifier.ownedStore)
+	assert.Nil(t, classifier.store)
+
+	configuredStore, err := vectorstore.NewVectorStore(context.Background(), &vectorstore.Config{
+		Enabled: true,
+		Type:    vectorstore.VectorStoreTypeChromem,
+		Config:  vectorstore.ChromemConfig{},
+	}, logger)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, classifier.Close())
+		require.NoError(t, configuredStore.Close(context.Background(), SemanticVectorStoreNamespace))
+	})
+
+	classifier.SetConfiguredStore(configuredStore)
+	assert.Nil(t, classifier.ownedStore, "vector_store mode must not allocate a private store before the embedding executor is wired")
+	classifier.SetEmbeddingFunc(testSemanticEmbedding)
+
+	require.Eventually(t, func() bool {
+		return classifier.Status().State == SemanticStatusReady
+	}, time.Second, 10*time.Millisecond)
+	assert.Same(t, configuredStore, classifier.store)
+	assert.Nil(t, classifier.ownedStore)
+}
+
+func TestSemanticClassifierSwitchesGenerationsOnlyAfterSuccessfulWarmup(t *testing.T) {
+	classifier := NewSemanticClassifier(context.Background(), bifrost.NewDefaultLogger(schemas.LogLevelError))
+	t.Cleanup(func() {
+		require.NoError(t, classifier.Close())
+	})
+
+	releaseV2 := make(chan struct{})
+	var requestModel atomic.Value
+	embed := func(ctx context.Context, semantic *SemanticConfig, text string) ([]float32, error) {
+		switch semantic.EmbeddingModel {
+		case "model-v1":
+			switch text {
+			case "simple exemplar", "routing request":
+				if text == "routing request" {
+					requestModel.Store(semantic.EmbeddingModel)
+				}
+				return []float32{1, 0}, nil
+			case "medium exemplar":
+				return []float32{0, 1}, nil
+			case "complex exemplar":
+				return []float32{-1, 0}, nil
+			}
+		case "model-v2":
+			switch text {
+			case "v2 simple":
+				select {
+				case <-releaseV2:
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+				return []float32{0, 1}, nil
+			case "v2 medium":
+				return []float32{-1, 0}, nil
+			case "v2 complex", "routing request":
+				if text == "routing request" {
+					requestModel.Store(semantic.EmbeddingModel)
+				}
+				return []float32{1, 0}, nil
+			}
+		case "model-v3":
+			return nil, fmt.Errorf("synthetic v3 warmup failure")
+		}
+		return nil, fmt.Errorf("unexpected semantic test input model=%q text=%q", semantic.EmbeddingModel, text)
+	}
+	classifier.SetEmbeddingFunc(embed)
+
+	v1 := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreEmbedded)
+	v1.Semantic.EmbeddingModel = "model-v1"
+	classifier.Configure(&v1)
+	require.Eventually(t, func() bool {
+		return classifier.Status().State == SemanticStatusReady
+	}, time.Second, 10*time.Millisecond)
+
+	classifier.mu.Lock()
+	v1Namespace := classifier.active.namespace
+	classifier.mu.Unlock()
+	v1Result, err := classifier.Classify(context.Background(), ComplexityInput{LastUserText: "routing request"})
+	require.NoError(t, err)
+	require.NotNil(t, v1Result)
+	assert.Equal(t, TierSimple, v1Result.Tier)
+	assert.Equal(t, "model-v1", requestModel.Load())
+
+	v2 := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreEmbedded)
+	v2.Semantic.EmbeddingModel = "model-v2"
+	v2.Keywords = EditableKeywordConfig{
+		SimpleKeywords:  []string{"v2 simple"},
+		MediumKeywords:  []string{"v2 medium"},
+		ComplexKeywords: []string{"v2 complex"},
+	}
+	classifier.Configure(&v2)
+	require.Eventually(t, func() bool {
+		status := classifier.Status()
+		return status.State == SemanticStatusWarming && status.ServingPrevious
+	}, time.Second, 10*time.Millisecond)
+
+	// F1 remains queryable while the first F2 embedding is deliberately blocked.
+	duringWarmup, err := classifier.Classify(context.Background(), ComplexityInput{LastUserText: "routing request"})
+	require.NoError(t, err)
+	require.NotNil(t, duringWarmup)
+	assert.Equal(t, TierSimple, duringWarmup.Tier)
+	assert.Equal(t, "model-v1", requestModel.Load())
+
+	close(releaseV2)
+	require.Eventually(t, func() bool {
+		return classifier.Status().State == SemanticStatusReady
+	}, time.Second, 10*time.Millisecond)
+
+	classifier.mu.Lock()
+	v2Namespace := classifier.active.namespace
+	activeStore := classifier.active.store
+	classifier.mu.Unlock()
+	assert.NotEqual(t, v1Namespace, v2Namespace)
+	v2Result, err := classifier.Classify(context.Background(), ComplexityInput{LastUserText: "routing request"})
+	require.NoError(t, err)
+	require.NotNil(t, v2Result)
+	assert.Equal(t, TierComplex, v2Result.Tier)
+	assert.Equal(t, "model-v2", requestModel.Load())
+
+	// The classifier owns this embedded store, so an unused F1 is reclaimed as
+	// soon as F2 becomes active.
+	v1Fingerprint := semanticFingerprint(&v1, semanticExemplars(&v1), testSemanticDimension)
+	_, err = activeStore.GetChunks(context.Background(), v1Namespace, []string{semanticMarkerID(v1Fingerprint)})
+	require.ErrorIs(t, err, vectorstore.ErrNotFound)
+
+	v3 := v2
+	v3.Semantic = cloneSemanticConfig(v2.Semantic)
+	v3.Semantic.EmbeddingModel = "model-v3"
+	classifier.Configure(&v3)
+	require.Eventually(t, func() bool {
+		status := classifier.Status()
+		return status.State == SemanticStatusFailed && status.ServingPrevious
+	}, time.Second, 10*time.Millisecond)
+
+	// A failed F3 keeps both the F2 namespace and F2 embedding configuration.
+	afterFailure, err := classifier.Classify(context.Background(), ComplexityInput{LastUserText: "routing request"})
+	require.NoError(t, err)
+	require.NotNil(t, afterFailure)
+	assert.Equal(t, TierComplex, afterFailure.Tier)
+	assert.Equal(t, "model-v2", requestModel.Load())
+	classifier.mu.Lock()
+	assert.Equal(t, v2Namespace, classifier.active.namespace)
+	classifier.mu.Unlock()
+
+	v3Fingerprint := semanticFingerprint(&v3, semanticExemplars(&v3), testSemanticDimension)
+	_, err = activeStore.GetChunks(
+		context.Background(),
+		semanticGenerationNamespace(v3Fingerprint),
+		[]string{semanticMarkerID(v3Fingerprint)},
+	)
+	require.ErrorIs(t, err, vectorstore.ErrNotFound, "a failed private generation must be discarded")
+}
+
+func TestSemanticClassifierDefersEmbeddedCleanupUntilInFlightRequestFinishes(t *testing.T) {
+	classifier := NewSemanticClassifier(context.Background(), bifrost.NewDefaultLogger(schemas.LogLevelError))
+	t.Cleanup(func() {
+		require.NoError(t, classifier.Close())
+	})
+
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	embed := func(ctx context.Context, semantic *SemanticConfig, text string) ([]float32, error) {
+		if text == "blocked request" {
+			close(requestStarted)
+			select {
+			case <-releaseRequest:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+			return []float32{1, 0}, nil
+		}
+		return testSemanticEmbedding(ctx, semantic, text)
+	}
+	classifier.SetEmbeddingFunc(embed)
+
+	v1 := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreEmbedded)
+	v1.Semantic.EmbeddingModel = "model-v1"
+	classifier.Configure(&v1)
+	require.Eventually(t, func() bool {
+		return classifier.Status().State == SemanticStatusReady
+	}, time.Second, 10*time.Millisecond)
+
+	classifier.mu.Lock()
+	v1Namespace := classifier.active.namespace
+	activeStore := classifier.active.store
+	classifier.mu.Unlock()
+	v1Fingerprint := semanticFingerprint(&v1, semanticExemplars(&v1), testSemanticDimension)
+	v1MarkerID := semanticMarkerID(v1Fingerprint)
+
+	type classification struct {
+		result *SemanticResult
+		err    error
+	}
+	classificationDone := make(chan classification, 1)
+	go func() {
+		result, err := classifier.Classify(context.Background(), ComplexityInput{LastUserText: "blocked request"})
+		classificationDone <- classification{result: result, err: err}
+	}()
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("classification did not acquire F1")
+	}
+
+	v2 := v1
+	v2.Semantic = cloneSemanticConfig(v1.Semantic)
+	v2.Semantic.EmbeddingModel = "model-v2"
+	classifier.Configure(&v2)
+	require.Eventually(t, func() bool {
+		return classifier.Status().State == SemanticStatusReady
+	}, time.Second, 10*time.Millisecond)
+
+	v1Markers, err := activeStore.GetChunks(context.Background(), v1Namespace, []string{v1MarkerID})
+	require.NoError(t, err)
+	require.Len(t, v1Markers, 1, "F1 must remain queryable while an earlier request still holds it")
+
+	close(releaseRequest)
+	classified := <-classificationDone
+	require.NoError(t, classified.err)
+	require.NotNil(t, classified.result)
+	assert.Equal(t, TierSimple, classified.result.Tier)
+	require.Eventually(t, func() bool {
+		_, err := activeStore.GetChunks(context.Background(), v1Namespace, []string{v1MarkerID})
+		return errors.Is(err, vectorstore.ErrNotFound)
+	}, time.Second, 10*time.Millisecond, "F1 must be reclaimed after its last request releases it")
+}
+
+func TestSemanticClassifierRetainsPreviousExternalGeneration(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelError)
+	store, err := vectorstore.NewVectorStore(context.Background(), &vectorstore.Config{
+		Enabled: true,
+		Type:    vectorstore.VectorStoreTypeChromem,
+		Config:  vectorstore.ChromemConfig{},
+	}, logger)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close(context.Background(), SemanticVectorStoreNamespace))
+	})
+
+	classifier := NewSemanticClassifier(context.Background(), logger)
+	t.Cleanup(func() {
+		require.NoError(t, classifier.Close())
+	})
+	classifier.SetConfiguredStore(store)
+	classifier.SetEmbeddingFunc(testSemanticEmbedding)
+
+	v1 := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreConfigured)
+	v1.Semantic.EmbeddingModel = "model-v1"
+	classifier.Configure(&v1)
+	require.Eventually(t, func() bool {
+		return classifier.Status().State == SemanticStatusReady
+	}, time.Second, 10*time.Millisecond)
+	v1Fingerprint := semanticFingerprint(&v1, semanticExemplars(&v1), testSemanticDimension)
+	v1Namespace := semanticGenerationNamespace(v1Fingerprint)
+	v1MarkerID := semanticMarkerID(v1Fingerprint)
+
+	v2 := v1
+	v2.Semantic = cloneSemanticConfig(v1.Semantic)
+	v2.Semantic.EmbeddingModel = "model-v2"
+	classifier.Configure(&v2)
+	require.Eventually(t, func() bool {
+		return classifier.Status().State == SemanticStatusReady
+	}, time.Second, 10*time.Millisecond)
+
+	v1Markers, err := store.GetChunks(context.Background(), v1Namespace, []string{v1MarkerID})
+	require.NoError(t, err)
+	require.Len(t, v1Markers, 1, "shared stores retain F1 because another replica may still serve it")
+}
+
+func TestSemanticClassifierReusesEmbeddedNamespaceForScalarOnlyChange(t *testing.T) {
+	classifier := NewSemanticClassifier(context.Background(), bifrost.NewDefaultLogger(schemas.LogLevelError))
+	t.Cleanup(func() {
+		require.NoError(t, classifier.Close())
+	})
+	classifier.SetEmbeddingFunc(testSemanticEmbedding)
+
+	config := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreEmbedded)
+	classifier.Configure(&config)
+	require.Eventually(t, func() bool {
+		return classifier.Status().State == SemanticStatusReady
+	}, time.Second, 10*time.Millisecond)
+
+	classifier.mu.Lock()
+	namespace := classifier.active.namespace
+	store := classifier.active.store
+	classifier.mu.Unlock()
+
+	config.Semantic.MinSimilarity = 0.8
+	classifier.Configure(&config)
+	require.Eventually(t, func() bool {
+		return classifier.Status().State == SemanticStatusReady
+	}, time.Second, 10*time.Millisecond)
+
+	classifier.mu.Lock()
+	assert.Equal(t, namespace, classifier.active.namespace)
+	classifier.mu.Unlock()
+	fingerprint := semanticFingerprint(&config, semanticExemplars(&config), testSemanticDimension)
+	markers, err := store.GetChunks(context.Background(), namespace, []string{semanticMarkerID(fingerprint)})
+	require.NoError(t, err)
+	require.Len(t, markers, 1, "scalar-only changes must reuse, not delete, the existing vectors")
+}
+
+func TestWarmSemanticExemplarsUsesBoundedBatches(t *testing.T) {
+	store, err := vectorstore.NewVectorStore(context.Background(), &vectorstore.Config{
+		Enabled: true,
+		Type:    vectorstore.VectorStoreTypeChromem,
+		Config:  vectorstore.ChromemConfig{},
+	}, bifrost.NewDefaultLogger(schemas.LogLevelError))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close(context.Background(), SemanticVectorStoreNamespace))
+	})
+
+	config := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreEmbedded)
+	config.Keywords.SimpleKeywords = makeSemanticTestPhrases("simple", 24)
+	config.Keywords.MediumKeywords = makeSemanticTestPhrases("medium", 23)
+	config.Keywords.ComplexKeywords = makeSemanticTestPhrases("complex", 23)
+
+	var batchSizes []int
+	batch := func(_ context.Context, _ *SemanticConfig, texts []string) ([][]float32, error) {
+		batchSizes = append(batchSizes, len(texts))
+		embeddings := make([][]float32, len(texts))
+		for index := range texts {
+			embeddings[index] = []float32{1, 0}
+		}
+		return embeddings, nil
+	}
+	single := func(_ context.Context, _ *SemanticConfig, text string) ([]float32, error) {
+		return nil, fmt.Errorf("unexpected single-input call for %q", text)
+	}
+
+	loaded, _, _, err := warmSemanticExemplars(context.Background(), store, &config, single, batch, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 70, loaded)
+	assert.Equal(t, []int{32, 32, 6}, batchSizes)
+}
+
+func TestWarmSemanticExemplarsFallsBackWhenBatchingIsUnsupported(t *testing.T) {
+	store, err := vectorstore.NewVectorStore(context.Background(), &vectorstore.Config{
+		Enabled: true,
+		Type:    vectorstore.VectorStoreTypeChromem,
+		Config:  vectorstore.ChromemConfig{},
+	}, bifrost.NewDefaultLogger(schemas.LogLevelError))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close(context.Background(), SemanticVectorStoreNamespace))
+	})
+
+	config := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreEmbedded)
+	config.Keywords.SimpleKeywords = makeSemanticTestPhrases("simple", 14)
+	config.Keywords.MediumKeywords = makeSemanticTestPhrases("medium", 13)
+	config.Keywords.ComplexKeywords = makeSemanticTestPhrases("complex", 13)
+
+	var batchCalls atomic.Int32
+	var singleCalls atomic.Int32
+	batch := func(_ context.Context, _ *SemanticConfig, _ []string) ([][]float32, error) {
+		batchCalls.Add(1)
+		return nil, ErrBatchEmbeddingsUnsupported
+	}
+	single := func(_ context.Context, _ *SemanticConfig, _ string) ([]float32, error) {
+		singleCalls.Add(1)
+		return []float32{1, 0}, nil
+	}
+
+	loaded, _, _, err := warmSemanticExemplars(context.Background(), store, &config, single, batch, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 40, loaded)
+	assert.EqualValues(t, 1, batchCalls.Load())
+	assert.EqualValues(t, 40, singleCalls.Load())
+}
+
+func TestWarmSemanticExemplarsRejectsInconsistentDetectedDimensions(t *testing.T) {
+	store, err := vectorstore.NewVectorStore(context.Background(), &vectorstore.Config{
+		Enabled: true,
+		Type:    vectorstore.VectorStoreTypeChromem,
+		Config:  vectorstore.ChromemConfig{},
+	}, bifrost.NewDefaultLogger(schemas.LogLevelError))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close(context.Background(), SemanticVectorStoreNamespace))
+	})
+
+	config := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreEmbedded)
+	batch := func(_ context.Context, _ *SemanticConfig, texts []string) ([][]float32, error) {
+		embeddings := make([][]float32, len(texts))
+		for index := range texts {
+			embeddings[index] = []float32{1, 0}
+		}
+		embeddings[len(embeddings)-1] = []float32{1, 0, 0}
+		return embeddings, nil
+	}
+
+	_, _, _, err = warmSemanticExemplars(context.Background(), store, &config, testSemanticEmbedding, batch, nil)
+	require.ErrorContains(t, err, "returned dimension 3, expected 2")
+}
+
+// TestSemanticRecordIDsAreUUIDs keeps deterministic records compatible with
+// backends such as Qdrant and Weaviate that require UUID identifiers.
+func TestSemanticRecordIDsAreUUIDs(t *testing.T) {
+	exemplar := semanticExemplar{Tier: TierMedium, Phrase: "example phrase"}
+	for _, id := range []string{semanticMarkerID("fingerprint"), semanticExemplarID("fingerprint", exemplar)} {
+		parsed, err := uuid.Parse(id)
+		require.NoError(t, err)
+		assert.Equal(t, uuid.Version(5), parsed.Version())
+	}
+}
+
+func TestSemanticFingerprintIgnoresPhraseOrder(t *testing.T) {
+	config := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreEmbedded)
+	exemplars := semanticExemplars(&config)
+	original := append([]semanticExemplar(nil), exemplars...)
+	reordered := []semanticExemplar{exemplars[2], exemplars[0], exemplars[1]}
+
+	assert.Equal(t, semanticFingerprint(&config, exemplars, testSemanticDimension), semanticFingerprint(&config, reordered, testSemanticDimension))
+	assert.Equal(t, original, exemplars, "fingerprinting must not reorder the caller's slice")
+}
+
+// semanticLifecycleProbeStore simulates a backend that cannot read a marker
+// before its generation namespace exists.
+type semanticLifecycleProbeStore struct {
+	vectorstore.VectorStore
+	created           bool
+	createdBeforeRead bool
+	deleted           bool
+	markerIDs         []string
+}
+
+// GetChunks rejects read-before-create and otherwise returns a missing marker.
+func (s *semanticLifecycleProbeStore) GetChunks(_ context.Context, _ string, ids []string) ([]vectorstore.SearchResult, error) {
+	s.createdBeforeRead = s.created
+	if !s.created {
+		return nil, fmt.Errorf("namespace does not exist")
+	}
+	s.markerIDs = append([]string(nil), ids...)
+	return []vectorstore.SearchResult{}, nil
+}
+
+// DeleteNamespace records any destructive lifecycle behavior.
+func (s *semanticLifecycleProbeStore) DeleteNamespace(ctx context.Context, namespace string) error {
+	s.deleted = true
+	return s.VectorStore.DeleteNamespace(ctx, namespace)
+}
+
+// CreateNamespace records that the immutable generation exists before reads.
+func (s *semanticLifecycleProbeStore) CreateNamespace(ctx context.Context, namespace string, dimension int, properties map[string]vectorstore.VectorStoreProperties) error {
+	s.created = true
+	return s.VectorStore.CreateNamespace(ctx, namespace, dimension, properties)
+}
+
+// testSemanticClassifierConfig returns the smallest valid semantic config with
+// one distinct shared phrase per routing tier.
+func testSemanticClassifierConfig(vectorStore string) AnalyzerConfig {
+	return AnalyzerConfig{
+		TierBoundaries: DefaultTierBoundaries(),
+		Keywords: EditableKeywordConfig{
+			SimpleKeywords:  []string{"simple exemplar"},
+			MediumKeywords:  []string{"medium exemplar"},
+			ComplexKeywords: []string{"complex exemplar"},
+		},
+		Semantic: &SemanticConfig{
+			Provider:       schemas.ModelProvider("openai"),
+			EmbeddingModel: "test-embedding-model",
+			Timeout:        time.Second,
+			VectorStore:    vectorStore,
+		},
+	}
+}
+
+// testSemanticEmbedding returns deterministic unit vectors for the phrases in
+// testSemanticClassifierConfig and their corresponding synthetic requests.
+func testSemanticEmbedding(_ context.Context, _ *SemanticConfig, text string) ([]float32, error) {
+	switch text {
+	case "simple exemplar", "simple request":
+		return []float32{1, 0}, nil
+	case "medium exemplar", "medium request":
+		return []float32{0, 1}, nil
+	case "complex exemplar", "complex request":
+		return []float32{-1, 0}, nil
+	case "borderline request":
+		// Equidistant from the simple and medium exemplars: cosine ~0.707 to
+		// both, which is a real match but a weak one.
+		return []float32{0.7071068, 0.7071068}, nil
+	default:
+		return nil, fmt.Errorf("unexpected semantic test text %q", text)
+	}
+}
+
+func makeSemanticTestPhrases(prefix string, count int) []string {
+	phrases := make([]string, count)
+	for index := range phrases {
+		phrases[index] = fmt.Sprintf("%s exemplar %d", prefix, index)
+	}
+	return phrases
+}
+
+// TestSemanticClassifierRearmsForProviderOnlyWhenFailed pins the recovery path
+// for the state an operator can otherwise not escape: warmup fails because the
+// provider cannot serve (every key disabled), they fix the provider, and the
+// classifier has no other reason to try again — writes to the complexity
+// configuration are the only other trigger, and nothing about it has changed.
+func TestSemanticClassifierRearmsForProviderOnlyWhenFailed(t *testing.T) {
+	classifier := NewSemanticClassifier(context.Background(), bifrost.NewDefaultLogger(schemas.LogLevelError))
+	t.Cleanup(func() {
+		require.NoError(t, classifier.Close())
+	})
+
+	// Flipped after the failing generation settles, standing in for the operator
+	// re-enabling the key. Set through the classifier's own lock so the warmup
+	// goroutine cannot read it mid-write.
+	var serving atomic.Bool
+	classifier.SetEmbeddingFunc(func(_ context.Context, _ *SemanticConfig, text string) ([]float32, error) {
+		if !serving.Load() {
+			return nil, fmt.Errorf("synthetic provider failure")
+		}
+		switch text {
+		case "simple exemplar":
+			return []float32{1, 0}, nil
+		case "medium exemplar":
+			return []float32{0, 1}, nil
+		case "complex exemplar":
+			return []float32{-1, 0}, nil
+		}
+		return nil, fmt.Errorf("unexpected text %q", text)
+	})
+
+	config := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreEmbedded)
+	classifier.Configure(&config)
+	require.Eventually(t, func() bool {
+		return classifier.Status().State == SemanticStatusFailed
+	}, time.Second, 10*time.Millisecond, "warmup should fail while the provider cannot serve")
+
+	// A provider this classifier does not embed through is none of its business:
+	// re-arming on every provider edit would re-embed every phrase for nothing.
+	serving.Store(true)
+	classifier.RearmForProvider(schemas.ModelProvider("anthropic"))
+	require.Never(t, func() bool {
+		return classifier.Status().State != SemanticStatusFailed
+	}, 200*time.Millisecond, 20*time.Millisecond, "an unrelated provider must not restart warmup")
+
+	classifier.RearmForProvider(config.Semantic.Provider)
+	require.Eventually(t, func() bool {
+		return classifier.Status().State == SemanticStatusReady
+	}, time.Second, 10*time.Millisecond, "the configured provider coming back should restart warmup")
+
+	// Healthy classifiers stay put: warmup re-embeds every phrase, so reacting to
+	// unrelated key edits on a serving provider would bill tokens for no gain.
+	classifier.mu.Lock()
+	revisionBefore := classifier.revision
+	classifier.mu.Unlock()
+	classifier.RearmForProvider(config.Semantic.Provider)
+	classifier.mu.Lock()
+	revisionAfter := classifier.revision
+	classifier.mu.Unlock()
+	assert.Equal(t, revisionBefore, revisionAfter, "a ready classifier must not re-embed on a provider change")
+}
+
+// TestSemanticClassifierEmbedsOnlyNewPhrasesOnTierEdit pins the cost model of
+// editing a tier list. Generations stay content-addressed, so adding one phrase
+// still mints a new fingerprint and writes every exemplar into a fresh
+// namespace — but only the added phrase may reach the embedding provider.
+// Re-embedding the whole set for a one-phrase edit is a bill the operator did
+// not ask for, and on a 150-phrase deployment it is the difference between one
+// request and a hundred and fifty.
+func TestSemanticClassifierEmbedsOnlyNewPhrasesOnTierEdit(t *testing.T) {
+	store, err := vectorstore.NewVectorStore(context.Background(), &vectorstore.Config{
+		Enabled: true,
+		Type:    vectorstore.VectorStoreTypeChromem,
+		Config:  vectorstore.ChromemConfig{},
+	}, bifrost.NewDefaultLogger(schemas.LogLevelError))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close(context.Background(), SemanticVectorStoreNamespace))
+	})
+
+	var embeddedMu sync.Mutex
+	var embedded []string
+	embed := func(_ context.Context, _ *SemanticConfig, text string) ([]float32, error) {
+		embeddedMu.Lock()
+		embedded = append(embedded, text)
+		embeddedMu.Unlock()
+		// Any distinct unit-ish vector of the configured width will do; this test
+		// is about which phrases reach the provider, not about what they classify as.
+		return []float32{float32(len(text)%7) + 1, float32(len(text)%5) + 1}, nil
+	}
+	takeEmbedded := func() []string {
+		embeddedMu.Lock()
+		defer embeddedMu.Unlock()
+		taken := append([]string(nil), embedded...)
+		embedded = nil
+		return taken
+	}
+
+	cache := newSemanticEmbeddingCache()
+	config := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreEmbedded)
+
+	loaded, firstNamespace, _, err := warmSemanticExemplars(context.Background(), store, &config, embed, nil, cache)
+	require.NoError(t, err)
+	assert.Equal(t, 3, loaded)
+	assert.ElementsMatch(t, []string{"simple exemplar", "medium exemplar", "complex exemplar"}, takeEmbedded())
+
+	// One phrase added to one tier. The other three are already held.
+	edited := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreEmbedded)
+	edited.Keywords.SimpleKeywords = append(edited.Keywords.SimpleKeywords, "brand new exemplar")
+
+	loaded, secondNamespace, _, err := warmSemanticExemplars(context.Background(), store, &edited, embed, nil, cache)
+	require.NoError(t, err)
+	assert.Equal(t, 4, loaded)
+	assert.Equal(t, []string{"brand new exemplar"}, takeEmbedded(), "only the added phrase may be embedded again")
+	assert.NotEqual(t, firstNamespace, secondNamespace, "an edited phrase set is still a new generation")
+
+	// Every exemplar, reused or freshly embedded, has to exist in the new
+	// generation: reuse must not turn into a partially populated namespace.
+	for _, exemplar := range semanticExemplars(&edited) {
+		id := semanticExemplarID(semanticFingerprint(&edited, semanticExemplars(&edited), testSemanticDimension), exemplar)
+		chunks, err := store.GetChunks(context.Background(), secondNamespace, []string{id})
+		require.NoError(t, err)
+		require.Len(t, chunks, 1, "exemplar %q missing from the new generation", exemplar.Phrase)
+	}
+
+	// Switching model invalidates every held vector: a vector produced by
+	// another model is not stale, it is wrong for this one.
+	remodelled := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreEmbedded)
+	remodelled.Semantic.EmbeddingModel = "another-embedding-model"
+	_, _, _, err = warmSemanticExemplars(context.Background(), store, &remodelled, embed, nil, cache)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"simple exemplar", "medium exemplar", "complex exemplar"}, takeEmbedded(),
+		"a model change must re-embed everything")
+}
+
+// TestSemanticClassifierStatusReportsCacheCoverage guards the signal the
+// configuration UI uses to estimate what a save will re-embed. The cache is
+// in-process, so a restart empties it while the saved phrases look unchanged —
+// coverage cannot be inferred from the persisted config and has to be reported.
+func TestSemanticClassifierStatusReportsCacheCoverage(t *testing.T) {
+	classifier := NewSemanticClassifier(context.Background(), bifrost.NewDefaultLogger(schemas.LogLevelError))
+	t.Cleanup(func() {
+		require.NoError(t, classifier.Close())
+	})
+
+	// A classifier that has never warmed holds nothing, so the next save embeds
+	// every phrase however little changed.
+	assert.Equal(t, 0, classifier.Status().CachedPhrases)
+
+	classifier.SetEmbeddingFunc(testSemanticEmbedding)
+	config := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreEmbedded)
+	classifier.Configure(&config)
+	require.Eventually(t, func() bool {
+		return classifier.Status().State == SemanticStatusReady
+	}, time.Second, 10*time.Millisecond)
+
+	assert.Equal(t, len(semanticExemplars(&config)), classifier.Status().CachedPhrases,
+		"a warmed classifier holds one vector per active phrase")
+}

--- a/plugins/routing/embedding.go
+++ b/plugins/routing/embedding.go
@@ -93,9 +93,15 @@ const warmupEmbeddingTimeout = 60 * time.Second
 func (p *RoutingPlugin) SetEmbeddingRequestExecutor(executor EmbeddingRequestExecutor) {
 	if executor == nil {
 		p.embeddingRequestExecutor.Store(nil)
+		if p.semanticClassifier != nil {
+			p.semanticClassifier.SetEmbeddingFunctions(nil, nil)
+		}
 		return
 	}
 	p.embeddingRequestExecutor.Store(&executor)
+	if p.semanticClassifier != nil {
+		p.semanticClassifier.SetEmbeddingFunctions(p.embedComplexityText, p.embedComplexityTexts)
+	}
 }
 
 // SetComplexityVectorStore supplies the configured shared VectorStore. The
@@ -104,9 +110,12 @@ func (p *RoutingPlugin) SetEmbeddingRequestExecutor(executor EmbeddingRequestExe
 func (p *RoutingPlugin) SetComplexityVectorStore(store vectorstore.VectorStore) {
 	if store == nil {
 		p.complexityVectorStore.Store(nil)
-		return
+	} else {
+		p.complexityVectorStore.Store(&store)
 	}
-	p.complexityVectorStore.Store(&store)
+	if p.semanticClassifier != nil {
+		p.semanticClassifier.SetConfiguredStore(store)
+	}
 }
 
 // embedComplexityText adapts Governance's Bifrost-aware embedding path to the

--- a/plugins/routing/main.go
+++ b/plugins/routing/main.go
@@ -70,6 +70,7 @@ type RoutingPlugin struct {
 	rules              rules.Store
 	engine             *rules.Engine
 	complexityAnalyzer atomic.Pointer[complexity.ComplexityAnalyzer]
+	semanticClassifier *complexity.SemanticClassifier
 
 	// governance supplies the virtual key, its live budget/rate-limit usage, and the provider
 	// materialization that runs once rules have decided. Required: rules address budgets and
@@ -139,11 +140,12 @@ func InitFromStore(
 	}
 
 	plugin := &RoutingPlugin{
-		rules:       ruleStore,
-		engine:      engine,
-		governance:  governancePlugin,
-		configStore: configStore,
-		logger:      logger,
+		rules:              ruleStore,
+		engine:             engine,
+		governance:         governancePlugin,
+		configStore:        configStore,
+		logger:             logger,
+		semanticClassifier: complexity.NewSemanticClassifier(ctx, logger),
 	}
 
 	var analyzerOverride *complexity.AnalyzerConfig
@@ -179,6 +181,40 @@ func (p *RoutingPlugin) storeComplexityAnalyzerConfig(config *complexity.Analyze
 		resolved = &defaults
 	}
 	p.complexityAnalyzer.Store(complexity.NewComplexityAnalyzerWithConfig(resolved))
+	if p.semanticClassifier != nil {
+		p.semanticClassifier.Configure(resolved)
+	}
+}
+
+// RearmComplexitySemanticClassifier restarts semantic warmup after the given
+// provider's own configuration changed (key re-enabled, model list widened).
+// The classifier decides whether the change is worth acting on.
+func (p *RoutingPlugin) RearmComplexitySemanticClassifier(provider schemas.ModelProvider) {
+	if p.semanticClassifier != nil {
+		p.semanticClassifier.RearmForProvider(provider)
+	}
+}
+
+// ValidateComplexityAnalyzerConfig runs the semantic classifier's own
+// validation before a handler persists a complexity configuration.
+//
+// This is schema validation only. It is routed through the classifier rather
+// than calling complexity.ValidateAndNormalize directly so that a future
+// setting whose validity depends on live process state has a seam to hook
+// into; no semantic setting needs one today.
+func (p *RoutingPlugin) ValidateComplexityAnalyzerConfig(config *complexity.AnalyzerConfig) error {
+	if p.semanticClassifier == nil {
+		return nil
+	}
+	return p.semanticClassifier.ValidateConfig(config)
+}
+
+// ComplexitySemanticStatus returns the current semantic classifier readiness.
+func (p *RoutingPlugin) ComplexitySemanticStatus() complexity.SemanticStatusInfo {
+	if p.semanticClassifier == nil {
+		return complexity.SemanticStatusInfo{State: complexity.SemanticStatusDisabled}
+	}
+	return p.semanticClassifier.Status()
 }
 
 // PreRequestHook evaluates routing rules, then materializes the virtual key's provider choice
@@ -293,7 +329,7 @@ func (p *RoutingPlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *sche
 	var computeComplexity func() *complexity.ComplexityResult
 	if analyzer := p.complexityAnalyzer.Load(); analyzer != nil {
 		computeComplexity = func() *complexity.ComplexityResult {
-			input, ok := complexity.BuildInput(req)
+			input, ok := complexity.BuildInput(ctx, req)
 			if !ok {
 				if p.logger != nil {
 					p.logger.Debug("[Routing] Complexity analysis skipped: unsupported request type")
@@ -418,6 +454,11 @@ func (p *RoutingPlugin) PostLLMHook(ctx *schemas.BifrostContext, resp *schemas.B
 // Cleanup implements schemas.BasePlugin.
 func (p *RoutingPlugin) Cleanup() error {
 	p.cleanupOnce.Do(func() {
+		if p.semanticClassifier != nil {
+			if err := p.semanticClassifier.Close(); err != nil {
+				p.logger.Warn("[Routing] failed to close semantic classifier: %v", err)
+			}
+		}
 		p.logger.Debug("[Routing] plugin cleaned up")
 	})
 	return nil


### PR DESCRIPTION
## Summary

Adds a semantic complexity classifier that routes requests by embedding the user's message and finding the nearest labelled exemplar in a VectorStore, replacing pure keyword matching for deployments that configure it. Also introduces harness-aware input sanitization so protocol wrappers injected by Claude Code and Codex are stripped before complexity analysis, and background Codex requests (prewarm, compaction, memory) are excluded from routing entirely.

## Changes

- **Semantic classifier (`semanticclassifier.go`)**: New `SemanticClassifier` type that embeds shared tier phrase lists into a fingerprinted, content-addressed VectorStore namespace. Supports single-input and batch embedding adapters, an in-process phrase vector cache to avoid re-embedding unchanged phrases on tier edits, configurable `min_similarity` floor, and a `message_history_count` window. Generations are immutable and identified by a SHA-256 fingerprint of provider, model, dimension, and sorted exemplar phrases. A retiring embedded namespace is held open until every in-flight classification against it completes. Shared (external) stores are never deleted, since another replica may still serve the previous generation.

- **Harness detection and input sanitization (`extract.go`)**: `BuildInput` now accepts a `BifrostContext` and detects whether the request originates from Claude Code or Codex via the `User-Agent` header. Known protocol XML wrappers (`<system-reminder>`, `<local-command-stdout>`, `<environment_context>`, `<user_shell_command>`, etc.) are stripped from user turns before complexity analysis. Turns that reduce to only housekeeping content cause the request to be skipped; turns that reduce to only context content are ignored while an earlier human turn remains the routing subject. Codex background request kinds (`prewarm`, `compaction`, `memory`) identified via the `x-codex-turn-metadata` header are excluded from routing entirely.

- **Plugin wiring (`main.go`, `embedding.go`)**: `RoutingPlugin` holds a `SemanticClassifier` and exposes `ComplexitySemanticStatus`, `ValidateComplexityAnalyzerConfig`, and `RearmComplexitySemanticClassifier`. The last method lets Governance restart a failed warmup when an operator re-enables a provider key, without requiring a complexity config re-save. `SetEmbeddingRequestExecutor` and `SetComplexityVectorStore` now propagate their values into the classifier. `BuildInput` receives the live `BifrostContext` at call sites.

- **Design decisions**: Phrase text is never written to the VectorStore as a property — only tier, kind, and fingerprint metadata are stored. The in-process exemplar index maps record IDs back to phrases so matched exemplars are named in routing logs without a stored-text round-trip. Scalar-only config changes (e.g. adjusting `min_similarity`) reuse the existing namespace rather than re-embedding. Malformed or unclosed XML tags in user messages are preserved rather than guessed at.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/routing/complexity/...
go test ./plugins/routing/...
```

Key scenarios covered by the new tests:
- Semantic classifier routes to the nearest shared tier phrase and names the matched exemplar
- Adopting an already-warmed shared-store generation does not re-embed exemplars
- `min_similarity` floor rejects weak matches while still reporting tier and score for logging
- `vector_store: configured` degrades to the embedded store when no store is wired
- A failed warmup is recoverable via `RearmForProvider` without re-saving the complexity config
- Editing a tier list re-embeds only the added phrases; switching models re-embeds everything
- Claude Code and Codex protocol wrappers are stripped; housekeeping-only turns skip routing
- Codex background request kinds (`prewarm`, `compaction`, `memory`) are excluded from routing
- Harness markers are ignored for unrecognized user agents

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Phrase text from the complexity tier configuration is never persisted to the VectorStore as a metadata property. Only tier label, record kind, and configuration fingerprint are stored. The `x-codex-turn-metadata` header is parsed field-by-field so a malformed or unknown field cannot alter the behavior of established fields. Harness detection is gated on exact user-agent matching; arbitrary user XML is not stripped unless the matching client is identified.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable