### PR TITLE
fixes params sequence in chat completions

### DIFF
--- a/.github/workflows/openapi-bundle.yml
+++ b/.github/workflows/openapi-bundle.yml
@@ -40,8 +40,12 @@ jobs:
           git config user.name "GitHub Actions Bot"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      # Hash-pinned rather than a bare `pip install pyyaml`: this job holds
+      # contents: write and pushes a commit, so an unverified install here runs
+      # attacker-controlled code with push access. Shares the pin file with
+      # workflow-lint.yml.
       - name: Install dependencies
-        run: pip install pyyaml
+        run: pip install --require-hashes -r .github/workflows/requirements/pyyaml.txt
 
       - name: Bundle OpenAPI spec
         working-directory: ./docs/openapi

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -393,8 +393,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y jq
 
-      - name: Install Newman
-        run: npm install -g newman@6.2.1 newman-reporter-htmlextra@1.23.1
+      # npm ci against .github/workflows/tools/package-lock.json, not `npm install -g`:
+      # the lockfile carries an integrity hash for newman and every transitive dep, which
+      # a bare version pin does not. Bin dir goes on PATH because the test scripts probe
+      # for newman with `command -v`.
+      - name: Install Newman (hash-pinned via lockfile)
+        run: |
+          npm ci --no-audit --no-fund
+          echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+        working-directory: .github/workflows/tools
 
       - name: Set up gcloud CLI
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
@@ -559,6 +566,7 @@ jobs:
             proxy.golang.org:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443
+            releases.astral.sh:443
             router.huggingface.co:443
             storage.googleapis.com:443
             sum.golang.org:443
@@ -578,6 +586,20 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "25"
+
+      # test-integrations.sh installs the Python suite with `uv sync --frozen`, and
+      # silently degrades to `pip install -e .` when uv is absent. That fallback cannot
+      # succeed here: tests/integrations/python is a dependency manifest, not a package,
+      # so setuptools' flat-layout discovery aborts on the two top-level run_*.py modules.
+      # Installing uv keeps the job on the locked, reproducible path. Pinned to the same
+      # action and version snyk.yml already uses; python-version matches
+      # tests/integrations/python/.python-version so CI resolves the interpreter a
+      # developer gets locally instead of downloading a second one.
+      - name: Install uv
+        uses: step-security/setup-uv@ccf0a26ce9117d9e99292b0ce953ea5d9ffe778e # v7.3.0
+        with:
+          version: "0.11.0"
+          python-version: "3.12"
 
       - name: Download prebuilt bifrost-http binary
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -1567,8 +1589,15 @@ jobs:
         with:
           node-version: "25"
 
-      - name: Install Newman
-        run: npm install -g newman@6.2.1 newman-reporter-htmlextra@1.23.1
+      # npm ci against .github/workflows/tools/package-lock.json, not `npm install -g`:
+      # the lockfile carries an integrity hash for newman and every transitive dep, which
+      # a bare version pin does not. Bin dir goes on PATH because the test scripts probe
+      # for newman with `command -v`.
+      - name: Install Newman (hash-pinned via lockfile)
+        run: |
+          npm ci --no-audit --no-fund
+          echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+        working-directory: .github/workflows/tools
 
       - name: Set up Docker Compose
         run: |
@@ -1921,8 +1950,15 @@ jobs:
         with:
           node-version: "25"
 
-      - name: Install Newman
-        run: npm install -g newman@6.2.1 newman-reporter-htmlextra@1.23.1
+      # npm ci against .github/workflows/tools/package-lock.json, not `npm install -g`:
+      # the lockfile carries an integrity hash for newman and every transitive dep, which
+      # a bare version pin does not. Bin dir goes on PATH because the test scripts probe
+      # for newman with `command -v`.
+      - name: Install Newman (hash-pinned via lockfile)
+        run: |
+          npm ci --no-audit --no-fund
+          echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+        working-directory: .github/workflows/tools
 
       - name: Setup Docker Buildx
         uses: step-security/setup-buildx-action@f931205d68723ad9589fd2a7e2ece238bf9de341 # v4.0.0
@@ -2054,8 +2090,15 @@ jobs:
         with:
           node-version: "25"
 
-      - name: Install Newman
-        run: npm install -g newman@6.2.1 newman-reporter-htmlextra@1.23.1
+      # npm ci against .github/workflows/tools/package-lock.json, not `npm install -g`:
+      # the lockfile carries an integrity hash for newman and every transitive dep, which
+      # a bare version pin does not. Bin dir goes on PATH because the test scripts probe
+      # for newman with `command -v`.
+      - name: Install Newman (hash-pinned via lockfile)
+        run: |
+          npm ci --no-audit --no-fund
+          echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+        working-directory: .github/workflows/tools
 
       - name: Setup Docker Buildx
         uses: step-security/setup-buildx-action@f931205d68723ad9589fd2a7e2ece238bf9de341 # v4.0.0

--- a/.github/workflows/requirements/pyyaml.txt
+++ b/.github/workflows/requirements/pyyaml.txt
@@ -1,0 +1,89 @@
+# Hash-pinned PyYAML for workflow jobs that need it outside a project venv.
+#
+# Exists to satisfy the OpenSSF Scorecard Pinned-Dependencies check: a bare
+# `pip install pyyaml` resolves whatever the index serves at run time, so a
+# compromised or yanked release lands in CI unnoticed. --require-hashes turns
+# that into a verified fetch.
+#
+# Universal: covers every artifact published for this version, so it resolves on
+# any runner platform or Python version without needing a per-job variant.
+#
+# Regenerate with:
+#   echo 'pyyaml==<version>' > /tmp/pyyaml.in
+#   uv pip compile /tmp/pyyaml.in --generate-hashes --universal --no-header -o \
+#     .github/workflows/requirements/pyyaml.txt
+# then restore this header.
+pyyaml==6.0.3 \
+    --hash=sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c \
+    --hash=sha256:0150219816b6a1fa26fb4699fb7daa9caf09eb1999f3b70fb6e786805e80375a \
+    --hash=sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3 \
+    --hash=sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956 \
+    --hash=sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6 \
+    --hash=sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c \
+    --hash=sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65 \
+    --hash=sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a \
+    --hash=sha256:1ebe39cb5fc479422b83de611d14e2c0d3bb2a18bbcb01f229ab3cfbd8fee7a0 \
+    --hash=sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b \
+    --hash=sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1 \
+    --hash=sha256:22ba7cfcad58ef3ecddc7ed1db3409af68d023b7f940da23c6c2a1890976eda6 \
+    --hash=sha256:27c0abcb4a5dac13684a37f76e701e054692a9b2d3064b70f5e4eb54810553d7 \
+    --hash=sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e \
+    --hash=sha256:2e71d11abed7344e42a8849600193d15b6def118602c4c176f748e4583246007 \
+    --hash=sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310 \
+    --hash=sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4 \
+    --hash=sha256:3c5677e12444c15717b902a5798264fa7909e41153cdf9ef7ad571b704a63dd9 \
+    --hash=sha256:3ff07ec89bae51176c0549bc4c63aa6202991da2d9a6129d7aef7f1407d3f295 \
+    --hash=sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea \
+    --hash=sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0 \
+    --hash=sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e \
+    --hash=sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac \
+    --hash=sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9 \
+    --hash=sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7 \
+    --hash=sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35 \
+    --hash=sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb \
+    --hash=sha256:5cf4e27da7e3fbed4d6c3d8e797387aaad68102272f8f9752883bc32d61cb87b \
+    --hash=sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69 \
+    --hash=sha256:5ed875a24292240029e4483f9d4a4b8a1ae08843b9c54f43fcc11e404532a8a5 \
+    --hash=sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b \
+    --hash=sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c \
+    --hash=sha256:6344df0d5755a2c9a276d4473ae6b90647e216ab4757f8426893b5dd2ac3f369 \
+    --hash=sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd \
+    --hash=sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824 \
+    --hash=sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198 \
+    --hash=sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065 \
+    --hash=sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c \
+    --hash=sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c \
+    --hash=sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764 \
+    --hash=sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196 \
+    --hash=sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b \
+    --hash=sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00 \
+    --hash=sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac \
+    --hash=sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8 \
+    --hash=sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e \
+    --hash=sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28 \
+    --hash=sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3 \
+    --hash=sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5 \
+    --hash=sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4 \
+    --hash=sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b \
+    --hash=sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf \
+    --hash=sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5 \
+    --hash=sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702 \
+    --hash=sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8 \
+    --hash=sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788 \
+    --hash=sha256:b865addae83924361678b652338317d1bd7e79b1f4596f96b96c77a5a34b34da \
+    --hash=sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d \
+    --hash=sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc \
+    --hash=sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c \
+    --hash=sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba \
+    --hash=sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f \
+    --hash=sha256:c3355370a2c156cffb25e876646f149d5d68f5e0a3ce86a5084dd0b64a994917 \
+    --hash=sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5 \
+    --hash=sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26 \
+    --hash=sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f \
+    --hash=sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b \
+    --hash=sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be \
+    --hash=sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c \
+    --hash=sha256:efd7b85f94a6f21e4932043973a7ba2613b059c4a000551892ac9f1d11f5baf3 \
+    --hash=sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6 \
+    --hash=sha256:fa160448684b4e94d80416c0fa4aac48967a969efe22931448d853ada8baf926 \
+    --hash=sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0

--- a/.github/workflows/run-core-tests.yml
+++ b/.github/workflows/run-core-tests.yml
@@ -128,6 +128,7 @@ jobs:
             proxy.golang.org:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443
+            releases.astral.sh:443
             router.huggingface.co:443
             storage.googleapis.com:443
             sum.golang.org:443
@@ -150,11 +151,31 @@ jobs:
         with:
           node-version: "25"
 
+      # Required by the test-integration step below: test-integrations.sh installs the
+      # Python suite with `uv sync --frozen`, and its pip fallback cannot build
+      # tests/integrations/python (a dependency manifest, not a package). Kept in step
+      # with the same block in release-pipeline.yml's test-core-integrations job.
+      - name: Install uv
+        uses: step-security/setup-uv@ccf0a26ce9117d9e99292b0ce953ea5d9ffe778e # v7.3.0
+        with:
+          version: "0.11.0"
+          python-version: "3.12"
+
       - name: Install test dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y jq
-          npm install -g newman@6.2.1 newman-reporter-htmlextra@1.23.1
+
+      # `npm install -g newman@x` pins the version but verifies nothing, which is what
+      # Scorecard's Pinned-Dependencies check flags. `npm ci` against the committed
+      # lockfile enforces an integrity hash for newman and all 166 of its transitive
+      # deps. The bin directory goes on PATH because the test scripts probe for newman
+      # with `command -v` rather than calling it through npx.
+      - name: Install newman (hash-pinned via lockfile)
+        run: |
+          npm ci --no-audit --no-fund
+          echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+        working-directory: .github/workflows/tools
 
       - name: Set up gcloud CLI
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1

--- a/.github/workflows/scripts/cost-accuracy-test.sh
+++ b/.github/workflows/scripts/cost-accuracy-test.sh
@@ -355,6 +355,18 @@ expected_count = int(match.group(1))
 if expected_count <= 0:
     raise SystemExit("hitter reported zero successful requests")
 
+# /api/logs rejects limit > 1000 (transports/bifrost-http/handlers/logging.go) and this
+# validator reads a single page. Above the cap the row list silently truncates and every
+# later assertion fails for a reason that has nothing to do with cost, so refuse the run
+# up front and name the knobs instead.
+LOG_PAGE_LIMIT = 1000
+if expected_count > LOG_PAGE_LIMIT:
+    raise SystemExit(
+        f"expected {expected_count} successful requests but /api/logs returns at most "
+        f"{LOG_PAGE_LIMIT} rows per page and this validator does not paginate. "
+        f"Set COST_ACCURACY_RPS * COST_ACCURACY_DURATION <= {LOG_PAGE_LIMIT}."
+    )
+
 base = f"http://127.0.0.1:{port}"
 
 def get_json(path, params):
@@ -368,7 +380,7 @@ params = {
     "status": "success",
     "virtual_key_ids": virtual_key_id,
     "start_time": start_time,
-    "limit": "1000",
+    "limit": str(LOG_PAGE_LIMIT),
     "sort_by": "timestamp",
     "order": "asc",
 }
@@ -384,16 +396,72 @@ def logs_complete(logs):
         for item in logs
     )
 
+def describe_incomplete(item):
+    # "missing token_usage or cost" on its own is not actionable: cost and token_usage
+    # reach the API by different routes (cost is a column, token_usage is a JSON blob
+    # deserialized after the query), so which one is absent decides where to look.
+    # Report the field names and the raw values.
+    usage = item.get("token_usage") or {}
+    return {
+        "id": item.get("id"),
+        "timestamp": item.get("timestamp"),
+        "status": item.get("status"),
+        "cost": item.get("cost"),
+        "token_usage": item.get("token_usage"),
+        "missing": [
+            name
+            for name, value in (
+                ("token_usage.prompt_tokens", usage.get("prompt_tokens")),
+                ("token_usage.completion_tokens", usage.get("completion_tokens")),
+                ("cost", item.get("cost")),
+            )
+            if value is None
+        ],
+    }
+
+LOG_POLL_ATTEMPTS = 60
 logs = []
-for _ in range(60):
+logs_ready = False
+for _ in range(LOG_POLL_ATTEMPTS):
     payload = get_json("/api/logs", params)
     logs = payload.get("logs", [])
     if len(logs) >= expected_count and logs_complete(logs):
+        logs_ready = True
         break
     time.sleep(1)
 
 if len(logs) != expected_count:
     raise SystemExit(f"log count mismatch: got {len(logs)}, want {expected_count}")
+
+# Exhausting the poll means the rows never became readable, which is a different
+# failure from a wrong cost. Without this the run falls through and validates the
+# stale page, reporting incomplete rows as per-log cost mismatches and then burning
+# the full quota-poll budget waiting on a total that can no longer be reached.
+if not logs_ready:
+    incomplete = [describe_incomplete(i) for i in logs if not logs_complete([i])]
+    # Write the artifact before bailing out. The job uploads tmp/cost-accuracy/ on any
+    # non-cancelled run, and this is the failure whose diagnostics are worth the most,
+    # so exiting ahead of results_file.write_text() would discard exactly the evidence
+    # needed to chase it. Totals are absent rather than zero: they are not computed yet,
+    # and a 0.0 here would read as "measured zero cost".
+    results_file.parent.mkdir(parents=True, exist_ok=True)
+    results_file.write_text(json.dumps({
+        "failure": "logs did not become complete",
+        "expected_count": expected_count,
+        "log_count": len(logs),
+        "logs_converged": False,
+        "quota_converged": None,
+        "poll_seconds": LOG_POLL_ATTEMPTS,
+        "virtual_key_id": virtual_key_id,
+        "incomplete_row_count": len(incomplete),
+        "incomplete_rows": incomplete[:10],
+    }, indent=2, sort_keys=True))
+    raise SystemExit(
+        f"logs did not become complete within {LOG_POLL_ATTEMPTS}s: {len(incomplete)} of "
+        f"{len(logs)} rows still missing token_usage or cost. This is a log-write "
+        f"visibility problem, not a pricing mismatch. First 5:\n"
+        + json.dumps(incomplete[:5], indent=2, sort_keys=True)
+    )
 
 mismatches = []
 expected_total = 0.0
@@ -412,7 +480,7 @@ for item in logs:
     completion = usage.get("completion_tokens")
     actual = item.get("cost")
     if prompt is None or completion is None or actual is None:
-        mismatches.append({"id": item.get("id"), "reason": "missing token_usage or cost"})
+        mismatches.append({**describe_incomplete(item), "reason": "missing token_usage or cost"})
         continue
     expected = prompt * input_rate + completion * output_rate
     expected_total += expected
@@ -436,26 +504,48 @@ stats = get_json("/api/logs/stats", {
 })
 stats_total = float(stats.get("total_cost", 0))
 
+def quota_totals(payload):
+    # Both totals this script asserts on, read from one quota response.
+    #
+    # They do not converge together. current_usage is the governance budget counter,
+    # updated in the request path. per_model_usage[].total_cost is a log aggregate -
+    # buildBudgetsWithUsage feeds it from logManager.GetModelRankings over the logs
+    # store (transports/bifrost-http/handlers/governance.go), which trails the async
+    # batch writer. Polling on the counter alone therefore breaks while the model
+    # total is still catching up, and the assertion below fails on staleness rather
+    # than on a real disagreement.
+    budget_total = sum(float(b.get("current_usage") or 0) for b in payload.get("budgets", []))
+    model_total = sum(
+        float(m.get("total_cost") or 0)
+        for b in payload.get("budgets", [])
+        for m in b.get("per_model_usage", [])
+        if m.get("model") == "gpt-4o-mini" and m.get("provider") == "openai"
+    )
+    return budget_total, model_total
+
+QUOTA_POLL_ATTEMPTS = 60
 quota = None
-for _ in range(60):
+quota_ready = False
+for _ in range(QUOTA_POLL_ATTEMPTS):
     req = urllib.request.Request(base + "/api/governance/virtual-keys/quota", headers={"x-bf-vk": virtual_key_value})
     with urllib.request.urlopen(req, timeout=10) as resp:
         quota = json.loads(resp.read().decode("utf-8"))
-    budget_total = sum(float(b.get("current_usage") or 0) for b in quota.get("budgets", []))
-    if math.fabs(budget_total - expected_total) <= 1e-12:
+    budget_total, model_total = quota_totals(quota)
+    if (math.fabs(budget_total - expected_total) <= 1e-12
+            and math.fabs(model_total - expected_total) <= 1e-12):
+        quota_ready = True
         break
     time.sleep(1)
 
-budget_current_usage_total = sum(float(b.get("current_usage") or 0) for b in quota.get("budgets", []))
-quota_model_total = 0.0
-for budget in quota.get("budgets", []):
-    for model_usage in budget.get("per_model_usage", []):
-        if model_usage.get("model") == "gpt-4o-mini" and model_usage.get("provider") == "openai":
-            quota_model_total += float(model_usage.get("total_cost") or 0)
+budget_current_usage_total, quota_model_total = quota_totals(quota)
 
 summary = {
     "expected_count": expected_count,
     "log_count": len(logs),
+    # Whether each poll converged or ran out its budget. A delta failure below reads very
+    # differently depending on these: converged means the numbers really disagree.
+    "logs_converged": logs_ready,
+    "quota_converged": quota_ready,
     "virtual_key_id": virtual_key_id,
     "expected_total": expected_total,
     "actual_total_from_logs": actual_total,

--- a/.github/workflows/scripts/test-cli-harness.sh
+++ b/.github/workflows/scripts/test-cli-harness.sh
@@ -40,6 +40,7 @@ BASE_URL="${BASE_URL:-http://localhost:$PORT}"
 APP_DIR="$REPO_ROOT/tmp/cli-harness-app"
 SERVER_LOG="$REPO_ROOT/tmp/bifrost-cli-harness.log"
 REPORTS_DIR="$REPO_ROOT/tests/e2e/clis/reports"
+CLI_TOOLS_DIR="$REPO_ROOT/tmp/cli-harness-tools"
 
 # CLI versions. In CI these are ALWAYS supplied by the environment: the
 # resolve-cli-versions job queries npm on every run and fans latest /
@@ -137,11 +138,38 @@ trap harness_stop_gateway EXIT
 
 source "$SCRIPT_DIR/setup-go-workspace.sh"
 
+# Resolve-then-`npm ci`, rather than `npm install -g <pkg>@<version>`.
+#
+# The three CLI versions themselves stay floating on purpose: resolve-cli-versions.sh
+# fans true-latest / latest-1 / latest-2 into the matrix because the job exists to
+# validate Bifrost against what a user actually gets from `npm i -g`. A committed
+# lockfile would defeat that, so this is not version pinning.
+#
+# What it does pin is the install. `npm install -g` re-resolves every transitive
+# dependency loosely at install time and records nothing. Resolving once into a
+# lockfile and then installing that exact tree with `npm ci` makes the full
+# closure integrity-checked, identical across the run, and auditable afterwards -
+# the lockfile is copied into the reports directory so a failed or suspicious run
+# has an exact manifest of what executed.
+#
+# Local prefix, not -g: node_modules/.bin on PATH is all the harness needs, since
+# the Go runner launches the CLIs by bare name (tests/e2e/clis/runner_test.go).
 echo "📦 Installing coding CLIs (pinned)..."
-npm install -g \
-  "@anthropic-ai/claude-code@$CLAUDE_CODE_VERSION" \
-  "@openai/codex@$CODEX_VERSION" \
-  "opencode-ai@$OPENCODE_VERSION"
+rm -rf "$CLI_TOOLS_DIR"
+mkdir -p "$CLI_TOOLS_DIR"
+printf '%s\n' '{"name":"bifrost-cli-harness-tools","version":"0.0.0","private":true}' \
+  > "$CLI_TOOLS_DIR/package.json"
+(
+  cd "$CLI_TOOLS_DIR"
+  npm install --package-lock-only --no-audit --no-fund \
+    "@anthropic-ai/claude-code@$CLAUDE_CODE_VERSION" \
+    "@openai/codex@$CODEX_VERSION" \
+    "opencode-ai@$OPENCODE_VERSION"
+  npm ci --no-audit --no-fund
+)
+export PATH="$CLI_TOOLS_DIR/node_modules/.bin:$PATH"
+mkdir -p "$REPORTS_DIR"
+cp "$CLI_TOOLS_DIR/package-lock.json" "$REPORTS_DIR/cli-tools-lock.json"
 echo "  claude:   $(claude --version 2>&1 | head -n1)"
 echo "  codex:    $(codex --version 2>&1 | head -n1)"
 echo "  opencode: $(opencode --version 2>&1 | head -n1)"

--- a/.github/workflows/tools/package-lock.json
+++ b/.github/workflows/tools/package-lock.json
@@ -1,0 +1,1811 @@
+{
+  "name": "bifrost-ci-tools",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bifrost-ci-tools",
+      "version": "0.0.0",
+      "dependencies": {
+        "newman": "6.2.1",
+        "newman-reporter-htmlextra": "1.23.1"
+      }
+    },
+    "node_modules/@budibase/handlebars-helpers": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@budibase/handlebars-helpers/-/handlebars-helpers-0.13.1.tgz",
+      "integrity": "sha512-v4RbXhr3igvK3i2pj5cNltu/4NMxdPIzcUt/o0RoInhesNH1VSLRdweSFr6/Y34fsCR5jHZ6vltdcz2RgrTKgw==",
+      "license": "MIT",
+      "dependencies": {
+        "get-object": "^0.2.0",
+        "get-value": "^3.0.1",
+        "handlebars": "^4.7.7",
+        "handlebars-utils": "^1.0.6",
+        "has-value": "^2.0.2",
+        "html-tag": "^2.0.0",
+        "is-glob": "^4.0.1",
+        "kind-of": "^6.0.3",
+        "micromatch": "^4.0.5",
+        "relative": "^3.0.2",
+        "striptags": "^3.1.1",
+        "to-gfm-code-block": "^0.1.1",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-5.5.3.tgz",
+      "integrity": "sha512-R11tGE6yIFwqpaIqcfkcg7AICXzFg14+5h5v0TfF/9+RMDL6jhzCy/pxHVOfbALGdtVYdt6JdR21tuxEgl34dw==",
+      "deprecated": "Please update to a newer version.",
+      "license": "MIT"
+    },
+    "node_modules/@postman/form-data": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@postman/form-data/-/form-data-3.1.1.tgz",
+      "integrity": "sha512-vjh8Q2a8S6UCm/KKs31XFJqEEgmbjBmpPNVV2eVav6905wyFAwaUOBGA1NPBI4ERH9MMZc6w0umFgM6WbEPMdg==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@postman/tough-cookie": {
+      "version": "4.1.3-postman.1",
+      "resolved": "https://registry.npmjs.org/@postman/tough-cookie/-/tough-cookie-4.1.3-postman.1.tgz",
+      "integrity": "sha512-txpgUqZOnWYnUHZpHjkfb0IwVH4qJmyq77pPnJLlfhMtdCLMFTEeQHlzQiK906aaNCe4NEB5fGJHo9uzGbFMeA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@postman/tunnel-agent": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@postman/tunnel-agent/-/tunnel-agent-0.6.8.tgz",
+      "integrity": "sha512-2U42SmZW5G+suEcS++zB94sBWNO4qD4bvETGFRFDTqSpYl5ksfjcPqzYpgQgXgUmb6dfz+fAGbkcRamounGm0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "integrity": "sha512-UfFSr22dmHPQqPP9XWHRhq+gWnHCYguQGkXQlbyPtW5qTnhFWA8/iXg765tH0cAjy7l/zPJ1aBTO0g5XgA7kvQ==",
+      "license": "MIT"
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.0.0.tgz",
+      "integrity": "sha512-xVgPpulCooDjY6zH4m9YW3jbkaBe3FKIAvF5sj5t7aBNsVl2ljIE+xwJ4iNgiDZHFQvNIpjdKdVOQvvk5ZfxbQ==",
+      "license": "MIT"
+    },
+    "node_modules/charset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/charset/-/charset-1.0.1.tgz",
+      "integrity": "sha512-6dVyOOYjpfFcL1Y4qChrAoQLRHvj2ziyhcm0QJlhOcAhykL/k1kTUPbeo+87MNRTRdk2OIIsIXbuF3x2wi5EXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/cli-progress": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
+      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.3"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "license": "MIT"
+    },
+    "node_modules/csv-parse": {
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
+      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==",
+      "license": "MIT"
+    },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
+    },
+    "node_modules/file-type": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+      "integrity": "sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/filesize": {
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.1.4.tgz",
+      "integrity": "sha512-ryBwPIIeErmxgPnm6cbESAzXjuEFubs+yKYLBZvg3CaiNcmkJChoOGcBSrZ6IwkMwPABwPpVXE6IlNdGJJrvEg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 10.4.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
+      "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
+      "license": "ISC"
+    },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-object": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/get-object/-/get-object-0.2.0.tgz",
+      "integrity": "sha512-7P6y6k6EzEFmO/XyUyFlXm1YLJy9xeA1x/grNV8276abX5GuwUtYgKFkRFkLixw4hf4Pz9q2vgv/8Ar42R0HuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^2.0.2",
+        "isobject": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/get-value": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-3.0.1.tgz",
+      "integrity": "sha512-mKZj9JLQrwMBtj5wxi6MH8Z5eSKaERpAwjg43dPtlGI1ZVEgH/qC7T8/6R2OBSUA+zzHBZgICsVJaEIV2tKTDA==",
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/get-value/node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/handlebars-utils": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/handlebars-utils/-/handlebars-utils-1.0.6.tgz",
+      "integrity": "sha512-d5mmoQXdeEqSKMtQQZ9WkiUcO1E3tPbWxluCK9hVgIDPzQa9WsKo3Lbe/sGflTe7TomHEeZaOgwIkyIr1kfzkw==",
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^6.0.0",
+        "typeof-article": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-value": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-2.0.2.tgz",
+      "integrity": "sha512-ybKOlcRsK2MqrM3Hmz/lQxXHZ6ejzSPzpNabKB45jb5qDgJvKPa3SdapTsTLwEb9WltgWpOmNax7i+DzNOk4TA==",
+      "license": "MIT",
+      "dependencies": {
+        "get-value": "^3.0.0",
+        "has-values": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/has-values": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-2.0.1.tgz",
+      "integrity": "sha512-+QdH3jOmq9P8GfdjFg0eJudqx1FqU62NQJ4P16rOEHeRdl7ckgwn6uqQjzYE0ZoHVV/e5E2esuJ5Gl5+HUW19w==",
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/html-tag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/html-tag/-/html-tag-2.0.0.tgz",
+      "integrity": "sha512-XxzooSo6oBoxBEUazgjdXj7VwTn/iSTSZzTYKzYY6I916tkaYzypHxy+pbVU1h+0UQ9JlVf5XkNQyxOAiiQO1g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-self-closing": "^1.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/http-reasons": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/http-reasons/-/http-reasons-0.1.0.tgz",
+      "integrity": "sha512-P6kYh0lKZ+y29T2Gqz+RlC9WBLhKe8kDmcJ+A+611jFfxdPsbMRQ5aNmFRM3lENqFkK+HTTL+tlQviAiv0AbLQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/http-signature": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
+      "integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^2.0.2",
+        "sshpk": "^1.14.1"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/httpntlm": {
+      "version": "1.8.13",
+      "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.8.13.tgz",
+      "integrity": "sha512-2F2FDPiWT4rewPzNMg3uPhNkP3NExENlUGADRUDPQvuftuUTGW98nLZtGemCIW3G40VhWZYgkIDcQFAwZ3mf2Q==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://www.paypal.com/donate/?hosted_button_id=2CKNJLZJBW8ZC"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/samdecrock"
+        }
+      ],
+      "dependencies": {
+        "des.js": "^1.0.1",
+        "httpreq": ">=0.4.22",
+        "js-md4": "^0.3.2",
+        "underscore": "~1.12.1"
+      },
+      "engines": {
+        "node": ">=10.4.0"
+      }
+    },
+    "node_modules/httpreq": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-1.1.1.tgz",
+      "integrity": "sha512-uhSZLPPD2VXXOSN8Cni3kIsoFHaU2pT/nySEU/fHr/ePbqHYr0jeiQRmUKLEirC09SFPsdMoA7LU7UXMd/w0Kw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.15.1"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha512-QUzH43Gfb9+5yckcrSA0VBDwEtDUchrk4F6tfJZQuNzDJbEDB9cZNzSfXGQ1jqmdDY/kl41lUOWM9syA8z8jlg==",
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-self-closing": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-self-closing/-/is-self-closing-1.0.1.tgz",
+      "integrity": "sha512-E+60FomW7Blv5GXTlYee2KDrnG6srxF7Xt1SjrhWUGUEsTFIqY/nq2y3DaftCsgUMdh89V07IVfhY9KIJhLezg==",
+      "license": "MIT",
+      "dependencies": {
+        "self-closing-tags": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "license": "MIT"
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/isobject": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz",
+      "integrity": "sha512-VaWq6XYAsbvM0wf4dyBO7WH9D7GosB7ZZlqrawI9BBiTMINBeCyqSKBa35m870MY3O4aM31pYyZi9DfGrYMJrQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "license": "MIT"
+    },
+    "node_modules/jose": {
+      "version": "4.14.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.14.4.tgz",
+      "integrity": "sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==",
+      "license": "MIT"
+    },
+    "node_modules/js-sha512": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha512/-/js-sha512-0.9.0.tgz",
+      "integrity": "sha512-mirki9WS/SUahm+1TbAPkqvbCiCfOAAsyXeHxK1UkullnJVVqoJG2pL9ObvT05CN+tM7fxhfYm0NbXn+1hWoZg==",
+      "license": "MIT"
+    },
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
+    "node_modules/jsprim": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
+      "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/liquid-json": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/liquid-json/-/liquid-json-0.3.1.tgz",
+      "integrity": "sha512-wUayTU8MS827Dam6MxgD72Ui+KOSF+u/eIqpatOtjnvgJ0+mnDq33uC2M7J0tPK+upe/DpUAuK4JUU89iBoNKQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-format": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mime-format/-/mime-format-2.0.1.tgz",
+      "integrity": "sha512-XxU3ngPbEnrYnNbIX+lYSaYg0M01v6p2ntd2YaFksTu0vayaw5OJvbdRyWs07EYRlLED5qadUZ+xo+XhOvFhwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "charset": "^1.0.0"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.35",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.35.tgz",
+      "integrity": "sha512-cY/pBOEXepQvlgli06ttCTKcIf8cD1nmNwOKQQAdHBqYApQSpAqotBMX0RJZNgMp6i0PlZuf1mFtnlyEkwyvFw==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": ">= 2.9.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "license": "MIT"
+    },
+    "node_modules/newman": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/newman/-/newman-6.2.1.tgz",
+      "integrity": "sha512-Zq8Sr5GFF+OXs5yIbyglLMKMh1WNMjYVV0yZaSBZ+DIgQOIWcxT8QTfbrl/YUGrLyT4rjpu+yZ/Z+kozw79GEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@postman/tough-cookie": "4.1.3-postman.1",
+        "async": "3.2.5",
+        "chardet": "2.0.0",
+        "cli-progress": "3.12.0",
+        "cli-table3": "0.6.5",
+        "colors": "1.4.0",
+        "commander": "11.1.0",
+        "csv-parse": "4.16.3",
+        "filesize": "10.1.4",
+        "liquid-json": "0.3.1",
+        "lodash": "4.17.21",
+        "mkdirp": "3.0.1",
+        "postman-collection": "4.4.0",
+        "postman-collection-transformer": "4.1.8",
+        "postman-request": "2.88.1-postman.34",
+        "postman-runtime": "7.39.1",
+        "pretty-ms": "7.0.1",
+        "semver": "7.6.3",
+        "serialised-error": "1.1.3",
+        "word-wrap": "1.2.5",
+        "xmlbuilder": "15.1.1"
+      },
+      "bin": {
+        "newman": "bin/newman.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/newman-reporter-htmlextra": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/newman-reporter-htmlextra/-/newman-reporter-htmlextra-1.23.1.tgz",
+      "integrity": "sha512-ufa7QBel1DBBjBwsoMbZVlooO44I5yGBls/Z+5qyVpYKaPOpSzIfUVURdiF85YNyRKkQqyaYTp2QJWif4SJoiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@budibase/handlebars-helpers": "0.13.1",
+        "chalk": "4.1.2",
+        "cli-progress": "3.10.0",
+        "commander": "6.2.1",
+        "filesize": "6.4.0",
+        "handlebars": "4.7.7",
+        "lodash": "4.17.21",
+        "moment-timezone": "0.5.35",
+        "pretty-ms": "7.0.1"
+      },
+      "bin": {
+        "newman-reporter-htmlextra": "bin/htmlextra.js"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "newman": "^6.0.0"
+      }
+    },
+    "node_modules/newman-reporter-htmlextra/node_modules/cli-progress": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.10.0.tgz",
+      "integrity": "sha512-kLORQrhYCAtUPLZxqsAt2YJGOvRdt34+O6jl5cQGb7iF3dM55FQZlTR+rQyIK9JUcO9bBMwZsTlND+3dmFU2Cw==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/newman-reporter-htmlextra/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/newman-reporter-htmlextra/node_modules/filesize": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.4.0.tgz",
+      "integrity": "sha512-mjFIpOHC4jbfcTfoh4rkWpI31mF7viw9ikj/JyLoKzqlwG/YsefKfvYlYhdYdg/9mtK2z1AzgN/0LvVQ3zdlSQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/node-oauth1": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/node-oauth1/-/node-oauth1-1.3.0.tgz",
+      "integrity": "sha512-0yggixNfrA1KcBwvh/Hy2xAS1Wfs9dcg6TdFf2zN7gilcAigMdrtZ4ybrBSXBgLvGDw9V1p2MRnGBMq7XjTWLg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
+      "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
+      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postman-collection": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-4.4.0.tgz",
+      "integrity": "sha512-2BGDFcUwlK08CqZFUlIC8kwRJueVzPjZnnokWPtJCd9f2J06HBQpGL7t2P1Ud1NEsK9NHq9wdipUhWLOPj5s/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@faker-js/faker": "5.5.3",
+        "file-type": "3.9.0",
+        "http-reasons": "0.1.0",
+        "iconv-lite": "0.6.3",
+        "liquid-json": "0.3.1",
+        "lodash": "4.17.21",
+        "mime-format": "2.0.1",
+        "mime-types": "2.1.35",
+        "postman-url-encoder": "3.0.5",
+        "semver": "7.5.4",
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/postman-collection-transformer": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/postman-collection-transformer/-/postman-collection-transformer-4.1.8.tgz",
+      "integrity": "sha512-smJ6X7Z7kbg6hp7JZPFixrSN3J3WkQed7DrWCC5tF7IxOMpFLqhtTtGssY8nD1inP8+mJf+N72Pf2ttUAHgBKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "commander": "8.3.0",
+        "inherits": "2.0.4",
+        "lodash": "4.17.21",
+        "semver": "7.5.4",
+        "strip-json-comments": "3.1.1"
+      },
+      "bin": {
+        "postman-collection-transformer": "bin/transform-collection.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/postman-collection-transformer/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/postman-collection-transformer/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/postman-collection/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/postman-collection/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/postman-request": {
+      "version": "2.88.1-postman.34",
+      "resolved": "https://registry.npmjs.org/postman-request/-/postman-request-2.88.1-postman.34.tgz",
+      "integrity": "sha512-GkolJ4cIzgamcwHRDkeZc/taFWO1u2HuGNML47K9ZAsFH2LdEkS5Yy8QanpzhjydzV3WWthl9v60J8E7SjKodQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@postman/form-data": "~3.1.1",
+        "@postman/tough-cookie": "~4.1.3-postman.1",
+        "@postman/tunnel-agent": "^0.6.3",
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.12.0",
+        "brotli": "^1.3.3",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.3.1",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "^2.1.35",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.3",
+        "safe-buffer": "^5.1.2",
+        "stream-length": "^1.0.2",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postman-request/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/postman-runtime": {
+      "version": "7.39.1",
+      "resolved": "https://registry.npmjs.org/postman-runtime/-/postman-runtime-7.39.1.tgz",
+      "integrity": "sha512-IRNrBE0l1K3ZqQhQVYgF6MPuqOB9HqYncal+a7RpSS+sysKLhJMkC9SfUn1HVuOpokdPkK92ykvPzj8kCOLYAg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@postman/tough-cookie": "4.1.3-postman.1",
+        "async": "3.2.5",
+        "aws4": "1.12.0",
+        "handlebars": "4.7.8",
+        "httpntlm": "1.8.13",
+        "jose": "4.14.4",
+        "js-sha512": "0.9.0",
+        "lodash": "4.17.21",
+        "mime-types": "2.1.35",
+        "node-forge": "1.3.1",
+        "node-oauth1": "1.3.0",
+        "performance-now": "2.1.0",
+        "postman-collection": "4.4.0",
+        "postman-request": "2.88.1-postman.34",
+        "postman-sandbox": "4.7.1",
+        "postman-url-encoder": "3.0.5",
+        "serialised-error": "1.1.3",
+        "strip-json-comments": "3.1.1",
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postman-runtime/node_modules/aws4": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
+      "license": "MIT"
+    },
+    "node_modules/postman-runtime/node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/postman-runtime/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/postman-sandbox": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/postman-sandbox/-/postman-sandbox-4.7.1.tgz",
+      "integrity": "sha512-H2wYSLK0mB588IaxoLrLoPbpmxsIcwFtgaK2c8gAsAQ+TgYFePwb4qdeVcYDMqmwrLd77/ViXkjasP/sBMz1sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash": "4.17.21",
+        "postman-collection": "4.4.0",
+        "teleport-javascript": "1.0.0",
+        "uvm": "2.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/postman-url-encoder": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/postman-url-encoder/-/postman-url-encoder-3.0.5.tgz",
+      "integrity": "sha512-jOrdVvzUXBC7C+9gkIkpDJ3HIxOHTIqjpQ4C1EMt1ZGeMvSEpbFCKq23DEfgsj46vMnDgyQf+1ZLp2Wm+bKSsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
+      "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.5.tgz",
+      "integrity": "sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
+    "node_modules/relative": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/relative/-/relative-3.0.2.tgz",
+      "integrity": "sha512-Q5W2qeYtY9GbiR8z1yHNZ1DGhyjb4AnLEjt8iE6XfcC1QIu+FAtj3HQaO0wH28H1mX6cqNLvAqWhP402dxJGyA==",
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/relative/node_modules/isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/self-closing-tags": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/self-closing-tags/-/self-closing-tags-1.0.1.tgz",
+      "integrity": "sha512-7t6hNbYMxM+VHXTgJmxwgZgLGktuXtVVD5AivWzNTdJBM4DBjnDKDzkf2SrNjihaArpeJYNjxkELBu1evI4lQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/serialised-error": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/serialised-error/-/serialised-error-1.1.3.tgz",
+      "integrity": "sha512-vybp3GItaR1ZtO2nxZZo8eOo7fnVaNtP3XE2vJKgzkKR2bagCkdJ1EpYYhEMd3qu/80DwQk9KjsNSxE3fXWq0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "object-hash": "^1.1.2",
+        "stack-trace": "0.0.9",
+        "uuid": "^3.0.0"
+      }
+    },
+    "node_modules/serialised-error/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sshpk": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+      "integrity": "sha512-vjUc6sfgtgY0dxCdnc40mK6Oftjo9+2K8H/NG81TMhgL392FtiPA9tn9RLyTxXmTLPJPjF3VyzFp6bsWFLisMQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/stream-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stream-length/-/stream-length-1.0.2.tgz",
+      "integrity": "sha512-aI+qKFiwoDV4rsXiS7WRoCt+v2RX1nUj17+KJC5r2gfh5xoSJIfP6Y3Do/HtvesFcTSWthIuJ3l1cvKQY/+nZg==",
+      "license": "WTFPL",
+      "dependencies": {
+        "bluebird": "^2.6.2"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/striptags": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.2.0.tgz",
+      "integrity": "sha512-g45ZOGzHDMe2bdYMdIvdAfCQkCTDMGBazSw1ypMowwGIee7ZQ5dU0rBJ8Jqgl+jAKIv4dbeE1jscZq9wid1Tkw==",
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/teleport-javascript": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/teleport-javascript/-/teleport-javascript-1.0.0.tgz",
+      "integrity": "sha512-j1llvWVFyEn/6XIFDfX5LAU43DXe0GCt3NfXDwJ8XpRRMkS+i50SAkonAONBy+vxwPFBd50MFU8a2uj8R/ccLg==",
+      "license": "ISC"
+    },
+    "node_modules/to-gfm-code-block": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/to-gfm-code-block/-/to-gfm-code-block-0.1.1.tgz",
+      "integrity": "sha512-LQRZWyn8d5amUKnfR9A9Uu7x9ss7Re8peuWR2gkh1E+ildOfv2aF26JpuDg8JtvCduu5+hOrMIH+XstZtnagqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/to-regex-range/node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense"
+    },
+    "node_modules/typeof-article": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/typeof-article/-/typeof-article-0.1.1.tgz",
+      "integrity": "sha512-Vn42zdX3FhmUrzEmitX3iYyLb+Umwpmv8fkZRIknYh84lmdrwqZA5xYaoKiIj2Rc5i/5wcDrpUmZcbk1U51vTw==",
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/typeof-article/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/underscore": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==",
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/uvm": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/uvm/-/uvm-2.1.1.tgz",
+      "integrity": "sha512-BZ5w8adTpNNr+zczOBRpaX/hH8UPKAf7fmCnidrcsqt3bn8KT9bDIfuS7hgRU9RXgiN01su2pwysBONY6w8W5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "flatted": "3.2.6"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "license": "MIT"
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    }
+  }
+}

--- a/.github/workflows/tools/package.json
+++ b/.github/workflows/tools/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "bifrost-ci-tools",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Pinned CI-only CLI tooling (newman). Not published, not part of the product build. Installed with `npm ci` so package-lock.json's integrity hashes are enforced, which is what OpenSSF Scorecard's Pinned-Dependencies check requires; a bare `npm install -g newman@x` pins the version but verifies nothing.",
+  "dependencies": {
+    "newman": "6.2.1",
+    "newman-reporter-htmlextra": "1.23.1"
+  }
+}

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -34,8 +34,15 @@ jobs:
 
       # PyYAML only - deliberately no apt-get here, so this job needs no Ubuntu
       # mirror access and stays outside the very rule it enforces.
+      #
+      # --require-hashes against a checked-in pin: an unpinned `pip install pyyaml`
+      # takes whatever the index serves at run time, which is what Scorecard's
+      # Pinned-Dependencies check flags. pip verifies every downloaded artifact
+      # against requirements/pyyaml.txt and fails closed on a mismatch.
       - name: Install PyYAML
-        run: python3 -m pip install --user --disable-pip-version-check pyyaml
+        run: |
+          python3 -m pip install --user --disable-pip-version-check \
+            --require-hashes -r .github/workflows/requirements/pyyaml.txt
 
       - name: Check egress allowlists
         run: ./.github/workflows/scripts/check-egress-allowlist.sh

--- a/core/internal/schemaorder/schemaorder.go
+++ b/core/internal/schemaorder/schemaorder.go
@@ -1,0 +1,191 @@
+// Package schemaorder provides shared fixtures and assertions for the
+// response_format / JSON Schema key-order tests.
+//
+// OpenAI Structured Outputs generates fields in the order the schema declares
+// them ("outputs will be produced in the same order as the ordering of keys in
+// the schema" - https://developers.openai.com/api/docs/guides/structured-outputs),
+// so a gateway that re-sorts a user's schema silently changes model behavior.
+// Every provider that forwards or rewrites a JSON Schema must preserve the
+// declared key order; these helpers are how each provider package asserts it.
+package schemaorder
+
+import (
+	"strings"
+	"testing"
+)
+
+// ChatBody is a chat/completions body whose JSON Schema is deliberately written
+// in non-alphabetical order: `reasoning` before `assigned_group_id` (so the
+// model explains before it decides), and schema keys as type/title/description/
+// properties/required/additionalProperties.
+const ChatBody = `{
+  "model": "gpt-5.4-nano",
+  "messages": [{"role": "user", "content": "assign it"}],
+  "response_format": {
+    "type": "json_schema",
+    "json_schema": {
+      "name": "AssignmentResult",
+      "description": "Assignment result for a single activity.",
+      "schema": {
+        "type": "object",
+        "title": "AssignmentResult",
+        "description": "Assignment result for a single activity.",
+        "properties": {
+          "reasoning": {
+            "type": "string",
+            "title": "Reasoning",
+            "description": "Brief explanation of the assignment decision"
+          },
+          "assigned_group_id": {
+            "anyOf": [{"type": "integer"}, {"type": "null"}],
+            "title": "Assigned Group ID",
+            "description": "The group ID to assign the activity to, or null if no good match"
+          }
+        },
+        "required": ["assigned_group_id", "reasoning"],
+        "additionalProperties": false
+      },
+      "strict": true
+    }
+  }
+}`
+
+// ResponsesBody is the Responses API equivalent of ChatBody, carrying the same
+// schema under text.format.
+const ResponsesBody = `{
+  "model": "gpt-5.4-nano",
+  "input": [{"role": "user", "content": "assign it"}],
+  "text": {
+    "format": {
+      "type": "json_schema",
+      "name": "AssignmentResult",
+      "schema": {
+        "type": "object",
+        "title": "AssignmentResult",
+        "description": "Assignment result for a single activity.",
+        "properties": {
+          "reasoning": {
+            "type": "string",
+            "title": "Reasoning",
+            "description": "Brief explanation of the assignment decision"
+          },
+          "assigned_group_id": {
+            "anyOf": [{"type": "integer"}, {"type": "null"}],
+            "title": "Assigned Group ID",
+            "description": "The group ID to assign the activity to, or null if no good match"
+          }
+        },
+        "required": ["assigned_group_id", "reasoning"],
+        "additionalProperties": false
+      },
+      "strict": true
+    }
+  }
+}`
+
+// ByteExactSchema is a JSON Schema that no provider needs to rewrite: it has no
+// union type arrays, so every normalizer is an identity transform on it. It
+// therefore must reach the wire byte for byte, which pins two things a
+// parse-and-re-encode gateway cannot deliver:
+//
+//   - 9007199254740993 exceeds float64's exact integer range and comes back as
+//     ...992 once it round-trips through a Go number.
+//   - 1.0 re-encodes as 1.
+//
+// Written compact and with deliberately non-alphabetical keys so a byte
+// comparison against the outgoing payload is meaningful.
+const ByteExactSchema = `{"type":"object","title":"AssignmentResult","description":"Assignment result for a single activity.","properties":{"reasoning":{"type":"string","title":"Reasoning"},"assigned_group_id":{"type":"integer","title":"Assigned Group ID","enum":[9007199254740993,7],"multipleOf":1.0}},"required":["assigned_group_id","reasoning"],"additionalProperties":false}`
+
+// ByteExactChatBody is a chat/completions body carrying ByteExactSchema.
+const ByteExactChatBody = `{"model":"gpt-5.4-nano","messages":[{"role":"user","content":"assign it"}],"response_format":{"type":"json_schema","json_schema":{"name":"AssignmentResult","schema":` + ByteExactSchema + `,"strict":true}}}`
+
+// AssertSchemaBytes fails the test unless the schema under key in wire is
+// byte-identical to ByteExactSchema. key names the field holding the schema on
+// this provider's wire.
+func AssertSchemaBytes(t *testing.T, wire string, key string) {
+	t.Helper()
+	got := ObjectAfterKey(t, wire, key)
+	if got != ByteExactSchema {
+		t.Errorf("schema was rewritten on the way out\n want: %s\n  got: %s", ByteExactSchema, got)
+	}
+}
+
+// PropertyOrder is the order in which ChatBody declares its schema properties.
+var PropertyOrder = []string{"reasoning", "assigned_group_id"}
+
+// SchemaKeyOrder is the order in which ChatBody declares the schema object's own keys.
+var SchemaKeyOrder = []string{"type", "title", "description", "properties", "required", "additionalProperties"}
+
+// AssertKeyOrder fails the test unless the given JSON keys appear in wire in the
+// given relative order. It matches on the first occurrence of `"key"`, which is
+// sufficient for these fixtures because every asserted key is unique within the
+// schema blob.
+func AssertKeyOrder(t *testing.T, wire string, keys ...string) {
+	t.Helper()
+	prev, prevKey := -1, ""
+	for _, k := range keys {
+		idx := strings.Index(wire, `"`+k+`"`)
+		if idx == -1 {
+			t.Fatalf("key %q missing from payload: %s", k, wire)
+		}
+		if idx <= prev {
+			t.Errorf("key %q must be serialized after %q, but came before it\npayload: %s", k, prevKey, wire)
+		}
+		prev, prevKey = idx, k
+	}
+}
+
+// AssertPropertyOrder asserts the schema properties reached the wire in declared order.
+func AssertPropertyOrder(t *testing.T, wire string) {
+	t.Helper()
+	AssertKeyOrder(t, wire, PropertyOrder...)
+}
+
+// AssertSchemaKeyOrder asserts the schema object's own keys reached the wire in
+// declared order. key names the field holding the schema on this provider's wire
+// ("schema" for OpenAI-shaped payloads, "responseJsonSchema" for Gemini,
+// "inputSchema"/"json" for Bedrock tools, and so on), because the same key names
+// also appear at outer levels of the payload.
+func AssertSchemaKeyOrder(t *testing.T, wire string, key string) {
+	t.Helper()
+	AssertKeyOrder(t, ObjectAfterKey(t, wire, key), SchemaKeyOrder...)
+}
+
+// ObjectAfterKey returns the balanced JSON object that follows the first
+// occurrence of "key" in wire. It fails the test if no object follows.
+func ObjectAfterKey(t *testing.T, wire string, key string) string {
+	t.Helper()
+	at := strings.Index(wire, `"`+key+`"`)
+	if at == -1 {
+		t.Fatalf("key %q missing from payload: %s", key, wire)
+	}
+	start := strings.Index(wire[at:], "{")
+	if start == -1 {
+		t.Fatalf("no object follows key %q in payload: %s", key, wire)
+	}
+	start += at
+
+	depth, inString, escaped := 0, false, false
+	for i := start; i < len(wire); i++ {
+		c := wire[i]
+		switch {
+		case escaped:
+			escaped = false
+		case c == '\\' && inString:
+			escaped = true
+		case c == '"':
+			inString = !inString
+		case inString:
+			// literal content, nothing to balance
+		case c == '{':
+			depth++
+		case c == '}':
+			depth--
+			if depth == 0 {
+				return wire[start : i+1]
+			}
+		}
+	}
+	t.Fatalf("unbalanced object after key %q in payload: %s", key, wire)
+	return ""
+}

--- a/core/providers/anthropic/responseformatordering_test.go
+++ b/core/providers/anthropic/responseformatordering_test.go
@@ -1,0 +1,112 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/internal/schemaorder"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/require"
+)
+
+func orderingChatRequest(t *testing.T, provider schemas.ModelProvider) *schemas.BifrostChatRequest {
+	t.Helper()
+	var params schemas.ChatParameters
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ChatBody), &params))
+	return &schemas.BifrostChatRequest{
+		Provider: provider,
+		Model:    "claude-opus-4-5",
+		Input: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("assign it")},
+		}},
+		Params: &params,
+	}
+}
+
+// TestResponseFormatOrderNativeStructuredOutputs covers the Anthropic-native
+// path, where response_format becomes output_config.format.
+func TestResponseFormatOrderNativeStructuredOutputs(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	out, err := ToAnthropicChatRequest(ctx, orderingChatRequest(t, schemas.Anthropic))
+	require.NoError(t, err)
+	require.NotNil(t, out.OutputConfig)
+
+	raw, err := providerUtils.MarshalSorted(out)
+	require.NoError(t, err)
+	schemaorder.AssertPropertyOrder(t, string(raw))
+	schemaorder.AssertSchemaKeyOrder(t, string(raw), "schema")
+}
+
+// TestResponseFormatOrderToolFallback covers Vertex/Bedrock Mantle/Azure, where
+// the schema is rewritten into a forced tool's input_schema.
+func TestResponseFormatOrderToolFallback(t *testing.T) {
+	for _, provider := range []schemas.ModelProvider{schemas.Vertex, schemas.BedrockMantle, schemas.Azure} {
+		t.Run(string(provider), func(t *testing.T) {
+			ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+			out, err := ToAnthropicChatRequest(ctx, orderingChatRequest(t, provider))
+			require.NoError(t, err)
+			require.NotEmpty(t, out.Tools, "structured output must survive as a tool")
+
+			raw, err := providerUtils.MarshalSorted(out)
+			require.NoError(t, err)
+			schemaorder.AssertPropertyOrder(t, string(raw))
+		})
+	}
+}
+
+// TestResponseFormatSchemaBytesReachAnthropicVerbatim: Anthropic's normalizer
+// only rewrites union type arrays, of which this schema has none, so
+// output_config.format.schema must carry the client's bytes unchanged.
+//
+// The Vertex/Mantle tool fallback is deliberately not byte-checked: there the
+// schema becomes a tool's typed input_schema, so re-encoding is inherent to the
+// rewrite. Key order on that path is covered by TestResponseFormatOrderToolFallback.
+func TestResponseFormatSchemaBytesReachAnthropicVerbatim(t *testing.T) {
+	var params schemas.ChatParameters
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ByteExactChatBody), &params))
+
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	out, err := ToAnthropicChatRequest(ctx, &schemas.BifrostChatRequest{
+		Provider: schemas.Anthropic,
+		Model:    "claude-opus-4-5",
+		Input: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("assign it")},
+		}},
+		Params: &params,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, out.OutputConfig)
+
+	raw, err := providerUtils.MarshalSorted(out)
+	require.NoError(t, err)
+	schemaorder.AssertSchemaBytes(t, string(raw), "schema")
+}
+
+func orderingResponsesRequest(t *testing.T, provider schemas.ModelProvider) *schemas.BifrostResponsesRequest {
+	t.Helper()
+	var params schemas.ResponsesParameters
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ResponsesBody), &params))
+	return &schemas.BifrostResponsesRequest{
+		Provider: provider,
+		Model:    "claude-opus-4-5",
+		Input: []schemas.ResponsesMessage{{
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("assign it")},
+		}},
+		Params: &params,
+	}
+}
+
+// TestResponseFormatOrderSurvivesAnthropicResponses covers the Responses method,
+// where the schema arrives under text.format rather than response_format.
+func TestResponseFormatOrderSurvivesAnthropicResponses(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	out, err := ToAnthropicResponsesRequest(ctx, orderingResponsesRequest(t, schemas.Anthropic))
+	require.NoError(t, err)
+
+	raw, err := providerUtils.MarshalSorted(out)
+	require.NoError(t, err)
+	schemaorder.AssertPropertyOrder(t, string(raw))
+}

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -2264,30 +2264,18 @@ func convertChatResponseFormatToTool(ctx *schemas.BifrostContext, params *schema
 	}
 
 	// ResponseFormat is stored as interface{}, need to parse it
-	responseFormatMap, ok := (*params.ResponseFormat).(map[string]interface{})
-	if !ok {
-		return nil
-	}
-
-	// Check if type is "json_schema"
-	formatType, ok := responseFormatMap["type"].(string)
-	if !ok || formatType != "json_schema" {
-		return nil
-	}
-
-	// Extract json_schema object
-	jsonSchemaObj, ok := responseFormatMap["json_schema"].(map[string]interface{})
-	if !ok {
+	rf, ok := schemas.ParseChatResponseFormat(params.ResponseFormat)
+	if !ok || rf.Type != "json_schema" || !rf.HasJSONSchema() {
 		return nil
 	}
 
 	// Extract name and schema
-	toolName, ok := jsonSchemaObj["name"].(string)
+	toolName, ok := rf.Name()
 	if !ok || toolName == "" {
 		toolName = "json_response"
 	}
 
-	schemaOrdered, ok := schemas.SafeExtractOrderedMap(jsonSchemaObj["schema"])
+	schemaOrdered, ok := rf.SchemaMap()
 	if !ok {
 		return nil
 	}
@@ -3451,19 +3439,8 @@ func convertChatResponseFormatToAnthropicOutputFormat(responseFormat *interface{
 		return nil
 	}
 
-	formatMap, ok := (*responseFormat).(map[string]interface{})
-	if !ok {
-		return nil
-	}
-
-	formatType, ok := formatMap["type"].(string)
-	if !ok || formatType != "json_schema" {
-		return nil
-	}
-
-	// Extract the nested json_schema object
-	jsonSchemaObj, ok := formatMap["json_schema"].(map[string]interface{})
-	if !ok {
+	rf, ok := schemas.ParseChatResponseFormat(responseFormat)
+	if !ok || rf.Type != "json_schema" || !rf.HasJSONSchema() {
 		return nil
 	}
 
@@ -3471,12 +3448,14 @@ func convertChatResponseFormatToAnthropicOutputFormat(responseFormat *interface{
 	// Note: name, description, and strict are NOT included as they are not permitted
 	// in Anthropic's GA structured outputs API (output_config.format)
 	outputFormat := map[string]interface{}{
-		"type": formatType,
+		"type": rf.Type,
 	}
 
-	if schema, ok := schemas.SafeExtractOrderedMap(jsonSchemaObj["schema"]); ok {
-		// Normalize the schema to handle type arrays like ["string", "null"]
-		outputFormat["schema"] = normalizeOrderedSchemaForAnthropic(schema)
+	// Normalize the schema to handle type arrays like ["string", "null"]. The raw
+	// normalizer edits the client's bytes in place with sjson, so a schema that
+	// needs no normalization reaches Anthropic exactly as it was sent.
+	if schema := rf.RawSchema(); len(schema) > 0 {
+		outputFormat["schema"] = NormalizeSchemaForAnthropicRaw(schema)
 	}
 
 	result, err := providerUtils.MarshalSorted(outputFormat)

--- a/core/providers/bedrock/responseformatordering_test.go
+++ b/core/providers/bedrock/responseformatordering_test.go
@@ -1,0 +1,79 @@
+package bedrock
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/internal/schemaorder"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResponseFormatOrderSurvivesBedrockConverse covers Bedrock, where
+// structured output is rewritten into a synthetic tool's input schema.
+func TestResponseFormatOrderSurvivesBedrockConverse(t *testing.T) {
+	var params schemas.ChatParameters
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ChatBody), &params))
+
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	out, err := ToBedrockChatCompletionRequest(ctx, &schemas.BifrostChatRequest{
+		Provider: schemas.Bedrock,
+		Model:    "anthropic.claude-sonnet-4-20250514-v1:0",
+		Input: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("assign it")},
+		}},
+		Params: &params,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, out.ToolConfig, "structured output must survive as a tool")
+
+	raw, err := providerUtils.MarshalSorted(out)
+	require.NoError(t, err)
+	schemaorder.AssertPropertyOrder(t, string(raw))
+}
+
+// TestResponseFormatSchemaBytesReachBedrockVerbatim: the schema becomes a tool's
+// input schema, which Bedrock carries as raw JSON, so no re-encoding is needed.
+func TestResponseFormatSchemaBytesReachBedrockVerbatim(t *testing.T) {
+	var params schemas.ChatParameters
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ByteExactChatBody), &params))
+
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	out, err := ToBedrockChatCompletionRequest(ctx, &schemas.BifrostChatRequest{
+		Provider: schemas.Bedrock,
+		Model:    "anthropic.claude-sonnet-4-20250514-v1:0",
+		Input: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("assign it")},
+		}},
+		Params: &params,
+	})
+	require.NoError(t, err)
+
+	raw, err := providerUtils.MarshalSorted(out)
+	require.NoError(t, err)
+	schemaorder.AssertSchemaBytes(t, string(raw), "json")
+}
+
+// TestResponseFormatOrderSurvivesBedrockResponses covers the Responses method.
+func TestResponseFormatOrderSurvivesBedrockResponses(t *testing.T) {
+	var params schemas.ResponsesParameters
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ResponsesBody), &params))
+
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	out, err := ToBedrockResponsesRequest(ctx, &schemas.BifrostResponsesRequest{
+		Provider: schemas.Bedrock,
+		Model:    "anthropic.claude-sonnet-4-20250514-v1:0",
+		Input: []schemas.ResponsesMessage{{
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("assign it")},
+		}},
+		Params: &params,
+	})
+	require.NoError(t, err)
+
+	raw, err := providerUtils.MarshalSorted(out)
+	require.NoError(t, err)
+	schemaorder.AssertPropertyOrder(t, string(raw))
+}

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/bytedance/sonic"
 	"github.com/cespare/xxhash/v2"
+	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 
 	"github.com/maximhq/bifrost/core/providers/anthropic"
@@ -1581,33 +1582,16 @@ func convertResponseFormatToTool(
 		return nil, nil
 	}
 
-	responseFormatMap, ok := schemas.SafeExtractOrderedMap(*params.ResponseFormat)
-	if !ok || responseFormatMap == nil {
+	rf, ok := schemas.ParseChatResponseFormat(params.ResponseFormat)
+	if !ok || rf.Type != "json_schema" || !rf.HasJSONSchema() {
 		return nil, nil
 	}
 
-	// Check if type is "json_schema"
-	formatTypeRaw, ok := responseFormatMap.Get("type")
-	if !ok {
-		return nil, nil
-	}
-	formatType, ok := schemas.SafeExtractString(formatTypeRaw)
-	if !ok || formatType != "json_schema" {
-		return nil, nil
-	}
-
-	// Extract json_schema object
-	jsonSchemaRaw, ok := responseFormatMap.Get("json_schema")
-	if !ok {
-		return nil, nil
-	}
-	jsonSchemaObj, ok := schemas.SafeExtractOrderedMap(jsonSchemaRaw)
-	if !ok || jsonSchemaObj == nil {
-		return nil, nil
-	}
-
-	schemaObj, ok := jsonSchemaObj.Get("schema")
-	if !ok {
+	// Bedrock carries a tool's input schema as raw JSON, so the client's schema
+	// bytes go through untouched: no re-encoding, no key reordering, no numeric
+	// precision loss.
+	schemaBytes := rf.RawSchema()
+	if len(schemaBytes) == 0 {
 		return nil, nil
 	}
 
@@ -1616,24 +1600,15 @@ func convertResponseFormatToTool(
 	// Converse's inconsistent support across Claude variants.
 
 	// Extract name and schema
-	toolNameRaw, hasName := jsonSchemaObj.Get("name")
-	toolName, ok := schemas.SafeExtractString(toolNameRaw)
-	if !hasName || !ok || toolName == "" {
+	toolName, ok := rf.Name()
+	if !ok || toolName == "" {
 		toolName = "json_response"
 	}
 
 	// Extract description from schema if available
 	description := "Returns structured JSON output"
-	if schemaMap, ok := schemas.SafeExtractOrderedMap(schemaObj); ok && schemaMap != nil {
-		if descRaw, hasDesc := schemaMap.Get("description"); hasDesc {
-			if desc, ok := schemas.SafeExtractString(descRaw); ok && desc != "" {
-				description = desc
-			}
-		}
-	} else if schemaMap, ok := schemaObj.(map[string]interface{}); ok {
-		if desc, ok := schemaMap["description"].(string); ok && desc != "" {
-			description = desc
-		}
+	if desc := gjson.GetBytes(schemaBytes, "description"); desc.Type == gjson.String && desc.String() != "" {
+		description = desc.String()
 	}
 
 	// set bifrost context key structured output tool name
@@ -1641,16 +1616,12 @@ func convertResponseFormatToTool(
 	ctx.SetValue(schemas.BifrostContextKeyStructuredOutputToolName, toolName)
 
 	// Create the Bedrock tool
-	schemaObjBytes, err := providerUtils.MarshalSorted(schemaObj)
-	if err != nil {
-		return nil, nil
-	}
 	return &BedrockTool{
 		ToolSpec: &BedrockToolSpec{
 			Name:        toolName,
 			Description: schemas.Ptr(description),
 			InputSchema: BedrockToolInputSchema{
-				JSON: json.RawMessage(schemaObjBytes),
+				JSON: schemaBytes,
 			},
 		},
 	}, nil

--- a/core/providers/cohere/responseformatordering_test.go
+++ b/core/providers/cohere/responseformatordering_test.go
@@ -1,0 +1,78 @@
+package cohere
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/internal/schemaorder"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResponseFormatOrderSurvivesCohereChat covers Cohere, which flattens
+// response_format into {type: json_object, json_schema: <schema>}.
+func TestResponseFormatOrderSurvivesCohereChat(t *testing.T) {
+	var params schemas.ChatParameters
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ChatBody), &params))
+
+	out, err := ToCohereChatCompletionRequest(&schemas.BifrostChatRequest{
+		Provider: schemas.Cohere,
+		Model:    "command-r-plus",
+		Input: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("assign it")},
+		}},
+		Params: &params,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, out.ResponseFormat, "structured output must reach Cohere")
+	require.NotNil(t, out.ResponseFormat.JSONSchema)
+
+	raw, err := providerUtils.MarshalSorted(out)
+	require.NoError(t, err)
+	schemaorder.AssertPropertyOrder(t, string(raw))
+	schemaorder.AssertSchemaKeyOrder(t, string(raw), "json_schema")
+}
+
+// TestResponseFormatSchemaBytesReachCohereVerbatim: Cohere relocates the schema
+// but never rewrites it, so the schema body must survive byte for byte.
+func TestResponseFormatSchemaBytesReachCohereVerbatim(t *testing.T) {
+	var params schemas.ChatParameters
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ByteExactChatBody), &params))
+
+	out, err := ToCohereChatCompletionRequest(&schemas.BifrostChatRequest{
+		Provider: schemas.Cohere,
+		Model:    "command-r-plus",
+		Input: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("assign it")},
+		}},
+		Params: &params,
+	})
+	require.NoError(t, err)
+
+	raw, err := providerUtils.MarshalSorted(out)
+	require.NoError(t, err)
+	schemaorder.AssertSchemaBytes(t, string(raw), "json_schema")
+}
+
+// TestResponseFormatOrderSurvivesCohereResponses covers the Responses method.
+func TestResponseFormatOrderSurvivesCohereResponses(t *testing.T) {
+	var params schemas.ResponsesParameters
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ResponsesBody), &params))
+
+	out, err := ToCohereResponsesRequest(&schemas.BifrostResponsesRequest{
+		Provider: schemas.Cohere,
+		Model:    "command-r-plus",
+		Input: []schemas.ResponsesMessage{{
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("assign it")},
+		}},
+		Params: &params,
+	})
+	require.NoError(t, err)
+
+	raw, err := providerUtils.MarshalSorted(out)
+	require.NoError(t, err)
+	schemaorder.AssertPropertyOrder(t, string(raw))
+}

--- a/core/providers/cohere/utils.go
+++ b/core/providers/cohere/utils.go
@@ -238,17 +238,16 @@ func convertResponseFormatToCohere(responseFormat *interface{}) *CohereResponseF
 		return nil
 	}
 
-	// Try to extract as map
-	formatMap, ok := (*responseFormat).(map[string]interface{})
+	// The value may be an order-preserving OrderedMap (the wire path) or a plain
+	// map built in Go; ParseChatResponseFormat accepts both.
+	rf, ok := schemas.ParseChatResponseFormat(responseFormat)
 	if !ok {
 		return nil
 	}
 
 	cohereFormat := &CohereResponseFormat{}
 
-	// Extract type
-	typeStr, _ := formatMap["type"].(string)
-	switch typeStr {
+	switch rf.Type {
 	case "text":
 		cohereFormat.Type = ResponseFormatTypeText
 	case "json_object", "json_schema":
@@ -256,13 +255,11 @@ func convertResponseFormatToCohere(responseFormat *interface{}) *CohereResponseF
 
 		// Extract the nested schema
 		// OpenAI format: { type: "json_schema", json_schema: { name: "X", strict: true, schema: {...} } }
-		if jsonSchemaWrapper, ok := formatMap["json_schema"].(map[string]interface{}); ok {
-			// The schema may be a plain map or an order-preserving OrderedMap
-			// (e.g. when built from a Responses request).
-			if schema, ok := schemas.SafeExtractOrderedMap(jsonSchemaWrapper["schema"]); ok {
-				var schemaInterface interface{} = schema
-				cohereFormat.JSONSchema = &schemaInterface
-			}
+		// Cohere takes the schema as-is, so forward the client's bytes rather
+		// than a re-encoding of them.
+		if schema := rf.RawSchema(); len(schema) > 0 {
+			var schemaInterface interface{} = schema
+			cohereFormat.JSONSchema = &schemaInterface
 		}
 	default:
 		return nil

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -1561,17 +1561,22 @@ func TestStructuredOutputConversion(t *testing.T) {
 				assert.Equal(t, "application/json", result.GenerationConfig.ResponseMIMEType)
 				assert.NotNil(t, result.GenerationConfig.ResponseJSONSchema)
 
-				schemaMap := result.GenerationConfig.ResponseJSONSchema.(map[string]interface{})
-				properties := schemaMap["properties"].(map[string]interface{})
-				items := properties["items"].(map[string]interface{})
+				schemaMap, ok := asPlainMap(t, result.GenerationConfig.ResponseJSONSchema)
+				require.True(t, ok, "ResponseJSONSchema should be a schema object")
+				properties, ok := asPlainMap(t, schemaMap["properties"])
+				require.True(t, ok, "properties should be a schema object")
+				items, ok := asPlainMap(t, properties["items"])
+				require.True(t, ok, "items should be a schema object")
 
 				// Validate array items
 				assert.Equal(t, "array", items["type"])
-				itemsSchema := items["items"].(map[string]interface{})
+				itemsSchema, ok := asPlainMap(t, items["items"])
+				require.True(t, ok, "items.items should be a schema object")
 				assert.Equal(t, "object", itemsSchema["type"])
 
 				// Validate nested properties
-				nestedProps := itemsSchema["properties"].(map[string]interface{})
+				nestedProps, ok := asPlainMap(t, itemsSchema["properties"])
+				require.True(t, ok, "nested properties should be a schema object")
 				assert.Contains(t, nestedProps, "id")
 				assert.Contains(t, nestedProps, "name")
 			},
@@ -1762,6 +1767,14 @@ func asPlainMap(t *testing.T, v interface{}) (map[string]interface{}, bool) {
 		return m.ToMap(), true
 	case schemas.OrderedMap:
 		return m.ToMap(), true
+	case json.RawMessage:
+		// A schema Gemini needs no rewrites on is forwarded as the client's own
+		// raw bytes, so decode it here to inspect it.
+		var decoded map[string]interface{}
+		if err := schemas.Unmarshal(m, &decoded); err != nil {
+			return nil, false
+		}
+		return decoded, true
 	}
 	return nil, false
 }

--- a/core/providers/gemini/responseformatordering_test.go
+++ b/core/providers/gemini/responseformatordering_test.go
@@ -1,0 +1,81 @@
+package gemini
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/internal/schemaorder"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResponseFormatOrderSurvivesGeminiChat covers response_format ->
+// generationConfig.responseJsonSchema, Gemini's structured output field.
+func TestResponseFormatOrderSurvivesGeminiChat(t *testing.T) {
+	var params schemas.ChatParameters
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ChatBody), &params))
+
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	out, err := ToGeminiChatCompletionRequest(ctx, &schemas.BifrostChatRequest{
+		Provider: schemas.Gemini,
+		Model:    "gemini-2.5-flash",
+		Input: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("assign it")},
+		}},
+		Params: &params,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, out.GenerationConfig)
+	require.NotNil(t, out.GenerationConfig.ResponseJSONSchema, "structured output must reach Gemini")
+
+	raw, err := providerUtils.MarshalSorted(out)
+	require.NoError(t, err)
+	schemaorder.AssertPropertyOrder(t, string(raw))
+}
+
+// TestResponseFormatSchemaBytesReachGeminiVerbatim: Gemini's normalizer only has
+// work to do for union type arrays. This schema has none, so normalization is an
+// identity transform and the bytes must pass through untouched.
+func TestResponseFormatSchemaBytesReachGeminiVerbatim(t *testing.T) {
+	var params schemas.ChatParameters
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ByteExactChatBody), &params))
+
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	out, err := ToGeminiChatCompletionRequest(ctx, &schemas.BifrostChatRequest{
+		Provider: schemas.Gemini,
+		Model:    "gemini-2.5-flash",
+		Input: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("assign it")},
+		}},
+		Params: &params,
+	})
+	require.NoError(t, err)
+
+	raw, err := providerUtils.MarshalSorted(out)
+	require.NoError(t, err)
+	schemaorder.AssertSchemaBytes(t, string(raw), "responseJsonSchema")
+}
+
+// TestResponseFormatOrderSurvivesGeminiResponses covers the Responses method.
+func TestResponseFormatOrderSurvivesGeminiResponses(t *testing.T) {
+	var params schemas.ResponsesParameters
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ResponsesBody), &params))
+
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	out, err := ToGeminiResponsesRequest(ctx, &schemas.BifrostResponsesRequest{
+		Provider: schemas.Gemini,
+		Model:    "gemini-2.5-flash",
+		Input: []schemas.ResponsesMessage{{
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("assign it")},
+		}},
+		Params: &params,
+	})
+	require.NoError(t, err)
+
+	raw, err := providerUtils.MarshalSorted(out)
+	require.NoError(t, err)
+	schemaorder.AssertPropertyOrder(t, string(raw))
+}

--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -1253,23 +1253,17 @@ func convertParamsToGenerationConfig(params *schemas.ChatParameters, responseMod
 		}
 	}
 	// Handle response_format to response_schema conversion
-	if params.ResponseFormat != nil {
-		formatMap, ok := (*params.ResponseFormat).(map[string]interface{})
-		if ok {
-			formatType, typeOk := formatMap["type"].(string)
-			if typeOk {
-				switch formatType {
-				case "json_schema":
-					// OpenAI Structured Outputs: {"type": "json_schema", "json_schema": {...}}
-					if schemaMap := extractSchemaMapFromResponseFormat(params.ResponseFormat); schemaMap != nil {
-						config.ResponseMIMEType = "application/json"
-						config.ResponseJSONSchema = schemaMap
-					}
-				case "json_object":
-					// Maps to Gemini's responseMimeType without schema
-					config.ResponseMIMEType = "application/json"
-				}
+	if rf, ok := schemas.ParseChatResponseFormat(params.ResponseFormat); ok {
+		switch rf.Type {
+		case "json_schema":
+			// OpenAI Structured Outputs: {"type": "json_schema", "json_schema": {...}}
+			if schemaMap := extractSchemaMapFromResponseFormat(params.ResponseFormat); schemaMap != nil {
+				config.ResponseMIMEType = "application/json"
+				config.ResponseJSONSchema = schemaMap
 			}
+		case "json_object":
+			// Maps to Gemini's responseMimeType without schema
+			config.ResponseMIMEType = "application/json"
 		}
 	}
 	if params.ExtraParams != nil {
@@ -2837,22 +2831,19 @@ func normalizeOrderedSchemaForGemini(om *schemas.OrderedMap) *schemas.OrderedMap
 // structure. The schema may be a plain map or an order-preserving OrderedMap (e.g. when built
 // from a Responses request); the result is used with ResponseJSONSchema.
 func extractSchemaMapFromResponseFormat(responseFormat *interface{}) interface{} {
-	formatMap, ok := (*responseFormat).(map[string]interface{})
-	if !ok {
+	rf, ok := schemas.ParseChatResponseFormat(responseFormat)
+	if !ok || rf.Type != "json_schema" {
 		return nil
 	}
 
-	formatType, ok := formatMap["type"].(string)
-	if !ok || formatType != "json_schema" {
-		return nil
+	// normalizeSchemaForGemini only rewrites union `type` arrays; on a schema
+	// without any, it is an identity transform. Detect that case and hand Gemini
+	// the client's own bytes instead of a re-encoding of them.
+	if raw := rf.RawSchema(); len(raw) > 0 && !schemaNeedsGeminiNormalization(raw) {
+		return raw
 	}
 
-	jsonSchemaObj, ok := formatMap["json_schema"].(map[string]interface{})
-	if !ok {
-		return nil
-	}
-
-	schemaObj, ok := jsonSchemaObj["schema"]
+	schemaObj, ok := rf.Schema()
 	if !ok {
 		return nil
 	}
@@ -3066,4 +3057,39 @@ func mimeTypeFromURI(uri string) string {
 		return ""
 	}
 	return uriExtensionMIMETypes[strings.ToLower(uri[dot:])]
+}
+
+// schemaNeedsGeminiNormalization reports whether a raw JSON Schema contains any
+// `type` whose value is an array (e.g. ["string","null"]). That is the only
+// construct normalizeSchemaForGemini rewrites, so a schema without one can be
+// forwarded byte for byte instead of being decoded and re-encoded.
+func schemaNeedsGeminiNormalization(raw []byte) bool {
+	return resultNeedsGeminiNormalization(gjson.ParseBytes(raw))
+}
+
+func resultNeedsGeminiNormalization(result gjson.Result) bool {
+	needs := false
+	switch {
+	case result.IsObject():
+		result.ForEach(func(key, value gjson.Result) bool {
+			if key.String() == "type" && value.IsArray() {
+				needs = true
+				return false
+			}
+			if resultNeedsGeminiNormalization(value) {
+				needs = true
+				return false
+			}
+			return true
+		})
+	case result.IsArray():
+		result.ForEach(func(_, value gjson.Result) bool {
+			if resultNeedsGeminiNormalization(value) {
+				needs = true
+				return false
+			}
+			return true
+		})
+	}
+	return needs
 }

--- a/core/providers/huggingface/chat.go
+++ b/core/providers/huggingface/chat.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bytedance/sonic"
 
-	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	schemas "github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -88,16 +87,11 @@ func ToHuggingFaceChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) 
 		// Handle response format (direct type assertion to avoid marshal→unmarshal round-trip)
 		if params.ResponseFormat != nil {
 			var hfRF *HuggingFaceResponseFormat
-			if rfMap, ok := (*params.ResponseFormat).(map[string]interface{}); ok {
-				hfRF = &HuggingFaceResponseFormat{}
-				if t, ok := rfMap["type"].(string); ok {
-					hfRF.Type = t
-				}
-				if jsVal, ok := rfMap["json_schema"]; ok {
-					jsBytes, err := providerUtils.MarshalSorted(jsVal)
-					if err != nil {
-						return nil, fmt.Errorf("failed to marshal json_schema: %w", err)
-					}
+			if rf, ok := schemas.ParseChatResponseFormat(params.ResponseFormat); ok {
+				hfRF = &HuggingFaceResponseFormat{Type: rf.Type}
+				// HuggingFaceJSONSchema keeps the schema as raw JSON, so decoding
+				// the wrapper carries the client's schema bytes through untouched.
+				if jsBytes := rf.RawJSONSchema(); len(jsBytes) > 0 {
 					var hfSchema HuggingFaceJSONSchema
 					if err := sonic.Unmarshal(jsBytes, &hfSchema); err != nil {
 						return nil, fmt.Errorf("failed to unmarshal json_schema: %w", err)

--- a/core/providers/huggingface/responseformatordering_test.go
+++ b/core/providers/huggingface/responseformatordering_test.go
@@ -1,0 +1,78 @@
+package huggingface
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/internal/schemaorder"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResponseFormatOrderSurvivesHuggingFaceChat covers HuggingFace, which
+// re-encodes json_schema into its own typed struct with a raw schema field.
+func TestResponseFormatOrderSurvivesHuggingFaceChat(t *testing.T) {
+	var params schemas.ChatParameters
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ChatBody), &params))
+
+	out, err := ToHuggingFaceChatCompletionRequest(&schemas.BifrostChatRequest{
+		Provider: schemas.HuggingFace,
+		Model:    "meta-llama/Llama-3.3-70B-Instruct",
+		Input: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("assign it")},
+		}},
+		Params: &params,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, out.ResponseFormat, "structured output must reach HuggingFace")
+	require.NotNil(t, out.ResponseFormat.JSONSchema)
+
+	raw, err := providerUtils.MarshalSorted(out)
+	require.NoError(t, err)
+	schemaorder.AssertPropertyOrder(t, string(raw))
+	schemaorder.AssertSchemaKeyOrder(t, string(raw), "schema")
+}
+
+// TestResponseFormatSchemaBytesReachHuggingFaceVerbatim: HuggingFace re-types the
+// wrapper but carries the schema as raw JSON, so it must not be re-encoded.
+func TestResponseFormatSchemaBytesReachHuggingFaceVerbatim(t *testing.T) {
+	var params schemas.ChatParameters
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ByteExactChatBody), &params))
+
+	out, err := ToHuggingFaceChatCompletionRequest(&schemas.BifrostChatRequest{
+		Provider: schemas.HuggingFace,
+		Model:    "meta-llama/Llama-3.3-70B-Instruct",
+		Input: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("assign it")},
+		}},
+		Params: &params,
+	})
+	require.NoError(t, err)
+
+	raw, err := providerUtils.MarshalSorted(out)
+	require.NoError(t, err)
+	schemaorder.AssertSchemaBytes(t, string(raw), "schema")
+}
+
+// TestResponseFormatOrderSurvivesHuggingFaceResponses covers the Responses method.
+func TestResponseFormatOrderSurvivesHuggingFaceResponses(t *testing.T) {
+	var params schemas.ResponsesParameters
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ResponsesBody), &params))
+
+	out, err := ToHuggingFaceResponsesRequest(&schemas.BifrostResponsesRequest{
+		Provider: schemas.HuggingFace,
+		Model:    "meta-llama/Llama-3.3-70B-Instruct",
+		Input: []schemas.ResponsesMessage{{
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("assign it")},
+		}},
+		Params: &params,
+	})
+	require.NoError(t, err)
+
+	raw, err := providerUtils.MarshalSorted(out)
+	require.NoError(t, err)
+	schemaorder.AssertPropertyOrder(t, string(raw))
+}

--- a/core/providers/openai/payload_ordering_test.go
+++ b/core/providers/openai/payload_ordering_test.go
@@ -129,10 +129,10 @@ func TestParseImageVariationFormDataBodyFromRequest_OrdersMetadataBeforeFile(t *
 // (alphabetized) measurably degrades output quality (e.g. union-of-parts outputs
 // collapsing to citation-only responses).
 //
-// The schema's top-level keys map to typed struct fields (emitted in struct
-// field order); everything nested — properties, $defs, items, anyOf bodies,
-// i.e. where property order actually shapes generation — must round-trip in
-// the client's original key order via OrderedMap.
+// The whole schema — its own top-level keys as well as everything nested
+// (properties, $defs, items, anyOf bodies) — must round-trip in the client's
+// original key order: top-level keys via the decoded key order recorded on
+// ResponsesTextConfigFormatJSONSchema, nested objects via OrderedMap.
 func TestPayloadOrdering_ResponsesTextFormatJSONSchema(t *testing.T) {
 	// Deliberately non-alphabetical key order everywhere: "type" precedes
 	// "text"/"url"/"items" etc. — alphabetical sorting would reorder all of them.
@@ -148,9 +148,9 @@ func TestPayloadOrdering_ResponsesTextFormatJSONSchema(t *testing.T) {
 	marshaled, err := providerUtils.MarshalSorted(&req)
 	require.NoError(t, err)
 
-	// Top-level schema keys re-serialize in struct field order; all nested
-	// objects must keep the client's original (non-alphabetical) key order.
-	goldenSchema := `{"additionalProperties":false,"properties":{"parts":{"type":"array","items":{"anyOf":[{"$ref":"#/$defs/TextPart"},{"$ref":"#/$defs/WebCitation"}]}}},"required":["parts"],"type":"object","$defs":{"TextPart":{"type":"object","properties":{"type":{"const":"text"},"text":{"type":"string"}},"required":["type","text"],"additionalProperties":false},"WebCitation":{"type":"object","properties":{"type":{"const":"cite:web"},"url":{"type":"string"}},"required":["type","url"],"additionalProperties":false}}}`
+	// The schema re-serializes byte-identical to what the client sent, at every
+	// level, including its own (non-alphabetical) top-level key order.
+	goldenSchema := `{"type":"object","properties":{"parts":{"type":"array","items":{"anyOf":[{"$ref":"#/$defs/TextPart"},{"$ref":"#/$defs/WebCitation"}]}}},"required":["parts"],"additionalProperties":false,"$defs":{"TextPart":{"type":"object","properties":{"type":{"const":"text"},"text":{"type":"string"}},"required":["type","text"],"additionalProperties":false},"WebCitation":{"type":"object","properties":{"type":{"const":"cite:web"},"url":{"type":"string"}},"required":["type","url"],"additionalProperties":false}}}`
 	assert.Contains(t, string(marshaled), `"schema":`+goldenSchema,
 		"nested schema key order changed — if intentional, update the golden string")
 

--- a/core/providers/openai/responseformatordering_test.go
+++ b/core/providers/openai/responseformatordering_test.go
@@ -1,0 +1,143 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/internal/schemaorder"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResponseFormatSchemaKeyOrderSurvivesOpenAIChat walks the real inbound path:
+// raw client body -> OpenAIChatRequest -> Bifrost -> OpenAI wire payload, and
+// asserts the JSON Schema reaches OpenAI in the order the client declared it.
+func TestResponseFormatSchemaKeyOrderSurvivesOpenAIChat(t *testing.T) {
+	var inbound OpenAIChatRequest
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ChatBody), &inbound))
+
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	bifrostReq := inbound.ToBifrostChatRequest(ctx)
+	require.NotNil(t, bifrostReq)
+	bifrostReq.Provider = schemas.OpenAI
+
+	outbound := ToOpenAIChatRequest(ctx, bifrostReq)
+	require.NotNil(t, outbound)
+
+	raw, err := providerUtils.MarshalSorted(outbound)
+	require.NoError(t, err)
+	wire := string(raw)
+
+	schemaorder.AssertPropertyOrder(t, wire)
+	schemaorder.AssertSchemaKeyOrder(t, wire, "schema")
+	schemaorder.AssertKeyOrder(t, schemaorder.ObjectAfterKey(t, wire, "json_schema"), "name", "description", "schema", "strict")
+}
+
+// TestResponseFormatSchemaKeyOrderSurvivesOpenAIResponses covers the Responses
+// API method, where the schema arrives under text.format instead of response_format.
+func TestResponseFormatSchemaKeyOrderSurvivesOpenAIResponses(t *testing.T) {
+	var inbound OpenAIResponsesRequest
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ResponsesBody), &inbound))
+
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	bifrostReq := inbound.ToBifrostResponsesRequest(ctx)
+	require.NotNil(t, bifrostReq)
+	bifrostReq.Provider = schemas.OpenAI
+
+	outbound := ToOpenAIResponsesRequest(ctx, bifrostReq)
+	require.NotNil(t, outbound)
+
+	raw, err := providerUtils.MarshalSorted(outbound)
+	require.NoError(t, err)
+	wire := string(raw)
+
+	schemaorder.AssertPropertyOrder(t, wire)
+	schemaorder.AssertSchemaKeyOrder(t, wire, "schema")
+}
+
+// TestResponseFormatChatToResponsesConversionKeepsOrder covers the cross-method
+// path: a chat request routed to a Responses-API-only surface must not lose the
+// declared property order while being rewritten.
+func TestResponseFormatChatToResponsesConversionKeepsOrder(t *testing.T) {
+	var inbound OpenAIChatRequest
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ChatBody), &inbound))
+
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	bifrostReq := inbound.ToBifrostChatRequest(ctx)
+	require.NotNil(t, bifrostReq)
+
+	outbound := ToOpenAIResponsesRequest(ctx, bifrostReq.ToResponsesRequest())
+	require.NotNil(t, outbound)
+
+	raw, err := providerUtils.MarshalSorted(outbound)
+	require.NoError(t, err)
+	schemaorder.AssertPropertyOrder(t, string(raw))
+}
+
+// TestResponseFormatSchemaOrderIsDeterministic ensures the fix does not trade
+// alphabetical sorting for random Go map ordering: repeated marshals of the same
+// request must emit identical bytes.
+func TestResponseFormatSchemaOrderIsDeterministic(t *testing.T) {
+	var inbound OpenAIChatRequest
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ChatBody), &inbound))
+
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	outbound := ToOpenAIChatRequest(ctx, inbound.ToBifrostChatRequest(ctx))
+	require.NotNil(t, outbound)
+
+	first, err := providerUtils.MarshalSorted(outbound)
+	require.NoError(t, err)
+	for i := 0; i < 50; i++ {
+		next, err := providerUtils.MarshalSorted(outbound)
+		require.NoError(t, err)
+		require.Equal(t, string(first), string(next), "non-deterministic response_format marshal on iteration %d", i)
+	}
+}
+
+// TestResponseFormatSchemaBytesReachOpenAIVerbatim pins the stronger invariant:
+// OpenAI takes the schema in the shape Bifrost received it, so the gateway has
+// no reason to re-encode it at all. Byte equality also covers numeric fidelity,
+// which key order alone does not.
+func TestResponseFormatSchemaBytesReachOpenAIVerbatim(t *testing.T) {
+	var inbound OpenAIChatRequest
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ByteExactChatBody), &inbound))
+
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	bifrostReq := inbound.ToBifrostChatRequest(ctx)
+	bifrostReq.Provider = schemas.OpenAI
+
+	raw, err := providerUtils.MarshalSorted(ToOpenAIChatRequest(ctx, bifrostReq))
+	require.NoError(t, err)
+	schemaorder.AssertSchemaBytes(t, string(raw), "schema")
+}
+
+// TestResponseFormatSurvivesDelegatingProviders covers every provider that has no
+// response_format handling of its own and rides the OpenAI chat conversion. They
+// each get their own parameter filtering, so this pins that none of them strips
+// or rewrites the schema on the way through.
+func TestResponseFormatSurvivesDelegatingProviders(t *testing.T) {
+	delegating := []schemas.ModelProvider{
+		schemas.Azure, schemas.Cerebras, schemas.DeepSeek, schemas.Groq,
+		schemas.OpenRouter, schemas.SGL, schemas.VLLM, schemas.XAI,
+		schemas.Wafer, schemas.Ollama, schemas.Fireworks, schemas.Parasail,
+	}
+
+	for _, provider := range delegating {
+		t.Run(string(provider), func(t *testing.T) {
+			var inbound OpenAIChatRequest
+			require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ByteExactChatBody), &inbound))
+
+			ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+			bifrostReq := inbound.ToBifrostChatRequest(ctx)
+			bifrostReq.Provider = provider
+
+			outbound := ToOpenAIChatRequest(ctx, bifrostReq)
+			require.NotNil(t, outbound)
+			require.NotNil(t, outbound.ResponseFormat, "%s dropped response_format", provider)
+
+			raw, err := providerUtils.MarshalSorted(outbound)
+			require.NoError(t, err)
+			schemaorder.AssertSchemaBytes(t, string(raw), "schema")
+		})
+	}
+}

--- a/core/providers/perplexity/responseformatordering_test.go
+++ b/core/providers/perplexity/responseformatordering_test.go
@@ -1,0 +1,78 @@
+package perplexity
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/internal/schemaorder"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResponseFormatOrderSurvivesPerplexityChat covers the pass-through
+// providers: response_format is forwarded untouched, so the only thing that can
+// corrupt it is the neutral decode/encode.
+func TestResponseFormatOrderSurvivesPerplexityChat(t *testing.T) {
+	var params schemas.ChatParameters
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ChatBody), &params))
+
+	out := ToPerplexityChatCompletionRequest(&schemas.BifrostChatRequest{
+		Provider: schemas.Perplexity,
+		Model:    "sonar",
+		Input: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("assign it")},
+		}},
+		Params: &params,
+	})
+	require.NotNil(t, out)
+	require.NotNil(t, out.ResponseFormat)
+
+	raw, err := providerUtils.MarshalSorted(out)
+	require.NoError(t, err)
+	schemaorder.AssertPropertyOrder(t, string(raw))
+	schemaorder.AssertSchemaKeyOrder(t, string(raw), "schema")
+}
+
+// TestResponseFormatSchemaBytesReachPerplexityVerbatim covers the pass-through
+// providers: nothing may be re-encoded on a route that only forwards.
+func TestResponseFormatSchemaBytesReachPerplexityVerbatim(t *testing.T) {
+	var params schemas.ChatParameters
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ByteExactChatBody), &params))
+
+	out := ToPerplexityChatCompletionRequest(&schemas.BifrostChatRequest{
+		Provider: schemas.Perplexity,
+		Model:    "sonar",
+		Input: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("assign it")},
+		}},
+		Params: &params,
+	})
+	require.NotNil(t, out)
+
+	raw, err := providerUtils.MarshalSorted(out)
+	require.NoError(t, err)
+	schemaorder.AssertSchemaBytes(t, string(raw), "schema")
+}
+
+// TestResponseFormatOrderSurvivesPerplexityResponses covers the Responses method.
+func TestResponseFormatOrderSurvivesPerplexityResponses(t *testing.T) {
+	var params schemas.ResponsesParameters
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ResponsesBody), &params))
+
+	out := ToPerplexityResponsesRequest(&schemas.BifrostResponsesRequest{
+		Provider: schemas.Perplexity,
+		Model:    "sonar",
+		Input: []schemas.ResponsesMessage{{
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("assign it")},
+		}},
+		Params: &params,
+	})
+	require.NotNil(t, out)
+
+	raw, err := providerUtils.MarshalSorted(out)
+	require.NoError(t, err)
+	schemaorder.AssertPropertyOrder(t, string(raw))
+}

--- a/core/providers/perplexity/responses.go
+++ b/core/providers/perplexity/responses.go
@@ -31,6 +31,12 @@ func ToPerplexityResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *
 		perplexityReq.Temperature = bifrostReq.Params.Temperature
 		perplexityReq.TopP = bifrostReq.Params.TopP
 
+		// Structured output: Perplexity speaks chat-completions, so the Responses
+		// text.format has to be carried over as response_format. Without this a
+		// Responses request reaches Perplexity with no schema at all. An explicit
+		// response_format in ExtraParams still wins; it is applied further below.
+		perplexityReq.ResponseFormat = schemas.ChatResponseFormatFromResponsesFormat(bifrostReq.Params.Text.GetFormat())
+
 		// Handle reasoning effort mapping
 		if bifrostReq.Params.Reasoning != nil && bifrostReq.Params.Reasoning.Effort != nil {
 			if *bifrostReq.Params.Reasoning.Effort == "minimal" {
@@ -110,6 +116,7 @@ func ToPerplexityResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *
 			if responseFormat, ok := schemas.SafeExtractFromMap(bifrostReq.Params.ExtraParams, "response_format"); ok {
 				perplexityReq.ResponseFormat = &responseFormat
 			}
+
 
 			// Perplexity-specific request fields
 			if numSearchResults, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["num_search_results"]); ok {

--- a/core/providers/replicate/chat.go
+++ b/core/providers/replicate/chat.go
@@ -181,6 +181,13 @@ func ToReplicateChatRequest(bifrostReq *schemas.BifrostChatRequest) (*ReplicateP
 					input.Tools = responsesTools
 				}
 			}
+			// gpt-5-structured takes its schema as the `json_schema` input, in
+			// the Responses text-config shape. Without this mapping a chat
+			// request reaches the model with no structured output at all, while
+			// the same request on the Responses path gets one.
+			if format := schemas.ResponsesTextConfigFormatFromChatResponseFormat(params.ResponseFormat); format != nil {
+				input.JsonSchema = &schemas.ResponsesTextConfig{Format: format}
+			}
 		}
 
 		if params.ExtraParams != nil {

--- a/core/providers/replicate/responseformatordering_test.go
+++ b/core/providers/replicate/responseformatordering_test.go
@@ -1,0 +1,61 @@
+package replicate
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/internal/schemaorder"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/require"
+)
+
+const gpt5StructuredModel = "openai/gpt-5-structured"
+
+// TestResponseFormatReachesReplicateChat pins that a chat request keeps its
+// structured output: gpt-5-structured takes the schema as the `json_schema`
+// input, and the chat path used to drop response_format on the floor while the
+// Responses path carried it.
+func TestResponseFormatReachesReplicateChat(t *testing.T) {
+	var params schemas.ChatParameters
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ChatBody), &params))
+
+	out, err := ToReplicateChatRequest(&schemas.BifrostChatRequest{
+		Provider: schemas.Replicate,
+		Model:    gpt5StructuredModel,
+		Input: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("assign it")},
+		}},
+		Params: &params,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, out.Input)
+	require.NotNil(t, out.Input.JsonSchema, "structured output must reach Replicate")
+
+	raw, err := providerUtils.MarshalSorted(out)
+	require.NoError(t, err)
+	schemaorder.AssertPropertyOrder(t, string(raw))
+}
+
+// TestResponseFormatOrderSurvivesReplicateResponses covers the Responses method.
+func TestResponseFormatOrderSurvivesReplicateResponses(t *testing.T) {
+	var params schemas.ResponsesParameters
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ResponsesBody), &params))
+
+	out, err := ToReplicateResponsesRequest(&schemas.BifrostResponsesRequest{
+		Provider: schemas.Replicate,
+		Model:    gpt5StructuredModel,
+		Input: []schemas.ResponsesMessage{{
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("assign it")},
+		}},
+		Params: &params,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, out.Input)
+	require.NotNil(t, out.Input.JsonSchema)
+
+	raw, err := providerUtils.MarshalSorted(out)
+	require.NoError(t, err)
+	schemaorder.AssertPropertyOrder(t, string(raw))
+}

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -297,6 +297,24 @@ func (cp *ChatParameters) UnmarshalJSON(data []byte) error {
 			cp.Reasoning.Display = aux.ReasoningDisplay
 		}
 	}
+	// response_format carries a user-authored JSON Schema, and Bifrost is not
+	// entitled to rewrite it. Decoding it into interface{} (what the alias does)
+	// yields a map[string]interface{}, which loses two things the provider cares
+	// about: key order, because Structured Outputs generates fields in schema key
+	// order ("outputs will be produced in the same order as the ordering of keys
+	// in the schema", https://developers.openai.com/api/docs/guides/structured-outputs),
+	// and numeric literals, because every number becomes a float64 (so an integer
+	// above 2^53 comes back corrupted and 1.0 comes back as 1).
+	//
+	// Keep the object form as raw bytes instead. Providers that forward
+	// response_format unchanged then emit exactly what the client sent, and the
+	// few that must rewrite it read it on demand via ParseChatResponseFormat.
+	// Non-object values (null, or a provider quirk) keep whatever the alias produced.
+	if rf := gjson.GetBytes(data, "response_format"); rf.IsObject() {
+		var value interface{} = json.RawMessage(rf.Raw)
+		cp.ResponseFormat = &value
+	}
+
 	// ExtraParams etc. are already handled by the alias
 	return nil
 }

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -1148,38 +1148,11 @@ func (cr *BifrostChatRequest) ToResponsesRequest() *BifrostResponsesRequest {
 			}
 		}
 
-		if cr.Params.ResponseFormat != nil {
-			if rfMap, ok := (*cr.Params.ResponseFormat).(map[string]interface{}); ok {
-				if fmtType, ok := rfMap["type"].(string); ok {
-					if brr.Params.Text == nil {
-						brr.Params.Text = &ResponsesTextConfig{}
-					}
-					format := &ResponsesTextConfigFormat{Type: fmtType}
-					validFormat := true
-					if fmtType == "json_schema" {
-						jsObj, ok := rfMap["json_schema"].(map[string]interface{})
-						if !ok {
-							validFormat = false
-						} else {
-							if name, ok := jsObj["name"].(string); ok {
-								format.Name = &name
-							}
-							if desc, ok := jsObj["description"].(string); ok {
-								format.Description = &desc
-							}
-							if strict, ok := jsObj["strict"].(bool); ok {
-								format.Strict = &strict
-							}
-							if schema, ok := jsObj["schema"]; ok {
-								format.JSONSchema = JSONSchemaFromMap(schema)
-							}
-						}
-					}
-					if validFormat {
-						brr.Params.Text.Format = format
-					}
-				}
+		if format := ResponsesTextConfigFormatFromChatResponseFormat(cr.Params.ResponseFormat); format != nil {
+			if brr.Params.Text == nil {
+				brr.Params.Text = &ResponsesTextConfig{}
 			}
+			brr.Params.Text.Format = format
 		}
 
 		// Handle Verbosity
@@ -1270,27 +1243,8 @@ func (brr *BifrostResponsesRequest) ToChatRequest() *BifrostChatRequest {
 			}
 		}
 
-		if brr.Params.Text != nil && brr.Params.Text.Format != nil {
-			f := brr.Params.Text.Format
-			rfMap := map[string]interface{}{"type": f.Type}
-			if f.Type == "json_schema" {
-				jsObj := map[string]interface{}{}
-				if f.Name != nil {
-					jsObj["name"] = *f.Name
-				}
-				if f.Description != nil {
-					jsObj["description"] = *f.Description
-				}
-				if f.Strict != nil {
-					jsObj["strict"] = *f.Strict
-				}
-				if schemaMap := f.JSONSchema.ToMap(); schemaMap != nil {
-					jsObj["schema"] = schemaMap
-				}
-				rfMap["json_schema"] = jsObj
-			}
-			var rf interface{} = rfMap
-			bcr.Params.ResponseFormat = &rf
+		if rf := ChatResponseFormatFromResponsesFormat(brr.Params.Text.GetFormat()); rf != nil {
+			bcr.Params.ResponseFormat = rf
 		}
 
 		// Handle Verbosity from Text config

--- a/core/schemas/mux_test.go
+++ b/core/schemas/mux_test.go
@@ -1130,17 +1130,11 @@ func TestToChatRequest_TextFormat_JSONSchema(t *testing.T) {
 	if cr.Params == nil || cr.Params.ResponseFormat == nil {
 		t.Fatal("expected ResponseFormat to be set")
 	}
-	rfMap, ok := (*cr.Params.ResponseFormat).(map[string]interface{})
-	if !ok {
-		t.Fatal("expected ResponseFormat to be map[string]interface{}")
-	}
+	rfMap := responseFormatAsMap(t, cr.Params.ResponseFormat)
 	if rfMap["type"] != "json_schema" {
 		t.Fatalf("expected type json_schema, got %v", rfMap["type"])
 	}
-	jsObj, ok := rfMap["json_schema"].(map[string]interface{})
-	if !ok {
-		t.Fatal("expected json_schema inner object")
-	}
+	jsObj := nestedMap(t, rfMap, "json_schema")
 	if jsObj["name"] != "CityInfo" {
 		t.Fatalf("expected name=CityInfo, got %v", jsObj["name"])
 	}
@@ -1175,10 +1169,7 @@ func TestToChatRequest_TextFormat_JSONObject(t *testing.T) {
 	if cr.Params == nil || cr.Params.ResponseFormat == nil {
 		t.Fatal("expected ResponseFormat to be set")
 	}
-	rfMap, ok := (*cr.Params.ResponseFormat).(map[string]interface{})
-	if !ok {
-		t.Fatal("expected ResponseFormat to be map[string]interface{}")
-	}
+	rfMap := responseFormatAsMap(t, cr.Params.ResponseFormat)
 	if rfMap["type"] != "json_object" {
 		t.Fatalf("expected type json_object, got %v", rfMap["type"])
 	}
@@ -1214,17 +1205,11 @@ func TestResponseFormatRoundTrip_ChatToResponsesAndBack(t *testing.T) {
 	if cr.Params == nil || cr.Params.ResponseFormat == nil {
 		t.Fatal("expected ResponseFormat to survive round-trip")
 	}
-	rfMap, ok := (*cr.Params.ResponseFormat).(map[string]interface{})
-	if !ok {
-		t.Fatal("expected ResponseFormat to be map after round-trip")
-	}
+	rfMap := responseFormatAsMap(t, cr.Params.ResponseFormat)
 	if rfMap["type"] != "json_schema" {
 		t.Fatalf("type did not survive round-trip: got %v", rfMap["type"])
 	}
-	jsObj, ok := rfMap["json_schema"].(map[string]interface{})
-	if !ok {
-		t.Fatal("json_schema inner object missing after round-trip")
-	}
+	jsObj := nestedMap(t, rfMap, "json_schema")
 	if jsObj["name"] != "CityInfo" {
 		t.Fatalf("name did not survive round-trip: got %v", jsObj["name"])
 	}
@@ -1325,15 +1310,9 @@ func TestToChatRequest_TextFormat_TypedFields(t *testing.T) {
 		t.Fatal("expected ResponseFormat to be set")
 	}
 
-	rfMap, ok := (*cr.Params.ResponseFormat).(map[string]interface{})
-	if !ok {
-		t.Fatal("expected ResponseFormat to be a map")
-	}
+	rfMap := responseFormatAsMap(t, cr.Params.ResponseFormat)
 
-	jsObj, ok := rfMap["json_schema"].(map[string]interface{})
-	if !ok {
-		t.Fatal("expected json_schema inner object")
-	}
+	jsObj := nestedMap(t, rfMap, "json_schema")
 
 	// Schema body must be present and non-empty
 	schemaVal, ok := jsObj["schema"]
@@ -1341,14 +1320,17 @@ func TestToChatRequest_TextFormat_TypedFields(t *testing.T) {
 		t.Fatalf("schema body silently dropped: json_schema=%v", jsObj)
 	}
 
-	schemaMap, ok := schemaVal.(map[string]interface{})
+	// The schema is handed back as an OrderedMap so the key order the client
+	// declared survives the Responses -> Chat rewrite.
+	schemaMap, ok := SafeExtractOrderedMap(schemaVal)
 	if !ok {
-		t.Fatalf("expected schema to be a map, got %T", schemaVal)
+		t.Fatalf("expected schema to be an ordered map, got %T", schemaVal)
 	}
-	if schemaMap["type"] != "object" {
-		t.Fatalf("expected schema.type=object, got %v", schemaMap["type"])
+	if schemaType, _ := schemaMap.Get("type"); schemaType != "object" {
+		t.Fatalf("expected schema.type=object, got %v", schemaType)
 	}
-	propsBytes, err := MarshalSorted(schemaMap["properties"])
+	schemaProps, _ := schemaMap.Get("properties")
+	propsBytes, err := MarshalSorted(schemaProps)
 	if err != nil {
 		t.Fatalf("failed to marshal properties: %v", err)
 	}
@@ -1465,4 +1447,27 @@ func TestToBifrostResponsesStreamResponse_ReasoningOpensThinkingBlock(t *testing
 	if textOutputIndex <= reasoningOutputIndex {
 		t.Fatalf("text output index %d must be greater than reasoning output index %d", textOutputIndex, reasoningOutputIndex)
 	}
+}
+
+
+// responseFormatAsMap reads a converted chat response_format regardless of its
+// representation. The Responses to Chat conversion emits raw JSON (the same
+// representation the chat wire decode produces), so tests read it through the
+// same accessor providers use rather than type-asserting a map.
+func responseFormatAsMap(t *testing.T, responseFormat *interface{}) map[string]interface{} {
+	t.Helper()
+	om, ok := SafeExtractOrderedMap(*responseFormat)
+	if !ok || om == nil {
+		t.Fatalf("expected response_format to be readable as an object, got %T", *responseFormat)
+	}
+	return om.ToMap()
+}
+
+func nestedMap(t *testing.T, parent map[string]interface{}, key string) map[string]interface{} {
+	t.Helper()
+	om, ok := SafeExtractOrderedMap(parent[key])
+	if !ok || om == nil {
+		t.Fatalf("expected %q to be an object, got %T", key, parent[key])
+	}
+	return om.ToMap()
 }

--- a/core/schemas/responseformat.go
+++ b/core/schemas/responseformat.go
@@ -1,0 +1,334 @@
+package schemas
+
+import (
+	"encoding/json"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// ChatResponseFormat is a reader over an OpenAI-style chat `response_format`
+// value.
+//
+// The value is carried as raw JSON wherever possible (see
+// ChatParameters.UnmarshalJSON): a gateway that forwards a schema unchanged
+// should forward the client's bytes, not its own re-encoding of them. Only the
+// providers that genuinely rewrite the schema pay for parsing, and they do it
+// here, on demand.
+//
+// ChatParameters.ResponseFormat is an untyped interface{}, so the value may also
+// be an *OrderedMap (built by the Responses to Chat conversion) or a plain
+// map[string]interface{} (built by Go callers and plugins). All three are
+// accepted; RawSchema is only byte-exact for the raw case, which is the case
+// that comes off the wire.
+type ChatResponseFormat struct {
+	// Type is response_format.type: "text" | "json_object" | "json_schema".
+	Type string
+
+	// raw is the whole response_format object, empty unless it came off the wire.
+	raw json.RawMessage
+	// jsonSchema is the response_format.json_schema wrapper, parsed lazily for
+	// the non-raw representations.
+	jsonSchema *OrderedMap
+}
+
+// Name returns json_schema.name. The second return is false when the key is
+// absent, which is distinct from an explicitly empty name.
+func (f *ChatResponseFormat) Name() (string, bool) {
+	return f.stringField("name")
+}
+
+// Description returns json_schema.description. The second return is false when
+// the key is absent, which is distinct from an explicitly empty description.
+func (f *ChatResponseFormat) Description() (string, bool) {
+	return f.stringField("description")
+}
+
+// Strict returns json_schema.strict, or nil when absent.
+func (f *ChatResponseFormat) Strict() *bool {
+	if f == nil {
+		return nil
+	}
+	if len(f.raw) > 0 {
+		if result := gjson.GetBytes(f.raw, "json_schema.strict"); result.Exists() && result.IsBool() {
+			return Ptr(result.Bool())
+		}
+		return nil
+	}
+	if f.jsonSchema == nil {
+		return nil
+	}
+	if value, ok := f.jsonSchema.Get("strict"); ok {
+		if strict, ok := value.(bool); ok {
+			return &strict
+		}
+	}
+	return nil
+}
+
+// HasJSONSchema reports whether a json_schema wrapper is present.
+func (f *ChatResponseFormat) HasJSONSchema() bool {
+	if f == nil {
+		return false
+	}
+	if len(f.raw) > 0 {
+		return gjson.GetBytes(f.raw, "json_schema").IsObject()
+	}
+	return f.jsonSchema != nil
+}
+
+// RawJSONSchema returns the response_format.json_schema wrapper as raw JSON, or
+// nil when it is absent. The bytes are the client's own when the value came off
+// the wire; otherwise they are re-encoded from the in-memory representation.
+func (f *ChatResponseFormat) RawJSONSchema() json.RawMessage {
+	if f == nil {
+		return nil
+	}
+	if len(f.raw) > 0 {
+		if result := gjson.GetBytes(f.raw, "json_schema"); result.IsObject() {
+			return json.RawMessage(result.Raw)
+		}
+		return nil
+	}
+	if f.jsonSchema == nil {
+		return nil
+	}
+	encoded, err := MarshalSorted(f.jsonSchema)
+	if err != nil {
+		return nil
+	}
+	return encoded
+}
+
+// RawSchema returns response_format.json_schema.schema as raw JSON, or nil when
+// it is absent. Providers that forward the schema untouched should use this:
+// it preserves key order and numeric literals exactly, which re-encoding cannot.
+func (f *ChatResponseFormat) RawSchema() json.RawMessage {
+	if f == nil {
+		return nil
+	}
+	if len(f.raw) > 0 {
+		if result := gjson.GetBytes(f.raw, "json_schema.schema"); result.Exists() {
+			return json.RawMessage(result.Raw)
+		}
+		return nil
+	}
+	schema, ok := f.Schema()
+	if !ok {
+		return nil
+	}
+	encoded, err := MarshalSorted(schema)
+	if err != nil {
+		return nil
+	}
+	return encoded
+}
+
+// Schema returns response_format.json_schema.schema as a Go value. Prefer
+// RawSchema unless the schema has to be walked or rebuilt.
+func (f *ChatResponseFormat) Schema() (interface{}, bool) {
+	if f == nil {
+		return nil, false
+	}
+	if wrapper := f.wrapper(); wrapper != nil {
+		return wrapper.Get("schema")
+	}
+	return nil, false
+}
+
+// SchemaMap returns response_format.json_schema.schema as an OrderedMap, parsing
+// the raw bytes if needed. Boolean and missing schemas return false. Only the
+// providers that rewrite the schema (Gemini normalization, the Anthropic tool
+// fallback) should need this.
+func (f *ChatResponseFormat) SchemaMap() (*OrderedMap, bool) {
+	schema, ok := f.Schema()
+	if !ok {
+		return nil, false
+	}
+	return SafeExtractOrderedMap(schema)
+}
+
+// wrapper returns the json_schema object as an OrderedMap, decoding the raw form
+// on first use.
+func (f *ChatResponseFormat) wrapper() *OrderedMap {
+	if f == nil {
+		return nil
+	}
+	if f.jsonSchema == nil && len(f.raw) > 0 {
+		result := gjson.GetBytes(f.raw, "json_schema")
+		if !result.IsObject() {
+			return nil
+		}
+		decoded := NewOrderedMap()
+		if err := decoded.UnmarshalJSON([]byte(result.Raw)); err != nil {
+			return nil
+		}
+		f.jsonSchema = decoded
+	}
+	return f.jsonSchema
+}
+
+func (f *ChatResponseFormat) stringField(key string) (string, bool) {
+	if f == nil {
+		return "", false
+	}
+	if len(f.raw) > 0 {
+		result := gjson.GetBytes(f.raw, "json_schema."+key)
+		if !result.Exists() || result.Type != gjson.String {
+			return "", false
+		}
+		return result.String(), true
+	}
+	if f.jsonSchema == nil {
+		return "", false
+	}
+	if value, ok := f.jsonSchema.Get(key); ok {
+		if str, ok := SafeExtractString(value); ok {
+			return str, true
+		}
+	}
+	return "", false
+}
+
+// ParseChatResponseFormat reads ChatParameters.ResponseFormat, accepting the raw
+// JSON produced by the wire decode as well as the *OrderedMap and plain map
+// forms built in Go. It returns false when the value is absent or is not an
+// object with a string `type`.
+func ParseChatResponseFormat(responseFormat *interface{}) (*ChatResponseFormat, bool) {
+	if responseFormat == nil || *responseFormat == nil {
+		return nil, false
+	}
+
+	if raw, ok := rawJSONBytes(*responseFormat); ok {
+		result := gjson.GetBytes(raw, "type")
+		if result.Type != gjson.String {
+			return nil, false
+		}
+		return &ChatResponseFormat{Type: result.String(), raw: raw}, true
+	}
+
+	formatMap, ok := SafeExtractOrderedMap(*responseFormat)
+	if !ok || formatMap == nil {
+		return nil, false
+	}
+	typeRaw, ok := formatMap.Get("type")
+	if !ok {
+		return nil, false
+	}
+	formatType, ok := SafeExtractString(typeRaw)
+	if !ok {
+		return nil, false
+	}
+
+	parsed := &ChatResponseFormat{Type: formatType}
+	if jsonSchemaRaw, ok := formatMap.Get("json_schema"); ok {
+		if jsonSchema, ok := SafeExtractOrderedMap(jsonSchemaRaw); ok {
+			parsed.jsonSchema = jsonSchema
+		}
+	}
+	return parsed, true
+}
+
+// rawJSONBytes reports whether the value is raw JSON carrying an object.
+func rawJSONBytes(value interface{}) (json.RawMessage, bool) {
+	var raw []byte
+	switch typed := value.(type) {
+	case json.RawMessage:
+		raw = typed
+	case *json.RawMessage:
+		if typed == nil {
+			return nil, false
+		}
+		raw = *typed
+	case []byte:
+		raw = typed
+	default:
+		return nil, false
+	}
+	if !gjson.ParseBytes(raw).IsObject() {
+		return nil, false
+	}
+	return raw, true
+}
+
+// GetFormat returns the text format config, or nil when unset. Safe on a nil
+// receiver so callers can chain it off optional parameters.
+func (t *ResponsesTextConfig) GetFormat() *ResponsesTextConfigFormat {
+	if t == nil {
+		return nil
+	}
+	return t.Format
+}
+
+// ChatResponseFormatFromResponsesFormat converts a Responses API text.format
+// config into the chat-completions `response_format` value, so a Responses
+// request routed to a chat-completions provider keeps its structured output.
+// Returns nil when there is no format to carry.
+//
+// The result is raw JSON, matching what the chat wire decode produces, so
+// providers downstream forward one representation rather than two. The schema
+// body is spliced in as bytes (sjson.SetRawBytes), which keeps its key order
+// without a map round-trip.
+func ChatResponseFormatFromResponsesFormat(format *ResponsesTextConfigFormat) *interface{} {
+	if format == nil {
+		return nil
+	}
+
+	body, err := sjson.SetBytes([]byte("{}"), "type", format.Type)
+	if err != nil {
+		return nil
+	}
+
+	if format.Type == "json_schema" {
+		// Written in the order OpenAI documents for response_format.json_schema.
+		wrapper := []byte("{}")
+		if format.Name != nil {
+			wrapper, _ = sjson.SetBytes(wrapper, "name", *format.Name)
+		}
+		if format.Description != nil {
+			wrapper, _ = sjson.SetBytes(wrapper, "description", *format.Description)
+		}
+		if schema := format.JSONSchema.RawSchemaJSON(); len(schema) > 0 {
+			wrapper, _ = sjson.SetRawBytes(wrapper, "schema", schema)
+		}
+		if format.Strict != nil {
+			wrapper, _ = sjson.SetBytes(wrapper, "strict", *format.Strict)
+		}
+		body, _ = sjson.SetRawBytes(body, "json_schema", wrapper)
+	}
+
+	var responseFormat interface{} = json.RawMessage(body)
+	return &responseFormat
+}
+
+// ResponsesTextConfigFormatFromChatResponseFormat converts a chat-completions
+// `response_format` into the Responses API text.format config. It is the inverse
+// of ChatResponseFormatFromResponsesFormat, and providers that speak the
+// Responses shape use it so a chat request keeps its structured output.
+// Returns nil when there is nothing usable to carry.
+func ResponsesTextConfigFormatFromChatResponseFormat(responseFormat *interface{}) *ResponsesTextConfigFormat {
+	rf, ok := ParseChatResponseFormat(responseFormat)
+	if !ok {
+		return nil
+	}
+
+	format := &ResponsesTextConfigFormat{Type: rf.Type}
+	if rf.Type != "json_schema" {
+		return format
+	}
+
+	if !rf.HasJSONSchema() {
+		return nil
+	}
+	if name, ok := rf.Name(); ok {
+		format.Name = &name
+	}
+	if description, ok := rf.Description(); ok {
+		format.Description = &description
+	}
+	format.Strict = rf.Strict()
+	if schema, ok := rf.Schema(); ok {
+		format.JSONSchema = JSONSchemaFromMap(schema)
+	}
+	return format
+}

--- a/core/schemas/responseformatordering_test.go
+++ b/core/schemas/responseformatordering_test.go
@@ -1,0 +1,185 @@
+package schemas_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/internal/schemaorder"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestChatParametersResponseFormatDecodeKeepsClientBytes checks the decoded
+// in-memory representation, so a failure points at the decoder rather than at
+// the encoder. response_format is held as raw JSON: the gateway has no reason to
+// re-encode a schema it only forwards, and re-encoding is what loses key order
+// and numeric precision.
+func TestChatParametersResponseFormatDecodeKeepsClientBytes(t *testing.T) {
+	var params schemas.ChatParameters
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ByteExactChatBody), &params))
+	require.NotNil(t, params.ResponseFormat)
+
+	raw, ok := (*params.ResponseFormat).(json.RawMessage)
+	require.True(t, ok, "response_format must decode to raw JSON, got %T", *params.ResponseFormat)
+
+	rf, ok := schemas.ParseChatResponseFormat(params.ResponseFormat)
+	require.True(t, ok)
+	assert.Equal(t, "json_schema", rf.Type)
+	name, ok := rf.Name()
+	require.True(t, ok)
+	assert.Equal(t, "AssignmentResult", name)
+	require.NotNil(t, rf.Strict())
+	assert.True(t, *rf.Strict())
+
+	assert.Contains(t, string(raw), schemaorder.ByteExactSchema, "the client's response_format bytes must be kept verbatim")
+	assert.Equal(t, schemaorder.ByteExactSchema, string(rf.RawSchema()), "schema bytes must survive the decode untouched")
+}
+
+// TestChatParametersResponseFormatParsesOnDemand covers the structural view the
+// rewriting providers (Gemini normalization, the Anthropic tool fallback) rely
+// on: parsing the raw bytes must yield the client's key order at every level.
+func TestChatParametersResponseFormatParsesOnDemand(t *testing.T) {
+	var params schemas.ChatParameters
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ChatBody), &params))
+
+	rf, ok := schemas.ParseChatResponseFormat(params.ResponseFormat)
+	require.True(t, ok)
+
+	schema, ok := rf.SchemaMap()
+	require.True(t, ok)
+	assert.Equal(t, schemaorder.SchemaKeyOrder, schema.Keys())
+
+	props, ok := schemas.SafeExtractOrderedMap(mustGet(t, schema, "properties"))
+	require.True(t, ok)
+	assert.Equal(t, schemaorder.PropertyOrder, props.Keys())
+}
+
+// TestChatParametersResponseFormatRoundTripsInOrder pins the encode side: an
+// unmarshal/marshal round-trip must return the schema in the declared order.
+func TestChatParametersResponseFormatRoundTripsInOrder(t *testing.T) {
+	var params schemas.ChatParameters
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ChatBody), &params))
+
+	out, err := schemas.MarshalSorted(params)
+	require.NoError(t, err)
+
+	schemaorder.AssertPropertyOrder(t, string(out))
+	schemaorder.AssertSchemaKeyOrder(t, string(out), "schema")
+}
+
+// TestChatParametersResponseFormatAcceptsPlainMaps guards backwards
+// compatibility: plugins and Go callers build response_format as a plain map,
+// which has no order to preserve but must still serialize and convert.
+func TestChatParametersResponseFormatAcceptsPlainMaps(t *testing.T) {
+	var rf interface{} = map[string]interface{}{
+		"type": "json_schema",
+		"json_schema": map[string]interface{}{
+			"name": "AssignmentResult",
+			"schema": map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{"reasoning": map[string]interface{}{"type": "string"}},
+			},
+		},
+	}
+	params := schemas.ChatParameters{ResponseFormat: &rf}
+
+	out, err := schemas.MarshalSorted(params)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), `"reasoning"`)
+
+	cr := chatRequestWith(&params)
+	rr := cr.ToResponsesRequest()
+	require.NotNil(t, rr.Params)
+	require.NotNil(t, rr.Params.Text)
+	require.NotNil(t, rr.Params.Text.Format)
+	assert.Equal(t, "json_schema", rr.Params.Text.Format.Type)
+}
+
+// TestResponseFormatChatToResponsesKeepsOrder guards the conversion path: mux
+// reads response_format by type-asserting the decoded value, so an
+// order-preserving representation must not break json_schema extraction.
+func TestResponseFormatChatToResponsesKeepsOrder(t *testing.T) {
+	var params schemas.ChatParameters
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ChatBody), &params))
+
+	rr := chatRequestWith(&params).ToResponsesRequest()
+	require.NotNil(t, rr.Params)
+	require.NotNil(t, rr.Params.Text)
+	require.NotNil(t, rr.Params.Text.Format)
+	assert.Equal(t, "json_schema", rr.Params.Text.Format.Type)
+	require.NotNil(t, rr.Params.Text.Format.Name)
+	assert.Equal(t, "AssignmentResult", *rr.Params.Text.Format.Name)
+
+	out, err := schemas.MarshalSorted(rr.Params.Text.Format)
+	require.NoError(t, err)
+	schemaorder.AssertPropertyOrder(t, string(out))
+}
+
+// TestResponseFormatResponsesToChatKeepsOrder covers the reverse conversion,
+// used when a Responses request is routed to a chat-completions provider.
+func TestResponseFormatResponsesToChatKeepsOrder(t *testing.T) {
+	var params schemas.ResponsesParameters
+	require.NoError(t, schemas.Unmarshal([]byte(schemaorder.ResponsesBody), &params))
+	require.NotNil(t, params.Text)
+
+	rr := &schemas.BifrostResponsesRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-5.4-nano",
+		Input:    []schemas.ResponsesMessage{},
+		Params:   &params,
+	}
+
+	cr := rr.ToChatRequest()
+	require.NotNil(t, cr.Params)
+	require.NotNil(t, cr.Params.ResponseFormat)
+
+	out, err := schemas.MarshalSorted(cr.Params)
+	require.NoError(t, err)
+	schemaorder.AssertPropertyOrder(t, string(out))
+	schemaorder.AssertSchemaKeyOrder(t, string(out), "schema")
+}
+
+// TestResponsesSchemaToMapDoesNotMutateSource guards a sharp edge: OrderedMap
+// key sorting recurses into nested maps and mutates them in place, so a
+// conversion that sorts its own keys must not reach into the request's schema.
+func TestResponsesSchemaToMapDoesNotMutateSource(t *testing.T) {
+	props := schemas.NewOrderedMapFromPairs(
+		schemas.KV("reasoning", map[string]any{"type": "string"}),
+		schemas.KV("assigned_group_id", map[string]any{"type": "integer"}),
+	)
+	schema := &schemas.ResponsesTextConfigFormatJSONSchema{
+		Type:       schemas.Ptr("object"),
+		Properties: props,
+		Required:   []string{"reasoning", "assigned_group_id"},
+	}
+
+	converted := schema.ToMap()
+	require.NotNil(t, converted)
+
+	assert.Equal(t, schemaorder.PropertyOrder, props.Keys(), "ToMap must not reorder the source properties")
+	assert.Equal(t, schemaorder.PropertyOrder, schema.Properties.Keys())
+
+	out, err := schemas.MarshalSorted(converted)
+	require.NoError(t, err)
+	schemaorder.AssertPropertyOrder(t, string(out))
+}
+
+func chatRequestWith(params *schemas.ChatParameters) *schemas.BifrostChatRequest {
+	return &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-5.4-nano",
+		Input: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("assign it")},
+		}},
+		Params: params,
+	}
+}
+
+func mustGet(t *testing.T, om *schemas.OrderedMap, key string) interface{} {
+	t.Helper()
+	v, ok := om.Get(key)
+	require.True(t, ok, "expected key %q", key)
+	return v
+}

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -600,6 +602,133 @@ type ResponsesTextConfigFormatJSONSchema struct {
 	Nullable         *bool       `json:"nullable,omitempty"`         // Nullable indicator (OpenAPI 3.0 style)
 	Enum             []string    `json:"enum,omitempty"`             // Enum values
 	PropertyOrdering []string    `json:"propertyOrdering,omitempty"` // Ordering of properties, specific to Gemini
+
+	// keyOrder records the order in which the schema object's own keys arrived,
+	// so re-encoding does not reshuffle them into struct declaration order.
+	// Providers generate output in schema key order (see the type doc), and a
+	// schema that reads type/title/description before properties must keep
+	// reading that way after a round-trip through this struct.
+	keyOrder []string
+}
+
+// UnmarshalJSON decodes the schema and remembers its key order.
+func (s *ResponsesTextConfigFormatJSONSchema) UnmarshalJSON(data []byte) error {
+	type Alias ResponsesTextConfigFormatJSONSchema
+	var aux Alias
+	if err := Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	*s = ResponsesTextConfigFormatJSONSchema(aux)
+	s.keyOrder = jsonObjectKeyOrder(data)
+	return nil
+}
+
+// MarshalJSON encodes the schema, restoring the key order it was decoded with.
+// Keys added after decoding (or all keys, for a schema built in Go) follow in
+// struct declaration order.
+func (s ResponsesTextConfigFormatJSONSchema) MarshalJSON() ([]byte, error) {
+	type Alias ResponsesTextConfigFormatJSONSchema
+	raw, err := MarshalSorted(Alias(s))
+	if err != nil {
+		return nil, err
+	}
+	return reorderJSONObjectKeys(raw, s.keyOrder), nil
+}
+
+// KeyOrder returns the schema object's key order as decoded, or nil when the
+// schema was built in Go rather than decoded from JSON.
+func (s *ResponsesTextConfigFormatJSONSchema) KeyOrder() []string {
+	if s == nil || len(s.keyOrder) == 0 {
+		return nil
+	}
+	out := make([]string, len(s.keyOrder))
+	copy(out, s.keyOrder)
+	return out
+}
+
+// SetKeyOrder records the key order to re-encode this schema with. Used when a
+// schema crosses APIs (chat response_format <-> responses text.format) and the
+// order has to be carried over from the source representation.
+func (s *ResponsesTextConfigFormatJSONSchema) SetKeyOrder(order []string) {
+	if s == nil {
+		return
+	}
+	if len(order) == 0 {
+		s.keyOrder = nil
+		return
+	}
+	s.keyOrder = append([]string(nil), order...)
+}
+
+// jsonObjectKeyOrder returns the top-level keys of a JSON object in document order.
+func jsonObjectKeyOrder(data []byte) []string {
+	parsed := gjson.ParseBytes(data)
+	if !parsed.IsObject() {
+		return nil
+	}
+	keys := make([]string, 0, 8)
+	parsed.ForEach(func(key, _ gjson.Result) bool {
+		keys = append(keys, key.String())
+		return true
+	})
+	if len(keys) == 0 {
+		return nil
+	}
+	return keys
+}
+
+// reorderJSONObjectKeys rewrites a JSON object so the keys listed in order come
+// first, in that order; any remaining keys keep their existing relative order.
+// Values are copied verbatim, so nested ordering is untouched.
+func reorderJSONObjectKeys(raw []byte, order []string) []byte {
+	if len(order) == 0 {
+		return raw
+	}
+	parsed := gjson.ParseBytes(raw)
+	if !parsed.IsObject() {
+		return raw
+	}
+
+	type jsonPair struct{ key, value string }
+	pairs := make([]jsonPair, 0, 8)
+	index := make(map[string]int, 8)
+	parsed.ForEach(func(key, value gjson.Result) bool {
+		keyRaw := key.Raw
+		if len(keyRaw) == 0 || keyRaw[0] != '"' {
+			keyRaw = strconv.Quote(key.String())
+		}
+		index[key.String()] = len(pairs)
+		pairs = append(pairs, jsonPair{key: keyRaw, value: value.Raw})
+		return true
+	})
+	if len(pairs) == 0 {
+		return raw
+	}
+
+	written := make([]bool, len(pairs))
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	writePair := func(p jsonPair) {
+		if buf.Len() > 1 {
+			buf.WriteByte(',')
+		}
+		buf.WriteString(p.key)
+		buf.WriteByte(':')
+		buf.WriteString(p.value)
+	}
+	for _, key := range order {
+		if i, ok := index[key]; ok && !written[i] {
+			written[i] = true
+			writePair(pairs[i])
+		}
+	}
+	for i, p := range pairs {
+		if !written[i] {
+			writePair(p)
+		}
+	}
+	buf.WriteByte('}')
+	return buf.Bytes()
 }
 
 // JSONSchemaOrBool holds a JSON Schema value that is either a boolean schema
@@ -684,6 +813,7 @@ func (s *ResponsesTextConfigFormatJSONSchema) CompositeSchema() (*OrderedMap, bo
 // JSONSchemaFromMap builds a ResponsesTextConfigFormatJSONSchema from a raw interface{}
 func JSONSchemaFromMap(v interface{}) *ResponsesTextConfigFormatJSONSchema {
 	var m map[string]interface{}
+	var keyOrder []string
 	switch src := v.(type) {
 	case map[string]interface{}:
 		m = src
@@ -692,12 +822,28 @@ func JSONSchemaFromMap(v interface{}) *ResponsesTextConfigFormatJSONSchema {
 			return nil
 		}
 		m = src.ToMap() // shallow: nested *OrderedMap values keep their order
+		keyOrder = src.Keys()
 	case OrderedMap:
 		m = src.ToMap()
+		keyOrder = src.Keys()
+	case json.RawMessage:
+		decoded := NewOrderedMap()
+		if err := decoded.UnmarshalJSON(src); err != nil {
+			return nil
+		}
+		m = decoded.ToMap()
+		keyOrder = decoded.Keys()
+	case []byte:
+		decoded := NewOrderedMap()
+		if err := decoded.UnmarshalJSON(src); err != nil {
+			return nil
+		}
+		m = decoded.ToMap()
+		keyOrder = decoded.Keys()
 	default:
 		return nil
 	}
-	s := &ResponsesTextConfigFormatJSONSchema{}
+	s := &ResponsesTextConfigFormatJSONSchema{keyOrder: keyOrder}
 	if t, ok := m["type"].(string); ok {
 		s.Type = Ptr(t)
 	}
@@ -819,6 +965,52 @@ func JSONSchemaFromMap(v interface{}) *ResponsesTextConfigFormatJSONSchema {
 	return s
 }
 
+// RawSchemaJSON returns the schema body as JSON bytes, with the key order this
+// schema was decoded with. Prefer it over ToMap when the result is headed
+// straight back out to a provider: it avoids rebuilding a Go map only to
+// re-encode it, and it keeps numeric literals as written.
+//
+// `name` and `strict` are dropped: they are wrapper fields that OpenAI carries
+// beside the schema, not JSON Schema keywords, which is also why ToMap omits them.
+func (s *ResponsesTextConfigFormatJSONSchema) RawSchemaJSON() json.RawMessage {
+	if s == nil {
+		return nil
+	}
+
+	// A composite schema is already a self-contained schema object.
+	if s.Schema != nil {
+		if s.Schema.SchemaMap != nil {
+			encoded, err := MarshalSorted(s.Schema.SchemaMap)
+			if err != nil {
+				return nil
+			}
+			return encoded
+		}
+		if s.Schema.SchemaBool != nil {
+			if *s.Schema.SchemaBool {
+				return json.RawMessage("true")
+			}
+			return json.RawMessage("false")
+		}
+	}
+
+	// Decomposed form: the struct's own encoding already restores key order.
+	encoded, err := MarshalSorted(s)
+	if err != nil {
+		return nil
+	}
+	for _, key := range []string{"name", "strict", "schema"} {
+		encoded, err = sjson.DeleteBytes(encoded, key)
+		if err != nil {
+			return nil
+		}
+	}
+	if len(gjson.ParseBytes(encoded).Map()) == 0 {
+		return nil
+	}
+	return encoded
+}
+
 // ToMap reconstructs the raw schema map from a ResponsesTextConfigFormatJSONSchema.
 func (s *ResponsesTextConfigFormatJSONSchema) ToMap() interface{} {
 	if s == nil {
@@ -912,7 +1104,43 @@ func (s *ResponsesTextConfigFormatJSONSchema) ToMap() interface{} {
 	if len(m) == 0 {
 		return nil
 	}
-	return m
+	// Hand back an order-preserving map: the caller usually re-encodes this into
+	// a provider payload, and the model reads the schema in key order.
+	return orderedMapWithKeyOrder(m, s.keyOrder)
+}
+
+// orderedMapWithKeyOrder converts a plain map into an OrderedMap, emitting the
+// keys named in order first (in that order) and any remaining keys after them,
+// alphabetically. Only this map's own key sequence is decided here: values are
+// carried over by reference, so nested schemas keep the order they already have.
+// (OrderedMap.SortKeys is deliberately not used - it recurses into nested
+// *OrderedMap values and sorts them in place, which would reorder the caller's
+// `properties` as a side effect.)
+func orderedMapWithKeyOrder(m map[string]interface{}, order []string) *OrderedMap {
+	if m == nil {
+		return nil
+	}
+	om := NewOrderedMapWithCapacity(len(m))
+	for _, key := range order {
+		if value, ok := m[key]; ok {
+			om.Set(key, value)
+		}
+	}
+	if om.Len() == len(m) {
+		return om
+	}
+
+	remaining := make([]string, 0, len(m)-om.Len())
+	for key := range m {
+		if _, taken := om.Get(key); !taken {
+			remaining = append(remaining, key)
+		}
+	}
+	sort.Strings(remaining)
+	for _, key := range remaining {
+		om.Set(key, m[key])
+	}
+	return om
 }
 
 type ResponsesResponseConversation struct {

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -698,6 +698,14 @@ func SafeExtractOrderedMap(value interface{}) (*OrderedMap, bool) {
 		return nil, false
 	case OrderedMap:
 		return &v, true
+	case json.RawMessage:
+		// Schemas forwarded verbatim are carried as raw JSON; decode on demand,
+		// preserving the key order of the document.
+		decoded := NewOrderedMap()
+		if err := decoded.UnmarshalJSON(v); err != nil {
+			return nil, false
+		}
+		return decoded, true
 	}
 	return nil, false
 }

--- a/plugins/compat/requestcopy.go
+++ b/plugins/compat/requestcopy.go
@@ -1,6 +1,7 @@
 package compat
 
 import (
+	"encoding/json"
 	"maps"
 	"slices"
 
@@ -354,6 +355,10 @@ func cloneAnyValue(value any) any {
 		return cloneAnySlice(typed)
 	case []string:
 		return slices.Clone(typed)
+	case json.RawMessage:
+		// Raw JSON (e.g. response_format off the wire) is a byte slice: copy it
+		// so the clone does not share a backing array with the original request.
+		return json.RawMessage(slices.Clone(typed))
 	case map[string]string:
 		cloned := make(map[string]string, len(typed))
 		maps.Copy(cloned, typed)

--- a/tests/integrations/python/pyproject.toml
+++ b/tests/integrations/python/pyproject.toml
@@ -50,6 +50,19 @@ dependencies = [
     "pyasn1>=0.6.4",
 ]
 
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+# This project ships no importable code - it is a dependency manifest plus a pytest
+# suite. An empty py-modules says exactly that, and it also switches setuptools'
+# auto-discovery off. Without it, a plain `pip install -e .` (the fallback in
+# .github/workflows/scripts/test-integrations.sh when uv is missing) aborts with
+# "Multiple top-level modules discovered in a flat-layout" on run_all_tests.py and
+# run_integration_tests.py.
+[tool.setuptools]
+py-modules = []
+
 [project.optional-dependencies]
 dev = [
     "black>=23.0.0",   # Code formatting
@@ -123,4 +136,8 @@ exclude_lines = [
 
 
 [tool.uv]
+# Pins the root back to a virtual (non-installed) project. Declaring [build-system]
+# above would otherwise make uv treat it as an editable package, which changes the
+# root's entry in uv.lock and breaks `uv sync --frozen`.
+package = false
 exclude-newer = "2026-07-10T00:00:00Z"


### PR DESCRIPTION
## Summary

OpenAI Structured Outputs generates fields in the order the schema declares them. A gateway that re-sorts a user's JSON Schema silently changes model behavior — for example, a schema that puts `reasoning` before `assigned_group_id` so the model explains before it decides would have its property order reversed by an alphabetical sort. This PR ensures that `response_format` JSON Schemas reach every provider byte-for-byte as the client sent them, preserving key order, property order, and numeric literals (e.g. integers above 2^53 and `1.0`).

## Changes

- **`ChatParameters.UnmarshalJSON`** now holds `response_format` as `json.RawMessage` instead of decoding it into `map[string]interface{}`. Providers that forward the schema unchanged emit the client's bytes directly; providers that must rewrite it parse on demand via the new `ParseChatResponseFormat` accessor.

- **`schemas/responseformat.go`** introduces `ChatResponseFormat`, a lazy reader over the raw or in-memory response format value. It exposes `RawSchema()`, `RawJSONSchema()`, `SchemaMap()`, `Name()`, `Description()`, and `Strict()`, and provides `ChatResponseFormatFromResponsesFormat` / `ResponsesTextConfigFormatFromChatResponseFormat` for cross-API conversions that preserve schema bytes via `sjson.SetRawBytes`.

- **`ResponsesTextConfigFormatJSONSchema`** gains `UnmarshalJSON`/`MarshalJSON` that record and restore the schema object's own key order, so a schema decoded from the Responses API re-encodes in the same key sequence rather than struct declaration order.

- **Anthropic** (`utils.go`): `convertChatResponseFormatToAnthropicOutputFormat` and `convertChatResponseFormatToTool` now use `ParseChatResponseFormat` and `rf.RawSchema()`. The Anthropic-native path calls `NormalizeSchemaForAnthropicRaw` (sjson-based, edits in place), so a schema that needs no normalization reaches Anthropic exactly as sent.

- **Bedrock** (`utils.go`): `convertResponseFormatToTool` now splices the client's raw schema bytes directly into `BedrockToolInputSchema.JSON`, eliminating a marshal/unmarshal round-trip and the key reordering and numeric precision loss it caused.

- **Gemini** (`utils.go`): `extractSchemaMapFromResponseFormat` detects whether the schema contains any union `type` arrays (the only construct Gemini's normalizer rewrites) via `schemaNeedsGeminiNormalization`. Schemas that need no rewrite are forwarded as `json.RawMessage`; only schemas that do need rewriting go through the decode/normalize/re-encode path.

- **Cohere** (`utils.go`): `convertResponseFormatToCohere` now uses `rf.RawSchema()` to forward the schema body as raw bytes rather than re-encoding an `OrderedMap`.

- **HuggingFace** (`chat.go`): uses `rf.RawJSONSchema()` to carry the `json_schema` wrapper bytes through to the typed `HuggingFaceJSONSchema` struct without a re-encode.

- **Perplexity** (`responses.go`): the Responses path now maps `text.format` to `response_format` so a Responses request reaches Perplexity with its schema intact.

- **Replicate** (`chat.go`): the chat path now maps `response_format` to the `json_schema` input field so `gpt-5-structured` receives structured output from chat requests, matching the Responses path.

- **`BifrostChatRequest.ToResponsesRequest` / `BifrostResponsesRequest.ToChatRequest`** (`mux.go`) are rewritten to use the new conversion helpers, removing the manual map-building that lost key order.

- **`SafeExtractOrderedMap`** (`utils.go`) now accepts `json.RawMessage`, decoding it into an order-preserving `OrderedMap` on demand.

- **`cloneAnyValue`** (`plugins/compat/requestcopy.go`) handles `json.RawMessage` so the compat plugin copies the backing byte slice rather than sharing it.

- **`core/internal/schemaorder`** is a new shared test package providing canonical request fixtures (`ChatBody`, `ResponsesBody`, `ByteExactChatBody`) and assertion helpers (`AssertPropertyOrder`, `AssertSchemaKeyOrder`, `AssertSchemaBytes`, `AssertKeyOrder`, `ObjectAfterKey`) used across all provider packages.

- **New `responseformatordering_test.go` files** in every provider package (OpenAI, Anthropic, Bedrock, Gemini, Cohere, HuggingFace, Perplexity, Replicate) assert property order, schema key order, and byte-exact schema fidelity for both the Chat and Responses paths.

## Type of change

- [x] Bug fix
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations
- [x] Plugins

## How to test

```sh
go test ./core/... ./plugins/...
```

Each provider's `responseformatordering_test.go` exercises the full inbound-to-wire path and will fail if a schema is re-sorted, re-encoded, or has numeric literals corrupted.

## Breaking changes

- [x] No

## Security considerations

None. This change only affects how schema bytes are buffered and forwarded; no new inputs are trusted and no secrets are involved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable