### PR TITLE
fix: enforce RFC 8414 issuer validation and MCP server discovery

### DIFF
--- a/framework/oauth2/discovery.go
+++ b/framework/oauth2/discovery.go
@@ -321,9 +321,11 @@ func fetchSingleAuthServerMetadata(ctx context.Context, issuer string) (*OAuthMe
 
 			if err := json.Unmarshal(bodyBytes, &metadata); err == nil {
 				// RFC 8414 §3.3 and OIDC Discovery §4.3 require the returned
-				// issuer to exactly match the issuer used for discovery. The direct
-				// issuer URL is a legacy fallback, however, and may be a guessed
-				// MCP server origin rather than an authorization-server issuer.
+				// issuer to exactly match the issuer used for discovery. Deliberately
+				// compare the serialized values without URI normalization, including
+				// scheme and host case. The direct issuer URL is a legacy fallback,
+				// however, and may be a guessed MCP server origin rather than an
+				// authorization-server issuer.
 				if metadata.Issuer != canonicalIssuer && candidateURL != canonicalIssuer {
 					issuerMismatchErr = fmt.Errorf("authorization-server metadata issuer mismatch at %s: got %q, want %q", candidateURL, metadata.Issuer, canonicalIssuer)
 					logger.Warn("[OAuth Discovery] %v", issuerMismatchErr)

--- a/framework/oauth2/discovery.go
+++ b/framework/oauth2/discovery.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -238,6 +239,7 @@ func attemptWellKnownDiscovery(ctx context.Context, serverURL string) ([]string,
 // fetchAuthorizationServerMetadata fetches OAuth endpoints from authorization server(s)
 // Tries multiple authorization servers until one succeeds
 func fetchAuthorizationServerMetadata(ctx context.Context, authServers []string) (*OAuthMetadata, error) {
+	var discoveryErrs []error
 	for _, issuer := range authServers {
 		logger.Debug(fmt.Sprintf("[OAuth Discovery] Fetching metadata from authorization server: %s", issuer))
 		metadata, err := fetchSingleAuthServerMetadata(ctx, issuer)
@@ -245,7 +247,13 @@ func fetchAuthorizationServerMetadata(ctx context.Context, authServers []string)
 			logger.Debug(fmt.Sprintf("[OAuth Discovery] Successfully fetched metadata from: %s", issuer))
 			return metadata, nil
 		}
+		if err != nil {
+			discoveryErrs = append(discoveryErrs, err)
+		}
 		logger.Debug(fmt.Sprintf("[OAuth Discovery] Failed to fetch from %s: %v", issuer, err))
+	}
+	if len(discoveryErrs) > 0 {
+		return nil, fmt.Errorf("failed to fetch metadata from any authorization server: %w", errors.Join(discoveryErrs...))
 	}
 	return nil, fmt.Errorf("failed to fetch metadata from any authorization server")
 }
@@ -288,6 +296,7 @@ func fetchSingleAuthServerMetadata(ctx context.Context, issuer string) (*OAuthMe
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 	}
+	var issuerMismatchErr error
 
 	for _, candidateURL := range candidateURLs {
 		logger.Debug(fmt.Sprintf("[OAuth Discovery] Trying metadata endpoint: %s", candidateURL))
@@ -316,7 +325,8 @@ func fetchSingleAuthServerMetadata(ctx context.Context, issuer string) (*OAuthMe
 				// issuer URL is a legacy fallback, however, and may be a guessed
 				// MCP server origin rather than an authorization-server issuer.
 				if metadata.Issuer != canonicalIssuer && candidateURL != canonicalIssuer {
-					logger.Debug(fmt.Sprintf("[OAuth Discovery] Metadata issuer mismatch at %s: got %q, want %q", candidateURL, metadata.Issuer, canonicalIssuer))
+					issuerMismatchErr = fmt.Errorf("authorization-server metadata issuer mismatch at %s: got %q, want %q", candidateURL, metadata.Issuer, canonicalIssuer)
+					logger.Warn("[OAuth Discovery] %v", issuerMismatchErr)
 					continue
 				}
 
@@ -329,6 +339,9 @@ func fetchSingleAuthServerMetadata(ctx context.Context, issuer string) (*OAuthMe
 		} else {
 			resp.Body.Close()
 		}
+	}
+	if issuerMismatchErr != nil {
+		return nil, issuerMismatchErr
 	}
 
 	return nil, fmt.Errorf("no valid metadata found for issuer: %s", issuer)

--- a/framework/oauth2/discovery.go
+++ b/framework/oauth2/discovery.go
@@ -23,6 +23,8 @@ type OAuthMetadata struct {
 	RegistrationURL  *string  `json:"registration_endpoint,omitempty"`
 	ScopesSupported  []string `json:"scopes_supported,omitempty"`
 	Resource         string   `json:"resource,omitempty"`
+	// Required by RFC 8414 and OIDC Discovery metadata; omitempty is retained
+	// for legacy metadata documents that omit it.
 	Issuer           string   `json:"issuer,omitempty"`
 	ResponseTypes    []string `json:"response_types_supported,omitempty"`
 	GrantTypes       []string `json:"grant_types_supported,omitempty"`

--- a/framework/oauth2/discovery.go
+++ b/framework/oauth2/discovery.go
@@ -253,7 +253,11 @@ func fetchAuthorizationServerMetadata(ctx context.Context, authServers []string)
 // fetchSingleAuthServerMetadata tries multiple well-known endpoints for a single authorization server
 // Implements RFC 8414 discovery
 func fetchSingleAuthServerMetadata(ctx context.Context, issuer string) (*OAuthMetadata, error) {
-	base, path := splitURL(issuer)
+	// RFC 8414 §3.1 requires removal of a terminating slash before the
+	// well-known path is inserted. Use the same normalized issuer when
+	// validating the metadata issuer (RFC 8414 §3.3).
+	canonicalIssuer := strings.TrimSuffix(issuer, "/")
+	base, path := splitURL(canonicalIssuer)
 	if base == "" {
 		return nil, fmt.Errorf("invalid issuer URL: %s", issuer)
 	}
@@ -268,7 +272,7 @@ func fetchSingleAuthServerMetadata(ctx context.Context, issuer string) (*OAuthMe
 		candidateURLs = append(candidateURLs,
 			fmt.Sprintf("%s/.well-known/oauth-authorization-server/%s", base, path),
 			fmt.Sprintf("%s/.well-known/openid-configuration/%s", base, path),
-			strings.TrimSuffix(issuer, "/")+"/.well-known/openid-configuration",
+			canonicalIssuer+"/.well-known/openid-configuration",
 		)
 	} else {
 		candidateURLs = append(candidateURLs,
@@ -279,7 +283,7 @@ func fetchSingleAuthServerMetadata(ctx context.Context, issuer string) (*OAuthMe
 
 	// Legacy compatibility fallback for authorization servers that publish
 	// metadata directly at the issuer URL. This is not part of MCP discovery.
-	candidateURLs = append(candidateURLs, strings.TrimSuffix(issuer, "/"))
+	candidateURLs = append(candidateURLs, canonicalIssuer)
 
 	client := &http.Client{
 		Timeout: 10 * time.Second,
@@ -311,8 +315,8 @@ func fetchSingleAuthServerMetadata(ctx context.Context, issuer string) (*OAuthMe
 				// issuer to exactly match the issuer used for discovery. Without
 				// this, metadata published by another issuer on the same host could
 				// be accepted for a path-bearing issuer.
-				if metadata.Issuer != issuer {
-					logger.Debug(fmt.Sprintf("[OAuth Discovery] Metadata issuer mismatch at %s: got %q, want %q", candidateURL, metadata.Issuer, issuer))
+				if metadata.Issuer != canonicalIssuer {
+					logger.Debug(fmt.Sprintf("[OAuth Discovery] Metadata issuer mismatch at %s: got %q, want %q", candidateURL, metadata.Issuer, canonicalIssuer))
 					continue
 				}
 

--- a/framework/oauth2/discovery.go
+++ b/framework/oauth2/discovery.go
@@ -258,19 +258,28 @@ func fetchSingleAuthServerMetadata(ctx context.Context, issuer string) (*OAuthMe
 		return nil, fmt.Errorf("invalid issuer URL: %s", issuer)
 	}
 
-	// Try different well-known endpoint patterns
+	// MCP's required discovery order is documented at:
+	// https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization/authorization-server-discovery#authorization-server-metadata-discovery
+	// RFC 8414 inserts the well-known path before a path-bearing issuer,
+	// while OIDC Discovery appends it to the issuer. Host-level URLs for a
+	// path-bearing issuer describe a different issuer and are not candidates.
 	var candidateURLs []string
 	if path != "" {
 		candidateURLs = append(candidateURLs,
 			fmt.Sprintf("%s/.well-known/oauth-authorization-server/%s", base, path),
 			fmt.Sprintf("%s/.well-known/openid-configuration/%s", base, path),
+			strings.TrimSuffix(issuer, "/")+"/.well-known/openid-configuration",
+		)
+	} else {
+		candidateURLs = append(candidateURLs,
+			fmt.Sprintf("%s/.well-known/oauth-authorization-server", base),
+			fmt.Sprintf("%s/.well-known/openid-configuration", base),
 		)
 	}
-	candidateURLs = append(candidateURLs,
-		fmt.Sprintf("%s/.well-known/oauth-authorization-server", base),
-		fmt.Sprintf("%s/.well-known/openid-configuration", base),
-		strings.TrimSuffix(issuer, "/"), // Try the issuer URL itself
-	)
+
+	// Legacy compatibility fallback for authorization servers that publish
+	// metadata directly at the issuer URL. This is not part of MCP discovery.
+	candidateURLs = append(candidateURLs, strings.TrimSuffix(issuer, "/"))
 
 	client := &http.Client{
 		Timeout: 10 * time.Second,
@@ -298,7 +307,16 @@ func fetchSingleAuthServerMetadata(ctx context.Context, issuer string) (*OAuthMe
 			}
 
 			if err := json.Unmarshal(bodyBytes, &metadata); err == nil {
-				// Validate that we got at least authorization_endpoint
+				// RFC 8414 §3.3 and OIDC Discovery §4.3 require the returned
+				// issuer to exactly match the issuer used for discovery. Without
+				// this, metadata published by another issuer on the same host could
+				// be accepted for a path-bearing issuer.
+				if metadata.Issuer != issuer {
+					logger.Debug(fmt.Sprintf("[OAuth Discovery] Metadata issuer mismatch at %s: got %q, want %q", candidateURL, metadata.Issuer, issuer))
+					continue
+				}
+
+				// Validate that we got at least authorization_endpoint.
 				if metadata.AuthorizationURL != "" {
 					logger.Debug(fmt.Sprintf("[OAuth Discovery] Valid metadata found at: %s", candidateURL))
 					return &metadata, nil

--- a/framework/oauth2/discovery.go
+++ b/framework/oauth2/discovery.go
@@ -312,10 +312,10 @@ func fetchSingleAuthServerMetadata(ctx context.Context, issuer string) (*OAuthMe
 
 			if err := json.Unmarshal(bodyBytes, &metadata); err == nil {
 				// RFC 8414 §3.3 and OIDC Discovery §4.3 require the returned
-				// issuer to exactly match the issuer used for discovery. Without
-				// this, metadata published by another issuer on the same host could
-				// be accepted for a path-bearing issuer.
-				if metadata.Issuer != canonicalIssuer {
+				// issuer to exactly match the issuer used for discovery. The direct
+				// issuer URL is a legacy fallback, however, and may be a guessed
+				// MCP server origin rather than an authorization-server issuer.
+				if metadata.Issuer != canonicalIssuer && candidateURL != canonicalIssuer {
 					logger.Debug(fmt.Sprintf("[OAuth Discovery] Metadata issuer mismatch at %s: got %q, want %q", candidateURL, metadata.Issuer, canonicalIssuer))
 					continue
 				}

--- a/framework/oauth2/discovery_test.go
+++ b/framework/oauth2/discovery_test.go
@@ -1,0 +1,85 @@
+package oauth2
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchSingleAuthServerMetadata_PathIssuerUsesOIDCPathAppendFallback(t *testing.T) {
+	SetLogger(bifrost.NewDefaultLogger(schemas.LogLevelError))
+
+	var requestedPaths []string
+	var issuer string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPaths = append(requestedPaths, r.URL.Path)
+		if r.URL.Path != "/tenant/prod/oidc/.well-known/openid-configuration" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"issuer":"` + issuer + `","authorization_endpoint":"https://issuer.example/authorize","token_endpoint":"https://issuer.example/token"}`))
+	}))
+	defer server.Close()
+	issuer = server.URL + "/tenant/prod/oidc"
+
+	metadata, err := fetchSingleAuthServerMetadata(context.Background(), issuer)
+	require.NoError(t, err)
+	require.NotNil(t, metadata)
+	assert.Equal(t, "https://issuer.example/authorize", metadata.AuthorizationURL)
+	assert.Equal(t, []string{
+		"/.well-known/oauth-authorization-server/tenant/prod/oidc",
+		"/.well-known/openid-configuration/tenant/prod/oidc",
+		"/tenant/prod/oidc/.well-known/openid-configuration",
+	}, requestedPaths)
+}
+
+func TestFetchSingleAuthServerMetadata_PathIssuerDoesNotTryHostLevelOIDCURL(t *testing.T) {
+	SetLogger(bifrost.NewDefaultLogger(schemas.LogLevelError))
+
+	var requestedPaths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPaths = append(requestedPaths, r.URL.Path)
+		if r.URL.Path == "/.well-known/openid-configuration" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"issuer":"https://issuer.example","authorization_endpoint":"https://issuer.example/authorize","token_endpoint":"https://issuer.example/token"}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	metadata, err := fetchSingleAuthServerMetadata(context.Background(), server.URL+"/tenant/prod/oidc")
+	require.Error(t, err)
+	assert.Nil(t, metadata)
+	assert.Equal(t, []string{
+		"/.well-known/oauth-authorization-server/tenant/prod/oidc",
+		"/.well-known/openid-configuration/tenant/prod/oidc",
+		"/tenant/prod/oidc/.well-known/openid-configuration",
+		"/tenant/prod/oidc",
+	}, requestedPaths)
+}
+
+func TestFetchSingleAuthServerMetadata_RejectsMismatchedIssuer(t *testing.T) {
+	SetLogger(bifrost.NewDefaultLogger(schemas.LogLevelError))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/oauth-authorization-server/tenant/prod/oidc" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"issuer":"https://issuer.example/other-tenant","authorization_endpoint":"https://issuer.example/authorize","token_endpoint":"https://issuer.example/token"}`))
+	}))
+	defer server.Close()
+
+	metadata, err := fetchSingleAuthServerMetadata(context.Background(), server.URL+"/tenant/prod/oidc")
+	require.Error(t, err)
+	assert.Nil(t, metadata)
+}

--- a/framework/oauth2/discovery_test.go
+++ b/framework/oauth2/discovery_test.go
@@ -83,3 +83,49 @@ func TestFetchSingleAuthServerMetadata_RejectsMismatchedIssuer(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, metadata)
 }
+
+func TestFetchSingleAuthServerMetadata_NormalizesTrailingSlashForPathIssuer(t *testing.T) {
+	SetLogger(bifrost.NewDefaultLogger(schemas.LogLevelError))
+
+	var requestedPaths []string
+	var canonicalIssuer string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPaths = append(requestedPaths, r.URL.Path)
+		if r.URL.Path != "/.well-known/oauth-authorization-server/tenant1" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"issuer":"` + canonicalIssuer + `","authorization_endpoint":"https://issuer.example/authorize"}`))
+	}))
+	defer server.Close()
+	canonicalIssuer = server.URL + "/tenant1"
+
+	metadata, err := fetchSingleAuthServerMetadata(context.Background(), canonicalIssuer+"/")
+	require.NoError(t, err)
+	require.NotNil(t, metadata)
+	assert.Equal(t, canonicalIssuer, metadata.Issuer)
+	assert.Equal(t, []string{"/.well-known/oauth-authorization-server/tenant1"}, requestedPaths)
+}
+
+func TestFetchSingleAuthServerMetadata_NormalizesTrailingSlashForRootIssuer(t *testing.T) {
+	SetLogger(bifrost.NewDefaultLogger(schemas.LogLevelError))
+
+	var requestedPaths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPaths = append(requestedPaths, r.URL.Path)
+		if r.URL.Path != "/.well-known/oauth-authorization-server" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"issuer":"` + server.URL + `","authorization_endpoint":"https://issuer.example/authorize"}`))
+	}))
+	defer server.Close()
+
+	metadata, err := fetchSingleAuthServerMetadata(context.Background(), server.URL+"/")
+	require.NoError(t, err)
+	require.NotNil(t, metadata)
+	assert.Equal(t, server.URL, metadata.Issuer)
+	assert.Equal(t, []string{"/.well-known/oauth-authorization-server"}, requestedPaths)
+}

--- a/framework/oauth2/discovery_test.go
+++ b/framework/oauth2/discovery_test.go
@@ -90,6 +90,25 @@ func TestFetchSingleAuthServerMetadata_RejectsMismatchedIssuer(t *testing.T) {
 	assert.ErrorContains(t, err, "authorization-server metadata issuer mismatch")
 }
 
+func TestFetchSingleAuthServerMetadata_RejectsMetadataWithoutIssuer(t *testing.T) {
+	SetLogger(bifrost.NewDefaultLogger(schemas.LogLevelError))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/oauth-authorization-server/tenant/prod/oidc" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"authorization_endpoint":"https://issuer.example/authorize","token_endpoint":"https://issuer.example/token"}`))
+	}))
+	defer server.Close()
+
+	metadata, err := fetchSingleAuthServerMetadata(context.Background(), server.URL+"/tenant/prod/oidc")
+	require.Error(t, err)
+	assert.Nil(t, metadata)
+	assert.ErrorContains(t, err, "authorization-server metadata issuer mismatch")
+}
+
 func TestFetchSingleAuthServerMetadata_NormalizesTrailingSlashForPathIssuer(t *testing.T) {
 	SetLogger(bifrost.NewDefaultLogger(schemas.LogLevelError))
 

--- a/framework/oauth2/discovery_test.go
+++ b/framework/oauth2/discovery_test.go
@@ -82,6 +82,12 @@ func TestFetchSingleAuthServerMetadata_RejectsMismatchedIssuer(t *testing.T) {
 	metadata, err := fetchSingleAuthServerMetadata(context.Background(), server.URL+"/tenant/prod/oidc")
 	require.Error(t, err)
 	assert.Nil(t, metadata)
+	assert.ErrorContains(t, err, "authorization-server metadata issuer mismatch")
+
+	metadata, err = fetchAuthorizationServerMetadata(context.Background(), []string{server.URL + "/tenant/prod/oidc"})
+	require.Error(t, err)
+	assert.Nil(t, metadata)
+	assert.ErrorContains(t, err, "authorization-server metadata issuer mismatch")
 }
 
 func TestFetchSingleAuthServerMetadata_NormalizesTrailingSlashForPathIssuer(t *testing.T) {

--- a/framework/oauth2/discovery_test.go
+++ b/framework/oauth2/discovery_test.go
@@ -129,3 +129,22 @@ func TestFetchSingleAuthServerMetadata_NormalizesTrailingSlashForRootIssuer(t *t
 	assert.Equal(t, server.URL, metadata.Issuer)
 	assert.Equal(t, []string{"/.well-known/oauth-authorization-server"}, requestedPaths)
 }
+
+func TestFetchSingleAuthServerMetadata_LegacyDirectIssuerFallbackAllowsDifferentIssuer(t *testing.T) {
+	SetLogger(bifrost.NewDefaultLogger(schemas.LogLevelError))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mcp" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"issuer":"https://auth.example/tenant-a","authorization_endpoint":"https://issuer.example/authorize"}`))
+	}))
+	defer server.Close()
+
+	metadata, err := fetchSingleAuthServerMetadata(context.Background(), server.URL+"/mcp")
+	require.NoError(t, err)
+	require.NotNil(t, metadata)
+	assert.Equal(t, "https://auth.example/tenant-a", metadata.Issuer)
+}


### PR DESCRIPTION
## Summary

- implement the MCP authorization-server discovery order for path-bearing issuers
- reject metadata whose issuer does not match the discovered issuer
- preserve direct-issuer discovery as a documented legacy fallback

## Why

Path-bearing authorization-server issuers can publish valid OIDC metadata at `<issuer>/.well-known/openid-configuration`. The discovery client now tries the RFC 8414 and OIDC locations required by the MCP authorization specification and rejects issuer-mismatched metadata.

Fixes #4371.

## Note for maintainers
Written partially by self ,  assisted by ai 

## Testing

- `go test ./oauth2`