### PR TITLE
adds topbar

### DIFF
--- a/tests/integrations/python/config.json
+++ b/tests/integrations/python/config.json
@@ -1,18 +1,13 @@
 {
   "$schema": "https://www.getbifrost.ai/schema",
-  "env_label": "Development",
   "mcp": {
     "client_configs": [
       {
         "name": "sse_mcp",
         "connection_type": "sse",
         "connection_string": "http://localhost:3012/sse",
-        "tools_to_execute": [
-          "*"
-        ],
-        "tools_to_auto_execute": [
-          "*"
-        ]
+        "tools_to_execute": ["*"],
+        "tools_to_auto_execute": ["*"]
       }
     ]
   },
@@ -23,9 +18,7 @@
           "name": "OpenAI API Key",
           "value": "env.OPENAI_API_KEY",
           "weight": 1,
-          "models": [
-            "*"
-          ],
+          "models": ["*"],
           "use_for_batch_api": true
         }
       ],
@@ -39,9 +32,7 @@
           "name": "ElevenLabs API Key",
           "value": "env.ELEVENLABS_API_KEY",
           "weight": 1,
-          "models": [
-            "*"
-          ],
+          "models": ["*"],
           "use_for_batch_api": false
         }
       ],
@@ -55,9 +46,7 @@
           "name": "Xai API Key",
           "value": "env.XAI_API_KEY",
           "weight": 1,
-          "models": [
-            "*"
-          ],
+          "models": ["*"],
           "use_for_batch_api": false
         }
       ],
@@ -71,9 +60,7 @@
           "name": "Hugging Face API Key",
           "value": "env.HUGGING_FACE_API_KEY",
           "weight": 1,
-          "models": [
-            "*"
-          ],
+          "models": ["*"],
           "use_for_batch_api": false
         }
       ],
@@ -87,9 +74,7 @@
           "name": "Anthropic API Key",
           "value": "env.ANTHROPIC_API_KEY",
           "weight": 1,
-          "models": [
-            "*"
-          ],
+          "models": ["*"],
           "use_for_batch_api": true
         }
       ],
@@ -103,9 +88,7 @@
           "name": "Gemini API Key",
           "value": "env.GEMINI_API_KEY",
           "weight": 1,
-          "models": [
-            "*"
-          ],
+          "models": ["*"],
           "use_for_batch_api": true
         }
       ],
@@ -123,9 +106,7 @@
             "auth_credentials": "env.VERTEX_CREDENTIALS"
           },
           "weight": 1,
-          "models": [
-            "*"
-          ],
+          "models": ["*"],
           "use_for_batch_api": true,
           "blacklisted_models": [
             "claude-sonnet-4-6",
@@ -160,9 +141,7 @@
           "name": "Mistral API Key",
           "value": "env.MISTRAL_API_KEY",
           "weight": 1,
-          "models": [
-            "*"
-          ]
+          "models": ["*"]
         }
       ],
       "network_config": {
@@ -175,9 +154,7 @@
           "name": "Cohere API Key",
           "value": "env.COHERE_API_KEY",
           "weight": 1,
-          "models": [
-            "*"
-          ]
+          "models": ["*"]
         }
       ],
       "network_config": {
@@ -190,9 +167,7 @@
           "name": "Parasail API Key",
           "value": "env.PARASAIL_API_KEY",
           "weight": 1,
-          "models": [
-            "*"
-          ]
+          "models": ["*"]
         }
       ],
       "network_config": {
@@ -205,9 +180,7 @@
           "name": "Groq API Key",
           "value": "env.GROQ_API_KEY",
           "weight": 1,
-          "models": [
-            "*"
-          ]
+          "models": ["*"]
         }
       ],
       "network_config": {
@@ -220,9 +193,7 @@
           "name": "Perplexity API Key",
           "value": "env.PERPLEXITY_API_KEY",
           "weight": 1,
-          "models": [
-            "*"
-          ]
+          "models": ["*"]
         }
       ],
       "network_config": {
@@ -235,9 +206,7 @@
           "name": "Cerebras API Key",
           "value": "env.CEREBRAS_API_KEY",
           "weight": 1,
-          "models": [
-            "*"
-          ]
+          "models": ["*"]
         }
       ],
       "network_config": {
@@ -250,9 +219,7 @@
           "name": "OpenRouter API Key",
           "value": "env.OPENROUTER_API_KEY",
           "weight": 1,
-          "models": [
-            "*"
-          ]
+          "models": ["*"]
         }
       ],
       "network_config": {
@@ -287,9 +254,7 @@
             }
           },
           "weight": 1,
-          "models": [
-            "*"
-          ],
+          "models": ["*"],
           "use_for_batch_api": true
         }
       ],
@@ -307,9 +272,7 @@
             "region": "env.AWS_REGION"
           },
           "weight": 1,
-          "models": [
-            "*"
-          ],
+          "models": ["*"],
           "use_for_batch_api": true
         }
       ],
@@ -327,9 +290,7 @@
             "region": "env.AWS_REGION"
           },
           "weight": 1,
-          "models": [
-            "*"
-          ],
+          "models": ["*"],
           "use_for_batch_api": true
         }
       ],
@@ -379,9 +340,7 @@
           "name": "DeepSeek API Key",
           "value": "env.DEEPSEEK_API_KEY",
           "weight": 1,
-          "models": [
-            "*"
-          ],
+          "models": ["*"],
           "use_for_batch_api": false
         }
       ],
@@ -421,182 +380,110 @@
         "provider_configs": [
           {
             "provider": "openai",
-            "allowed_models": [
-              "*"
-            ],
-            "key_ids": [
-              "*"
-            ],
+            "allowed_models": ["*"],
+            "key_ids": ["*"],
             "weight": 1.0
           },
           {
             "provider": "elevenlabs",
-            "allowed_models": [
-              "*"
-            ],
-            "key_ids": [
-              "*"
-            ],
+            "allowed_models": ["*"],
+            "key_ids": ["*"],
             "weight": 1.0
           },
           {
             "provider": "xai",
-            "allowed_models": [
-              "*"
-            ],
-            "key_ids": [
-              "*"
-            ],
+            "allowed_models": ["*"],
+            "key_ids": ["*"],
             "weight": 1.0
           },
           {
             "provider": "huggingface",
-            "allowed_models": [
-              "*"
-            ],
-            "key_ids": [
-              "*"
-            ],
+            "allowed_models": ["*"],
+            "key_ids": ["*"],
             "weight": 1.0
           },
           {
             "provider": "anthropic",
-            "allowed_models": [
-              "*"
-            ],
-            "key_ids": [
-              "*"
-            ],
+            "allowed_models": ["*"],
+            "key_ids": ["*"],
             "weight": 1.0
           },
           {
             "provider": "gemini",
-            "allowed_models": [
-              "*"
-            ],
-            "key_ids": [
-              "*"
-            ],
+            "allowed_models": ["*"],
+            "key_ids": ["*"],
             "weight": 1.0
           },
           {
             "provider": "vertex",
-            "allowed_models": [
-              "*"
-            ],
-            "key_ids": [
-              "*"
-            ],
+            "allowed_models": ["*"],
+            "key_ids": ["*"],
             "weight": 1.0
           },
           {
             "provider": "mistral",
-            "allowed_models": [
-              "*"
-            ],
-            "key_ids": [
-              "*"
-            ],
+            "allowed_models": ["*"],
+            "key_ids": ["*"],
             "weight": 1.0
           },
           {
             "provider": "cohere",
-            "allowed_models": [
-              "*"
-            ],
-            "key_ids": [
-              "*"
-            ],
+            "allowed_models": ["*"],
+            "key_ids": ["*"],
             "weight": 1.0
           },
           {
             "provider": "parasail",
-            "allowed_models": [
-              "*"
-            ],
-            "key_ids": [
-              "*"
-            ],
+            "allowed_models": ["*"],
+            "key_ids": ["*"],
             "weight": 1.0
           },
           {
             "provider": "groq",
-            "allowed_models": [
-              "*"
-            ],
-            "key_ids": [
-              "*"
-            ],
+            "allowed_models": ["*"],
+            "key_ids": ["*"],
             "weight": 1.0
           },
           {
             "provider": "perplexity",
-            "allowed_models": [
-              "*"
-            ],
-            "key_ids": [
-              "*"
-            ],
+            "allowed_models": ["*"],
+            "key_ids": ["*"],
             "weight": 1.0
           },
           {
             "provider": "cerebras",
-            "allowed_models": [
-              "*"
-            ],
-            "key_ids": [
-              "*"
-            ],
+            "allowed_models": ["*"],
+            "key_ids": ["*"],
             "weight": 1.0
           },
           {
             "provider": "openrouter",
-            "allowed_models": [
-              "*"
-            ],
-            "key_ids": [
-              "*"
-            ],
+            "allowed_models": ["*"],
+            "key_ids": ["*"],
             "weight": 1.0
           },
           {
             "provider": "azure",
-            "allowed_models": [
-              "*"
-            ],
-            "key_ids": [
-              "*"
-            ],
+            "allowed_models": ["*"],
+            "key_ids": ["*"],
             "weight": 1.0
           },
           {
             "provider": "bedrock",
-            "allowed_models": [
-              "*"
-            ],
-            "key_ids": [
-              "*"
-            ],
+            "allowed_models": ["*"],
+            "key_ids": ["*"],
             "weight": 1.0
           },
           {
             "provider": "bedrock_mantle",
-            "allowed_models": [
-              "*"
-            ],
-            "key_ids": [
-              "*"
-            ],
+            "allowed_models": ["*"],
+            "key_ids": ["*"],
             "weight": 1.0
           },
           {
             "provider": "deepseek",
-            "allowed_models": [
-              "*"
-            ],
-            "key_ids": [
-              "*"
-            ],
+            "allowed_models": ["*"],
+            "key_ids": ["*"],
             "weight": 1.0
           }
         ]
@@ -609,9 +496,7 @@
   "client": {
     "drop_excess_requests": false,
     "initial_pool_size": 300,
-    "allowed_origins": [
-      "*"
-    ],
+    "allowed_origins": ["*"],
     "enable_logging": true,
     "enforce_auth_on_inference": false,
     "max_request_body_size_mb": 100

--- a/ui/app/_fallbacks/enterprise/components/mcp-tool-groups/mcpToolGroups.tsx
+++ b/ui/app/_fallbacks/enterprise/components/mcp-tool-groups/mcpToolGroups.tsx
@@ -1,15 +1,13 @@
+import PageTitle from "@/components/pageTitle";
 import { ToolCase } from "lucide-react";
 import ContactUsView from "../views/contactUsView";
 
 export default function MCPToolGroups() {
 	return (
 		<>
-			<div className="mb-4 flex items-center justify-between gap-4">
-				<div>
-					<h2 className="text-lg font-semibold tracking-tight">MCP Tool Groups</h2>
-					<p className="text-muted-foreground text-sm">Configure tool groups for MCP servers to organize and govern tools.</p>
-				</div>
-			</div>
+			{/* The name and description live in the topbar, like every other page —
+			    an inline <h2> here would just repeat the title shown above it. */}
+			<PageTitle title="MCP Tool Groups">Configure tool groups for MCP servers to organize and govern tools.</PageTitle>
 			<div className="rounded-sm border">
 				<div className="flex w-full flex-col items-center justify-center py-16">
 					<ContactUsView

--- a/ui/app/_fallbacks/enterprise/components/scim/scimView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/scim/scimView.tsx
@@ -2,15 +2,19 @@ import { BookUser } from "lucide-react";
 import ContactUsView from "../views/contactUsView";
 
 export default function SCIMView() {
+	// Same bordered panel the other enterprise placeholders use, so the upsell
+	// reads as page content rather than as the page background.
 	return (
-		<div className="h-full w-full">
-			<ContactUsView
-				className="mx-auto min-h-[80vh]"
-				icon={<BookUser className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
-				title="Unlock SCIM based access management for user provisioning"
-				description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
-				readmeLink="https://docs.getbifrost.ai/enterprise/advanced-governance"
-			/>
+		<div className="rounded-sm border">
+			<div className="flex w-full flex-col items-center justify-center py-16">
+				<ContactUsView
+					className="mx-auto w-full max-w-lg"
+					icon={<BookUser className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
+					title="Unlock SCIM based access management for user provisioning"
+					description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
+					readmeLink="https://docs.getbifrost.ai/enterprise/advanced-governance"
+				/>
+			</div>
 		</div>
 	);
 }

--- a/ui/app/clientLayout.tsx
+++ b/ui/app/clientLayout.tsx
@@ -4,10 +4,12 @@ import OnboardingWidget from "@/components/onboardingWidget";
 import ProgressProvider from "@/components/progressBar";
 import Sidebar from "@/components/sidebar";
 import { ThemeProvider } from "@/components/themeProvider";
+import Topbar from "@/components/topbar";
 import TrialExpiryBanner from "@/components/trialExpiryBanner";
 import { Button } from "@/components/ui/button";
-import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
+import { SidebarProvider } from "@/components/ui/sidebar";
 import { useStoreSync } from "@/hooks/useStoreSync";
+import { TopbarProvider } from "@/lib/contexts/topbarContext";
 import { WebSocketProvider } from "@/hooks/useWebSocket";
 import { getErrorMessage, ReduxProvider, useGetCoreConfigQuery, useIsAuthEnabledQuery } from "@/lib/store";
 import { BifrostConfig } from "@/lib/types/config";
@@ -51,12 +53,6 @@ function AppContent({ children }: { children: React.ReactNode }) {
 	// neither a fragment nor a cookie to drive the tempTokenScoped per-visitor
 	// logic.
 	const publicShell = matches.some((m) => (m.staticData as { publicShell?: boolean } | undefined)?.publicShell === true);
-	const pathname = useLocation({ select: (location) => location.pathname });
-	const mobilePageTitle = (pathname.split("/").filter(Boolean).at(-1) ?? "Dashboard")
-		.split("-")
-		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-		.join(" ");
-
 	// Probe dashboard auth state on opted-in routes. is-auth-enabled is whitelisted
 	// (no 401 risk) and returns whether the current cookie is a valid session.
 	const { data: authState, isLoading: authLoading } = useIsAuthEnabledQuery(undefined, { skip: !tempTokenScoped });
@@ -118,28 +114,38 @@ function AppContent({ children }: { children: React.ReactNode }) {
 		<WebSocketProvider>
 			<CookiesProvider>
 				<StoreSyncInitializer />
-				<SidebarProvider>
-					<Sidebar />
-					<div className="dark:bg-card custom-scrollbar content-container mx-0 h-dvh w-full min-w-0 overflow-auto border border-gray-200 bg-white md:my-[0.5rem] md:mr-[0.5rem] md:h-[calc(100dvh-1rem)] md:rounded-md md:px-10 dark:border-zinc-800">
-						<div className="bg-card sticky top-0 z-20 flex h-12 min-w-0 items-center border-b px-4 md:hidden">
-							<div className="flex min-w-0 items-center gap-2">
-								<SidebarTrigger className="shrink-0" />
-								<span className="truncate text-sm font-semibold">{mobilePageTitle}</span>
+				<TopbarProvider>
+					<SidebarProvider>
+						<Sidebar />
+						{/* Content column: a fixed-height flex stack so the topbar takes its
+					    48px and the content card absorbs the remainder. The topbar has no
+					    background of its own, so it reads as the same surface as the
+					    sidebar (both show the page body background). */}
+						<div className="flex h-dvh w-full min-w-0 flex-col">
+							<Topbar />
+							{/* No w-full: in a column flex container the cross axis is width, and
+							    an explicit 100% would sit *outside* the right margin, pushing it
+							    off-screen. Default align-items:stretch already fills the column
+							    minus margins. No top margin either: the card butts against the
+							    60px topbar so its top edge lands on the same line as the sidebar's
+							    search input, and --app-content-viewport compensates so full-height
+							    pages still measure to the card's inner height. */}
+							<div className="dark:bg-card custom-scrollbar content-container mx-0 min-h-0 min-w-0 flex-1 overflow-auto border border-gray-200 bg-white md:mr-2 md:mb-2 md:rounded-md md:px-10 dark:border-zinc-800">
+								<TrialExpiryBanner />
+								<main className="custom-scrollbar content-container-inner relative mx-auto flex h-full min-h-0 flex-col overflow-y-hidden md:p-4">
+									{isLoading ? (
+										<FullPageLoader />
+									) : (
+										<FullPage config={bifrostConfig} hasError={!!error} isRetrying={isFetching} onRetry={refetch}>
+											{children}
+										</FullPage>
+									)}
+								</main>
+								{bifrostConfig?.is_db_connected && <OnboardingWidget />}
 							</div>
 						</div>
-						<TrialExpiryBanner />
-						<main className="custom-scrollbar content-container-inner relative mx-auto flex h-[calc(100%-3rem)] min-h-0 flex-col overflow-y-hidden md:h-full md:p-4">
-							{isLoading ? (
-								<FullPageLoader />
-							) : (
-								<FullPage config={bifrostConfig} hasError={!!error} isRetrying={isFetching} onRetry={refetch}>
-									{children}
-								</FullPage>
-							)}
-						</main>
-						{bifrostConfig?.is_db_connected && <OnboardingWidget />}
-					</div>
-				</SidebarProvider>
+					</SidebarProvider>
+				</TopbarProvider>
 			</CookiesProvider>
 		</WebSocketProvider>
 	);

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -96,7 +96,20 @@
 	--radius-md: calc(var(--radius) - 2px);
 	--radius-lg: var(--radius);
 	--radius-xl: calc(var(--radius) + 4px);
-	--height-base: calc(100vh - 130px);
+	/* Height of the app topbar, and the viewport height left underneath it for
+	   page content. Anything rendered inside the content card must size against
+	   --app-content-viewport rather than 100dvh, or it overflows the card by
+	   exactly the topbar's height and gives the whole shell a second scrollbar.
+	   Full-viewport surfaces that sit outside the card — dialogs, portalled
+	   popovers, the sidebar, the auth-only MinimalShell — keep using 100dvh. */
+	--app-topbar-height: 3.25rem;
+	/* Pages size themselves as `calc(var(--app-content-viewport) - 1rem)` — a
+	   leftover from when the card carried my-2. It now has only mb-2, so add
+	   that 0.5rem back here to keep their subtraction landing exactly on the
+	   card's inner height. */
+	--app-content-viewport: calc(100dvh - var(--app-topbar-height) + 0.5rem);
+
+	--height-base: calc(var(--app-content-viewport) - 130px);
 
 	/* Font size overrides - format: [size, { line-height: value }] */
 	--text-xs: 0.75rem;

--- a/ui/app/workspace/audit-logs/page.tsx
+++ b/ui/app/workspace/audit-logs/page.tsx
@@ -2,7 +2,7 @@ import AuditLogsView from "@enterprise/components/audit-logs/auditLogsView";
 
 export default function AuditLogsPage() {
 	return (
-		<div className="no-padding-parent no-border-parent bg-background flex h-[calc(100vh-16px)] w-full">
+		<div className="no-padding-parent no-border-parent bg-background flex h-[calc(var(--app-content-viewport)_-_16px)] w-full">
 			<AuditLogsView />
 		</div>
 	);

--- a/ui/app/workspace/cluster/page.tsx
+++ b/ui/app/workspace/cluster/page.tsx
@@ -2,7 +2,7 @@ import ClusterView from "@enterprise/components/cluster/clusterView";
 
 export default function ClusterPage() {
 	return (
-		<div className="mx-auto h-[calc(100dvh-50px)] w-full max-w-7xl p-4 md:p-0">
+		<div className="mx-auto h-[calc(var(--app-content-viewport)_-_50px)] w-full max-w-7xl p-4 md:p-0">
 			<ClusterView />
 		</div>
 	);

--- a/ui/app/workspace/complexity-router/page.tsx
+++ b/ui/app/workspace/complexity-router/page.tsx
@@ -1,3 +1,4 @@
+import PageTitle from "@/components/pageTitle";
 import FullPageLoader from "@/components/fullPageLoader";
 import {
 	AlertDialog,
@@ -335,7 +336,7 @@ export default function ComplexityRouterPage() {
 	const hasErrors = Boolean(boundaryErrors || keywordErrors);
 
 	return (
-		<div className="no-padding-parent flex h-[calc(100dvh_-_16px)] min-w-0 flex-col">
+		<div className="no-padding-parent flex h-[calc(var(--app-content-viewport)_-_16px)] min-w-0 flex-col">
 			<ScrollArea className="min-h-0 w-full flex-1">
 				<form
 					id="complexity-router-form"
@@ -344,15 +345,12 @@ export default function ComplexityRouterPage() {
 					noValidate
 				>
 					{/* ── Page header ── */}
-					<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-						<div className="space-y-1.5">
-							<h1 className="text-2xl font-semibold tracking-tight">Complexity Router</h1>
-							<p className="text-muted-foreground max-w-2xl text-sm leading-relaxed">
-								Tune how incoming requests are classified into four tiers. Thresholds and keyword lists feed the{" "}
-								<code className="bg-muted rounded-sm px-1 py-0.5 font-mono text-xs">complexity_tier</code> field that routing rules can
-								target.
-							</p>
-						</div>
+					<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-end">
+						<PageTitle>
+							Tune how incoming requests are classified into four tiers. Thresholds and keyword lists feed the{" "}
+							<code className="bg-muted rounded-sm px-1 py-0.5 font-mono text-xs">complexity_tier</code> field that routing rules can
+							target.
+						</PageTitle>
 						<Button asChild variant="outline" size="sm" className="w-full shrink-0 sm:w-fit" data-testid="complexity-router-docs-link">
 							<a href={"https://docs.getbifrost.ai/features/governance/complexity-router"} target="_blank" rel="noopener noreferrer">
 								<ExternalLink className="size-3.5" />

--- a/ui/app/workspace/config/views/cachingView.tsx
+++ b/ui/app/workspace/config/views/cachingView.tsx
@@ -1,3 +1,4 @@
+import PageTitle from "@/components/pageTitle";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -264,18 +265,15 @@ export default function CachingView() {
 
 	return (
 		<div className="mx-auto w-full max-w-4xl space-y-6">
-			<div>
-				<h2 className="text-lg font-semibold tracking-tight">Local Cache</h2>
-				<p className="text-muted-foreground text-sm">
-					Cache responses locally with two complementary lookup paths: <b>direct</b> hash matching for exact replays, and <b>semantic</b>{" "}
-					similarity search for related content. Send the <b>x-bf-cache-key</b> header to scope cached responses to a tenant or feature.{" "}
-					{!isVectorStoreEnabled && (
-						<span className="text-destructive font-medium">
-							Requires a vector store to be configured and enabled in <code>config.json</code>.
-						</span>
-					)}
-				</p>
-			</div>
+			<PageTitle title="Local Cache">
+				Cache responses locally with two complementary lookup paths: <b>direct</b> hash matching for exact replays, and <b>semantic</b>{" "}
+				similarity search for related content. Send the <b>x-bf-cache-key</b> header to scope cached responses to a tenant or feature.{" "}
+				{!isVectorStoreEnabled && (
+					<span className="text-destructive font-medium">
+						Requires a vector store to be configured and enabled in <code>config.json</code>.
+					</span>
+				)}
+			</PageTitle>
 
 			{configError !== undefined && (
 				<div className="border-destructive/50 bg-destructive/10 rounded-sm border p-4">
@@ -328,7 +326,7 @@ export default function CachingView() {
 								<div className="space-y-2">
 									<Label className="text-sm font-medium">Cache Mode</Label>
 									<Tabs value={mode} onValueChange={(v) => setMode(v as CacheMode)}>
-										<TabsList className="flex w-full justify-start overflow-x-auto">
+										<TabsList className="flex w-full justify-start">
 											<TabsTrigger value="direct" data-testid="caching-mode-direct-tab">
 												Direct only
 											</TabsTrigger>

--- a/ui/app/workspace/config/views/clientSettingsView.tsx
+++ b/ui/app/workspace/config/views/clientSettingsView.tsx
@@ -1,3 +1,4 @@
+import PageTitle from "@/components/pageTitle";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -287,10 +288,7 @@ export default function ClientSettingsView() {
 
 	return (
 		<div className="mx-auto w-full max-w-4xl space-y-6">
-			<div>
-				<h2 className="text-lg font-semibold tracking-tight">Client Settings</h2>
-				<p className="text-muted-foreground text-sm">Configure client behavior and request handling.</p>
-			</div>
+			<PageTitle title="Client Settings">Configure client behavior and request handling.</PageTitle>
 
 			<div className="space-y-4">
 				{/* Drop Excess Requests */}

--- a/ui/app/workspace/config/views/compatibilityView.tsx
+++ b/ui/app/workspace/config/views/compatibilityView.tsx
@@ -1,3 +1,4 @@
+import PageTitle from "@/components/pageTitle";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { getErrorMessage, useGetCoreConfigQuery, useUpdateCoreConfigMutation } from "@/lib/store";
@@ -57,21 +58,18 @@ export default function CompatibilityView() {
 
 	return (
 		<div className="mx-auto w-full max-w-4xl space-y-6">
-			<div>
-				<h2 className="text-lg font-semibold tracking-tight">Compatibility</h2>
-				<p className="text-muted-foreground text-sm">
-					Configure request conversions and compatibility fallbacks.{" "}
-					<a
-						className="text-primary underline"
-						href="https://docs.getbifrost.ai/features/compat-plugin"
-						target="_blank"
-						rel="noopener noreferrer"
-						data-testid="litellm-docs-link"
-					>
-						Learn more
-					</a>
-				</p>
-			</div>
+			<PageTitle title="Compatibility">
+				Configure request conversions and compatibility fallbacks.{" "}
+				<a
+					className="text-primary underline"
+					href="https://docs.getbifrost.ai/features/compat-plugin"
+					target="_blank"
+					rel="noopener noreferrer"
+					data-testid="litellm-docs-link"
+				>
+					Learn more
+				</a>
+			</PageTitle>
 
 			<div className="space-y-4">
 				<div className="flex items-center justify-between space-x-2">

--- a/ui/app/workspace/config/views/featureFlagsView.tsx
+++ b/ui/app/workspace/config/views/featureFlagsView.tsx
@@ -1,3 +1,4 @@
+import PageTitle from "@/components/pageTitle";
 import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
@@ -27,13 +28,10 @@ export default function FeatureFlagsView() {
 
 	return (
 		<div className="w-full space-y-4">
-			<div>
-				<h2 className="text-lg font-semibold tracking-tight">Feature Flags</h2>
-				<p className="text-muted-foreground text-sm">
-					Toggle in-process feature flags. Flags are declared in code; values can also be set via{" "}
-					<code className="text-xs">config.json</code> or Helm, in which case they appear here as locked.
-				</p>
-			</div>
+			<PageTitle title="Feature Flags">
+				Toggle in-process feature flags. Flags are declared in code; values can also be set via <code className="text-xs">config.json</code>{" "}
+				or Helm, in which case they appear here as locked.
+			</PageTitle>
 
 			{isLoading && <p className="text-muted-foreground text-sm">Loading feature flags...</p>}
 			{isError && <p className="text-sm text-red-500">Failed to load feature flags: {getErrorMessage(error)}</p>}

--- a/ui/app/workspace/config/views/loggingView.tsx
+++ b/ui/app/workspace/config/views/loggingView.tsx
@@ -1,3 +1,4 @@
+import PageTitle from "@/components/pageTitle";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -76,10 +77,7 @@ export default function LoggingView() {
 
 	return (
 		<div className="mx-auto w-full max-w-4xl space-y-4 px-4 py-6 md:px-0">
-			<div>
-				<h2 className="text-lg font-semibold tracking-tight">Logs Settings</h2>
-				<p className="text-muted-foreground text-sm">Configure logging settings for requests and responses.</p>
-			</div>
+			<PageTitle title="Logs Settings">Configure logging settings for requests and responses.</PageTitle>
 
 			<div className="space-y-4">
 				{/* Enable Logs */}

--- a/ui/app/workspace/config/views/mcpView.tsx
+++ b/ui/app/workspace/config/views/mcpView.tsx
@@ -1,3 +1,4 @@
+import PageTitle from "@/components/pageTitle";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -256,10 +257,7 @@ export default function MCPView() {
 
 	return (
 		<div className="mx-auto w-full max-w-4xl space-y-4 px-4 py-6 md:px-0" data-testid="mcp-settings-view">
-			<div>
-				<h2 className="text-lg font-semibold tracking-tight">MCP Settings</h2>
-				<p className="text-muted-foreground text-sm">Configure MCP (Model Context Protocol) agent and tool settings.</p>
-			</div>
+			<PageTitle title="MCP Settings">Configure MCP (Model Context Protocol) agent and tool settings.</PageTitle>
 			<div className="space-y-4">
 				{/* Max Agent Depth */}
 				<div className="flex items-center justify-between space-x-2 rounded-sm border p-4">

--- a/ui/app/workspace/config/views/modelSettingsView.tsx
+++ b/ui/app/workspace/config/views/modelSettingsView.tsx
@@ -1,3 +1,4 @@
+import PageTitle from "@/components/pageTitle";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -132,10 +133,7 @@ export default function ModelSettingsView() {
 	return (
 		<div className="mx-auto w-full max-w-7xl space-y-4" data-testid="model-settings-view">
 			<form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-				<div>
-					<h2 className="text-lg font-semibold tracking-tight">Model Settings</h2>
-					<p className="text-muted-foreground text-sm">Configure pricing and routing behaviour.</p>
-				</div>
+				<PageTitle title="Model Settings">Configure pricing and routing behaviour.</PageTitle>
 
 				<div className="space-y-4">
 					{/* Pricing Datasheet URL */}

--- a/ui/app/workspace/config/views/performanceTuningView.tsx
+++ b/ui/app/workspace/config/views/performanceTuningView.tsx
@@ -1,3 +1,4 @@
+import PageTitle from "@/components/pageTitle";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -87,10 +88,7 @@ export default function PerformanceTuningView() {
 
 	return (
 		<div className="mx-auto w-full max-w-4xl space-y-4">
-			<div>
-				<h2 className="text-lg font-semibold tracking-tight">Performance Tuning</h2>
-				<p className="text-muted-foreground text-sm">Configure performance-related settings.</p>
-			</div>
+			<PageTitle title="Performance Tuning">Configure performance-related settings.</PageTitle>
 
 			<Alert variant="destructive">
 				<AlertTriangle className="h-4 w-4" />

--- a/ui/app/workspace/config/views/pricingConfigView.tsx
+++ b/ui/app/workspace/config/views/pricingConfigView.tsx
@@ -1,3 +1,4 @@
+import PageTitle from "@/components/pageTitle";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -89,10 +90,7 @@ export default function PricingConfigView() {
 	return (
 		<div className="mx-auto w-full max-w-7xl space-y-4" data-testid="pricing-config-view">
 			<form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-				<div>
-					<h2 className="text-lg font-semibold tracking-tight">Pricing Configuration</h2>
-					<p className="text-muted-foreground text-sm">Configure custom pricing datasheet and sync intervals.</p>
-				</div>
+				<PageTitle title="Pricing Configuration">Configure custom pricing datasheet and sync intervals.</PageTitle>
 
 				<div className="space-y-4">
 					{/* Pricing Datasheet URL */}

--- a/ui/app/workspace/config/views/proxyView.tsx
+++ b/ui/app/workspace/config/views/proxyView.tsx
@@ -1,3 +1,4 @@
+import PageTitle from "@/components/pageTitle";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -59,10 +60,7 @@ export default function ProxyView() {
 		<div className="mx-auto w-full max-w-4xl space-y-4">
 			<Form {...form}>
 				<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-					<div>
-						<h2 className="text-lg font-semibold tracking-tight">Proxy Settings</h2>
-						<p className="text-muted-foreground text-sm">Configure global proxy settings for outbound requests.</p>
-					</div>
+					<PageTitle title="Proxy Settings">Configure global proxy settings for outbound requests.</PageTitle>
 
 					<fieldset disabled={!hasSettingsUpdateAccess} className="space-y-4">
 						{/* Enable Proxy */}

--- a/ui/app/workspace/config/views/securityView.tsx
+++ b/ui/app/workspace/config/views/securityView.tsx
@@ -1,3 +1,4 @@
+import PageTitle from "@/components/pageTitle";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -230,10 +231,7 @@ export default function SecurityView() {
 
 	return (
 		<div className="mx-auto w-full max-w-4xl space-y-4">
-			<div>
-				<h2 className="text-lg font-semibold tracking-tight">Security Settings</h2>
-				<p className="text-muted-foreground text-sm">Configure security and access control settings.</p>
-			</div>
+			<PageTitle title="Security Settings">Configure security and access control settings.</PageTitle>
 
 			<div className="space-y-4">
 				{/* Password Protect the Dashboard */}

--- a/ui/app/workspace/custom-pricing/overrides/page.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/page.tsx
@@ -2,7 +2,7 @@ import ScopedPricingOverridesView from "@/app/workspace/custom-pricing/overrides
 
 export default function ScopedPricingOverridesPage() {
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] min-h-0 w-full flex-col overflow-hidden p-4">
+		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_1rem)] min-h-0 w-full flex-col overflow-hidden p-4">
 			<ScopedPricingOverridesView />
 		</div>
 	);

--- a/ui/app/workspace/custom-pricing/overrides/scopedPricingOverridesView.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/scopedPricingOverridesView.tsx
@@ -1,3 +1,4 @@
+import PageTitle from "@/components/pageTitle";
 import { VirtualKeySelector } from "@/components/entitySelectors/virtualKeySelector";
 import FullPageLoader from "@/components/fullPageLoader";
 import {
@@ -296,16 +297,31 @@ export default function ScopedPricingOverridesView() {
 
 	const hasActiveFilters = debouncedSearch || scopeKind !== "all" || userID || virtualKeyID || providerID || providerKeyID;
 
+	// Rendered on every branch below, not just the populated one: PageTitle draws
+	// nothing inline, and without it the topbar drops to the route-derived
+	// fallback, which for this route reads "Overrides".
+	const pageTitle = (
+		<PageTitle title="Pricing Overrides">
+			Set custom rates for any model across global, virtual key, or user scopes, optionally narrowed to a specific provider or key
+		</PageTitle>
+	);
+
 	// Without this the table chrome paints first, then swaps to the full-page empty
 	// state once the first response resolves to zero rows. Hold a plain loader until
 	// then; later filter/page fetches keep the table so the chrome doesn't jump.
 	if (isLoading && !hasLoadedOnceRef.current) {
-		return <FullPageLoader />;
+		return (
+			<>
+				{pageTitle}
+				<FullPageLoader />
+			</>
+		);
 	}
 
 	if (!isLoading && !error && totalCount === 0 && !hasActiveFilters) {
 		return (
 			<>
+				{pageTitle}
 				<PricingOverridesEmptyState onCreateClick={openCreateDrawer} />
 				<PricingOverrideSheet
 					open={isDrawerOpen}
@@ -319,21 +335,9 @@ export default function ScopedPricingOverridesView() {
 
 	return (
 		<div className="flex flex-col overflow-y-auto">
-			<div className="mb-4 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
-				<div>
-					<h2 className="text-lg font-semibold tracking-tight">Pricing Overrides</h2>
-					<p className="text-muted-foreground text-sm">
-						Set custom rates for any model across global, virtual key, or user scopes, optionally narrowed to a specific provider or key
-					</p>
-				</div>
-				<Button data-testid="pricing-override-create-btn" onClick={openCreateDrawer} className="gap-2">
-					<Plus className="h-4 w-4" />
-					<span className="hidden sm:inline">New Override</span>
-				</Button>
-			</div>
-
-			{/* Search and filters */}
+			{/* Search, filters and actions */}
 			<div className="mb-4 flex flex-wrap items-center gap-2">
+				{pageTitle}
 				<div className="relative w-full max-w-sm">
 					<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
 					<Input
@@ -368,6 +372,18 @@ export default function ScopedPricingOverridesView() {
 						Clear
 					</Button>
 				)}
+
+				{/* The label is hidden below sm, leaving an icon with no accessible
+				    name, so the name is carried on the button itself. */}
+				<Button
+					data-testid="pricing-override-create-btn"
+					onClick={openCreateDrawer}
+					className="gap-2 sm:ml-auto"
+					aria-label="New pricing override"
+				>
+					<Plus className="h-4 w-4" />
+					<span className="hidden sm:inline">New Override</span>
+				</Button>
 			</div>
 
 			<div className="mb-2 overflow-hidden rounded-sm border">

--- a/ui/app/workspace/dashboard/components/charts/chartCard.tsx
+++ b/ui/app/workspace/dashboard/components/charts/chartCard.tsx
@@ -12,6 +12,12 @@ interface ChartCardProps {
 	loading?: boolean;
 	testId?: string;
 	className?: string;
+	// Let the card grow to its content instead of the fixed chart height. Needed
+	// by cards that render a ranked legend under the plot. This has to be a prop
+	// rather than an `h-full` in `className`: cn() merges per variant, so a
+	// caller class only cancels the unprefixed height and leaves `sm:h-[330px]`
+	// in place, which clips the legend at the sm breakpoint and up.
+	autoHeight?: boolean;
 	total?: ReactNode;
 	totalLabel?: string;
 	totalTooltip?: ReactNode;
@@ -132,10 +138,16 @@ export function ChartCard({
 	secondaryTotal,
 	secondaryTotalLabel,
 	secondaryTotalTooltip,
+	autoHeight,
 }: ChartCardProps) {
+	const heightClass = autoHeight ? "h-auto" : "h-[260px] sm:h-[330px]";
+	// An auto-height card has no height for the skeleton's `h-full` to resolve
+	// against, so the loading state keeps the fixed height as a floor.
+	const loadingHeightClass = autoHeight ? "h-auto min-h-[260px] sm:min-h-[330px]" : heightClass;
+
 	if (loading) {
 		return (
-			<Card className={cn("min-w-0 rounded-sm p-2 shadow-none h-[260px] sm:h-[330px]", className)} data-testid={testId}>
+			<Card className={cn("min-w-0 rounded-sm p-2 shadow-none", loadingHeightClass, className)} data-testid={testId}>
 				<Header
 					title={title}
 					controls={controls}
@@ -156,7 +168,7 @@ export function ChartCard({
 	}
 
 	return (
-		<Card className={cn("min-w-0 rounded-sm p-2 shadow-none h-[260px] sm:h-[330px]", className)} data-testid={testId}>
+		<Card className={cn("min-w-0 rounded-sm p-2 shadow-none", heightClass, className)} data-testid={testId}>
 			<Header
 				title={title}
 				controls={controls}

--- a/ui/app/workspace/dashboard/components/dimensionRankingsTab.tsx
+++ b/ui/app/workspace/dashboard/components/dimensionRankingsTab.tsx
@@ -80,7 +80,8 @@ function TopDimensionChart({
 			title={`Top ${dimensionLabel}s`}
 			loading={loading}
 			testId={`${testIdPrefix}-top-chart`}
-			className="z-[1] h-full"
+			className="z-[1]"
+			autoHeight
 			totalLabel={attributed && actualTotal === null ? "Total Requests (attributed)" : "Total Requests"}
 			total={
 				actualTotal !== null ? (

--- a/ui/app/workspace/dashboard/components/exportPopover.tsx
+++ b/ui/app/workspace/dashboard/components/exportPopover.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -84,12 +85,34 @@ export function ExportPopover({ getData, activeTab, onPreloadData, onPdfExport, 
 
 	return (
 		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
-				<Button variant="outline" size="default" disabled={exporting} data-testid="dashboard-export-trigger">
-					{exporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
-					{exporting ? "Exporting..." : "Export"}
-				</Button>
-			</DropdownMenuTrigger>
+			<Tooltip>
+				{/* The span carries the tooltip, not the Button: a disabled button
+				    emits no pointer or focus events, so anchoring the trigger on it
+				    would hide the "Exporting..." tooltip exactly while it is the one
+				    worth reading. DropdownMenuTrigger stays on the Button so the
+				    disabled state still blocks a second export. */}
+				<TooltipTrigger asChild>
+					<span tabIndex={0} className="inline-flex">
+						<DropdownMenuTrigger asChild>
+							{/* Icon-only: the label would crowd the tab strip it now shares a
+						    row with. State still reads from the spinner + tooltip. */}
+							{/* size="icon" is size-9; the date range trigger next to it uses the
+						    default h-7.5, so pin the square to that height instead. */}
+							<Button
+								variant="outline"
+								size="icon"
+								className="size-7.5"
+								disabled={exporting}
+								data-testid="dashboard-export-trigger"
+								aria-label={exporting ? "Exporting..." : "Export"}
+							>
+								{exporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
+							</Button>
+						</DropdownMenuTrigger>
+					</span>
+				</TooltipTrigger>
+				<TooltipContent side="bottom">{exporting ? "Exporting..." : "Export"}</TooltipContent>
+			</Tooltip>
 			<DropdownMenuContent align="end">
 				<DropdownMenuSub>
 					<DropdownMenuSubTrigger data-testid="export-csv-item" className="flex gap-2">

--- a/ui/app/workspace/dashboard/components/modelRankingsTab.tsx
+++ b/ui/app/workspace/dashboard/components/modelRankingsTab.tsx
@@ -156,7 +156,8 @@ function TopModelsChart({
 			title="Top Models"
 			loading={loadingModels}
 			testId="dashboard-rankings-top-models"
-			className="z-[1] h-full"
+			className="z-[1]"
+			autoHeight
 			totalLabel="Total"
 			total={grandTotal !== null ? <NumberFlow value={grandTotal} format={COMPACT_NUMBER_FORMAT} /> : undefined}
 			totalTooltip={grandTotal !== null ? grandTotal.toLocaleString("en-US") : undefined}

--- a/ui/app/workspace/dashboard/page.tsx
+++ b/ui/app/workspace/dashboard/page.tsx
@@ -467,110 +467,113 @@ export default function DashboardPage() {
 	const activeTab = (urlState.tab || "overview") as DashboardTab;
 
 	return (
-		<div id="dashboard-root" className="no-padding-parent no-border-parent bg-background flex h-[calc(100vh_-_16px)] w-full gap-3">
+		<div
+			id="dashboard-root"
+			className="no-padding-parent no-border-parent bg-background flex h-[calc(var(--app-content-viewport)_-_16px)] w-full gap-3"
+		>
 			{/* Sidebar Filters */}
 			<LogsFilterSidebar filters={filters} onFiltersChange={setFilters} />
 
 			{/* Main Content */}
 			<ScrollArea className="bg-card flex min-w-0 flex-1 flex-col gap-4 rounded-l-md" viewportClassName="no-table">
-				{/* Header */}
-				<div className="flex flex-wrap items-center justify-between gap-2 p-4">
-					<div className="flex w-full flex-wrap items-center gap-2 sm:w-auto">
-						<h1 className="text-lg font-semibold">Dashboard</h1>
-					</div>
-					<div className="flex items-center gap-2">
-						<ExportPopover
-							getData={getDashboardData}
-							activeTab={activeTab}
-							onPreloadData={handlePreloadData}
-							onPdfExport={handlePdfExport}
-							onExportDone={handleExportDone}
-						/>
-						{activeTab === "mcp" && mcpFilterData && (
-							<div className="flex w-full flex-wrap items-center gap-1 sm:w-auto">
-								{(mcpFilterData.tool_names?.length ?? 0) > 0 && (
-									<ModelFilterSelect
-										models={mcpFilterData.tool_names ?? []}
-										selectedModel={selectedMcpToolNames.length === 1 ? selectedMcpToolNames[0] : "all"}
-										onModelChange={(value) => {
-											if (value === "all") {
-												setUrlState({ mcp_tool_names: "" });
-											} else {
-												setUrlState({ mcp_tool_names: value });
-											}
-										}}
-										placeholder="All Tools"
-										data-testid="dashboard-mcp-tool-filter"
-									/>
-								)}
-								{(mcpFilterData.server_labels?.length ?? 0) > 0 && (
-									<ModelFilterSelect
-										models={mcpFilterData.server_labels ?? []}
-										selectedModel={selectedMcpServerLabels.length === 1 ? selectedMcpServerLabels[0] : "all"}
-										onModelChange={(value) => {
-											if (value === "all") {
-												setUrlState({ mcp_server_labels: "" });
-											} else {
-												setUrlState({ mcp_server_labels: value });
-											}
-										}}
-										placeholder="All Servers"
-										data-testid="dashboard-mcp-server-filter"
-									/>
-								)}
-							</div>
-						)}
-						<DateTimePickerWithRange
-							dateTime={dateRange}
-							onDateTimeUpdate={handleDateRangeChange}
-							preDefinedPeriods={TIME_PERIODS}
-							predefinedPeriod={urlState.period || undefined}
-							onPredefinedPeriodChange={handlePeriodChange}
-							triggerTestId="dashboard-filter-daterange"
-							popupAlignment="end"
-							showTimezone
-							timezone={timezone}
-							onTimezoneChange={setTimezone}
-						/>
-					</div>
-				</div>
-
 				<div className="p-4">
 					{/* Tabs */}
 					<Tabs value={activeTab} onValueChange={handleTabChange}>
-						<div className="mb-2 max-w-full overflow-x-auto">
-							<TabsList className="w-max min-w-max">
-								<TabsTrigger className="shrink-0" value="overview" data-testid="dashboard-tab-overview">
-									Overview
-								</TabsTrigger>
-								<TabsTrigger className="shrink-0" value="provider-usage" data-testid="dashboard-tab-provider-usage">
-									Provider Usage
-								</TabsTrigger>
-								<TabsTrigger className="shrink-0" value="rankings" data-testid="dashboard-tab-rankings">
-									Model Rankings
-								</TabsTrigger>
-								<TabsTrigger className="shrink-0" value="mcp" data-testid="dashboard-tab-mcp">
-									MCP usage
-								</TabsTrigger>
-								<TabsTrigger className="shrink-0" value="team-rankings" data-testid="dashboard-tab-team-rankings">
-									Team Rankings
-								</TabsTrigger>
-								<TabsTrigger className="shrink-0" value="user-rankings" data-testid="dashboard-tab-user-rankings">
-									User Rankings
-								</TabsTrigger>
-								<TabsTrigger className="shrink-0" value="virtual-key-rankings" data-testid="dashboard-tab-virtual-key-rankings">
-									Virtual Key Rankings
-								</TabsTrigger>
-								<TabsTrigger className="shrink-0" value="customer-rankings" data-testid="dashboard-tab-customer-rankings">
-									Customer Rankings
-								</TabsTrigger>
-								<TabsTrigger className="shrink-0" value="bu-rankings" data-testid="dashboard-tab-bu-rankings">
-									BU Rankings
-								</TabsTrigger>
-								<TabsTrigger value="app-rankings" data-testid="dashboard-tab-app-rankings">
-									App Rankings
-								</TabsTrigger>
-							</TabsList>
+						<div className="mb-2 flex flex-col gap-2 lg:flex-row lg:items-center">
+							{/* min-w-0 keeps the tab strip from pushing the filters off the row —
+							    there are eleven tabs. TabsList collapses whatever does not fit
+							    into its own dropdown, so no horizontal scrolling is needed. */}
+							<div className="max-w-full min-w-0 flex-1">
+								{/* Stays w-max: TabsTrigger is flex-1, so a full-width list would
+								    stretch every tab across the row. */}
+								<TabsList className="w-max min-w-max">
+									<TabsTrigger className="shrink-0" value="overview" data-testid="dashboard-tab-overview">
+										Overview
+									</TabsTrigger>
+									<TabsTrigger className="shrink-0" value="provider-usage" data-testid="dashboard-tab-provider-usage">
+										Provider Usage
+									</TabsTrigger>
+									<TabsTrigger className="shrink-0" value="rankings" data-testid="dashboard-tab-rankings">
+										Model Rankings
+									</TabsTrigger>
+									<TabsTrigger className="shrink-0" value="mcp" data-testid="dashboard-tab-mcp">
+										MCP usage
+									</TabsTrigger>
+									<TabsTrigger className="shrink-0" value="team-rankings" data-testid="dashboard-tab-team-rankings">
+										Team Rankings
+									</TabsTrigger>
+									<TabsTrigger className="shrink-0" value="user-rankings" data-testid="dashboard-tab-user-rankings">
+										User Rankings
+									</TabsTrigger>
+									<TabsTrigger className="shrink-0" value="virtual-key-rankings" data-testid="dashboard-tab-virtual-key-rankings">
+										Virtual Key Rankings
+									</TabsTrigger>
+									<TabsTrigger className="shrink-0" value="customer-rankings" data-testid="dashboard-tab-customer-rankings">
+										Customer Rankings
+									</TabsTrigger>
+									<TabsTrigger className="shrink-0" value="bu-rankings" data-testid="dashboard-tab-bu-rankings">
+										BU Rankings
+									</TabsTrigger>
+									<TabsTrigger value="app-rankings" data-testid="dashboard-tab-app-rankings">
+										App Rankings
+									</TabsTrigger>
+								</TabsList>
+							</div>
+							<div className="flex shrink-0 flex-wrap items-center gap-2 lg:ml-auto">
+								<ExportPopover
+									getData={getDashboardData}
+									activeTab={activeTab}
+									onPreloadData={handlePreloadData}
+									onPdfExport={handlePdfExport}
+									onExportDone={handleExportDone}
+								/>
+								{activeTab === "mcp" && mcpFilterData && (
+									<div className="flex w-full flex-wrap items-center gap-1 sm:w-auto">
+										{(mcpFilterData.tool_names?.length ?? 0) > 0 && (
+											<ModelFilterSelect
+												models={mcpFilterData.tool_names ?? []}
+												selectedModel={selectedMcpToolNames.length === 1 ? selectedMcpToolNames[0] : "all"}
+												onModelChange={(value) => {
+													if (value === "all") {
+														setUrlState({ mcp_tool_names: "" });
+													} else {
+														setUrlState({ mcp_tool_names: value });
+													}
+												}}
+												placeholder="All Tools"
+												data-testid="dashboard-mcp-tool-filter"
+											/>
+										)}
+										{(mcpFilterData.server_labels?.length ?? 0) > 0 && (
+											<ModelFilterSelect
+												models={mcpFilterData.server_labels ?? []}
+												selectedModel={selectedMcpServerLabels.length === 1 ? selectedMcpServerLabels[0] : "all"}
+												onModelChange={(value) => {
+													if (value === "all") {
+														setUrlState({ mcp_server_labels: "" });
+													} else {
+														setUrlState({ mcp_server_labels: value });
+													}
+												}}
+												placeholder="All Servers"
+												data-testid="dashboard-mcp-server-filter"
+											/>
+										)}
+									</div>
+								)}
+								<DateTimePickerWithRange
+									dateTime={dateRange}
+									onDateTimeUpdate={handleDateRangeChange}
+									preDefinedPeriods={TIME_PERIODS}
+									predefinedPeriod={urlState.period || undefined}
+									onPredefinedPeriodChange={handlePeriodChange}
+									triggerTestId="dashboard-filter-daterange"
+									popupAlignment="end"
+									showTimezone
+									timezone={timezone}
+									onTimezoneChange={setTimezone}
+								/>
+							</div>
 						</div>
 						{/* Overview Tab */}
 						<TabsContent value="overview" {...(exportingAll && { forceMount: true })}>

--- a/ui/app/workspace/edge-control/devices/page.tsx
+++ b/ui/app/workspace/edge-control/devices/page.tsx
@@ -2,7 +2,7 @@ import DevicesView from "@enterprise/components/edge-control/devicesView";
 
 export default function EdgeDevicesPage() {
 	return (
-		<div data-testid="edge-devices-page" className="dark:bg-card no-padding-parent no-border-parent h-[calc(100vh_-_16px)]">
+		<div data-testid="edge-devices-page" className="dark:bg-card no-padding-parent no-border-parent h-[calc(var(--app-content-viewport)_-_16px)]">
 			<DevicesView />
 		</div>
 	);

--- a/ui/app/workspace/edge-control/inventory/page.tsx
+++ b/ui/app/workspace/edge-control/inventory/page.tsx
@@ -2,7 +2,7 @@ import InventoryView from "@enterprise/components/edge-control/inventoryView";
 
 export default function EdgeInventoryPage() {
 	return (
-		<div data-testid="edge-inventory-page" className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] w-full max-w-7xl p-4">
+		<div data-testid="edge-inventory-page" className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_1rem)] w-full max-w-7xl p-4">
 			<InventoryView />
 		</div>
 	);

--- a/ui/app/workspace/governance/access-profiles/page.tsx
+++ b/ui/app/workspace/governance/access-profiles/page.tsx
@@ -10,7 +10,7 @@ export default function AccessProfilesPage() {
 	}
 
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] w-full flex-col p-4">
+		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_1rem)] w-full flex-col p-4">
 			<AccessProfilesIndexView />
 		</div>
 	);

--- a/ui/app/workspace/governance/business-units/page.tsx
+++ b/ui/app/workspace/governance/business-units/page.tsx
@@ -2,7 +2,7 @@ import { BusinessUnitsView } from "@enterprise/components/user-groups/businessUn
 
 export default function GovernanceBusinessUnitsPage() {
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] w-full flex-col p-4">
+		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_1rem)] w-full flex-col p-4">
 			<BusinessUnitsView />
 		</div>
 	);

--- a/ui/app/workspace/governance/customers/page.tsx
+++ b/ui/app/workspace/governance/customers/page.tsx
@@ -79,7 +79,7 @@ export default function GovernanceCustomersPage() {
 	}
 
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] w-full flex-col p-4">
+		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_1rem)] w-full flex-col p-4">
 			<CustomersTable
 				customers={customersData?.customers || []}
 				totalCount={customersData?.total_count || 0}

--- a/ui/app/workspace/governance/rbac/page.tsx
+++ b/ui/app/workspace/governance/rbac/page.tsx
@@ -2,7 +2,7 @@ import RBACView from "@enterprise/components/rbac/rbacView";
 
 export default function GovernanceRbacPage() {
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] w-full flex-col p-4">
+		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_1rem)] w-full flex-col p-4">
 			<RBACView />
 		</div>
 	);

--- a/ui/app/workspace/governance/teams/page.tsx
+++ b/ui/app/workspace/governance/teams/page.tsx
@@ -2,7 +2,7 @@ import { TeamsView } from "@enterprise/components/user-groups/teamsView";
 
 export default function GovernanceTeamsPage() {
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] w-full flex-col p-4" data-testid="teams-view">
+		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_1rem)] w-full flex-col p-4" data-testid="teams-view">
 			<TeamsView />
 		</div>
 	);

--- a/ui/app/workspace/governance/users/page.tsx
+++ b/ui/app/workspace/governance/users/page.tsx
@@ -2,7 +2,7 @@ import UsersView from "@enterprise/components/user-groups/usersView";
 
 export default function GovernanceUsersPage() {
 	return (
-		<div className="no-padding-parent mx-auto h-[calc(100dvh-1rem)] w-full p-4">
+		<div className="no-padding-parent mx-auto h-[calc(var(--app-content-viewport)_-_1rem)] w-full p-4">
 			<UsersView />
 		</div>
 	);

--- a/ui/app/workspace/governance/views/customerTable.tsx
+++ b/ui/app/workspace/governance/views/customerTable.tsx
@@ -1,3 +1,4 @@
+import PageTitle from "@/components/pageTitle";
 import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
 import {
 	AlertDialog,
@@ -181,10 +182,16 @@ export default function CustomersTable({
 
 	const hasActiveFilters = debouncedSearch;
 
+	// Rendered on the empty branch too, not just the populated one: PageTitle
+	// draws nothing inline, and leaving it out drops the topbar to the
+	// route-derived fallback.
+	const pageTitle = <PageTitle title="Customers">Manage customer accounts with their own teams, budgets, and access controls.</PageTitle>;
+
 	// True empty state: no customers at all (not just filtered to zero)
 	if (totalCount === 0 && !hasActiveFilters && !isFetching) {
 		return (
 			<>
+				{pageTitle}
 				<TooltipProvider>
 					<CustomerSheet
 						open={showCustomerSheet}
@@ -223,18 +230,8 @@ export default function CustomersTable({
 				/>
 
 				<div className="flex grow flex-col">
-					<div className="mb-4 flex flex-wrap items-center justify-between gap-2">
-						<div>
-							<h2 className="text-lg font-semibold">Customers</h2>
-							<p className="text-muted-foreground text-sm">Manage customer accounts with their own teams, budgets, and access controls.</p>
-						</div>
-						<Button data-testid="customer-button-create" onClick={handleAddCustomer} disabled={!hasCreateAccess}>
-							<Plus className="h-4 w-4" />
-							Add Customer
-						</Button>
-					</div>
-
-					<div className="mb-4 flex items-center gap-3">
+					<div className="mb-4 flex flex-wrap items-center gap-3">
+						{pageTitle}
 						<div className="relative max-w-sm flex-1">
 							<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
 							<Input
@@ -246,6 +243,10 @@ export default function CustomersTable({
 								data-testid="customers-search-input"
 							/>
 						</div>
+						<Button className="ml-auto" data-testid="customer-button-create" onClick={handleAddCustomer} disabled={!hasCreateAccess}>
+							<Plus className="h-4 w-4" />
+							Add Customer
+						</Button>
 					</div>
 
 					<div className="mb-2 grow overflow-auto rounded-sm border" data-testid="customer-table-container">

--- a/ui/app/workspace/governance/views/teamsTable.tsx
+++ b/ui/app/workspace/governance/views/teamsTable.tsx
@@ -1,3 +1,4 @@
+import PageTitle from "@/components/pageTitle";
 import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
 import {
 	AlertDialog,
@@ -202,10 +203,16 @@ export default function TeamsTable({
 
 	const hasActiveFilters = debouncedSearch;
 
+	// Rendered on the empty branch too, not just the populated one: PageTitle
+	// draws nothing inline, and leaving it out drops the topbar to the
+	// route-derived fallback.
+	const pageTitle = <PageTitle title="Teams">Organize users into teams with shared budgets and access controls.</PageTitle>;
+
 	// True empty state: no teams at all (not just filtered to zero)
 	if (totalCount === 0 && !hasActiveFilters && !isLoading) {
 		return (
 			<>
+				{pageTitle}
 				<TooltipProvider>
 					{showTeamSheet && <TeamSheet team={editingTeam} onSave={handleTeamSaved} onCancel={onDialogClose} />}
 					<TeamsEmptyState onAddClick={handleAddTeam} canCreate={hasCreateAccess} />
@@ -220,18 +227,8 @@ export default function TeamsTable({
 				{showTeamSheet && <TeamSheet team={editingTeam} onSave={handleTeamSaved} onCancel={onDialogClose} />}
 
 				<div className="flex grow flex-col overflow-y-auto">
-					<div className="mb-4 flex flex-wrap items-center justify-between gap-2">
-						<div>
-							<h2 className="text-lg font-semibold">Teams</h2>
-							<p className="text-muted-foreground text-sm">Organize users into teams with shared budgets and access controls.</p>
-						</div>
-						<Button data-testid="create-team-btn" onClick={handleAddTeam} disabled={!hasCreateAccess}>
-							<Plus className="h-4 w-4" />
-							Add Team
-						</Button>
-					</div>
-
-					<div className="mb-4 flex items-center gap-3">
+					<div className="mb-4 flex flex-wrap items-center gap-3">
+						{pageTitle}
 						<div className="relative max-w-sm flex-1">
 							<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
 							<Input
@@ -243,6 +240,10 @@ export default function TeamsTable({
 								data-testid="teams-search-input"
 							/>
 						</div>
+						<Button className="ml-auto" data-testid="create-team-btn" onClick={handleAddTeam} disabled={!hasCreateAccess}>
+							<Plus className="h-4 w-4" />
+							Add Team
+						</Button>
 					</div>
 
 					<div className="mb-2 grow overflow-auto rounded-sm border" data-testid="teams-table">

--- a/ui/app/workspace/governance/virtual-keys/page.tsx
+++ b/ui/app/workspace/governance/virtual-keys/page.tsx
@@ -118,7 +118,7 @@ export default function GovernanceVirtualKeysPage() {
 	};
 
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] min-h-0 w-full flex-col overflow-hidden p-4">
+		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_1rem)] min-h-0 w-full flex-col overflow-hidden p-4">
 			<VirtualKeysTable
 				virtualKeys={virtualKeysData?.virtual_keys || []}
 				totalCount={virtualKeysData?.total_count || 0}

--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -733,7 +733,7 @@ export default function LogsPage() {
 	);
 
 	return (
-		<div className="dark:bg-card no-padding-parent no-border-parent h-[calc(100vh_-_16px)]">
+		<div className="dark:bg-card no-padding-parent no-border-parent h-[calc(var(--app-content-viewport)_-_16px)]">
 			{showEmptyState ? (
 				<EmptyState error={error ?? (logsError ? getErrorMessage(logsError as Parameters<typeof getErrorMessage>[0]) : null)} />
 			) : (

--- a/ui/app/workspace/logs/views/emptyState.tsx
+++ b/ui/app/workspace/logs/views/emptyState.tsx
@@ -259,7 +259,7 @@ const result = await chain.invoke({ input: "What is LangChain?" });`,
 				</div>
 
 				<Tabs defaultValue="curl" className="w-full rounded-lg border">
-					<TabsList className="flex h-10 w-full justify-start overflow-x-auto rounded-t-lg rounded-b-none">
+					<TabsList className="flex h-10 w-full justify-start rounded-t-lg rounded-b-none">
 						<TabsTrigger value="curl">cURL</TabsTrigger>
 						<TabsTrigger value="openai">OpenAI SDK</TabsTrigger>
 						<TabsTrigger value="anthropic">Anthropic SDK</TabsTrigger>

--- a/ui/app/workspace/mcp-logs/page.tsx
+++ b/ui/app/workspace/mcp-logs/page.tsx
@@ -437,7 +437,7 @@ export default function MCPLogsPage() {
 			) : showEmptyState ? (
 				<MCPEmptyState error={displayError} />
 			) : (
-				<div className="no-padding-parent no-border-parent bg-background flex h-[calc(100vh_-_16px)] w-full gap-3">
+				<div className="no-padding-parent no-border-parent bg-background flex h-[calc(var(--app-content-viewport)_-_16px)] w-full gap-3">
 					{/* Sidebar Filters */}
 					<MCPFilterSidebar filters={filters} onFiltersChange={setFilters} />
 

--- a/ui/app/workspace/mcp-logs/views/emptyState.tsx
+++ b/ui/app/workspace/mcp-logs/views/emptyState.tsx
@@ -264,7 +264,7 @@ if (response.choices[0].message.tool_calls) {
 				</div>
 
 				<Tabs defaultValue="manual" className="w-full rounded-lg border">
-					<TabsList className="flex h-10 w-full justify-start overflow-x-auto rounded-t-lg rounded-b-none">
+					<TabsList className="flex h-10 w-full justify-start rounded-t-lg rounded-b-none">
 						<TabsTrigger value="manual">Manual Tool Execution</TabsTrigger>
 						<TabsTrigger value="agent">Agent Mode (Auto-Execute)</TabsTrigger>
 					</TabsList>

--- a/ui/app/workspace/mcp-registry/library/page.tsx
+++ b/ui/app/workspace/mcp-registry/library/page.tsx
@@ -1,3 +1,4 @@
+import PageTitle from "@/components/pageTitle";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scrollArea";
@@ -154,7 +155,7 @@ export default function MCPLibraryPage() {
 	const isCatalogEmpty = !isFetching && totalCount === 0 && !debouncedSearch && !hasActiveFilters;
 
 	return (
-		<div className="dark:bg-card no-padding-parent no-border-parent min-h-full md:h-[calc(100dvh_-_16px)]">
+		<div className="dark:bg-card no-padding-parent no-border-parent min-h-full md:h-[calc(var(--app-content-viewport)_-_16px)]">
 			<div className="bg-background flex min-h-full w-full grow gap-3 md:h-full">
 				{/* Sidebar Filters */}
 				<MCPLibraryFilterSidebar filters={filters} onFiltersChange={setFilters} />
@@ -162,13 +163,62 @@ export default function MCPLibraryPage() {
 				{/* Main Content */}
 				<div className="bg-card min-h-full w-full rounded-l-md md:h-full">
 					<div className="flex min-h-full flex-col gap-4 p-4 pb-2 md:h-full">
-						{/* Header */}
-						<div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-							<div className="space-y-1">
-								<h2 className="text-lg font-semibold tracking-tight">MCP Server Library</h2>
-								<p className="text-muted-foreground max-w-2xl text-sm">Browse and install MCP servers from the synced catalog.</p>
-							</div>
-							<div className="flex items-center gap-2">
+						{/* Search + Actions */}
+						<div className="-mx-2 flex flex-col gap-3 px-2 py-2 sm:flex-row sm:items-center">
+							<PageTitle title="MCP Server Library">Browse and install MCP servers from the synced catalog.</PageTitle>
+							{!isCatalogEmpty && (
+								<>
+									<div className="relative max-w-md flex-1">
+										<Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+										<Input
+											value={urlState.search}
+											onChange={(e) => setUrlState({ search: e.target.value, offset: 0 })}
+											placeholder="Search servers..."
+											className="h-9 pl-9"
+											data-testid="mcp-library-search-input"
+										/>
+									</div>
+									<div className="border-border flex w-fit overflow-hidden rounded-sm border p-0.5" aria-label="Library view mode">
+										<Button
+											type="button"
+											variant="ghost"
+											size="sm"
+											className={cn(
+												"h-8 rounded-xs border border-transparent px-2.5 shadow-none",
+												viewMode === "table" &&
+													"border-primary bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground",
+											)}
+											onClick={() => handleViewModeChange("table")}
+											aria-pressed={viewMode === "table"}
+											// The "Table" label is hidden below sm, leaving a bare icon.
+											aria-label="Table view"
+											data-testid="mcp-library-table-view-toggle"
+										>
+											<List className="h-4 w-4" />
+											<span className="hidden sm:inline">Table</span>
+										</Button>
+										<Button
+											type="button"
+											variant="ghost"
+											size="sm"
+											className={cn(
+												"h-8 rounded-xs border border-transparent px-2.5 shadow-none",
+												viewMode === "grid" &&
+													"border-primary bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground",
+											)}
+											onClick={() => handleViewModeChange("grid")}
+											aria-pressed={viewMode === "grid"}
+											// The "Grid" label is hidden below sm, leaving a bare icon.
+											aria-label="Grid view"
+											data-testid="mcp-library-grid-view-toggle"
+										>
+											<LayoutGrid className="h-4 w-4" />
+											<span className="hidden sm:inline">Grid</span>
+										</Button>
+									</div>
+								</>
+							)}
+							<div className="flex items-center gap-2 sm:ml-auto">
 								{hasCreateMCPClientAccess && (
 									<Button variant="outline" size="sm" onClick={() => setAddServerOpen(true)} data-testid="mcp-library-add-server-btn">
 										<Plus className="h-4 w-4" />
@@ -184,55 +234,6 @@ export default function MCPLibraryPage() {
 							</div>
 						</div>
 
-						{/* Search */}
-						{!isCatalogEmpty && (
-							<div className="-mx-2 flex flex-col gap-3 px-2 py-2 sm:flex-row sm:items-center sm:justify-between">
-								<div className="relative max-w-md flex-1">
-									<Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
-									<Input
-										value={urlState.search}
-										onChange={(e) => setUrlState({ search: e.target.value, offset: 0 })}
-										placeholder="Search servers..."
-										className="h-9 pl-9"
-										data-testid="mcp-library-search-input"
-									/>
-								</div>
-								<div className="border-border flex w-fit overflow-hidden rounded-sm border p-0.5" aria-label="Library view mode">
-									<Button
-										type="button"
-										variant="ghost"
-										size="sm"
-										className={cn(
-											"h-8 rounded-xs border border-transparent px-2.5 shadow-none",
-											viewMode === "table" &&
-												"border-primary bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground",
-										)}
-										onClick={() => handleViewModeChange("table")}
-										aria-pressed={viewMode === "table"}
-										data-testid="mcp-library-table-view-toggle"
-									>
-										<List className="h-4 w-4" />
-										<span className="hidden sm:inline">Table</span>
-									</Button>
-									<Button
-										type="button"
-										variant="ghost"
-										size="sm"
-										className={cn(
-											"h-8 rounded-xs border border-transparent px-2.5 shadow-none",
-											viewMode === "grid" &&
-												"border-primary bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground",
-										)}
-										onClick={() => handleViewModeChange("grid")}
-										aria-pressed={viewMode === "grid"}
-										data-testid="mcp-library-grid-view-toggle"
-									>
-										<LayoutGrid className="h-4 w-4" />
-										<span className="hidden sm:inline">Grid</span>
-									</Button>
-								</div>
-							</div>
-						)}
 						<div className="flex flex-col md:min-h-0 md:grow md:overflow-hidden">
 							{/* Loading skeletons */}
 							{isFetching && servers.length === 0 ? (

--- a/ui/app/workspace/mcp-registry/page.tsx
+++ b/ui/app/workspace/mcp-registry/page.tsx
@@ -156,11 +156,11 @@ export default function MCPServersPage() {
 	// Onboarding empty state: no servers at all and no active filters/search.
 	// Render full-width without the filter sidebar (the table renders the CTA).
 	if (totalCount === 0 && !filtersActive && !debouncedSearch && !urlState.server) {
-		return <div className="mx-auto flex h-[calc(100dvh-50px)] w-full max-w-7xl flex-col">{table}</div>;
+		return <div className="mx-auto flex h-[calc(var(--app-content-viewport)_-_50px)] w-full max-w-7xl flex-col">{table}</div>;
 	}
 
 	return (
-		<div className="dark:bg-card no-padding-parent no-border-parent h-[calc(100dvh_-_16px)]">
+		<div className="dark:bg-card no-padding-parent no-border-parent h-[calc(var(--app-content-viewport)_-_16px)]">
 			<div className="bg-background flex h-full w-full grow gap-3">
 				<MCPClientsFilterSidebar filters={filters} onFiltersChange={setFilters} />
 				<div className="bg-card h-full w-full overflow-hidden rounded-l-md">

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -1,3 +1,4 @@
+import PageTitle from "@/components/pageTitle";
 import ClientForm from "@/app/workspace/mcp-registry/views/mcpClientForm";
 import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
 import {
@@ -563,10 +564,16 @@ export default function MCPClientsTable({
 
 	const hasActiveFilters = Boolean(debouncedSearch) || Boolean(server) || filtersActive;
 
+	// Rendered on the empty branch too, not just the populated one: PageTitle
+	// draws nothing inline, and leaving it out drops the topbar to the
+	// route-derived fallback, which for this route reads "MCP Registry".
+	const pageTitle = <PageTitle title="MCP Server Catalog">Manage servers that can connect to the MCP Tools endpoint.</PageTitle>;
+
 	// True empty state: no servers at all (not just filtered to zero)
 	if (totalCount === 0 && !hasActiveFilters) {
 		return (
 			<>
+				{pageTitle}
 				{formOpen && <ClientForm open={formOpen} onClose={() => setFormOpen(false)} onSaved={handleSaved} />}
 				<MCPServersEmptyState onAddClick={handleCreate} canCreate={hasCreateMCPClientAccess} />
 			</>
@@ -862,34 +869,10 @@ export default function MCPClientsTable({
 				</DialogContent>
 			</Dialog>
 
-			<div className="mb-4 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
-				<div>
-					<h2 className="text-lg font-semibold tracking-tight">MCP Server Catalog</h2>
-					<p className="text-muted-foreground text-sm">Manage servers that can connect to the MCP Tools endpoint.</p>
-				</div>
-				<div className="flex gap-2">
-					<MCPUsageGuideSheet />
-					<Button asChild variant="outline" data-testid="mcp-library-link-btn" className="h-8">
-						<Link to="/workspace/mcp-registry/library">
-							<Box />
-							<span className="hidden sm:inline">Library</span>
-						</Link>
-					</Button>
-					<Button
-						onClick={handleCreate}
-						disabled={!hasCreateMCPClientAccess}
-						data-testid="create-mcp-client-btn"
-						aria-label="New MCP Server"
-						className="h-8 gap-2"
-					>
-						<Plus />
-						<span className="hidden sm:inline">New MCP Server</span>
-					</Button>
-				</div>
-			</div>
+			{/* Toolbar: Search + Actions */}
+			<div className="mb-4 flex flex-wrap items-center gap-3">
+				{pageTitle}
 
-			{/* Toolbar: Search */}
-			<div className="mb-4 flex items-center gap-3">
 				<div className="relative max-w-sm flex-1">
 					<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
 					<Input
@@ -913,6 +896,27 @@ export default function MCPClientsTable({
 						<X className="size-3" />
 					</Button>
 				)}
+
+				<div className="flex gap-2 sm:ml-auto">
+					<MCPUsageGuideSheet />
+					<Button asChild variant="outline" data-testid="mcp-library-link-btn" className="h-8">
+						{/* The label is hidden below sm, leaving a bare icon. */}
+						<Link to="/workspace/mcp-registry/library" aria-label="MCP server library">
+							<Box />
+							<span className="hidden sm:inline">Library</span>
+						</Link>
+					</Button>
+					<Button
+						onClick={handleCreate}
+						disabled={!hasCreateMCPClientAccess}
+						data-testid="create-mcp-client-btn"
+						aria-label="New MCP Server"
+						className="h-8 gap-2"
+					>
+						<Plus />
+						<span className="hidden sm:inline">New MCP Server</span>
+					</Button>
+				</div>
 			</div>
 
 			<div className="flex grow flex-col overflow-hidden">

--- a/ui/app/workspace/mcp-registry/views/mcpUsageGuide/mcpUsageGuideSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpUsageGuide/mcpUsageGuideSheet.tsx
@@ -147,7 +147,9 @@ export function MCPUsageGuideSheet() {
 								<span>Harness</span>
 							</div>
 							<Tabs value={harness} onValueChange={(value) => setUrlState({ harness: value as HarnessID })}>
-								<TabsList className="no-scrollbar flex w-full flex-row justify-start overflow-x-auto rounded-sm">
+								{/* No overflow-x-auto: TabsList now collapses whatever does not fit
+								    into its own trailing dropdown, so the strip never clips. */}
+								<TabsList className="flex w-full flex-row justify-start rounded-sm">
 									{HARNESSES.map((h) => (
 										<TabsTrigger key={h.id} value={h.id} className="flex flex-none shrink-0 gap-2">
 											<div className="flex items-center gap-2">

--- a/ui/app/workspace/mcp-sessions/page.tsx
+++ b/ui/app/workspace/mcp-sessions/page.tsx
@@ -122,11 +122,11 @@ export default function MCPSessionsPage() {
 	// No sessions at all and no active filters/search: render full-width
 	// without the filter sidebar, mirroring the MCP clients onboarding state.
 	if (totalCount === 0 && !hasActiveFilters) {
-		return <div className="mx-auto flex h-[calc(100dvh-50px)] w-full max-w-7xl flex-col">{table}</div>;
+		return <div className="mx-auto flex h-[calc(var(--app-content-viewport)_-_50px)] w-full max-w-7xl flex-col">{table}</div>;
 	}
 
 	return (
-		<div className="dark:bg-card no-padding-parent no-border-parent h-[calc(100dvh_-_16px)]">
+		<div className="dark:bg-card no-padding-parent no-border-parent h-[calc(var(--app-content-viewport)_-_16px)]">
 			<div className="bg-background flex h-full w-full grow gap-3">
 				<MCPSessionsFilterSidebar filters={filters} onFiltersChange={setFilters} />
 				<div className="bg-card h-full w-full overflow-hidden rounded-l-md">

--- a/ui/app/workspace/mcp-sessions/views/sessionsTable.tsx
+++ b/ui/app/workspace/mcp-sessions/views/sessionsTable.tsx
@@ -17,6 +17,7 @@
 //                 Caller must resubmit values.
 //   pending:      flow row, user must complete OAuth authentication.
 
+import PageTitle from "@/components/pageTitle";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -134,14 +135,9 @@ export default function SessionsTable({
 				</AlertDialogContent>
 			</AlertDialog>
 
-			<div className="mb-4 flex items-center justify-between gap-4">
-				<div>
-					<h2 className="text-lg font-semibold tracking-tight">MCP Auth Sessions</h2>
-					<p className="text-muted-foreground text-sm">
-						Per-user credentials stored for MCP servers (OAuth tokens and submitted headers), plus any pending authentication flows.
-					</p>
-				</div>
-			</div>
+			<PageTitle title="MCP Auth Sessions">
+				Per-user credentials stored for MCP servers (OAuth tokens and submitted headers), plus any pending authentication flows.
+			</PageTitle>
 
 			<div className="mb-4 flex items-center gap-3">
 				<div className="relative max-w-sm min-w-[200px] flex-1">

--- a/ui/app/workspace/model-catalog/views/modelCatalogTable.tsx
+++ b/ui/app/workspace/model-catalog/views/modelCatalogTable.tsx
@@ -1,3 +1,4 @@
+import PageTitle from "@/components/pageTitle";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -66,11 +67,8 @@ export default function ModelCatalogTable({
 			</div>
 
 			{/* Header + Filter */}
-			<div className="flex items-center justify-between">
-				<div>
-					<h2 className="text-lg font-semibold">Model Catalog</h2>
-					<p className="text-muted-foreground text-sm">Overview of all configured providers, models, and usage.</p>
-				</div>
+			<div className="flex items-center justify-end">
+				<PageTitle title="Model Catalog">Overview of all configured providers, models, and usage.</PageTitle>
 				<Select
 					value={providerFilter || "all"}
 					onValueChange={(val) => onProviderFilterChange(val === "all" ? "" : val)}

--- a/ui/app/workspace/model-catalog/views/modelCatalogView.tsx
+++ b/ui/app/workspace/model-catalog/views/modelCatalogView.tsx
@@ -23,7 +23,7 @@ export default function ModelCatalogView() {
 	}
 
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] min-h-0 w-full max-w-7xl flex-col overflow-hidden p-4">
+		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_1rem)] min-h-0 w-full max-w-7xl flex-col overflow-hidden p-4">
 			<Tabs value={tab} onValueChange={(value) => setTab(value as ModelCatalogTab)} className="flex min-h-0 grow flex-col gap-4">
 				<TabsList className="shrink-0">
 					<TabsTrigger value="overview" data-testid="model-catalog-tab-overview">

--- a/ui/app/workspace/model-limits/page.tsx
+++ b/ui/app/workspace/model-limits/page.tsx
@@ -2,7 +2,7 @@ import ModelLimitsView from "./views/modelLimitsView";
 
 export default function ModelLimitsPage() {
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] min-h-0 w-full flex-col overflow-hidden p-4">
+		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_1rem)] min-h-0 w-full flex-col overflow-hidden p-4">
 			<ModelLimitsView />
 		</div>
 	);

--- a/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
@@ -19,6 +19,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { resetDurationLabels, supportsCalendarAlignment } from "@/lib/constants/governance";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
+import PageTitle from "@/components/pageTitle";
 import { getModelLimitScope, getModelLimitScopes } from "@/lib/registries/modelLimitScopes";
 import { getErrorMessage, useDeleteModelConfigMutation, useGetModelConfigQuery } from "@/lib/store";
 import { ModelProvider } from "@/lib/types/config";
@@ -218,12 +219,22 @@ export default function ModelLimitsTable({
 
 	const hasActiveFilters = debouncedSearch || scope || provider;
 
+	// Rendered on the empty branch too, not just the populated one: PageTitle
+	// draws nothing inline, and leaving it out drops the topbar to the
+	// route-derived fallback, which for this route reads "Model Limits".
+	const pageTitle = (
+		<PageTitle title="Budgets & Limits">
+			Configure budgets and rate limits at any scope: virtual keys, users, providers, or specific models.
+		</PageTitle>
+	);
+
 	// True empty state: no model limits at all (not just filtered to zero).
 	// Suppress while the initial load is in flight so we don't flash the empty
 	// state before the API responds.
 	if (totalCount === 0 && !hasActiveFilters && !isLoading) {
 		return (
 			<>
+				{pageTitle}
 				{isSheetOpen && <ModelLimitSheet modelConfig={editingModelConfig} onSave={closeModelLimitSheet} onCancel={closeModelLimitSheet} />}
 				<ModelLimitsEmptyState onAddClick={handleAddModelLimit} canCreate={hasCreateAccess} />
 			</>
@@ -259,21 +270,9 @@ export default function ModelLimitsTable({
 			</AlertDialog>
 
 			<div className="flex flex-col overflow-y-auto">
-				<div className="mb-4 flex flex-wrap items-center justify-between gap-2">
-					<div>
-						<h1 className="text-lg font-semibold">Budgets &amp; Limits</h1>
-						<p className="text-muted-foreground text-sm">
-							Configure budgets and rate limits at any scope: virtual keys, users, providers, or specific models.
-						</p>
-					</div>
-					<Button onClick={handleAddModelLimit} disabled={!hasCreateAccess} data-testid="model-limits-button-create">
-						<Plus className="h-4 w-4" />
-						Add Limit
-					</Button>
-				</div>
-
-				{/* Toolbar: Search + Filters */}
+				{/* Toolbar: Search + Filters + Actions */}
 				<div className="mb-4 flex flex-wrap items-center gap-3">
+					{pageTitle}
 					<div className="relative min-w-[220px] flex-1">
 						<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
 						<Input
@@ -331,6 +330,11 @@ export default function ModelLimitsTable({
 							Clear filters
 						</Button>
 					)}
+
+					<Button className="ml-auto" onClick={handleAddModelLimit} disabled={!hasCreateAccess} data-testid="model-limits-button-create">
+						<Plus className="h-4 w-4" />
+						Add Limit
+					</Button>
 				</div>
 
 				<div className="mb-2 overflow-hidden rounded-sm border" data-testid="model-limits-table">

--- a/ui/app/workspace/oauth-grants/page.tsx
+++ b/ui/app/workspace/oauth-grants/page.tsx
@@ -1,3 +1,4 @@
+import PageTitle from "@/components/pageTitle";
 import { Input } from "@/components/ui/input";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { getErrorMessage, useGetOAuth2GrantsQuery, useRevokeOAuth2GrantMutation } from "@/lib/store";
@@ -93,14 +94,9 @@ export default function OAuthGrantsPage() {
 		<div className="flex h-full flex-col">
 			<RevokeGrantDialog open={pendingDelete !== null} onOpenChange={(open) => !open && setPendingDelete(null)} onConfirm={confirmRevoke} />
 
-			<div className="mb-4 flex items-center justify-between gap-4">
-				<div>
-					<h2 className="text-lg font-semibold tracking-tight">OAuth Grants</h2>
-					<p className="text-muted-foreground text-sm">
-						Active downstream OAuth grants issued to MCP clients that connected via the OAuth consent flow.
-					</p>
-				</div>
-			</div>
+			<PageTitle title="OAuth Grants">
+				Active downstream OAuth grants issued to MCP clients that connected via the OAuth consent flow.
+			</PageTitle>
 
 			<div className="mb-4 flex items-center gap-3">
 				<div className="relative max-w-sm min-w-[200px] flex-1">
@@ -144,11 +140,11 @@ export default function OAuthGrantsPage() {
 	// No grants at all and no active filters/search: render full-width without
 	// the filter sidebar, mirroring the MCP clients/sessions onboarding state.
 	if (!isLoading && totalCount === 0 && !hasActiveFilters) {
-		return <div className="mx-auto flex h-[calc(100dvh-50px)] w-full max-w-7xl flex-col p-4 md:p-0">{content}</div>;
+		return <div className="mx-auto flex h-[calc(var(--app-content-viewport)_-_50px)] w-full max-w-7xl flex-col p-4 md:p-0">{content}</div>;
 	}
 
 	return (
-		<div className="dark:bg-card no-padding-parent no-border-parent h-[calc(100dvh_-_16px)]">
+		<div className="dark:bg-card no-padding-parent no-border-parent h-[calc(var(--app-content-viewport)_-_16px)]">
 			<div className="bg-background flex h-full w-full grow gap-3">
 				<OAuthGrantsFilterSidebar filters={filters} onFiltersChange={setFilters} />
 				<div className="bg-card h-full w-full overflow-hidden rounded-l-md">

--- a/ui/app/workspace/observability/fragments/otelFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/otelFormFragment.tsx
@@ -184,6 +184,11 @@ export function OtelFormFragment({
 		setProfileOpenState((prev) => ({ ...prev, [index]: open }));
 	};
 
+	const handleAddProfile = () => {
+		append(emptyProfile());
+		setProfileOpenState((prev) => ({ ...prev, [fields.length]: true }));
+	};
+
 	const handleRemoveProfile = (index: number) => {
 		remove(index);
 		setProfileOpenState((prev) => {
@@ -216,7 +221,7 @@ export function OtelFormFragment({
 							index={index}
 							hasOtelAccess={hasOtelAccess}
 							canRemove={fields.length > 1}
-							open={profileOpenState[index] ?? true}
+							open={profileOpenState[index] ?? false}
 							onOpenChange={(open) => handleProfileOpenChange(index, open)}
 							onRemove={() => handleRemoveProfile(index)}
 						/>
@@ -227,7 +232,7 @@ export function OtelFormFragment({
 					type="button"
 					variant="outline"
 					size="sm"
-					onClick={() => append(emptyProfile())}
+					onClick={handleAddProfile}
 					disabled={!hasOtelAccess}
 					data-testid="otel-add-profile-btn"
 				>

--- a/ui/app/workspace/providers/dialogs/providerConfigSheet.tsx
+++ b/ui/app/workspace/providers/dialogs/providerConfigSheet.tsx
@@ -110,7 +110,9 @@ export default function ProviderConfigSheet({ show, onCancel, provider }: Props)
 				<div className="px-4 py-4 md:px-8">
 					<div className="w-full rounded-sm border">
 						<Tabs defaultValue={tabs[0]?.id} value={selectedTab} onValueChange={setSelectedTab}>
-							<div className="custom-scrollbar mb-4 w-full overflow-x-auto">
+							{/* TabsList collapses overflowing tabs into its own dropdown, so this
+							    no longer needs to scroll horizontally. */}
+							<div className="mb-4 w-full">
 								<TabsList className="h-10 w-max min-w-full justify-start rounded-tl-sm rounded-tr-sm rounded-br-none rounded-bl-none">
 									{tabs.map((tab) => (
 										<TabsTrigger

--- a/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
@@ -495,7 +495,7 @@ export function ApiKeyFormFragment({ control, providerName, baseProviderType, fo
 								}
 							}}
 						>
-							<TabsList className="flex w-full justify-start overflow-x-auto">
+							<TabsList className="flex w-full justify-start">
 								<TabsTrigger data-testid="apikey-azure-default-credential-tab" value="default_credential">
 									Default Credential
 								</TabsTrigger>
@@ -646,7 +646,7 @@ export function ApiKeyFormFragment({ control, providerName, baseProviderType, fo
 								}
 							}}
 						>
-							<TabsList className="flex w-full justify-start overflow-x-auto">
+							<TabsList className="flex w-full justify-start">
 								<TabsTrigger data-testid="apikey-vertex-service-account-tab" value="service_account">
 									Service Account (Attached)
 								</TabsTrigger>
@@ -908,7 +908,7 @@ export function ApiKeyFormFragment({ control, providerName, baseProviderType, fo
 								}
 							}}
 						>
-							<TabsList className="flex w-full justify-start overflow-x-auto">
+							<TabsList className="flex w-full justify-start">
 								<TabsTrigger data-testid="apikey-bedrock-iam-role-tab" value="iam_role">
 									IAM Role (Inherited)
 								</TabsTrigger>
@@ -1157,7 +1157,7 @@ export function ApiKeyFormFragment({ control, providerName, baseProviderType, fo
 								}
 							}}
 						>
-							<TabsList className="flex w-full justify-start overflow-x-auto">
+							<TabsList className="flex w-full justify-start">
 								<TabsTrigger data-testid="apikey-bedrock-mantle-iam-role-tab" value="iam_role">
 									IAM Role (Inherited)
 								</TabsTrigger>

--- a/ui/app/workspace/providers/page.tsx
+++ b/ui/app/workspace/providers/page.tsx
@@ -202,7 +202,7 @@ export default function Providers() {
 					setShowCustomProviderSheet(false);
 				}}
 			/>
-			<div className={cn("w-full flex-col md:flex md:max-h-[calc(100vh-70px)] md:w-[300px]", mobileDetailOpen ? "hidden" : "flex")}>
+			<div className={cn("w-full flex-col md:flex md:max-h-[calc(var(--app-content-viewport)_-_70px)] md:w-[300px]", mobileDetailOpen ? "hidden" : "flex")}>
 				<TooltipProvider>
 					<div className="custom-scrollbar flex-1 overflow-y-auto">
 						<div className="rounded-md bg-zinc-50/50 md:p-4 dark:bg-zinc-800/20">
@@ -274,12 +274,12 @@ export default function Providers() {
 					Providers
 				</Button>
 				{isLoadingProvider && (
-					<div className="bg-muted/10 flex w-full items-center justify-center rounded-md md:max-h-[calc(100vh-300px)]">
+					<div className="bg-muted/10 flex w-full items-center justify-center rounded-md md:max-h-[calc(var(--app-content-viewport)_-_300px)]">
 						<FullPageLoader />
 					</div>
 				)}
 				{!selectedProvider && (
-					<div className="bg-muted/10 flex w-full items-center justify-center rounded-md md:max-h-[calc(100vh-300px)]">
+					<div className="bg-muted/10 flex w-full items-center justify-center rounded-md md:max-h-[calc(var(--app-content-viewport)_-_300px)]">
 						<div className="text-muted-foreground text-sm">Select a provider</div>
 					</div>
 				)}

--- a/ui/app/workspace/routing-rules/page.tsx
+++ b/ui/app/workspace/routing-rules/page.tsx
@@ -7,7 +7,7 @@ import { RoutingRulesView } from "./views/routingRulesView";
 
 export default function RoutingRulesPage() {
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] min-h-0 w-full flex-col overflow-hidden p-4">
+		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_1rem)] min-h-0 w-full flex-col overflow-hidden p-4">
 			<RoutingRulesView />
 		</div>
 	);

--- a/ui/app/workspace/routing-rules/tree/page.tsx
+++ b/ui/app/workspace/routing-rules/tree/page.tsx
@@ -12,7 +12,7 @@ export const metadata = {
 
 export default function RoutingTreePage() {
 	return (
-		<div className="no-padding-parent no-border-parent h-[calc(100dvh_)] w-full">
+		<div className="no-padding-parent no-border-parent h-[calc(var(--app-content-viewport)_)] w-full">
 			<RoutingTreeView />
 		</div>
 	);

--- a/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
@@ -107,6 +107,8 @@ interface RoutingRulesTableProps {
 	offset: number;
 	limit: number;
 	onOffsetChange: (offset: number) => void;
+	/** Page-level actions rendered at the right end of the same row as the search. */
+	actions?: React.ReactNode;
 }
 
 export function RoutingRulesTable({
@@ -122,6 +124,7 @@ export function RoutingRulesTable({
 	offset,
 	limit,
 	onOffsetChange,
+	actions,
 }: RoutingRulesTableProps) {
 	const [deleteRuleId, setDeleteRuleId] = useState<string | null>(null);
 	const [deleteRoutingRule, { isLoading: isDeleting }] = useDeleteRoutingRuleMutation();
@@ -173,8 +176,8 @@ export function RoutingRulesTable({
 
 	return (
 		<>
-			{/* Toolbar: Search */}
-			<div className="mb-4 flex items-center gap-3">
+			{/* Toolbar: Search + Actions */}
+			<div className="mb-4 flex flex-wrap items-center gap-3">
 				<div className="relative max-w-sm flex-1">
 					<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
 					<Input
@@ -186,6 +189,7 @@ export function RoutingRulesTable({
 						data-testid="routing-rules-search-input"
 					/>
 				</div>
+				{actions && <div className="flex items-center gap-2 sm:ml-auto">{actions}</div>}
 			</div>
 
 			<div className="mb-2 overflow-hidden rounded-sm border">

--- a/ui/app/workspace/routing-rules/views/routingRulesView.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRulesView.tsx
@@ -3,6 +3,7 @@
  * Main orchestrator component for routing rules management
  */
 
+import PageTitle from "@/components/pageTitle";
 import { Button } from "@/components/ui/button";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { useGetRoutingRulesQuery } from "@/lib/store/apis/routingRulesApi";
@@ -114,27 +115,7 @@ export function RoutingRulesView() {
 
 	return (
 		<div className="flex flex-col overflow-y-auto">
-			{/* Header */}
-			<div className="mb-4 flex flex-wrap items-center justify-between gap-2">
-				<div>
-					<h1 className="text-foreground text-lg font-semibold">Routing Rules</h1>
-					<p className="text-muted-foreground text-sm">Manage CEL-based routing rules for intelligent request routing across providers</p>
-				</div>
-				<div className="flex items-center gap-2">
-					<Button variant="outline" size="sm" asChild className="gap-2">
-						<Link to="/workspace/routing-rules/tree">
-							<GitBranch className="h-4 w-4" />
-							<span className="hidden sm:inline">View Tree</span>
-						</Link>
-					</Button>
-					{canCreate && (
-						<Button data-testid="create-routing-rule-btn" onClick={handleCreateNew} disabled={isLoading} className="gap-2">
-							<Plus className="h-4 w-4" />
-							<span className="hidden sm:inline">New Rule</span>
-						</Button>
-					)}
-				</div>
-			</div>
+			<PageTitle>Manage CEL-based routing rules for intelligent request routing across providers</PageTitle>
 
 			<RoutingRulesTable
 				rules={rules}
@@ -149,6 +130,30 @@ export function RoutingRulesView() {
 				offset={offset}
 				limit={PAGE_SIZE}
 				onOffsetChange={setOffset}
+				actions={
+					<>
+						{/* The labels are hidden below sm, leaving an icon with no
+						    accessible name, so the name is carried on the control itself. */}
+						<Button variant="outline" size="sm" asChild className="gap-2">
+							<Link to="/workspace/routing-rules/tree" aria-label="View routing rules tree">
+								<GitBranch className="h-4 w-4" />
+								<span className="hidden sm:inline">View Tree</span>
+							</Link>
+						</Button>
+						{canCreate && (
+							<Button
+								data-testid="create-routing-rule-btn"
+								onClick={handleCreateNew}
+								disabled={isLoading}
+								className="gap-2"
+								aria-label="New routing rule"
+							>
+								<Plus className="h-4 w-4" />
+								<span className="hidden sm:inline">New Rule</span>
+							</Button>
+						)}
+					</>
+				}
 			/>
 
 			<RoutingRuleSheet open={dialogOpen} onOpenChange={handleDialogOpenChange} editingRule={editingRule} />

--- a/ui/app/workspace/scim/page.tsx
+++ b/ui/app/workspace/scim/page.tsx
@@ -1,11 +1,12 @@
 import SCIMView from "@enterprise/components/scim/scimView";
 
 export default function SCIMPage() {
+	// No no-padding-parent / no-border-parent / bg-background wrapper here: those opt
+	// out of the white content card in clientLayout, which left this page reading grey
+	// while every sibling placeholder sat on the card. Matches mcp-tool-groups.
 	return (
-		<div className="no-padding-parent bg-background no-border-parent flex min-h-full w-full flex-col md:h-[calc(100dvh-1rem)]">
-			<div className="mx-auto w-full grow overflow-visible md:overflow-y-auto">
-				<SCIMView />
-			</div>
+		<div className="mx-auto w-full max-w-7xl px-4 md:px-0">
+			<SCIMView />
 		</div>
 	);
 }

--- a/ui/app/workspace/skills-repo/components/skillListView.tsx
+++ b/ui/app/workspace/skills-repo/components/skillListView.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import PageTitle from "@/components/pageTitle";
 import FullPageLoader from "@/components/fullPageLoader";
 import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
 import {
@@ -411,77 +412,9 @@ export function SkillsListView({
 	return (
 		<div className="flex w-full min-w-0 flex-1 flex-col">
 			{/* Header */}
-			<div className="mb-4 flex shrink-0 flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-0">
-				<div className="min-w-0">
-					<div className="flex items-center gap-2">
-						<h2 className="text-lg font-semibold">Skills Repository</h2>
-						<Badge aria-label="Skills Repository is in beta">Beta</Badge>
-					</div>
-					<p className="text-muted-foreground text-sm">Manage Agent Skills for distribution to AI coding assistants</p>
-				</div>
-				<div className="grid grid-cols-3 items-center gap-2 md:flex">
-					{isGitAvailable ? (
-						<MarketplacePopover />
-					) : (
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<span tabIndex={0}>
-									<Button variant="outline" size="sm" disabled title="Register as Marketplace" aria-label="Register as Marketplace">
-										<Package className="h-3.5 w-3.5" />
-										<span className="hidden md:inline">Register as Marketplace</span>
-									</Button>
-								</span>
-							</TooltipTrigger>
-							<TooltipContent side="bottom">
-								<p className="max-w-xs text-xs">
-									Git is not available on the server. Install git and restart Bifrost to enable marketplace registration for Claude Code and
-									Codex.
-								</p>
-							</TooltipContent>
-						</Tooltip>
-					)}
-					<Button
-						variant="outline"
-						size="sm"
-						data-testid="skill-download-all-btn"
-						onClick={async () => {
-							setIsDownloadingAll(true);
-							try {
-								const res = await fetch(`${getApiBaseUrl()}/skills/serve/all/download.zip`);
-								if (!res.ok) throw new Error("Download failed");
-								const blob = await res.blob();
-								const url = URL.createObjectURL(blob);
-								const link = document.createElement("a");
-								link.href = url;
-								link.download = "all-skills.zip";
-								document.body.appendChild(link);
-								link.click();
-								document.body.removeChild(link);
-								URL.revokeObjectURL(url);
-							} catch {
-								toast.error("Failed to download skills");
-							} finally {
-								setIsDownloadingAll(false);
-							}
-						}}
-						disabled={!skills?.length || isDownloadingAll}
-						title="Download all skills"
-						aria-label="Download all skills"
-					>
-						{isDownloadingAll ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
-						<span className="hidden md:inline">{isDownloadingAll ? "Downloading..." : "Download All Skills"}</span>
-					</Button>
-					{hasCreateAccess && (
-						<Button data-testid="skill-create-btn" onClick={onCreateNew} size="sm" title="New skill" aria-label="New skill">
-							<Plus className="h-4 w-4" />
-							<span className="hidden md:inline">New Skill</span>
-						</Button>
-					)}
-				</div>
-			</div>
-
-			{/* Search + All-skills version */}
-			<div className="mb-4 flex flex-col gap-3 md:flex-row md:items-center">
+			{/* Search + All-skills version + Actions */}
+			<div className="mb-4 flex shrink-0 flex-col gap-3 md:flex-row md:items-center">
+				<PageTitle title="Skills Repository">Manage Agent Skills for distribution to AI coding assistants</PageTitle>
 				<div className="relative w-full flex-1 md:max-w-sm">
 					<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
 					<Input
@@ -545,6 +478,70 @@ export function SkillsListView({
 							{allSkillsVersionData?.version ?? "0.0.0"}
 						</Badge>
 					)}
+				</div>
+				<div className="flex shrink-0 items-center gap-2 md:ml-auto">
+					{/* The title now lives in the topbar; the beta marker stays on the
+					    page so it reads next to the actions it qualifies. */}
+					<Badge aria-label="Skills Repository is in beta">Beta</Badge>
+					<div className="grid grid-cols-3 items-center gap-2 md:flex">
+						{isGitAvailable ? (
+							<MarketplacePopover />
+						) : (
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<span tabIndex={0}>
+										<Button variant="outline" size="sm" disabled title="Register as Marketplace" aria-label="Register as Marketplace">
+											<Package className="h-3.5 w-3.5" />
+											<span className="hidden md:inline">Register as Marketplace</span>
+										</Button>
+									</span>
+								</TooltipTrigger>
+								<TooltipContent side="bottom">
+									<p className="max-w-xs text-xs">
+										Git is not available on the server. Install git and restart Bifrost to enable marketplace registration for Claude Code
+										and Codex.
+									</p>
+								</TooltipContent>
+							</Tooltip>
+						)}
+						<Button
+							variant="outline"
+							size="sm"
+							data-testid="skill-download-all-btn"
+							onClick={async () => {
+								setIsDownloadingAll(true);
+								try {
+									const res = await fetch(`${getApiBaseUrl()}/skills/serve/all/download.zip`);
+									if (!res.ok) throw new Error("Download failed");
+									const blob = await res.blob();
+									const url = URL.createObjectURL(blob);
+									const link = document.createElement("a");
+									link.href = url;
+									link.download = "all-skills.zip";
+									document.body.appendChild(link);
+									link.click();
+									document.body.removeChild(link);
+									URL.revokeObjectURL(url);
+								} catch {
+									toast.error("Failed to download skills");
+								} finally {
+									setIsDownloadingAll(false);
+								}
+							}}
+							disabled={!skills?.length || isDownloadingAll}
+							title="Download all skills"
+							aria-label="Download all skills"
+						>
+							{isDownloadingAll ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
+							<span className="hidden md:inline">{isDownloadingAll ? "Downloading..." : "Download All Skills"}</span>
+						</Button>
+						{hasCreateAccess && (
+							<Button data-testid="skill-create-btn" onClick={onCreateNew} size="sm" title="New skill" aria-label="New skill">
+								<Plus className="h-4 w-4" />
+								<span className="hidden md:inline">New Skill</span>
+							</Button>
+						)}
+					</div>
 				</div>
 			</div>
 

--- a/ui/app/workspace/skills-repo/page.tsx
+++ b/ui/app/workspace/skills-repo/page.tsx
@@ -56,7 +56,7 @@ export default function SkillsRepoPage() {
 
 	// List view
 	return (
-		<div className="no-padding-parent flex min-h-full w-full min-w-0 flex-col p-4 md:h-[calc(100dvh_-_16px)] md:min-h-0">
+		<div className="no-padding-parent flex min-h-full w-full min-w-0 flex-col p-4 md:h-[calc(var(--app-content-viewport)_-_16px)] md:min-h-0">
 			<SkillsListView onSelectSkill={handleSelectSkill} onCreateNew={() => setUrlState({ create: true, skillId: null, edit: false })} />
 		</div>
 	);

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -1,3 +1,4 @@
+import PageTitle from "@/components/pageTitle";
 import { BudgetDisplay } from "@/components/budgetDisplay";
 import { CustomerSelector } from "@/components/entitySelectors/customerSelector";
 import { TeamSelector } from "@/components/entitySelectors/teamSelector";
@@ -785,36 +786,9 @@ export default function VirtualKeysTable({
 			</AlertDialog>
 
 			<div className="flex min-h-0 w-full grow flex-col overflow-hidden">
-				<div className="mb-4 flex shrink-0 flex-wrap items-center justify-between gap-2">
-					<div>
-						<h2 className="text-lg font-semibold">Virtual Keys</h2>
-						<p className="text-muted-foreground text-sm">Manage virtual keys, their permissions, budgets, and rate limits.</p>
-					</div>
-					<div className="flex flex-wrap items-center gap-2">
-						{selectedCount > 0 && (
-							<Button
-								variant="outline"
-								onClick={() => setShowBulkRotateDialog(true)}
-								disabled={!hasUpdateAccess || isBulkRotating}
-								data-testid="vk-bulk-rotate-btn"
-							>
-								<RotateCcw className="h-4 w-4" />
-								Rotate selected ({selectedCount})
-							</Button>
-						)}
-						<Button variant="outline" onClick={openExportDialog} disabled={virtualKeys.length === 0} data-testid="vk-export-btn">
-							<Download className="h-4 w-4" />
-							Export CSV
-						</Button>
-						<Button onClick={handleAddVirtualKey} disabled={!hasCreateAccess} data-testid="create-vk-btn">
-							<Plus className="h-4 w-4" />
-							Add Virtual Key
-						</Button>
-					</div>
-				</div>
-
-				{/* Toolbar: Search + Filters */}
+				{/* Toolbar: Search + Filters + Actions */}
 				<div className="mb-4 flex shrink-0 flex-wrap items-center gap-3">
+					<PageTitle title="Virtual Keys">Manage virtual keys, their permissions, budgets, and rate limits.</PageTitle>
 					<div className="relative w-full max-w-sm flex-1 basis-full sm:basis-auto">
 						<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
 						<Input
@@ -879,6 +853,28 @@ export default function VirtualKeysTable({
 							/>
 						</div>
 					)}
+
+					<div className="flex flex-wrap items-center gap-2 sm:ml-auto">
+						{selectedCount > 0 && (
+							<Button
+								variant="outline"
+								onClick={() => setShowBulkRotateDialog(true)}
+								disabled={!hasUpdateAccess || isBulkRotating}
+								data-testid="vk-bulk-rotate-btn"
+							>
+								<RotateCcw className="h-4 w-4" />
+								Rotate selected ({selectedCount})
+							</Button>
+						)}
+						<Button variant="outline" onClick={openExportDialog} disabled={virtualKeys.length === 0} data-testid="vk-export-btn">
+							<Download className="h-4 w-4" />
+							Export CSV
+						</Button>
+						<Button onClick={handleAddVirtualKey} disabled={!hasCreateAccess} data-testid="create-vk-btn">
+							<Plus className="h-4 w-4" />
+							Add Virtual Key
+						</Button>
+					</div>
 				</div>
 
 				<div className="mb-2 min-h-0 grow overflow-hidden rounded-sm border">

--- a/ui/app/workspace/webhooks/views/webhooksFilterBar.tsx
+++ b/ui/app/workspace/webhooks/views/webhooksFilterBar.tsx
@@ -24,6 +24,8 @@ export interface WebhooksFilterBarProps {
 	onStatusFilterChange: (value: string[]) => void;
 	hasActiveFilters: boolean;
 	onClearFilters: () => void;
+	/** Page-level actions rendered at the right end of the same row as the search. */
+	actions?: React.ReactNode;
 }
 
 export default function WebhooksFilterBar(props: WebhooksFilterBarProps) {
@@ -68,6 +70,7 @@ export default function WebhooksFilterBar(props: WebhooksFilterBarProps) {
 					Clear filters
 				</Button>
 			)}
+			{props.actions && <div className="flex items-center gap-2 sm:ml-auto">{props.actions}</div>}
 		</div>
 	);
 }

--- a/ui/app/workspace/webhooks/views/webhooksView.tsx
+++ b/ui/app/workspace/webhooks/views/webhooksView.tsx
@@ -1,3 +1,4 @@
+import PageTitle from "@/components/pageTitle";
 import FullPageLoader from "@/components/fullPageLoader";
 import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
 import {
@@ -324,19 +325,10 @@ export default function WebhooksView() {
 				<WebhooksEmptyState onAddClick={handleAdd} canCreate={hasCreateAccess} />
 			) : (
 				<>
-					<div className="flex items-center justify-between">
-						<div>
-							<h2 className="text-lg font-semibold tracking-tight">Webhooks</h2>
-							<p className="text-muted-foreground text-sm">
-								Register endpoints to receive signed notifications when async inference jobs complete or fail. Pass the endpoint's name in
-								the <code>x-bf-async-webhook</code> header when submitting a job.
-							</p>
-						</div>
-						<Button onClick={handleAdd} disabled={!hasCreateAccess} data-testid="create-webhook-btn">
-							<Plus className="h-4 w-4" />
-							Add Endpoint
-						</Button>
-					</div>
+					<PageTitle title="Webhooks">
+						Register endpoints to receive signed notifications when async inference jobs complete or fail. Pass the endpoint's name in the{" "}
+						<code>x-bf-async-webhook</code> header when submitting a job.
+					</PageTitle>
 
 					<WebhooksFilterBar
 						search={urlState.q}
@@ -347,6 +339,12 @@ export default function WebhooksView() {
 						onStatusFilterChange={(value) => setUrlState({ status: value.length ? value : null, offset: 0 })}
 						hasActiveFilters={hasActiveFilters}
 						onClearFilters={handleClearFilters}
+						actions={
+							<Button onClick={handleAdd} disabled={!hasCreateAccess} data-testid="create-webhook-btn">
+								<Plus className="h-4 w-4" />
+								Add Endpoint
+							</Button>
+						}
 					/>
 
 					<div className={`overflow-auto rounded-sm border ${isFetching ? "opacity-70" : ""}`}>

--- a/ui/components/noPermissionView.tsx
+++ b/ui/components/noPermissionView.tsx
@@ -11,7 +11,7 @@ export function NoPermissionView({ entity, className, align = "middle" }: NoPerm
 	return (
 		<div
 			className={cn(
-				"flex min-h-[calc(100vh-200px)] flex-col items-center  gap-4 text-center",
+				"flex min-h-[calc(var(--app-content-viewport)_-_200px)] flex-col items-center  gap-4 text-center",
 				align === "middle" ? "justify-center" : "justify-start",
 				className,
 			)}

--- a/ui/components/pageTitle.tsx
+++ b/ui/components/pageTitle.tsx
@@ -1,0 +1,55 @@
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hoverCard";
+import { useDescriptionSlot, useSetTopbarTitle } from "@/lib/contexts/topbarContext";
+import { Info } from "lucide-react";
+import { createPortal } from "react-dom";
+
+/**
+ * Declares the page's title and, optionally, its description. Renders nothing
+ * inline — the title is hoisted into the <Topbar>, and the description becomes
+ * an info icon beside it that opens on hover.
+ *
+ * Drop it where the old heading lived so the page still reads as its own
+ * source of truth:
+ *
+ *   <PageTitle title="Webhooks">
+ *     Register endpoints to receive signed notifications. Pass the endpoint&apos;s
+ *     name in the <code>x-bf-async-webhook</code> header.
+ *   </PageTitle>
+ *
+ * The description is portalled rather than lifted through context state, so it
+ * can be arbitrary JSX — links, <code>, conditional spans — without its
+ * unstable identity re-rendering the whole shell on every parent render.
+ *
+ * `title` is only needed when the route slug wouldn't produce the right label
+ * (tab views, "&"-joined names). Without it the topbar falls back to the last
+ * path segment.
+ */
+export default function PageTitle({ title, children }: { title?: string; children?: React.ReactNode }) {
+	useSetTopbarTitle(title);
+	const slot = useDescriptionSlot();
+
+	if (!children || !slot) return null;
+
+	return createPortal(
+		<HoverCard openDelay={100} closeDelay={100}>
+			<HoverCardTrigger asChild>
+				<button
+					type="button"
+					data-testid="page-description-trigger"
+					aria-label="About this page"
+					className="text-muted-foreground hover:text-foreground flex size-5 shrink-0 cursor-help items-center justify-center rounded-sm transition-colors"
+				>
+					<Info className="size-4" strokeWidth={2} />
+				</button>
+			</HoverCardTrigger>
+			<HoverCardContent
+				align="start"
+				side="bottom"
+				className="text-muted-foreground w-80 rounded-sm text-sm leading-relaxed font-normal shadow-none"
+			>
+				{children}
+			</HoverCardContent>
+		</HoverCard>,
+		slot,
+	);
+}

--- a/ui/components/prompts/promptsView.tsx
+++ b/ui/components/prompts/promptsView.tsx
@@ -34,7 +34,7 @@ export default function PromptsView() {
 
 	if (folders.length === 0 && prompts.length === 0) {
 		return (
-			<div className="no-padding-parent no-border-parent flex h-[calc(100dvh_-_18px)] w-full items-center">
+			<div className="no-padding-parent no-border-parent flex h-[calc(var(--app-content-viewport)_-_18px)] w-full items-center">
 				<PromptSheets />
 				<PromptsEmptyState />
 			</div>
@@ -43,7 +43,7 @@ export default function PromptsView() {
 
 	if (isMobile) {
 		return (
-			<div className="no-padding-parent no-border-parent bg-background flex h-[calc(100dvh_-_16px)] w-full flex-col gap-2 overflow-auto">
+			<div className="no-padding-parent no-border-parent bg-background flex h-[calc(var(--app-content-viewport)_-_16px)] w-full flex-col gap-2 overflow-auto">
 				<DeleteFolderDialog />
 				<DeletePromptDialog />
 				<PromptSheets />
@@ -78,7 +78,7 @@ export default function PromptsView() {
 	}
 
 	return (
-		<div className="no-padding-parent no-border-parent bg-background h-[calc(100dvh_-_16px)] w-full">
+		<div className="no-padding-parent no-border-parent bg-background h-[calc(var(--app-content-viewport)_-_16px)] w-full">
 			<DeleteFolderDialog />
 			<DeletePromptDialog />
 			<PromptSheets />

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -6,7 +6,6 @@ import {
 	BookUser,
 	Boxes,
 	BoxIcon,
-	BugIcon,
 	Building,
 	Building2,
 	ChartColumnBig,
@@ -26,7 +25,6 @@ import {
 	Landmark,
 	LaptopMinimalCheck,
 	LayoutGrid,
-	LogOut,
 	Logs,
 	Megaphone,
 	Network,
@@ -47,7 +45,6 @@ import {
 	Telescope,
 	ToolCase,
 	TrendingUp,
-	User,
 	UserRoundCheck,
 	Users,
 	Wallet,
@@ -56,7 +53,6 @@ import {
 } from "lucide-react";
 
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { Separator } from "@/components/ui/separator";
 import {
 	Sidebar,
 	SidebarContent,
@@ -76,17 +72,13 @@ import { HIDDEN_UNTIL_NAV_COOKIE, REMIND_LATER_COOKIE, useOnboardingChecklist } 
 import { useWebSocket } from "@/hooks/useWebSocket";
 import { IS_ENTERPRISE } from "@/lib/constants/config";
 import { useBranding } from "@/lib/hooks/useBranding";
-import { useGetCoreConfigQuery, useGetLatestReleaseQuery, useGetVersionQuery, useLogoutMutation } from "@/lib/store";
+import { useGetCoreConfigQuery, useGetLatestReleaseQuery, useGetVersionQuery } from "@/lib/store";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import type { UserInfo } from "@enterprise/lib/store/utils/tokenManager";
-import { getUserInfo } from "@enterprise/lib/store/utils/tokenManager";
-import { BooksIcon, DiscordLogoIcon, GithubLogoIcon } from "@phosphor-icons/react";
 import { Link, useLocation, useNavigate } from "@tanstack/react-router";
 import { ChevronRight } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useCookies } from "react-cookie";
-import { ThemeToggle } from "./themeToggle";
 import { Badge } from "./ui/badge";
 import { PromoCardStack } from "./ui/promoCardStack";
 
@@ -117,32 +109,6 @@ const MCPIcon = ({ className }: { className?: string }) => (
 );
 
 // Main navigation items
-
-// External links
-const externalLinks = [
-	{
-		title: "Discord Server",
-		url: "https://discord.gg/exN5KAydbU",
-		icon: DiscordLogoIcon,
-	},
-	{
-		title: "GitHub Repository",
-		url: "https://github.com/maximhq/bifrost",
-		icon: GithubLogoIcon,
-	},
-	{
-		title: "Report a bug",
-		url: "https://github.com/maximhq/bifrost/issues/new?title=[Bug Report]&labels=bug&type=bug&projects=maximhq/1",
-		icon: BugIcon,
-		strokeWidth: 1.5,
-	},
-	{
-		title: "Full Documentation",
-		url: "https://docs.getbifrost.ai",
-		icon: BooksIcon,
-		strokeWidth: 1,
-	},
-];
 
 // Base promotional card (memoized outside component to prevent recreation)
 const productionSetupHelpCard = {
@@ -544,8 +510,6 @@ export default function AppSidebar() {
 	const { state: sidebarState, isMobile, toggleSidebar } = useSidebar();
 	const [mounted, setMounted] = useState(false);
 	const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set());
-	const [areCardsEmpty, setAreCardsEmpty] = useState(false);
-	const [userPopoverOpen, setUserPopoverOpen] = useState(false);
 	const [searchQuery, setSearchQuery] = useState("");
 	const [focusedIndex, setFocusedIndex] = useState(-1);
 	const searchInputRef = useRef<HTMLInputElement>(null);
@@ -1185,18 +1149,6 @@ export default function AppSidebar() {
 
 	const { data: version } = useGetVersionQuery();
 	const { resolvedTheme } = useTheme();
-	const [logout] = useLogoutMutation();
-
-	// Get user info from localStorage (for enterprise SCIM OAuth)
-	const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
-
-	useEffect(() => {
-		if (IS_ENTERPRISE) {
-			const info = getUserInfo();
-			setUserInfo(info);
-		}
-	}, []);
-
 	const showNewReleaseBanner = useMemo(() => {
 		if (IS_ENTERPRISE) return false;
 		if (latestRelease && version) {
@@ -1204,7 +1156,6 @@ export default function AppSidebar() {
 		}
 		return false;
 	}, [latestRelease, version]);
-	const isAuthEnabled = coreConfig?.auth_config?.is_enabled || false;
 
 	useEffect(() => {
 		setMounted(true);
@@ -1457,25 +1408,6 @@ export default function AppSidebar() {
 		handleResumeOnboarding,
 	]);
 
-	// Reset areCardsEmpty when promoCards changes
-	useEffect(() => {
-		if (promoCards.length > 0) {
-			setAreCardsEmpty(false);
-		}
-	}, [promoCards]);
-
-	// The promo card stack is hidden via CSS when collapsed (icon rail), so it
-	// shouldn't reserve vertical space there — otherwise the nav icon list
-	// gets squeezed into a shorter scroll area for a card nobody can see.
-	const hasPromoCards = promoCards.length > 0 && !areCardsEmpty && (isMobile || sidebarState !== "collapsed");
-	// When cards are present: 13rem (header 3rem + bottom section ~10rem)
-	// When no cards: 8rem (header 3rem + bottom section without cards ~5rem)
-	const sidebarGroupHeight = hasPromoCards ? "h-[calc(100vh-13rem)]" : "h-[calc(100vh-8rem)]";
-
-	const handleCardsEmpty = () => {
-		setAreCardsEmpty(true);
-	};
-
 	const handlePromoDismiss = useCallback(
 		(cardId: string) => {
 			if (cardId === "production-setup") {
@@ -1507,22 +1439,11 @@ export default function AppSidebar() {
 		[setCookie, cookies],
 	);
 
-	const handleLogout = async () => {
-		try {
-			setUserPopoverOpen(false);
-			await logout().unwrap();
-			navigate("/login");
-		} catch {
-			// Even if logout fails on server, redirect to login
-			navigate("/login");
-		}
-	};
-
 	return (
 		<Sidebar collapsible="icon" className="overflow-y-clip border-none bg-transparent">
 			<SidebarHeader className="mt-1 ml-2 flex justify-between px-0 group-data-[collapsible=icon]:ml-0 group-data-[collapsible=icon]:h-auto">
 				{/* Expanded state: horizontal layout */}
-				<div className="flex h-10 w-full items-center justify-between px-1.5 group-data-[collapsible=icon]:hidden">
+				<div className="flex h-8 w-full items-center justify-between px-1.5 group-data-[collapsible=icon]:hidden">
 					<Link to="/workspace/logs" className="group flex items-center gap-2 pl-2">
 						{/* max-w caps an unusually wide uploaded logo so it cannot push the
 						    collapse button out of the header; object-contain preserves its
@@ -1541,10 +1462,10 @@ export default function AppSidebar() {
 				</div>
 				{/* Collapsed state: vertical layout */}
 				<div
-					className="hidden w-full cursor-pointer flex-col items-center gap-2 py-2 group-data-[collapsible=icon]:flex"
+					className="hidden w-full cursor-pointer flex-col items-center gap-2 py-1 group-data-[collapsible=icon]:flex"
 					onClick={toggleSidebar}
 				>
-					<img className="h-[22px] w-auto object-contain" src={iconSrc} alt={logoAlt} width={22} height={22} style={{ width: 18 }} />
+					<img className="size-[22px] object-contain" src={iconSrc} alt={logoAlt} width={22} height={22} />
 				</div>
 			</SidebarHeader>
 			{envLabel && (
@@ -1586,8 +1507,8 @@ export default function AppSidebar() {
 					</kbd>
 				</div>
 			</div>
-			<SidebarContent className="overflow-hidden pb-4">
-				<SidebarGroup className={`custom-scrollbar ${sidebarGroupHeight} overflow-scroll`}>
+			<SidebarContent className="overflow-hidden">
+				<SidebarGroup className="custom-scrollbar min-h-0 flex-1 overflow-y-auto">
 					<SidebarGroupContent>
 						<SidebarMenu className="space-y-0.5">
 							{filteredItems.map((item) => {
@@ -1614,85 +1535,23 @@ export default function AppSidebar() {
 						</SidebarMenu>
 					</SidebarGroupContent>
 				</SidebarGroup>
-				<div className="flex flex-col gap-4 px-3 group-data-[collapsible=icon]:px-1">
+				<div className="mt-auto flex flex-col gap-4 px-3 pb-2 group-data-[collapsible=icon]:px-1">
 					<div className="mx-1 group-data-[collapsible=icon]:hidden">
-						<PromoCardStack cards={promoCards} onCardsEmpty={handleCardsEmpty} onDismiss={handlePromoDismiss} />
+						<PromoCardStack cards={promoCards} onDismiss={handlePromoDismiss} />
 					</div>
-					<div className="flex flex-row">
-						<div className="mx-auto flex flex-row gap-4 group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:gap-2">
-							{sidebarState !== "collapsed" &&
-								externalLinks.map((item, index) => (
-									<a
-										key={index}
-										href={item.url}
-										target="_blank"
-										rel="noopener noreferrer"
-										className="group flex w-full items-center justify-between"
-										title={item.title}
-									>
-										<div className="flex items-center space-x-3">
-											<item.icon
-												className="hover:text-primary text-muted-foreground h-5 w-5"
-												size={22}
-												weight="regular"
-												strokeWidth={item.strokeWidth}
-											/>
-										</div>
-									</a>
-								))}
-							<ThemeToggle />
-							{IS_ENTERPRISE && userInfo ? (
-								<Popover open={userPopoverOpen} onOpenChange={setUserPopoverOpen}>
-									<PopoverTrigger asChild>
-										<button
-											className="hover:text-primary text-muted-foreground flex cursor-pointer items-center space-x-3 p-0.5"
-											type="button"
-											aria-label="User menu"
-										>
-											<User className="hover:text-primary text-muted-foreground h-4 w-4" size={20} strokeWidth={2} />
-										</button>
-									</PopoverTrigger>
-									<PopoverContent side="top" align="start" className="w-56 p-0">
-										<div className="flex flex-col">
-											<div className="px-4 py-3">
-												<p className="text-sm font-medium">{userInfo.name || userInfo.email || userInfo.preferred_username || "User"}</p>
-											</div>
-											<Separator />
-											<button
-												onClick={handleLogout}
-												className="hover:bg-accent hover:text-accent-foreground flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm transition-colors"
-												type="button"
-											>
-												<LogOut className="h-4 w-4" strokeWidth={2} />
-												<span>Logout</span>
-											</button>
-										</div>
-									</PopoverContent>
-								</Popover>
-							) : isAuthEnabled ? (
-								<div>
-									<button
-										className="hover:text-primary text-muted-foreground flex cursor-pointer items-center space-x-3 p-0.5"
-										onClick={handleLogout}
-										type="button"
-										aria-label="Logout"
-									>
-										<LogOut className="hover:text-primary text-muted-foreground h-4 w-4" size={20} strokeWidth={2} />
-									</button>
-								</div>
-							) : null}
-							<div className="hidden w-full cursor-pointer flex-col items-center group-data-[collapsible=icon]:flex">
-								<button
-									onClick={toggleSidebar}
-									type="button"
-									data-testid="sidebar-expand-btn"
-									className="text-muted-foreground hover:text-foreground hover:bg-sidebar-accent flex cursor-pointer items-center justify-center rounded-md transition-colors"
-									aria-label="Expand sidebar"
-								>
-									<PanelLeftOpen className="h-4 w-4" />
-								</button>
-							</div>
-						</div>
+					{/* Socials, theme toggle and the user/logout menu moved to <Topbar>.
+					    All that remains here is the expand affordance for the collapsed
+					    rail, since the collapsed header doubles as the collapse target. */}
+					<div className="hidden w-full cursor-pointer flex-col items-center group-data-[collapsible=icon]:flex">
+						<button
+							onClick={toggleSidebar}
+							type="button"
+							data-testid="sidebar-expand-btn"
+							className="text-muted-foreground hover:text-foreground hover:bg-sidebar-accent flex cursor-pointer items-center justify-center rounded-md transition-colors"
+							aria-label="Expand sidebar"
+						>
+							<PanelLeftOpen className="h-4 w-4" />
+						</button>
 					</div>
 					<div className="mx-auto flex flex-col items-center gap-1 group-data-[collapsible=icon]:hidden">
 						<div className="font-mono text-xs">{version ?? ""}</div>

--- a/ui/components/themeToggle.tsx
+++ b/ui/components/themeToggle.tsx
@@ -1,12 +1,36 @@
-import { Moon, Sun } from "lucide-react";
+import { Check, Laptop, Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 
 import { Button } from "@/components/ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
 
-export function ThemeToggle() {
-	const { setTheme } = useTheme();
+const THEMES = [
+	{ value: "light", label: "Light", icon: Sun },
+	{ value: "dark", label: "Dark", icon: Moon },
+	{ value: "system", label: "System", icon: Laptop },
+] as const;
 
+/**
+ * The theme choices as bare dropdown items, so they can be embedded in a larger
+ * menu (e.g. the topbar account menu) rather than only in their own popover.
+ */
+export function ThemeToggleItems() {
+	const { theme, setTheme } = useTheme();
+
+	return (
+		<>
+			{THEMES.map(({ value, label, icon: Icon }) => (
+				<DropdownMenuItem key={value} onClick={() => setTheme(value)} className="cursor-pointer">
+					<Icon className="size-4" strokeWidth={2} />
+					<span className="flex-1">{label}</span>
+					{theme === value && <Check className="text-muted-foreground size-3.5" strokeWidth={2.5} />}
+				</DropdownMenuItem>
+			))}
+		</>
+	);
+}
+
+export function ThemeToggle() {
 	return (
 		<DropdownMenu>
 			<DropdownMenuTrigger asChild>
@@ -21,9 +45,7 @@ export function ThemeToggle() {
 				</Button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent align="end">
-				<DropdownMenuItem onClick={() => setTheme("light")}>Light</DropdownMenuItem>
-				<DropdownMenuItem onClick={() => setTheme("dark")}>Dark</DropdownMenuItem>
-				<DropdownMenuItem onClick={() => setTheme("system")}>System</DropdownMenuItem>
+				<ThemeToggleItems />
 			</DropdownMenuContent>
 		</DropdownMenu>
 	);

--- a/ui/components/topbar.tsx
+++ b/ui/components/topbar.tsx
@@ -1,0 +1,198 @@
+import { ThemeToggle } from "@/components/themeToggle";
+import { deriveTitleFromPathname } from "@/components/topbar.utils";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuGroup,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdownMenu";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import { IS_ENTERPRISE } from "@/lib/constants/config";
+import { useDescriptionSlotRef, useTopbarTitle } from "@/lib/contexts/topbarContext";
+import { useGetCoreConfigQuery, useLogoutMutation } from "@/lib/store";
+import type { UserInfo } from "@enterprise/lib/store/utils/tokenManager";
+import { getUserInfo } from "@enterprise/lib/store/utils/tokenManager";
+import { BooksIcon, DiscordLogoIcon, GithubLogoIcon } from "@phosphor-icons/react";
+import { useLocation, useNavigate } from "@tanstack/react-router";
+import { BugIcon, ChevronDown, LogOut, Menu, User } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+// External links that used to live in the sidebar footer icon row. They now
+// render as labelled rows inside the topbar menu, which is both more legible
+// than a row of bare glyphs and frees the sidebar footer for the promo card.
+const externalLinks: {
+	title: string;
+	url: string;
+	// Mixed lucide + phosphor icons, which disagree on their prop surface
+	// (`weight` vs `strokeWidth`), so the slot is intentionally loose.
+	icon: React.ComponentType<Record<string, unknown>>;
+	strokeWidth?: number;
+}[] = [
+	{
+		title: "Discord Server",
+		url: "https://discord.gg/exN5KAydbU",
+		icon: DiscordLogoIcon,
+	},
+	{
+		title: "GitHub Repository",
+		url: "https://github.com/maximhq/bifrost",
+		icon: GithubLogoIcon,
+	},
+	{
+		title: "Report a bug",
+		url: "https://github.com/maximhq/bifrost/issues/new?title=[Bug Report]&labels=bug&type=bug&projects=maximhq/1",
+		icon: BugIcon,
+		strokeWidth: 1.5,
+	},
+	{
+		title: "Full Documentation",
+		url: "https://docs.getbifrost.ai",
+		icon: BooksIcon,
+		strokeWidth: 1,
+	},
+];
+
+/**
+ * Resolves the topbar title. A page can name itself via useSetTopbarTitle();
+ * otherwise we derive it from the last non-empty path segment, e.g.
+ * "/workspace/mcp-registry" -> "MCP Registry".
+ */
+function usePageTitle() {
+	const pathname = useLocation({ select: (location) => location.pathname });
+	const override = useTopbarTitle();
+	const derived = useMemo(() => deriveTitleFromPathname(pathname), [pathname]);
+	return override ?? derived;
+}
+
+/**
+ * Topbar renders the strip above the inset content card. It deliberately
+ * carries no background of its own so it reads as the same surface as the
+ * sidebar — both simply show the page body background, since <Sidebar> is
+ * rendered with `bg-transparent border-none`.
+ *
+ * It is 52px tall (h-13) with pt-1, putting its centred row at y=28 — the same
+ * axis as the sidebar logo, which SidebarHeader's `mt-1 + p-2` around an h-8 row
+ * centres at 28. 52px is also where the sidebar's search input starts, so the
+ * content card below lines up with it. Keep this in sync with
+ * --app-topbar-height in globals.css — every full-height page measures itself
+ * against that variable.
+ */
+export default function Topbar() {
+	const title = usePageTitle();
+	const setDescriptionSlot = useDescriptionSlotRef();
+	const navigate = useNavigate();
+	const [logout] = useLogoutMutation();
+	const { data: coreConfig } = useGetCoreConfigQuery({});
+
+	// Enterprise SCIM/OAuth stashes the profile in localStorage. Read it after
+	// mount so SSR/first paint doesn't diverge from the hydrated tree.
+	const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
+	useEffect(() => {
+		if (IS_ENTERPRISE) {
+			setUserInfo(getUserInfo());
+		}
+	}, []);
+
+	const isAuthEnabled = coreConfig?.auth_config?.is_enabled || false;
+	const showUserPill = IS_ENTERPRISE && !!userInfo;
+	const canLogout = showUserPill || isAuthEnabled;
+
+	const displayName = userInfo?.name || userInfo?.email || userInfo?.preferred_username || "User";
+	// Only show the email as a second line when it isn't already the headline.
+	const secondaryLine = userInfo?.email && userInfo.email !== displayName ? userInfo.email : undefined;
+
+	const handleLogout = async () => {
+		try {
+			await logout().unwrap();
+		} finally {
+			// Redirect regardless — a failed server-side logout still means the
+			// user intended to end the session locally.
+			navigate({ to: "/login" });
+		}
+	};
+
+	return (
+		<header className="flex h-13 w-full shrink-0 items-center gap-2 px-3 pt-1 md:pr-4 md:pl-2" data-testid="topbar-container-root">
+			<div className="flex min-w-0 flex-1 items-center gap-2">
+				<SidebarTrigger className="shrink-0 md:hidden" />
+				{/* text-lg font-semibold is the existing in-page <h1> scale, so hoisting
+				    the title here doesn't visually demote it. */}
+				<h1 className="truncate text-lg font-semibold">{title}</h1>
+				{/* Anchor for <PageTitle>'s description popover. Pages portal into
+				    this node, so the topbar never has to know their content. */}
+				<span ref={setDescriptionSlot} className="flex shrink-0 items-center" />
+			</div>
+
+			{/* Theme stays a first-class topbar control rather than a menu entry —
+			    it's a display preference, not an account action. */}
+			<ThemeToggle />
+
+			<DropdownMenu>
+				<DropdownMenuTrigger asChild>
+					{showUserPill ? (
+						<button
+							type="button"
+							data-testid="topbar-user-pill"
+							aria-label="Account menu"
+							className="border-border bg-card/60 text-foreground hover:bg-accent hover:text-accent-foreground flex h-8 max-w-[140px] min-w-0 cursor-pointer items-center gap-1.5 rounded-full border py-0 pr-2 pl-1 transition-colors sm:max-w-[220px]"
+						>
+							<span className="bg-muted text-muted-foreground flex size-6 shrink-0 items-center justify-center rounded-full">
+								<User className="size-3.5" strokeWidth={2} />
+							</span>
+							{/* min-w-0 + truncate is what keeps a 200-character display
+							    name from stretching the pill and pushing the page title
+							    out of the topbar. */}
+							<span className="min-w-0 truncate text-sm font-medium">{displayName}</span>
+							<ChevronDown className="text-muted-foreground size-3.5 shrink-0" strokeWidth={2} />
+						</button>
+					) : (
+						<button
+							type="button"
+							data-testid="topbar-menu-btn"
+							aria-label="Open menu"
+							className="text-muted-foreground hover:bg-accent hover:text-accent-foreground flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-md transition-colors"
+						>
+							<Menu className="size-4" strokeWidth={2} />
+						</button>
+					)}
+				</DropdownMenuTrigger>
+
+				<DropdownMenuContent align="end" sideOffset={4} className="w-60">
+					{showUserPill && (
+						<>
+							<DropdownMenuLabel className="flex min-w-0 flex-col gap-0.5 py-2">
+								<span className="truncate text-sm font-medium">{displayName}</span>
+								{secondaryLine && <span className="text-muted-foreground truncate text-xs font-normal">{secondaryLine}</span>}
+							</DropdownMenuLabel>
+							<DropdownMenuSeparator />
+						</>
+					)}
+
+					<DropdownMenuGroup>
+						{externalLinks.map((item) => (
+							<DropdownMenuItem key={item.title} asChild>
+								<a href={item.url} target="_blank" rel="noopener noreferrer" className="cursor-pointer">
+									<item.icon className="size-4" size={16} weight="regular" strokeWidth={item.strokeWidth} />
+									<span className="truncate">{item.title}</span>
+								</a>
+							</DropdownMenuItem>
+						))}
+					</DropdownMenuGroup>
+
+					{canLogout && (
+						<>
+							<DropdownMenuSeparator />
+							<DropdownMenuItem onClick={handleLogout} data-testid="topbar-logout-btn" className="cursor-pointer">
+								<LogOut className="size-4" strokeWidth={2} />
+								<span>Sign out</span>
+							</DropdownMenuItem>
+						</>
+					)}
+				</DropdownMenuContent>
+			</DropdownMenu>
+		</header>
+	);
+}

--- a/ui/components/topbar.utils.test.ts
+++ b/ui/components/topbar.utils.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { deriveTitleFromPathname } from "./topbar.utils";
+
+describe("deriveTitleFromPathname", () => {
+	it("title-cases the last path segment", () => {
+		expect(deriveTitleFromPathname("/workspace/governance")).toBe("Governance");
+	});
+
+	it("splits hyphenated segments into words", () => {
+		expect(deriveTitleFromPathname("/workspace/routing-rules")).toBe("Routing Rules");
+	});
+
+	it("shouts known acronyms", () => {
+		expect(deriveTitleFromPathname("/workspace/mcp-registry")).toBe("MCP Registry");
+	});
+
+	it("falls back to Dashboard at the root", () => {
+		expect(deriveTitleFromPathname("/")).toBe("Dashboard");
+		expect(deriveTitleFromPathname("")).toBe("Dashboard");
+	});
+
+	it("ignores a trailing slash", () => {
+		expect(deriveTitleFromPathname("/workspace/governance/")).toBe("Governance");
+	});
+
+	// These are why <PageTitle> has to be rendered on a page's loading and empty
+	// branches too: on these routes the derived fallback is not a blank title,
+	// it is a *different* one, so dropping to it is a silent mislabel.
+	it("cannot reproduce titles the slug does not contain", () => {
+		expect(deriveTitleFromPathname("/workspace/custom-pricing/overrides")).toBe("Overrides");
+		expect(deriveTitleFromPathname("/workspace/model-limits")).toBe("Model Limits");
+	});
+});

--- a/ui/components/topbar.utils.ts
+++ b/ui/components/topbar.utils.ts
@@ -1,0 +1,30 @@
+/** Path segments that are shouted rather than capitalised. */
+const titleAcronyms: Record<string, string> = {
+	ai: "AI",
+	api: "API",
+	llm: "LLM",
+	mcp: "MCP",
+	oauth: "OAuth",
+	rbac: "RBAC",
+	scim: "SCIM",
+	sdk: "SDK",
+	sso: "SSO",
+};
+
+function formatTitlePart(part: string) {
+	return titleAcronyms[part.toLowerCase()] ?? part.charAt(0).toUpperCase() + part.slice(1);
+}
+
+/**
+ * Fallback title for a route that does not name itself, derived from the last
+ * non-empty path segment: "/workspace/mcp-registry" -> "MCP Registry".
+ *
+ * This is only ever a guess. Several routes carry a name the slug cannot
+ * produce ("/workspace/model-limits" is "Budgets & Limits"), which is why a
+ * page that renders <PageTitle> must render it on every branch — including its
+ * loading and empty states. Falling back there does not blank the topbar, it
+ * silently shows a different title.
+ */
+export function deriveTitleFromPathname(pathname: string): string {
+	return (pathname.split("/").filter(Boolean).at(-1) ?? "Dashboard").split("-").map(formatTitlePart).join(" ");
+}

--- a/ui/components/ui/tabs.tsx
+++ b/ui/components/ui/tabs.tsx
@@ -1,19 +1,159 @@
 import * as TabsPrimitive from "@radix-ui/react-tabs";
+import { ChevronDown } from "lucide-react";
 import * as React from "react";
 
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
+import { partitionTabs } from "@/components/ui/tabs.utils";
 import { cn } from "@/lib/utils";
 
-function Tabs({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Root>) {
-	return <TabsPrimitive.Root data-slot="tabs" className={cn("flex flex-col gap-2", className)} {...props} />;
+/**
+ * The selected value plus a setter, so <TabsList> can decide which trigger must
+ * stay on screen and can still switch tabs from the overflow dropdown. Radix
+ * keeps this in a private context, so we mirror it on the way through.
+ */
+const TabsValueContext = React.createContext<{ value?: string; setValue: (next: string) => void }>({ setValue: () => {} });
+
+/** Room reserved for the overflow dropdown trigger once it is shown. */
+const MORE_BUTTON_WIDTH = 40;
+
+function Tabs({ className, value, defaultValue, onValueChange, ...props }: React.ComponentProps<typeof TabsPrimitive.Root>) {
+	// Track the uncontrolled case ourselves; the controlled case just reads `value`.
+	const [uncontrolled, setUncontrolled] = React.useState(defaultValue);
+	const current = value ?? uncontrolled;
+
+	const setValue = React.useCallback(
+		(next: string) => {
+			if (value === undefined) setUncontrolled(next);
+			onValueChange?.(next);
+		},
+		[value, onValueChange],
+	);
+
+	const context = React.useMemo(() => ({ value: current, setValue }), [current, setValue]);
+
+	return (
+		<TabsValueContext.Provider value={context}>
+			<TabsPrimitive.Root
+				data-slot="tabs"
+				className={cn("flex flex-col gap-2", className)}
+				value={value}
+				defaultValue={defaultValue}
+				onValueChange={setValue}
+				{...props}
+			/>
+		</TabsValueContext.Provider>
+	);
 }
 
-function TabsList({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.List>) {
+type TabsTriggerElement = React.ReactElement<{ value?: string; children?: React.ReactNode }>;
+
+/**
+ * Renders the triggers that fit on one row and collapses the rest into a
+ * trailing dropdown.
+ *
+ * The alternative - a horizontally scrolling strip - hides tabs behind an
+ * affordance most people never find, and inside a sheet a trackpad's horizontal
+ * gesture fights the sheet's own scrolling. Strips that already fit are
+ * untouched: partitionTabs returns everything inline and no dropdown renders.
+ */
+function TabsList({ className, children, ...props }: React.ComponentProps<typeof TabsPrimitive.List>) {
+	const items = React.useMemo(
+		() => React.Children.toArray(children).filter((child) => React.isValidElement(child)) as TabsTriggerElement[],
+		[children],
+	);
+	const { value: activeValue, setValue } = React.useContext(TabsValueContext);
+	const activeIndex = items.findIndex((item) => item.props.value === activeValue);
+
+	const listRef = React.useRef<HTMLDivElement>(null);
+	const [containerWidth, setContainerWidth] = React.useState(0);
+	// Widths are captured on the first pass, while every trigger is still inline;
+	// a trigger moved into the dropdown reports 0 and could not be re-measured.
+	// `count` invalidates the cache when the set of tabs changes.
+	const [metrics, setMetrics] = React.useState<{ count: number; widths: number[] }>({ count: -1, widths: [] });
+	const measured = metrics.count === items.length;
+
+	React.useLayoutEffect(() => {
+		const list = listRef.current;
+		if (measured || !list) return;
+		const widths = Array.from(list.children).map((child) => (child as HTMLElement).offsetWidth);
+		if (widths.length === items.length && widths.every((width) => width > 0)) {
+			setMetrics({ count: items.length, widths });
+		}
+	}, [measured, items.length]);
+
+	// Measure the PARENT, never the list. TabsList is `w-fit inline-flex` by
+	// default and consumers often set `w-max`, so the list's own width is just the
+	// sum of its children - comparing against it would always report "everything
+	// fits" and the dropdown would never appear. The parent is what actually
+	// constrains the row. Measuring the parent also avoids a feedback loop:
+	// hiding a tab shrinks the list, which would re-trigger a list-based observer.
+	React.useEffect(() => {
+		const list = listRef.current;
+		if (!list || typeof ResizeObserver === "undefined") return;
+		const parent = list.parentElement;
+		const target = parent ?? list;
+
+		const measure = () => {
+			const horizontalPadding = (element: HTMLElement) => {
+				const style = window.getComputedStyle(element);
+				return (Number.parseFloat(style.paddingLeft) || 0) + (Number.parseFloat(style.paddingRight) || 0);
+			};
+			// clientWidth excludes border and scrollbar but includes padding, and the
+			// list's own padding is not available to its children either.
+			const outer = parent ? parent.clientWidth - horizontalPadding(parent) : list.clientWidth;
+			setContainerWidth(Math.max(0, outer - horizontalPadding(list)));
+		};
+
+		measure();
+		const observer = new ResizeObserver(measure);
+		observer.observe(target);
+		return () => observer.disconnect();
+	}, []);
+
+	const { visible, overflow } = measured
+		? partitionTabs({ itemWidths: metrics.widths, containerWidth, moreButtonWidth: MORE_BUTTON_WIDTH, activeIndex })
+		: { visible: items.map((_, index) => index), overflow: [] as number[] };
+
 	return (
 		<TabsPrimitive.List
+			ref={listRef}
 			data-slot="tabs-list"
 			className={cn("bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]", className)}
 			{...props}
-		/>
+		>
+			{visible.map((index) => items[index])}
+			{overflow.length > 0 && (
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild>
+						<button
+							type="button"
+							data-testid="tabs-overflow-trigger"
+							aria-label={`Show ${overflow.length} more ${overflow.length === 1 ? "tab" : "tabs"}`}
+							className="text-foreground hover:bg-background/60 focus-visible:ring-ring/50 flex h-[calc(100%-1px)] shrink-0 cursor-pointer items-center gap-0.5 rounded-sm border border-transparent px-2 text-sm font-medium focus-visible:ring-[3px] focus-visible:outline-1"
+						>
+							{overflow.length}
+							<ChevronDown className="size-3.5" />
+						</button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent align="end">
+						{overflow.map((index) => {
+							const item = items[index];
+							const itemValue = item.props.value;
+							return (
+								<DropdownMenuItem
+									key={itemValue ?? index}
+									className="cursor-pointer"
+									data-state={itemValue === activeValue ? "active" : "inactive"}
+									onSelect={() => itemValue !== undefined && setValue(itemValue)}
+								>
+									{item.props.children}
+								</DropdownMenuItem>
+							);
+						})}
+					</DropdownMenuContent>
+				</DropdownMenu>
+			)}
+		</TabsPrimitive.List>
 	);
 }
 

--- a/ui/components/ui/tabs.utils.test.ts
+++ b/ui/components/ui/tabs.utils.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { partitionTabs } from "./tabs.utils";
+
+// Six 100px tabs, matching the Install Bifrost MCP harness strip that overflows.
+const SIX = [100, 100, 100, 100, 100, 100];
+const MORE = 40;
+
+describe("partitionTabs", () => {
+	it("keeps every tab inline when they all fit", () => {
+		expect(partitionTabs({ itemWidths: SIX, containerWidth: 600, moreButtonWidth: MORE, activeIndex: 0 })).toEqual({
+			visible: [0, 1, 2, 3, 4, 5],
+			overflow: [],
+		});
+	});
+
+	it("keeps every tab inline before the container has been measured", () => {
+		// First paint reports 0; collapsing there would flash a dropdown that
+		// immediately disappears once layout settles.
+		expect(partitionTabs({ itemWidths: SIX, containerWidth: 0, moreButtonWidth: MORE, activeIndex: 0 })).toEqual({
+			visible: [0, 1, 2, 3, 4, 5],
+			overflow: [],
+		});
+	});
+
+	it("moves the tabs that do not fit into the overflow, reserving room for the more button", () => {
+		// 450px total: the more button takes 40, leaving 410 => four 100px tabs.
+		expect(partitionTabs({ itemWidths: SIX, containerWidth: 450, moreButtonWidth: MORE, activeIndex: 0 })).toEqual({
+			visible: [0, 1, 2, 3],
+			overflow: [4, 5],
+		});
+	});
+
+	it("preserves DOM order in both groups", () => {
+		const result = partitionTabs({ itemWidths: SIX, containerWidth: 250, moreButtonWidth: MORE, activeIndex: 0 });
+		expect(result.visible).toEqual([...result.visible].sort((a, b) => a - b));
+		expect(result.overflow).toEqual([...result.overflow].sort((a, b) => a - b));
+		expect([...result.visible, ...result.overflow].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4, 5]);
+	});
+
+	it("pulls the active tab inline when it would otherwise be hidden", () => {
+		// Active tab 5 must stay visible: the selected harness is the one the
+		// user is reading, so it cannot be the one buried in the dropdown.
+		const result = partitionTabs({ itemWidths: SIX, containerWidth: 450, moreButtonWidth: MORE, activeIndex: 5 });
+		expect(result.visible).toContain(5);
+		expect(result.overflow).not.toContain(5);
+	});
+
+	it("keeps the active tab inline even when only one tab fits", () => {
+		const result = partitionTabs({ itemWidths: SIX, containerWidth: 145, moreButtonWidth: MORE, activeIndex: 3 });
+		expect(result.visible).toEqual([3]);
+		expect(result.overflow).toEqual([0, 1, 2, 4, 5]);
+	});
+
+	it("keeps filling after a tab that is too wide to fit", () => {
+		// A single wide tab must not strand the row: stopping at it left ~190px of
+		// empty space on the dashboard while three tabs sat in the dropdown.
+		const result = partitionTabs({ itemWidths: [50, 300, 50, 50], containerWidth: 240, moreButtonWidth: MORE, activeIndex: 0 });
+		expect(result.visible).toEqual([0, 2, 3]);
+		expect(result.overflow).toEqual([1]);
+	});
+
+	it("leaves no room for a tab it could still have fitted", () => {
+		const itemWidths = [50, 300, 50, 50];
+		const containerWidth = 240;
+		const { visible, overflow } = partitionTabs({ itemWidths, containerWidth, moreButtonWidth: MORE, activeIndex: 0 });
+		const used = visible.reduce((sum, index) => sum + itemWidths[index], 0);
+		const available = containerWidth - MORE;
+		for (const index of overflow) {
+			expect(used + itemWidths[index]).toBeGreaterThan(available);
+		}
+	});
+
+	it("handles an empty strip", () => {
+		expect(partitionTabs({ itemWidths: [], containerWidth: 300, moreButtonWidth: MORE, activeIndex: -1 })).toEqual({
+			visible: [],
+			overflow: [],
+		});
+	});
+});

--- a/ui/components/ui/tabs.utils.ts
+++ b/ui/components/ui/tabs.utils.ts
@@ -1,0 +1,72 @@
+/**
+ * Splits a tab strip into the triggers that fit on one row and the ones that
+ * have to move into the trailing overflow dropdown.
+ *
+ * A horizontally scrolling strip hides tabs behind an affordance most people
+ * never find - especially inside a sheet, where a trackpad's horizontal gesture
+ * fights the sheet's own scroll. Collapsing the remainder into a dropdown keeps
+ * every tab reachable with a normal click.
+ */
+export interface TabsOverflowInput {
+	/** Measured width of each trigger, in DOM order. */
+	itemWidths: number[];
+	/** Width available to the row. */
+	containerWidth: number;
+	/** Width the "more" dropdown trigger occupies once it is shown. */
+	moreButtonWidth: number;
+	/** Index of the active trigger, or -1 when nothing is selected. */
+	activeIndex: number;
+}
+
+export interface TabsOverflowResult {
+	/** Indices rendered inline, in DOM order. */
+	visible: number[];
+	/** Indices rendered inside the dropdown, in DOM order. */
+	overflow: number[];
+}
+
+export function partitionTabs({ itemWidths, containerWidth, moreButtonWidth, activeIndex }: TabsOverflowInput): TabsOverflowResult {
+	const allVisible = () => ({ visible: itemWidths.map((_, index) => index), overflow: [] as number[] });
+
+	if (itemWidths.length === 0) return { visible: [], overflow: [] };
+	// Width is 0 until the first layout pass. Collapsing on that reading would
+	// flash a dropdown that vanishes a frame later.
+	if (containerWidth <= 0) return allVisible();
+
+	const total = itemWidths.reduce((sum, width) => sum + width, 0);
+	if (total <= containerWidth) return allVisible();
+
+	// Overflowing, so the dropdown trigger is on screen and takes its own room.
+	const available = containerWidth - moreButtonWidth;
+	const hasActive = activeIndex >= 0 && activeIndex < itemWidths.length;
+
+	// The selected tab is the one being read, so it claims its width before
+	// anything else and never hides in the dropdown.
+	const activeFits = hasActive && itemWidths[activeIndex] <= available;
+	let used = activeFits ? itemWidths[activeIndex] : 0;
+
+	const visible: number[] = [];
+	for (let index = 0; index < itemWidths.length; index++) {
+		if (hasActive && index === activeIndex) continue;
+		// `continue`, not `break`: one unusually wide tab must not strand the row.
+		// Stopping at it pushes every narrower tab behind it into the dropdown and
+		// leaves the freed space visibly empty. Skipping it keeps the remaining
+		// tabs inline, still in DOM order - only the tab that genuinely cannot fit
+		// moves into the menu.
+		if (used + itemWidths[index] > available) continue;
+		visible.push(index);
+		used += itemWidths[index];
+	}
+
+	if (activeFits) {
+		visible.push(activeIndex);
+		visible.sort((a, b) => a - b);
+	} else if (hasActive && visible.length === 0) {
+		// Nothing fits at all - show the selected tab rather than an empty row.
+		visible.push(activeIndex);
+	}
+
+	const inVisible = new Set(visible);
+	const overflow = itemWidths.map((_, index) => index).filter((index) => !inVisible.has(index));
+	return { visible, overflow };
+}

--- a/ui/lib/contexts/topbarContext.tsx
+++ b/ui/lib/contexts/topbarContext.tsx
@@ -1,0 +1,78 @@
+import { createContext, useContext, useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from "react";
+import { EMPTY_TITLE_ENTRY, claimTitle, releaseTitle, type TopbarTitleEntry } from "./topbarContext.utils";
+
+interface TopbarContextValue {
+	/** Page-supplied title override; null means "fall back to the route-derived title". */
+	title: string | null;
+	/** Write side, ownership-aware. Prefer useSetTopbarTitle over calling this directly. */
+	setTitleEntry: Dispatch<SetStateAction<TopbarTitleEntry>>;
+	/**
+	 * DOM node the topbar exposes next to the title. Page descriptions are
+	 * portalled into it rather than lifted through state, because a description
+	 * is arbitrary JSX (links, <code>, conditional spans) whose identity changes
+	 * every render — storing that in context would loop.
+	 */
+	descriptionSlot: HTMLElement | null;
+	setDescriptionSlot: Dispatch<SetStateAction<HTMLElement | null>>;
+}
+
+const TopbarContext = createContext<TopbarContextValue | null>(null);
+
+export function TopbarProvider({ children }: { children: React.ReactNode }) {
+	const [titleEntry, setTitleEntry] = useState<TopbarTitleEntry>(EMPTY_TITLE_ENTRY);
+	const [descriptionSlot, setDescriptionSlot] = useState<HTMLElement | null>(null);
+	const value = useMemo(
+		() => ({ title: titleEntry.value, setTitleEntry, descriptionSlot, setDescriptionSlot }),
+		[titleEntry.value, descriptionSlot],
+	);
+	return <TopbarContext.Provider value={value}>{children}</TopbarContext.Provider>;
+}
+
+/** Read side — used by <Topbar>. Returns null outside a provider so the topbar still renders. */
+export function useTopbarTitle(): string | null {
+	return useContext(TopbarContext)?.title ?? null;
+}
+
+/** Registers the topbar's description anchor. Called by <Topbar> via a ref callback. */
+export function useDescriptionSlotRef() {
+	return useContext(TopbarContext)?.setDescriptionSlot;
+}
+
+/** Read side for <PageTitle>, which portals its description into this node. */
+export function useDescriptionSlot(): HTMLElement | null {
+	return useContext(TopbarContext)?.descriptionSlot ?? null;
+}
+
+/**
+ * Write side — a page calls this to name itself in the topbar instead of
+ * rendering its own <h1>:
+ *
+ *   useSetTopbarTitle("Budgets & Limits");
+ *
+ * Pass undefined/null to leave the route-derived fallback in place.
+ *
+ * The title is cleared on unmount, but only if this caller still owns it:
+ * during a route transition the incoming page mounts and sets its title before
+ * the outgoing page's cleanup runs, so an unconditional reset would wipe the
+ * new title. Ownership is an opaque per-caller token rather than the title
+ * text, because two routes may legitimately share a title string — see
+ * topbarContext.utils.ts.
+ */
+export function useSetTopbarTitle(title: string | null | undefined) {
+	const setTitleEntry = useContext(TopbarContext)?.setTitleEntry;
+	const resolved = title ?? null;
+	// One token per hook instance, stable for its whole lifetime.
+	const ownerRef = useRef<symbol | null>(null);
+	if (ownerRef.current === null) ownerRef.current = Symbol("topbar-title");
+	const owner = ownerRef.current;
+
+	useEffect(() => {
+		if (!setTitleEntry) return;
+		setTitleEntry((current) => claimTitle(current, owner, resolved));
+	}, [setTitleEntry, owner, resolved]);
+
+	useEffect(() => {
+		if (!setTitleEntry) return;
+		return () => setTitleEntry((current) => releaseTitle(current, owner));
+	}, [setTitleEntry, owner]);
+}

--- a/ui/lib/contexts/topbarContext.utils.test.ts
+++ b/ui/lib/contexts/topbarContext.utils.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { EMPTY_TITLE_ENTRY, claimTitle, releaseTitle } from "./topbarContext.utils";
+
+const pageA = Symbol("page-a");
+const pageB = Symbol("page-b");
+
+describe("claimTitle", () => {
+	it("records the value and its owner", () => {
+		expect(claimTitle(EMPTY_TITLE_ENTRY, pageA, "Logs")).toEqual({ value: "Logs", owner: pageA });
+	});
+
+	it("lets a later page take over the title", () => {
+		const owned = claimTitle(EMPTY_TITLE_ENTRY, pageA, "Logs");
+		expect(claimTitle(owned, pageB, "Budgets & Limits")).toEqual({ value: "Budgets & Limits", owner: pageB });
+	});
+
+	it("returns the same object when nothing changed, so the provider does not re-render", () => {
+		const owned = claimTitle(EMPTY_TITLE_ENTRY, pageA, "Logs");
+		expect(claimTitle(owned, pageA, "Logs")).toBe(owned);
+	});
+});
+
+describe("releaseTitle", () => {
+	it("clears the title when the owner is still the one unmounting", () => {
+		const owned = claimTitle(EMPTY_TITLE_ENTRY, pageA, "Logs");
+		expect(releaseTitle(owned, pageA)).toEqual(EMPTY_TITLE_ENTRY);
+	});
+
+	it("leaves a title set by a different page alone", () => {
+		// Route change: B mounts and claims before A's cleanup runs.
+		const handedOver = claimTitle(claimTitle(EMPTY_TITLE_ENTRY, pageA, "Logs"), pageB, "Budgets & Limits");
+		expect(releaseTitle(handedOver, pageA)).toEqual({ value: "Budgets & Limits", owner: pageB });
+	});
+
+	it("leaves the incoming page's title alone even when both pages use the same text", () => {
+		// The reason ownership cannot be inferred from the title string: A and B
+		// both call themselves "Logs", so comparing text would make A's cleanup
+		// clear the title B just claimed, dropping the topbar to the
+		// route-derived fallback.
+		const handedOver = claimTitle(claimTitle(EMPTY_TITLE_ENTRY, pageA, "Logs"), pageB, "Logs");
+		expect(releaseTitle(handedOver, pageA)).toEqual({ value: "Logs", owner: pageB });
+	});
+});

--- a/ui/lib/contexts/topbarContext.utils.ts
+++ b/ui/lib/contexts/topbarContext.utils.ts
@@ -1,0 +1,32 @@
+/**
+ * Ownership bookkeeping for the topbar title.
+ *
+ * A page names itself in the topbar on mount and gives the name back on
+ * unmount. React runs those out of order across a route change: the incoming
+ * page's effect fires *before* the outgoing page's cleanup, so a release that
+ * did not check ownership would wipe the title the new page just set.
+ *
+ * Ownership is tracked with an opaque per-caller token rather than the title
+ * text, because two routes are free to use the same title string and text
+ * comparison cannot tell "the page I replaced" from "the page that replaced
+ * me".
+ */
+export interface TopbarTitleEntry {
+	/** null means "fall back to the route-derived title". */
+	value: string | null;
+	/** Opaque token identifying the caller that set `value`. */
+	owner: symbol | null;
+}
+
+export const EMPTY_TITLE_ENTRY: TopbarTitleEntry = { value: null, owner: null };
+
+/** A caller takes the title, becoming its owner. */
+export function claimTitle(current: TopbarTitleEntry, owner: symbol, value: string | null): TopbarTitleEntry {
+	if (current.value === value && current.owner === owner) return current;
+	return { value, owner };
+}
+
+/** A caller gives the title back. A no-op unless that caller still owns it. */
+export function releaseTitle(current: TopbarTitleEntry, owner: symbol): TopbarTitleEntry {
+	return current.owner === owner ? EMPTY_TITLE_ENTRY : current;
+}


### PR DESCRIPTION
## Summary

Introduces a persistent `<Topbar>` component that sits above the inset content card on every page. Page titles are hoisted into it via a lightweight context (`TopbarProvider` / `useSetTopbarTitle`), and page descriptions are portalled into a DOM slot the topbar exposes next to the title — avoiding the re-render loop that would result from storing arbitrary JSX in context state. A new `<PageTitle>` component replaces every inline `<h1>`/`<h2>` + description block across the workspace, rendering nothing inline and instead driving the topbar title and an info-icon hover card.

The external links (Discord, GitHub, bug report, docs) and the user/logout controls that previously lived in the sidebar footer are moved into a topbar dropdown menu, where they are labelled and more discoverable. The sidebar footer is simplified to just the expand affordance for the collapsed rail.

## Changes

- **`ui/components/topbar.tsx`** — new 48px header strip. Renders the page title (from context or derived from the last path segment with acronym normalisation), a description slot anchor, the theme toggle, and a dropdown menu containing external links and the user/logout action.
- **`ui/lib/contexts/topbarContext.tsx`** — new context providing `useSetTopbarTitle`, `useTopbarTitle`, `useDescriptionSlot`, and `useDescriptionSlotRef`. Title ownership is tracked with a ref so that a mounting page's `setTitle` call is not wiped by the unmounting page's cleanup.
- **`ui/components/pageTitle.tsx`** — new component. Calls `useSetTopbarTitle` and portals an `<Info>` hover card into the topbar's description slot. Renders nothing in the page body.
- **`ui/app/clientLayout.tsx`** — wraps the sidebar provider in `<TopbarProvider>`, inserts `<Topbar>` above the content card, removes the old mobile sticky header (title + `SidebarTrigger`), and adjusts the flex layout so the topbar takes its fixed height and the content card fills the remainder.
- **`ui/components/sidebar.tsx`** — removes external links, theme toggle, user popover, and logout button from the footer. Retains only the collapsed-rail expand button and the promo card stack.
- **`ui/components/themeToggle.tsx`** — extracts `<ThemeToggleItems>` (bare dropdown items with active-state checkmarks) so the items can be embedded in a larger menu. `<ThemeToggle>` now uses them internally.
- **All workspace page/view components** — inline `<h1>`/`<h2>` + description `<p>` blocks replaced with `<PageTitle title="…">description</PageTitle>`. Action buttons that were paired with the heading are moved into the search/filter toolbar row, pushed to the right with `sm:ml-auto`.
- **`tests/integrations/python/config.json`** — removes `env_label` field and collapses single-element JSON arrays onto one line for readability.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i
pnpm build
```

1. Open the dashboard and navigate between pages — the topbar should display the correct page title on each route.
2. Pages with a `<PageTitle>` description should show an `ⓘ` icon beside the title; hovering it should reveal the description in a card.
3. The sidebar footer should no longer contain external links, the theme toggle, or the logout button.
4. The topbar menu (hamburger or user pill) should contain Discord, GitHub, bug report, and docs links, plus a "Sign out" entry when auth is enabled.
5. On mobile, the `SidebarTrigger` should appear in the topbar rather than in a sticky in-page header.
6. Theme switching via the topbar toggle should work as before.

## Screenshots/Recordings

Before/after screenshots recommended — the topbar is a visible layout change on every page.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The logout flow and user-info display are unchanged in behaviour; only their render location moved from the sidebar to the topbar dropdown.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable