### PR TITLE
opertouer reasoning rejections

### DIFF
--- a/core/encryptedreasoning_test.go
+++ b/core/encryptedreasoning_test.go
@@ -803,14 +803,39 @@ func TestIsEncryptedReasoningRejection(t *testing.T) {
 			want: true,
 		},
 		{
-			// Anthropic rejects a thinking signature too, but the strip only clears
-			// encrypted_content, so a retry would resend the same payload.
-			name: "anthropic thinking signature rejection stays unhandled",
+			// This case expected false while the strip only cleared encrypted_content
+			// on Responses-shaped requests: a retry would have resent the same
+			// signature and earned the same 400, so recognising the refusal only
+			// bought a wasted upstream call.
+			//
+			// stripChatUnverifiableReasoning (#6110) removed that constraint. It is
+			// the chat-shaped strip, and stripChatReasoningDetails clears
+			// detail.Signature and detail.Data on every replayed assistant turn -- so
+			// the retry now goes out without the signature the new model refused.
+			// This exact message is the trigger that function's doc comment names:
+			// a complexity or virtual-model router picks a model per turn, and turn
+			// N+1 replays a thinking block minted by whoever answered turn N.
+			//
+			// Recognising it is therefore correct, and the remediation is real.
+			name: "anthropic thinking signature rejection triggers the chat-shaped strip",
 			err: &schemas.BifrostError{
 				StatusCode: schemas.Ptr(400),
 				Error: &schemas.ErrorField{
 					Type:    schemas.Ptr("invalid_request_error"),
 					Message: "messages.1.content.0: Invalid `signature` in `thinking` block",
+				},
+			},
+			want: true,
+		},
+		{
+			// The guard the case above relies on: a bare "signature" with no reasoning
+			// word must stay unrecognised. SigV4 mismatches read like this, and
+			// stripping reasoning cannot fix one.
+			name: "request-signing failure is not a reasoning rejection",
+			err: &schemas.BifrostError{
+				StatusCode: schemas.Ptr(400),
+				Error: &schemas.ErrorField{
+					Message: "The request signature we calculated does not match the signature you provided",
 				},
 			},
 			want: false,

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -1024,6 +1024,81 @@ type ChatMessage struct {
 	*ChatAssistantMessage
 }
 
+// MarshalJSON implements custom JSON marshalling for ChatMessage.
+//
+// The mirror of UnmarshalJSON below, and needed for the same reason: Go promotes
+// an embedded type's MarshalJSON to the outer struct, so ChatAssistantMessage's
+// marshaller would otherwise serialise a ChatMessage as ONLY its assistant fields,
+// silently dropping role, content and name from every message on the wire.
+//
+// The embedded pointers are flattened by hand rather than by struct embedding,
+// because embedding them in the output type would re-promote the same method and
+// reintroduce the bug this exists to prevent.
+//
+// The fragments are spliced textually rather than merged through a map: a Go map
+// marshals its keys in sorted order, which silently reorders every message body
+// on the wire (payload_ordering_test.go pins that ordering, and providers that
+// hash or cache on the raw payload are sensitive to it).
+func (cm ChatMessage) MarshalJSON() ([]byte, error) {
+	// Base fields first, in declaration order. Marshalled through a plain struct so
+	// the omitempty rules and ChatMessageContent's own marshaller are honoured
+	// exactly as declared.
+	base, err := Marshal(struct {
+		Name    *string             `json:"name,omitempty"`
+		Role    ChatMessageRole     `json:"role,omitempty"`
+		Content *ChatMessageContent `json:"content,omitempty"`
+	}{Name: cm.Name, Role: cm.Role, Content: cm.Content})
+	if err != nil {
+		return nil, err
+	}
+	fragments := [][]byte{base}
+
+	// Only one of the embedded pointers is ever set (see the struct comment), but
+	// appending both keeps this correct if that ever stops holding.
+	if cm.ChatToolMessage != nil {
+		encoded, err := Marshal(cm.ChatToolMessage)
+		if err != nil {
+			return nil, err
+		}
+		fragments = append(fragments, encoded)
+	}
+	if cm.ChatAssistantMessage != nil {
+		encoded, err := Marshal(cm.ChatAssistantMessage)
+		if err != nil {
+			return nil, err
+		}
+		fragments = append(fragments, encoded)
+	}
+
+	return spliceJSONObjects(fragments), nil
+}
+
+// spliceJSONObjects concatenates the bodies of several JSON objects into one,
+// preserving the order the fragments were produced in. Each fragment must be a
+// marshalled object; empty ones contribute nothing.
+func spliceJSONObjects(fragments [][]byte) []byte {
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	first := true
+	for _, fragment := range fragments {
+		trimmed := bytes.TrimSpace(fragment)
+		if len(trimmed) < 2 || trimmed[0] != '{' || trimmed[len(trimmed)-1] != '}' {
+			continue
+		}
+		body := bytes.TrimSpace(trimmed[1 : len(trimmed)-1])
+		if len(body) == 0 {
+			continue
+		}
+		if !first {
+			buf.WriteByte(',')
+		}
+		buf.Write(body)
+		first = false
+	}
+	buf.WriteByte('}')
+	return buf.Bytes()
+}
+
 // UnmarshalJSON implements custom JSON unmarshalling for ChatMessage.
 // This is needed because ChatAssistantMessage has a custom UnmarshalJSON method,
 // which interferes with the JSON library's handling of other fields in ChatMessage.
@@ -1413,6 +1488,43 @@ type ChatAssistantMessage struct {
 	ToolCalls        []ChatAssistantMessageToolCall   `json:"tool_calls,omitempty"`
 }
 
+// MarshalJSON emits reasoning under both spellings the ecosystem uses.
+//
+// OpenRouter defines them as interchangeable: reasoning text "will appear in the
+// `reasoning` field of each message", and "you can also use `reasoning_content`
+// as an alias - it functions identically to `reasoning`"
+// (https://openrouter.ai/docs/use-cases/reasoning-tokens). DeepSeek and xAI spell
+// it reasoning_content; OpenRouter-shaped clients read reasoning. UnmarshalJSON
+// below already accepts either on the way in, so emitting only one on the way out
+// left a client written against the other spelling seeing no reasoning at all -
+// the text was present the whole time, under a key it never looked at.
+//
+// The alias is derived from Reasoning at marshal time rather than stored, so the
+// two can never disagree, and a message with no reasoning gains no empty key.
+//
+// This does NOT reach provider requests. The outbound OpenAI-family wire type is
+// openai.OpenAIChatAssistantMessage, which has its own field set (and already
+// spells the outbound field reasoning_content); the other providers build their
+// own message types. This type is the internal/response shape.
+//
+// NOTE: ChatMessage embeds *ChatAssistantMessage, and Go promotes an embedded
+// type's MarshalJSON to the outer struct - so ChatMessage carries its own
+// MarshalJSON to stop this one swallowing role/content/name. Same reason
+// ChatMessage.UnmarshalJSON exists. Do not remove one without the other.
+func (cm ChatAssistantMessage) MarshalJSON() ([]byte, error) {
+	type Alias ChatAssistantMessage
+	if cm.Reasoning == nil {
+		return Marshal(Alias(cm))
+	}
+	return Marshal(struct {
+		Alias
+		ReasoningContent *string `json:"reasoning_content,omitempty"`
+	}{
+		Alias:            Alias(cm),
+		ReasoningContent: cm.Reasoning,
+	})
+}
+
 // UnmarshalJSON implements custom unmarshalling for ChatAssistantMessage.
 // If Reasoning is non-nil and ReasoningDetails is nil/empty, it adds a single
 // ChatReasoningDetails entry of type "reasoning.text" with the text set to Reasoning.
@@ -1593,6 +1705,28 @@ type ChatStreamResponseChoiceDelta struct {
 	Annotations      []ChatAssistantMessageAnnotation `json:"annotations,omitempty"`   // URL citations from web search
 	ToolCalls        []ChatAssistantMessageToolCall   `json:"tool_calls,omitempty"`    // If tool calls used (supports incremental updates)
 	ExtraContent     json.RawMessage                  `json:"extra_content,omitempty"` // Provider-specific metadata (e.g. Gemini thought markers, thought_signature)
+}
+
+// MarshalJSON emits reasoning under both spellings, matching
+// ChatAssistantMessage.MarshalJSON. See that method for why the alias exists.
+//
+// Streaming needs this independently of the non-streaming path: DeepSeek streams
+// its thinking phase under reasoning_content, so a client written against that
+// wire watched a Bifrost stream emit the entire reasoning phase under a key it
+// never read. Unlike ChatAssistantMessage this type is not embedded anywhere, so
+// no companion marshaller is required.
+func (d ChatStreamResponseChoiceDelta) MarshalJSON() ([]byte, error) {
+	type Alias ChatStreamResponseChoiceDelta
+	if d.Reasoning == nil {
+		return Marshal(Alias(d))
+	}
+	return Marshal(struct {
+		Alias
+		ReasoningContent *string `json:"reasoning_content,omitempty"`
+	}{
+		Alias:            Alias(d),
+		ReasoningContent: d.Reasoning,
+	})
 }
 
 // UnmarshalJSON implements custom unmarshalling for ChatStreamResponseChoiceDelta.

--- a/core/schemas/reasoningcontentalias_test.go
+++ b/core/schemas/reasoningcontentalias_test.go
@@ -1,0 +1,135 @@
+package schemas
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// OpenRouter treats reasoning_content as a bidirectional alias of reasoning:
+// "Reasoning tokens will appear in the `reasoning` field of each message ... You
+// can also use `reasoning_content` as an alias - it functions identically to
+// `reasoning`" (https://openrouter.ai/docs/use-cases/reasoning-tokens).
+//
+// Bifrost only did the inbound half: ChatAssistantMessage.UnmarshalJSON folds an
+// incoming reasoning_content into Reasoning, but nothing ever emitted the alias
+// back out. A client written against DeepSeek or xAI - both of which spell the
+// field reasoning_content - therefore read a Bifrost response as having no
+// reasoning at all, even though the text was right there under a different key.
+func TestReasoningContentAliasIsEmittedOnOutput(t *testing.T) {
+	reasoning := "Working through the escape counts night by night."
+
+	t.Run("assistant message emits both spellings", func(t *testing.T) {
+		encoded, err := json.Marshal(ChatAssistantMessage{Reasoning: &reasoning})
+		require.NoError(t, err)
+
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal(encoded, &decoded))
+		assert.Equal(t, reasoning, decoded["reasoning"])
+		assert.Equal(t, reasoning, decoded["reasoning_content"], "reasoning_content alias must be emitted")
+	})
+
+	t.Run("no reasoning means no alias key", func(t *testing.T) {
+		encoded, err := json.Marshal(ChatAssistantMessage{})
+		require.NoError(t, err)
+
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal(encoded, &decoded))
+		_, hasAlias := decoded["reasoning_content"]
+		assert.False(t, hasAlias, "an assistant message without reasoning must not carry an empty alias")
+	})
+
+	// The load-bearing case. ChatMessage embeds *ChatAssistantMessage, and Go
+	// promotes an embedded type's MarshalJSON to the outer struct: adding one to
+	// ChatAssistantMessage without a matching ChatMessage.MarshalJSON makes the
+	// whole message serialise as just the assistant fields, silently dropping
+	// role, content and name from every chat response. ChatMessage.UnmarshalJSON
+	// already exists for exactly this reason on the decode side.
+	t.Run("embedding does not swallow the outer message fields", func(t *testing.T) {
+		content := "The farmer has 14 sheep."
+		name := "assistant-1"
+		msg := ChatMessage{
+			Name:    &name,
+			Role:    ChatMessageRoleAssistant,
+			Content: &ChatMessageContent{ContentStr: &content},
+			ChatAssistantMessage: &ChatAssistantMessage{
+				Reasoning: &reasoning,
+			},
+		}
+
+		encoded, err := json.Marshal(msg)
+		require.NoError(t, err)
+
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal(encoded, &decoded))
+		assert.Equal(t, string(ChatMessageRoleAssistant), decoded["role"], "role must survive the embedded marshaller")
+		assert.Equal(t, content, decoded["content"], "content must survive the embedded marshaller")
+		assert.Equal(t, name, decoded["name"], "name must survive the embedded marshaller")
+		assert.Equal(t, reasoning, decoded["reasoning"])
+		assert.Equal(t, reasoning, decoded["reasoning_content"])
+	})
+
+	t.Run("tool message flattening still works", func(t *testing.T) {
+		callID := "call_123"
+		content := "42"
+		msg := ChatMessage{
+			Role:            ChatMessageRoleTool,
+			Content:         &ChatMessageContent{ContentStr: &content},
+			ChatToolMessage: &ChatToolMessage{ToolCallID: &callID},
+		}
+
+		encoded, err := json.Marshal(msg)
+		require.NoError(t, err)
+
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal(encoded, &decoded))
+		assert.Equal(t, string(ChatMessageRoleTool), decoded["role"])
+		assert.Equal(t, callID, decoded["tool_call_id"])
+		_, hasAlias := decoded["reasoning_content"]
+		assert.False(t, hasAlias)
+	})
+
+	// Streaming carries the same asymmetry in a different type:
+	// ChatStreamResponseChoiceDelta.UnmarshalJSON also folds reasoning_content in,
+	// and also never emitted it back. DeepSeek streams its reasoning under exactly
+	// that key, so a DeepSeek-shaped client consuming a Bifrost stream would watch
+	// the whole thinking phase go by without seeing a single token of it.
+	t.Run("stream delta emits both spellings", func(t *testing.T) {
+		encoded, err := json.Marshal(ChatStreamResponseChoiceDelta{Reasoning: &reasoning})
+		require.NoError(t, err)
+
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal(encoded, &decoded))
+		assert.Equal(t, reasoning, decoded["reasoning"])
+		assert.Equal(t, reasoning, decoded["reasoning_content"], "stream deltas must carry the alias too")
+	})
+
+	t.Run("stream delta without reasoning has no alias key", func(t *testing.T) {
+		content := "hello"
+		encoded, err := json.Marshal(ChatStreamResponseChoiceDelta{Content: &content})
+		require.NoError(t, err)
+
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal(encoded, &decoded))
+		assert.Equal(t, content, decoded["content"], "ordinary content deltas must be untouched")
+		_, hasAlias := decoded["reasoning_content"]
+		assert.False(t, hasAlias)
+	})
+
+	// The alias is emitted from Reasoning rather than stored, so a marshal/unmarshal
+	// round trip must not end up with two independent copies that can drift.
+	t.Run("round trip keeps a single source of truth", func(t *testing.T) {
+		encoded, err := json.Marshal(ChatAssistantMessage{Reasoning: &reasoning})
+		require.NoError(t, err)
+
+		var back ChatAssistantMessage
+		require.NoError(t, json.Unmarshal(encoded, &back))
+		require.NotNil(t, back.Reasoning)
+		assert.Equal(t, reasoning, *back.Reasoning)
+		require.Len(t, back.ReasoningDetails, 1, "the synthesized reasoning_details entry must survive")
+		require.NotNil(t, back.ReasoningDetails[0].Text)
+		assert.Equal(t, reasoning, *back.ReasoningDetails[0].Text)
+	})
+}

--- a/tests/e2e/api/HARNESS_COVERAGE_BACKLOG.md
+++ b/tests/e2e/api/HARNESS_COVERAGE_BACKLOG.md
@@ -71,7 +71,7 @@ Sources:
 
 ### Other endpoints
 
-- [ ] **Embeddings** (`POST /v1/embeddings`)
+- [x] **Embeddings** (`POST /v1/embeddings`) - folder 53: batch-input arity (53.C1), `dimensions` maps to OpenAI `dimensions` (53.D1), `encoding_format: "base64"` returns a packed string (53.E1)
 - [ ] **Audio speech (TTS)** (`POST /v1/audio/speech`)
 - [ ] **Audio transcription** (`POST /v1/audio/transcriptions`)
 - [ ] **Image generation** (`POST /v1/images/generations`)
@@ -211,6 +211,37 @@ Sources:
 - [ ] **JP geo profile** (`jp.anthropic.claude-*`)
 - [ ] **AU geo profile** (`au.anthropic.claude-haiku-4-5`)
 
+### Embeddings (`POST /model/{modelId}/invoke`)
+
+Sources:
+- Titan Text Embeddings: <https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-embed-text.html>
+- Cohere Embed v4: <https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-embed-v4.html>
+- Cohere Embed v3: <https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-embed-v3.html>
+
+Bedrock is the only provider carrying two incompatible embedding envelopes behind one name.
+`DetermineEmbeddingModelType` picks between them by substring match on the model id, so the same
+`/v1/embeddings` request behaves differently depending on whether the id contains `titan` or
+`cohere`. There is no embedding route on the `/bedrock` drop-in: `/bedrock/model/{id}/invoke`
+converts to Converse and then to Responses, so Bedrock embeddings are reachable only via
+`/v1/embeddings`, `/openai/v1/embeddings`, `/genai/.../:embedContent` and `/cohere/v2/embed`.
+
+- [x] **Titan V2 baseline** (`inputText`, one vector out, `inputTextTokenCount` to usage) - folder 53.A1
+- [x] **Titan `dimensions`** (1024 default | 512 | 256) - folder 53.A2
+- [x] **Titan array-input collapse** (no batch shape; Bifrost joins with `" \n"`, returns 1 vector) - folder 53.A3
+- [x] **Titan `normalize`** (default true; proven via L2 norm of the returned vector) - folder 53.A4 / 53.A5
+- [x] **Titan `embeddingTypes`** (camelCase; `embeddingsByType` recovered through `x-bf-send-back-raw-response`) - folder 53.A6
+- [x] **Cohere v4 `input_type`** (required by AWS; both the native `/cohere/v2/embed` route and `extra_params`) - folder 53.B1 / 53.B4
+- [x] **Cohere v4 `embedding_types`** (`embeddings_by_type` int8 parse branch) - folder 53.B2
+- [x] **Cohere v4 array input** (one vector per text, the arity divergence against Titan) - folder 53.B5
+- [x] **Cohere v4 `output_dimension`** (256 | 512 | 1024 | 1536) - folder 53.B6 / 53.D4
+- [x] **Usage backfill from `X-Amzn-Bedrock-Input-Token-Count`** (Cohere embed omits usage from the body; #3917) - folder 53.B7
+- [ ] **Titan G1** (`amazon.titan-embed-text-v1`) - `inputText` only, no `dimensions`/`normalize`; sending either is expected to be rejected
+- [ ] **Titan multimodal** (`amazon.titan-embed-image-v1`) - `inputImage` is not mapped by `ToBedrockTitanEmbeddingRequest` at all
+- [ ] **Cohere v4 multimodal** (`images` data-URI array, `inputs` interleaved text+image blocks) - the typed fields exist on `BedrockCohereEmbeddingRequest` but nothing populates them: the Cohere dialect converter drops both, and a JSON body yields `[]interface{}`, which misses the `v.([]string)` assertion in `ToBedrockCohereEmbeddingRequest`
+- [ ] **Cohere v3** (`cohere.embed-english-v3`) - fixed 1024 dims, `truncate` is `NONE|START|END` on v3 versus `NONE|LEFT|RIGHT` on v4, so the shared converter cannot validate the enum
+- [ ] **`truncate` / `max_tokens` passthrough** to Cohere on Bedrock
+- [ ] **Drop-in routes with parameters** - §8.3.I/§8.3.J send a bare single string to `/openai/v1/embeddings` and `:embedContent`; neither carries `dimensions`, `encoding_format` or any extra param
+
 ### Other Bedrock surfaces
 
 - [ ] **Application inference profiles** (custom profiles created via API)
@@ -265,7 +296,7 @@ Sources:
 ### Other endpoints
 
 - [ ] **Count tokens** (`POST /v1beta/models/{model}:countTokens`)
-- [ ] **Embed content** (`POST /v1beta/models/{model}:embedContent`)
+- [~] **Embed content** (`POST /v1beta/models/{model}:embedContent`) - §8.3.J posts the native shape at the drop-in route; folder 53 covers the parameter surface via `/v1/embeddings` (arity 53.C2, `outputDimensionality` 53.D2, `encoding_format` ignored 53.E4). Native `:embedContent` carrying `taskType`/`title`/`outputDimensionality` in the Gemini body is still uncovered.
 - [ ] **Batch embed** (`POST /v1beta/models/{model}:batchEmbedContents`)
 - [~] **Cached content CRUD** (`POST /v1beta/cachedContents`, list, get, update, delete): typed lifecycle implemented for both Gemini and Vertex; harness `Gemini: list cached contents` runs against real upstream (list only; create/retrieve/update/delete not yet exercised)
 - [ ] **Files API** (`POST /v1beta/files` upload, list, get, delete)

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -110,6 +110,10 @@
           "    } else if (Array.isArray(j.embedding)) {",
           "        shape = 'bedrock-titan-embedding';",
           "        hasContent = j.embedding.length > 0;",
+          "    } else if (Array.isArray(j.results) && j.results.length > 0 && j.results[0] && typeof j.results[0].index === 'number' && (typeof j.results[0].relevance_score === 'number' || typeof j.results[0].relevanceScore === 'number')) {",
+          "        shape = 'rerank';",
+          "        // A rerank response ranks the documents it was given; it generates no text, so the ranked list IS the content. Matched on index + a relevance score rather than on `results` alone, which is too generic to claim off other shapes. This branch went missing until now because no rerank row had ever returned 2xx: every bedrock row was rejected pre-flight for not naming its model as an ARN, and every vertex row 403s on discoveryengine IAM - and the content check is gated on code < 400, so it never ran.",
+          "        hasContent = j.results.length > 0;",
           "    } else if (Array.isArray(j.predictions)) {",
           "        shape = 'vertex-predictions';",
           "        hasContent = j.predictions.length > 0;",
@@ -127127,7 +127131,7 @@
               ]
             },
             {
-              "name": "48.6 /cohere/v2/rerank -> bedrock/amazon.rerank-v1:0",
+              "name": "48.6 /cohere/v2/rerank -> bedrock/cohere.rerank-v3-5:0",
               "request": {
                 "method": "POST",
                 "header": [
@@ -127138,7 +127142,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"model\": \"bedrock/amazon.rerank-v1:0\",\n  \"query\": \"What is the capital of France?\",\n  \"documents\": [\n    \"Paris is the capital of France.\",\n    \"Berlin is the capital of Germany.\"\n  ],\n  \"top_n\": 2\n}"
+                  "raw": "{\n  \"model\": \"bedrock/cohere.rerank-v3-5:0\",\n  \"query\": \"What is the capital of France?\",\n  \"documents\": [\n    \"Paris is the capital of France.\",\n    \"Berlin is the capital of Germany.\"\n  ],\n  \"top_n\": 2\n}"
                 },
                 "url": {
                   "raw": "{{baseUrl}}/cohere/v2/rerank",
@@ -127528,7 +127532,7 @@
               ]
             },
             {
-              "name": "48.6 /bedrock/rerank -> bedrock/amazon.rerank-v1:0",
+              "name": "48.6 /bedrock/rerank -> bedrock/cohere.rerank-v3-5:0",
               "request": {
                 "method": "POST",
                 "header": [
@@ -127539,7 +127543,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"queries\": [\n    {\n      \"type\": \"TEXT\",\n      \"textQuery\": {\n        \"text\": \"What is the capital of France?\"\n      }\n    }\n  ],\n  \"sources\": [\n    {\n      \"type\": \"INLINE\",\n      \"inlineDocumentSource\": {\n        \"type\": \"TEXT\",\n        \"textDocument\": {\n          \"text\": \"Paris is the capital of France.\"\n        }\n      }\n    },\n    {\n      \"type\": \"INLINE\",\n      \"inlineDocumentSource\": {\n        \"type\": \"TEXT\",\n        \"textDocument\": {\n          \"text\": \"Berlin is the capital of Germany.\"\n        }\n      }\n    },\n    {\n      \"type\": \"INLINE\",\n      \"inlineDocumentSource\": {\n        \"type\": \"TEXT\",\n        \"textDocument\": {\n          \"text\": \"Madrid is the capital of Spain.\"\n        }\n      }\n    }\n  ],\n  \"rerankingConfiguration\": {\n    \"type\": \"BEDROCK_RERANKING_MODEL\",\n    \"bedrockRerankingConfiguration\": {\n      \"modelConfiguration\": {\n        \"modelArn\": \"bedrock/amazon.rerank-v1:0\"\n      },\n      \"numberOfResults\": 3\n    }\n  }\n}"
+                  "raw": "{\n  \"queries\": [\n    {\n      \"type\": \"TEXT\",\n      \"textQuery\": {\n        \"text\": \"What is the capital of France?\"\n      }\n    }\n  ],\n  \"sources\": [\n    {\n      \"type\": \"INLINE\",\n      \"inlineDocumentSource\": {\n        \"type\": \"TEXT\",\n        \"textDocument\": {\n          \"text\": \"Paris is the capital of France.\"\n        }\n      }\n    },\n    {\n      \"type\": \"INLINE\",\n      \"inlineDocumentSource\": {\n        \"type\": \"TEXT\",\n        \"textDocument\": {\n          \"text\": \"Berlin is the capital of Germany.\"\n        }\n      }\n    },\n    {\n      \"type\": \"INLINE\",\n      \"inlineDocumentSource\": {\n        \"type\": \"TEXT\",\n        \"textDocument\": {\n          \"text\": \"Madrid is the capital of Spain.\"\n        }\n      }\n    }\n  ],\n  \"rerankingConfiguration\": {\n    \"type\": \"BEDROCK_RERANKING_MODEL\",\n    \"bedrockRerankingConfiguration\": {\n      \"modelConfiguration\": {\n        \"modelArn\": \"bedrock/cohere.rerank-v3-5:0\"\n      },\n      \"numberOfResults\": 3\n    }\n  }\n}"
                 },
                 "url": {
                   "raw": "{{baseUrl}}/bedrock/rerank",
@@ -127924,7 +127928,7 @@
               ]
             },
             {
-              "name": "[SKIP] 48.6 /v1/rank -> bedrock/amazon.rerank-v1:0 (no unified rerank route: /v1/rank is registered only under the /genai prefix - see transports/bifrost-http/integrations/genai.go createGenAIRerankRouteConfig)",
+              "name": "[SKIP] 48.6 /v1/rank -> bedrock/cohere.rerank-v3-5:0 (no unified rerank route: /v1/rank is registered only under the /genai prefix - see transports/bifrost-http/integrations/genai.go createGenAIRerankRouteConfig)",
               "request": {
                 "method": "POST",
                 "header": [
@@ -127935,7 +127939,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"model\": \"bedrock/amazon.rerank-v1:0\",\n  \"query\": \"What is the capital of France?\",\n  \"documents\": [\n    \"Paris is the capital of France.\",\n    \"Berlin is the capital of Germany.\"\n  ],\n  \"top_n\": 2\n}"
+                  "raw": "{\n  \"model\": \"bedrock/cohere.rerank-v3-5:0\",\n  \"query\": \"What is the capital of France?\",\n  \"documents\": [\n    \"Paris is the capital of France.\",\n    \"Berlin is the capital of Germany.\"\n  ],\n  \"top_n\": 2\n}"
                 },
                 "url": {
                   "raw": "{{baseUrl}}/v1/rank",
@@ -128324,7 +128328,7 @@
               ]
             },
             {
-              "name": "48.6 /genai/v1/rank -> bedrock/amazon.rerank-v1:0",
+              "name": "48.6 /genai/v1/rank -> bedrock/cohere.rerank-v3-5:0",
               "request": {
                 "method": "POST",
                 "header": [
@@ -128335,7 +128339,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"model\": \"bedrock/amazon.rerank-v1:0\",\n  \"query\": \"What is the capital of France?\",\n  \"records\": [\n    {\n      \"id\": \"1\",\n      \"content\": \"Paris is the capital of France.\"\n    },\n    {\n      \"id\": \"2\",\n      \"content\": \"Berlin is the capital of Germany.\"\n    },\n    {\n      \"id\": \"3\",\n      \"content\": \"Madrid is the capital of Spain.\"\n    }\n  ],\n  \"topN\": 3\n}"
+                  "raw": "{\n  \"model\": \"bedrock/cohere.rerank-v3-5:0\",\n  \"query\": \"What is the capital of France?\",\n  \"records\": [\n    {\n      \"id\": \"1\",\n      \"content\": \"Paris is the capital of France.\"\n    },\n    {\n      \"id\": \"2\",\n      \"content\": \"Berlin is the capital of Germany.\"\n    },\n    {\n      \"id\": \"3\",\n      \"content\": \"Madrid is the capital of Spain.\"\n    }\n  ],\n  \"topN\": 3\n}"
                 },
                 "url": {
                   "raw": "{{baseUrl}}/genai/v1/rank",
@@ -129926,6 +129930,1401 @@
                   "});"
                 ]
               }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "53. Embeddings x provider x parameter surface",
+      "description": "Embedding coverage before this folder was one request per provider, each sending a single string and asserting nothing beyond the collection-level status check - and that check is a no-op for embeddings, because the shape branch it lands in is Array.isArray(j.data) with hasContent = j.data.length >= 0, which is true for an empty list. A provider returning zero vectors passed.\n\nThis folder pins the request parameter surface end to end: what the caller sends at the gateway, what the provider-native field is called, and what observable property of the response proves the rename survived the trip. Bedrock gets the depth because it is the only provider carrying two incompatible embedding envelopes behind one name, chosen by substring match on the model id.\n\nRoute reachability worth knowing before adding rows here: /v1/embeddings parses exactly four body fields (model, input, encoding_format, dimensions) plus fallbacks. Every other key is dropped silently unless the request carries x-bf-passthrough-extra-params: true and nests the key under \"extra_params\" (transports/bifrost-http/integrations/router.go). There is no embedding route on the /bedrock drop-in at all - /bedrock/model/{id}/invoke converts to Converse and then to Responses - so Bedrock embeddings are reachable only through /v1/embeddings, /openai/v1/embeddings, /genai/.../:embedContent and /cohere/v2/embed.\n\nSub-folder names avoid provider keywords on purpose. runners/filter-collection.mjs matches PROVIDER against ancestor folder names as well as the item body, so naming this folder after Bedrock would hand every openai/gemini/vertex/azure row to the bedrock partition.",
+      "item": [
+        {
+          "name": "53.A Bedrock Titan envelope (amazon.titan-embed-*)",
+          "description": "Titan takes a single `inputText` string and returns a single vector, so Bifrost joins array input with \" \\n\" before sending (core/providers/bedrock/embedding.go ToBedrockTitanEmbeddingRequest). These rows pin the Titan-shaped request body reaching AWS and the single-vector response coming back.\n\nAWS request fields (docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-embed-text.html): inputText (required), dimensions (1024 default | 512 | 256), normalize (default true), embeddingTypes (camelCase, [\"float\"] | [\"binary\"] | both). Response: embedding, inputTextTokenCount, embeddingsByType.\n\nnormalize and embeddingTypes are not first-class fields on /v1/embeddings - only model, input, encoding_format and dimensions are parsed there. They reach the provider through x-bf-passthrough-extra-params: true plus an \"extra_params\" object, which is the door those rows use.",
+          "item": [
+            {
+              "name": "53.A1 bedrock/amazon.titan-embed-text-v2:0 - baseline single input",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"bedrock/amazon.titan-embed-text-v2:0\",\n  \"input\": \"Hello world\"\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/embeddings",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "embeddings"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Infra noise (auth/rate/upstream) is not what this row pins - let the",
+                      "// collection-level 2xx test own it and skip the feature assertion.",
+                      "// 400 is deliberately NOT guarded: a rejected embedding body is a real finding.",
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "var j; try { j = pm.response.json(); } catch (e) {",
+                      "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                      "var data = j.data || [];",
+                      "pm.test('returns 1 vector(s) - Titan returns exactly one embedding', function () {",
+                      "  pm.expect(data.length, 'wrong vector count; body: ' + pm.response.text().slice(0, 300))",
+                      "    .to.eql(1);",
+                      "  for (var i = 0; i < data.length; i++) {",
+                      "    pm.expect(Array.isArray(data[i].embedding), 'data[' + i + '].embedding is not an array').to.be.true;",
+                      "    pm.expect(data[i].embedding.length, 'data[' + i + '].embedding is empty').to.be.above(0);",
+                      "  }",
+                      "});",
+                      "pm.test('usage is backfilled from inputTextTokenCount', function () {",
+                      "  pm.expect(j.usage, 'usage missing entirely').to.be.an('object');",
+                      "  pm.expect(j.usage.prompt_tokens, 'prompt_tokens not populated from inputTextTokenCount')",
+                      "    .to.be.above(0);",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "53.A2 bedrock/amazon.titan-embed-text-v2:0 - dimensions:256 reaches the wire",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"bedrock/amazon.titan-embed-text-v2:0\",\n  \"input\": \"Hello world\",\n  \"dimensions\": 256\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/embeddings",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "embeddings"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Infra noise (auth/rate/upstream) is not what this row pins - let the",
+                      "// collection-level 2xx test own it and skip the feature assertion.",
+                      "// 400 is deliberately NOT guarded: a rejected embedding body is a real finding.",
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "var j; try { j = pm.response.json(); } catch (e) {",
+                      "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                      "var data = j.data || [];",
+                      "pm.test('vector length is 256 - Params.Dimensions maps to Titan `dimensions`', function () {",
+                      "  pm.expect(data.length, 'no embedding returned: ' + pm.response.text().slice(0, 300)).to.be.above(0);",
+                      "  pm.expect(Array.isArray(data[0].embedding), 'embedding is not an array').to.be.true;",
+                      "  pm.expect(data[0].embedding.length, 'wrong dimensionality').to.eql(256);",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "53.A3 bedrock/amazon.titan-embed-text-v2:0 - array input collapses to one vector",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"bedrock/amazon.titan-embed-text-v2:0\",\n  \"input\": [\n    \"alpha kestrel harbor\",\n    \"beta lantern quarry\",\n    \"gamma meridian trellis\"\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/embeddings",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "embeddings"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Infra noise (auth/rate/upstream) is not what this row pins - let the",
+                      "// collection-level 2xx test own it and skip the feature assertion.",
+                      "// 400 is deliberately NOT guarded: a rejected embedding body is a real finding.",
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "var j; try { j = pm.response.json(); } catch (e) {",
+                      "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                      "var data = j.data || [];",
+                      "pm.test('returns 1 vector(s) - Titan has no batch shape; Bifrost concatenates the array into one inputText', function () {",
+                      "  pm.expect(data.length, 'wrong vector count; body: ' + pm.response.text().slice(0, 300))",
+                      "    .to.eql(1);",
+                      "  for (var i = 0; i < data.length; i++) {",
+                      "    pm.expect(Array.isArray(data[i].embedding), 'data[' + i + '].embedding is not an array').to.be.true;",
+                      "    pm.expect(data[i].embedding.length, 'data[' + i + '].embedding is empty').to.be.above(0);",
+                      "  }",
+                      "});",
+                      "// Contrast with 53.B5: the same array on a Bedrock Cohere model returns 3 vectors.",
+                      "// Same provider, same route, different model family, different arity."
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "53.A4 bedrock/amazon.titan-embed-text-v2:0 - normalize:true is unit length (control)",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-passthrough-extra-params",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"bedrock/amazon.titan-embed-text-v2:0\",\n  \"input\": \"Hello world\",\n  \"extra_params\": {\n    \"normalize\": true\n  }\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/embeddings",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "embeddings"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Infra noise (auth/rate/upstream) is not what this row pins - let the",
+                      "// collection-level 2xx test own it and skip the feature assertion.",
+                      "// 400 is deliberately NOT guarded: a rejected embedding body is a real finding.",
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "var j; try { j = pm.response.json(); } catch (e) {",
+                      "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                      "var data = j.data || [];",
+                      "var v = (data[0] || {}).embedding || [];",
+                      "var sumsq = 0; for (var i = 0; i < v.length; i++) { sumsq += v[i] * v[i]; }",
+                      "var norm = Math.sqrt(sumsq);",
+                      "pm.test('normalized vector has L2 norm ~= 1', function () {",
+                      "  pm.expect(v.length, 'no embedding returned').to.be.above(0);",
+                      "  pm.expect(Math.abs(norm - 1), 'L2 norm was ' + norm + ', expected ~1').to.be.below(0.05);",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "53.A5 bedrock/amazon.titan-embed-text-v2:0 - normalize:false changes the vector",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-passthrough-extra-params",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"bedrock/amazon.titan-embed-text-v2:0\",\n  \"input\": \"Hello world\",\n  \"extra_params\": {\n    \"normalize\": false\n  }\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/embeddings",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "embeddings"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Infra noise (auth/rate/upstream) is not what this row pins - let the",
+                      "// collection-level 2xx test own it and skip the feature assertion.",
+                      "// 400 is deliberately NOT guarded: a rejected embedding body is a real finding.",
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "var j; try { j = pm.response.json(); } catch (e) {",
+                      "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                      "var data = j.data || [];",
+                      "var v = (data[0] || {}).embedding || [];",
+                      "var sumsq = 0; for (var i = 0; i < v.length; i++) { sumsq += v[i] * v[i]; }",
+                      "var norm = Math.sqrt(sumsq);",
+                      "pm.test('un-normalized vector has L2 norm != 1 (proves normalize reached AWS)', function () {",
+                      "  pm.expect(v.length, 'no embedding returned').to.be.above(0);",
+                      "  pm.expect(Math.abs(norm - 1), 'L2 norm was ' + norm + '; a value of ~1 means normalize:false was dropped before it reached Bedrock').to.be.above(0.05);",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "53.A6 bedrock/amazon.titan-embed-text-v2:0 - embeddingTypes float+binary",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-passthrough-extra-params",
+                    "value": "true"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-response",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"bedrock/amazon.titan-embed-text-v2:0\",\n  \"input\": \"Hello world\",\n  \"extra_params\": {\n    \"embeddingTypes\": [\n      \"float\",\n      \"binary\"\n    ]\n  }\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/embeddings",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "embeddings"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Infra noise (auth/rate/upstream) is not what this row pins - let the",
+                      "// collection-level 2xx test own it and skip the feature assertion.",
+                      "// 400 is deliberately NOT guarded: a rejected embedding body is a real finding.",
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "var j; try { j = pm.response.json(); } catch (e) {",
+                      "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                      "var data = j.data || [];",
+                      "// AWS documents embeddingTypes (camelCase) as a Titan V2 field, and warns that the",
+                      "// `embedding` field is omitted entirely when embeddingTypes contains only \"binary\".",
+                      "// This row asks for both, so the normalized float path must stay intact while the",
+                      "// binary variant is still recoverable from the raw provider payload.",
+                      "pm.test('returns 1 vector(s) - float path survives alongside binary', function () {",
+                      "  pm.expect(data.length, 'wrong vector count; body: ' + pm.response.text().slice(0, 300))",
+                      "    .to.eql(1);",
+                      "  for (var i = 0; i < data.length; i++) {",
+                      "    pm.expect(Array.isArray(data[i].embedding), 'data[' + i + '].embedding is not an array').to.be.true;",
+                      "    pm.expect(data[i].embedding.length, 'data[' + i + '].embedding is empty').to.be.above(0);",
+                      "  }",
+                      "});",
+                      "pm.test('embeddingsByType.binary reached the caller via raw_response', function () {",
+                      "  var raw = (j.extra_fields || {}).raw_response || {};",
+                      "  var byType = raw.embeddingsByType || {};",
+                      "  pm.expect(byType, 'embeddingsByType missing from raw_response; embeddingTypes may have been dropped before Bedrock: ' + JSON.stringify(raw).slice(0, 300)).to.have.property('binary');",
+                      "  pm.expect(Array.isArray(byType.binary), 'embeddingsByType.binary is not an array').to.be.true;",
+                      "  pm.expect(byType.binary.length, 'embeddingsByType.binary is empty').to.be.above(0);",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "53.B Bedrock Cohere envelope (cohere.embed-v4)",
+          "description": "The second Bedrock embedding envelope. DetermineEmbeddingModelType (core/providers/bedrock/embedding.go) switches on model family via plain substring match, so a model id containing \"cohere\" takes a completely different request and response shape from one containing \"titan\": `texts` array in, N vectors out, versus one `inputText` in and one vector out.\n\nAWS request fields (docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-embed-v4.html): input_type is REQUIRED (search_document | search_query | classification | clustering), output_dimension 256 | 512 | 1024 | 1536 (default 1536), embedding_types float | int8 | uint8 | binary | ubinary, truncate NONE | LEFT | RIGHT. Response is {embeddings, response_type} where response_type is \"embeddings_floats\" by default and \"embeddings_by_type\" once embedding_types is set.\n\nNote that /cohere/v2/embed only returns the raw provider payload when the resolved provider is Cohere itself; for a bedrock/* model it returns the normalized Bifrost shape, so every row below asserts against data[].embedding regardless of route.",
+          "item": [
+            {
+              "name": "53.B1 bedrock/global.cohere.embed-v4:0 - /cohere/v2/embed with input_type",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"bedrock/global.cohere.embed-v4:0\",\n  \"texts\": [\n    \"alpha kestrel harbor\",\n    \"beta lantern quarry\"\n  ],\n  \"input_type\": \"search_document\"\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/cohere/v2/embed",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "cohere",
+                    "v2",
+                    "embed"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Infra noise (auth/rate/upstream) is not what this row pins - let the",
+                      "// collection-level 2xx test own it and skip the feature assertion.",
+                      "// 400 is deliberately NOT guarded: a rejected embedding body is a real finding.",
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "var j; try { j = pm.response.json(); } catch (e) {",
+                      "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                      "var data = j.data || [];",
+                      "pm.test('returns 2 vector(s) - Cohere embeds each text independently', function () {",
+                      "  pm.expect(data.length, 'wrong vector count; body: ' + pm.response.text().slice(0, 300))",
+                      "    .to.eql(2);",
+                      "  for (var i = 0; i < data.length; i++) {",
+                      "    pm.expect(Array.isArray(data[i].embedding), 'data[' + i + '].embedding is not an array').to.be.true;",
+                      "    pm.expect(data[i].embedding.length, 'data[' + i + '].embedding is empty').to.be.above(0);",
+                      "  }",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "53.B2 bedrock/global.cohere.embed-v4:0 - /cohere/v2/embed embedding_types int8",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"bedrock/global.cohere.embed-v4:0\",\n  \"texts\": [\n    \"alpha kestrel harbor\"\n  ],\n  \"input_type\": \"search_document\",\n  \"embedding_types\": [\n    \"int8\"\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/cohere/v2/embed",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "cohere",
+                    "v2",
+                    "embed"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Infra noise (auth/rate/upstream) is not what this row pins - let the",
+                      "// collection-level 2xx test own it and skip the feature assertion.",
+                      "// 400 is deliberately NOT guarded: a rejected embedding body is a real finding.",
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "var j; try { j = pm.response.json(); } catch (e) {",
+                      "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                      "var data = j.data || [];",
+                      "// embedding_types flips the Bedrock response to response_type \"embeddings_by_type\", which",
+                      "// takes a different parse branch (BedrockCohereEmbeddingResponse.ToBifrostEmbeddingResponse).",
+                      "// The Cohere dialect parser builds this key as a real []string, which is the only path that",
+                      "// satisfies the v.([]string) assertion in ToBedrockCohereEmbeddingRequest - a JSON body on",
+                      "// /v1/embeddings yields []interface{} and misses that typed field.",
+                      "pm.test('returns 1 vector(s) - int8 branch of embeddings_by_type', function () {",
+                      "  pm.expect(data.length, 'wrong vector count; body: ' + pm.response.text().slice(0, 300))",
+                      "    .to.eql(1);",
+                      "  for (var i = 0; i < data.length; i++) {",
+                      "    pm.expect(Array.isArray(data[i].embedding), 'data[' + i + '].embedding is not an array').to.be.true;",
+                      "    pm.expect(data[i].embedding.length, 'data[' + i + '].embedding is empty').to.be.above(0);",
+                      "  }",
+                      "});",
+                      "pm.test('values are int8, not floats', function () {",
+                      "  var v = data[0].embedding;",
+                      "  for (var i = 0; i < v.length; i++) {",
+                      "    pm.expect(v[i] % 1, 'value at ' + i + ' is not an integer: ' + v[i]).to.eql(0);",
+                      "    pm.expect(v[i], 'value at ' + i + ' is outside int8 range: ' + v[i]).to.be.within(-128, 127);",
+                      "  }",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "53.B3 bedrock/global.cohere.embed-v4:0 - plain /v1/embeddings with no input_type",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"bedrock/global.cohere.embed-v4:0\",\n  \"input\": \"Hello world\"\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/embeddings",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "embeddings"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Infra noise (auth/rate/upstream) is not what this row pins - let the",
+                      "// collection-level 2xx test own it and skip the feature assertion.",
+                      "// 400 is deliberately NOT guarded: a rejected embedding body is a real finding.",
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "var j; try { j = pm.response.json(); } catch (e) {",
+                      "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                      "var data = j.data || [];",
+                      "// The plainest possible OpenAI-shaped call against a Bedrock Cohere model.",
+                      "// BedrockCohereEmbeddingRequest.InputType is tagged `json:\"input_type\"` with no omitempty",
+                      "// (core/providers/bedrock/types.go), so a caller who omits it sends \"input_type\": \"\" to",
+                      "// Bedrock, and AWS documents input_type as required with a fixed enum. A 400 here is a",
+                      "// Bifrost defect, not a caller error: the same request shape works on every other provider.",
+                      "pm.test('returns 1 vector(s) - a Bedrock Cohere embed must not require caller-supplied input_type', function () {",
+                      "  pm.expect(data.length, 'wrong vector count; body: ' + pm.response.text().slice(0, 300))",
+                      "    .to.eql(1);",
+                      "  for (var i = 0; i < data.length; i++) {",
+                      "    pm.expect(Array.isArray(data[i].embedding), 'data[' + i + '].embedding is not an array').to.be.true;",
+                      "    pm.expect(data[i].embedding.length, 'data[' + i + '].embedding is empty').to.be.above(0);",
+                      "  }",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "53.B4 bedrock/global.cohere.embed-v4:0 - /v1/embeddings + extra_params.input_type",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-passthrough-extra-params",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"bedrock/global.cohere.embed-v4:0\",\n  \"input\": \"Hello world\",\n  \"extra_params\": {\n    \"input_type\": \"search_query\"\n  }\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/embeddings",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "embeddings"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Infra noise (auth/rate/upstream) is not what this row pins - let the",
+                      "// collection-level 2xx test own it and skip the feature assertion.",
+                      "// 400 is deliberately NOT guarded: a rejected embedding body is a real finding.",
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "var j; try { j = pm.response.json(); } catch (e) {",
+                      "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                      "var data = j.data || [];",
+                      "// The working counterpart to 53.B3: input_type supplied through the passthrough door.",
+                      "pm.test('returns 1 vector(s) - input_type via extra_params reaches Bedrock', function () {",
+                      "  pm.expect(data.length, 'wrong vector count; body: ' + pm.response.text().slice(0, 300))",
+                      "    .to.eql(1);",
+                      "  for (var i = 0; i < data.length; i++) {",
+                      "    pm.expect(Array.isArray(data[i].embedding), 'data[' + i + '].embedding is not an array').to.be.true;",
+                      "    pm.expect(data[i].embedding.length, 'data[' + i + '].embedding is empty').to.be.above(0);",
+                      "  }",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "53.B5 bedrock/global.cohere.embed-v4:0 - array input returns one vector per text",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-passthrough-extra-params",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"bedrock/global.cohere.embed-v4:0\",\n  \"input\": [\n    \"alpha kestrel harbor\",\n    \"beta lantern quarry\",\n    \"gamma meridian trellis\"\n  ],\n  \"extra_params\": {\n    \"input_type\": \"search_document\"\n  }\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/embeddings",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "embeddings"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Infra noise (auth/rate/upstream) is not what this row pins - let the",
+                      "// collection-level 2xx test own it and skip the feature assertion.",
+                      "// 400 is deliberately NOT guarded: a rejected embedding body is a real finding.",
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "var j; try { j = pm.response.json(); } catch (e) {",
+                      "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                      "var data = j.data || [];",
+                      "pm.test('returns 3 vector(s) - Cohere embeds each array element separately', function () {",
+                      "  pm.expect(data.length, 'wrong vector count; body: ' + pm.response.text().slice(0, 300))",
+                      "    .to.eql(3);",
+                      "  for (var i = 0; i < data.length; i++) {",
+                      "    pm.expect(Array.isArray(data[i].embedding), 'data[' + i + '].embedding is not an array').to.be.true;",
+                      "    pm.expect(data[i].embedding.length, 'data[' + i + '].embedding is empty').to.be.above(0);",
+                      "  }",
+                      "});",
+                      "// The arity divergence inside a single provider: 53.A3 sends this same array to a Titan",
+                      "// model on the same route and gets 1 vector back.",
+                      "pm.test('indices are 0,1,2 in order', function () {",
+                      "  for (var i = 0; i < data.length; i++) {",
+                      "    pm.expect(data[i].index, 'data[' + i + '].index is out of order').to.eql(i);",
+                      "  }",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "53.B6 bedrock/global.cohere.embed-v4:0 - dimensions:512 maps to output_dimension",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-passthrough-extra-params",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"bedrock/global.cohere.embed-v4:0\",\n  \"input\": \"Hello world\",\n  \"dimensions\": 512,\n  \"extra_params\": {\n    \"input_type\": \"search_document\"\n  }\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/embeddings",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "embeddings"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Infra noise (auth/rate/upstream) is not what this row pins - let the",
+                      "// collection-level 2xx test own it and skip the feature assertion.",
+                      "// 400 is deliberately NOT guarded: a rejected embedding body is a real finding.",
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "var j; try { j = pm.response.json(); } catch (e) {",
+                      "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                      "var data = j.data || [];",
+                      "pm.test('vector length is 512 - Params.Dimensions maps to Cohere `output_dimension`', function () {",
+                      "  pm.expect(data.length, 'no embedding returned: ' + pm.response.text().slice(0, 300)).to.be.above(0);",
+                      "  pm.expect(Array.isArray(data[0].embedding), 'embedding is not an array').to.be.true;",
+                      "  pm.expect(data[0].embedding.length, 'wrong dimensionality').to.eql(512);",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "53.B7 bedrock/global.cohere.embed-v4:0 - usage backfilled from Bedrock token header",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-passthrough-extra-params",
+                    "value": "true"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-response",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"bedrock/global.cohere.embed-v4:0\",\n  \"input\": \"Hello world\",\n  \"extra_params\": {\n    \"input_type\": \"search_document\"\n  }\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/embeddings",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "embeddings"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Infra noise (auth/rate/upstream) is not what this row pins - let the",
+                      "// collection-level 2xx test own it and skip the feature assertion.",
+                      "// 400 is deliberately NOT guarded: a rejected embedding body is a real finding.",
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "var j; try { j = pm.response.json(); } catch (e) {",
+                      "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                      "var data = j.data || [];",
+                      "// Bedrock Cohere embed omits token usage from the response body and reports it only in the",
+                      "// X-Amzn-Bedrock-Input-Token-Count response header. inputTokensFromHeaders backfills Usage",
+                      "// from it (#3917); without that backfill this call would bill as zero tokens.",
+                      "pm.test('usage.prompt_tokens is populated despite an empty body usage', function () {",
+                      "  pm.expect(j.usage, 'usage missing entirely').to.be.an('object');",
+                      "  pm.expect(j.usage.prompt_tokens, 'prompt_tokens is 0/absent - the token header backfill regressed').to.be.above(0);",
+                      "  pm.expect(j.usage.total_tokens, 'total_tokens is 0/absent').to.be.above(0);",
+                      "});",
+                      "pm.test('the source header is present on the response', function () {",
+                      "  var headers = (j.extra_fields || {}).provider_response_headers || {};",
+                      "  var found = false;",
+                      "  for (var k in headers) {",
+                      "    if (k.toLowerCase() === 'x-amzn-bedrock-input-token-count') { found = true; }",
+                      "  }",
+                      "  pm.expect(found, 'X-Amzn-Bedrock-Input-Token-Count not surfaced; keys: ' +",
+                      "    Object.keys(headers).join(',')).to.be.true;",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "53.C Batch-input arity parity (/v1/embeddings)",
+          "description": "An array of N inputs must come back as N vectors with indices 0..N-1, on every provider that supports embeddings. This is the invariant callers actually depend on when they embed a document chunk list in one request and zip the results back against their own array.\n\nThe documented exception lives in 53.A3: Bedrock Titan has no batch request shape, so Bifrost concatenates the array into a single inputText and returns exactly one vector. Bedrock Cohere (53.B5) honours the array normally. That divergence is inside one provider, selected by model family, which is why it needs its own rows rather than a cell in this table.",
+          "item": [
+            {
+              "name": "53.C1 openai/text-embedding-3-small - array of 3 returns 3 vectors",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"openai/text-embedding-3-small\",\n  \"input\": [\n    \"alpha kestrel harbor\",\n    \"beta lantern quarry\",\n    \"gamma meridian trellis\"\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/embeddings",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "embeddings"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Infra noise (auth/rate/upstream) is not what this row pins - let the",
+                      "// collection-level 2xx test own it and skip the feature assertion.",
+                      "// 400 is deliberately NOT guarded: a rejected embedding body is a real finding.",
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "var j; try { j = pm.response.json(); } catch (e) {",
+                      "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                      "var data = j.data || [];",
+                      "pm.test('returns 3 vector(s) - one vector per input element', function () {",
+                      "  pm.expect(data.length, 'wrong vector count; body: ' + pm.response.text().slice(0, 300))",
+                      "    .to.eql(3);",
+                      "  for (var i = 0; i < data.length; i++) {",
+                      "    pm.expect(Array.isArray(data[i].embedding), 'data[' + i + '].embedding is not an array').to.be.true;",
+                      "    pm.expect(data[i].embedding.length, 'data[' + i + '].embedding is empty').to.be.above(0);",
+                      "  }",
+                      "});",
+                      "pm.test('indices are 0,1,2 in order', function () {",
+                      "  for (var i = 0; i < data.length; i++) {",
+                      "    pm.expect(data[i].index, 'data[' + i + '].index is out of order').to.eql(i);",
+                      "  }",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "53.C2 gemini/gemini-embedding-001 - array of 3 returns 3 vectors",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"gemini/gemini-embedding-001\",\n  \"input\": [\n    \"alpha kestrel harbor\",\n    \"beta lantern quarry\",\n    \"gamma meridian trellis\"\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/embeddings",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "embeddings"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Infra noise (auth/rate/upstream) is not what this row pins - let the",
+                      "// collection-level 2xx test own it and skip the feature assertion.",
+                      "// 400 is deliberately NOT guarded: a rejected embedding body is a real finding.",
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "var j; try { j = pm.response.json(); } catch (e) {",
+                      "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                      "var data = j.data || [];",
+                      "pm.test('returns 3 vector(s) - one vector per input element', function () {",
+                      "  pm.expect(data.length, 'wrong vector count; body: ' + pm.response.text().slice(0, 300))",
+                      "    .to.eql(3);",
+                      "  for (var i = 0; i < data.length; i++) {",
+                      "    pm.expect(Array.isArray(data[i].embedding), 'data[' + i + '].embedding is not an array').to.be.true;",
+                      "    pm.expect(data[i].embedding.length, 'data[' + i + '].embedding is empty').to.be.above(0);",
+                      "  }",
+                      "});",
+                      "pm.test('indices are 0,1,2 in order', function () {",
+                      "  for (var i = 0; i < data.length; i++) {",
+                      "    pm.expect(data[i].index, 'data[' + i + '].index is out of order').to.eql(i);",
+                      "  }",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "53.C3 vertex/text-embedding-005 - array of 3 returns 3 vectors",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"vertex/text-embedding-005\",\n  \"input\": [\n    \"alpha kestrel harbor\",\n    \"beta lantern quarry\",\n    \"gamma meridian trellis\"\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/embeddings",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "embeddings"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Infra noise (auth/rate/upstream) is not what this row pins - let the",
+                      "// collection-level 2xx test own it and skip the feature assertion.",
+                      "// 400 is deliberately NOT guarded: a rejected embedding body is a real finding.",
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "var j; try { j = pm.response.json(); } catch (e) {",
+                      "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                      "var data = j.data || [];",
+                      "pm.test('returns 3 vector(s) - one vector per input element', function () {",
+                      "  pm.expect(data.length, 'wrong vector count; body: ' + pm.response.text().slice(0, 300))",
+                      "    .to.eql(3);",
+                      "  for (var i = 0; i < data.length; i++) {",
+                      "    pm.expect(Array.isArray(data[i].embedding), 'data[' + i + '].embedding is not an array').to.be.true;",
+                      "    pm.expect(data[i].embedding.length, 'data[' + i + '].embedding is empty').to.be.above(0);",
+                      "  }",
+                      "});",
+                      "pm.test('indices are 0,1,2 in order', function () {",
+                      "  for (var i = 0; i < data.length; i++) {",
+                      "    pm.expect(data[i].index, 'data[' + i + '].index is out of order').to.eql(i);",
+                      "  }",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "53.C4 azure/text-embedding-ada-002 - array of 3 returns 3 vectors",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"azure/text-embedding-ada-002\",\n  \"input\": [\n    \"alpha kestrel harbor\",\n    \"beta lantern quarry\",\n    \"gamma meridian trellis\"\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/embeddings",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "embeddings"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Infra noise (auth/rate/upstream) is not what this row pins - let the",
+                      "// collection-level 2xx test own it and skip the feature assertion.",
+                      "// 400 is deliberately NOT guarded: a rejected embedding body is a real finding.",
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "var j; try { j = pm.response.json(); } catch (e) {",
+                      "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                      "var data = j.data || [];",
+                      "pm.test('returns 3 vector(s) - one vector per input element', function () {",
+                      "  pm.expect(data.length, 'wrong vector count; body: ' + pm.response.text().slice(0, 300))",
+                      "    .to.eql(3);",
+                      "  for (var i = 0; i < data.length; i++) {",
+                      "    pm.expect(Array.isArray(data[i].embedding), 'data[' + i + '].embedding is not an array').to.be.true;",
+                      "    pm.expect(data[i].embedding.length, 'data[' + i + '].embedding is empty').to.be.above(0);",
+                      "  }",
+                      "});",
+                      "pm.test('indices are 0,1,2 in order', function () {",
+                      "  for (var i = 0; i < data.length; i++) {",
+                      "    pm.expect(data[i].index, 'data[' + i + '].index is out of order').to.eql(i);",
+                      "  }",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "53.D dimensions maps to the provider-native output size",
+          "description": "`dimensions` is one of only four fields /v1/embeddings parses natively (model, input, encoding_format, dimensions), and each provider spells it differently on the wire: Titan and OpenAI use `dimensions`, Cohere on Bedrock uses `output_dimension`, Gemini uses `outputDimensionality`, Vertex uses parameters.outputDimensionality. Asserting the returned vector length is the only end-to-end proof the rename happened.\n\nazure/text-embedding-ada-002 is deliberately absent: ada-002 predates Matryoshka truncation and has no dimensions knob, so the row would pin an upstream rejection rather than a mapping. Bedrock Titan is covered by 53.A2 at 256.",
+          "item": [
+            {
+              "name": "53.D1 openai/text-embedding-3-small - dimensions:256",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"openai/text-embedding-3-small\",\n  \"input\": \"Hello world\",\n  \"dimensions\": 256\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/embeddings",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "embeddings"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Infra noise (auth/rate/upstream) is not what this row pins - let the",
+                      "// collection-level 2xx test own it and skip the feature assertion.",
+                      "// 400 is deliberately NOT guarded: a rejected embedding body is a real finding.",
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "var j; try { j = pm.response.json(); } catch (e) {",
+                      "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                      "var data = j.data || [];",
+                      "pm.test('vector length is 256 - OpenAI `dimensions`', function () {",
+                      "  pm.expect(data.length, 'no embedding returned: ' + pm.response.text().slice(0, 300)).to.be.above(0);",
+                      "  pm.expect(Array.isArray(data[0].embedding), 'embedding is not an array').to.be.true;",
+                      "  pm.expect(data[0].embedding.length, 'wrong dimensionality').to.eql(256);",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "53.D2 gemini/gemini-embedding-001 - dimensions:256",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"gemini/gemini-embedding-001\",\n  \"input\": \"Hello world\",\n  \"dimensions\": 256\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/embeddings",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "embeddings"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Infra noise (auth/rate/upstream) is not what this row pins - let the",
+                      "// collection-level 2xx test own it and skip the feature assertion.",
+                      "// 400 is deliberately NOT guarded: a rejected embedding body is a real finding.",
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "var j; try { j = pm.response.json(); } catch (e) {",
+                      "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                      "var data = j.data || [];",
+                      "pm.test('vector length is 256 - Gemini `outputDimensionality`', function () {",
+                      "  pm.expect(data.length, 'no embedding returned: ' + pm.response.text().slice(0, 300)).to.be.above(0);",
+                      "  pm.expect(Array.isArray(data[0].embedding), 'embedding is not an array').to.be.true;",
+                      "  pm.expect(data[0].embedding.length, 'wrong dimensionality').to.eql(256);",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "53.D3 vertex/text-embedding-005 - dimensions:256",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"vertex/text-embedding-005\",\n  \"input\": \"Hello world\",\n  \"dimensions\": 256\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/embeddings",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "embeddings"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Infra noise (auth/rate/upstream) is not what this row pins - let the",
+                      "// collection-level 2xx test own it and skip the feature assertion.",
+                      "// 400 is deliberately NOT guarded: a rejected embedding body is a real finding.",
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "var j; try { j = pm.response.json(); } catch (e) {",
+                      "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                      "var data = j.data || [];",
+                      "pm.test('vector length is 256 - Vertex parameters.outputDimensionality', function () {",
+                      "  pm.expect(data.length, 'no embedding returned: ' + pm.response.text().slice(0, 300)).to.be.above(0);",
+                      "  pm.expect(Array.isArray(data[0].embedding), 'embedding is not an array').to.be.true;",
+                      "  pm.expect(data[0].embedding.length, 'wrong dimensionality').to.eql(256);",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "53.D4 bedrock/global.cohere.embed-v4:0 - dimensions:256",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-passthrough-extra-params",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"bedrock/global.cohere.embed-v4:0\",\n  \"input\": \"Hello world\",\n  \"dimensions\": 256,\n  \"extra_params\": {\n    \"input_type\": \"search_document\"\n  }\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/embeddings",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "embeddings"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Infra noise (auth/rate/upstream) is not what this row pins - let the",
+                      "// collection-level 2xx test own it and skip the feature assertion.",
+                      "// 400 is deliberately NOT guarded: a rejected embedding body is a real finding.",
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "var j; try { j = pm.response.json(); } catch (e) {",
+                      "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                      "var data = j.data || [];",
+                      "pm.test('vector length is 256 - Bedrock Cohere `output_dimension`', function () {",
+                      "  pm.expect(data.length, 'no embedding returned: ' + pm.response.text().slice(0, 300)).to.be.above(0);",
+                      "  pm.expect(Array.isArray(data[0].embedding), 'embedding is not an array').to.be.true;",
+                      "  pm.expect(data[0].embedding.length, 'wrong dimensionality').to.eql(256);",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "53.E encoding_format base64 divergence",
+          "description": "encoding_format is parsed into EmbeddingParameters but only one provider converter reads it (HuggingFace). OpenAI-family providers forward the field verbatim and the upstream API returns packed base64; Bedrock, Gemini and Vertex have no equivalent request field, so the flag is dropped and float arrays come back.\n\nThese rows pin the divergence as it actually is rather than asserting a uniformity that does not exist. They fail in both useful directions: if an OpenAI-family row starts returning arrays the passthrough broke, and if a Bedrock/Gemini row starts returning a string then something began encoding on the provider's behalf, which changes the byte size and the type callers see.",
+          "item": [
+            {
+              "name": "53.E1 openai/text-embedding-3-small - encoding_format base64",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"openai/text-embedding-3-small\",\n  \"input\": \"Hello world\",\n  \"encoding_format\": \"base64\"\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/embeddings",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "embeddings"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Infra noise (auth/rate/upstream) is not what this row pins - let the",
+                      "// collection-level 2xx test own it and skip the feature assertion.",
+                      "// 400 is deliberately NOT guarded: a rejected embedding body is a real finding.",
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "var j; try { j = pm.response.json(); } catch (e) {",
+                      "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                      "var data = j.data || [];",
+                      "pm.test('embedding is a base64 string - OpenAI honours encoding_format', function () {",
+                      "  pm.expect(data.length, 'no embedding returned: ' + pm.response.text().slice(0, 300)).to.be.above(0);",
+                      "  pm.expect(data[0].embedding, 'expected a base64 string, got ' +",
+                      "    (Array.isArray(data[0].embedding) ? 'an array' : typeof data[0].embedding)).to.be.a('string');",
+                      "  pm.expect(data[0].embedding.length, 'base64 string is empty').to.be.above(0);",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "53.E2 azure/text-embedding-ada-002 - encoding_format base64",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"azure/text-embedding-ada-002\",\n  \"input\": \"Hello world\",\n  \"encoding_format\": \"base64\"\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/embeddings",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "embeddings"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Infra noise (auth/rate/upstream) is not what this row pins - let the",
+                      "// collection-level 2xx test own it and skip the feature assertion.",
+                      "// 400 is deliberately NOT guarded: a rejected embedding body is a real finding.",
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "var j; try { j = pm.response.json(); } catch (e) {",
+                      "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                      "var data = j.data || [];",
+                      "pm.test('embedding is a base64 string - Azure serves the OpenAI embeddings API', function () {",
+                      "  pm.expect(data.length, 'no embedding returned: ' + pm.response.text().slice(0, 300)).to.be.above(0);",
+                      "  pm.expect(data[0].embedding, 'expected a base64 string, got ' +",
+                      "    (Array.isArray(data[0].embedding) ? 'an array' : typeof data[0].embedding)).to.be.a('string');",
+                      "  pm.expect(data[0].embedding.length, 'base64 string is empty').to.be.above(0);",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "53.E3 bedrock/amazon.titan-embed-text-v2:0 - encoding_format base64 is ignored",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"bedrock/amazon.titan-embed-text-v2:0\",\n  \"input\": \"Hello world\",\n  \"encoding_format\": \"base64\"\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/embeddings",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "embeddings"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Infra noise (auth/rate/upstream) is not what this row pins - let the",
+                      "// collection-level 2xx test own it and skip the feature assertion.",
+                      "// 400 is deliberately NOT guarded: a rejected embedding body is a real finding.",
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "var j; try { j = pm.response.json(); } catch (e) {",
+                      "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                      "var data = j.data || [];",
+                      "pm.test('embedding is still a float array - Bedrock InvokeModel has no encoding_format field', function () {",
+                      "  pm.expect(data.length, 'no embedding returned: ' + pm.response.text().slice(0, 300)).to.be.above(0);",
+                      "  pm.expect(Array.isArray(data[0].embedding), 'expected a float array; a string here would mean Bifrost started encoding on the provider\\'s behalf').to.be.true;",
+                      "  pm.expect(data[0].embedding.length, 'embedding is empty').to.be.above(0);",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "53.E4 gemini/gemini-embedding-001 - encoding_format base64 is ignored",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"gemini/gemini-embedding-001\",\n  \"input\": \"Hello world\",\n  \"encoding_format\": \"base64\"\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/embeddings",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "embeddings"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Infra noise (auth/rate/upstream) is not what this row pins - let the",
+                      "// collection-level 2xx test own it and skip the feature assertion.",
+                      "// 400 is deliberately NOT guarded: a rejected embedding body is a real finding.",
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "var j; try { j = pm.response.json(); } catch (e) {",
+                      "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                      "var data = j.data || [];",
+                      "pm.test('embedding is still a float array - embedContent has no encoding_format field', function () {",
+                      "  pm.expect(data.length, 'no embedding returned: ' + pm.response.text().slice(0, 300)).to.be.above(0);",
+                      "  pm.expect(Array.isArray(data[0].embedding), 'expected a float array; a string here would mean Bifrost started encoding on the provider\\'s behalf').to.be.true;",
+                      "  pm.expect(data[0].embedding.length, 'embedding is empty').to.be.above(0);",
+                      "});"
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }


### PR DESCRIPTION
## Summary

Two serialization bugs caused reasoning content to silently disappear from Bifrost responses. Clients written against the `reasoning_content` field spelling (DeepSeek, xAI) received no reasoning at all, even though the text was present under the `reasoning` key. A companion bug caused `ChatMessage.MarshalJSON` to be swallowed by the promoted `ChatAssistantMessage.MarshalJSON`, dropping `role`, `content`, and `name` from every serialized chat message. This PR fixes both the outbound alias emission and the embedding promotion bug, corrects the encrypted reasoning rejection classifier, and adds a comprehensive embedding parameter surface test folder to the provider harness.

## Changes

- **`reasoning_content` alias emitted on output**: `ChatAssistantMessage.MarshalJSON` and `ChatStreamResponseChoiceDelta.MarshalJSON` now emit both `reasoning` and `reasoning_content` when reasoning is present. The alias is derived from `Reasoning` at marshal time so the two fields can never disagree, and messages without reasoning gain no empty key. This mirrors what `UnmarshalJSON` already accepted on the way in.

- **`ChatMessage.MarshalJSON` added to prevent field loss**: Go promotes an embedded type's `MarshalJSON` to the outer struct, so adding one to `ChatAssistantMessage` without a matching one on `ChatMessage` caused the entire message to serialize as only assistant fields, silently dropping `role`, `content`, and `name`. A custom `ChatMessage.MarshalJSON` splices the base fields and embedded fragments textually (via `spliceJSONObjects`) rather than through a map, preserving declaration order and avoiding silent key reordering that providers sensitive to payload hashing would notice.

- **Encrypted reasoning rejection classifier corrected**: The test case for Anthropic's thinking signature rejection was previously expected to return `false` because the old strip only cleared `encrypted_content` on Responses-shaped requests, making a retry pointless. `stripChatUnverifiableReasoning` (#6110) removed that constraint by clearing `detail.Signature` and `detail.Data` on every replayed assistant turn, so recognizing the rejection is now correct and the remediation is real. A new guard test ensures bare "signature" errors (e.g. SigV4 mismatches) are not misclassified as reasoning rejections.

- **Rerank harness model corrected**: Bedrock rerank rows in the provider harness were targeting `amazon.rerank-v1:0`; updated to `cohere.rerank-v3-5:0`. A missing `rerank` shape branch was added to the collection-level response classifier so rerank 2xx responses are recognized as having content.

- **Embedding parameter surface test folder (53)**: A new folder in the provider harness covers the full embedding parameter surface end-to-end across providers. Sub-folders cover Bedrock Titan envelope behavior (baseline, `dimensions`, array-input collapse, `normalize`, `embeddingTypes`), Bedrock Cohere envelope behavior (`input_type`, `embedding_types`, array arity, `output_dimension`, usage backfill from `X-Amzn-Bedrock-Input-Token-Count`), batch-input arity parity across OpenAI/Gemini/Vertex/Azure, `dimensions` mapping to provider-native field names, and `encoding_format: base64` divergence between providers that honor it and those that ignore it.

- **Coverage backlog updated**: Embeddings marked complete for the OpenAI and Gemini sections; Bedrock embedding coverage gaps documented in detail.

## Type of change

- [x] Bug fix
- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
go test ./core/... ./core/schemas/...
```

The new `TestReasoningContentAliasIsEmittedOnOutput` test in `core/schemas/reasoningcontentalias_test.go` covers all serialization cases: assistant message alias emission, no alias on empty reasoning, embedding field survival through the promoted marshaller, tool message flattening, stream delta alias emission, and round-trip single source of truth.

The updated `TestIsEncryptedReasoningRejection` in `core/encryptedreasoning_test.go` covers the corrected classifier behavior and the new SigV4 guard case.

E2E harness folder 53 can be run against a live gateway to validate the embedding parameter surface.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #6110 (referenced by `stripChatUnverifiableReasoning`)
References #3917 (Bedrock Cohere token header backfill)

## Security considerations

None. No auth, secrets, PII, or sandboxing changes.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable