### PR TITLE
adds airgapped flow for mcp catalog

### DIFF
--- a/docs/deployment-guides/how-to/airgapped.mdx
+++ b/docs/deployment-guides/how-to/airgapped.mdx
@@ -6,13 +6,18 @@ icon: "wifi-slash"
 
 ## Overview
 
-Bifrost fetches its pricing and model parameter datasheets from `https://getbifrost.ai/datasheet` on startup and periodically in the background. In environments without outbound internet access, these fetches fail and Bifrost cannot start.
+Bifrost reaches out to `getbifrost.ai` for two things:
 
-Both fields accept `file://` URLs so you can load the datasheets from the local filesystem instead.
+| Data | Default source | Startup behaviour if unreachable |
+| --- | --- | --- |
+| Pricing and model parameter datasheets | `https://getbifrost.ai/datasheet` | Bifrost cannot start |
+| MCP server library catalog | `https://getbifrost.ai/mcp-library` | Bifrost starts, MCP Library page stays empty |
+
+Every one of these URLs accepts a `file://` value, so you can load the data from the local filesystem instead.
 
 ---
 
-## Setup
+## Datasheets
 
 **1. Download the datasheets** on a machine with internet access:
 
@@ -38,13 +43,87 @@ Transfer the files to your air-gapped host (or bake them into your container ima
 ```
 
 <Note>
-`file://` URLs require three slashes followed by an absolute path.
+An absolute `file://` URL takes three slashes followed by the path. Relative references are also accepted (`file://./pricing.json` or `file:./pricing.json`) and resolve against the Bifrost process working directory.
 </Note>
 
 **3. Ensure the files are accessible** to the Bifrost process at the configured paths before starting.
 
 ---
 
-## Keeping datasheets current
+## MCP server library
 
-Bifrost re-reads the file on every sync tick (`pricing_sync_interval`, minimum 3600 s).
+The MCP Library page is populated by a catalog synced from `https://getbifrost.ai/mcp-library`. Air-gapped deployments have two options.
+
+### Option A: serve the catalog from a local file
+
+**1. Obtain a catalog file.** Either download the hosted one on a connected machine, or copy the community catalog that ships in the Bifrost repository at `community/mcp-library/servers.json`:
+
+```bash
+curl -o mcp-library.json https://getbifrost.ai/mcp-library
+```
+
+**2. Point Bifrost at it** in `config.json`:
+
+```json
+{
+  "framework": {
+    "pricing": {
+      "mcp_library_url": "file:///opt/bifrost/mcp-library.json",
+      "mcp_library_sync_interval": 86400
+    }
+  }
+}
+```
+
+The same value can be set from the UI under **MCP Registry → Library → Settings**.
+
+The file is a JSON envelope with a `servers` array:
+
+```json
+{
+  "lastUpdatedAt": "2026-06-09T00:00:00Z",
+  "servers": [
+    {
+      "name": "Filesystem",
+      "description": "Read and write files on the local filesystem within configured directories.",
+      "category": "Developer Tools",
+      "connection_type": "stdio",
+      "stdio_config": { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem"] },
+      "auth_type": "none"
+    }
+  ]
+}
+```
+
+Entries are keyed by a slug derived from `name`, so re-syncing an updated file updates rows in place. Servers you added yourself through the UI are never overwritten by a sync.
+
+### Option B: turn the catalog sync off
+
+If you do not want a server catalog at all, set the interval to `0`:
+
+```json
+{
+  "framework": {
+    "pricing": {
+      "mcp_library_sync_interval": 0
+    }
+  }
+}
+```
+
+Bifrost then skips the catalog fetch at startup and never schedules a background sync, so no requests go to `getbifrost.ai`. Anything already stored in the database is still served, MCP servers can still be added manually, and **Force Sync Now** in the UI still runs on demand.
+
+<Note>
+Catalog entries carry an `icon_url` pointing at a remote image. On an air-gapped host those images do not load and the UI falls back to a generic MCP icon. This is cosmetic and does not affect server connectivity.
+</Note>
+
+---
+
+## Keeping local data current
+
+Bifrost re-reads each local file on every sync tick, so updating a file on disk is enough. No restart is needed.
+
+| Setting | Cadence | Minimum | Disable |
+| --- | --- | --- | --- |
+| `pricing_sync_interval` | Default 24 h | 3600 s | Not supported |
+| `mcp_library_sync_interval` | Default 24 h | 3600 s | Set to `0` |

--- a/framework/modelcatalog/config.go
+++ b/framework/modelcatalog/config.go
@@ -26,6 +26,14 @@ const (
 	// corrupted config and falls back to the default.
 	LiveModelsSyncDisabled = int64(0)
 
+	// MCPLibrarySyncDisabled is the sentinel for "never sync the MCP server
+	// catalog in the background". Mirrors LiveModelsSyncDisabled: 0 is a
+	// deliberate opt-out, a negative value is corrupted config that falls back
+	// to the default. Set this on an air-gapped deployment that does not ship a
+	// local catalog file, so the gateway stops dialing the default endpoint on
+	// every tick. An explicit force-sync from the UI still runs.
+	MCPLibrarySyncDisabled = int64(0)
+
 	ConfigLastPricingSyncKey    = "LastModelPricingSync"
 	ConfigLastParamsSyncKey     = "LastModelParametersSync"
 	ConfigLastMCPLibrarySyncKey = "LastMCPLibrarySync"

--- a/framework/modelcatalog/datasheet/localfiles_test.go
+++ b/framework/modelcatalog/datasheet/localfiles_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-// TestFilePathFromURL verifies that filePathFromURL resolves every shape of
+// TestFilePathFromURL verifies that FilePathFromURL resolves every shape of
 // file:// URL to a usable filesystem path. url.Parse scatters a relative path
 // across Opaque/Host/Path depending on its form, so the resolver must reassemble
 // it. This is what lets the example configs reference datasheets with relative
@@ -34,8 +34,8 @@ func TestFilePathFromURL(t *testing.T) {
 		if err != nil {
 			t.Fatalf("url.Parse(%q): %v", tc.raw, err)
 		}
-		if got := filePathFromURL(parsed); got != tc.want {
-			t.Errorf("filePathFromURL(%q) = %q, want %q", tc.raw, got, tc.want)
+		if got := FilePathFromURL(parsed); got != tc.want {
+			t.Errorf("FilePathFromURL(%q) = %q, want %q", tc.raw, got, tc.want)
 		}
 	}
 }

--- a/framework/modelcatalog/datasheet/params.go
+++ b/framework/modelcatalog/datasheet/params.go
@@ -125,7 +125,7 @@ func (s *Store) loadModelParametersFromURL(ctx context.Context) (map[string]json
 	var data []byte
 
 	if parsed.Scheme == "file" {
-		data, err = os.ReadFile(filePathFromURL(parsed))
+		data, err = os.ReadFile(FilePathFromURL(parsed))
 		if err != nil {
 			return nil, fmt.Errorf("failed to read model parameters file: %w", err)
 		}

--- a/framework/modelcatalog/datasheet/sync.go
+++ b/framework/modelcatalog/datasheet/sync.go
@@ -143,7 +143,7 @@ func (s *Store) applyPricingData(pricingData map[string]Entry) {
 	s.mu.Unlock()
 }
 
-// filePathFromURL resolves a parsed file:// URL to a filesystem path,
+// FilePathFromURL resolves a parsed file:// URL to a filesystem path,
 // supporting both absolute and relative references. Go's url.Parse scatters a
 // relative path across different fields depending on its form, so we reassemble
 // it here:
@@ -154,7 +154,11 @@ func (s *Store) applyPricingData(pricingData map[string]Entry) {
 //
 // Relative paths resolve against the process working directory, matching how the
 // sqlite config store treats a relative "path" value.
-func filePathFromURL(parsed *url.URL) string {
+//
+// Exported because every air-gapped source in the catalog resolves file:// URLs
+// the same way: the pricing datasheet, the model parameters datasheet, and the
+// MCP library catalog (modelcatalog.fetchMCPLibrary).
+func FilePathFromURL(parsed *url.URL) string {
 	if parsed.Opaque != "" {
 		return parsed.Opaque
 	}
@@ -179,7 +183,7 @@ func (s *Store) loadPricingFromURL(ctx context.Context) (map[string]Entry, error
 	var data []byte
 
 	if parsed.Scheme == "file" {
-		data, err = os.ReadFile(filePathFromURL(parsed))
+		data, err = os.ReadFile(FilePathFromURL(parsed))
 		if err != nil {
 			return nil, fmt.Errorf("failed to read pricing file: %w", err)
 		}

--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -52,6 +52,25 @@ type ModelCatalog struct {
 	wg         sync.WaitGroup
 }
 
+// resolveMCPLibrarySyncInterval maps the configured MCP library sync interval
+// onto a duration. MCPLibrarySyncDisabled (0) is an explicit opt-out and is
+// returned as a zero duration, which every scheduling path below reads as
+// "never sync in the background". Nil or a negative value falls back to the
+// default cadence.
+func resolveMCPLibrarySyncInterval(config *Config) time.Duration {
+	if config == nil || config.MCPLibrarySyncInterval == nil {
+		return DefaultSyncInterval
+	}
+	switch val := *config.MCPLibrarySyncInterval; {
+	case val == MCPLibrarySyncDisabled:
+		return 0
+	case val < 0:
+		return DefaultSyncInterval
+	default:
+		return time.Duration(val) * time.Second
+	}
+}
+
 func Init(ctx context.Context, config *Config, configStore configstore.ConfigStore, logger schemas.Logger) (*ModelCatalog, error) {
 	pricingURL := DefaultPricingURL
 	if config != nil && config.PricingURL != nil {
@@ -65,10 +84,7 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 	if config != nil && config.MCPLibraryURL != nil && *config.MCPLibraryURL != "" {
 		mcpLibraryURL = *config.MCPLibraryURL
 	}
-	mcpLibrarySyncInterval := DefaultSyncInterval
-	if config != nil && config.MCPLibrarySyncInterval != nil && *config.MCPLibrarySyncInterval > 0 {
-		mcpLibrarySyncInterval = time.Duration(*config.MCPLibrarySyncInterval) * time.Second
-	}
+	mcpLibrarySyncInterval := resolveMCPLibrarySyncInterval(config)
 	syncInterval := DefaultSyncInterval
 	if config != nil && config.PricingSyncInterval != nil {
 		syncInterval = time.Duration(*config.PricingSyncInterval) * time.Second
@@ -202,12 +218,20 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 		// MCP library catalog follows the datasheet bootstrap pattern: if the DB
 		// already has catalog rows, refresh from URL in the background; if it is
 		// empty, block startup until the first remote sync lands so the library page
-		// is populated immediately after boot.
+		// is populated immediately after boot. A disabled interval short-circuits
+		// both paths.
 		hasMCPLibraryData, err := mc.hasMCPLibraryData(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load initial MCP library data: %w", err)
 		}
-		if hasMCPLibraryData {
+		switch {
+		case mcpLibrarySyncInterval == 0:
+			// Explicitly disabled (air-gapped deployments with no local catalog
+			// file). Skip the startup fetch entirely so boot does not wait on an
+			// endpoint that is unreachable by design. Whatever is already in the
+			// DB stays served, and a force-sync from the UI still works.
+			logger.Info("MCP library sync is disabled (mcp_library_sync_interval=0), skipping startup sync")
+		case hasMCPLibraryData:
 			logger.Info("existing MCP library data found in database, syncing from URL in background")
 			mc.wg.Add(1)
 			go func() {
@@ -222,7 +246,7 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 					mc.syncMu.Unlock()
 				}
 			}()
-		} else {
+		default:
 			// Empty DB: attempt a blocking sync so the library page is populated
 			// immediately after boot. Unlike pricing, a failure here is non-fatal
 			// — the background worker will retry on the next tick.
@@ -307,10 +331,7 @@ func (mc *ModelCatalog) UpdateSyncConfig(ctx context.Context, config *Config) er
 	if config != nil && config.MCPLibraryURL != nil && *config.MCPLibraryURL != "" {
 		mcpLibraryURL = *config.MCPLibraryURL
 	}
-	mcpLibrarySyncInterval := DefaultSyncInterval
-	if config != nil && config.MCPLibrarySyncInterval != nil && *config.MCPLibrarySyncInterval > 0 {
-		mcpLibrarySyncInterval = time.Duration(*config.MCPLibrarySyncInterval) * time.Second
-	}
+	mcpLibrarySyncInterval := resolveMCPLibrarySyncInterval(config)
 	mc.syncMu.Lock()
 	mc.mcpLibraryURL = mcpLibraryURL
 	mc.mcpLibrarySyncInterval = mcpLibrarySyncInterval
@@ -572,7 +593,18 @@ func (mc *ModelCatalog) isMCPLibrarySyncDue() bool {
 	lastSyncedAt := mc.lastMCPLibrarySyncedAt
 	syncInterval := mc.mcpLibrarySyncInterval
 	mc.syncMu.RUnlock()
-	if syncInterval <= 0 {
+	return mcpLibrarySyncDue(lastSyncedAt, syncInterval)
+}
+
+// mcpLibrarySyncDue decides whether the background worker should run a catalog
+// sync. Split out from isMCPLibrarySyncDue so the scheduling rules are testable
+// without a config store. A zero interval is the MCPLibrarySyncDisabled opt-out;
+// a negative one is corrupted state that falls back to the default cadence.
+func mcpLibrarySyncDue(lastSyncedAt time.Time, syncInterval time.Duration) bool {
+	if syncInterval == 0 {
+		return false
+	}
+	if syncInterval < 0 {
 		syncInterval = DefaultSyncInterval
 	}
 	return lastSyncedAt.IsZero() || time.Since(lastSyncedAt) >= syncInterval

--- a/framework/modelcatalog/mcp_library_sync.go
+++ b/framework/modelcatalog/mcp_library_sync.go
@@ -15,6 +15,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/modelcatalog/datasheet"
 	"gorm.io/gorm"
 )
 
@@ -24,6 +25,15 @@ const (
 	retryBackoffMin        = time.Second      // initial wait before the first retry
 	maxMCPLibraryBodyBytes = 50 << 20         // 50 MiB — hard cap on the catalog payload to prevent OOM
 )
+
+// isFileURL reports whether rawURL points at a local catalog file rather than a
+// remote endpoint. Used to skip network-shaped retry behaviour on the air-gapped
+// path. An unparseable URL is treated as non-file so it still flows into the
+// normal validation and error reporting in fetchMCPLibrary.
+func isFileURL(rawURL string) bool {
+	parsed, err := url.Parse(rawURL)
+	return err == nil && parsed.Scheme == "file"
+}
 
 // withRetries runs op up to maxRetries+1 times, waiting with exponential
 // backoff (starting at retryBackoffMin, capped at maxBackoff) between attempts.
@@ -102,7 +112,15 @@ func SyncMCPLibrary(ctx context.Context, url string, store configstore.ConfigSto
 		url = DefaultMCPLibraryURL
 	}
 
-	entries, err := withRetries(ctx, urlFetchMaxRetries, urlFetchMaxBackoff, func() ([]MCPLibraryEntry, error) {
+	// A local catalog file either exists or it does not; retrying with backoff
+	// only adds boot latency on an air-gapped host with a bad path. Retries stay
+	// on the network path where a transient failure is plausible.
+	maxRetries := urlFetchMaxRetries
+	if isFileURL(url) {
+		maxRetries = 0
+	}
+
+	entries, err := withRetries(ctx, maxRetries, urlFetchMaxBackoff, func() ([]MCPLibraryEntry, error) {
 		return fetchMCPLibrary(ctx, url)
 	})
 	if err != nil {
@@ -240,7 +258,10 @@ func fetchMCPLibrary(ctx context.Context, rawURL string) ([]MCPLibraryEntry, err
 
 	var data []byte
 	if parsed.Scheme == "file" {
-		f, err := os.Open(parsed.Path)
+		// Resolve through the shared datasheet helper so relative
+		// (file://./servers.json) and localhost-host (file://localhost/abs/...)
+		// forms work here exactly as they do for the pricing datasheets.
+		f, err := os.Open(datasheet.FilePathFromURL(parsed))
 		if err != nil {
 			return nil, fmt.Errorf("failed to open MCP library file: %w", err)
 		}

--- a/framework/modelcatalog/mcplibrarysync_test.go
+++ b/framework/modelcatalog/mcplibrarysync_test.go
@@ -24,15 +24,105 @@ func TestFetchMCPLibraryFromFileURL(t *testing.T) {
 	require.Equal(t, schemas.MCPConnectionTypeSTDIO, entries[0].ConnectionType)
 }
 
+// TestFetchMCPLibraryFromRelativeFileURL covers the air-gapped path where the
+// catalog is referenced relatively (baked into an image next to the binary, or
+// mounted at a path relative to the working directory) rather than by absolute
+// path. url.Parse scatters these forms across Opaque/Host/Path, so the fetch has
+// to go through datasheet.FilePathFromURL to reassemble them. Reading
+// parsed.Path directly resolves every case below to the wrong path.
+func TestFetchMCPLibraryFromRelativeFileURL(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "servers.json")
+	payload := `{"servers":[{"name":"Filesystem","connection_type":"stdio","auth_type":"none"}]}`
+	require.NoError(t, os.WriteFile(path, []byte(payload), 0o600))
+
+	// Relative forms resolve against the process working directory, so run from
+	// the catalog's directory. t.Chdir restores the previous directory on cleanup.
+	t.Chdir(dir)
+
+	for _, rawURL := range []string{
+		"file://./servers.json",
+		"file:./servers.json",
+		"file:servers.json",
+		"file://localhost" + path,
+	} {
+		t.Run(rawURL, func(t *testing.T) {
+			entries, err := fetchMCPLibrary(context.Background(), rawURL)
+			require.NoError(t, err)
+			require.Len(t, entries, 1)
+			require.Equal(t, "Filesystem", entries[0].Name)
+		})
+	}
+}
+
+// TestIsFileURL guards the retry carve-out: a local catalog file either exists
+// or it does not, so retrying with backoff only adds boot latency.
+func TestIsFileURL(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]bool{
+		"file:///opt/bifrost/servers.json":  true,
+		"file://./servers.json":             true,
+		"file:servers.json":                 true,
+		"https://getbifrost.ai/mcp-library": false,
+		"http://internal.corp/mcp-library":  false,
+		"":                                  false,
+		"://not a url":                      false,
+	}
+	for rawURL, want := range cases {
+		if got := isFileURL(rawURL); got != want {
+			t.Errorf("isFileURL(%q) = %v, want %v", rawURL, got, want)
+		}
+	}
+}
+
+// TestResolveMCPLibrarySyncInterval pins the disabled sentinel: 0 means "never
+// sync in the background" for air-gapped deployments, while nil and corrupted
+// negatives fall back to the default cadence.
+func TestResolveMCPLibrarySyncInterval(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, DefaultSyncInterval, resolveMCPLibrarySyncInterval(nil))
+	require.Equal(t, DefaultSyncInterval, resolveMCPLibrarySyncInterval(&Config{}))
+	require.Equal(t, time.Duration(0), resolveMCPLibrarySyncInterval(&Config{MCPLibrarySyncInterval: new(MCPLibrarySyncDisabled)}))
+	require.Equal(t, DefaultSyncInterval, resolveMCPLibrarySyncInterval(&Config{MCPLibrarySyncInterval: new(int64(-1))}))
+	require.Equal(t, 2*time.Hour, resolveMCPLibrarySyncInterval(&Config{MCPLibrarySyncInterval: new(int64(7200))}))
+}
+
+// TestMCPLibrarySyncDue verifies the background ticker never fires a catalog
+// sync once the interval is the disabled sentinel. That is what stops an
+// air-gapped gateway from dialing the default endpoint on every tick forever.
+func TestMCPLibrarySyncDue(t *testing.T) {
+	t.Parallel()
+
+	never := time.Time{}
+	recent := time.Now()
+	stale := time.Now().Add(-48 * time.Hour)
+
+	// Disabled: not due even when the catalog has never synced.
+	require.False(t, mcpLibrarySyncDue(never, 0))
+	require.False(t, mcpLibrarySyncDue(stale, 0))
+
+	// Enabled: due on first run and once the interval has elapsed.
+	require.True(t, mcpLibrarySyncDue(never, DefaultSyncInterval))
+	require.True(t, mcpLibrarySyncDue(stale, DefaultSyncInterval))
+	require.False(t, mcpLibrarySyncDue(recent, DefaultSyncInterval))
+
+	// Corrupted negative falls back to the default cadence rather than
+	// silently behaving like the disabled sentinel.
+	require.True(t, mcpLibrarySyncDue(stale, -time.Second))
+	require.False(t, mcpLibrarySyncDue(recent, -time.Second))
+}
+
 func TestWithRetries_TableDriven(t *testing.T) {
 	t.Parallel()
 
 	errTransient := errors.New("transient")
 
 	tests := []struct {
-		name         string
-		maxRetries   int
-		maxBackoff   time.Duration
+		name       string
+		maxRetries int
+		maxBackoff time.Duration
 		// failCount is how many times op fails before succeeding.
 		// Set to -1 to always fail.
 		failCount    int
@@ -70,12 +160,12 @@ func TestWithRetries_TableDriven(t *testing.T) {
 			// from retryBackoffMin) outlasts the 20ms ctx timeout, forcing
 			// cancellation during the wait rather than after exhausting
 			// retries.
-			name:         "context cancelled before success",
-			maxRetries:   5,
-			maxBackoff:   time.Second,
-			failCount:    -1,
-			ctxTimeout:   20 * time.Millisecond,
-			wantErr:      context.DeadlineExceeded,
+			name:       "context cancelled before success",
+			maxRetries: 5,
+			maxBackoff: time.Second,
+			failCount:  -1,
+			ctxTimeout: 20 * time.Millisecond,
+			wantErr:    context.DeadlineExceeded,
 		},
 		{
 			name:         "backoff does not exceed cap",

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -387,14 +387,15 @@ false
 {{- if .Values.bifrost.framework.pricing.mcpLibraryUrl }}
 {{- $_ := set $pricing "mcp_library_url" .Values.bifrost.framework.pricing.mcpLibraryUrl }}
 {{- end }}
-{{- if .Values.bifrost.framework.pricing.mcpLibrarySyncInterval }}
+{{- /* nil-aware: 0 is a meaningful value here (disables the catalog sync) */ -}}
+{{- if not (kindIs "invalid" .Values.bifrost.framework.pricing.mcpLibrarySyncInterval) }}
 {{- $_ := set $pricing "mcp_library_sync_interval" .Values.bifrost.framework.pricing.mcpLibrarySyncInterval }}
 {{- end }}
 {{- /* nil-aware: 0 is a meaningful value here (disables the background refresh) */ -}}
 {{- if not (kindIs "invalid" .Values.bifrost.framework.pricing.liveModelsSyncInterval) }}
 {{- $_ := set $pricing "live_models_sync_interval" .Values.bifrost.framework.pricing.liveModelsSyncInterval }}
 {{- end }}
-{{- if or $pricing.pricing_url $pricing.model_parameters_url $pricing.pricing_sync_interval $pricing.mcp_library_url $pricing.mcp_library_sync_interval (hasKey $pricing "live_models_sync_interval") }}
+{{- if or $pricing.pricing_url $pricing.model_parameters_url $pricing.pricing_sync_interval $pricing.mcp_library_url (hasKey $pricing "mcp_library_sync_interval") (hasKey $pricing "live_models_sync_interval") }}
 {{- $_ := set $framework "pricing" $pricing }}
 {{- end }}
 {{- end }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -663,9 +663,9 @@
                 },
                 "mcpLibrarySyncInterval": {
                   "type": "integer",
-                  "description": "MCP library sync interval in seconds. Default is 24 hours. Minimum is 3600 seconds (1 hour).",
+                  "description": "MCP library sync interval in seconds. Set to 0 to disable background catalog syncing entirely (air-gapped deployments with no local catalog file). Default is 24 hours; minimum when enabled is 3600 seconds (1 hour).",
                   "default": 86400,
-                  "minimum": 3600
+                  "anyOf": [{ "const": 0 }, { "minimum": 3600 }]
                 },
                 "liveModelsSyncInterval": {
                   "type": "integer",

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -366,8 +366,10 @@ bifrost:
       # Sync interval in seconds (default: 86400 = 24 hours, minimum: 3600)
       pricingSyncInterval: 86400
       # Custom MCP server catalog URL (optional, leave empty to use the default Bifrost catalog)
+      # Accepts a file:// URL to load the catalog from local disk in air-gapped deployments
       # mcpLibraryUrl: ""
-      # MCP library sync interval in seconds (default: 86400 = 24 hours, minimum: 3600)
+      # MCP library sync interval in seconds
+      # (default: 86400 = 24 hours, minimum: 3600; set to 0 to disable catalog syncing)
       # mcpLibrarySyncInterval: 86400
       # How often each provider's model list is re-fetched in the background, in seconds
       # (default: 3600 = 1 hour, minimum: 60; set to 0 to disable background refresh)

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -4623,7 +4623,13 @@ func ResolveFrameworkPricingConfig(
 		if fileConfig.Pricing.MCPLibrarySyncInterval != nil {
 			val := *fileConfig.Pricing.MCPLibrarySyncInterval
 			switch {
-			case val <= 0:
+			case val == modelcatalog.MCPLibrarySyncDisabled:
+				// Explicit opt-out (air-gapped deployments with no local catalog
+				// file), not corruption. Passed through untouched so Phase 3 does
+				// not "repair" it back to the default.
+				disabled := modelcatalog.MCPLibrarySyncDisabled
+				fileMCPLibrarySyncSeconds = &disabled
+			case val < 0:
 				logger.Warn("mcp_library_sync_interval in config.json is invalid (%d seconds), ignoring — using default (%d seconds)", val, defaultSyncSeconds)
 			case val < modelcatalog.MinimumPricingSyncIntervalSec:
 				clamped := modelcatalog.MinimumPricingSyncIntervalSec
@@ -4798,7 +4804,16 @@ func ResolveFrameworkPricingConfig(
 		if dbConfig.MCPLibrarySyncInterval != nil {
 			val := *dbConfig.MCPLibrarySyncInterval
 			switch {
-			case val <= 0:
+			case val == modelcatalog.MCPLibrarySyncDisabled:
+				// 0 is a deliberate opt-out rather than corruption, so it is
+				// honoured instead of being backfilled with the default.
+				if fileChanged && fileMCPLibrarySyncSeconds != nil {
+					logger.Info("mcp_library_sync_interval from config.json overrides DB (file hash changed): file=%d db=disabled — updating DB", *fileMCPLibrarySyncSeconds)
+					needsDBUpdate = true
+				} else {
+					resolvedMCPLibrarySyncInterval = dbConfig.MCPLibrarySyncInterval
+				}
+			case val < 0:
 				logger.Warn("mcp_library_sync_interval in DB is corrupted (%d seconds), ignoring — backfilling with %d seconds", val, *resolvedMCPLibrarySyncInterval)
 				needsDBUpdate = true
 			case val < modelcatalog.MinimumPricingSyncIntervalSec:

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -18789,7 +18789,7 @@ func TestResolveFrameworkPricingConfig(t *testing.T) {
 	})
 
 	t.Run("mcp library invalid db interval falls back and requests db update", func(t *testing.T) {
-		invalidDBSync := int64(0)
+		invalidDBSync := int64(-1)
 		dbConfig := &tables.TableFrameworkConfig{
 			ID:                     10,
 			MCPLibraryURL:          &defaultMCPLibraryURL,
@@ -18800,6 +18800,36 @@ func TestResolveFrameworkPricingConfig(t *testing.T) {
 		require.True(t, needsDBUpdate)
 		require.Equal(t, defaultSyncSeconds, *normalizedTable.MCPLibrarySyncInterval)
 		require.Equal(t, defaultSyncSeconds, *normalizedModelCatalog.MCPLibrarySyncInterval)
+	})
+
+	// 0 is the air-gapped opt-out (modelcatalog.MCPLibrarySyncDisabled), not
+	// corruption: it must survive a resolve untouched instead of being
+	// backfilled with the default, or a disabled deployment would silently
+	// resume dialing the default catalog endpoint on the next boot.
+	t.Run("mcp library disabled db interval is honoured", func(t *testing.T) {
+		disabled := modelcatalog.MCPLibrarySyncDisabled
+		dbConfig := &tables.TableFrameworkConfig{
+			ID:                     10,
+			MCPLibraryURL:          &defaultMCPLibraryURL,
+			MCPLibrarySyncInterval: &disabled,
+		}
+
+		normalizedTable, normalizedModelCatalog, _ := ResolveFrameworkPricingConfig(dbConfig, nil)
+		require.Equal(t, modelcatalog.MCPLibrarySyncDisabled, *normalizedTable.MCPLibrarySyncInterval)
+		require.Equal(t, modelcatalog.MCPLibrarySyncDisabled, *normalizedModelCatalog.MCPLibrarySyncInterval)
+	})
+
+	t.Run("mcp library disabled file interval is honoured", func(t *testing.T) {
+		disabled := modelcatalog.MCPLibrarySyncDisabled
+		fileConfig := &framework.FrameworkConfig{
+			Pricing: &modelcatalog.Config{
+				MCPLibrarySyncInterval: &disabled,
+			},
+		}
+
+		normalizedTable, normalizedModelCatalog, _ := ResolveFrameworkPricingConfig(nil, fileConfig)
+		require.Equal(t, modelcatalog.MCPLibrarySyncDisabled, *normalizedTable.MCPLibrarySyncInterval)
+		require.Equal(t, modelcatalog.MCPLibrarySyncDisabled, *normalizedModelCatalog.MCPLibrarySyncInterval)
 	})
 
 	t.Run("invalid db interval (zero) falls back and requests db update", func(t *testing.T) {

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -4023,16 +4023,16 @@
         },
         "mcp_library_url": {
           "type": "string",
-          "description": "URL to a custom MCP server catalog. Leave empty to use the default Bifrost catalog.",
+          "description": "URL to a custom MCP server catalog. Leave empty to use the default Bifrost catalog. Accepts a file:// URL to load the catalog from local disk in air-gapped deployments.",
           "optional": true,
           "format": "uri"
         },
         "mcp_library_sync_interval": {
           "type": "integer",
-          "description": "MCP library sync interval in seconds. Default is 24 hours. Minimum is 3600 seconds (1 hour).",
+          "description": "MCP library sync interval in seconds. Set to 0 to disable background catalog syncing entirely (air-gapped deployments with no local catalog file); an explicit force-sync still works. Default is 24 hours; minimum when enabled is 3600 seconds (1 hour).",
           "default": 86400,
           "optional": true,
-          "minimum": 3600
+          "anyOf": [{ "const": 0 }, { "minimum": 3600 }]
         },
         "live_models_sync_interval": {
           "type": "integer",

--- a/ui/app/workspace/config/views/mcpView.tsx
+++ b/ui/app/workspace/config/views/mcpView.tsx
@@ -255,7 +255,7 @@ export default function MCPView() {
 	}, [bifrostConfig, localConfig, localValues, updateCoreConfig]);
 
 	return (
-		<div className="mx-auto w-full max-w-7xl space-y-4" data-testid="mcp-settings-view">
+		<div className="mx-auto w-full max-w-4xl space-y-4 px-4 py-6 md:px-0" data-testid="mcp-settings-view">
 			<div>
 				<h2 className="text-lg font-semibold tracking-tight">MCP Settings</h2>
 				<p className="text-muted-foreground text-sm">Configure MCP (Model Context Protocol) agent and tool settings.</p>

--- a/ui/app/workspace/mcp-registry/library/views/mcpLibrarySettingsSheet.tsx
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibrarySettingsSheet.tsx
@@ -9,19 +9,28 @@ import { useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
+import { toIntervalHours } from "./mcpLibrarySettingsSheet.utils";
 
 const mcpLibrarySettingsSchema = z.object({
+	// file:// is accepted so air-gapped deployments can point the catalog at a
+	// local file that ships with the image or volume, matching how the pricing
+	// datasheet URLs are handled in modelSettingsView.
 	mcp_library_url: z
 		.string()
 		.trim()
 		.refine(
-			(value) => value === "" || value.startsWith("http://") || value.startsWith("https://"),
-			"URL must start with http:// or https://",
+			(value) =>
+				value === "" || value.startsWith("http://") || value.startsWith("https://") || value.startsWith("file://"),
+			"URL must start with http://, https://, or file://",
 		),
+	// 0 disables background syncing entirely. Force Sync Now still works.
+	// Anything else has to be at least an hour: transports/config.schema.json
+	// declares mcp_library_sync_interval as `anyOf: [{const: 0}, {minimum:
+	// 3600}]`, so a fractional value below 1h would be rejected server-side.
 	mcp_library_sync_interval_hours: z
 		.number({ message: "Sync interval is required" })
-		.min(1, "Sync interval must be at least 1 hour")
-		.max(8760, "Sync interval cannot exceed 8760 hours (1 year)"),
+		.max(8760, "Sync interval cannot exceed 8760 hours (1 year)")
+		.refine((hours) => hours === 0 || hours >= 1, "Sync interval must be 0 (disabled) or at least 1 hour"),
 });
 
 type MCPLibrarySettingsFormData = z.infer<typeof mcpLibrarySettingsSchema>;
@@ -58,14 +67,14 @@ export function MCPLibrarySettingsSheet({ open, onClose }: MCPLibrarySettingsShe
 		if (!open || !config) return;
 		reset({
 			mcp_library_url: config.mcp_library_url || "",
-			mcp_library_sync_interval_hours: Math.round((config.mcp_library_sync_interval || 86400) / 3600),
+			mcp_library_sync_interval_hours: toIntervalHours(config.mcp_library_sync_interval),
 		});
 	}, [config, open, reset]);
 
 	const hasChanges = useMemo(() => {
 		if (!config || !isDirty) return false;
 		const serverUrl = config.mcp_library_url || "";
-		const serverInterval = Math.round((config.mcp_library_sync_interval || 86400) / 3600);
+		const serverInterval = toIntervalHours(config.mcp_library_sync_interval);
 		return formValues.mcp_library_url !== serverUrl || formValues.mcp_library_sync_interval_hours !== serverInterval;
 	}, [config, formValues, isDirty]);
 
@@ -113,7 +122,8 @@ export function MCPLibrarySettingsSheet({ open, onClose }: MCPLibrarySettingsShe
 							<div className="space-y-0.5">
 								<Label htmlFor="mcp-library-url">Library Sync URL</Label>
 								<p className="text-muted-foreground text-sm">
-									URL to a custom MCP server catalog. Leave empty to use the default Bifrost catalog.
+									URL to a custom MCP server catalog. Leave empty to use the default Bifrost catalog. Use a{" "}
+									<code>file://</code> URL to load the catalog from local disk in air-gapped deployments.
 								</p>
 							</div>
 							<Input
@@ -130,11 +140,19 @@ export function MCPLibrarySettingsSheet({ open, onClose }: MCPLibrarySettingsShe
 						<div className="space-y-2 rounded-sm border p-4">
 							<div className="space-y-0.5">
 								<Label htmlFor="mcp-library-sync-interval">Sync Interval (hours)</Label>
-								<p className="text-muted-foreground text-sm">How often to sync the MCP server catalog from the source URL.</p>
+								<p className="text-muted-foreground text-sm">
+									How often to sync the MCP server catalog from the source URL. Set to 0 to disable background syncing;
+									Force Sync Now still works.
+								</p>
 							</div>
 							<Input
 								id="mcp-library-sync-interval"
 								type="number"
+								// step="any" so a stored non-whole-hour interval (5400s = 1.5h is
+								// valid config) stays editable instead of tripping the number
+								// input's default step of 1.
+								step="any"
+								min={0}
 								data-testid="mcp-library-sync-interval-input"
 								className={errors.mcp_library_sync_interval_hours ? "border-destructive" : ""}
 								{...register("mcp_library_sync_interval_hours", { valueAsNumber: true })}

--- a/ui/app/workspace/mcp-registry/library/views/mcpLibrarySettingsSheet.utils.test.ts
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibrarySettingsSheet.utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { toIntervalHours } from "./mcpLibrarySettingsSheet.utils";
+
+describe("toIntervalHours", () => {
+	it("defaults to 24 when the interval is missing", () => {
+		expect(toIntervalHours(undefined)).toBe(24);
+		expect(toIntervalHours(null)).toBe(24);
+	});
+
+	it("keeps 0 as 0 so 'syncing disabled' survives the round trip", () => {
+		expect(toIntervalHours(0)).toBe(0);
+	});
+
+	it("converts whole-hour intervals", () => {
+		expect(toIntervalHours(3600)).toBe(1);
+		expect(toIntervalHours(86400)).toBe(24);
+	});
+
+	it("preserves non-whole-hour intervals instead of rounding them", () => {
+		// 5400s is valid per transports/config.schema.json (anyOf: const 0 |
+		// minimum 3600). Rounding it to 2 makes the next save write 7200.
+		expect(toIntervalHours(5400)).toBe(1.5);
+		expect(toIntervalHours(4500)).toBe(1.25);
+	});
+
+	it("round-trips a fractional interval back to the exact stored seconds", () => {
+		expect(toIntervalHours(5400) * 3600).toBe(5400);
+	});
+});

--- a/ui/app/workspace/mcp-registry/library/views/mcpLibrarySettingsSheet.utils.ts
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibrarySettingsSheet.utils.ts
@@ -1,0 +1,17 @@
+/**
+ * toIntervalHours converts the stored MCP library sync interval (seconds) into
+ * the hours the settings form shows.
+ *
+ * Two values have to survive the round trip untouched, because the form writes
+ * `hours * 3600` back on every save - even a save that only changed the URL:
+ *   - 0 means "background syncing disabled" and must not collapse into the 24h
+ *     default the way a missing value does.
+ *   - Non-whole-hour intervals are legal. transports/config.schema.json declares
+ *     mcp_library_sync_interval as `anyOf: [{const: 0}, {minimum: 3600}]`, so a
+ *     stored 5400 (1.5h) is valid config; rounding it to 2h would silently
+ *     rewrite it to 7200 on the next save.
+ */
+export function toIntervalHours(seconds: number | undefined | null): number {
+	if (seconds === undefined || seconds === null) return 24;
+	return seconds / 3600;
+}

--- a/ui/app/workspace/mcp-settings/page.tsx
+++ b/ui/app/workspace/mcp-settings/page.tsx
@@ -2,7 +2,7 @@ import MCPView from "../config/views/mcpView";
 
 export default function MCPSettingsPage() {
 	return (
-		<div className="no-padding-parent mx-auto w-full max-w-7xl p-4">
+		<div className="no-padding-parent mx-auto flex w-full">
 			<MCPView />
 		</div>
 	);


### PR DESCRIPTION
## Summary

Extends Bifrost's air-gapped deployment support to cover the MCP server library catalog in addition to the existing pricing and model parameter datasheets. Previously, air-gapped hosts had no way to suppress the catalog fetch or serve it from a local file, causing unnecessary network attempts to `getbifrost.ai` on every sync tick.

## Changes

- **`mcp_library_sync_interval: 0` disables background catalog syncing** — introduces `MCPLibrarySyncDisabled` as an explicit sentinel (mirroring `LiveModelsSyncDisabled`). A zero interval skips the startup fetch and never schedules a background sync, so no requests go to `getbifrost.ai`. Force Sync Now from the UI still works. Negative values continue to be treated as corrupted config and fall back to the default cadence.
- **`file://` URLs for the MCP library catalog** — `fetchMCPLibrary` now resolves file URLs through the shared `datasheet.FilePathFromURL` helper (exported from `sync.go`) so relative forms (`file://./servers.json`, `file:servers.json`) and `file://localhost/...` work identically to how they work for the pricing datasheets.
- **No retry backoff on local file paths** — `SyncMCPLibrary` skips the exponential-backoff retry loop when the URL is a `file://` reference, since a missing local file is not a transient failure and retrying only adds boot latency.
- **Config resolution fixes** — `ResolveFrameworkPricingConfig` previously treated `0` as corrupted and backfilled the default, which would silently re-enable syncing on the next boot. It now passes `MCPLibrarySyncDisabled` through untouched in both the file-config and DB-config paths.
- **Helm chart nil-awareness** — the `mcpLibrarySyncInterval` template condition is updated from a truthiness check to `kindIs "invalid"` so that `0` is correctly written into the rendered config rather than omitted.
- **Schema updates** — both `config.schema.json` and `values.schema.json` now allow `0` as a valid value via `anyOf: [{ const: 0 }, { minimum: 3600 }]`.
- **UI updates** — the MCP Library Settings sheet accepts `file://` URLs, allows a sync interval of `0` (with updated validation message), and preserves `0` through the hours round-trip without collapsing it to the 24h default. MCP Settings page layout is tightened to `max-w-4xl` with consistent padding.
- **Documentation** — the air-gapped guide is restructured into separate Datasheets and MCP server library sections, documents both Option A (local file) and Option B (disable sync), and adds a sync-settings reference table.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
# Core/Transports
go test ./framework/modelcatalog/... ./transports/bifrost-http/lib/...

# UI
cd ui
pnpm i
pnpm build
```

**Air-gapped datasheet path:**
1. Download `https://getbifrost.ai/mcp-library` to a local file.
2. Set `mcp_library_url: "file:///opt/bifrost/mcp-library.json"` in `config.json`.
3. Start Bifrost — the MCP Library page should populate from the local file with no outbound requests.

**Disabled sync path:**
1. Set `mcp_library_sync_interval: 0` in `config.json`.
2. Start Bifrost — confirm the log line `MCP library sync is disabled (mcp_library_sync_interval=0), skipping startup sync` appears and no requests are made to `getbifrost.ai` on subsequent ticks.
3. Confirm Force Sync Now in the UI still triggers a sync.

**Relative file URL:**
1. Place `servers.json` in the Bifrost working directory.
2. Set `mcp_library_url: "file://./servers.json"` and verify the catalog loads correctly.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

`file://` URL support is limited to paths readable by the Bifrost process user. No new network surface is introduced; the change reduces outbound connections for air-gapped deployments.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable