### PR TITLE
feat: replace per-request semaphore drop model with batched buffer flushing for observability plugins and add configurable `observability_flush_interval_seconds`

### DIFF
--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -77,34 +77,35 @@ type ClientConfig struct {
 	AllowPerRequestRawOverride            bool                                  `json:"allow_per_request_raw_override"`             // Allow per-request override of raw request/response visibility via x-bf-send-back-raw-request and x-bf-send-back-raw-response headers
 	AllowDirectKeys                       bool                                  `json:"allow_direct_keys"`                          // Allow callers to bypass the registered key pool via x-bf-direct-key: true header
 	DisableDBPingsInHealth                bool                                  `json:"disable_db_pings_in_health"`
-	LogRetentionDays                      int                                   `json:"log_retention_days" validate:"min=1"`         // Number of days to retain logs (minimum 1 day)
-	EnforceAuthOnInference                bool                                  `json:"enforce_auth_on_inference"`                   // Require auth (VK, API key, or user token) on inference endpoints
-	DualCredentialConflictBehavior        tables.DualCredentialConflictBehavior `json:"dual_credential_conflict_behavior,omitempty"` // Behavior when both an IDP token and a VK are present on an inference request
-	EnforceGovernanceHeader               bool                                  `json:"enforce_governance_header,omitempty"`         // Deprecated: use EnforceAuthOnInference
-	EnforceSCIMAuth                       bool                                  `json:"enforce_scim_auth,omitempty"`                 // Deprecated: use EnforceAuthOnInference
-	AllowedOrigins                        []string                              `json:"allowed_origins,omitempty"`                   // Additional allowed origins for CORS and WebSocket (localhost is always allowed)
-	AllowedHeaders                        []string                              `json:"allowed_headers,omitempty"`                   // Additional allowed headers for CORS and WebSocket
-	MaxRequestBodySizeMB                  int                                   `json:"max_request_body_size_mb"`                    // The maximum request body size in MB
-	Compat                                CompatConfig                          `json:"compat"`                                      // Compat plugin configuration
-	MCPAgentDepth                         int                                   `json:"mcp_agent_depth"`                             // The maximum depth for MCP agent mode tool execution
-	MCPToolExecutionTimeout               int                                   `json:"mcp_tool_execution_timeout"`                  // The timeout for individual tool execution in seconds
-	MCPCodeModeBindingLevel               string                                `json:"mcp_code_mode_binding_level"`                 // Code mode binding level: "server" or "tool"
-	MCPToolSyncInterval                   int                                   `json:"mcp_tool_sync_interval"`                      // Global tool sync interval in minutes (default: 10, 0 = disabled)
-	MCPDisableAutoToolInject              bool                                  `json:"mcp_disable_auto_tool_inject"`                // When true, MCP tools are not injected into requests by default
-	MCPEnableTempTokenAuth                bool                                  `json:"mcp_enable_temp_token_auth"`                  // When true, scoped temp tokens can authorize MCP per-user OAuth and per-user-headers auth pages. User-mode flows never mint regardless.
-	HeaderFilterConfig                    *tables.GlobalHeaderFilterConfig      `json:"header_filter_config,omitempty"`              // Global header filtering configuration for x-bf-eh-* headers
-	AsyncJobResultTTL                     int                                   `json:"async_job_result_ttl"`                        // Default TTL for async job results in seconds (default: 3600 = 1 hour)
-	RequiredHeaders                       []string                              `json:"required_headers,omitempty"`                  // Headers that must be present on every request (case-insensitive)
-	LoggingHeaders                        []string                              `json:"logging_headers,omitempty"`                   // Headers to capture in log metadata
-	WhitelistedRoutes                     []string                              `json:"whitelisted_routes,omitempty"`                // Routes that bypass auth middleware
-	HideDeletedVirtualKeysInFilters       bool                                  `json:"hide_deleted_virtual_keys_in_filters"`        // Hide deleted virtual keys from logs/MCP filter data
-	RoutingChainMaxDepth                  int                                   `json:"routing_chain_max_depth"`                     // Maximum depth for routing rule chain evaluation (default: 10)
-	MCPExternalClientURL                  *schemas.SecretVar                    `json:"mcp_external_client_url,omitempty"`           // Public base URL used as redirect_uri when Bifrost acts as an OAuth client to upstream MCP servers. Supports env var syntax ("env.MY_VAR")
-	MCPServerAuthMode                     tables.MCPServerAuthMode              `json:"mcp_server_auth_mode,omitempty"`              // How /mcp authenticates inbound clients: headers (default), both, or oauth.
-	OAuth2ServerConfig                    *tables.OAuth2ServerConfig            `json:"oauth2_server_config,omitempty"`              // OAuth2 AS-specific settings (IssuerURL, token TTLs). Only relevant when MCPServerAuthMode is both or oauth.
-	ConfigHash                            string                                `json:"-"`                                           // Config hash for reconciliation (not serialized)
-	DumpErrorsInConsoleLogs               bool                                  `json:"dump_errors_in_console_logs"`                 // Dump error details in console logs
-	WebhookConfig                         *tables.WebhookConfig                 `json:"webhook_config,omitempty"`                    // Global webhook delivery settings; nil means all defaults
+	LogRetentionDays                      int                                   `json:"log_retention_days" validate:"min=1"`            // Number of days to retain logs (minimum 1 day)
+	EnforceAuthOnInference                bool                                  `json:"enforce_auth_on_inference"`                      // Require auth (VK, API key, or user token) on inference endpoints
+	DualCredentialConflictBehavior        tables.DualCredentialConflictBehavior `json:"dual_credential_conflict_behavior,omitempty"`    // Behavior when both an IDP token and a VK are present on an inference request
+	EnforceGovernanceHeader               bool                                  `json:"enforce_governance_header,omitempty"`            // Deprecated: use EnforceAuthOnInference
+	EnforceSCIMAuth                       bool                                  `json:"enforce_scim_auth,omitempty"`                    // Deprecated: use EnforceAuthOnInference
+	AllowedOrigins                        []string                              `json:"allowed_origins,omitempty"`                      // Additional allowed origins for CORS and WebSocket (localhost is always allowed)
+	AllowedHeaders                        []string                              `json:"allowed_headers,omitempty"`                      // Additional allowed headers for CORS and WebSocket
+	MaxRequestBodySizeMB                  int                                   `json:"max_request_body_size_mb"`                       // The maximum request body size in MB
+	Compat                                CompatConfig                          `json:"compat"`                                         // Compat plugin configuration
+	MCPAgentDepth                         int                                   `json:"mcp_agent_depth"`                                // The maximum depth for MCP agent mode tool execution
+	MCPToolExecutionTimeout               int                                   `json:"mcp_tool_execution_timeout"`                     // The timeout for individual tool execution in seconds
+	MCPCodeModeBindingLevel               string                                `json:"mcp_code_mode_binding_level"`                    // Code mode binding level: "server" or "tool"
+	MCPToolSyncInterval                   int                                   `json:"mcp_tool_sync_interval"`                         // Global tool sync interval in minutes (default: 10, 0 = disabled)
+	MCPDisableAutoToolInject              bool                                  `json:"mcp_disable_auto_tool_inject"`                   // When true, MCP tools are not injected into requests by default
+	MCPEnableTempTokenAuth                bool                                  `json:"mcp_enable_temp_token_auth"`                     // When true, scoped temp tokens can authorize MCP per-user OAuth and per-user-headers auth pages. User-mode flows never mint regardless.
+	HeaderFilterConfig                    *tables.GlobalHeaderFilterConfig      `json:"header_filter_config,omitempty"`                 // Global header filtering configuration for x-bf-eh-* headers
+	AsyncJobResultTTL                     int                                   `json:"async_job_result_ttl"`                           // Default TTL for async job results in seconds (default: 3600 = 1 hour)
+	RequiredHeaders                       []string                              `json:"required_headers,omitempty"`                     // Headers that must be present on every request (case-insensitive)
+	LoggingHeaders                        []string                              `json:"logging_headers,omitempty"`                      // Headers to capture in log metadata
+	WhitelistedRoutes                     []string                              `json:"whitelisted_routes,omitempty"`                   // Routes that bypass auth middleware
+	HideDeletedVirtualKeysInFilters       bool                                  `json:"hide_deleted_virtual_keys_in_filters"`           // Hide deleted virtual keys from logs/MCP filter data
+	RoutingChainMaxDepth                  int                                   `json:"routing_chain_max_depth"`                        // Maximum depth for routing rule chain evaluation (default: 10)
+	MCPExternalClientURL                  *schemas.SecretVar                    `json:"mcp_external_client_url,omitempty"`              // Public base URL used as redirect_uri when Bifrost acts as an OAuth client to upstream MCP servers. Supports env var syntax ("env.MY_VAR")
+	MCPServerAuthMode                     tables.MCPServerAuthMode              `json:"mcp_server_auth_mode,omitempty"`                 // How /mcp authenticates inbound clients: headers (default), both, or oauth.
+	OAuth2ServerConfig                    *tables.OAuth2ServerConfig            `json:"oauth2_server_config,omitempty"`                 // OAuth2 AS-specific settings (IssuerURL, token TTLs). Only relevant when MCPServerAuthMode is both or oauth.
+	ConfigHash                            string                                `json:"-"`                                              // Config hash for reconciliation (not serialized)
+	DumpErrorsInConsoleLogs               bool                                  `json:"dump_errors_in_console_logs"`                    // Dump error details in console logs
+	WebhookConfig                         *tables.WebhookConfig                 `json:"webhook_config,omitempty"`                       // Global webhook delivery settings; nil means all defaults
+	ObservabilityFlushIntervalSeconds     int                                   `json:"observability_flush_interval_seconds,omitempty"` // Interval in seconds for flushing observability data to the backend. Default is 10 seconds. Only through config.json
 }
 
 // IsMCPOAuthDiscoveryEnabled reports whether the well-known OAuth discovery

--- a/framework/tracing/obsisolation_test.go
+++ b/framework/tracing/obsisolation_test.go
@@ -60,15 +60,44 @@ func (p *blockingObsPlugin) Inject(_ context.Context, _ *schemas.Trace) error {
 	return nil
 }
 
-// TestCompleteAndFlushTrace_SlowPluginDoesNotDelayOthers is the core regression: the
-// observability plugins used to be invoked sequentially on a single flush goroutine, so
-// a connector doing blocking network I/O sat in front of every plugin after it —
-// including the logging plugin, whose Inject is what enqueues the row for Postgres.
+// newTestTracer builds a tracer with a short flush interval so tests don't wait the full 10s tick to see a low-volume trace delivered.
+func newTestTracer(store *TraceStore, flushInterval time.Duration) *Tracer {
+	tracer := NewTracer(store, nil, nil)
+	tracer.flushInterval = flushInterval
+	return tracer
+}
+
+// TestSetObservabilityFlushIntervalSeconds covers the config-supplied interval: valid values
+// pass through and non-positive falls back to the default.
+func TestSetObservabilityFlushIntervalSeconds(t *testing.T) {
+	cases := []struct {
+		in   int
+		want time.Duration
+	}{
+		{0, DefaultObservabilityFlushInterval},
+		{-5, DefaultObservabilityFlushInterval},
+		{30, 30 * time.Second},
+		{600, 600 * time.Second},
+	}
+	for _, c := range cases {
+		store := NewTraceStore(time.Minute, nil)
+		tr := NewTracer(store, nil, nil)
+		tr.SetObservabilityFlushIntervalSeconds(c.in)
+		if tr.flushInterval != c.want {
+			t.Fatalf("SetObservabilityFlushIntervalSeconds(%d) = %v, want %v", c.in, tr.flushInterval, c.want)
+		}
+		store.Stop()
+	}
+}
+
+// TestCompleteAndFlushTrace_SlowPluginDoesNotDelayOthers is the core isolation guarantee:
+// a connector doing blocking network I/O in Inject must not hold up delivery to another
+// connector — including the logging plugin, whose Inject enqueues the row for the DB.
 func TestCompleteAndFlushTrace_SlowPluginDoesNotDelayOthers(t *testing.T) {
 	store := NewTraceStore(5*time.Minute, nil)
 	defer store.Stop()
 
-	tracer := NewTracer(store, nil, nil)
+	tracer := newTestTracer(store, 20*time.Millisecond)
 	defer tracer.Stop()
 
 	const slowInject = 750 * time.Millisecond
@@ -96,50 +125,152 @@ func TestCompleteAndFlushTrace_SlowPluginDoesNotDelayOthers(t *testing.T) {
 	}
 }
 
-// TestCompleteAndFlushTrace_BoundsInjectsPerPlugin verifies the concurrency cap. Without
-// it, one goroutine and one full trace snapshot accumulate per request for as long as the
-// collector hangs, and that heap/scheduler pressure is what starves the log batch writer.
-func TestCompleteAndFlushTrace_BoundsInjectsPerPlugin(t *testing.T) {
+// TestCompleteAndFlushTrace_CountTriggerFlushesBeforeTick verifies the count trigger: once a
+// connector's buffer reaches batchSize it flushes immediately, without waiting for the
+// interval tick, and nothing is dropped.
+func TestCompleteAndFlushTrace_CountTriggerFlushesBeforeTick(t *testing.T) {
 	store := NewTraceStore(5*time.Minute, nil)
 	defer store.Stop()
 
-	tracer := NewTracer(store, nil, nil)
+	// Long interval so the timer cannot be what flushes — only the size trigger can.
+	tracer := newTestTracer(store, time.Hour)
+	defer tracer.Stop()
+	tracer.batchSize = 64
 
-	stuck := &blockingObsPlugin{name: "stuck-connector", release: make(chan struct{})}
-	tracer.SetObservabilityPlugins([]schemas.ObservabilityPlugin{stuck})
+	counter := &blockingObsPlugin{name: "counter"}
+	tracer.SetObservabilityPlugins([]schemas.ObservabilityPlugin{counter})
 
-	const overshoot = 250
-	total := maxConcurrentInjectsPerPlugin + overshoot
+	// Exactly one full batch: the 64th append should trigger a flush on its own.
+	for range 64 {
+		tracer.CompleteAndFlushTrace(tracer.CreateTrace(""))
+	}
+	tracer.waitForFlushes(5 * time.Second)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for counter.started.Load() < 64 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := counter.started.Load(); got != 64 {
+		t.Fatalf("expected all 64 buffered traces delivered by the size trigger, got %d", got)
+	}
+	if dropped := tracer.ObservabilityDropCounts()["counter"]; dropped != 0 {
+		t.Fatalf("expected no drops, got %d", dropped)
+	}
+}
+
+// TestCompleteAndFlushTrace_HungPluginBuffersThenDeliversAll is the end-to-end promise:
+// push 10000 traces at a plugin whose Inject hangs. They fill the buffer and pile up behind
+// blocked flush goroutines — delivered nowhere, but dropped nowhere either. Once the plugin
+// unblocks, every single one of the 10000 must drain through.
+func TestCompleteAndFlushTrace_HungPluginBuffersThenDeliversAll(t *testing.T) {
+	store := NewTraceStore(5*time.Minute, nil)
+	defer store.Stop()
+
+	// Short interval so the trailing partial batch (10000 is not a multiple of 1024) is
+	// flushed by the timer too, exercising both triggers under the hang.
+	tracer := newTestTracer(store, 50*time.Millisecond)
+	tracer.batchSize = 1024
+	defer tracer.Stop()
+
+	hung := &blockingObsPlugin{name: "hung", release: make(chan struct{})}
+	// Release on every exit path so a failed assertion doesn't leave flush goroutines
+	// blocked in Inject (pinning their batches) for the rest of the package run.
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(hung.release) }) }
+	defer release()
+	tracer.SetObservabilityPlugins([]schemas.ObservabilityPlugin{hung})
+
+	const total = 10000
 	for range total {
 		tracer.CompleteAndFlushTrace(tracer.CreateTrace(""))
 	}
-
-	// Wait for the semaphore to saturate and the excess to be skipped.
-	deadline := time.Now().Add(10 * time.Second)
-	for tracer.ObservabilityDropCounts()["stuck-connector"] == 0 && time.Now().Before(deadline) {
-		time.Sleep(5 * time.Millisecond)
+	// All producer appends complete quickly even though every flush goroutine is stuck.
+	if !tracer.waitForFlushes(5 * time.Second) {
+		t.Fatal("producers did not finish appending")
 	}
 
-	if got := stuck.maxInFlight.Load(); got > maxConcurrentInjectsPerPlugin {
-		t.Fatalf("concurrent injects exceeded the cap: got %d, cap %d", got, maxConcurrentInjectsPerPlugin)
+	// Wait — with a deadline, not a fixed sleep — until every count-triggered batch is
+	// dispatched and blocked in Inject. total/1024 = 9 full batches are guaranteed regardless
+	// of scheduler timing (the trailing 784 flush via the timer or the final drain). A delayed
+	// scheduler only makes this poll take longer; it cannot let the test pass before the work
+	// has happened. The bound is `>= minBatches` because a timer tick may also dispatch the
+	// partial, which would only raise the count — never lower it.
+	const minBatches = total / 1024 // 9
+	deadline := time.Now().Add(5 * time.Second)
+	for hung.inFlight.Load() < minBatches && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
 	}
-	if dropped := tracer.ObservabilityDropCounts()["stuck-connector"]; dropped == 0 {
-		t.Fatal("expected traces to be skipped once the plugin saturated, got 0")
+	// Each blocked flush goroutine is stuck on the first trace of its batch, so inFlight ==
+	// started == number of dispatched batches: some traces are in Inject, the vast majority
+	// wait behind them — and none are dropped.
+	if got := hung.inFlight.Load(); got < minBatches {
+		t.Fatalf("expected at least %d flush goroutines blocked in Inject, got %d", minBatches, got)
+	}
+	if s := hung.started.Load(); s >= total {
+		t.Fatalf("while hung, expected some-but-not-all traces in Inject, got %d/%d", s, total)
+	}
+	if d := tracer.ObservabilityDropCounts()["hung"]; d != 0 {
+		t.Fatalf("expected no drops while buffering, got %d", d)
 	}
 
-	close(stuck.release)
-	tracer.Stop()
+	// Release: every buffered / in-flight trace must now drain through.
+	release()
+
+	deadline = time.Now().Add(15 * time.Second)
+	for hung.started.Load() < total && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Millisecond)
+	}
+	if got := hung.started.Load(); got != total {
+		t.Fatalf("expected all %d traces delivered after release, got %d", total, got)
+	}
+	if d := tracer.ObservabilityDropCounts()["hung"]; d != 0 {
+		t.Fatalf("expected zero drops overall, got %d", d)
+	}
 }
 
-// TestWaitForFlushes_TimesOutOnHungPlugin ensures a connector blocked on an unreachable
-// collector cannot hold up shutdown or a config reload.
-func TestWaitForFlushes_TimesOutOnHungPlugin(t *testing.T) {
+// TestCompleteAndFlushTrace_TimerFlushesPartialBatch verifies the interval trigger: a
+// sub-batch of traces that never reaches batchSize is still delivered on the next tick.
+func TestCompleteAndFlushTrace_TimerFlushesPartialBatch(t *testing.T) {
 	store := NewTraceStore(5*time.Minute, nil)
 	defer store.Stop()
 
-	tracer := NewTracer(store, nil, nil)
+	tracer := newTestTracer(store, 20*time.Millisecond)
+	defer tracer.Stop()
+	tracer.batchSize = 1024 // far above what we push, so only the timer can flush
+
+	counter := &blockingObsPlugin{name: "counter"}
+	tracer.SetObservabilityPlugins([]schemas.ObservabilityPlugin{counter})
+
+	const n = 5
+	for range n {
+		tracer.CompleteAndFlushTrace(tracer.CreateTrace(""))
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for counter.started.Load() < n && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := counter.started.Load(); got != n {
+		t.Fatalf("expected the partial batch of %d flushed by the timer, got %d", n, got)
+	}
+}
+
+// TestDrainObsPlugins_TimesOutOnHungPlugin ensures a connector blocked on an unreachable
+// collector cannot hold up shutdown or a config reload. The blocking work lives in a flush
+// goroutine, so the bounded wait that protects shutdown is drainObsPlugins.
+func TestDrainObsPlugins_TimesOutOnHungPlugin(t *testing.T) {
+	store := NewTraceStore(5*time.Minute, nil)
+	defer store.Stop()
+
+	tracer := newTestTracer(store, 20*time.Millisecond)
+	defer tracer.Stop()
 
 	hung := &blockingObsPlugin{name: "hung-connector", release: make(chan struct{})}
+	// Release on every exit path so a failed assertion doesn't leave a flush goroutine
+	// blocked in Inject for the rest of the package run.
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(hung.release) }) }
+	defer release()
 	tracer.SetObservabilityPlugins([]schemas.ObservabilityPlugin{hung})
 	tracer.CompleteAndFlushTrace(tracer.CreateTrace(""))
 
@@ -151,16 +282,22 @@ func TestWaitForFlushes_TimesOutOnHungPlugin(t *testing.T) {
 		t.Fatal("hung plugin was never injected")
 	}
 
-	start := time.Now()
-	if completed := tracer.waitForFlushes(200 * time.Millisecond); completed {
-		t.Fatal("waitForFlushes reported completion while a plugin was still blocked")
-	}
-	if elapsed := time.Since(start); elapsed > 2*time.Second {
-		t.Fatalf("waitForFlushes did not honour its timeout: took %v", elapsed)
+	// The producer append completes promptly even while a flush goroutine is stuck in Inject.
+	if completed := tracer.waitForFlushes(2 * time.Second); !completed {
+		t.Fatal("waitForFlushes should complete once the snapshot is appended")
 	}
 
-	close(hung.release)
-	tracer.Stop()
+	// Draining, however, must honour its timeout rather than block on the stuck Inject.
+	start := time.Now()
+	tracer.drainObsPlugins(200 * time.Millisecond)
+	if elapsed := time.Since(start); elapsed < 200*time.Millisecond {
+		t.Fatalf("drainObsPlugins returned before a blocked flush could have finished: %v", elapsed)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("drainObsPlugins did not honour its timeout: took %v", elapsed)
+	}
+
+	release()
 }
 
 // TestSetObservabilityPlugins_DedupesByName preserves the behaviour the old flush loop
@@ -169,27 +306,58 @@ func TestSetObservabilityPlugins_DedupesByName(t *testing.T) {
 	store := NewTraceStore(5*time.Minute, nil)
 	defer store.Stop()
 
-	tracer := NewTracer(store, nil, nil)
+	tracer := newTestTracer(store, 20*time.Millisecond)
 	defer tracer.Stop()
 
 	dup := &blockingObsPlugin{name: "dup-connector"}
 	tracer.SetObservabilityPlugins([]schemas.ObservabilityPlugin{dup, dup, dup})
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tracer.CompleteAndFlushTrace(tracer.CreateTrace(""))
-	}()
-	wg.Wait()
+	// Dedup is structural: three identically-named plugins collapse to a single slot. Assert
+	// that directly — it's deterministic — instead of waiting to see whether a duplicate slot
+	// also fires.
+	loaded := tracer.obsPlugins.Load()
+	n := 0
+	if loaded != nil {
+		n = len(*loaded)
+	}
+	if n != 1 {
+		t.Fatalf("expected exactly one slot after dedup, got %d", n)
+	}
 
+	// The single slot still delivers: one trace in, injected exactly once. Deadline-bounded
+	// wait, no fixed sleep.
+	tracer.CompleteAndFlushTrace(tracer.CreateTrace(""))
 	deadline := time.Now().Add(5 * time.Second)
-	for dup.started.Load() == 0 && time.Now().Before(deadline) {
+	for dup.started.Load() < 1 && time.Now().Before(deadline) {
 		time.Sleep(time.Millisecond)
 	}
-	tracer.waitForFlushes(5 * time.Second)
-
 	if got := dup.started.Load(); got != 1 {
-		t.Fatalf("expected a duplicate-named plugin to be injected once, got %d", got)
+		t.Fatalf("expected the deduped plugin injected once, got %d", got)
+	}
+}
+
+// TestObsSlot_PostCloseEnqueueStillDelivers is the shutdown-window guarantee: a trace
+// appended after the slot has been told to stop — a producer still holding a retired slot
+// during a config reload — is flushed immediately rather than lost in a batch the timer will
+// never drain again.
+func TestObsSlot_PostCloseEnqueueStillDelivers(t *testing.T) {
+	p := &blockingObsPlugin{name: "late"}
+	slot := &obsPluginSlot{
+		plugin:        p,
+		name:          p.name,
+		batchSize:     1000,      // never reached; only the timer or close flushes
+		flushInterval: time.Hour, // never ticks during the test
+		stop:          make(chan struct{}),
+	}
+	slot.start(nil)
+
+	// One buffered before close (drained by the final flush), one after close (self-flushed).
+	slot.enqueue(&schemas.Trace{}, nil)
+	slot.signalStop()
+	slot.enqueue(&schemas.Trace{}, nil)
+
+	slot.wg.Wait()
+	if got := p.started.Load(); got != 2 {
+		t.Fatalf("expected both traces delivered (none lost across close), got %d", got)
 	}
 }

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -14,28 +14,126 @@ import (
 )
 
 const (
-	// maxConcurrentInjectsPerPlugin bounds how many traces may sit inside a single
-	// observability connector's Inject at once. A connector pointed at a wrong or
-	// black-holed endpoint blocks on network I/O while pinning a full trace snapshot;
-	// uncapped that is one goroutine and one snapshot per request, whose heap and
-	// scheduler pressure starves the rest of the process — notably the logging
-	// plugin's single DB batch writer, whose queue then drops rows silently.
-	// Each connector gets its own budget so a stalled one cannot crowd out a healthy one.
-	maxConcurrentInjectsPerPlugin = 1024
+	DefaultObservabilityBatchSize     = 1000             // number of traces to accumulate before flushing to a connector; the count cap is the primary trigger for busy connectors
+	DefaultObservabilityFlushInterval = 10 * time.Second // how often to flush a connector's buffer, even if the count cap hasn't been hit
 
-	// flushStopTimeout bounds how long Stop waits for in-flight trace exports, so a
-	// hung collector cannot block shutdown or a config reload.
+	// flushStopTimeout bounds how long Stop waits for in-flight flushes, so a hung
+	// connector cannot block shutdown or a config reload.
 	flushStopTimeout = 10 * time.Second
 )
 
-// obsPluginSlot pairs an observability plugin with its own concurrency budget and
-// drop counter. Isolating the budget per connector is what keeps a misconfigured
-// exporter from consuming the capacity that healthy connectors need.
+// obsPluginSlot gives one observability plugin its own batch buffer and a timer goroutine
+// that flushes it. Traces accumulate in the buffer; a flush hands the whole batch to a new
+// goroutine (so it never blocks accumulation) which delivers each trace via Inject. Nothing
+// is dropped — producers always append. Each connector has its own buffer so a slow one
+// can't hold up the others.
 type obsPluginSlot struct {
-	plugin  schemas.ObservabilityPlugin
-	name    string
-	sem     chan struct{}
-	dropped atomic.Int64
+	plugin schemas.ObservabilityPlugin
+	name   string
+
+	batchSize     int
+	flushInterval time.Duration
+
+	mu     sync.Mutex       // guards batch and closed
+	batch  []*schemas.Trace // accumulating buffer; swapped out on flush
+	closed bool             // set once the timer goroutine is stopping; late appends flush immediately
+
+	stop    chan struct{}  // closed to tell the timer goroutine to do a final flush and exit
+	stopped sync.Once      // so stop is only closed once (reload and Stop can race)
+	wg      sync.WaitGroup // timer goroutine + in-flight flush goroutines, for a bounded drain
+
+	dropped atomic.Int64 // retained for ObservabilityDropCounts; stays 0 in this design
+}
+
+// start launches the timer goroutine that flushes the buffer every flushInterval.
+func (s *obsPluginSlot) start(logger schemas.Logger) {
+	s.wg.Add(1)
+	go s.run(logger)
+}
+
+// run flushes on every tick and once more on stop, so buffered traces are delivered even
+// when traffic is too light to ever fill a batch.
+func (s *obsPluginSlot) run(logger schemas.Logger) {
+	defer s.wg.Done()
+	ticker := time.NewTicker(s.flushInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			s.flush(s.take(), logger)
+		case <-s.stop:
+			s.flush(s.take(), logger) // final flush of whatever is left
+			return
+		}
+	}
+}
+
+// enqueue appends a trace and flushes early once the buffer reaches the count cap.
+func (s *obsPluginSlot) enqueue(trace *schemas.Trace, logger schemas.Logger) {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		s.flush([]*schemas.Trace{trace}, logger)
+		return
+	}
+	s.batch = append(s.batch, trace)
+	if len(s.batch) < s.batchSize {
+		s.mu.Unlock()
+		return
+	}
+	batch := s.batch
+	s.batch = nil
+	s.mu.Unlock()
+	s.flush(batch, logger)
+}
+
+// take atomically swaps the current buffer out for a fresh one and returns it.
+func (s *obsPluginSlot) take() []*schemas.Trace {
+	s.mu.Lock()
+	batch := s.batch
+	s.batch = nil
+	s.mu.Unlock()
+	return batch
+}
+
+// flush delivers a batch on its own goroutine so accumulation never blocks on a slow
+// connector. Empty batches are a no-op.
+func (s *obsPluginSlot) flush(batch []*schemas.Trace, logger schemas.Logger) {
+	if len(batch) == 0 {
+		return
+	}
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		for _, trace := range batch {
+			s.inject(trace, logger)
+		}
+	}()
+}
+
+// inject hands one trace to the plugin, recovering from panics so a bad backend can't take
+// down the flush goroutine.
+func (s *obsPluginSlot) inject(trace *schemas.Trace, logger schemas.Logger) {
+	defer func() {
+		if r := recover(); r != nil && logger != nil {
+			logger.Error("observability plugin %s panicked during trace injection: %v", s.name, r)
+		}
+	}()
+	if err := s.plugin.Inject(context.Background(), trace); err != nil && logger != nil {
+		logger.Warn("observability plugin %s failed to inject trace: %v", s.name, err)
+	}
+}
+
+// signalStop tells the timer goroutine to do its final flush and exit. Safe to call twice.
+// closed is set before stop is closed so a concurrent enqueue either lands in the buffer the
+// final flush will drain, or observes closed and flushes on its own — never lost.
+func (s *obsPluginSlot) signalStop() {
+	s.stopped.Do(func() {
+		s.mu.Lock()
+		s.closed = true
+		s.mu.Unlock()
+		close(s.stop)
+	})
 }
 
 // Tracer implements schemas.Tracer using TraceStore.
@@ -50,6 +148,12 @@ type Tracer struct {
 	obsPlugins        atomic.Pointer[[]*obsPluginSlot]
 	cachedHdrPatterns atomic.Pointer[[]string]
 	flushWG           sync.WaitGroup
+
+	// batchSize and flushInterval size each connector's buffer, read when the plugin slots are
+	// built. They default to the DefaultObservability* values; tests override them before
+	// SetObservabilityPlugins.
+	batchSize     int
+	flushInterval time.Duration
 }
 
 // NewTracer creates a new Tracer wrapping the given TraceStore.
@@ -62,7 +166,23 @@ func NewTracer(store *TraceStore, pricingManager *modelcatalog.ModelCatalog, log
 		pricingManager: pricingManager,
 		logger:         logger,
 		obsPlugins:     atomic.Pointer[[]*obsPluginSlot]{},
+		batchSize:      DefaultObservabilityBatchSize,
+		flushInterval:  DefaultObservabilityFlushInterval,
 	}
+}
+
+// SetObservabilityFlushIntervalSeconds sets how often each connector flushes its buffer,
+// from a config-supplied seconds value. Non-positive falls back to the default.
+// Call before SetObservabilityPlugins for it to take effect.
+func (t *Tracer) SetObservabilityFlushIntervalSeconds(seconds int) {
+	if t == nil {
+		return
+	}
+	if seconds <= 0 {
+		t.flushInterval = DefaultObservabilityFlushInterval
+		return
+	}
+	t.flushInterval = time.Duration(seconds) * time.Second
 }
 
 // SetObservabilityPlugins updates the plugins that receive completed traces.
@@ -72,9 +192,17 @@ func (t *Tracer) SetObservabilityPlugins(obsPlugins []schemas.ObservabilityPlugi
 	if t == nil {
 		return
 	}
-	// Build one slot per distinct plugin, each with its own concurrency budget.
+	// Build one slot per distinct plugin, each with its own buffer and timer goroutine.
 	// Deduplication by name happens here rather than on every flush, so the hot
 	// path does not rebuild a map per trace.
+	batchSize := t.batchSize
+	if batchSize <= 0 {
+		batchSize = DefaultObservabilityBatchSize
+	}
+	flushInterval := t.flushInterval
+	if flushInterval <= 0 {
+		flushInterval = DefaultObservabilityFlushInterval
+	}
 	slots := make([]*obsPluginSlot, 0, len(obsPlugins))
 	seenPlugins := make(map[string]struct{}, len(obsPlugins))
 	for _, plugin := range obsPlugins {
@@ -86,13 +214,26 @@ func (t *Tracer) SetObservabilityPlugins(obsPlugins []schemas.ObservabilityPlugi
 			continue
 		}
 		seenPlugins[name] = struct{}{}
-		slots = append(slots, &obsPluginSlot{
-			plugin: plugin,
-			name:   name,
-			sem:    make(chan struct{}, maxConcurrentInjectsPerPlugin),
-		})
+		slot := &obsPluginSlot{
+			plugin:        plugin,
+			name:          name,
+			batchSize:     batchSize,
+			flushInterval: flushInterval,
+			stop:          make(chan struct{}),
+		}
+		slot.start(t.logger)
+		slots = append(slots, slot)
 	}
+
+	// Swap in the new slots, then tell the old ones to do a final flush and wind down. They
+	// drain in the background — no need to block the reload on them.
+	old := t.obsPlugins.Load()
 	t.obsPlugins.Store(&slots)
+	if old != nil {
+		for _, slot := range *old {
+			slot.signalStop()
+		}
+	}
 
 	seen := make(map[string]struct{})
 	var patterns []string
@@ -770,15 +911,50 @@ func (t *Tracer) AttachPluginLogs(traceID string, logs []schemas.PluginLogEntry)
 // Stop stops the tracer and releases its resources.
 // This stops the internal TraceStore's cleanup goroutine.
 func (t *Tracer) Stop() {
-	// Bounded wait: a connector blocked on an unreachable collector would otherwise
-	// hold up shutdown and config reload indefinitely (gRPC exports carry no deadline
-	// of their own).
+	// Let in-flight producers finish appending (fast — no network), then drain the connector
+	// buffers via a final flush. Both phases share a single flushStopTimeout budget — the drain
+	// gets whatever the (usually near-instant) producer wait didn't use — so a connector stuck on
+	// an unreachable collector can't push total shutdown past one timeout (gRPC exports carry no
+	// deadline of their own).
+	deadline := time.Now().Add(flushStopTimeout)
 	t.waitForFlushes(flushStopTimeout)
+	t.drainObsPlugins(time.Until(deadline))
 	if t.store != nil {
 		t.store.Stop()
 	}
 	if t.accumulator != nil {
 		t.accumulator.Cleanup()
+	}
+}
+
+// drainObsPlugins tells every connector to do a final flush and waits up to timeout for its
+// timer and flush goroutines to finish. Anything still in flight when the budget runs out is
+// abandoned — best-effort telemetry must never block shutdown. A non-positive timeout (the
+// shared budget already spent by an earlier phase) means don't wait: signal and move on.
+func (t *Tracer) drainObsPlugins(timeout time.Duration) {
+	if timeout < 0 {
+		timeout = 0
+	}
+	loaded := t.obsPlugins.Load()
+	if loaded == nil {
+		return
+	}
+	done := make(chan struct{})
+	go func() {
+		for _, slot := range *loaded {
+			slot.signalStop()
+		}
+		for _, slot := range *loaded {
+			slot.wg.Wait()
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		if t.logger != nil {
+			t.logger.Warn("timed out after %s draining observability plugin buffers; continuing shutdown", timeout)
+		}
 	}
 }
 
@@ -841,52 +1017,20 @@ func (t *Tracer) CompleteAndFlushTrace(traceID string) {
 			slots = *loaded
 		}
 
-		// Fan out rather than iterate: every connector receives the trace on its own
-		// goroutine, so a connector doing blocking network I/O can never delay another.
-		// This used to be a sequential loop, where only the builtin plugin ordering
-		// (logging before otel) kept a stalled exporter from sitting in front of the
-		// logging plugin's DB enqueue — accidental protection that any custom or
-		// reordered connector would have removed.
-		var wg sync.WaitGroup
+		// Append the snapshot to each connector's buffer and return. The snapshot is detached
+		// from the pooled trace, so it's safe to hold in the buffers after this goroutine
+		// releases the pooled object below, and safe for all connectors to share one copy
+		// (they only read it). enqueue never blocks: it appends and, at most, hands a full
+		// batch off to a new flush goroutine.
 		for _, slot := range slots {
-			// Non-blocking acquire. A saturated connector is skipped and counted; parking
-			// yet another goroutine on it is exactly the failure this cap exists to stop.
-			select {
-			case slot.sem <- struct{}{}:
-			default:
-				// Throttled: at saturation this fires once per request, which would make
-				// the logging itself a second source of load.
-				if n := slot.dropped.Add(1); (n == 1 || n%1000 == 0) && t.logger != nil {
-					t.logger.Warn("observability plugin %s saturated at %d concurrent injects, skipped trace %s (%d skipped so far)",
-						slot.name, maxConcurrentInjectsPerPlugin, exportTrace.TraceID, n)
-				}
-				continue
-			}
-			wg.Add(1)
-			go func(slot *obsPluginSlot) {
-				defer wg.Done()
-				defer func() { <-slot.sem }()
-				// Isolate each plugin callback — one bad observability backend should
-				// not crash the server or prevent other plugins from receiving the trace.
-				defer func() {
-					if r := recover(); r != nil && t.logger != nil {
-						t.logger.Error("observability plugin %s panicked during trace injection: %v", slot.name, r)
-					}
-				}()
-				if err := slot.plugin.Inject(context.Background(), exportTrace); err != nil && t.logger != nil {
-					t.logger.Warn("observability plugin %s failed to inject trace: %v", slot.name, err)
-				}
-			}(slot)
+			slot.enqueue(exportTrace, t.logger)
 		}
-		// Join before the deferred ReleaseTrace runs: connectors read exportTrace, and
-		// the pooled trace it was snapshotted from must not be recycled underneath them.
-		wg.Wait()
 	})
 }
 
 // ObservabilityDropCounts returns, per observability plugin name, how many traces were
-// skipped because that plugin was already at its concurrency cap. A non-zero and rising
-// count means the connector's backend is unreachable or too slow to keep up.
+// dropped before delivery. Retained for API compatibility; this delivery path buffers rather
+// than drops, so counts stay at zero.
 func (t *Tracer) ObservabilityDropCounts() map[string]int64 {
 	if t == nil {
 		return nil

--- a/framework/tracing/tracer_test.go
+++ b/framework/tracing/tracer_test.go
@@ -53,6 +53,7 @@ func TestTracer_CompleteAndFlushTraceInjectsObservabilityPlugins(t *testing.T) {
 	defer store.Stop()
 
 	tracer := NewTracer(store, nil, nil)
+	tracer.flushInterval = 20 * time.Millisecond // deliver the single trace on the next tick, not the 10s default
 	defer tracer.Stop()
 
 	traceID := tracer.CreateTrace("")
@@ -82,6 +83,7 @@ func TestTracer_CompleteAndFlushTraceRedactsContentBeforeInject(t *testing.T) {
 	defer store.Stop()
 
 	tracer := NewTracer(store, nil, nil)
+	tracer.flushInterval = 20 * time.Millisecond // deliver the single trace on the next tick, not the 10s default
 	defer tracer.Stop()
 
 	traceID := tracer.CreateTrace("")
@@ -132,6 +134,7 @@ func TestTracer_SetTraceRedactionReplacementsSurvivesLaterObservabilityPlugins(t
 	defer store.Stop()
 
 	tracer := NewTracer(store, nil, nil)
+	tracer.flushInterval = 20 * time.Millisecond // deliver the single trace on the next tick, not the 10s default
 	defer tracer.Stop()
 
 	traceID := tracer.CreateTrace("")

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -338,6 +338,9 @@ false
 {{- if .Values.bifrost.client.routingChainMaxDepth }}
 {{- $_ := set $client "routing_chain_max_depth" .Values.bifrost.client.routingChainMaxDepth }}
 {{- end }}
+{{- if .Values.bifrost.client.observabilityFlushIntervalSeconds }}
+{{- $_ := set $client "observability_flush_interval_seconds" .Values.bifrost.client.observabilityFlushIntervalSeconds }}
+{{- end }}
 {{- if hasKey .Values.bifrost.client "allowDirectKeys" }}
 {{- $_ := set $client "allow_direct_keys" .Values.bifrost.client.allowDirectKeys }}
 {{- end }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -571,6 +571,13 @@
               "description": "Maximum depth for routing rule chain evaluation",
               "default": 10
             },
+            "observabilityFlushIntervalSeconds": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 600,
+              "description": "How often, in seconds, each observability connector (OTEL, logging) flushes its trace buffer. Read from config.json/helm only; not persisted to the database. Maps to client.observability_flush_interval_seconds.",
+              "default": 10
+            },
             "allowDirectKeys": {
               "type": "boolean",
               "description": "Allow callers to bypass the registered key pool by supplying x-bf-direct-key: true with an Authorization header carrying the provider key. Maps to client.allow_direct_keys.",

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -334,6 +334,7 @@ bifrost:
     # hideDeletedVirtualKeysInFilters: false  # Omit deleted virtual keys from logs/MCP filter data
     # whitelistedRoutes: []           # Routes that bypass auth middleware
     # routingChainMaxDepth: 10        # Maximum depth for routing rule chain evaluation
+    # observabilityFlushIntervalSeconds: 10  # How often each observability connector (OTEL, logging) flushes its trace buffer (config.json/helm only, not persisted to DB; max 600)
     # allowDirectKeys: false          # Allow callers to bypass the key pool via x-bf-direct-key + Authorization header
     # mcpExternalClientUrl: ""        # Public base URL used as redirect_uri when Bifrost is an OAuth client to MCP servers
     # How /mcp authenticates inbound MCP clients: headers (default), both, or oauth

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -39,6 +39,7 @@ import (
 	"github.com/maximhq/bifrost/framework/oauth2"
 	"github.com/maximhq/bifrost/framework/objectstore"
 	plugins "github.com/maximhq/bifrost/framework/plugins"
+	"github.com/maximhq/bifrost/framework/tracing"
 	"github.com/maximhq/bifrost/framework/vectorstore"
 	"github.com/maximhq/bifrost/plugins/compat"
 	"github.com/maximhq/bifrost/plugins/governance"
@@ -662,23 +663,24 @@ type Config struct {
 
 // DefaultClientConfig is the default client config used when no config is provided.
 var DefaultClientConfig = configstore.ClientConfig{
-	DropExcessRequests:              false,
-	PrometheusLabels:                []string{},
-	InitialPoolSize:                 schemas.DefaultInitialPoolSize,
-	EnableLogging:                   new(true),
-	DisableContentLogging:           false,
-	RetainContentInObjectStorage:    false,
-	EnforceAuthOnInference:          false,
-	AllowedOrigins:                  []string{"*"},
-	AllowedHeaders:                  []string{},
-	WhitelistedRoutes:               []string{},
-	MaxRequestBodySizeMB:            100,
-	MCPAgentDepth:                   10,
-	MCPToolExecutionTimeout:         30,
-	MCPCodeModeBindingLevel:         string(schemas.CodeModeBindingLevelServer),
-	MCPEnableTempTokenAuth:          false,
-	HideDeletedVirtualKeysInFilters: false,
-	RoutingChainMaxDepth:            rules.DefaultChainMaxDepth,
+	DropExcessRequests:                false,
+	PrometheusLabels:                  []string{},
+	InitialPoolSize:                   schemas.DefaultInitialPoolSize,
+	EnableLogging:                     new(true),
+	DisableContentLogging:             false,
+	RetainContentInObjectStorage:      false,
+	EnforceAuthOnInference:            false,
+	AllowedOrigins:                    []string{"*"},
+	AllowedHeaders:                    []string{},
+	WhitelistedRoutes:                 []string{},
+	MaxRequestBodySizeMB:              100,
+	MCPAgentDepth:                     10,
+	MCPToolExecutionTimeout:           30,
+	MCPCodeModeBindingLevel:           string(schemas.CodeModeBindingLevelServer),
+	MCPEnableTempTokenAuth:            false,
+	HideDeletedVirtualKeysInFilters:   false,
+	RoutingChainMaxDepth:              governance.DefaultRoutingChainMaxDepth,
+	ObservabilityFlushIntervalSeconds: int(tracing.DefaultObservabilityFlushInterval / time.Second),
 }
 
 // applyV1Compat normalizes ConfigData to restore v1.4.x allow-list semantics.
@@ -1165,6 +1167,9 @@ func applyClientConfigDefaults(cc *configstore.ClientConfig) {
 	if cc.RoutingChainMaxDepth == 0 {
 		cc.RoutingChainMaxDepth = DefaultClientConfig.RoutingChainMaxDepth
 	}
+	if cc.ObservabilityFlushIntervalSeconds == 0 {
+		cc.ObservabilityFlushIntervalSeconds = DefaultClientConfig.ObservabilityFlushIntervalSeconds
+	}
 	if cc.MCPToolExecutionTimeout == 0 {
 		cc.MCPToolExecutionTimeout = DefaultClientConfig.MCPToolExecutionTimeout
 	}
@@ -1219,6 +1224,14 @@ func sanitizeMCPExternalOAuthURLs(client *configstore.ClientConfig) {
 // The hash covers both the client section and mcp.tool_manager_config so that UI changes to either
 // survive restarts when the file is unchanged.
 func loadClientConfig(ctx context.Context, config *Config, configData *ConfigData) {
+	defer func() {
+		if configData != nil && configData.Client != nil && config.ClientConfig != nil {
+			if v := configData.Client.ObservabilityFlushIntervalSeconds; v > 0 {
+				config.ClientConfig.ObservabilityFlushIntervalSeconds = v
+			}
+		}
+	}()
+
 	var clientConfig *configstore.ClientConfig
 	var err error
 	if config.ConfigStore != nil {

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -2620,6 +2620,8 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	// Initializing tracer with embedded streaming accumulator
 	traceStore := tracing.NewTraceStore(60*time.Minute, logger)
 	tracer := tracing.NewTracer(traceStore, s.Config.ModelCatalog, logger)
+	// config.json/helm-derived flush interval (not DB-persisted); set before building slots.
+	tracer.SetObservabilityFlushIntervalSeconds(s.Config.ClientConfig.ObservabilityFlushIntervalSeconds)
 	tracer.SetObservabilityPlugins(observabilityPlugins)
 	s.Client.SetTracer(tracer)
 	s.TracingMiddleware = handlers.NewTracingMiddleware(tracer)

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -296,6 +296,13 @@
           "description": "Maximum depth for routing rule chain evaluation",
           "default": 10
         },
+        "observability_flush_interval_seconds": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 600,
+          "description": "How often, in seconds, each observability connector (OTEL, logging) flushes its trace buffer regardless of fill level.",
+          "default": 10
+        },
         "mcp_external_client_url": {
           "anyOf": [
             {


### PR DESCRIPTION
### TL;DR

Replaces the per-plugin concurrency semaphore (which dropped traces when saturated) with a buffered batch-flush architecture that guarantees delivery without dropping.

### What changed?

Each observability plugin slot now owns a batch buffer and a dedicated timer goroutine instead of a semaphore. Traces are appended to the buffer via `enqueue`, which flushes early when the buffer reaches `batchSize` and also flushes on every `flushInterval` tick. Each flush hands its batch to a new goroutine so accumulation never blocks on a slow connector. A `drainObsPlugins` call was added to `Stop` to perform a final bounded flush before shutdown.

The old `maxConcurrentInjectsPerPlugin` cap and its drop-on-saturation logic are removed. `ObservabilityDropCounts` is retained for API compatibility but counts will remain zero under normal operation.

`SetObservabilityPlugins` now starts timer goroutines for incoming slots and signals old slots to wind down in the background on reload. `CompleteAndFlushTrace` no longer joins a per-trace `sync.WaitGroup` before releasing the pooled trace — the snapshot is safe to hold in buffers because connectors only read it.

`TestCompleteAndFlushTrace_BoundsInjectsPerPlugin` is replaced by three new tests covering the size trigger, the timer trigger, and the end-to-end hang-then-drain scenario. `TestWaitForFlushes_TimesOutOnHungPlugin` is renamed to `TestDrainObsPlugins_TimesOutOnHungPlugin` to reflect the corrected shutdown boundary. A `newTestTracer` helper is introduced so tests don't wait the full 10-second default interval.

### How to test?

Run the isolation test suite:

```
go test ./framework/tracing/... -run TestCompleteAndFlushTrace -v
go test ./framework/tracing/... -run TestDrainObsPlugins -v
go test ./framework/tracing/... -v
```

The new tests cover: size-triggered early flush, timer-triggered partial-batch flush, and a hung plugin that buffers 10,000 traces and delivers all of them after unblocking with zero drops.

### Why make this change?

The previous semaphore design dropped traces silently once a connector hit its concurrency cap. A connector pointed at an unreachable endpoint would saturate quickly, and every trace after that was discarded rather than buffered. The buffered batch design preserves all traces while still isolating connectors from each other — a slow or hung connector fills its own buffer and blocks its own flush goroutines without affecting any other connector's delivery path.