### PR TITLE
[fix]: make SSE heartbeat framing integration-aware

### DIFF
--- a/transports/bifrost-http/integrations/genai.go
+++ b/transports/bifrost-http/integrations/genai.go
@@ -240,6 +240,7 @@ func CreateGenAIRouteConfigs(pathPrefix string) []RouteConfig {
 			return gemini.ToGeminiError(err)
 		},
 		StreamConfig: &StreamConfig{
+			HeartbeatFraming: lib.SSEHeartbeatDelimitedCommentBlock,
 			ResponsesStreamResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostResponsesStreamResponse) (string, interface{}, error) {
 				// Store state in context so it persists across chunks of the same stream
 				const stateKey = "gemini_stream_state"

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -428,6 +428,7 @@ type StreamConfig struct {
 	TranscriptionStreamResponseConverter   TranscriptionStreamResponseConverter   // Function to convert BifrostTranscriptionResponse to streaming format
 	ImageGenerationStreamResponseConverter ImageGenerationStreamResponseConverter // Function to convert BifrostImageGenerationStreamResponse to streaming format
 	ErrorConverter                         StreamErrorConverter                   // Function to convert BifrostError to streaming error format
+	HeartbeatFraming                       lib.SSEHeartbeatFraming                // Wire framing for no-op SSE heartbeat comments
 }
 
 type RouteConfigType string
@@ -2776,7 +2777,14 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 		var heartbeatDone chan struct{}
 		var heartbeatExited <-chan struct{}
 		if config.Type != RouteConfigTypeBedrock {
-			heartbeatDone, heartbeatExited = lib.StartSSEHeartbeat(lib.DefaultSSEHeartbeatInterval, reader.SendHeartbeat, cancel)
+			heartbeatFraming := lib.SSEHeartbeatBareCommentLine
+			if config.StreamConfig != nil {
+				heartbeatFraming = config.StreamConfig.HeartbeatFraming
+			}
+			sendHeartbeat := func() bool {
+				return reader.SendHeartbeatWithFraming(heartbeatFraming)
+			}
+			heartbeatDone, heartbeatExited = lib.StartSSEHeartbeat(lib.DefaultSSEHeartbeatInterval, sendHeartbeat, cancel)
 		}
 
 		defer func() {

--- a/transports/bifrost-http/integrations/router_heartbeat_test.go
+++ b/transports/bifrost-http/integrations/router_heartbeat_test.go
@@ -59,6 +59,46 @@ func Test_handleStreamingSSESendsHeartbeatDuringIdleGap(t *testing.T) {
 	})
 }
 
+// Test_handleStreamingGenAIDelimitsHeartbeatComment verifies the GenAI integration emits
+// its heartbeat as a self-contained SSE comment block. The official Google GenAI SDK splits
+// streams on blank-line delimiters and otherwise groups a bare comment line with the next
+// data event, causing that event to be discarded because the combined block starts with ':'.
+func Test_handleStreamingGenAIDelimitsHeartbeatComment(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		stream := make(chan *schemas.BifrostStreamChunk)
+		router := NewGenericRouter(nil, &mockHandlerStore{}, nil, nil, bifrost.NewNoOpLogger())
+		ctx := &fasthttp.RequestCtx{}
+		var streamRoute *RouteConfig
+		routes := CreateGenAIRouteConfigs("/genai")
+		for i := range routes {
+			if routes[i].StreamConfig != nil {
+				streamRoute = &routes[i]
+				break
+			}
+		}
+		require.NotNil(t, streamRoute)
+		router.handleStreaming(ctx, nil, *streamRoute, stream, func() {})
+
+		bodyStream := ctx.Response.BodyStream()
+		type readResult struct {
+			body string
+			err  error
+		}
+		readDone := make(chan readResult, 1)
+		go func() {
+			b, err := io.ReadAll(bodyStream)
+			readDone <- readResult{body: string(b), err: err}
+		}()
+
+		time.Sleep(2*lib.DefaultSSEHeartbeatInterval + time.Millisecond)
+		close(stream)
+
+		result := <-readDone
+		require.NoError(t, result.err)
+		assert.Contains(t, result.body, ": heartbeat\n\n")
+	})
+}
+
 // Test_passthroughHeartbeatEligible pins down the content-type gate handlePassthroughStream
 // uses to decide whether the heartbeat is safe to inject: only when the resolved
 // content-type is actually SSE. Injecting anything into a non-SSE passthrough body (e.g.

--- a/transports/bifrost-http/lib/streamreader.go
+++ b/transports/bifrost-http/lib/streamreader.go
@@ -142,12 +142,23 @@ func (r *SSEStreamReader) SendDone() bool {
 	return r.Send([]byte("data: [DONE]\n\n"))
 }
 
-// sseHeartbeatFrame is an SSE comment line that every compliant client ignores.
-// Deliberately no trailing blank line: that's the event-dispatch signal, and
-// some deployed decoders (e.g. openai-go ssestream < v3.43.0) dispatch an empty
-// event on it and abort the stream (#5874). A bare comment line is still a real
-// socket write, which is all the disconnect probe needs.
-var sseHeartbeatFrame = []byte(": heartbeat\n")
+// SSEHeartbeatFraming controls how a heartbeat comment is terminated on the wire.
+type SSEHeartbeatFraming uint8
+
+const (
+	// SSEHeartbeatBareCommentLine preserves compatibility with decoders such as
+	// openai-go ssestream before v3.43.0, which dispatch an empty event for a
+	// comment block followed by a blank line (#5874).
+	SSEHeartbeatBareCommentLine SSEHeartbeatFraming = iota
+	// SSEHeartbeatDelimitedCommentBlock emits a self-contained comment block for
+	// clients that parse streams as blank-line-delimited blocks.
+	SSEHeartbeatDelimitedCommentBlock
+)
+
+var (
+	sseHeartbeatFrame          = []byte(": heartbeat\n")
+	sseDelimitedHeartbeatFrame = []byte(": heartbeat\n\n")
+)
 
 // SendHeartbeat sends a no-op SSE comment line purely to force an additional
 // downstream write attempt. Client-disconnect detection in this reader is
@@ -180,6 +191,12 @@ var sseHeartbeatFrame = []byte(": heartbeat\n")
 // itself and each Send ends in "\n\n", so the stream is always at a boundary there and
 // heartbeats are never skipped.
 func (r *SSEStreamReader) SendHeartbeat() bool {
+	return r.SendHeartbeatWithFraming(SSEHeartbeatBareCommentLine)
+}
+
+// SendHeartbeatWithFraming sends a no-op SSE heartbeat using the requested wire framing.
+// It preserves SendHeartbeat's line-boundary and disconnect-detection semantics.
+func (r *SSEStreamReader) SendHeartbeatWithFraming(framing SSEHeartbeatFraming) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	// A real disconnect outranks a skip: report it even when mid-line.
@@ -191,7 +208,11 @@ func (r *SSEStreamReader) SendHeartbeat() bool {
 	if !r.atLineBoundary {
 		return true
 	}
-	return r.sendLocked(sseHeartbeatFrame)
+	heartbeatFrame := sseHeartbeatFrame
+	if framing == SSEHeartbeatDelimitedCommentBlock {
+		heartbeatFrame = sseDelimitedHeartbeatFrame
+	}
+	return r.sendLocked(heartbeatFrame)
 }
 
 // Done closes the event channel, signaling to Read that the stream is finished.

--- a/transports/bifrost-http/lib/streamreader_test.go
+++ b/transports/bifrost-http/lib/streamreader_test.go
@@ -1145,6 +1145,36 @@ func TestSSEStreamReaderSendHeartbeat(t *testing.T) {
 	}
 }
 
+func TestSSEStreamReaderSendHeartbeatWithFraming(t *testing.T) {
+	tests := []struct {
+		name    string
+		framing SSEHeartbeatFraming
+		want    string
+	}{
+		{"bare comment line", SSEHeartbeatBareCommentLine, ": heartbeat\n"},
+		{"delimited comment block", SSEHeartbeatDelimitedCommentBlock, ": heartbeat\n\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewSSEStreamReader()
+			go func() {
+				r.SendHeartbeatWithFraming(tt.framing)
+				r.Done()
+			}()
+
+			buf := make([]byte, 4096)
+			n, err := r.Read(buf)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := string(buf[:n]); got != tt.want {
+				t.Errorf("heartbeat frame = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestSSEStreamReaderSendHeartbeatAfterClose verifies the same disconnect
 // contract as the other Send* wrappers: false once the reader is closed.
 func TestSSEStreamReaderSendHeartbeatAfterClose(t *testing.T) {

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -21,6 +21,7 @@
 
 ## 🐞 Fixed
 
+- **GenAI SSE Heartbeats** - GenAI streams delimit heartbeat comments so Google SDK clients preserve the following event (thanks [@dani29](https://github.com/dani29)!) (#6240)
 - **Path Normalization Auth Bypass** - Fixed a path normalization flaw that allowed auth to be bypassed (#5763)
 - **Minimal Reasoning Effort on GPT-5 Models** - `reasoning_effort: "minimal"` is preserved for GPT-5-family OpenAI models instead of being downgraded to `low` (thanks [@jitokim](https://github.com/jitokim)!) (#6046)
 - **Gemini Truncated Response Finish Reason** - Truncated Gemini responses report `MAX_TOKENS` instead of `OTHER` (thanks [@AdityaPainuli](https://github.com/AdityaPainuli)!) (#5979)


### PR DESCRIPTION
## Summary

Fixes the GenAI SSE interoperability failure reported in #6240 without reverting the older OpenAI Go compatibility fix from #5883.

Bifrost currently emits every heartbeat as a bare comment line (`: heartbeat\n`). The official Google GenAI JavaScript SDK splits streams at blank-line delimiters and discards a combined heartbeat-plus-data block because it does not begin with `data:`. A valid model event, including a function call, can therefore disappear while a later `STOP` event survives.

## Changes

- Add an internal `SSEHeartbeatFraming` abstraction to the stream reader.
- Preserve the bare comment line as the zero-value/default framing for compatibility with `openai-go` before v3.43.0 (#5874).
- Let downstream integrations declare their heartbeat framing through `StreamConfig`.
- Configure the typed GenAI integration to use a self-contained comment block (`: heartbeat\n\n`).
- Keep boundary locking, disconnect detection, Bedrock behavior, and raw passthrough behavior unchanged.
- Add reader-level framing coverage and an integration regression test using the real GenAI route configuration.
- Document the fix in the transports changelog.

The framing choice belongs to the downstream integration contract rather than the upstream provider or model. It is intentionally not exposed as user configuration.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

The GenAI regression test was confirmed red before the implementation: the stream contained bare heartbeat lines and no self-contained comment block.

```sh
go test ./transports/bifrost-http/lib ./transports/bifrost-http/integrations \
  -run 'TestSSEStreamReaderSendHeartbeat|Test_handleStreaming(SSESendsHeartbeatDuringIdleGap|GenAIDelimitsHeartbeatComment)$' \
  -count=1

go test -race ./transports/bifrost-http/lib \
  -run '^(TestSSEStreamReader|TestStartSSEHeartbeat)' \
  -count=1 -timeout=60s

go test -race ./transports/bifrost-http/integrations \
  -run '^Test_handleStreaming(SSESendsHeartbeatDuringIdleGap|GenAIDelimitsHeartbeatComment)$' \
  -count=1 -timeout=60s

go test ./transports/bifrost-http/integrations -count=1 -timeout=90s
go vet ./transports/bifrost-http/lib ./transports/bifrost-http/integrations
```

All commands above pass locally.

A credential-free replay through `@google/genai@2.17.1` also changes from dropping `submit_output` with the bare comment line to preserving it with the delimited comment block.

No new configuration or environment variable is introduced.

## Breaking changes

- [ ] Yes
- [x] No

Existing integrations retain the current bare heartbeat framing unless they explicitly select another framing.

## Related issues

Closes #6240.

Related compatibility fixes: #5874, #5883, #5905, and #5927.

<!-- ref REI-3246 -->

## Security considerations

None. This changes only the framing of synthetic SSE heartbeat comments on the typed GenAI route.

## Checklist

- [x] I read the contribution guidelines and followed the repository conventions.
- [x] I added a regression test and confirmed it failed before the implementation.
- [x] I added reader-level and integration-level coverage.
- [x] I updated the transports changelog.
- [x] The affected Go packages compile and pass targeted tests.
- [x] The affected concurrency paths pass with the race detector.
- [x] No breaking change or user-facing configuration was introduced.
