### PR TITLE
optimize baseline compute ds for governance

### DIFF
--- a/plugins/governance/baselines.go
+++ b/plugins/governance/baselines.go
@@ -1,0 +1,80 @@
+package governance
+
+// Baselines are the usage other cluster nodes have already accumulated but
+// have not yet flushed to the database. Every enforcement decision adds them to
+// this node's own in-memory counters, so that all nodes converge on the same
+// cluster-wide total without any of them reading the others' counters directly.
+//
+// These are lookup interfaces rather than maps on purpose. The caller holding
+// the data is free to keep it in whatever structure it likes, including one
+// that is mutated concurrently as peer updates arrive, and callees here can
+// only ask about the handful of IDs a request actually involves. Passing a map
+// forced the holder to publish a fully materialised copy on every change, which
+// costs one full copy per update at cluster scale.
+//
+// A nil value of either interface is not usable directly. Callers that may pass
+// nil should normalise it first with BudgetBaselinesOrEmpty or
+// RateLimitBaselinesOrEmpty.
+
+// BudgetBaselines reports remote unflushed spend per budget ID.
+type BudgetBaselines interface {
+	// BudgetUsage returns the amount other nodes have spent against budgetID
+	// since the last database flush, or zero if they have spent nothing.
+	BudgetUsage(budgetID string) float64
+}
+
+// RateLimitBaselines reports remote unflushed token and request counts per
+// rate limit ID. Both dimensions come from one interface because every caller
+// that needs one needs the other, and they are always read from the same
+// underlying snapshot.
+type RateLimitBaselines interface {
+	// TokenUsage returns the tokens other nodes have consumed against
+	// rateLimitID since the last database flush.
+	TokenUsage(rateLimitID string) int64
+	// RequestUsage returns the requests other nodes have counted against
+	// rateLimitID since the last database flush.
+	RequestUsage(rateLimitID string) int64
+}
+
+// MapBudgetBaselines adapts a plain map to BudgetBaselines. It is the natural
+// choice for tests and for single-node deployments, where the whole set is
+// small and already materialised. The zero value (a nil map) reports zero for
+// every ID, which is exactly the "no cluster peers" case.
+type MapBudgetBaselines map[string]float64
+
+// BudgetUsage implements BudgetBaselines.
+func (m MapBudgetBaselines) BudgetUsage(budgetID string) float64 { return m[budgetID] }
+
+// MapRateLimitBaselines adapts a pair of plain maps to RateLimitBaselines. As
+// with MapBudgetBaselines, nil maps report zero for every ID.
+type MapRateLimitBaselines struct {
+	Tokens   map[string]int64
+	Requests map[string]int64
+}
+
+// TokenUsage implements RateLimitBaselines.
+func (m MapRateLimitBaselines) TokenUsage(rateLimitID string) int64 { return m.Tokens[rateLimitID] }
+
+// RequestUsage implements RateLimitBaselines.
+func (m MapRateLimitBaselines) RequestUsage(rateLimitID string) int64 {
+	return m.Requests[rateLimitID]
+}
+
+// BudgetBaselinesOrEmpty returns baselines, or an empty set when it is nil, so
+// that callers can be handed nil and still dereference safely. This replaces
+// the previous "if baselines == nil { baselines = map[string]float64{} }" guard
+// and, unlike it, allocates nothing.
+func BudgetBaselinesOrEmpty(baselines BudgetBaselines) BudgetBaselines {
+	if baselines == nil {
+		return MapBudgetBaselines(nil)
+	}
+	return baselines
+}
+
+// RateLimitBaselinesOrEmpty mirrors BudgetBaselinesOrEmpty for rate limits.
+func RateLimitBaselinesOrEmpty(baselines RateLimitBaselines) RateLimitBaselines {
+	if baselines == nil {
+		return MapRateLimitBaselines{}
+	}
+	return baselines
+}

--- a/plugins/governance/budgetcycle_test.go
+++ b/plugins/governance/budgetcycle_test.go
@@ -395,7 +395,7 @@ func TestVirtualKeyReloadDoesNotResurrectOverrideCycles(t *testing.T) {
 	require.Equal(t, 2, reset.OverrideCyclesRemaining, "one window closed, so one cycle should be spent")
 
 	// A virtual-key reload lands, replaying the pristine grant.
-	store.UpdateVirtualKeyInMemory(ctx, pristine, nil, nil, nil)
+	store.UpdateVirtualKeyInMemory(ctx, pristine, nil, nil)
 
 	got := store.LoadBudget(ctx, budget.ID)
 	require.NotNil(t, got)
@@ -693,7 +693,7 @@ func TestQuarterDefinitionSurvivesVirtualKeyReload(t *testing.T) {
 	// delegates to CreateVirtualKeyInMemory when nothing is cached yet.
 	t.Run("first load", func(t *testing.T) {
 		store := newStandaloneStore(t)
-		store.UpdateVirtualKeyInMemory(ctx, newQuarterlyVK(time.February, 250), nil, nil, nil)
+		store.UpdateVirtualKeyInMemory(ctx, newQuarterlyVK(time.February, 250), nil, nil)
 		assertQuarterly(t, store.LoadBudget(ctx, "vk-quarterly-budget"), 250)
 	})
 
@@ -704,7 +704,7 @@ func TestQuarterDefinitionSurvivesVirtualKeyReload(t *testing.T) {
 	// definition dropped only here would survive every first-load test.
 	t.Run("reload over an existing virtual key", func(t *testing.T) {
 		store := newStandaloneStore(t)
-		store.UpdateVirtualKeyInMemory(ctx, newQuarterlyVK(time.January, 0), nil, nil, nil)
+		store.UpdateVirtualKeyInMemory(ctx, newQuarterlyVK(time.January, 0), nil, nil)
 
 		// Simulate accrued spend on the cached copy, then reload with an edited
 		// fiscal calendar, exactly as a peer would after the operator changes it.
@@ -713,7 +713,7 @@ func TestQuarterDefinitionSurvivesVirtualKeyReload(t *testing.T) {
 		cached.CurrentUsage = 250
 		store.storeBudget(cached.ID, cached)
 
-		store.UpdateVirtualKeyInMemory(ctx, newQuarterlyVK(time.February, 0), nil, nil, nil)
+		store.UpdateVirtualKeyInMemory(ctx, newQuarterlyVK(time.February, 0), nil, nil)
 		assertQuarterly(t, store.LoadBudget(ctx, "vk-quarterly-budget"), 250)
 	})
 }

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -734,7 +734,7 @@ func (p *GovernancePlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *s
 		RequestType:              requestType,
 		Headers:                  headers,
 		QueryParams:              queryParams,
-		BudgetAndRateLimitStatus: p.store.GetBudgetAndRateLimitStatus(ctx, model, provider, virtualKey, nil, nil, nil),
+		BudgetAndRateLimitStatus: p.store.GetBudgetAndRateLimitStatus(ctx, model, provider, virtualKey, nil, nil),
 		computeComplexity:        computeComplexity,
 	}
 

--- a/plugins/governance/modelprovidergovernance_test.go
+++ b/plugins/governance/modelprovidergovernance_test.go
@@ -78,7 +78,7 @@ func TestStore_CheckProviderBudget_WithBaseline(t *testing.T) {
 	require.NoError(t, err)
 
 	// With baseline that would exceed limit
-	baselines := map[string]float64{"budget1": 15.0}
+	baselines := MapBudgetBaselines{"budget1": 15.0}
 	_, err = store.CheckProviderBudget(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, baselines)
 	assert.Error(t, err, "Should reject when current usage + baseline exceeds limit")
 	assert.Contains(t, err.Error(), "budget exceeded")
@@ -93,7 +93,7 @@ func TestStore_CheckProviderRateLimit_NoConfig(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
-	decision, err := store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil, nil)
+	decision, err := store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil)
 	assert.NoError(t, err, "Should allow when no provider config exists")
 	assert.Equal(t, DecisionAllow, decision)
 }
@@ -106,7 +106,7 @@ func TestStore_CheckProviderRateLimit_NoRateLimit(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	decision, err := store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil, nil)
+	decision, err := store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil)
 	assert.NoError(t, err, "Should allow when provider has no rate limit")
 	assert.Equal(t, DecisionAllow, decision)
 }
@@ -121,7 +121,7 @@ func TestStore_CheckProviderRateLimit_TokenLimitExceeded(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	decision, err := store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil, nil)
+	decision, err := store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil)
 	assert.Error(t, err, "Should reject when provider token limit is exceeded")
 	assert.Equal(t, DecisionTokenLimited, decision)
 	assert.Contains(t, err.Error(), "token limit exceeded")
@@ -137,7 +137,7 @@ func TestStore_CheckProviderRateLimit_RequestLimitExceeded(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	decision, err := store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil, nil)
+	decision, err := store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil)
 	assert.Error(t, err, "Should reject when provider request limit is exceeded")
 	assert.Equal(t, DecisionRequestLimited, decision)
 	assert.Contains(t, err.Error(), "request limit exceeded")
@@ -153,7 +153,7 @@ func TestStore_CheckProviderRateLimit_BothLimitsExceeded(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	decision, err := store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil, nil)
+	decision, err := store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil)
 	assert.Error(t, err, "Should reject when both provider token and request limits are exceeded")
 	assert.Equal(t, DecisionRateLimited, decision) // General rate limited when both are exceeded
 	assert.Contains(t, err.Error(), "rate limit")
@@ -169,7 +169,7 @@ func TestStore_CheckProviderRateLimit_WithinLimits(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	decision, err := store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil, nil)
+	decision, err := store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil)
 	assert.NoError(t, err, "Should allow when provider rate limits are within limits")
 	assert.Equal(t, DecisionAllow, decision)
 }
@@ -369,7 +369,7 @@ func TestStore_CheckModelRateLimit_NoConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
-	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil, nil)
+	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil)
 	assert.NoError(t, err, "Should allow when no model config exists")
 	assert.Equal(t, DecisionAllow, decision)
 }
@@ -385,7 +385,7 @@ func TestStore_CheckModelRateLimit_ModelOnly_TokenLimitExceeded(t *testing.T) {
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
-	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil, nil)
+	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil)
 	assert.Error(t, err, "Should reject when model token limit is exceeded")
 	assert.Equal(t, DecisionTokenLimited, decision)
 	assert.Contains(t, err.Error(), "token limit exceeded")
@@ -402,7 +402,7 @@ func TestStore_CheckModelRateLimit_ModelOnly_RequestLimitExceeded(t *testing.T) 
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
-	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil, nil)
+	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil)
 	assert.Error(t, err, "Should reject when model request limit is exceeded")
 	assert.Equal(t, DecisionRequestLimited, decision)
 	assert.Contains(t, err.Error(), "request limit exceeded")
@@ -420,7 +420,7 @@ func TestStore_CheckModelRateLimit_ModelWithProvider_WithinLimits(t *testing.T) 
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
-	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil, nil)
+	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil)
 	assert.NoError(t, err, "Should allow when model+provider rate limits are within limits")
 	assert.Equal(t, DecisionAllow, decision)
 }
@@ -441,7 +441,7 @@ func TestStore_CheckModelRateLimit_BothModelAndModelProvider_ChecksBoth(t *testi
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
-	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil, nil)
+	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil)
 	assert.Error(t, err, "Should reject when model-only rate limit is exceeded")
 	assert.Equal(t, DecisionTokenLimited, decision)
 	assert.Contains(t, err.Error(), "token limit exceeded")
@@ -463,7 +463,7 @@ func TestStore_CheckModelRateLimit_BothModelAndModelProvider_ChecksBoth_RequestL
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
-	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil, nil)
+	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil)
 	assert.Error(t, err, "Should reject when model-only rate limit (request limit) is exceeded")
 	assert.Equal(t, DecisionRequestLimited, decision)
 	assert.Contains(t, err.Error(), "request limit exceeded")
@@ -483,7 +483,7 @@ func TestStore_CheckModelRateLimit_ProviderSpecific_DifferentProvider_Passes(t *
 
 	// Request with Azure (different provider) for same model should pass
 	provider := schemas.Azure
-	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4o", Provider: provider}, nil, nil)
+	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4o", Provider: provider}, nil)
 	assert.NoError(t, err, "Should allow when model config is provider-specific and different provider is used")
 	assert.Equal(t, DecisionAllow, decision)
 }
@@ -502,7 +502,7 @@ func TestStore_CheckModelRateLimit_ProviderSpecific_DifferentProvider_Passes_Req
 
 	// Request with Azure (different provider) for same model should pass
 	provider := schemas.Azure
-	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4o", Provider: provider}, nil, nil)
+	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4o", Provider: provider}, nil)
 	assert.NoError(t, err, "Should allow when model config is provider-specific and different provider is used (request limit)")
 	assert.Equal(t, DecisionAllow, decision)
 }
@@ -574,7 +574,7 @@ func TestStore_UpdateProviderRateLimitUsage_UpdatesTokens(t *testing.T) {
 	assert.NoError(t, err, "Should successfully update provider token usage")
 
 	// Check that tokens were updated but requests were not
-	decision, err := store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil, nil)
+	decision, err := store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil)
 	assert.NoError(t, err, "Should still be within token limit")
 	assert.Equal(t, DecisionAllow, decision)
 
@@ -583,7 +583,7 @@ func TestStore_UpdateProviderRateLimitUsage_UpdatesTokens(t *testing.T) {
 	assert.NoError(t, err, "Should successfully update provider token usage even when exceeding")
 
 	// Now should be exceeded
-	decision, err = store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil, nil)
+	decision, err = store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil)
 	assert.Error(t, err, "Should reject when provider token limit is exceeded after update")
 	assert.Equal(t, DecisionTokenLimited, decision)
 	assert.Contains(t, err.Error(), "token limit exceeded")
@@ -606,7 +606,7 @@ func TestStore_UpdateProviderRateLimitUsage_UpdatesRequests(t *testing.T) {
 	}
 
 	// Should still be within limit
-	decision, err := store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil, nil)
+	decision, err := store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil)
 	assert.NoError(t, err, "Should allow when provider request limit is within limit")
 	assert.Equal(t, DecisionAllow, decision)
 
@@ -617,7 +617,7 @@ func TestStore_UpdateProviderRateLimitUsage_UpdatesRequests(t *testing.T) {
 	}
 
 	// Now should be exceeded
-	decision, err = store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil, nil)
+	decision, err = store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil)
 	assert.Error(t, err, "Should reject when provider request limit is exceeded after update")
 	assert.Equal(t, DecisionRequestLimited, decision)
 	assert.Contains(t, err.Error(), "request limit exceeded")
@@ -728,7 +728,7 @@ func TestStore_UpdateModelRateLimitUsage_ModelOnly_UpdatesUsage(t *testing.T) {
 	assert.NoError(t, err, "Should successfully update model token usage")
 
 	// Should still be within limit
-	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil, nil)
+	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil)
 	assert.NoError(t, err, "Should allow when model token limit is within limit")
 	assert.Equal(t, DecisionAllow, decision)
 
@@ -737,7 +737,7 @@ func TestStore_UpdateModelRateLimitUsage_ModelOnly_UpdatesUsage(t *testing.T) {
 	assert.NoError(t, err, "Should successfully update model token usage even when exceeding")
 
 	// Now should be exceeded
-	decision, err = store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil, nil)
+	decision, err = store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil)
 	assert.Error(t, err, "Should reject when model token limit is exceeded after update")
 	assert.Equal(t, DecisionTokenLimited, decision)
 	assert.Contains(t, err.Error(), "token limit exceeded")
@@ -763,7 +763,7 @@ func TestStore_UpdateModelRateLimitUsage_ModelWithProvider_UpdatesUsage(t *testi
 	assert.NoError(t, err, "Should successfully update both model-only and model+provider token usage")
 
 	// Should still be within limit
-	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil, nil)
+	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil)
 	assert.NoError(t, err, "Should allow when both rate limits are within limit")
 	assert.Equal(t, DecisionAllow, decision)
 
@@ -772,7 +772,7 @@ func TestStore_UpdateModelRateLimitUsage_ModelWithProvider_UpdatesUsage(t *testi
 	assert.NoError(t, err, "Should successfully update model token usage even when exceeding")
 
 	// Now should be exceeded (model-only rate limit exceeded)
-	decision, err = store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil, nil)
+	decision, err = store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil)
 	assert.Error(t, err, "Should reject when model-only token limit is exceeded after update")
 	assert.Equal(t, DecisionTokenLimited, decision)
 	assert.Contains(t, err.Error(), "token limit exceeded")
@@ -796,7 +796,7 @@ func TestStore_UpdateModelRateLimitUsage_ModelOnly_UpdatesUsage_RequestLimit(t *
 	}
 
 	// Should still be within limit
-	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil, nil)
+	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil)
 	assert.NoError(t, err, "Should allow when model request limit is within limit")
 	assert.Equal(t, DecisionAllow, decision)
 
@@ -807,7 +807,7 @@ func TestStore_UpdateModelRateLimitUsage_ModelOnly_UpdatesUsage_RequestLimit(t *
 	}
 
 	// Now should be exceeded
-	decision, err = store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil, nil)
+	decision, err = store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil)
 	assert.Error(t, err, "Should reject when model request limit is exceeded after update")
 	assert.Equal(t, DecisionRequestLimited, decision)
 	assert.Contains(t, err.Error(), "request limit exceeded")
@@ -836,7 +836,7 @@ func TestStore_UpdateModelRateLimitUsage_ModelWithProvider_UpdatesUsage_RequestL
 	}
 
 	// Should still be within limit
-	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil, nil)
+	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil)
 	assert.NoError(t, err, "Should allow when both rate limits are within limit")
 	assert.Equal(t, DecisionAllow, decision)
 
@@ -847,7 +847,7 @@ func TestStore_UpdateModelRateLimitUsage_ModelWithProvider_UpdatesUsage_RequestL
 	}
 
 	// Now should be exceeded (model-only rate limit exceeded)
-	decision, err = store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil, nil)
+	decision, err = store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: provider}, nil)
 	assert.Error(t, err, "Should reject when model-only request limit is exceeded after update")
 	assert.Equal(t, DecisionRequestLimited, decision)
 	assert.Contains(t, err.Error(), "request limit exceeded")
@@ -2349,7 +2349,7 @@ func TestStore_CheckModelRateLimit_CrossProviderModelMatch(t *testing.T) {
 	}, mc)
 	require.NoError(t, err)
 
-	decision, errResult := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "openai/gpt-4o", Provider: schemas.OpenRouter}, nil, nil)
+	decision, errResult := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "openai/gpt-4o", Provider: schemas.OpenRouter}, nil)
 	assert.Error(t, errResult, "Should reject: openai/gpt-4o should match model-only rate limit for gpt-4o")
 	assert.Contains(t, errResult.Error(), "token limit exceeded")
 	assert.NotEqual(t, DecisionAllow, decision)
@@ -2402,7 +2402,7 @@ func TestStore_UpdateModelRateLimitUsage_CrossProviderModelMatch(t *testing.T) {
 	assert.NoError(t, err, "Should successfully update rate limit via cross-provider match")
 
 	// Rate limit should now be exceeded
-	decision, errResult := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "openai/gpt-4o", Provider: schemas.OpenRouter}, nil, nil)
+	decision, errResult := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "openai/gpt-4o", Provider: schemas.OpenRouter}, nil)
 	assert.Error(t, errResult, "Token limit should be exceeded after usage update via cross-provider match")
 	assert.Contains(t, errResult.Error(), "token limit exceeded")
 	assert.NotEqual(t, DecisionAllow, decision)
@@ -2511,7 +2511,7 @@ func TestStore_UpdateProviderModelUsage_BumpsAllModelsWildcard(t *testing.T) {
 	require.NoError(t, err)
 
 	// Within limit initially.
-	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4o", Provider: schemas.OpenAI}, nil, nil)
+	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4o", Provider: schemas.OpenAI}, nil)
 	require.NoError(t, err)
 	require.Equal(t, DecisionAllow, decision)
 
@@ -2519,7 +2519,7 @@ func TestStore_UpdateProviderModelUsage_BumpsAllModelsWildcard(t *testing.T) {
 	require.NoError(t, store.UpdateProviderAndModelRateLimitUsageInMemory(context.Background(), "gpt-4o", schemas.OpenAI, 150, true, true))
 
 	// Now the all-models rate limit trips for any model on the provider.
-	decision, err = store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4o-mini", Provider: schemas.OpenAI}, nil, nil)
+	decision, err = store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4o-mini", Provider: schemas.OpenAI}, nil)
 	assert.Error(t, err)
 	assert.Equal(t, DecisionTokenLimited, decision)
 }
@@ -2632,7 +2632,7 @@ func TestStore_CheckVirtualKeyScopedModelRateLimit_TokenLimitExceeded(t *testing
 	}, nil)
 	require.NoError(t, err)
 
-	decision, err := store.CheckScopedModelRateLimit(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil, nil)
+	decision, err := store.CheckScopedModelRateLimit(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
 	assert.Error(t, err, "Should reject when per-VK model token limit is exceeded")
 	assert.Equal(t, DecisionTokenLimited, decision)
 }
@@ -2648,7 +2648,7 @@ func TestStore_CheckVirtualKeyScopedModelRateLimit_WithinLimit(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	decision, err := store.CheckScopedModelRateLimit(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil, nil)
+	decision, err := store.CheckScopedModelRateLimit(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, DecisionAllow, decision)
 }
@@ -2670,7 +2670,7 @@ func TestStore_VirtualKeyScopedModel_RecordThenCheck_TokenLimitTrips(t *testing.
 	req := &EvaluationRequest{Model: "claude-opus-4-7", Provider: schemas.Anthropic}
 
 	// Initially within limit.
-	decision, err := store.CheckScopedModelRateLimit(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, req, nil, nil)
+	decision, err := store.CheckScopedModelRateLimit(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, req, nil)
 	require.NoError(t, err)
 	require.Equal(t, DecisionAllow, decision)
 
@@ -2679,7 +2679,7 @@ func TestStore_VirtualKeyScopedModel_RecordThenCheck_TokenLimitTrips(t *testing.
 	require.NoError(t, store.UpdateScopedModelRateLimitUsageInMemory(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, "claude-opus-4-7", schemas.Anthropic, 150, true, true))
 
 	// Now the scoped check must trip.
-	decision, err = store.CheckScopedModelRateLimit(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, req, nil, nil)
+	decision, err = store.CheckScopedModelRateLimit(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, req, nil)
 	assert.Error(t, err)
 	assert.Equal(t, DecisionTokenLimited, decision)
 }

--- a/plugins/governance/resolver.go
+++ b/plugins/governance/resolver.go
@@ -89,7 +89,7 @@ func (r *BudgetResolver) EvaluateModelAndProviderRequest(ctx *schemas.BifrostCon
 	}
 	// 1. Check provider-level rate limits FIRST (before model-level checks)
 	if provider != "" {
-		if decision, err := r.store.CheckProviderRateLimit(ctx, request, nil, nil); err != nil || isRateLimitViolation(decision) {
+		if decision, err := r.store.CheckProviderRateLimit(ctx, request, nil); err != nil || isRateLimitViolation(decision) {
 			return &EvaluationResult{
 				Decision: decision,
 				Reason:   fmt.Sprintf("Provider-level rate limit check failed: %s", reasonFromErr(err, decision)),
@@ -105,7 +105,7 @@ func (r *BudgetResolver) EvaluateModelAndProviderRequest(ctx *schemas.BifrostCon
 	}
 	// 3. Check model-level rate limits (after provider-level checks)
 	if model != "" {
-		if decision, err := r.store.CheckModelRateLimit(ctx, request, nil, nil); err != nil || isRateLimitViolation(decision) {
+		if decision, err := r.store.CheckModelRateLimit(ctx, request, nil); err != nil || isRateLimitViolation(decision) {
 			return &EvaluationResult{
 				Decision: decision,
 				Reason:   fmt.Sprintf("Model-level rate limit check failed: %s", reasonFromErr(err, decision)),
@@ -136,7 +136,7 @@ func (r *BudgetResolver) EvaluateCustomerRequest(ctx *schemas.BifrostContext, cu
 		}
 	}
 	// Check customer-level rate limits
-	if decision, err := r.store.CheckCustomerRateLimit(ctx, customerID, request, nil, nil); err != nil || isRateLimitViolation(decision) {
+	if decision, err := r.store.CheckCustomerRateLimit(ctx, customerID, request, nil); err != nil || isRateLimitViolation(decision) {
 		return &EvaluationResult{
 			Decision: decision,
 			Reason:   fmt.Sprintf("Customer-level rate limit exceeded: %s", reasonFromErr(err, decision)),
@@ -166,7 +166,7 @@ func (r *BudgetResolver) EvaluateTeamRequest(ctx *schemas.BifrostContext, teamID
 		}
 	}
 	// Check team-level rate limits
-	if decision, err := r.store.CheckTeamRateLimit(ctx, teamID, request, nil, nil); err != nil || isRateLimitViolation(decision) {
+	if decision, err := r.store.CheckTeamRateLimit(ctx, teamID, request, nil); err != nil || isRateLimitViolation(decision) {
 		return &EvaluationResult{
 			Decision: decision,
 			Reason:   fmt.Sprintf("Team-level rate limit exceeded: %s", reasonFromErr(err, decision)),
@@ -201,7 +201,7 @@ func (r *BudgetResolver) EvaluateUserRequest(ctx *schemas.BifrostContext, userID
 	}
 
 	// Check user-level rate limits
-	if decision, err := r.store.CheckUserRateLimit(ctx, userID, request, nil, nil); err != nil || isRateLimitViolation(decision) {
+	if decision, err := r.store.CheckUserRateLimit(ctx, userID, request, nil); err != nil || isRateLimitViolation(decision) {
 		return &EvaluationResult{
 			Decision: decision,
 			Reason:   fmt.Sprintf("User-level rate limit exceeded: %s", reasonFromErr(err, decision)),
@@ -220,7 +220,7 @@ func (r *BudgetResolver) EvaluateUserRequest(ctx *schemas.BifrostContext, userID
 	// VK-scoped block in EvaluateVirtualKeyRequest. Gated on model being present —
 	// MCP tool execution (no model) is excluded naturally by this guard.
 	if request.Model != "" {
-		if decision, err := r.store.CheckScopedModelRateLimit(ctx, configstoreTables.ModelConfigScopeUser, userID, request, nil, nil); err != nil || isRateLimitViolation(decision) {
+		if decision, err := r.store.CheckScopedModelRateLimit(ctx, configstoreTables.ModelConfigScopeUser, userID, request, nil); err != nil || isRateLimitViolation(decision) {
 			return &EvaluationResult{
 				Decision: decision,
 				Reason:   fmt.Sprintf("User-level model rate limit exceeded: %s", reasonFromErr(err, decision)),
@@ -319,7 +319,7 @@ func (r *BudgetResolver) EvaluateVirtualKeyRequest(ctx *schemas.BifrostContext, 
 		// request must satisfy both (most-restrictive wins). Gated on a model being present,
 		// mirroring the global model checks.
 		if model != "" {
-			if decision, err := r.store.CheckScopedModelRateLimit(ctx, configstoreTables.ModelConfigScopeVirtualKey, vk.ID, evaluationRequest, nil, nil); err != nil || isRateLimitViolation(decision) {
+			if decision, err := r.store.CheckScopedModelRateLimit(ctx, configstoreTables.ModelConfigScopeVirtualKey, vk.ID, evaluationRequest, nil); err != nil || isRateLimitViolation(decision) {
 				return &EvaluationResult{
 					Decision:   decision,
 					Reason:     fmt.Sprintf("Model-level rate limit check failed (virtual key scope): %s", reasonFromErr(err, decision)),
@@ -414,7 +414,7 @@ func (r *BudgetResolver) isProviderAllowed(vk *configstoreTables.TableVirtualKey
 
 // checkRateLimitHierarchy checks provider-level rate limits first, then VK rate limits using flexible approach
 func (r *BudgetResolver) checkRateLimitHierarchy(ctx context.Context, vk *configstoreTables.TableVirtualKey, request *EvaluationRequest) *EvaluationResult {
-	if decision, err := r.store.CheckVirtualKeyRateLimit(ctx, vk, request, nil, nil); err != nil || isRateLimitViolation(decision) {
+	if decision, err := r.store.CheckVirtualKeyRateLimit(ctx, vk, request, nil); err != nil || isRateLimitViolation(decision) {
 		// Check provider-level first (matching check order), then VK-level.
 		// Resolve by ID from the canonical rate-limit map because embedded
 		// references can intentionally remain stale after request-time resets.
@@ -481,7 +481,7 @@ func (r *BudgetResolver) isProviderRateLimitViolated(ctx context.Context, vk *co
 	request := &EvaluationRequest{Provider: schemas.ModelProvider(config.Provider)}
 
 	// 1. Check global provider-level rate limit first
-	if decision, err := r.store.CheckProviderRateLimit(ctx, request, nil, nil); err != nil || isRateLimitViolation(decision) {
+	if decision, err := r.store.CheckProviderRateLimit(ctx, request, nil); err != nil || isRateLimitViolation(decision) {
 		r.logger.Debug(fmt.Sprintf("Global provider rate limit exceeded for provider %s", config.Provider))
 		return true
 	}
@@ -490,7 +490,7 @@ func (r *BudgetResolver) isProviderRateLimitViolated(ctx context.Context, vk *co
 	if config.RateLimitID == nil {
 		return false
 	}
-	decision, err := r.store.CheckVirtualKeyRateLimit(ctx, vk, request, nil, nil)
+	decision, err := r.store.CheckVirtualKeyRateLimit(ctx, vk, request, nil)
 	if err != nil || isRateLimitViolation(decision) {
 		r.logger.Debug(fmt.Sprintf("VK provider config rate limit exceeded for VK %s, provider %s", vk.ID, config.Provider))
 		return true

--- a/plugins/governance/routing.go
+++ b/plugins/governance/routing.go
@@ -150,7 +150,7 @@ func (re *RoutingEngine) EvaluateRoutingRules(ctx *schemas.BifrostContext, routi
 		iterCtx.Model = currentModel
 		// Refresh budget/rate-limit status for the current provider/model so chained
 		// rules that test budget_used, tokens_used, or request see fresh data.
-		iterCtx.BudgetAndRateLimitStatus = re.store.GetBudgetAndRateLimitStatus(ctx, currentModel, currentProvider, routingCtx.VirtualKey, nil, nil, nil)
+		iterCtx.BudgetAndRateLimitStatus = re.store.GetBudgetAndRateLimitStatus(ctx, currentModel, currentProvider, routingCtx.VirtualKey, nil, nil)
 
 		variables, err := extractRoutingVariables(&iterCtx)
 		if err != nil {

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -121,6 +121,13 @@ type BudgetAndRateLimitStatus struct {
 //     DB-backed) and prevents retry loops on policy violations.
 type GovernanceStore interface {
 	GetGovernanceData(ctx context.Context) *GovernanceData
+	// RangeBudgetUsage and RangeRateLimitUsage walk only the usage counters.
+	// Callers that want usage and nothing else should use these rather than
+	// GetGovernanceData, which rebuilds the whole object graph.
+	RangeBudgetUsage(fn func(budgetID string, usage BudgetUsageSnapshot) bool)
+	RangeRateLimitUsage(fn func(rateLimitID string, usage RateLimitUsageSnapshot) bool)
+	BudgetUsageByID(budgetID string) (BudgetUsageSnapshot, bool)
+	RateLimitUsageByID(rateLimitID string) (RateLimitUsageSnapshot, bool)
 	GetVirtualKey(ctx context.Context, vkValue string) (*configstoreTables.TableVirtualKey, bool)
 	GetVirtualKeyByID(ctx context.Context, vkID string) (*configstoreTables.TableVirtualKey, bool)
 	// Budget crud.
@@ -137,20 +144,20 @@ type GovernanceStore interface {
 	UpsertRateLimitConfig(ctx context.Context, rateLimitID string, config *configstoreTables.TableRateLimit)
 	DeleteRateLimit(ctx context.Context, rateLimitID string)
 	// Provider-level governance checks
-	CheckProviderBudget(ctx context.Context, request *EvaluationRequest, baselines map[string]float64) (Decision, error)
-	CheckProviderRateLimit(ctx context.Context, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error)
+	CheckProviderBudget(ctx context.Context, request *EvaluationRequest, baselines BudgetBaselines) (Decision, error)
+	CheckProviderRateLimit(ctx context.Context, request *EvaluationRequest, rateLimitBaselines RateLimitBaselines) (Decision, error)
 	// Model-level governance checks
-	CheckModelBudget(ctx context.Context, request *EvaluationRequest, baselines map[string]float64) (Decision, error)
-	CheckModelRateLimit(ctx context.Context, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error)
+	CheckModelBudget(ctx context.Context, request *EvaluationRequest, baselines BudgetBaselines) (Decision, error)
+	CheckModelRateLimit(ctx context.Context, request *EvaluationRequest, rateLimitBaselines RateLimitBaselines) (Decision, error)
 	// Scoped model-level governance checks (aggregate with the global model checks above).
 	// scope/scopeID identify the owning entity (e.g. "virtual_key" + VK.ID, or any other
 	// scope registered via tables.RegisterModelConfigScope). An empty scope or scopeID
 	// is a no-op (returns DecisionAllow).
-	CheckScopedModelBudget(ctx context.Context, scope, scopeID string, request *EvaluationRequest, baselines map[string]float64) (Decision, error)
-	CheckScopedModelRateLimit(ctx context.Context, scope, scopeID string, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error)
+	CheckScopedModelBudget(ctx context.Context, scope, scopeID string, request *EvaluationRequest, baselines BudgetBaselines) (Decision, error)
+	CheckScopedModelRateLimit(ctx context.Context, scope, scopeID string, request *EvaluationRequest, rateLimitBaselines RateLimitBaselines) (Decision, error)
 	// VK-level governance checks
-	CheckVirtualKeyBudget(ctx context.Context, vk *configstoreTables.TableVirtualKey, request *EvaluationRequest, baselines map[string]float64) (Decision, error)
-	CheckVirtualKeyRateLimit(ctx context.Context, vk *configstoreTables.TableVirtualKey, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error)
+	CheckVirtualKeyBudget(ctx context.Context, vk *configstoreTables.TableVirtualKey, request *EvaluationRequest, baselines BudgetBaselines) (Decision, error)
+	CheckVirtualKeyRateLimit(ctx context.Context, vk *configstoreTables.TableVirtualKey, request *EvaluationRequest, rateLimitBaselines RateLimitBaselines) (Decision, error)
 	// In-memory usage updates (for VK-level)
 	UpdateVirtualKeyBudgetUsageInMemory(ctx context.Context, vk *configstoreTables.TableVirtualKey, provider schemas.ModelProvider, cost float64) error
 	UpdateVirtualKeyRateLimitUsageInMemory(ctx context.Context, vk *configstoreTables.TableVirtualKey, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error
@@ -178,29 +185,29 @@ type GovernanceStore interface {
 	UpdateProviderAndModelBudgetUsageInMemory(ctx context.Context, model string, provider schemas.ModelProvider, cost float64) error
 	UpdateProviderAndModelRateLimitUsageInMemory(ctx context.Context, model string, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error
 	// Dump operations
-	DumpRateLimits(ctx context.Context, tokenBaselines map[string]int64, requestBaselines map[string]int64) error
-	DumpBudgets(ctx context.Context, baselines map[string]float64) error
+	DumpRateLimits(ctx context.Context, rateLimitBaselines RateLimitBaselines) error
+	DumpBudgets(ctx context.Context, baselines BudgetBaselines) error
 	// In-memory CRUD operations
 	CreateVirtualKeyInMemory(ctx context.Context, vk *configstoreTables.TableVirtualKey)
-	UpdateVirtualKeyInMemory(ctx context.Context, vk *configstoreTables.TableVirtualKey, budgetBaselines map[string]float64, rateLimitTokensBaselines map[string]int64, rateLimitRequestsBaselines map[string]int64)
+	UpdateVirtualKeyInMemory(ctx context.Context, vk *configstoreTables.TableVirtualKey, budgetBaselines BudgetBaselines, rateLimitBaselines RateLimitBaselines)
 	DeleteVirtualKeyInMemory(ctx context.Context, vkID string)
 	CreateTeamInMemory(ctx context.Context, team *configstoreTables.TableTeam)
-	UpdateTeamInMemory(ctx context.Context, team *configstoreTables.TableTeam, budgetBaselines map[string]float64)
+	UpdateTeamInMemory(ctx context.Context, team *configstoreTables.TableTeam, budgetBaselines BudgetBaselines)
 	DeleteTeamInMemory(ctx context.Context, teamID string)
 	// Customer information
 	CreateCustomerInMemory(ctx context.Context, customer *configstoreTables.TableCustomer)
-	UpdateCustomerInMemory(ctx context.Context, customer *configstoreTables.TableCustomer, budgetBaselines map[string]float64)
+	UpdateCustomerInMemory(ctx context.Context, customer *configstoreTables.TableCustomer, budgetBaselines BudgetBaselines)
 	DeleteCustomerInMemory(ctx context.Context, customerID string)
 	// Team level CheckUserBudget
-	CheckTeamBudget(ctx context.Context, teamID string, request *EvaluationRequest, baselines map[string]float64) (Decision, error)
-	CheckTeamRateLimit(ctx context.Context, teamID string, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error)
+	CheckTeamBudget(ctx context.Context, teamID string, request *EvaluationRequest, baselines BudgetBaselines) (Decision, error)
+	CheckTeamRateLimit(ctx context.Context, teamID string, request *EvaluationRequest, rateLimitBaselines RateLimitBaselines) (Decision, error)
 	// Team-level live budget/rate-limit collectors (resolved from the hot maps);
 	// used by the enterprise user→team→business-unit hierarchy collector.
 	CollectTeamBudgets(ctx context.Context, teamID string) []*configstoreTables.TableBudget
 	CollectTeamRateLimits(ctx context.Context, teamID string) []*configstoreTables.TableRateLimit
 	// Customer-level governance checks
-	CheckCustomerBudget(ctx context.Context, customerID string, request *EvaluationRequest, baselines map[string]float64) (Decision, error)
-	CheckCustomerRateLimit(ctx context.Context, customerID string, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error)
+	CheckCustomerBudget(ctx context.Context, customerID string, request *EvaluationRequest, baselines BudgetBaselines) (Decision, error)
+	CheckCustomerRateLimit(ctx context.Context, customerID string, request *EvaluationRequest, rateLimitBaselines RateLimitBaselines) (Decision, error)
 	// User governance in-memory operations (enterprise-only, but interface defined here for compatibility)
 	GetUserGovernance(ctx context.Context, userID string) (*UserGovernance, bool)
 	CreateUserGovernanceInMemory(ctx context.Context, userID string, budget *configstoreTables.TableBudget, rateLimit *configstoreTables.TableRateLimit)
@@ -208,8 +215,8 @@ type GovernanceStore interface {
 	DeleteUserGovernanceInMemory(ctx context.Context, userID string)
 	CreateUserNameInMemory(ctx context.Context, userID string, userName string)
 	// User-level governance checks (enterprise-only)
-	CheckUserBudget(ctx context.Context, userID string, request *EvaluationRequest, baselines map[string]float64) (Decision, error)
-	CheckUserRateLimit(ctx context.Context, userID string, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error)
+	CheckUserBudget(ctx context.Context, userID string, request *EvaluationRequest, baselines BudgetBaselines) (Decision, error)
+	CheckUserRateLimit(ctx context.Context, userID string, request *EvaluationRequest, rateLimitBaselines RateLimitBaselines) (Decision, error)
 	UpdateUserBudgetUsageInMemory(ctx context.Context, userID string, cost float64) error
 	UpdateUserRateLimitUsageInMemory(ctx context.Context, userID string, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error
 	// Model config in-memory operations
@@ -222,7 +229,7 @@ type GovernanceStore interface {
 	// Routing Rules CEL caching
 	GetRoutingProgram(ctx context.Context, rule *configstoreTables.TableRoutingRule) (cel.Program, error)
 	// Budget and rate limit status queries for routing with baseline support
-	GetBudgetAndRateLimitStatus(ctx context.Context, model string, provider schemas.ModelProvider, vk *configstoreTables.TableVirtualKey, budgetBaselines map[string]float64, tokenBaselines map[string]int64, requestBaselines map[string]int64) *BudgetAndRateLimitStatus
+	GetBudgetAndRateLimitStatus(ctx context.Context, model string, provider schemas.ModelProvider, vk *configstoreTables.TableVirtualKey, budgetBaselines BudgetBaselines, rateLimitBaselines RateLimitBaselines) *BudgetAndRateLimitStatus
 	// Routing Rules CRUD
 	HasRoutingRules(ctx context.Context) bool
 	GetAllRoutingRules(ctx context.Context) []*configstoreTables.TableRoutingRule
@@ -1177,7 +1184,11 @@ func (gs *LocalGovernanceStore) deleteVirtualKeyByValue(value string) {
 }
 
 // CheckRateLimit checks rate limits for tokens and requests across categories
-func (gs *LocalGovernanceStore) CheckRateLimit(ctx context.Context, entityWiseRateLimits EntityWiseRateLimits, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error) {
+func (gs *LocalGovernanceStore) CheckRateLimit(ctx context.Context, entityWiseRateLimits EntityWiseRateLimits, rateLimitBaselines RateLimitBaselines) (Decision, error) {
+	// Normalised here rather than only in the callers: a nil map was safe to
+	// index, but a nil interface is not, so the lowest-level consumer is the
+	// one place that has to be certain.
+	rateLimitBaselines = RateLimitBaselinesOrEmpty(rateLimitBaselines)
 	for entity, rateLimits := range entityWiseRateLimits {
 		for _, rateLimit := range rateLimits {
 			var violations []string
@@ -1202,14 +1213,8 @@ func (gs *LocalGovernanceStore) CheckRateLimit(ctx context.Context, entityWiseRa
 				}
 			}
 
-			tokensBaseline, exists := tokensBaselines[rateLimit.ID]
-			if !exists {
-				tokensBaseline = 0
-			}
-			requestsBaseline, exists := requestsBaselines[rateLimit.ID]
-			if !exists {
-				requestsBaseline = 0
-			}
+			tokensBaseline := rateLimitBaselines.TokenUsage(rateLimit.ID)
+			requestsBaseline := rateLimitBaselines.RequestUsage(rateLimit.ID)
 
 			// Token limits - check if total usage (local + remote baseline) exceeds limit
 			// Skip this check if token limit has expired
@@ -1252,7 +1257,11 @@ func (gs *LocalGovernanceStore) CheckRateLimit(ctx context.Context, entityWiseRa
 
 // Generic check budget method
 // The idea is to keep this as a common method for checking all budgets. The entire business logic resides in here
-func (gs *LocalGovernanceStore) CheckBudget(ctx context.Context, entityWiseBudgets EntityWiseBudgets, baselines map[string]float64) (Decision, error) {
+func (gs *LocalGovernanceStore) CheckBudget(ctx context.Context, entityWiseBudgets EntityWiseBudgets, baselines BudgetBaselines) (Decision, error) {
+	// Normalised here rather than only in the callers: a nil map was safe to
+	// index, but a nil interface is not, so the lowest-level consumer is the
+	// one place that has to be certain.
+	baselines = BudgetBaselinesOrEmpty(baselines)
 	// Check each budget in hierarchy order using in-memory data
 	now := time.Now()
 	for entity, budgets := range entityWiseBudgets {
@@ -1273,10 +1282,7 @@ func (gs *LocalGovernanceStore) CheckBudget(ctx context.Context, entityWiseBudge
 				gs.logger.Debug("LocalStore CheckBudget: Budget %s (%s) expired, skipping check", budget.ID, entity)
 				continue
 			}
-			baseline, exists := baselines[budget.ID]
-			if !exists {
-				baseline = 0
-			}
+			baseline := baselines.BudgetUsage(budget.ID)
 			effectiveMaxLimit := budget.EffectiveMaxLimit()
 			gs.logger.Debug("LocalStore CheckBudget: Checking %s budget %s: local=%.4f, remote=%.4f, total=%.4f, limit=%.4f",
 				entity, budget.ID, budget.CurrentUsage, baseline, budget.CurrentUsage+baseline, effectiveMaxLimit)
@@ -1292,14 +1298,11 @@ func (gs *LocalGovernanceStore) CheckBudget(ctx context.Context, entityWiseBudge
 }
 
 // CheckVirtualKeyBudget performs virtual key level budget checking using in-memory store data (lock-free for high performance)
-func (gs *LocalGovernanceStore) CheckVirtualKeyBudget(ctx context.Context, vk *configstoreTables.TableVirtualKey, request *EvaluationRequest, baselines map[string]float64) (Decision, error) {
+func (gs *LocalGovernanceStore) CheckVirtualKeyBudget(ctx context.Context, vk *configstoreTables.TableVirtualKey, request *EvaluationRequest, baselines BudgetBaselines) (Decision, error) {
 	if vk == nil {
 		return DecisionVirtualKeyNotFound, fmt.Errorf("virtual key cannot be nil")
 	}
-	// This is to prevent nil pointer dereference
-	if baselines == nil {
-		baselines = map[string]float64{}
-	}
+	baselines = BudgetBaselinesOrEmpty(baselines)
 	// Extract provider from request
 	var provider schemas.ModelProvider
 	if request != nil {
@@ -1307,19 +1310,12 @@ func (gs *LocalGovernanceStore) CheckVirtualKeyBudget(ctx context.Context, vk *c
 	}
 	// Use helper to collect budgets and their names (lock-free)
 	budgetsWithCategories := gs.collectBudgetsFromHierarchy(ctx, vk, provider)
-	gs.logger.Debug("LocalStore CheckBudget: Received %d baselines from remote nodes", len(baselines))
-	for budgetID, baseline := range baselines {
-		gs.logger.Debug("  - Baseline for budget %s: %.4f", budgetID, baseline)
-	}
 	return gs.CheckBudget(ctx, budgetsWithCategories, baselines)
 }
 
 // CheckProviderBudget performs budget checking for provider-level configs (lock-free for high performance)
-func (gs *LocalGovernanceStore) CheckProviderBudget(ctx context.Context, request *EvaluationRequest, baselines map[string]float64) (Decision, error) {
-	// This is to prevent nil pointer dereference
-	if baselines == nil {
-		baselines = map[string]float64{}
-	}
+func (gs *LocalGovernanceStore) CheckProviderBudget(ctx context.Context, request *EvaluationRequest, baselines BudgetBaselines) (Decision, error) {
+	baselines = BudgetBaselinesOrEmpty(baselines)
 	// Extract provider from request
 	var provider schemas.ModelProvider
 	if request != nil {
@@ -1346,7 +1342,7 @@ func (gs *LocalGovernanceStore) CheckProviderBudget(ctx context.Context, request
 }
 
 // CheckProviderRateLimit checks provider-level rate limits and returns evaluation result if violated
-func (gs *LocalGovernanceStore) CheckProviderRateLimit(ctx context.Context, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error) {
+func (gs *LocalGovernanceStore) CheckProviderRateLimit(ctx context.Context, request *EvaluationRequest, rateLimitBaselines RateLimitBaselines) (Decision, error) {
 	// Extract provider from request
 	var provider schemas.ModelProvider
 	if request != nil {
@@ -1369,7 +1365,7 @@ func (gs *LocalGovernanceStore) CheckProviderRateLimit(ctx context.Context, requ
 	if rateLimit == nil {
 		return DecisionAllow, nil
 	}
-	return gs.CheckRateLimit(ctx, EntityWiseRateLimits{providerKey: []*configstoreTables.TableRateLimit{rateLimit}}, tokensBaselines, requestsBaselines)
+	return gs.CheckRateLimit(ctx, EntityWiseRateLimits{providerKey: []*configstoreTables.TableRateLimit{rateLimit}}, rateLimitBaselines)
 }
 
 const modelConfigWildcard = configstoreTables.ModelConfigAllModels
@@ -1519,11 +1515,8 @@ func (gs *LocalGovernanceStore) loadModelConfigBudgets(ctx context.Context, mc *
 
 // CheckModelBudget performs budget checking for global-scope model-level configs, across all
 // four tiers (exact model±provider and all-models "*"±provider).
-func (gs *LocalGovernanceStore) CheckModelBudget(ctx context.Context, request *EvaluationRequest, baselines map[string]float64) (Decision, error) {
-	// This is to prevent nil pointer dereference
-	if baselines == nil {
-		baselines = map[string]float64{}
-	}
+func (gs *LocalGovernanceStore) CheckModelBudget(ctx context.Context, request *EvaluationRequest, baselines BudgetBaselines) (Decision, error) {
+	baselines = BudgetBaselinesOrEmpty(baselines)
 	model, provider := extractModelAndProvider(request)
 	entityWiseBudgets := EntityWiseBudgets{}
 	for _, mc := range gs.collectModelConfigsFor(ctx, configstoreTables.ModelConfigScopeGlobal, "", model, provider) {
@@ -1535,13 +1528,11 @@ func (gs *LocalGovernanceStore) CheckModelBudget(ctx context.Context, request *E
 }
 
 // CheckTeamBudget checks team-level budget and returns evaluation result if violated
-func (gs *LocalGovernanceStore) CheckTeamBudget(ctx context.Context, teamID string, request *EvaluationRequest, baselines map[string]float64) (Decision, error) {
+func (gs *LocalGovernanceStore) CheckTeamBudget(ctx context.Context, teamID string, request *EvaluationRequest, baselines BudgetBaselines) (Decision, error) {
 	if teamID == "" {
 		return DecisionAllow, nil
 	}
-	if baselines == nil {
-		baselines = map[string]float64{}
-	}
+	baselines = BudgetBaselinesOrEmpty(baselines)
 	teamValue, exists := gs.teams.Load(teamID)
 	if !exists || teamValue == nil {
 		return DecisionAllow, nil
@@ -1564,13 +1555,8 @@ func (gs *LocalGovernanceStore) CheckTeamBudget(ctx context.Context, teamID stri
 }
 
 // CheckTeamRateLimit checks team-level rate limit and returns evaluation result if violated
-func (gs *LocalGovernanceStore) CheckTeamRateLimit(ctx context.Context, teamID string, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error) {
-	if tokensBaselines == nil {
-		tokensBaselines = map[string]int64{}
-	}
-	if requestsBaselines == nil {
-		requestsBaselines = map[string]int64{}
-	}
+func (gs *LocalGovernanceStore) CheckTeamRateLimit(ctx context.Context, teamID string, request *EvaluationRequest, rateLimitBaselines RateLimitBaselines) (Decision, error) {
+	rateLimitBaselines = RateLimitBaselinesOrEmpty(rateLimitBaselines)
 	teamValue, exists := gs.teams.Load(teamID)
 	if !exists || teamValue == nil {
 		return DecisionAllow, nil
@@ -1585,7 +1571,7 @@ func (gs *LocalGovernanceStore) CheckTeamRateLimit(ctx context.Context, teamID s
 	}
 	key := fmt.Sprintf("Team:%s", teamID)
 	entityWiseRateLimits := EntityWiseRateLimits{key: {teamRateLimit}}
-	return gs.CheckRateLimit(ctx, entityWiseRateLimits, tokensBaselines, requestsBaselines)
+	return gs.CheckRateLimit(ctx, entityWiseRateLimits, rateLimitBaselines)
 }
 
 // CollectTeamBudgets returns the live budget objects configured for a team,
@@ -1736,13 +1722,11 @@ func (gs *LocalGovernanceStore) GetCustomerName(ctx context.Context, customerID 
 }
 
 // CheckCustomerBudget checks customer-level budget and returns evaluation result if violated
-func (gs *LocalGovernanceStore) CheckCustomerBudget(ctx context.Context, customerID string, request *EvaluationRequest, baselines map[string]float64) (Decision, error) {
+func (gs *LocalGovernanceStore) CheckCustomerBudget(ctx context.Context, customerID string, request *EvaluationRequest, baselines BudgetBaselines) (Decision, error) {
 	if customerID == "" {
 		return DecisionAllow, nil
 	}
-	if baselines == nil {
-		baselines = map[string]float64{}
-	}
+	baselines = BudgetBaselinesOrEmpty(baselines)
 	customerValue, exists := gs.customers.Load(customerID)
 	if !exists || customerValue == nil {
 		return DecisionAllow, nil
@@ -1766,16 +1750,11 @@ func (gs *LocalGovernanceStore) CheckCustomerBudget(ctx context.Context, custome
 }
 
 // CheckCustomerRateLimit checks customer-level rate limit and returns evaluation result if violated
-func (gs *LocalGovernanceStore) CheckCustomerRateLimit(ctx context.Context, customerID string, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error) {
+func (gs *LocalGovernanceStore) CheckCustomerRateLimit(ctx context.Context, customerID string, request *EvaluationRequest, rateLimitBaselines RateLimitBaselines) (Decision, error) {
 	if customerID == "" {
 		return DecisionAllow, nil
 	}
-	if tokensBaselines == nil {
-		tokensBaselines = map[string]int64{}
-	}
-	if requestsBaselines == nil {
-		requestsBaselines = map[string]int64{}
-	}
+	rateLimitBaselines = RateLimitBaselinesOrEmpty(rateLimitBaselines)
 	customerValue, exists := gs.customers.Load(customerID)
 	if !exists || customerValue == nil {
 		return DecisionAllow, nil
@@ -1790,24 +1769,19 @@ func (gs *LocalGovernanceStore) CheckCustomerRateLimit(ctx context.Context, cust
 	}
 	key := fmt.Sprintf("Customer:%s", customerID)
 	entityWiseRateLimits := EntityWiseRateLimits{key: {customerRateLimit}}
-	return gs.CheckRateLimit(ctx, entityWiseRateLimits, tokensBaselines, requestsBaselines)
+	return gs.CheckRateLimit(ctx, entityWiseRateLimits, rateLimitBaselines)
 }
 
 // CheckUserBudget checks if user's budget allows the request (enterprise-only)
 // Community build: silent no-op so user-governance absence never silently denies requests.
-func (gs *LocalGovernanceStore) CheckUserBudget(ctx context.Context, userID string, request *EvaluationRequest, baselines map[string]float64) (Decision, error) {
+func (gs *LocalGovernanceStore) CheckUserBudget(ctx context.Context, userID string, request *EvaluationRequest, baselines BudgetBaselines) (Decision, error) {
 	return DecisionAllow, nil
 }
 
 // CheckModelRateLimit checks global-scope model-level rate limits across all four tiers
-func (gs *LocalGovernanceStore) CheckModelRateLimit(ctx context.Context, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error) {
+func (gs *LocalGovernanceStore) CheckModelRateLimit(ctx context.Context, request *EvaluationRequest, rateLimitBaselines RateLimitBaselines) (Decision, error) {
 	// This is to prevent nil pointer dereference
-	if tokensBaselines == nil {
-		tokensBaselines = map[string]int64{}
-	}
-	if requestsBaselines == nil {
-		requestsBaselines = map[string]int64{}
-	}
+	rateLimitBaselines = RateLimitBaselinesOrEmpty(rateLimitBaselines)
 	model, provider := extractModelAndProvider(request)
 	entityWiseRateLimits := make(EntityWiseRateLimits)
 	for _, mc := range gs.collectModelConfigsFor(ctx, configstoreTables.ModelConfigScopeGlobal, "", model, provider) {
@@ -1818,19 +1792,17 @@ func (gs *LocalGovernanceStore) CheckModelRateLimit(ctx context.Context, request
 			entityWiseRateLimits[modelConfigEntityKey(mc)] = []*configstoreTables.TableRateLimit{rateLimit}
 		}
 	}
-	return gs.CheckRateLimit(ctx, entityWiseRateLimits, tokensBaselines, requestsBaselines)
+	return gs.CheckRateLimit(ctx, entityWiseRateLimits, rateLimitBaselines)
 }
 
 // CheckScopedModelBudget enforces budgets from model configs scoped to the given
 // (scope, scopeID) — e.g. ("virtual_key", vk.ID). Checked in addition to the global
 // model budgets; a request must satisfy both. Empty scope or scopeID is a no-op.
-func (gs *LocalGovernanceStore) CheckScopedModelBudget(ctx context.Context, scope, scopeID string, request *EvaluationRequest, baselines map[string]float64) (Decision, error) {
+func (gs *LocalGovernanceStore) CheckScopedModelBudget(ctx context.Context, scope, scopeID string, request *EvaluationRequest, baselines BudgetBaselines) (Decision, error) {
 	if scope == "" || scopeID == "" {
 		return DecisionAllow, nil
 	}
-	if baselines == nil {
-		baselines = map[string]float64{}
-	}
+	baselines = BudgetBaselinesOrEmpty(baselines)
 	model, provider := extractModelAndProvider(request)
 	entityWiseBudgets := EntityWiseBudgets{}
 	for _, mc := range gs.collectModelConfigsFor(ctx, scope, scopeID, model, provider) {
@@ -1843,16 +1815,11 @@ func (gs *LocalGovernanceStore) CheckScopedModelBudget(ctx context.Context, scop
 
 // CheckScopedModelRateLimit enforces rate limits from model configs scoped to the given
 // (scope, scopeID), in addition to the global model rate limits.
-func (gs *LocalGovernanceStore) CheckScopedModelRateLimit(ctx context.Context, scope, scopeID string, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error) {
+func (gs *LocalGovernanceStore) CheckScopedModelRateLimit(ctx context.Context, scope, scopeID string, request *EvaluationRequest, rateLimitBaselines RateLimitBaselines) (Decision, error) {
 	if scope == "" || scopeID == "" {
 		return DecisionAllow, nil
 	}
-	if tokensBaselines == nil {
-		tokensBaselines = map[string]int64{}
-	}
-	if requestsBaselines == nil {
-		requestsBaselines = map[string]int64{}
-	}
+	rateLimitBaselines = RateLimitBaselinesOrEmpty(rateLimitBaselines)
 	model, provider := extractModelAndProvider(request)
 	entityWiseRateLimits := make(EntityWiseRateLimits)
 	for _, mc := range gs.collectModelConfigsFor(ctx, scope, scopeID, model, provider) {
@@ -1863,17 +1830,17 @@ func (gs *LocalGovernanceStore) CheckScopedModelRateLimit(ctx context.Context, s
 			entityWiseRateLimits[modelConfigEntityKey(mc)] = []*configstoreTables.TableRateLimit{rateLimit}
 		}
 	}
-	return gs.CheckRateLimit(ctx, entityWiseRateLimits, tokensBaselines, requestsBaselines)
+	return gs.CheckRateLimit(ctx, entityWiseRateLimits, rateLimitBaselines)
 }
 
 // CheckUserRateLimit checks if user's rate limit allows the request (enterprise-only)
 // Community build: silent no-op so user-governance absence never silently denies requests.
-func (gs *LocalGovernanceStore) CheckUserRateLimit(ctx context.Context, userID string, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error) {
+func (gs *LocalGovernanceStore) CheckUserRateLimit(ctx context.Context, userID string, request *EvaluationRequest, rateLimitBaselines RateLimitBaselines) (Decision, error) {
 	return DecisionAllow, nil
 }
 
 // CheckVirtualKeyRateLimit checks a virtual key  rate limit and returns evaluation result if violated (true if violated, false if not)
-func (gs *LocalGovernanceStore) CheckVirtualKeyRateLimit(ctx context.Context, vk *configstoreTables.TableVirtualKey, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error) {
+func (gs *LocalGovernanceStore) CheckVirtualKeyRateLimit(ctx context.Context, vk *configstoreTables.TableVirtualKey, request *EvaluationRequest, rateLimitBaselines RateLimitBaselines) (Decision, error) {
 	// Extract provider from request
 	var provider schemas.ModelProvider
 	if request != nil {
@@ -1882,13 +1849,8 @@ func (gs *LocalGovernanceStore) CheckVirtualKeyRateLimit(ctx context.Context, vk
 	// Collect rate limits and their names from the hierarchy
 	entityWiseRateLimits := gs.collectRateLimitsFromHierarchy(ctx, vk, provider)
 	// This is to prevent nil pointer dereference
-	if tokensBaselines == nil {
-		tokensBaselines = map[string]int64{}
-	}
-	if requestsBaselines == nil {
-		requestsBaselines = map[string]int64{}
-	}
-	return gs.CheckRateLimit(ctx, entityWiseRateLimits, tokensBaselines, requestsBaselines)
+	rateLimitBaselines = RateLimitBaselinesOrEmpty(rateLimitBaselines)
+	return gs.CheckRateLimit(ctx, entityWiseRateLimits, rateLimitBaselines)
 }
 
 // UpdateVirtualKeyBudgetUsageInMemory performs atomic budget updates across the hierarchy (both in memory and in database)
@@ -2683,17 +2645,12 @@ func (gs *LocalGovernanceStore) resetRateLimitDimensionBatch(ctx context.Context
 }
 
 // DumpRateLimits dumps all rate limits to the database
-func (gs *LocalGovernanceStore) DumpRateLimits(ctx context.Context, tokenBaselines map[string]int64, requestBaselines map[string]int64) error {
+func (gs *LocalGovernanceStore) DumpRateLimits(ctx context.Context, rateLimitBaselines RateLimitBaselines) error {
 	if gs.configStore == nil {
 		return nil
 	}
 	// This is to prevent nil pointer dereference
-	if tokenBaselines == nil {
-		tokenBaselines = map[string]int64{}
-	}
-	if requestBaselines == nil {
-		requestBaselines = map[string]int64{}
-	}
+	rateLimitBaselines = RateLimitBaselinesOrEmpty(rateLimitBaselines)
 	// Range over ALL rate limits in memory (mirrors DumpBudgets pattern).
 	// This covers rate limits from every source: virtual keys, model configs,
 	// providers, teams, customers, AND access profiles — whose IDs were
@@ -2711,12 +2668,8 @@ func (gs *LocalGovernanceStore) DumpRateLimits(ctx context.Context, tokenBaselin
 			RequestCurrentUsage: rateLimit.RequestCurrentUsage,
 			RequestLastReset:    rateLimit.RequestLastReset,
 		}
-		if tokenBaseline, exists := tokenBaselines[rateLimit.ID]; exists {
-			update.TokenCurrentUsage += tokenBaseline
-		}
-		if requestBaseline, exists := requestBaselines[rateLimit.ID]; exists {
-			update.RequestCurrentUsage += requestBaseline
-		}
+		update.TokenCurrentUsage += rateLimitBaselines.TokenUsage(rateLimit.ID)
+		update.RequestCurrentUsage += rateLimitBaselines.RequestUsage(rateLimit.ID)
 		rateLimitUpdates = append(rateLimitUpdates, update)
 		return true
 	})
@@ -2752,7 +2705,7 @@ func (gs *LocalGovernanceStore) DumpRateLimits(ctx context.Context, tokenBaselin
 // Split into a snapshot and a write so the gap between them is expressible in a
 // test: that gap is where an operator reset can land, and the reset generations
 // taken here are what let the write recognise a row cleared underneath it.
-func (gs *LocalGovernanceStore) DumpBudgets(ctx context.Context, baselines map[string]float64) error {
+func (gs *LocalGovernanceStore) DumpBudgets(ctx context.Context, baselines BudgetBaselines) error {
 	if gs.configStore == nil {
 		return nil
 	}
@@ -2762,11 +2715,8 @@ func (gs *LocalGovernanceStore) DumpBudgets(ctx context.Context, baselines map[s
 
 // snapshotBudgetRows captures every budget's current usage as dump rows, together
 // with the reset generation each row was read at.
-func (gs *LocalGovernanceStore) snapshotBudgetRows(baselines map[string]float64) ([]budgetDumpRow, map[string]uint64) {
-	// This is to prevent nil pointer dereference
-	if baselines == nil {
-		baselines = map[string]float64{}
-	}
+func (gs *LocalGovernanceStore) snapshotBudgetRows(baselines BudgetBaselines) ([]budgetDumpRow, map[string]uint64) {
+	baselines = BudgetBaselinesOrEmpty(baselines)
 	// Read the generations first. Taking them before the budgets means a reset that
 	// races this snapshot is either fully visible in both, or shows up as a bumped
 	// generation later; it can never look unchanged while the usage read was stale.
@@ -2786,10 +2736,7 @@ func (gs *LocalGovernanceStore) snapshotBudgetRows(baselines map[string]float64)
 	for _, budget := range budgets {
 		// Fold this node's view of remote usage in before writing so every node
 		// persists the same cluster-wide total.
-		newUsage := budget.CurrentUsage
-		if baseline, exists := baselines[budget.ID]; exists {
-			newUsage += baseline
-		}
+		newUsage := budget.CurrentUsage + baselines.BudgetUsage(budget.ID)
 		rows = append(rows, budgetDumpRow{
 			ID:                      budget.ID,
 			CurrentUsage:            newUsage,
@@ -3584,7 +3531,7 @@ func (gs *LocalGovernanceStore) CreateVirtualKeyInMemory(ctx context.Context, vk
 }
 
 // UpdateVirtualKeyInMemory updates an existing virtual key in the in-memory store (lock-free)
-func (gs *LocalGovernanceStore) UpdateVirtualKeyInMemory(ctx context.Context, vk *configstoreTables.TableVirtualKey, budgetBaselines map[string]float64, rateLimitTokensBaselines map[string]int64, rateLimitRequestsBaselines map[string]int64) {
+func (gs *LocalGovernanceStore) UpdateVirtualKeyInMemory(ctx context.Context, vk *configstoreTables.TableVirtualKey, budgetBaselines BudgetBaselines, rateLimitBaselines RateLimitBaselines) {
 	if vk == nil {
 		return // Nothing to update
 	}
@@ -3867,7 +3814,7 @@ func (gs *LocalGovernanceStore) CreateTeamInMemory(ctx context.Context, team *co
 }
 
 // UpdateTeamInMemory updates an existing team in the in-memory store (lock-free)
-func (gs *LocalGovernanceStore) UpdateTeamInMemory(ctx context.Context, team *configstoreTables.TableTeam, budgetBaselines map[string]float64) {
+func (gs *LocalGovernanceStore) UpdateTeamInMemory(ctx context.Context, team *configstoreTables.TableTeam, budgetBaselines BudgetBaselines) {
 	if team == nil {
 		return // Nothing to update
 	}
@@ -3995,7 +3942,7 @@ func (gs *LocalGovernanceStore) CreateCustomerInMemory(ctx context.Context, cust
 }
 
 // UpdateCustomerInMemory updates an existing customer in the in-memory store (lock-free)
-func (gs *LocalGovernanceStore) UpdateCustomerInMemory(ctx context.Context, customer *configstoreTables.TableCustomer, budgetBaselines map[string]float64) {
+func (gs *LocalGovernanceStore) UpdateCustomerInMemory(ctx context.Context, customer *configstoreTables.TableCustomer, budgetBaselines BudgetBaselines) {
 	if customer == nil {
 		return // Nothing to update
 	}
@@ -4651,17 +4598,10 @@ func (gs *LocalGovernanceStore) GetRoutingProgram(ctx context.Context, rule *con
 
 // GetBudgetAndRateLimitStatus returns the current budget and rate limit status for provider and model combination
 // Accounts for baseline usage from remote nodes when calculating percentages
-func (gs *LocalGovernanceStore) GetBudgetAndRateLimitStatus(ctx context.Context, model string, provider schemas.ModelProvider, vk *configstoreTables.TableVirtualKey, budgetBaselines map[string]float64, tokenBaselines map[string]int64, requestBaselines map[string]int64) *BudgetAndRateLimitStatus {
+func (gs *LocalGovernanceStore) GetBudgetAndRateLimitStatus(ctx context.Context, model string, provider schemas.ModelProvider, vk *configstoreTables.TableVirtualKey, budgetBaselines BudgetBaselines, rateLimitBaselines RateLimitBaselines) *BudgetAndRateLimitStatus {
 	// Prevent nil pointer dereferences
-	if budgetBaselines == nil {
-		budgetBaselines = map[string]float64{}
-	}
-	if tokenBaselines == nil {
-		tokenBaselines = map[string]int64{}
-	}
-	if requestBaselines == nil {
-		requestBaselines = map[string]int64{}
-	}
+	budgetBaselines = BudgetBaselinesOrEmpty(budgetBaselines)
+	rateLimitBaselines = RateLimitBaselinesOrEmpty(rateLimitBaselines)
 
 	result := &BudgetAndRateLimitStatus{
 		BudgetPercentUsed:           0,
@@ -4681,14 +4621,14 @@ func (gs *LocalGovernanceStore) GetBudgetAndRateLimitStatus(ctx context.Context,
 			if rateLimitValue, ok := gs.rateLimits.Load(*modelConfig.RateLimitID); ok && rateLimitValue != nil {
 				if rateLimit, ok := rateLimitValue.(*configstoreTables.TableRateLimit); ok && rateLimit != nil {
 					if rateLimit.TokenMaxLimit != nil && *rateLimit.TokenMaxLimit > 0 {
-						tokenPercent := float64(rateLimit.TokenCurrentUsage+tokenBaselines[rateLimit.ID]) / float64(*rateLimit.TokenMaxLimit) * 100
+						tokenPercent := float64(rateLimit.TokenCurrentUsage+rateLimitBaselines.TokenUsage(rateLimit.ID)) / float64(*rateLimit.TokenMaxLimit) * 100
 						if tokenPercent > result.RateLimitTokenPercentUsed {
 							result.RateLimitTokenPercentUsed = tokenPercent
 						}
 					}
 					// Calculate request percent used
 					if rateLimit.RequestMaxLimit != nil && *rateLimit.RequestMaxLimit > 0 {
-						requestPercent := float64(rateLimit.RequestCurrentUsage+requestBaselines[rateLimit.ID]) / float64(*rateLimit.RequestMaxLimit) * 100
+						requestPercent := float64(rateLimit.RequestCurrentUsage+rateLimitBaselines.RequestUsage(rateLimit.ID)) / float64(*rateLimit.RequestMaxLimit) * 100
 						if requestPercent > result.RateLimitRequestPercentUsed {
 							result.RateLimitRequestPercentUsed = requestPercent
 						}
@@ -4701,7 +4641,7 @@ func (gs *LocalGovernanceStore) GetBudgetAndRateLimitStatus(ctx context.Context,
 			if budgetValue, ok := gs.budgets.Load(modelConfig.Budgets[bi].ID); ok && budgetValue != nil {
 				if budget, ok := budgetValue.(*configstoreTables.TableBudget); ok && budget != nil {
 					if effectiveMaxLimit := budget.EffectiveMaxLimit(); effectiveMaxLimit > 0 {
-						budgetPercent := float64(budget.CurrentUsage+budgetBaselines[budget.ID]) / effectiveMaxLimit * 100
+						budgetPercent := float64(budget.CurrentUsage+budgetBaselines.BudgetUsage(budget.ID)) / effectiveMaxLimit * 100
 						if budgetPercent > result.BudgetPercentUsed {
 							result.BudgetPercentUsed = budgetPercent
 						}
@@ -4740,14 +4680,14 @@ func (gs *LocalGovernanceStore) GetBudgetAndRateLimitStatus(ctx context.Context,
 					if rateLimit, ok := rateLimitValue.(*configstoreTables.TableRateLimit); ok && rateLimit != nil {
 						// Calculate token percent used
 						if rateLimit.TokenMaxLimit != nil && *rateLimit.TokenMaxLimit > 0 {
-							tokenPercent := float64(rateLimit.TokenCurrentUsage+tokenBaselines[rateLimit.ID]) / float64(*rateLimit.TokenMaxLimit) * 100
+							tokenPercent := float64(rateLimit.TokenCurrentUsage+rateLimitBaselines.TokenUsage(rateLimit.ID)) / float64(*rateLimit.TokenMaxLimit) * 100
 							if tokenPercent > result.RateLimitTokenPercentUsed {
 								result.RateLimitTokenPercentUsed = tokenPercent
 							}
 						}
 						// Calculate request percent used
 						if rateLimit.RequestMaxLimit != nil && *rateLimit.RequestMaxLimit > 0 {
-							requestPercent := float64(rateLimit.RequestCurrentUsage+requestBaselines[rateLimit.ID]) / float64(*rateLimit.RequestMaxLimit) * 100
+							requestPercent := float64(rateLimit.RequestCurrentUsage+rateLimitBaselines.RequestUsage(rateLimit.ID)) / float64(*rateLimit.RequestMaxLimit) * 100
 							if requestPercent > result.RateLimitRequestPercentUsed {
 								result.RateLimitRequestPercentUsed = requestPercent
 							}
@@ -4760,7 +4700,7 @@ func (gs *LocalGovernanceStore) GetBudgetAndRateLimitStatus(ctx context.Context,
 				if budgetValue, ok := gs.budgets.Load(*providerTable.BudgetID); ok && budgetValue != nil {
 					if budget, ok := budgetValue.(*configstoreTables.TableBudget); ok && budget != nil {
 						if effectiveMaxLimit := budget.EffectiveMaxLimit(); effectiveMaxLimit > 0 {
-							budgetPercent := float64(budget.CurrentUsage+budgetBaselines[budget.ID]) / effectiveMaxLimit * 100
+							budgetPercent := float64(budget.CurrentUsage+budgetBaselines.BudgetUsage(budget.ID)) / effectiveMaxLimit * 100
 							if budgetPercent > result.BudgetPercentUsed {
 								result.BudgetPercentUsed = budgetPercent
 							}
@@ -4784,14 +4724,14 @@ func (gs *LocalGovernanceStore) GetBudgetAndRateLimitStatus(ctx context.Context,
 							if rateLimit, ok := rateLimitValue.(*configstoreTables.TableRateLimit); ok && rateLimit != nil {
 								// Calculate token percent used
 								if rateLimit.TokenMaxLimit != nil && *rateLimit.TokenMaxLimit > 0 {
-									tokenPercent := float64(rateLimit.TokenCurrentUsage+tokenBaselines[rateLimit.ID]) / float64(*rateLimit.TokenMaxLimit) * 100
+									tokenPercent := float64(rateLimit.TokenCurrentUsage+rateLimitBaselines.TokenUsage(rateLimit.ID)) / float64(*rateLimit.TokenMaxLimit) * 100
 									if tokenPercent > result.RateLimitTokenPercentUsed {
 										result.RateLimitTokenPercentUsed = tokenPercent
 									}
 								}
 								// Calculate request percent used
 								if rateLimit.RequestMaxLimit != nil && *rateLimit.RequestMaxLimit > 0 {
-									requestPercent := float64(rateLimit.RequestCurrentUsage+requestBaselines[rateLimit.ID]) / float64(*rateLimit.RequestMaxLimit) * 100
+									requestPercent := float64(rateLimit.RequestCurrentUsage+rateLimitBaselines.RequestUsage(rateLimit.ID)) / float64(*rateLimit.RequestMaxLimit) * 100
 									if requestPercent > result.RateLimitRequestPercentUsed {
 										result.RateLimitRequestPercentUsed = requestPercent
 									}
@@ -4804,7 +4744,7 @@ func (gs *LocalGovernanceStore) GetBudgetAndRateLimitStatus(ctx context.Context,
 						if budgetValue, ok := gs.budgets.Load(b.ID); ok && budgetValue != nil {
 							if budget, ok := budgetValue.(*configstoreTables.TableBudget); ok && budget != nil {
 								if effectiveMaxLimit := budget.EffectiveMaxLimit(); effectiveMaxLimit > 0 {
-									budgetPercent := float64(budget.CurrentUsage+budgetBaselines[budget.ID]) / effectiveMaxLimit * 100
+									budgetPercent := float64(budget.CurrentUsage+budgetBaselines.BudgetUsage(budget.ID)) / effectiveMaxLimit * 100
 									if budgetPercent > result.BudgetPercentUsed {
 										result.BudgetPercentUsed = budgetPercent
 									}

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -174,7 +174,7 @@ func TestGovernanceStoreCheckBudgetUsesOverride(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, DecisionAllow, decision)
 
-	decision, err = store.CheckBudget(context.Background(), EntityWiseBudgets{"VirtualKey": {budget}}, map[string]float64{budget.ID: 15})
+	decision, err = store.CheckBudget(context.Background(), EntityWiseBudgets{"VirtualKey": {budget}}, MapBudgetBaselines{budget.ID: 15})
 	require.Error(t, err)
 	assert.Equal(t, DecisionBudgetExceeded, decision)
 	assert.Contains(t, err.Error(), "125.0000 dollars")
@@ -674,7 +674,7 @@ func TestGovernanceStore_UpdateVirtualKeyInMemory_RotatedValueRemovesOldLookup(t
 
 	updated := *vk
 	updated.Value = *schemas.NewSecretVar("sk-bf-new")
-	store.UpdateVirtualKeyInMemory(context.Background(), &updated, nil, nil, nil)
+	store.UpdateVirtualKeyInMemory(context.Background(), &updated, nil, nil)
 
 	oldVK, oldFound := store.GetVirtualKey(context.Background(), "sk-bf-old")
 	assert.False(t, oldFound)
@@ -1106,14 +1106,14 @@ func TestGovernanceStore_RateLimitStatus(t *testing.T) {
 	store.providers.Store("openai", providerConfig)
 
 	// Get status
-	status := store.GetBudgetAndRateLimitStatus(context.Background(), "", schemas.ModelProvider("openai"), nil, nil, nil, nil)
+	status := store.GetBudgetAndRateLimitStatus(context.Background(), "", schemas.ModelProvider("openai"), nil, nil, nil)
 
 	assert.NotNil(t, status)
 	assert.Equal(t, 50.0, status.RateLimitTokenPercentUsed)
 
 	// Update usage to exhausted state
 	rl.TokenCurrentUsage = 1000
-	status = store.GetBudgetAndRateLimitStatus(context.Background(), "", schemas.ModelProvider("openai"), nil, nil, nil, nil)
+	status = store.GetBudgetAndRateLimitStatus(context.Background(), "", schemas.ModelProvider("openai"), nil, nil, nil)
 
 	assert.Equal(t, 100.0, status.RateLimitTokenPercentUsed)
 }
@@ -1141,14 +1141,14 @@ func TestGovernanceStore_BudgetStatus(t *testing.T) {
 	store.providers.Store("openai", providerConfig)
 
 	// Get status
-	status := store.GetBudgetAndRateLimitStatus(context.Background(), "", schemas.ModelProvider("openai"), nil, nil, nil, nil)
+	status := store.GetBudgetAndRateLimitStatus(context.Background(), "", schemas.ModelProvider("openai"), nil, nil, nil)
 
 	assert.NotNil(t, status)
 	assert.Equal(t, 60.0, status.BudgetPercentUsed)
 
 	// Update usage to exhausted state
 	budget.CurrentUsage = 100.0
-	status = store.GetBudgetAndRateLimitStatus(context.Background(), "", schemas.ModelProvider("openai"), nil, nil, nil, nil)
+	status = store.GetBudgetAndRateLimitStatus(context.Background(), "", schemas.ModelProvider("openai"), nil, nil, nil)
 
 	assert.Equal(t, 100.0, status.BudgetPercentUsed)
 }
@@ -1181,7 +1181,7 @@ func TestGetBudgetAndRateLimitStatus_VKScopedModelConfig(t *testing.T) {
 
 	store.virtualKeys.Store(vkValue, vk)
 
-	status := store.GetBudgetAndRateLimitStatus(context.Background(), "gpt-5", schemas.ModelProvider(providerName), vk, nil, nil, nil)
+	status := store.GetBudgetAndRateLimitStatus(context.Background(), "gpt-5", schemas.ModelProvider(providerName), vk, nil, nil)
 
 	require.NotNil(t, status)
 	assert.Greater(t, status.BudgetPercentUsed, 100.0, "VK-scoped model budget at 120%% must be visible to routing status")
@@ -1208,7 +1208,7 @@ func TestGetBudgetAndRateLimitStatus_VKScopedModelConfig_NoMatchOtherProvider(t 
 	store.virtualKeys.Store(vkValue, vk)
 
 	// Query for anthropic — should not see the openai-scoped budget.
-	status := store.GetBudgetAndRateLimitStatus(context.Background(), "claude-3-5-sonnet", schemas.ModelProvider("anthropic"), vk, nil, nil, nil)
+	status := store.GetBudgetAndRateLimitStatus(context.Background(), "claude-3-5-sonnet", schemas.ModelProvider("anthropic"), vk, nil, nil)
 
 	require.NotNil(t, status)
 	assert.Equal(t, 0.0, status.BudgetPercentUsed, "openai VK-scoped budget must not appear for anthropic requests")
@@ -1229,7 +1229,7 @@ func TestGetBudgetAndRateLimitStatus_GlobalModelConfig(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	status := store.GetBudgetAndRateLimitStatus(context.Background(), "gpt-5", schemas.ModelProvider(providerName), nil, nil, nil, nil)
+	status := store.GetBudgetAndRateLimitStatus(context.Background(), "gpt-5", schemas.ModelProvider(providerName), nil, nil, nil)
 
 	require.NotNil(t, status)
 	assert.Equal(t, 75.0, status.BudgetPercentUsed, "global model+provider budget must be visible to routing status")

--- a/plugins/governance/tracker.go
+++ b/plugins/governance/tracker.go
@@ -264,7 +264,7 @@ func (t *UsageTracker) resetExpiredCounters(ctx context.Context) {
 	}
 
 	// ==== PART 3: Dump all rate limits and budgets to database ====
-	if err := t.store.DumpRateLimits(ctx, nil, nil); err != nil {
+	if err := t.store.DumpRateLimits(ctx, nil); err != nil {
 		t.logger.Error("failed to dump rate limits to database: %v", err)
 	}
 	if err := t.store.DumpBudgets(ctx, nil); err != nil {
@@ -397,7 +397,7 @@ func (t *UsageTracker) Cleanup() error {
 	if err := t.store.DumpBudgets(context.Background(), nil); err != nil {
 		t.logger.Error("final budget dump on shutdown failed: %v", err)
 	}
-	if err := t.store.DumpRateLimits(context.Background(), nil, nil); err != nil {
+	if err := t.store.DumpRateLimits(context.Background(), nil); err != nil {
 		t.logger.Error("final rate-limit dump on shutdown failed: %v", err)
 	}
 

--- a/plugins/governance/usagesnapshot.go
+++ b/plugins/governance/usagesnapshot.go
@@ -1,0 +1,111 @@
+package governance
+
+import (
+	"time"
+
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+)
+
+// BudgetUsageSnapshot is one budget's usage counters, with none of the
+// configuration or relationships that hang off the budget itself.
+type BudgetUsageSnapshot struct {
+	CurrentUsage float64
+	LastReset    time.Time
+}
+
+// RateLimitUsageSnapshot is one rate limit's usage counters.
+type RateLimitUsageSnapshot struct {
+	TokenCurrentUsage   int64
+	RequestCurrentUsage int64
+	TokenLastReset      time.Time
+	RequestLastReset    time.Time
+}
+
+// RangeBudgetUsage calls fn for every budget's usage counters, stopping early
+// if fn returns false.
+//
+// This exists because cluster usage sync wants exactly these numbers and
+// nothing else. Reaching them through GetGovernanceData meant deep copying
+// every virtual key, team and customer, hydrating their budget slices and
+// sorting nested lists, then reading two fields off the result and discarding
+// the rest. On a deployment with a hundred thousand virtual keys that is a
+// hundred thousand struct copies every few seconds on every node, whether or
+// not any of it changed.
+//
+// Values are read from the live map, so a budget being charged concurrently may
+// be observed either side of that charge. Usage sync is eventually consistent
+// by design and re-reads on the next tick, so a single tick's skew is expected.
+func (gs *LocalGovernanceStore) RangeBudgetUsage(fn func(budgetID string, usage BudgetUsageSnapshot) bool) {
+	gs.budgets.Range(func(key, value any) bool {
+		budgetID, ok := key.(string)
+		if !ok {
+			return true
+		}
+		budget, ok := value.(*configstoreTables.TableBudget)
+		if !ok || budget == nil {
+			return true
+		}
+		return fn(budgetID, BudgetUsageSnapshot{
+			CurrentUsage: budget.CurrentUsage,
+			LastReset:    budget.LastReset,
+		})
+	})
+}
+
+// RangeRateLimitUsage calls fn for every rate limit's usage counters, stopping
+// early if fn returns false. See RangeBudgetUsage.
+func (gs *LocalGovernanceStore) RangeRateLimitUsage(fn func(rateLimitID string, usage RateLimitUsageSnapshot) bool) {
+	gs.rateLimits.Range(func(key, value any) bool {
+		rateLimitID, ok := key.(string)
+		if !ok {
+			return true
+		}
+		rateLimit, ok := value.(*configstoreTables.TableRateLimit)
+		if !ok || rateLimit == nil {
+			return true
+		}
+		return fn(rateLimitID, RateLimitUsageSnapshot{
+			TokenCurrentUsage:   rateLimit.TokenCurrentUsage,
+			RequestCurrentUsage: rateLimit.RequestCurrentUsage,
+			TokenLastReset:      rateLimit.TokenLastReset,
+			RequestLastReset:    rateLimit.RequestLastReset,
+		})
+	})
+}
+
+// BudgetUsageByID returns one budget's usage counters. Reports false when the
+// budget is not in memory, which a caller working from a list of recently
+// charged IDs must handle: the budget may have been deleted in between.
+func (gs *LocalGovernanceStore) BudgetUsageByID(budgetID string) (BudgetUsageSnapshot, bool) {
+	value, ok := gs.budgets.Load(budgetID)
+	if !ok {
+		return BudgetUsageSnapshot{}, false
+	}
+	budget, ok := value.(*configstoreTables.TableBudget)
+	if !ok || budget == nil {
+		return BudgetUsageSnapshot{}, false
+	}
+	return BudgetUsageSnapshot{
+		CurrentUsage: budget.CurrentUsage,
+		LastReset:    budget.LastReset,
+	}, true
+}
+
+// RateLimitUsageByID returns one rate limit's usage counters. See
+// BudgetUsageByID.
+func (gs *LocalGovernanceStore) RateLimitUsageByID(rateLimitID string) (RateLimitUsageSnapshot, bool) {
+	value, ok := gs.rateLimits.Load(rateLimitID)
+	if !ok {
+		return RateLimitUsageSnapshot{}, false
+	}
+	rateLimit, ok := value.(*configstoreTables.TableRateLimit)
+	if !ok || rateLimit == nil {
+		return RateLimitUsageSnapshot{}, false
+	}
+	return RateLimitUsageSnapshot{
+		TokenCurrentUsage:   rateLimit.TokenCurrentUsage,
+		RequestCurrentUsage: rateLimit.RequestCurrentUsage,
+		TokenLastReset:      rateLimit.TokenLastReset,
+		RequestLastReset:    rateLimit.RequestLastReset,
+	}, true
+}

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -456,7 +456,7 @@ func (s *BifrostHTTPServer) ReloadVirtualKey(ctx context.Context, id string) (*t
 	if existingVK, found := store.GetVirtualKeyByID(ctx, virtualKey.ID); found && existingVK != nil && existingVK.Value.IsSet() && existingVK.Value.GetValue() != virtualKey.Value.GetValue() {
 		s.MCPServerHandler.DeleteVKMCPServer(existingVK.Value.GetValue())
 	}
-	store.UpdateVirtualKeyInMemory(ctx, virtualKey, nil, nil, nil)
+	store.UpdateVirtualKeyInMemory(ctx, virtualKey, nil, nil)
 	// Snapshot in-memory VK-scoped config IDs before the upserts so we can evict
 	// the ones that no longer exist in the DB (e.g. a standalone VK adopted into
 	// an access profile has its VK-scoped governance model configs deleted).


### PR DESCRIPTION
## Summary

Replaces the raw `map[string]float64`, `map[string]int64` (tokens), and `map[string]int64` (requests) parameters used throughout the governance store's budget and rate-limit APIs with two typed interfaces: `BudgetBaselines` and `RateLimitBaselines`. This eliminates the need to materialise and copy full maps on every cluster-sync update, and removes dozens of scattered nil-guard patterns by centralising them in `BudgetBaselinesOrEmpty` / `RateLimitBaselinesOrEmpty`.

Two new files are introduced: `baselines.go` defines the interfaces and their map-backed adapters (`MapBudgetBaselines`, `MapRateLimitBaselines`), and `usagesnapshot.go` adds lightweight `BudgetUsageSnapshot` / `RateLimitUsageSnapshot` types together with `RangeBudgetUsage`, `RangeRateLimitUsage`, `BudgetUsageByID`, and `RateLimitUsageByID` on `LocalGovernanceStore`. These range/lookup methods let cluster-sync code read only the usage counters it needs without triggering a full `GetGovernanceData` rebuild.

## Changes

- **`baselines.go`** — introduces `BudgetBaselines` and `RateLimitBaselines` interfaces, `MapBudgetBaselines` / `MapRateLimitBaselines` map adapters for tests and single-node deployments, and `BudgetBaselinesOrEmpty` / `RateLimitBaselinesOrEmpty` helpers that return a zero-value adapter instead of nil, allocating nothing.
- **`usagesnapshot.go`** — adds `BudgetUsageSnapshot` and `RateLimitUsageSnapshot` structs, and four methods on `LocalGovernanceStore` (`RangeBudgetUsage`, `RangeRateLimitUsage`, `BudgetUsageByID`, `RateLimitUsageByID`) that read directly from the live sync maps without copying the full object graph.
- **`store.go` / `GovernanceStore` interface** — all `Check*`, `Dump*`, `Update*InMemory`, and `GetBudgetAndRateLimitStatus` signatures updated to accept `BudgetBaselines` / `RateLimitBaselines` instead of separate maps. The two separate token/request baseline maps for rate limits are collapsed into a single `RateLimitBaselines` argument everywhere. Nil-guard boilerplate at each call site is replaced by a single normalisation call at the lowest-level consumer (`CheckBudget`, `CheckRateLimit`).
- **`resolver.go`, `routing.go`, `main.go`, `tracker.go`, `server.go`** — call sites updated to match the new signatures; internal callers that previously passed `nil, nil` for the two rate-limit maps now pass a single `nil`.
- **Tests** — `map[string]float64` / `map[string]int64` literals replaced with `MapBudgetBaselines` / `MapRateLimitBaselines`, and `UpdateVirtualKeyInMemory` / `CheckProvider*` / `CheckModel*` calls updated to the collapsed signatures.

**Design decision:** interfaces rather than maps are used so that a holder of live, concurrently-mutated peer-usage data can implement the interface directly without publishing a full copy on every peer update. The `MapBudgetBaselines` / `MapRateLimitBaselines` adapters preserve the simple map semantics for tests and single-node cases at zero extra cost.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/...
go test ./transports/bifrost-http/...
```

All existing governance tests cover the refactored paths. No behaviour changes are expected; the nil-baseline and map-baseline cases are exercised by the existing test suite.

## Breaking changes

- [x] Yes
- [ ] No

Any external implementation of the `GovernanceStore` interface must update its method signatures to accept `BudgetBaselines` / `RateLimitBaselines` instead of the previous map types. The `UpdateVirtualKeyInMemory` signature drops one parameter (the two separate rate-limit maps become one `RateLimitBaselines`). Callers passing concrete `map[string]int64` values should wrap them in `MapRateLimitBaselines{Tokens: ..., Requests: ...}`.

## Related issues

## Security considerations

None. This is a pure API-shape refactor; no auth, secrets, or PII handling is changed.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable