### PR TITLE
complexity: supports image+text input

### DIFF
--- a/plugins/governance/complexityextract.go
+++ b/plugins/governance/complexityextract.go
@@ -143,8 +143,13 @@ func extractChatText(content *schemas.ChatMessageContent) string {
 	return text
 }
 
-// extractChatTextOnly returns chat content only when every block is text,
-// allowing mixed-modality user prompts to opt out of complexity routing.
+// extractChatTextOnly returns the text portion of a user chat turn, ignoring
+// non-text blocks (images, files, audio) so mixed-modality prompts still feed
+// their text into complexity routing. It succeeds whenever at least one non-empty
+// text block is present; it returns false only when there is no usable text at
+// all. The analyzer self-gates on lexical signal, so a text-light turn with no
+// signal (e.g. "what's this?" beside an image) still yields no tier and falls
+// through to default routing.
 func extractChatTextOnly(content *schemas.ChatMessageContent) (string, bool) {
 	if content == nil {
 		return "", false
@@ -152,16 +157,15 @@ func extractChatTextOnly(content *schemas.ChatMessageContent) (string, bool) {
 	if content.ContentStr != nil {
 		return *content.ContentStr, true
 	}
-	if len(content.ContentBlocks) == 0 {
-		return "", false
-	}
 
 	var text string
 	for _, block := range content.ContentBlocks {
-		if !isChatTextBlock(block) || block.Text == nil || *block.Text == "" {
-			return "", false
+		if isChatTextBlock(block) && block.Text != nil && *block.Text != "" {
+			text = appendText(text, *block.Text)
 		}
-		text = appendText(text, *block.Text)
+	}
+	if strings.TrimSpace(text) == "" {
+		return "", false
 	}
 	return text, true
 }
@@ -185,8 +189,10 @@ func extractResponsesText(content *schemas.ResponsesMessageContent) string {
 	return text
 }
 
-// extractResponsesTextOnly returns Responses content only when every block is
-// input text, avoiding synthesized prompts for mixed-modality user requests.
+// extractResponsesTextOnly returns the text portion of a user Responses turn,
+// ignoring non-text blocks (images, files, audio) so mixed-modality requests
+// still feed their text into complexity routing. It succeeds whenever at least
+// one non-empty input-text block is present, mirroring extractChatTextOnly.
 func extractResponsesTextOnly(content *schemas.ResponsesMessageContent) (string, bool) {
 	if content == nil {
 		return "", false
@@ -194,16 +200,15 @@ func extractResponsesTextOnly(content *schemas.ResponsesMessageContent) (string,
 	if content.ContentStr != nil {
 		return *content.ContentStr, true
 	}
-	if len(content.ContentBlocks) == 0 {
-		return "", false
-	}
 
 	var text string
 	for _, block := range content.ContentBlocks {
-		if !isResponsesInputTextBlock(block) || block.Text == nil || *block.Text == "" {
-			return "", false
+		if isResponsesInputTextBlock(block) && block.Text != nil && *block.Text != "" {
+			text = appendText(text, *block.Text)
 		}
-		text = appendText(text, *block.Text)
+	}
+	if strings.TrimSpace(text) == "" {
+		return "", false
 	}
 	return text, true
 }

--- a/plugins/governance/complexityextract_test.go
+++ b/plugins/governance/complexityextract_test.go
@@ -237,15 +237,17 @@ func TestBuildComplexityInput_SkipsUnsupportedRequestTypesEvenWhenTextIsPresent(
 	assert.Empty(t, input.LastUserText)
 }
 
-func TestBuildComplexityInput_SkipsMixedModalityUserContent(t *testing.T) {
+func TestBuildComplexityInput_ExtractsTextFromMixedModalityUserContent(t *testing.T) {
 	userRole := schemas.ResponsesInputMessageRoleUser
 
 	tests := []struct {
-		name string
-		req  *schemas.BifrostRequest
+		name     string
+		req      *schemas.BifrostRequest
+		wantText string
 	}{
 		{
-			name: "chat_text_plus_image",
+			name:     "chat_text_plus_image",
+			wantText: "What changed in this screenshot?",
 			req: &schemas.BifrostRequest{
 				RequestType: schemas.ChatCompletionRequest,
 				ChatRequest: &schemas.BifrostChatRequest{
@@ -262,7 +264,8 @@ func TestBuildComplexityInput_SkipsMixedModalityUserContent(t *testing.T) {
 			},
 		},
 		{
-			name: "responses_text_plus_file",
+			name:     "responses_text_plus_file",
+			wantText: "Summarize this document",
 			req: &schemas.BifrostRequest{
 				RequestType: schemas.ResponsesRequest,
 				ResponsesRequest: &schemas.BifrostResponsesRequest{
@@ -271,6 +274,56 @@ func TestBuildComplexityInput_SkipsMixedModalityUserContent(t *testing.T) {
 							Role: &userRole,
 							Content: complexityResponsesBlocks(
 								complexityResponsesTextBlock("Summarize this document"),
+								schemas.ResponsesMessageContentBlock{Type: schemas.ResponsesInputMessageContentBlockTypeFile},
+							),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, ok := buildComplexityInput(tt.req)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantText, input.LastUserText)
+		})
+	}
+}
+
+func TestBuildComplexityInput_SkipsUserContentWithoutText(t *testing.T) {
+	userRole := schemas.ResponsesInputMessageRoleUser
+
+	tests := []struct {
+		name string
+		req  *schemas.BifrostRequest
+	}{
+		{
+			name: "chat_image_only",
+			req: &schemas.BifrostRequest{
+				RequestType: schemas.ChatCompletionRequest,
+				ChatRequest: &schemas.BifrostChatRequest{
+					Input: []schemas.ChatMessage{
+						{
+							Role: schemas.ChatMessageRoleUser,
+							Content: complexityChatBlocks(
+								schemas.ChatContentBlock{Type: schemas.ChatContentBlockTypeImage},
+							),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "responses_file_only",
+			req: &schemas.BifrostRequest{
+				RequestType: schemas.ResponsesRequest,
+				ResponsesRequest: &schemas.BifrostResponsesRequest{
+					Input: []schemas.ResponsesMessage{
+						{
+							Role: &userRole,
+							Content: complexityResponsesBlocks(
 								schemas.ResponsesMessageContentBlock{Type: schemas.ResponsesInputMessageContentBlockTypeFile},
 							),
 						},


### PR DESCRIPTION
## Summary

Mixed-modality user turns (e.g. text + image, text + file) were previously excluded entirely from complexity routing because the extraction functions returned false as soon as any non-text block was encountered. This meant the text portion of those prompts was silently dropped, preventing the complexity analyzer from acting on legitimate lexical signal. This PR changes the extraction logic to collect text blocks and ignore non-text blocks, so mixed-modality prompts still contribute their text to routing.

## Changes

- `extractChatTextOnly` and `extractResponsesTextOnly` now iterate all content blocks, accumulate text from text-typed blocks, and skip non-text blocks (images, files, audio) rather than bailing out on the first non-text block.
- Both functions now return false only when no usable text is found at all (empty or whitespace-only result), preserving the existing behavior for purely non-text turns.
- The early-exit guard on empty `ContentBlocks` slices was removed since the loop and the post-loop empty check handle that case correctly.
- The test `TestBuildComplexityInput_SkipsMixedModalityUserContent` was renamed to `TestBuildComplexityInput_ExtractsTextFromMixedModalityUserContent` and updated to assert that the extracted text matches the text block content.
- A new test `TestBuildComplexityInput_SkipsUserContentWithoutText` covers the case where a turn contains only non-text blocks (image-only, file-only), confirming those still produce no complexity input.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/...
```

The updated and new test cases cover both the mixed-modality extraction path and the text-absent fallback path. Confirm that `TestBuildComplexityInput_ExtractsTextFromMixedModalityUserContent` passes with the expected text values and that `TestBuildComplexityInput_SkipsUserContentWithoutText` confirms no input is produced for image-only or file-only turns.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No auth, secrets, PII, or sandboxing implications. The change affects only how text is extracted from structured content blocks before being passed to the complexity analyzer.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable