### PR TITLE
fix(ui): use cached branding in updating screen and flatten border radii/shadows

### DIFF
--- a/ui/app/__notFound.tsx
+++ b/ui/app/__notFound.tsx
@@ -11,7 +11,7 @@ export function NotFoundComponent() {
 					<Link
 						data-testid="not-found-go-home-link"
 						to="/workspace/logs"
-						className="bg-primary text-primary-foreground focus-visible:ring-primary inline-flex items-center rounded-md px-4 py-2 text-sm font-medium shadow transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+						className="bg-primary text-primary-foreground focus-visible:ring-primary inline-flex items-center rounded-sm px-4 py-2 text-sm font-medium transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
 					>
 						Go home
 					</Link>

--- a/ui/app/__updating.tsx
+++ b/ui/app/__updating.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { useBranding } from "@/lib/hooks/useBranding";
+import { getCachedBrandingAssets } from "@/lib/hooks/useBranding";
 import { getEndpointUrl } from "@/lib/utils/port";
 import { consumeAutoReload, startVersionPoll } from "@/lib/utils/versionSkew";
 import { Loader2, RefreshCw, Sparkles } from "lucide-react";
@@ -13,8 +13,8 @@ export function UpdatingBanner() {
 			role="status"
 			aria-live="polite"
 		>
-			<div className="bg-card/95 pointer-events-auto flex w-full max-w-xl items-center gap-3 rounded-lg border p-2.5 pr-3 shadow-xl backdrop-blur sm:gap-4 sm:p-3">
-				<div className="bg-primary/10 text-primary relative flex size-9 shrink-0 items-center justify-center rounded-md">
+			<div className="bg-card/95 pointer-events-auto flex w-full max-w-xl items-center gap-3 rounded-sm border p-2.5 pr-3 backdrop-blur sm:gap-4 sm:p-3">
+				<div className="bg-primary/10 text-primary relative flex size-9 shrink-0 items-center justify-center rounded-sm">
 					<span className="bg-primary/20 absolute size-2.5 rounded-full motion-safe:animate-ping" aria-hidden="true" />
 					<span className="bg-primary relative size-2 rounded-full" aria-hidden="true" />
 				</div>
@@ -38,7 +38,9 @@ export function UpdatingBanner() {
 }
 
 export function UpdatingScreen() {
-	const { logoSrc, logoAlt } = useBranding(false);
+	// Rendered above <ReduxProvider> (main.tsx) and as the router error component,
+	// so branding has to come from the cache rather than a query.
+	const [{ logoSrc, logoAlt }] = useState(() => getCachedBrandingAssets(false));
 	const [autoReloadExhausted, setAutoReloadExhausted] = useState(false);
 
 	useEffect(
@@ -72,7 +74,7 @@ export function UpdatingScreen() {
 				aria-hidden="true"
 			/>
 			<section
-				className="bg-card w-full max-w-lg overflow-hidden rounded-xl border shadow-[0_24px_80px_-36px_rgba(0,0,0,0.35)]"
+				className="bg-card w-full max-w-lg overflow-hidden rounded-sm border"
 				aria-labelledby="updating-title"
 				aria-describedby="updating-description"
 				aria-live="polite"
@@ -82,7 +84,7 @@ export function UpdatingScreen() {
 				</div>
 
 				<div className="px-5 py-8 sm:px-8 sm:py-10">
-					<div className="bg-primary/10 text-primary flex size-12 items-center justify-center rounded-xl">
+					<div className="bg-primary/10 text-primary flex size-12 items-center justify-center rounded-sm">
 						<Sparkles className="size-5" aria-hidden="true" />
 					</div>
 					<h1 id="updating-title" className="text-foreground mt-5 text-2xl font-semibold tracking-tight">

--- a/ui/app/clientLayout.tsx
+++ b/ui/app/clientLayout.tsx
@@ -188,8 +188,8 @@ function FullPage({
 function ConfigUnreachable({ isRetrying, onRetry }: { isRetrying: boolean; onRetry: () => void }) {
 	return (
 		<div className="h-base flex items-center justify-center p-4 sm:p-6" data-testid="config-unreachable">
-			<section className="bg-card w-full max-w-lg rounded-xl border p-6 shadow-sm sm:p-8" aria-labelledby="config-unreachable-title">
-				<div className="bg-muted text-muted-foreground flex size-11 items-center justify-center rounded-lg">
+			<section className="bg-card w-full max-w-lg rounded-sm border p-6 sm:p-8" aria-labelledby="config-unreachable-title">
+				<div className="bg-muted text-muted-foreground flex size-11 items-center justify-center rounded-sm">
 					<WifiOff className="size-5" aria-hidden="true" />
 				</div>
 				<h1 id="config-unreachable-title" className="text-foreground mt-5 text-xl font-semibold tracking-tight">

--- a/ui/lib/hooks/useBranding.ts
+++ b/ui/lib/hooks/useBranding.ts
@@ -131,6 +131,31 @@ export interface BrandingAssets {
  * the response is outstanding. The pre-hydration shell is separately rewritten
  * server-side to cover the initial document load, before any of this runs.
  */
+function toBrandingAssets(branding: BrandingState | undefined, isDark: boolean): BrandingAssets {
+	const hasLogo = Boolean(branding?.has_logo && branding.logo_url);
+	const hasIcon = Boolean(branding?.has_icon && branding.icon_url);
+
+	return {
+		logoSrc: hasLogo ? resolveBrandingAssetUrl(branding!.logo_url) : isDark ? DEFAULT_LOGO_DARK : DEFAULT_LOGO_LIGHT,
+		iconSrc: hasIcon ? resolveBrandingAssetUrl(branding!.icon_url) : isDark ? DEFAULT_ICON_DARK : DEFAULT_ICON_LIGHT,
+		isCustom: Boolean(branding?.enabled),
+		logoAlt: branding?.enabled ? "" : "Bifrost",
+	};
+}
+
+/**
+ * Branding for surfaces that render outside <ReduxProvider> — the version-skew
+ * updating screen sits above RouterProvider and is also the router's error
+ * component, so it has no store to query and calling the hook there throws.
+ *
+ * Cache-only by design: those screens paint during an upgrade, when the API is
+ * mid-rollout and a request would likely fail anyway. Falls back to the bundled
+ * defaults when nothing has been cached yet.
+ */
+export function getCachedBrandingAssets(isDark: boolean): BrandingAssets {
+	return toBrandingAssets(IS_ENTERPRISE ? readCachedBranding() : undefined, isDark);
+}
+
 export function useBranding(isDark: boolean): BrandingAssets {
 	// Fires on the login screen too, where no session exists — the endpoint is
 	// public precisely so this works pre-auth. Skipped on OSS, where the whole
@@ -149,13 +174,5 @@ export function useBranding(isDark: boolean): BrandingAssets {
 	// hydrateRoot), so there is no server markup for this to mismatch against.
 	const branding = data ?? (IS_ENTERPRISE ? readCachedBranding() : undefined);
 
-	const hasLogo = Boolean(branding?.has_logo && branding.logo_url);
-	const hasIcon = Boolean(branding?.has_icon && branding.icon_url);
-
-	return {
-		logoSrc: hasLogo ? resolveBrandingAssetUrl(branding!.logo_url) : isDark ? DEFAULT_LOGO_DARK : DEFAULT_LOGO_LIGHT,
-		iconSrc: hasIcon ? resolveBrandingAssetUrl(branding!.icon_url) : isDark ? DEFAULT_ICON_DARK : DEFAULT_ICON_LIGHT,
-		isCustom: Boolean(branding?.enabled),
-		logoAlt: branding?.enabled ? "" : "Bifrost",
-	};
+	return toBrandingAssets(branding, isDark);
 }


### PR DESCRIPTION
## Summary

Fixes a crash in the updating/version-skew screen caused by calling `useBranding` outside of `<ReduxProvider>`, and standardizes UI border radius styling to use `rounded-sm` instead of larger variants.

## Changes

- Extracted a `getCachedBrandingAssets` function from `useBranding` that reads branding directly from the local cache without requiring Redux store access. The `UpdatingScreen` component now uses this instead of the hook, since it renders above `<ReduxProvider>` and also serves as the router's error component.
- Refactored the shared asset-building logic into a `toBrandingAssets` helper to avoid duplication between `getCachedBrandingAssets` and `useBranding`.
- Replaced `rounded-lg`, `rounded-md`, and `rounded-xl` with `rounded-sm` across the not-found page, updating banner, updating screen, and config-unreachable section for visual consistency.
- Removed `shadow` and `shadow-xl` from several components as part of the same styling pass.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Trigger a version-skew scenario (e.g., deploy a new backend while the UI is open) and confirm the updating screen renders without errors and displays branding correctly. Also verify the not-found and config-unreachable screens render with the updated styling.

## Screenshots/Recordings

Before/after screenshots of the updating screen, not-found page, and config-unreachable section showing the updated border radius and removed shadows.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable