### PR TITLE
feat: explicit prompt cache for Bedrock Mantle GPT-5.6 Responses

### DIFF
--- a/core/providers/bedrockmantle/bedrockmantle.go
+++ b/core/providers/bedrockmantle/bedrockmantle.go
@@ -318,6 +318,7 @@ func (provider *BedrockMantleProvider) Responses(ctx *schemas.BifrostContext, ke
 		)
 	}
 
+	applyExplicitPromptCache(request)
 	url := mantleOpenAIURL(mantleEndpoints(key.BedrockMantleKeyConfig), region, schemas.ResolveCanonicalModel(ctx, request.Model), "responses")
 	return openai.HandleOpenAIResponsesRequest(
 		ctx,
@@ -379,6 +380,7 @@ func (provider *BedrockMantleProvider) ResponsesStream(ctx *schemas.BifrostConte
 		)
 	}
 
+	applyExplicitPromptCache(request)
 	url := mantleOpenAIURL(mantleEndpoints(key.BedrockMantleKeyConfig), region, schemas.ResolveCanonicalModel(ctx, request.Model), "responses")
 	return openai.HandleOpenAIResponsesStreaming(
 		ctx, provider.mantleStreamingClient, url, request,

--- a/core/providers/bedrockmantle/prompt_cache.go
+++ b/core/providers/bedrockmantle/prompt_cache.go
@@ -1,0 +1,101 @@
+package bedrockmantle
+
+import (
+	"strings"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+const explicitPromptCacheMode = "explicit"
+
+// applyExplicitPromptCache pins GPT-5.6 Mantle Responses requests to explicit
+// cache mode with a breakpoint on the first cacheable input block.
+//
+// Mantle's default (implicit) breakpoint sits on the latest message, so agent
+// loops rewrite the full prompt at the 1.25× cache-write rate every turn.
+// A fixed breakpoint on the stable prefix (instructions/tools plus the first
+// input block) is what AWS documents for that workload. Requests that already
+// set prompt_cache_options or a breakpoint are left unchanged.
+func applyExplicitPromptCache(request *schemas.BifrostResponsesRequest) {
+	if request == nil {
+		return
+	}
+	_, model := parseBedrockRegionAndModel(request.Model)
+	if !strings.Contains(model, "gpt-5.6") {
+		return
+	}
+	if requestHasPromptCache(request) {
+		return
+	}
+	if !markFirstCacheableBreakpoint(request) {
+		return
+	}
+	params := schemas.ResponsesParameters{}
+	if request.Params != nil {
+		params = *request.Params
+	}
+	mode := explicitPromptCacheMode
+	params.PromptCacheOptions = &schemas.PromptCacheOptions{Mode: &mode}
+	request.Params = &params
+}
+
+func requestHasPromptCache(request *schemas.BifrostResponsesRequest) bool {
+	if request.Params != nil && request.Params.PromptCacheOptions != nil {
+		return true
+	}
+	for _, msg := range request.Input {
+		if msg.Content == nil {
+			continue
+		}
+		for _, block := range msg.Content.ContentBlocks {
+			if block.PromptCacheBreakpoint != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func markFirstCacheableBreakpoint(request *schemas.BifrostResponsesRequest) bool {
+	mode := explicitPromptCacheMode
+	breakpoint := &schemas.PromptCacheBreakpoint{Mode: &mode}
+	for i := range request.Input {
+		msg := request.Input[i]
+		if msg.Content == nil {
+			continue
+		}
+		if msg.Content.ContentStr != nil && *msg.Content.ContentStr != "" {
+			copied := schemas.DeepCopyResponsesMessage(msg)
+			text := *copied.Content.ContentStr
+			copied.Content.ContentStr = nil
+			copied.Content.ContentBlocks = []schemas.ResponsesMessageContentBlock{{
+				Type:                  schemas.ResponsesInputMessageContentBlockTypeText,
+				Text:                  &text,
+				PromptCacheBreakpoint: breakpoint,
+			}}
+			request.Input[i] = copied
+			return true
+		}
+		for j, block := range msg.Content.ContentBlocks {
+			if !isCacheableContentBlock(block.Type) {
+				continue
+			}
+			copied := schemas.DeepCopyResponsesMessage(msg)
+			copied.Content.ContentBlocks[j].PromptCacheBreakpoint = breakpoint
+			request.Input[i] = copied
+			return true
+		}
+	}
+	return false
+}
+
+func isCacheableContentBlock(blockType schemas.ResponsesMessageContentBlockType) bool {
+	switch blockType {
+	case schemas.ResponsesInputMessageContentBlockTypeText,
+		schemas.ResponsesInputMessageContentBlockTypeImage,
+		schemas.ResponsesInputMessageContentBlockTypeFile:
+		return true
+	default:
+		return false
+	}
+}

--- a/core/providers/bedrockmantle/prompt_cache_test.go
+++ b/core/providers/bedrockmantle/prompt_cache_test.go
@@ -1,0 +1,138 @@
+package bedrockmantle
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyExplicitPromptCache_MarksFirstInputText(t *testing.T) {
+	text := "hello"
+	req := &schemas.BifrostResponsesRequest{
+		Model: "openai.gpt-5.6-sol",
+		Input: []schemas.ResponsesMessage{{
+			Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{
+				ContentBlocks: []schemas.ResponsesMessageContentBlock{{
+					Type: schemas.ResponsesInputMessageContentBlockTypeText,
+					Text: &text,
+				}},
+			},
+		}},
+	}
+
+	applyExplicitPromptCache(req)
+
+	require.NotNil(t, req.Params)
+	require.NotNil(t, req.Params.PromptCacheOptions)
+	require.Equal(t, explicitPromptCacheMode, *req.Params.PromptCacheOptions.Mode)
+	require.NotNil(t, req.Input[0].Content.ContentBlocks[0].PromptCacheBreakpoint)
+	require.Equal(t, explicitPromptCacheMode, *req.Input[0].Content.ContentBlocks[0].PromptCacheBreakpoint.Mode)
+}
+
+func TestApplyExplicitPromptCache_ConvertsContentString(t *testing.T) {
+	text := "stable prefix"
+	req := &schemas.BifrostResponsesRequest{
+		Model: "us-east-1/openai.gpt-5.6-terra",
+		Input: []schemas.ResponsesMessage{{
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleDeveloper),
+			Content: &schemas.ResponsesMessageContent{ContentStr: &text},
+		}},
+	}
+
+	applyExplicitPromptCache(req)
+
+	require.Nil(t, req.Input[0].Content.ContentStr)
+	require.Len(t, req.Input[0].Content.ContentBlocks, 1)
+	require.Equal(t, schemas.ResponsesInputMessageContentBlockTypeText, req.Input[0].Content.ContentBlocks[0].Type)
+	require.Equal(t, text, *req.Input[0].Content.ContentBlocks[0].Text)
+	require.NotNil(t, req.Input[0].Content.ContentBlocks[0].PromptCacheBreakpoint)
+}
+
+func TestApplyExplicitPromptCache_LeavesClientCacheAlone(t *testing.T) {
+	text := "hello"
+	mode := "implicit"
+	req := &schemas.BifrostResponsesRequest{
+		Model: "openai.gpt-5.6-sol",
+		Params: &schemas.ResponsesParameters{
+			PromptCacheOptions: &schemas.PromptCacheOptions{Mode: &mode},
+		},
+		Input: []schemas.ResponsesMessage{{
+			Content: &schemas.ResponsesMessageContent{
+				ContentBlocks: []schemas.ResponsesMessageContentBlock{{
+					Type: schemas.ResponsesInputMessageContentBlockTypeText,
+					Text: &text,
+				}},
+			},
+		}},
+	}
+
+	applyExplicitPromptCache(req)
+
+	require.Equal(t, "implicit", *req.Params.PromptCacheOptions.Mode)
+	require.Nil(t, req.Input[0].Content.ContentBlocks[0].PromptCacheBreakpoint)
+}
+
+func TestApplyExplicitPromptCache_SkipsNonGPT56(t *testing.T) {
+	text := "hello"
+	req := &schemas.BifrostResponsesRequest{
+		Model: "openai.gpt-5.5",
+		Input: []schemas.ResponsesMessage{{
+			Content: &schemas.ResponsesMessageContent{
+				ContentBlocks: []schemas.ResponsesMessageContentBlock{{
+					Type: schemas.ResponsesInputMessageContentBlockTypeText,
+					Text: &text,
+				}},
+			},
+		}},
+	}
+
+	applyExplicitPromptCache(req)
+
+	require.Nil(t, req.Params)
+	require.Nil(t, req.Input[0].Content.ContentBlocks[0].PromptCacheBreakpoint)
+}
+
+func TestApplyExplicitPromptCache_LeavesExistingBreakpointAlone(t *testing.T) {
+	text := "hello"
+	mode := explicitPromptCacheMode
+	req := &schemas.BifrostResponsesRequest{
+		Model: "openai.gpt-5.6-sol",
+		Input: []schemas.ResponsesMessage{{
+			Content: &schemas.ResponsesMessageContent{
+				ContentBlocks: []schemas.ResponsesMessageContentBlock{{
+					Type:                  schemas.ResponsesInputMessageContentBlockTypeText,
+					Text:                  &text,
+					PromptCacheBreakpoint: &schemas.PromptCacheBreakpoint{Mode: &mode},
+				}},
+			},
+		}},
+	}
+
+	applyExplicitPromptCache(req)
+
+	require.Nil(t, req.Params)
+	require.Equal(t, explicitPromptCacheMode, *req.Input[0].Content.ContentBlocks[0].PromptCacheBreakpoint.Mode)
+}
+
+func TestApplyExplicitPromptCache_DoesNotMutateOriginalBlock(t *testing.T) {
+	text := "hello"
+	original := schemas.ResponsesMessage{
+		Content: &schemas.ResponsesMessageContent{
+			ContentBlocks: []schemas.ResponsesMessageContentBlock{{
+				Type: schemas.ResponsesInputMessageContentBlockTypeText,
+				Text: &text,
+			}},
+		},
+	}
+	req := &schemas.BifrostResponsesRequest{
+		Model: "openai.gpt-5.6-luna",
+		Input: []schemas.ResponsesMessage{original},
+	}
+
+	applyExplicitPromptCache(req)
+
+	require.Nil(t, original.Content.ContentBlocks[0].PromptCacheBreakpoint)
+	require.NotNil(t, req.Input[0].Content.ContentBlocks[0].PromptCacheBreakpoint)
+}

--- a/docs/providers/supported-providers/bedrock-mantle.mdx
+++ b/docs/providers/supported-providers/bedrock-mantle.mdx
@@ -39,6 +39,7 @@ You can discover the exact IDs your account serves with a **list-models** reques
 | Reasoning / extended thinking (Claude) | ✅ |
 | Structured outputs | ✅ |
 | Prompt caching (Claude) | ✅ |
+| Prompt caching (GPT-5.6 Responses) | ✅ |
 | List models | ✅ |
 | Count tokens (Claude only) | ✅ |
 | Text completion, embeddings, batch, files, images, audio, rerank | ❌ |
@@ -46,6 +47,8 @@ You can discover the exact IDs your account serves with a **list-models** reques
 Count tokens uses the native-Anthropic `/anthropic/v1/messages/count_tokens` path, so it is available for Claude models only - `gpt-*` and Gemma models return an unsupported-operation error. This path is the only way to count tokens for Claude models that ship cross-Region-inference-only on `bedrock-runtime` and therefore have no regional endpoint for the Bedrock `CountTokens` API. See the AWS guide on [counting tokens on the bedrock-mantle endpoint](https://docs.aws.amazon.com/bedrock/latest/userguide/count-tokens.html#count-tokens-mantle).
 
 For Claude models, request/response handling (beta headers, cache control, reasoning, message conversion) follows the same rules as the [Bedrock provider's Anthropic behavior](./bedrock) — refer to that page for the deep parameter mapping.
+
+On GPT-5.6 Responses (`openai.gpt-5.6-*`), Bifrost sets `prompt_cache_options.mode=explicit` and a `prompt_cache_breakpoint` on the first cacheable input block when the client omitted both. That keeps the cache prefix stable across agent turns instead of Mantle's implicit "latest message" breakpoint, which rewrites the full prompt every turn. Requests that already set cache options or a breakpoint are forwarded unchanged.
 
 ---
 

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -171,6 +171,7 @@ var responsesParamsKnownFields = map[string]bool{
 	"parallel_tool_calls":    true,
 	"previous_response_id":   true,
 	"prompt_cache_key":       true,
+	"prompt_cache_options":   true,
 	"prompt_cache_retention": true,
 	"reasoning":              true,
 	"safety_identifier":      true,


### PR DESCRIPTION
## Summary

GPT-5.6 on Bedrock Mantle defaults to implicit prompt caching, which places a breakpoint on the **latest** message. Agentic loops therefore rewrite the full prompt every turn and pay the 1.25× cache-write rate.

This change applies only on the first-class `bedrock_mantle` provider, for GPT-5.6 Responses (unary + stream):

- If the client already set `prompt_cache_options` or any `prompt_cache_breakpoint`, the request is unchanged.
- Otherwise set `prompt_cache_options.mode=explicit` and mark the first cacheable input block (`input_text` / `input_image` / `input_file`).

That is the AWS-documented shape for a stable prefix (instructions + tools + first input block) across agent turns.

Closes https://github.com/maximhq/bifrost/issues/6180

## Type of change

- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] Docs

## How to test

```sh
cd core
go test ./providers/bedrockmantle/ -count=1
```

Local check against Mantle (needs `bedrock-mantle:CreateInference`): send two `/v1/responses` calls with a ≥1024-token stable prefix and the same `prompt_cache_key`. The logged input should carry `prompt_cache_breakpoint.mode=explicit` on the first `input_text` block; the second call should show cache reads.

## Breaking changes

- [x] No

## Related issues

Closes #6180
Related: https://github.com/openai/codex/issues/37674

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed