### PR TITLE
updates docs for enterprise changelog

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1876,6 +1876,7 @@
             "item": "Enterprise",
             "icon": "building",
             "pages": [
+              "changelogs/ent-v1.5.11"
               "changelogs/ent-v2.0.0-prerelease3",
               "changelogs/ent-v1.5.10",
               "changelogs/ent-v1.5.9",


### PR DESCRIPTION
## Summary

Adds the `ent-v1.5.11` changelog entry to the documentation navigation and adds a trailing newline to `docs.json`.

## Changes

- Added `changelogs/ent-v1.5.11` as the first entry in the Enterprise changelogs section of `docs.json`, placing it at the top of the list in the correct chronological order
- Added a trailing newline at the end of `docs.json`

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Navigate to the Enterprise changelogs section of the documentation and verify that the `ent-v1.5.11` changelog appears at the top of the list and links correctly to its page.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable