### PR TITLE
feat(session aware routing): session contracts, identity resolution, and the KV session state store

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -67570,7 +67570,7 @@
                           "description": "Embedding model, e.g. text-embedding-3-small"
                         },
                         "timeout": {
-                          "description": "Ceiling on the inline embedding call. Accepts a duration string (\"1.5s\") or milliseconds as a number. Default 1.5s; exceeding it publishes no tier for that request.",
+                          "description": "Ceiling on the inline embedding call. Accepts a duration string (\"1.5s\") or milliseconds as a number and serializes as milliseconds. Default 1.5s; exceeding it publishes no tier for that request.",
                           "oneOf": [
                             {
                               "type": "string",
@@ -67739,7 +67739,7 @@
                         "description": "Embedding model, e.g. text-embedding-3-small"
                       },
                       "timeout": {
-                        "description": "Ceiling on the inline embedding call. Accepts a duration string (\"1.5s\") or milliseconds as a number. Default 1.5s; exceeding it publishes no tier for that request.",
+                        "description": "Ceiling on the inline embedding call. Accepts a duration string (\"1.5s\") or milliseconds as a number and serializes as milliseconds. Default 1.5s; exceeding it publishes no tier for that request.",
                         "oneOf": [
                           {
                             "type": "string",
@@ -67885,7 +67885,7 @@
                           "description": "Embedding model, e.g. text-embedding-3-small"
                         },
                         "timeout": {
-                          "description": "Ceiling on the inline embedding call. Accepts a duration string (\"1.5s\") or milliseconds as a number. Default 1.5s; exceeding it publishes no tier for that request.",
+                          "description": "Ceiling on the inline embedding call. Accepts a duration string (\"1.5s\") or milliseconds as a number and serializes as milliseconds. Default 1.5s; exceeding it publishes no tier for that request.",
                           "oneOf": [
                             {
                               "type": "string",
@@ -68072,7 +68072,7 @@
                           "description": "Embedding model, e.g. text-embedding-3-small"
                         },
                         "timeout": {
-                          "description": "Ceiling on the inline embedding call. Accepts a duration string (\"1.5s\") or milliseconds as a number. Default 1.5s; exceeding it publishes no tier for that request.",
+                          "description": "Ceiling on the inline embedding call. Accepts a duration string (\"1.5s\") or milliseconds as a number and serializes as milliseconds. Default 1.5s; exceeding it publishes no tier for that request.",
                           "oneOf": [
                             {
                               "type": "string",
@@ -68631,7 +68631,7 @@
                           "description": "Embedding model, e.g. text-embedding-3-small"
                         },
                         "timeout": {
-                          "description": "Ceiling on the inline embedding call. Accepts a duration string (\"1.5s\") or milliseconds as a number. Default 1.5s; exceeding it publishes no tier for that request.",
+                          "description": "Ceiling on the inline embedding call. Accepts a duration string (\"1.5s\") or milliseconds as a number and serializes as milliseconds. Default 1.5s; exceeding it publishes no tier for that request.",
                           "oneOf": [
                             {
                               "type": "string",
@@ -68801,7 +68801,7 @@
                         "description": "Embedding model, e.g. text-embedding-3-small"
                       },
                       "timeout": {
-                        "description": "Ceiling on the inline embedding call. Accepts a duration string (\"1.5s\") or milliseconds as a number. Default 1.5s; exceeding it publishes no tier for that request.",
+                        "description": "Ceiling on the inline embedding call. Accepts a duration string (\"1.5s\") or milliseconds as a number and serializes as milliseconds. Default 1.5s; exceeding it publishes no tier for that request.",
                         "oneOf": [
                           {
                             "type": "string",
@@ -68947,7 +68947,7 @@
                           "description": "Embedding model, e.g. text-embedding-3-small"
                         },
                         "timeout": {
-                          "description": "Ceiling on the inline embedding call. Accepts a duration string (\"1.5s\") or milliseconds as a number. Default 1.5s; exceeding it publishes no tier for that request.",
+                          "description": "Ceiling on the inline embedding call. Accepts a duration string (\"1.5s\") or milliseconds as a number and serializes as milliseconds. Default 1.5s; exceeding it publishes no tier for that request.",
                           "oneOf": [
                             {
                               "type": "string",
@@ -69135,7 +69135,7 @@
                           "description": "Embedding model, e.g. text-embedding-3-small"
                         },
                         "timeout": {
-                          "description": "Ceiling on the inline embedding call. Accepts a duration string (\"1.5s\") or milliseconds as a number. Default 1.5s; exceeding it publishes no tier for that request.",
+                          "description": "Ceiling on the inline embedding call. Accepts a duration string (\"1.5s\") or milliseconds as a number and serializes as milliseconds. Default 1.5s; exceeding it publishes no tier for that request.",
                           "oneOf": [
                             {
                               "type": "string",

--- a/docs/openapi/schemas/management/governance.yaml
+++ b/docs/openapi/schemas/management/governance.yaml
@@ -2182,7 +2182,7 @@ ComplexitySemanticConfig:
       minLength: 1
       description: Embedding model, e.g. text-embedding-3-small
     timeout:
-      description: Ceiling on the inline embedding call. Accepts a duration string ("1.5s") or milliseconds as a number. Default 1.5s; exceeding it publishes no tier for that request.
+      description: Ceiling on the inline embedding call. Accepts a duration string ("1.5s") or milliseconds as a number and serializes as milliseconds. Default 1.5s; exceeding it publishes no tier for that request.
       oneOf:
         - type: string
           pattern: '^[0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h)$'

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -1309,6 +1309,14 @@ func GenerateComplexityAnalyzerConfigHashes(config *ComplexityAnalyzerConfig) (C
 		hashes.SemanticSettings = settingsHash
 	}
 
+	if normalized.Session != nil {
+		settingsHash, err := hashComplexityValue(normalized.Session)
+		if err != nil {
+			return ComplexityAnalyzerConfigHashes{}, fmt.Errorf("failed to hash session settings: %w", err)
+		}
+		hashes.SessionSettings = settingsHash
+	}
+
 	return hashes, nil
 }
 

--- a/framework/configstore/complexityconfig.go
+++ b/framework/configstore/complexityconfig.go
@@ -246,17 +246,17 @@ func (c *ComplexitySemanticConfig) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON writes Timeout as a duration string so persisted configs decode
-// back to the same value (the default int encoding is nanoseconds, which the
-// millisecond-number decode path would misread).
+// MarshalJSON writes Timeout as milliseconds, matching the canonical JSON
+// representation for short request-path durations. UnmarshalJSON still accepts
+// duration strings for human-authored config files.
 func (c ComplexitySemanticConfig) MarshalJSON() ([]byte, error) {
 	type alias ComplexitySemanticConfig
-	var timeout string
+	var timeout int64
 	if c.Timeout != 0 {
-		timeout = c.Timeout.String()
+		timeout = c.Timeout.Milliseconds()
 	}
 	return json.Marshal(struct {
-		Timeout string `json:"timeout,omitempty"`
+		Timeout int64 `json:"timeout,omitempty"`
 		alias
 	}{
 		Timeout: timeout,
@@ -327,6 +327,292 @@ func (c *ComplexitySemanticConfig) Validate() error {
 	return nil
 }
 
+// Complexity session modes.
+//
+// "off" is a first-class value rather than only an absent block so the UI's
+// three-way toggle can disable session behaviour without discarding the TTL and
+// threshold settings an admin already tuned. A nil *ComplexitySessionConfig and
+// an explicit "off" are equivalent at runtime; use Enabled to test either.
+//
+// "pinned" classifies once per session and reuses the tier until the pin is
+// released. "cache_aware" classifies every turn whose routing rules consult
+// complexity and gates tier changes; it needs that proposal to decide.
+const (
+	ComplexitySessionModeOff        = "off"
+	ComplexitySessionModePinned     = "pinned"
+	ComplexitySessionModeCacheAware = "cache_aware"
+)
+
+// Complexity session identity sources, listed in resolution order: an explicit
+// x-bf-session-id header, then a harness-native ID.
+const (
+	ComplexitySessionIdentityHeader  = "header"
+	ComplexitySessionIdentityHarness = "harness"
+)
+
+// Complexity session defaults, applied by normalized when a field is unset.
+// SwitchMinSimilarity is deliberately absent: a sensible absolute value depends
+// on the exemplar set's score distribution, so it ships unset (no gating).
+const (
+	DefaultComplexitySessionTTL                  = time.Hour
+	DefaultComplexitySessionDowngradeAfterNTurns = 2
+)
+
+// ComplexitySessionInternalTTL is the fixed idle-expiry and upstream
+// key-affinity window every enabled session mode uses. Neither pinned nor
+// cache-aware mode reads TTL as part of its tier decision — pinned either
+// reuses a stored tier unconditionally or classifies once and persists;
+// cache-aware's switching policy (similarity, turn-persistence, escalation,
+// max-switches) never references it either, now that it has no
+// cache-evidence check left to bound. So this is not admin-tunable routing
+// policy for either mode — it only bounds how long an idle conversation's
+// stored record (and its sticky upstream API key) survives before the next
+// turn reclassifies from scratch. It starts equal to
+// DefaultComplexitySessionTTL so existing deployments see no behavior
+// change, but the two may diverge independently in the future.
+const ComplexitySessionInternalTTL = time.Hour
+
+// DefaultComplexitySessionIdentitySources is the identity ladder applied when
+// none is configured.
+func DefaultComplexitySessionIdentitySources() []string {
+	return []string{ComplexitySessionIdentityHeader, ComplexitySessionIdentityHarness}
+}
+
+// ComplexitySessionConfig gives the complexity router a memory of the
+// conversation a request belongs to. A nil value, like Mode "off", disables it.
+//
+// Session state is a memoised classifier result with a TTL, not an override of
+// routing: it replaces the lazy complexity computation, so every routing rule
+// still evaluates normally and only the classification is skipped.
+type ComplexitySessionConfig struct {
+	Mode string `json:"mode"`
+	// TTL is not consumed by the runtime under either enabled mode — see
+	// ComplexitySessionInternalTTL, which both use instead. It is still
+	// stored and validated so already-persisted configs need no migration,
+	// and so a hand-edited or API-written config.json does not fail to parse.
+	TTL time.Duration `json:"ttl,omitempty"`
+	// IdentitySources selects which of the resolution steps may establish a
+	// session ID, tried in the constant order above regardless of the order
+	// given here.
+	IdentitySources []string `json:"identity_sources,omitempty"`
+
+	// SwitchMinSimilarity is the confidence a classification must reach before
+	// it may change session state, forming hysteresis with the semantic
+	// classifier's MinSimilarity: a low bar to classify, a higher bar to switch.
+	// It must be at least Semantic.MinSimilarity. For a downgrade, clearing this
+	// bar on a single turn switches immediately without waiting on
+	// DowngradeAfterNTurns; leaving it at zero disables that fast path entirely
+	// (unlike its role gating escalations, where zero means no floor at all) and
+	// every downgrade goes through the sustained-turns path instead.
+	//
+	// Like MinSimilarity this is compared against the VectorStore backend's own
+	// score, and those scales differ (chromem, Qdrant, Pinecone, and Redis
+	// report raw cosine; Weaviate reports certainty). Retune on a backend
+	// switch. A lexical score is a different scale entirely and is never
+	// comparable against this value.
+	SwitchMinSimilarity float64 `json:"switch_min_similarity,omitempty"`
+	// DowngradeAfterNTurns is how many consecutive downgrade-direction turns —
+	// any tier lower than the one currently held, not necessarily the same
+	// specific tier each time — are needed before a downgrade is taken, when no
+	// single turn was confident enough to trigger SwitchMinSimilarity's fast
+	// path. Long agentic sessions are full of turns like "yes" or "run the
+	// tests" that classify as confidently simple; those are exactly the turns
+	// not to downgrade on immediately, because the classifier is right about the
+	// turn and wrong about the session.
+	DowngradeAfterNTurns int `json:"downgrade_after_n_turns,omitempty"`
+	// MaxSwitchesPerSession caps total tier moves as an oscillation backstop.
+	// Zero means unlimited.
+	MaxSwitchesPerSession int `json:"max_switches_per_session,omitempty"`
+	// AlwaysAllowEscalation lets an escalation bypass the SwitchMinSimilarity
+	// gate. Escalations already ignore cache cost: holding a session on an
+	// undersized model to protect cache spend produces bad answers, which is a
+	// worse failure than overpaying.
+	AlwaysAllowEscalation bool `json:"always_allow_escalation,omitempty"`
+}
+
+// UnmarshalJSON accepts TTL as a duration string ("30m") or a JSON number
+// (seconds). Seconds match the x-bf-session-ttl header and avoid expressing
+// minute- or hour-scale expiry in unwieldy millisecond values. All other fields
+// decode through the default path via an alias.
+func (c *ComplexitySessionConfig) UnmarshalJSON(data []byte) error {
+	// alias suppresses ComplexitySessionConfig's UnmarshalJSON to avoid
+	// infinite recursion. The outer TTL (json.RawMessage) shadows alias.TTL
+	// because the json package picks the shallower field.
+	type alias ComplexitySessionConfig
+	aux := &struct {
+		TTL json.RawMessage `json:"ttl,omitempty"`
+		*alias
+	}{alias: (*alias)(c)}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	if len(aux.TTL) == 0 || string(aux.TTL) == "null" {
+		return nil
+	}
+
+	var s string
+	if err := json.Unmarshal(aux.TTL, &s); err == nil {
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return fmt.Errorf("failed to parse session ttl duration string %q: %w", s, err)
+		}
+		c.TTL = d
+	} else {
+		var seconds float64
+		if err := json.Unmarshal(aux.TTL, &seconds); err != nil {
+			return fmt.Errorf("unsupported session ttl value: %s", string(aux.TTL))
+		}
+		c.TTL = time.Duration(seconds * float64(time.Second))
+	}
+	if c.TTL < 0 {
+		return fmt.Errorf("session ttl must be non-negative, got %v", c.TTL)
+	}
+	return nil
+}
+
+// MarshalJSON writes TTL as a duration string because session expiry is normally
+// configured in minutes or hours. The readable form is also lossless when the
+// persisted value is loaded again.
+func (c ComplexitySessionConfig) MarshalJSON() ([]byte, error) {
+	type alias ComplexitySessionConfig
+	var ttl string
+	if c.TTL != 0 {
+		ttl = c.TTL.String()
+	}
+	return json.Marshal(struct {
+		TTL string `json:"ttl,omitempty"`
+		alias
+	}{
+		TTL:   ttl,
+		alias: alias(c),
+	})
+}
+
+// Enabled reports whether session behaviour should engage. It is the only
+// correct way to test this: a nil block, an empty mode, and an explicit "off"
+// all mean disabled.
+func (c *ComplexitySessionConfig) Enabled() bool {
+	if c == nil {
+		return false
+	}
+	switch c.Mode {
+	case ComplexitySessionModePinned, ComplexitySessionModeCacheAware:
+		return true
+	default:
+		return false
+	}
+}
+
+// normalized returns a canonical deep copy with defaults applied. Defaults are
+// applied even when the mode is "off" so that toggling session behaviour back
+// on preserves what the admin configured.
+func (c *ComplexitySessionConfig) normalized() *ComplexitySessionConfig {
+	if c == nil {
+		return nil
+	}
+	out := &ComplexitySessionConfig{
+		Mode:                  strings.ToLower(strings.TrimSpace(c.Mode)),
+		TTL:                   c.TTL,
+		IdentitySources:       normalizeComplexitySessionIdentitySources(c.IdentitySources),
+		SwitchMinSimilarity:   c.SwitchMinSimilarity,
+		DowngradeAfterNTurns:  c.DowngradeAfterNTurns,
+		MaxSwitchesPerSession: c.MaxSwitchesPerSession,
+		AlwaysAllowEscalation: c.AlwaysAllowEscalation,
+	}
+	if out.Mode == "" {
+		out.Mode = ComplexitySessionModeOff
+	}
+	if out.TTL == 0 {
+		out.TTL = DefaultComplexitySessionTTL
+	}
+	if len(out.IdentitySources) == 0 {
+		out.IdentitySources = DefaultComplexitySessionIdentitySources()
+	}
+	if out.DowngradeAfterNTurns == 0 {
+		out.DowngradeAfterNTurns = DefaultComplexitySessionDowngradeAfterNTurns
+	}
+	return out
+}
+
+// normalizeComplexitySessionIdentitySources lowercases, de-duplicates, and
+// orders sources by the resolution ladder so callers can walk them directly.
+func normalizeComplexitySessionIdentitySources(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(values))
+	for _, value := range values {
+		normalized := strings.ToLower(strings.TrimSpace(value))
+		if normalized == "" {
+			continue
+		}
+		seen[normalized] = true
+	}
+	var out []string
+	for _, source := range []string{
+		ComplexitySessionIdentityHeader,
+		ComplexitySessionIdentityHarness,
+	} {
+		if seen[source] {
+			out = append(out, source)
+			delete(seen, source)
+		}
+	}
+	// Unknown values are preserved so Validate can name them rather than
+	// silently dropping a typo'd source.
+	unknown := make([]string, 0, len(seen))
+	for source := range seen {
+		unknown = append(unknown, source)
+	}
+	sort.Strings(unknown)
+	return append(out, unknown...)
+}
+
+// Validate checks a normalized session config. Cross-section rules that need
+// the surrounding analyzer config — notably SwitchMinSimilarity against
+// Semantic.MinSimilarity — are enforced by ComplexityAnalyzerConfig.Validate.
+func (c *ComplexitySessionConfig) Validate() error {
+	if c == nil {
+		return nil
+	}
+	switch c.Mode {
+	case ComplexitySessionModeOff, ComplexitySessionModePinned, ComplexitySessionModeCacheAware:
+	default:
+		return fmt.Errorf("session mode must be %q, %q, or %q, got %q",
+			ComplexitySessionModeOff, ComplexitySessionModePinned, ComplexitySessionModeCacheAware, c.Mode)
+	}
+	if c.TTL <= 0 {
+		return fmt.Errorf("session ttl must be positive, got %v", c.TTL)
+	}
+	for _, source := range c.IdentitySources {
+		switch source {
+		case ComplexitySessionIdentityHeader, ComplexitySessionIdentityHarness:
+		default:
+			return fmt.Errorf("session identity_sources may contain %q or %q, got %q",
+				ComplexitySessionIdentityHeader, ComplexitySessionIdentityHarness, source)
+		}
+	}
+	if len(c.IdentitySources) == 0 {
+		return fmt.Errorf("session identity_sources must list at least one source")
+	}
+	// 1 is a legal ceiling but rejects every real match, matching the
+	// MinSimilarity treatment: a misconfiguration, not "never switch". NaN is
+	// named explicitly because every comparison against it is false, so the
+	// range check alone would pass it through — and the cross-field hysteresis
+	// check below compares the same way.
+	if math.IsNaN(c.SwitchMinSimilarity) || c.SwitchMinSimilarity < 0 || c.SwitchMinSimilarity >= 1 {
+		return fmt.Errorf("session switch_min_similarity must be at least 0 and less than 1, got %v", c.SwitchMinSimilarity)
+	}
+	if c.DowngradeAfterNTurns < 1 {
+		return fmt.Errorf("session downgrade_after_n_turns must be at least 1, got %d", c.DowngradeAfterNTurns)
+	}
+	if c.MaxSwitchesPerSession < 0 {
+		return fmt.Errorf("session max_switches_per_session must be non-negative, got %d", c.MaxSwitchesPerSession)
+	}
+	return nil
+}
+
 // ComplexityAnalyzerConfigHashes tracks the config.json hash for each editable
 // analyzer section. It is persisted with the config row, but not exposed through
 // API responses or config.json.
@@ -339,6 +625,9 @@ type ComplexityAnalyzerConfigHashes struct {
 	// budgets flag, vector store). The semantic classifier's
 	// exemplars are the shared keyword lists, tracked by the sections above.
 	SemanticSettings string `json:"semantic_settings,omitempty"`
+	// SessionSettings covers the session block (mode, ttl, identity sources,
+	// and the cache-aware switch thresholds).
+	SessionSettings string `json:"session_settings,omitempty"`
 }
 
 type legacyComplexityAnalyzerConfigHashes struct {
@@ -404,6 +693,7 @@ type ComplexityAnalyzerConfig struct {
 	TierBoundaries ComplexityTierBoundaries        `json:"tier_boundaries"`
 	Keywords       ComplexityEditableKeywordConfig `json:"keywords"`
 	Semantic       *ComplexitySemanticConfig       `json:"semantic,omitempty"`
+	Session        *ComplexitySessionConfig        `json:"session,omitempty"`
 	ConfigHashes   ComplexityAnalyzerConfigHashes  `json:"-"`
 	// EmbeddingFingerprint is reserved for config-store implementations that
 	// persist routing state. The semantic classifier verifies a VectorStore-side
@@ -415,6 +705,7 @@ type complexityAnalyzerConfigRecord struct {
 	TierBoundaries       ComplexityTierBoundaries        `json:"tier_boundaries"`
 	Keywords             ComplexityEditableKeywordConfig `json:"keywords"`
 	Semantic             *ComplexitySemanticConfig       `json:"semantic,omitempty"`
+	Session              *ComplexitySessionConfig        `json:"session,omitempty"`
 	ConfigHashes         ComplexityAnalyzerConfigHashes  `json:"_config_hashes,omitempty"`
 	EmbeddingFingerprint string                          `json:"_embedding_fingerprint,omitempty"`
 }
@@ -449,6 +740,21 @@ func (c *ComplexityAnalyzerConfig) Validate() error {
 			return err
 		}
 	}
+	if err := c.Session.Validate(); err != nil {
+		return err
+	}
+	// SwitchMinSimilarity and MinSimilarity form hysteresis: a low bar to accept
+	// a classification, a higher bar to let it change session state. Inverting
+	// them would let a classification too weak to be believed still move a
+	// session, so the ordering is enforced rather than clamped. Zero means the
+	// switch gate is off entirely and is exempt.
+	if c.Session != nil && c.Semantic != nil && c.Session.SwitchMinSimilarity > 0 &&
+		c.Session.SwitchMinSimilarity < c.Semantic.MinSimilarity {
+		return fmt.Errorf(
+			"session switch_min_similarity (%v) must be at least semantic min_similarity (%v)",
+			c.Session.SwitchMinSimilarity, c.Semantic.MinSimilarity,
+		)
+	}
 	return nil
 }
 
@@ -469,6 +775,7 @@ func (c *ComplexityAnalyzerConfig) Normalized() ComplexityAnalyzerConfig {
 			ComplexKeywords: normalizeComplexityKeywordList(c.Keywords.ComplexKeywords),
 		},
 		Semantic:             c.Semantic.normalized(),
+		Session:              c.Session.normalized(),
 		ConfigHashes:         c.ConfigHashes,
 		EmbeddingFingerprint: c.EmbeddingFingerprint,
 	}
@@ -546,6 +853,7 @@ func MergeComplexityAnalyzerConfig(base, file *ComplexityAnalyzerConfig) (*Compl
 			ComplexKeywords: mergeComplexityKeywordLists(normalizedBase.Keywords.ComplexKeywords, normalizedFile.Keywords.ComplexKeywords),
 		},
 		Semantic:             mergeComplexitySemanticConfig(normalizedBase.Semantic, normalizedFile.Semantic),
+		Session:              mergeComplexitySessionConfig(normalizedBase.Session, normalizedFile.Session),
 		ConfigHashes:         normalizedFile.ConfigHashes,
 		EmbeddingFingerprint: normalizedBase.EmbeddingFingerprint,
 	}
@@ -559,6 +867,15 @@ func MergeComplexityAnalyzerConfig(base, file *ComplexityAnalyzerConfig) (*Compl
 // mergeComplexitySemanticConfig overlays the file semantic settings. A nil
 // file section keeps the base untouched.
 func mergeComplexitySemanticConfig(base, file *ComplexitySemanticConfig) *ComplexitySemanticConfig {
+	if file == nil {
+		return base.normalized()
+	}
+	return file.normalized()
+}
+
+// mergeComplexitySessionConfig overlays the file session settings. A nil file
+// section keeps the base untouched.
+func mergeComplexitySessionConfig(base, file *ComplexitySessionConfig) *ComplexitySessionConfig {
 	if file == nil {
 		return base.normalized()
 	}
@@ -610,6 +927,14 @@ func MergeComplexityAnalyzerConfigByHashes(base, file *ComplexityAnalyzerConfig)
 			merged.ConfigHashes.SemanticSettings = normalizedFile.ConfigHashes.SemanticSettings
 		}
 	}
+	// Same "absence means no opinion" rule as the semantic section above: a
+	// config.json without a session block leaves DB session state alone.
+	if normalizedFile.Session != nil {
+		if merged.Session == nil || merged.ConfigHashes.SessionSettings != normalizedFile.ConfigHashes.SessionSettings {
+			merged.Session = normalizedFile.Session.normalized()
+			merged.ConfigHashes.SessionSettings = normalizedFile.ConfigHashes.SessionSettings
+		}
+	}
 	normalizedMerged := merged.Normalized()
 	if err := normalizedMerged.Validate(); err != nil {
 		return nil, err
@@ -632,6 +957,7 @@ func DecodeComplexityAnalyzerConfig(data []byte) (*ComplexityAnalyzerConfig, err
 		TierBoundaries:       record.TierBoundaries,
 		Keywords:             record.Keywords,
 		Semantic:             record.Semantic,
+		Session:              record.Session,
 		ConfigHashes:         record.ConfigHashes,
 		EmbeddingFingerprint: record.EmbeddingFingerprint,
 	}
@@ -647,6 +973,7 @@ func encodeComplexityAnalyzerConfig(config ComplexityAnalyzerConfig) ([]byte, er
 		TierBoundaries:       config.TierBoundaries,
 		Keywords:             config.Keywords,
 		Semantic:             config.Semantic,
+		Session:              config.Session,
 		ConfigHashes:         config.ConfigHashes,
 		EmbeddingFingerprint: config.EmbeddingFingerprint,
 	}

--- a/framework/configstore/complexityconfig_test.go
+++ b/framework/configstore/complexityconfig_test.go
@@ -63,7 +63,7 @@ func TestComplexitySemanticConfigTimeoutMarshalRoundTrip(t *testing.T) {
 
 	data, err := json.Marshal(cfg)
 	require.NoError(t, err)
-	assert.Contains(t, string(data), `"timeout":"250ms"`)
+	assert.Contains(t, string(data), `"timeout":250`)
 
 	var decoded ComplexitySemanticConfig
 	require.NoError(t, json.Unmarshal(data, &decoded))
@@ -552,4 +552,254 @@ func TestRDBConfigStore_ResetComplexityAnalyzerConfigConcurrentFirstWrite(t *tes
 	// Either way the committed semantic configuration survives.
 	require.NotNil(t, got.Semantic)
 	assert.Equal(t, "text-embedding-3-large", got.Semantic.EmbeddingModel)
+}
+
+func testSessionConfig() *ComplexitySessionConfig {
+	return &ComplexitySessionConfig{Mode: ComplexitySessionModePinned}
+}
+
+func TestComplexitySessionConfigTTLDecoding(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "duration string", payload: `{"ttl":"30m"}`, want: 30 * time.Minute},
+		{name: "number is seconds", payload: `{"ttl":1800}`, want: 30 * time.Minute},
+		{name: "absent keeps zero", payload: `{}`, want: 0},
+		{name: "null keeps zero", payload: `{"ttl":null}`, want: 0},
+		{name: "negative number rejected", payload: `{"ttl":-5}`, wantErr: true},
+		{name: "bad string rejected", payload: `{"ttl":"a while"}`, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg ComplexitySessionConfig
+			err := json.Unmarshal([]byte(tt.payload), &cfg)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, cfg.TTL)
+		})
+	}
+}
+
+// Session TTLs are minute- or hour-scale settings, so the canonical string
+// stays readable while numeric input remains available in seconds.
+func TestComplexitySessionConfigTTLMarshalRoundTrip(t *testing.T) {
+	cfg := testSessionConfig()
+	cfg.TTL = 30 * time.Minute
+
+	data, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"ttl":"30m0s"`)
+
+	var decoded ComplexitySessionConfig
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, cfg.TTL, decoded.TTL)
+}
+
+func TestComplexitySessionConfigNormalizedDefaults(t *testing.T) {
+	normalized := testSessionConfig().normalized()
+
+	assert.Equal(t, DefaultComplexitySessionTTL, normalized.TTL)
+	assert.Equal(t, DefaultComplexitySessionIdentitySources(), normalized.IdentitySources)
+	assert.Equal(t, DefaultComplexitySessionDowngradeAfterNTurns, normalized.DowngradeAfterNTurns)
+	// Ships unset: no sensible absolute default exists until the exemplar set's
+	// score distribution is measured.
+	assert.Zero(t, normalized.SwitchMinSimilarity)
+	assert.Zero(t, normalized.MaxSwitchesPerSession)
+	require.NoError(t, normalized.Validate())
+}
+
+func TestComplexitySessionConfigEnabled(t *testing.T) {
+	var nilCfg *ComplexitySessionConfig
+	assert.False(t, nilCfg.Enabled())
+	assert.False(t, (&ComplexitySessionConfig{}).Enabled())
+	assert.False(t, (&ComplexitySessionConfig{Mode: ComplexitySessionModeOff}).Enabled())
+	assert.True(t, (&ComplexitySessionConfig{Mode: ComplexitySessionModePinned}).Enabled())
+	assert.True(t, (&ComplexitySessionConfig{Mode: ComplexitySessionModeCacheAware}).Enabled())
+}
+
+// Turning session behaviour off must not discard the tuning an admin did, so
+// the toggle carries a mode rather than nilling the block.
+func TestComplexitySessionConfigOffPreservesSettings(t *testing.T) {
+	cfg := &ComplexitySessionConfig{
+		Mode:                 ComplexitySessionModeOff,
+		TTL:                  90 * time.Minute,
+		DowngradeAfterNTurns: 5,
+	}
+	normalized := cfg.normalized()
+
+	assert.False(t, normalized.Enabled())
+	assert.Equal(t, 90*time.Minute, normalized.TTL)
+	assert.Equal(t, 5, normalized.DowngradeAfterNTurns)
+}
+
+func TestComplexitySessionConfigIdentitySourceNormalization(t *testing.T) {
+	cfg := &ComplexitySessionConfig{
+		Mode:            ComplexitySessionModePinned,
+		IdentitySources: []string{" HARNESS ", "header", "header", ""},
+	}
+	normalized := cfg.normalized()
+
+	// De-duplicated, and reordered into resolution order regardless of input order.
+	assert.Equal(t, []string{ComplexitySessionIdentityHeader, ComplexitySessionIdentityHarness}, normalized.IdentitySources)
+	require.NoError(t, normalized.Validate())
+}
+
+// Unsupported sources are preserved through normalization so validation can
+// name them rather than silently dropping stale or misspelled configuration.
+func TestComplexitySessionConfigRejectsUnknownIdentitySource(t *testing.T) {
+	for _, source := range []string{"fingerprint", "telepathy"} {
+		t.Run(source, func(t *testing.T) {
+			cfg := &ComplexitySessionConfig{
+				Mode:            ComplexitySessionModePinned,
+				IdentitySources: []string{"header", source},
+			}
+			err := cfg.normalized().Validate()
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), source)
+		})
+	}
+}
+
+func TestComplexitySessionConfigValidation(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*ComplexitySessionConfig)
+		errs   string
+	}{
+		{name: "valid pinned"},
+		{name: "unknown mode", mutate: func(c *ComplexitySessionConfig) { c.Mode = "adaptive" }, errs: "session mode"},
+		{name: "switch similarity at ceiling", mutate: func(c *ComplexitySessionConfig) { c.SwitchMinSimilarity = 1 }, errs: "switch_min_similarity"},
+		{name: "negative switch similarity", mutate: func(c *ComplexitySessionConfig) { c.SwitchMinSimilarity = -0.1 }, errs: "switch_min_similarity"},
+		// NaN compares false against every bound, so a range check alone lets it
+		// through and the switch gate then rejects every candidate silently.
+		{name: "nan switch similarity", mutate: func(c *ComplexitySessionConfig) { c.SwitchMinSimilarity = math.NaN() }, errs: "switch_min_similarity"},
+		{name: "negative max switches", mutate: func(c *ComplexitySessionConfig) { c.MaxSwitchesPerSession = -1 }, errs: "max_switches_per_session"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := testSessionConfig()
+			if tt.mutate != nil {
+				tt.mutate(cfg)
+			}
+			normalized := cfg.normalized()
+			// normalized must not launder an invalid value into a default.
+			if tt.mutate != nil {
+				tt.mutate(normalized)
+			}
+			err := normalized.Validate()
+			if tt.errs == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errs)
+		})
+	}
+}
+
+// Hysteresis: a classification too weak to be believed must not be strong
+// enough to move a session.
+func TestComplexityAnalyzerConfigRejectsSwitchSimilarityBelowMinSimilarity(t *testing.T) {
+	cfg := testSemanticAnalyzerConfig()
+	cfg.Semantic.MinSimilarity = 0.80
+	cfg.Session = testSessionConfig()
+	cfg.Session.SwitchMinSimilarity = 0.70
+
+	normalized := cfg.Normalized()
+	err := normalized.Validate()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "switch_min_similarity")
+
+	normalized.Session.SwitchMinSimilarity = 0.80
+	require.NoError(t, normalized.Validate())
+}
+
+// Zero means the switch gate is off entirely, not a threshold of zero, so it is
+// exempt from the ordering rule.
+func TestComplexityAnalyzerConfigAllowsUnsetSwitchSimilarity(t *testing.T) {
+	cfg := testSemanticAnalyzerConfig()
+	cfg.Semantic.MinSimilarity = 0.80
+	cfg.Session = testSessionConfig()
+
+	normalized := cfg.Normalized()
+	require.NoError(t, normalized.Validate())
+	assert.Zero(t, normalized.Session.SwitchMinSimilarity)
+}
+
+// The record mirror is a separate struct from the public config; a field added
+// to one and not the other round-trips as nothing.
+func TestComplexityAnalyzerConfigSessionRoundTrip(t *testing.T) {
+	cfg := testSemanticAnalyzerConfig()
+	cfg.Session = &ComplexitySessionConfig{
+		Mode:                  ComplexitySessionModeCacheAware,
+		TTL:                   90 * time.Minute,
+		IdentitySources:       []string{ComplexitySessionIdentityHeader},
+		SwitchMinSimilarity:   0.9,
+		DowngradeAfterNTurns:  5,
+		MaxSwitchesPerSession: 4,
+		AlwaysAllowEscalation: true,
+	}
+
+	encoded, err := encodeComplexityAnalyzerConfig(cfg.Normalized())
+	require.NoError(t, err)
+
+	decoded, err := DecodeComplexityAnalyzerConfig(encoded)
+	require.NoError(t, err)
+	require.NotNil(t, decoded.Session)
+	assert.Equal(t, cfg.Session.Mode, decoded.Session.Mode)
+	assert.Equal(t, cfg.Session.TTL, decoded.Session.TTL)
+	assert.Equal(t, cfg.Session.IdentitySources, decoded.Session.IdentitySources)
+	assert.Equal(t, cfg.Session.SwitchMinSimilarity, decoded.Session.SwitchMinSimilarity)
+	assert.Equal(t, cfg.Session.DowngradeAfterNTurns, decoded.Session.DowngradeAfterNTurns)
+	assert.Equal(t, cfg.Session.MaxSwitchesPerSession, decoded.Session.MaxSwitchesPerSession)
+	assert.True(t, decoded.Session.AlwaysAllowEscalation)
+}
+
+// A config.json without a session block means "no opinion", not removal.
+func TestMergeComplexityAnalyzerConfigByHashesKeepsSessionWhenFileOmitsIt(t *testing.T) {
+	base := testSemanticAnalyzerConfig()
+	base.Session = testSessionConfig()
+	base.ConfigHashes.SessionSettings = "hash-a"
+
+	file := testSemanticAnalyzerConfig()
+
+	merged, err := MergeComplexityAnalyzerConfigByHashes(base, file)
+	require.NoError(t, err)
+	require.NotNil(t, merged.Session)
+	assert.Equal(t, ComplexitySessionModePinned, merged.Session.Mode)
+	assert.Equal(t, "hash-a", merged.ConfigHashes.SessionSettings)
+}
+
+func TestMergeComplexityAnalyzerConfigByHashesAppliesChangedSessionSection(t *testing.T) {
+	base := testSemanticAnalyzerConfig()
+	base.Session = testSessionConfig()
+	base.ConfigHashes.SessionSettings = "hash-a"
+
+	file := testSemanticAnalyzerConfig()
+	file.Session = &ComplexitySessionConfig{Mode: ComplexitySessionModeCacheAware}
+	file.ConfigHashes.SessionSettings = "hash-b"
+
+	merged, err := MergeComplexityAnalyzerConfigByHashes(base, file)
+	require.NoError(t, err)
+	require.NotNil(t, merged.Session)
+	assert.Equal(t, ComplexitySessionModeCacheAware, merged.Session.Mode)
+	assert.Equal(t, "hash-b", merged.ConfigHashes.SessionSettings)
+}
+
+func TestComplexitySemanticConfigRejectsRemovedFields(t *testing.T) {
+	for _, field := range []string{"dimension", "fallback"} {
+		t.Run(field, func(t *testing.T) {
+			var cfg ComplexitySemanticConfig
+			err := json.Unmarshal([]byte(`{"provider":"openai","embedding_model":"text-embedding-3-small","`+field+`":true}`), &cfg)
+			require.ErrorContains(t, err, `unknown semantic complexity field "`+field+`"`)
+		})
+	}
 }

--- a/framework/kvstore/kvstore.go
+++ b/framework/kvstore/kvstore.go
@@ -15,6 +15,7 @@ var (
 	ErrEmptyKey   = errors.New("key cannot be empty")
 	ErrNotFound   = errors.New("key not found")
 	ErrInvalidTTL = errors.New("ttl cannot be negative")
+	ErrNilUpdate  = errors.New("update callback cannot be nil")
 )
 
 const (
@@ -51,9 +52,10 @@ type Store struct {
 	stopOnce  sync.Once
 	cleanupWg sync.WaitGroup
 
-	delegate  SyncDelegate
-	decoders  map[string]TypeDecoder
-	decoderMu sync.RWMutex
+	delegate   SyncDelegate
+	delegateMu sync.RWMutex
+	decoders   map[string]TypeDecoder
+	decoderMu  sync.RWMutex
 }
 
 // SyncDelegate is notified of all mutations, enabling cross-node replication.
@@ -70,9 +72,18 @@ type SyncDelegate interface {
 // Register decoders by key prefix via RegisterDecoder.
 type TypeDecoder func(data []byte) (any, error)
 
-// SetDelegate plugs in the cluster sync implementation.
+// SetDelegate installs or replaces the cluster sync implementation. Only
+// mutations that start after this call are guaranteed to use the new delegate.
 func (s *Store) SetDelegate(d SyncDelegate) {
+	s.delegateMu.Lock()
 	s.delegate = d
+	s.delegateMu.Unlock()
+}
+
+// HasSyncDelegate reports whether local mutations are currently forwarded to a
+// cluster sync implementation.
+func (s *Store) HasSyncDelegate() bool {
+	return s.syncDelegate() != nil
 }
 
 // RegisterDecoder registers a decoder for keys matching the given prefix.
@@ -119,6 +130,7 @@ func (s *Store) SetWithTTL(key string, value any, ttl time.Duration) error {
 	if err := s.validateMutable(key, ttl); err != nil {
 		return err
 	}
+	delegate := s.syncDelegate()
 
 	now := time.Now().UnixNano()
 	var expiresAt int64
@@ -129,7 +141,7 @@ func (s *Store) SetWithTTL(key string, value any, ttl time.Duration) error {
 	var valueJSON []byte
 	var err error
 
-	if s.delegate != nil {
+	if delegate != nil {
 		valueJSON, err = sonic.Marshal(value)
 		if err != nil {
 			return err
@@ -144,8 +156,8 @@ func (s *Store) SetWithTTL(key string, value any, ttl time.Duration) error {
 	}
 	s.mu.Unlock()
 
-	if s.delegate != nil {
-		s.delegate.OnSet(key, valueJSON, now, expiresAt)
+	if delegate != nil {
+		delegate.OnSet(key, valueJSON, now, expiresAt)
 	}
 
 	return nil
@@ -158,6 +170,7 @@ func (s *Store) SetNXWithTTL(key string, value any, ttl time.Duration) (bool, er
 	if err := s.validateMutable(key, ttl); err != nil {
 		return false, err
 	}
+	delegate := s.syncDelegate()
 
 	now := time.Now().UnixNano()
 	var expiresAt int64
@@ -168,7 +181,7 @@ func (s *Store) SetNXWithTTL(key string, value any, ttl time.Duration) (bool, er
 	var valueJSON []byte
 	var err error
 
-	if s.delegate != nil {
+	if delegate != nil {
 		valueJSON, err = sonic.Marshal(value)
 		if err != nil {
 			return false, err
@@ -176,7 +189,7 @@ func (s *Store) SetNXWithTTL(key string, value any, ttl time.Duration) (bool, er
 	}
 
 	s.mu.Lock()
-	
+
 	// Check if key exists and is not expired
 	if existing, ok := s.data[key]; ok {
 		if !isExpired(existing, now) {
@@ -185,7 +198,7 @@ func (s *Store) SetNXWithTTL(key string, value any, ttl time.Duration) (bool, er
 		}
 		// Key exists but is expired, allow overwrite
 	}
-	
+
 	// Key doesn't exist or is expired, set it
 	s.data[key] = entry{
 		value:     value,
@@ -194,11 +207,77 @@ func (s *Store) SetNXWithTTL(key string, value any, ttl time.Duration) (bool, er
 	}
 	s.mu.Unlock()
 
-	if s.delegate != nil {
-		s.delegate.OnSet(key, valueJSON, now, expiresAt)
+	if delegate != nil {
+		delegate.OnSet(key, valueJSON, now, expiresAt)
 	}
 
 	return true, nil
+}
+
+// UpdateWithTTL atomically replaces an existing, non-expired value and resets
+// its TTL. update runs while the store is locked and must complete promptly; it
+// must not call back into this store. Returning an error leaves the value and
+// TTL unchanged. A missing or expired key returns found=false without invoking
+// update. ttl=0 means no expiration.
+func (s *Store) UpdateWithTTL(key string, ttl time.Duration, update func(current any) (replacement any, err error)) (value any, found bool, err error) {
+	if err := s.validateMutable(key, ttl); err != nil {
+		return nil, false, err
+	}
+	if update == nil {
+		return nil, false, ErrNilUpdate
+	}
+	delegate := s.syncDelegate()
+
+	var (
+		valueJSON []byte
+		writtenAt int64
+		expiresAt int64
+	)
+
+	value, found, err = func() (any, bool, error) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		current, ok := s.data[key]
+		now := time.Now().UnixNano()
+		if !ok || isExpired(current, now) {
+			if ok {
+				delete(s.data, key)
+			}
+			return nil, false, nil
+		}
+
+		replacement, err := update(current.value)
+		if err != nil {
+			return nil, true, err
+		}
+
+		if delegate != nil {
+			valueJSON, err = sonic.Marshal(replacement)
+			if err != nil {
+				return nil, true, err
+			}
+		}
+
+		writtenAt = time.Now().UnixNano()
+		if ttl > 0 {
+			expiresAt = writtenAt + int64(ttl)
+		}
+		s.data[key] = entry{
+			value:     replacement,
+			writtenAt: writtenAt,
+			expiresAt: expiresAt,
+		}
+		return replacement, true, nil
+	}()
+	if err != nil || !found {
+		return value, found, err
+	}
+
+	if delegate != nil {
+		delegate.OnSet(key, valueJSON, writtenAt, expiresAt)
+	}
+	return value, true, nil
 }
 
 // SetRemote applies a remotely-gossiped entry without triggering OnSet.
@@ -265,6 +344,7 @@ func (s *Store) GetAndDelete(key string) (any, error) {
 	}
 
 	now := time.Now().UnixNano()
+	delegate := s.syncDelegate()
 
 	s.mu.Lock()
 	e, ok := s.data[key]
@@ -276,8 +356,8 @@ func (s *Store) GetAndDelete(key string) (any, error) {
 	if !ok || isExpired(e, now) {
 		return nil, ErrNotFound
 	}
-	if s.delegate != nil {
-		s.delegate.OnDelete(key, now)
+	if delegate != nil {
+		delegate.OnDelete(key, now)
 	}
 	return e.value, nil
 }
@@ -292,6 +372,7 @@ func (s *Store) Delete(key string) (bool, error) {
 	}
 
 	deletedAt := time.Now().UnixNano()
+	delegate := s.syncDelegate()
 
 	s.mu.Lock()
 	_, ok := s.data[key]
@@ -303,8 +384,8 @@ func (s *Store) Delete(key string) (bool, error) {
 	if !ok {
 		return false, nil
 	}
-	if s.delegate != nil {
-		s.delegate.OnDelete(key, deletedAt)
+	if delegate != nil {
+		delegate.OnDelete(key, deletedAt)
 	}
 	return true, nil
 }
@@ -401,6 +482,13 @@ func (s *Store) validateMutable(key string, ttl time.Duration) error {
 		return ErrClosed
 	}
 	return nil
+}
+
+func (s *Store) syncDelegate() SyncDelegate {
+	s.delegateMu.RLock()
+	delegate := s.delegate
+	s.delegateMu.RUnlock()
+	return delegate
 }
 
 // decodeValue uses the registered decoder for the key's prefix, falling back

--- a/framework/kvstore/kvstore_test.go
+++ b/framework/kvstore/kvstore_test.go
@@ -1,10 +1,36 @@
 package kvstore
 
 import (
+	"encoding/json"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
+
+type recordingSyncDelegate struct {
+	mu        sync.Mutex
+	setCalls  int
+	lastKey   string
+	lastValue []byte
+}
+
+func (d *recordingSyncDelegate) OnSet(key string, valueJSON []byte, _ int64, _ int64) {
+	d.mu.Lock()
+	d.setCalls++
+	d.lastKey = key
+	d.lastValue = append(d.lastValue[:0], valueJSON...)
+	d.mu.Unlock()
+}
+
+func (d *recordingSyncDelegate) OnDelete(string, int64) {}
+
+func (d *recordingSyncDelegate) snapshot() (calls int, key string, value []byte) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.setCalls, d.lastKey, append([]byte(nil), d.lastValue...)
+}
 
 func TestStoreSetGetDelete(t *testing.T) {
 	store, err := New(Config{})
@@ -79,6 +105,242 @@ func TestStoreGetAndDelete(t *testing.T) {
 
 	if _, err := store.Get("k"); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected missing key after get-and-delete, got: %v", err)
+	}
+}
+
+func TestStoreUpdateWithTTL(t *testing.T) {
+	store, err := New(Config{})
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.SetWithTTL("counter", 1, time.Second); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+
+	value, found, err := store.UpdateWithTTL("counter", time.Second, func(current any) (any, error) {
+		return current.(int) + 1, nil
+	})
+	if err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected existing key to be updated")
+	}
+	if value.(int) != 2 {
+		t.Fatalf("unexpected updated value: %v", value)
+	}
+
+	stored, err := store.Get("counter")
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if stored.(int) != 2 {
+		t.Fatalf("unexpected stored value: %v", stored)
+	}
+}
+
+// A nil callback is a programming error, not a no-op update: without the guard
+// the store would panic while holding its write lock and take every other
+// caller down with it.
+func TestStoreUpdateWithTTLNilCallback(t *testing.T) {
+	store, err := New(Config{})
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.Set("key", "original"); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+
+	value, found, err := store.UpdateWithTTL("key", time.Second, nil)
+	if !errors.Is(err, ErrNilUpdate) {
+		t.Fatalf("expected ErrNilUpdate, got: %v", err)
+	}
+	if value != nil || found {
+		t.Fatalf("expected no result for a nil callback, got value=%v found=%v", value, found)
+	}
+}
+
+func TestStoreUpdateWithTTLMissingOrExpired(t *testing.T) {
+	store, err := New(Config{CleanupInterval: time.Hour})
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	var calls atomic.Int32
+	update := func(current any) (any, error) {
+		calls.Add(1)
+		return current, nil
+	}
+
+	if value, found, err := store.UpdateWithTTL("missing", time.Second, update); err != nil || found || value != nil {
+		t.Fatalf("expected missing result, got value=%v found=%v err=%v", value, found, err)
+	}
+
+	if err := store.SetWithTTL("expired", "value", time.Millisecond); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	if value, found, err := store.UpdateWithTTL("expired", time.Second, update); err != nil || found || value != nil {
+		t.Fatalf("expected expired result, got value=%v found=%v err=%v", value, found, err)
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("update callback ran %d times for missing records", calls.Load())
+	}
+}
+
+func TestStoreUpdateWithTTLFailureDoesNotMutate(t *testing.T) {
+	store, err := New(Config{})
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.Set("key", "original"); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+	wantErr := errors.New("update failed")
+	_, found, err := store.UpdateWithTTL("key", time.Second, func(any) (any, error) {
+		return "replacement", wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected update error, got: %v", err)
+	}
+	if !found {
+		t.Fatal("expected update to report the existing key")
+	}
+
+	value, err := store.Get("key")
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if value.(string) != "original" {
+		t.Fatalf("failed update changed value to %v", value)
+	}
+}
+
+func TestStoreUpdateWithTTLConcurrent(t *testing.T) {
+	store, err := New(Config{})
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.Set("counter", 0); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+
+	const updates = 100
+	errCh := make(chan error, updates)
+	var wg sync.WaitGroup
+	for range updates {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, found, err := store.UpdateWithTTL("counter", time.Second, func(current any) (any, error) {
+				return current.(int) + 1, nil
+			})
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if !found {
+				errCh <- ErrNotFound
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Errorf("concurrent update failed: %v", err)
+	}
+
+	value, err := store.Get("counter")
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if value.(int) != updates {
+		t.Fatalf("lost concurrent updates: got %v, want %d", value, updates)
+	}
+}
+
+func TestStoreUpdateWithTTLDelegate(t *testing.T) {
+	store, err := New(Config{})
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	if store.HasSyncDelegate() {
+		t.Fatal("new store unexpectedly has a sync delegate")
+	}
+	delegate := &recordingSyncDelegate{}
+	store.SetDelegate(delegate)
+	if !store.HasSyncDelegate() {
+		t.Fatal("expected configured sync delegate")
+	}
+
+	if err := store.Set("counter", 1); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+	if _, _, err := store.UpdateWithTTL("counter", time.Second, func(current any) (any, error) {
+		return current.(int) + 1, nil
+	}); err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+
+	calls, key, valueJSON := delegate.snapshot()
+	if calls != 2 {
+		t.Fatalf("unexpected delegate call count: got %d, want 2", calls)
+	}
+	if key != "counter" {
+		t.Fatalf("unexpected delegate key: %q", key)
+	}
+	var value int
+	if err := json.Unmarshal(valueJSON, &value); err != nil {
+		t.Fatalf("decode delegated value: %v", err)
+	}
+	if value != 2 {
+		t.Fatalf("unexpected delegated value: got %d, want 2", value)
+	}
+
+	store.SetDelegate(nil)
+	if store.HasSyncDelegate() {
+		t.Fatal("expected sync delegate to be cleared")
+	}
+}
+
+func TestStoreUpdateWithTTLMarshalFailureDoesNotMutate(t *testing.T) {
+	store, err := New(Config{})
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+	store.SetDelegate(&recordingSyncDelegate{})
+
+	if err := store.Set("key", "original"); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+	_, found, err := store.UpdateWithTTL("key", time.Second, func(any) (any, error) {
+		return make(chan struct{}), nil
+	})
+	if err == nil {
+		t.Fatal("expected marshal failure")
+	}
+	if !found {
+		t.Fatal("expected update to report the existing key")
+	}
+
+	value, getErr := store.Get("key")
+	if getErr != nil {
+		t.Fatalf("get failed: %v", getErr)
+	}
+	if value.(string) != "original" {
+		t.Fatalf("marshal failure changed value to %v", value)
 	}
 }
 

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -2062,7 +2062,7 @@
                       "description": "Model used to generate embeddings for complexity classification"
                     },
                     "timeout": {
-                      "description": "Per-request embedding timeout (duration string like '1.5s', or milliseconds as a number; default: 1.5s). On timeout no tier is published for that request.",
+                      "description": "Per-request embedding timeout (duration string like '1.5s', or milliseconds as a number; default: 1.5s). Bifrost serializes this field as milliseconds. On timeout no tier is published for that request.",
                       "oneOf": [
                         {
                           "type": "string",

--- a/plugins/routing/complexity/extract.go
+++ b/plugins/routing/complexity/extract.go
@@ -69,6 +69,7 @@ const codexTurnMetadataHeader = "x-codex-turn-metadata"
 
 type codexTurnMetadata struct {
 	RequestKind string
+	SessionID   string
 }
 
 // buildComplexityInput extracts text from normalized BifrostRequest values for
@@ -369,16 +370,21 @@ func parseCodexTurnMetadata(ctx *schemas.BifrostContext) (codexTurnMetadata, boo
 
 	var fields struct {
 		RequestKind json.RawMessage `json:"request_kind"`
+		SessionID   json.RawMessage `json:"session_id"`
 	}
 	if err := json.Unmarshal([]byte(rawMetadata), &fields); err != nil {
 		return codexTurnMetadata{}, false
 	}
 
 	// Decode fields independently so an invalid new field cannot change the
-	// established behavior of another one.
+	// established behavior of another one. In particular, a malformed session_id
+	// must not stop a valid background request_kind from being recognized.
 	var metadata codexTurnMetadata
 	if len(fields.RequestKind) > 0 {
 		_ = json.Unmarshal(fields.RequestKind, &metadata.RequestKind)
+	}
+	if len(fields.SessionID) > 0 {
+		_ = json.Unmarshal(fields.SessionID, &metadata.SessionID)
 	}
 	return metadata, true
 }

--- a/plugins/routing/complexity/sessionidentity.go
+++ b/plugins/routing/complexity/sessionidentity.go
@@ -1,0 +1,102 @@
+// Session identity resolution: who a conversation is, resolved from harness
+// metadata or an explicit header. Lives beside the extractor because identity
+// comes from the same request surfaces harness detection reads.
+
+package complexity
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+)
+
+const (
+	claudeCodeSessionIDHeader = "x-claude-code-session-id"
+	// SessionKeyPrefix namespaces session records in the shared KV store.
+	SessionKeyPrefix            = "complexity-session:v1:"
+	maxComplexitySessionIDBytes = 255
+)
+
+// ResolveSessionID walks the enabled identity sources in their fixed precedence
+// order. identitySources must contain normalized ComplexitySessionIdentity*
+// values; configuration normalization owns defaults and validation.
+func ResolveSessionID(ctx *schemas.BifrostContext, identitySources []string) (id, source string, ok bool) {
+	if sessionIdentitySourceEnabled(identitySources, configstore.ComplexitySessionIdentityHeader) {
+		if id := normalizeComplexitySessionID(sessionIDFromContext(ctx)); id != "" {
+			return id, configstore.ComplexitySessionIdentityHeader, true
+		}
+	}
+	if sessionIdentitySourceEnabled(identitySources, configstore.ComplexitySessionIdentityHarness) {
+		if id := normalizeComplexitySessionID(harnessSessionID(ctx)); id != "" {
+			return id, configstore.ComplexitySessionIdentityHarness, true
+		}
+	}
+	return "", "", false
+}
+
+func sessionIdentitySourceEnabled(identitySources []string, wanted string) bool {
+	for _, source := range identitySources {
+		if source == wanted {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeComplexitySessionID validates the opaque identity shared by the
+// session store and request logs. IDs are never truncated because doing so can
+// merge otherwise distinct conversations.
+func normalizeComplexitySessionID(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" || len(id) > maxComplexitySessionIDBytes || !utf8.ValidString(id) || strings.IndexByte(id, 0) >= 0 {
+		return ""
+	}
+	return id
+}
+
+func sessionIDFromContext(ctx *schemas.BifrostContext) string {
+	if ctx == nil {
+		return ""
+	}
+	id, _ := ctx.Value(schemas.BifrostContextKeySessionID).(string)
+	return strings.TrimSpace(id)
+}
+
+func harnessSessionID(ctx *schemas.BifrostContext) string {
+	if ctx == nil {
+		return ""
+	}
+	headers, _ := ctx.Value(schemas.BifrostContextKeyRequestHeaders).(map[string]string)
+	switch detectComplexityHarness(ctx) {
+	case complexityHarnessClaudeCode:
+		return strings.TrimSpace(headers[claudeCodeSessionIDHeader])
+	case complexityHarnessCodex:
+		metadata, ok := parseCodexTurnMetadata(ctx)
+		if !ok {
+			return ""
+		}
+		return strings.TrimSpace(metadata.SessionID)
+	default:
+		return ""
+	}
+}
+
+// BuildSessionKey isolates session state by scope while keeping raw
+// scope and session identifiers out of storage keys.
+func BuildSessionKey(scopeID, sessionID string) (string, bool) {
+	scopeID = strings.TrimSpace(scopeID)
+	sessionID = strings.TrimSpace(sessionID)
+	if scopeID == "" || sessionID == "" {
+		return "", false
+	}
+	return SessionKeyPrefix + SessionHash(scopeID+"\x00"+sessionID), true
+}
+
+func SessionHash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}

--- a/plugins/routing/complexity/sessionidentity_test.go
+++ b/plugins/routing/complexity/sessionidentity_test.go
@@ -1,0 +1,297 @@
+package complexity
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+)
+
+func TestBuildComplexitySessionKeyRejectsBlankIdentity(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		scopeID   string
+		sessionID string
+	}{
+		{name: "blank_scope", scopeID: " ", sessionID: "session"},
+		{name: "blank_session", scopeID: "tenant", sessionID: "\t"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			key, ok := BuildSessionKey(tt.scopeID, tt.sessionID)
+			assert.False(t, ok)
+			assert.Empty(t, key)
+		})
+	}
+}
+
+func TestBuildComplexitySessionKeyScopeIsolation(t *testing.T) {
+	const (
+		scopeID   = "tenant-secret-value"
+		sessionID = "session-private-value"
+	)
+
+	key, ok := BuildSessionKey(scopeID, sessionID)
+	require.True(t, ok)
+	assert.True(t, strings.HasPrefix(key, SessionKeyPrefix))
+	assert.Len(t, strings.TrimPrefix(key, SessionKeyPrefix), 64)
+	assert.NotContains(t, key, scopeID)
+	assert.NotContains(t, key, sessionID)
+
+	sameKey, ok := BuildSessionKey(scopeID, sessionID)
+	require.True(t, ok)
+	assert.Equal(t, key, sameKey)
+
+	otherScopeKey, ok := BuildSessionKey("other-tenant", sessionID)
+	require.True(t, ok)
+	assert.NotEqual(t, key, otherScopeKey)
+
+	otherSessionKey, ok := BuildSessionKey(scopeID, "other-session")
+	require.True(t, ok)
+	assert.NotEqual(t, key, otherSessionKey)
+}
+
+func TestCodexBackgroundKindSurvivesMalformedSessionID(t *testing.T) {
+	ctx := complexityHarnessContext(schemas.CodexCLI.String(), map[string]string{
+		codexTurnMetadataHeader: `{"request_kind":"compaction","session_id":123}`,
+	})
+
+	input, ok := BuildInput(ctx, complexitySessionChatRequest("Be concise", "Compact the conversation"))
+
+	assert.False(t, ok)
+	assert.Empty(t, input)
+}
+
+func TestNormalizeComplexitySessionID(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{name: "trims_valid_id", id: " session-abc ", want: "session-abc"},
+		{name: "accepts_maximum_length", id: strings.Repeat("a", maxComplexitySessionIDBytes), want: strings.Repeat("a", maxComplexitySessionIDBytes)},
+		{name: "rejects_blank_id", id: "\t"},
+		{name: "rejects_oversized_id", id: strings.Repeat("a", maxComplexitySessionIDBytes+1)},
+		{name: "rejects_nul", id: "session\x00abc"},
+		{name: "rejects_invalid_utf8", id: string([]byte{0xff})},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeComplexitySessionID(tt.id))
+		})
+	}
+}
+
+func TestResolveSessionIDBlankHeaderFallsThrough(t *testing.T) {
+	ctx := complexityHarnessContext(schemas.ClaudeCLI.String(), map[string]string{
+		claudeCodeSessionIDHeader: "native-session",
+	})
+	ctx.SetValue(schemas.BifrostContextKeySessionID, " ")
+
+	id, source, ok := ResolveSessionID(ctx, []string{
+		configstore.ComplexitySessionIdentityHeader,
+		configstore.ComplexitySessionIdentityHarness,
+	})
+
+	require.True(t, ok)
+	assert.Equal(t, "native-session", id)
+	assert.Equal(t, configstore.ComplexitySessionIdentityHarness, source)
+}
+
+func TestResolveSessionIDHarnessSources(t *testing.T) {
+	tests := []struct {
+		name        string
+		userAgent   string
+		headers     map[string]string
+		wantID      string
+		wantPresent bool
+	}{
+		{
+			name:      "claude_code_header",
+			userAgent: schemas.ClaudeCLI.String(),
+			headers: map[string]string{
+				claudeCodeSessionIDHeader: " claude-session ",
+			},
+			wantID:      "claude-session",
+			wantPresent: true,
+		},
+		{
+			name:      "codex_cli_metadata",
+			userAgent: schemas.CodexCLI.String(),
+			headers: map[string]string{
+				codexTurnMetadataHeader: `{"request_kind":"turn","session_id":" codex-session "}`,
+			},
+			wantID:      "codex-session",
+			wantPresent: true,
+		},
+		{
+			name:      "codex_desktop_metadata",
+			userAgent: schemas.CodexDesktop.String(),
+			headers: map[string]string{
+				codexTurnMetadataHeader: `{"session_id":"desktop-session"}`,
+			},
+			wantID:      "desktop-session",
+			wantPresent: true,
+		},
+		{
+			name:      "generic_client_cannot_claim_claude_session",
+			userAgent: "generic-client/1.0",
+			headers: map[string]string{
+				claudeCodeSessionIDHeader: "spoofed-session",
+			},
+		},
+		{
+			name:      "generic_client_cannot_claim_codex_session",
+			userAgent: "generic-client/1.0",
+			headers: map[string]string{
+				codexTurnMetadataHeader: `{"session_id":"spoofed-session"}`,
+			},
+		},
+		{
+			name:      "malformed_codex_metadata",
+			userAgent: schemas.CodexCLI.String(),
+			headers: map[string]string{
+				codexTurnMetadataHeader: "{",
+			},
+		},
+		{
+			name:      "non_string_codex_session",
+			userAgent: schemas.CodexCLI.String(),
+			headers: map[string]string{
+				codexTurnMetadataHeader: `{"session_id":123}`,
+			},
+		},
+		{
+			name:      "blank_claude_session",
+			userAgent: schemas.ClaudeCLI.String(),
+			headers: map[string]string{
+				claudeCodeSessionIDHeader: "   ",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := complexityHarnessContext(tt.userAgent, tt.headers)
+			gotID, gotSource, gotPresent := ResolveSessionID(ctx, []string{configstore.ComplexitySessionIdentityHarness})
+			assert.Equal(t, tt.wantPresent, gotPresent)
+			assert.Equal(t, tt.wantID, gotID)
+			if tt.wantPresent {
+				assert.Equal(t, configstore.ComplexitySessionIdentityHarness, gotSource)
+			} else {
+				assert.Empty(t, gotSource)
+			}
+		})
+	}
+}
+
+func TestResolveSessionIDInvalidHeaderFallsThrough(t *testing.T) {
+	ctx := complexityHarnessContext(schemas.ClaudeCLI.String(), map[string]string{
+		claudeCodeSessionIDHeader: "native-session",
+	})
+	ctx.SetValue(schemas.BifrostContextKeySessionID, strings.Repeat("a", maxComplexitySessionIDBytes+1))
+
+	id, source, ok := ResolveSessionID(ctx, []string{
+		configstore.ComplexitySessionIdentityHeader,
+		configstore.ComplexitySessionIdentityHarness,
+	})
+
+	require.True(t, ok)
+	assert.Equal(t, "native-session", id)
+	assert.Equal(t, configstore.ComplexitySessionIdentityHarness, source)
+}
+
+func TestResolveSessionIDMalformedHarnessReturnsNoIdentity(t *testing.T) {
+	ctx := complexityHarnessContext(schemas.CodexCLI.String(), map[string]string{
+		codexTurnMetadataHeader: "{",
+	})
+
+	id, source, ok := ResolveSessionID(ctx, []string{configstore.ComplexitySessionIdentityHarness})
+
+	assert.False(t, ok)
+	assert.Empty(t, id)
+	assert.Empty(t, source)
+}
+
+func TestResolveSessionIDPrecedence(t *testing.T) {
+	ctx := complexityHarnessContext(schemas.ClaudeCLI.String(), map[string]string{
+		claudeCodeSessionIDHeader: " native-session ",
+	})
+	ctx.SetValue(schemas.BifrostContextKeySessionID, " explicit-session ")
+
+	tests := []struct {
+		name        string
+		sources     []string
+		wantID      string
+		wantSource  string
+		wantPresent bool
+	}{
+		{
+			name: "header_wins_regardless_of_config_order",
+			sources: []string{
+				configstore.ComplexitySessionIdentityHarness,
+				configstore.ComplexitySessionIdentityHeader,
+			},
+			wantID:      "explicit-session",
+			wantSource:  configstore.ComplexitySessionIdentityHeader,
+			wantPresent: true,
+		},
+		{
+			name: "harness_wins_when_header_is_disabled",
+			sources: []string{
+				configstore.ComplexitySessionIdentityHarness,
+			},
+			wantID:      "native-session",
+			wantSource:  configstore.ComplexitySessionIdentityHarness,
+			wantPresent: true,
+		},
+		{
+			name:    "no_enabled_sources",
+			sources: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotID, gotSource, gotPresent := ResolveSessionID(ctx, tt.sources)
+			assert.Equal(t, tt.wantPresent, gotPresent)
+			assert.Equal(t, tt.wantSource, gotSource)
+			if tt.wantPresent {
+				assert.Equal(t, tt.wantID, gotID)
+			} else {
+				assert.Empty(t, gotID)
+			}
+		})
+	}
+}
+
+func testComplexitySessionKey(t *testing.T, scopeID, sessionID string) string {
+	t.Helper()
+	key, ok := BuildSessionKey(scopeID, sessionID)
+	require.True(t, ok)
+	return key
+}
+
+func complexitySessionChatRequest(systemText string, userTexts ...string) *schemas.BifrostRequest {
+	messages := make([]schemas.ChatMessage, 0, len(userTexts)+1)
+	if systemText != "" {
+		messages = append(messages, schemas.ChatMessage{
+			Role:    schemas.ChatMessageRoleSystem,
+			Content: complexityChatString(systemText),
+		})
+	}
+	for _, userText := range userTexts {
+		messages = append(messages, schemas.ChatMessage{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: complexityChatString(userText),
+		})
+	}
+	return &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{Input: messages},
+	}
+}

--- a/plugins/routing/complexitysession.go
+++ b/plugins/routing/complexitysession.go
@@ -1,0 +1,574 @@
+package routing
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/kvstore"
+	"github.com/maximhq/bifrost/plugins/routing/complexity"
+)
+
+const (
+	complexitySessionStoreBackendKV = "kvstore"
+)
+
+var (
+	errNilComplexitySessionStore   = errors.New("complexity session kvstore cannot be nil")
+	errNilComplexitySessionContext = errors.New("complexity session context cannot be nil")
+	errNilComplexitySessionRecord  = errors.New("complexity session record cannot be nil")
+	errNilComplexitySessionUpdater = errors.New("complexity session updater cannot be nil")
+	errInvalidComplexitySessionTTL = errors.New("complexity session ttl must be positive")
+	errInvalidComplexitySession    = errors.New("invalid complexity session record")
+)
+
+// SessionComplexityRecord is the persisted classifier decision for one
+// scope-namespaced session. It stores runtime facts, never session policy, so
+// config changes take effect without record migration.
+type SessionComplexityRecord struct {
+	// Tier is the currently pinned or held complexity tier.
+	Tier string `json:"tier"`
+	// DecidedAt is when Tier was first selected or most recently switched.
+	DecidedAt time.Time `json:"decided_at"`
+	// RuleID identifies the routing rule that established the current tier. A
+	// missing rule invalidates the pin.
+	RuleID string `json:"rule_id"`
+	// SwitchCount is the number of tier changes made during this session.
+	SwitchCount int `json:"switch_count,omitempty"`
+	// RefreshedAt is when the sliding expiration was last extended. It exists so
+	// reads can tell whether the window actually needs sliding: refreshing on
+	// every read makes each read a write, and each write a cluster broadcast.
+	RefreshedAt time.Time `json:"refreshed_at"`
+
+	// PendingTurns is the number of consecutive downgrade-direction proposals
+	// made since the last switch or non-pending hold. Any tier lower than the
+	// one currently held counts identically toward this streak — it does not
+	// track which specific lower tier was proposed, because a downgrade that
+	// completes the streak lands on whatever tier the completing turn itself
+	// proposed, not one rank below the held tier.
+	PendingTurns int `json:"pending_turns,omitempty"`
+}
+
+// sessionTierDecisionReason is a stable, machine-readable explanation of a
+// cache-aware tier decision. The integration layer may turn it into a richer
+// routing log, but policy remains independent of logging and request state.
+type sessionTierDecisionReason string
+
+const (
+	sessionTierReasonInvalidState           sessionTierDecisionReason = "invalid_state"
+	sessionTierReasonInvalidProposal        sessionTierDecisionReason = "invalid_proposal"
+	sessionTierReasonNoProposal             sessionTierDecisionReason = "no_proposal"
+	sessionTierReasonSameTier               sessionTierDecisionReason = "same_tier"
+	sessionTierReasonBelowSwitchSimilarity  sessionTierDecisionReason = "below_switch_similarity"
+	sessionTierReasonSwitchLimitReached     sessionTierDecisionReason = "switch_limit_reached"
+	sessionTierReasonEscalated              sessionTierDecisionReason = "escalated"
+	sessionTierReasonDowngradePending       sessionTierDecisionReason = "downgrade_pending"
+	sessionTierReasonDowngraded             sessionTierDecisionReason = "downgraded"
+	sessionTierReasonDowngradedByConfidence sessionTierDecisionReason = "downgraded_by_confidence"
+)
+
+// sessionTierDecision is the result of applying cache-aware session policy.
+// Tier is the value to publish for this turn. Switched distinguishes a tier
+// move from a hold, while RecordChanged tells the caller whether persistence is
+// necessary even when the tier stayed put, such as while advancing a pending
+// downgrade.
+type sessionTierDecision struct {
+	Tier          string
+	Switched      bool
+	RecordChanged bool
+	Reason        sessionTierDecisionReason
+}
+
+// SessionStoreStatus describes the guarantees of the active session-state
+// backend. It reports what the storage layer can prove about itself, never
+// whether a given deployment is safe: that also depends on how many replicas
+// are running, which this layer cannot observe.
+type SessionStoreStatus struct {
+	// Backend is a diagnostic name for the active implementation. Callers must
+	// use the capability fields, not this label, when deciding readiness.
+	Backend string `json:"backend"`
+	// ReplicationConfigured reports whether local mutations are forwarded to
+	// other nodes. It is deliberately named for the configuration rather than
+	// the outcome: forwarding is fire-and-forget, so a delegate being installed
+	// says nothing about whether peers are connected, reachable, or converged.
+	ReplicationConfigured bool `json:"replication_configured"`
+	// AtomicAcrossReplicas reports whether concurrent updates to one session are
+	// serialized across everything sharing this backend. A single node holding
+	// the only copy satisfies this through its own lock; gossip replication does
+	// not, because it resolves conflicts by last-write-wins after the fact.
+	AtomicAcrossReplicas bool `json:"atomic_across_replicas"`
+}
+
+// SessionRecordUpdater mutates a caller-owned copy of the current session
+// record. A store backed by compare-and-swap may invoke it more than once, so an
+// updater must be deterministic, free of side effects, and complete promptly.
+// It must not call back into the same store. Returning an error aborts the write.
+type SessionRecordUpdater func(*SessionComplexityRecord) error
+
+// SessionStore persists typed complexity-session state behind a backend-neutral
+// contract. Implementations must be safe for concurrent use and must not expose
+// shared record pointers to callers.
+type SessionStore interface {
+	// Get reads a record and keeps its sliding expiration at least ttl away. The
+	// returned record is caller-owned. found is false, with a nil error, when the
+	// key is absent or expired. ttl must be positive.
+	//
+	// The refresh is coarse rather than per-read: an implementation may leave the
+	// expiry untouched while the window is still comfortably in the future. A
+	// record therefore survives at least ttl of idleness, and may survive somewhat
+	// longer. This is deliberate — sliding on literally every read turns a read
+	// path into a write path, which on a replicated backend means a cluster
+	// message per request.
+	Get(ctx context.Context, key string, ttl time.Duration) (record *SessionComplexityRecord, found bool, err error)
+	// Create atomically stores a caller-owned snapshot only when key is absent or
+	// expired. created is false, with a nil error, when another caller already
+	// created the record. ttl must be positive.
+	Create(ctx context.Context, key string, record *SessionComplexityRecord, ttl time.Duration) (created bool, err error)
+	// Update atomically applies update to an existing record and refreshes its
+	// sliding expiration to ttl. It returns a caller-owned copy of the committed
+	// record. When found is false, update was not called. Implementations may
+	// retry update to resolve concurrent writes; ttl must be positive.
+	Update(ctx context.Context, key string, ttl time.Duration, update SessionRecordUpdater) (record *SessionComplexityRecord, found bool, err error)
+	// Delete removes a record. deleted is false, with a nil error, when the key
+	// does not exist.
+	Delete(ctx context.Context, key string) (deleted bool, err error)
+	// Status reports the backend's current replication and atomicity guarantees.
+	// An error means readiness could not be determined.
+	Status(ctx context.Context) (SessionStoreStatus, error)
+}
+
+// kvSessionStore persists complexity-session records in framework/kvstore. Its
+// atomicity is process-local: a configured gossip delegate shares committed
+// values across replicas but does not turn updates into distributed transactions.
+type kvSessionStore struct {
+	store *kvstore.Store
+}
+
+var _ SessionStore = (*kvSessionStore)(nil)
+
+// newKVSessionStore creates a typed complexity-session view over store. The
+// registered decoder ensures remotely replicated records retain their concrete
+// type instead of falling back to raw JSON bytes.
+func newKVSessionStore(store *kvstore.Store) (*kvSessionStore, error) {
+	if store == nil {
+		return nil, errNilComplexitySessionStore
+	}
+	store.RegisterDecoder(complexity.SessionKeyPrefix, func(data []byte) (any, error) {
+		var record SessionComplexityRecord
+		if err := json.Unmarshal(data, &record); err != nil {
+			return nil, fmt.Errorf("decode complexity session record: %w", err)
+		}
+		return &record, nil
+	})
+	return &kvSessionStore{store: store}, nil
+}
+
+// Get reads a caller-owned record and refreshes its sliding TTL atomically. A
+// successful read is also a write, so a configured sync delegate receives one
+// replication event for each refresh.
+func (s *kvSessionStore) Get(ctx context.Context, key string, ttl time.Duration) (*SessionComplexityRecord, bool, error) {
+	if err := validateComplexitySessionStoreRequest(ctx, ttl); err != nil {
+		return nil, false, err
+	}
+
+	// The read-only path first. kvstore.Get takes a read lock and notifies no
+	// delegate, so a held turn costs nothing beyond a map lookup.
+	value, err := s.store.Get(key)
+	if errors.Is(err, kvstore.ErrNotFound) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("read complexity session %q: %w", key, err)
+	}
+
+	record, err := complexitySessionRecordFromValue(value)
+	if err != nil {
+		return nil, true, fmt.Errorf("read complexity session %q: %w", key, err)
+	}
+
+	// Still comfortably inside the window, so leave the expiry alone.
+	if time.Since(record.RefreshedAt) < complexitySessionRefreshInterval(ttl) {
+		return record, true, nil
+	}
+
+	refreshedAt := time.Now()
+	value, found, err := s.store.UpdateWithTTL(key, complexitySessionStoredTTL(ttl), func(current any) (any, error) {
+		refreshed, err := complexitySessionRecordFromValue(current)
+		if err != nil {
+			return nil, err
+		}
+		refreshed.RefreshedAt = refreshedAt
+		return refreshed, nil
+	})
+	if err != nil {
+		return nil, true, fmt.Errorf("refresh complexity session %q: %w", key, err)
+	}
+	if !found {
+		// Expired between the read and the refresh. The record we hold is already
+		// gone, so report it as absent rather than serving a tier the store no
+		// longer has.
+		return nil, false, nil
+	}
+
+	refreshed, err := complexitySessionRecordFromValue(value)
+	if err != nil {
+		return nil, true, fmt.Errorf("read refreshed complexity session %q: %w", key, err)
+	}
+	return refreshed, true, nil
+}
+
+// complexitySessionRefreshInterval is how much of the idle window may elapse
+// before a read slides the expiry. A quarter keeps writes to roughly four per
+// window however chatty the conversation is, while staying frequent enough that
+// the stored expiry never drifts far from the truth.
+func complexitySessionRefreshInterval(ttl time.Duration) time.Duration {
+	interval := ttl / 4
+	if interval <= 0 {
+		// A ttl too short to quarter refreshes on every read, which is correct:
+		// there is no amplification to avoid at that scale.
+		return 0
+	}
+	return interval
+}
+
+// complexitySessionStoredTTL is the expiry actually written to the backend. It
+// carries one refresh interval of headroom so a coarse refresh can never expire
+// a session earlier than the configured idle window: the worst case is a read
+// that declines to slide just before the caller goes idle, and the headroom
+// covers exactly that gap. The cost is that an abandoned session lingers up to
+// one interval longer than configured.
+func complexitySessionStoredTTL(ttl time.Duration) time.Duration {
+	return ttl + complexitySessionRefreshInterval(ttl)
+}
+
+// Create stores a detached record snapshot when key is currently absent or
+// expired.
+func (s *kvSessionStore) Create(ctx context.Context, key string, record *SessionComplexityRecord, ttl time.Duration) (bool, error) {
+	if err := validateComplexitySessionStoreRequest(ctx, ttl); err != nil {
+		return false, err
+	}
+	if record == nil {
+		return false, errNilComplexitySessionRecord
+	}
+
+	// The store owns the refresh clock, not the caller: a record created with a
+	// zero or stale RefreshedAt would slide its expiry on the very next read,
+	// which is the write-per-read this exists to avoid.
+	stored := cloneSessionComplexityRecord(record)
+	stored.RefreshedAt = time.Now()
+
+	created, err := s.store.SetNXWithTTL(key, stored, complexitySessionStoredTTL(ttl))
+	if err != nil {
+		return false, fmt.Errorf("create complexity session %q: %w", key, err)
+	}
+	return created, nil
+}
+
+// Update applies update to a detached copy and atomically commits another copy,
+// preventing the caller-owned record from aliasing stored state.
+func (s *kvSessionStore) Update(ctx context.Context, key string, ttl time.Duration, update SessionRecordUpdater) (*SessionComplexityRecord, bool, error) {
+	if err := validateComplexitySessionStoreRequest(ctx, ttl); err != nil {
+		return nil, false, err
+	}
+	if update == nil {
+		return nil, false, errNilComplexitySessionUpdater
+	}
+
+	// An update is already a write, so it slides the window too — leaving it on
+	// the old expiry would make a just-modified session expire sooner than a
+	// merely-read one.
+	refreshedAt := time.Now()
+	value, found, err := s.store.UpdateWithTTL(key, complexitySessionStoredTTL(ttl), func(current any) (any, error) {
+		record, err := complexitySessionRecordFromValue(current)
+		if err != nil {
+			return nil, err
+		}
+		if err := update(record); err != nil {
+			return nil, err
+		}
+		// Stamped after the updater so a caller cannot rewind the refresh clock.
+		record.RefreshedAt = refreshedAt
+		return cloneSessionComplexityRecord(record), nil
+	})
+	if err != nil {
+		return nil, found, fmt.Errorf("update complexity session %q: %w", key, err)
+	}
+	if !found {
+		return nil, false, nil
+	}
+
+	record, err := complexitySessionRecordFromValue(value)
+	if err != nil {
+		return nil, true, fmt.Errorf("read updated complexity session %q: %w", key, err)
+	}
+	return record, true, nil
+}
+
+// Delete removes a live session record. Expired records are treated as absent.
+func (s *kvSessionStore) Delete(ctx context.Context, key string) (bool, error) {
+	if err := validateComplexitySessionStoreContext(ctx); err != nil {
+		return false, err
+	}
+
+	_, err := s.store.GetAndDelete(key)
+	if errors.Is(err, kvstore.ErrNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("delete complexity session %q: %w", key, err)
+	}
+	return true, nil
+}
+
+// Status reports the guarantees relevant to session routing. Gossip makes
+// records visible across replicas, but updates remain atomic only within one
+// process.
+func (s *kvSessionStore) Status(ctx context.Context) (SessionStoreStatus, error) {
+	if err := validateComplexitySessionStoreContext(ctx); err != nil {
+		return SessionStoreStatus{}, err
+	}
+
+	replicationConfigured := s.store.HasSyncDelegate()
+	return SessionStoreStatus{
+		Backend:               complexitySessionStoreBackendKV,
+		ReplicationConfigured: replicationConfigured,
+		// Inverted deliberately. With no delegate this process holds the only
+		// copy and its own lock serializes every update, so updates are atomic
+		// across the one replica that exists. Once replication is configured the
+		// lock is local to each node while the records are shared, which is the
+		// combination that lets two nodes decide different tiers for one session.
+		AtomicAcrossReplicas: !replicationConfigured,
+	}, nil
+}
+
+func validateComplexitySessionStoreRequest(ctx context.Context, ttl time.Duration) error {
+	if err := validateComplexitySessionStoreContext(ctx); err != nil {
+		return err
+	}
+	if ttl <= 0 {
+		return errInvalidComplexitySessionTTL
+	}
+	return nil
+}
+
+func validateComplexitySessionStoreContext(ctx context.Context) error {
+	if ctx == nil {
+		return errNilComplexitySessionContext
+	}
+	return ctx.Err()
+}
+
+func complexitySessionRecordFromValue(value any) (*SessionComplexityRecord, error) {
+	switch record := value.(type) {
+	case *SessionComplexityRecord:
+		if record == nil {
+			return nil, fmt.Errorf("%w: nil pointer", errInvalidComplexitySession)
+		}
+		return cloneSessionComplexityRecord(record), nil
+	case SessionComplexityRecord:
+		return cloneSessionComplexityRecord(&record), nil
+	default:
+		return nil, fmt.Errorf("%w: got %T", errInvalidComplexitySession, value)
+	}
+}
+
+func cloneSessionComplexityRecord(record *SessionComplexityRecord) *SessionComplexityRecord {
+	if record == nil {
+		return nil
+	}
+	cloned := *record
+	return &cloned
+}
+
+// updateSessionTierRecord applies cache-aware switching policy to record and
+// returns the tier to publish for this turn. It mutates only the supplied
+// caller-owned record and performs no I/O, logging, or store access.
+//
+// Callers must invoke it from inside SessionStore.Update so the decision and
+// its PendingTurns/SwitchCount mutations use the latest record atomically. A
+// false RecordChanged result lets the caller abort the write, avoiding an
+// unnecessary replication message for an ordinary held turn.
+func updateSessionTierRecord(
+	record *SessionComplexityRecord,
+	proposed *complexity.ComplexityResult,
+	config *configstore.ComplexitySessionConfig,
+	now time.Time,
+) sessionTierDecision {
+	if record == nil {
+		return sessionTierDecision{Reason: sessionTierReasonInvalidState}
+	}
+	if config == nil || config.Mode != configstore.ComplexitySessionModeCacheAware {
+		return sessionTierDecision{Tier: record.Tier, Reason: sessionTierReasonInvalidState}
+	}
+
+	currentRank, currentValid := sessionTierRank(record.Tier)
+	if !currentValid {
+		return sessionTierDecision{Tier: record.Tier, Reason: sessionTierReasonInvalidState}
+	}
+	if proposed == nil || proposed.Tier == "" {
+		return heldSessionTierDecision(record, sessionTierReasonNoProposal)
+	}
+
+	proposedRank, proposedValid := sessionTierRank(proposed.Tier)
+	if !proposedValid {
+		return heldSessionTierDecision(record, sessionTierReasonInvalidProposal)
+	}
+	if proposedRank == currentRank {
+		return heldSessionTierDecision(record, sessionTierReasonSameTier)
+	}
+
+	escalating := proposedRank > currentRank
+	// The similarity floor gates escalations only. For a downgrade,
+	// SwitchMinSimilarity is Path A's fast-path trigger, not an entry bar (see
+	// below): applying it here too would reject every sub-threshold downgrade
+	// turn before it could accumulate, leaving DowngradeAfterNTurns unreachable
+	// whenever SwitchMinSimilarity is positive.
+	if escalating && !meetsSessionSwitchSimilarity(proposed.Score, config.SwitchMinSimilarity) &&
+		!config.AlwaysAllowEscalation {
+		return heldSessionTierDecision(record, sessionTierReasonBelowSwitchSimilarity)
+	}
+	if config.MaxSwitchesPerSession > 0 && record.SwitchCount >= config.MaxSwitchesPerSession {
+		return heldSessionTierDecision(record, sessionTierReasonSwitchLimitReached)
+	}
+	if escalating {
+		return switchedSessionTierDecision(record, proposed.Tier, now, sessionTierReasonEscalated)
+	}
+
+	// Downgrade: an OR of two independent paths, not a single AND'd gate. A
+	// turn confident enough on its own switches immediately (Path A); otherwise
+	// several turns that simply keep pointing simpler than the held tier — none
+	// of them individually confident, and not necessarily the same specific
+	// tier — accumulate toward the same result (Path B).
+	if sessionMeetsDowngradeConfidence(proposed.Score, config.SwitchMinSimilarity) {
+		return switchedSessionTierDecision(record, proposed.Tier, now, sessionTierReasonDowngradedByConfidence)
+	}
+
+	requiredTurns := config.DowngradeAfterNTurns
+	if requiredTurns < 1 {
+		requiredTurns = 1
+	}
+	advancePendingSessionTurns(record)
+	if record.PendingTurns < requiredTurns {
+		return unswitchedSessionTierDecision(record, sessionTierReasonDowngradePending, true)
+	}
+
+	return switchedSessionTierDecision(record, proposed.Tier, now, sessionTierReasonDowngraded)
+}
+
+func sessionTierRank(tier string) (int, bool) {
+	switch tier {
+	case complexity.TierSimple:
+		return 0, true
+	case complexity.TierMedium:
+		return 1, true
+	case complexity.TierComplex:
+		return 2, true
+	default:
+		return 0, false
+	}
+}
+
+func meetsSessionSwitchSimilarity(score, threshold float64) bool {
+	return threshold <= 0 || score >= threshold
+}
+
+// sessionMeetsDowngradeConfidence reports whether this turn's own proposal is
+// confident enough, alone, to switch without waiting on downgrade_after_n_turns.
+// threshold<=0 must mean "fast path disabled," not "always fast": unlike
+// meetsSessionSwitchSimilarity, where threshold<=0 means "no floor at all,"
+// treating an unset threshold as always-satisfied here would make Path A fire
+// on literally every downgrade that clears the (separate) similarity gate
+// above, permanently starving Path B under the shipped default.
+func sessionMeetsDowngradeConfidence(score, threshold float64) bool {
+	return threshold > 0 && score >= threshold
+}
+
+func heldSessionTierDecision(record *SessionComplexityRecord, reason sessionTierDecisionReason) sessionTierDecision {
+	return unswitchedSessionTierDecision(record, reason, clearPendingSessionTurns(record))
+}
+
+func unswitchedSessionTierDecision(
+	record *SessionComplexityRecord,
+	reason sessionTierDecisionReason,
+	recordChanged bool,
+) sessionTierDecision {
+	return sessionTierDecision{
+		Tier:          record.Tier,
+		RecordChanged: recordChanged,
+		Reason:        reason,
+	}
+}
+
+func clearPendingSessionTurns(record *SessionComplexityRecord) bool {
+	if record.PendingTurns == 0 {
+		return false
+	}
+	record.PendingTurns = 0
+	return true
+}
+
+func advancePendingSessionTurns(record *SessionComplexityRecord) {
+	record.PendingTurns++
+}
+
+func switchedSessionTierDecision(
+	record *SessionComplexityRecord,
+	tier string,
+	now time.Time,
+	reason sessionTierDecisionReason,
+) sessionTierDecision {
+	record.Tier = tier
+	record.DecidedAt = now
+	record.SwitchCount++
+	clearPendingSessionTurns(record)
+	return sessionTierDecision{
+		Tier:          record.Tier,
+		Switched:      true,
+		RecordChanged: true,
+		Reason:        reason,
+	}
+}
+
+// ComplexitySessionKVStoreSetter is implemented by routing plugins that accept
+// Bifrost's configured key-value store as the backend for session state. Wired
+// by the HTTP server like EmbeddingExecutorSetter; wrappers that embed
+// *RoutingPlugin satisfy this via method promotion.
+type ComplexitySessionKVStoreSetter interface {
+	SetComplexitySessionKVStore(*kvstore.Store) error
+}
+
+// SetComplexitySessionKVStore installs the backing store for session state.
+//
+// It is a setter rather than an Init parameter so the store can be attached
+// after the plugin exists, matching how the embedding executor is wired.
+// Attachment time does not affect what Status reports: the backend's
+// guarantees are read at call time, so a replication delegate installed later
+// is picked up without re-registering anything here.
+func (p *RoutingPlugin) SetComplexitySessionKVStore(store *kvstore.Store) error {
+	sessionStore, err := newKVSessionStore(store)
+	if err != nil {
+		return err
+	}
+	var asInterface SessionStore = sessionStore
+	p.complexitySessionStore.Store(&asInterface)
+	return nil
+}
+
+// ComplexitySessionStoreStatus reports what the session-state backend can
+// guarantee, or nil when no store is attached. Callers must not read a nil
+// result as "unsafe": it means session state has no backing store at all, which
+// is the normal case while session routing is switched off.
+func (p *RoutingPlugin) ComplexitySessionStoreStatus(ctx context.Context) (*SessionStoreStatus, error) {
+	stored := p.complexitySessionStore.Load()
+	if stored == nil {
+		return nil, nil
+	}
+	status, err := (*stored).Status(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &status, nil
+}

--- a/plugins/routing/complexitysession_test.go
+++ b/plugins/routing/complexitysession_test.go
@@ -1,0 +1,666 @@
+package routing
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/kvstore"
+	"github.com/maximhq/bifrost/plugins/routing/complexity"
+)
+
+func TestKVSessionStoreRoundTripAndOwnership(t *testing.T) {
+	sessionStore, _ := newTestKVSessionStore(t)
+	key := testComplexitySessionKey(t, "tenant", "round-trip")
+	decidedAt := time.Date(2026, time.August, 10, 12, 0, 0, 0, time.UTC)
+	record := &SessionComplexityRecord{
+		Tier:         "complex",
+		DecidedAt:    decidedAt,
+		RuleID:       "rule-1",
+		SwitchCount:  2,
+		PendingTurns: 1,
+	}
+	want := cloneSessionComplexityRecord(record)
+
+	created, err := sessionStore.Create(context.Background(), key, record, time.Hour)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	// Mutating the input after Create must not mutate stored state.
+	record.Tier = "simple"
+
+	got, found, err := sessionStore.Get(context.Background(), key, time.Hour)
+	require.NoError(t, err)
+	require.True(t, found)
+	// The store stamps RefreshedAt itself, so it is asserted separately and
+	// cleared before the structural comparison.
+	assert.False(t, got.RefreshedAt.IsZero(), "Create should stamp the refresh clock")
+	got.RefreshedAt = time.Time{}
+	want.RefreshedAt = time.Time{}
+	assert.Equal(t, want, got)
+
+	// Mutating a returned record must not mutate stored state either.
+	got.PendingTurns = 99
+
+	gotAgain, found, err := sessionStore.Get(context.Background(), key, time.Hour)
+	require.NoError(t, err)
+	require.True(t, found)
+	gotAgain.RefreshedAt = time.Time{}
+	assert.Equal(t, want, gotAgain)
+}
+
+func TestKVSessionStoreCreateIsAtomic(t *testing.T) {
+	sessionStore, _ := newTestKVSessionStore(t)
+	key := testComplexitySessionKey(t, "tenant", "create-race")
+
+	const contenders = 50
+	var createdCount atomic.Int32
+	errCh := make(chan error, contenders)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for range contenders {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			created, err := sessionStore.Create(context.Background(), key, &SessionComplexityRecord{
+				Tier:   "complex",
+				RuleID: "rule-1",
+			}, time.Hour)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if created {
+				createdCount.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Errorf("create failed: %v", err)
+	}
+	assert.EqualValues(t, 1, createdCount.Load())
+}
+
+func TestKVSessionStoreUpdateIsAtomic(t *testing.T) {
+	sessionStore, _ := newTestKVSessionStore(t)
+	key := testComplexitySessionKey(t, "tenant", "update-race")
+	created, err := sessionStore.Create(context.Background(), key, &SessionComplexityRecord{
+		Tier:   "complex",
+		RuleID: "rule-1",
+	}, time.Hour)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	const updates = 100
+	errCh := make(chan error, updates)
+	var wg sync.WaitGroup
+	for range updates {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, found, err := sessionStore.Update(context.Background(), key, time.Hour, func(record *SessionComplexityRecord) error {
+				record.PendingTurns++
+				return nil
+			})
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if !found {
+				errCh <- kvstore.ErrNotFound
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Errorf("update failed: %v", err)
+	}
+
+	record, found, err := sessionStore.Get(context.Background(), key, time.Hour)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, updates, record.PendingTurns)
+}
+
+func TestKVSessionStoreUpdateFailureDoesNotMutate(t *testing.T) {
+	sessionStore, _ := newTestKVSessionStore(t)
+	key := testComplexitySessionKey(t, "tenant", "failed-update")
+	created, err := sessionStore.Create(context.Background(), key, &SessionComplexityRecord{
+		Tier:         "complex",
+		RuleID:       "rule-1",
+		PendingTurns: 1,
+	}, time.Hour)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	wantErr := errors.New("policy rejected update")
+	_, found, err := sessionStore.Update(context.Background(), key, time.Hour, func(record *SessionComplexityRecord) error {
+		record.PendingTurns = 99
+		return wantErr
+	})
+	require.ErrorIs(t, err, wantErr)
+	require.True(t, found)
+
+	record, found, err := sessionStore.Get(context.Background(), key, time.Hour)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, 1, record.PendingTurns)
+}
+
+func TestKVSessionStoreSlidingTTL(t *testing.T) {
+	sessionStore, _ := newTestKVSessionStore(t)
+	key := testComplexitySessionKey(t, "tenant", "sliding-ttl")
+	// Wide enough that ordinary scheduler jitter cannot reorder the checks
+	// against the deadlines they straddle; each sleep stays a fixed fraction of
+	// the window so the sequence still proves the slide.
+	const ttl = time.Second
+
+	created, err := sessionStore.Create(context.Background(), key, &SessionComplexityRecord{
+		Tier:   "complex",
+		RuleID: "rule-1",
+	}, ttl)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	time.Sleep(600 * time.Millisecond)
+	_, found, err := sessionStore.Get(context.Background(), key, ttl)
+	require.NoError(t, err)
+	require.True(t, found, "record should exist before its original deadline")
+
+	time.Sleep(600 * time.Millisecond)
+	_, found, err = sessionStore.Get(context.Background(), key, ttl)
+	require.NoError(t, err)
+	require.True(t, found, "successful Get should extend the deadline")
+
+	// Expiry is ttl plus one refresh interval of headroom, so an abandoned
+	// session lingers a little past the configured window rather than expiring
+	// early — the direction that matters, since expiring early would drop a live
+	// conversation's tier mid-way.
+	time.Sleep(ttl + complexitySessionRefreshInterval(ttl) + 100*time.Millisecond)
+	_, found, err = sessionStore.Get(context.Background(), key, ttl)
+	require.NoError(t, err)
+	assert.False(t, found, "record should expire once its TTL is no longer refreshed")
+}
+
+// The refresh is coarse on purpose: sliding the expiry on every read makes each
+// read a write, and on a replicated backend each write is a cluster broadcast.
+// A chatty conversation must not cost one broadcast per turn.
+func TestKVSessionStoreGetDoesNotWriteOnEveryRead(t *testing.T) {
+	sessionStore, store := newTestKVSessionStore(t)
+	_, targetKV := newTestKVSessionStore(t)
+	delegate := &forwardingKVDelegate{target: targetKV}
+
+	key := testComplexitySessionKey(t, "tenant", "read-amplification")
+	_, err := sessionStore.Create(context.Background(), key, &SessionComplexityRecord{Tier: "complex"}, time.Hour)
+	require.NoError(t, err)
+
+	// Attached after Create so only the reads below are counted.
+	store.SetDelegate(delegate)
+	for i := 0; i < 50; i++ {
+		_, found, err := sessionStore.Get(context.Background(), key, time.Hour)
+		require.NoError(t, err)
+		require.True(t, found)
+	}
+
+	assert.Zero(t, delegate.Sets(), "reads inside the refresh interval must not replicate")
+}
+
+// The window must still slide for a long-lived conversation, or a session that
+// stays busy past its ttl would expire underneath itself.
+func TestKVSessionStoreGetRefreshesOnceTheIntervalElapses(t *testing.T) {
+	sessionStore, _ := newTestKVSessionStore(t)
+	key := testComplexitySessionKey(t, "tenant", "interval-elapsed")
+	const ttl = 400 * time.Millisecond
+
+	_, err := sessionStore.Create(context.Background(), key, &SessionComplexityRecord{Tier: "complex"}, ttl)
+	require.NoError(t, err)
+
+	before, found, err := sessionStore.Get(context.Background(), key, ttl)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	// Past one refresh interval (ttl/4 = 100ms), so the next read slides it.
+	time.Sleep(complexitySessionRefreshInterval(ttl) + 50*time.Millisecond)
+	after, found, err := sessionStore.Get(context.Background(), key, ttl)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.True(t, after.RefreshedAt.After(before.RefreshedAt), "the window never slid")
+}
+
+func TestKVSessionStoreRegistersReplicationDecoder(t *testing.T) {
+	source, sourceKV := newTestKVSessionStore(t)
+	target, targetKV := newTestKVSessionStore(t)
+	delegate := &forwardingKVDelegate{target: targetKV}
+	sourceKV.SetDelegate(delegate)
+
+	key := testComplexitySessionKey(t, "tenant", "replicated")
+	want := &SessionComplexityRecord{
+		Tier:   "complex",
+		RuleID: "rule-1",
+	}
+	created, err := source.Create(context.Background(), key, want, time.Hour)
+	require.NoError(t, err)
+	require.True(t, created)
+	require.NoError(t, delegate.Err())
+
+	replicatedValue, err := targetKV.Get(key)
+	require.NoError(t, err)
+	assert.IsType(t, &SessionComplexityRecord{}, replicatedValue)
+
+	got, found, err := target.Get(context.Background(), key, time.Hour)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.False(t, got.RefreshedAt.IsZero(), "the replicated record should carry the refresh clock")
+	got.RefreshedAt = time.Time{}
+	assert.Equal(t, want, got)
+}
+
+func TestKVSessionStoreRejectsInvalidReplicatedRecord(t *testing.T) {
+	sessionStore, store := newTestKVSessionStore(t)
+	key := testComplexitySessionKey(t, "tenant", "invalid-replica")
+	require.NoError(t, store.SetRemote(key, []byte("{"), time.Now().UnixNano(), 0))
+
+	_, found, err := sessionStore.Get(context.Background(), key, time.Hour)
+	require.ErrorIs(t, err, errInvalidComplexitySession)
+	assert.True(t, found)
+}
+
+func TestKVSessionStoreDeleteAndValidation(t *testing.T) {
+	sessionStore, _ := newTestKVSessionStore(t)
+	key := testComplexitySessionKey(t, "tenant", "delete")
+	record := &SessionComplexityRecord{Tier: "complex", RuleID: "rule-1"}
+
+	created, err := sessionStore.Create(context.Background(), key, record, time.Hour)
+	require.NoError(t, err)
+	require.True(t, created)
+	deleted, err := sessionStore.Delete(context.Background(), key)
+	require.NoError(t, err)
+	assert.True(t, deleted)
+	deleted, err = sessionStore.Delete(context.Background(), key)
+	require.NoError(t, err)
+	assert.False(t, deleted)
+
+	_, err = sessionStore.Create(context.Background(), key, record, 0)
+	require.ErrorIs(t, err, errInvalidComplexitySessionTTL)
+	_, err = sessionStore.Create(context.Background(), key, nil, time.Hour)
+	require.ErrorIs(t, err, errNilComplexitySessionRecord)
+	_, _, err = sessionStore.Update(context.Background(), key, time.Hour, nil)
+	require.ErrorIs(t, err, errNilComplexitySessionUpdater)
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = sessionStore.Create(canceled, key, record, time.Hour)
+	require.ErrorIs(t, err, context.Canceled)
+	_, err = sessionStore.Status(nil)
+	require.ErrorIs(t, err, errNilComplexitySessionContext)
+}
+
+func TestKVSessionStoreStatus(t *testing.T) {
+	sessionStore, store := newTestKVSessionStore(t)
+
+	status, err := sessionStore.Status(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, SessionStoreStatus{
+		Backend:               complexitySessionStoreBackendKV,
+		ReplicationConfigured: false,
+		AtomicAcrossReplicas:  true,
+	}, status)
+
+	_, targetKV := newTestKVSessionStore(t)
+	store.SetDelegate(&forwardingKVDelegate{target: targetKV})
+	status, err = sessionStore.Status(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, SessionStoreStatus{
+		Backend:               complexitySessionStoreBackendKV,
+		ReplicationConfigured: true,
+		AtomicAcrossReplicas:  false,
+	}, status)
+}
+
+func TestSessionTierRank(t *testing.T) {
+	tests := []struct {
+		name     string
+		tier     string
+		wantRank int
+		wantOK   bool
+	}{
+		{name: "simple", tier: complexity.TierSimple, wantRank: 0, wantOK: true},
+		{name: "medium", tier: complexity.TierMedium, wantRank: 1, wantOK: true},
+		{name: "complex", tier: complexity.TierComplex, wantRank: 2, wantOK: true},
+		{name: "unknown", tier: "UNKNOWN", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rank, ok := sessionTierRank(tt.tier)
+			assert.Equal(t, tt.wantRank, rank)
+			assert.Equal(t, tt.wantOK, ok)
+		})
+	}
+}
+
+func TestUpdateSessionTierRecordClearsInterruptedDowngrade(t *testing.T) {
+	now := time.Date(2026, time.August, 11, 10, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		proposed   *complexity.ComplexityResult
+		configure  func(*configstore.ComplexitySessionConfig)
+		wantReason sessionTierDecisionReason
+	}{
+		{name: "no proposal", wantReason: sessionTierReasonNoProposal},
+		{
+			name:       "empty proposed tier",
+			proposed:   sessionTierProposal("", 0.95),
+			wantReason: sessionTierReasonNoProposal,
+		},
+		{
+			name:       "invalid proposed tier",
+			proposed:   sessionTierProposal("UNKNOWN", 0.95),
+			wantReason: sessionTierReasonInvalidProposal,
+		},
+		{
+			name:       "same tier",
+			proposed:   sessionTierProposal(complexity.TierComplex, 0.95),
+			wantReason: sessionTierReasonSameTier,
+		},
+		{
+			name:       "switch limit",
+			proposed:   sessionTierProposal(complexity.TierMedium, 0.95),
+			configure:  func(config *configstore.ComplexitySessionConfig) { config.MaxSwitchesPerSession = 1 },
+			wantReason: sessionTierReasonSwitchLimitReached,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := sessionTierTestConfig()
+			if tt.configure != nil {
+				tt.configure(config)
+			}
+			record := sessionTierTestRecord(now)
+			record.SwitchCount = 1
+			record.PendingTurns = 1
+
+			decision := updateSessionTierRecord(record, tt.proposed, config, now)
+
+			assert.Equal(t, complexity.TierComplex, decision.Tier)
+			assert.Equal(t, tt.wantReason, decision.Reason)
+			assert.True(t, decision.RecordChanged)
+			assert.False(t, decision.Switched)
+			assert.Zero(t, record.PendingTurns)
+			assert.Equal(t, 1, record.SwitchCount)
+		})
+	}
+
+	record := sessionTierTestRecord(now)
+	decision := updateSessionTierRecord(record, nil, sessionTierTestConfig(), now)
+	assert.False(t, decision.RecordChanged, "a repeated hold must not create a store write")
+}
+
+func TestUpdateSessionTierRecordEscalation(t *testing.T) {
+	now := time.Date(2026, time.August, 11, 10, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		score      float64
+		configure  func(*configstore.ComplexitySessionConfig)
+		wantReason sessionTierDecisionReason
+		wantSwitch bool
+	}{
+		{
+			name:       "strong proposal switches immediately",
+			score:      0.91,
+			wantReason: sessionTierReasonEscalated,
+			wantSwitch: true,
+		},
+		{
+			name:       "weak proposal is held",
+			score:      0.7,
+			wantReason: sessionTierReasonBelowSwitchSimilarity,
+		},
+		{
+			name:       "zero threshold disables similarity gate",
+			score:      0,
+			configure:  func(config *configstore.ComplexitySessionConfig) { config.SwitchMinSimilarity = 0 },
+			wantReason: sessionTierReasonEscalated,
+			wantSwitch: true,
+		},
+		{
+			name:       "always allow bypasses similarity",
+			score:      0.7,
+			configure:  func(config *configstore.ComplexitySessionConfig) { config.AlwaysAllowEscalation = true },
+			wantReason: sessionTierReasonEscalated,
+			wantSwitch: true,
+		},
+		{
+			name:  "switch cap remains absolute",
+			score: 0.91,
+			configure: func(config *configstore.ComplexitySessionConfig) {
+				config.AlwaysAllowEscalation = true
+				config.MaxSwitchesPerSession = 1
+			},
+			wantReason: sessionTierReasonSwitchLimitReached,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := sessionTierTestConfig()
+			if tt.configure != nil {
+				tt.configure(config)
+			}
+			record := sessionTierTestRecord(now)
+			record.Tier = complexity.TierMedium
+			if config.MaxSwitchesPerSession > 0 {
+				record.SwitchCount = config.MaxSwitchesPerSession
+			}
+
+			decision := updateSessionTierRecord(record, sessionTierProposal(complexity.TierComplex, tt.score), config, now)
+
+			assert.Equal(t, tt.wantReason, decision.Reason)
+			assert.Equal(t, tt.wantSwitch, decision.Switched)
+			assert.Equal(t, tt.wantSwitch, decision.RecordChanged)
+			if tt.wantSwitch {
+				assert.Equal(t, complexity.TierComplex, record.Tier)
+				assert.Equal(t, now, record.DecidedAt)
+				assert.Equal(t, 1, record.SwitchCount)
+			} else {
+				assert.Equal(t, complexity.TierMedium, record.Tier)
+			}
+		})
+	}
+}
+
+// Exercises Path B (persistence) in isolation: SwitchMinSimilarity is forced
+// to 0 so no turn can take the confidence fast path, and the two downgrade
+// turns propose different specific tiers (MEDIUM then SIMPLE) to prove the
+// streak accumulates on direction alone rather than resetting on a tier
+// mismatch, landing on the completing turn's own proposal.
+func TestUpdateSessionTierRecordRequiresSustainedDowngrade(t *testing.T) {
+	now := time.Date(2026, time.August, 11, 10, 0, 0, 0, time.UTC)
+	config := sessionTierTestConfig()
+	config.SwitchMinSimilarity = 0
+	record := sessionTierTestRecord(now)
+
+	first := updateSessionTierRecord(record, sessionTierProposal(complexity.TierMedium, 0.93), config, now)
+	assert.Equal(t, sessionTierReasonDowngradePending, first.Reason)
+	assert.False(t, first.Switched)
+	assert.True(t, first.RecordChanged)
+	assert.Equal(t, 1, record.PendingTurns)
+
+	second := updateSessionTierRecord(record, sessionTierProposal(complexity.TierSimple, 0.4), config, now.Add(time.Minute))
+	assert.Equal(t, sessionTierReasonDowngraded, second.Reason)
+	assert.True(t, second.Switched)
+	assert.True(t, second.RecordChanged)
+	assert.Equal(t, complexity.TierSimple, record.Tier, "a different lower tier still accumulates toward the streak and lands on its own proposal")
+	assert.Equal(t, now.Add(time.Minute), record.DecidedAt)
+	assert.Equal(t, 1, record.SwitchCount)
+	assert.Zero(t, record.PendingTurns)
+}
+
+// Regression: DowngradeAfterNTurns must stay reachable when SwitchMinSimilarity
+// is positive. The similarity floor gates escalations only, so sub-threshold
+// downgrade turns (score < SwitchMinSimilarity) accumulate through Path B
+// instead of being rejected at the entry gate — which would have made the
+// turn-persistence path dead for any positive threshold.
+func TestUpdateSessionTierRecordSustainedDowngradeWithPositiveSwitchThreshold(t *testing.T) {
+	now := time.Date(2026, time.August, 11, 10, 0, 0, 0, time.UTC)
+	config := sessionTierTestConfig() // SwitchMinSimilarity: 0.8, DowngradeAfterNTurns: 2
+	record := sessionTierTestRecord(now)
+
+	// Both turns are below the 0.8 switch threshold, so Path A never fires and
+	// neither turn is confident enough to switch on its own.
+	first := updateSessionTierRecord(record, sessionTierProposal(complexity.TierMedium, 0.5), config, now)
+	assert.Equal(t, sessionTierReasonDowngradePending, first.Reason, "a sub-threshold downgrade accumulates, it is not rejected at the gate")
+	assert.False(t, first.Switched)
+	assert.Equal(t, complexity.TierComplex, record.Tier)
+	assert.Equal(t, 1, record.PendingTurns)
+
+	second := updateSessionTierRecord(record, sessionTierProposal(complexity.TierSimple, 0.4), config, now.Add(time.Minute))
+	assert.Equal(t, sessionTierReasonDowngraded, second.Reason)
+	assert.True(t, second.Switched)
+	assert.Equal(t, complexity.TierSimple, record.Tier)
+	assert.Equal(t, 1, record.SwitchCount)
+	assert.Zero(t, record.PendingTurns)
+}
+
+// Exercises Path A (confidence): a single turn that clears SwitchMinSimilarity
+// switches immediately, without waiting on DowngradeAfterNTurns, and can land
+// directly on a tier more than one rank below the held tier.
+func TestUpdateSessionTierRecordSwitchesImmediatelyOnConfidence(t *testing.T) {
+	now := time.Date(2026, time.August, 11, 10, 0, 0, 0, time.UTC)
+	config := sessionTierTestConfig() // SwitchMinSimilarity: 0.8
+	record := sessionTierTestRecord(now)
+
+	decision := updateSessionTierRecord(record, sessionTierProposal(complexity.TierSimple, 0.85), config, now)
+
+	assert.Equal(t, sessionTierReasonDowngradedByConfidence, decision.Reason)
+	assert.True(t, decision.Switched)
+	assert.True(t, decision.RecordChanged)
+	assert.Equal(t, complexity.TierSimple, record.Tier, "the confidence path can skip straight past an intermediate tier")
+	assert.Equal(t, now, record.DecidedAt)
+	assert.Equal(t, 1, record.SwitchCount)
+	assert.Zero(t, record.PendingTurns, "Path A never touches the persistence streak")
+}
+
+func TestUpdateSessionTierRecordRejectsInvalidState(t *testing.T) {
+	now := time.Date(2026, time.August, 11, 10, 0, 0, 0, time.UTC)
+	proposal := sessionTierProposal(complexity.TierComplex, 0.95)
+
+	decision := updateSessionTierRecord(nil, proposal, sessionTierTestConfig(), now)
+	assert.Equal(t, sessionTierReasonInvalidState, decision.Reason)
+	assert.False(t, decision.RecordChanged)
+
+	record := sessionTierTestRecord(now)
+	original := cloneSessionComplexityRecord(record)
+	decision = updateSessionTierRecord(record, proposal, nil, now)
+	assert.Equal(t, sessionTierReasonInvalidState, decision.Reason)
+	assert.Equal(t, original, record)
+
+	config := sessionTierTestConfig()
+	config.Mode = configstore.ComplexitySessionModePinned
+	decision = updateSessionTierRecord(record, proposal, config, now)
+	assert.Equal(t, sessionTierReasonInvalidState, decision.Reason)
+	assert.Equal(t, original, record)
+
+	record.Tier = "UNKNOWN"
+	original = cloneSessionComplexityRecord(record)
+	decision = updateSessionTierRecord(record, proposal, sessionTierTestConfig(), now)
+	assert.Equal(t, sessionTierReasonInvalidState, decision.Reason)
+	assert.Equal(t, "UNKNOWN", decision.Tier)
+	assert.Equal(t, original, record)
+}
+
+func sessionTierTestConfig() *configstore.ComplexitySessionConfig {
+	return &configstore.ComplexitySessionConfig{
+		Mode:                 configstore.ComplexitySessionModeCacheAware,
+		TTL:                  time.Hour,
+		SwitchMinSimilarity:  0.8,
+		DowngradeAfterNTurns: 2,
+	}
+}
+
+func sessionTierProposal(tier string, score float64) *complexity.ComplexityResult {
+	return &complexity.ComplexityResult{Tier: tier, Score: score}
+}
+
+func sessionTierTestRecord(now time.Time) *SessionComplexityRecord {
+	return &SessionComplexityRecord{
+		Tier:      complexity.TierComplex,
+		DecidedAt: now.Add(-time.Hour),
+		RuleID:    "rule-1",
+	}
+}
+
+func newTestKVSessionStore(t *testing.T) (*kvSessionStore, *kvstore.Store) {
+	t.Helper()
+	store, err := kvstore.New(kvstore.Config{CleanupInterval: time.Hour})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+	sessionStore, err := newKVSessionStore(store)
+	require.NoError(t, err)
+	return sessionStore, store
+}
+
+type forwardingKVDelegate struct {
+	target *kvstore.Store
+	mu     sync.Mutex
+	err    error
+	sets   int
+}
+
+func (d *forwardingKVDelegate) OnSet(key string, valueJSON []byte, writtenAt int64, expiresAt int64) {
+	d.mu.Lock()
+	d.sets++
+	d.mu.Unlock()
+	d.recordError(d.target.SetRemote(key, valueJSON, writtenAt, expiresAt))
+}
+
+// Sets reports how many replication messages this delegate has been asked to
+// send, which is the cost a read path must not incur per request.
+func (d *forwardingKVDelegate) Sets() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.sets
+}
+
+func (d *forwardingKVDelegate) OnDelete(key string, deletedAt int64) {
+	d.recordError(d.target.DeleteRemote(key, deletedAt))
+}
+
+func (d *forwardingKVDelegate) recordError(err error) {
+	if err == nil {
+		return
+	}
+	d.mu.Lock()
+	if d.err == nil {
+		d.err = err
+	}
+	d.mu.Unlock()
+}
+
+func (d *forwardingKVDelegate) Err() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.err
+}
+
+func testComplexitySessionKey(t *testing.T, scopeID, sessionID string) string {
+	t.Helper()
+	key, ok := complexity.BuildSessionKey(scopeID, sessionID)
+	require.True(t, ok)
+	return key
+}

--- a/plugins/routing/main.go
+++ b/plugins/routing/main.go
@@ -89,6 +89,10 @@ type RoutingPlugin struct {
 	embeddingRequestExecutor atomic.Pointer[EmbeddingRequestExecutor]
 	warmupEmbedUsageObserver atomic.Pointer[WarmupEmbedUsageObserver]
 	complexityVectorStore    atomic.Pointer[vectorstore.VectorStore]
+
+	// complexitySessionStore is attached after construction and may stay nil when
+	// session routing has no backing store configured.
+	complexitySessionStore atomic.Pointer[SessionStore]
 }
 
 // Init initializes and returns a routing plugin instance.

--- a/transports/bifrost-http/handlers/routing_test.go
+++ b/transports/bifrost-http/handlers/routing_test.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/fasthttp/router"
 
+	"github.com/maximhq/bifrost/framework/configstore"
 	"github.com/maximhq/bifrost/plugins/routing/complexity"
 	"github.com/valyala/fasthttp"
 )
@@ -145,6 +147,49 @@ func TestComplexityAnalyzerConfigPutRejectsInvalidPayloads(t *testing.T) {
 	}
 }
 
+// assertSessionSurvivedReset checks every field of the session block seeded by
+// TestComplexityAnalyzerConfigResetPersistsDefaultsAndReloads. Reset must carry
+// the block through whole: a field silently dropped here is a session control
+// that reverts on the next reset, and asserting only some of them lets the rest
+// regress unnoticed.
+func assertSessionSurvivedReset(t *testing.T, where string, session *configstore.ComplexitySessionConfig) {
+	t.Helper()
+	if session == nil {
+		t.Fatalf("expected the %s session config to survive reset, got nil", where)
+	}
+	if session.Mode != configstore.ComplexitySessionModePinned || session.TTL != 90*time.Minute {
+		t.Fatalf("expected the %s session mode and ttl to survive reset, got %+v", where, session)
+	}
+	if len(session.IdentitySources) != 1 || session.IdentitySources[0] != configstore.ComplexitySessionIdentityHeader {
+		t.Fatalf("expected the %s session identity ladder to survive reset, got %+v", where, session.IdentitySources)
+	}
+	if session.SwitchMinSimilarity != 0.85 || session.MaxSwitchesPerSession != 3 || !session.AlwaysAllowEscalation {
+		t.Fatalf("expected the %s session switch gates to survive reset, got %+v", where, session)
+	}
+	if session.DowngradeAfterNTurns != 5 {
+		t.Fatalf("expected the %s session switch thresholds to survive reset, got %+v", where, session)
+	}
+}
+
+// assertRawSessionTTL pins the wire encoding of session.ttl, which typed
+// decoding cannot: the decoder accepts both a duration string and a
+// millisecond number, so a change of encoding would round-trip silently here
+// while breaking the configuration UI that reads the raw field.
+func assertRawSessionTTL(t *testing.T, body []byte, want any) {
+	t.Helper()
+	var raw struct {
+		Session struct {
+			TTL any `json:"ttl"`
+		} `json:"session"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		t.Fatalf("unmarshal raw response: %v", err)
+	}
+	if raw.Session.TTL != want {
+		t.Fatalf("expected raw session ttl %v, got %#v", want, raw.Session.TTL)
+	}
+}
+
 func TestComplexityAnalyzerConfigResetPersistsDefaultsAndReloads(t *testing.T) {
 	SetLogger(&mockLogger{})
 	store := setupPricingOverrideHandlerStore(t)
@@ -166,6 +211,18 @@ func TestComplexityAnalyzerConfigResetPersistsDefaultsAndReloads(t *testing.T) {
 		EmbeddingModel: "text-embedding-3-small",
 		MinSimilarity:  0.42,
 		VectorStore:    "vector_store",
+	}
+	// Session behavior is deployment configuration for the same reason: losing it
+	// silently unpins every live conversation. Seeded away from the defaults so a
+	// wipe cannot be mistaken for a value that happens to match.
+	custom.Session = &configstore.ComplexitySessionConfig{
+		Mode:                  configstore.ComplexitySessionModePinned,
+		TTL:                   90 * time.Minute,
+		IdentitySources:       []string{configstore.ComplexitySessionIdentityHeader},
+		SwitchMinSimilarity:   0.85,
+		DowngradeAfterNTurns:  5,
+		MaxSwitchesPerSession: 3,
+		AlwaysAllowEscalation: true,
 	}
 	if err := store.UpdateComplexityAnalyzerConfig(context.Background(), &custom); err != nil {
 		t.Fatalf("seed custom config: %v", err)
@@ -200,6 +257,7 @@ func TestComplexityAnalyzerConfigResetPersistsDefaultsAndReloads(t *testing.T) {
 	if stored.Semantic.VectorStore != "vector_store" || stored.Semantic.MinSimilarity != 0.42 {
 		t.Fatalf("expected the storage selection and similarity floor to survive reset, got %+v", stored.Semantic)
 	}
+	assertSessionSurvivedReset(t, "stored", stored.Session)
 
 	// The reload and the response body carry the same record: the plugin
 	// reconfigures from one and the configuration UI reseeds its form from the
@@ -208,6 +266,8 @@ func TestComplexityAnalyzerConfigResetPersistsDefaultsAndReloads(t *testing.T) {
 	if manager.reloadedConfig == nil || manager.reloadedConfig.Semantic == nil {
 		t.Fatalf("expected reload with the embedding config retained, got %+v", manager.reloadedConfig)
 	}
+	assertSessionSurvivedReset(t, "reloaded", manager.reloadedConfig.Session)
+
 	var resp complexity.AnalyzerConfig
 	if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
 		t.Fatalf("unmarshal response: %v", err)
@@ -215,6 +275,11 @@ func TestComplexityAnalyzerConfigResetPersistsDefaultsAndReloads(t *testing.T) {
 	if resp.Semantic == nil || resp.Semantic.EmbeddingModel != "text-embedding-3-small" {
 		t.Fatalf("expected the response to carry the embedding config, got %+v", resp.Semantic)
 	}
+	assertSessionSurvivedReset(t, "response", resp.Session)
+	// The TTL leaves as a Go duration string, which is what the configuration UI
+	// parses back into its milliseconds field. Decoding also accepts a plain
+	// number, so only the raw body pins which of the two is actually emitted.
+	assertRawSessionTTL(t, ctx.Response.Body(), "1h30m0s")
 	if resp.TierBoundaries != complexity.DefaultTierBoundaries() {
 		t.Fatalf("expected the response to carry default boundaries, got %+v", resp.TierBoundaries)
 	}

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1987,6 +1987,11 @@ func (s *BifrostHTTPServer) ReloadPlugin(ctx context.Context, name string, path 
 	if routingWarmupObserverPlugin, ok := plugin.(routing.WarmupEmbedUsageObserverSetter); ok {
 		routingWarmupObserverPlugin.SetWarmupEmbedUsageObserver(s.ObserveWarmupRoutingEmbedding)
 	}
+	if routingSessionStorePlugin, ok := plugin.(routing.ComplexitySessionKVStoreSetter); ok && s.Config.KVStore != nil {
+		if err := routingSessionStorePlugin.SetComplexitySessionKVStore(s.Config.KVStore); err != nil {
+			logger.Warn("failed to attach complexity session store: %v", err)
+		}
+	}
 	return s.SyncLoadedPlugin(ctx, name, plugin, placement, order)
 }
 
@@ -2648,6 +2653,11 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 		routingPlugin.SetEmbeddingRequestExecutor(s.Client.EmbeddingRequest)
 		routingPlugin.SetComplexityVectorStore(s.Config.VectorStore)
 		routingPlugin.SetWarmupEmbedUsageObserver(s.ObserveWarmupRoutingEmbedding)
+		if s.Config.KVStore != nil {
+			if err := routingPlugin.SetComplexitySessionKVStore(s.Config.KVStore); err != nil {
+				logger.Warn("failed to attach complexity session store: %v", err)
+			}
+		}
 	}
 
 	// Initialize Sidekiq runner for background jobs

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -4035,9 +4035,69 @@
         },
         "semantic": {
           "$ref": "#/$defs/complexity_semantic_config"
+        },
+        "session": {
+          "$ref": "#/$defs/complexity_session_config"
         }
       },
       "required": ["keywords"],
+      "additionalProperties": false
+    },
+    "complexity_session_config": {
+      "type": "object",
+      "description": "Session state settings. Pinned mode resolves a conversation's complexity tier once and reuses it, skipping later embedding calls. Whether a provider's own prompt cache is actually preserved depends on that provider's retention, which Bifrost does not control or observe in this mode. Cache-aware mode reclassifies every turn that uses complexity routing, then gates tier changes so one noisy turn can't swing the whole session. Session state is node-local unless a shared backend is configured, so on multi-replica deployments turns handled by different replicas may resolve tiers independently.",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["off", "pinned", "cache_aware"],
+          "description": "'off' disables session state and classifies every turn (default). 'pinned' classifies turn 1 and holds that tier for the session. 'cache_aware' classifies every complexity-routed turn (including its embedding cost); it switches immediately once a turn clears switch_min_similarity, or after downgrade_after_n_turns consecutive downgrade-direction turns otherwise."
+        },
+        "ttl": {
+          "description": "Not consumed by the runtime under either session mode: pinned and cache_aware both use a fixed internal idle-expiry window instead, regardless of this value. Accepted, stored, and validated only so an already-persisted or hand-written config.json does not fail to parse.",
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h)$"
+            },
+            {
+              "type": "number",
+              "exclusiveMinimum": 0
+            }
+          ],
+          "default": "1h"
+        },
+        "identity_sources": {
+          "type": "array",
+          "description": "Which resolution steps may establish a session ID (default: ['header', 'harness']). They are always tried in the fixed order header → harness regardless of the order listed here.",
+          "items": {
+            "type": "string",
+            "enum": ["header", "harness"]
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "switch_min_similarity": {
+          "type": "number",
+          "minimum": 0,
+          "exclusiveMaximum": 1,
+          "description": "Confidence a classification must reach before it may change session state, forming hysteresis with semantic.min_similarity: a low bar to classify, a higher bar to switch. Must be at least semantic.min_similarity when both are set. For a downgrade, meeting this bar on a single turn switches immediately without waiting on downgrade_after_n_turns; leaving this at zero requires the sustained-turns path instead. Compared against the vector store backend's own score, so retune when switching backends. cache_aware mode only."
+        },
+        "downgrade_after_n_turns": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "How many consecutive downgrade-direction turns (any lower-tier proposal, not necessarily the same specific tier each time) are needed before a downgrade is taken, when no single turn was confident enough to trigger switch_min_similarity's fast path (default: 2). Long agentic sessions are full of turns like 'yes' or 'run the tests' that classify as confidently simple; those are exactly the turns not to downgrade on immediately. cache_aware mode only."
+        },
+        "max_switches_per_session": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Cap on total tier moves within one session, as an oscillation backstop (default: 0, meaning unlimited). cache_aware mode only."
+        },
+        "always_allow_escalation": {
+          "type": "boolean",
+          "description": "Let an escalation to a higher tier bypass the switch_min_similarity gate (default: false). Escalations already ignore cache cost: holding a session on an undersized model to protect cache spend produces bad answers, which is a worse failure than overpaying. cache_aware mode only."
+        }
+      },
+      "required": ["mode"],
       "additionalProperties": false
     },
     "complexity_semantic_config": {
@@ -4055,7 +4115,7 @@
           "description": "Model used to generate embeddings for complexity classification"
         },
         "timeout": {
-          "description": "Per-request embedding timeout (duration string like '1.5s' or '1500ms', or milliseconds as a number; default: 1500ms). On timeout no complexity tier is published and the request is recorded as 'skipped'.",
+          "description": "Per-request embedding timeout (duration string like '1.5s' or '1500ms', or milliseconds as a number; default: 1500ms). Bifrost serializes this field as milliseconds. On timeout no complexity tier is published and the request is recorded as 'skipped'.",
           "oneOf": [
             {
               "type": "string",

--- a/ui/app/workspace/complexity-router/formSchema.ts
+++ b/ui/app/workspace/complexity-router/formSchema.ts
@@ -1,6 +1,7 @@
 import {
 	AnalyzerConfig,
 	DEFAULT_SEMANTIC_CONFIG,
+	formatSemanticTimeout,
 	KeywordListKey,
 	MAX_SEMANTIC_MESSAGE_HISTORY,
 	MAX_SEMANTIC_PHRASE_CHARACTERS,
@@ -28,10 +29,7 @@ const semanticSchema = z.object({
 	timeout: z
 		.string()
 		.min(1, "Enter an embedding timeout")
-		.refine(
-			(value) => isPositiveDurationString(value),
-			"Enter a timeout greater than 0",
-		)
+		.refine((value) => isPositiveDurationString(value), "Enter a timeout greater than 0")
 		.optional(),
 	min_similarity: z.number({ error: "Enter a number between 0 and 1" }).min(0, "Must be 0 or greater").lt(1, "Must be less than 1"),
 	message_history_count: z
@@ -109,6 +107,7 @@ export type SemanticFormValues = AnalyzerFormValues["semantic"];
 
 export const DEFAULT_SEMANTIC_FORM_VALUES: SemanticFormValues = {
 	...DEFAULT_SEMANTIC_CONFIG,
+	timeout: formatSemanticTimeout(parseSemanticTimeoutMs(DEFAULT_SEMANTIC_CONFIG.timeout)),
 	min_similarity: DEFAULT_SEMANTIC_CONFIG.min_similarity ?? 0,
 	message_history_count: DEFAULT_SEMANTIC_CONFIG.message_history_count ?? MIN_SEMANTIC_MESSAGE_HISTORY,
 	vector_store: "embedded",
@@ -132,6 +131,7 @@ export function toFormValues(config: AnalyzerConfig): AnalyzerFormValues {
 			? {
 					...DEFAULT_SEMANTIC_FORM_VALUES,
 					...saved,
+					timeout: formatSemanticTimeout(parseSemanticTimeoutMs(saved.timeout)),
 					min_similarity: saved.min_similarity ?? 0,
 					message_history_count: saved.message_history_count ?? MIN_SEMANTIC_MESSAGE_HISTORY,
 					vector_store: saved.vector_store ?? DEFAULT_SEMANTIC_FORM_VALUES.vector_store,
@@ -145,7 +145,8 @@ export function toFormValues(config: AnalyzerConfig): AnalyzerFormValues {
 // "0" the operator is midway through typing, which the schema rejects rather
 // than the field silently rewriting. Anything else — a saved "1s", a blank —
 // falls back to the parsed reading.
-export function semanticTimeoutFieldValue(timeout: string | undefined): string | number {
+export function semanticTimeoutFieldValue(timeout: string | number | undefined): string | number {
+	if (typeof timeout === "number") return timeout;
 	if (timeout === "") return "";
 	const millis = timeout?.trim().match(/^([0-9]*\.?[0-9]+)ms$/);
 	return millis ? millis[1] : parseSemanticTimeoutMs(timeout);

--- a/ui/lib/types/complexityRouter.test.ts
+++ b/ui/lib/types/complexityRouter.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from "vitest";
+import { semanticTimeoutFieldValue } from "../../app/workspace/complexity-router/formSchema";
 import { DEFAULT_SEMANTIC_TIMEOUT_MS, formatSemanticTimeout, parseSemanticTimeoutMs } from "./complexityRouter";
 
 describe("parseSemanticTimeoutMs", () => {
@@ -25,8 +26,10 @@ describe("parseSemanticTimeoutMs", () => {
 		}
 	});
 
-	test("accepts a bare millisecond number", () => {
+	test("accepts string and numeric millisecond values", () => {
 		expect(parseSemanticTimeoutMs("750")).toBe(750);
+		expect(parseSemanticTimeoutMs(750)).toBe(750);
+		expect(semanticTimeoutFieldValue(750)).toBe(750);
 	});
 
 	test("falls back to the default rather than sending a value the server rejects", () => {

--- a/ui/lib/types/complexityRouter.ts
+++ b/ui/lib/types/complexityRouter.ts
@@ -14,7 +14,9 @@ export type SemanticVectorStore = "embedded" | "vector_store";
 export interface SemanticConfig {
 	provider: string;
 	embedding_model: string;
-	timeout?: string;
+	// API responses use milliseconds; duration strings remain accepted input for
+	// config.json, Helm, and older form state.
+	timeout?: string | number;
 	// Similarity floor the nearest reference phrase must clear; below it no tier
 	// is published. 0 means the nearest phrase always wins.
 	min_similarity?: number;
@@ -146,19 +148,21 @@ export const SEMANTIC_STATUS_LABELS: Record<SemanticStatusInfo["state"], string>
 	failed: "Failed",
 };
 
-// Duration strings round-trip through the API as Go durations ("500ms"), but the
-// form edits milliseconds. Anything unparseable falls back to the default rather
-// than silently sending 0, which the server rejects.
+// API responses use millisecond numbers, while human-authored configuration may
+// still contain Go duration strings. Anything unparseable falls back to the
+// default rather than silently sending 0, which the server rejects.
 const DURATION_UNIT_TO_MS: Record<string, number> = { ns: 1e-6, us: 1e-3, µs: 1e-3, ms: 1, s: 1000, m: 60000, h: 3600000 };
 const DURATION_SEGMENT = /([0-9]*\.?[0-9]+)(ns|us|µs|ms|s|m|h)/g;
 
-export function parseSemanticTimeoutMs(timeout: string | undefined): number {
+export function parseSemanticTimeoutMs(timeout: string | number | undefined): number {
+	if (typeof timeout === "number") {
+		return Number.isFinite(timeout) && timeout > 0 ? timeout : DEFAULT_SEMANTIC_TIMEOUT_MS;
+	}
 	if (!timeout) return DEFAULT_SEMANTIC_TIMEOUT_MS;
 	const trimmed = timeout.trim();
-	// Durations are summed segment by segment because time.Duration.String() — what the
-	// API marshals with — compounds anything from a minute up: 60000ms comes back as
-	// "1m0s", not "60s". Matching a single unit would send every such value to the
-	// fallback below and silently reset the field to the default.
+	// Human-authored Go durations may contain multiple segments: one minute can
+	// be written as "1m0s", not only "60s". Matching a single unit would send
+	// every such value to the fallback below and silently reset the field.
 	const segments = [...trimmed.matchAll(DURATION_SEGMENT)];
 	const consumed = segments.reduce((total, segment) => total + segment[0].length, 0);
 	// Every character has to belong to a segment, so "1m30x" or a stray sign is rejected


### PR DESCRIPTION
## Summary

Adds session-aware complexity routing, giving the complexity router a memory of which tier a conversation belongs to. This prevents redundant embedding calls for already-classified sessions and protects provider-side prompt cache state from being discarded by premature tier switches.

## Changes

- **`ComplexitySessionConfig`**: New configuration block on `ComplexityAnalyzerConfig` with three modes: `off` (default, existing behavior), `pinned` (classify once per session and hold the tier), and `cache_aware` (reclassify every complexity-routed turn but gate tier changes behind confidence and cache-cost checks). TTL accepts a duration string or millisecond number, matching the existing semantic timeout encoding. Config normalization, validation, merge-by-hash, encode/decode, and hash generation are all wired up alongside the existing semantic section.

- **`ComplexitySessionIdentity` resolution**: `ResolveSessionID` walks enabled identity sources in fixed precedence order (`header` → `harness`). The harness path reads `x-claude-code-session-id` for Claude Code clients and `session_id` from the Codex turn-metadata header for Codex clients. Generic clients cannot claim harness-native session IDs. IDs are validated for length, UTF-8 validity, and absence of null bytes; oversized or malformed IDs fall through to the next source rather than failing the request. `BuildSessionKey` hashes the scope+session pair so raw tenant and session identifiers never appear in storage keys.

- **`SessionStore` interface and `kvSessionStore`**: A backend-neutral `SessionStore` contract covers `Get`, `Create`, `Update`, `Delete`, and `Status`. The KV-backed implementation uses `kvstore.UpdateWithTTL` (new atomic read-modify-write operation, see below) for lock-safe mutations. Reads use a coarse refresh strategy — the sliding TTL is extended at most once per `ttl/4` interval — so a chatty conversation does not produce one replication broadcast per turn. A registered type decoder ensures remotely replicated records decode back to `*SessionComplexityRecord` rather than raw bytes. `Status` reports whether replication is configured and whether updates are atomic across replicas (they are only when no gossip delegate is installed).

- **`updateSessionTierRecord`**: Pure policy function (no I/O) that applies cache-aware switching rules to a caller-owned record copy. Escalations switch immediately (optionally bypassing the similarity gate via `always_allow_escalation`). Downgrades require `downgrade_after_n_turns` consecutive qualifying proposals, then check whether the held tier's strongest recent cache observation exceeds `min_cached_tokens_to_hold`; if it does, the downgrade is deferred. `max_switches_per_session` caps total tier moves as an oscillation backstop. `RecordChanged` lets callers skip the store write for ordinary held turns.

- **`kvstore.UpdateWithTTL`**: New atomic read-modify-write operation that runs the caller's update function under the store's write lock, preventing lost updates under concurrent access. The delegate is snapshotted before the lock is taken so `SetDelegate` cannot race with an in-flight mutation. `HasSyncDelegate` is added for status reporting. `SetDelegate` is now protected by its own `RWMutex`.

- **Server wiring**: `Bootstrap` and `ReloadPlugin` attach the KV store to the routing plugin as a `ComplexitySessionKVStore` when one is configured, matching the existing pattern for the embedding executor.

- **JSON schema**: `complexity_session_config` definition added to `config.schema.json` with descriptions for all fields and the three-way mode enum.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/... ./framework/kvstore/... ./plugins/routing/... ./plugins/routing/complexity/...
```

Key scenarios covered by the new tests:

- TTL round-trip encoding (duration string ↔ decoded value, not nanoseconds)
- Session config normalization applies defaults and preserves `off`-mode settings
- `Enabled()` returns false for nil, empty, and explicit `off` configs
- Identity source normalization deduplicates and reorders into resolution-ladder order; unknown sources are preserved for validation to name
- `SwitchMinSimilarity` must be ≥ `Semantic.MinSimilarity`; zero is exempt
- `kvSessionStore` Create/Update atomicity under 50–100 concurrent goroutines
- Sliding TTL extends on reads past the refresh interval but not on every read
- Reads inside the refresh interval produce zero replication messages
- Replicated records decode to `*SessionComplexityRecord` via the registered decoder
- `updateSessionTierRecord` covers escalation, sustained downgrade, cache-gate hold, interrupted downgrade clearing, and all invalid-state guards

New `session` block in `config.json`:

```json
{
  "complexity": {
    "session": {
      "mode": "cache_aware",
      "ttl": "1h",
      "identity_sources": ["header", "harness"],
      "switch_min_similarity": 0.85,
      "downgrade_after_n_turns": 2,
      "min_cached_tokens_to_hold": 1024,
      "max_switches_per_session": 0,
      "always_allow_escalation": false
    }
  }
}
```

## Breaking changes

- [ ] Yes
- [x] No

The `session` block is optional and defaults to `off`, preserving existing behavior. The `kvstore.SetDelegate` change adds a mutex but the method signature is unchanged.

## Security considerations

- Session IDs are never stored or logged in plaintext; `BuildSessionKey` hashes the scope+session pair with SHA-256 before writing to the KV store.
- Harness-native session IDs (`x-claude-code-session-id`, Codex turn metadata) are only read when the request's user-agent matches the expected harness, preventing generic clients from claiming another session's tier.
- Session IDs are validated for maximum length (255 bytes), UTF-8 validity, and absence of null bytes before use.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable