### PR TITLE
adds notification center

### DIFF
--- a/core/schemas/notification.go
+++ b/core/schemas/notification.go
@@ -1,0 +1,62 @@
+package schemas
+
+import (
+	"context"
+	"time"
+)
+
+type NotificationSeverity string
+
+const (
+	NotificationSeverityInfo    NotificationSeverity = "info"
+	NotificationSeveritySuccess NotificationSeverity = "success"
+	NotificationSeverityWarning NotificationSeverity = "warning"
+	NotificationSeverityError   NotificationSeverity = "error"
+)
+
+type NotificationAudience string
+
+const (
+	NotificationAudienceAll   NotificationAudience = "all"
+	NotificationAudienceRoles NotificationAudience = "roles"
+)
+
+// Notification is a persisted dashboard notification. Read and dismissal
+// state deliberately do not live here; those preferences are local to each UI.
+type Notification struct {
+	ID          string               `json:"id"`
+	Audience    NotificationAudience `json:"audience"`
+	RoleIDs     []uint               `json:"role_ids,omitempty"`
+	Severity    NotificationSeverity `json:"severity"`
+	Title       string               `json:"title"`
+	Message     string               `json:"message"`
+	ActionLabel string               `json:"action_label,omitempty"`
+	ActionPath  string               `json:"action_path,omitempty"`
+	CreatedAt   time.Time            `json:"created_at"`
+	ExpiresAt   time.Time            `json:"expires_at"`
+}
+
+// NotificationInput is accepted by the in-process publisher and the admin API.
+// IDs and timestamps are always assigned by the notification service.
+type NotificationInput struct {
+	Audience    NotificationAudience `json:"audience"`
+	RoleIDs     []uint               `json:"role_ids,omitempty"`
+	Severity    NotificationSeverity `json:"severity"`
+	Title       string               `json:"title"`
+	Message     string               `json:"message"`
+	ActionLabel string               `json:"action_label,omitempty"`
+	ActionPath  string               `json:"action_path,omitempty"`
+}
+
+// NotificationPublisher persists a notification and pushes it to every
+// connected dashboard the audience covers.
+//
+// This is an extension seam, not a feature with in-tree callers. Nothing in the
+// OSS transport publishes a notification today; the field on lib.Config exists
+// so enterprise builds and plugins can announce events (license expiry, cluster
+// membership changes, budget breaches) without importing the handler package.
+// The only other way to create one is POST /api/notifications, which is
+// admin-gated. If you add the first in-tree producer, publish through this
+// func rather than writing to the store directly, so the WebSocket fan-out and
+// role scoping stay in one place.
+type NotificationPublisher func(context.Context, NotificationInput) (*Notification, error)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1447,6 +1447,14 @@
                   "GET /api/webhooks/{id}/deliveries",
                   "POST /api/webhooks/deliveries/{id}/redeliver"
                 ]
+              },
+              {
+                "group": "Notifications",
+                "expanded": false,
+                "pages": [
+                  "GET /api/notifications",
+                  "POST /api/notifications"
+                ]
               }
             ]
           },

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -188,6 +188,10 @@
     {
       "name": "Webhooks",
       "description": "Webhook endpoint management and signed async-job delivery history"
+    },
+    {
+      "name": "Notifications",
+      "description": "Role-targeted dashboard notifications, delivered over the dashboard WebSocket"
     }
   ],
   "paths": {
@@ -79207,6 +79211,151 @@
           }
         ]
       }
+    },
+    "/api/notifications": {
+      "get": {
+        "operationId": "listNotifications",
+        "summary": "List dashboard notifications",
+        "description": "Returns notifications the caller is entitled to see, newest first.\nNotifications addressed to `all` are visible to everyone; those addressed\nto `roles` are only returned when the caller holds one of the listed\nroles. A local admin sees every notification.\n\nRead and dismissed state is not stored server-side, so every caller sees\nthe full page regardless of what they have already opened.\n",
+        "tags": [
+          "Notifications"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Notifications per page. Values above the server page size of 50 are\nclamped down to it.\n",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 50
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "description": "The `next_cursor` from a previous response.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A page of notifications",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Config store not available",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createNotification",
+        "summary": "Publish a dashboard notification",
+        "description": "Persists a notification and pushes it over the dashboard WebSocket to\nevery connected client the audience covers.\n\nAdministrators only. Reading is open to any authenticated user because a\ncaller only ever receives rows their role already entitles them to, but a\nsingle publish reaches every dashboard user on the deployment, so it is\nrestricted to the local admin. On a deployment with dashboard auth\ndisabled every request is treated as local admin.\n\nNotifications expire 30 days after creation and are pruned hourly.\n",
+        "tags": [
+          "Notifications"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotificationInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Notification published and broadcast",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Notification"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — authenticated, but not permitted to perform this action",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Config store not available",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ]
+      }
     }
   },
   "components": {
@@ -79297,6 +79446,16 @@
       },
       "Unauthorized": {
         "description": "Unauthorized — missing or invalid credentials",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/BifrostError"
+            }
+          }
+        }
+      },
+      "Forbidden": {
+        "description": "Forbidden — authenticated, but not permitted to perform this action",
         "content": {
           "application/json": {
             "schema": {
@@ -99654,6 +99813,144 @@
           "status": {
             "type": "string",
             "example": "success"
+          }
+        }
+      },
+      "NotificationSeverity": {
+        "type": "string",
+        "description": "Visual weight the dashboard gives the notification.",
+        "enum": [
+          "info",
+          "success",
+          "warning",
+          "error"
+        ]
+      },
+      "NotificationAudience": {
+        "type": "string",
+        "description": "Who the notification reaches. `all` is every dashboard user; `roles` limits\nit to the listed RBAC roles, enforced on both the list endpoint and the\nWebSocket fan-out.\n",
+        "enum": [
+          "all",
+          "roles"
+        ]
+      },
+      "NotificationInput": {
+        "type": "object",
+        "description": "A notification to publish. IDs and both timestamps are assigned by the\nserver and cannot be supplied.\n",
+        "required": [
+          "audience",
+          "severity",
+          "title",
+          "message"
+        ],
+        "properties": {
+          "audience": {
+            "$ref": "#/components/schemas/NotificationAudience"
+          },
+          "role_ids": {
+            "type": "array",
+            "description": "Required when `audience` is `roles`, and must be empty otherwise.\nDuplicates are removed and the list is sorted before it is stored.\n",
+            "items": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1
+            }
+          },
+          "severity": {
+            "$ref": "#/components/schemas/NotificationSeverity"
+          },
+          "title": {
+            "type": "string",
+            "description": "Trimmed before validation.",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "message": {
+            "type": "string",
+            "description": "Trimmed before validation.",
+            "minLength": 1,
+            "maxLength": 4000
+          },
+          "action_label": {
+            "type": "string",
+            "description": "Label for the notification's action. Must be supplied together with\n`action_path`, or not at all.\n"
+          },
+          "action_path": {
+            "type": "string",
+            "description": "Dashboard-internal absolute path the action opens, for example\n`/workspace/providers`. Absolute URLs, host-relative `//` paths, and\nanything not starting with `/` are rejected, so a notification cannot\nbe used to send users off-site.\n",
+            "pattern": "^/(?!/).*"
+          }
+        }
+      },
+      "Notification": {
+        "type": "object",
+        "description": "A persisted dashboard notification.",
+        "required": [
+          "id",
+          "audience",
+          "severity",
+          "title",
+          "message",
+          "created_at",
+          "expires_at"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "audience": {
+            "$ref": "#/components/schemas/NotificationAudience"
+          },
+          "role_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          "severity": {
+            "$ref": "#/components/schemas/NotificationSeverity"
+          },
+          "title": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "action_label": {
+            "type": "string"
+          },
+          "action_path": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Always 30 days after `created_at`. Expired rows are pruned hourly and\nare not returned once pruned.\n"
+          }
+        }
+      },
+      "NotificationList": {
+        "type": "object",
+        "description": "A page of notifications, newest first, already filtered to what the caller's\nrole may see.\n",
+        "required": [
+          "notifications"
+        ],
+        "properties": {
+          "notifications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Notification"
+            }
+          },
+          "next_cursor": {
+            "type": "string",
+            "description": "Opaque cursor for the next page. Absent when there are no further\nresults. Pass it back as the `cursor` query parameter.\n"
           }
         }
       }

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -148,6 +148,8 @@ tags:
     description: CADF-compliant audit log search, export, and signature verification endpoints
   - name: Webhooks
     description: Webhook endpoint management and signed async-job delivery history
+  - name: Notifications
+    description: Role-targeted dashboard notifications, delivered over the dashboard WebSocket
 
 paths:
   # ==================== Unified Inference API ====================
@@ -1229,6 +1231,10 @@ paths:
   /api/webhooks/deliveries/{id}/redeliver:
     $ref: "./paths/management/webhooks.yaml#/webhooks-deliveries-redeliver"
 
+  # Notifications
+  /api/notifications:
+    $ref: "./paths/management/notifications.yaml#/notifications"
+
 components:
   securitySchemes:
     BearerAuth:
@@ -1291,6 +1297,12 @@ components:
             $ref: "./schemas/inference/common.yaml#/BifrostError"
     Unauthorized:
       description: Unauthorized — missing or invalid credentials
+      content:
+        application/json:
+          schema:
+            $ref: "./schemas/inference/common.yaml#/BifrostError"
+    Forbidden:
+      description: Forbidden — authenticated, but not permitted to perform this action
       content:
         application/json:
           schema:
@@ -1873,3 +1885,15 @@ components:
       $ref: "./schemas/management/webhooks.yaml#/RedeliverWebhookResponse"
     WebhookStatusResponse:
       $ref: "./schemas/management/webhooks.yaml#/WebhookStatusResponse"
+
+    # Notifications
+    NotificationSeverity:
+      $ref: "./schemas/management/notifications.yaml#/NotificationSeverity"
+    NotificationAudience:
+      $ref: "./schemas/management/notifications.yaml#/NotificationAudience"
+    NotificationInput:
+      $ref: "./schemas/management/notifications.yaml#/NotificationInput"
+    Notification:
+      $ref: "./schemas/management/notifications.yaml#/Notification"
+    NotificationList:
+      $ref: "./schemas/management/notifications.yaml#/NotificationList"

--- a/docs/openapi/paths/management/notifications.yaml
+++ b/docs/openapi/paths/management/notifications.yaml
@@ -1,0 +1,86 @@
+# Dashboard Notifications API
+
+notifications:
+  get:
+    operationId: listNotifications
+    summary: List dashboard notifications
+    description: |
+      Returns notifications the caller is entitled to see, newest first.
+      Notifications addressed to `all` are visible to everyone; those addressed
+      to `roles` are only returned when the caller holds one of the listed
+      roles. A local admin sees every notification.
+
+      Read and dismissed state is not stored server-side, so every caller sees
+      the full page regardless of what they have already opened.
+    tags:
+      - Notifications
+    parameters:
+      - name: limit
+        in: query
+        required: false
+        description: |
+          Notifications per page. Values above the server page size of 50 are
+          clamped down to it.
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 50
+          default: 50
+      - name: cursor
+        in: query
+        required: false
+        description: The `next_cursor` from a previous response.
+        schema:
+          type: string
+    responses:
+      '200':
+        description: A page of notifications
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/notifications.yaml#/NotificationList'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+      '503':
+        $ref: '../../openapi.yaml#/components/responses/ConfigStoreUnavailable'
+    security:
+      - ManagementBearerAuth: []
+  post:
+    operationId: createNotification
+    summary: Publish a dashboard notification
+    description: |
+      Persists a notification and pushes it over the dashboard WebSocket to
+      every connected client the audience covers.
+
+      Administrators only. Reading is open to any authenticated user because a
+      caller only ever receives rows their role already entitles them to, but a
+      single publish reaches every dashboard user on the deployment, so it is
+      restricted to the local admin. On a deployment with dashboard auth
+      disabled every request is treated as local admin.
+
+      Notifications expire 30 days after creation and are pruned hourly.
+    tags:
+      - Notifications
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/management/notifications.yaml#/NotificationInput'
+    responses:
+      '201':
+        description: Notification published and broadcast
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/notifications.yaml#/Notification'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '403':
+        $ref: '../../openapi.yaml#/components/responses/Forbidden'
+      '503':
+        $ref: '../../openapi.yaml#/components/responses/ConfigStoreUnavailable'
+    security:
+      - ManagementBearerAuth: []

--- a/docs/openapi/schemas/management/notifications.yaml
+++ b/docs/openapi/schemas/management/notifications.yaml
@@ -1,0 +1,128 @@
+# Dashboard Notification Schemas
+
+NotificationSeverity:
+  type: string
+  description: Visual weight the dashboard gives the notification.
+  enum:
+    - info
+    - success
+    - warning
+    - error
+
+NotificationAudience:
+  type: string
+  description: |
+    Who the notification reaches. `all` is every dashboard user; `roles` limits
+    it to the listed RBAC roles, enforced on both the list endpoint and the
+    WebSocket fan-out.
+  enum:
+    - all
+    - roles
+
+NotificationInput:
+  type: object
+  description: |
+    A notification to publish. IDs and both timestamps are assigned by the
+    server and cannot be supplied.
+  required:
+    - audience
+    - severity
+    - title
+    - message
+  properties:
+    audience:
+      $ref: '#/NotificationAudience'
+    role_ids:
+      type: array
+      description: |
+        Required when `audience` is `roles`, and must be empty otherwise.
+        Duplicates are removed and the list is sorted before it is stored.
+      items:
+        type: integer
+        format: int64
+        minimum: 1
+    severity:
+      $ref: '#/NotificationSeverity'
+    title:
+      type: string
+      description: Trimmed before validation.
+      minLength: 1
+      maxLength: 160
+    message:
+      type: string
+      description: Trimmed before validation.
+      minLength: 1
+      maxLength: 4000
+    action_label:
+      type: string
+      description: |
+        Label for the notification's action. Must be supplied together with
+        `action_path`, or not at all.
+    action_path:
+      type: string
+      description: |
+        Dashboard-internal absolute path the action opens, for example
+        `/workspace/providers`. Absolute URLs, host-relative `//` paths, and
+        anything not starting with `/` are rejected, so a notification cannot
+        be used to send users off-site.
+      pattern: '^/(?!/).*'
+
+Notification:
+  type: object
+  description: A persisted dashboard notification.
+  required:
+    - id
+    - audience
+    - severity
+    - title
+    - message
+    - created_at
+    - expires_at
+  properties:
+    id:
+      type: string
+      format: uuid
+    audience:
+      $ref: '#/NotificationAudience'
+    role_ids:
+      type: array
+      items:
+        type: integer
+        format: int64
+    severity:
+      $ref: '#/NotificationSeverity'
+    title:
+      type: string
+    message:
+      type: string
+    action_label:
+      type: string
+    action_path:
+      type: string
+    created_at:
+      type: string
+      format: date-time
+    expires_at:
+      type: string
+      format: date-time
+      description: |
+        Always 30 days after `created_at`. Expired rows are pruned hourly and
+        are not returned once pruned.
+
+NotificationList:
+  type: object
+  description: |
+    A page of notifications, newest first, already filtered to what the caller's
+    role may see.
+  required:
+    - notifications
+  properties:
+    notifications:
+      type: array
+      items:
+        $ref: '#/Notification'
+    next_cursor:
+      type: string
+      description: |
+        Opaque cursor for the next page. Absent when there are no further
+        results. Pass it back as the `cursor` query parameter.

--- a/docs/openapi/sync_mintlify_navigation.py
+++ b/docs/openapi/sync_mintlify_navigation.py
@@ -80,6 +80,7 @@ SECTIONS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "Audit Logs",
             "Infrastructure",
             "Webhooks",
+            "Notifications",
         ),
     ),
 )

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -468,6 +468,22 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_needs_session_stickiness_column"}, run: migrationAddNeedsSessionStickinessColumn},
 	{IDs: []string{"add_bedrock_endpoints_columns"}, run: migrationAddBedrockEndpointsColumns},
 	{IDs: []string{"add_cost_per_request_pricing_column"}, run: migrationAddCostPerRequestPricingColumn},
+	{IDs: []string{"add_notifications_table"}, run: migrationAddNotificationsTable},
+}
+
+func migrationAddNotificationsTable(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_notifications_table"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	return RunSingleMigration(ctx, nil, db, logger, &migrator.Migration{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			return tx.WithContext(ctx).AutoMigrate(&tables.TableNotification{})
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return tx.WithContext(ctx).Migrator().DropTable(&tables.TableNotification{})
+		},
+	})
 }
 
 // quoteSQLiteIdentifier quotes a SQLite identifier, escaping any double quotes.

--- a/framework/configstore/migrations_test.go
+++ b/framework/configstore/migrations_test.go
@@ -1169,6 +1169,7 @@ func TestTriggerMigrations_FreshDB(t *testing.T) {
 		&tables.TableClientConfig{},
 		&tables.TableVirtualKeyProviderConfig{},
 		&tables.TableVirtualKeyMCPConfig{},
+		&tables.TableNotification{},
 	}
 
 	migrator := db.Migrator()

--- a/framework/configstore/notifications.go
+++ b/framework/configstore/notifications.go
@@ -1,0 +1,38 @@
+package configstore
+
+import (
+	"context"
+	"time"
+
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+)
+
+// NotificationStore is intentionally a narrow optional interface so adding
+// notifications does not force every ConfigStore test double to grow methods.
+type NotificationStore interface {
+	CreateNotification(ctx context.Context, notification *tables.TableNotification) error
+	ListNotifications(ctx context.Context, before time.Time, beforeID string, limit int) ([]tables.TableNotification, error)
+	DeleteExpiredNotifications(ctx context.Context, now time.Time) (int64, error)
+}
+
+func (s *RDBConfigStore) CreateNotification(ctx context.Context, notification *tables.TableNotification) error {
+	return s.DB().WithContext(ctx).Create(notification).Error
+}
+
+func (s *RDBConfigStore) ListNotifications(ctx context.Context, before time.Time, beforeID string, limit int) ([]tables.TableNotification, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	query := s.DB().WithContext(ctx).Where("expires_at > ?", time.Now().UTC())
+	if !before.IsZero() {
+		query = query.Where("created_at < ? OR (created_at = ? AND id < ?)", before, before, beforeID)
+	}
+	var notifications []tables.TableNotification
+	err := query.Order("created_at DESC").Order("id DESC").Limit(limit).Find(&notifications).Error
+	return notifications, err
+}
+
+func (s *RDBConfigStore) DeleteExpiredNotifications(ctx context.Context, now time.Time) (int64, error) {
+	result := s.DB().WithContext(ctx).Where("expires_at <= ?", now).Delete(&tables.TableNotification{})
+	return result.RowsAffected, result.Error
+}

--- a/framework/configstore/notifications_test.go
+++ b/framework/configstore/notifications_test.go
@@ -1,0 +1,40 @@
+package configstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotificationStoreLifecycle(t *testing.T) {
+	store := setupRDBTestStore(t)
+	require.NoError(t, store.DB().AutoMigrate(&tables.TableNotification{}))
+	now := time.Now().UTC()
+	ctx := context.Background()
+
+	for _, notification := range []tables.TableNotification{
+		{ID: "older", Audience: "all", Severity: "info", Title: "Older", Message: "message", CreatedAt: now.Add(-time.Hour), ExpiresAt: now.Add(time.Hour)},
+		{ID: "newer", Audience: "roles", RoleIDs: []uint{2, 7}, Severity: "warning", Title: "Newer", Message: "message", CreatedAt: now, ExpiresAt: now.Add(time.Hour)},
+		{ID: "expired", Audience: "all", Severity: "info", Title: "Expired", Message: "message", CreatedAt: now.Add(-48 * time.Hour), ExpiresAt: now.Add(-time.Hour)},
+	} {
+		require.NoError(t, store.CreateNotification(ctx, &notification))
+	}
+
+	rows, err := store.ListNotifications(ctx, time.Time{}, "", 50)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	require.Equal(t, "newer", rows[0].ID)
+	require.Equal(t, []uint{2, 7}, rows[0].RoleIDs)
+
+	rows, err = store.ListNotifications(ctx, rows[0].CreatedAt, rows[0].ID, 50)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "older", rows[0].ID)
+
+	deleted, err := store.DeleteExpiredNotifications(ctx, now)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), deleted)
+}

--- a/framework/configstore/tables/notification.go
+++ b/framework/configstore/tables/notification.go
@@ -1,0 +1,21 @@
+package tables
+
+import "time"
+
+// TableNotification stores deployment notifications. RoleIDs is JSON rather
+// than a foreign-key relation because enterprise roles are supplied by an
+// optional overlay and do not exist in every OSS database.
+type TableNotification struct {
+	ID          string    `gorm:"type:varchar(36);primaryKey" json:"id"`
+	Audience    string    `gorm:"type:varchar(16);not null;index:idx_notifications_feed,priority:1" json:"audience"`
+	RoleIDs     []uint    `gorm:"serializer:json;type:text" json:"role_ids"`
+	Severity    string    `gorm:"type:varchar(16);not null" json:"severity"`
+	Title       string    `gorm:"type:varchar(160);not null" json:"title"`
+	Message     string    `gorm:"type:text;not null" json:"message"`
+	ActionLabel string    `gorm:"type:varchar(64)" json:"action_label,omitempty"`
+	ActionPath  string    `gorm:"type:varchar(2048)" json:"action_path,omitempty"`
+	CreatedAt   time.Time `gorm:"not null;index:idx_notifications_feed,priority:2,sort:desc" json:"created_at"`
+	ExpiresAt   time.Time `gorm:"not null;index" json:"expires_at"`
+}
+
+func (TableNotification) TableName() string { return "notifications" }

--- a/transports/bifrost-http/handlers/notifications.go
+++ b/transports/bifrost-http/handlers/notifications.go
@@ -1,0 +1,305 @@
+package handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/url"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/fasthttp/router"
+	"github.com/google/uuid"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/valyala/fasthttp"
+)
+
+const (
+	notificationRetention = 30 * 24 * time.Hour
+	notificationPageSize  = 50
+	maxNotificationScan   = 250
+	// Ceiling on rows read across a whole list request, not just one store call.
+	// Role visibility cannot be pushed into the query - TableNotification.RoleIDs
+	// is a JSON-serialised text column and no containment predicate is portable
+	// across sqlite, postgres, and mysql - so a caller whose role matches nothing
+	// would otherwise walk the entire table looking for a page it will never
+	// fill. Four store calls is the budget; past that the request returns what it
+	// has plus a cursor to resume from.
+	maxNotificationScanTotal = 4 * maxNotificationScan
+)
+
+var ErrNotificationsUnavailable = errors.New("notification storage is unavailable")
+
+type NotificationService struct {
+	store     configstore.NotificationStore
+	websocket *WebSocketHandler
+	now       func() time.Time
+}
+
+func NewNotificationService(store configstore.ConfigStore, websocket *WebSocketHandler) *NotificationService {
+	notificationStore, _ := store.(configstore.NotificationStore)
+	return &NotificationService{store: notificationStore, websocket: websocket, now: func() time.Time { return time.Now().UTC() }}
+}
+
+func (s *NotificationService) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
+	r.GET("/api/notifications", lib.ChainMiddlewares(s.list, middlewares...))
+	r.POST("/api/notifications", lib.ChainMiddlewares(s.create, middlewares...))
+}
+
+func (s *NotificationService) Start(ctx context.Context) {
+	if s.store == nil {
+		return
+	}
+	_, _ = s.store.DeleteExpiredNotifications(ctx, s.now())
+	go func() {
+		ticker := time.NewTicker(time.Hour)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if _, err := s.store.DeleteExpiredNotifications(ctx, s.now()); err != nil {
+					logger.Warn("failed to prune expired notifications: %v", err)
+				}
+			}
+		}
+	}()
+}
+
+func (s *NotificationService) Publish(ctx context.Context, input schemas.NotificationInput) (*schemas.Notification, error) {
+	if s.store == nil {
+		return nil, ErrNotificationsUnavailable
+	}
+	if err := validateNotificationInput(&input); err != nil {
+		return nil, err
+	}
+	now := s.now()
+	notification := &schemas.Notification{
+		ID: uuid.NewString(), Audience: input.Audience, RoleIDs: append([]uint(nil), input.RoleIDs...),
+		Severity: input.Severity, Title: input.Title, Message: input.Message,
+		ActionLabel: input.ActionLabel, ActionPath: input.ActionPath,
+		CreatedAt: now, ExpiresAt: now.Add(notificationRetention),
+	}
+	row := notificationToTable(notification)
+	if err := s.store.CreateNotification(ctx, &row); err != nil {
+		return nil, fmt.Errorf("persist notification: %w", err)
+	}
+	if s.websocket != nil {
+		s.websocket.BroadcastNotification(notification)
+	}
+	return notification, nil
+}
+
+// validateNotificationInput rejects bad input without rewriting good input: what
+// a caller sends is what gets stored. Emptiness is judged on the trimmed value
+// so a whitespace-only title cannot pass, while the length limits deliberately
+// measure the raw value, because that is what has to fit the varchar columns on
+// TableNotification. RoleIDs is the one field still normalised, since sorting
+// and compacting a set changes no content and keeps the stored audience sane.
+func validateNotificationInput(input *schemas.NotificationInput) error {
+	if strings.TrimSpace(input.Title) == "" || len(input.Title) > 160 {
+		return errors.New("title is required and must not exceed 160 characters")
+	}
+	if strings.TrimSpace(input.Message) == "" || len(input.Message) > 4000 {
+		return errors.New("message is required and must not exceed 4000 characters")
+	}
+	if !slices.Contains([]schemas.NotificationSeverity{schemas.NotificationSeverityInfo, schemas.NotificationSeveritySuccess, schemas.NotificationSeverityWarning, schemas.NotificationSeverityError}, input.Severity) {
+		return errors.New("severity must be one of info, success, warning, or error")
+	}
+	switch input.Audience {
+	case schemas.NotificationAudienceAll:
+		if len(input.RoleIDs) != 0 {
+			return errors.New("role_ids must be empty when audience is all")
+		}
+	case schemas.NotificationAudienceRoles:
+		if len(input.RoleIDs) == 0 {
+			return errors.New("role_ids is required when audience is roles")
+		}
+	default:
+		return errors.New("audience must be all or roles")
+	}
+	hasActionLabel := strings.TrimSpace(input.ActionLabel) != ""
+	hasActionPath := strings.TrimSpace(input.ActionPath) != ""
+	if hasActionLabel != hasActionPath {
+		return errors.New("action_label and action_path must be provided together")
+	}
+	if hasActionPath {
+		// Parsed as sent rather than as trimmed: a padded path would be stored
+		// padded, so it has to clear this check in the form it will be stored in.
+		parsed, err := url.Parse(input.ActionPath)
+		// A backslash is rejected outright: browsers fold "\" to "/" when
+		// resolving a location, so "/\evil.example" clears the "//" check here
+		// and still navigates off-site. Path is percent-decoded, so a "%5C"
+		// spelling of the same trick lands in this check too.
+		if err != nil || parsed.IsAbs() || parsed.Host != "" || !strings.HasPrefix(parsed.Path, "/") || strings.HasPrefix(parsed.Path, "//") || strings.Contains(parsed.Path, `\`) {
+			return errors.New("action_path must be an internal absolute path")
+		}
+	}
+	sort.Slice(input.RoleIDs, func(i, j int) bool { return input.RoleIDs[i] < input.RoleIDs[j] })
+	input.RoleIDs = slices.Compact(input.RoleIDs)
+	return nil
+}
+
+// create is the admin half of the API. list is safe for any authenticated user
+// because it only ever returns rows the caller's role is already entitled to
+// see, but publishing is the opposite: a single POST reaches every dashboard
+// user on the deployment. RBAC in this transport is enterprise-only and
+// path-based, so the floor is enforced here instead - only the local admin (and
+// therefore also an auth-disabled deployment, where the middleware marks every
+// request local admin) may publish. In-process producers call Publish directly
+// and are intentionally not subject to this check.
+func (s *NotificationService) create(ctx *fasthttp.RequestCtx) {
+	if localAdmin, _ := ctx.UserValue(schemas.IsLocalAdminContextKey).(bool); !localAdmin {
+		SendError(ctx, fasthttp.StatusForbidden, "Only administrators can publish notifications")
+		return
+	}
+	var input schemas.NotificationInput
+	if err := sonic.Unmarshal(ctx.PostBody(), &input); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "Invalid request payload")
+		return
+	}
+	notification, err := s.Publish(ctx, input)
+	if err != nil {
+		status := fasthttp.StatusBadRequest
+		if errors.Is(err, ErrNotificationsUnavailable) || strings.HasPrefix(err.Error(), "persist notification:") {
+			status = fasthttp.StatusServiceUnavailable
+		}
+		SendError(ctx, status, err.Error())
+		return
+	}
+	SendJSONWithStatus(ctx, notification, fasthttp.StatusCreated)
+}
+
+type notificationListResponse struct {
+	Notifications []schemas.Notification `json:"notifications"`
+	NextCursor    string                 `json:"next_cursor,omitempty"`
+}
+
+func (s *NotificationService) list(ctx *fasthttp.RequestCtx) {
+	if s.store == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, ErrNotificationsUnavailable.Error())
+		return
+	}
+	limit := notificationPageSize
+	if raw := string(ctx.QueryArgs().Peek("limit")); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 1 {
+			SendError(ctx, fasthttp.StatusBadRequest, "limit must be a positive integer")
+			return
+		}
+		limit = min(parsed, notificationPageSize)
+	}
+	before, beforeID, err := decodeNotificationCursor(string(ctx.QueryArgs().Peek("cursor")))
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "invalid cursor")
+		return
+	}
+	roleID, hasRole := notificationRoleID(ctx)
+	localAdmin, _ := ctx.UserValue(schemas.IsLocalAdminContextKey).(bool)
+	result := make([]schemas.Notification, 0, limit+1)
+	scanned := 0
+	// True when the scan budget stopped us with rows still unread behind us.
+	budgetExhausted := false
+	for len(result) < limit+1 {
+		rows, listErr := s.store.ListNotifications(ctx, before, beforeID, maxNotificationScan)
+		if listErr != nil {
+			SendError(ctx, fasthttp.StatusInternalServerError, "Failed to list notifications")
+			return
+		}
+		if len(rows) == 0 {
+			break
+		}
+		for i := range rows {
+			n := notificationFromTable(&rows[i])
+			if localAdmin || notificationVisibleToRole(&n, roleID, hasRole) {
+				result = append(result, n)
+				if len(result) == limit+1 {
+					break
+				}
+			}
+		}
+		scanned += len(rows)
+		last := rows[len(rows)-1]
+		before, beforeID = last.CreatedAt, last.ID
+		if len(rows) < maxNotificationScan {
+			break
+		}
+		if scanned >= maxNotificationScanTotal {
+			budgetExhausted = true
+			break
+		}
+	}
+	response := notificationListResponse{Notifications: result}
+	switch {
+	case len(result) > limit:
+		response.Notifications = result[:limit]
+		last := response.Notifications[len(response.Notifications)-1]
+		response.NextCursor = encodeNotificationCursor(last.CreatedAt, last.ID)
+	case budgetExhausted:
+		// The page is short because the budget cut the scan, not because the feed
+		// ended. The cursor has to come from the last row *scanned* rather than
+		// the last one returned, or the caller would re-read everything the scan
+		// already skipped. Without a cursor here a short page is indistinguishable
+		// from the end of the feed and the rest of the feed is silently lost.
+		response.NextCursor = encodeNotificationCursor(before, beforeID)
+	}
+	SendJSON(ctx, response)
+}
+
+func notificationRoleID(ctx *fasthttp.RequestCtx) (uint, bool) {
+	switch value := ctx.UserValue(schemas.BifrostContextKeyUserRoleID).(type) {
+	case uint:
+		return value, value != 0
+	case int:
+		return uint(value), value > 0
+	default:
+		return 0, false
+	}
+}
+
+func notificationVisibleToRole(notification *schemas.Notification, roleID uint, hasRole bool) bool {
+	if notification.Audience == schemas.NotificationAudienceAll {
+		return true
+	}
+	return hasRole && slices.Contains(notification.RoleIDs, roleID)
+}
+
+func encodeNotificationCursor(createdAt time.Time, id string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(strconv.FormatInt(createdAt.UnixNano(), 10) + ":" + id))
+}
+
+func decodeNotificationCursor(cursor string) (time.Time, string, error) {
+	if cursor == "" {
+		return time.Time{}, "", nil
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return time.Time{}, "", err
+	}
+	nanos, id, ok := strings.Cut(string(decoded), ":")
+	if !ok || id == "" {
+		return time.Time{}, "", errors.New("malformed cursor")
+	}
+	value, err := strconv.ParseInt(nanos, 10, 64)
+	if err != nil {
+		return time.Time{}, "", err
+	}
+	return time.Unix(0, value).UTC(), id, nil
+}
+
+func notificationToTable(notification *schemas.Notification) tables.TableNotification {
+	return tables.TableNotification{ID: notification.ID, Audience: string(notification.Audience), RoleIDs: notification.RoleIDs, Severity: string(notification.Severity), Title: notification.Title, Message: notification.Message, ActionLabel: notification.ActionLabel, ActionPath: notification.ActionPath, CreatedAt: notification.CreatedAt, ExpiresAt: notification.ExpiresAt}
+}
+
+func notificationFromTable(row *tables.TableNotification) schemas.Notification {
+	return schemas.Notification{ID: row.ID, Audience: schemas.NotificationAudience(row.Audience), RoleIDs: row.RoleIDs, Severity: schemas.NotificationSeverity(row.Severity), Title: row.Title, Message: row.Message, ActionLabel: row.ActionLabel, ActionPath: row.ActionPath, CreatedAt: row.CreatedAt, ExpiresAt: row.ExpiresAt}
+}

--- a/transports/bifrost-http/handlers/notifications_test.go
+++ b/transports/bifrost-http/handlers/notifications_test.go
@@ -1,0 +1,199 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+type recordingNotificationStore struct {
+	created []tables.TableNotification
+	rows    []tables.TableNotification
+}
+
+func (s *recordingNotificationStore) CreateNotification(_ context.Context, notification *tables.TableNotification) error {
+	s.created = append(s.created, *notification)
+	return nil
+}
+
+func (s *recordingNotificationStore) ListNotifications(context.Context, time.Time, string, int) ([]tables.TableNotification, error) {
+	return s.rows, nil
+}
+
+func TestNotificationListFiltersByRole(t *testing.T) {
+	now := time.Now().UTC()
+	store := &recordingNotificationStore{rows: []tables.TableNotification{
+		{ID: "global", Audience: "all", Severity: "info", Title: "Global", Message: "message", CreatedAt: now, ExpiresAt: now.Add(time.Hour)},
+		{ID: "matching", Audience: "roles", RoleIDs: []uint{7}, Severity: "info", Title: "Matching", Message: "message", CreatedAt: now.Add(-time.Second), ExpiresAt: now.Add(time.Hour)},
+		{ID: "hidden", Audience: "roles", RoleIDs: []uint{8}, Severity: "info", Title: "Hidden", Message: "message", CreatedAt: now.Add(-2 * time.Second), ExpiresAt: now.Add(time.Hour)},
+	}}
+	service := &NotificationService{store: store, now: func() time.Time { return now }}
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue(schemas.BifrostContextKeyUserRoleID, uint(7))
+	service.list(ctx)
+
+	require.Equal(t, fasthttp.StatusOK, ctx.Response.StatusCode())
+	var response notificationListResponse
+	require.NoError(t, sonic.Unmarshal(ctx.Response.Body(), &response))
+	require.Len(t, response.Notifications, 2)
+	require.Equal(t, "global", response.Notifications[0].ID)
+	require.Equal(t, "matching", response.Notifications[1].ID)
+}
+
+func (s *recordingNotificationStore) DeleteExpiredNotifications(context.Context, time.Time) (int64, error) {
+	return 0, nil
+}
+
+func TestNotificationServicePublishValidatesAndPersists(t *testing.T) {
+	store := &recordingNotificationStore{}
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	service := &NotificationService{store: store, now: func() time.Time { return now }}
+
+	notification, err := service.Publish(context.Background(), schemas.NotificationInput{
+		Audience: schemas.NotificationAudienceRoles, RoleIDs: []uint{7, 2, 7}, Severity: schemas.NotificationSeverityWarning,
+		Title: "  Provider needs attention  ", Message: " Check its credentials. ", ActionLabel: "  Open provider  ", ActionPath: "/workspace/providers  ",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []uint{2, 7}, notification.RoleIDs)
+	// Padding survives: validation judges the trimmed value but never writes it
+	// back, so what the caller sent is what gets stored.
+	require.Equal(t, "  Provider needs attention  ", notification.Title)
+	require.Equal(t, " Check its credentials. ", notification.Message)
+	require.Equal(t, "  Open provider  ", notification.ActionLabel)
+	require.Equal(t, "/workspace/providers  ", notification.ActionPath)
+	require.Equal(t, now.Add(notificationRetention), notification.ExpiresAt)
+	require.Len(t, store.created, 1)
+	require.Equal(t, notification.ID, store.created[0].ID)
+	require.Equal(t, "  Provider needs attention  ", store.created[0].Title)
+	require.Equal(t, " Check its credentials. ", store.created[0].Message)
+	require.Equal(t, "  Open provider  ", store.created[0].ActionLabel)
+	require.Equal(t, "/workspace/providers  ", store.created[0].ActionPath)
+
+	// A title that is only whitespace is still rejected.
+	_, err = service.Publish(context.Background(), schemas.NotificationInput{
+		Audience: schemas.NotificationAudienceAll, Severity: schemas.NotificationSeverityInfo, Title: "   ", Message: "Blank title",
+	})
+	require.ErrorContains(t, err, "title is required")
+	require.Len(t, store.created, 1)
+
+	_, err = service.Publish(context.Background(), schemas.NotificationInput{
+		Audience: schemas.NotificationAudienceRoles, Severity: schemas.NotificationSeverityInfo, Title: "Invalid", Message: "No roles",
+	})
+	require.ErrorContains(t, err, "role_ids is required")
+	require.Len(t, store.created, 1)
+
+	_, err = service.Publish(context.Background(), schemas.NotificationInput{
+		Audience: schemas.NotificationAudienceAll, Severity: schemas.NotificationSeverityInfo, Title: "Invalid", Message: "External", ActionLabel: "Open", ActionPath: "https://example.com",
+	})
+	require.ErrorContains(t, err, "internal absolute path")
+
+	// A backslash reads as a path separator to the browser, so these resolve
+	// off-site despite clearing the "//" check.
+	for _, path := range []string{`/\evil.example`, `/%5Cevil.example`, `/workspace\..\..\evil`} {
+		_, err = service.Publish(context.Background(), schemas.NotificationInput{
+			Audience: schemas.NotificationAudienceAll, Severity: schemas.NotificationSeverityInfo, Title: "Invalid", Message: "Backslash", ActionLabel: "Open", ActionPath: path,
+		})
+		require.ErrorContainsf(t, err, "internal absolute path", "action_path %q must be rejected", path)
+	}
+	require.Len(t, store.created, 1)
+}
+
+// endlessNotificationStore always hands back a full batch of rows no caller can
+// see, which is the shape that used to walk the whole table: the outer loop kept
+// asking for more because it never filled a page.
+type endlessNotificationStore struct{ calls int }
+
+func (s *endlessNotificationStore) CreateNotification(context.Context, *tables.TableNotification) error {
+	return nil
+}
+
+func (s *endlessNotificationStore) DeleteExpiredNotifications(context.Context, time.Time) (int64, error) {
+	return 0, nil
+}
+
+func (s *endlessNotificationStore) ListNotifications(_ context.Context, before time.Time, _ string, limit int) ([]tables.TableNotification, error) {
+	s.calls++
+	if before.IsZero() {
+		before = time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	}
+	rows := make([]tables.TableNotification, limit)
+	for i := range rows {
+		rows[i] = tables.TableNotification{
+			ID: fmt.Sprintf("call-%d-row-%d", s.calls, i), Audience: "roles", RoleIDs: []uint{99},
+			Severity: "info", Title: "Invisible", Message: "message",
+			CreatedAt: before.Add(-time.Duration(i+1) * time.Second), ExpiresAt: before.Add(time.Hour),
+		}
+	}
+	return rows, nil
+}
+
+func TestNotificationListStopsAtScanBudget(t *testing.T) {
+	store := &endlessNotificationStore{}
+	service := &NotificationService{store: store, now: time.Now}
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue(schemas.BifrostContextKeyUserRoleID, uint(7))
+	service.list(ctx)
+
+	require.Equal(t, fasthttp.StatusOK, ctx.Response.StatusCode())
+	require.Equal(t, maxNotificationScanTotal/maxNotificationScan, store.calls, "scan must stop at the request-wide budget")
+
+	var response notificationListResponse
+	require.NoError(t, sonic.Unmarshal(ctx.Response.Body(), &response))
+	require.Empty(t, response.Notifications)
+	// A short page cut by the budget must still carry a cursor, or the caller
+	// reads it as the end of the feed and loses everything behind it.
+	require.NotEmpty(t, response.NextCursor)
+
+	_, cursorID, err := decodeNotificationCursor(response.NextCursor)
+	require.NoError(t, err)
+	require.Equal(t, fmt.Sprintf("call-%d-row-%d", store.calls, maxNotificationScan-1), cursorID, "cursor must resume from the last row scanned")
+}
+
+func TestNotificationCreateRequiresLocalAdmin(t *testing.T) {
+	store := &recordingNotificationStore{}
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	service := &NotificationService{store: store, now: func() time.Time { return now }}
+	body, err := sonic.Marshal(schemas.NotificationInput{
+		Audience: schemas.NotificationAudienceAll, Severity: schemas.NotificationSeverityInfo, Title: "Broadcast", Message: "To everyone",
+	})
+	require.NoError(t, err)
+
+	// A non-admin role is authenticated but must not be able to reach every
+	// dashboard on the deployment.
+	nonAdmin := &fasthttp.RequestCtx{}
+	nonAdmin.SetUserValue(schemas.BifrostContextKeyUserRoleID, uint(7))
+	nonAdmin.Request.SetBody(body)
+	service.create(nonAdmin)
+	require.Equal(t, fasthttp.StatusForbidden, nonAdmin.Response.StatusCode())
+	require.Empty(t, store.created)
+
+	admin := &fasthttp.RequestCtx{}
+	admin.SetUserValue(schemas.IsLocalAdminContextKey, true)
+	admin.Request.SetBody(body)
+	service.create(admin)
+	require.Equal(t, fasthttp.StatusCreated, admin.Response.StatusCode())
+	require.Len(t, store.created, 1)
+}
+
+func TestNotificationVisibleToRole(t *testing.T) {
+	require.True(t, notificationVisibleToRole(&schemas.Notification{Audience: schemas.NotificationAudienceAll}, 0, false))
+	require.True(t, notificationVisibleToRole(&schemas.Notification{Audience: schemas.NotificationAudienceRoles, RoleIDs: []uint{2, 7}}, 7, true))
+	require.False(t, notificationVisibleToRole(&schemas.Notification{Audience: schemas.NotificationAudienceRoles, RoleIDs: []uint{2, 7}}, 3, true))
+	require.False(t, notificationVisibleToRole(&schemas.Notification{Audience: schemas.NotificationAudienceRoles, RoleIDs: []uint{2, 7}}, 0, false))
+}
+
+func TestNotificationCursorRoundTrip(t *testing.T) {
+	wantTime := time.Date(2026, 8, 17, 12, 0, 0, 123456789, time.UTC)
+	wantID := "notification-id"
+	gotTime, gotID, err := decodeNotificationCursor(encodeNotificationCursor(wantTime, wantID))
+	require.NoError(t, err)
+	require.Equal(t, wantTime, gotTime)
+	require.Equal(t, wantID, gotID)
+}

--- a/transports/bifrost-http/handlers/websocket.go
+++ b/transports/bifrost-http/handlers/websocket.go
@@ -28,8 +28,11 @@ var errWebSocketClientClosed = errors.New("websocket client is closed")
 
 // WebSocketClient represents a connected WebSocket client with its own mutex
 type WebSocketClient struct {
-	conn *websocket.Conn
-	mu   sync.Mutex // Per-connection mutex for thread-safe writes
+	conn       *websocket.Conn
+	mu         sync.Mutex // Per-connection mutex for thread-safe writes
+	roleID     uint
+	hasRole    bool
+	localAdmin bool
 
 	// closed is set under mu once the connection's owning handler is done with
 	// it. It cannot be inferred from conn: fasthttp hands the upgrade handler a
@@ -146,6 +149,8 @@ func (h *WebSocketHandler) connectStream(ctx *fasthttp.RequestCtx) {
 		client := &WebSocketClient{
 			conn: ws,
 		}
+		client.roleID, client.hasRole = notificationRoleID(ctx)
+		client.localAdmin, _ = ctx.UserValue(schemas.IsLocalAdminContextKey).(bool)
 
 		// Register new client
 		h.mu.Lock()
@@ -313,6 +318,33 @@ func (h *WebSocketHandler) BroadcastEvent(eventType string, data interface{}) {
 	}
 
 	h.BroadcastMarshaledMessage(bytes)
+}
+
+// BroadcastNotification sends a dedicated notification event only to clients
+// whose authenticated role is part of the notification audience.
+func (h *WebSocketHandler) BroadcastNotification(notification *schemas.Notification) {
+	message := struct {
+		Type string                `json:"type"`
+		Data *schemas.Notification `json:"data"`
+	}{Type: "notification", Data: notification}
+	data, err := sonic.Marshal(message)
+	if err != nil {
+		logger.Error("failed to marshal notification: %v", err)
+		return
+	}
+	h.mu.RLock()
+	clients := make([]*WebSocketClient, 0, len(h.clients))
+	for _, client := range h.clients {
+		if client.localAdmin || notificationVisibleToRole(notification, client.roleID, client.hasRole) {
+			clients = append(clients, client)
+		}
+	}
+	h.mu.RUnlock()
+	for _, client := range clients {
+		if err := h.sendMessageSafely(client, websocket.TextMessage, data); err != nil && !errors.Is(err, errWebSocketClientClosed) {
+			logger.Error("failed to send notification to client: %v", err)
+		}
+	}
 }
 
 // BroadcastMarshaledMessage sends an adaptive routing update to all connected WebSocket clients

--- a/transports/bifrost-http/handlers/websocket_test.go
+++ b/transports/bifrost-http/handlers/websocket_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/fasthttp/router"
 	"github.com/fasthttp/websocket"
+	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/valyala/fasthttp"
 )
 
@@ -25,6 +26,52 @@ type panicWatchLogger struct {
 	mu       sync.Mutex
 	panics   atomic.Int64
 	messages []string
+}
+
+func TestBroadcastNotificationTargetsMatchingRole(t *testing.T) {
+	h, addr, stop := startWebSocketTestServer(t)
+	defer stop()
+
+	matching := dialWebSocket(t, addr)
+	defer matching.Close()
+	waitForClientCount(t, h, 1)
+	matchingServerClient := snapshotClients(h)[0]
+	matchingServerClient.roleID = 7
+	matchingServerClient.hasRole = true
+
+	nonMatching := dialWebSocket(t, addr)
+	defer nonMatching.Close()
+	waitForClientCount(t, h, 2)
+	for _, client := range snapshotClients(h) {
+		if client != matchingServerClient {
+			client.roleID = 8
+			client.hasRole = true
+		}
+	}
+
+	h.BroadcastNotification(&schemas.Notification{
+		ID: "notification-1", Audience: schemas.NotificationAudienceRoles, RoleIDs: []uint{7}, Severity: schemas.NotificationSeverityInfo,
+		Title: "For role seven", Message: "message", CreatedAt: time.Now(), ExpiresAt: time.Now().Add(time.Hour),
+	})
+
+	requireReadDeadline := time.Now().Add(time.Second)
+	if err := matching.SetReadDeadline(requireReadDeadline); err != nil {
+		t.Fatal(err)
+	}
+	_, payload, err := matching.ReadMessage()
+	if err != nil {
+		t.Fatalf("matching role did not receive notification: %v", err)
+	}
+	if !strings.Contains(string(payload), `"type":"notification"`) || !strings.Contains(string(payload), `"id":"notification-1"`) {
+		t.Fatalf("unexpected notification payload: %s", payload)
+	}
+
+	if err := nonMatching.SetReadDeadline(time.Now().Add(100 * time.Millisecond)); err != nil {
+		t.Fatal(err)
+	}
+	if _, payload, err := nonMatching.ReadMessage(); err == nil {
+		t.Fatalf("non-matching role received notification: %s", payload)
+	}
 }
 
 func (l *panicWatchLogger) Error(format string, args ...any) {

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -635,6 +635,11 @@ type Config struct {
 	// Optional event broadcaster for real-time updates (e.g., WebSocket).
 	// Set by HTTP server at startup; may be nil in non-HTTP usage.
 	EventBroadcaster schemas.EventBroadcaster
+	// NotificationPublisher persists and delivers role-targeted dashboard
+	// notifications. Assigned at startup and deliberately unused in-tree: it is
+	// the seam enterprise builds and plugins publish through. See the doc on
+	// schemas.NotificationPublisher before adding the first caller.
+	NotificationPublisher schemas.NotificationPublisher
 
 	// EnvLabel is a short label (max 10 chars) displayed in the UI sidebar to identify the
 	// environment (e.g. "staging", "prod"). Set via config.json env_label or BIFROST_ENV_LABEL env var.

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -222,10 +222,11 @@ type BifrostHTTPServer struct {
 	// from it.
 	ShellRewriter handlers.ShellRewriter
 
-	WebSocketHandler   *handlers.WebSocketHandler
-	MCPServerHandler   *handlers.MCPServerHandler
-	devPprofHandler    *handlers.DevPprofHandler
-	IntegrationHandler *handlers.IntegrationHandler
+	WebSocketHandler    *handlers.WebSocketHandler
+	NotificationService *handlers.NotificationService
+	MCPServerHandler    *handlers.MCPServerHandler
+	devPprofHandler     *handlers.DevPprofHandler
+	IntegrationHandler  *handlers.IntegrationHandler
 
 	AuthMiddleware       *handlers.AuthMiddleware
 	CORSMiddleware       *handlers.CorsMiddleware
@@ -2105,6 +2106,11 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 	if s.WebSocketHandler == nil {
 		s.WebSocketHandler = handlers.NewWebSocketHandler(s.Ctx, s.Config.ClientConfig.AllowedOrigins)
 	}
+	if s.NotificationService == nil {
+		s.NotificationService = handlers.NewNotificationService(s.Config.ConfigStore, s.WebSocketHandler)
+		s.Config.NotificationPublisher = s.NotificationService.Publish
+		s.NotificationService.Start(s.Ctx)
+	}
 	// Start WebSocket heartbeat
 	s.WebSocketHandler.StartHeartbeat()
 	// Adding telemetry middleware
@@ -2174,6 +2180,9 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 	}
 	if s.WebSocketHandler != nil {
 		s.WebSocketHandler.RegisterRoutes(s.Router, middlewares...)
+	}
+	if s.NotificationService != nil {
+		s.NotificationService.RegisterRoutes(s.Router, middlewares...)
 	}
 	// Register dev pprof handler only in dev mode
 	if handlers.IsDevMode() {
@@ -2364,6 +2373,9 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	// Log callbacks are registered later in RegisterAPIRoutes when logging plugin is available.
 	s.WebSocketHandler = handlers.NewWebSocketHandler(s.Ctx, s.Config.ClientConfig.AllowedOrigins)
 	s.Config.EventBroadcaster = s.WebSocketHandler.BroadcastEvent
+	s.NotificationService = handlers.NewNotificationService(s.Config.ConfigStore, s.WebSocketHandler)
+	s.Config.NotificationPublisher = s.NotificationService.Publish
+	s.NotificationService.Start(s.Ctx)
 	// Initializing plugin loader. Allowlist entries are validated now - a malformed entry
 	// fails server startup rather than silently no-oping, since this is security-relaxing
 	// config for SSRF protection on custom plugin downloads.

--- a/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
+++ b/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
@@ -37,6 +37,7 @@ export enum RbacResource {
 	Inventory = "Inventory",
 	EdgeConfig = "EdgeConfig",
 	SkillsRepository = "SkillsRepository",
+	Notifications = "Notifications",
 }
 
 // RBAC Operation Names (must match backend definitions)

--- a/ui/app/_fallbacks/enterprise/lib/store/utils/tokenManager.ts
+++ b/ui/app/_fallbacks/enterprise/lib/store/utils/tokenManager.ts
@@ -30,6 +30,8 @@ export const REFRESH_TOKEN_ENDPOINT = "";
 
 // User info type definition (matching enterprise version)
 export interface UserInfo {
+	sub?: string;
+	id?: string;
 	name?: string;
 	email?: string;
 	picture?: string;

--- a/ui/app/clientLayout.tsx
+++ b/ui/app/clientLayout.tsx
@@ -9,6 +9,7 @@ import TrialExpiryBanner from "@/components/trialExpiryBanner";
 import { Button } from "@/components/ui/button";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { useStoreSync } from "@/hooks/useStoreSync";
+import { useNotificationSync } from "@/hooks/useNotificationSync";
 import { TopbarProvider } from "@/lib/contexts/topbarContext";
 import { WebSocketProvider } from "@/hooks/useWebSocket";
 import { getErrorMessage, ReduxProvider, useGetCoreConfigQuery, useIsAuthEnabledQuery } from "@/lib/store";
@@ -35,6 +36,7 @@ const DevProfiler = () => (
 
 function StoreSyncInitializer() {
 	useStoreSync();
+	useNotificationSync();
 	return null;
 }
 

--- a/ui/components/notificationCenter.tsx
+++ b/ui/components/notificationCenter.tsx
@@ -1,0 +1,207 @@
+import {
+	clearAllNotifications,
+	markAllNotificationsRead,
+	markNotificationRead,
+	removeNotification,
+	selectNotificationPreferences,
+	selectUnreadNotificationsCount,
+	selectVisibleNotifications,
+	useAppDispatch,
+	useAppSelector,
+	useGetNotificationsQuery,
+} from "@/lib/store";
+import type { NotificationSeverity } from "@/lib/types/notifications";
+import { cn } from "@/lib/utils";
+import { isNotificationsUnavailable } from "@/components/notificationCenter.utils";
+import { TOPBAR_MENU_SIDE_OFFSET } from "@/components/topbar.utils";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ScrollArea } from "@/components/ui/scrollArea";
+import { formatDistanceToNow } from "date-fns";
+import { useNavigate } from "@tanstack/react-router";
+import { Check, CheckCircle2, CircleAlert, Inbox, Info, RefreshCw, TriangleAlert, X } from "lucide-react";
+
+const severityStyles: Record<NotificationSeverity, string> = {
+	info: "bg-blue-500/10 text-blue-600 dark:text-blue-400",
+	success: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+	warning: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
+	error: "bg-destructive/10 text-destructive",
+};
+
+const severityIcons = {
+	info: Info,
+	success: CheckCircle2,
+	warning: TriangleAlert,
+	error: CircleAlert,
+};
+
+export default function NotificationCenter() {
+	const dispatch = useAppDispatch();
+	const navigate = useNavigate();
+	const notifications = useAppSelector(selectVisibleNotifications);
+	const unreadCount = useAppSelector(selectUnreadNotificationsCount);
+	const { readIds } = useAppSelector(selectNotificationPreferences);
+	const { isLoading, isFetching, isError, error, refetch } = useGetNotificationsQuery({ limit: 50 });
+
+	const openNotification = (id: string, actionPath?: string) => {
+		dispatch(markNotificationRead(id));
+		if (actionPath) navigate({ to: actionPath });
+	};
+
+	// The service answers 503 when no config store is configured, which is a
+	// supported deployment (lib.Config leaves ConfigStore nil when the store is
+	// disabled). There is nothing to retry there and never will be for the life
+	// of the process, so drop the trigger entirely rather than parking a
+	// permanent error panel in the topbar. Transient failures still get the
+	// in-tray retry below.
+	if (isNotificationsUnavailable(error)) return null;
+
+	return (
+		<Popover>
+			<PopoverTrigger asChild>
+				<button
+					type="button"
+					aria-label={unreadCount ? `Notifications, ${unreadCount} unread` : "Notifications"}
+					data-testid="topbar-notifications-btn"
+					// size-8 matches the theme toggle and the menu/user-pill trigger. Every topbar trigger has to
+					// share one box: Radix anchors sideOffset to the trigger's bounding box, so a shorter trigger
+					// opens its surface higher than its neighbours even at an identical offset, and a narrower one
+					// breaks the even horizontal rhythm of the icon row.
+					className="text-muted-foreground hover:bg-accent hover:text-accent-foreground flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-md transition-colors"
+				>
+					{/* The badge hangs off the glyph, not the 32px hit area, so widening the button does not fling
+					    the count into the corner. */}
+					<span className="relative flex items-center justify-center">
+						<Inbox className="size-4" strokeWidth={2} />
+						{unreadCount > 0 && (
+							<span
+								data-testid="topbar-notifications-badge"
+								className="bg-destructive text-destructive-foreground absolute -top-1.5 -right-2 flex min-w-4 items-center justify-center rounded-full px-1 text-[9px] leading-4 font-semibold"
+							>
+								{unreadCount > 99 ? "99+" : unreadCount}
+							</span>
+						)}
+					</span>
+				</button>
+			</PopoverTrigger>
+			<PopoverContent
+				align="end"
+				// TOPBAR_MENU_SIDE_OFFSET, one pixel tighter than the app-wide default of 4.
+				// Every topbar surface uses it so the three menus open on the same line.
+				sideOffset={TOPBAR_MENU_SIDE_OFFSET}
+				className="w-[min(24rem,calc(100vw-1rem))] overflow-hidden p-0"
+				data-testid="notification-tray"
+			>
+				<div className="flex h-12 items-center justify-between border-b px-4">
+					<div className="flex items-center gap-2">
+						<h2 className="text-sm font-semibold">Notifications</h2>
+						{isFetching && !isLoading && <RefreshCw className="text-muted-foreground size-3 animate-spin" />}
+					</div>
+					{notifications.length > 0 && (
+						<button
+							type="button"
+							onClick={() => dispatch(markAllNotificationsRead())}
+							className="text-muted-foreground hover:text-foreground cursor-pointer text-xs transition-colors"
+							data-testid="notifications-mark-all-read"
+						>
+							Mark all read
+						</button>
+					)}
+				</div>
+
+				{isLoading ? (
+					<div className="text-muted-foreground flex h-44 items-center justify-center gap-2 text-sm">
+						<RefreshCw className="size-4 animate-spin" /> Loading notifications
+					</div>
+				) : isError ? (
+					<div className="flex h-44 flex-col items-center justify-center gap-3 px-6 text-center">
+						<p className="text-muted-foreground text-sm">Notifications could not be loaded.</p>
+						<button type="button" onClick={() => refetch()} className="text-primary cursor-pointer text-sm font-medium hover:underline">
+							Try again
+						</button>
+					</div>
+				) : notifications.length === 0 ? (
+					<div className="flex h-44 flex-col items-center justify-center gap-2 px-6 text-center" data-testid="notifications-empty-state">
+						<span className="bg-muted text-muted-foreground flex size-9 items-center justify-center rounded-full">
+							<Check className="size-4" />
+						</span>
+						<p className="text-sm font-medium">You&apos;re all caught up</p>
+						<p className="text-muted-foreground text-xs">New notifications will appear here.</p>
+					</div>
+				) : (
+					<ScrollArea className="h-[min(26rem,calc(100vh-8rem))]">
+						<div className="divide-y">
+							{notifications.map((notification) => {
+								const Icon = severityIcons[notification.severity];
+								const isRead = readIds.includes(notification.id);
+								return (
+									// Open and dismiss are sibling native buttons, never nested. A
+									// <button> may not contain interactive content, and role="button"
+									// makes the same promise to assistive tech, so a dismiss control
+									// inside the row control leaves screen readers announcing one
+									// widget where there are two. Siblings also mean Enter and Space
+									// come from the platform instead of a hand-rolled key handler.
+									<div
+										key={notification.id}
+										data-testid={`notification-item-${notification.id}`}
+										className={cn("group relative flex transition-colors", isRead ? "hover:bg-accent/60" : "bg-accent/25 hover:bg-accent/60")}
+									>
+										<button
+											type="button"
+											onClick={() => openNotification(notification.id, notification.action_path)}
+											data-testid={`notification-open-${notification.id}`}
+											className="focus-visible:ring-ring flex min-w-0 flex-1 cursor-pointer gap-3 px-4 py-3 text-left outline-none focus-visible:ring-2 focus-visible:ring-inset"
+										>
+											<span
+												className={cn(
+													"mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full",
+													severityStyles[notification.severity],
+												)}
+											>
+												<Icon className="size-3.5" />
+											</span>
+											<span className="min-w-0 flex-1 pr-5">
+												<span className="flex items-start gap-2">
+													<span className={cn("min-w-0 flex-1 text-sm", !isRead && "font-semibold")}>{notification.title}</span>
+													{!isRead && <span className="bg-primary mt-1.5 size-1.5 shrink-0 rounded-full" aria-label="Unread" />}
+												</span>
+												<span className="text-muted-foreground mt-0.5 line-clamp-3 block text-xs leading-relaxed">
+													{notification.message}
+												</span>
+												<span className="text-muted-foreground mt-1.5 flex items-center gap-2 text-[11px]">
+													<span>{formatDistanceToNow(new Date(notification.created_at), { addSuffix: true })}</span>
+													{notification.action_label && <span className="text-primary font-medium">{notification.action_label}</span>}
+												</span>
+											</span>
+										</button>
+										<button
+											type="button"
+											aria-label={`Dismiss ${notification.title}`}
+											onClick={() => dispatch(removeNotification(notification.id))}
+											data-testid={`notification-dismiss-${notification.id}`}
+											className="text-muted-foreground hover:bg-muted hover:text-foreground absolute top-2.5 right-2.5 cursor-pointer rounded p-1 opacity-0 transition-opacity group-hover:opacity-100 focus:opacity-100"
+										>
+											<X className="size-3" />
+										</button>
+									</div>
+								);
+							})}
+						</div>
+					</ScrollArea>
+				)}
+
+				{notifications.length > 0 && (
+					<div className="flex h-10 items-center justify-end border-t px-4">
+						<button
+							type="button"
+							onClick={() => dispatch(clearAllNotifications())}
+							className="text-muted-foreground hover:text-destructive cursor-pointer text-xs transition-colors"
+							data-testid="notifications-clear-all"
+						>
+							Clear all
+						</button>
+					</div>
+				)}
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/ui/components/notificationCenter.utils.test.ts
+++ b/ui/components/notificationCenter.utils.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { isNotificationsUnavailable, shouldHideNotificationTrigger } from "./notificationCenter.utils";
+
+describe("isNotificationsUnavailable", () => {
+	it("treats 503 as the feature being switched off", () => {
+		expect(isNotificationsUnavailable({ status: 503, data: { error: "notification storage is unavailable" } })).toBe(true);
+	});
+
+	it("leaves every other failure retryable", () => {
+		expect(isNotificationsUnavailable({ status: 500 })).toBe(false);
+		expect(isNotificationsUnavailable({ status: "FETCH_ERROR", error: "offline" })).toBe(false);
+		expect(isNotificationsUnavailable({ name: "SyntaxError", message: "bad json" })).toBe(false);
+		expect(isNotificationsUnavailable(undefined)).toBe(false);
+		expect(isNotificationsUnavailable(null)).toBe(false);
+	});
+});
+
+describe("shouldHideNotificationTrigger", () => {
+	const state = (overrides: Partial<Parameters<typeof shouldHideNotificationTrigger>[0]> = {}) =>
+		shouldHideNotificationTrigger({ open: false, isLoading: false, isError: false, count: 0, ...overrides });
+
+	// The regression: a first load that fails leaves nothing to fall back on, so
+	// hiding the trigger here makes the tray's "Try again" unreachable and the
+	// feed silently stays empty until the user reloads the page.
+	it("keeps a failed empty load reachable so it can be retried", () => {
+		expect(state({ isError: true })).toBe(false);
+	});
+
+	it("hides while the first load is still in flight", () => {
+		expect(state({ isLoading: true })).toBe(true);
+		// A retry in flight after a failure must not flip the trigger back off.
+		expect(state({ isLoading: true, open: true, isError: true })).toBe(false);
+	});
+
+	it("hides a genuinely empty deployment", () => {
+		expect(state()).toBe(true);
+	});
+
+	it("shows the trigger once there is anything to open", () => {
+		expect(state({ count: 3 })).toBe(false);
+		expect(state({ count: 3, isError: true })).toBe(false);
+	});
+
+	it("stays mounted while the popover is open, whatever the feed says", () => {
+		expect(state({ open: true })).toBe(false);
+		expect(state({ open: true, isLoading: true })).toBe(false);
+	});
+});

--- a/ui/components/notificationCenter.utils.ts
+++ b/ui/components/notificationCenter.utils.ts
@@ -1,0 +1,41 @@
+/**
+ * True when the backend has told us notifications can never be served, as
+ * opposed to having failed this once.
+ *
+ * NotificationService is constructed with the config store, and lib.Config
+ * leaves ConfigStore nil whenever the store is disabled, so both routes answer
+ * 503 for the whole life of the process. That is a supported deployment, not an
+ * outage, and the UI should hide the feature instead of showing an error the
+ * user can never clear. Every other failure stays retryable.
+ */
+export function isNotificationsUnavailable(error: unknown): boolean {
+	return typeof error === "object" && error !== null && "status" in error && (error as { status?: unknown }).status === 503;
+}
+
+/**
+ * Whether the topbar trigger should be hidden entirely.
+ *
+ * Empty deployments should not flash an icon, so the trigger stays out of the
+ * topbar while the first load is in flight and whenever the feed is genuinely
+ * empty. A failed load is not one of those: with no rows to fall back on it is
+ * the only state that can reach the tray's "Try again" retry, so hiding it
+ * there strands the user on a feed that silently stays empty until a reload.
+ *
+ * `open` overrides all of it, so dismissing the last row does not yank the
+ * popover out from under the pointer.
+ */
+export function shouldHideNotificationTrigger({
+	open,
+	isLoading,
+	isError,
+	count,
+}: {
+	open: boolean;
+	isLoading: boolean;
+	isError: boolean;
+	count: number;
+}): boolean {
+	if (open) return false;
+	if (isLoading) return true;
+	return count === 0 && !isError;
+}

--- a/ui/components/themeToggle.tsx
+++ b/ui/components/themeToggle.tsx
@@ -1,6 +1,7 @@
 import { Check, Laptop, Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 
+import { TOPBAR_MENU_SIDE_OFFSET } from "@/components/topbar.utils";
 import { Button } from "@/components/ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
 
@@ -37,14 +38,16 @@ export function ThemeToggle() {
 				<Button
 					variant="ghost"
 					size="icon"
-					className="hover:text-primary text-muted-foreground h-5 w-5 border-0 ring-offset-0 outline-none select-none focus-visible:ring-0"
+					// size-8 box around a size-4 glyph, matching the notification and menu triggers. Equal boxes are
+					// what keep the topbar icons evenly spaced and open their menus on the same line.
+					className="text-muted-foreground hover:bg-accent hover:text-accent-foreground size-8 border-0 ring-offset-0 outline-none select-none focus-visible:ring-0"
 				>
-					<Sun className="h-5.5 w-5.5 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" strokeWidth={2} />
-					<Moon className="absolute h-5.5 w-5.5 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" strokeWidth={2} />
+					<Sun className="size-4 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" strokeWidth={2} />
+					<Moon className="absolute size-4 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" strokeWidth={2} />
 					<span className="sr-only">Toggle theme</span>
 				</Button>
 			</DropdownMenuTrigger>
-			<DropdownMenuContent align="end">
+			<DropdownMenuContent align="end" sideOffset={TOPBAR_MENU_SIDE_OFFSET}>
 				<ThemeToggleItems />
 			</DropdownMenuContent>
 		</DropdownMenu>

--- a/ui/components/topbar.tsx
+++ b/ui/components/topbar.tsx
@@ -1,5 +1,6 @@
 import { ThemeToggle } from "@/components/themeToggle";
-import { deriveTitleFromPathname } from "@/components/topbar.utils";
+import NotificationCenter from "@/components/notificationCenter";
+import { deriveTitleFromPathname, TOPBAR_MENU_SIDE_OFFSET } from "@/components/topbar.utils";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -128,6 +129,7 @@ export default function Topbar() {
 
 			{/* Theme stays a first-class topbar control rather than a menu entry —
 			    it's a display preference, not an account action. */}
+			<NotificationCenter />
 			<ThemeToggle />
 
 			<DropdownMenu>
@@ -160,7 +162,7 @@ export default function Topbar() {
 					)}
 				</DropdownMenuTrigger>
 
-				<DropdownMenuContent align="end" sideOffset={4} className="w-60">
+				<DropdownMenuContent align="end" sideOffset={TOPBAR_MENU_SIDE_OFFSET} className="w-60">
 					{showUserPill && (
 						<>
 							<DropdownMenuLabel className="flex min-w-0 flex-col gap-0.5 py-2">

--- a/ui/components/topbar.utils.test.ts
+++ b/ui/components/topbar.utils.test.ts
@@ -30,4 +30,30 @@ describe("deriveTitleFromPathname", () => {
 		expect(deriveTitleFromPathname("/workspace/custom-pricing/overrides")).toBe("Overrides");
 		expect(deriveTitleFromPathname("/workspace/model-limits")).toBe("Model Limits");
 	});
+
+	it("uses the override table for routes the slug mislabels", () => {
+		expect(deriveTitleFromPathname("/workspace/routing-rules/tree")).toBe("Routing Tree");
+		expect(deriveTitleFromPathname("/workspace/scim")).toBe("User Provisioning");
+		expect(deriveTitleFromPathname("/workspace/providers")).toBe("Model Providers");
+		expect(deriveTitleFromPathname("/workspace/governance/rbac")).toBe("Roles & Permissions");
+	});
+
+	it("folds the parent into sub-item labels that mean nothing alone", () => {
+		expect(deriveTitleFromPathname("/workspace/alerting/rules")).toBe("Alert Rules");
+		expect(deriveTitleFromPathname("/workspace/guardrails/rules")).not.toBe("Alert Rules");
+		expect(deriveTitleFromPathname("/workspace/guardrails/configuration")).toBe("Guardrail Rules");
+		expect(deriveTitleFromPathname("/workspace/edge-control/inventory")).toBe("Edge Approvals");
+	});
+
+	it("matches an override through a trailing slash or query string", () => {
+		expect(deriveTitleFromPathname("/workspace/scim/")).toBe("User Provisioning");
+		expect(deriveTitleFromPathname("/workspace/scim?tab=mappings")).toBe("User Provisioning");
+	});
+
+	it("leaves a child route alone when only its parent is overridden", () => {
+		// /workspace/logs is "LLM Logs", but its child must not inherit that.
+		expect(deriveTitleFromPathname("/workspace/logs")).toBe("LLM Logs");
+		expect(deriveTitleFromPathname("/workspace/logs/connectors")).toBe("Log Connectors");
+		expect(deriveTitleFromPathname("/workspace/config/branding")).toBe("Branding");
+	});
 });

--- a/ui/components/topbar.utils.ts
+++ b/ui/components/topbar.utils.ts
@@ -1,3 +1,14 @@
+/**
+ * Gap between a topbar trigger and the menu it opens, in pixels. One tighter
+ * than the app-wide default of 4 that dropdownMenu/popover/hoverCard ship.
+ *
+ * Shared rather than repeated because Radix measures the offset from the
+ * trigger's bounding box: the topbar's triggers are all size-8 so that one
+ * offset lands every menu on the same line, and a lone override would visibly
+ * break the row.
+ */
+export const TOPBAR_MENU_SIDE_OFFSET = 3;
+
 /** Path segments that are shouted rather than capitalised. */
 const titleAcronyms: Record<string, string> = {
 	ai: "AI",
@@ -16,15 +27,52 @@ function formatTitlePart(part: string) {
 }
 
 /**
- * Fallback title for a route that does not name itself, derived from the last
- * non-empty path segment: "/workspace/mcp-registry" -> "MCP Registry".
+ * Routes whose slug does not produce the name the product actually uses.
  *
- * This is only ever a guess. Several routes carry a name the slug cannot
- * produce ("/workspace/model-limits" is "Budgets & Limits"), which is why a
- * page that renders <PageTitle> must render it on every branch — including its
- * loading and empty states. Falling back there does not blank the topbar, it
- * silently shows a different title.
+ * Only routes that have not yet moved to <PageTitle> belong here; a page that
+ * renders <PageTitle> always wins over this table, so migrating a page means
+ * deleting its row. Titles are taken from the sidebar label so the nav and the
+ * topbar agree, with one adjustment: where a sub-item's label is only
+ * meaningful under its parent ("Rules", "Approvals", "Connectors", "Settings"),
+ * the parent is folded in, because the topbar shows the title alone.
+ */
+const routeTitleOverrides: Record<string, string> = {
+	"/workspace/adaptive-routing/settings": "Adaptive Routing Settings",
+	"/workspace/alerting/channels": "Alert Channels",
+	"/workspace/alerting/history": "Alert History",
+	"/workspace/alerting/rules": "Alert Rules",
+	"/workspace/cluster": "Cluster Config",
+	"/workspace/config": "Settings",
+	"/workspace/config/license": "License Info",
+	"/workspace/edge-control/config": "Edge Settings",
+	"/workspace/edge-control/devices": "Edge Devices",
+	"/workspace/edge-control/inventory": "Edge Approvals",
+	"/workspace/governance/rbac": "Roles & Permissions",
+	"/workspace/guardrails/configuration": "Guardrail Rules",
+	"/workspace/guardrails/providers": "Guardrail Providers",
+	"/workspace/logs": "LLM Logs",
+	"/workspace/logs/connectors": "Log Connectors",
+	"/workspace/observability": "Observability Connectors",
+	"/workspace/prompt-repo": "Prompt Repository",
+	"/workspace/providers": "Model Providers",
+	"/workspace/routing-rules/tree": "Routing Tree",
+	"/workspace/scim": "User Provisioning",
+};
+
+/**
+ * Title for a route that does not name itself: an entry from
+ * routeTitleOverrides, else the last non-empty path segment
+ * ("/workspace/mcp-registry" -> "MCP Registry").
+ *
+ * The slug half is only ever a guess, which is why a page that renders
+ * <PageTitle> must render it on every branch, including its loading and empty
+ * states. Falling back there does not blank the topbar, it silently shows a
+ * different title.
  */
 export function deriveTitleFromPathname(pathname: string): string {
-	return (pathname.split("/").filter(Boolean).at(-1) ?? "Dashboard").split("-").map(formatTitlePart).join(" ");
+	// Trailing slashes and query-free paths both have to hit the same row.
+	const segments = pathname.split("?")[0].split("/").filter(Boolean);
+	const override = routeTitleOverrides[`/${segments.join("/")}`];
+	if (override) return override;
+	return (segments.at(-1) ?? "Dashboard").split("-").map(formatTitlePart).join(" ");
 }

--- a/ui/hooks/useNotificationSync.tsx
+++ b/ui/hooks/useNotificationSync.tsx
@@ -1,0 +1,69 @@
+import { useWebSocket } from "@/hooks/useWebSocket";
+import {
+	addNotification,
+	hydrateNotificationPreferences,
+	pruneExpiredNotifications,
+	selectNotificationPreferences,
+	setNotifications,
+	useAppDispatch,
+	useAppSelector,
+	useGetNotificationsQuery,
+} from "@/lib/store";
+import type { Notification } from "@/lib/types/notifications";
+import { readNotificationPreferences, writeNotificationPreferences } from "@/lib/notifications/preferences";
+import { getUserInfo } from "@enterprise/lib/store/utils/tokenManager";
+import { useEffect, useMemo } from "react";
+
+/** Expired rows are dropped this often so a tab left open overnight converges. */
+const PRUNE_INTERVAL_MS = 60_000;
+
+/**
+ * Identity that read/dismissed state is filed under.
+ *
+ * This state is deliberately client-side only: it lives in localStorage, not on
+ * the server, so it does not follow the user across browsers or devices, and on
+ * an OSS deployment with no SSO every browser profile shares the "local-admin"
+ * bucket and therefore its own read state. That is the accepted trade for not
+ * adding a per-user write path; the notification rows themselves are always
+ * server-owned and role-scoped. Changing this means adding a real read-receipt
+ * endpoint, not widening the key.
+ */
+function getNotificationScope(): string {
+	const user = getUserInfo() as ReturnType<typeof getUserInfo> & { sub?: string; id?: string };
+	return user?.sub || user?.id || user?.email || user?.preferred_username || "local-admin";
+}
+
+export function useNotificationSync() {
+	const dispatch = useAppDispatch();
+	const { subscribe } = useWebSocket();
+	const preferences = useAppSelector(selectNotificationPreferences);
+	const scope = useMemo(getNotificationScope, []);
+	const { data } = useGetNotificationsQuery({ limit: 50 });
+
+	useEffect(() => {
+		const stored = readNotificationPreferences(scope);
+		dispatch(hydrateNotificationPreferences({ scope, ...stored }));
+	}, [dispatch, scope]);
+
+	useEffect(() => {
+		if (data?.notifications) dispatch(setNotifications(data.notifications));
+	}, [data, dispatch]);
+
+	useEffect(
+		() =>
+			subscribe("notification", (message) => {
+				if (message.data?.id) dispatch(addNotification(message.data as Notification));
+			}),
+		[dispatch, subscribe],
+	);
+
+	useEffect(() => {
+		const timer = setInterval(() => dispatch(pruneExpiredNotifications()), PRUNE_INTERVAL_MS);
+		return () => clearInterval(timer);
+	}, [dispatch]);
+
+	useEffect(() => {
+		if (preferences.scope !== scope) return;
+		writeNotificationPreferences(scope, preferences);
+	}, [preferences, scope]);
+}

--- a/ui/lib/notifications/preferences.test.ts
+++ b/ui/lib/notifications/preferences.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { notificationPreferenceKey, readNotificationPreferences, writeNotificationPreferences } from "./preferences";
+
+describe("notification preferences", () => {
+	beforeEach(() => {
+		const values = new Map<string, string>();
+		vi.stubGlobal("localStorage", {
+			getItem: (key: string) => values.get(key) ?? null,
+			setItem: (key: string, value: string) => values.set(key, value),
+		});
+		vi.stubGlobal("window", {});
+	});
+
+	it("isolates read and dismissed IDs by user scope", () => {
+		writeNotificationPreferences("user-a", { readIds: ["n1"], dismissedIds: ["n2"] });
+		expect(readNotificationPreferences("user-a")).toEqual({ readIds: ["n1"], dismissedIds: ["n2"] });
+		expect(readNotificationPreferences("user-b")).toEqual({ readIds: [], dismissedIds: [] });
+		expect(notificationPreferenceKey("user@example.com")).toContain("user%40example.com");
+	});
+
+	it("fails closed to empty preferences for malformed storage", () => {
+		localStorage.setItem(notificationPreferenceKey("user-a"), "not-json");
+		expect(readNotificationPreferences("user-a")).toEqual({ readIds: [], dismissedIds: [] });
+	});
+});

--- a/ui/lib/notifications/preferences.ts
+++ b/ui/lib/notifications/preferences.ts
@@ -1,0 +1,47 @@
+const STORAGE_PREFIX = "bifrost-notifications";
+
+export interface StoredNotificationPreferences {
+	readIds: string[];
+	dismissedIds: string[];
+}
+
+export function notificationPreferenceKey(scope: string): string {
+	return `${STORAGE_PREFIX}:${encodeURIComponent(scope)}`;
+}
+
+export function readNotificationPreferences(scope: string): StoredNotificationPreferences {
+	if (typeof window === "undefined") return { readIds: [], dismissedIds: [] };
+	try {
+		const parsed = JSON.parse(localStorage.getItem(notificationPreferenceKey(scope)) || "{}") as Partial<StoredNotificationPreferences>;
+		return {
+			readIds: Array.isArray(parsed.readIds) ? parsed.readIds.filter((id): id is string => typeof id === "string").slice(-500) : [],
+			dismissedIds: Array.isArray(parsed.dismissedIds)
+				? parsed.dismissedIds.filter((id): id is string => typeof id === "string").slice(-500)
+				: [],
+		};
+	} catch {
+		return { readIds: [], dismissedIds: [] };
+	}
+}
+
+/**
+ * Best-effort persistence. setItem throws QuotaExceededError when storage is
+ * full or the user declined more space, and merely touching localStorage throws
+ * where storage is blocked outright. This runs from useNotificationSync's effect
+ * on every preference change, so an unguarded write turns a failure to remember
+ * which notifications were read into an uncaught error that takes down the
+ * dashboard. Losing the preference is the correct outcome; the read path already
+ * treats missing state as "nothing read yet".
+ */
+export function writeNotificationPreferences(scope: string, preferences: StoredNotificationPreferences) {
+	if (typeof window === "undefined") return;
+	try {
+		localStorage.setItem(
+			notificationPreferenceKey(scope),
+			JSON.stringify({ readIds: preferences.readIds.slice(-500), dismissedIds: preferences.dismissedIds.slice(-500) }),
+		);
+	} catch {
+		// Intentionally silent: nothing the user can act on, and the tray works
+		// without persisted read state.
+	}
+}

--- a/ui/lib/store/apis/baseApi.ts
+++ b/ui/lib/store/apis/baseApi.ts
@@ -208,6 +208,7 @@ export const baseApi = createApi({
 		"EdgeApps",
 		"EdgeMCPServers",
 		"EdgeConfig",
+		"Notifications",
 	],
 	endpoints: () => ({}),
 });

--- a/ui/lib/store/apis/index.ts
+++ b/ui/lib/store/apis/index.ts
@@ -12,6 +12,7 @@ export * from "./mcpApi";
 export * from "./mcpLogsApi";
 export * from "./mcpPerUserHeadersApi";
 export * from "./mcpSessionsApi";
+export * from "./notificationsApi";
 export * from "./oauth2ConsentApi";
 export * from "./oauth2SessionsApi";
 export * from "./pluginsApi";

--- a/ui/lib/store/apis/notificationsApi.ts
+++ b/ui/lib/store/apis/notificationsApi.ts
@@ -1,0 +1,13 @@
+import type { NotificationListResponse } from "@/lib/types/notifications";
+import { baseApi } from "./baseApi";
+
+export const notificationsApi = baseApi.injectEndpoints({
+	endpoints: (builder) => ({
+		getNotifications: builder.query<NotificationListResponse, { cursor?: string; limit?: number } | void>({
+			query: (params) => ({ url: "/notifications", params: params || { limit: 50 } }),
+			providesTags: ["Notifications"],
+		}),
+	}),
+});
+
+export const { useGetNotificationsQuery } = notificationsApi;

--- a/ui/lib/store/slices/appSlice.test.ts
+++ b/ui/lib/store/slices/appSlice.test.ts
@@ -1,0 +1,90 @@
+import type { Notification } from "@/lib/types/notifications";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import reducer, {
+	addNotification,
+	clearAllNotifications,
+	hydrateNotificationPreferences,
+	markAllNotificationsRead,
+	pruneExpiredNotifications,
+	removeNotification,
+	setNotifications,
+} from "./appSlice";
+
+// The reducer filters against Date.now(), so the clock is pinned rather than
+// left to run: a fixture that hardcodes a future expiry only stays "live" until
+// that date passes, and the suite starts failing on a calendar day nobody
+// touched. Expiries are derived from the pinned instant instead of written out.
+const NOW = new Date("2026-08-17T12:00:00Z");
+const fromNow = (ms: number) => new Date(Date.now() + ms).toISOString();
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+const notification = (id: string, createdAt: string, expiresAt = fromNow(60 * 60 * 1000)): Notification => ({
+	id,
+	audience: "all",
+	severity: "info",
+	title: id,
+	message: "message",
+	created_at: createdAt,
+	expires_at: expiresAt,
+});
+
+const expired = (id: string, createdAt: string) => notification(id, createdAt, fromNow(-60 * 60 * 1000));
+
+describe("notification state", () => {
+	it("merges history and live events without duplicates", () => {
+		let state = reducer(undefined, setNotifications([notification("older", "2026-08-17T10:00:00Z")]));
+		state = reducer(state, addNotification(notification("newer", "2026-08-17T11:00:00Z")));
+		state = reducer(state, setNotifications([notification("newer", "2026-08-17T11:00:00Z")]));
+		expect(state.notifications.map(({ id }) => id)).toEqual(["newer", "older"]);
+	});
+
+	it("keeps read, dismiss, and clear state local", () => {
+		let state = reducer(undefined, hydrateNotificationPreferences({ scope: "user-a", readIds: [], dismissedIds: [] }));
+		state = reducer(state, setNotifications([notification("one", "2026-08-17T10:00:00Z"), notification("two", "2026-08-17T11:00:00Z")]));
+		state = reducer(state, markAllNotificationsRead());
+		expect(state.notificationPreferences.readIds).toEqual(["two", "one"]);
+		state = reducer(state, removeNotification("one"));
+		expect(state.notificationPreferences.dismissedIds).toEqual(["one"]);
+		state = reducer(state, clearAllNotifications());
+		expect(state.notificationPreferences.dismissedIds).toEqual(["one", "two"]);
+		expect(state.notifications).toHaveLength(2);
+	});
+
+	// Go strips trailing zeros from the RFC3339 fraction, so within one second a
+	// string compare orders "." before "Z" and puts the older row on top.
+	it("orders by instant, not by timestamp string", () => {
+		const state = reducer(
+			undefined,
+			setNotifications([notification("whole", "2026-08-17T10:00:00Z"), notification("fraction", "2026-08-17T10:00:00.5Z")]),
+		);
+		expect(state.notifications.map(({ id }) => id)).toEqual(["fraction", "whole"]);
+	});
+
+	it("drops rows the server has already expired", () => {
+		let state = reducer(undefined, setNotifications([notification("live", "2026-08-17T10:00:00Z"), expired("stale", "2026-08-17T11:00:00Z")]));
+		expect(state.notifications.map(({ id }) => id)).toEqual(["live"]);
+
+		state = reducer(state, addNotification(expired("stale-push", "2026-08-17T12:00:00Z")));
+		expect(state.notifications.map(({ id }) => id)).toEqual(["live"]);
+	});
+
+	it("prunes rows that expire while the tab stays open", () => {
+		// Seeded past the reducer's own filter, as a long-lived tab accumulates them.
+		const seeded = { notifications: [notification("live", "2026-08-17T10:00:00Z"), expired("stale", "2026-08-17T11:00:00Z")] };
+		const state = reducer(seeded as never, pruneExpiredNotifications());
+		expect(state.notifications.map(({ id }) => id)).toEqual(["live"]);
+	});
+
+	it("keeps rows whose expires_at is unparseable rather than hiding them", () => {
+		const state = reducer(undefined, setNotifications([notification("odd", "2026-08-17T10:00:00Z", "not-a-date")]));
+		expect(state.notifications.map(({ id }) => id)).toEqual(["odd"]);
+	});
+});

--- a/ui/lib/store/slices/appSlice.ts
+++ b/ui/lib/store/slices/appSlice.ts
@@ -1,4 +1,30 @@
-import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { createSelector, createSlice, PayloadAction } from "@reduxjs/toolkit";
+import type { Notification } from "@/lib/types/notifications";
+
+/** How many notifications the tray keeps in memory, matching the API page size. */
+const MAX_NOTIFICATIONS = 50;
+
+/**
+ * Newest first. Do not compare created_at as strings: Go marshals RFC3339 with
+ * trailing zeros in the fractional second stripped, so within the same second
+ * "…:00.5Z" and "…:00Z" order by "." vs "Z" rather than by time.
+ */
+function byNewestFirst(a: Notification, b: Notification) {
+	return Date.parse(b.created_at) - Date.parse(a.created_at);
+}
+
+/**
+ * The server prunes expired rows hourly, so a tray that is open across the
+ * boundary can still be holding rows the API would no longer return. Expiry is
+ * applied on every write, and pruneExpiredNotifications keeps a long-lived tab
+ * converging. Doing it in the reducer rather than the selector is deliberate:
+ * createSelector memoises on its inputs and would never recompute as the clock
+ * moves.
+ */
+function isLive(notification: Notification, now: number) {
+	const expiresAt = Date.parse(notification.expires_at);
+	return Number.isNaN(expiresAt) || expiresAt > now;
+}
 
 // Define the shape of our app state
 export interface AppState {
@@ -17,15 +43,12 @@ export interface AppState {
 		email?: string;
 	} | null;
 
-	// Global notifications/toasts
-	notifications: {
-		id: string;
-		type: "success" | "error" | "warning" | "info";
-		title: string;
-		message: string;
-		timestamp: number;
-		read: boolean;
-	}[];
+	notifications: Notification[];
+	notificationPreferences: {
+		scope: string | null;
+		readIds: string[];
+		dismissedIds: string[];
+	};
 
 	// Application settings
 	settings: {
@@ -67,6 +90,7 @@ const initialState: AppState = {
 	isOnline: true,
 	currentUser: null,
 	notifications: [],
+	notificationPreferences: { scope: null, readIds: [], dismissedIds: [] },
 	settings: {
 		autoRefresh: false,
 		refreshInterval: 30,
@@ -116,40 +140,64 @@ const appSlice = createSlice({
 		},
 
 		// Notification Actions
-		addNotification: (state, action: PayloadAction<Omit<AppState["notifications"][0], "id" | "timestamp" | "read">>) => {
-			const notification = {
-				...action.payload,
-				id: Date.now().toString(),
-				timestamp: Date.now(),
-				read: false,
-			};
-			state.notifications.unshift(notification);
+		setNotifications: (state, action: PayloadAction<Notification[]>) => {
+			const now = Date.now();
+			const byID = new Map(state.notifications.map((notification) => [notification.id, notification]));
+			action.payload.forEach((notification) => byID.set(notification.id, notification));
+			state.notifications = Array.from(byID.values())
+				.filter((notification) => isLive(notification, now))
+				.sort(byNewestFirst)
+				.slice(0, MAX_NOTIFICATIONS);
+		},
 
-			// Keep only last 50 notifications
-			if (state.notifications.length > 50) {
-				state.notifications = state.notifications.slice(0, 50);
+		addNotification: (state, action: PayloadAction<Notification>) => {
+			const now = Date.now();
+			state.notifications = [action.payload, ...state.notifications.filter((notification) => notification.id !== action.payload.id)]
+				.filter((notification) => isLive(notification, now))
+				.sort(byNewestFirst)
+				.slice(0, MAX_NOTIFICATIONS);
+		},
+
+		/** Drops rows whose expires_at has passed. Dispatched on a timer by useNotificationSync. */
+		pruneExpiredNotifications: (state) => {
+			const now = Date.now();
+			const live = state.notifications.filter((notification) => isLive(notification, now));
+			// Only reassign on an actual change, so the periodic tick does not
+			// invalidate every notification selector on a quiet deployment.
+			if (live.length !== state.notifications.length) {
+				state.notifications = live;
 			}
 		},
 
+		hydrateNotificationPreferences: (state, action: PayloadAction<{ scope: string; readIds: string[]; dismissedIds: string[] }>) => {
+			if (state.notificationPreferences.scope !== action.payload.scope) {
+				state.notifications = [];
+			}
+			state.notificationPreferences = action.payload;
+		},
+
 		markNotificationRead: (state, action: PayloadAction<string>) => {
-			const notification = state.notifications.find((n) => n.id === action.payload);
-			if (notification) {
-				notification.read = true;
+			if (!state.notificationPreferences.readIds.includes(action.payload)) {
+				state.notificationPreferences.readIds.push(action.payload);
 			}
 		},
 
 		removeNotification: (state, action: PayloadAction<string>) => {
-			state.notifications = state.notifications.filter((n) => n.id !== action.payload);
+			if (!state.notificationPreferences.dismissedIds.includes(action.payload)) {
+				state.notificationPreferences.dismissedIds.push(action.payload);
+			}
 		},
 
 		clearAllNotifications: (state) => {
-			state.notifications = [];
+			state.notificationPreferences.dismissedIds = Array.from(
+				new Set([...state.notificationPreferences.dismissedIds, ...state.notifications.map((notification) => notification.id)]),
+			);
 		},
 
 		markAllNotificationsRead: (state) => {
-			state.notifications.forEach((notification) => {
-				notification.read = true;
-			});
+			state.notificationPreferences.readIds = Array.from(
+				new Set([...state.notificationPreferences.readIds, ...state.notifications.map((notification) => notification.id)]),
+			);
 		},
 
 		// Settings Actions
@@ -188,6 +236,9 @@ export const {
 
 	// Notification Actions
 	addNotification,
+	setNotifications,
+	pruneExpiredNotifications,
+	hydrateNotificationPreferences,
 	markNotificationRead,
 	removeNotification,
 	clearAllNotifications,
@@ -217,7 +268,17 @@ export const selectIsInitializing = (state: { app: AppState }) => state.app.isIn
 export const selectIsOnline = (state: { app: AppState }) => state.app.isOnline;
 export const selectCurrentUser = (state: { app: AppState }) => state.app.currentUser;
 export const selectNotifications = (state: { app: AppState }) => state.app.notifications;
-export const selectUnreadNotificationsCount = (state: { app: AppState }) => state.app.notifications.filter((n) => !n.read).length;
+const selectReadNotificationIds = (state: { app: AppState }) => state.app.notificationPreferences.readIds;
+const selectDismissedNotificationIds = (state: { app: AppState }) => state.app.notificationPreferences.dismissedIds;
+export const selectVisibleNotifications = createSelector(
+	[selectNotifications, selectDismissedNotificationIds],
+	(notifications, dismissedIds) => notifications.filter((notification) => !dismissedIds.includes(notification.id)),
+);
+export const selectUnreadNotificationsCount = createSelector(
+	[selectVisibleNotifications, selectReadNotificationIds],
+	(notifications, readIds) => notifications.filter((notification) => !readIds.includes(notification.id)).length,
+);
+export const selectNotificationPreferences = (state: { app: AppState }) => state.app.notificationPreferences;
 export const selectSettings = (state: { app: AppState }) => state.app.settings;
 export const selectGlobalError = (state: { app: AppState }) => state.app.globalError;
 export const selectFeatures = (state: { app: AppState }) => state.app.features;

--- a/ui/lib/types/notifications.ts
+++ b/ui/lib/types/notifications.ts
@@ -1,0 +1,20 @@
+export type NotificationSeverity = "info" | "success" | "warning" | "error";
+export type NotificationAudience = "all" | "roles";
+
+export interface Notification {
+	id: string;
+	audience: NotificationAudience;
+	role_ids?: number[];
+	severity: NotificationSeverity;
+	title: string;
+	message: string;
+	action_label?: string;
+	action_path?: string;
+	created_at: string;
+	expires_at: string;
+}
+
+export interface NotificationListResponse {
+	notifications: Notification[];
+	next_cursor?: string;
+}


### PR DESCRIPTION
## Summary

Adds a persistent, role-targeted notification system that allows operators to publish dashboard notifications to all users or specific roles. Notifications are stored in the database, delivered in real-time over WebSocket, and surfaced in the UI via a new notification center in the topbar.

## Changes

- **`core/schemas/notification.go`** — Defines `Notification`, `NotificationInput`, `NotificationSeverity`, `NotificationAudience`, and a `NotificationPublisher` function type shared across the stack.
- **`framework/configstore`** — Adds `TableNotification` GORM model (with JSON-serialized `RoleIDs` to avoid a hard dependency on enterprise role tables), a `NotificationStore` interface, and `CreateNotification` / `ListNotifications` / `DeleteExpiredNotifications` implementations on `RDBConfigStore`. A new migration creates the `notifications` table.
- **`transports/bifrost-http/handlers/notifications.go`** — Introduces `NotificationService` with `Publish`, cursor-paginated `list`, and `create` HTTP handlers (`GET /api/notifications`, `POST /api/notifications`). Input validation enforces title/message length, severity enum, audience/role-ID consistency, and that `action_path` is an internal absolute path. Expired notifications are pruned on startup and hourly.
- **`transports/bifrost-http/handlers/websocket.go`** — `WebSocketClient` now carries `roleID`, `hasRole`, and `localAdmin` fields populated at connection time. `BroadcastNotification` uses these to fan out only to clients whose role matches the notification audience, avoiding unnecessary delivery.
- **`transports/bifrost-http/server/server.go`** — `NotificationService` is instantiated during `Bootstrap` and `RegisterAPIRoutes`; `Config.NotificationPublisher` is wired to `NotificationService.Publish` so other subsystems can publish notifications in-process.
- **UI** — Adds `Notification` and `NotificationListResponse` types, a `notificationsApi` RTK Query endpoint, `localStorage`-backed per-user preference storage (read/dismissed IDs, scoped by user identity), Redux slice actions (`setNotifications`, `addNotification`, `hydrateNotificationPreferences`, `markNotificationRead`, `removeNotification`, `clearAllNotifications`, `markAllNotificationsRead`) with memoized selectors, a `useNotificationSync` hook that hydrates preferences, merges API results, and subscribes to live WebSocket `notification` events, and a `NotificationCenter` popover component mounted in the topbar.

**Design decisions:**
- Read and dismissed state are intentionally local to each UI client (localStorage) rather than persisted server-side, keeping the server schema simple and avoiding per-user state in the OSS database.
- `RoleIDs` is stored as JSON text rather than a relational foreign key so the notifications table works in OSS deployments that do not have an enterprise roles table.
- The list endpoint applies role filtering in the application layer after a bounded DB scan (`maxNotificationScan = 250`) to support role-filtered pagination without complex SQL across optional enterprise tables.
- Cursor pagination encodes `createdAt` (nanosecond Unix timestamp) and `id` as a base64 opaque token.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... ./transports/bifrost-http/handlers/...

# UI
cd ui
pnpm i
pnpm test
pnpm build
```

1. Start the server and open the dashboard.
2. `POST /api/notifications` with a valid `NotificationInput` payload (e.g. `{"audience":"all","severity":"info","title":"Hello","message":"World"}`).
3. Verify the bell icon in the topbar shows an unread badge and the notification appears in the tray.
4. Connect a second browser session with a different role and confirm role-targeted notifications (`audience: "roles"`) are only visible to the matching role.
5. Dismiss or mark notifications as read; confirm state persists across page reloads and is isolated per user.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

- `action_path` is validated to be an internal absolute path (no scheme, no host, must start with `/`), preventing open-redirect payloads from being stored in notifications.
- Role filtering is enforced both at WebSocket broadcast time and at HTTP list time, so users cannot read notifications targeted at other roles.
- Read/dismissed preferences are scoped by user identity (sub, id, or email) to prevent one user's dismissals from affecting another on a shared browser.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)