### PR TITLE
feat(ui): extract shared `FilterSidebarTrigger` component with mobile topbar portal

### DIFF
--- a/ui/app/workspace/mcp-registry/library/views/mcpLibraryFilterSidebar.tsx
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibraryFilterSidebar.tsx
@@ -1,3 +1,4 @@
+import { FilterSidebarTrigger } from "@/components/filters/filterSidebarTrigger";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
@@ -7,7 +8,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useGetMCPLibraryFilterDataQuery } from "@/lib/store";
 import { cn } from "@/lib/utils";
-import { ChevronDown, Filter, PanelLeftClose, PanelLeftOpen, RotateCcw, Search } from "lucide-react";
+import { ChevronDown, PanelLeftClose, RotateCcw, Search } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 const COLLAPSE_STORAGE_KEY = "mcp-library-filter-sidebar-collapsed";
@@ -75,25 +76,7 @@ export function MCPLibraryFilterSidebar({ filters, onFiltersChange }: SidebarPro
 
 	if (collapsed) {
 		return (
-			<Button
-				type="button"
-				onClick={toggleCollapsed}
-				variant="outline"
-				size="sm"
-				className="group fixed top-2 right-4 z-30 flex h-8 w-8 shrink-0 flex-row items-center justify-center gap-0 rounded-md p-0 shadow-lg md:static md:h-full md:w-10 md:flex-col md:justify-start md:gap-3 md:rounded-l-none md:rounded-r-md md:border-0 md:py-4 md:shadow-none md:hover:text-current md:active:scale-100"
-				title="Show filters"
-				aria-label="Show filters"
-				data-testid="mcpLibraryFilterSidebar-toggle-show"
-			>
-				<Filter className="text-muted-foreground group-hover:text-foreground size-4 transition-colors md:hidden" />
-				<PanelLeftOpen className="text-muted-foreground group-hover:text-foreground hidden size-4 transition-colors md:block" />
-				<span className="hidden rotate-180 select-none [writing-mode:vertical-rl] md:block">Filters</span>
-				{activeFilterCount > 0 && (
-					<span className="bg-primary text-primary-foreground md:bg-primary/10 md:text-primary absolute -top-1 -right-1 flex size-5 items-center justify-center rounded-full text-[10px] font-medium md:static md:size-6 md:text-xs">
-						{activeFilterCount}
-					</span>
-				)}
-			</Button>
+			<FilterSidebarTrigger activeFilterCount={activeFilterCount} onClick={toggleCollapsed} testId="mcpLibraryFilterSidebar-toggle-show" />
 		);
 	}
 

--- a/ui/app/workspace/mcp-registry/views/mcpClientsFilterSidebar.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsFilterSidebar.tsx
@@ -1,3 +1,4 @@
+import { FilterSidebarTrigger } from "@/components/filters/filterSidebarTrigger";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
@@ -6,7 +7,7 @@ import { ScrollArea } from "@/components/ui/scrollArea";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useGetVirtualKeysQuery } from "@/lib/store";
 import { cn } from "@/lib/utils";
-import { ChevronDown, Filter, LoaderCircle, PanelLeftClose, PanelLeftOpen, RotateCcw, Search } from "lucide-react";
+import { ChevronDown, LoaderCircle, PanelLeftClose, RotateCcw, Search } from "lucide-react";
 import { type Ref, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 const COLLAPSE_STORAGE_KEY = "mcp-clients-filter-sidebar-collapsed";
@@ -131,25 +132,7 @@ export function MCPClientsFilterSidebar({ filters, onFiltersChange }: SidebarPro
 
 	if (collapsed) {
 		return (
-			<Button
-				type="button"
-				onClick={toggleCollapsed}
-				variant="outline"
-				size="sm"
-				className="group md:bg-card md:hover:bg-card md:dark:bg-card md:dark:hover:bg-card fixed top-2 right-4 z-30 flex h-8 w-8 shrink-0 flex-row items-center justify-center gap-0 rounded-md p-0 shadow-lg md:static md:h-full md:w-10 md:flex-col md:justify-start md:gap-3 md:rounded-l-none md:rounded-r-md md:border-0 md:py-4 md:shadow-none md:hover:text-current md:active:scale-100"
-				title="Show filters"
-				aria-label="Show filters"
-				data-testid="mcpClientsFilterSidebar-toggle-show"
-			>
-				<Filter className="text-muted-foreground group-hover:text-foreground size-4 transition-colors md:hidden" />
-				<PanelLeftOpen className="text-muted-foreground group-hover:text-foreground hidden size-4 transition-colors md:block" />
-				<span className="hidden rotate-180 select-none [writing-mode:vertical-rl] md:block">Filters</span>
-				{activeFilterCount > 0 && (
-					<span className="bg-primary text-primary-foreground md:bg-primary/10 md:text-primary absolute -top-1 -right-1 flex size-5 items-center justify-center rounded-full text-[10px] font-medium md:static md:size-6 md:text-xs">
-						{activeFilterCount}
-					</span>
-				)}
-			</Button>
+			<FilterSidebarTrigger activeFilterCount={activeFilterCount} onClick={toggleCollapsed} testId="mcpClientsFilterSidebar-toggle-show" />
 		);
 	}
 

--- a/ui/app/workspace/mcp-sessions/views/mcpSessionsFilterSidebar.tsx
+++ b/ui/app/workspace/mcp-sessions/views/mcpSessionsFilterSidebar.tsx
@@ -4,6 +4,7 @@
 // State/behavior mirrors mcpClientsFilterSidebar.tsx; kept as its own copy
 // since the two pages filter on unrelated fields.
 
+import { FilterSidebarTrigger } from "@/components/filters/filterSidebarTrigger";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
@@ -13,18 +14,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { getUserSearchQuery } from "@/lib/registries/userPicker";
 import { useGetMCPClientsQuery, useGetVirtualKeysQuery } from "@/lib/store";
 import { cn } from "@/lib/utils";
-import {
-	ChevronDown,
-	Filter,
-	Fingerprint,
-	KeyRound,
-	LoaderCircle,
-	PanelLeftClose,
-	PanelLeftOpen,
-	RotateCcw,
-	Search,
-	UserRound,
-} from "lucide-react";
+import { ChevronDown, Fingerprint, KeyRound, LoaderCircle, PanelLeftClose, RotateCcw, Search, UserRound } from "lucide-react";
 import { type Ref, useCallback, useEffect, useMemo, useRef, useState } from "react";
 // Side-effect import: registers the enterprise user search hook (if this is
 // an enterprise build) before this module's first render. OSS has no user
@@ -165,25 +155,11 @@ export function MCPSessionsFilterSidebar({ filters, onFiltersChange }: SidebarPr
 
 	if (collapsed) {
 		return (
-			<Button
-				type="button"
+			<FilterSidebarTrigger
+				activeFilterCount={activeFilterCount}
 				onClick={toggleCollapsed}
-				variant="outline"
-				size="sm"
-				className="group md:bg-card md:hover:bg-card md:dark:bg-card md:dark:hover:bg-card fixed top-2 right-4 z-30 flex h-8 w-8 shrink-0 flex-row items-center justify-center gap-0 rounded-md p-0 shadow-lg md:static md:h-full md:w-10 md:flex-col md:justify-start md:gap-3 md:rounded-l-none md:rounded-r-md md:border-0 md:py-4 md:shadow-none md:hover:text-current md:active:scale-100"
-				title="Show filters"
-				aria-label="Show filters"
-				data-testid="mcp-sessions-filter-sidebar-toggle-show"
-			>
-				<Filter className="text-muted-foreground group-hover:text-foreground size-4 transition-colors md:hidden" />
-				<PanelLeftOpen className="text-muted-foreground group-hover:text-foreground hidden size-4 transition-colors md:block" />
-				<span className="hidden rotate-180 select-none [writing-mode:vertical-rl] md:block">Filters</span>
-				{activeFilterCount > 0 && (
-					<span className="bg-primary text-primary-foreground md:bg-primary/10 md:text-primary absolute -top-1 -right-1 flex size-5 items-center justify-center rounded-full text-[10px] font-medium md:static md:size-6 md:text-xs">
-						{activeFilterCount}
-					</span>
-				)}
-			</Button>
+				testId="mcp-sessions-filter-sidebar-toggle-show"
+			/>
 		);
 	}
 

--- a/ui/app/workspace/oauth-grants/views/oauthGrantsFilterSidebar.tsx
+++ b/ui/app/workspace/oauth-grants/views/oauthGrantsFilterSidebar.tsx
@@ -4,6 +4,7 @@
 // State/behavior mirrors mcpSessionsFilterSidebar.tsx; kept as its own copy
 // since this page filters on unrelated fields.
 
+import { FilterSidebarTrigger } from "@/components/filters/filterSidebarTrigger";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
@@ -13,18 +14,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { getUserSearchQuery } from "@/lib/registries/userPicker";
 import { useGetVirtualKeysQuery } from "@/lib/store";
 import { cn } from "@/lib/utils";
-import {
-	ChevronDown,
-	Filter,
-	Fingerprint,
-	KeyRound,
-	LoaderCircle,
-	PanelLeftClose,
-	PanelLeftOpen,
-	RotateCcw,
-	Search,
-	UserRound,
-} from "lucide-react";
+import { ChevronDown, Fingerprint, KeyRound, LoaderCircle, PanelLeftClose, RotateCcw, Search, UserRound } from "lucide-react";
 import { type Ref, useCallback, useEffect, useMemo, useRef, useState } from "react";
 // Side-effect import: registers the enterprise user search hook (if this is
 // an enterprise build) before this module's first render. OSS has no user
@@ -133,25 +123,7 @@ export function OAuthGrantsFilterSidebar({ filters, onFiltersChange }: SidebarPr
 
 	if (collapsed) {
 		return (
-			<Button
-				type="button"
-				onClick={toggleCollapsed}
-				variant="outline"
-				size="sm"
-				className="group md:bg-card md:hover:bg-card md:dark:bg-card md:dark:hover:bg-card fixed top-2 right-4 z-30 flex h-8 w-8 shrink-0 flex-row items-center justify-center gap-0 rounded-md p-0 shadow-lg md:static md:h-full md:w-10 md:flex-col md:justify-start md:gap-3 md:rounded-l-none md:rounded-r-md md:border-0 md:py-4 md:shadow-none md:hover:text-current md:active:scale-100"
-				title="Show filters"
-				aria-label="Show filters"
-				data-testid="oauthGrantsFilterSidebar-toggle-show"
-			>
-				<Filter className="text-muted-foreground group-hover:text-foreground size-4 transition-colors md:hidden" />
-				<PanelLeftOpen className="text-muted-foreground group-hover:text-foreground hidden size-4 transition-colors md:block" />
-				<span className="hidden rotate-180 select-none [writing-mode:vertical-rl] md:block">Filters</span>
-				{activeFilterCount > 0 && (
-					<span className="bg-primary text-primary-foreground md:bg-primary/10 md:text-primary absolute -top-1 -right-1 flex size-5 items-center justify-center rounded-full text-[10px] font-medium md:static md:size-6 md:text-xs">
-						{activeFilterCount}
-					</span>
-				)}
-			</Button>
+			<FilterSidebarTrigger activeFilterCount={activeFilterCount} onClick={toggleCollapsed} testId="oauthGrantsFilterSidebar-toggle-show" />
 		);
 	}
 

--- a/ui/components/filters/filterSidebarTrigger.tsx
+++ b/ui/components/filters/filterSidebarTrigger.tsx
@@ -1,0 +1,65 @@
+import { Button } from "@/components/ui/button";
+import { useMobileFilterSlot } from "@/lib/contexts/topbarContext";
+import { Filter, PanelLeftOpen } from "lucide-react";
+import { createPortal } from "react-dom";
+
+interface FilterSidebarTriggerProps {
+	activeFilterCount: number;
+	onClick: () => void;
+	testId?: string;
+}
+
+/**
+ * Shared collapsed-state trigger for filter sidebars.
+ *
+ * On mobile the compact trigger is portalled into the topbar, immediately
+ * before notifications. Desktop keeps the existing full-height sidebar rail.
+ */
+export function FilterSidebarTrigger({ activeFilterCount, onClick, testId }: FilterSidebarTriggerProps) {
+	const mobileFilterSlot = useMobileFilterSlot();
+
+	return (
+		<>
+			{mobileFilterSlot &&
+				createPortal(
+					<Button
+						type="button"
+						onClick={onClick}
+						variant="ghost"
+						size="sm"
+						className="group relative flex size-8 shrink-0 items-center justify-center rounded-sm border-0 p-0 shadow-none md:hidden"
+						title="Show filters"
+						aria-label="Show filters"
+						data-testid={testId ? `${testId}-mobile` : undefined}
+					>
+						<Filter className="text-muted-foreground group-hover:text-foreground size-4 transition-colors" />
+						{activeFilterCount > 0 && (
+							<span className="bg-primary text-primary-foreground absolute -top-1 -right-1 flex size-5 items-center justify-center rounded-full text-[10px] font-medium">
+								{activeFilterCount}
+							</span>
+						)}
+					</Button>,
+					mobileFilterSlot,
+				)}
+
+			<Button
+				type="button"
+				onClick={onClick}
+				variant="outline"
+				size="sm"
+				className="group bg-card hover:bg-card dark:bg-card dark:hover:bg-card hidden h-full w-10 shrink-0 flex-col items-center justify-start gap-3 rounded-l-none rounded-r-md border-0 py-4 shadow-none hover:text-current active:scale-100 md:flex"
+				title="Show filters"
+				aria-label="Show filters"
+				data-testid={testId}
+			>
+				<PanelLeftOpen className="text-muted-foreground group-hover:text-foreground size-4 transition-colors" />
+				<span className="rotate-180 select-none [writing-mode:vertical-rl]">Filters</span>
+				{activeFilterCount > 0 && (
+					<span className="bg-primary/10 text-primary flex size-6 items-center justify-center rounded-full text-xs font-medium">
+						{activeFilterCount}
+					</span>
+				)}
+			</Button>
+		</>
+	);
+}

--- a/ui/components/filters/logsFilterSidebar.tsx
+++ b/ui/components/filters/logsFilterSidebar.tsx
@@ -1,3 +1,4 @@
+import { FilterSidebarTrigger } from "@/components/filters/filterSidebarTrigger";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
@@ -10,7 +11,7 @@ import { RequestTypeLabels, RequestTypes, RoutingEngineUsedLabels, Statuses } fr
 import { useGetAvailableFilterDataQuery, useGetProvidersQuery } from "@/lib/store";
 import type { LogFilters } from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
-import { ChevronDown, Filter, LoaderCircle, PanelLeftClose, PanelLeftOpen, Plus, RotateCcw, Search } from "lucide-react";
+import { ChevronDown, LoaderCircle, PanelLeftClose, Plus, RotateCcw, Search } from "lucide-react";
 import { Ref, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 const COLLAPSE_STORAGE_KEY = "logs-filter-sidebar-collapsed";
@@ -71,26 +72,7 @@ export function LogsFilterSidebar({ filters, onFiltersChange }: LogsSidebarProps
 
 	// Collapsed: thin rail with vertical "Filters" label — whole rail is clickable to expand
 	if (collapsed) {
-		return (
-			<Button
-				type="button"
-				onClick={toggleCollapsed}
-				variant="outline"
-				size="sm"
-				className="group md:bg-card md:hover:bg-card md:dark:bg-card md:dark:hover:bg-card fixed top-2 right-4 z-30 flex h-8 w-8 shrink-0 flex-row items-center justify-center gap-0 rounded-md p-0 shadow-lg md:static md:h-full md:w-10 md:flex-col md:justify-start md:gap-3 md:rounded-l-none md:rounded-r-md md:border-0 md:py-4 md:shadow-none md:hover:text-current md:active:scale-100"
-				title="Show filters"
-				aria-label="Show filters"
-			>
-				<Filter className="text-muted-foreground group-hover:text-foreground size-4 transition-colors md:hidden" />
-				<PanelLeftOpen className="text-muted-foreground group-hover:text-foreground hidden size-4 transition-colors md:block" />
-				<span className="hidden rotate-180 select-none [writing-mode:vertical-rl] md:block">Filters</span>
-				{activeFilterCount > 0 && (
-					<span className="bg-primary text-primary-foreground md:bg-primary/10 md:text-primary absolute -top-1 -right-1 flex size-5 items-center justify-center rounded-full text-[10px] font-medium md:static md:size-6 md:text-xs">
-						{activeFilterCount}
-					</span>
-				)}
-			</Button>
-		);
+		return <FilterSidebarTrigger activeFilterCount={activeFilterCount} onClick={toggleCollapsed} />;
 	}
 
 	return (

--- a/ui/components/filters/mcpFilterSidebar.tsx
+++ b/ui/components/filters/mcpFilterSidebar.tsx
@@ -1,3 +1,4 @@
+import { FilterSidebarTrigger } from "@/components/filters/filterSidebarTrigger";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
@@ -10,7 +11,7 @@ import { Statuses } from "@/lib/constants/logs";
 import { useGetMCPLogsFilterDataQuery } from "@/lib/store";
 import type { MCPToolLogFilters } from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
-import { ChevronDown, Filter, LoaderCircle, PanelLeftClose, PanelLeftOpen, Plus, RotateCcw, Search } from "lucide-react";
+import { ChevronDown, LoaderCircle, PanelLeftClose, Plus, RotateCcw, Search } from "lucide-react";
 import { Ref, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 const COLLAPSE_STORAGE_KEY = "mcp-filter-sidebar-collapsed";
@@ -68,26 +69,7 @@ export function MCPFilterSidebar({ filters, onFiltersChange }: MCPFilterSidebarP
 
 	// Collapsed: thin rail with vertical "Filters" label — whole rail is clickable to expand
 	if (collapsed) {
-		return (
-			<Button
-				type="button"
-				onClick={toggleCollapsed}
-				variant="outline"
-				size="sm"
-				className="group md:bg-card md:hover:bg-card md:dark:bg-card md:dark:hover:bg-card fixed top-2 right-4 z-30 flex h-8 w-8 shrink-0 flex-row items-center justify-center gap-0 rounded-md p-0 shadow-lg md:static md:h-full md:w-10 md:flex-col md:justify-start md:gap-3 md:rounded-l-none md:rounded-r-md md:border-0 md:py-4 md:shadow-none md:hover:text-current md:active:scale-100"
-				title="Show filters"
-				aria-label="Show filters"
-			>
-				<Filter className="text-muted-foreground group-hover:text-foreground size-4 transition-colors md:hidden" />
-				<PanelLeftOpen className="text-muted-foreground group-hover:text-foreground hidden size-4 transition-colors md:block" />
-				<span className="hidden rotate-180 select-none [writing-mode:vertical-rl] md:block">Filters</span>
-				{activeFilterCount > 0 && (
-					<span className="bg-primary text-primary-foreground md:bg-primary/10 md:text-primary absolute -top-1 -right-1 flex size-5 items-center justify-center rounded-full text-[10px] font-medium md:static md:size-6 md:text-xs">
-						{activeFilterCount}
-					</span>
-				)}
-			</Button>
-		);
+		return <FilterSidebarTrigger activeFilterCount={activeFilterCount} onClick={toggleCollapsed} />;
 	}
 
 	return (

--- a/ui/components/notificationCenter.tsx
+++ b/ui/components/notificationCenter.tsx
@@ -78,7 +78,7 @@ export default function NotificationCenter() {
 						{unreadCount > 0 && (
 							<span
 								data-testid="topbar-notifications-badge"
-								className="bg-destructive text-destructive-foreground absolute -top-1.5 -right-2 flex min-w-4 items-center justify-center rounded-full px-1 text-[9px] leading-4 font-semibold"
+								className="absolute -top-1.5 -right-2 flex min-w-4 items-center justify-center rounded-full bg-red-600 px-1 text-[9px] leading-4 font-semibold text-white dark:bg-red-700"
 							>
 								{unreadCount > 99 ? "99+" : unreadCount}
 							</span>

--- a/ui/components/topbar.tsx
+++ b/ui/components/topbar.tsx
@@ -12,13 +12,15 @@ import {
 } from "@/components/ui/dropdownMenu";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { IS_ENTERPRISE } from "@/lib/constants/config";
-import { useDescriptionSlotRef, useTopbarTitle } from "@/lib/contexts/topbarContext";
+import { useDescriptionSlotRef, useMobileFilterSlotRef, useTopbarTitle } from "@/lib/contexts/topbarContext";
+import { useBranding } from "@/lib/hooks/useBranding";
 import { useGetCoreConfigQuery, useLogoutMutation } from "@/lib/store";
 import type { UserInfo } from "@enterprise/lib/store/utils/tokenManager";
 import { getUserInfo } from "@enterprise/lib/store/utils/tokenManager";
 import { BooksIcon, DiscordLogoIcon, GithubLogoIcon } from "@phosphor-icons/react";
 import { useLocation, useNavigate } from "@tanstack/react-router";
 import { BugIcon, ChevronDown, LogOut, Menu, User } from "lucide-react";
+import { useTheme } from "next-themes";
 import { useEffect, useMemo, useState } from "react";
 
 // External links that used to live in the sidebar footer icon row. They now
@@ -84,9 +86,12 @@ function usePageTitle() {
 export default function Topbar() {
 	const title = usePageTitle();
 	const setDescriptionSlot = useDescriptionSlotRef();
+	const setMobileFilterSlot = useMobileFilterSlotRef();
 	const navigate = useNavigate();
 	const [logout] = useLogoutMutation();
 	const { data: coreConfig } = useGetCoreConfigQuery({});
+	const { resolvedTheme } = useTheme();
+	const { logoSrc, logoAlt } = useBranding(resolvedTheme === "dark");
 
 	// Enterprise SCIM/OAuth stashes the profile in localStorage. Read it after
 	// mount so SSR/first paint doesn't diverge from the hydrated tree.
@@ -119,16 +124,18 @@ export default function Topbar() {
 		<header className="flex h-13 w-full shrink-0 items-center gap-2 px-3 pt-1 md:pr-4 md:pl-2" data-testid="topbar-container-root">
 			<div className="flex min-w-0 flex-1 items-center gap-2">
 				<SidebarTrigger className="shrink-0 md:hidden" />
+				<img className="h-[22px] w-auto max-w-[120px] object-contain md:hidden" src={logoSrc} alt={logoAlt} width={70} height={70} />
 				{/* text-lg font-semibold is the existing in-page <h1> scale, so hoisting
 				    the title here doesn't visually demote it. */}
-				<h1 className="truncate text-lg font-semibold">{title}</h1>
+				<h1 className="hidden truncate text-lg font-semibold md:block">{title}</h1>
 				{/* Anchor for <PageTitle>'s description popover. Pages portal into
 				    this node, so the topbar never has to know their content. */}
-				<span ref={setDescriptionSlot} className="flex shrink-0 items-center" />
+				<span ref={setDescriptionSlot} className="hidden shrink-0 items-center md:flex" />
 			</div>
 
 			{/* Theme stays a first-class topbar control rather than a menu entry —
 			    it's a display preference, not an account action. */}
+			<span ref={setMobileFilterSlot} className="flex shrink-0 items-center md:hidden" />
 			<NotificationCenter />
 			<ThemeToggle />
 
@@ -139,16 +146,17 @@ export default function Topbar() {
 							type="button"
 							data-testid="topbar-user-pill"
 							aria-label="Account menu"
-							className="border-border bg-card/60 text-foreground hover:bg-accent hover:text-accent-foreground flex h-8 max-w-[140px] min-w-0 cursor-pointer items-center gap-1.5 rounded-full border py-0 pr-2 pl-1 transition-colors sm:max-w-[220px]"
+							className="text-muted-foreground hover:bg-accent hover:text-accent-foreground md:border-border md:bg-card/60 md:text-foreground flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-md transition-colors md:h-8 md:w-auto md:max-w-[220px] md:min-w-0 md:gap-1.5 md:rounded-full md:border md:py-0 md:pr-2 md:pl-1"
 						>
-							<span className="bg-muted text-muted-foreground flex size-6 shrink-0 items-center justify-center rounded-full">
+							<span className="bg-muted text-muted-foreground hidden size-6 shrink-0 items-center justify-center rounded-full md:flex">
 								<User className="size-3.5" strokeWidth={2} />
 							</span>
+							<User className="size-4 md:hidden" strokeWidth={2} />
 							{/* min-w-0 + truncate is what keeps a 200-character display
 							    name from stretching the pill and pushing the page title
 							    out of the topbar. */}
-							<span className="min-w-0 truncate text-sm font-medium">{displayName}</span>
-							<ChevronDown className="text-muted-foreground size-3.5 shrink-0" strokeWidth={2} />
+							<span className="hidden min-w-0 truncate text-sm font-medium md:block">{displayName}</span>
+							<ChevronDown className="text-muted-foreground hidden size-3.5 shrink-0 md:block" strokeWidth={2} />
 						</button>
 					) : (
 						<button

--- a/ui/lib/contexts/topbarContext.tsx
+++ b/ui/lib/contexts/topbarContext.tsx
@@ -14,6 +14,9 @@ interface TopbarContextValue {
 	 */
 	descriptionSlot: HTMLElement | null;
 	setDescriptionSlot: Dispatch<SetStateAction<HTMLElement | null>>;
+	/** Mobile-only anchor for a page's collapsed filter-sidebar trigger. */
+	mobileFilterSlot: HTMLElement | null;
+	setMobileFilterSlot: Dispatch<SetStateAction<HTMLElement | null>>;
 }
 
 const TopbarContext = createContext<TopbarContextValue | null>(null);
@@ -21,9 +24,10 @@ const TopbarContext = createContext<TopbarContextValue | null>(null);
 export function TopbarProvider({ children }: { children: React.ReactNode }) {
 	const [titleEntry, setTitleEntry] = useState<TopbarTitleEntry>(EMPTY_TITLE_ENTRY);
 	const [descriptionSlot, setDescriptionSlot] = useState<HTMLElement | null>(null);
+	const [mobileFilterSlot, setMobileFilterSlot] = useState<HTMLElement | null>(null);
 	const value = useMemo(
-		() => ({ title: titleEntry.value, setTitleEntry, descriptionSlot, setDescriptionSlot }),
-		[titleEntry.value, descriptionSlot],
+		() => ({ title: titleEntry.value, setTitleEntry, descriptionSlot, setDescriptionSlot, mobileFilterSlot, setMobileFilterSlot }),
+		[titleEntry.value, descriptionSlot, mobileFilterSlot],
 	);
 	return <TopbarContext.Provider value={value}>{children}</TopbarContext.Provider>;
 }
@@ -41,6 +45,16 @@ export function useDescriptionSlotRef() {
 /** Read side for <PageTitle>, which portals its description into this node. */
 export function useDescriptionSlot(): HTMLElement | null {
 	return useContext(TopbarContext)?.descriptionSlot ?? null;
+}
+
+/** Registers the mobile filter-trigger anchor exposed by <Topbar>. */
+export function useMobileFilterSlotRef() {
+	return useContext(TopbarContext)?.setMobileFilterSlot;
+}
+
+/** Read side for filter sidebars, which portal their mobile trigger here. */
+export function useMobileFilterSlot(): HTMLElement | null {
+	return useContext(TopbarContext)?.mobileFilterSlot ?? null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Extracts the duplicated collapsed-state filter sidebar trigger button into a shared `FilterSidebarTrigger` component and improves the mobile topbar layout so the filter trigger appears inline with the notification bell rather than as a floating overlay.

## Changes

- Added `ui/components/filters/filterSidebarTrigger.tsx` — a new shared component that renders the collapsed filter sidebar trigger. On desktop it renders the existing full-height sidebar rail button. On mobile it portals a compact icon button into a new `mobileFilterSlot` anchor in the topbar, placing it immediately before the notification bell.
- Replaced the duplicated inline `<Button>` collapsed-state blocks in `logsFilterSidebar`, `mcpFilterSidebar`, `mcpLibraryFilterSidebar`, `mcpClientsFilterSidebar`, `mcpSessionsFilterSidebar`, and `oauthGrantsFilterSidebar` with a single `<FilterSidebarTrigger />` call.
- Added `mobileFilterSlot` and `setMobileFilterSlot` to `TopbarContext` and exposed `useMobileFilterSlot` / `useMobileFilterSlotRef` hooks so filter sidebars can portal their mobile trigger into the topbar without the topbar needing to know page-specific content.
- Updated `Topbar` to render the `mobileFilterSlot` anchor span between the left content area and the notification bell, and to show the brand logo on mobile in place of the page title (which is now hidden on small screens).
- Collapsed the user pill on mobile to a bare icon button, hiding the display name and chevron below the `md` breakpoint.
- Changed the notification badge to use explicit `bg-red-600`/`dark:bg-red-700` classes instead of `bg-destructive` to ensure consistent color regardless of theme token overrides.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i
pnpm build
```

1. Open any page that has a filter sidebar (Logs, MCP Logs, MCP Library, MCP Clients, MCP Sessions, OAuth Grants).
2. Collapse the filter sidebar and verify the trigger appears correctly on desktop (full-height rail) and mobile (icon in topbar next to the notification bell).
3. Confirm the active filter count badge renders on both breakpoints when filters are applied.
4. Verify the mobile topbar shows the brand logo and a bare user icon, with the full pill restored at the `md` breakpoint.
5. Confirm the notification badge is visually red in both light and dark themes.

## Screenshots/Recordings

Before/after screenshots recommended for the mobile topbar layout and the collapsed filter trigger placement on both breakpoints.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable