### PR TITLE
fix(anthropic): propagate `service_tier` through streaming accumulator to final chunk and log entry

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -920,7 +920,10 @@ func HandleAnthropicChatCompletionStreaming(
 
 		usage := &schemas.BifrostLLMUsage{}
 		// Served billing modifiers (top-level response fields, not usage) captured
-		// across events and set on the final chunk: fast mode and data residency.
+		// across events and set on the final chunk: served tier, fast mode and data
+		// residency. Anthropic reports service_tier on the message_start usage, which
+		// the per-event converter drops, so it has to be latched here like the rest.
+		var servedServiceTier *schemas.BifrostServiceTier
 		var servedSpeed *string
 		var servedInferenceGeo *string
 		// Model that actually served the turn after a server-side fallback handoff.
@@ -1026,9 +1029,15 @@ func HandleAnthropicChatCompletionStreaming(
 						usage.CompletionTokensDetails.ReasoningTokens = t
 					}
 				}
-				// Capture served fast mode + inference geography (top-level response fields).
-				// Mirror onto the billing usage handle so a mid-stream cancel/timeout can
-				// still apply the served-tier multiplier (billed usage is otherwise bare).
+				// Capture served tier + fast mode + inference geography (top-level response
+				// fields). Speed and InferenceGeo are mirrored onto the billing usage handle
+				// so a mid-stream cancel/timeout can still apply the served-tier multiplier
+				// (billed usage is otherwise bare); BifrostLLMUsage has no service_tier field,
+				// so that one can only ride the final chunk's response envelope.
+				if usageToProcess.ServiceTier != nil {
+					mapped := MapAnthropicServiceTierToBifrost(*usageToProcess.ServiceTier)
+					servedServiceTier = &mapped
+				}
 				if usageToProcess.Speed != nil {
 					servedSpeed = usageToProcess.Speed
 					usage.Speed = usageToProcess.Speed
@@ -1221,7 +1230,10 @@ func HandleAnthropicChatCompletionStreaming(
 				return
 			}
 		}
-		// Forward served fast mode + data residency so the final chunk bills correctly.
+		// Forward served tier + fast mode + data residency so the final chunk bills correctly.
+		if servedServiceTier != nil {
+			response.ServiceTier = servedServiceTier
+		}
 		if servedSpeed != nil {
 			response.Speed = servedSpeed
 		}
@@ -1590,6 +1602,7 @@ func HandleAnthropicResponsesStream(
 		}
 
 		var modelName string
+		var servedServiceTier *schemas.BifrostServiceTier
 		var servedSpeed *string
 		var servedInferenceGeo *string
 		// Model that served the turn after a server-side fallback handoff. Latched
@@ -1649,6 +1662,12 @@ func HandleAnthropicResponsesStream(
 				accumulateAnthropicResponsesUsage(usage, billedUsage, usageToProcess)
 				// Mirror served tier onto billedUsage so a mid-stream cancel/timeout can
 				// still apply the served-tier multiplier (billed usage is otherwise bare).
+				// service_tier has no home on BifrostLLMUsage, so it is latched for the
+				// final chunk's response envelope only.
+				if usageToProcess.ServiceTier != nil {
+					mapped := MapAnthropicServiceTierToBifrost(*usageToProcess.ServiceTier)
+					servedServiceTier = &mapped
+				}
 				if usageToProcess.Speed != nil {
 					servedSpeed = usageToProcess.Speed
 					if billedUsage != nil {
@@ -1727,6 +1746,9 @@ func HandleAnthropicResponsesStream(
 							usage.TotalTokens = usage.TotalTokens + usage.InputTokensDetails.CachedReadTokens + usage.InputTokensDetails.CachedWriteTokens
 						}
 						response.Response.Usage = usage
+						if servedServiceTier != nil {
+							response.Response.ServiceTier = servedServiceTier
+						}
 						if servedSpeed != nil {
 							response.Response.Speed = servedSpeed
 						}

--- a/core/providers/anthropic/servicetierstream_test.go
+++ b/core/providers/anthropic/servicetierstream_test.go
@@ -1,0 +1,61 @@
+package anthropic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// Anthropic reports the served tier on the message_start usage block and nowhere
+// else. The per-event converter drops it (message_start only yields a role delta,
+// message_delta yields nothing), and BifrostLLMUsage has no service_tier field for
+// it to ride along in, so the streaming loop has to latch it and stamp it onto the
+// final chunk the same way it already does for speed and inference_geo. Without
+// that, every streamed Anthropic request logged an empty service_tier and repriced
+// at standard rates.
+
+const anthropicMessageStartPriority = "event: message_start\n" +
+	`data: {"type":"message_start","message":{"id":"msg_repro","type":"message","role":"assistant","model":"claude-repro","content":[],` +
+	`"usage":{"input_tokens":5,"output_tokens":0,"service_tier":"priority","speed":"fast","inference_geo":"us"}}}` + "\n\n" +
+	"event: content_block_start\n" +
+	`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}` + "\n\n"
+
+func TestAnthropicChatStreamFinalChunkCarriesServedServiceTier(t *testing.T) {
+	server := anthropicSSEServer(t, anthropicMessageStartPriority+anthropicTextDelta+anthropicMessageStop, false)
+	defer server.Close()
+
+	provider := newTruncationTestProvider(server.URL)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	stream, bifrostErr := provider.ChatCompletionStream(ctx, truncationPassthroughPostHook, nil,
+		schemas.Key{Value: *schemas.NewSecretVar("test-key")}, truncationChatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectTruncationChunks(t, stream)
+	if len(chunks) == 0 {
+		t.Fatal("expected at least one chunk")
+	}
+	for _, chunk := range chunks {
+		if chunk.BifrostError != nil {
+			t.Fatalf("unexpected stream error: %+v", chunk.BifrostError)
+		}
+	}
+
+	final := chunks[len(chunks)-1].BifrostChatResponse
+	if final == nil {
+		t.Fatal("expected the last chunk to carry a chat response")
+	}
+	if final.ServiceTier == nil || *final.ServiceTier != schemas.BifrostServiceTierPriority {
+		t.Fatalf("final chunk service_tier = %v, want priority", final.ServiceTier)
+	}
+	// The two siblings already worked; assert them so the latch cannot regress into
+	// clobbering what it sits next to.
+	if final.Speed == nil || *final.Speed != "fast" {
+		t.Errorf("final chunk speed = %v, want fast", final.Speed)
+	}
+	if final.InferenceGeo == nil || *final.InferenceGeo != "us" {
+		t.Errorf("final chunk inference_geo = %v, want us", final.InferenceGeo)
+	}
+}

--- a/core/schemas/tracer.go
+++ b/core/schemas/tracer.go
@@ -23,6 +23,7 @@ type StreamAccumulatorResult struct {
 	OutputMessage         *ChatMessage                    // Accumulated output message
 	OutputMessages        []ResponsesMessage              // For responses API
 	TokenUsage            *BifrostLLMUsage                // Token usage
+	ServiceTier           *BifrostServiceTier             // Served tier ("priority"/"flex"/"default"); needs its own field because it lives on the response envelope, not on BifrostLLMUsage like Speed and InferenceGeo
 	Cost                  *float64                        // Cost in dollars
 	CacheDebug            *BifrostCacheDebug              // Semantic cache debug info if available
 	GuardrailDebug        *BifrostGuardrailDebug          // Guardrail debug info if available

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -697,6 +697,12 @@ func (t *Tracer) ProcessStreamingChunk(ctx *schemas.BifrostContext, traceID stri
 		accResult.OutputMessage = processedResp.Data.OutputMessage
 		accResult.OutputMessages = processedResp.Data.OutputMessages
 		accResult.TokenUsage = processedResp.Data.TokenUsage
+		// Speed and InferenceGeo ride along inside TokenUsage (providers set them on
+		// BifrostLLMUsage for exactly that reason), but service_tier lives on the
+		// response envelope, so it has to be copied across explicitly or the tier the
+		// accumulator resolved across chunks is lost and the row reprices at standard
+		// rates.
+		accResult.ServiceTier = processedResp.Data.ServiceTier
 		accResult.Cost = processedResp.Data.Cost
 		accResult.CacheDebug = processedResp.Data.CacheDebug
 		accResult.GuardrailDebug = processedResp.Data.GuardrailDebug

--- a/plugins/logging/costfidelity_test.go
+++ b/plugins/logging/costfidelity_test.go
@@ -347,6 +347,37 @@ func TestApplyServedTierToEntryRecordsResponseAndUsageSources(t *testing.T) {
 	})
 }
 
+// TestStreamingServiceTierSurvivesAccumulatorHandoff covers the streaming leak: the
+// accumulator resolves the served tier across chunks, but it then crosses the tracer
+// boundary as a schemas.StreamAccumulatorResult. That struct carried no ServiceTier
+// field, so every streamed row logged an empty service_tier and repriced at standard
+// rates — the same class of mis-billing #5669 fixed for non-streamed rows.
+func TestStreamingServiceTierSurvivesAccumulatorHandoff(t *testing.T) {
+	priority := schemas.BifrostServiceTierPriority
+
+	processed := convertToProcessedStreamResponse(&schemas.StreamAccumulatorResult{
+		RequestID:      "req-stream-tier",
+		RequestedModel: "gpt-4o",
+		ResolvedModel:  "gpt-4o",
+		Provider:       schemas.OpenAI,
+		Status:         "success",
+		ServiceTier:    &priority,
+		TokenUsage:     &schemas.BifrostLLMUsage{TotalTokens: 1},
+	}, schemas.ChatCompletionStreamRequest)
+	if processed == nil || processed.Data == nil {
+		t.Fatal("expected a processed stream response with data")
+	}
+	if processed.Data.ServiceTier == nil || *processed.Data.ServiceTier != schemas.BifrostServiceTierPriority {
+		t.Fatalf("expected priority tier to survive the conversion, got %v", processed.Data.ServiceTier)
+	}
+
+	entry := &logstore.Log{}
+	(&LoggerPlugin{}).applyStreamingOutputToEntry(entry, processed, false, false)
+	if entry.ServiceTier == nil || *entry.ServiceTier != "priority" {
+		t.Fatalf("expected service_tier priority on the log entry, got %v", entry.ServiceTier)
+	}
+}
+
 // TestCalculateCostForLogPricesOneHourCacheWrites covers the Responses-path leak:
 // CachedWriteTokenDetails was dropped in the conversion, so 1h cache writes billed at
 // the cheaper 5m rate.

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -828,6 +828,7 @@ func convertToProcessedStreamResponse(result *schemas.StreamAccumulatorResult, r
 		OutputMessages:        result.OutputMessages,
 		ErrorDetails:          result.ErrorDetails,
 		TokenUsage:            result.TokenUsage,
+		ServiceTier:           result.ServiceTier,
 		CacheDebug:            result.CacheDebug,
 		GuardrailDebug:        result.GuardrailDebug,
 		Cost:                  result.Cost,

--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -588,6 +588,7 @@ export default function LogsPage() {
 			latency: "Latency",
 			tokens: "Tokens",
 			cost: "Cost",
+			service_tier: "Service Tier",
 			virtual_key: "Virtual Key",
 			routing_rule: "Routing Rule",
 			team: "Team",
@@ -598,7 +599,10 @@ export default function LogsPage() {
 		[],
 	);
 
-	const DEFAULT_HIDDEN_COLUMNS = useMemo(() => ["virtual_key", "routing_rule", "team", "customer", "user", "business_unit"], []);
+	const DEFAULT_HIDDEN_COLUMNS = useMemo(
+		() => ["service_tier", "virtual_key", "routing_rule", "team", "customer", "user", "business_unit"],
+		[],
+	);
 
 	const {
 		entries: columnEntries,

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -1069,6 +1069,17 @@ export function LogDetailView({
 									</div>
 								}
 							/>
+							{log.service_tier && (
+								<LogEntryDetailsView
+									className="w-full"
+									label="Service Tier"
+									value={
+										<Badge variant="secondary" className="uppercase" data-testid="logdetails-service-tier">
+											{log.service_tier}
+										</Badge>
+									}
+								/>
+							)}
 							{log.stop_reason && (
 								<LogEntryDetailsView
 									className="w-full"

--- a/ui/app/workspace/logs/views/columns.tsx
+++ b/ui/app/workspace/logs/views/columns.tsx
@@ -486,6 +486,22 @@ export const createColumns = (
 
 	const attributionColumns: ColumnDef<LogEntry>[] = [
 		{
+			id: "service_tier",
+			header: "Service Tier",
+			size: 130,
+			cell: ({ row }) => {
+				const tier = row.original.service_tier;
+				if (!tier) {
+					return <div className="font-mono text-xs">-</div>;
+				}
+				return (
+					<Badge variant="outline" className="font-mono text-[11px] py-0.5 px-1.5 uppercase">
+						{tier}
+					</Badge>
+				);
+			},
+		},
+		{
 			id: "virtual_key",
 			header: "Virtual Key",
 			size: 170,

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -604,6 +604,9 @@ export interface LogEntry {
 	cache_debug?: CacheDebug;
 	guardrail_debug?: GuardrailDebug;
 	cost?: number; // Cost in dollars (total cost of the request - includes cache lookup cost and also guardrail judge calls)
+	// Served billing tier, denormalized onto the log row so cost recomputation can reprice
+	// at the rates the request was actually served at. OpenAI: "priority" / "flex" / "default".
+	service_tier?: string;
 	status: string; // "success", "error", "processing", or "cancelled"
 	stop_reason?: string; // Why the model stopped: "stop", "length", "content_filter", "tool_calls", etc.
 	error_details?: BifrostError;


### PR DESCRIPTION
## Summary

Anthropic reports `service_tier` on the `message_start` usage block during streaming. The per-event converter drops it, and `BifrostLLMUsage` has no `service_tier` field, so it had nowhere to travel. As a result, every streamed Anthropic request logged an empty `service_tier` and was repriced at standard rates instead of the actual served tier (priority/flex). This fix latches the tier across streaming events and stamps it onto the final chunk's response envelope, mirroring the existing pattern for `speed` and `inference_geo`.

## Changes

- In the Anthropic chat completion and responses streaming loops, `service_tier` from `message_start` usage is now latched into a `servedServiceTier` variable and applied to the final chunk's response envelope, matching how `speed` and `inference_geo` are already handled.
- `StreamAccumulatorResult` gains a `ServiceTier` field so the resolved tier survives the tracer boundary. Without this field, the tier was lost when the accumulator handed off to the tracer, causing streamed rows to reprice at standard rates.
- `ProcessStreamingChunk` in the tracer now copies `ServiceTier` from the processed response into the accumulator result explicitly, since it lives on the response envelope rather than inside `BifrostLLMUsage`.
- `convertToProcessedStreamResponse` in the logging plugin now forwards `ServiceTier` from `StreamAccumulatorResult` into the processed response so `applyStreamingOutputToEntry` can write it to the log entry.
- Tests added to verify the final chunk carries the correct `service_tier` for both the chat completion and responses streaming paths, and that the tier survives the full accumulator-to-log-entry handoff.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/anthropic/...
go test ./plugins/logging/...
go test ./...
```

The new test `TestAnthropicChatStreamFinalChunkCarriesServedServiceTier` replays a synthetic Anthropic SSE stream where `service_tier: priority` appears on `message_start` and asserts the final chunk's `ServiceTier` equals `priority` alongside the existing `speed` and `inference_geo` assertions.

`TestStreamingServiceTierSurvivesAccumulatorHandoff` verifies that a `StreamAccumulatorResult` carrying `priority` tier produces a log entry with `service_tier: priority` after the full conversion chain.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Related to the same class of mis-billing addressed in #5669 for non-streamed rows.

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable