### PR TITLE
perf: optimize ordered map's marshalJson

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -5160,6 +5160,19 @@ func (bifrost *Bifrost) shouldContinueWithFallbacks(fallback schemas.Fallback, f
 	return true
 }
 
+// populateLatencyExtraFields stamps upstream and overhead onto resp's ExtraFields,
+// deriving overhead from the request-start time on ctx. No-ops when unmeasured, so
+// absent stays distinct from zero. Call before RunPostLLMHooks so logging sees it.
+func populateLatencyExtraFields(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse) {
+	if resp == nil {
+		return
+	}
+	resp.PopulateUpstreamLatency(ctx)
+	if start, ok := ctx.Value(schemas.BifrostContextKeyRequestStartTime).(time.Time); ok {
+		resp.PopulateOverheadLatency(ctx, time.Since(start))
+	}
+}
+
 // handleRequest handles the request to the provider based on the request type
 // It handles plugin hooks, request validation, response processing, and fallback providers.
 // If the primary provider fails, it will try each fallback provider in order until one succeeds.
@@ -5175,10 +5188,13 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 
 	// Reset first: bifrost.ctx is shared across every nil-ctx caller.
 	ctx.ResetUpstreamLatency()
-	// Stamp on the way out, after every attempt and fallback.
+	// Whole-request start for top-down overhead (total minus upstream). On ctx so
+	// tryRequest can stamp the response before post-hooks, where logging reads it.
+	ctx.SetValue(schemas.BifrostContextKeyRequestStartTime, time.Now())
+	// Backstop for the returned body if a post-hook replaced the response.
 	defer func() {
 		ctx.StampUpstreamLatency()
-		resp.PopulateUpstreamLatency(ctx)
+		populateLatencyExtraFields(ctx, resp)
 	}()
 
 	// Try the primary provider first
@@ -5315,6 +5331,9 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 	}
 
 	ctx.ResetUpstreamLatency()
+	// Whole-request start for overhead on the streaming short-circuit path; the
+	// normal path derives its total from the final chunk.
+	ctx.SetValue(schemas.BifrostContextKeyRequestStartTime, time.Now())
 
 	// Try the primary provider first
 	ctx.SetValue(schemas.BifrostContextKeyFallbackIndex, 0)
@@ -5485,6 +5504,9 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 		// Handle short-circuit with response (success case)
 		if shortCircuit.Response != nil {
 			shortCircuit.Response.PopulateExtraFields(req.RequestType, provider, model, model)
+			// Cache hit / short-circuit: upstream 0, overhead is the whole request.
+			// Stamp before post-hooks for logging.
+			populateLatencyExtraFields(ctx, shortCircuit.Response)
 			resp, bifrostErr := pipeline.RunPostLLMHooks(ctx, shortCircuit.Response, nil, preCount)
 			if bifrostErr != nil {
 				bifrostErr.PopulateExtraFields(req.RequestType, provider, model, model)
@@ -5597,6 +5619,9 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 	pluginCount := len(*bifrost.llmPlugins.Load())
 	select {
 	case result = <-msg.Response:
+		// Accumulator is complete once the provider returns; stamp before post-hooks
+		// so logging reads it off ExtraFields.
+		populateLatencyExtraFields(msg.Context, result)
 		resp, bifrostErr := pipeline.RunPostLLMHooks(msg.Context, result, nil, pluginCount)
 		if bifrostErr != nil {
 			bifrostErr.PopulateExtraFields(req.RequestType, provider, model, model)
@@ -5733,6 +5758,9 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 		// Handle short-circuit with response (success case)
 		if shortCircuit.Response != nil {
 			shortCircuit.Response.PopulateExtraFields(req.RequestType, provider, model, model)
+			// Cache hit / short-circuit: upstream 0, overhead is the whole request.
+			// Stamp before post-hooks for logging.
+			populateLatencyExtraFields(ctx, shortCircuit.Response)
 			resp, bifrostErr := pipeline.RunPostLLMHooks(ctx, shortCircuit.Response, nil, preCount)
 			if bifrostErr != nil {
 				bifrostErr.PopulateExtraFields(req.RequestType, provider, model, model)

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4601,7 +4601,7 @@ func (bifrost *Bifrost) getProviderQueue(providerKey schemas.ModelProvider) (*Pr
 		pq := pqValue.(*ProviderQueue)
 		return pq, nil
 	}
-	bifrost.logger.Debug(fmt.Sprintf("Creating new request queue for provider %s at runtime", providerKey))
+	bifrost.logger.Debug("Creating new request queue for provider %s at runtime", providerKey)
 	config, err := bifrost.account.GetConfigForProvider(providerKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get config for provider %s: %v", providerKey, err)
@@ -5156,7 +5156,7 @@ func (bifrost *Bifrost) shouldContinueWithFallbacks(fallback schemas.Fallback, f
 		return false
 	}
 
-	bifrost.logger.Debug(fmt.Sprintf("Fallback provider %s failed: %s", fallback.Provider, fallbackErr.Error.Message))
+	bifrost.logger.Debug("Fallback provider %s failed: %s", fallback.Provider, fallbackErr.Error.Message)
 	return true
 }
 
@@ -5210,17 +5210,17 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 		return nil, err
 	}
 
-	bifrost.logger.Debug(fmt.Sprintf("primary provider %s with model %s and %d fallbacks", provider, model, len(fallbacks)))
+	bifrost.logger.Debug("primary provider %s with model %s and %d fallbacks", provider, model, len(fallbacks))
 
 	primaryResult, primaryErr := bifrost.tryRequest(ctx, req)
 	if primaryErr != nil {
 		if primaryErr.Error != nil {
-			bifrost.logger.Debug(fmt.Sprintf("primary provider %s with model %s returned error: %s", provider, model, primaryErr.Error.Message))
+			bifrost.logger.Debug("primary provider %s with model %s returned error: %s", provider, model, primaryErr.Error.Message)
 		} else {
-			bifrost.logger.Debug(fmt.Sprintf("primary provider %s with model %s returned error: %v", provider, model, primaryErr))
+			bifrost.logger.Debug("primary provider %s with model %s returned error: %v", provider, model, primaryErr)
 		}
 		if len(fallbacks) > 0 {
-			bifrost.logger.Debug(fmt.Sprintf("check if we should try %d fallbacks", len(fallbacks)))
+			bifrost.logger.Debug("check if we should try %d fallbacks", len(fallbacks))
 		}
 	}
 
@@ -5244,7 +5244,7 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 	// Try fallbacks in order
 	for i, fallback := range fallbacks {
 		ctx.SetValue(schemas.BifrostContextKeyFallbackIndex, i+1)
-		bifrost.logger.Debug(fmt.Sprintf("trying fallback provider %s with model %s", fallback.Provider, fallback.Model))
+		bifrost.logger.Debug("trying fallback provider %s with model %s", fallback.Provider, fallback.Model)
 		ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelInfo, fmt.Sprintf("Trying fallback %d/%d: %s/%s (previous attempt failed: %s)", i+1, len(fallbacks), fallback.Provider, fallback.Model, routingErrorSummary(lastErr)))
 		ctx.SetValue(schemas.BifrostContextKeyFallbackRequestID, uuid.New().String())
 		clearCtxForFallback(ctx)
@@ -5260,7 +5260,7 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 
 		fallbackReq := bifrost.prepareFallbackRequest(req, fallback)
 		if fallbackReq == nil {
-			bifrost.logger.Debug(fmt.Sprintf("fallback provider %s with model %s is nil", fallback.Provider, fallback.Model))
+			bifrost.logger.Debug("fallback provider %s with model %s is nil", fallback.Provider, fallback.Model)
 			ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelWarn, fmt.Sprintf("Fallback %s/%s skipped: missing provider config", fallback.Provider, fallback.Model))
 			tracer.SetAttribute(handle, "error", "fallback request preparation failed")
 			tracer.EndSpan(handle, schemas.SpanStatusError, "fallback request preparation failed")
@@ -5275,7 +5275,7 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 		result.SetFallbackRoutingInfo(provider, model)
 		fallbackErr.SetFallbackRoutingInfo(provider, model)
 		if fallbackErr == nil {
-			bifrost.logger.Debug(fmt.Sprintf("successfully used fallback provider %s with model %s", fallback.Provider, fallback.Model))
+			bifrost.logger.Debug("successfully used fallback provider %s with model %s", fallback.Provider, fallback.Model)
 			ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelInfo, fmt.Sprintf("Request served by fallback %s/%s (attempt %d/%d)", fallback.Provider, fallback.Model, i+1, len(fallbacks)))
 			tracer.EndSpan(handle, schemas.SpanStatusOk, "")
 			return result, nil
@@ -5343,17 +5343,17 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 		return nil, err
 	}
 
-	bifrost.logger.Debug(fmt.Sprintf("primary provider %s with model %s and %d fallbacks", provider, model, len(fallbacks)))
+	bifrost.logger.Debug("primary provider %s with model %s and %d fallbacks", provider, model, len(fallbacks))
 
 	primaryResult, primaryErr := bifrost.tryStreamRequest(ctx, req)
 	if primaryErr != nil {
 		if primaryErr.Error != nil {
-			bifrost.logger.Debug(fmt.Sprintf("primary provider %s with model %s returned error: %s", provider, model, primaryErr.Error.Message))
+			bifrost.logger.Debug("primary provider %s with model %s returned error: %s", provider, model, primaryErr.Error.Message)
 		} else {
-			bifrost.logger.Debug(fmt.Sprintf("primary provider %s with model %s returned error: %v", provider, model, primaryErr))
+			bifrost.logger.Debug("primary provider %s with model %s returned error: %v", provider, model, primaryErr)
 		}
 		if len(fallbacks) > 0 {
-			bifrost.logger.Debug(fmt.Sprintf("check if we should try %d fallbacks", len(fallbacks)))
+			bifrost.logger.Debug("check if we should try %d fallbacks", len(fallbacks))
 		}
 	}
 
@@ -5419,7 +5419,7 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 				}
 				ctx.SetRoutingInfoSnapshot(ri)
 			}
-			bifrost.logger.Debug(fmt.Sprintf("successfully used fallback provider %s with model %s", fallback.Provider, fallback.Model))
+			bifrost.logger.Debug("successfully used fallback provider %s with model %s", fallback.Provider, fallback.Model)
 			ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelInfo, fmt.Sprintf("Request served by fallback %s/%s (attempt %d/%d)", fallback.Provider, fallback.Model, i+1, len(fallbacks)))
 			tracer.EndSpan(handle, schemas.SpanStatusOk, "")
 			return result, nil
@@ -7630,7 +7630,7 @@ func (p *PluginPipeline) RunLLMPreHooks(ctx *schemas.BifrostContext, req *schema
 		pluginName := plugin.GetName()
 		p.logger.Debug("running pre-hook for plugin %s", pluginName)
 		// Start span for this plugin's PreLLMHook
-		spanCtx, handle := p.tracer.StartSpan(ctx, fmt.Sprintf("plugin.%s.prehook", sanitizeSpanName(pluginName)), schemas.SpanKindPlugin)
+		spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).prehook, schemas.SpanKindPlugin)
 		// Update pluginCtx with span context for nested operations
 		if spanCtx != nil {
 			if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
@@ -7683,7 +7683,7 @@ func (p *PluginPipeline) RunPreRequestHooks(ctx *schemas.BifrostContext, req *sc
 	for _, plugin := range p.llmPlugins {
 		pluginName := plugin.GetName()
 		p.logger.Debug("running pre-request hook for plugin %s", pluginName)
-		spanCtx, handle := p.tracer.StartSpan(ctx, fmt.Sprintf("plugin.%s.prerequesthook", sanitizeSpanName(pluginName)), schemas.SpanKindPlugin)
+		spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).prerequesthook, schemas.SpanKindPlugin)
 		if spanCtx != nil {
 			if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
 				ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
@@ -7769,7 +7769,7 @@ func (p *PluginPipeline) RunPostLLMHooks(ctx *schemas.BifrostContext, resp *sche
 			}
 		} else {
 			// For non-streaming: create span per plugin (existing behavior)
-			spanCtx, handle := p.tracer.StartSpan(ctx, fmt.Sprintf("plugin.%s.posthook", sanitizeSpanName(pluginName)), schemas.SpanKindPlugin)
+			spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).posthook, schemas.SpanKindPlugin)
 			// Update pluginCtx with span context for nested operations
 			if spanCtx != nil {
 				if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
@@ -7827,7 +7827,7 @@ func (p *PluginPipeline) RunMCPPreHooks(ctx *schemas.BifrostContext, req *schema
 		pluginName := plugin.GetName()
 		p.logger.Debug("running MCP pre-hook for plugin %s", pluginName)
 		// Start span for this plugin's PreMCPHook
-		spanCtx, handle := p.tracer.StartSpan(ctx, fmt.Sprintf("plugin.%s.mcp_prehook", sanitizeSpanName(pluginName)), schemas.SpanKindPlugin)
+		spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).mcpPrehook, schemas.SpanKindPlugin)
 		// Update pluginCtx with span context for nested operations
 		if spanCtx != nil {
 			if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
@@ -7883,7 +7883,7 @@ func (p *PluginPipeline) RunMCPPostHooks(ctx *schemas.BifrostContext, mcpResp *s
 		pluginName := plugin.GetName()
 		p.logger.Debug("running MCP post-hook for plugin %s", pluginName)
 		// Create span per plugin
-		spanCtx, handle := p.tracer.StartSpan(ctx, fmt.Sprintf("plugin.%s.mcp_posthook", sanitizeSpanName(pluginName)), schemas.SpanKindPlugin)
+		spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).mcpPosthook, schemas.SpanKindPlugin)
 		// Update pluginCtx with span context for nested operations
 		if spanCtx != nil {
 			if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
@@ -7937,7 +7937,7 @@ func (p *PluginPipeline) RunMCPPreConnectionHooks(ctx *schemas.BifrostContext, r
 	for i, plugin := range p.mcpPlugins {
 		pluginName := plugin.GetName()
 		p.logger.Debug("running MCP connect pre-hook for plugin %s", pluginName)
-		spanCtx, handle := p.tracer.StartSpan(ctx, fmt.Sprintf("plugin.%s.mcp_connect_prehook", sanitizeSpanName(pluginName)), schemas.SpanKindPlugin)
+		spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).mcpConnectPrehook, schemas.SpanKindPlugin)
 		if spanCtx != nil {
 			if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
 				ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
@@ -8000,7 +8000,7 @@ func (p *PluginPipeline) RunMCPPostConnectionHooks(ctx *schemas.BifrostContext, 
 		plugin := p.mcpPlugins[i]
 		pluginName := plugin.GetName()
 		p.logger.Debug("running MCP connect post-hook for plugin %s", pluginName)
-		spanCtx, handle := p.tracer.StartSpan(ctx, fmt.Sprintf("plugin.%s.mcp_connect_posthook", sanitizeSpanName(pluginName)), schemas.SpanKindPlugin)
+		spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).mcpConnectPosthook, schemas.SpanKindPlugin)
 		if spanCtx != nil {
 			if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
 				ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
@@ -8182,7 +8182,7 @@ func (p *PluginPipeline) FinalizeStreamingPostHookSpans(ctx context.Context) {
 	// Start spans in execution order (nested: each is a child of the previous)
 	for _, entry := range snapshot {
 		// Create span as child of the previous span (nested hierarchy)
-		newCtx, handle := tracer.StartSpan(currentCtx, fmt.Sprintf("plugin.%s.posthook", sanitizeSpanName(entry.pluginName)), schemas.SpanKindPlugin)
+		newCtx, handle := tracer.StartSpan(currentCtx, pluginSpanNamesFor(entry.pluginName).posthook, schemas.SpanKindPlugin)
 		if handle == nil {
 			continue
 		}

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6244,14 +6244,20 @@ func executeRequestWithRetries[T any](
 			spanName = fmt.Sprintf("%s %s", otelOp, model)
 			spanKind = schemas.SpanKindLLMCall
 		}
-		spanCtx, handle := tracer.StartSpan(ctx, spanName, spanKind)
-		tracer.SetAttribute(handle, schemas.AttrProviderName, schemas.OTelProviderName(providerKey))
-		tracer.SetAttribute(handle, schemas.AttrBifrostProviderName, string(providerKey)) // raw Bifrost short name, mirrors canonical gen_ai.provider.name
-		tracer.SetAttribute(handle, schemas.AttrRequestModel, model)
-		tracer.SetAttribute(handle, schemas.AttrOperationName, otelOp)
-		tracer.SetAttribute(handle, schemas.AttrLegacyRequestType, string(requestType)) // legacy: replaced by gen_ai.operation.name
+		spanID, handle := tracer.StartSpanID(ctx, spanName, spanKind)
+		// Resolve the span once and write attributes directly. Previously each
+		// attribute was a separate tracer.SetAttribute, and every call re-resolved
+		// the span (trace lookup + linear span scan over all spans in the trace):
+		// ~30 lookups per request. span.SetAttribute is nil-safe, so a nil span
+		// (e.g. NoOpTracer) makes the whole block a no-op with no branch here.
+		span := tracer.SpanFromHandle(handle)
+		span.SetAttribute(schemas.AttrProviderName, schemas.OTelProviderName(providerKey))
+		span.SetAttribute(schemas.AttrBifrostProviderName, string(providerKey)) // raw Bifrost short name, mirrors canonical gen_ai.provider.name
+		span.SetAttribute(schemas.AttrRequestModel, model)
+		span.SetAttribute(schemas.AttrOperationName, otelOp)
+		span.SetAttribute(schemas.AttrLegacyRequestType, string(requestType)) // legacy: replaced by gen_ai.operation.name
 		if attempts > 0 {
-			tracer.SetAttribute(handle, schemas.AttrLegacyRetryCount, attempts) // legacy: bare key with no semconv prefix
+			span.SetAttribute(schemas.AttrLegacyRetryCount, attempts) // legacy: bare key with no semconv prefix
 		}
 
 		// Add context-related attributes (selected key, virtual key, team, customer, etc.)
@@ -6260,76 +6266,76 @@ func executeRequestWithRetries[T any](
 		// are the canonical home going forward; once all dashboards migrate, drop the
 		// gen_ai.* lines (grep for "// legacy:" in this block).
 		if selectedKeyID, ok := ctx.Value(schemas.BifrostContextKeySelectedKeyID).(string); ok && selectedKeyID != "" {
-			tracer.SetAttribute(handle, schemas.AttrSelectedKeyID, selectedKeyID) // legacy: gen_ai.* placement of bifrost-internal attr
-			tracer.SetAttribute(handle, schemas.AttrBifrostSelectedKeyID, selectedKeyID)
+			span.SetAttribute(schemas.AttrSelectedKeyID, selectedKeyID) // legacy: gen_ai.* placement of bifrost-internal attr
+			span.SetAttribute(schemas.AttrBifrostSelectedKeyID, selectedKeyID)
 		}
 		if selectedKeyName, ok := ctx.Value(schemas.BifrostContextKeySelectedKeyName).(string); ok && selectedKeyName != "" {
-			tracer.SetAttribute(handle, schemas.AttrSelectedKeyName, selectedKeyName) // legacy: gen_ai.* placement of bifrost-internal attr
-			tracer.SetAttribute(handle, schemas.AttrBifrostSelectedKeyName, selectedKeyName)
+			span.SetAttribute(schemas.AttrSelectedKeyName, selectedKeyName) // legacy: gen_ai.* placement of bifrost-internal attr
+			span.SetAttribute(schemas.AttrBifrostSelectedKeyName, selectedKeyName)
 		}
 		if virtualKeyID, ok := ctx.Value(schemas.BifrostContextKeyGovernanceVirtualKeyID).(string); ok && virtualKeyID != "" {
-			tracer.SetAttribute(handle, schemas.AttrVirtualKeyID, virtualKeyID) // legacy: gen_ai.* placement of bifrost-internal attr
-			tracer.SetAttribute(handle, schemas.AttrBifrostVirtualKeyID, virtualKeyID)
+			span.SetAttribute(schemas.AttrVirtualKeyID, virtualKeyID) // legacy: gen_ai.* placement of bifrost-internal attr
+			span.SetAttribute(schemas.AttrBifrostVirtualKeyID, virtualKeyID)
 		}
 		if virtualKeyName, ok := ctx.Value(schemas.BifrostContextKeyGovernanceVirtualKeyName).(string); ok && virtualKeyName != "" {
-			tracer.SetAttribute(handle, schemas.AttrVirtualKeyName, virtualKeyName) // legacy: gen_ai.* placement of bifrost-internal attr
-			tracer.SetAttribute(handle, schemas.AttrBifrostVirtualKeyName, virtualKeyName)
+			span.SetAttribute(schemas.AttrVirtualKeyName, virtualKeyName) // legacy: gen_ai.* placement of bifrost-internal attr
+			span.SetAttribute(schemas.AttrBifrostVirtualKeyName, virtualKeyName)
 		}
 		if teamID, ok := ctx.Value(schemas.BifrostContextKeyGovernanceTeamID).(string); ok && teamID != "" {
-			tracer.SetAttribute(handle, schemas.AttrTeamID, teamID) // legacy: gen_ai.* placement of bifrost-internal attr
-			tracer.SetAttribute(handle, schemas.AttrBifrostTeamID, teamID)
+			span.SetAttribute(schemas.AttrTeamID, teamID) // legacy: gen_ai.* placement of bifrost-internal attr
+			span.SetAttribute(schemas.AttrBifrostTeamID, teamID)
 		}
 		if teamName, ok := ctx.Value(schemas.BifrostContextKeyGovernanceTeamName).(string); ok && teamName != "" {
-			tracer.SetAttribute(handle, schemas.AttrTeamName, teamName) // legacy: gen_ai.* placement of bifrost-internal attr
-			tracer.SetAttribute(handle, schemas.AttrBifrostTeamName, teamName)
+			span.SetAttribute(schemas.AttrTeamName, teamName) // legacy: gen_ai.* placement of bifrost-internal attr
+			span.SetAttribute(schemas.AttrBifrostTeamName, teamName)
 		}
 		if customerID, ok := ctx.Value(schemas.BifrostContextKeyGovernanceCustomerID).(string); ok && customerID != "" {
-			tracer.SetAttribute(handle, schemas.AttrCustomerID, customerID) // legacy: gen_ai.* placement of bifrost-internal attr
-			tracer.SetAttribute(handle, schemas.AttrBifrostCustomerID, customerID)
+			span.SetAttribute(schemas.AttrCustomerID, customerID) // legacy: gen_ai.* placement of bifrost-internal attr
+			span.SetAttribute(schemas.AttrBifrostCustomerID, customerID)
 		}
 		if customerName, ok := ctx.Value(schemas.BifrostContextKeyGovernanceCustomerName).(string); ok && customerName != "" {
-			tracer.SetAttribute(handle, schemas.AttrCustomerName, customerName) // legacy: gen_ai.* placement of bifrost-internal attr
-			tracer.SetAttribute(handle, schemas.AttrBifrostCustomerName, customerName)
+			span.SetAttribute(schemas.AttrCustomerName, customerName) // legacy: gen_ai.* placement of bifrost-internal attr
+			span.SetAttribute(schemas.AttrBifrostCustomerName, customerName)
 		}
 		if businessUnitID, ok := ctx.Value(schemas.BifrostContextKeyGovernanceBusinessUnitID).(string); ok && businessUnitID != "" {
-			tracer.SetAttribute(handle, schemas.AttrBifrostBusinessUnitID, businessUnitID)
+			span.SetAttribute(schemas.AttrBifrostBusinessUnitID, businessUnitID)
 		}
 		if businessUnitName, ok := ctx.Value(schemas.BifrostContextKeyGovernanceBusinessUnitName).(string); ok && businessUnitName != "" {
-			tracer.SetAttribute(handle, schemas.AttrBifrostBusinessUnitName, businessUnitName)
+			span.SetAttribute(schemas.AttrBifrostBusinessUnitName, businessUnitName)
 		}
 		if teamIDs, ok := ctx.Value(schemas.BifrostContextKeyGovernanceTeamIDs).([]string); ok && len(teamIDs) > 0 {
-			tracer.SetAttribute(handle, schemas.AttrBifrostTeamIDs, teamIDs)
+			span.SetAttribute(schemas.AttrBifrostTeamIDs, teamIDs)
 		}
 		if teamNames, ok := ctx.Value(schemas.BifrostContextKeyGovernanceTeamNames).([]string); ok && len(teamNames) > 0 {
-			tracer.SetAttribute(handle, schemas.AttrBifrostTeamNames, teamNames)
+			span.SetAttribute(schemas.AttrBifrostTeamNames, teamNames)
 		}
 		if customerIDs, ok := ctx.Value(schemas.BifrostContextKeyGovernanceCustomerIDs).([]string); ok && len(customerIDs) > 0 {
-			tracer.SetAttribute(handle, schemas.AttrBifrostCustomerIDs, customerIDs)
+			span.SetAttribute(schemas.AttrBifrostCustomerIDs, customerIDs)
 		}
 		if customerNames, ok := ctx.Value(schemas.BifrostContextKeyGovernanceCustomerNames).([]string); ok && len(customerNames) > 0 {
-			tracer.SetAttribute(handle, schemas.AttrBifrostCustomerNames, customerNames)
+			span.SetAttribute(schemas.AttrBifrostCustomerNames, customerNames)
 		}
 		if businessUnitIDs, ok := ctx.Value(schemas.BifrostContextKeyGovernanceBusinessUnitIDs).([]string); ok && len(businessUnitIDs) > 0 {
-			tracer.SetAttribute(handle, schemas.AttrBifrostBusinessUnitIDs, businessUnitIDs)
+			span.SetAttribute(schemas.AttrBifrostBusinessUnitIDs, businessUnitIDs)
 		}
 		if businessUnitNames, ok := ctx.Value(schemas.BifrostContextKeyGovernanceBusinessUnitNames).([]string); ok && len(businessUnitNames) > 0 {
-			tracer.SetAttribute(handle, schemas.AttrBifrostBusinessUnitNames, businessUnitNames)
+			span.SetAttribute(schemas.AttrBifrostBusinessUnitNames, businessUnitNames)
 		}
 		if userID, ok := ctx.Value(schemas.BifrostContextKeyUserID).(string); ok && userID != "" {
-			tracer.SetAttribute(handle, schemas.AttrBifrostUserID, userID)
+			span.SetAttribute(schemas.AttrBifrostUserID, userID)
 		}
 		if userName, ok := ctx.Value(schemas.BifrostContextKeyUserName).(string); ok && userName != "" {
-			tracer.SetAttribute(handle, schemas.AttrBifrostUserName, userName)
+			span.SetAttribute(schemas.AttrBifrostUserName, userName)
 		}
 		if userEmail, ok := ctx.Value(schemas.BifrostContextKeyUserEmail).(string); ok && userEmail != "" {
-			tracer.SetAttribute(handle, schemas.AttrBifrostUserEmail, userEmail)
+			span.SetAttribute(schemas.AttrBifrostUserEmail, userEmail)
 		}
 		if fallbackIndex, ok := ctx.Value(schemas.BifrostContextKeyFallbackIndex).(int); ok {
-			tracer.SetAttribute(handle, schemas.AttrFallbackIndex, fallbackIndex) // legacy: gen_ai.* placement of bifrost-internal attr
-			tracer.SetAttribute(handle, schemas.AttrBifrostFallbackIndex, fallbackIndex)
+			span.SetAttribute(schemas.AttrFallbackIndex, fallbackIndex) // legacy: gen_ai.* placement of bifrost-internal attr
+			span.SetAttribute(schemas.AttrBifrostFallbackIndex, fallbackIndex)
 		}
-		tracer.SetAttribute(handle, schemas.AttrNumberOfRetries, attempts) // legacy: gen_ai.* placement of bifrost-internal attr
-		tracer.SetAttribute(handle, schemas.AttrBifrostRetries, attempts)
+		span.SetAttribute(schemas.AttrNumberOfRetries, attempts) // legacy: gen_ai.* placement of bifrost-internal attr
+		span.SetAttribute(schemas.AttrBifrostRetries, attempts)
 
 		// Surface caller-supplied extra headers (from x-bf-eh-* and direct-allowlist
 		// header forwarding) as span attributes so observability backends see the
@@ -6338,7 +6344,9 @@ func executeRequestWithRetries[T any](
 		exportHeaderAttributes := func(headers map[string][]string) {
 			for name, values := range headers {
 				if value, export := extraHeaderSpanAttribute(name, values); export {
-					tracer.SetAttribute(handle, schemas.AttrExtraHeaderPrefix+name, value)
+					// Write via the already-resolved span (C1), not tracer.SetAttribute,
+					// which re-resolves the span per call.
+					span.SetAttribute(schemas.AttrExtraHeaderPrefix+name, value)
 				}
 			}
 		}
@@ -6359,8 +6367,10 @@ func executeRequestWithRetries[T any](
 			tracer.PopulateLLMRequestAttributes(handle, req)
 		}
 
-		// Update context with span ID
-		ctx.SetValue(schemas.BifrostContextKeySpanID, spanCtx.Value(schemas.BifrostContextKeySpanID))
+		// Update context with span ID (no valueCtx alloc; StartSpanID returned it).
+		if spanID != "" {
+			ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
+		}
 
 		// Record stream start time for TTFT calculation (only for streaming requests)
 		// This is also used by RunPostLLMHooks to detect streaming mode
@@ -6629,6 +6639,14 @@ func clearAnthropicPassthroughForNonNativeProvider(ctx *schemas.BifrostContext, 
 // It manages retries, error handling, and response processing.
 func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas.ProviderConfig, pq *ProviderQueue, waitGroup *sync.WaitGroup) {
 	defer waitGroup.Done()
+
+	// Reusable timer for the response/error/stream handoff guard below. One timer per
+	// (long-lived) worker, reset per use, instead of a fresh time.After on every request:
+	// time.After leaks a live timer for the full 5s after each request, piling ~5s worth
+	// of timers on the runtime heap under load. Reset/Stop is race-free on Go 1.23+.
+	deliveryTimer := time.NewTimer(time.Hour)
+	deliveryTimer.Stop()
+	defer deliveryTimer.Stop()
 
 	for {
 		var req *ChannelMessage
@@ -7090,6 +7108,7 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 			bifrostError.PopulateRoutingInfo(attemptRoutingInfo)
 
 			// Send error with context awareness to prevent deadlock
+			deliveryTimer.Reset(5 * time.Second)
 			select {
 			case req.Err <- *bifrostError:
 				// Error sent successfully
@@ -7100,10 +7119,11 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 				// processing input tokens). tryRequest returned on ctx.Done and will
 				// never receive it, so bill/log it here. Non-streaming only.
 				bifrost.billAbandonedTerminal(req, nil, bifrostError)
-			case <-time.After(5 * time.Second):
+			case <-deliveryTimer.C:
 				// Timeout to prevent indefinite blocking
 				bifrost.logger.Warn("Timeout while sending error response, client may have disconnected")
 			}
+			deliveryTimer.Stop()
 		} else {
 			if result != nil {
 				result.PopulateExtraFields(req.RequestType, provider.GetProviderKey(), originalModelRequested, resolvedModel)
@@ -7111,18 +7131,21 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 			}
 			if IsStreamRequestType(req.RequestType) {
 				// Send stream with context awareness to prevent deadlock
+				deliveryTimer.Reset(5 * time.Second)
 				select {
 				case req.ResponseStream <- stream:
 					// Stream sent successfully
 				case <-req.Context.Done():
 					// Client no longer listening, log and continue
 					bifrost.logger.Debug("Client context cancelled while sending stream response")
-				case <-time.After(5 * time.Second):
+				case <-deliveryTimer.C:
 					// Timeout to prevent indefinite blocking
 					bifrost.logger.Warn("Timeout while sending stream response, client may have disconnected")
 				}
+				deliveryTimer.Stop()
 			} else {
 				// Send response with context awareness to prevent deadlock
+				deliveryTimer.Reset(5 * time.Second)
 				select {
 				case req.Response <- result:
 					// Response sent successfully
@@ -7133,10 +7156,11 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 					// (consuming tokens). tryRequest returned on ctx.Done and will never
 					// receive it, so bill/log it here.
 					bifrost.billAbandonedTerminal(req, result, nil)
-				case <-time.After(5 * time.Second):
+				case <-deliveryTimer.C:
 					// Timeout to prevent indefinite blocking
 					bifrost.logger.Warn("Timeout while sending response, client may have disconnected")
 				}
+				deliveryTimer.Stop()
 			}
 		}
 	}
@@ -7630,12 +7654,10 @@ func (p *PluginPipeline) RunLLMPreHooks(ctx *schemas.BifrostContext, req *schema
 		pluginName := plugin.GetName()
 		p.logger.Debug("running pre-hook for plugin %s", pluginName)
 		// Start span for this plugin's PreLLMHook
-		spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).prehook, schemas.SpanKindPlugin)
-		// Update pluginCtx with span context for nested operations
-		if spanCtx != nil {
-			if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
-				ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
-			}
+		spanID, handle := p.tracer.StartSpanID(ctx, pluginSpanNamesFor(pluginName).prehook, schemas.SpanKindPlugin)
+		// Mirror the new span ID into ctx for nested operations (no valueCtx alloc).
+		if spanID != "" {
+			ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
 		}
 
 		pluginCtx := ctx.WithPluginScope(&pluginName)
@@ -7683,11 +7705,9 @@ func (p *PluginPipeline) RunPreRequestHooks(ctx *schemas.BifrostContext, req *sc
 	for _, plugin := range p.llmPlugins {
 		pluginName := plugin.GetName()
 		p.logger.Debug("running pre-request hook for plugin %s", pluginName)
-		spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).prerequesthook, schemas.SpanKindPlugin)
-		if spanCtx != nil {
-			if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
-				ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
-			}
+		spanID, handle := p.tracer.StartSpanID(ctx, pluginSpanNamesFor(pluginName).prerequesthook, schemas.SpanKindPlugin)
+		if spanID != "" {
+			ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
 		}
 
 		pluginCtx := ctx.WithPluginScope(&pluginName)
@@ -7769,12 +7789,10 @@ func (p *PluginPipeline) RunPostLLMHooks(ctx *schemas.BifrostContext, resp *sche
 			}
 		} else {
 			// For non-streaming: create span per plugin (existing behavior)
-			spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).posthook, schemas.SpanKindPlugin)
-			// Update pluginCtx with span context for nested operations
-			if spanCtx != nil {
-				if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
-					ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
-				}
+			spanID, handle := p.tracer.StartSpanID(ctx, pluginSpanNamesFor(pluginName).posthook, schemas.SpanKindPlugin)
+			// Mirror the new span ID into ctx for nested operations (no valueCtx alloc).
+			if spanID != "" {
+				ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
 			}
 			pluginCtx := ctx.WithPluginScope(&pluginName)
 			resp, bifrostErr, err = plugin.PostLLMHook(pluginCtx, resp, bifrostErr)
@@ -7827,12 +7845,10 @@ func (p *PluginPipeline) RunMCPPreHooks(ctx *schemas.BifrostContext, req *schema
 		pluginName := plugin.GetName()
 		p.logger.Debug("running MCP pre-hook for plugin %s", pluginName)
 		// Start span for this plugin's PreMCPHook
-		spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).mcpPrehook, schemas.SpanKindPlugin)
-		// Update pluginCtx with span context for nested operations
-		if spanCtx != nil {
-			if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
-				ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
-			}
+		spanID, handle := p.tracer.StartSpanID(ctx, pluginSpanNamesFor(pluginName).mcpPrehook, schemas.SpanKindPlugin)
+		// Mirror the new span ID into ctx for nested operations (no valueCtx alloc).
+		if spanID != "" {
+			ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
 		}
 
 		pluginCtx := ctx.WithPluginScope(&pluginName)
@@ -7883,12 +7899,10 @@ func (p *PluginPipeline) RunMCPPostHooks(ctx *schemas.BifrostContext, mcpResp *s
 		pluginName := plugin.GetName()
 		p.logger.Debug("running MCP post-hook for plugin %s", pluginName)
 		// Create span per plugin
-		spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).mcpPosthook, schemas.SpanKindPlugin)
-		// Update pluginCtx with span context for nested operations
-		if spanCtx != nil {
-			if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
-				ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
-			}
+		spanID, handle := p.tracer.StartSpanID(ctx, pluginSpanNamesFor(pluginName).mcpPosthook, schemas.SpanKindPlugin)
+		// Mirror the new span ID into ctx for nested operations (no valueCtx alloc).
+		if spanID != "" {
+			ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
 		}
 
 		pluginCtx := ctx.WithPluginScope(&pluginName)
@@ -7937,11 +7951,9 @@ func (p *PluginPipeline) RunMCPPreConnectionHooks(ctx *schemas.BifrostContext, r
 	for i, plugin := range p.mcpPlugins {
 		pluginName := plugin.GetName()
 		p.logger.Debug("running MCP connect pre-hook for plugin %s", pluginName)
-		spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).mcpConnectPrehook, schemas.SpanKindPlugin)
-		if spanCtx != nil {
-			if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
-				ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
-			}
+		spanID, handle := p.tracer.StartSpanID(ctx, pluginSpanNamesFor(pluginName).mcpConnectPrehook, schemas.SpanKindPlugin)
+		if spanID != "" {
+			ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
 		}
 
 		pluginCtx := ctx.WithPluginScope(&pluginName)
@@ -8000,11 +8012,9 @@ func (p *PluginPipeline) RunMCPPostConnectionHooks(ctx *schemas.BifrostContext, 
 		plugin := p.mcpPlugins[i]
 		pluginName := plugin.GetName()
 		p.logger.Debug("running MCP connect post-hook for plugin %s", pluginName)
-		spanCtx, handle := p.tracer.StartSpan(ctx, pluginSpanNamesFor(pluginName).mcpConnectPosthook, schemas.SpanKindPlugin)
-		if spanCtx != nil {
-			if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
-				ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
-			}
+		spanID, handle := p.tracer.StartSpanID(ctx, pluginSpanNamesFor(pluginName).mcpConnectPosthook, schemas.SpanKindPlugin)
+		if spanID != "" {
+			ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
 		}
 
 		pluginCtx := ctx.WithPluginScope(&pluginName)

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -8136,6 +8136,9 @@ func flushPluginLogs(ctx *schemas.BifrostContext) {
 // drainAndAttachPluginLogs drains accumulated plugin logs from the BifrostContext
 // and attaches them to the trace for later retrieval by observability plugins.
 func drainAndAttachPluginLogs(ctx *schemas.BifrostContext) {
+	if !ctx.HasPluginLogs() {
+		return
+	}
 	tracer, traceID, err := GetTracerFromContext(ctx)
 	if err != nil || tracer == nil || traceID == "" {
 		return

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -1313,7 +1313,7 @@ func HandleAnthropicResponsesRequest(
 	if isLargeResp, _ := ctx.Value(schemas.BifrostContextKeyLargeResponseMode).(bool); isLargeResp {
 		preview, _ := ctx.Value(schemas.BifrostContextKeyLargePayloadResponsePreview).(string)
 		return &schemas.BifrostResponsesResponse{
-			ID:        schemas.Ptr("resp_" + providerUtils.GetRandomString(50)),
+			ID:        schemas.Ptr("resp_" + schemas.GetRandomString(50)),
 			Object:    "response",
 			CreatedAt: int(time.Now().Unix()),
 			Model:     request.Model,

--- a/core/providers/anthropic/requestbuilder.go
+++ b/core/providers/anthropic/requestbuilder.go
@@ -343,7 +343,7 @@ func BuildAnthropicResponsesRequestBody(ctx *schemas.BifrostContext, request *sc
 
 		AddMissingBetaHeadersToContext(ctx, reqBody, cfg.Provider)
 
-		jsonBody, err = providerUtils.MarshalSorted(reqBody)
+		jsonBody, err = providerUtils.MarshalProviderRequest(reqBody)
 		if err != nil {
 			return nil, newErr(schemas.ErrProviderRequestMarshal, fmt.Errorf("failed to marshal request body: %w", err), jsonBody)
 		}
@@ -603,7 +603,7 @@ func BuildAnthropicChatRequestBody(ctx *schemas.BifrostContext, request *schemas
 
 		AddMissingBetaHeadersToContext(ctx, reqBody, cfg.Provider)
 
-		jsonBody, err = providerUtils.MarshalSorted(reqBody)
+		jsonBody, err = providerUtils.MarshalProviderRequest(reqBody)
 		if err != nil {
 			return nil, newErr(schemas.ErrProviderRequestMarshal, fmt.Errorf("failed to marshal request body: %w", err), jsonBody)
 		}

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -5622,7 +5622,7 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 					},
 				}
 				if isOutputMessage {
-					bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
+					bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
 				}
 				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}
@@ -5638,7 +5638,7 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 					},
 				}
 				if isOutputMessage {
-					bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
+					bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
 				}
 				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}
@@ -5653,14 +5653,14 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 					},
 				}
 				if isOutputMessage {
-					bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
+					bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
 				}
 				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}
 
 		case AnthropicContentBlockTypeThinking:
 			if block.Thinking != nil {
-				id := new("rs_" + providerUtils.GetRandomString(50))
+				id := new("rs_" + schemas.GetRandomString(50))
 				var recoveredID *string
 				signature := block.Signature
 				if signature != nil {
@@ -5694,7 +5694,7 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 			// Handle redacted thinking (encrypted content)
 			if block.Data != nil {
 				encryptedContent := *block.Data
-				id := new("rs_" + providerUtils.GetRandomString(50))
+				id := new("rs_" + schemas.GetRandomString(50))
 				var recoveredID *string
 				if extractedID, rest, ok := providerUtils.ExtractReasoningItemID(*block.Data); ok {
 					id = extractedID
@@ -5828,7 +5828,7 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 			Role: role,
 		}
 		if isOutputMessage {
-			bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
+			bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
 			bifrostMsg.Content = &schemas.ResponsesMessageContent{
 				ContentBlocks: accumulatedTextContent,
 			}
@@ -5849,7 +5849,7 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 				},
 			}
 			if isOutputMessage {
-				bifrostMsg.ID = schemas.Ptr("fc_" + providerUtils.GetRandomString(50))
+				bifrostMsg.ID = schemas.Ptr("fc_" + schemas.GetRandomString(50))
 			}
 
 			// Check for computer tool use
@@ -5924,7 +5924,7 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 				}
 
 				bifrostMsg := schemas.ResponsesMessage{
-					ID:     schemas.Ptr("cmp_" + providerUtils.GetRandomString(50)),
+					ID:     schemas.Ptr("cmp_" + schemas.GetRandomString(50)),
 					Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
 					Role:   role,
 					Status: schemas.Ptr("completed"),
@@ -5955,7 +5955,7 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 				fallback.TriggerCategory = block.Trigger.Category
 			}
 			bifrostMessages = append(bifrostMessages, schemas.ResponsesMessage{
-				ID:     schemas.Ptr("fb_" + providerUtils.GetRandomString(50)),
+				ID:     schemas.Ptr("fb_" + schemas.GetRandomString(50)),
 				Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
 				Role:   role,
 				Status: schemas.Ptr("completed"),
@@ -6000,7 +6000,7 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 					}
 
 					bifrostMsg = schemas.ResponsesMessage{
-						ID:     schemas.Ptr("msg_" + providerUtils.GetRandomString(50)),
+						ID:     schemas.Ptr("msg_" + schemas.GetRandomString(50)),
 						Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
 						Role:   role,
 						Status: schemas.Ptr("completed"),
@@ -6036,7 +6036,7 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 					},
 				}
 				if isOutputMessage {
-					bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
+					bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
 				}
 				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}
@@ -6050,7 +6050,7 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 					},
 				}
 				if isOutputMessage {
-					bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
+					bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
 				}
 				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}
@@ -6064,7 +6064,7 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 					},
 				}
 				if isOutputMessage {
-					bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
+					bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
 				}
 				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}
@@ -6103,7 +6103,7 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 				}
 				id := extractedID
 				if id == nil {
-					id = new("rs_" + providerUtils.GetRandomString(50))
+					id = new("rs_" + schemas.GetRandomString(50))
 				}
 				bifrostMsg := schemas.ResponsesMessage{
 					ID:   id,
@@ -6144,7 +6144,7 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 					},
 				}
 				if isOutputMessage {
-					bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
+					bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
 				}
 				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			} else {
@@ -6160,7 +6160,7 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 						},
 					}
 					if isOutputMessage {
-						bifrostMsg.ID = schemas.Ptr("fc_" + providerUtils.GetRandomString(50))
+						bifrostMsg.ID = schemas.Ptr("fc_" + schemas.GetRandomString(50))
 					}
 
 					// here need to check for computer tool use
@@ -6423,7 +6423,7 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 					},
 				}
 				if isOutputMessage {
-					bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
+					bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
 				}
 				// Initialize the nested struct before any writes
 				bifrostMsg.ResponsesToolMessage.Output = &schemas.ResponsesToolMessageOutputStruct{}
@@ -6465,7 +6465,7 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 	if len(reasoningContentBlocks) > 0 {
 		id := reasoningItemID
 		if id == nil {
-			id = new("rs_" + providerUtils.GetRandomString(50))
+			id = new("rs_" + schemas.GetRandomString(50))
 		}
 		reasoningMessage := schemas.ResponsesMessage{
 			ID:   id,

--- a/core/providers/cohere/responses.go
+++ b/core/providers/cohere/responses.go
@@ -471,7 +471,7 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 				role := schemas.ResponsesInputMessageRoleAssistant
 
 				// Generate stable ID for reasoning item
-				itemID := "rs_" + providerUtils.GetRandomString(50)
+				itemID := "rs_" + schemas.GetRandomString(50)
 				state.ItemIDs[outputIndex] = itemID
 
 				item := &schemas.ResponsesMessage{

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -789,7 +789,7 @@ func (provider *GeminiProvider) responsesWithLargeResponseDetection(
 		preview, _ := ctx.Value(schemas.BifrostContextKeyLargePayloadResponsePreview).(string)
 		usage := extractUsageFromResponsePrefetch([]byte(preview))
 		bifrostResponse := &schemas.BifrostResponsesResponse{
-			ID:        schemas.Ptr("resp_" + providerUtils.GetRandomString(50)),
+			ID:        schemas.Ptr("resp_" + schemas.GetRandomString(50)),
 			CreatedAt: int(time.Now().Unix()),
 			Model:     request.Model,
 			Usage:     usage,

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -265,7 +265,7 @@ func (response *GenerateContentResponse) ToResponsesBifrostResponsesResponse() *
 
 	// Create the BifrostResponse with Responses structure
 	bifrostResp := &schemas.BifrostResponsesResponse{
-		ID:        schemas.Ptr("resp_" + providerUtils.GetRandomString(50)),
+		ID:        schemas.Ptr("resp_" + schemas.GetRandomString(50)),
 		CreatedAt: int(time.Now().Unix()),
 		Model:     response.ModelVersion,
 	}
@@ -3254,7 +3254,7 @@ func convertGeminiCandidatesToResponsesOutput(candidates []*Candidate) []schemas
 			case part.Text != "":
 				// Regular text message
 				msg := schemas.ResponsesMessage{
-					ID:     schemas.Ptr("msg_" + providerUtils.GetRandomString(50)),
+					ID:     schemas.Ptr("msg_" + schemas.GetRandomString(50)),
 					Role:   schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
 					Status: schemas.Ptr("completed"),
 					Content: &schemas.ResponsesMessageContent{
@@ -3307,7 +3307,7 @@ func convertGeminiCandidatesToResponsesOutput(candidates []*Candidate) []schemas
 					Arguments: &argumentsStr,
 				}
 				msg := schemas.ResponsesMessage{
-					ID:                   schemas.Ptr("fc_" + providerUtils.GetRandomString(50)),
+					ID:                   schemas.Ptr("fc_" + schemas.GetRandomString(50)),
 					Role:                 schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
 					Type:                 schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
 					Status:               schemas.Ptr("completed"),

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -934,7 +934,17 @@ func HandleOpenAIChatCompletionRequest(
 	// A 200 is not proof of success on every OpenAI-compatible provider: some report
 	// failures in-band once the status line is already committed. Left unchecked those
 	// surface to the caller as a 200 with null choices and null usage.
-	if inBandErr := ErrorInSuccessfulChatBody(body); inBandErr != nil {
+	// The non-custom path already validated body via HandleProviderResponse's
+	// sonic.Unmarshal, so it skips the redundant gjson.ValidBytes rescan. A custom
+	// handler makes no such guarantee, so validate before scanning to avoid reading an
+	// "error" object out of malformed JSON.
+	var inBandErr *schemas.BifrostError
+	if customResponseHandler != nil {
+		inBandErr = ErrorInSuccessfulChatBody(body)
+	} else {
+		inBandErr = errorInValidatedChatBody(body)
+	}
+	if inBandErr != nil {
 		logger.Debug("in-band error on a 200 from %s provider: %s", providerName, inBandErr.Error.Message)
 		return nil, providerUtils.EnrichError(ctx, inBandErr, jsonData, body, sendBackRawRequest, sendBackRawResponse, latency)
 	}

--- a/core/providers/openai/successerror.go
+++ b/core/providers/openai/successerror.go
@@ -26,7 +26,13 @@ func ErrorInSuccessfulChatBody(body []byte) *schemas.BifrostError {
 	if len(body) == 0 || !gjson.ValidBytes(body) {
 		return nil
 	}
+	return errorInValidatedChatBody(body)
+}
 
+// errorInValidatedChatBody is ErrorInSuccessfulChatBody's core, for callers that
+// have already proven body is valid JSON (e.g. a successful sonic.Unmarshal on
+// the same bytes) and so can skip the redundant full-body gjson.ValidBytes scan.
+func errorInValidatedChatBody(body []byte) *schemas.BifrostError {
 	errObj := gjson.GetBytes(body, "error")
 	if !errObj.Exists() || !errObj.IsObject() {
 		return nil

--- a/core/providers/utils/largeresponse.go
+++ b/core/providers/utils/largeresponse.go
@@ -146,8 +146,8 @@ func FinalizeResponseWithLargeDetection(
 		if err != nil {
 			return nil, false, NewBifrostOperationError(schemas.ErrProviderResponseDecode, err)
 		}
-		// Copy body before caller releases resp
-		return append([]byte(nil), body...), false, nil
+		// CheckAndDecodeBody already returns an owned copy, safe after release.
+		return body, false, nil
 	}
 
 	contentLength := resp.Header.ContentLength()
@@ -170,7 +170,7 @@ func FinalizeResponseWithLargeDetection(
 		if err != nil {
 			return nil, false, NewBifrostOperationError(schemas.ErrProviderResponseDecode, err)
 		}
-		return append([]byte(nil), body...), false, nil
+		return body, false, nil
 	}
 
 	// Unknown Content-Length (chunked transfer encoding) — buffer up to responseThreshold
@@ -217,7 +217,7 @@ func FinalizeResponseWithLargeDetection(
 		if err != nil {
 			return nil, false, NewBifrostOperationError(schemas.ErrProviderResponseDecode, err)
 		}
-		return append([]byte(nil), body...), false, nil
+		return body, false, nil
 	}
 
 	// Known large response (Content-Length > threshold) — prefetch first 64KB for
@@ -232,7 +232,7 @@ func FinalizeResponseWithLargeDetection(
 		if err != nil {
 			return nil, false, NewBifrostOperationError(schemas.ErrProviderResponseDecode, err)
 		}
-		return append([]byte(nil), body...), false, nil
+		return body, false, nil
 	}
 
 	// Decompress on-the-fly if provider returned gzip-encoded response.

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
 	"net"
 	"net/http"
 	"net/textproto"
@@ -198,6 +197,19 @@ var sortedAPI = sonic.Config{SortMapKeys: true}.Froze()
 // MarshalSorted marshals v to JSON with map keys sorted alphabetically.
 func MarshalSorted(v interface{}) ([]byte, error) {
 	return sortedAPI.Marshal(v)
+}
+
+// MarshalProviderRequest marshals a converted provider request body to wire JSON.
+// Typed provider requests implement json.Marshaler (they strip Bifrost-only fields
+// and already emit sorted, minified JSON), so we call MarshalJSON directly. Wrapping
+// that in MarshalSorted would only make sonic re-compact the whole body a second time
+// through its slow marshaler path, and SortMapKeys does not reorder a marshaler's
+// opaque output anyway. Plain structs fall back to MarshalSorted. Output is identical.
+func MarshalProviderRequest(v interface{}) ([]byte, error) {
+	if m, ok := v.(json.Marshaler); ok {
+		return m.MarshalJSON()
+	}
+	return MarshalSorted(v)
 }
 
 // MarshalSortedIndent marshals v to indented JSON with map keys sorted alphabetically.
@@ -1576,7 +1588,7 @@ func MergeExtraParamsIntoJSON(jsonBody []byte, extraParams map[string]interface{
 		}
 	}
 
-	// Rebuild compact JSON, then indent for consistent formatting
+	// Rebuild compact JSON in the original key order
 	var compact bytes.Buffer
 	compact.WriteByte('{')
 	for i, kv := range pairs {
@@ -1594,12 +1606,7 @@ func MergeExtraParamsIntoJSON(jsonBody []byte, extraParams map[string]interface{
 	}
 	compact.WriteByte('}')
 
-	// Re-indent to match the expected formatting
-	var indented bytes.Buffer
-	if err := json.Indent(&indented, compact.Bytes(), "", "  "); err != nil {
-		return compact.Bytes(), nil
-	}
-	return indented.Bytes(), nil
+	return compact.Bytes(), nil
 }
 
 // CheckContextAndGetRequestBody checks if the raw request body should be used, and returns it if it exists.
@@ -1618,7 +1625,8 @@ func CheckContextAndGetRequestBody(ctx context.Context, request RequestBodyGette
 			return nil, NewBifrostOperationError("request body is not provided", nil)
 		}
 
-		jsonBody, err := MarshalSortedIndent(convertedBody, "", "  ")
+		// Indenting is removed to reduce data on wire
+		jsonBody, err := MarshalProviderRequest(convertedBody)
 		if err != nil {
 			return nil, NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
 		}
@@ -1837,8 +1845,7 @@ func EnrichError(
 // on responses that are almost certainly valid JSON.
 func HandleProviderResponse[T any](responseBody []byte, response *T, requestBody []byte, sendBackRawRequest bool, sendBackRawResponse bool) (rawRequest interface{}, rawResponse interface{}, bifrostErr *schemas.BifrostError) {
 	// Check for empty response
-	trimmed := strings.TrimSpace(string(responseBody))
-	if len(trimmed) == 0 {
+	if len(bytes.TrimSpace(responseBody)) == 0 {
 		return nil, nil, &schemas.BifrostError{
 			IsBifrostError: true,
 			Error: &schemas.ErrorField{
@@ -3479,20 +3486,6 @@ func HandleMultipleListModelsRequests(
 	response.ExtraFields.Latency = latency.Milliseconds()
 
 	return response, nil
-}
-
-// GetRandomString generates a random alphanumeric string of the given length.
-func GetRandomString(length int) string {
-	if length <= 0 {
-		return ""
-	}
-	randomSource := rand.New(rand.NewSource(time.Now().UnixNano()))
-	letters := []rune("abcdef0123456789")
-	b := make([]rune, length)
-	for i := range b {
-		b[i] = letters[randomSource.Intn(len(letters))]
-	}
-	return string(b)
 }
 
 // GetReasoningEffortFromBudgetTokens maps a reasoning token budget to OpenAI reasoning effort.

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2516,6 +2516,17 @@ func ProcessAndSendResponse(
 		}
 	}
 
+	// Final chunk: the stream has drained, so upstream is complete. Stamp the body
+	// before post-hooks persist it (completeDeferredSpan handles the trace span).
+	if isFinalChunk := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator); isFinalChunk != nil {
+		if final, ok := isFinalChunk.(bool); ok && final && response != nil {
+			response.PopulateUpstreamLatency(ctx)
+			if ef := response.GetExtraFields(); ef != nil && ef.Latency > 0 {
+				response.PopulateOverheadLatency(ctx, time.Duration(ef.Latency)*time.Millisecond)
+			}
+		}
+	}
+
 	// Run post hooks on the response (note: accumulated chunks above contain pre-hook data)
 	processedResponse, processedError := postHookRunner(ctx, response, nil)
 

--- a/core/schemas/allocfix_bench_test.go
+++ b/core/schemas/allocfix_bench_test.go
@@ -1,0 +1,230 @@
+package schemas
+
+// Deterministic before/after microbenchmarks for the overhead-latency fix batch.
+// Wall-clock p99 on the load harness is too noisy to see sub-microsecond,
+// per-request changes; -benchmem allocs/op is deterministic and is the honest
+// proof for these fixes.
+//
+// Run:
+//
+//	go test ./core/schemas/ -run '^$' -bench 'FixBatch' -benchmem
+//
+// Interpretation:
+//   - Timer + SpanReset are ALLOCATION fixes: expect allocs/op to drop to ~0.
+//   - ReservedKey is a CPU/latency fix (fewer comparisons): expect ns/op to
+//     drop, allocs/op unchanged (0 in both).
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+)
+
+// ---- Fix 1: per-worker reusable delivery timer vs time.After per request ----
+
+// benchTimerDur is large so a fresh timer never actually fires inside the loop;
+// we measure only the cost of arming it, which is what the request path pays.
+const benchTimerDur = time.Hour
+
+// Old path: the worker armed time.After(5s) on every request. time.After is
+// NewTimer(d).C, so each call heap-allocates a Timer and its channel. Stop() so
+// the benchmark does not pile up b.N live timers (the leak we are fixing); the
+// allocation measured is identical to time.After's.
+func BenchmarkFixBatch_Timer_PerRequest(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		t := time.NewTimer(benchTimerDur)
+		t.Stop()
+	}
+}
+
+// New path: one timer per (long-lived) worker, reset per request.
+func BenchmarkFixBatch_Timer_Reused(b *testing.B) {
+	t := time.NewTimer(benchTimerDur)
+	t.Stop()
+	b.ReportAllocs()
+	for b.Loop() {
+		t.Reset(benchTimerDur)
+		t.Stop()
+	}
+}
+
+// ---- Fix 2: Span.Reset reuses the attribute map vs nil-ing it ----
+
+// benchSpanAttrKeys/Vals model a typical span's attribute set. Values are
+// pre-boxed into []any so interface boxing is constant across both benchmarks
+// and the only allocation difference is the attribute map itself.
+var (
+	benchSpanAttrKeys = []string{
+		"bifrost.provider", "bifrost.model", "bifrost.request.id",
+		"bifrost.upstream.duration_ms", "http.status_code", "gen_ai.system",
+		"span.kind", "bifrost.stream",
+	}
+	benchSpanAttrVals = []any{
+		"openai", "gpt-4o", "req-abcdef", 1439.0, 200, "openai", "llm.call", true,
+	}
+)
+
+func populateSpanAttrs(s *Span) {
+	for i, k := range benchSpanAttrKeys {
+		s.SetAttribute(k, benchSpanAttrVals[i])
+	}
+}
+
+// New path: the real Span.Reset (clear + reuse). Steady state re-fills a cleared
+// map with retained capacity, so no map allocation after the first cycle.
+func BenchmarkFixBatch_SpanReset_Reuse(b *testing.B) {
+	s := &Span{}
+	populateSpanAttrs(s) // warm the map once so capacity is retained
+	s.Reset()
+	b.ReportAllocs()
+	for b.Loop() {
+		populateSpanAttrs(s)
+		s.Reset()
+	}
+}
+
+// Old path: replicate the pre-fix Reset (s.Attributes = nil). The next
+// SetAttribute then make()s a fresh map every cycle: one map alloc per pooled
+// span per request.
+func oldSpanReset(s *Span) {
+	s.SpanID = ""
+	s.ParentID = ""
+	s.TraceID = ""
+	s.Name = ""
+	s.Kind = SpanKindUnspecified
+	s.StartTime = time.Time{}
+	s.EndTime = time.Time{}
+	s.Status = SpanStatusUnset
+	s.StatusMsg = ""
+	s.Attributes = nil
+	s.Events = s.Events[:0]
+}
+
+func BenchmarkFixBatch_SpanReset_Nil(b *testing.B) {
+	s := &Span{}
+	populateSpanAttrs(s)
+	oldSpanReset(s)
+	b.ReportAllocs()
+	for b.Loop() {
+		populateSpanAttrs(s)
+		oldSpanReset(s)
+	}
+}
+
+// ---- Fix 3: reserved-key check, map lookup vs slices.Contains linear scan ----
+
+// oldReservedSlice mirrors the pre-fix []any, built from the same key set so
+// membership semantics match exactly. Miss case = full scan (the worst case,
+// and the common case since most context writes are not reserved keys).
+func oldReservedSlice() []any {
+	s := make([]any, 0, len(reservedKeys))
+	for k := range reservedKeys {
+		s = append(s, k)
+	}
+	return s
+}
+
+var benchReservedMissKey any = BifrostContextKey("x-not-a-reserved-key")
+
+func BenchmarkFixBatch_ReservedKey_SliceScan(b *testing.B) {
+	old := oldReservedSlice()
+	b.ReportAllocs()
+	var ok bool
+	for b.Loop() {
+		ok = slices.Contains(old, benchReservedMissKey)
+	}
+	_ = ok
+}
+
+func BenchmarkFixBatch_ReservedKey_MapLookup(b *testing.B) {
+	b.ReportAllocs()
+	var ok bool
+	for b.Loop() {
+		ok = isReservedKey(benchReservedMissKey)
+	}
+	_ = ok
+}
+
+// ---- Fix 4: logging plugin skips the identity/governance context reads on
+// non-final stream chunks. This is a CPU/latency fix, not an allocation fix:
+// each read is one RLock + map lookup (BifrostContext.Value), returning an
+// already-boxed value, so allocs/op is ~0. The number below is the per-chunk
+// cost the gate now avoids; multiply by (chunks - 1) for a stream's saving. ----
+
+// loggingIdentityKeys mirrors the block moved past the non-final-chunk gate in
+// plugins/logging/main.go (the ~19 identity/governance lookups feeding
+// applyOutputFieldsToEntry).
+var loggingIdentityKeys = []any{
+	BifrostContextKeySelectedKeyID, BifrostContextKeySelectedKeyName,
+	BifrostContextKeyGovernanceVirtualKeyID, BifrostContextKeyGovernanceVirtualKeyName,
+	BifrostContextKeyGovernanceRoutingRuleID, BifrostContextKeyGovernanceRoutingRuleName,
+	BifrostContextKeySelectedPromptName, BifrostContextKeySelectedPromptVersion,
+	BifrostContextKeySelectedPromptID, BifrostContextKeyGovernanceTeamID,
+	BifrostContextKeyGovernanceTeamName, BifrostContextKeyGovernanceCustomerID,
+	BifrostContextKeyGovernanceCustomerName, BifrostContextKeyUserID,
+	BifrostContextKeyUserName, BifrostContextKeyGovernanceBusinessUnitID,
+	BifrostContextKeyGovernanceBusinessUnitName, BifrostContextKeyNumberOfRetries,
+	BifrostContextKeyAttemptTrail,
+}
+
+func newBenchIdentityContext() *BifrostContext {
+	bc := NewBifrostContext(context.Background(), time.Now().Add(time.Hour))
+	for _, k := range loggingIdentityKeys {
+		bc.SetValue(k, "v")
+	}
+	return bc
+}
+
+// The per-non-final-chunk work the gate now skips: read the full identity block.
+func BenchmarkFixBatch_LoggingPerChunkReads(b *testing.B) {
+	bc := newBenchIdentityContext()
+	b.ReportAllocs()
+	var sink any
+	for b.Loop() {
+		for _, k := range loggingIdentityKeys {
+			sink = bc.Value(k)
+		}
+	}
+	_ = sink
+}
+
+// ---- Fix C5: presize the per-request userValues map (~25 SetValue writes) ----
+var benchC5Keys = func() []any {
+	k := make([]any, 25)
+	for i := range k {
+		k[i] = BifrostContextKey("k" + string(rune('a'+i)))
+	}
+	return k
+}()
+
+func BenchmarkFixC5_MapSize0(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		m := make(map[any]any)
+		for _, k := range benchC5Keys {
+			m[k] = "v"
+		}
+	}
+}
+
+func BenchmarkFixC5_MapPresized(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		m := make(map[any]any, 32)
+		for _, k := range benchC5Keys {
+			m[k] = "v"
+		}
+	}
+}
+
+func BenchmarkFixC5_MapHint16(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		m := make(map[any]any, 16)
+		for _, k := range benchC5Keys {
+			m[k] = "v"
+		}
+	}
+}

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -300,6 +300,7 @@ const (
 	BifrostContextKeySpanID                              BifrostContextKey = "bifrost-span-id"                                  // string (current span ID for child span creation - set by tracer)
 	BifrostContextKeyParentSpanID                        BifrostContextKey = "bifrost-parent-span-id"                           // string (parent span ID from W3C traceparent header - set by tracing middleware)
 	BifrostContextKeyStreamStartTime                     BifrostContextKey = "bifrost-stream-start-time"                        // time.Time (start time for streaming TTFT calculation - set by bifrost)
+	BifrostContextKeyRequestStartTime                    BifrostContextKey = "bifrost-request-start-time"                       // time.Time (whole-request start for overhead - set by bifrost)
 	BifrostContextKeyTracer                              BifrostContextKey = "bifrost-tracer"                                   // Tracer (tracer instance for completing deferred spans - set by bifrost)
 	BifrostContextKeyModelCatalog                        BifrostContextKey = "bifrost-model-catalog"                            // ModelInfoProvider (model pricing/capability catalog backing ctx.GetModelInfo and ctx.CalculateCost - set by bifrost)
 	BifrostContextKeyDeferTraceCompletion                BifrostContextKey = "bifrost-defer-trace-completion"                   // bool (signals trace completion should be deferred for streaming - set by streaming handlers)
@@ -1727,13 +1728,19 @@ type BifrostResponseExtraFields struct {
 	// matched (i.e. RoutingInfo.ResolvedKeyAlias != nil), otherwise
 	// RoutingInfo.Model. Still populated for backward compatibility; new
 	// consumers should read from RoutingInfo.
-	ResolvedModelUsed string     `json:"resolved_model_used,omitempty"`
-	Latency           int64      `json:"latency"` // in milliseconds (for streaming responses this will be each chunk latency, and the last chunk latency will be the total latency)
+	ResolvedModelUsed string `json:"resolved_model_used,omitempty"`
+	Latency           int64  `json:"latency"` // in milliseconds (for streaming responses this will be each chunk latency, and the last chunk latency will be the total latency)
 	// UpstreamLatency is the total time spent blocked on upstream sockets across
 	// every attempt, in milliseconds. Unlike Latency it survives retries and
 	// fallbacks, so total-UpstreamLatency is Bifrost's own cost. Nil when the
 	// request never accumulated one; nil means unknown, not zero.
-	UpstreamLatency           *int64             `json:"upstream_latency,omitempty"`
+	UpstreamLatency *int64 `json:"upstream_latency,omitempty"`
+	// OverheadLatency is Bifrost's own cost (total minus UpstreamLatency), in ms.
+	// Not serialized (json:"-"): at response time it can only be an estimate, since
+	// serializing this response is itself overhead. The authoritative value is
+	// stamped on the trace and logged at completion; this is only the untraced
+	// fallback. Nil means unknown.
+	OverheadLatency           *int64                 `json:"-"`
 	ChunkIndex                int                    `json:"chunk_index"` // used for streaming responses to identify the chunk index, will be 0 for non-streaming responses
 	RawRequest                interface{}            `json:"raw_request,omitempty"`
 	RawResponse               interface{}            `json:"raw_response,omitempty"`
@@ -1747,8 +1754,8 @@ type BifrostResponseExtraFields struct {
 	// web_search requested against a non-Nova Bedrock model). Currently populated
 	// only by the Bedrock provider.
 	DroppedUnsupportedTools []string          `json:"dropped_unsupported_tools,omitempty"`
-	ProviderResponseHeaders map[string]string     `json:"provider_response_headers,omitempty"` // HTTP response headers from the provider (filtered to exclude transport-level headers)
-	PassthroughPath         string                `json:"passthrough_path,omitempty"`          // Stripped provider path for passthrough requests, e.g. "/v1/chat/completions"
+	ProviderResponseHeaders map[string]string `json:"provider_response_headers,omitempty"` // HTTP response headers from the provider (filtered to exclude transport-level headers)
+	PassthroughPath         string            `json:"passthrough_path,omitempty"`          // Stripped provider path for passthrough requests, e.g. "/v1/chat/completions"
 }
 
 type RoutingInfo struct {

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -11,29 +11,46 @@ import (
 
 var NoDeadline time.Time
 
-var reservedKeys = []any{
-	BifrostContextKeyVirtualKey,
-	BifrostContextKeyAPIKeyName,
-	BifrostContextKeyAPIKeyID,
-	BifrostContextKeyDirectKey,
-	BifrostContextKeyRequestID,
-	BifrostContextKeyFallbackRequestID,
-	BifrostContextKeySelectedKeyID,
-	BifrostContextKeySelectedKeyName,
-	BifrostContextKeyNumberOfRetries,
-	BifrostContextKeyFallbackIndex,
-	BifrostContextKeySkipKeySelection,
-	BifrostContextKeyPassthroughHeaders,
-	BifrostContextKeySkipBudgetAndRateLimits,
-	BifrostContextKeySkipProviderCheck,
-	BifrostContextKeyURLPath,
-	BifrostContextKeyDeferTraceCompletion,
-	BifrostContextKeyAttemptTrail,
-	BifrostContextKeyStreamGated,
-	BifrostContextKeyMCPHealthCheckRequest,
-	BifrostContextKeyUpstreamLatency,
-	BifrostContextKeyRoutingInfo,
-	BifrostContextKeyMCPInboundBearer,
+// reservedKeys is a set (not a slice) so the per-write guard is O(1) instead of a
+// linear interface-equality scan; the guard runs on every restricted write, per
+// chunk on streams. Keyed by BifrostContextKey (not any) so isReservedKey can
+// assert the type before indexing: SetValue/ClearValue/GetAndSetValue accept any,
+// and indexing a map with a non-comparable key (slice, map, func) would panic.
+var reservedKeys = map[BifrostContextKey]struct{}{
+	BifrostContextKeyVirtualKey:              {},
+	BifrostContextKeyAPIKeyName:              {},
+	BifrostContextKeyAPIKeyID:                {},
+	BifrostContextKeyDirectKey:               {},
+	BifrostContextKeyRequestID:               {},
+	BifrostContextKeyFallbackRequestID:       {},
+	BifrostContextKeySelectedKeyID:           {},
+	BifrostContextKeySelectedKeyName:         {},
+	BifrostContextKeyNumberOfRetries:         {},
+	BifrostContextKeyFallbackIndex:           {},
+	BifrostContextKeySkipKeySelection:        {},
+	BifrostContextKeyPassthroughHeaders:      {},
+	BifrostContextKeySkipBudgetAndRateLimits: {},
+	BifrostContextKeySkipProviderCheck:       {},
+	BifrostContextKeyURLPath:                 {},
+	BifrostContextKeyDeferTraceCompletion:    {},
+	BifrostContextKeyAttemptTrail:            {},
+	BifrostContextKeyStreamGated:             {},
+	BifrostContextKeyMCPHealthCheckRequest:   {},
+	BifrostContextKeyUpstreamLatency:         {},
+	BifrostContextKeyRoutingInfo:             {},
+	BifrostContextKeyMCPInboundBearer:        {},
+}
+
+// isReservedKey reports whether key is a reserved context key whose writes are
+// blocked while blockRestrictedWrites is set. Non-BifrostContextKey keys (which
+// may be non-comparable) are never reserved and must not reach the map index.
+func isReservedKey(key any) bool {
+	contextKey, ok := key.(BifrostContextKey)
+	if !ok {
+		return false
+	}
+	_, ok = reservedKeys[contextKey]
+	return ok
 }
 
 // pluginLogStore holds plugin log entries accumulated during request processing.
@@ -96,7 +113,6 @@ func NewBifrostContext(parent context.Context, deadline time.Time) *BifrostConte
 		deadline:              deadline,
 		hasDeadline:           !deadline.IsZero(),
 		done:                  make(chan struct{}),
-		userValues:            make(map[any]any),
 		blockRestrictedWrites: atomic.Bool{},
 	}
 	ctx.blockRestrictedWrites.Store(false)
@@ -379,14 +395,14 @@ func (bc *BifrostContext) SetValue(key, value any) {
 		return
 	}
 	// Check if the key is a reserved key
-	if bc.blockRestrictedWrites.Load() && slices.Contains(reservedKeys, key) {
+	if bc.blockRestrictedWrites.Load() && isReservedKey(key) {
 		// we silently drop writes for these reserved keys
 		return
 	}
 	bc.valuesMu.Lock()
 	defer bc.valuesMu.Unlock()
 	if bc.userValues == nil {
-		bc.userValues = make(map[any]any)
+		bc.userValues = make(map[any]any, 16)
 	}
 	bc.userValues[key] = value
 }
@@ -403,7 +419,7 @@ func (bc *BifrostContext) setReservedValue(key, value any) {
 	bc.valuesMu.Lock()
 	defer bc.valuesMu.Unlock()
 	if bc.userValues == nil {
-		bc.userValues = make(map[any]any)
+		bc.userValues = make(map[any]any, 16)
 	}
 	bc.userValues[key] = value
 }
@@ -426,7 +442,7 @@ func (bc *BifrostContext) ClearValue(key any) {
 		return
 	}
 	// Check if the key is a reserved key
-	if bc.blockRestrictedWrites.Load() && slices.Contains(reservedKeys, key) {
+	if bc.blockRestrictedWrites.Load() && isReservedKey(key) {
 		// we silently drop writes for these reserved keys
 		return
 	}
@@ -446,12 +462,12 @@ func (bc *BifrostContext) GetAndSetValue(key any, value any) any {
 	bc.valuesMu.Lock()
 	defer bc.valuesMu.Unlock()
 	// Check if the key is a reserved key
-	if bc.blockRestrictedWrites.Load() && slices.Contains(reservedKeys, key) {
+	if bc.blockRestrictedWrites.Load() && isReservedKey(key) {
 		// we silently drop writes for these reserved keys
 		return bc.userValues[key]
 	}
 	if bc.userValues == nil {
-		bc.userValues = make(map[any]any)
+		bc.userValues = make(map[any]any, 16)
 	}
 	oldValue := bc.userValues[key]
 	bc.userValues[key] = value

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -830,6 +830,22 @@ func (bc *BifrostContext) GetPluginLogs() []PluginLogEntry {
 	return copied
 }
 
+// HasPluginLogs reports whether DrainPluginLogs would return any entries,
+// without draining or copying. Lets hot callers skip a tracer lookup when
+// there is nothing to attach, while still leaving the buffer intact.
+func (bc *BifrostContext) HasPluginLogs() bool {
+	if bc.valueDelegate != nil {
+		return false // scoped contexts share the store but must not drain it
+	}
+	store := bc.pluginLogs.Load()
+	if store == nil {
+		return false
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	return len(store.logs) > 0
+}
+
 // DrainPluginLogs transfers ownership of the plugin log slice to the caller.
 // The internal log store is returned to the pool after draining.
 // Returns nil if no logs have been recorded.

--- a/core/schemas/context_test.go
+++ b/core/schemas/context_test.go
@@ -477,3 +477,43 @@ func TestNewBifrostContext_WatchdogRaceWithReleasedScope(t *testing.T) {
 		_, _ = c.Deadline()
 	}
 }
+
+// TestReservedKey_SkipProviderCheckIsProtected pins BifrostContextKeySkipProviderCheck
+// as reserved. Governance uses it to bypass virtual-key provider allowlists, so a
+// restricted (plugin) write must not be able to flip it. It regressed out of
+// reservedKeys during the slice->map refactor.
+func TestReservedKey_SkipProviderCheckIsProtected(t *testing.T) {
+	if !isReservedKey(BifrostContextKeySkipProviderCheck) {
+		t.Fatal("BifrostContextKeySkipProviderCheck must be a reserved key")
+	}
+
+	ctx := NewBifrostContext(context.Background(), NoDeadline)
+	defer ctx.Cancel()
+
+	// Trusted write before the guard is armed.
+	ctx.SetValue(BifrostContextKeySkipProviderCheck, true)
+	ctx.BlockRestrictedWrites()
+
+	// A restricted write must be silently dropped, leaving the flag untouched.
+	ctx.SetValue(BifrostContextKeySkipProviderCheck, false)
+	if v := ctx.Value(BifrostContextKeySkipProviderCheck); v != true {
+		t.Fatalf("reserved key overwritten under BlockRestrictedWrites: got %v, want true", v)
+	}
+}
+
+// TestReservedKey_NonComparableKeyDoesNotPanic guards the reserved-write path against
+// non-comparable keys. isReservedKey indexes reservedKeys, which panics on a slice/map/
+// func key unless the type is asserted first, and ClearValue reaches that guard even
+// when userValues is nil.
+func TestReservedKey_NonComparableKeyDoesNotPanic(t *testing.T) {
+	if isReservedKey([]string{"not", "comparable"}) {
+		t.Fatal("a non-comparable key must never be reported reserved")
+	}
+
+	ctx := NewBifrostContext(context.Background(), NoDeadline)
+	defer ctx.Cancel()
+	ctx.BlockRestrictedWrites()
+
+	// userValues is still nil here; the guard must not panic before that check.
+	ctx.ClearValue([]string{"slice", "key"})
+}

--- a/core/schemas/orderedmap.go
+++ b/core/schemas/orderedmap.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"unicode/utf8"
 )
 
 // OrderedMap is a map that preserves insertion order of keys.
@@ -177,33 +178,145 @@ func (om OrderedMap) MarshalJSON() ([]byte, error) {
 	if om.values == nil {
 		return []byte("null"), nil
 	}
-
 	var buf bytes.Buffer
-	buf.WriteByte('{')
+	if err := om.appendJSON(&buf); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
 
+// appendJSON writes the OrderedMap as compact JSON directly into dst, in key
+// order. Nested OrderedMap values recurse here rather than routing back through
+// MarshalSorted -> sonic's json.Marshaler path, which re-compacts (and would
+// re-escape) every nesting level. Output is byte-identical to marshaling each
+// value with MarshalSorted, because MarshalJSON already emits compact,
+// HTML-escaped JSON, so the skipped sonic pass would be a no-op.
+func (om OrderedMap) appendJSON(dst *bytes.Buffer) error {
+	if om.values == nil {
+		dst.WriteString("null")
+		return nil
+	}
+	dst.WriteByte('{')
 	for i, k := range om.keys {
 		if i > 0 {
-			buf.WriteByte(',')
+			dst.WriteByte(',')
 		}
-
-		// key
-		keyBytes, err := MarshalSorted(k)
-		if err != nil {
-			return nil, err
+		appendJSONString(dst, k)
+		dst.WriteByte(':')
+		if err := appendValueJSON(dst, om.values[k]); err != nil {
+			return err
 		}
-		buf.Write(keyBytes)
-		buf.WriteByte(':')
-
-		// value — nested *OrderedMap values will use their own MarshalJSON
-		valBytes, err := MarshalSorted(om.values[k])
-		if err != nil {
-			return nil, err
-		}
-		buf.Write(valBytes)
 	}
+	dst.WriteByte('}')
+	return nil
+}
 
-	buf.WriteByte('}')
-	return buf.Bytes(), nil
+const hexDigits = "0123456789abcdef"
+
+// appendJSONString writes s as a JSON string literal into dst, byte-identical to
+// sonic.ConfigStd / encoding/json with HTML escaping on: escapes ", \, control
+// chars, <, >, & (as \u00xx), and U+2028/U+2029; passes valid UTF-8 through and
+// replaces invalid bytes with the "\ufffd" escape. Avoids a full sonic encode per key/string.
+func appendJSONString(dst *bytes.Buffer, s string) {
+	dst.WriteByte('"')
+	start := 0
+	for i := 0; i < len(s); {
+		if b := s[i]; b < utf8.RuneSelf {
+			if jsonSafeSet[b] {
+				i++
+				continue
+			}
+			if start < i {
+				dst.WriteString(s[start:i])
+			}
+			switch b {
+			case '\\', '"':
+				dst.WriteByte('\\')
+				dst.WriteByte(b)
+			case '\n':
+				dst.WriteString(`\n`)
+			case '\r':
+				dst.WriteString(`\r`)
+			case '\t':
+				dst.WriteString(`\t`)
+			default:
+				// control chars and <, >, & -> \u00xx
+				dst.WriteString(`\u00`)
+				dst.WriteByte(hexDigits[b>>4])
+				dst.WriteByte(hexDigits[b&0xF])
+			}
+			i++
+			start = i
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == utf8.RuneError && size == 1 {
+			if start < i {
+				dst.WriteString(s[start:i])
+			}
+			// Match encoding/json and sonic.ConfigStd: invalid UTF-8 becomes its JSON
+			// escape "\ufffd", not the raw replacement-char bytes, so output stays byte-identical.
+			dst.WriteString("\\ufffd")
+			i += size
+			start = i
+			continue
+		}
+		if r == '\u2028' || r == '\u2029' {
+			if start < i {
+				dst.WriteString(s[start:i])
+			}
+			dst.WriteString(`\u202`)
+			dst.WriteByte(hexDigits[r&0xF])
+			i += size
+			start = i
+			continue
+		}
+		i += size
+	}
+	if start < len(s) {
+		dst.WriteString(s[start:])
+	}
+	dst.WriteByte('"')
+}
+
+// jsonSafeSet[b] is true for ASCII bytes that need no escaping under HTML-safe
+// JSON encoding: printable, excluding ", \, <, >, & and control chars.
+var jsonSafeSet = func() [utf8.RuneSelf]bool {
+	var s [utf8.RuneSelf]bool
+	for c := 0x20; c < utf8.RuneSelf; c++ {
+		s[c] = true
+	}
+	s['"'] = false
+	s['\\'] = false
+	s['<'] = false
+	s['>'] = false
+	s['&'] = false
+	return s
+}()
+
+// appendValueJSON encodes a single OrderedMap value into dst. OrderedMap values
+// recurse directly; everything else falls back to MarshalSorted (byte-identical).
+func appendValueJSON(dst *bytes.Buffer, v interface{}) error {
+	switch val := v.(type) {
+	case *OrderedMap:
+		if val == nil {
+			dst.WriteString("null")
+			return nil
+		}
+		return val.appendJSON(dst)
+	case OrderedMap:
+		return val.appendJSON(dst)
+	case string:
+		appendJSONString(dst, val)
+		return nil
+	default:
+		b, err := MarshalSorted(v)
+		if err != nil {
+			return err
+		}
+		dst.Write(b)
+		return nil
+	}
 }
 
 // MarshalSorted serializes the OrderedMap to JSON with keys sorted alphabetically.

--- a/core/schemas/orderedmap_marshal_diff_test.go
+++ b/core/schemas/orderedmap_marshal_diff_test.go
@@ -1,0 +1,263 @@
+package schemas
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/bytedance/sonic"
+)
+
+// The optimized OrderedMap.MarshalJSON recurses into nested OrderedMap values
+// directly instead of routing each through MarshalSorted (sonic's json.Marshaler
+// path), which used to re-compact/re-escape every nesting level. That is safe
+// iff MarshalJSON already emits what that sonic pass would produce — i.e. its
+// output is compaction-stable. MarshalSorted(om) (== sonic.ConfigStd.Marshal) is
+// exactly the pass the old code applied to each nested value, so:
+//
+//	bytes.Equal(om.MarshalJSON(), MarshalSorted(om))
+//
+// verifying it for a value proves the skipped pass was a no-op there, and because
+// JSON compaction/escaping is structurally local, top-level stability implies it
+// at every nesting level. This is the byte-identity guardrail for the change.
+func assertMarshalStable(t *testing.T, name string, om *OrderedMap) {
+	t.Helper()
+	direct, err := om.MarshalJSON()
+	if err != nil {
+		t.Fatalf("%s: MarshalJSON error: %v", name, err)
+	}
+	viaSonic, err := MarshalSorted(om) // == sonic.ConfigStd.Marshal, the old per-level pass
+	if err != nil {
+		t.Fatalf("%s: MarshalSorted error: %v", name, err)
+	}
+	if !bytes.Equal(direct, viaSonic) {
+		t.Fatalf("%s: MarshalJSON not compaction-stable\n direct: %s\n sonic:  %s", name, direct, viaSonic)
+	}
+}
+
+func TestOrderedMapMarshal_ByteIdentical(t *testing.T) {
+	cases := map[string]*OrderedMap{
+		"empty": NewOrderedMap(),
+		"scalars": NewOrderedMapFromPairs(
+			KV("b", "x"), KV("a", 1), KV("z", true), KV("n", nil),
+		),
+		"array": NewOrderedMapFromPairs(
+			KV("items", []interface{}{1, "a", true, nil}),
+		),
+		// #6235 order-sensitive shape: non-alphabetical property order must survive.
+		"json_schema_ordered": NewOrderedMapFromPairs(
+			KV("type", "object"),
+			KV("title", "AssignmentResult"),
+			KV("description", "Assignment result for a single activity."),
+			KV("properties", NewOrderedMapFromPairs(
+				KV("reasoning", NewOrderedMapFromPairs(
+					KV("type", "string"),
+					KV("title", "Reasoning"),
+					KV("description", "Brief explanation"),
+				)),
+				KV("assigned_group_id", NewOrderedMapFromPairs(
+					KV("anyOf", []interface{}{
+						NewOrderedMapFromPairs(KV("type", "integer")),
+						NewOrderedMapFromPairs(KV("type", "null")),
+					}),
+					KV("title", "Assigned Group ID"),
+				)),
+			)),
+			KV("required", []interface{}{"assigned_group_id", "reasoning"}),
+			KV("additionalProperties", false),
+		),
+		// Escaping: HTML chars, quotes, backslashes, control chars, unicode/emoji.
+		"escaping": NewOrderedMapFromPairs(
+			KV("html", "<script>a && b</script>"),
+			KV("quote", `he said "hi"\ and left`),
+			KV("ctrl", "tab\tnewline\nreturn\r"),
+			KV("unicode", "café — 🚀 —   "),
+		),
+		// Keys that need escaping.
+		"tricky_keys": NewOrderedMapFromPairs(
+			KV("a<b&c>", 1),
+			KV(`a"b\c`, 2),
+			KV("emoji🚀key", 3),
+		),
+		// Numbers: negatives, floats, values above 2^53.
+		"numbers": NewOrderedMapFromPairs(
+			KV("neg", -42), KV("float", 3.14159), KV("big", int64(9007199254740993)), KV("zero", 0),
+		),
+		"null_value_map": {values: nil}, // marshals to null
+	}
+	for name, om := range cases {
+		assertMarshalStable(t, name, om)
+	}
+
+	// Deeply nested (build 8 levels).
+	deep := NewOrderedMapFromPairs(KV("leaf", "end"))
+	for i := 0; i < 8; i++ {
+		deep = NewOrderedMapFromPairs(KV("child", deep), KV("i", i))
+	}
+	assertMarshalStable(t, "deep_nesting", deep)
+}
+
+// TestOrderedMapMarshal_InvalidUTF8 pins that invalid UTF-8 in keys and values is
+// emitted as the escaped replacement rune, byte-identical to sonic.ConfigStd (and
+// encoding/json). assertMarshalStable cannot catch this: MarshalSorted(om) also runs
+// om.MarshalJSON (OrderedMap is a json.Marshaler) and sonic's compaction accepts a
+// literal replacement rune, so both sides would agree even while both diverge from
+// sonic marshaling the equivalent plain map. Comparing against sonic.ConfigStd on a
+// plain map is the real oracle here.
+func TestOrderedMapMarshal_InvalidUTF8(t *testing.T) {
+	bad := string([]byte{'a', 0xff, 'b'}) // lone 0xff -> invalid UTF-8
+
+	cases := []struct {
+		name string
+		om   *OrderedMap
+		ref  map[string]interface{}
+	}{
+		{"invalid_value", NewOrderedMapFromPairs(KV("k", bad)), map[string]interface{}{"k": bad}},
+		{"invalid_key", NewOrderedMapFromPairs(KV(bad, "v")), map[string]interface{}{bad: "v"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.om.MarshalJSON()
+			if err != nil {
+				t.Fatalf("MarshalJSON: %v", err)
+			}
+			want, err := sonic.ConfigStd.Marshal(tc.ref)
+			if err != nil {
+				t.Fatalf("sonic.ConfigStd.Marshal: %v", err)
+			}
+			if !bytes.Equal(got, want) {
+				t.Fatalf("invalid-UTF-8 output diverges from sonic.ConfigStd:\n  got  %s\n  want %s", got, want)
+			}
+		})
+	}
+}
+
+// FuzzOrderedMapMarshal parses arbitrary JSON objects into an OrderedMap (which
+// preserves key order and nests OrderedMaps) and asserts MarshalJSON stays
+// compaction-stable — catching any escaping/number/edge case the corpus misses.
+func FuzzOrderedMapMarshal(f *testing.F) {
+	seeds := []string{
+		`{}`,
+		`{"a":1,"b":"x"}`,
+		`{"o":{"n":{"deep":true}},"arr":[1,{"k":"<v>"},null]}`,
+		`{"html":"<a>&</a>","q":"\"x\"","u":"café 🚀"}`,
+		`{"z":1,"a":2,"m":3}`,
+		`{"big":9007199254740993,"f":1.5,"neg":-7}`,
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		om := &OrderedMap{}
+		if err := om.UnmarshalJSON(data); err != nil {
+			return // only JSON objects round-trip through OrderedMap
+		}
+		direct, err := om.MarshalJSON()
+		if err != nil {
+			t.Fatalf("MarshalJSON error on %q: %v", data, err)
+		}
+		viaSonic, err := MarshalSorted(om)
+		if err != nil {
+			t.Fatalf("MarshalSorted error on %q: %v", data, err)
+		}
+		if !bytes.Equal(direct, viaSonic) {
+			t.Fatalf("not compaction-stable\n input:  %s\n direct: %s\n sonic:  %s", data, direct, viaSonic)
+		}
+	})
+}
+
+// buildBigSchema builds a large, deeply-nested JSON-Schema-shaped OrderedMap:
+// nProps top-level properties, each an object with a few structural keys, and
+// every `depth`-th one nested `depth` levels deep with an array-of-objects —
+// closer to a real tool-heavy / MCP-injected request.
+func buildBigSchema(nProps, depth int) *OrderedMap {
+	leaf := func(desc string) *OrderedMap {
+		return NewOrderedMapFromPairs(
+			KV("type", "string"),
+			KV("title", desc),
+			KV("description", "Field "+desc+" with a reasonably long description to size the payload"),
+			KV("enum", []interface{}{"alpha", "beta", "gamma", "delta"}),
+		)
+	}
+	nest := func(d int, inner *OrderedMap) *OrderedMap {
+		for i := 0; i < d; i++ {
+			inner = NewOrderedMapFromPairs(
+				KV("type", "object"),
+				KV("description", "nested level"),
+				KV("properties", NewOrderedMapFromPairs(
+					KV("child", inner),
+					KV("items", NewOrderedMapFromPairs(
+						KV("type", "array"),
+						KV("items", inner),
+					)),
+				)),
+				KV("required", []interface{}{"child"}),
+				KV("additionalProperties", false),
+			)
+		}
+		return inner
+	}
+	props := NewOrderedMapWithCapacity(nProps)
+	req := make([]interface{}, 0, nProps)
+	for i := 0; i < nProps; i++ {
+		name := "param_" + string(rune('a'+i%26)) + string(rune('0'+i%10))
+		if i%depth == 0 {
+			props.Set(name, nest(depth, leaf(name)))
+		} else {
+			props.Set(name, leaf(name))
+		}
+		req = append(req, name)
+	}
+	return NewOrderedMapFromPairs(
+		KV("type", "object"),
+		KV("title", "BigTool"),
+		KV("description", "A large tool schema for benchmarking"),
+		KV("properties", props),
+		KV("required", req),
+		KV("additionalProperties", false),
+	)
+}
+
+func TestOrderedMapMarshal_BigSchemaStable(t *testing.T) {
+	assertMarshalStable(t, "big_schema", buildBigSchema(24, 4))
+}
+
+func BenchmarkOrderedMapMarshalBig(b *testing.B) {
+	om := buildBigSchema(24, 4)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := om.MarshalJSON(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkOrderedMapMarshal marshals a realistic, tool-schema-shaped nested
+// OrderedMap. Run against HEAD vs this change to quantify the win.
+func BenchmarkOrderedMapMarshal(b *testing.B) {
+	om := NewOrderedMapFromPairs(
+		KV("type", "object"),
+		KV("properties", NewOrderedMapFromPairs(
+			KV("location", NewOrderedMapFromPairs(KV("type", "string"), KV("description", "City and state"))),
+			KV("unit", NewOrderedMapFromPairs(
+				KV("type", "string"),
+				KV("enum", []interface{}{"celsius", "fahrenheit"}),
+				KV("description", "Temperature unit"),
+			)),
+			KV("days", NewOrderedMapFromPairs(
+				KV("type", "array"),
+				KV("items", NewOrderedMapFromPairs(KV("type", "integer"))),
+				KV("description", "Forecast horizon in days"),
+			)),
+		)),
+		KV("required", []interface{}{"location"}),
+		KV("additionalProperties", false),
+	)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := om.MarshalJSON(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -471,7 +471,14 @@ func (s *Span) Reset() {
 	s.EndTime = time.Time{}
 	s.Status = SpanStatusUnset
 	s.StatusMsg = ""
-	s.Attributes = nil
+	// Reuse the attribute map across pool cycles: tracing/store.go clears and
+	// refills it, so nil-ing here forced a fresh map alloc per pooled span every
+	// request. Drop only an outlier-sized map so one huge request can't pin it.
+	if len(s.Attributes) > 64 {
+		s.Attributes = nil
+	} else {
+		clear(s.Attributes)
+	}
 	s.Events = s.Events[:0]
 }
 

--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -380,6 +380,27 @@ func (s *Span) SetAttribute(key string, value any) {
 	s.Attributes[key] = value
 }
 
+// SetAttributes merges an already-built attribute map into the span under a
+// single lock. Preferred over a caller-side range + SetAttribute loop (one lock
+// per entry) when the map already exists (e.g. the Populate*Attributes output).
+// Nil values are skipped, matching SetAttribute.
+func (s *Span) SetAttributes(attrs map[string]any) {
+	if s == nil || len(attrs) == 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.Attributes == nil {
+		s.Attributes = make(map[string]any, len(attrs))
+	}
+	for k, v := range attrs {
+		if v == nil {
+			continue
+		}
+		s.Attributes[k] = v
+	}
+}
+
 // snapshotForExport returns a copy of the span whose Attributes (and Events)
 // are cloned under the span lock, so observability exporters can read them
 // concurrently while a late writer (streaming finalization, redaction) may still

--- a/core/schemas/tracer.go
+++ b/core/schemas/tracer.go
@@ -56,6 +56,12 @@ type Tracer interface {
 	// The context should be used for subsequent operations to maintain span hierarchy.
 	StartSpan(ctx context.Context, name string, kind SpanKind) (context.Context, SpanHandle)
 
+	// StartSpanID is like StartSpan but returns the new span's ID instead of a
+	// context wrapped in a valueCtx. Callers that only mirror the ID into a
+	// *BifrostContext (via SetValue) use this to avoid a per-span context alloc.
+	// Returns ("", nil) when no trace is present or span creation fails.
+	StartSpanID(ctx context.Context, name string, kind SpanKind) (string, SpanHandle)
+
 	// EndSpan completes a span with status and optional message.
 	// Should be called when the operation represented by the span is complete.
 	EndSpan(handle SpanHandle, status SpanStatus, statusMsg string)
@@ -63,6 +69,12 @@ type Tracer interface {
 	// SetAttribute sets an attribute on the span.
 	// Attributes provide additional context about the operation.
 	SetAttribute(handle SpanHandle, key string, value any)
+
+	// SpanFromHandle resolves the *Span for a handle once, so a caller writing many
+	// attributes (e.g. the per-request LLM-call block) can call span.SetAttribute
+	// directly instead of paying a trace+span lookup on every attribute. Returns
+	// nil if the handle does not resolve; span.SetAttribute is nil-safe.
+	SpanFromHandle(handle SpanHandle) *Span
 
 	// GetSpanHandleByID retrieves a span handle for the given trace and span ID.
 	// If spanID is nil, returns a handle for the trace's root span.
@@ -202,11 +214,18 @@ func (n *NoOpTracer) StartSpan(ctx context.Context, _ string, _ SpanKind) (conte
 	return ctx, nil
 }
 
+// StartSpanID does nothing.
+func (n *NoOpTracer) StartSpanID(_ context.Context, _ string, _ SpanKind) (string, SpanHandle) {
+	return "", nil
+}
+
 // EndSpan does nothing.
 func (n *NoOpTracer) EndSpan(_ SpanHandle, _ SpanStatus, _ string) {}
 
 // SetAttribute does nothing.
 func (n *NoOpTracer) SetAttribute(_ SpanHandle, _ string, _ any) {}
+
+func (n *NoOpTracer) SpanFromHandle(_ SpanHandle) *Span { return nil }
 
 // GetSpanHandleByID returns nil.
 func (n *NoOpTracer) GetSpanHandleByID(_ string, _ *string) SpanHandle { return nil }

--- a/core/schemas/upstreamlatency.go
+++ b/core/schemas/upstreamlatency.go
@@ -138,6 +138,23 @@ func (r *BifrostResponse) PopulateUpstreamLatency(ctx context.Context) {
 	}
 }
 
+// PopulateOverheadLatency copies Bifrost's own cost onto the response's ExtraFields,
+// derived from total via CalculateOverhead. Left nil when no accumulator is present,
+// so absent stays distinct from zero.
+func (r *BifrostResponse) PopulateOverheadLatency(ctx context.Context, total time.Duration) {
+	if r == nil {
+		return
+	}
+	overhead, ok := CalculateOverhead(ctx, total)
+	if !ok {
+		return
+	}
+	if ef := r.GetExtraFields(); ef != nil {
+		ms := int64(overhead / time.Millisecond)
+		ef.OverheadLatency = &ms
+	}
+}
+
 // CalculateOverhead derives Bifrost's own cost from a total wall-clock duration.
 //
 // Clamps at zero. The two measurements come from different clocks started at

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -3,14 +3,13 @@ package schemas
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net/url"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 )
 
 // Ptr creates a pointer to any value.
@@ -19,16 +18,19 @@ func Ptr[T any](v T) *T {
 	return &v
 }
 
-// GetRandomString generates a random alphanumeric string of the given length.
+// letters is the hex alphabet GetRandomString draws from.
+const letters = "abcdef0123456789"
+
+// GetRandomString generates a random hex string of the given length.
+// Uses rand/v2 (seedless, per-thread): the old per-call time-seeded source cost
+// ~7µs per call and could mint identical strings for same-tick calls.
 func GetRandomString(length int) string {
 	if length <= 0 {
 		return ""
 	}
-	randomSource := rand.New(rand.NewSource(time.Now().UnixNano()))
-	letters := []rune("abcdef0123456789")
-	b := make([]rune, length)
+	b := make([]byte, length)
 	for i := range b {
-		b[i] = letters[randomSource.Intn(len(letters))]
+		b[i] = letters[rand.IntN(len(letters))]
 	}
 	return string(b)
 }

--- a/core/utils.go
+++ b/core/utils.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/maximhq/bifrost/core/mcp"
@@ -697,6 +698,43 @@ func ValidateExternalURL(urlStr string, allowPrivateNetwork bool) error {
 // sanitizeSpanName sanitizes a span name to remove capital letters and spaces to make it a valid span name.
 func sanitizeSpanName(name string) string {
 	return schemas.SanitizePluginSpanName(name)
+}
+
+// pluginSpanNameSet holds the precomputed "plugin.<name>.<hook>" span names for
+// one plugin. Building them with Sprintf on every hook invocation costs ~2
+// allocs per span at request rate; plugin names are static, so cache them.
+type pluginSpanNameSet struct {
+	prehook            string
+	prerequesthook     string
+	posthook           string
+	mcpPrehook         string
+	mcpPosthook        string
+	mcpConnectPrehook  string
+	mcpConnectPosthook string
+}
+
+// pluginSpanNameCache maps plugin name -> *pluginSpanNameSet. Bounded by the
+// number of distinct registered plugins.
+var pluginSpanNameCache sync.Map
+
+func pluginSpanNamesFor(name string) *pluginSpanNameSet {
+	if v, ok := pluginSpanNameCache.Load(name); ok {
+		return v.(*pluginSpanNameSet)
+	}
+	s := sanitizeSpanName(name)
+	set := &pluginSpanNameSet{
+		prehook:            "plugin." + s + ".prehook",
+		prerequesthook:     "plugin." + s + ".prerequesthook",
+		posthook:           "plugin." + s + ".posthook",
+		mcpPrehook:         "plugin." + s + ".mcp_prehook",
+		mcpPosthook:        "plugin." + s + ".mcp_posthook",
+		mcpConnectPrehook:  "plugin." + s + ".mcp_connect_prehook",
+		mcpConnectPosthook: "plugin." + s + ".mcp_connect_posthook",
+	}
+	if v, loaded := pluginSpanNameCache.LoadOrStore(name, set); loaded {
+		return v.(*pluginSpanNameSet)
+	}
+	return set
 }
 
 // IsCodemodeTool returns true if the given tool name is a codemode tool.

--- a/framework/gencache/gencache.go
+++ b/framework/gencache/gencache.go
@@ -1,0 +1,146 @@
+// Package gencache provides a generation-stamped memo cache: a value cache whose
+// entries are invalidated wholesale when a monotonic "generation" counter advances.
+//
+// Unlike an LRU, there is no per-entry TTL and no eviction order. Every entry
+// carries the generation it was computed under; a read is a hit only if that stamp
+// still matches the current generation. Any change to the underlying data bumps the
+// generation, which invalidates every entry at once without touching the map.
+//
+// It fits when: the value is a pure function of some shared state, that state
+// changes rarely relative to reads, and a single monotonic counter can stand in for
+// "the state changed" (e.g. a sum of write counters across the stores the value is
+// derived from).
+package gencache
+
+import "sync"
+
+// GenFunc returns the current generation. It must strictly increase (never repeat a
+// prior value) whenever the data the cache derives from changes; any increase
+// invalidates every cached entry. It is called on every Get/GetOrCompute, so keep it
+// cheap — typically a sum of atomic counters.
+type GenFunc func() uint64
+
+type entry[V any] struct {
+	gen uint64
+	val V
+}
+
+// Cache is a concurrent generation-stamped memo. The zero value is not usable;
+// construct one with New.
+type Cache[V any] struct {
+	mu         sync.RWMutex
+	m          map[string]entry[V]
+	gen        GenFunc
+	maxEntries int
+	clone      func(V) V
+	skipStore  func(V) bool
+}
+
+// Option configures a Cache.
+type Option[V any] func(*Cache[V])
+
+// WithClone makes Get and GetOrCompute return clone(v) rather than the stored value,
+// so callers cannot mutate cached state through the value they receive. Use it for
+// mutable values such as slices or maps (e.g. a wrapper around slices.Clone).
+// Default: the stored value is returned as-is, which is correct only when V is
+// treated as immutable.
+func WithClone[V any](clone func(V) V) Option[V] {
+	return func(c *Cache[V]) { c.clone = clone }
+}
+
+// WithSkipStore leaves results matching skip out of the cache: they are still
+// returned, but recomputed on the next call. Use it to avoid caching "not found"
+// answers, e.g. func(v []T) bool { return len(v) == 0 }. Default: every result is
+// stored.
+func WithSkipStore[V any](skip func(V) bool) Option[V] {
+	return func(c *Cache[V]) { c.skipStore = skip }
+}
+
+// New builds a Cache. gen supplies the current generation (see GenFunc). maxEntries
+// bounds the map: when inserting a new key would exceed it, the whole map is flushed
+// first, because cache keys are often client-controlled and an unbounded map is a
+// memory-growth vector. A maxEntries <= 0 means unbounded.
+func New[V any](gen GenFunc, maxEntries int, opts ...Option[V]) *Cache[V] {
+	c := &Cache[V]{
+		m:          make(map[string]entry[V]),
+		gen:        gen,
+		maxEntries: maxEntries,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+func (c *Cache[V]) out(v V) V {
+	if c.clone != nil {
+		return c.clone(v)
+	}
+	return v
+}
+
+// Get returns the cached value for key when it is present and still current
+// (honoring WithClone). The bool reports whether it was a live hit; a stale or
+// missing entry returns the zero value and false.
+func (c *Cache[V]) Get(key string) (V, bool) {
+	gen := c.gen()
+	c.mu.RLock()
+	e, ok := c.m[key]
+	c.mu.RUnlock()
+	if ok && e.gen == gen {
+		return c.out(e.val), true
+	}
+	var zero V
+	return zero, false
+}
+
+// GetOrCompute returns the current cached value for key, or computes it with
+// compute, stores it, and returns it.
+//
+// The stored entry is stamped with the generation read BEFORE compute ran: if the
+// underlying data changes while compute is in flight, the entry is left stale and
+// the next call recomputes — the cache never serves a stale read. Honors WithClone
+// on the returned value and WithSkipStore (a skipped result is returned but not
+// cached). compute may run concurrently for the same key under load; it must be
+// safe to call redundantly and its results must be equivalent.
+func (c *Cache[V]) GetOrCompute(key string, compute func() V) V {
+	gen := c.gen()
+
+	c.mu.RLock()
+	e, ok := c.m[key]
+	c.mu.RUnlock()
+	if ok && e.gen == gen {
+		return c.out(e.val)
+	}
+
+	val := compute()
+	if c.skipStore != nil && c.skipStore(val) {
+		return c.out(val)
+	}
+
+	c.mu.Lock()
+	if c.maxEntries > 0 {
+		if _, exists := c.m[key]; !exists && len(c.m) >= c.maxEntries {
+			c.m = make(map[string]entry[V])
+		}
+	}
+	c.m[key] = entry[V]{gen: gen, val: val}
+	c.mu.Unlock()
+
+	return c.out(val)
+}
+
+// Len returns the number of entries currently held, counting stale ones that have
+// not yet been overwritten or flushed.
+func (c *Cache[V]) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.m)
+}
+
+// Flush drops every entry.
+func (c *Cache[V]) Flush() {
+	c.mu.Lock()
+	c.m = make(map[string]entry[V])
+	c.mu.Unlock()
+}

--- a/framework/gencache/gencache_test.go
+++ b/framework/gencache/gencache_test.go
@@ -1,0 +1,171 @@
+package gencache
+
+import (
+	"fmt"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// cloneInts is a WithClone helper for []int values.
+func cloneInts(v []int) []int { return slices.Clone(v) }
+
+func TestGetOrCompute_CachesWithinGeneration(t *testing.T) {
+	var gen uint64
+	var computes int
+	c := New[int](func() uint64 { return gen }, 0)
+
+	load := func() int { computes++; return 42 }
+	if v := c.GetOrCompute("k", load); v != 42 {
+		t.Fatalf("got %d, want 42", v)
+	}
+	if v := c.GetOrCompute("k", load); v != 42 {
+		t.Fatalf("got %d, want 42", v)
+	}
+	if computes != 1 {
+		t.Fatalf("compute ran %d times, want 1 (second call should hit)", computes)
+	}
+}
+
+func TestGetOrCompute_RecomputesOnGenerationBump(t *testing.T) {
+	var gen uint64
+	var computes int
+	c := New[int](func() uint64 { return gen }, 0)
+	load := func() int { computes++; return computes }
+
+	if v := c.GetOrCompute("k", load); v != 1 {
+		t.Fatalf("first got %d, want 1", v)
+	}
+	gen++ // any store write bumps the generation
+	if v := c.GetOrCompute("k", load); v != 2 {
+		t.Fatalf("post-bump got %d, want 2 (must recompute)", v)
+	}
+	if computes != 2 {
+		t.Fatalf("compute ran %d times, want 2", computes)
+	}
+}
+
+func TestGetOrCompute_StampsWithPreComputeGeneration(t *testing.T) {
+	// A generation bump that happens DURING compute must leave the entry stale,
+	// so the next read recomputes rather than serving a value already outdated.
+	var gen uint64
+	c := New[int](func() uint64 { return gen }, 0)
+
+	first := c.GetOrCompute("k", func() int {
+		gen++ // data changed while we were computing
+		return 1
+	})
+	if first != 1 {
+		t.Fatalf("first got %d, want 1", first)
+	}
+	// The stored entry was stamped with gen=0 but current gen is 1 → miss.
+	var recomputed bool
+	second := c.GetOrCompute("k", func() int { recomputed = true; return 2 })
+	if !recomputed || second != 2 {
+		t.Fatalf("entry stamped during compute was not treated as stale (recomputed=%v, val=%d)", recomputed, second)
+	}
+}
+
+func TestGetOrCompute_SkipStoreLeavesUncached(t *testing.T) {
+	var gen uint64
+	c := New[[]int](func() uint64 { return gen }, 0,
+		WithSkipStore(func(v []int) bool { return len(v) == 0 }))
+
+	if got := c.GetOrCompute("empty", func() []int { return nil }); len(got) != 0 {
+		t.Fatalf("got %v, want empty", got)
+	}
+	if _, ok := c.Get("empty"); ok {
+		t.Fatal("empty result must not be cached")
+	}
+	if c.Len() != 0 {
+		t.Fatalf("Len=%d, want 0", c.Len())
+	}
+}
+
+func TestGetOrCompute_BoundedFlushesOnOverflow(t *testing.T) {
+	const max = 8
+	var gen uint64
+	c := New[int](func() uint64 { return gen }, max)
+
+	for i := 0; i < max; i++ {
+		c.GetOrCompute(fmt.Sprintf("k%d", i), func() int { return i })
+	}
+	if c.Len() != max {
+		t.Fatalf("Len=%d, want %d (at cap)", c.Len(), max)
+	}
+	// One more distinct key must flush rather than grow past the cap.
+	c.GetOrCompute("overflow", func() int { return 99 })
+	if c.Len() > max {
+		t.Fatalf("cache grew past cap: Len=%d, want <= %d", c.Len(), max)
+	}
+	if v, ok := c.Get("overflow"); !ok || v != 99 {
+		t.Fatalf("new key missing after flush: v=%d ok=%v", v, ok)
+	}
+}
+
+func TestWithClone_IsolatesCallerFromCache(t *testing.T) {
+	var gen uint64
+	c := New[[]int](func() uint64 { return gen }, 0, WithClone(cloneInts))
+
+	first := c.GetOrCompute("k", func() []int { return []int{1, 2, 3} })
+	for i := range first {
+		first[i] = -1 // corrupt the returned slice
+	}
+	second, ok := c.Get("k")
+	if !ok {
+		t.Fatal("expected a live hit")
+	}
+	if !slices.Equal(second, []int{1, 2, 3}) {
+		t.Fatalf("caller mutation leaked into cache: %v", second)
+	}
+}
+
+func TestGet_MissOnStaleAndAbsent(t *testing.T) {
+	var gen uint64
+	c := New[int](func() uint64 { return gen }, 0)
+
+	if _, ok := c.Get("absent"); ok {
+		t.Fatal("absent key reported present")
+	}
+	c.GetOrCompute("k", func() int { return 1 })
+	if _, ok := c.Get("k"); !ok {
+		t.Fatal("fresh key reported absent")
+	}
+	gen++
+	if _, ok := c.Get("k"); ok {
+		t.Fatal("stale key reported present")
+	}
+}
+
+func TestFlush(t *testing.T) {
+	var gen uint64
+	c := New[int](func() uint64 { return gen }, 0)
+	c.GetOrCompute("a", func() int { return 1 })
+	c.GetOrCompute("b", func() int { return 2 })
+	c.Flush()
+	if c.Len() != 0 {
+		t.Fatalf("Len=%d after Flush, want 0", c.Len())
+	}
+}
+
+func TestConcurrentGetOrCompute_NoRace(t *testing.T) {
+	var gen atomic.Uint64
+	c := New[int](func() uint64 { return gen.Load() }, 1024)
+
+	var wg sync.WaitGroup
+	for w := 0; w < 16; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				key := fmt.Sprintf("k%d", i%64)
+				_ = c.GetOrCompute(key, func() int { return i })
+				if i%50 == 0 {
+					gen.Add(1) // interleave invalidations
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+}

--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -55,6 +55,10 @@ SELECT
     COALESCE(percentile_cont(0.90) WITHIN GROUP (ORDER BY latency), 0) AS p90_latency,
     COALESCE(percentile_cont(0.95) WITHIN GROUP (ORDER BY latency), 0) AS p95_latency,
     COALESCE(percentile_cont(0.99) WITHIN GROUP (ORDER BY latency), 0) AS p99_latency,
+    COALESCE(AVG(overhead_latency), 0) AS avg_overhead,
+    COALESCE(percentile_cont(0.90) WITHIN GROUP (ORDER BY overhead_latency), 0) AS p90_overhead,
+    COALESCE(percentile_cont(0.95) WITHIN GROUP (ORDER BY overhead_latency), 0) AS p95_overhead,
+    COALESCE(percentile_cont(0.99) WITHIN GROUP (ORDER BY overhead_latency), 0) AS p99_overhead,
     COALESCE(SUM(prompt_tokens), 0) AS total_prompt_tokens,
     COALESCE(SUM(completion_tokens), 0) AS total_completion_tokens,
     -- Throughput measures restricted to rows with a positive measured latency,
@@ -141,6 +145,10 @@ var mvLogsHourlyRequiredColumns = []string{
 	"total_tokens",
 	"total_cached_read_tokens",
 	"total_cost",
+	"avg_overhead",
+	"p90_overhead",
+	"p95_overhead",
+	"p99_overhead",
 }
 
 // legacyMatViewNames are matviews from previous schema versions that no longer
@@ -1708,6 +1716,10 @@ func (s *RDBLogStore) getLatencyHistogramFromMatView(ctx context.Context, filter
 		P90Latency      float64 `gorm:"column:p90_lat"`
 		P95Latency      float64 `gorm:"column:p95_lat"`
 		P99Latency      float64 `gorm:"column:p99_lat"`
+		AvgOverhead     float64 `gorm:"column:avg_ovh"`
+		P90Overhead     float64 `gorm:"column:p90_ovh"`
+		P95Overhead     float64 `gorm:"column:p95_ovh"`
+		P99Overhead     float64 `gorm:"column:p99_ovh"`
 		TotalRequests   int64   `gorm:"column:total_requests"`
 	}
 	// Weighted average of percentiles across hourly buckets
@@ -1719,6 +1731,10 @@ func (s *RDBLogStore) getLatencyHistogramFromMatView(ctx context.Context, filter
 		CASE WHEN SUM(count) > 0 THEN SUM(p90_latency * count) / SUM(count) ELSE 0 END AS p90_lat,
 		CASE WHEN SUM(count) > 0 THEN SUM(p95_latency * count) / SUM(count) ELSE 0 END AS p95_lat,
 		CASE WHEN SUM(count) > 0 THEN SUM(p99_latency * count) / SUM(count) ELSE 0 END AS p99_lat,
+		CASE WHEN SUM(count) > 0 THEN SUM(avg_overhead * count) / SUM(count) ELSE 0 END AS avg_ovh,
+		CASE WHEN SUM(count) > 0 THEN SUM(p90_overhead * count) / SUM(count) ELSE 0 END AS p90_ovh,
+		CASE WHEN SUM(count) > 0 THEN SUM(p95_overhead * count) / SUM(count) ELSE 0 END AS p95_ovh,
+		CASE WHEN SUM(count) > 0 THEN SUM(p99_overhead * count) / SUM(count) ELSE 0 END AS p99_ovh,
 		SUM(count) AS total_requests
 	`, bucketSizeSeconds, bucketSizeSeconds)).
 		Group("bucket_timestamp").
@@ -1742,6 +1758,10 @@ func (s *RDBLogStore) getLatencyHistogramFromMatView(ctx context.Context, filter
 			b.P90Latency = r.P90Latency
 			b.P95Latency = r.P95Latency
 			b.P99Latency = r.P99Latency
+			b.AvgOverhead = r.AvgOverhead
+			b.P90Overhead = r.P90Overhead
+			b.P95Overhead = r.P95Overhead
+			b.P99Overhead = r.P99Overhead
 			b.TotalRequests = r.TotalRequests
 		}
 		buckets = append(buckets, b)

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -289,6 +289,7 @@ var logstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"mcp_tool_logs_add_endpoint_columns"}, run: migrationAddEndpointColumnsToMCPToolLogs},
 	{IDs: []string{"mcp_tool_logs_add_plugin_logs_column"}, run: migrationAddMCPPluginLogsColumn},
 	{IDs: []string{"logs_add_video_edit_input_column"}, run: migrationAddVideoEditInputColumn},
+	{IDs: []string{"logs_add_upstream_and_overhead_latency_columns"}, run: migrationAddUpstreamAndOverheadLatencyColumns},
 }
 
 // areThereAnyPendingMigrations returns true if there are any pending migrations to be applied.
@@ -626,6 +627,43 @@ func migrationAddGuardrailDebugColumn(ctx context.Context, db *gorm.DB, logger s
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while adding guardrail_debug column: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddUpstreamAndOverheadLatencyColumns adds the upstream_latency and
+// overhead_latency columns to the logs table.
+func migrationAddUpstreamAndOverheadLatencyColumns(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "logs_add_upstream_and_overhead_latency_columns"
+	logger.Info("[logstore] starting migration %s", migrationName)
+	defer logger.Info("[logstore] finished migration %s", migrationName)
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if err := addColumnIfNotExists(tx, logger, &Log{}, "upstream_latency"); err != nil {
+				return err
+			}
+			if err := addColumnIfNotExists(tx, logger, &Log{}, "overhead_latency"); err != nil {
+				return err
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if err := dropColumnIfExists(tx, logger, &Log{}, "upstream_latency"); err != nil {
+				return err
+			}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "overhead_latency"); err != nil {
+				return err
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while adding upstream/overhead latency columns: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -1240,7 +1240,7 @@ func (s *RDBLogStore) listSelectColumns() string {
 		// rows it can carry the provider's full (unbounded) error payload, and 25+ such
 		// rows can push the /api/logs response past Cloud Run's 32MB body limit (500s).
 		// The full error is still served by the detail endpoint (GetLog / GET /api/logs/{id}).
-		"latency", "token_usage", "cost", "status", "stream",
+		"latency", "upstream_latency", "overhead_latency", "token_usage", "cost", "status", "stream",
 		fmt.Sprintf("substr(content_summary, 1, %d) AS content_summary", maxContentSummaryBytes),
 		"metadata", "cache_debug",
 		"is_large_payload_request", "is_large_payload_response",

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -2282,6 +2282,10 @@ func (s *RDBLogStore) getLatencyHistogramClickHouse(ctx context.Context, baseQue
 		P90Latency      sql.NullFloat64 `gorm:"column:p90_latency"`
 		P95Latency      sql.NullFloat64 `gorm:"column:p95_latency"`
 		P99Latency      sql.NullFloat64 `gorm:"column:p99_latency"`
+		AvgOverhead     sql.NullFloat64 `gorm:"column:avg_overhead"`
+		P90Overhead     sql.NullFloat64 `gorm:"column:p90_overhead"`
+		P95Overhead     sql.NullFloat64 `gorm:"column:p95_overhead"`
+		P99Overhead     sql.NullFloat64 `gorm:"column:p99_overhead"`
 		TotalRequests   int64           `gorm:"column:total_requests"`
 	}
 
@@ -2291,6 +2295,10 @@ func (s *RDBLogStore) getLatencyHistogramClickHouse(ctx context.Context, baseQue
 		quantile(0.90)(latency) as p90_latency,
 		quantile(0.95)(latency) as p95_latency,
 		quantile(0.99)(latency) as p99_latency,
+		AVG(overhead_latency) as avg_overhead,
+		quantile(0.90)(overhead_latency) as p90_overhead,
+		quantile(0.95)(overhead_latency) as p95_overhead,
+		quantile(0.99)(overhead_latency) as p99_overhead,
 		COUNT(*) as total_requests
 	`, unixBucketExpr("clickhouse", bucketSizeSeconds))
 
@@ -2312,6 +2320,10 @@ func (s *RDBLogStore) getLatencyHistogramClickHouse(ctx context.Context, baseQue
 			P90Latency:    r.P90Latency.Float64,
 			P95Latency:    r.P95Latency.Float64,
 			P99Latency:    r.P99Latency.Float64,
+			AvgOverhead:   r.AvgOverhead.Float64,
+			P90Overhead:   r.P90Overhead.Float64,
+			P95Overhead:   r.P95Overhead.Float64,
+			P99Overhead:   r.P99Overhead.Float64,
 			TotalRequests: r.TotalRequests,
 		}
 	}
@@ -2328,6 +2340,10 @@ func (s *RDBLogStore) getLatencyHistogramPercentileCont(ctx context.Context, bas
 		P90Latency      sql.NullFloat64 `gorm:"column:p90_latency"`
 		P95Latency      sql.NullFloat64 `gorm:"column:p95_latency"`
 		P99Latency      sql.NullFloat64 `gorm:"column:p99_latency"`
+		AvgOverhead     sql.NullFloat64 `gorm:"column:avg_overhead"`
+		P90Overhead     sql.NullFloat64 `gorm:"column:p90_overhead"`
+		P95Overhead     sql.NullFloat64 `gorm:"column:p95_overhead"`
+		P99Overhead     sql.NullFloat64 `gorm:"column:p99_overhead"`
 		TotalRequests   int64           `gorm:"column:total_requests"`
 	}
 
@@ -2337,6 +2353,10 @@ func (s *RDBLogStore) getLatencyHistogramPercentileCont(ctx context.Context, bas
 		percentile_cont(0.90) WITHIN GROUP (ORDER BY latency) as p90_latency,
 		percentile_cont(0.95) WITHIN GROUP (ORDER BY latency) as p95_latency,
 		percentile_cont(0.99) WITHIN GROUP (ORDER BY latency) as p99_latency,
+		AVG(overhead_latency) as avg_overhead,
+		percentile_cont(0.90) WITHIN GROUP (ORDER BY overhead_latency) as p90_overhead,
+		percentile_cont(0.95) WITHIN GROUP (ORDER BY overhead_latency) as p95_overhead,
+		percentile_cont(0.99) WITHIN GROUP (ORDER BY overhead_latency) as p99_overhead,
 		COUNT(*) as total_requests
 	`, bucketSizeSeconds, bucketSizeSeconds)
 
@@ -2358,6 +2378,10 @@ func (s *RDBLogStore) getLatencyHistogramPercentileCont(ctx context.Context, bas
 			P90Latency:    r.P90Latency.Float64,
 			P95Latency:    r.P95Latency.Float64,
 			P99Latency:    r.P99Latency.Float64,
+			AvgOverhead:   r.AvgOverhead.Float64,
+			P90Overhead:   r.P90Overhead.Float64,
+			P95Overhead:   r.P95Overhead.Float64,
+			P99Overhead:   r.P99Overhead.Float64,
 			TotalRequests: r.TotalRequests,
 		}
 	}
@@ -2369,12 +2393,13 @@ func (s *RDBLogStore) getLatencyHistogramPercentileCont(ctx context.Context, bas
 // which lacks percentile_cont.
 func (s *RDBLogStore) getLatencyHistogramSQLite(ctx context.Context, baseQuery *gorm.DB, filters SearchFilters, bucketSizeSeconds int64) (*LatencyHistogramResult, error) {
 	var results []struct {
-		BucketTimestamp int64   `gorm:"column:bucket_timestamp"`
-		Latency         float64 `gorm:"column:latency"`
+		BucketTimestamp int64           `gorm:"column:bucket_timestamp"`
+		Latency         float64         `gorm:"column:latency"`
+		Overhead        sql.NullFloat64 `gorm:"column:overhead_latency"`
 	}
 
 	selectClause := fmt.Sprintf(
-		`(CAST(strftime('%%s', timestamp) AS INTEGER) / %d) * %d as bucket_timestamp, latency`,
+		`(CAST(strftime('%%s', timestamp) AS INTEGER) / %d) * %d as bucket_timestamp, latency, overhead_latency`,
 		bucketSizeSeconds, bucketSizeSeconds,
 	)
 
@@ -2385,51 +2410,80 @@ func (s *RDBLogStore) getLatencyHistogramSQLite(ctx context.Context, baseQuery *
 		return nil, fmt.Errorf("failed to get latency histogram: %w", err)
 	}
 
-	type bucketData struct {
-		latencies []float64
-	}
-	bucketMap := make(map[int64]*bucketData)
+	bucketMap := make(map[int64]*latencyHistogramBucketData)
 	var orderedKeys []int64
 
 	for _, r := range results {
 		bd, exists := bucketMap[r.BucketTimestamp]
 		if !exists {
-			bd = &bucketData{}
+			bd = &latencyHistogramBucketData{}
 			bucketMap[r.BucketTimestamp] = bd
 			orderedKeys = append(orderedKeys, r.BucketTimestamp)
 		}
 		bd.latencies = append(bd.latencies, r.Latency)
+		if r.Overhead.Valid {
+			bd.overheads = append(bd.overheads, r.Overhead.Float64)
+		}
 	}
 
 	computedBuckets := make(map[int64]LatencyHistogramBucket, len(bucketMap))
 	for ts, bd := range bucketMap {
-		var sum float64
-		for _, v := range bd.latencies {
-			sum += v
-		}
-		computedBuckets[ts] = LatencyHistogramBucket{
-			Timestamp:     time.Unix(ts, 0).UTC(),
-			AvgLatency:    sum / float64(len(bd.latencies)),
-			P90Latency:    computePercentile(bd.latencies, 0.90),
-			P95Latency:    computePercentile(bd.latencies, 0.95),
-			P99Latency:    computePercentile(bd.latencies, 0.99),
-			TotalRequests: int64(len(bd.latencies)),
-		}
+		computedBuckets[ts] = bd.toBucket(ts)
 	}
 
 	return s.buildLatencyHistogramResult(computedBuckets, orderedKeys, filters, bucketSizeSeconds)
+}
+
+// latencyHistogramBucketData accumulates per-bucket latency and overhead values
+// for the Go-based percentile paths (SQLite, MySQL). Latencies arrive sorted from
+// the query; overheads arrive in latency order, so toBucket sorts them.
+type latencyHistogramBucketData struct {
+	latencies []float64
+	overheads []float64
+}
+
+func (bd *latencyHistogramBucketData) toBucket(ts int64) LatencyHistogramBucket {
+	b := LatencyHistogramBucket{
+		Timestamp:     time.Unix(ts, 0).UTC(),
+		AvgLatency:    average(bd.latencies),
+		P90Latency:    computePercentile(bd.latencies, 0.90),
+		P95Latency:    computePercentile(bd.latencies, 0.95),
+		P99Latency:    computePercentile(bd.latencies, 0.99),
+		TotalRequests: int64(len(bd.latencies)),
+	}
+	if len(bd.overheads) > 0 {
+		sort.Float64s(bd.overheads)
+		b.AvgOverhead = average(bd.overheads)
+		b.P90Overhead = computePercentile(bd.overheads, 0.90)
+		b.P95Overhead = computePercentile(bd.overheads, 0.95)
+		b.P99Overhead = computePercentile(bd.overheads, 0.99)
+	}
+	return b
+}
+
+// average returns the arithmetic mean, or 0 for an empty slice.
+func average(vs []float64) float64 {
+	if len(vs) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, v := range vs {
+		sum += v
+	}
+	return sum / float64(len(vs))
 }
 
 // getLatencyHistogramMySQL uses Go-based percentile computation for MySQL
 // which lacks percentile_cont.
 func (s *RDBLogStore) getLatencyHistogramMySQL(ctx context.Context, baseQuery *gorm.DB, filters SearchFilters, bucketSizeSeconds int64) (*LatencyHistogramResult, error) {
 	var results []struct {
-		BucketTimestamp int64   `gorm:"column:bucket_timestamp"`
-		Latency         float64 `gorm:"column:latency"`
+		BucketTimestamp int64           `gorm:"column:bucket_timestamp"`
+		Latency         float64         `gorm:"column:latency"`
+		Overhead        sql.NullFloat64 `gorm:"column:overhead_latency"`
 	}
 
 	selectClause := fmt.Sprintf(
-		`(FLOOR(UNIX_TIMESTAMP(timestamp) / %d) * %d) as bucket_timestamp, latency`,
+		`(FLOOR(UNIX_TIMESTAMP(timestamp) / %d) * %d) as bucket_timestamp, latency, overhead_latency`,
 		bucketSizeSeconds, bucketSizeSeconds,
 	)
 
@@ -2440,36 +2494,25 @@ func (s *RDBLogStore) getLatencyHistogramMySQL(ctx context.Context, baseQuery *g
 		return nil, fmt.Errorf("failed to get latency histogram: %w", err)
 	}
 
-	type bucketData struct {
-		latencies []float64
-	}
-	bucketMap := make(map[int64]*bucketData)
+	bucketMap := make(map[int64]*latencyHistogramBucketData)
 	var orderedKeys []int64
 
 	for _, r := range results {
 		bd, exists := bucketMap[r.BucketTimestamp]
 		if !exists {
-			bd = &bucketData{}
+			bd = &latencyHistogramBucketData{}
 			bucketMap[r.BucketTimestamp] = bd
 			orderedKeys = append(orderedKeys, r.BucketTimestamp)
 		}
 		bd.latencies = append(bd.latencies, r.Latency)
+		if r.Overhead.Valid {
+			bd.overheads = append(bd.overheads, r.Overhead.Float64)
+		}
 	}
 
 	computedBuckets := make(map[int64]LatencyHistogramBucket, len(bucketMap))
 	for ts, bd := range bucketMap {
-		var sum float64
-		for _, v := range bd.latencies {
-			sum += v
-		}
-		computedBuckets[ts] = LatencyHistogramBucket{
-			Timestamp:     time.Unix(ts, 0).UTC(),
-			AvgLatency:    sum / float64(len(bd.latencies)),
-			P90Latency:    computePercentile(bd.latencies, 0.90),
-			P95Latency:    computePercentile(bd.latencies, 0.95),
-			P99Latency:    computePercentile(bd.latencies, 0.99),
-			TotalRequests: int64(len(bd.latencies)),
-		}
+		computedBuckets[ts] = bd.toBucket(ts)
 	}
 
 	return s.buildLatencyHistogramResult(computedBuckets, orderedKeys, filters, bucketSizeSeconds)

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -242,6 +242,8 @@ type Log struct {
 	CacheDebug              string    `gorm:"type:text" json:"-"`                                                      // JSON serialized *schemas.BifrostCacheDebug
 	GuardrailDebug          string    `gorm:"type:text" json:"-"`                                                      // JSON serialized *schemas.BifrostGuardrailDebug
 	Latency                 *float64  `gorm:"index:idx_logs_latency" json:"latency,omitempty"`
+	UpstreamLatency         *float64  `gorm:"index:idx_logs_upstream_latency" json:"upstream_latency,omitempty"`                          // Provider socket time across all attempts, ms; nil = unmeasured
+	OverheadLatency         *float64  `gorm:"index:idx_logs_overhead_latency" json:"overhead_latency,omitempty"`                          // Bifrost overhead (total minus upstream), ms; nil = unmeasured
 	TokenUsage              string    `gorm:"type:text" json:"-"`                                                                         // JSON serialized *schemas.LLMUsage
 	Cost                    *float64  `gorm:"index" json:"cost,omitempty"`                                                                // Cost in dollars (total cost of the request - includes cache lookup cost)
 	Status                  string    `gorm:"type:varchar(50);index;index:idx_logs_ts_provider_status,priority:3;not null" json:"status"` // "processing", "success", or "error"

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -1659,6 +1659,10 @@ type LatencyHistogramBucket struct {
 	P90Latency    float64   `json:"p90_latency"`
 	P95Latency    float64   `json:"p95_latency"`
 	P99Latency    float64   `json:"p99_latency"`
+	AvgOverhead   float64   `json:"avg_overhead"`
+	P90Overhead   float64   `json:"p90_overhead"`
+	P95Overhead   float64   `json:"p95_overhead"`
+	P99Overhead   float64   `json:"p99_overhead"`
 	TotalRequests int64     `json:"total_requests"`
 }
 

--- a/framework/logstore/throughput_test.go
+++ b/framework/logstore/throughput_test.go
@@ -108,3 +108,72 @@ func TestThroughputHistogramMath(t *testing.T) {
 	require.InDelta(t, 200.0, tpByProvider["openai"], 1e-6)
 	require.InDelta(t, 100.0, tpByProvider["anthropic"], 1e-6)
 }
+
+// TestLatencyOverheadHistogramMath verifies GetLatencyHistogram returns overhead
+// avg/percentiles alongside latency, and that a row with a latency but no measured
+// overhead (an untraced or pre-migration row) still counts toward latency and
+// TotalRequests while being excluded from the overhead aggregation.
+func TestLatencyOverheadHistogramMath(t *testing.T) {
+	ctx := context.Background()
+	sq, err := newSqliteLogStore(ctx, &SQLiteConfig{
+		Path: filepath.Join(t.TempDir(), "latency_overhead.db"),
+	}, testLogger{})
+	require.NoError(t, err)
+
+	base := time.Now().UTC().Truncate(time.Second)
+	// All rows land in the same 1h bucket.
+	mk := func(id string, latencyMs float64, overheadMs *float64) *Log {
+		l := &Log{
+			ID:            id,
+			Timestamp:     base,
+			Object:        "chat.completion",
+			Provider:      "openai",
+			Model:         "gpt-4o",
+			Status:        "success",
+			SelectedKeyID: "sk1",
+			Latency:       f64PtrP(latencyMs),
+			CreatedAt:     base,
+		}
+		l.OverheadLatency = overheadMs
+		return l
+	}
+
+	// Five rows carry both latency and overhead; one carries latency only (overhead
+	// unmeasured). Latency aggregates over all six; overhead over the five measured.
+	require.NoError(t, sq.Create(ctx, mk("l1", 100, f64PtrP(10))))
+	require.NoError(t, sq.Create(ctx, mk("l2", 200, f64PtrP(20))))
+	require.NoError(t, sq.Create(ctx, mk("l3", 300, f64PtrP(30))))
+	require.NoError(t, sq.Create(ctx, mk("l4", 400, f64PtrP(40))))
+	require.NoError(t, sq.Create(ctx, mk("l5", 500, f64PtrP(50))))
+	require.NoError(t, sq.Create(ctx, mk("l6", 600, nil)))
+
+	window := SearchFilters{
+		StartTime: timePtrP(base.Add(-time.Hour)),
+		EndTime:   timePtrP(base.Add(time.Hour)),
+	}
+
+	res, err := sq.GetLatencyHistogram(ctx, window, 3600)
+	require.NoError(t, err)
+	var got *LatencyHistogramBucket
+	for i := range res.Buckets {
+		if res.Buckets[i].TotalRequests > 0 {
+			got = &res.Buckets[i]
+			break
+		}
+	}
+	require.NotNil(t, got, "expected a non-empty bucket")
+	require.Equal(t, int64(6), got.TotalRequests, "the overhead-less row still counts")
+
+	// Latency over [100,200,300,400,500,600] (n=6): computePercentile uses linear
+	// interpolation at rank p*(n-1).
+	require.InDelta(t, 350.0, got.AvgLatency, 1e-6)
+	require.InDelta(t, 550.0, got.P90Latency, 1e-6) // rank 4.5 -> 500*0.5 + 600*0.5
+	require.InDelta(t, 575.0, got.P95Latency, 1e-6) // rank 4.75 -> 500*0.25 + 600*0.75
+	require.InDelta(t, 595.0, got.P99Latency, 1e-6) // rank 4.95 -> 500*0.05 + 600*0.95
+
+	// Overhead over [10,20,30,40,50] (n=5) only: the nil-overhead row is skipped.
+	require.InDelta(t, 30.0, got.AvgOverhead, 1e-6)
+	require.InDelta(t, 46.0, got.P90Overhead, 1e-6) // rank 3.6 -> 40*0.4 + 50*0.6
+	require.InDelta(t, 48.0, got.P95Overhead, 1e-6) // rank 3.8 -> 40*0.2 + 50*0.8
+	require.InDelta(t, 49.6, got.P99Overhead, 1e-6) // rank 3.96 -> 40*0.04 + 50*0.96
+}

--- a/framework/modelcatalog/datasheet/store.go
+++ b/framework/modelcatalog/datasheet/store.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	bifrost "github.com/maximhq/bifrost/core"
@@ -66,6 +67,10 @@ type Store struct {
 	onModelParametersApplied func()
 	datasheetByProvider      map[schemas.ModelProvider][]string // rebuilt every reload
 	deprecatedByProvider     map[schemas.ModelProvider][]string // rebuilt every reload
+
+	// writeGen counts membership rebuilds; the composer's model→provider memo
+	// stamps it to detect staleness. Atomic so readers skip mu.
+	writeGen atomic.Uint64
 
 	// Overrides under their own mutex: writes here don't block pricing reads
 	// (the hot CalculateCost path takes mu.RLock and overridesMu.RLock
@@ -500,4 +505,11 @@ func (s *Store) rebuildDatasheetViewUnsafe() {
 		slices.Sort(models)
 		s.deprecatedByProvider[provider] = models
 	}
+
+	s.writeGen.Add(1)
+}
+
+// WriteGen returns the monotonic count of membership rebuilds.
+func (s *Store) WriteGen() uint64 {
+	return s.writeGen.Load()
 }

--- a/framework/modelcatalog/keyconfig/store.go
+++ b/framework/modelcatalog/keyconfig/store.go
@@ -18,6 +18,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -60,6 +61,10 @@ type Store struct {
 	mu      sync.RWMutex
 	entries map[schemas.ModelProvider]*providerState
 	logger  schemas.Logger
+
+	// writeGen counts entry mutations; the composer's model→provider memo
+	// stamps it to detect staleness. Atomic so readers skip mu.
+	writeGen atomic.Uint64
 }
 
 // New constructs an empty Store.
@@ -88,6 +93,12 @@ func (s *Store) Replace(snapshot map[schemas.ModelProvider][]schemas.Key) {
 		}
 	}
 	s.entries = next
+	s.writeGen.Add(1)
+}
+
+// WriteGen returns the monotonic count of entry mutations.
+func (s *Store) WriteGen() uint64 {
+	return s.writeGen.Load()
 }
 
 // SetProvider replaces the cached state for one provider. Call after a
@@ -98,9 +109,11 @@ func (s *Store) SetProvider(provider schemas.ModelProvider, keys []schemas.Key) 
 	defer s.mu.Unlock()
 	if st == nil {
 		delete(s.entries, provider)
+		s.writeGen.Add(1)
 		return
 	}
 	s.entries[provider] = st
+	s.writeGen.Add(1)
 }
 
 // RemoveProvider drops all state for the provider. Call on provider delete.
@@ -108,6 +121,7 @@ func (s *Store) RemoveProvider(provider schemas.ModelProvider) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.entries, provider)
+	s.writeGen.Add(1)
 }
 
 // EntriesFor returns all per-key entries for the provider (including

--- a/framework/modelcatalog/live/store.go
+++ b/framework/modelcatalog/live/store.go
@@ -18,6 +18,7 @@ package live
 import (
 	"slices"
 	"sync"
+	"sync/atomic"
 
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -50,6 +51,11 @@ type Store struct {
 	// look current again after the provider was re-added.
 	gen    map[schemas.ModelProvider]uint64
 	logger schemas.Logger
+
+	// writeGen counts entry mutations across all providers; the composer's
+	// model→provider memo stamps it to detect staleness. Distinct from gen,
+	// which is per-provider and guards in-flight fetch races.
+	writeGen atomic.Uint64
 }
 
 func New(logger schemas.Logger) *Store {
@@ -73,6 +79,12 @@ func (s *Store) Upsert(provider schemas.ModelProvider, keyID string, unfiltered 
 	s.mu.Lock()
 	s.entries[k] = Entry{Models: cp}
 	s.mu.Unlock()
+	s.writeGen.Add(1)
+}
+
+// WriteGen returns the monotonic count of entry mutations across all providers.
+func (s *Store) WriteGen() uint64 {
+	return s.writeGen.Load()
 }
 
 // Generation returns the provider's current invalidation counter. Read it
@@ -102,6 +114,7 @@ func (s *Store) UpsertIfCurrent(provider schemas.ModelProvider, keyID string, un
 		return false
 	}
 	s.entries[k] = Entry{Models: cp}
+	s.writeGen.Add(1)
 	return true
 }
 
@@ -113,6 +126,7 @@ func (s *Store) UpsertIfCurrent(provider schemas.ModelProvider, keyID string, un
 // nothing cached yet, and that is the write this has to stop.
 func (s *Store) bumpLocked(provider schemas.ModelProvider) {
 	s.gen[provider]++
+	s.writeGen.Add(1)
 }
 
 // Invalidate drops both filtered and unfiltered entries for one key. Called

--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -40,6 +40,12 @@ type ModelCatalog struct {
 	// loadCapabilities fills a capability cache miss.
 	loadCapabilities func(schemas.ModelProvider, string) (*schemas.ModelCapabilities, error)
 
+	// providerMemo caches GetProvidersForModel per model, stamped with
+	// catalogGeneration() at compute time; any store write invalidates every
+	// entry. Capped at providerMemoMaxEntries, flushed on overflow.
+	providerMemoMu sync.RWMutex
+	providerMemo   map[string]providerMemoEntry
+
 	// MCP library sync configuration (protected by syncMu)
 	mcpLibraryURL          string
 	mcpLibrarySyncInterval time.Duration
@@ -114,6 +120,7 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 		live:         live.New(logger),
 		keyconf:      keyconfig.New(logger),
 		capabilities: lrucache.New[*schemas.ModelCapabilities](capabilityCacheSize),
+		providerMemo: make(map[string]providerMemoEntry),
 		done:         make(chan struct{}),
 	}
 	mc.syncCtx, mc.syncCancel = context.WithCancel(ctx)

--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -19,6 +19,7 @@ import (
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/gencache"
 	"github.com/maximhq/bifrost/framework/lrucache"
 	"github.com/maximhq/bifrost/framework/modelcatalog/datasheet"
 	"github.com/maximhq/bifrost/framework/modelcatalog/keyconfig"
@@ -40,11 +41,8 @@ type ModelCatalog struct {
 	// loadCapabilities fills a capability cache miss.
 	loadCapabilities func(schemas.ModelProvider, string) (*schemas.ModelCapabilities, error)
 
-	// providerMemo caches GetProvidersForModel per model, stamped with
-	// catalogGeneration() at compute time; any store write invalidates every
-	// entry. Capped at providerMemoMaxEntries, flushed on overflow.
-	providerMemoMu sync.RWMutex
-	providerMemo   map[string]providerMemoEntry
+	providersForModel *gencache.Cache[[]schemas.ModelProvider]
+	modelsForProvider *gencache.Cache[[]string]
 
 	// MCP library sync configuration (protected by syncMu)
 	mcpLibraryURL          string
@@ -120,9 +118,9 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 		live:         live.New(logger),
 		keyconf:      keyconfig.New(logger),
 		capabilities: lrucache.New[*schemas.ModelCapabilities](capabilityCacheSize),
-		providerMemo: make(map[string]providerMemoEntry),
 		done:         make(chan struct{}),
 	}
+	mc.initCaches()
 	mc.syncCtx, mc.syncCancel = context.WithCancel(ctx)
 
 	// Core providers reach capabilities through this hook — they cannot import
@@ -649,12 +647,14 @@ func (mc *ModelCatalog) knownProviders() []schemas.ModelProvider {
 // NewTestCatalog constructs a minimal ModelCatalog for unit tests. Does not
 // start background workers or hit external services.
 func NewTestCatalog(baseModelIndex map[string]string) *ModelCatalog {
-	return &ModelCatalog{
+	mc := &ModelCatalog{
 		datasheet: datasheet.NewTestStore(baseModelIndex),
 		live:      live.New(nil),
 		keyconf:   keyconfig.New(nil),
 		done:      make(chan struct{}),
 	}
+	mc.initCaches()
+	return mc
 }
 
 // NewTestCatalogWithDatasheet wraps a caller-provided datasheet.Store (e.g. one
@@ -662,10 +662,12 @@ func NewTestCatalog(baseModelIndex map[string]string) *ModelCatalog {
 // LoadFromURLIntoMemory) in a ModelCatalog, so tests in other packages can
 // exercise real pricing/cost computation without reaching the network.
 func NewTestCatalogWithDatasheet(ds *datasheet.Store) *ModelCatalog {
-	return &ModelCatalog{
+	mc := &ModelCatalog{
 		datasheet: ds,
 		live:      live.New(nil),
 		keyconf:   keyconfig.New(nil),
 		done:      make(chan struct{}),
 	}
+	mc.initCaches()
+	return mc
 }

--- a/framework/modelcatalog/modelinfo_test.go
+++ b/framework/modelcatalog/modelinfo_test.go
@@ -62,12 +62,14 @@ func modelInfoCatalog(t *testing.T) *ModelCatalog {
 	if err := ds.LoadModelParamsFromURLIntoMemory(t.Context()); err != nil {
 		t.Fatalf("load model-parameters testdata: %v", err)
 	}
-	return &ModelCatalog{
+	mc := &ModelCatalog{
 		datasheet: ds,
 		live:      live.New(nil),
 		keyconf:   keyconfig.New(nil),
 		done:      make(chan struct{}),
 	}
+	mc.initCaches()
+	return mc
 }
 
 func TestGetModelInfoPopulatesPricingAndLimits(t *testing.T) {

--- a/framework/modelcatalog/models.go
+++ b/framework/modelcatalog/models.go
@@ -150,11 +150,63 @@ func (mc *ModelCatalog) GetDistinctBaseModelNames() []string {
 	return mc.datasheet.DistinctBaseModelNames()
 }
 
+// providerMemoEntry is a memoized GetProvidersForModel result and the
+// catalogGeneration it was computed under.
+type providerMemoEntry struct {
+	gen uint64
+	val []schemas.ModelProvider
+}
+
+// providerMemoMaxEntries bounds the memo; model strings are client-controlled
+// and would otherwise grow it without limit. On overflow the map is flushed
+// and hot entries repopulate on demand.
+const providerMemoMaxEntries = 4096
+
+// catalogGeneration sums the three stores' write counters. Every write bumps
+// exactly one counter by one, so the sum strictly increases and no two
+// catalog states share a value.
+func (mc *ModelCatalog) catalogGeneration() uint64 {
+	return mc.datasheet.WriteGen() + mc.keyconf.WriteGen() + mc.live.WriteGen()
+}
+
 // GetProvidersForModel returns every provider that can serve the model.
-// Composes across stores and applies the cross-provider special cases
-// (openrouter / vertex / groq-gpt / bedrock-claude) preserved verbatim from
-// the pre-refactor implementation.
+// Memoized per model (bounded, empty results uncached); any store write
+// invalidates (see catalogGeneration). Returns a fresh clone the caller
+// may mutate.
 func (mc *ModelCatalog) GetProvidersForModel(model string) []schemas.ModelProvider {
+	gen := mc.catalogGeneration()
+
+	mc.providerMemoMu.RLock()
+	entry, ok := mc.providerMemo[model]
+	mc.providerMemoMu.RUnlock()
+	if ok && entry.gen == gen {
+		return slices.Clone(entry.val)
+	}
+
+	val := mc.computeProvidersForModel(model)
+	// Unknown models resolve to nothing; skipping memoising
+	if len(val) == 0 {
+		return val
+	}
+
+	// Stamp with the generation read before compute: a write during compute
+	// leaves the entry stale and the next call recomputes.
+	mc.providerMemoMu.Lock()
+	if mc.providerMemo == nil {
+		mc.providerMemo = make(map[string]providerMemoEntry)
+	}
+	if _, exists := mc.providerMemo[model]; !exists && len(mc.providerMemo) >= providerMemoMaxEntries {
+		mc.providerMemo = make(map[string]providerMemoEntry)
+	}
+	mc.providerMemo[model] = providerMemoEntry{gen: gen, val: val}
+	mc.providerMemoMu.Unlock()
+
+	return slices.Clone(val)
+}
+
+// computeProvidersForModel composes the uncached answer across stores,
+// including the openrouter / vertex / groq-gpt / bedrock-claude special cases.
+func (mc *ModelCatalog) computeProvidersForModel(model string) []schemas.ModelProvider {
 	baseModel := mc.datasheet.BaseModelName(model)
 
 	providers := make([]schemas.ModelProvider, 0)
@@ -265,17 +317,25 @@ func (mc *ModelCatalog) IsModelAllowedForProvider(provider schemas.ModelProvider
 		return false
 	}
 
+	// Bare-name match needs no catalog access and covers most allowlists.
+	if slices.Contains(allowedModels, model) {
+		return true
+	}
+
+	// Only provider-prefixed entries ("openai/gpt-4o") need the provider
+	// catalog; build it once, and only when one exists.
+	if !slices.ContainsFunc(allowedModels, func(m string) bool { return strings.Contains(m, "/") }) {
+		return false
+	}
 	providerCatalogModels := mc.GetModelsForProvider(provider)
 	for _, allowedModel := range allowedModels {
-		if allowedModel == model {
-			return true
+		if !strings.Contains(allowedModel, "/") {
+			continue
 		}
-		if strings.Contains(allowedModel, "/") {
-			if slices.Contains(providerCatalogModels, allowedModel) {
-				_, modelPart := schemas.ParseModelString(allowedModel, "")
-				if modelPart == model {
-					return true
-				}
+		if slices.Contains(providerCatalogModels, allowedModel) {
+			_, modelPart := schemas.ParseModelString(allowedModel, "")
+			if modelPart == model {
+				return true
 			}
 		}
 	}

--- a/framework/modelcatalog/models.go
+++ b/framework/modelcatalog/models.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/gencache"
 )
 
 // providersWithPartialListModels enumerates providers whose /v1/models response
@@ -24,7 +25,15 @@ var providersWithPartialListModels = map[schemas.ModelProvider]bool{
 // provider. Filtered live entries are authoritative when present (they were
 // pre-gated by ListModelsPipeline against the key's allow/block/aliases);
 // otherwise the datasheet view is filtered by the keyconfig aggregates.
+//
+// Memoized; returns a fresh clone the caller may mutate.
 func (mc *ModelCatalog) GetModelsForProvider(provider schemas.ModelProvider) []string {
+	return mc.modelsForProvider.GetOrCompute(string(provider), func() []string {
+		return mc.computeModelsForProvider(provider)
+	})
+}
+
+func (mc *ModelCatalog) computeModelsForProvider(provider schemas.ModelProvider) []string {
 	blacklisted := mc.keyconf.BlacklistedFor(provider)
 	allowed := mc.keyconf.AllowedFor(provider)
 
@@ -150,58 +159,50 @@ func (mc *ModelCatalog) GetDistinctBaseModelNames() []string {
 	return mc.datasheet.DistinctBaseModelNames()
 }
 
-// providerMemoEntry is a memoized GetProvidersForModel result and the
-// catalogGeneration it was computed under.
-type providerMemoEntry struct {
-	gen uint64
-	val []schemas.ModelProvider
-}
+// catalogMemoMaxEntries bounds each catalog memo: model/provider keys are
+// client-controlled, so an unbounded map is a memory-growth vector.
+const catalogMemoMaxEntries = 4096
 
-// providerMemoMaxEntries bounds the memo; model strings are client-controlled
-// and would otherwise grow it without limit. On overflow the map is flushed
-// and hot entries repopulate on demand.
-const providerMemoMaxEntries = 4096
-
-// catalogGeneration sums the three stores' write counters. Every write bumps
-// exactly one counter by one, so the sum strictly increases and no two
-// catalog states share a value.
+// catalogGeneration sums the three stores' write counters. Each write bumps one
+// counter by one, so the sum strictly increases: no two catalog states collide.
 func (mc *ModelCatalog) catalogGeneration() uint64 {
 	return mc.datasheet.WriteGen() + mc.keyconf.WriteGen() + mc.live.WriteGen()
 }
 
+// initCaches builds the memos. Every constructor must call it before use: the
+// cached getters deref the caches with no nil guard.
+func (mc *ModelCatalog) initCaches() {
+	mc.providersForModel = newProvidersForModelCache(mc)
+	mc.modelsForProvider = newModelsForProviderCache(mc)
+}
+
+// Clone-on-return: the resolver sorts the result in place.
+func newProvidersForModelCache(mc *ModelCatalog) *gencache.Cache[[]schemas.ModelProvider] {
+	return gencache.New(
+		mc.catalogGeneration,
+		catalogMemoMaxEntries,
+		gencache.WithClone(func(v []schemas.ModelProvider) []schemas.ModelProvider { return slices.Clone(v) }),
+		gencache.WithSkipStore(func(v []schemas.ModelProvider) bool { return len(v) == 0 }),
+	)
+}
+
+// catalogGeneration is a valid stamp here too: the list derives from the same
+// three stores. Clone-on-return: callers sort the result in place.
+func newModelsForProviderCache(mc *ModelCatalog) *gencache.Cache[[]string] {
+	return gencache.New(
+		mc.catalogGeneration,
+		catalogMemoMaxEntries,
+		gencache.WithClone(func(v []string) []string { return slices.Clone(v) }),
+		gencache.WithSkipStore(func(v []string) bool { return len(v) == 0 }),
+	)
+}
+
 // GetProvidersForModel returns every provider that can serve the model.
-// Memoized per model (bounded, empty results uncached); any store write
-// invalidates (see catalogGeneration). Returns a fresh clone the caller
-// may mutate.
+// Memoized; returns a fresh clone the caller may mutate.
 func (mc *ModelCatalog) GetProvidersForModel(model string) []schemas.ModelProvider {
-	gen := mc.catalogGeneration()
-
-	mc.providerMemoMu.RLock()
-	entry, ok := mc.providerMemo[model]
-	mc.providerMemoMu.RUnlock()
-	if ok && entry.gen == gen {
-		return slices.Clone(entry.val)
-	}
-
-	val := mc.computeProvidersForModel(model)
-	// Unknown models resolve to nothing; skipping memoising
-	if len(val) == 0 {
-		return val
-	}
-
-	// Stamp with the generation read before compute: a write during compute
-	// leaves the entry stale and the next call recomputes.
-	mc.providerMemoMu.Lock()
-	if mc.providerMemo == nil {
-		mc.providerMemo = make(map[string]providerMemoEntry)
-	}
-	if _, exists := mc.providerMemo[model]; !exists && len(mc.providerMemo) >= providerMemoMaxEntries {
-		mc.providerMemo = make(map[string]providerMemoEntry)
-	}
-	mc.providerMemo[model] = providerMemoEntry{gen: gen, val: val}
-	mc.providerMemoMu.Unlock()
-
-	return slices.Clone(val)
+	return mc.providersForModel.GetOrCompute(model, func() []schemas.ModelProvider {
+		return mc.computeProvidersForModel(model)
+	})
 }
 
 // computeProvidersForModel composes the uncached answer across stores,

--- a/framework/modelcatalog/models_allowed_test.go
+++ b/framework/modelcatalog/models_allowed_test.go
@@ -1,0 +1,50 @@
+package modelcatalog
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/modelcatalog/datasheet"
+	"github.com/maximhq/bifrost/framework/modelcatalog/keyconfig"
+	"github.com/maximhq/bifrost/framework/modelcatalog/live"
+)
+
+// TestIsModelAllowedForProvider_ExplicitList pins the explicit-allowlist branch
+// after the option-1 lazy-defer rewrite: bare-name and provider-prefixed
+// matching must behave exactly as before.
+func TestIsModelAllowedForProvider_ExplicitList(t *testing.T) {
+	mc := &ModelCatalog{
+		datasheet:    datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
+		live:         live.New(nil),
+		keyconf:      keyconfig.New(nil),
+		providerMemo: make(map[string]providerMemoEntry),
+		done:         make(chan struct{}),
+	}
+	// Give OpenAI a live catalog carrying a provider-prefixed entry, so the
+	// prefixed branch has something to match (ParseModelString only strips
+	// recognized provider prefixes, so this must be a real provider).
+	provider := schemas.OpenAI
+	mc.UpsertLive(provider, "k1", false, []string{"openai/gpt-4o", "gpt-4o"})
+
+	cases := []struct {
+		name    string
+		model   string
+		allowed schemas.WhiteList
+		want    bool
+	}{
+		{"bare direct match", "gpt-4o", schemas.WhiteList{"gpt-4o", "claude"}, true},
+		{"bare no match (deny)", "gpt-4o", schemas.WhiteList{"claude", "gemini"}, false},
+		{"empty allowlist denies", "gpt-4o", schemas.WhiteList{}, false},
+		{"prefixed match", "gpt-4o", schemas.WhiteList{"openai/gpt-4o"}, true},
+		{"prefixed present but wrong model", "gpt-4o-mini", schemas.WhiteList{"openai/gpt-4o"}, false},
+		{"match after a prefixed miss (ordering)", "gpt-4o", schemas.WhiteList{"openai/other", "openai/gpt-4o"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mc.IsModelAllowedForProvider(provider, tc.model, nil, tc.allowed)
+			if got != tc.want {
+				t.Errorf("IsModelAllowedForProvider(%q, %v) = %v, want %v", tc.model, tc.allowed, got, tc.want)
+			}
+		})
+	}
+}

--- a/framework/modelcatalog/models_allowed_test.go
+++ b/framework/modelcatalog/models_allowed_test.go
@@ -14,12 +14,12 @@ import (
 // matching must behave exactly as before.
 func TestIsModelAllowedForProvider_ExplicitList(t *testing.T) {
 	mc := &ModelCatalog{
-		datasheet:    datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
-		live:         live.New(nil),
-		keyconf:      keyconfig.New(nil),
-		providerMemo: make(map[string]providerMemoEntry),
-		done:         make(chan struct{}),
+		datasheet: datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
+		live:      live.New(nil),
+		keyconf:   keyconfig.New(nil),
+		done:      make(chan struct{}),
 	}
+	mc.initCaches()
 	// Give OpenAI a live catalog carrying a provider-prefixed entry, so the
 	// prefixed branch has something to match (ParseModelString only strips
 	// recognized provider prefixes, so this must be a real provider).

--- a/framework/modelcatalog/models_memo_bench_test.go
+++ b/framework/modelcatalog/models_memo_bench_test.go
@@ -56,12 +56,12 @@ func benchCatalog(tb testing.TB, nProviders, nModels int) (*ModelCatalog, []stri
 	kc := keyconfig.New(nil)
 	kc.Replace(kcSnapshot)
 	mc := &ModelCatalog{
-		datasheet:    ds,
-		live:         live.New(nil),
-		keyconf:      kc,
-		providerMemo: make(map[string]providerMemoEntry),
-		done:         make(chan struct{}),
+		datasheet: ds,
+		live:      live.New(nil),
+		keyconf:   kc,
+		done:      make(chan struct{}),
 	}
+	mc.initCaches()
 	return mc, models
 }
 
@@ -89,6 +89,9 @@ func BenchmarkProvidersForModel_Uncached(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		// computeProvidersForModel -> GetModelsForProvider, so flush modelsForProvider
+		// each iteration or it stays warm and this stops measuring the pre-cache path.
+		mc.modelsForProvider.Flush()
 		_ = mc.computeProvidersForModel(q[i%len(q)])
 	}
 }
@@ -103,6 +106,9 @@ func BenchmarkProvidersForModel_UncachedScale(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
+				// flush modelsForProvider each iteration so the compute path stays cold
+				// (computeProvidersForModel -> GetModelsForProvider is otherwise memoised).
+				mc.modelsForProvider.Flush()
 				_ = mc.computeProvidersForModel(q[i%len(q)])
 			}
 		})
@@ -133,10 +139,11 @@ func BenchmarkIsModelAllowed_Uncached(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		model := q[i%len(q)]
-		// bust the memo each iteration to simulate the pre-cache cost
-		mc.providerMemoMu.Lock()
-		clear(mc.providerMemo)
-		mc.providerMemoMu.Unlock()
+		// bust both memos each iteration to simulate the pre-cache cost:
+		// IsModelAllowedForProvider -> computeProvidersForModel -> GetModelsForProvider,
+		// so modelsForProvider must be flushed too or it stays warm after iteration 1.
+		mc.providersForModel.Flush()
+		mc.modelsForProvider.Flush()
 		_ = mc.IsModelAllowedForProvider(schemas.ModelProvider("provider00"), model, nil, unrestricted)
 	}
 }

--- a/framework/modelcatalog/models_memo_bench_test.go
+++ b/framework/modelcatalog/models_memo_bench_test.go
@@ -1,0 +1,214 @@
+package modelcatalog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/modelcatalog/datasheet"
+	"github.com/maximhq/bifrost/framework/modelcatalog/keyconfig"
+	"github.com/maximhq/bifrost/framework/modelcatalog/live"
+)
+
+// benchCatalog builds a catalog at roughly production scale: nProviders each
+// serving nModels, with versioned model ids so BaseModelName does real work.
+// Every provider gets an unrestricted ["*"] allowlist so IsModelAllowedForProvider
+// takes the GetProvidersForModel path (the hot path in governance/loadbalancer).
+func benchCatalog(tb testing.TB, nProviders, nModels int) (*ModelCatalog, []string) {
+	tb.Helper()
+
+	var sb strings.Builder
+	sb.WriteString("{\n")
+	var models []string
+	first := true
+	kcSnapshot := map[schemas.ModelProvider][]schemas.Key{}
+	for p := 0; p < nProviders; p++ {
+		provider := fmt.Sprintf("provider%02d", p)
+		for m := 0; m < nModels; m++ {
+			base := fmt.Sprintf("model-%02d-%03d", p, m)
+			// versioned id so BaseModelName -> SplitModelAndVersion does work
+			id := base + "-2024-08-06"
+			if !first {
+				sb.WriteString(",\n")
+			}
+			first = false
+			sb.WriteString(fmt.Sprintf(`  %q: {"provider":%q,"mode":"chat","base_model":%q}`, id, provider, base))
+			models = append(models, id)
+		}
+		kcSnapshot[schemas.ModelProvider(provider)] = []schemas.Key{
+			{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"*"}},
+		}
+	}
+	sb.WriteString("\n}\n")
+
+	path := filepath.Join(tb.TempDir(), "pricing.json")
+	if err := os.WriteFile(path, []byte(sb.String()), 0o600); err != nil {
+		tb.Fatalf("write pricing: %v", err)
+	}
+	ds := datasheet.New(nil, nil, datasheet.Config{URL: "file://" + path})
+	if err := ds.LoadFromURLIntoMemory(tb.Context()); err != nil {
+		tb.Fatalf("load pricing: %v", err)
+	}
+
+	kc := keyconfig.New(nil)
+	kc.Replace(kcSnapshot)
+	mc := &ModelCatalog{
+		datasheet:    ds,
+		live:         live.New(nil),
+		keyconf:      kc,
+		providerMemo: make(map[string]providerMemoEntry),
+		done:         make(chan struct{}),
+	}
+	return mc, models
+}
+
+// rotate returns model ids to query: a small hot set (what a real workload hits
+// repeatedly) rather than every distinct model once.
+func benchQueryModels(all []string, n int) []string {
+	if n > len(all) {
+		n = len(all)
+	}
+	out := make([]string, n)
+	// spread the picks across providers
+	step := len(all) / n
+	if step == 0 {
+		step = 1
+	}
+	for i := 0; i < n; i++ {
+		out[i] = all[(i*step)%len(all)]
+	}
+	return out
+}
+
+func BenchmarkProvidersForModel_Uncached(b *testing.B) {
+	mc, all := benchCatalog(b, 15, 50)
+	q := benchQueryModels(all, 8)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = mc.computeProvidersForModel(q[i%len(q)])
+	}
+}
+
+// scale sweep: uncached cost is ~O(providers × models), so it grows with the
+// datasheet. Brackets where a real catalog sits.
+func BenchmarkProvidersForModel_UncachedScale(b *testing.B) {
+	for _, sz := range []struct{ p, m int }{{15, 50}, {20, 100}, {30, 150}, {40, 250}} {
+		b.Run(fmt.Sprintf("%dx%d", sz.p, sz.m), func(b *testing.B) {
+			mc, all := benchCatalog(b, sz.p, sz.m)
+			q := benchQueryModels(all, 8)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = mc.computeProvidersForModel(q[i%len(q)])
+			}
+		})
+	}
+}
+
+func BenchmarkProvidersForModel_Cached(b *testing.B) {
+	mc, all := benchCatalog(b, 15, 50)
+	q := benchQueryModels(all, 8)
+	// warm the memo
+	for _, m := range q {
+		_ = mc.GetProvidersForModel(m)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = mc.GetProvidersForModel(q[i%len(q)])
+	}
+}
+
+// IsModelAllowedForProvider with ["*"] is the exact call governance and the
+// loadbalancer make per request; measure it uncached vs cached.
+func BenchmarkIsModelAllowed_Uncached(b *testing.B) {
+	mc, all := benchCatalog(b, 15, 50)
+	q := benchQueryModels(all, 8)
+	unrestricted := schemas.WhiteList{"*"}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		model := q[i%len(q)]
+		// bust the memo each iteration to simulate the pre-cache cost
+		mc.providerMemoMu.Lock()
+		clear(mc.providerMemo)
+		mc.providerMemoMu.Unlock()
+		_ = mc.IsModelAllowedForProvider(schemas.ModelProvider("provider00"), model, nil, unrestricted)
+	}
+}
+
+// GetModelsForProvider is the single-provider rebuild the explicit-list branch
+// pays per call (uncached today).
+func BenchmarkGetModelsForProvider(b *testing.B) {
+	mc, _ := benchCatalog(b, 15, 50)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = mc.GetModelsForProvider(schemas.ModelProvider("provider00"))
+	}
+}
+
+// Explicit-list IsModelAllowedForProvider: allowedModels holds a specific set,
+// not ["*"]. bare-name direct match: option 1 resolves this without touching the
+// catalog at all.
+func BenchmarkIsModelAllowed_ExplicitList(b *testing.B) {
+	mc, all := benchCatalog(b, 15, 50)
+	q := benchQueryModels(all, 8)
+	// realistic explicit allowlist for provider00: a handful of its own models,
+	// including the ones we query.
+	explicit := schemas.WhiteList(append([]string{}, q...))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = mc.IsModelAllowedForProvider(schemas.ModelProvider("provider00"), q[i%len(q)], nil, explicit)
+	}
+}
+
+// bare-name allowlist, model NOT present (deny). No "/" entries, so option 1
+// still never touches the catalog.
+func BenchmarkIsModelAllowed_ExplicitList_Deny(b *testing.B) {
+	mc, all := benchCatalog(b, 15, 50)
+	explicit := schemas.WhiteList{"nope-a", "nope-b", "nope-c"}
+	q := benchQueryModels(all, 8)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = mc.IsModelAllowedForProvider(schemas.ModelProvider("provider00"), q[i%len(q)], nil, explicit)
+	}
+}
+
+// provider-prefixed allowlist ("provider00/model..."). This is the one explicit
+// shape option 1 cannot make free: it must build the provider catalog once to
+// resolve the prefix. Shows the residual cost option 2 would target.
+func BenchmarkIsModelAllowed_ExplicitList_Prefixed(b *testing.B) {
+	mc, all := benchCatalog(b, 15, 50)
+	q := benchQueryModels(all, 8)
+	prefixed := make(schemas.WhiteList, len(q))
+	for i, m := range q {
+		prefixed[i] = "provider00/" + m
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = mc.IsModelAllowedForProvider(schemas.ModelProvider("provider00"), q[i%len(q)], nil, prefixed)
+	}
+}
+
+func BenchmarkIsModelAllowed_Cached(b *testing.B) {
+	mc, all := benchCatalog(b, 15, 50)
+	q := benchQueryModels(all, 8)
+	unrestricted := schemas.WhiteList{"*"}
+	for _, m := range q {
+		_ = mc.IsModelAllowedForProvider(schemas.ModelProvider("provider00"), m, nil, unrestricted)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		model := q[i%len(q)]
+		_ = mc.IsModelAllowedForProvider(schemas.ModelProvider("provider00"), model, nil, unrestricted)
+	}
+}

--- a/framework/modelcatalog/models_memo_test.go
+++ b/framework/modelcatalog/models_memo_test.go
@@ -1,7 +1,6 @@
 package modelcatalog
 
 import (
-	"fmt"
 	"slices"
 	"testing"
 
@@ -20,12 +19,12 @@ func TestProviderMemoInvalidatesOnWrite(t *testing.T) {
 		schemas.OpenAI: {{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}}},
 	})
 	mc := &ModelCatalog{
-		datasheet:    datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
-		live:         live.New(nil),
-		keyconf:      kc,
-		providerMemo: make(map[string]providerMemoEntry),
-		done:         make(chan struct{}),
+		datasheet: datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
+		live:      live.New(nil),
+		keyconf:   kc,
+		done:      make(chan struct{}),
 	}
+	mc.initCaches()
 
 	// Prime the memo.
 	got := mc.GetProvidersForModel("gpt-4o")
@@ -57,59 +56,18 @@ func TestProviderMemoSkipsEmptyResults(t *testing.T) {
 		schemas.OpenAI: {{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}}},
 	})
 	mc := &ModelCatalog{
-		datasheet:    datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
-		live:         live.New(nil),
-		keyconf:      kc,
-		providerMemo: make(map[string]providerMemoEntry),
-		done:         make(chan struct{}),
+		datasheet: datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
+		live:      live.New(nil),
+		keyconf:   kc,
+		done:      make(chan struct{}),
 	}
+	mc.initCaches()
 
 	if got := mc.GetProvidersForModel("junk-model-xyz"); len(got) != 0 {
 		t.Fatalf("expected no providers for junk model, got %v", got)
 	}
-	mc.providerMemoMu.RLock()
-	_, cached := mc.providerMemo["junk-model-xyz"]
-	mc.providerMemoMu.RUnlock()
-	if cached {
+	if _, cached := mc.providersForModel.Get("junk-model-xyz"); cached {
 		t.Fatalf("empty result was cached")
-	}
-}
-
-// TestProviderMemoBounded pins the overflow flush: inserting a new key into a
-// full memo must not grow it past providerMemoMaxEntries.
-func TestProviderMemoBounded(t *testing.T) {
-	kc := keyconfig.New(nil)
-	kc.Replace(map[schemas.ModelProvider][]schemas.Key{
-		schemas.OpenAI: {{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}}},
-	})
-	mc := &ModelCatalog{
-		datasheet:    datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
-		live:         live.New(nil),
-		keyconf:      kc,
-		providerMemo: make(map[string]providerMemoEntry),
-		done:         make(chan struct{}),
-	}
-
-	// Fill to the cap with synthetic entries, then insert one real new model.
-	mc.providerMemoMu.Lock()
-	for i := 0; len(mc.providerMemo) < providerMemoMaxEntries; i++ {
-		mc.providerMemo[fmt.Sprintf("filler-%d", i)] = providerMemoEntry{}
-	}
-	mc.providerMemoMu.Unlock()
-
-	if got := mc.GetProvidersForModel("gpt-4o"); !slices.Contains(got, schemas.OpenAI) {
-		t.Fatalf("expected OpenAI, got %v", got)
-	}
-
-	mc.providerMemoMu.RLock()
-	size := len(mc.providerMemo)
-	_, cached := mc.providerMemo["gpt-4o"]
-	mc.providerMemoMu.RUnlock()
-	if size > providerMemoMaxEntries {
-		t.Fatalf("memo grew past cap: %d entries", size)
-	}
-	if !cached {
-		t.Fatalf("new model missing from memo after flush")
 	}
 }
 
@@ -122,12 +80,12 @@ func TestProviderMemoReturnsClone(t *testing.T) {
 		schemas.Anthropic: {{ID: "k2", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}}},
 	})
 	mc := &ModelCatalog{
-		datasheet:    datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
-		live:         live.New(nil),
-		keyconf:      kc,
-		providerMemo: make(map[string]providerMemoEntry),
-		done:         make(chan struct{}),
+		datasheet: datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
+		live:      live.New(nil),
+		keyconf:   kc,
+		done:      make(chan struct{}),
 	}
+	mc.initCaches()
 
 	first := mc.GetProvidersForModel("gpt-4o")
 	if len(first) < 2 {

--- a/framework/modelcatalog/models_memo_test.go
+++ b/framework/modelcatalog/models_memo_test.go
@@ -1,0 +1,147 @@
+package modelcatalog
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/modelcatalog/datasheet"
+	"github.com/maximhq/bifrost/framework/modelcatalog/keyconfig"
+	"github.com/maximhq/bifrost/framework/modelcatalog/live"
+)
+
+// TestProviderMemoInvalidatesOnWrite pins the correctness of the generation
+// stamp: a store write must make GetProvidersForModel recompute, never serve a
+// cached membership from before the write.
+func TestProviderMemoInvalidatesOnWrite(t *testing.T) {
+	kc := keyconfig.New(nil)
+	kc.Replace(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}}},
+	})
+	mc := &ModelCatalog{
+		datasheet:    datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
+		live:         live.New(nil),
+		keyconf:      kc,
+		providerMemo: make(map[string]providerMemoEntry),
+		done:         make(chan struct{}),
+	}
+
+	// Prime the memo.
+	got := mc.GetProvidersForModel("gpt-4o")
+	if !slices.Contains(got, schemas.OpenAI) {
+		t.Fatalf("expected OpenAI before write, got %v", got)
+	}
+	if !slices.Contains(mc.GetProvidersForModel("gpt-4o"), schemas.OpenAI) {
+		t.Fatalf("cached read lost OpenAI")
+	}
+
+	// Add a second provider that serves the same model. This is a keyconfig
+	// write, which must invalidate the memo.
+	kc.SetProvider(schemas.Anthropic, []schemas.Key{
+		{ID: "k2", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}},
+	})
+
+	got = mc.GetProvidersForModel("gpt-4o")
+	if !slices.Contains(got, schemas.Anthropic) {
+		t.Fatalf("memo served stale membership after write: got %v, want Anthropic included", got)
+	}
+}
+
+// TestProviderMemoSkipsEmptyResults pins that unknown models are never cached:
+// model strings are client-controlled, so caching misses would let junk names
+// grow the memo.
+func TestProviderMemoSkipsEmptyResults(t *testing.T) {
+	kc := keyconfig.New(nil)
+	kc.Replace(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}}},
+	})
+	mc := &ModelCatalog{
+		datasheet:    datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
+		live:         live.New(nil),
+		keyconf:      kc,
+		providerMemo: make(map[string]providerMemoEntry),
+		done:         make(chan struct{}),
+	}
+
+	if got := mc.GetProvidersForModel("junk-model-xyz"); len(got) != 0 {
+		t.Fatalf("expected no providers for junk model, got %v", got)
+	}
+	mc.providerMemoMu.RLock()
+	_, cached := mc.providerMemo["junk-model-xyz"]
+	mc.providerMemoMu.RUnlock()
+	if cached {
+		t.Fatalf("empty result was cached")
+	}
+}
+
+// TestProviderMemoBounded pins the overflow flush: inserting a new key into a
+// full memo must not grow it past providerMemoMaxEntries.
+func TestProviderMemoBounded(t *testing.T) {
+	kc := keyconfig.New(nil)
+	kc.Replace(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}}},
+	})
+	mc := &ModelCatalog{
+		datasheet:    datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
+		live:         live.New(nil),
+		keyconf:      kc,
+		providerMemo: make(map[string]providerMemoEntry),
+		done:         make(chan struct{}),
+	}
+
+	// Fill to the cap with synthetic entries, then insert one real new model.
+	mc.providerMemoMu.Lock()
+	for i := 0; len(mc.providerMemo) < providerMemoMaxEntries; i++ {
+		mc.providerMemo[fmt.Sprintf("filler-%d", i)] = providerMemoEntry{}
+	}
+	mc.providerMemoMu.Unlock()
+
+	if got := mc.GetProvidersForModel("gpt-4o"); !slices.Contains(got, schemas.OpenAI) {
+		t.Fatalf("expected OpenAI, got %v", got)
+	}
+
+	mc.providerMemoMu.RLock()
+	size := len(mc.providerMemo)
+	_, cached := mc.providerMemo["gpt-4o"]
+	mc.providerMemoMu.RUnlock()
+	if size > providerMemoMaxEntries {
+		t.Fatalf("memo grew past cap: %d entries", size)
+	}
+	if !cached {
+		t.Fatalf("new model missing from memo after flush")
+	}
+}
+
+// TestProviderMemoReturnsClone pins that callers can mutate the returned slice
+// (the resolver sorts it in place) without corrupting the cached entry.
+func TestProviderMemoReturnsClone(t *testing.T) {
+	kc := keyconfig.New(nil)
+	kc.Replace(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI:    {{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}}},
+		schemas.Anthropic: {{ID: "k2", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}}},
+	})
+	mc := &ModelCatalog{
+		datasheet:    datasheet.NewTestStore(map[string]string{"gpt-4o": "gpt-4o"}),
+		live:         live.New(nil),
+		keyconf:      kc,
+		providerMemo: make(map[string]providerMemoEntry),
+		done:         make(chan struct{}),
+	}
+
+	first := mc.GetProvidersForModel("gpt-4o")
+	if len(first) < 2 {
+		t.Fatalf("expected >=2 providers, got %v", first)
+	}
+	// Corrupt the returned slice.
+	for i := range first {
+		first[i] = "MUTATED"
+	}
+
+	second := mc.GetProvidersForModel("gpt-4o")
+	for _, p := range second {
+		if p == "MUTATED" {
+			t.Fatalf("caller mutation leaked into cached entry: %v", second)
+		}
+	}
+}

--- a/framework/modelcatalog/pool_test.go
+++ b/framework/modelcatalog/pool_test.go
@@ -143,6 +143,7 @@ func TestGetModelsForProvider_DeprecatedDatasheetModelsRespectAllowBlock(t *test
 				keyconf:   kc,
 				done:      make(chan struct{}),
 			}
+			mc.initCaches()
 			mc.UpsertLive(schemas.OpenAI, "k1", false, []string{"live-model"})
 
 			got := mc.GetModelsForProvider(schemas.OpenAI)

--- a/framework/tracing/allocfix_bench_test.go
+++ b/framework/tracing/allocfix_bench_test.go
@@ -1,0 +1,143 @@
+package tracing
+
+// Deterministic before/after benchmark for fix C1: batching the per-request
+// LLM-call span attribute writes. The old path issued ~30 individual
+// tracer.SetAttribute calls, each re-resolving the span (GetTrace + linear
+// GetSpan scan over all spans in the trace) and taking the span lock. The new
+// path (SetAttributes) resolves the span once and writes under a single lock.
+//
+// Run:
+//
+//	go test ./framework/tracing/ -run '^$' -bench 'FixC1' -benchmem
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// benchC1Setup builds a trace with a realistic number of sibling spans (so the
+// per-call GetSpan linear scan is exercised) and returns the tracer plus a
+// handle to the last span (worst-case scan position).
+func benchC1Setup(nSpans int) (*Tracer, schemas.SpanHandle) {
+	store := NewTraceStore(5*time.Minute, nil)
+	tracer := NewTracer(store, nil, nil)
+	traceID := tracer.CreateTrace("")
+	ctx := context.WithValue(context.Background(), schemas.BifrostContextKeyTraceID, traceID)
+	ctx, target := tracer.StartSpan(ctx, "http-request", schemas.SpanKindHTTPRequest)
+	for i := 0; i < nSpans; i++ {
+		_, h := tracer.StartSpan(ctx, "span"+strconv.Itoa(i), schemas.SpanKindPlugin)
+		target = h
+	}
+	return tracer, target
+}
+
+// 30 attribute key/value pairs, matching the count set on the LLM-call span.
+var (
+	benchC1Keys = func() []string {
+		k := make([]string, 30)
+		for i := range k {
+			k[i] = "attr" + strconv.Itoa(i)
+		}
+		return k
+	}()
+	benchC1Values = func() []any {
+		v := make([]any, 30)
+		for i := range v {
+			v[i] = "value" + strconv.Itoa(i)
+		}
+		return v
+	}()
+)
+
+// Old path: one SetAttribute per attribute (re-resolves span + locks each time).
+func BenchmarkFixC1_PerAttribute(b *testing.B) {
+	tracer, h := benchC1Setup(15)
+	defer tracer.Stop()
+	b.ReportAllocs()
+	for b.Loop() {
+		for i, k := range benchC1Keys {
+			tracer.SetAttribute(h, k, benchC1Values[i])
+		}
+	}
+}
+
+// New path: resolve the span once (SpanFromHandle), then write directly. One
+// lookup instead of ~30, no extra allocation.
+func BenchmarkFixC1_ResolveOnce(b *testing.B) {
+	tracer, h := benchC1Setup(15)
+	defer tracer.Stop()
+	b.ReportAllocs()
+	for b.Loop() {
+		span := tracer.SpanFromHandle(h)
+		for i, k := range benchC1Keys {
+			span.SetAttribute(k, benchC1Values[i])
+		}
+	}
+}
+
+// Fix C7: StartSpanID avoids the per-span context.WithValue (valueCtx) node that
+// StartSpan allocates. The plugin-hook pipeline only needs the span ID (it
+// mirrors it into the BifrostContext), so the valueCtx was pure waste. Both
+// benchmarks create a span per iteration; the delta is the valueCtx allocation.
+func BenchmarkFixC7_StartSpan(b *testing.B) {
+	store := NewTraceStore(time.Hour, nil)
+	defer store.Stop()
+	tracer := NewTracer(store, nil, nil)
+	defer tracer.Stop()
+	traceID := tracer.CreateTrace("")
+	ctx := context.WithValue(context.Background(), schemas.BifrostContextKeyTraceID, traceID)
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = tracer.StartSpan(ctx, "s", schemas.SpanKindPlugin)
+	}
+}
+
+func BenchmarkFixC7_StartSpanID(b *testing.B) {
+	store := NewTraceStore(time.Hour, nil)
+	defer store.Stop()
+	tracer := NewTracer(store, nil, nil)
+	defer tracer.Stop()
+	traceID := tracer.CreateTrace("")
+	ctx := context.WithValue(context.Background(), schemas.BifrostContextKeyTraceID, traceID)
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = tracer.StartSpanID(ctx, "s", schemas.SpanKindPlugin)
+	}
+}
+
+// Fix C2: the Populate*Attributes output map already exists (it's reused for
+// root-span propagation), so the win is writing it into the span under ONE lock
+// instead of a range + SetAttribute loop (one lock per entry). Span resolved once.
+var benchC2Attrs = map[string]any{
+	"gen_ai.provider.name": "openai", "bifrost.provider.name": "openai",
+	"gen_ai.request.model": "gpt-4o", "gen_ai.operation.name": "chat",
+	"gen_ai.request.temperature": 0.7, "gen_ai.request.max_tokens": 512,
+	"gen_ai.request.top_p": 0.9, "gen_ai.input.messages": "hello",
+	"gen_ai.request.stream": false, "bifrost.request.tools_count": 1,
+}
+
+func BenchmarkFixC2_PerEntryLoop(b *testing.B) {
+	tracer, h := benchC1Setup(15)
+	defer tracer.Stop()
+	span := tracer.SpanFromHandle(h)
+	b.ReportAllocs()
+	for b.Loop() {
+		for k, v := range benchC2Attrs {
+			span.SetAttribute(k, v)
+		}
+	}
+}
+
+func BenchmarkFixC2_BulkSetAttributes(b *testing.B) {
+	tracer, h := benchC1Setup(15)
+	defer tracer.Stop()
+	span := tracer.SpanFromHandle(h)
+	b.ReportAllocs()
+	for b.Loop() {
+		span.SetAttributes(benchC2Attrs)
+	}
+}

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -837,7 +837,6 @@ func (t *Tracer) CompleteAndFlushTrace(traceID string) {
 		exportTrace.StampOverheadDuration()
 
 		var slots []*obsPluginSlot
-		dumpSpanTimings(exportTrace)
 		if loaded := t.obsPlugins.Load(); loaded != nil {
 			slots = *loaded
 		}

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -206,9 +206,23 @@ type spanHandle struct {
 // 2. BifrostContextKeyParentSpanID - incoming parent from W3C traceparent (for root spans)
 // 3. No parent - creates a root span with no parent
 func (t *Tracer) StartSpan(ctx context.Context, name string, kind schemas.SpanKind) (context.Context, schemas.SpanHandle) {
+	spanID, handle := t.StartSpanID(ctx, name, kind)
+	if handle == nil {
+		return ctx, nil
+	}
+	// Update context with new span ID for child-span linking.
+	return context.WithValue(ctx, schemas.BifrostContextKeySpanID, spanID), handle
+}
+
+// StartSpanID creates a span exactly like StartSpan but returns the new span's ID
+// instead of wrapping ctx in a context.WithValue node. Callers that only need the
+// ID (e.g. to mirror it into a *BifrostContext via SetValue, as the plugin-hook
+// pipeline does) use this to avoid a valueCtx allocation per span. Returns
+// ("", nil) when there is no trace in ctx or span creation fails.
+func (t *Tracer) StartSpanID(ctx context.Context, name string, kind schemas.SpanKind) (string, schemas.SpanHandle) {
 	traceID := GetTraceID(ctx)
 	if traceID == "" {
-		return ctx, nil
+		return "", nil
 	}
 
 	// Get parent span ID from context - first check for existing span in this service
@@ -227,11 +241,9 @@ func (t *Tracer) StartSpan(ctx context.Context, name string, kind schemas.SpanKi
 		span = t.store.StartSpan(traceID, name, kind)
 	}
 	if span == nil {
-		return ctx, nil
+		return "", nil
 	}
-	// Update context with new span ID
-	newCtx := context.WithValue(ctx, schemas.BifrostContextKeySpanID, span.SpanID)
-	return newCtx, &spanHandle{traceID: traceID, spanID: span.SpanID}
+	return span.SpanID, &spanHandle{traceID: traceID, spanID: span.SpanID}
 }
 
 // EndSpan completes a span with the given status and message.
@@ -257,6 +269,21 @@ func (t *Tracer) SetAttribute(handle schemas.SpanHandle, key string, value any) 
 	if span != nil {
 		span.SetAttribute(key, value)
 	}
+}
+
+// SpanFromHandle resolves the *Span for a handle once. Callers writing many
+// attributes use it to avoid a trace+span lookup per attribute; span.SetAttribute
+// is nil-safe, so a nil return is fine to write against.
+func (t *Tracer) SpanFromHandle(handle schemas.SpanHandle) *schemas.Span {
+	h, ok := handle.(*spanHandle)
+	if !ok || h == nil {
+		return nil
+	}
+	trace := t.store.GetTrace(h.traceID)
+	if trace == nil {
+		return nil
+	}
+	return trace.GetSpan(h.spanID)
 }
 
 // GetSpanHandleByID retrieves a span handle for the given trace and span ID.
@@ -317,9 +344,7 @@ func (t *Tracer) PopulateLLMRequestAttributes(handle schemas.SpanHandle, req *sc
 	}
 
 	attrs := PopulateRequestAttributes(req)
-	for k, v := range attrs {
-		span.SetAttribute(k, v)
-	}
+	span.SetAttributes(attrs)
 
 	// Propagate input messages and request model to root span so observability backends (e.g. Langfuse)
 	// can display Input and model name at the top-level trace without requiring users to drill into llm.call.
@@ -378,9 +403,7 @@ func (t *Tracer) PopulateLLMResponseAttributes(ctx *schemas.BifrostContext, hand
 		}
 		span.SetAttribute(k, v)
 	}
-	for k, v := range PopulateErrorAttributes(err) {
-		span.SetAttribute(k, v)
-	}
+	span.SetAttributes(PopulateErrorAttributes(err))
 
 	// Enrichment dimensions derivable only post-response, attached here so every
 	// connector reads them from one place (see core/schemas EnrichmentDims):
@@ -814,6 +837,7 @@ func (t *Tracer) CompleteAndFlushTrace(traceID string) {
 		exportTrace.StampOverheadDuration()
 
 		var slots []*obsPluginSlot
+		dumpSpanTimings(exportTrace)
 		if loaded := t.obsPlugins.Load(); loaded != nil {
 			slots = *loaded
 		}

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -1315,9 +1315,12 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	// latency stamped by the semantic cache plugin over the original provider
 	// latency preserved in the cached response.
 	var latency int64
+	var upstreamLatency, overheadLatency *int64
 	if result != nil {
 		ef := result.GetExtraFields()
 		latency = ef.Latency
+		upstreamLatency = ef.UpstreamLatency
+		overheadLatency = ef.OverheadLatency
 		// Model that actually served the turn when the provider swapped models inside
 		// one call. entry.Model still names what the caller asked for.
 		if ef.RoutingInfo.ServerSideFallbackModel != nil {
@@ -1337,7 +1340,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			entry.ServerSideFallbackModel = &m
 		}
 	}
-	applyOutputFieldsToEntry(entry, selectedKeyID, selectedKeyName, virtualKeyID, virtualKeyName, routingRuleID, routingRuleName, selectedPromptID, selectedPromptName, selectedPromptVersion, teamID, teamName, customerID, customerName, userID, userName, businessUnitID, businessUnitName, numberOfRetries, latency, attemptTrail)
+	applyOutputFieldsToEntry(entry, selectedKeyID, selectedKeyName, virtualKeyID, virtualKeyName, routingRuleID, routingRuleName, selectedPromptID, selectedPromptName, selectedPromptVersion, teamID, teamName, customerID, customerName, userID, userName, businessUnitID, businessUnitName, numberOfRetries, latency, upstreamLatency, overheadLatency, attemptTrail)
 	applyResolvedAliasInfo(entry, resolvedKeyAlias)
 	// Attach cluster governance metadata for disconnected node usage recovery
 	if nodeID, _ := p.clusterNodeID.Load().(string); nodeID != "" {
@@ -1485,6 +1488,10 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			// Apply streaming output fields to the entry
 			entry.Stream = true
 			p.applyStreamingOutputToEntry(entry, streamResponse, shouldStoreRaw, contentLoggingEnabled)
+			// Read off the raw final-chunk ExtraFields, not the rebuilt streamResponse.
+			if result != nil {
+				applyUpstreamOverheadToEntry(entry, result.GetExtraFields())
+			}
 		}
 		if entry.ErrorDetailsParsed != nil {
 			entry.Status = logStatusForError(entry.ErrorDetailsParsed)
@@ -1712,10 +1719,57 @@ func (p *LoggerPlugin) Inject(_ context.Context, trace *schemas.Trace) error {
 	}
 	// Serialize plugin logs once for all entries
 	pluginLogsJSON := serializePluginLogs(trace.PluginLogs)
+	// Backfill upstream/overhead from the authoritative values the tracer stamped on
+	// the root span at completion, so the log matches the trace connectors exactly.
+	// Supersedes the mid-request PostLLMHook estimate. Only overwrite when present.
+	var upstreamMs, overheadMs float64
+	var upOK, ovOK bool
+	if trace.RootSpan != nil && trace.RootSpan.Attributes != nil {
+		upstreamMs, upOK = traceAttrFloatMs(trace.RootSpan.Attributes, schemas.AttrBifrostUpstreamDurationMs)
+		overheadMs, ovOK = traceAttrFloatMs(trace.RootSpan.Attributes, schemas.AttrBifrostOverheadDurationMs)
+	}
+
 	p.logger.Debug("Inject: enqueuing %d log entries", len(pending.entries))
-	// Enqueue each log entry (supports multiple attempts per trace)
-	for _, entry := range pending.entries {
+	// Upstream/overhead are request-level: put them on one row per trace, not all.
+	// A trace can log many rows (list_models fans out per provider; fallbacks add a
+	// row per attempt), and stamping every one would count the same overhead N times
+	// in the graphs. Clear the rest, keeping their per-row latency.
+	//
+	// Pick the target row deterministically (latest Timestamp, tie-broken by ID)
+	// rather than by slice position: list_models fans out concurrently under one
+	// trace, so entries append in nondeterministic completion order and a positional
+	// "last" would attach trace latency to a random provider row. For sequential
+	// fallbacks the latest Timestamp is still the terminal attempt.
+	stampIdx := 0
+	for i, entry := range pending.entries {
+		best := pending.entries[stampIdx]
+		if entry.Timestamp.After(best.Timestamp) ||
+			(entry.Timestamp.Equal(best.Timestamp) && entry.ID > best.ID) {
+			stampIdx = i
+		}
+	}
+	for i, entry := range pending.entries {
 		entry.PluginLogs = pluginLogsJSON
+		if i == stampIdx {
+			if upOK {
+				u := upstreamMs
+				entry.UpstreamLatency = &u
+			}
+			if ovOK {
+				o := overheadMs
+				entry.OverheadLatency = &o
+			}
+			// Latency = full-request wall-clock = upstream + overhead. Summing (not
+			// the raw span duration) keeps latency >= upstream when overhead clamps
+			// to zero, so the breakdown always adds up.
+			if upOK && ovOK {
+				total := upstreamMs + overheadMs
+				entry.Latency = &total
+			}
+		} else if upOK || ovOK {
+			entry.UpstreamLatency = nil
+			entry.OverheadLatency = nil
+		}
 		p.logger.Debug("Inject: enqueuing log entry %s", entry.ID)
 		p.enqueueLogEntry(entry, p.makePostWriteCallback(nil))
 	}
@@ -1732,6 +1786,20 @@ func serializePluginLogs(logs []schemas.PluginLogEntry) string {
 		return ""
 	}
 	return string(data)
+}
+
+// traceAttrFloatMs reads a millisecond span attribute, tolerating int/int64/float64.
+func traceAttrFloatMs(attrs map[string]any, key string) (float64, bool) {
+	switch v := attrs[key].(type) {
+	case float64:
+		return v, true
+	case int64:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	default:
+		return 0, false
+	}
 }
 
 // MCP Plugin Interface Implementation

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -1166,26 +1166,6 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	if ok && fallbackRequestID != "" {
 		requestID = fallbackRequestID
 	}
-	selectedKeyID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedKeyID)
-	selectedKeyName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedKeyName)
-	virtualKeyID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceVirtualKeyID)
-	virtualKeyName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceVirtualKeyName)
-	routingRuleID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceRoutingRuleID)
-	routingRuleName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceRoutingRuleName)
-	selectedPromptName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedPromptName)
-	selectedPromptVersion := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedPromptVersion)
-	selectedPromptID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedPromptID)
-	teamID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceTeamID)
-	teamName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceTeamName)
-	customerID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceCustomerID)
-	customerName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceCustomerName)
-	userID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyUserID)
-	userName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyUserName)
-	businessUnitID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceBusinessUnitID)
-	businessUnitName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceBusinessUnitName)
-	numberOfRetries := bifrost.GetIntFromContext(ctx, schemas.BifrostContextKeyNumberOfRetries)
-	attemptTrail, _ := ctx.Value(schemas.BifrostContextKeyAttemptTrail).([]schemas.KeyAttemptRecord)
-
 	requestType, _, originalModelRequested, resolvedModelUsed := bifrost.GetResponseFields(result, bifrostErr)
 	resolvedKeyAlias := bifrost.GetResponseRoutingInfo(result, bifrostErr).ResolvedKeyAlias
 	shouldStoreRaw, _ := ctx.Value(schemas.BifrostContextKeyShouldStoreRawInLogs).(bool)
@@ -1291,6 +1271,30 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 		}
 		return result, bifrostErr, nil
 	}
+
+	// Governance/key/prompt fields, needed only by the final/error/non-streaming
+	// paths below (applyOutputFieldsToEntry). Read here, after the non-final-chunk
+	// fast path, so intermediate chunks skip these ~19 locked context lookups.
+	selectedKeyID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedKeyID)
+	selectedKeyName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedKeyName)
+	virtualKeyID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceVirtualKeyID)
+	virtualKeyName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceVirtualKeyName)
+	routingRuleID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceRoutingRuleID)
+	routingRuleName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceRoutingRuleName)
+	selectedPromptName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedPromptName)
+	selectedPromptVersion := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedPromptVersion)
+	selectedPromptID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedPromptID)
+	teamID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceTeamID)
+	teamName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceTeamName)
+	customerID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceCustomerID)
+	customerName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceCustomerName)
+	userID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyUserID)
+	userName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyUserName)
+	businessUnitID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceBusinessUnitID)
+	businessUnitName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceBusinessUnitName)
+	numberOfRetries := bifrost.GetIntFromContext(ctx, schemas.BifrostContextKeyNumberOfRetries)
+	attemptTrail, _ := ctx.Value(schemas.BifrostContextKeyAttemptTrail).([]schemas.KeyAttemptRecord)
+
 	// Extract routing engine logs from context before entering goroutine
 	routingEngineLogs := formatRoutingEngineLogs(ctx.GetRoutingEngineLogs())
 	if requestType == schemas.RealtimeRequest {

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -1609,6 +1609,92 @@ func TestStoreOrEnqueueRetryPreservesAllEntries(t *testing.T) {
 	}
 }
 
+// injectAndCollect runs Inject and returns the enqueued entries keyed by ID.
+func injectAndCollect(t *testing.T, entries []*logstore.Log, upstreamMs, overheadMs float64) map[string]*logstore.Log {
+	t.Helper()
+	plugin := &LoggerPlugin{
+		logger:     testLogger{},
+		writeQueue: make(chan *writeQueueEntry, len(entries)),
+	}
+	traceID := "trace-overhead-order"
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyTraceID, traceID)
+	for _, e := range entries {
+		plugin.storeOrEnqueueEntry(ctx, e, nil)
+	}
+	trace := &schemas.Trace{
+		TraceID: traceID,
+		RootSpan: &schemas.Span{
+			Attributes: map[string]any{
+				schemas.AttrBifrostUpstreamDurationMs: upstreamMs,
+				schemas.AttrBifrostOverheadDurationMs: overheadMs,
+			},
+		},
+	}
+	if err := plugin.Inject(context.Background(), trace); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	out := make(map[string]*logstore.Log, len(entries))
+	for len(plugin.writeQueue) > 0 {
+		qe := <-plugin.writeQueue
+		out[qe.log.ID] = qe.log
+	}
+	if len(out) != len(entries) {
+		t.Fatalf("expected %d enqueued entries, got %d", len(entries), len(out))
+	}
+	return out
+}
+
+// TestInject_StampsOverheadOnLatestTimestampRow guards against positional selection:
+// a concurrent list_models fan-out appends entries under one trace in nondeterministic
+// completion order, so request-level upstream/overhead must land on the latest-Timestamp
+// row, not "whichever slice position happened to be last". Here the latest row is the
+// middle one, so a positional "last" would stamp the wrong entry.
+func TestInject_StampsOverheadOnLatestTimestampRow(t *testing.T) {
+	base := time.Now().UTC()
+	got := injectAndCollect(t, []*logstore.Log{
+		{ID: "a", Provider: "openai", Timestamp: base},
+		{ID: "b", Provider: "anthropic", Timestamp: base.Add(2 * time.Second)}, // latest, but middle
+		{ID: "c", Provider: "gemini", Timestamp: base.Add(1 * time.Second)},    // positional last
+	}, 10, 5)
+
+	b := got["b"]
+	if b.UpstreamLatency == nil || *b.UpstreamLatency != 10 {
+		t.Fatalf("entry b UpstreamLatency = %v, want 10", b.UpstreamLatency)
+	}
+	if b.OverheadLatency == nil || *b.OverheadLatency != 5 {
+		t.Fatalf("entry b OverheadLatency = %v, want 5", b.OverheadLatency)
+	}
+	if b.Latency == nil || *b.Latency != 15 {
+		t.Fatalf("entry b Latency = %v, want 15 (upstream+overhead)", b.Latency)
+	}
+	for _, id := range []string{"a", "c"} {
+		if e := got[id]; e.UpstreamLatency != nil || e.OverheadLatency != nil {
+			t.Fatalf("entry %s must not carry request-level latency: up=%v ov=%v", id, e.UpstreamLatency, e.OverheadLatency)
+		}
+	}
+}
+
+// TestInject_OverheadTieBrokenByID pins determinism when timestamps collide (the
+// realistic fan-out case): the highest ID wins, so the target row is stable across runs.
+func TestInject_OverheadTieBrokenByID(t *testing.T) {
+	ts := time.Now().UTC()
+	got := injectAndCollect(t, []*logstore.Log{
+		{ID: "id-c", Provider: "openai", Timestamp: ts},
+		{ID: "id-a", Provider: "anthropic", Timestamp: ts},
+		{ID: "id-b", Provider: "gemini", Timestamp: ts},
+	}, 8, 2)
+
+	if e := got["id-c"]; e.OverheadLatency == nil || *e.OverheadLatency != 2 {
+		t.Fatalf("highest ID id-c should carry overhead, got %v", e.OverheadLatency)
+	}
+	for _, id := range []string{"id-a", "id-b"} {
+		if e := got[id]; e.UpstreamLatency != nil || e.OverheadLatency != nil {
+			t.Fatalf("entry %s must not carry request-level latency", id)
+		}
+	}
+}
+
 func TestConvertToProcessedStreamResponseUsesResponsesStreamTypeForWebSocketResponses(t *testing.T) {
 	result := &schemas.StreamAccumulatorResult{
 		RequestID:      "req-ws-3000",

--- a/plugins/logging/writer.go
+++ b/plugins/logging/writer.go
@@ -576,6 +576,7 @@ func applyOutputFieldsToEntry(
 	businessUnitID, businessUnitName string,
 	numberOfRetries int,
 	latency int64,
+	upstreamLatency, overheadLatency *int64,
 	attemptTrail []schemas.KeyAttemptRecord,
 ) {
 	entry.SelectedKeyID = selectedKeyID
@@ -632,7 +633,30 @@ func applyOutputFieldsToEntry(
 		latF := float64(latency)
 		entry.Latency = &latF
 	}
+	setUpstreamOverheadLatency(entry, upstreamLatency, overheadLatency)
 	if len(attemptTrail) > 0 {
 		entry.AttemptTrailParsed = attemptTrail
 	}
+}
+
+// setUpstreamOverheadLatency copies upstream/overhead onto the entry. nil stays nil,
+// so an absent measurement is never persisted as zero.
+func setUpstreamOverheadLatency(entry *logstore.Log, upstreamLatency, overheadLatency *int64) {
+	if upstreamLatency != nil {
+		upF := float64(*upstreamLatency)
+		entry.UpstreamLatency = &upF
+	}
+	if overheadLatency != nil {
+		ovF := float64(*overheadLatency)
+		entry.OverheadLatency = &ovF
+	}
+}
+
+// applyUpstreamOverheadToEntry copies upstream/overhead from a response's ExtraFields
+// onto the entry. Used by the streaming path.
+func applyUpstreamOverheadToEntry(entry *logstore.Log, ef *schemas.BifrostResponseExtraFields) {
+	if ef == nil {
+		return
+	}
+	setUpstreamOverheadLatency(entry, ef.UpstreamLatency, ef.OverheadLatency)
 }

--- a/ui/app/workspace/dashboard/components/charts/overheadChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/overheadChart.tsx
@@ -1,0 +1,205 @@
+import type { LatencyHistogramResponse } from "@/lib/types/logs";
+import { memo, useMemo } from "react";
+import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { formatFullTimestamp, formatLatency, formatTimestamp, LATENCY_COLORS } from "../../utils/chartUtils";
+import { ChartErrorBoundary } from "./chartErrorBoundary";
+import type { ChartType } from "./chartTypeToggle";
+
+interface OverheadChartProps {
+	data: LatencyHistogramResponse | null;
+	chartType: ChartType;
+	startTime: number;
+	endTime: number;
+}
+
+function CustomTooltip({ active, payload }: any) {
+	if (!active || !payload || !payload.length) return null;
+
+	const data = payload[0]?.payload;
+	if (!data) return null;
+
+	return (
+		<div className="rounded-sm border border-zinc-200 bg-white px-3 py-2 shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
+			<div className="mb-1 text-xs text-zinc-500">{formatFullTimestamp(data.timestamp)}</div>
+			<div className="space-y-1 text-sm">
+				<div className="flex items-center justify-between gap-4">
+					<span className="flex items-center gap-1.5">
+						<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.avg }} />
+						<span className="text-zinc-600 dark:text-zinc-400">Avg</span>
+					</span>
+					<span className="font-medium">{formatLatency(data.avg_overhead ?? 0)}</span>
+				</div>
+				<div className="flex items-center justify-between gap-4">
+					<span className="flex items-center gap-1.5">
+						<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.p90 }} />
+						<span className="text-zinc-600 dark:text-zinc-400">P90</span>
+					</span>
+					<span className="font-medium">{formatLatency(data.p90_overhead ?? 0)}</span>
+				</div>
+				<div className="flex items-center justify-between gap-4">
+					<span className="flex items-center gap-1.5">
+						<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.p95 }} />
+						<span className="text-zinc-600 dark:text-zinc-400">P95</span>
+					</span>
+					<span className="font-medium">{formatLatency(data.p95_overhead ?? 0)}</span>
+				</div>
+				<div className="flex items-center justify-between gap-4">
+					<span className="flex items-center gap-1.5">
+						<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.p99 }} />
+						<span className="text-zinc-600 dark:text-zinc-400">P99</span>
+					</span>
+					<span className="font-medium">{formatLatency(data.p99_overhead ?? 0)}</span>
+				</div>
+				<div className="flex items-center justify-between gap-4 border-t border-zinc-200 pt-1 dark:border-zinc-700">
+					<span className="text-zinc-600 dark:text-zinc-400">Requests</span>
+					<span className="font-medium">{(data.total_requests ?? 0).toLocaleString()}</span>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function OverheadChartImpl({ data, chartType, startTime, endTime }: OverheadChartProps) {
+	const chartData = useMemo(() => {
+		if (!data?.buckets || !data.bucket_size_seconds) {
+			return [];
+		}
+
+		return data.buckets.map((bucket, index) => ({
+			...bucket,
+			index,
+			formattedTime: formatTimestamp(bucket.timestamp, data.bucket_size_seconds),
+		}));
+	}, [data]);
+
+	if (!data?.buckets || chartData.length === 0) {
+		return <div className="text-muted-foreground flex h-full items-center justify-center text-sm">No data available</div>;
+	}
+
+	const commonProps = {
+		data: chartData,
+		margin: { top: 6, right: 4, left: 4, bottom: 0 },
+	};
+
+	return (
+		<ChartErrorBoundary resetKey={`${startTime}-${endTime}-${chartData.length}`}>
+			<ResponsiveContainer width="100%" height="100%">
+				{chartType === "bar" ? (
+					<BarChart {...commonProps} barCategoryGap={1}>
+						<CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-zinc-200 dark:stroke-zinc-700" />
+						<XAxis
+							dataKey="index"
+							type="number"
+							domain={[-0.5, chartData.length - 0.5]}
+							tick={{ fontSize: 11, className: "fill-zinc-500", dy: 5 }}
+							tickLine={false}
+							axisLine={false}
+							tickFormatter={(idx) => chartData[Math.round(idx)]?.formattedTime || ""}
+							interval="preserveStartEnd"
+						/>
+						<YAxis
+							tick={{ fontSize: 11, className: "fill-zinc-500" }}
+							tickLine={false}
+							axisLine={false}
+							width={55}
+							tickFormatter={formatLatency}
+							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
+							allowDataOverflow={false}
+						/>
+						<Tooltip content={<CustomTooltip />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
+						<Bar
+							isAnimationActive={false}
+							dataKey="avg_overhead"
+							fill={LATENCY_COLORS.avg}
+							fillOpacity={0.9}
+							barSize={8}
+							radius={[2, 2, 0, 0]}
+						/>
+						<Bar
+							isAnimationActive={false}
+							dataKey="p90_overhead"
+							fill={LATENCY_COLORS.p90}
+							fillOpacity={0.9}
+							barSize={8}
+							radius={[2, 2, 0, 0]}
+						/>
+						<Bar
+							isAnimationActive={false}
+							dataKey="p95_overhead"
+							fill={LATENCY_COLORS.p95}
+							fillOpacity={0.9}
+							barSize={8}
+							radius={[2, 2, 0, 0]}
+						/>
+						<Bar
+							isAnimationActive={false}
+							dataKey="p99_overhead"
+							fill={LATENCY_COLORS.p99}
+							fillOpacity={0.9}
+							barSize={8}
+							radius={[2, 2, 0, 0]}
+						/>
+					</BarChart>
+				) : (
+					<AreaChart {...commonProps}>
+						<CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-zinc-200 dark:stroke-zinc-700" />
+						<XAxis
+							dataKey="index"
+							type="number"
+							domain={[-0.5, chartData.length - 0.5]}
+							tick={{ fontSize: 11, className: "fill-zinc-500" }}
+							tickLine={false}
+							axisLine={false}
+							tickFormatter={(idx) => chartData[Math.round(idx)]?.formattedTime || ""}
+							interval="preserveStartEnd"
+						/>
+						<YAxis
+							tick={{ fontSize: 11, className: "fill-zinc-500" }}
+							tickLine={false}
+							axisLine={false}
+							width={55}
+							tickFormatter={formatLatency}
+							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
+							allowDataOverflow={false}
+						/>
+						<Tooltip content={<CustomTooltip />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
+						{/* Render P99 first (behind), then overlay in descending order so Avg is in front */}
+						<Area
+							isAnimationActive={false}
+							type="monotone"
+							dataKey="p99_overhead"
+							stroke={LATENCY_COLORS.p99}
+							fill={LATENCY_COLORS.p99}
+							fillOpacity={0.15}
+						/>
+						<Area
+							isAnimationActive={false}
+							type="monotone"
+							dataKey="p95_overhead"
+							stroke={LATENCY_COLORS.p95}
+							fill={LATENCY_COLORS.p95}
+							fillOpacity={0.2}
+						/>
+						<Area
+							isAnimationActive={false}
+							type="monotone"
+							dataKey="p90_overhead"
+							stroke={LATENCY_COLORS.p90}
+							fill={LATENCY_COLORS.p90}
+							fillOpacity={0.25}
+						/>
+						<Area
+							isAnimationActive={false}
+							type="monotone"
+							dataKey="avg_overhead"
+							stroke={LATENCY_COLORS.avg}
+							fill={LATENCY_COLORS.avg}
+							fillOpacity={0.4}
+						/>
+					</AreaChart>
+				)}
+			</ResponsiveContainer>
+		</ChartErrorBoundary>
+	);
+}
+export const OverheadChart = memo(OverheadChartImpl);

--- a/ui/app/workspace/dashboard/components/overviewTab.tsx
+++ b/ui/app/workspace/dashboard/components/overviewTab.tsx
@@ -27,6 +27,7 @@ import { type ChartType, ChartTypeToggle } from "./charts/chartTypeToggle";
 import { CostChart } from "./charts/costChart";
 import ExternalCacheTokenMeterChart from "./charts/externalCacheTokenMeterChart";
 import { LatencyChart } from "./charts/latencyChart";
+import { OverheadChart } from "./charts/overheadChart";
 import { ThroughputChart } from "./charts/throughputChart";
 import LocalCacheTokenMeterChart from "./charts/localCacheTokenMeterChart";
 import { LogVolumeChart } from "./charts/logVolumeChart";
@@ -63,6 +64,7 @@ export interface OverviewTabProps {
 	costChartType: ChartType;
 	modelChartType: ChartType;
 	latencyChartType: ChartType;
+	overheadChartType: ChartType;
 	throughputChartType: ChartType;
 
 	// Model selections
@@ -80,6 +82,7 @@ export interface OverviewTabProps {
 	onCostChartToggle: (type: ChartType) => void;
 	onModelChartToggle: (type: ChartType) => void;
 	onLatencyChartToggle: (type: ChartType) => void;
+	onOverheadChartToggle: (type: ChartType) => void;
 	onThroughputChartToggle: (type: ChartType) => void;
 
 	// Filter callbacks
@@ -109,6 +112,7 @@ function OverviewTabImpl({
 	costChartType,
 	modelChartType,
 	latencyChartType,
+	overheadChartType,
 	throughputChartType,
 	costModel,
 	usageModel,
@@ -120,6 +124,7 @@ function OverviewTabImpl({
 	onCostChartToggle,
 	onModelChartToggle,
 	onLatencyChartToggle,
+	onOverheadChartToggle,
 	onThroughputChartToggle,
 	onCostModelChange,
 	onUsageModelChange,
@@ -163,6 +168,20 @@ function OverviewTabImpl({
 			const reqs = b.total_requests ?? 0;
 			if (reqs === 0) continue;
 			weighted += (b.avg_latency ?? 0) * reqs;
+			count += reqs;
+		}
+		return count > 0 ? weighted / count : null;
+	}, [latencyData]);
+
+	// Request-weighted average Bifrost overhead across buckets, mirroring latencyAvg.
+	const overheadAvg = useMemo(() => {
+		if (!latencyData?.buckets || latencyData.buckets.length === 0) return null;
+		let weighted = 0;
+		let count = 0;
+		for (const b of latencyData.buckets) {
+			const reqs = b.total_requests ?? 0;
+			if (reqs === 0) continue;
+			weighted += (b.avg_overhead ?? 0) * reqs;
 			count += reqs;
 		}
 		return count > 0 ? weighted / count : null;
@@ -459,6 +478,45 @@ function OverviewTabImpl({
 					}
 				>
 					<LatencyChart data={latencyData} chartType={latencyChartType} startTime={startTime} endTime={endTime} />
+				</ChartCard>
+
+				{/* Bifrost Overhead Chart */}
+				<ChartCard
+					title="Bifrost Overhead"
+					loading={loadingLatency}
+					testId="chart-overhead"
+					totalLabel="Avg"
+					total={
+						overheadAvg !== null ? (
+							<NumberFlow value={overheadAvg} format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }} suffix="ms" />
+						) : undefined
+					}
+					totalTooltip={overheadAvg !== null ? `${overheadAvg.toLocaleString("en-US", { maximumFractionDigits: 6 })}ms` : undefined}
+					legend={
+						<div className={CHART_HEADER_LEGEND_CLASS}>
+							<span className="flex items-center gap-1">
+								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.avg }} />
+								<span className="text-muted-foreground">Avg</span>
+							</span>
+							<span className="flex items-center gap-1">
+								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.p90 }} />
+								<span className="text-muted-foreground">P90</span>
+							</span>
+							<span className="flex items-center gap-1">
+								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.p95 }} />
+								<span className="text-muted-foreground">P95</span>
+							</span>
+							<span className="flex items-center gap-1">
+								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.p99 }} />
+								<span className="text-muted-foreground">P99</span>
+							</span>
+						</div>
+					}
+					controls={
+						<ChartTypeToggle chartType={overheadChartType} onToggle={onOverheadChartToggle} data-testid="dashboard-overhead-chart-toggle" />
+					}
+				>
+					<OverheadChart data={latencyData} chartType={overheadChartType} startTime={startTime} endTime={endTime} />
 				</ChartCard>
 
 				{/* Throughput (tokens/sec) Chart */}

--- a/ui/app/workspace/dashboard/components/tabViews/overviewTabView.tsx
+++ b/ui/app/workspace/dashboard/components/tabViews/overviewTabView.tsx
@@ -42,6 +42,7 @@ interface OverviewTabViewProps {
 	costChartType: ChartType;
 	modelChartType: ChartType;
 	latencyChartType: ChartType;
+	overheadChartType: ChartType;
 	throughputChartType: ChartType;
 	costModel: string;
 	usageModel: string;
@@ -50,6 +51,7 @@ interface OverviewTabViewProps {
 	onCostChartToggle: (type: ChartType) => void;
 	onModelChartToggle: (type: ChartType) => void;
 	onLatencyChartToggle: (type: ChartType) => void;
+	onOverheadChartToggle: (type: ChartType) => void;
 	onThroughputChartToggle: (type: ChartType) => void;
 	onCostModelChange: (model: string) => void;
 	onUsageModelChange: (model: string) => void;
@@ -66,6 +68,7 @@ export const OverviewTabView = forwardRef<OverviewTabViewHandle, OverviewTabView
 		costChartType,
 		modelChartType,
 		latencyChartType,
+		overheadChartType,
 		throughputChartType,
 		costModel,
 		usageModel,
@@ -74,6 +77,7 @@ export const OverviewTabView = forwardRef<OverviewTabViewHandle, OverviewTabView
 		onCostChartToggle,
 		onModelChartToggle,
 		onLatencyChartToggle,
+		onOverheadChartToggle,
 		onThroughputChartToggle,
 		onCostModelChange,
 		onUsageModelChange,
@@ -161,6 +165,7 @@ export const OverviewTabView = forwardRef<OverviewTabViewHandle, OverviewTabView
 			costChartType={costChartType}
 			modelChartType={modelChartType}
 			latencyChartType={latencyChartType}
+			overheadChartType={overheadChartType}
 			throughputChartType={throughputChartType}
 			costModel={costModel}
 			usageModel={usageModel}
@@ -172,6 +177,7 @@ export const OverviewTabView = forwardRef<OverviewTabViewHandle, OverviewTabView
 			onCostChartToggle={onCostChartToggle}
 			onModelChartToggle={onModelChartToggle}
 			onLatencyChartToggle={onLatencyChartToggle}
+			onOverheadChartToggle={onOverheadChartToggle}
 			onThroughputChartToggle={onThroughputChartToggle}
 			onCostModelChange={onCostModelChange}
 			onUsageModelChange={onUsageModelChange}

--- a/ui/app/workspace/dashboard/page.tsx
+++ b/ui/app/workspace/dashboard/page.tsx
@@ -65,6 +65,7 @@ export default function DashboardPage() {
 			cost_chart: parseAsString.withDefault("bar"),
 			model_chart: parseAsString.withDefault("bar"),
 			latency_chart: parseAsString.withDefault("bar"),
+			overhead_chart: parseAsString.withDefault("bar"),
 			throughput_chart: parseAsString.withDefault("bar"),
 			cost_model: parseAsString.withDefault("all"),
 			usage_model: parseAsString.withDefault("all"),
@@ -307,6 +308,7 @@ export default function DashboardPage() {
 	const handleCostChartToggle = useCallback((type: ChartType) => setUrlState({ cost_chart: type }), [setUrlState]);
 	const handleModelChartToggle = useCallback((type: ChartType) => setUrlState({ model_chart: type }), [setUrlState]);
 	const handleLatencyChartToggle = useCallback((type: ChartType) => setUrlState({ latency_chart: type }), [setUrlState]);
+	const handleOverheadChartToggle = useCallback((type: ChartType) => setUrlState({ overhead_chart: type }), [setUrlState]);
 	const handleThroughputChartToggle = useCallback((type: ChartType) => setUrlState({ throughput_chart: type }), [setUrlState]);
 	const handleProviderCostChartToggle = useCallback((type: ChartType) => setUrlState({ provider_cost_chart: type }), [setUrlState]);
 	const handleProviderTokenChartToggle = useCallback((type: ChartType) => setUrlState({ provider_token_chart: type }), [setUrlState]);
@@ -589,6 +591,7 @@ export default function DashboardPage() {
 									costChartType={toChartType(urlState.cost_chart)}
 									modelChartType={toChartType(urlState.model_chart)}
 									latencyChartType={toChartType(urlState.latency_chart)}
+									overheadChartType={toChartType(urlState.overhead_chart)}
 									throughputChartType={toChartType(urlState.throughput_chart)}
 									costModel={urlState.cost_model}
 									usageModel={urlState.usage_model}
@@ -597,6 +600,7 @@ export default function DashboardPage() {
 									onCostChartToggle={handleCostChartToggle}
 									onModelChartToggle={handleModelChartToggle}
 									onLatencyChartToggle={handleLatencyChartToggle}
+									onOverheadChartToggle={handleOverheadChartToggle}
 									onThroughputChartToggle={handleThroughputChartToggle}
 									onCostModelChange={handleCostModelChange}
 									onUsageModelChange={handleUsageModelChange}

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -1007,7 +1007,20 @@ export function LogDetailView({
 							<LogEntryDetailsView
 								className="w-full"
 								label="Latency"
+								tooltip="Total end-to-end request time: upstream plus Bifrost overhead."
 								value={log.latency == null || isNaN(log.latency) ? "N/A" : <div>{log.latency.toFixed(2)}ms</div>}
+							/>
+							<LogEntryDetailsView
+								className="w-full"
+								label="Upstream Latency"
+								tooltip="Time spent waiting on the provider, summed across every attempt."
+								value={log.upstream_latency == null || isNaN(log.upstream_latency) ? "N/A" : <div>{log.upstream_latency.toFixed(2)}ms</div>}
+							/>
+							<LogEntryDetailsView
+								className="w-full"
+								label="Bifrost Overhead"
+								tooltip="Time added by Bifrost itself: routing, plugins, and processing."
+								value={log.overhead_latency == null || isNaN(log.overhead_latency) ? "N/A" : <div>{log.overhead_latency.toFixed(2)}ms</div>}
 							/>
 						</div>
 					</div>

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -410,6 +410,17 @@ function StatusPill({ status }: { status: Status }) {
 	);
 }
 
+// Colors an HTTP status code badge by response class.
+function statusCodeBadgeClass(code: number): string {
+	if (code >= 200 && code < 300)
+		return "bg-green-50 text-green-700 border-green-200 dark:bg-green-950/40 dark:text-green-400 dark:border-green-900";
+	if (code >= 300 && code < 400)
+		return "bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950/40 dark:text-blue-400 dark:border-blue-900";
+	if (code >= 400 && code < 500)
+		return "bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-400 dark:border-amber-900";
+	return "bg-red-50 text-red-700 border-red-200 dark:bg-red-950/40 dark:text-red-400 dark:border-red-900";
+}
+
 function HeroStat({
 	label,
 	value,
@@ -666,6 +677,11 @@ export function LogDetailView({
 				status_code?: number;
 			})
 		: null;
+	// Only errors and passthrough requests carry a real HTTP status code; others have none.
+	// Non-HTTP errors (timeouts, network, marshal) default to 0; treat that as no status
+	// so the header doesn't render a misleading red "0" badge.
+	const rawStatusCode = log.error_details?.status_code ?? passthroughParams?.status_code ?? null;
+	const statusCode = rawStatusCode === 0 ? null : rawStatusCode;
 
 	// Tools can also be declared inside Responses input items instead of the
 	// top-level tools param (codex code-mode models send an `additional_tools`
@@ -799,7 +815,6 @@ export function LogDetailView({
 				<div className="flex items-start justify-between gap-6 px-5 pt-5 pb-4">
 					<div className="min-w-0 flex-1">
 						<div className="flex flex-wrap items-center gap-2">
-							<StatusPill status={log.status as Status} />
 							<Badge
 								variant="outline"
 								className={cn(
@@ -809,6 +824,15 @@ export function LogDetailView({
 							>
 								{RequestTypeLabels[log.object as keyof typeof RequestTypeLabels] ?? log.object}
 							</Badge>
+							<StatusPill status={log.status as Status} />
+							{statusCode != null && (
+								<Badge
+									variant="outline"
+									className={cn("rounded-sm px-2 py-0.5 font-medium tabular-nums", statusCodeBadgeClass(statusCode))}
+								>
+									{statusCode}
+								</Badge>
+							)}
 							{log.routing_rule && (
 								<Link
 									to="/workspace/logs"

--- a/ui/app/workspace/logs/views/logEntryDetailsView.tsx
+++ b/ui/app/workspace/logs/views/logEntryDetailsView.tsx
@@ -1,4 +1,6 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import { Info } from "lucide-react";
 
 interface Props {
 	className?: string;
@@ -7,6 +9,7 @@ interface Props {
 	valueClassName?: string;
 	label: string;
 	value: React.ReactNode | null;
+	tooltip?: string;
 	hideExpandable?: boolean;
 	orientation?: "horizontal" | "vertical";
 	align?: "left" | "right";
@@ -27,8 +30,18 @@ export default function LogEntryDetailsView(props: Props) {
 		>
 			<div className={props.containerClassName}>
 				{props.label !== "" && (
-					<div className="text-muted-foreground flex shrink-0 flex-row items-center gap-2 pb-2 text-xs font-medium">
+					<div className="text-muted-foreground flex shrink-0 flex-row items-center gap-1.5 pb-2 text-xs font-medium">
 						{props.label.toUpperCase().replace(/_/g, " ")}
+						{props.tooltip && (
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<Info className="text-muted-foreground/60 hover:text-muted-foreground h-3 w-3 cursor-help" />
+								</TooltipTrigger>
+								<TooltipContent sideOffset={6} className="max-w-xs">
+									{props.tooltip}
+								</TooltipContent>
+							</Tooltip>
+						)}
 					</div>
 				)}
 				<div

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -774,6 +774,10 @@ export interface LatencyHistogramBucket {
 	p90_latency: number;
 	p95_latency: number;
 	p99_latency: number;
+	avg_overhead: number;
+	p90_overhead: number;
+	p95_overhead: number;
+	p99_overhead: number;
 	total_requests: number;
 }
 

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -600,6 +600,8 @@ export interface LogEntry {
 	tools?: Tool[];
 	tool_calls?: ToolCall[];
 	latency?: number;
+	upstream_latency?: number; // provider socket time across all attempts, ms
+	overhead_latency?: number; // Bifrost overhead (total minus upstream), ms
 	token_usage?: LLMUsage;
 	cache_debug?: CacheDebug;
 	guardrail_debug?: GuardrailDebug;


### PR DESCRIPTION
## Summary

`OrderedMap.MarshalJSON` previously routed every nested `OrderedMap` value through `MarshalSorted` (sonic's `json.Marshaler`), which re-compacted and re-escaped the JSON at every nesting level. For deeply nested or large schemas (e.g. tool/MCP-injected schemas), this caused redundant allocations and encoding passes proportional to nesting depth. This PR eliminates those redundant passes by recursing directly into nested `OrderedMap` values during marshaling, while keeping output byte-identical to the old path.

## Changes

- Introduced `appendJSON` on `OrderedMap` that writes compact JSON directly into a `bytes.Buffer`, recursing into nested `OrderedMap` values without re-routing through `MarshalSorted`.
- Added `appendJSONString` — a zero-allocation, inline JSON string encoder that matches `encoding/json`/sonic HTML-safe escaping exactly: escapes `"`, `\`, control characters, `<`, `>`, `&` (as `\u00xx`), and U+2028/U+2029; replaces invalid UTF-8 bytes with `\uFFFD`.
- Added `appendValueJSON` to dispatch on value type: `*OrderedMap` and `OrderedMap` recurse directly; `string` uses `appendJSONString`; everything else falls back to `MarshalSorted`.
- Added `jsonSafeSet` — a 128-entry lookup table for ASCII bytes that require no escaping, avoiding per-byte branching overhead.
- Added `orderedmap_marshal_diff_test.go` with:
    - `assertMarshalStable` — byte-identity guardrail asserting `MarshalJSON` output equals `MarshalSorted` output.
    - `TestOrderedMapMarshal_ByteIdentical` — covers empty maps, scalars, arrays, HTML/escape edge cases, tricky keys, numbers, null, deep nesting, and a realistic JSON Schema shape.
    - `FuzzOrderedMapMarshal` — fuzz harness that round-trips arbitrary JSON objects through `UnmarshalJSON` → `MarshalJSON` and asserts compaction stability.
    - `TestOrderedMapMarshal_BigSchemaStable` and benchmarks (`BenchmarkOrderedMapMarshal`, `BenchmarkOrderedMapMarshalBig`) for regression detection and performance measurement.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/... -run TestOrderedMapMarshal
go test ./core/schemas/... -run TestOrderedMapMarshal_BigSchemaStable
go test ./core/schemas/... -fuzz FuzzOrderedMapMarshal -fuzztime=30s
go test ./core/schemas/... -bench BenchmarkOrderedMapMarshal -benchmem
```

All `TestOrderedMapMarshal_*` tests must pass. The fuzz target should find no stability violations. Benchmark results should show reduced allocations and improved throughput compared to the previous implementation, with gains scaling with nesting depth.

## Numbers

- 1\.6× faster on a small tool schema, 13.3× faster on a big/deeply-nested schema; 45–92% fewer allocations
- OrderedMap marshal share of CPU ~40% → ~1%.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

- none

## Security considerations

The new `appendJSONString` encoder preserves HTML-safe escaping (`<`, `>`, `&` → `\u00xx`) matching `encoding/json` and sonic's default behavior, so no XSS or injection surface is introduced or removed.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable