### PR TITLE
feat(session aware routing): session observability — log columns, filters, and the sessions configuration UI

### DIFF
--- a/framework/logstore/logstoreparity_test.go
+++ b/framework/logstore/logstoreparity_test.go
@@ -118,6 +118,7 @@ type parityLogSpec struct {
 	tier                       *string
 	mechanism                  *string
 	tierScore                  *float64
+	session                    ComplexitySessionLogFields
 	metadata                   *string
 	cacheDebug                 string
 	content                    string
@@ -129,7 +130,7 @@ type parityLogSpec struct {
 
 func (s parityLogSpec) toLog(base time.Time) *Log {
 	ts := base.Add(-time.Duration(s.offsetSec) * time.Second)
-	return &Log{
+	logEntry := &Log{
 		ID:                    s.id,
 		Timestamp:             ts,
 		Object:                s.object,
@@ -170,6 +171,8 @@ func (s parityLogSpec) toLog(base time.Time) *Log {
 		RateLimitIDs:          s.rateLimitIDs,
 		CreatedAt:             ts,
 	}
+	logEntry.ComplexitySessionLogFields = s.session
+	return logEntry
 }
 
 func paritySpecs() []parityLogSpec {
@@ -180,12 +183,14 @@ func paritySpecs() []parityLogSpec {
 			cost: f64PtrP(0.5), latency: f64PtrP(100), tokens: [3]int{100, 50, 150}, stopReason: strPtrP("stop"),
 			routing: strPtrP("governance,loadbalancing"), metadata: strPtrP(`{"env":"prod"}`),
 			tier: strPtrP("COMPLEX"), mechanism: strPtrP("lexical"), tierScore: f64PtrP(0.55),
+			session:    ComplexitySessionLogFields{ComplexitySessionID: strPtrP("conversation-1"), ComplexitySessionMode: strPtrP("pinned"), ComplexitySessionTierSource: strPtrP("memoised"), ComplexitySessionSwitchCount: intPtrP(0)},
 			cacheDebug: `{"hit_type":"direct"}`, content: "alpha bravo hello", parentID: strPtrP("sess1")},
 		{id: "p2", offsetSec: 90, object: "chat.completion", provider: "openai", model: "gpt-4o", status: "success",
 			vkID: strPtrP("vk1"), vkName: strPtrP("VK One"), teamID: strPtrP("t1"), userID: strPtrP("u2"),
 			cost: f64PtrP(1.25), latency: f64PtrP(250), tokens: [3]int{200, 100, 300}, stopReason: strPtrP("length"),
 			routing: strPtrP("governance"), metadata: strPtrP(`{"env":"dev"}`),
 			tier: strPtrP("SIMPLE"), mechanism: strPtrP("lexical"), tierScore: f64PtrP(0.08),
+			session:    ComplexitySessionLogFields{ComplexitySessionID: strPtrP("conversation-2"), ComplexitySessionMode: strPtrP("cache_aware"), ComplexitySessionTierSource: strPtrP("held"), ComplexitySessionSwitchCount: intPtrP(2)},
 			cacheDebug: `{"hit_type":"semantic"}`, content: "charlie delta", parentID: strPtrP("sess1")},
 		{id: "p3", offsetSec: 80, object: "chat.completion", provider: "openai", model: "gpt-4o-mini", status: "error",
 			vkID: strPtrP("vk2"), vkName: strPtrP("VK Two"), teamID: strPtrP("t2"), userID: strPtrP("u2"),
@@ -447,8 +452,10 @@ func logProjection(l *Log) map[string]any {
 		"prompt_tokens": l.PromptTokens, "completion_tokens": l.CompletionTokens,
 		"total_tokens": l.TotalTokens, "stop_reason": l.StopReason,
 		"complexity_tier": l.ComplexityTier, "complexity_mechanism": l.ComplexityMechanism,
-		"complexity_score": l.ComplexityScore,
-		"content_summary":  l.ContentSummary,
+		"complexity_score":      l.ComplexityScore,
+		"complexity_session_id": l.ComplexitySessionID, "complexity_session_mode": l.ComplexitySessionMode,
+		"complexity_session_tier_source": l.ComplexitySessionTierSource, "complexity_session_switch_count": l.ComplexitySessionSwitchCount,
+		"content_summary": l.ContentSummary,
 	}
 }
 
@@ -568,33 +575,36 @@ func TestLogStoreParity(t *testing.T) {
 	// --- Phase: reads ---
 
 	searchCases := map[string]SearchFilters{
-		"all":                   window,
-		"providers":             {Providers: []string{"openai"}},
-		"models":                {Models: []string{"gpt-4o", "claude-3"}},
-		"status":                {Status: []string{"success"}},
-		"stop_reasons":          {StopReasons: []string{"stop"}},
-		"complexity_tiers":      {ComplexityTiers: []string{"COMPLEX", "MEDIUM"}},
-		"complexity_mechanisms": {ComplexityMechanisms: []string{"lexical"}},
-		"mechanism_skipped":     {ComplexityMechanisms: []string{"skipped"}},
-		"objects":               {Objects: []string{"embedding"}},
-		"aliases":               {Aliases: []string{"a1"}},
-		"selected_keys":         {SelectedKeyIDs: []string{"sk1"}},
-		"virtual_keys":          {VirtualKeyIDs: []string{"vk1"}},
-		"teams":                 {TeamIDs: []string{"t1", "t3"}},
-		"customers":             {CustomerIDs: []string{"c1"}},
-		"users":                 {UserIDs: []string{"u1"}},
-		"business_units":        {BusinessUnitIDs: []string{"b1"}},
-		"routing_engines":       {RoutingEngineUsed: []string{"loadbalancing", "routing-rule"}},
-		"time_range":            {StartTime: timePtrP(base.Add(-75 * time.Second)), EndTime: timePtrP(base.Add(-25 * time.Second))},
-		"latency_range":         {MinLatency: f64PtrP(80), MaxLatency: f64PtrP(260)},
-		"token_range":           {MinTokens: intPtrP(100), MaxTokens: intPtrP(600)},
-		"cost_range":            {MinCost: f64PtrP(1.0), MaxCost: f64PtrP(2.6)},
-		"missing_cost":          {MissingCostOnly: true},
-		"cache_direct":          {CacheHitTypes: []string{"direct"}},
-		"cache_semantic":        {CacheHitTypes: []string{"semantic"}},
-		"metadata":              {MetadataFilters: map[string]string{"env": "prod"}},
-		"content_search":        {ContentSearch: "charlie"},
-		"parent_request":        {ParentRequestID: "sess1"},
+		"all":                             window,
+		"providers":                       {Providers: []string{"openai"}},
+		"models":                          {Models: []string{"gpt-4o", "claude-3"}},
+		"status":                          {Status: []string{"success"}},
+		"stop_reasons":                    {StopReasons: []string{"stop"}},
+		"complexity_tiers":                {ComplexityTiers: []string{"COMPLEX", "MEDIUM"}},
+		"complexity_mechanisms":           {ComplexityMechanisms: []string{"lexical"}},
+		"complexity_session_id":           {ComplexitySessionID: "conversation-1"},
+		"mechanism_skipped":               {ComplexityMechanisms: []string{"skipped"}},
+		"complexity_session_modes":        {ComplexitySessionModes: []string{"cache_aware"}},
+		"complexity_session_tier_sources": {ComplexitySessionTierSources: []string{"memoised"}},
+		"objects":                         {Objects: []string{"embedding"}},
+		"aliases":                         {Aliases: []string{"a1"}},
+		"selected_keys":                   {SelectedKeyIDs: []string{"sk1"}},
+		"virtual_keys":                    {VirtualKeyIDs: []string{"vk1"}},
+		"teams":                           {TeamIDs: []string{"t1", "t3"}},
+		"customers":                       {CustomerIDs: []string{"c1"}},
+		"users":                           {UserIDs: []string{"u1"}},
+		"business_units":                  {BusinessUnitIDs: []string{"b1"}},
+		"routing_engines":                 {RoutingEngineUsed: []string{"loadbalancing", "routing-rule"}},
+		"time_range":                      {StartTime: timePtrP(base.Add(-75 * time.Second)), EndTime: timePtrP(base.Add(-25 * time.Second))},
+		"latency_range":                   {MinLatency: f64PtrP(80), MaxLatency: f64PtrP(260)},
+		"token_range":                     {MinTokens: intPtrP(100), MaxTokens: intPtrP(600)},
+		"cost_range":                      {MinCost: f64PtrP(1.0), MaxCost: f64PtrP(2.6)},
+		"missing_cost":                    {MissingCostOnly: true},
+		"cache_direct":                    {CacheHitTypes: []string{"direct"}},
+		"cache_semantic":                  {CacheHitTypes: []string{"semantic"}},
+		"metadata":                        {MetadataFilters: map[string]string{"env": "prod"}},
+		"content_search":                  {ContentSearch: "charlie"},
+		"parent_request":                  {ParentRequestID: "sess1"},
 	}
 	for name, filters := range searchCases {
 		t.Run("SearchLogs/"+name, func(t *testing.T) {

--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -950,6 +950,9 @@ func canUseMatViewFilters(f SearchFilters) bool {
 		len(f.StopReasons) == 0 &&
 		len(f.ComplexityTiers) == 0 &&
 		len(f.ComplexityMechanisms) == 0 &&
+		f.ComplexitySessionID == "" &&
+		len(f.ComplexitySessionModes) == 0 &&
+		len(f.ComplexitySessionTierSources) == 0 &&
 		f.MinLatency == nil && f.MaxLatency == nil &&
 		f.MinTokens == nil && f.MaxTokens == nil &&
 		f.MinCost == nil && f.MaxCost == nil &&

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -289,6 +289,7 @@ var logstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"mcp_tool_logs_add_endpoint_columns"}, run: migrationAddEndpointColumnsToMCPToolLogs},
 	{IDs: []string{"mcp_tool_logs_add_plugin_logs_column"}, run: migrationAddMCPPluginLogsColumn},
 	{IDs: []string{"logs_add_complexity_routing_columns"}, run: migrationAddComplexityRoutingColumns},
+	{IDs: []string{"logs_add_complexity_session_columns"}, run: migrationAddComplexitySessionColumns},
 }
 
 // areThereAnyPendingMigrations returns true if there are any pending migrations to be applied.
@@ -2711,6 +2712,21 @@ var performanceIndexes = []performanceIndexDef{
 		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_complexity_mechanism ON logs(complexity_mechanism) WHERE complexity_mechanism IS NOT NULL",
 	},
 	{
+		table: "logs",
+		name:  "idx_logs_complexity_session_id",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_complexity_session_id ON logs(complexity_session_id) WHERE complexity_session_id IS NOT NULL",
+	},
+	{
+		table: "logs",
+		name:  "idx_logs_complexity_session_mode",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_complexity_session_mode ON logs(complexity_session_mode) WHERE complexity_session_mode IS NOT NULL",
+	},
+	{
+		table: "logs",
+		name:  "idx_logs_complexity_session_tier_source",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_complexity_session_tier_source ON logs(complexity_session_tier_source) WHERE complexity_session_tier_source IS NOT NULL",
+	},
+	{
 		table: "mcp_tool_logs",
 		name:  "idx_mcp_logs_user_id",
 		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_user_id ON mcp_tool_logs(user_id)",
@@ -3658,6 +3674,65 @@ func migrationAddComplexityRoutingColumns(ctx context.Context, db *gorm.DB, logg
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while adding complexity routing columns: %w", err)
+	}
+	return nil
+}
+
+// migrationAddComplexitySessionColumns adds nullable request-log fields for
+// session-aware complexity decisions. SQLite creates the session ID index in
+// this migration; PostgreSQL builds its partial index concurrently through the
+// existing background index reconciler.
+func migrationAddComplexitySessionColumns(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "logs_add_complexity_session_columns"
+	logger.Info("[logstore] starting migration %s", migrationName)
+	defer logger.Info("[logstore] finished migration %s", migrationName)
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			for _, field := range []string{
+				"complexity_session_id",
+				"complexity_session_mode",
+				"complexity_session_tier_source",
+				"complexity_session_switch_count",
+			} {
+				if err := addColumnIfNotExists(tx, logger, &Log{}, field); err != nil {
+					return err
+				}
+			}
+			mg := tx.Migrator()
+			if tx.Dialector.Name() != "postgres" && !mg.HasIndex(&Log{}, "idx_logs_complexity_session_id") {
+				if err := mg.CreateIndex(&Log{}, "idx_logs_complexity_session_id"); err != nil {
+					return fmt.Errorf("create complexity_session_id index: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if mg.HasIndex(&Log{}, "idx_logs_complexity_session_id") {
+				if err := mg.DropIndex(&Log{}, "idx_logs_complexity_session_id"); err != nil {
+					return err
+				}
+			}
+			for _, field := range []string{
+				"complexity_session_switch_count",
+				"complexity_session_tier_source",
+				"complexity_session_mode",
+				"complexity_session_id",
+			} {
+				if err := dropColumnIfExists(tx, logger, &Log{}, field); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while adding complexity session columns: %w", err)
 	}
 	return nil
 }

--- a/framework/logstore/migrations_test.go
+++ b/framework/logstore/migrations_test.go
@@ -49,6 +49,32 @@ func TestMigrationAddMCPPluginLogsColumn(t *testing.T) {
 	assert.Equal(t, int64(1), count)
 }
 
+// TestMigrationAddComplexitySessionColumns verifies that session observability
+// is additive, idempotent, and leaves existing request logs untouched.
+func TestMigrationAddComplexitySessionColumns(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "migrations.db")), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	require.NoError(t, err)
+	require.NoError(t, db.Exec("CREATE TABLE logs (id TEXT PRIMARY KEY)").Error)
+	require.NoError(t, db.Exec("INSERT INTO logs (id) VALUES (?)", "existing-log").Error)
+
+	ctx := context.Background()
+	require.NoError(t, migrationAddComplexitySessionColumns(ctx, db, testLogger{}))
+	for _, field := range []string{
+		"ComplexitySessionID",
+		"ComplexitySessionMode",
+		"ComplexitySessionTierSource",
+		"ComplexitySessionSwitchCount",
+	} {
+		assert.True(t, db.Migrator().HasColumn(&Log{}, field), "missing migrated field %s", field)
+	}
+	require.True(t, db.Migrator().HasIndex(&Log{}, "idx_logs_complexity_session_id"))
+	require.NoError(t, migrationAddComplexitySessionColumns(ctx, db, testLogger{}))
+
+	var count int64
+	require.NoError(t, db.Table("logs").Where("id = ?", "existing-log").Count(&count).Error)
+	assert.Equal(t, int64(1), count)
+}
+
 // pgTestSchema is this package's dedicated Postgres schema. Test packages
 // (configstore, configstore/tables, logstore) run in parallel against the same
 // database, so each one works in its own schema to avoid clobbering the

--- a/framework/logstore/multi_team_filter_test.go
+++ b/framework/logstore/multi_team_filter_test.go
@@ -89,4 +89,7 @@ func TestCanUseMatViewFilters_ExcludesTeamBU(t *testing.T) {
 	assert.False(t, canUseMatViewFilters(SearchFilters{BusinessUnitIDs: []string{"bu1"}}), "BU filter must force the raw path")
 	assert.False(t, canUseMatViewFilters(SearchFilters{CustomerIDs: []string{"c1"}}), "customer filter must force the raw path")
 	assert.False(t, canUseMatViewFilters(SearchFilters{ParentRequestID: "req-1"}), "parent request filter has no matview dimension and must force the raw path")
+	assert.False(t, canUseMatViewFilters(SearchFilters{ComplexitySessionID: "session-1"}), "session ID is not materialized and must force the raw path")
+	assert.False(t, canUseMatViewFilters(SearchFilters{ComplexitySessionModes: []string{"pinned"}}), "session mode is not materialized and must force the raw path")
+	assert.False(t, canUseMatViewFilters(SearchFilters{ComplexitySessionTierSources: []string{"held"}}), "session tier source is not materialized and must force the raw path")
 }

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -305,6 +305,15 @@ func (s *RDBLogStore) applyFilters(baseQuery *gorm.DB, filters SearchFilters) *g
 	if len(filters.ComplexityMechanisms) > 0 {
 		baseQuery = baseQuery.Where("complexity_mechanism IN ?", filters.ComplexityMechanisms)
 	}
+	if filters.ComplexitySessionID != "" {
+		baseQuery = baseQuery.Where("complexity_session_id = ?", filters.ComplexitySessionID)
+	}
+	if len(filters.ComplexitySessionModes) > 0 {
+		baseQuery = baseQuery.Where("complexity_session_mode IN ?", filters.ComplexitySessionModes)
+	}
+	if len(filters.ComplexitySessionTierSources) > 0 {
+		baseQuery = baseQuery.Where("complexity_session_tier_source IN ?", filters.ComplexitySessionTierSources)
+	}
 	if len(filters.Objects) > 0 {
 		baseQuery = baseQuery.Where("object_type IN ?", filters.Objects)
 	}
@@ -1238,6 +1247,7 @@ func (s *RDBLogStore) listSelectColumns() string {
 		"virtual_key_id", "virtual_key_name",
 		"routing_engines_used", "routing_rule_id", "routing_rule_name",
 		"complexity_tier", "complexity_mechanism",
+		"complexity_session_id", "complexity_session_mode", "complexity_session_tier_source", "complexity_session_switch_count",
 		"user_id", "user_name", "team_id", "team_name", "customer_id", "customer_name",
 		"business_unit_id", "business_unit_name",
 		"team_ids", "team_names", "customer_ids", "customer_names", "business_unit_ids", "business_unit_names",

--- a/framework/logstore/rdb_perf_test.go
+++ b/framework/logstore/rdb_perf_test.go
@@ -35,6 +35,31 @@ func newTestSQLiteStore(t *testing.T) *RDBLogStore {
 	return store
 }
 
+func TestComplexitySessionIDFilter(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	sessionA := "conversation-a"
+	sessionB := "conversation-b"
+
+	for _, entry := range []*Log{
+		{ID: "session-a-log", Timestamp: now, Object: "chat.completion", Provider: "openai", Model: "gpt-4o-mini", Status: "success", ComplexitySessionLogFields: ComplexitySessionLogFields{ComplexitySessionID: &sessionA}},
+		{ID: "session-b-log", Timestamp: now.Add(time.Second), Object: "chat.completion", Provider: "openai", Model: "gpt-4o-mini", Status: "success", ComplexitySessionLogFields: ComplexitySessionLogFields{ComplexitySessionID: &sessionB}},
+	} {
+		if err := store.Create(ctx, entry); err != nil {
+			t.Fatalf("Create(%s) error = %v", entry.ID, err)
+		}
+	}
+
+	result, err := store.SearchLogs(ctx, SearchFilters{ComplexitySessionID: sessionA}, PaginationOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("SearchLogs(complexity session ID) error = %v", err)
+	}
+	if len(result.Logs) != 1 || result.Logs[0].ID != "session-a-log" {
+		t.Fatalf("expected only session-a-log, got %+v", result.Logs)
+	}
+}
+
 func TestCancelledStatusIncludedInLogAggregates(t *testing.T) {
 	store := newTestSQLiteStore(t)
 	ctx := context.Background()

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -46,38 +46,41 @@ const (
 
 // SearchFilters represents the available filters for log searches
 type SearchFilters struct {
-	Providers            []string          `json:"providers,omitempty"`
-	Models               []string          `json:"models,omitempty"`
-	Aliases              []string          `json:"aliases,omitempty"`
-	Status               []string          `json:"status,omitempty"`
-	StopReasons          []string          `json:"stop_reasons,omitempty"` // For filtering by stop reason (stop, length, content_filter, refusal, tool_calls, etc.)
-	Objects              []string          `json:"objects,omitempty"`      // For filtering by request type (chat.completion, text.completion, embedding)
-	ParentRequestID      string            `json:"parent_request_id,omitempty"`
-	RootsOnly            bool              `json:"roots_only,omitempty"` // Hide rows whose parent_request_id points at another row matching these same filters, so each chain lists as its root request only. Ignored when ParentRequestID is set.
-	SelectedKeyIDs       []string          `json:"selected_key_ids,omitempty"`
-	VirtualKeyIDs        []string          `json:"virtual_key_ids,omitempty"`
-	RoutingRuleIDs       []string          `json:"routing_rule_ids,omitempty"`
-	ComplexityTiers      []string          `json:"complexity_tiers,omitempty"`      // For filtering by routing complexity tier (SIMPLE, MEDIUM, COMPLEX)
-	ComplexityMechanisms []string          `json:"complexity_mechanisms,omitempty"` // For filtering by complexity classification mechanism (lexical, skipped)
-	TeamIDs              []string          `json:"team_ids,omitempty"`
-	CustomerIDs          []string          `json:"customer_ids,omitempty"`
-	UserIDs              []string          `json:"user_ids,omitempty"`
-	BusinessUnitIDs      []string          `json:"business_unit_ids,omitempty"`
-	RoutingEngineUsed    []string          `json:"routing_engine_used,omitempty"` // For filtering by routing engine (routing-rule, governance, loadbalancing)
-	Apps                 []string          `json:"apps,omitempty"`                // Backend-detected client apps
-	UserAgents           []string          `json:"user_agents,omitempty"`         // Raw User-Agent strings; kept for compatibility/debug filtering
-	StartTime            *time.Time        `json:"start_time,omitempty"`
-	EndTime              *time.Time        `json:"end_time,omitempty"`
-	MinLatency           *float64          `json:"min_latency,omitempty"`
-	MaxLatency           *float64          `json:"max_latency,omitempty"`
-	MinTokens            *int              `json:"min_tokens,omitempty"`
-	MaxTokens            *int              `json:"max_tokens,omitempty"`
-	MinCost              *float64          `json:"min_cost,omitempty"`
-	MaxCost              *float64          `json:"max_cost,omitempty"`
-	MissingCostOnly      bool              `json:"missing_cost_only,omitempty"`
-	CacheHitTypes        []string          `json:"cache_hit_types,omitempty"` // For filtering by local-cache hit type ("direct", "semantic")
-	ContentSearch        string            `json:"content_search,omitempty"`
-	MetadataFilters      map[string]string `json:"metadata_filters,omitempty"` // key=metadataKey, value=metadataValue for filtering by metadata
+	Providers                    []string          `json:"providers,omitempty"`
+	Models                       []string          `json:"models,omitempty"`
+	Aliases                      []string          `json:"aliases,omitempty"`
+	Status                       []string          `json:"status,omitempty"`
+	StopReasons                  []string          `json:"stop_reasons,omitempty"` // For filtering by stop reason (stop, length, content_filter, refusal, tool_calls, etc.)
+	Objects                      []string          `json:"objects,omitempty"`      // For filtering by request type (chat.completion, text.completion, embedding)
+	ParentRequestID              string            `json:"parent_request_id,omitempty"`
+	RootsOnly                    bool              `json:"roots_only,omitempty"` // Hide rows whose parent_request_id points at another row matching these same filters, so each chain lists as its root request only. Ignored when ParentRequestID is set.
+	SelectedKeyIDs               []string          `json:"selected_key_ids,omitempty"`
+	VirtualKeyIDs                []string          `json:"virtual_key_ids,omitempty"`
+	RoutingRuleIDs               []string          `json:"routing_rule_ids,omitempty"`
+	ComplexityTiers              []string          `json:"complexity_tiers,omitempty"`                // For filtering by routing complexity tier (SIMPLE, MEDIUM, COMPLEX)
+	ComplexityMechanisms         []string          `json:"complexity_mechanisms,omitempty"`           // For filtering by complexity classification mechanism (semantic, skipped)
+	ComplexitySessionID          string            `json:"complexity_session_id,omitempty"`           // Exact opaque session ID used by session-aware complexity routing
+	ComplexitySessionModes       []string          `json:"complexity_session_modes,omitempty"`        // Session policy mode (pinned, cache_aware)
+	ComplexitySessionTierSources []string          `json:"complexity_session_tier_sources,omitempty"` // Published tier source (classified, memoised, held)
+	TeamIDs                      []string          `json:"team_ids,omitempty"`
+	CustomerIDs                  []string          `json:"customer_ids,omitempty"`
+	UserIDs                      []string          `json:"user_ids,omitempty"`
+	BusinessUnitIDs              []string          `json:"business_unit_ids,omitempty"`
+	RoutingEngineUsed            []string          `json:"routing_engine_used,omitempty"` // For filtering by routing engine (routing-rule, governance, loadbalancing)
+	Apps                         []string          `json:"apps,omitempty"`                // Backend-detected client apps
+	UserAgents                   []string          `json:"user_agents,omitempty"`         // Raw User-Agent strings; kept for compatibility/debug filtering
+	StartTime                    *time.Time        `json:"start_time,omitempty"`
+	EndTime                      *time.Time        `json:"end_time,omitempty"`
+	MinLatency                   *float64          `json:"min_latency,omitempty"`
+	MaxLatency                   *float64          `json:"max_latency,omitempty"`
+	MinTokens                    *int              `json:"min_tokens,omitempty"`
+	MaxTokens                    *int              `json:"max_tokens,omitempty"`
+	MinCost                      *float64          `json:"min_cost,omitempty"`
+	MaxCost                      *float64          `json:"max_cost,omitempty"`
+	MissingCostOnly              bool              `json:"missing_cost_only,omitempty"`
+	CacheHitTypes                []string          `json:"cache_hit_types,omitempty"` // For filtering by local-cache hit type ("direct", "semantic")
+	ContentSearch                string            `json:"content_search,omitempty"`
+	MetadataFilters              map[string]string `json:"metadata_filters,omitempty"` // key=metadataKey, value=metadataValue for filtering by metadata
 	// RankingLimit caps the number of rows returned by the ranking queries
 	// (GetModelRankings / GetUserRankings / GetDimensionRankings). nil means
 	// "use the store default" (defaultMaxRankingsLimit); a value <= 0 means
@@ -169,6 +172,17 @@ func (u *UserAgentMapping) BeforeCreate(tx *gorm.DB) error {
 		return errors.New("id is required")
 	}
 	return nil
+}
+
+// ComplexitySessionLogFields contains the nullable request-log facts emitted
+// when session policy evaluates a complexity-routed turn. Its anonymous
+// embedding in Log keeps both the database columns and JSON response fields
+// flat.
+type ComplexitySessionLogFields struct {
+	ComplexitySessionID          *string `gorm:"type:varchar(255);index:idx_logs_complexity_session_id" json:"complexity_session_id,omitempty"` // Raw opaque session identity for exact log lookup; never place PII or secrets in this value
+	ComplexitySessionMode        *string `gorm:"type:varchar(20)" json:"complexity_session_mode,omitempty"`                                     // Session policy evaluated for this turn (pinned, cache_aware)
+	ComplexitySessionTierSource  *string `gorm:"type:varchar(20)" json:"complexity_session_tier_source,omitempty"`                              // Published tier source (classified, memoised, held); NULL when no tier was established
+	ComplexitySessionSwitchCount *int    `gorm:"column:complexity_session_switch_count" json:"complexity_session_switch_count,omitempty"`       // Persisted tier-switch count; NULL when store failure makes it unknowable
 }
 
 // Log represents a complete log entry for a request/response cycle
@@ -354,6 +368,8 @@ type Log struct {
 	VirtualKey  *tables.TableVirtualKey  `gorm:"-" json:"virtual_key,omitempty"`  // redacted
 	SelectedKey *schemas.Key             `gorm:"-" json:"selected_key,omitempty"` // redacted
 	RoutingRule *tables.TableRoutingRule `gorm:"-" json:"routing_rule,omitempty"` // redacted
+
+	ComplexitySessionLogFields
 
 	// usageRebuiltFromColumns records that TokenUsageParsed came from the lossy
 	// denormalized-column rebuild in DeserializeFields rather than from a real

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -1159,9 +1159,6 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	virtualKeyName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceVirtualKeyName)
 	routingRuleID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceRoutingRuleID)
 	routingRuleName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceRoutingRuleName)
-	complexityTier := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceComplexityTier)
-	complexityMechanism := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceComplexityMechanism)
-	complexityScore, hasComplexityScore := ctx.Value(schemas.BifrostContextKeyGovernanceComplexityScore).(float64)
 	selectedPromptName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedPromptName)
 	selectedPromptVersion := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedPromptVersion)
 	selectedPromptID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedPromptID)
@@ -1230,15 +1227,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			}
 			applyModelAlias(entry, originalModelRequested, resolvedModelUsed)
 			applyResolvedAliasInfo(entry, resolvedKeyAlias)
-			if complexityTier != "" {
-				entry.ComplexityTier = &complexityTier
-			}
-			if complexityMechanism != "" {
-				entry.ComplexityMechanism = &complexityMechanism
-			}
-			if hasComplexityScore {
-				entry.ComplexityScore = &complexityScore
-			}
+			applyComplexityContextToEntry(ctx, entry)
 			entry.ErrorDetailsParsed = sanitizeErrorForLogging(bifrostErr, contentLoggingEnabled, shouldStoreRaw)
 			entry.GuardrailDebugParsed = guardrailDebug
 			p.applyInternalCallCosts(ctx, entry, guardrailDebug)
@@ -1333,15 +1322,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 		}
 	}
 	applyOutputFieldsToEntry(entry, selectedKeyID, selectedKeyName, virtualKeyID, virtualKeyName, routingRuleID, routingRuleName, selectedPromptID, selectedPromptName, selectedPromptVersion, teamID, teamName, customerID, customerName, userID, userName, businessUnitID, businessUnitName, numberOfRetries, latency, attemptTrail)
-	if complexityTier != "" {
-		entry.ComplexityTier = &complexityTier
-	}
-	if complexityMechanism != "" {
-		entry.ComplexityMechanism = &complexityMechanism
-	}
-	if hasComplexityScore {
-		entry.ComplexityScore = &complexityScore
-	}
+	applyComplexityContextToEntry(ctx, entry)
 	applyResolvedAliasInfo(entry, resolvedKeyAlias)
 	// Attach cluster governance metadata for disconnected node usage recovery
 	if nodeID, _ := p.clusterNodeID.Load().(string); nodeID != "" {

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -270,6 +270,10 @@ func TestPostLLMHookNoPendingErrorPreservesMetadata(t *testing.T) {
 		"region": "us-east",
 	})
 	ctx.SetValue(schemas.BifrostIsAsyncRequest, true)
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexitySessionID, "conversation-abc")
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexitySessionMode, "cache_aware")
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexitySessionTierSource, "held")
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexitySessionSwitchCount, 0)
 
 	statusCode := 500
 	bifrostErr := &schemas.BifrostError{
@@ -313,6 +317,18 @@ func TestPostLLMHookNoPendingErrorPreservesMetadata(t *testing.T) {
 	}
 	if got := logEntry.MetadataParsed["isAsyncRequest"]; got != true {
 		t.Fatalf("expected async metadata true, got %#v", got)
+	}
+	if logEntry.ComplexitySessionID == nil || *logEntry.ComplexitySessionID != "conversation-abc" {
+		t.Fatalf("expected minimal error entry to preserve complexity session ID, got %v", logEntry.ComplexitySessionID)
+	}
+	if logEntry.ComplexitySessionMode == nil || *logEntry.ComplexitySessionMode != "cache_aware" {
+		t.Fatalf("expected minimal error entry to preserve complexity session mode, got %v", logEntry.ComplexitySessionMode)
+	}
+	if logEntry.ComplexitySessionTierSource == nil || *logEntry.ComplexitySessionTierSource != "held" {
+		t.Fatalf("expected minimal error entry to preserve complexity session tier source, got %v", logEntry.ComplexitySessionTierSource)
+	}
+	if logEntry.ComplexitySessionSwitchCount == nil || *logEntry.ComplexitySessionSwitchCount != 0 {
+		t.Fatalf("expected known zero switch count, got %v", logEntry.ComplexitySessionSwitchCount)
 	}
 }
 
@@ -658,6 +674,10 @@ func TestPostLLMHookCapturesComplexityRoutingContext(t *testing.T) {
 	ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexityTier, "COMPLEX")
 	ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexityMechanism, "lexical")
 	ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexityScore, 0.42)
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexitySessionID, "conversation-abc")
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexitySessionMode, "pinned")
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexitySessionTierSource, "memoised")
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexitySessionSwitchCount, 2)
 
 	statusCode := 500
 	bifrostErr := &schemas.BifrostError{
@@ -690,6 +710,18 @@ func TestPostLLMHookCapturesComplexityRoutingContext(t *testing.T) {
 	}
 	if entry.ComplexityScore == nil || *entry.ComplexityScore != 0.42 {
 		t.Fatalf("expected complexity_score 0.42, got %v", entry.ComplexityScore)
+	}
+	if entry.ComplexitySessionID == nil || *entry.ComplexitySessionID != "conversation-abc" {
+		t.Fatalf("expected complexity_session_id, got %v", entry.ComplexitySessionID)
+	}
+	if entry.ComplexitySessionMode == nil || *entry.ComplexitySessionMode != "pinned" {
+		t.Fatalf("expected complexity_session_mode pinned, got %v", entry.ComplexitySessionMode)
+	}
+	if entry.ComplexitySessionTierSource == nil || *entry.ComplexitySessionTierSource != "memoised" {
+		t.Fatalf("expected complexity_session_tier_source memoised, got %v", entry.ComplexitySessionTierSource)
+	}
+	if entry.ComplexitySessionSwitchCount == nil || *entry.ComplexitySessionSwitchCount != 2 {
+		t.Fatalf("expected complexity_session_switch_count 2, got %v", entry.ComplexitySessionSwitchCount)
 	}
 }
 

--- a/plugins/logging/writer.go
+++ b/plugins/logging/writer.go
@@ -561,6 +561,34 @@ func applyResolvedAliasInfo(entry *logstore.Log, resolvedAlias *schemas.Resolved
 	}
 }
 
+// applyComplexityContextToEntry copies the structured complexity-routing and
+// session observability fields from request context. Keeping this in one helper
+// ensures the normal completion path and the no-pending minimal-error path
+// cannot drift apart as new fields are added.
+func applyComplexityContextToEntry(ctx *schemas.BifrostContext, entry *logstore.Log) {
+	if ctx == nil || entry == nil {
+		return
+	}
+	setString := func(key schemas.BifrostContextKey, destination **string) {
+		value, _ := ctx.Value(key).(string)
+		if value != "" {
+			*destination = &value
+		}
+	}
+
+	setString(schemas.BifrostContextKeyGovernanceComplexityTier, &entry.ComplexityTier)
+	setString(schemas.BifrostContextKeyGovernanceComplexityMechanism, &entry.ComplexityMechanism)
+	setString(schemas.BifrostContextKeyGovernanceComplexitySessionID, &entry.ComplexitySessionID)
+	setString(schemas.BifrostContextKeyGovernanceComplexitySessionMode, &entry.ComplexitySessionMode)
+	setString(schemas.BifrostContextKeyGovernanceComplexitySessionTierSource, &entry.ComplexitySessionTierSource)
+	if score, ok := ctx.Value(schemas.BifrostContextKeyGovernanceComplexityScore).(float64); ok {
+		entry.ComplexityScore = &score
+	}
+	if switchCount, ok := ctx.Value(schemas.BifrostContextKeyGovernanceComplexitySessionSwitchCount).(int); ok {
+		entry.ComplexitySessionSwitchCount = &switchCount
+	}
+}
+
 // applyOutputFieldsToEntry sets common output fields on a log entry.
 func applyOutputFieldsToEntry(
 	entry *logstore.Log,

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -1044,6 +1044,15 @@ func parseComplexityFilters(ctx *fasthttp.RequestCtx, filters *logstore.SearchFi
 	if complexityMechanisms := string(ctx.QueryArgs().Peek("complexity_mechanisms")); complexityMechanisms != "" {
 		filters.ComplexityMechanisms = parseCommaSeparated(complexityMechanisms)
 	}
+	if sessionID := strings.TrimSpace(string(ctx.QueryArgs().Peek("complexity_session_id"))); sessionID != "" {
+		filters.ComplexitySessionID = sessionID
+	}
+	if sessionModes := string(ctx.QueryArgs().Peek("complexity_session_modes")); sessionModes != "" {
+		filters.ComplexitySessionModes = parseCommaSeparated(sessionModes)
+	}
+	if tierSources := string(ctx.QueryArgs().Peek("complexity_session_tier_sources")); tierSources != "" {
+		filters.ComplexitySessionTierSources = parseCommaSeparated(tierSources)
+	}
 }
 
 // parseHistogramFilters extracts common filter parameters from query args

--- a/transports/bifrost-http/handlers/logging_test.go
+++ b/transports/bifrost-http/handlers/logging_test.go
@@ -34,10 +34,13 @@ func TestShouldUseFilterDataCacheAllowsUnscopedEmptyQuery(t *testing.T) {
 }
 
 func TestParseComplexityFilters(t *testing.T) {
-	t.Run("parses tier and mechanism values", func(t *testing.T) {
+	t.Run("parses complexity and session dimensions", func(t *testing.T) {
 		ctx := &fasthttp.RequestCtx{}
 		ctx.QueryArgs().Set("complexity_tiers", "SIMPLE,COMPLEX")
-		ctx.QueryArgs().Set("complexity_mechanisms", "semantic,lexical")
+		ctx.QueryArgs().Set("complexity_mechanisms", "semantic,session")
+		ctx.QueryArgs().Set("complexity_session_id", " session-abc ")
+		ctx.QueryArgs().Set("complexity_session_modes", "pinned,cache_aware")
+		ctx.QueryArgs().Set("complexity_session_tier_sources", "classified,held")
 		filters := &logstore.SearchFilters{}
 
 		parseComplexityFilters(ctx, filters)
@@ -45,15 +48,27 @@ func TestParseComplexityFilters(t *testing.T) {
 		if got, want := filters.ComplexityTiers, []string{"SIMPLE", "COMPLEX"}; !reflect.DeepEqual(got, want) {
 			t.Fatalf("complexity tiers = %#v, want %#v", got, want)
 		}
-		if got, want := filters.ComplexityMechanisms, []string{"semantic", "lexical"}; !reflect.DeepEqual(got, want) {
+		if got, want := filters.ComplexityMechanisms, []string{"semantic", "session"}; !reflect.DeepEqual(got, want) {
 			t.Fatalf("complexity mechanisms = %#v, want %#v", got, want)
+		}
+		if got, want := filters.ComplexitySessionID, "session-abc"; got != want {
+			t.Fatalf("complexity session ID = %q, want %q", got, want)
+		}
+		if got, want := filters.ComplexitySessionModes, []string{"pinned", "cache_aware"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("complexity session modes = %#v, want %#v", got, want)
+		}
+		if got, want := filters.ComplexitySessionTierSources, []string{"classified", "held"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("complexity session tier sources = %#v, want %#v", got, want)
 		}
 	})
 
 	t.Run("leaves filters unchanged when parameters are absent", func(t *testing.T) {
 		filters := &logstore.SearchFilters{
-			ComplexityTiers:      []string{"MEDIUM"},
-			ComplexityMechanisms: []string{"skipped"},
+			ComplexityTiers:              []string{"MEDIUM"},
+			ComplexityMechanisms:         []string{"skipped"},
+			ComplexitySessionID:          "session-existing",
+			ComplexitySessionModes:       []string{"pinned"},
+			ComplexitySessionTierSources: []string{"memoised"},
 		}
 
 		parseComplexityFilters(&fasthttp.RequestCtx{}, filters)
@@ -63,6 +78,15 @@ func TestParseComplexityFilters(t *testing.T) {
 		}
 		if got, want := filters.ComplexityMechanisms, []string{"skipped"}; !reflect.DeepEqual(got, want) {
 			t.Fatalf("complexity mechanisms = %#v, want %#v", got, want)
+		}
+		if got, want := filters.ComplexitySessionID, "session-existing"; got != want {
+			t.Fatalf("complexity session ID = %q, want %q", got, want)
+		}
+		if got, want := filters.ComplexitySessionModes, []string{"pinned"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("complexity session modes = %#v, want %#v", got, want)
+		}
+		if got, want := filters.ComplexitySessionTierSources, []string{"memoised"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("complexity session tier sources = %#v, want %#v", got, want)
 		}
 	})
 }

--- a/ui/app/workspace/complexity-router/formSchema.test.ts
+++ b/ui/app/workspace/complexity-router/formSchema.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { tryParseSessionTtlMinutes } from "@/lib/types/complexityRouter";
+import { DEFAULT_SESSION_FORM_VALUES, isPositiveDurationString, normalizeSessionTtl, sessionTtlFieldValue, toFormValues } from "./formSchema";
+
+describe("isPositiveDurationString", () => {
+	it("accepts positive single-unit duration strings", () => {
+		expect(isPositiveDurationString("60m")).toBe(true);
+		expect(isPositiveDurationString("1h")).toBe(true);
+	});
+
+	it("rejects blank, zero, malformed, and multi-unit Go strings", () => {
+		expect(isPositiveDurationString("")).toBe(false);
+		expect(isPositiveDurationString("0m")).toBe(false);
+		expect(isPositiveDurationString("60")).toBe(false);
+		expect(isPositiveDurationString("bogus")).toBe(false);
+		// Form state must be single-unit; multi-unit belongs on the wire only.
+		expect(isPositiveDurationString("1h0m0s")).toBe(false);
+		expect(isPositiveDurationString("30m0s")).toBe(false);
+	});
+});
+
+describe("tryParseSessionTtlMinutes", () => {
+	it("parses single-unit and Go Duration.String multi-unit forms", () => {
+		expect(tryParseSessionTtlMinutes("60m")).toBe(60);
+		expect(tryParseSessionTtlMinutes("1h")).toBe(60);
+		expect(tryParseSessionTtlMinutes("1h0m0s")).toBe(60);
+		expect(tryParseSessionTtlMinutes("30m0s")).toBe(30);
+		expect(tryParseSessionTtlMinutes("1h30m")).toBe(90);
+		expect(tryParseSessionTtlMinutes("90s")).toBe(1.5);
+	});
+
+	it("returns null for blank, malformed, or partially matched input", () => {
+		expect(tryParseSessionTtlMinutes(undefined)).toBeNull();
+		expect(tryParseSessionTtlMinutes("")).toBeNull();
+		expect(tryParseSessionTtlMinutes("a while")).toBeNull();
+		// Trailing garbage must not silently truncate to the matched prefix.
+		expect(tryParseSessionTtlMinutes("5m x")).toBeNull();
+	});
+});
+
+describe("normalizeSessionTtl", () => {
+	it("collapses any valid duration into the single-unit minute string the form owns", () => {
+		expect(normalizeSessionTtl("1h0m0s")).toBe("60m");
+		expect(normalizeSessionTtl("30m")).toBe("30m");
+		expect(normalizeSessionTtl("1h30m")).toBe("90m");
+	});
+
+	it("falls back to the default TTL for blank or malformed input", () => {
+		expect(normalizeSessionTtl(undefined)).toBe(DEFAULT_SESSION_FORM_VALUES.ttl);
+		expect(normalizeSessionTtl("")).toBe(DEFAULT_SESSION_FORM_VALUES.ttl);
+		expect(normalizeSessionTtl("bogus")).toBe(DEFAULT_SESSION_FORM_VALUES.ttl);
+	});
+});
+
+describe("sessionTtlFieldValue", () => {
+	it("feeds the minutes control the raw digits of a minute string", () => {
+		expect(sessionTtlFieldValue("45m")).toBe("45");
+	});
+
+	it("converts other valid durations to a minute count", () => {
+		expect(sessionTtlFieldValue("1h")).toBe(60);
+		expect(sessionTtlFieldValue("1h30m")).toBe(90);
+	});
+
+	it("keeps blank input blank and drops garbage", () => {
+		expect(sessionTtlFieldValue("")).toBe("");
+		expect(sessionTtlFieldValue(undefined)).toBe("");
+		expect(sessionTtlFieldValue("a while")).toBe("");
+	});
+});
+
+describe("toFormValues", () => {
+	const base = {
+		keywords: { simple_keywords: ["a"], medium_keywords: ["b"], complex_keywords: ["c"] },
+	};
+
+	it("uses session defaults when the config carries no session block", () => {
+		const values = toFormValues(base as never);
+		expect(values.session).toEqual(DEFAULT_SESSION_FORM_VALUES);
+	});
+
+	it("fills the holes Go's omitempty leaves in a saved session block", () => {
+		const values = toFormValues({
+			...base,
+			session: { mode: "cache_aware", ttl: "1h0m0s" },
+		} as never);
+		expect(values.session.mode).toBe("cache_aware");
+		expect(values.session.ttl).toBe("60m");
+		expect(values.session.identity_sources).toEqual(DEFAULT_SESSION_FORM_VALUES.identity_sources);
+		expect(values.session.downgrade_after_n_turns).toBe(DEFAULT_SESSION_FORM_VALUES.downgrade_after_n_turns);
+		expect(values.session.switch_min_similarity).toBe(0);
+		expect(values.session.max_switches_per_session).toBe(0);
+	});
+});

--- a/ui/app/workspace/complexity-router/formSchema.ts
+++ b/ui/app/workspace/complexity-router/formSchema.ts
@@ -1,12 +1,15 @@
 import {
 	AnalyzerConfig,
 	DEFAULT_SEMANTIC_CONFIG,
+	DEFAULT_SESSION_CONFIG,
+	DEFAULT_SESSION_IDENTITY_SOURCES,
 	formatSemanticTimeout,
 	KeywordListKey,
 	MAX_SEMANTIC_MESSAGE_HISTORY,
 	MAX_SEMANTIC_PHRASE_CHARACTERS,
 	MIN_SEMANTIC_MESSAGE_HISTORY,
 	parseSemanticTimeoutMs,
+	tryParseSessionTtlMinutes,
 } from "@/lib/types/complexityRouter";
 import { z } from "zod";
 
@@ -41,6 +44,27 @@ const semanticSchema = z.object({
 	vector_store: z.enum(["embedded", "vector_store"]).optional(),
 });
 
+const sessionSchema = z.object({
+	mode: z.enum(["off", "pinned", "cache_aware"]),
+	// Edited in minutes but stored as a Go duration, so a malformed or
+	// non-positive entry is caught here rather than snapped back to the default
+	// while the operator is still typing.
+	ttl: z
+		.string()
+		.min(1, "Enter a session timeout")
+		.refine((value) => isPositiveDurationString(value), "Enter a timeout greater than 0"),
+	// The server rejects an empty ladder, and with nothing able to identify a
+	// session the feature silently does nothing.
+	identity_sources: z.array(z.enum(["header", "harness"])).min(1, "Select at least one way to identify a session"),
+	switch_min_similarity: z.number({ error: "Enter a number between 0 and 1" }).min(0, "Must be 0 or greater").lt(1, "Must be less than 1"),
+	downgrade_after_n_turns: z.number({ error: "Enter a whole number of turns" }).int("Must be a whole number").min(1, "Must be at least 1"),
+	max_switches_per_session: z
+		.number({ error: "Enter a whole number of switches" })
+		.int("Must be a whole number")
+		.min(0, "Must be 0 or greater"),
+	always_allow_escalation: z.boolean(),
+});
+
 export const analyzerConfigSchema = z
 	.object({
 		keywords: z.object({
@@ -49,8 +73,25 @@ export const analyzerConfigSchema = z
 			complex_keywords: z.array(z.string()).min(1, "Complex phrases cannot be empty"),
 		}),
 		semantic: semanticSchema,
+		session: sessionSchema,
 	})
 	.superRefine((data, ctx) => {
+		// Mirrors the cross-field rule in ComplexityAnalyzerConfig.Validate. The
+		// two numbers form hysteresis — a low bar to classify a turn, a higher bar
+		// to move a whole session — so inverting them makes a session easier to
+		// switch than a single turn is to classify.
+		//
+		// The other value is edited in the embedding sheet, so the message has to
+		// name where it lives; an error pointing at a number the operator cannot
+		// see from here is unactionable.
+		if (data.session.switch_min_similarity > 0 && data.session.switch_min_similarity < data.semantic.min_similarity) {
+			ctx.addIssue({
+				code: "custom",
+				message: `Must be at least the minimum similarity threshold (${data.semantic.min_similarity}), which is set in the embedding configuration.`,
+				path: ["session", "switch_min_similarity"],
+			});
+		}
+
 		// A blank provider and model means the classifier simply is not configured
 		// yet, which is a legal state: phrase edits still save. Half-filled is not,
 		// because it cannot be turned into a working classifier.
@@ -104,6 +145,17 @@ export const analyzerConfigSchema = z
 // needs a concrete value, so the schema's inferred type is the source of truth.
 export type AnalyzerFormValues = z.infer<typeof analyzerConfigSchema>;
 export type SemanticFormValues = AnalyzerFormValues["semantic"];
+export type SessionFormValues = AnalyzerFormValues["session"];
+
+export const DEFAULT_SESSION_FORM_VALUES: SessionFormValues = {
+	mode: DEFAULT_SESSION_CONFIG.mode,
+	ttl: DEFAULT_SESSION_CONFIG.ttl ?? "60m",
+	identity_sources: [...DEFAULT_SESSION_IDENTITY_SOURCES],
+	switch_min_similarity: DEFAULT_SESSION_CONFIG.switch_min_similarity ?? 0,
+	downgrade_after_n_turns: DEFAULT_SESSION_CONFIG.downgrade_after_n_turns ?? 2,
+	max_switches_per_session: DEFAULT_SESSION_CONFIG.max_switches_per_session ?? 0,
+	always_allow_escalation: DEFAULT_SESSION_CONFIG.always_allow_escalation ?? false,
+};
 
 export const DEFAULT_SEMANTIC_FORM_VALUES: SemanticFormValues = {
 	...DEFAULT_SEMANTIC_CONFIG,
@@ -120,11 +172,21 @@ export const DEFAULT_FORM_VALUES: AnalyzerFormValues = {
 		complex_keywords: [],
 	},
 	semantic: DEFAULT_SEMANTIC_FORM_VALUES,
+	session: DEFAULT_SESSION_FORM_VALUES,
 };
+
+// Go serializes durations with compound units such as "1h0m0s", while the
+// form owns a minutes-only value. Canonicalize valid saved durations so an
+// untouched session config still passes the form schema.
+export function normalizeSessionTtl(ttl: string | undefined): string {
+	const minutes = tryParseSessionTtlMinutes(ttl);
+	return minutes === null ? DEFAULT_SESSION_FORM_VALUES.ttl : `${minutes}m`;
+}
 
 // Fills in the fields the API omitted so the semantic controls stay controlled.
 export function toFormValues(config: AnalyzerConfig): AnalyzerFormValues {
 	const saved = config.semantic;
+	const savedSession = config.session;
 	return {
 		keywords: config.keywords,
 		semantic: saved
@@ -137,6 +199,26 @@ export function toFormValues(config: AnalyzerConfig): AnalyzerFormValues {
 					vector_store: saved.vector_store ?? DEFAULT_SEMANTIC_FORM_VALUES.vector_store,
 				}
 			: DEFAULT_SEMANTIC_FORM_VALUES,
+		// Go omits every zero-valued session field, so a saved block arrives with
+		// holes. Each one is filled from the same default the gateway's own
+		// normalization would apply, rather than from the zero value: a 0 TTL or an
+		// empty identity ladder reads as "disabled" while the mode still says
+		// enabled.
+		session: savedSession
+			? {
+					...DEFAULT_SESSION_FORM_VALUES,
+					...savedSession,
+					ttl: normalizeSessionTtl(savedSession.ttl),
+					identity_sources:
+						savedSession.identity_sources && savedSession.identity_sources.length > 0
+							? savedSession.identity_sources
+							: DEFAULT_SESSION_FORM_VALUES.identity_sources,
+					switch_min_similarity: savedSession.switch_min_similarity ?? 0,
+					downgrade_after_n_turns: savedSession.downgrade_after_n_turns ?? DEFAULT_SESSION_FORM_VALUES.downgrade_after_n_turns,
+					max_switches_per_session: savedSession.max_switches_per_session ?? 0,
+					always_allow_escalation: savedSession.always_allow_escalation ?? false,
+				}
+			: DEFAULT_SESSION_FORM_VALUES,
 	};
 }
 
@@ -150,4 +232,20 @@ export function semanticTimeoutFieldValue(timeout: string | number | undefined):
 	if (timeout === "") return "";
 	const millis = timeout?.trim().match(/^([0-9]*\.?[0-9]+)ms$/);
 	return millis ? millis[1] : parseSemanticTimeoutMs(timeout);
+}
+
+// Same round-trip as semanticTimeoutFieldValue, in minutes: a value this control
+// wrote comes back digit for digit, a saved Go duration like "1h0m0s" is rendered
+// as the equivalent minute count, and malformed raw state is left visibly blank
+// instead of being masked as the default.
+export function sessionTtlFieldValue(ttl: string | undefined): string | number {
+	if (ttl === "") return "";
+	const trimmed = ttl?.trim();
+	if (!trimmed) return "";
+	const minutes = trimmed.match(/^([0-9]*\.?[0-9]+)m$/);
+	if (minutes) return minutes[1];
+	const parsed = tryParseSessionTtlMinutes(trimmed);
+	if (parsed !== null) return parsed;
+	const numeric = Number(trimmed);
+	return Number.isFinite(numeric) ? numeric : "";
 }

--- a/ui/app/workspace/complexity-router/page.tsx
+++ b/ui/app/workspace/complexity-router/page.tsx
@@ -23,13 +23,13 @@ import {
 	useResetComplexityAnalyzerConfigMutation,
 	useUpdateComplexityAnalyzerConfigMutation,
 } from "@/lib/store/apis/governanceApi";
-import { AnalyzerConfig, KeywordListKey, TIER_PHRASE_LIST_DEFINITIONS } from "@/lib/types/complexityRouter";
+import { AnalyzerConfig, KeywordListKey, SESSION_MODE_LABELS, TIER_PHRASE_LIST_DEFINITIONS } from "@/lib/types/complexityRouter";
 import { ModelProvider } from "@/lib/types/config";
 import { DBKey } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { ExternalLink, Info, LoaderCircle, RotateCcw, Save, Settings2, TriangleAlert } from "lucide-react";
+import { ExternalLink, History, Info, LoaderCircle, RotateCcw, Save, Settings2, TriangleAlert } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -42,6 +42,7 @@ import {
 import { ClassifierStatusBadge } from "./views/classifierStatusBadge";
 import EmbeddingConfigSheet from "./views/embeddingConfigSheet";
 import { SectionHeading } from "./views/formPrimitives";
+import SessionConfigSheet from "./views/sessionConfigSheet";
 
 // Embedding-capable providers gate this page, matching the local cache screen's
 // rule: built-ins are listed in EmbeddingSupportedProviders, custom providers
@@ -83,6 +84,7 @@ export default function ComplexityRouterPage() {
 	const [submitError, setSubmitError] = useState<string | null>(null);
 	const [restoreDialogOpen, setRestoreDialogOpen] = useState(false);
 	const [embeddingSheetOpen, setEmbeddingSheetOpen] = useState(false);
+	const [sessionSheetOpen, setSessionSheetOpen] = useState(false);
 
 	const { data: providersData, isLoading: providersLoading } = useGetProvidersQuery();
 	const { data: allKeys, isLoading: keysLoading } = useGetAllKeysQuery();
@@ -104,8 +106,12 @@ export default function ComplexityRouterPage() {
 	// that had already recovered. It polls slowly because it is waiting on a
 	// human, where warming is polled fast to keep the progress bar moving.
 	const [statusPollInterval, setStatusPollInterval] = useState(0);
+	// Also fetched when only session behavior is configured: the same endpoint now
+	// carries the session store's guarantees, and skipping on the classifier alone
+	// left the session sheet with nothing to report on a deployment that had
+	// enabled sessions without configuring embeddings.
 	const { data: semanticStatus, isLoading: statusLoading } = useGetComplexitySemanticStatusQuery(undefined, {
-		skip: !data?.semantic,
+		skip: !data?.semantic && !data?.session,
 		pollingInterval: statusPollInterval,
 	});
 	useEffect(() => {
@@ -133,6 +139,7 @@ export default function ComplexityRouterPage() {
 
 	const liveSemantic = watch("semantic");
 	const liveKeywords = watch("keywords");
+	const liveSession = watch("session");
 
 	// Narrows the model list to what this provider's enabled keys can actually
 	// serve. /api/models only applies per-key allow-lists and blacklists when it
@@ -150,6 +157,10 @@ export default function ComplexityRouterPage() {
 	// react-hook-form keeps reverted fields in dirtyFields with a false value, so
 	// the flags are what matter, not the key count.
 	const hasUnsavedEmbeddingChanges = Object.values(dirtyFields.semantic ?? {}).some(Boolean);
+	const hasUnsavedSessionChanges = Object.values(dirtyFields.session ?? {}).some(Boolean);
+
+	const sessionMode = liveSession?.mode ?? "off";
+	const isSessionEnabled = sessionMode === "pinned" || sessionMode === "cache_aware";
 
 	const totalPhrases = useMemo(
 		() =>
@@ -271,15 +282,22 @@ export default function ComplexityRouterPage() {
 		// select has no clear option, and Restore defaults goes through its own
 		// endpoint.
 		const semantic = values.semantic.provider && values.semantic.embedding_model ? values.semantic : (data?.semantic ?? undefined);
+		// "off" is a stored value, not an absent block, so turning session behavior
+		// off keeps the settings behind it. The block is only introduced once it
+		// says something: a deployment that never opens the sheet keeps saving a
+		// config without one rather than acquiring an inert "off" block.
+		const session = values.session.mode !== "off" || data?.session ? values.session : undefined;
 		const payload: AnalyzerConfig = {
 			keywords: values.keywords,
 			...(semantic ? { semantic } : {}),
+			...(session ? { session } : {}),
 		};
 		updateConfig(payload)
 			.unwrap()
 			.then((res) => {
 				reset(toFormValues(res));
 				setEmbeddingSheetOpen(false);
+				setSessionSheetOpen(false);
 				toast.success("Configuration saved", { position: "top-right" });
 			})
 			.catch((err) => {
@@ -292,6 +310,7 @@ export default function ComplexityRouterPage() {
 	// the message is hidden under the overlay.
 	const submit = handleSubmit(onValid, (formErrors) => {
 		if (!formErrors.semantic) setEmbeddingSheetOpen(false);
+		if (!formErrors.session) setSessionSheetOpen(false);
 	});
 
 	if (isLoading && !data) {
@@ -321,7 +340,7 @@ export default function ComplexityRouterPage() {
 	}
 
 	const keywordErrors = errors.keywords;
-	const hasErrors = Boolean(keywordErrors || errors.semantic);
+	const hasErrors = Boolean(keywordErrors || errors.semantic || errors.session);
 	const canSave = canUpdate && isDirty && !isResetting && !(isSubmitted && hasErrors);
 
 	// Rendered on the page and again inside the sheet: the re-embed cost is a
@@ -404,6 +423,22 @@ export default function ComplexityRouterPage() {
 										<span className="size-1.5 rounded-full bg-amber-500" role="status" aria-label="Unsaved embedding changes" />
 									)}
 								</Button>
+								{/* The mode rides in the label rather than in a separate chip: unlike
+								    the classifier there is no async state to report, so a badge would
+								    only ever restate what the button already says. */}
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onClick={() => setSessionSheetOpen(true)}
+									data-testid="complexity-router-session-config-button"
+								>
+									<History className="size-3.5" />
+									Session: {SESSION_MODE_LABELS[sessionMode]}
+									{hasUnsavedSessionChanges && (
+										<span className="size-1.5 rounded-full bg-amber-500" role="status" aria-label="Unsaved session changes" />
+									)}
+								</Button>
 								<Button asChild variant="outline" size="sm" data-testid="complexity-router-docs-link">
 									<a href={"https://docs.getbifrost.ai/features/governance/complexity-router"} target="_blank" rel="noopener noreferrer">
 										<ExternalLink className="size-3.5" />
@@ -429,6 +464,27 @@ export default function ComplexityRouterPage() {
 									</span>
 								}
 							/>
+
+							{/* Session mode changes when these phrases affect routing. Pinned mode
+							    consults them only on the first turn; cache-aware mode consults them
+							    on every relevant turn but may hold the existing tier. That distinction
+							    is otherwise invisible while an operator tunes the phrase lists. */}
+							{isSessionEnabled && (
+								<Alert variant="info" data-testid="complexity-router-session-scope-callout">
+									<Info className="h-4 w-4" />
+									{/* AlertDescription lays its children out as grid rows, so the
+									    sentence has to reach it as a single node — an inline <span>
+									    among the text broke it across three lines. */}
+									<AlertDescription>
+										<span>
+											Session behavior is set to <span className="font-medium">{SESSION_MODE_LABELS[sessionMode]}</span>, so
+											{sessionMode === "pinned"
+												? " these phrases classify the first turn. Later turns keep that tier without being classified again."
+												: " these phrases classify every complexity-routed turn, using one embedding each time. A new tier applies only when confidence and cache conditions allow it."}
+										</span>
+									</AlertDescription>
+								</Alert>
+							)}
 
 							<Alert variant="info" data-testid="complexity-router-phrase-defaults-callout">
 								<Info className="h-4 w-4" />
@@ -559,14 +615,30 @@ export default function ComplexityRouterPage() {
 				submitError={submitError}
 			/>
 
+			<SessionConfigSheet
+				open={sessionSheetOpen}
+				onOpenChange={setSessionSheetOpen}
+				control={control}
+				register={register}
+				errors={errors.session}
+				session={liveSession}
+				canUpdate={canUpdate}
+				isClassifierConfigured={isClassifierConfigured}
+				storeStatus={semanticStatus?.session_store}
+				storeStatusLoading={statusLoading}
+				canSave={canSave}
+				isSaving={isSaving}
+				onSave={() => void submit()}
+			/>
+
 			<AlertDialog open={restoreDialogOpen} onOpenChange={setRestoreDialogOpen}>
 				<AlertDialogContent>
 					<AlertDialogHeader>
 						<AlertDialogTitle>Restore defaults</AlertDialogTitle>
 						<AlertDialogDescription>
 							This will replace the phrase to tier mapping with the default reference phrases. Your current phrases will be lost and this
-							action cannot be undone. Your embedding configuration is kept, so classification keeps running and the restored phrases are
-							embedded through the configured provider straight away.
+							action cannot be undone. Your embedding configuration and session behavior are kept, so classification keeps running and the
+							restored phrases are embedded through the configured provider straight away.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>

--- a/ui/app/workspace/complexity-router/views/sessionConfigSheet.tsx
+++ b/ui/app/workspace/complexity-router/views/sessionConfigSheet.tsx
@@ -1,0 +1,348 @@
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Switch } from "@/components/ui/switch";
+import {
+	SESSION_IDENTITY_SOURCE_OPTIONS,
+	SESSION_MODE_OPTIONS,
+	SessionIdentitySource,
+	sessionStoreReadiness,
+	SessionStoreReadiness,
+	SessionStoreStatus,
+} from "@/lib/types/complexityRouter";
+import { cn } from "@/lib/utils";
+import { Info, LoaderCircle, Save, TriangleAlert } from "lucide-react";
+import { Controller, type Control, type FieldErrors, type UseFormRegister } from "react-hook-form";
+import type { AnalyzerFormValues, SessionFormValues } from "../formSchema";
+import { FieldLabel } from "./formPrimitives";
+
+// "replicated-not-atomic" deliberately has no entry: it's covered in the docs
+// rather than the UI, since a banner explaining replica-consistency mechanics
+// is more than most operators configuring this form need to see.
+const READINESS_COPY: Partial<Record<SessionStoreReadiness, { title: string; body: string }>> = {
+	"node-local": {
+		title: "Session state is node-local.",
+		body: "Each gateway holds its own copy. That is fine on a single replica; if you run more than one, a conversation is tracked separately on each and can be pinned to a different tier on each.",
+	},
+	"shared-atomic": {
+		title: "Shared and atomic.",
+		body: "Every replica sees the same session records and concurrent updates to one conversation are serialized across them.",
+	},
+};
+
+interface Props {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	control: Control<AnalyzerFormValues>;
+	register: UseFormRegister<AnalyzerFormValues>;
+	errors: FieldErrors<AnalyzerFormValues>["session"];
+	session: SessionFormValues | undefined;
+	canUpdate: boolean;
+	// True once an embedding provider and model are saved. Session behavior acts
+	// on the tier the classifier produces, so with no classifier there is nothing
+	// to pin and these settings sit inert.
+	isClassifierConfigured: boolean;
+	// What the session backend reports about itself. Undefined means no store is
+	// attached, which is not the same as an unsafe one.
+	storeStatus: SessionStoreStatus | undefined;
+	storeStatusLoading: boolean;
+	canSave: boolean;
+	isSaving: boolean;
+	onSave: () => void;
+}
+
+// SessionConfigSheet holds the whole session block. Like the embedding sheet it
+// is a sheet rather than a page section: mode is chosen once and then left
+// alone, while the phrase lists behind it are what operators actually tune.
+//
+// Its fields are bound to the page's form, so closing the sheet keeps edits
+// pending; the page footer can still save or discard them.
+export default function SessionConfigSheet({
+	open,
+	onOpenChange,
+	control,
+	register,
+	errors,
+	session,
+	canUpdate,
+	isClassifierConfigured,
+	storeStatus,
+	storeStatusLoading,
+	canSave,
+	isSaving,
+	onSave,
+}: Props) {
+	const mode = session?.mode ?? "off";
+	const readiness = sessionStoreReadiness(storeStatus);
+	const isEnabled = mode === "pinned" || mode === "cache_aware";
+	const isCacheAware = mode === "cache_aware";
+	const fieldsDisabled = !canUpdate || !isEnabled;
+
+	return (
+		<Sheet open={open} onOpenChange={onOpenChange}>
+			<SheetContent className="flex flex-col p-0" data-testid="complexity-router-session-sheet">
+				<SheetHeader className="flex flex-col items-start gap-1 px-6 py-4" headerClassName="bg-card z-10 mb-0 border-b">
+					<SheetTitle>Session behavior</SheetTitle>
+					<SheetDescription className="text-xs">
+						Whether a conversation keeps its first tier for the whole session, or reclassifies every turn and only changes tier when
+						confidence or sustained signal says so.
+					</SheetDescription>
+				</SheetHeader>
+
+				<div className="custom-scrollbar min-h-0 flex-1 space-y-5 overflow-y-auto px-6 py-5">
+					{/* Session behavior acts on the classifier's output, so without a
+					    classifier these controls save but never do anything. */}
+					{!isClassifierConfigured && (
+						<Alert variant="info" data-testid="complexity-router-session-needs-classifier">
+							<Info className="h-4 w-4" />
+							<AlertDescription>
+								No embedding classifier is configured, so no tier is produced and there is nothing for a session to hold. These settings
+								save, but take effect only once the classifier is running.
+							</AlertDescription>
+						</Alert>
+					)}
+
+					<div className="space-y-2">
+						<FieldLabel htmlFor="session-mode">Mode</FieldLabel>
+						<Controller
+							control={control}
+							name="session.mode"
+							render={({ field }) => (
+								<Select value={field.value} onValueChange={field.onChange} disabled={!canUpdate}>
+									<SelectTrigger className="w-full" id="session-mode" data-testid="complexity-router-session-mode-select">
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										{SESSION_MODE_OPTIONS.map((option) => (
+											<SelectItem key={option.value} value={option.value}>
+												{option.label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							)}
+						/>
+						<p className="text-muted-foreground text-xs leading-relaxed">
+							{SESSION_MODE_OPTIONS.find((option) => option.value === mode)?.description}
+						</p>
+					</div>
+
+					{/* The backend can only describe itself, it cannot see how many
+					    replicas are running, so neither of these two say "safe". They
+					    say what the storage guarantees and leave the topology to the
+					    operator, who is the only one who knows it. */}
+					{isEnabled && !storeStatusLoading && readiness && READINESS_COPY[readiness] && (
+						<Alert variant={readiness === "shared-atomic" ? "info" : "warning"} data-testid="complexity-router-session-store-readiness">
+							{readiness === "shared-atomic" ? <Info className="h-4 w-4" /> : <TriangleAlert className="h-4 w-4" />}
+							<AlertDescription>
+								<span>
+									<span className="font-medium">{READINESS_COPY[readiness].title}</span> {READINESS_COPY[readiness].body}
+								</span>
+							</AlertDescription>
+						</Alert>
+					)}
+
+					<div className="space-y-2">
+						<FieldLabel tooltip="Tried in order from the top. The first one that yields an ID wins, so a caller-sent header always beats a harness-provided one.">
+							How a conversation is identified
+						</FieldLabel>
+						<Controller
+							control={control}
+							name="session.identity_sources"
+							render={({ field }) => (
+								<div className="divide-y rounded-sm border">
+									{SESSION_IDENTITY_SOURCE_OPTIONS.map((option) => {
+										const checked = field.value?.includes(option.value) ?? false;
+										return (
+											<div key={option.value} className="flex items-start gap-3 p-3">
+												<Checkbox
+													id={`session-identity-${option.value}`}
+													data-testid={`complexity-router-session-identity-${option.value}`}
+													className="mt-0.5"
+													checked={checked}
+													disabled={fieldsDisabled}
+													onCheckedChange={(next) => {
+														const current = field.value ?? [];
+														// Rebuilt from the option order rather than by
+														// appending, so the saved list reads in the same
+														// order the gateway tries them.
+														const selected = new Set<SessionIdentitySource>(current);
+														if (next === true) selected.add(option.value);
+														else selected.delete(option.value);
+														field.onChange(
+															SESSION_IDENTITY_SOURCE_OPTIONS.map((entry) => entry.value).filter((value) => selected.has(value)),
+														);
+													}}
+												/>
+												<div className="space-y-1">
+													<Label htmlFor={`session-identity-${option.value}`} className="text-xs font-medium">
+														{option.label}
+													</Label>
+													<p className="text-muted-foreground text-xs leading-relaxed">{option.description}</p>
+												</div>
+											</div>
+										);
+									})}
+								</div>
+							)}
+						/>
+						{errors?.identity_sources && <p className="text-destructive text-xs">{errors.identity_sources.message}</p>}
+					</div>
+
+					{/* Every control below only reads in cache_aware mode. They are hidden
+					    rather than disabled in the other modes: a disabled field still
+					    reads as a setting that applies, and there are five of them. */}
+					{isCacheAware && (
+						<div className="space-y-5 border-t pt-5" data-testid="complexity-router-session-cache-aware-fields">
+							<div className="space-y-1">
+								<h3 className="text-sm font-semibold">When a session may change tier</h3>
+								<p className="text-muted-foreground text-xs leading-relaxed">
+									A turn switches the session immediately if it's confident enough on its own, or once enough consecutive turns favor
+									the move. These decide how sure and how sustained that needs to be.
+								</p>
+							</div>
+
+							<div className="grid gap-4 sm:grid-cols-2">
+								<div className="space-y-2">
+									<FieldLabel
+										htmlFor="session-switch-min-similarity"
+										tooltip="Deliberately higher than the classifier's own minimum similarity: a low bar to classify a single turn, a higher bar to move a whole conversation. For a downgrade, clearing this on one turn switches immediately without waiting for the turn count below. 0 disables that fast path, so every downgrade waits for sustained turns instead."
+									>
+										Minimum similarity to switch
+									</FieldLabel>
+									<Input
+										id="session-switch-min-similarity"
+										data-testid="complexity-router-session-switch-similarity-input"
+										type="number"
+										min={0}
+										max={0.99}
+										step={0.05}
+										disabled={fieldsDisabled}
+										aria-invalid={errors?.switch_min_similarity ? true : undefined}
+										className={cn("font-mono", errors?.switch_min_similarity && "border-destructive focus-visible:ring-destructive")}
+										{...register("session.switch_min_similarity", {
+											valueAsNumber: true,
+										})}
+									/>
+									{errors?.switch_min_similarity ? (
+										<p className="text-destructive text-xs">{errors.switch_min_similarity.message}</p>
+									) : (
+										<p className="text-muted-foreground text-xs leading-relaxed">
+											Between 0 and 1. A single turn this confident switches right away.
+										</p>
+									)}
+								</div>
+
+								<div className="space-y-2">
+									<FieldLabel
+										htmlFor="session-downgrade-after-n-turns"
+										tooltip="Long sessions are full of turns like 'yes' or 'run the tests' that classify as confidently simple. Those are exactly the turns not to downgrade on: the classifier is right about the turn and wrong about the conversation. Any lower tier counts toward this, not just the same one each time."
+									>
+										Turns before downgrading
+									</FieldLabel>
+									<Input
+										id="session-downgrade-after-n-turns"
+										data-testid="complexity-router-session-downgrade-input"
+										type="number"
+										min={1}
+										step={1}
+										disabled={fieldsDisabled}
+										aria-invalid={errors?.downgrade_after_n_turns ? true : undefined}
+										className={cn("font-mono", errors?.downgrade_after_n_turns && "border-destructive focus-visible:ring-destructive")}
+										{...register("session.downgrade_after_n_turns", {
+											valueAsNumber: true,
+										})}
+									/>
+									{errors?.downgrade_after_n_turns ? (
+										<p className="text-destructive text-xs">{errors.downgrade_after_n_turns.message}</p>
+									) : (
+										<p className="text-muted-foreground text-xs leading-relaxed">
+											Used only when no single turn was confident enough to switch immediately.
+										</p>
+									)}
+								</div>
+							</div>
+
+							<div className="grid gap-4 sm:grid-cols-2">
+								<div className="space-y-2">
+									<FieldLabel
+										htmlFor="session-max-switches"
+										tooltip="A backstop against a session oscillating between tiers. 0 means no limit."
+									>
+										Maximum switches per session
+									</FieldLabel>
+									<Input
+										id="session-max-switches"
+										data-testid="complexity-router-session-max-switches-input"
+										type="number"
+										min={0}
+										step={1}
+										disabled={fieldsDisabled}
+										aria-invalid={errors?.max_switches_per_session ? true : undefined}
+										className={cn("font-mono", errors?.max_switches_per_session && "border-destructive focus-visible:ring-destructive")}
+										{...register("session.max_switches_per_session", {
+											valueAsNumber: true,
+										})}
+									/>
+									{errors?.max_switches_per_session ? (
+										<p className="text-destructive text-xs">{errors.max_switches_per_session.message}</p>
+									) : (
+										<p className="text-muted-foreground text-xs leading-relaxed">0 means no limit.</p>
+									)}
+								</div>
+							</div>
+
+							<div className="flex items-center justify-between gap-6 border-t pt-4">
+								<FieldLabel
+									htmlFor="session-always-allow-escalation"
+									tooltip="An escalation already accepts the cost of switching: holding a conversation on an undersized model to avoid that cost produces worse answers, which is a worse outcome than switching."
+								>
+									Always allow escalation to a higher tier
+								</FieldLabel>
+								<Controller
+									control={control}
+									name="session.always_allow_escalation"
+									render={({ field }) => (
+										<Switch
+											id="session-always-allow-escalation"
+											data-testid="complexity-router-session-escalation-switch"
+											checked={field.value ?? false}
+											onCheckedChange={field.onChange}
+											disabled={fieldsDisabled}
+										/>
+									)}
+								/>
+							</div>
+						</div>
+					)}
+				</div>
+
+				<SheetFooter className="bg-card flex-row items-center justify-end gap-2 border-t px-6 py-4">
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						onClick={() => onOpenChange(false)}
+						data-testid="complexity-router-session-sheet-close-button"
+					>
+						Close
+					</Button>
+					<Button
+						type="button"
+						size="sm"
+						onClick={onSave}
+						disabled={!canSave || isSaving}
+						data-testid="complexity-router-session-sheet-save-button"
+					>
+						{isSaving ? <LoaderCircle className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
+						{isSaving ? "Saving…" : "Save changes"}
+					</Button>
+				</SheetFooter>
+			</SheetContent>
+		</Sheet>
+	);
+}

--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -92,6 +92,9 @@ export default function LogsPage() {
 			user_agents: parseAsSafeArrayOf.withDefault([]),
 			complexity_tiers: parseAsSafeArrayOf.withDefault([]),
 			complexity_mechanisms: parseAsSafeArrayOf.withDefault([]),
+			complexity_session_id: parseAsSafeString.withDefault(""),
+			complexity_session_modes: parseAsSafeArrayOf.withDefault([]),
+			complexity_session_tier_sources: parseAsSafeArrayOf.withDefault([]),
 			user_ids: parseAsSafeArrayOf.withDefault([]),
 			team_ids: parseAsSafeArrayOf.withDefault([]),
 			customer_ids: parseAsSafeArrayOf.withDefault([]),
@@ -123,7 +126,7 @@ export default function LogsPage() {
 	const polling = urlState.polling;
 	// Grouped view collapses fallback chains under their root. Disabled while a
 	// session filter is active — that view is already scoped to one chain/session.
-	const grouped = urlState.grouped && !urlState.parent_request_id;
+	const grouped = urlState.grouped && !urlState.parent_request_id && !urlState.complexity_session_id;
 
 	// Convert URL state to filters and pagination for API calls
 	const filters: LogFilters = useMemo(
@@ -143,6 +146,9 @@ export default function LogsPage() {
 			user_agents: urlState.user_agents,
 			complexity_tiers: urlState.complexity_tiers,
 			complexity_mechanisms: urlState.complexity_mechanisms,
+			complexity_session_id: urlState.complexity_session_id,
+			complexity_session_modes: urlState.complexity_session_modes,
+			complexity_session_tier_sources: urlState.complexity_session_tier_sources,
 			user_ids: urlState.user_ids,
 			team_ids: urlState.team_ids,
 			customer_ids: urlState.customer_ids,
@@ -183,6 +189,9 @@ export default function LogsPage() {
 			urlState.user_agents,
 			urlState.complexity_tiers,
 			urlState.complexity_mechanisms,
+			urlState.complexity_session_id,
+			urlState.complexity_session_modes,
+			urlState.complexity_session_tier_sources,
 			urlState.user_ids,
 			urlState.team_ids,
 			urlState.customer_ids,
@@ -244,6 +253,9 @@ export default function LogsPage() {
 				user_agents: newFilters.user_agents || [],
 				complexity_tiers: newFilters.complexity_tiers || [],
 				complexity_mechanisms: newFilters.complexity_mechanisms || [],
+				complexity_session_id: newFilters.complexity_session_id || "",
+				complexity_session_modes: newFilters.complexity_session_modes || [],
+				complexity_session_tier_sources: newFilters.complexity_session_tier_sources || [],
 				user_ids: newFilters.user_ids || [],
 				team_ids: newFilters.team_ids || [],
 				customer_ids: newFilters.customer_ids || [],
@@ -374,7 +386,20 @@ export default function LogsPage() {
 				parent_request_id: parentRequestId,
 			});
 		},
-		[filters, setFilters],
+		[filters, setFilters, setUrlState],
+	);
+
+	const handleFilterByComplexitySessionId = useCallback(
+		(sessionID: string) => {
+			setSelectedSessionId(null);
+			setSessionHighlightedLogId(null);
+			setUrlState({ selected_log: "" }, { history: "replace" });
+			setFilters({
+				...filters,
+				complexity_session_id: sessionID,
+			});
+		},
+		[filters, setFilters, setUrlState],
 	);
 
 	// --- Grouped view: chain expansion state -------------------------------
@@ -880,6 +905,7 @@ export default function LogsPage() {
 						hasPrev={selectedLogIndex > 0 || (selectedLogIndex !== -1 && pagination.offset > 0)}
 						hasNext={selectedLogIndex !== -1 && (selectedLogIndex < logs.length - 1 || pagination.offset + pagination.limit < totalItems)}
 						onFilterByParentRequestId={handleFilterByParentRequestId}
+						onFilterByComplexitySessionId={handleFilterByComplexitySessionId}
 						onViewSession={(sessionId, logId) => {
 							setUrlState({ selected_log: "" }, { history: "replace" });
 							setSessionHighlightedLogId(logId);

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -38,7 +38,7 @@ import {
 	RoutingEngineUsedLabels,
 	Status,
 } from "@/lib/constants/logs";
-import { COMPLEXITY_MECHANISM_LABELS } from "@/lib/types/complexityRouter";
+import { COMPLEXITY_MECHANISM_LABELS, COMPLEXITY_SESSION_TIER_SOURCE_LABELS, SESSION_MODE_LABELS } from "@/lib/types/complexityRouter";
 import { ContentBlock, LogEntry, ResponsesMessage } from "@/lib/types/logs";
 import { useGetUserAgentMappingsQuery } from "@/lib/store";
 import { cn } from "@/lib/utils";
@@ -632,6 +632,7 @@ interface LogDetailViewProps {
 	onClose?: () => void;
 	headerAction?: ReactNode;
 	onFilterByParentRequestId?: (parentRequestId: string) => void;
+	onFilterByComplexitySessionId?: (sessionID: string) => void;
 }
 
 export function LogDetailView({
@@ -643,6 +644,7 @@ export function LogDetailView({
 	onClose,
 	headerAction,
 	onFilterByParentRequestId,
+	onFilterByComplexitySessionId,
 }: LogDetailViewProps) {
 	const { copy: copyBody } = useCopyToClipboard({
 		successMessage: "Request body copied to clipboard",
@@ -1372,6 +1374,51 @@ export function LogDetailView({
 							)}
 							{complexityRouting.score !== undefined && (
 								<LogEntryDetailsView className="w-full" label="Complexity Score" value={complexityRouting.score.toFixed(2)} />
+							)}
+							{log.complexity_session_id && (
+								<LogEntryDetailsView
+									className="w-full"
+									label="Complexity Session ID"
+									value={
+										<span className="flex min-w-0 items-center gap-1">
+											{onFilterByComplexitySessionId ? (
+												<Tooltip>
+													<TooltipTrigger asChild>
+														<button
+															type="button"
+															className="min-w-0 cursor-pointer text-left font-mono text-xs break-all text-blue-600 underline-offset-2 hover:underline focus-visible:underline focus-visible:outline-none dark:text-blue-400"
+															onClick={() => onFilterByComplexitySessionId(log.complexity_session_id as string)}
+															data-testid="logdetails-filter-complexity-session-id-button"
+														>
+															{log.complexity_session_id}
+														</button>
+													</TooltipTrigger>
+													<TooltipContent sideOffset={6}>Filter this complexity session</TooltipContent>
+												</Tooltip>
+											) : (
+												<code className="min-w-0 font-mono text-xs break-all">{log.complexity_session_id}</code>
+											)}
+											<CopyInlineButton text={log.complexity_session_id} testId="logdetails-copy-complexity-session-id-button" />
+										</span>
+									}
+								/>
+							)}
+							{log.complexity_session_mode && (
+								<LogEntryDetailsView
+									className="w-full"
+									label="Complexity Session Mode"
+									value={SESSION_MODE_LABELS[log.complexity_session_mode] ?? log.complexity_session_mode}
+								/>
+							)}
+							{log.complexity_session_tier_source && (
+								<LogEntryDetailsView
+									className="w-full"
+									label="Session Tier Source"
+									value={COMPLEXITY_SESSION_TIER_SOURCE_LABELS[log.complexity_session_tier_source] ?? log.complexity_session_tier_source}
+								/>
+							)}
+							{log.complexity_session_switch_count !== undefined && (
+								<LogEntryDetailsView className="w-full" label="Session Tier Switches" value={log.complexity_session_switch_count} />
 							)}
 
 							{(log.params as any)?.audio && (

--- a/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
@@ -20,6 +20,7 @@ interface LogDetailSheetProps {
 	canReveal?: boolean;
 	onViewSession?: (sessionId: string, logId: string) => void;
 	onFilterByParentRequestId?: (parentRequestId: string) => void;
+	onFilterByComplexitySessionId?: (sessionID: string) => void;
 }
 
 export function LogDetailSheet({
@@ -33,6 +34,7 @@ export function LogDetailSheet({
 	canReveal = false,
 	onViewSession,
 	onFilterByParentRequestId,
+	onFilterByComplexitySessionId,
 }: LogDetailSheetProps) {
 	const [pollingInterval, setPollingInterval] = useState(0);
 	const {
@@ -87,6 +89,7 @@ export function LogDetailSheet({
 						canReveal={canReveal}
 						onClose={() => onOpenChange(false)}
 						onFilterByParentRequestId={onFilterByParentRequestId}
+						onFilterByComplexitySessionId={onFilterByComplexitySessionId}
 						headerAction={
 							<>
 								{displayLog.parent_request_id && onViewSession ? (

--- a/ui/components/filters/logsFilterSidebar.tsx
+++ b/ui/components/filters/logsFilterSidebar.tsx
@@ -9,7 +9,16 @@ import { TruncatedLabel } from "@/components/ui/truncatedLabel";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { RequestTypeLabels, RequestTypes, RoutingEngineUsedLabels, Statuses } from "@/lib/constants/logs";
 import { useGetAvailableFilterDataQuery, useGetProvidersQuery } from "@/lib/store";
-import { COMPLEXITY_TIER_VALUES, LEGACY_COMPLEXITY_TIER_VALUES, COMPLEXITY_MECHANISM_LABELS, COMPLEXITY_MECHANISM_VALUES } from "@/lib/types/complexityRouter";
+import {
+	COMPLEXITY_MECHANISM_LABELS,
+	COMPLEXITY_MECHANISM_VALUES,
+	COMPLEXITY_SESSION_LOG_MODE_VALUES,
+	COMPLEXITY_SESSION_TIER_SOURCE_LABELS,
+	COMPLEXITY_SESSION_TIER_SOURCE_VALUES,
+	COMPLEXITY_TIER_VALUES,
+	LEGACY_COMPLEXITY_TIER_VALUES,
+	SESSION_MODE_LABELS,
+} from "@/lib/types/complexityRouter";
 import type { LogFilters } from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
 import { ChevronDown, LoaderCircle, PanelLeftClose, Plus, RotateCcw, Search } from "lucide-react";
@@ -111,6 +120,7 @@ export function LogsFilterSidebar({ filters, onFiltersChange }: LogsSidebarProps
 					<RoutingRulesFilter filters={filters} onFiltersChange={onFiltersChange} />
 					<ComplexityTierFilter filters={filters} onFiltersChange={onFiltersChange} />
 					<ComplexityMechanismFilter filters={filters} onFiltersChange={onFiltersChange} />
+					<ComplexitySessionFilter filters={filters} onFiltersChange={onFiltersChange} />
 					<LocalCachingFilter filters={filters} onFiltersChange={onFiltersChange} />
 					<UserFilter filters={filters} onFiltersChange={onFiltersChange} />
 					<TeamFilter filters={filters} onFiltersChange={onFiltersChange} />
@@ -926,6 +936,68 @@ function ComplexityMechanismFilter({ filters, onFiltersChange, defaultOpen }: Fi
 					testId={`complexity-mechanism-filter-checkbox-${mechanism}`}
 				/>
 			))}
+		</FilterSection>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// ComplexitySessionFilter – mode and tier source share one compact section
+// ---------------------------------------------------------------------------
+
+function ComplexitySessionFilter({ filters, onFiltersChange, defaultOpen }: FilterComponentProps) {
+	const hasActive =
+		!!filters.complexity_session_id ||
+		(filters.complexity_session_modes || []).length > 0 ||
+		(filters.complexity_session_tier_sources || []).length > 0;
+	return (
+		<FilterSection title="Complexity Session" defaultOpen={defaultOpen || hasActive} testId="complexity-session-filter-toggle">
+			<div className="space-y-3">
+				<div>
+					<div className="text-muted-foreground mb-1 px-2 text-xs font-medium">Session ID</div>
+					<div className="relative">
+						<Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
+						<Input
+							value={filters.complexity_session_id || ""}
+							onChange={(event) => onFiltersChange({ ...filters, complexity_session_id: event.target.value })}
+							placeholder="Exact session ID"
+							className="h-8 border-0 pl-8 text-sm"
+							data-testid="complexity-session-id-filter-input"
+						/>
+					</div>
+				</div>
+				<div>
+					<div className="text-muted-foreground mb-1 px-2 text-xs font-medium">Mode</div>
+					{COMPLEXITY_SESSION_LOG_MODE_VALUES.map((mode) => (
+						<CheckboxFilterItem
+							key={mode}
+							label={SESSION_MODE_LABELS[mode]}
+							checked={(filters.complexity_session_modes || []).includes(mode)}
+							onCheckedChange={() => {
+								const current = filters.complexity_session_modes || [];
+								const next = current.includes(mode) ? current.filter((value) => value !== mode) : [...current, mode];
+								onFiltersChange({ ...filters, complexity_session_modes: next });
+							}}
+							testId={`complexity-session-mode-filter-checkbox-${mode}`}
+						/>
+					))}
+				</div>
+				<div>
+					<div className="text-muted-foreground mb-1 px-2 text-xs font-medium">Tier source</div>
+					{COMPLEXITY_SESSION_TIER_SOURCE_VALUES.map((source) => (
+						<CheckboxFilterItem
+							key={source}
+							label={COMPLEXITY_SESSION_TIER_SOURCE_LABELS[source]}
+							checked={(filters.complexity_session_tier_sources || []).includes(source)}
+							onCheckedChange={() => {
+								const current = filters.complexity_session_tier_sources || [];
+								const next = current.includes(source) ? current.filter((value) => value !== source) : [...current, source];
+								onFiltersChange({ ...filters, complexity_session_tier_sources: next });
+							}}
+							testId={`complexity-session-tier-source-filter-checkbox-${source}`}
+						/>
+					))}
+				</div>
+			</div>
 		</FilterSection>
 	);
 }

--- a/ui/lib/store/apis/logsApi.ts
+++ b/ui/lib/store/apis/logsApi.ts
@@ -68,6 +68,15 @@ function buildFilterParams(filters: LogFilters): Record<string, string | number>
 	if (filters.complexity_mechanisms && filters.complexity_mechanisms.length > 0) {
 		params.complexity_mechanisms = filters.complexity_mechanisms.join(",");
 	}
+	if (filters.complexity_session_id) {
+		params.complexity_session_id = filters.complexity_session_id;
+	}
+	if (filters.complexity_session_modes && filters.complexity_session_modes.length > 0) {
+		params.complexity_session_modes = filters.complexity_session_modes.join(",");
+	}
+	if (filters.complexity_session_tier_sources && filters.complexity_session_tier_sources.length > 0) {
+		params.complexity_session_tier_sources = filters.complexity_session_tier_sources.join(",");
+	}
 	if (filters.period) {
 		params.period = filters.period;
 	} else {

--- a/ui/lib/types/complexityRouter.ts
+++ b/ui/lib/types/complexityRouter.ts
@@ -27,6 +27,17 @@ export interface SemanticConfig {
 	vector_store?: SemanticVectorStore;
 }
 
+// What the session-state backend can prove about itself. Absent when no store is
+// attached, which is the normal case with session routing off.
+export interface SessionStoreStatus {
+	backend: string;
+	// Named for the configuration, not the outcome: replication is
+	// fire-and-forget, so this says a delegate is installed, not that peers are
+	// connected or converged.
+	replication_configured: boolean;
+	atomic_across_replicas: boolean;
+}
+
 export interface SemanticStatusInfo {
 	state: "disabled" | "warming" | "ready" | "failed";
 	loaded: number;
@@ -39,11 +50,62 @@ export interface SemanticStatusInfo {
 	// unchanged. Reuse cannot be inferred from the persisted config alone; zero
 	// means the next save re-embeds every phrase regardless of what changed.
 	cached_phrases?: number;
+	session_store?: SessionStoreStatus;
+}
+
+// The three states an operator can actually be in. Derived from the two
+// booleans rather than reported directly, because the storage layer can only
+// describe itself — it cannot see how many replicas are running, so it can never
+// say "safe" on its own.
+export type SessionStoreReadiness = "node-local" | "replicated-not-atomic" | "shared-atomic";
+
+export function sessionStoreReadiness(status: SessionStoreStatus | undefined): SessionStoreReadiness | undefined {
+	if (!status) return undefined;
+	if (!status.replication_configured) return "node-local";
+	return status.atomic_across_replicas ? "shared-atomic" : "replicated-not-atomic";
+}
+
+// Mirrors ComplexitySessionMode* in framework/configstore. "off" is a real
+// stored value rather than an absent block, so an operator who turns session
+// behavior off keeps the settings they tuned instead of losing them.
+export type SessionMode = "off" | "pinned" | "cache_aware";
+
+// Session log rows exist only when policy ran, so "off" can never be emitted.
+export const COMPLEXITY_SESSION_LOG_MODE_VALUES: Array<Exclude<SessionMode, "off">> = ["pinned", "cache_aware"];
+
+// Mirrors the tier-source values published by the governance plugin. This is
+// deliberately separate from complexity_mechanism: cache-aware held turns keep
+// the semantic mechanism even though the proposal did not supply the final tier.
+export type ComplexitySessionTierSource = "classified" | "memoised" | "held";
+
+export const COMPLEXITY_SESSION_TIER_SOURCE_VALUES: ComplexitySessionTierSource[] = ["classified", "memoised", "held"];
+
+export const COMPLEXITY_SESSION_TIER_SOURCE_LABELS: Record<ComplexitySessionTierSource, string> = {
+	classified: "Classified this turn",
+	memoised: "Reused pinned tier",
+	held: "Held session tier",
+};
+
+// Mirrors ComplexitySessionIdentity* in framework/configstore. The gateway
+// always tries these in the order header → harness regardless of how they are
+// listed in persisted configuration.
+export type SessionIdentitySource = "header" | "harness";
+
+export interface SessionConfig {
+	mode: SessionMode;
+	ttl?: string;
+	identity_sources?: SessionIdentitySource[];
+	// cache_aware only, from here down.
+	switch_min_similarity?: number;
+	downgrade_after_n_turns?: number;
+	max_switches_per_session?: number;
+	always_allow_escalation?: boolean;
 }
 
 export interface AnalyzerConfig {
 	keywords: EditableKeywordConfig;
 	semantic?: SemanticConfig;
+	session?: SessionConfig;
 }
 
 export type KeywordListKey = keyof EditableKeywordConfig;
@@ -61,7 +123,10 @@ export const LEGACY_COMPLEXITY_TIER_VALUES = ["REASONING"] as const;
 // LEGACY_COMPLEXITY_TIER_VALUES): the complexity_mechanism column ships with the
 // semantic classifier, so no row was ever written with the retired "lexical"
 // mechanism and filtering on it could only ever return nothing.
-export const COMPLEXITY_MECHANISM_VALUES = ["semantic", "skipped"] as const;
+// "session" means the tier was reused from session state and no classifier ran
+// for that turn, which is the difference between a held conversation and a
+// freshly embedded one.
+export const COMPLEXITY_MECHANISM_VALUES = ["semantic", "session", "skipped"] as const;
 
 // Labels cover "lexical" even though nothing filters on it. Rows predating the
 // structured columns record their decision only in the prose routing log, and
@@ -70,6 +135,7 @@ export const COMPLEXITY_MECHANISM_VALUES = ["semantic", "skipped"] as const;
 export const COMPLEXITY_MECHANISM_LABELS: Record<string, string> = {
 	lexical: "Lexical",
 	semantic: "Semantic",
+	session: "Session",
 	skipped: "Skipped",
 };
 
@@ -178,4 +244,119 @@ export function parseSemanticTimeoutMs(timeout: string | number | undefined): nu
 export function formatSemanticTimeout(milliseconds: number): string {
 	const safe = Number.isFinite(milliseconds) && milliseconds > 0 ? milliseconds : DEFAULT_SEMANTIC_TIMEOUT_MS;
 	return `${safe}ms`;
+}
+
+// Mirrors DefaultComplexitySession* in framework/configstore.
+export const DEFAULT_SESSION_TTL_MINUTES = 60;
+export const DEFAULT_SESSION_DOWNGRADE_AFTER_N_TURNS = 2;
+
+// Fingerprint is deliberately absent, matching DefaultComplexitySessionIdentitySources:
+// it groups conversations by their opening text, so two unrelated sessions that
+// start the same way would share one tier.
+export const DEFAULT_SESSION_IDENTITY_SOURCES: SessionIdentitySource[] = ["header", "harness"];
+
+export const DEFAULT_SESSION_CONFIG: SessionConfig = {
+	mode: "off",
+	ttl: `${DEFAULT_SESSION_TTL_MINUTES}m`,
+	identity_sources: DEFAULT_SESSION_IDENTITY_SOURCES,
+	switch_min_similarity: 0,
+	downgrade_after_n_turns: DEFAULT_SESSION_DOWNGRADE_AFTER_N_TURNS,
+	max_switches_per_session: 0,
+	always_allow_escalation: false,
+};
+
+// These are the wire values, not display aliases: config.json and the governance
+// API take the same three strings.
+export const SESSION_MODE_OPTIONS: Array<{
+	value: SessionMode;
+	label: string;
+	description: string;
+}> = [
+	{
+		value: "off",
+		label: "Off",
+		description: "Every turn is classified independently. Tiers can change mid-conversation.",
+	},
+	{
+		value: "pinned",
+		label: "Pinned",
+		description:
+			"The first turn of a conversation picks the tier and the rest of the session keeps the same model until it goes idle. Cost savings depend on the provider's own prompt cache, which Bifrost doesn't control.",
+	},
+	{
+		value: "cache_aware",
+		label: "Dynamic",
+		description:
+			"Reclassifies every complexity-routed turn (one embedding each time), then moves the session once a turn is confident enough on its own, or once enough consecutive turns favor the move.",
+	},
+];
+
+export const SESSION_MODE_LABELS: Record<SessionMode, string> = {
+	off: "Off",
+	pinned: "Pinned",
+	cache_aware: "Dynamic",
+};
+
+export const SESSION_IDENTITY_SOURCE_OPTIONS: Array<{
+	value: SessionIdentitySource;
+	label: string;
+	description: string;
+}> = [
+	{
+		value: "header",
+		label: "Session header",
+		description: "Uses the x-bf-session-id header sent by the caller. The most explicit source, and the only one the caller controls.",
+	},
+	{
+		value: "harness",
+		label: "Harness session ID",
+		description: "Uses the conversation ID that coding harnesses such as Claude Code and Codex already send.",
+	},
+];
+
+// Go's time.Duration.String() emits concatenated units ("1h0m0s", "30m0s"), not
+// only the single-unit forms the minutes control writes ("60m"). Accept both so
+// a saved config can round-trip into the form without looking malformed.
+const GO_DURATION_UNIT_TO_MINUTES: Record<string, number> = {
+	ns: 1 / 6e10,
+	us: 1 / 6e7,
+	µs: 1 / 6e7,
+	μs: 1 / 6e7,
+	ms: 1 / 60000,
+	s: 1 / 60,
+	m: 1,
+	h: 60,
+};
+
+// Returns null when the string is blank, zero, negative, or not a Go duration.
+export function tryParseSessionTtlMinutes(ttl: string | undefined): number | null {
+	if (!ttl) return null;
+	const trimmed = ttl.trim();
+	if (!trimmed) return null;
+
+	// Local /g regex — a shared lastIndex would leak across calls.
+	const partRe = /([0-9]*\.?[0-9]+)(ns|us|µs|μs|ms|s|m|h)/g;
+	let total = 0;
+	let matched = 0;
+	let part: RegExpExecArray | null;
+	while ((part = partRe.exec(trimmed)) !== null) {
+		if (part.index !== matched) return null;
+		matched = part.index + part[0].length;
+		const value = Number(part[1]);
+		const unit = GO_DURATION_UNIT_TO_MINUTES[part[2]];
+		if (!Number.isFinite(value) || unit === undefined) return null;
+		total += value * unit;
+	}
+	if (matched === 0 || matched !== trimmed.length) {
+		const numeric = Number(trimmed);
+		return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
+	}
+	return Number.isFinite(total) && total > 0 ? total : null;
+}
+
+// TTL round-trips as a Go duration ("1h0m0s", "30m") but the form edits minutes.
+// Anything unparseable falls back to the default rather than sending 0, which
+// the server rejects.
+export function parseSessionTtlMinutes(ttl: string | undefined): number {
+	return tryParseSessionTtlMinutes(ttl) ?? DEFAULT_SESSION_TTL_MINUTES;
 }

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -2,6 +2,7 @@
 
 import { DBKey, VirtualKey } from "./governance";
 import { RoutingRule } from "./routingRules";
+import type { ComplexitySessionTierSource, SessionMode } from "./complexityRouter";
 
 // Speech and Transcription types
 export interface VoiceConfig {
@@ -570,6 +571,10 @@ export interface LogEntry {
 	complexity_tier?: string; // Complexity tier used for routing ("SIMPLE", "MEDIUM", "COMPLEX"); absent when no routing rule referenced complexity_tier
 	complexity_mechanism?: string; // How the complexity tier was classified ("semantic", "skipped"); absent when no routing rule referenced complexity_tier
 	complexity_score?: number; // Classifier score: the semantic classifier's similarity to the nearest reference phrase
+	complexity_session_id?: string; // Raw opaque session ID used for exact log lookup
+	complexity_session_mode?: Exclude<SessionMode, "off">;
+	complexity_session_tier_source?: ComplexitySessionTierSource;
+	complexity_session_switch_count?: number; // Absent when the session store could not provide a trustworthy count
 	routing_engine_logs?: string; // Human-readable routing decision logs
 	plugin_logs?: string; // JSON string of plugin execution logs grouped by plugin name
 	selected_key?: DBKey;
@@ -650,6 +655,9 @@ export interface LogFilters {
 	stop_reasons?: string[]; // For filtering by stop reason (stop, length, content_filter, refusal, tool_calls, etc.)
 	complexity_tiers?: string[]; // For filtering by routing complexity tier (SIMPLE, MEDIUM, COMPLEX)
 	complexity_mechanisms?: string[]; // For filtering by complexity classification mechanism (semantic, skipped)
+	complexity_session_id?: string;
+	complexity_session_modes?: string[];
+	complexity_session_tier_sources?: string[];
 	objects?: string[]; // For filtering by request type (chat.completion, text.completion, embedding)
 	start_time?: string; // RFC3339 format
 	end_time?: string; // RFC3339 format

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,6 +9,7 @@
 		"build": "vite build && npm run typecheck && npm run copy-build",
 		"copy-build": "rm -rf ../transports/bifrost-http/ui && cp -r out ../transports/bifrost-http/ui",
 		"start": "vite preview",
+		"test": "vitest run",
 		"lint": "oxlint",
 		"format": "oxfmt",
 		"format:check": "oxfmt --check",

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -13,7 +13,7 @@
 		"isolatedModules": true,
 		"jsx": "preserve",
 		"incremental": true,
-		"types": ["vite/client"],
+		"types": ["vite/client", "node"],
 		"paths": {
 			"@/*": ["./*"],
 			"@enterprise/*": ["./app/enterprise/*", "./app/_fallbacks/enterprise/*"],

--- a/ui/vitest.config.mts
+++ b/ui/vitest.config.mts
@@ -1,7 +1,9 @@
+import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
 import path from "path";
 
 export default defineConfig({
+	plugins: [react()],
 	resolve: {
 		alias: {
 			"@": path.resolve(__dirname, "."),


### PR DESCRIPTION
## Summary

Adds session-aware complexity routing observability end-to-end: new database columns record which session a turn belonged to, how its tier was decided, and how many times that session has switched tiers. These fields are surfaced in the log detail view, filterable from the sidebar, and configurable through a new Session sheet on the complexity router page.

## Changes

- Added `ComplexitySessionLogFields` as an embedded struct on `Log`, carrying `complexity_session_id`, `complexity_session_mode`, `complexity_session_tier_source`, and `complexity_session_switch_count`
- Added a database migration (`logs_add_complexity_session_columns`) that adds the four columns and creates a partial index on `complexity_session_id` for SQLite; PostgreSQL builds its index concurrently through the background reconciler
- Added two new performance indexes on `complexity_session_mode` and `complexity_session_tier_source` for PostgreSQL
- Extended `SearchFilters` with `ComplexitySessionID`, `ComplexitySessionModes`, and `ComplexitySessionTierSources`; wired them into `applyFilters` and `listSelectColumns` in the RDB store
- Excluded `ComplexitySessionModes` and `ComplexitySessionTierSources` from the materialized-view fast path so they always hit the raw query path
- Consolidated the inline complexity context extraction in the logging plugin into a single `applyComplexityContextToEntry` helper, which now also reads the four new session context keys, preventing the normal and minimal-error paths from drifting apart
- Added `SessionConfig`, `SessionStoreStatus`, `SessionStoreReadiness`, and related constants and helpers to the frontend type layer
- Added a `SessionConfigSheet` component with controls for mode, TTL, identity sources, and all cache-aware hysteresis parameters, including a store-readiness banner that describes what the session backend can actually guarantee
- Added a `ComplexitySessionFilter` section to the log filter sidebar covering session ID exact match, mode checkboxes, and tier-source checkboxes
- Extended the log detail view to display session ID (with a click-to-filter button), session mode, tier source, and switch count
- Extended `LogFilters` and the logs API builder to pass the new session filter parameters
- Added `formSchema` tests covering `isPositiveDurationString`, `tryParseSessionTtlMinutes`, `normalizeSessionTtl`, `sessionTtlFieldValue`, and `toFormValues` session hydration
- Added a `vitest run` npm script and migrated `vitest.config.ts` to `.mts` with the React plugin

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/logstore/... ./plugins/logging/...

# UI
cd ui
npm i
npm test
npm run build
```

To validate the migration:
1. Start with an existing database that has the `logs` table but not the session columns.
2. Restart the gateway; the migration should add the four columns and the `idx_logs_complexity_session_id` index without touching existing rows.
3. Run the gateway with session-aware complexity routing enabled, make a few requests, and confirm `complexity_session_id`, `complexity_session_mode`, `complexity_session_tier_source`, and `complexity_session_switch_count` appear in the log response and are filterable from the sidebar.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

`complexity_session_id` is documented as an opaque identifier. It is indexed and surfaced in logs and the UI. Operators must ensure no PII or secrets are placed in session IDs passed via the `x-bf-session-id` header, as the value is stored verbatim and visible to anyone with log access.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable