### PR TITLE
feat: limit unary provider response bodies

### DIFF
--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -2924,8 +2924,12 @@ func (provider *BedrockProvider) FileDelete(ctx *schemas.BifrostContext, keys []
 
 		// S3 DELETE returns 204 No Content on success
 		if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
-			body, _ := providerUtils.ReadHTTPResponseBody(resp, provider.networkConfig.MaxResponseBodySize)
+			body, readErr := providerUtils.ReadHTTPResponseBody(resp, provider.networkConfig.MaxResponseBodySize)
 			resp.Body.Close()
+			if readErr != nil {
+				lastErr = providerUtils.NewBifrostOperationError("error reading S3 DELETE response", readErr)
+				continue
+			}
 			lastErr = providerUtils.NewProviderAPIError(fmt.Sprintf("S3 DELETE failed: %s", string(body)), nil, resp.StatusCode, nil, nil)
 			continue
 		}
@@ -3004,8 +3008,12 @@ func (provider *BedrockProvider) FileContent(ctx *schemas.BifrostContext, keys [
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			body, _ := providerUtils.ReadHTTPResponseBody(resp, provider.networkConfig.MaxResponseBodySize)
+			body, readErr := providerUtils.ReadHTTPResponseBody(resp, provider.networkConfig.MaxResponseBodySize)
 			resp.Body.Close()
+			if readErr != nil {
+				lastErr = providerUtils.NewBifrostOperationError("error reading S3 GET response", readErr)
+				continue
+			}
 			lastErr = providerUtils.NewProviderAPIError(fmt.Sprintf("S3 GET failed: %s", string(body)), nil, resp.StatusCode, nil, nil)
 			continue
 		}

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -366,15 +366,9 @@ func (provider *BedrockProvider) executeBedrockRequest(req *http.Request) ([]byt
 	defer resp.Body.Close()
 
 	// Read response body
-	body, err := io.ReadAll(resp.Body)
+	body, err := providerUtils.ReadHTTPResponseBody(resp, provider.networkConfig.MaxResponseBodySize)
 	if err != nil {
-		return nil, latency, providerResponseHeaders, providerUtils.SetErrorLatency(&schemas.BifrostError{
-			IsBifrostError: true,
-			Error: &schemas.ErrorField{
-				Message: "error reading request",
-				Error:   err,
-			},
-		}, latency)
+		return nil, latency, providerResponseHeaders, providerUtils.SetErrorLatency(providerUtils.NewBifrostOperationError("error reading request", err), latency)
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -460,15 +454,9 @@ func (provider *BedrockProvider) completeAgentRuntimeRequest(ctx *schemas.Bifros
 	providerResponseHeaders := providerUtils.ExtractProviderResponseHeadersFromHTTP(resp)
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := providerUtils.ReadHTTPResponseBody(resp, provider.networkConfig.MaxResponseBodySize)
 	if err != nil {
-		return nil, latency, providerResponseHeaders, providerUtils.SetErrorLatency(&schemas.BifrostError{
-			IsBifrostError: true,
-			Error: &schemas.ErrorField{
-				Message: "error reading request",
-				Error:   err,
-			},
-		}, latency)
+		return nil, latency, providerResponseHeaders, providerUtils.SetErrorLatency(providerUtils.NewBifrostOperationError("error reading request", err), latency)
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -565,8 +553,11 @@ func (provider *BedrockProvider) makeStreamingRequest(ctx *schemas.BifrostContex
 
 	// Check for HTTP errors — use parseBedrockHTTPError to preserve upstream error details
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := providerUtils.ReadHTTPResponseBody(resp, provider.networkConfig.MaxResponseBodySize)
 		resp.Body.Close()
+		if readErr != nil {
+			return nil, providerUtils.SetErrorLatency(providerUtils.NewBifrostOperationError("error reading response", readErr), latency)
+		}
 		return nil, providerUtils.SetErrorLatency(parseBedrockHTTPError(resp.StatusCode, resp.Header, body), latency)
 	}
 
@@ -803,7 +794,7 @@ func (provider *BedrockProvider) listMantleModels(ctx *schemas.BifrostContext, k
 		provider.logger.Warn("mantle list-models request failed: %v", err)
 		return nil
 	}
-	responseBody, err := io.ReadAll(resp.Body)
+	responseBody, err := providerUtils.ReadHTTPResponseBody(resp, provider.networkConfig.MaxResponseBodySize)
 	resp.Body.Close()
 	if err != nil {
 		provider.logger.Warn("failed to read mantle list-models response: %v", err)
@@ -922,7 +913,7 @@ func (provider *BedrockProvider) listModelsByKey(ctx *schemas.BifrostContext, ke
 	}
 
 	// Read response body and close
-	responseBody, err := io.ReadAll(resp.Body)
+	responseBody, err := providerUtils.ReadHTTPResponseBody(resp, provider.networkConfig.MaxResponseBodySize)
 	resp.Body.Close()
 	if err != nil {
 		return nil, providerUtils.SetErrorLatency(&schemas.BifrostError{
@@ -2590,8 +2581,11 @@ func (provider *BedrockProvider) FileUpload(ctx *schemas.BifrostContext, key sch
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := providerUtils.ReadHTTPResponseBody(resp, provider.networkConfig.MaxResponseBodySize)
 		provider.logger.Error("s3 upload failed: %d", resp.StatusCode)
+		if readErr != nil {
+			return nil, providerUtils.NewBifrostOperationError("error reading response", readErr)
+		}
 		return nil, providerUtils.NewProviderAPIError(fmt.Sprintf("S3 upload failed: %s", string(body)), nil, resp.StatusCode, nil, nil)
 	}
 
@@ -2717,7 +2711,7 @@ func (provider *BedrockProvider) FileList(ctx *schemas.BifrostContext, keys []sc
 		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderDoRequest, err)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := providerUtils.ReadHTTPResponseBody(resp, provider.networkConfig.MaxResponseBodySize)
 	resp.Body.Close()
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("error reading response", err)
@@ -2930,7 +2924,7 @@ func (provider *BedrockProvider) FileDelete(ctx *schemas.BifrostContext, keys []
 
 		// S3 DELETE returns 204 No Content on success
 		if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
+			body, _ := providerUtils.ReadHTTPResponseBody(resp, provider.networkConfig.MaxResponseBodySize)
 			resp.Body.Close()
 			lastErr = providerUtils.NewProviderAPIError(fmt.Sprintf("S3 DELETE failed: %s", string(body)), nil, resp.StatusCode, nil, nil)
 			continue
@@ -3010,13 +3004,13 @@ func (provider *BedrockProvider) FileContent(ctx *schemas.BifrostContext, keys [
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
+			body, _ := providerUtils.ReadHTTPResponseBody(resp, provider.networkConfig.MaxResponseBodySize)
 			resp.Body.Close()
 			lastErr = providerUtils.NewProviderAPIError(fmt.Sprintf("S3 GET failed: %s", string(body)), nil, resp.StatusCode, nil, nil)
 			continue
 		}
 
-		body, err := io.ReadAll(resp.Body)
+		body, err := providerUtils.ReadHTTPResponseBody(resp, provider.networkConfig.MaxResponseBodySize)
 		resp.Body.Close()
 		if err != nil {
 			lastErr = providerUtils.NewBifrostOperationError("error reading S3 object content", err)
@@ -3218,7 +3212,7 @@ func (provider *BedrockProvider) BatchCreate(ctx *schemas.BifrostContext, key sc
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := providerUtils.ReadHTTPResponseBody(resp, provider.networkConfig.MaxResponseBodySize)
 	if err != nil {
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("error reading response", err), jsonData, nil, sendBackRawRequest, sendBackRawResponse)
 	}
@@ -3342,7 +3336,7 @@ func (provider *BedrockProvider) BatchList(ctx *schemas.BifrostContext, keys []s
 		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderDoRequest, err)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := providerUtils.ReadHTTPResponseBody(resp, provider.networkConfig.MaxResponseBodySize)
 	resp.Body.Close()
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("error reading response", err)
@@ -3456,7 +3450,7 @@ func (provider *BedrockProvider) fetchBatchManifest(ctx *schemas.BifrostContext,
 		return nil
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := providerUtils.ReadHTTPResponseBody(resp, provider.networkConfig.MaxResponseBodySize)
 	if err != nil {
 		provider.logger.Debug("failed to read manifest body: %v", err)
 		return nil
@@ -3523,7 +3517,7 @@ func (provider *BedrockProvider) BatchRetrieve(ctx *schemas.BifrostContext, keys
 			continue
 		}
 
-		body, err := io.ReadAll(resp.Body)
+		body, err := providerUtils.ReadHTTPResponseBody(resp, provider.networkConfig.MaxResponseBodySize)
 		resp.Body.Close()
 		if err != nil {
 			lastErr = providerUtils.NewBifrostOperationError("error reading response", err)
@@ -3667,7 +3661,7 @@ func (provider *BedrockProvider) BatchCancel(ctx *schemas.BifrostContext, keys [
 			continue
 		}
 
-		body, err := io.ReadAll(resp.Body)
+		body, err := providerUtils.ReadHTTPResponseBody(resp, provider.networkConfig.MaxResponseBodySize)
 		resp.Body.Close()
 		if err != nil {
 			lastErr = providerUtils.NewBifrostOperationError("error reading response", err)

--- a/core/providers/utils/httpresponse_test.go
+++ b/core/providers/utils/httpresponse_test.go
@@ -1,0 +1,60 @@
+package utils
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestReadHTTPResponseBody_EnforcesKnownContentLength(t *testing.T) {
+	resp := &http.Response{
+		ContentLength: 5,
+		Body:          io.NopCloser(strings.NewReader("12345")),
+	}
+
+	body, err := ReadHTTPResponseBody(resp, 4)
+	if !errors.Is(err, ErrResponseBodyTooLarge) {
+		t.Fatalf("error = %v, want ErrResponseBodyTooLarge", err)
+	}
+	if body != nil {
+		t.Fatalf("body = %q, want nil", body)
+	}
+}
+
+func TestReadHTTPResponseBody_EnforcesUnknownContentLength(t *testing.T) {
+	resp := &http.Response{
+		ContentLength: -1,
+		Body:          io.NopCloser(strings.NewReader("12345")),
+	}
+
+	body, err := ReadHTTPResponseBody(resp, 4)
+	if !errors.Is(err, ErrResponseBodyTooLarge) {
+		t.Fatalf("error = %v, want ErrResponseBodyTooLarge", err)
+	}
+	if body != nil {
+		t.Fatalf("body = %q, want nil", body)
+	}
+}
+
+func TestReadHTTPResponseBody_AllowsExactLimitAndUnlimited(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		max  int64
+	}{
+		{name: "exact", max: 5},
+		{name: "unlimited", max: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &http.Response{ContentLength: 5, Body: io.NopCloser(strings.NewReader("12345"))}
+			body, err := ReadHTTPResponseBody(resp, tc.max)
+			if err != nil {
+				t.Fatalf("error = %v", err)
+			}
+			if string(body) != "12345" {
+				t.Fatalf("body = %q, want 12345", body)
+			}
+		})
+	}
+}

--- a/core/providers/utils/httpresponse_test.go
+++ b/core/providers/utils/httpresponse_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/valyala/fasthttp"
 )
 
 func TestReadHTTPResponseBody_EnforcesKnownContentLength(t *testing.T) {
@@ -54,6 +56,26 @@ func TestReadHTTPResponseBody_AllowsExactLimitAndUnlimited(t *testing.T) {
 			}
 			if string(body) != "12345" {
 				t.Fatalf("body = %q, want 12345", body)
+			}
+		})
+	}
+}
+
+func TestNewBifrostOperationError_ResponseBodyTooLargeSetsBadGateway(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{name: "net/http bounded reader", err: ErrResponseBodyTooLarge},
+		{name: "fasthttp unary client", err: fasthttp.ErrBodyTooLarge},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := NewBifrostOperationError("error reading response", tc.err)
+			if err.StatusCode == nil || *err.StatusCode != http.StatusBadGateway {
+				t.Fatalf("StatusCode = %v, want %d", err.StatusCode, http.StatusBadGateway)
+			}
+			if err.Error == nil || err.Error.Message != "provider response body exceeds configured maximum size" {
+				t.Fatalf("error message = %#v, want response-size error", err.Error)
 			}
 		})
 	}

--- a/core/providers/utils/largeresponse_test.go
+++ b/core/providers/utils/largeresponse_test.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+func TestPrepareResponseStreaming_EnterpriseThresholdOverridesClientLimit(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyLargeResponseThreshold, int64(4096))
+	base := &fasthttp.Client{MaxResponseBodySize: 1024}
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+
+	active := PrepareResponseStreaming(ctx, base, resp)
+
+	if active.MaxResponseBodySize != 4096 {
+		t.Fatalf("Enterprise threshold: got %d, want 4096", active.MaxResponseBodySize)
+	}
+	if !active.StreamResponseBody {
+		t.Fatal("Enterprise response client must enable streaming")
+	}
+}

--- a/core/providers/utils/streamingclient_test.go
+++ b/core/providers/utils/streamingclient_test.go
@@ -18,11 +18,12 @@ import (
 // config from the base.
 func TestBuildStreamingClient_ZerosReadWriteTimeout(t *testing.T) {
 	base := &fasthttp.Client{
-		ReadTimeout:        30 * time.Second,
-		WriteTimeout:       30 * time.Second,
-		MaxConnDuration:    5 * time.Minute,
-		MaxConnWaitTimeout: 15 * time.Second,
-		MaxConnsPerHost:    123,
+		ReadTimeout:         30 * time.Second,
+		WriteTimeout:        30 * time.Second,
+		MaxConnDuration:     5 * time.Minute,
+		MaxConnWaitTimeout:  15 * time.Second,
+		MaxConnsPerHost:     123,
+		MaxResponseBodySize: 1024,
 	}
 	ConfigureDialer(base, false)
 
@@ -39,6 +40,9 @@ func TestBuildStreamingClient_ZerosReadWriteTimeout(t *testing.T) {
 	}
 	if !stream.StreamResponseBody {
 		t.Error("StreamResponseBody: got false, want true")
+	}
+	if stream.MaxResponseBodySize != 0 {
+		t.Errorf("MaxResponseBodySize: got %d, want 0 for streaming", stream.MaxResponseBodySize)
 	}
 	if stream.MaxConnWaitTimeout != base.MaxConnWaitTimeout {
 		t.Errorf("MaxConnWaitTimeout should be preserved: got %v, want %v",
@@ -65,6 +69,17 @@ func TestBuildStreamingClient_BaseUnchanged(t *testing.T) {
 	}
 	if base.MaxConnDuration != 5*time.Minute {
 		t.Errorf("base MaxConnDuration mutated: got %v, want 5m", base.MaxConnDuration)
+	}
+}
+
+func TestBuildStreamingClient_ClearsUnaryResponseLimit(t *testing.T) {
+	base := &fasthttp.Client{MaxResponseBodySize: 1024}
+	stream := BuildStreamingClient(base)
+	if stream.MaxResponseBodySize != 0 {
+		t.Fatalf("MaxResponseBodySize: got %d, want 0", stream.MaxResponseBodySize)
+	}
+	if base.MaxResponseBodySize != 1024 {
+		t.Fatalf("base MaxResponseBodySize mutated: got %d, want 1024", base.MaxResponseBodySize)
 	}
 }
 

--- a/core/providers/utils/tls_test.go
+++ b/core/providers/utils/tls_test.go
@@ -68,6 +68,33 @@ func TestConfigureTLS_ReturnsUnchangedWhenNeitherSet(t *testing.T) {
 	}
 }
 
+func TestConfigureTLS_AppliesMaxResponseBodySize(t *testing.T) {
+	client := &fasthttp.Client{}
+	ConfigureTLS(client, schemas.NetworkConfig{MaxResponseBodySize: 4096}, testLogger{})
+
+	if client.MaxResponseBodySize != 4096 {
+		t.Fatalf("MaxResponseBodySize: got %d, want 4096", client.MaxResponseBodySize)
+	}
+}
+
+func TestConfigureTLS_ZeroClearsMaxResponseBodySize(t *testing.T) {
+	client := &fasthttp.Client{MaxResponseBodySize: 4096}
+	ConfigureTLS(client, schemas.NetworkConfig{}, testLogger{})
+
+	if client.MaxResponseBodySize != 0 {
+		t.Fatalf("MaxResponseBodySize: got %d, want 0 for unlimited config", client.MaxResponseBodySize)
+	}
+}
+
+func TestConfigureTLS_NegativeMaxResponseBodySizeFailsClosed(t *testing.T) {
+	client := &fasthttp.Client{}
+	ConfigureTLS(client, schemas.NetworkConfig{MaxResponseBodySize: -1}, testLogger{})
+
+	if client.MaxResponseBodySize != 1 {
+		t.Fatalf("MaxResponseBodySize: got %d, want fail-closed limit of 1", client.MaxResponseBodySize)
+	}
+}
+
 func TestConfigureTLS_SetsInsecureSkipVerify(t *testing.T) {
 	client := &fasthttp.Client{}
 	logger := testLogger{}

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -13,6 +13,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/textproto"
@@ -391,6 +393,9 @@ func makeRequestWithDoFunc(ctx context.Context, do func() error) (time.Duration,
 		// Single accumulation point for every unary provider call.
 		schemas.AddUpstreamLatency(ctx, latency)
 		if err != nil {
+			if errors.Is(err, fasthttp.ErrBodyTooLarge) {
+				return latency, SetErrorLatency(NewBifrostOperationError(schemas.ErrProviderResponseTooLarge, err), latency), noop
+			}
 			if errors.Is(err, context.Canceled) {
 				return latency, &schemas.BifrostError{
 					IsBifrostError: false,
@@ -499,6 +504,37 @@ func DoHTTPRequest(client *http.Client, req *http.Request) (*http.Response, erro
 		resp.Body = &upstreamTimingBody{inner: resp.Body, ctx: req.Context()}
 	}
 	return resp, err
+}
+
+// ErrResponseBodyTooLarge is returned when a bounded net/http response reader
+// consumes more than the configured provider response limit.
+var ErrResponseBodyTooLarge = errors.New(schemas.ErrProviderResponseTooLarge)
+
+// ReadHTTPResponseBody reads a unary net/http response with an optional byte
+// limit. The extra byte probe distinguishes an oversized body from an exact
+// boundary and prevents partial JSON/XML from being treated as a successful
+// response. A zero limit preserves the historical unlimited behavior.
+func ReadHTTPResponseBody(resp *http.Response, maxBytes int64) ([]byte, error) {
+	if resp == nil || resp.Body == nil {
+		return nil, io.ErrUnexpectedEOF
+	}
+	if maxBytes <= 0 {
+		return io.ReadAll(resp.Body)
+	}
+	if resp.ContentLength > maxBytes {
+		return nil, ErrResponseBodyTooLarge
+	}
+	if maxBytes == math.MaxInt64 {
+		return io.ReadAll(resp.Body)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, ErrResponseBodyTooLarge
+	}
+	return body, nil
 }
 
 // Deprecated: ConfigureRetry is now handled internally by ConfigureDialer.
@@ -791,6 +827,23 @@ func createTLSConfigWithCA(caCertPEM string) (*tls.Config, error) {
 // ConfigureTLS applies TLS settings from NetworkConfig to the fasthttp client.
 // It merges with any existing TLSConfig (e.g., from ConfigureProxy).
 func ConfigureTLS(client *fasthttp.Client, networkConfig schemas.NetworkConfig, logger schemas.Logger) *fasthttp.Client {
+	// MaxResponseBodySize is enforced by the unary client. Streaming clients
+	// explicitly clear this value in BuildStreamingClient, while Enterprise's
+	// large-response client replaces it with its own streaming threshold.
+	if networkConfig.MaxResponseBodySize < 0 {
+		// Negative values are invalid (the config schema rejects them). Fail closed
+		// for direct core callers or stale persisted configuration instead of
+		// silently converting an invalid value into unlimited buffering.
+		logger.Error("invalid provider configuration: network_config.max_response_body_size cannot be negative")
+		client.MaxResponseBodySize = 1
+	} else if networkConfig.MaxResponseBodySize > 0 && networkConfig.MaxResponseBodySize <= int64(math.MaxInt) {
+		client.MaxResponseBodySize = int(networkConfig.MaxResponseBodySize)
+	} else {
+		// Zero is explicitly unlimited. Clear a value inherited by a reused
+		// client so a config reload cannot retain a stale response bound.
+		client.MaxResponseBodySize = 0
+	}
+
 	if networkConfig.CACertPEM != nil && networkConfig.CACertPEM.IsFromSecret() && networkConfig.CACertPEM.GetValue() == "" {
 		errMsg := fmt.Sprintf("invalid provider configuration: %s references %q but it resolved to an empty value", "network_config.ca_cert_pem", networkConfig.CACertPEM.GetRawRef())
 		logger.Error(errMsg)
@@ -1372,6 +1425,7 @@ func BuildStreamingClient(base *fasthttp.Client) *fasthttp.Client {
 	c.ReadTimeout = 0
 	c.WriteTimeout = 0
 	c.MaxConnDuration = 0
+	c.MaxResponseBodySize = 0
 	c.StreamResponseBody = true
 	return c
 }
@@ -2188,6 +2242,9 @@ func NewConfigurationError(message string) *schemas.BifrostError {
 // NewBifrostOperationError creates a standardized error for bifrost operation errors.
 // This helper reduces code duplication across providers that have bifrost operation errors.
 func NewBifrostOperationError(message string, err error) *schemas.BifrostError {
+	if errors.Is(err, ErrResponseBodyTooLarge) {
+		message = schemas.ErrProviderResponseTooLarge
+	}
 	return &schemas.BifrostError{
 		IsBifrostError: true,
 		Error: &schemas.ErrorField{

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"math/rand"
 	"net"
 	"net/http"
 	"net/textproto"
@@ -2242,11 +2241,19 @@ func NewConfigurationError(message string) *schemas.BifrostError {
 // NewBifrostOperationError creates a standardized error for bifrost operation errors.
 // This helper reduces code duplication across providers that have bifrost operation errors.
 func NewBifrostOperationError(message string, err error) *schemas.BifrostError {
-	if errors.Is(err, ErrResponseBodyTooLarge) {
+	if errors.Is(err, ErrResponseBodyTooLarge) || errors.Is(err, fasthttp.ErrBodyTooLarge) {
 		message = schemas.ErrProviderResponseTooLarge
+	}
+	var statusCode *int
+	if message == schemas.ErrProviderResponseTooLarge {
+		// The gateway rejected an upstream response, so surface a provider-side
+		// bad-gateway error rather than the generic 500 used for internal failures.
+		status := http.StatusBadGateway
+		statusCode = &status
 	}
 	return &schemas.BifrostError{
 		IsBifrostError: true,
+		StatusCode:     statusCode,
 		Error: &schemas.ErrorField{
 			Message: message,
 			Error:   err,

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -44,6 +44,7 @@ const (
 	ErrProviderResponseUnmarshal    = "failed to unmarshal response from provider API"
 	ErrProviderResponseEmpty        = "empty response received from provider"
 	ErrProviderResponseHTML         = "HTML response received from provider"
+	ErrProviderResponseTooLarge     = "provider response body exceeds configured maximum size"
 	ErrProviderRawRequestUnmarshal  = "failed to unmarshal raw request from provider API"
 	ErrProviderRawResponseUnmarshal = "failed to unmarshal raw response from provider API"
 	ErrProviderResponseDecompress   = "failed to decompress provider's response"
@@ -70,6 +71,7 @@ type NetworkConfig struct {
 	StreamIdleTimeoutInSeconds     int               `json:"stream_idle_timeout_in_seconds,omitempty"` // Idle timeout per stream chunk (0 = use default 60s)
 	KeepAliveTimeoutInSeconds      int               `json:"keep_alive_timeout_in_seconds,omitempty"`  // Idle keep-alive for pooled connections; set below the upstream server's keep-alive to avoid reusing connections it has already closed. Default: 30s
 	MaxConnsPerHost                int               `json:"max_conns_per_host,omitempty"`             // Max TCP connections per provider host (default: 5000)
+	MaxResponseBodySize            int64             `json:"max_response_body_size,omitempty"`         // Maximum ordinary non-streaming response body size in bytes (0 = unlimited)
 	EnforceHTTP2                   bool              `json:"enforce_http2,omitempty"`                  // Force HTTP/2 on provider connections (relevant for net/http-based providers like Bedrock)
 	HTTP2PingIntervalInSeconds     int               `json:"http2_ping_interval_in_seconds,omitempty"` // Seconds of stream idle before an HTTP/2 keepalive PING (0 = disabled; only when enforce_http2)
 	BetaHeaderOverrides            map[string]bool   `json:"beta_header_overrides,omitempty"`          // Override default beta header support per provider (keys are prefixes like "redact-thinking-")
@@ -96,6 +98,7 @@ func (nc *NetworkConfig) UnmarshalJSON(data []byte) error {
 		StreamIdleTimeoutInSeconds     int               `json:"stream_idle_timeout_in_seconds,omitempty"`
 		KeepAliveTimeoutInSeconds      int               `json:"keep_alive_timeout_in_seconds,omitempty"`
 		MaxConnsPerHost                int               `json:"max_conns_per_host,omitempty"`
+		MaxResponseBodySize            int64             `json:"max_response_body_size,omitempty"`
 		EnforceHTTP2                   bool              `json:"enforce_http2,omitempty"`
 		HTTP2PingIntervalInSeconds     int               `json:"http2_ping_interval_in_seconds,omitempty"`
 		BetaHeaderOverrides            map[string]bool   `json:"beta_header_overrides,omitempty"`
@@ -117,6 +120,7 @@ func (nc *NetworkConfig) UnmarshalJSON(data []byte) error {
 	nc.StreamIdleTimeoutInSeconds = alias.StreamIdleTimeoutInSeconds
 	nc.KeepAliveTimeoutInSeconds = alias.KeepAliveTimeoutInSeconds
 	nc.MaxConnsPerHost = alias.MaxConnsPerHost
+	nc.MaxResponseBodySize = alias.MaxResponseBodySize
 	nc.EnforceHTTP2 = alias.EnforceHTTP2
 	nc.HTTP2PingIntervalInSeconds = alias.HTTP2PingIntervalInSeconds
 	nc.BetaHeaderOverrides = alias.BetaHeaderOverrides
@@ -191,6 +195,7 @@ func (nc NetworkConfig) MarshalJSON() ([]byte, error) {
 		StreamIdleTimeoutInSeconds     int               `json:"stream_idle_timeout_in_seconds,omitempty"`
 		KeepAliveTimeoutInSeconds      int               `json:"keep_alive_timeout_in_seconds,omitempty"`
 		MaxConnsPerHost                int               `json:"max_conns_per_host,omitempty"`
+		MaxResponseBodySize            int64             `json:"max_response_body_size,omitempty"`
 		EnforceHTTP2                   bool              `json:"enforce_http2,omitempty"`
 		HTTP2PingIntervalInSeconds     int               `json:"http2_ping_interval_in_seconds,omitempty"`
 		BetaHeaderOverrides            map[string]bool   `json:"beta_header_overrides,omitempty"`
@@ -209,6 +214,7 @@ func (nc NetworkConfig) MarshalJSON() ([]byte, error) {
 		StreamIdleTimeoutInSeconds: nc.StreamIdleTimeoutInSeconds,
 		KeepAliveTimeoutInSeconds:  nc.KeepAliveTimeoutInSeconds,
 		MaxConnsPerHost:            nc.MaxConnsPerHost,
+		MaxResponseBodySize:        nc.MaxResponseBodySize,
 		EnforceHTTP2:               nc.EnforceHTTP2,
 		HTTP2PingIntervalInSeconds: nc.HTTP2PingIntervalInSeconds,
 		BetaHeaderOverrides:        nc.BetaHeaderOverrides,

--- a/core/schemas/serialization_test.go
+++ b/core/schemas/serialization_test.go
@@ -1150,6 +1150,22 @@ func TestNetworkConfig_StreamIdleTimeoutRoundTrip(t *testing.T) {
 	assert.Contains(t, string(data), `"stream_idle_timeout_in_seconds":120`)
 }
 
+func TestNetworkConfig_MaxResponseBodySizeRoundTrip(t *testing.T) {
+	nc := NetworkConfig{
+		DefaultRequestTimeoutInSeconds: 300,
+		MaxResponseBodySize:            50 * 1024 * 1024,
+	}
+
+	data, err := json.Marshal(nc)
+	require.NoError(t, err)
+
+	var decoded NetworkConfig
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	assert.Equal(t, int64(50*1024*1024), decoded.MaxResponseBodySize)
+	assert.Contains(t, string(data), `"max_response_body_size":52428800`)
+}
+
 func TestNetworkConfig_HTTP2PingInterval(t *testing.T) {
 	nc := NetworkConfig{EnforceHTTP2: true, HTTP2PingIntervalInSeconds: 45}
 	data, err := json.Marshal(nc)

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -4058,6 +4058,11 @@
           "maximum": 10000,
           "description": "Maximum number of TCP connections per provider host. For HTTP/2 (e.g. Bedrock), each connection supports ~100 concurrent streams. Default: 5000."
         },
+        "max_response_body_size": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum provider response body size in bytes for ordinary non-streaming responses; 0 means unlimited."
+        },
         "beta_header_overrides": {
           "type": "object",
           "additionalProperties": {

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -3972,6 +3972,11 @@
           "maximum": 10000,
           "description": "Maximum number of TCP connections per provider host. For HTTP/2 (e.g. Bedrock), each connection supports ~100 concurrent streams. Default: 5000."
         },
+        "max_response_body_size": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum provider response body size in bytes for ordinary non-streaming responses; 0 means unlimited."
+        },
         "beta_header_overrides": {
           "type": "object",
           "additionalProperties": {

--- a/ui/app/workspace/providers/fragments/networkFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/networkFormFragment.tsx
@@ -111,6 +111,8 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 			}
 			return;
 		}
+		const maxResponseBodySize = Number(data.network_config?.max_response_body_size ?? 0);
+		const normalizedMaxResponseBodySize = Number.isFinite(maxResponseBodySize) ? maxResponseBodySize : 0;
 		// Create updated provider configuration
 		const updatedProvider = buildProviderUpdatePayload(provider, {
 			network_config: {
@@ -129,7 +131,7 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 				keep_alive_timeout_in_seconds:
 					data.network_config?.keep_alive_timeout_in_seconds ?? DefaultNetworkConfig.keep_alive_timeout_in_seconds,
 				max_conns_per_host: data.network_config?.max_conns_per_host ?? DefaultNetworkConfig.max_conns_per_host,
-				max_response_body_size: data.network_config?.max_response_body_size ?? 0,
+				max_response_body_size: normalizedMaxResponseBodySize,
 				enforce_http2: data.network_config?.enforce_http2 ?? DefaultNetworkConfig.enforce_http2,
 				http2_ping_interval_in_seconds:
 					data.network_config?.http2_ping_interval_in_seconds ?? DefaultNetworkConfig.http2_ping_interval_in_seconds,
@@ -140,7 +142,13 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 			.unwrap()
 			.then(() => {
 				toast.success("Provider configuration updated successfully");
-				form.reset(data);
+				form.reset({
+					...data,
+					network_config: {
+						...data.network_config,
+						max_response_body_size: normalizedMaxResponseBodySize,
+					},
+				});
 			})
 			.catch((err) => {
 				toast.error("Failed to update provider configuration", {

--- a/ui/app/workspace/providers/fragments/networkFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/networkFormFragment.tsx
@@ -88,6 +88,7 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 				keep_alive_timeout_in_seconds:
 					provider.network_config?.keep_alive_timeout_in_seconds ?? DefaultNetworkConfig.keep_alive_timeout_in_seconds,
 				max_conns_per_host: provider.network_config?.max_conns_per_host ?? DefaultNetworkConfig.max_conns_per_host,
+				max_response_body_size: provider.network_config?.max_response_body_size ?? 0,
 				enforce_http2: provider.network_config?.enforce_http2 ?? DefaultNetworkConfig.enforce_http2,
 				http2_ping_interval_in_seconds:
 					provider.network_config?.http2_ping_interval_in_seconds ?? DefaultNetworkConfig.http2_ping_interval_in_seconds,
@@ -128,6 +129,7 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 				keep_alive_timeout_in_seconds:
 					data.network_config?.keep_alive_timeout_in_seconds ?? DefaultNetworkConfig.keep_alive_timeout_in_seconds,
 				max_conns_per_host: data.network_config?.max_conns_per_host ?? DefaultNetworkConfig.max_conns_per_host,
+				max_response_body_size: data.network_config?.max_response_body_size ?? 0,
 				enforce_http2: data.network_config?.enforce_http2 ?? DefaultNetworkConfig.enforce_http2,
 				http2_ping_interval_in_seconds:
 					data.network_config?.http2_ping_interval_in_seconds ?? DefaultNetworkConfig.http2_ping_interval_in_seconds,
@@ -165,6 +167,7 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 				keep_alive_timeout_in_seconds:
 					provider.network_config?.keep_alive_timeout_in_seconds ?? DefaultNetworkConfig.keep_alive_timeout_in_seconds,
 				max_conns_per_host: provider.network_config?.max_conns_per_host ?? DefaultNetworkConfig.max_conns_per_host,
+				max_response_body_size: provider.network_config?.max_response_body_size ?? 0,
 				enforce_http2: provider.network_config?.enforce_http2 ?? DefaultNetworkConfig.enforce_http2,
 				http2_ping_interval_in_seconds:
 					provider.network_config?.http2_ping_interval_in_seconds ?? DefaultNetworkConfig.http2_ping_interval_in_seconds,
@@ -437,6 +440,38 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 								)}
 							/>
 						</div>
+						<FormField
+							control={form.control}
+							name="network_config.max_response_body_size"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Max Response Body Size (bytes)</FormLabel>
+									<FormControl>
+										<Input
+											data-testid="network-config-max-response-body-size-input"
+											placeholder="0 (unlimited)"
+											{...field}
+											value={field.value === undefined || Number.isNaN(field.value) ? "" : field.value}
+											disabled={!hasUpdateProviderAccess}
+											onChange={(e) => {
+												const value = e.target.value;
+												if (value === "") {
+													field.onChange(undefined);
+													return;
+												}
+												const parsed = Number(value);
+												if (!Number.isNaN(parsed)) field.onChange(parsed);
+												form.trigger("network_config");
+											}}
+										/>
+									</FormControl>
+									<FormDescription>
+										Limits ordinary non-streaming provider responses. Set 0 for unlimited.
+									</FormDescription>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
 						<FormField
 							control={form.control}
 							name="network_config.enforce_http2"

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -275,6 +275,7 @@ export interface NetworkConfig {
 	stream_idle_timeout_in_seconds?: number;
 	keep_alive_timeout_in_seconds?: number;
 	max_conns_per_host?: number;
+	max_response_body_size?: number;
 	enforce_http2?: boolean;
 	http2_ping_interval_in_seconds?: number;
 	beta_header_overrides?: Record<string, boolean>;

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -440,6 +440,11 @@ export const networkConfigSchema = z
 			.min(1, "Max connections must be at least 1")
 			.max(10000, "Max connections must be at most 10000")
 			.optional(),
+		max_response_body_size: z
+			.number()
+			.int("Max response body size must be a whole number of bytes")
+			.min(0, "Max response body size cannot be negative")
+			.optional(),
 		enforce_http2: z.boolean().optional(),
 		http2_ping_interval_in_seconds: z
 			.number()
@@ -504,6 +509,11 @@ export const networkFormConfigSchema = z
 			.int("Max connections must be a whole number")
 			.min(1, "Max connections must be at least 1")
 			.max(10000, "Max connections must be at most 10000")
+			.optional(),
+		max_response_body_size: z.coerce
+			.number("Max response body size must be a number")
+			.int("Max response body size must be a whole number of bytes")
+			.min(0, "Max response body size cannot be negative")
 			.optional(),
 		enforce_http2: z.boolean().optional(),
 		http2_ping_interval_in_seconds: z.coerce


### PR DESCRIPTION
## Summary

Adds an optional per-provider maximum response body size for ordinary, non-streaming provider responses. `0` preserves unlimited behavior, while oversized bodies return `provider response body exceeds configured maximum size` before parsing.

## Changes

- Add `network_config.max_response_body_size` to the shared schema, JSON serialization, provider form, and per-provider UI validation.
- Enforce the bound on unary fasthttp clients and Bedrock's net/http response readers, including known and unknown content lengths; map limit failures to a Bifrost operation error.
- Keep explicit streaming and Enterprise large-response clients unbounded by the OSS setting; Enterprise thresholds retain precedence when that path is active.
- Add Go coverage for serialization, unary/streaming client configuration, Enterprise precedence, and bounded net/http reads.

## Type of change

- [x] New feature

## Breaking changes

- [x] No

## Related issue

- #5557

## Test report

| Command | Result |
| --- | --- |
| `go test ./core/providers/utils ./core/providers/bedrock ./core/schemas` | PASS |
| `go test ./core/providers/openai ./core/providers/anthropic ./core/providers/groq ./core/providers/vertex ./core/providers/gemini` | PASS |
| `git diff --check` | PASS |

Raw Go test output:

```text
ok   github.com/maximhq/bifrost/core/providers/utils    20.156s
ok   github.com/maximhq/bifrost/core/providers/bedrock  0.424s
ok   github.com/maximhq/bifrost/core/schemas             (cached)
ok   github.com/maximhq/bifrost/core/providers/openai   0.337s
ok   github.com/maximhq/bifrost/core/providers/anthropic 0.262s
ok   github.com/maximhq/bifrost/core/providers/groq     0.013s
ok   github.com/maximhq/bifrost/core/providers/vertex   0.049s
ok   github.com/maximhq/bifrost/core/providers/gemini   0.216s
```
