### PR TITLE
chore: release Bifrost Helm chart v2.1.36 with `claimsSyncMode` for all SCIM providers and optional Okta `apiToken`

### DIFF
--- a/docs/changelogs/helm-v2.1.36.mdx
+++ b/docs/changelogs/helm-v2.1.36.mdx
@@ -1,0 +1,13 @@
+---
+title: "v2.1.36"
+description: "Helm v2.1.36 changelog - 2026-08-18"
+---
+
+<Update label="Bifrost Helm" description="v2.1.36">
+
+## Changelog
+
+- Added `bifrost.scim.config.claimsSyncMode` (`both` default, or `scim`) to every SCIM/SSO provider — selects, when SCIM is enabled, whether IdP login/refresh claims still drive role/team/business-unit/profile sync and JIT user creation (`both`) or SCIM is the sole source of truth (`scim`). Renders into the provider's `claimsSyncMode`.
+- Made `bifrost.scim.config.apiToken` optional for the Okta provider — removed it from the Okta config `required` set (it was contradicting the docs, which describe the API token as optional and only needed for 24-hour background user/group reconciliation). SCIM validation now requires only `issuerUrl`, `clientId`, and `clientSecret`.
+
+</Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1988,6 +1988,7 @@
             "item": "Helm",
             "icon": "box",
             "pages": [
+              "changelogs/helm-v2.1.36",
               "changelogs/helm-v2.1.35",
               "changelogs/helm-v2.1.34",
               {

--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.35
+version: 2.1.36
 appVersion: "1.5.12"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,9 +4,14 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.1.35
+**Latest Version:** 2.1.36
 
 ## Changelog
+
+### 2.1.36
+
+- Added `bifrost.scim.config.claimsSyncMode` (`both` default, or `scim`) to every SCIM/SSO provider — selects, when SCIM is enabled, whether IdP login/refresh claims still drive role/team/business-unit/profile sync and JIT user creation (`both`) or SCIM is the sole source of truth (`scim`). Renders into the provider's `claimsSyncMode`.
+- Made `bifrost.scim.config.apiToken` optional for the Okta provider — removed it from the Okta config `required` set (it was contradicting the docs, which describe the API token as optional and only needed for 24-hour background user/group reconciliation). SCIM validation now requires only `issuerUrl`, `clientId`, and `clientSecret`.
 
 ### 2.1.35
 

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -1995,9 +1995,6 @@ Call this template at the beginning of deployment/stateful templates
 {{- if not $scimValidation.config.clientSecret }}
 {{- fail "ERROR: bifrost.scim.config.clientSecret is required when SCIM provider is Okta." }}
 {{- end }}
-{{- if not $scimValidation.config.apiToken }}
-{{- fail "ERROR: bifrost.scim.config.apiToken is required when SCIM provider is Okta." }}
-{{- end }}
 {{- end }}
 {{- if eq $scimValidation.provider "entra" }}
 {{- if not $scimValidation.config.tenantId }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -2368,7 +2368,7 @@
                       },
                       "apiToken": {
                         "type": "string",
-                        "description": "Okta API token for Admin API access"
+                        "description": "Okta API token for Admin API access (optional; enables 24-hour background user/group reconciliation)"
                       },
                       "audience": {
                         "type": "string",
@@ -2396,13 +2396,14 @@
                       },
                       "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
                       "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
+                      "claimsSyncMode": {"$ref": "#/$defs/scim_claims_sync_mode"},
                       "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
                       "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
                       "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
                       "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"},
                       "provisioningToken": {"$ref": "#/$defs/scim_provisioning_token"}
                     },
-                    "required": ["issuerUrl", "clientId", "clientSecret", "apiToken"],
+                    "required": ["issuerUrl", "clientId", "clientSecret"],
                     "additionalProperties": false
                   }
                 }
@@ -2470,6 +2471,7 @@
                       },
                       "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
                       "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
+                      "claimsSyncMode": {"$ref": "#/$defs/scim_claims_sync_mode"},
                       "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
                       "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
                       "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
@@ -2538,6 +2540,7 @@
                       },
                       "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
                       "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
+                      "claimsSyncMode": {"$ref": "#/$defs/scim_claims_sync_mode"},
                       "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
                       "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
                       "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
@@ -2604,6 +2607,7 @@
                       },
                       "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
                       "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
+                      "claimsSyncMode": {"$ref": "#/$defs/scim_claims_sync_mode"},
                       "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
                       "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
                       "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
@@ -2680,6 +2684,7 @@
                       },
                       "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
                       "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
+                      "claimsSyncMode": {"$ref": "#/$defs/scim_claims_sync_mode"},
                       "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
                       "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
                       "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
@@ -2778,6 +2783,7 @@
                       },
                       "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
                       "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
+                      "claimsSyncMode": {"$ref": "#/$defs/scim_claims_sync_mode"},
                       "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
                       "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
                       "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
@@ -2851,6 +2857,7 @@
                       },
                       "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
                       "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
+                      "claimsSyncMode": {"$ref": "#/$defs/scim_claims_sync_mode"},
                       "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
                       "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
                       "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
@@ -6724,6 +6731,12 @@
       "enum": ["highestPermissionCount", "order"],
       "default": "highestPermissionCount",
       "description": "How a single role is chosen when a user resolves to more than one role: 'highestPermissionCount' (default) picks the role with the most permissions; 'order' evaluates the attribute-role mappings top to bottom and the first matching rule wins."
+    },
+    "scim_claims_sync_mode": {
+      "type": "string",
+      "enum": ["both", "scim"],
+      "default": "both",
+      "description": "When SCIM is enabled, selects whether IdP login/refresh claims still drive role/team/business-unit/profile sync and JIT user creation: 'both' (default) keeps syncing from both claims and SCIM; 'scim' makes SCIM the sole source of truth — claims are ignored for provisioning and new users must be pushed by SCIM. Inert when SCIM is disabled (claims always sync then)."
     },
     "scim_attribute_team_mappings": {
       "type": "array",

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -1005,7 +1005,7 @@ bifrost:
       # authServerType: "org"  # "org" or "custom"; auto-detected from issuer URL when omitted
       # clientId: ""
       # clientSecret: ""
-      # apiToken: ""
+      # apiToken: ""  # optional — enables 24-hour background user/group reconciliation
       # audience: ""
       # # Extra OAuth scopes on top of the base openid/profile/email/offline_access set
       # # (for Custom Authorization Servers where claims like "groups" are gated behind a scope).
@@ -1049,6 +1049,10 @@ bifrost:
       #     attributeType: "group"                   # "user" (SCIM User attribute) or "group" (match SCIM Group)
       #     attributeValue: "displayName"
       # provisioningToken: "env.SCIM_PROVISIONING_TOKEN"  # bearer token the IdP presents; generate: openssl rand -base64 32 | tr '+/' '-_' | tr -d '='
+      # # Claims-sync mode (Enterprise). Shared across every provider above; only matters when SCIM is enabled:
+      # # "both" (default) = login/refresh claims and SCIM both sync roles/teams/business-units/profile and can JIT-create users;
+      # # "scim" = SCIM is the sole source of truth — claims are ignored for provisioning and new users must be pushed by SCIM.
+      # claimsSyncMode: "both"
       #
       # # Auth proxy / identity-aware proxy (Enterprise). Shared across every provider above:
       # # when a Zero Trust / ZTNA proxy fronts the IdP, Bifrost reads the login credential from the

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -6008,7 +6008,7 @@
         },
         "apiToken": {
           "type": "string",
-          "description": "Okta API token for Admin API access"
+          "description": "Okta API token for Admin API access (optional; enables 24-hour background user/group reconciliation)"
         },
         "audience": {
           "type": "string",
@@ -6034,15 +6034,18 @@
           "description": "JWT claim field for roles (default: 'roles')",
           "default": "roles"
         },
-        "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
-        "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
-        "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
-        "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
-        "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
-        "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"},
-        "provisioningToken": {"$ref": "#/$defs/scim_provisioning_token"}
+        "attributeRoleMappings": { "$ref": "#/$defs/scim_attribute_role_mappings" },
+        "roleResolutionStrategy": { "$ref": "#/$defs/scim_role_resolution_strategy" },
+        "claimsSyncMode": { "$ref": "#/$defs/scim_claims_sync_mode" },
+        "attributeTeamMappings": { "$ref": "#/$defs/scim_attribute_team_mappings" },
+        "attributeBusinessUnitMappings": {
+          "$ref": "#/$defs/scim_attribute_business_unit_mappings"
+        },
+        "authProxy": { "$ref": "#/$defs/scim_auth_proxy" },
+        "claimScimAttributes": { "$ref": "#/$defs/scim_claim_attributes" },
+        "provisioningToken": { "$ref": "#/$defs/scim_provisioning_token" }
       },
-      "required": ["issuerUrl", "clientId", "clientSecret", "apiToken"],
+      "required": ["issuerUrl", "clientId", "clientSecret"],
       "additionalProperties": false
     },
     "entra_config": {
@@ -6091,13 +6094,16 @@
           "description": "JWT claim field for roles (default: 'roles')",
           "default": "roles"
         },
-        "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
-        "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
-        "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
-        "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
-        "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
-        "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"},
-        "provisioningToken": {"$ref": "#/$defs/scim_provisioning_token"}
+        "attributeRoleMappings": { "$ref": "#/$defs/scim_attribute_role_mappings" },
+        "roleResolutionStrategy": { "$ref": "#/$defs/scim_role_resolution_strategy" },
+        "claimsSyncMode": { "$ref": "#/$defs/scim_claims_sync_mode" },
+        "attributeTeamMappings": { "$ref": "#/$defs/scim_attribute_team_mappings" },
+        "attributeBusinessUnitMappings": {
+          "$ref": "#/$defs/scim_attribute_business_unit_mappings"
+        },
+        "authProxy": { "$ref": "#/$defs/scim_auth_proxy" },
+        "claimScimAttributes": { "$ref": "#/$defs/scim_claim_attributes" },
+        "provisioningToken": { "$ref": "#/$defs/scim_provisioning_token" }
       },
       "required": ["tenantId", "clientId"],
       "additionalProperties": false
@@ -6142,11 +6148,14 @@
           "description": "JWT claim field for roles (default: 'roles')",
           "default": "roles"
         },
-        "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
-        "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
-        "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
-        "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
-        "authProxy": {"$ref": "#/$defs/scim_auth_proxy"}
+        "attributeRoleMappings": { "$ref": "#/$defs/scim_attribute_role_mappings" },
+        "roleResolutionStrategy": { "$ref": "#/$defs/scim_role_resolution_strategy" },
+        "claimsSyncMode": { "$ref": "#/$defs/scim_claims_sync_mode" },
+        "attributeTeamMappings": { "$ref": "#/$defs/scim_attribute_team_mappings" },
+        "attributeBusinessUnitMappings": {
+          "$ref": "#/$defs/scim_attribute_business_unit_mappings"
+        },
+        "authProxy": { "$ref": "#/$defs/scim_auth_proxy" }
       },
       "required": ["serverUrl", "realm", "clientId", "clientSecret"],
       "additionalProperties": false
@@ -6201,13 +6210,16 @@
           "description": "Override the default OIDC scopes requested during login",
           "items": { "type": "string" }
         },
-        "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
-        "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
-        "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
-        "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
-        "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
-        "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"},
-        "provisioningToken": {"$ref": "#/$defs/scim_provisioning_token"}
+        "attributeRoleMappings": { "$ref": "#/$defs/scim_attribute_role_mappings" },
+        "roleResolutionStrategy": { "$ref": "#/$defs/scim_role_resolution_strategy" },
+        "claimsSyncMode": { "$ref": "#/$defs/scim_claims_sync_mode" },
+        "attributeTeamMappings": { "$ref": "#/$defs/scim_attribute_team_mappings" },
+        "attributeBusinessUnitMappings": {
+          "$ref": "#/$defs/scim_attribute_business_unit_mappings"
+        },
+        "authProxy": { "$ref": "#/$defs/scim_auth_proxy" },
+        "claimScimAttributes": { "$ref": "#/$defs/scim_claim_attributes" },
+        "provisioningToken": { "$ref": "#/$defs/scim_provisioning_token" }
       },
       "required": ["issuerUrl", "clientId"],
       "additionalProperties": false
@@ -6251,12 +6263,15 @@
           "description": "JWT claim field for team/group IDs (default: 'groups')",
           "default": "groups"
         },
-        "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
-        "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
-        "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
-        "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
-        "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
-        "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"}
+        "attributeRoleMappings": { "$ref": "#/$defs/scim_attribute_role_mappings" },
+        "roleResolutionStrategy": { "$ref": "#/$defs/scim_role_resolution_strategy" },
+        "claimsSyncMode": { "$ref": "#/$defs/scim_claims_sync_mode" },
+        "attributeTeamMappings": { "$ref": "#/$defs/scim_attribute_team_mappings" },
+        "attributeBusinessUnitMappings": {
+          "$ref": "#/$defs/scim_attribute_business_unit_mappings"
+        },
+        "authProxy": { "$ref": "#/$defs/scim_auth_proxy" },
+        "claimScimAttributes": { "$ref": "#/$defs/scim_claim_attributes" }
       },
       "required": ["domain", "clientId"],
       "additionalProperties": false
@@ -6310,12 +6325,15 @@
           "description": "Claim field for team/group IDs (default: 'groups')",
           "default": "groups"
         },
-        "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
-        "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
-        "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
-        "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
-        "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
-        "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"}
+        "attributeRoleMappings": { "$ref": "#/$defs/scim_attribute_role_mappings" },
+        "roleResolutionStrategy": { "$ref": "#/$defs/scim_role_resolution_strategy" },
+        "claimsSyncMode": { "$ref": "#/$defs/scim_claims_sync_mode" },
+        "attributeTeamMappings": { "$ref": "#/$defs/scim_attribute_team_mappings" },
+        "attributeBusinessUnitMappings": {
+          "$ref": "#/$defs/scim_attribute_business_unit_mappings"
+        },
+        "authProxy": { "$ref": "#/$defs/scim_auth_proxy" },
+        "claimScimAttributes": { "$ref": "#/$defs/scim_claim_attributes" }
       },
       "required": ["domain", "clientId"],
       "additionalProperties": false,
@@ -6395,13 +6413,16 @@
           "type": "string",
           "description": "JWT claim field for team IDs"
         },
-        "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
-        "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
-        "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
-        "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
-        "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
-        "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"},
-        "provisioningToken": {"$ref": "#/$defs/scim_provisioning_token"}
+        "attributeRoleMappings": { "$ref": "#/$defs/scim_attribute_role_mappings" },
+        "roleResolutionStrategy": { "$ref": "#/$defs/scim_role_resolution_strategy" },
+        "claimsSyncMode": { "$ref": "#/$defs/scim_claims_sync_mode" },
+        "attributeTeamMappings": { "$ref": "#/$defs/scim_attribute_team_mappings" },
+        "attributeBusinessUnitMappings": {
+          "$ref": "#/$defs/scim_attribute_business_unit_mappings"
+        },
+        "authProxy": { "$ref": "#/$defs/scim_auth_proxy" },
+        "claimScimAttributes": { "$ref": "#/$defs/scim_claim_attributes" },
+        "provisioningToken": { "$ref": "#/$defs/scim_provisioning_token" }
       },
       "required": ["product"],
       "additionalProperties": false
@@ -7752,6 +7773,12 @@
       "enum": ["highestPermissionCount", "order"],
       "default": "highestPermissionCount",
       "description": "How a single role is chosen when a user resolves to more than one role: 'highestPermissionCount' (default) picks the role with the most permissions; 'order' evaluates the attribute-role mappings top to bottom and the first matching rule wins."
+    },
+    "scim_claims_sync_mode": {
+      "type": "string",
+      "enum": ["both", "scim"],
+      "default": "both",
+      "description": "When SCIM is enabled, selects whether IdP login/refresh claims still drive role/team/business-unit/profile sync and JIT user creation: 'both' (default) keeps syncing from both claims and SCIM; 'scim' makes SCIM the sole source of truth — claims are ignored for provisioning and new users must be pushed by SCIM. Inert when SCIM is disabled (claims always sync then)."
     },
     "scim_attribute_team_mappings": {
       "type": "array",


### PR DESCRIPTION
## Summary

This PR releases Helm chart v2.1.36, introducing a new `claimsSyncMode` field for all SCIM/SSO providers and fixing an incorrect validation requirement for the Okta `apiToken` field.

## Changes

- Added `bifrost.scim.config.claimsSyncMode` (enum: `both` | `scim`, default: `both`) to every SCIM/SSO provider config. When SCIM is enabled, `both` keeps IdP login/refresh claims driving role/team/business-unit/profile sync and JIT user creation alongside SCIM, while `scim` makes SCIM the sole source of truth and ignores claims for provisioning entirely.
- Removed `apiToken` from the Okta provider's `required` field set in both the Helm values schema and the transport config schema. The API token is optional — it only enables 24-hour background user/group reconciliation — and requiring it contradicted the existing documentation. Okta SCIM validation now only requires `issuerUrl`, `clientId`, and `clientSecret`.
- Removed the corresponding Helm template validation guard that was failing deployments when `apiToken` was absent for Okta.
- Updated the `apiToken` description in both schemas to clarify its optional nature.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Deploy the Helm chart with an Okta SCIM provider configured **without** `apiToken` and confirm the chart renders and deploys without validation errors.

Deploy with `claimsSyncMode: "scim"` set and verify the value renders into the provider's `claimsSyncMode` field in the generated config.

```sh
helm template bifrost ./helm-charts/bifrost -f your-values.yaml | grep claimsSyncMode
helm lint ./helm-charts/bifrost -f your-values.yaml
```

**New config fields:**

| Field | Type | Default | Description |
|---|---|---|---|
| `bifrost.scim.config.claimsSyncMode` | `string` | `both` | `both` = claims + SCIM both sync; `scim` = SCIM is sole source of truth |
| `bifrost.scim.config.apiToken` (Okta) | `string` | _(none)_ | Now optional; enables 24-hour background user/group reconciliation |

## Breaking changes

- [ ] Yes
- [x] No

The removal of the `apiToken` required validation is backwards compatible — existing configs with `apiToken` set continue to work, and configs without it no longer fail.

## Related issues

N/A

## Security considerations

The `apiToken` field remains supported and should still be treated as a secret when provided. No new secrets or auth surfaces are introduced by `claimsSyncMode`.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable