### PR TITLE
refactor: add gencache package and wire in GetModelsForProvider to gencache

### DIFF
--- a/framework/gencache/gencache.go
+++ b/framework/gencache/gencache.go
@@ -1,0 +1,146 @@
+// Package gencache provides a generation-stamped memo cache: a value cache whose
+// entries are invalidated wholesale when a monotonic "generation" counter advances.
+//
+// Unlike an LRU, there is no per-entry TTL and no eviction order. Every entry
+// carries the generation it was computed under; a read is a hit only if that stamp
+// still matches the current generation. Any change to the underlying data bumps the
+// generation, which invalidates every entry at once without touching the map.
+//
+// It fits when: the value is a pure function of some shared state, that state
+// changes rarely relative to reads, and a single monotonic counter can stand in for
+// "the state changed" (e.g. a sum of write counters across the stores the value is
+// derived from).
+package gencache
+
+import "sync"
+
+// GenFunc returns the current generation. It must strictly increase (never repeat a
+// prior value) whenever the data the cache derives from changes; any increase
+// invalidates every cached entry. It is called on every Get/GetOrCompute, so keep it
+// cheap — typically a sum of atomic counters.
+type GenFunc func() uint64
+
+type entry[V any] struct {
+	gen uint64
+	val V
+}
+
+// Cache is a concurrent generation-stamped memo. The zero value is not usable;
+// construct one with New.
+type Cache[V any] struct {
+	mu         sync.RWMutex
+	m          map[string]entry[V]
+	gen        GenFunc
+	maxEntries int
+	clone      func(V) V
+	skipStore  func(V) bool
+}
+
+// Option configures a Cache.
+type Option[V any] func(*Cache[V])
+
+// WithClone makes Get and GetOrCompute return clone(v) rather than the stored value,
+// so callers cannot mutate cached state through the value they receive. Use it for
+// mutable values such as slices or maps (e.g. a wrapper around slices.Clone).
+// Default: the stored value is returned as-is, which is correct only when V is
+// treated as immutable.
+func WithClone[V any](clone func(V) V) Option[V] {
+	return func(c *Cache[V]) { c.clone = clone }
+}
+
+// WithSkipStore leaves results matching skip out of the cache: they are still
+// returned, but recomputed on the next call. Use it to avoid caching "not found"
+// answers, e.g. func(v []T) bool { return len(v) == 0 }. Default: every result is
+// stored.
+func WithSkipStore[V any](skip func(V) bool) Option[V] {
+	return func(c *Cache[V]) { c.skipStore = skip }
+}
+
+// New builds a Cache. gen supplies the current generation (see GenFunc). maxEntries
+// bounds the map: when inserting a new key would exceed it, the whole map is flushed
+// first, because cache keys are often client-controlled and an unbounded map is a
+// memory-growth vector. A maxEntries <= 0 means unbounded.
+func New[V any](gen GenFunc, maxEntries int, opts ...Option[V]) *Cache[V] {
+	c := &Cache[V]{
+		m:          make(map[string]entry[V]),
+		gen:        gen,
+		maxEntries: maxEntries,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+func (c *Cache[V]) out(v V) V {
+	if c.clone != nil {
+		return c.clone(v)
+	}
+	return v
+}
+
+// Get returns the cached value for key when it is present and still current
+// (honoring WithClone). The bool reports whether it was a live hit; a stale or
+// missing entry returns the zero value and false.
+func (c *Cache[V]) Get(key string) (V, bool) {
+	gen := c.gen()
+	c.mu.RLock()
+	e, ok := c.m[key]
+	c.mu.RUnlock()
+	if ok && e.gen == gen {
+		return c.out(e.val), true
+	}
+	var zero V
+	return zero, false
+}
+
+// GetOrCompute returns the current cached value for key, or computes it with
+// compute, stores it, and returns it.
+//
+// The stored entry is stamped with the generation read BEFORE compute ran: if the
+// underlying data changes while compute is in flight, the entry is left stale and
+// the next call recomputes — the cache never serves a stale read. Honors WithClone
+// on the returned value and WithSkipStore (a skipped result is returned but not
+// cached). compute may run concurrently for the same key under load; it must be
+// safe to call redundantly and its results must be equivalent.
+func (c *Cache[V]) GetOrCompute(key string, compute func() V) V {
+	gen := c.gen()
+
+	c.mu.RLock()
+	e, ok := c.m[key]
+	c.mu.RUnlock()
+	if ok && e.gen == gen {
+		return c.out(e.val)
+	}
+
+	val := compute()
+	if c.skipStore != nil && c.skipStore(val) {
+		return c.out(val)
+	}
+
+	c.mu.Lock()
+	if c.maxEntries > 0 {
+		if _, exists := c.m[key]; !exists && len(c.m) >= c.maxEntries {
+			c.m = make(map[string]entry[V])
+		}
+	}
+	c.m[key] = entry[V]{gen: gen, val: val}
+	c.mu.Unlock()
+
+	return c.out(val)
+}
+
+// Len returns the number of entries currently held, counting stale ones that have
+// not yet been overwritten or flushed.
+func (c *Cache[V]) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.m)
+}
+
+// Flush drops every entry.
+func (c *Cache[V]) Flush() {
+	c.mu.Lock()
+	c.m = make(map[string]entry[V])
+	c.mu.Unlock()
+}

--- a/framework/gencache/gencache_test.go
+++ b/framework/gencache/gencache_test.go
@@ -1,0 +1,171 @@
+package gencache
+
+import (
+	"fmt"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// cloneInts is a WithClone helper for []int values.
+func cloneInts(v []int) []int { return slices.Clone(v) }
+
+func TestGetOrCompute_CachesWithinGeneration(t *testing.T) {
+	var gen uint64
+	var computes int
+	c := New[int](func() uint64 { return gen }, 0)
+
+	load := func() int { computes++; return 42 }
+	if v := c.GetOrCompute("k", load); v != 42 {
+		t.Fatalf("got %d, want 42", v)
+	}
+	if v := c.GetOrCompute("k", load); v != 42 {
+		t.Fatalf("got %d, want 42", v)
+	}
+	if computes != 1 {
+		t.Fatalf("compute ran %d times, want 1 (second call should hit)", computes)
+	}
+}
+
+func TestGetOrCompute_RecomputesOnGenerationBump(t *testing.T) {
+	var gen uint64
+	var computes int
+	c := New[int](func() uint64 { return gen }, 0)
+	load := func() int { computes++; return computes }
+
+	if v := c.GetOrCompute("k", load); v != 1 {
+		t.Fatalf("first got %d, want 1", v)
+	}
+	gen++ // any store write bumps the generation
+	if v := c.GetOrCompute("k", load); v != 2 {
+		t.Fatalf("post-bump got %d, want 2 (must recompute)", v)
+	}
+	if computes != 2 {
+		t.Fatalf("compute ran %d times, want 2", computes)
+	}
+}
+
+func TestGetOrCompute_StampsWithPreComputeGeneration(t *testing.T) {
+	// A generation bump that happens DURING compute must leave the entry stale,
+	// so the next read recomputes rather than serving a value already outdated.
+	var gen uint64
+	c := New[int](func() uint64 { return gen }, 0)
+
+	first := c.GetOrCompute("k", func() int {
+		gen++ // data changed while we were computing
+		return 1
+	})
+	if first != 1 {
+		t.Fatalf("first got %d, want 1", first)
+	}
+	// The stored entry was stamped with gen=0 but current gen is 1 → miss.
+	var recomputed bool
+	second := c.GetOrCompute("k", func() int { recomputed = true; return 2 })
+	if !recomputed || second != 2 {
+		t.Fatalf("entry stamped during compute was not treated as stale (recomputed=%v, val=%d)", recomputed, second)
+	}
+}
+
+func TestGetOrCompute_SkipStoreLeavesUncached(t *testing.T) {
+	var gen uint64
+	c := New[[]int](func() uint64 { return gen }, 0,
+		WithSkipStore(func(v []int) bool { return len(v) == 0 }))
+
+	if got := c.GetOrCompute("empty", func() []int { return nil }); len(got) != 0 {
+		t.Fatalf("got %v, want empty", got)
+	}
+	if _, ok := c.Get("empty"); ok {
+		t.Fatal("empty result must not be cached")
+	}
+	if c.Len() != 0 {
+		t.Fatalf("Len=%d, want 0", c.Len())
+	}
+}
+
+func TestGetOrCompute_BoundedFlushesOnOverflow(t *testing.T) {
+	const max = 8
+	var gen uint64
+	c := New[int](func() uint64 { return gen }, max)
+
+	for i := 0; i < max; i++ {
+		c.GetOrCompute(fmt.Sprintf("k%d", i), func() int { return i })
+	}
+	if c.Len() != max {
+		t.Fatalf("Len=%d, want %d (at cap)", c.Len(), max)
+	}
+	// One more distinct key must flush rather than grow past the cap.
+	c.GetOrCompute("overflow", func() int { return 99 })
+	if c.Len() > max {
+		t.Fatalf("cache grew past cap: Len=%d, want <= %d", c.Len(), max)
+	}
+	if v, ok := c.Get("overflow"); !ok || v != 99 {
+		t.Fatalf("new key missing after flush: v=%d ok=%v", v, ok)
+	}
+}
+
+func TestWithClone_IsolatesCallerFromCache(t *testing.T) {
+	var gen uint64
+	c := New[[]int](func() uint64 { return gen }, 0, WithClone(cloneInts))
+
+	first := c.GetOrCompute("k", func() []int { return []int{1, 2, 3} })
+	for i := range first {
+		first[i] = -1 // corrupt the returned slice
+	}
+	second, ok := c.Get("k")
+	if !ok {
+		t.Fatal("expected a live hit")
+	}
+	if !slices.Equal(second, []int{1, 2, 3}) {
+		t.Fatalf("caller mutation leaked into cache: %v", second)
+	}
+}
+
+func TestGet_MissOnStaleAndAbsent(t *testing.T) {
+	var gen uint64
+	c := New[int](func() uint64 { return gen }, 0)
+
+	if _, ok := c.Get("absent"); ok {
+		t.Fatal("absent key reported present")
+	}
+	c.GetOrCompute("k", func() int { return 1 })
+	if _, ok := c.Get("k"); !ok {
+		t.Fatal("fresh key reported absent")
+	}
+	gen++
+	if _, ok := c.Get("k"); ok {
+		t.Fatal("stale key reported present")
+	}
+}
+
+func TestFlush(t *testing.T) {
+	var gen uint64
+	c := New[int](func() uint64 { return gen }, 0)
+	c.GetOrCompute("a", func() int { return 1 })
+	c.GetOrCompute("b", func() int { return 2 })
+	c.Flush()
+	if c.Len() != 0 {
+		t.Fatalf("Len=%d after Flush, want 0", c.Len())
+	}
+}
+
+func TestConcurrentGetOrCompute_NoRace(t *testing.T) {
+	var gen atomic.Uint64
+	c := New[int](func() uint64 { return gen.Load() }, 1024)
+
+	var wg sync.WaitGroup
+	for w := 0; w < 16; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				key := fmt.Sprintf("k%d", i%64)
+				_ = c.GetOrCompute(key, func() int { return i })
+				if i%50 == 0 {
+					gen.Add(1) // interleave invalidations
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+}

--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -19,6 +19,7 @@ import (
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/gencache"
 	"github.com/maximhq/bifrost/framework/lrucache"
 	"github.com/maximhq/bifrost/framework/modelcatalog/datasheet"
 	"github.com/maximhq/bifrost/framework/modelcatalog/keyconfig"
@@ -40,11 +41,8 @@ type ModelCatalog struct {
 	// loadCapabilities fills a capability cache miss.
 	loadCapabilities func(schemas.ModelProvider, string) (*schemas.ModelCapabilities, error)
 
-	// providerMemo caches GetProvidersForModel per model, stamped with
-	// catalogGeneration() at compute time; any store write invalidates every
-	// entry. Capped at providerMemoMaxEntries, flushed on overflow.
-	providerMemoMu sync.RWMutex
-	providerMemo   map[string]providerMemoEntry
+	providersForModel *gencache.Cache[[]schemas.ModelProvider]
+	modelsForProvider *gencache.Cache[[]string]
 
 	// MCP library sync configuration (protected by syncMu)
 	mcpLibraryURL          string
@@ -120,9 +118,9 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 		live:         live.New(logger),
 		keyconf:      keyconfig.New(logger),
 		capabilities: lrucache.New[*schemas.ModelCapabilities](capabilityCacheSize),
-		providerMemo: make(map[string]providerMemoEntry),
 		done:         make(chan struct{}),
 	}
+	mc.initCaches()
 	mc.syncCtx, mc.syncCancel = context.WithCancel(ctx)
 
 	// Core providers reach capabilities through this hook — they cannot import
@@ -649,12 +647,14 @@ func (mc *ModelCatalog) knownProviders() []schemas.ModelProvider {
 // NewTestCatalog constructs a minimal ModelCatalog for unit tests. Does not
 // start background workers or hit external services.
 func NewTestCatalog(baseModelIndex map[string]string) *ModelCatalog {
-	return &ModelCatalog{
+	mc := &ModelCatalog{
 		datasheet: datasheet.NewTestStore(baseModelIndex),
 		live:      live.New(nil),
 		keyconf:   keyconfig.New(nil),
 		done:      make(chan struct{}),
 	}
+	mc.initCaches()
+	return mc
 }
 
 // NewTestCatalogWithDatasheet wraps a caller-provided datasheet.Store (e.g. one
@@ -662,10 +662,12 @@ func NewTestCatalog(baseModelIndex map[string]string) *ModelCatalog {
 // LoadFromURLIntoMemory) in a ModelCatalog, so tests in other packages can
 // exercise real pricing/cost computation without reaching the network.
 func NewTestCatalogWithDatasheet(ds *datasheet.Store) *ModelCatalog {
-	return &ModelCatalog{
+	mc := &ModelCatalog{
 		datasheet: ds,
 		live:      live.New(nil),
 		keyconf:   keyconfig.New(nil),
 		done:      make(chan struct{}),
 	}
+	mc.initCaches()
+	return mc
 }

--- a/framework/modelcatalog/modelinfo_test.go
+++ b/framework/modelcatalog/modelinfo_test.go
@@ -62,12 +62,14 @@ func modelInfoCatalog(t *testing.T) *ModelCatalog {
 	if err := ds.LoadModelParamsFromURLIntoMemory(t.Context()); err != nil {
 		t.Fatalf("load model-parameters testdata: %v", err)
 	}
-	return &ModelCatalog{
+	mc := &ModelCatalog{
 		datasheet: ds,
 		live:      live.New(nil),
 		keyconf:   keyconfig.New(nil),
 		done:      make(chan struct{}),
 	}
+	mc.initCaches()
+	return mc
 }
 
 func TestGetModelInfoPopulatesPricingAndLimits(t *testing.T) {

--- a/framework/modelcatalog/models.go
+++ b/framework/modelcatalog/models.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/gencache"
 )
 
 // providersWithPartialListModels enumerates providers whose /v1/models response
@@ -24,7 +25,15 @@ var providersWithPartialListModels = map[schemas.ModelProvider]bool{
 // provider. Filtered live entries are authoritative when present (they were
 // pre-gated by ListModelsPipeline against the key's allow/block/aliases);
 // otherwise the datasheet view is filtered by the keyconfig aggregates.
+//
+// Memoized; returns a fresh clone the caller may mutate.
 func (mc *ModelCatalog) GetModelsForProvider(provider schemas.ModelProvider) []string {
+	return mc.modelsForProvider.GetOrCompute(string(provider), func() []string {
+		return mc.computeModelsForProvider(provider)
+	})
+}
+
+func (mc *ModelCatalog) computeModelsForProvider(provider schemas.ModelProvider) []string {
 	blacklisted := mc.keyconf.BlacklistedFor(provider)
 	allowed := mc.keyconf.AllowedFor(provider)
 
@@ -150,58 +159,50 @@ func (mc *ModelCatalog) GetDistinctBaseModelNames() []string {
 	return mc.datasheet.DistinctBaseModelNames()
 }
 
-// providerMemoEntry is a memoized GetProvidersForModel result and the
-// catalogGeneration it was computed under.
-type providerMemoEntry struct {
-	gen uint64
-	val []schemas.ModelProvider
-}
+// catalogMemoMaxEntries bounds each catalog memo: model/provider keys are
+// client-controlled, so an unbounded map is a memory-growth vector.
+const catalogMemoMaxEntries = 4096
 
-// providerMemoMaxEntries bounds the memo; model strings are client-controlled
-// and would otherwise grow it without limit. On overflow the map is flushed
-// and hot entries repopulate on demand.
-const providerMemoMaxEntries = 4096
-
-// catalogGeneration sums the three stores' write counters. Every write bumps
-// exactly one counter by one, so the sum strictly increases and no two
-// catalog states share a value.
+// catalogGeneration sums the three stores' write counters. Each write bumps one
+// counter by one, so the sum strictly increases: no two catalog states collide.
 func (mc *ModelCatalog) catalogGeneration() uint64 {
 	return mc.datasheet.WriteGen() + mc.keyconf.WriteGen() + mc.live.WriteGen()
 }
 
+// initCaches builds the memos. Every constructor must call it before use: the
+// cached getters deref the caches with no nil guard.
+func (mc *ModelCatalog) initCaches() {
+	mc.providersForModel = newProvidersForModelCache(mc)
+	mc.modelsForProvider = newModelsForProviderCache(mc)
+}
+
+// Clone-on-return: the resolver sorts the result in place.
+func newProvidersForModelCache(mc *ModelCatalog) *gencache.Cache[[]schemas.ModelProvider] {
+	return gencache.New(
+		mc.catalogGeneration,
+		catalogMemoMaxEntries,
+		gencache.WithClone(func(v []schemas.ModelProvider) []schemas.ModelProvider { return slices.Clone(v) }),
+		gencache.WithSkipStore(func(v []schemas.ModelProvider) bool { return len(v) == 0 }),
+	)
+}
+
+// catalogGeneration is a valid stamp here too: the list derives from the same
+// three stores. Clone-on-return: callers sort the result in place.
+func newModelsForProviderCache(mc *ModelCatalog) *gencache.Cache[[]string] {
+	return gencache.New(
+		mc.catalogGeneration,
+		catalogMemoMaxEntries,
+		gencache.WithClone(func(v []string) []string { return slices.Clone(v) }),
+		gencache.WithSkipStore(func(v []string) bool { return len(v) == 0 }),
+	)
+}
+
 // GetProvidersForModel returns every provider that can serve the model.
-// Memoized per model (bounded, empty results uncached); any store write
-// invalidates (see catalogGeneration). Returns a fresh clone the caller
-// may mutate.
+// Memoized; returns a fresh clone the caller may mutate.
 func (mc *ModelCatalog) GetProvidersForModel(model string) []schemas.ModelProvider {
-	gen := mc.catalogGeneration()
-
-	mc.providerMemoMu.RLock()
-	entry, ok := mc.providerMemo[model]
-	mc.providerMemoMu.RUnlock()
-	if ok && entry.gen == gen {
-		return slices.Clone(entry.val)
-	}
-
-	val := mc.computeProvidersForModel(model)
-	// Unknown models resolve to nothing; skipping memoising
-	if len(val) == 0 {
-		return val
-	}
-
-	// Stamp with the generation read before compute: a write during compute
-	// leaves the entry stale and the next call recomputes.
-	mc.providerMemoMu.Lock()
-	if mc.providerMemo == nil {
-		mc.providerMemo = make(map[string]providerMemoEntry)
-	}
-	if _, exists := mc.providerMemo[model]; !exists && len(mc.providerMemo) >= providerMemoMaxEntries {
-		mc.providerMemo = make(map[string]providerMemoEntry)
-	}
-	mc.providerMemo[model] = providerMemoEntry{gen: gen, val: val}
-	mc.providerMemoMu.Unlock()
-
-	return slices.Clone(val)
+	return mc.providersForModel.GetOrCompute(model, func() []schemas.ModelProvider {
+		return mc.computeProvidersForModel(model)
+	})
 }
 
 // computeProvidersForModel composes the uncached answer across stores,

--- a/framework/modelcatalog/models_allowed_test.go
+++ b/framework/modelcatalog/models_allowed_test.go
@@ -14,12 +14,12 @@ import (
 // matching must behave exactly as before.
 func TestIsModelAllowedForProvider_ExplicitList(t *testing.T) {
 	mc := &ModelCatalog{
-		datasheet:    datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
-		live:         live.New(nil),
-		keyconf:      keyconfig.New(nil),
-		providerMemo: make(map[string]providerMemoEntry),
-		done:         make(chan struct{}),
+		datasheet: datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
+		live:      live.New(nil),
+		keyconf:   keyconfig.New(nil),
+		done:      make(chan struct{}),
 	}
+	mc.initCaches()
 	// Give OpenAI a live catalog carrying a provider-prefixed entry, so the
 	// prefixed branch has something to match (ParseModelString only strips
 	// recognized provider prefixes, so this must be a real provider).

--- a/framework/modelcatalog/models_memo_bench_test.go
+++ b/framework/modelcatalog/models_memo_bench_test.go
@@ -56,12 +56,12 @@ func benchCatalog(tb testing.TB, nProviders, nModels int) (*ModelCatalog, []stri
 	kc := keyconfig.New(nil)
 	kc.Replace(kcSnapshot)
 	mc := &ModelCatalog{
-		datasheet:    ds,
-		live:         live.New(nil),
-		keyconf:      kc,
-		providerMemo: make(map[string]providerMemoEntry),
-		done:         make(chan struct{}),
+		datasheet: ds,
+		live:      live.New(nil),
+		keyconf:   kc,
+		done:      make(chan struct{}),
 	}
+	mc.initCaches()
 	return mc, models
 }
 
@@ -89,6 +89,9 @@ func BenchmarkProvidersForModel_Uncached(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		// computeProvidersForModel -> GetModelsForProvider, so flush modelsForProvider
+		// each iteration or it stays warm and this stops measuring the pre-cache path.
+		mc.modelsForProvider.Flush()
 		_ = mc.computeProvidersForModel(q[i%len(q)])
 	}
 }
@@ -103,6 +106,9 @@ func BenchmarkProvidersForModel_UncachedScale(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
+				// flush modelsForProvider each iteration so the compute path stays cold
+				// (computeProvidersForModel -> GetModelsForProvider is otherwise memoised).
+				mc.modelsForProvider.Flush()
 				_ = mc.computeProvidersForModel(q[i%len(q)])
 			}
 		})
@@ -133,10 +139,11 @@ func BenchmarkIsModelAllowed_Uncached(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		model := q[i%len(q)]
-		// bust the memo each iteration to simulate the pre-cache cost
-		mc.providerMemoMu.Lock()
-		clear(mc.providerMemo)
-		mc.providerMemoMu.Unlock()
+		// bust both memos each iteration to simulate the pre-cache cost:
+		// IsModelAllowedForProvider -> computeProvidersForModel -> GetModelsForProvider,
+		// so modelsForProvider must be flushed too or it stays warm after iteration 1.
+		mc.providersForModel.Flush()
+		mc.modelsForProvider.Flush()
 		_ = mc.IsModelAllowedForProvider(schemas.ModelProvider("provider00"), model, nil, unrestricted)
 	}
 }

--- a/framework/modelcatalog/models_memo_test.go
+++ b/framework/modelcatalog/models_memo_test.go
@@ -1,7 +1,6 @@
 package modelcatalog
 
 import (
-	"fmt"
 	"slices"
 	"testing"
 
@@ -20,12 +19,12 @@ func TestProviderMemoInvalidatesOnWrite(t *testing.T) {
 		schemas.OpenAI: {{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}}},
 	})
 	mc := &ModelCatalog{
-		datasheet:    datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
-		live:         live.New(nil),
-		keyconf:      kc,
-		providerMemo: make(map[string]providerMemoEntry),
-		done:         make(chan struct{}),
+		datasheet: datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
+		live:      live.New(nil),
+		keyconf:   kc,
+		done:      make(chan struct{}),
 	}
+	mc.initCaches()
 
 	// Prime the memo.
 	got := mc.GetProvidersForModel("gpt-4o")
@@ -57,59 +56,18 @@ func TestProviderMemoSkipsEmptyResults(t *testing.T) {
 		schemas.OpenAI: {{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}}},
 	})
 	mc := &ModelCatalog{
-		datasheet:    datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
-		live:         live.New(nil),
-		keyconf:      kc,
-		providerMemo: make(map[string]providerMemoEntry),
-		done:         make(chan struct{}),
+		datasheet: datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
+		live:      live.New(nil),
+		keyconf:   kc,
+		done:      make(chan struct{}),
 	}
+	mc.initCaches()
 
 	if got := mc.GetProvidersForModel("junk-model-xyz"); len(got) != 0 {
 		t.Fatalf("expected no providers for junk model, got %v", got)
 	}
-	mc.providerMemoMu.RLock()
-	_, cached := mc.providerMemo["junk-model-xyz"]
-	mc.providerMemoMu.RUnlock()
-	if cached {
+	if _, cached := mc.providersForModel.Get("junk-model-xyz"); cached {
 		t.Fatalf("empty result was cached")
-	}
-}
-
-// TestProviderMemoBounded pins the overflow flush: inserting a new key into a
-// full memo must not grow it past providerMemoMaxEntries.
-func TestProviderMemoBounded(t *testing.T) {
-	kc := keyconfig.New(nil)
-	kc.Replace(map[schemas.ModelProvider][]schemas.Key{
-		schemas.OpenAI: {{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}}},
-	})
-	mc := &ModelCatalog{
-		datasheet:    datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
-		live:         live.New(nil),
-		keyconf:      kc,
-		providerMemo: make(map[string]providerMemoEntry),
-		done:         make(chan struct{}),
-	}
-
-	// Fill to the cap with synthetic entries, then insert one real new model.
-	mc.providerMemoMu.Lock()
-	for i := 0; len(mc.providerMemo) < providerMemoMaxEntries; i++ {
-		mc.providerMemo[fmt.Sprintf("filler-%d", i)] = providerMemoEntry{}
-	}
-	mc.providerMemoMu.Unlock()
-
-	if got := mc.GetProvidersForModel("gpt-4o"); !slices.Contains(got, schemas.OpenAI) {
-		t.Fatalf("expected OpenAI, got %v", got)
-	}
-
-	mc.providerMemoMu.RLock()
-	size := len(mc.providerMemo)
-	_, cached := mc.providerMemo["gpt-4o"]
-	mc.providerMemoMu.RUnlock()
-	if size > providerMemoMaxEntries {
-		t.Fatalf("memo grew past cap: %d entries", size)
-	}
-	if !cached {
-		t.Fatalf("new model missing from memo after flush")
 	}
 }
 
@@ -122,12 +80,12 @@ func TestProviderMemoReturnsClone(t *testing.T) {
 		schemas.Anthropic: {{ID: "k2", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}}},
 	})
 	mc := &ModelCatalog{
-		datasheet:    datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
-		live:         live.New(nil),
-		keyconf:      kc,
-		providerMemo: make(map[string]providerMemoEntry),
-		done:         make(chan struct{}),
+		datasheet: datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
+		live:      live.New(nil),
+		keyconf:   kc,
+		done:      make(chan struct{}),
 	}
+	mc.initCaches()
 
 	first := mc.GetProvidersForModel("gpt-4o")
 	if len(first) < 2 {

--- a/framework/modelcatalog/pool_test.go
+++ b/framework/modelcatalog/pool_test.go
@@ -143,6 +143,7 @@ func TestGetModelsForProvider_DeprecatedDatasheetModelsRespectAllowBlock(t *test
 				keyconf:   kc,
 				done:      make(chan struct{}),
 			}
+			mc.initCaches()
 			mc.UpsertLive(schemas.OpenAI, "k1", false, []string{"live-model"})
 
 			got := mc.GetModelsForProvider(schemas.OpenAI)

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -837,7 +837,6 @@ func (t *Tracer) CompleteAndFlushTrace(traceID string) {
 		exportTrace.StampOverheadDuration()
 
 		var slots []*obsPluginSlot
-		dumpSpanTimings(exportTrace)
 		if loaded := t.obsPlugins.Load(); loaded != nil {
 			slots = *loaded
 		}


### PR DESCRIPTION
## Summary

Introduces a generic, generation-stamped memo cache (`framework/gencache`) and migrates the `ModelCatalog`'s per-model and per-provider lookup memos onto it, replacing the hand-rolled `providerMemo` map and its bespoke locking/invalidation logic.

## Changes

- **New `framework/gencache` package**: A concurrent, generation-stamped key→value cache. Entries are invalidated wholesale when a monotonic generation counter advances (supplied as a `GenFunc`). Supports optional clone-on-return (`WithClone`) to prevent callers from mutating cached state, and optional skip-store (`WithSkipStore`) to avoid caching sentinel values like empty slices. The map is flushed rather than grown when a configurable `maxEntries` cap is reached, guarding against unbounded memory growth from client-controlled keys.

- **`ModelCatalog` memo refactor**: Removed the inline `providerMemoEntry` struct, `providerMemoMu sync.RWMutex`, and `providerMemo map[string]providerMemoEntry` fields. Replaced them with two `*gencache.Cache` fields — `providersForModel` and `modelsForProvider` — both keyed on `catalogGeneration()`. Added `initCaches()` which all constructors (including test helpers) now call, ensuring the caches are always initialized before use.

- **`GetModelsForProvider` memoized**: Previously unmemoized; now backed by `modelsForProvider` cache with the same generation stamp, clone-on-return, and skip-store-on-empty semantics as `GetProvidersForModel`.

- **Test and benchmark updates**: All inline `ModelCatalog` struct literals that previously set `providerMemo` directly now call `mc.initCaches()` instead. The `BenchmarkIsModelAllowed_Uncached` benchmark uses `mc.providersForModel.Flush()` to bust the cache. The `TestProviderMemoBounded` test (which manually filled the internal map) is removed, as the equivalent behavior is covered by `gencache`'s own `TestGetOrCompute_BoundedFlushesOnOverflow` test.

- **Removed stray `dumpSpanTimings` call** from `tracer.go`'s `CompleteAndFlushTrace`.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/gencache/...
go test ./framework/modelcatalog/...
go test -race ./framework/gencache/... ./framework/modelcatalog/...
go test -bench=. ./framework/modelcatalog/...
```

All existing memo invalidation, clone isolation, skip-store, and bounded-flush behaviors are covered by tests in both packages.

## Breaking changes

- [x] No

## Security considerations

The `maxEntries` cap on both caches prevents unbounded memory growth from client-controlled model or provider key strings, which was already the intent of the previous `providerMemoMaxEntries` constant.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable