### PR TITLE
feat(ui): add service tier column and detail view to logs

### DIFF
--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -588,6 +588,7 @@ export default function LogsPage() {
 			latency: "Latency",
 			tokens: "Tokens",
 			cost: "Cost",
+			service_tier: "Service Tier",
 			virtual_key: "Virtual Key",
 			routing_rule: "Routing Rule",
 			team: "Team",
@@ -598,7 +599,10 @@ export default function LogsPage() {
 		[],
 	);
 
-	const DEFAULT_HIDDEN_COLUMNS = useMemo(() => ["virtual_key", "routing_rule", "team", "customer", "user", "business_unit"], []);
+	const DEFAULT_HIDDEN_COLUMNS = useMemo(
+		() => ["service_tier", "virtual_key", "routing_rule", "team", "customer", "user", "business_unit"],
+		[],
+	);
 
 	const {
 		entries: columnEntries,

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -1069,6 +1069,17 @@ export function LogDetailView({
 									</div>
 								}
 							/>
+							{log.service_tier && (
+								<LogEntryDetailsView
+									className="w-full"
+									label="Service Tier"
+									value={
+										<Badge variant="secondary" className="uppercase" data-testid="logdetails-service-tier">
+											{log.service_tier}
+										</Badge>
+									}
+								/>
+							)}
 							{log.stop_reason && (
 								<LogEntryDetailsView
 									className="w-full"

--- a/ui/app/workspace/logs/views/columns.tsx
+++ b/ui/app/workspace/logs/views/columns.tsx
@@ -486,6 +486,22 @@ export const createColumns = (
 
 	const attributionColumns: ColumnDef<LogEntry>[] = [
 		{
+			id: "service_tier",
+			header: "Service Tier",
+			size: 130,
+			cell: ({ row }) => {
+				const tier = row.original.service_tier;
+				if (!tier) {
+					return <div className="font-mono text-xs">-</div>;
+				}
+				return (
+					<Badge variant="outline" className="font-mono text-[11px] py-0.5 px-1.5 uppercase">
+						{tier}
+					</Badge>
+				);
+			},
+		},
+		{
 			id: "virtual_key",
 			header: "Virtual Key",
 			size: 170,

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -604,6 +604,9 @@ export interface LogEntry {
 	cache_debug?: CacheDebug;
 	guardrail_debug?: GuardrailDebug;
 	cost?: number; // Cost in dollars (total cost of the request - includes cache lookup cost and also guardrail judge calls)
+	// Served billing tier, denormalized onto the log row so cost recomputation can reprice
+	// at the rates the request was actually served at. OpenAI: "priority" / "flex" / "default".
+	service_tier?: string;
 	status: string; // "success", "error", "processing", or "cancelled"
 	stop_reason?: string; // Why the model stopped: "stop", "length", "content_filter", "tool_calls", etc.
 	error_details?: BifrostError;


### PR DESCRIPTION
## Summary

Adds `service_tier` as a tracked field on log entries, enabling cost recomputation to reprice requests at the rates they were actually served at. This surfaces the billing tier (e.g., OpenAI's `"priority"`, `"flex"`, or `"default"`) in both the logs table and the log detail view.

## Changes

- Added `service_tier?: string` to the `LogEntry` type, denormalized onto the log row so cost recomputation can use the correct tier rates.
- Added a `service_tier` column to the logs table, rendering the tier as an uppercase badge when present and `-` when absent.
- Added `"Service Tier"` to the column label map and included `"service_tier"` in the default hidden columns list so it is available but not shown by default.
- Added a `Service Tier` field to the log detail view that renders conditionally when the value is present.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Make a request through a provider that returns a `service_tier` in its response (e.g., OpenAI with `service_tier: "flex"` or `"priority"`).
2. Open the Logs page and enable the **Service Tier** column via the column visibility menu.
3. Verify the tier is displayed as an uppercase badge in the table row.
4. Click into the log entry and confirm the **Service Tier** field appears in the detail view.
5. For a request without a `service_tier`, confirm the column shows `-` and the detail view field is absent.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

_Add before/after screenshots showing the Service Tier column in the logs table and the field in the log detail view._

## Breaking changes

- [x] No

## Related issues

## Security considerations

No security implications. `service_tier` is a non-sensitive billing metadata field.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable