### PR TITLE
feat(logstore): add `DimensionScope` ceiling to bound grouping dimension values per caller

### DIFF
--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -358,6 +358,7 @@ const (
 	BifrostContextKeyUserEmail                           BifrostContextKey = "bifrost-user-email"                 // string (to store the user email (set by enterprise auth middleware - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyMCPInboundBearer                    BifrostContextKey = "bifrost-mcp-inbound-bearer"         // string (the caller's validated identity-provider token, used as the subject of delegated token exchange; set by the upstream auth layer - DO NOT SET THIS MANUALLY. SECURITY: live credential - never log its value)
 	BifrostContextKeyQueryScope                          BifrostContextKey = "bifrost-query-scope"                // configstore.QueryScope (func that mutates a query; set by upstream wrapper - DO NOT SET THIS MANUALLY)
+	BifrostContextKeyDimensionScope                      BifrostContextKey = "bifrost-dimension-scope"            // queryscope.DimensionScope (bounds the VALUES of a grouping dimension; set by upstream wrapper - DO NOT SET THIS MANUALLY)
 	BifrostContextKeyVisibilityFilterProvider            BifrostContextKey = "bifrost-visibility-filter-provider" // DEPRECATED: replaced by BifrostContextKeyQueryScope. Will be removed once all callers migrate.
 	BifrostContextKeyTargetUserID                        BifrostContextKey = "target_user_id"
 	BifrostContextKeyIsAzureUserAgent                    BifrostContextKey = "bifrost-is-azure-user-agent" // bool (set by bifrost - DO NOT SET THIS MANUALLY)) - whether the request is an Azure user agent (only used in gateway)

--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+	"github.com/maximhq/bifrost/framework/queryscope"
 	"sort"
 	"strings"
 	"sync"
@@ -2064,6 +2065,9 @@ func (s *RDBLogStore) getDimensionCostHistogramFromMatView(ctx context.Context, 
 	}
 	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
+	// Same ceiling as the raw path: bounded dimensions must not name ids the
+	// caller may not be shown, even when the aggregate is served pre-computed.
+	q = applyDimensionCeiling(ctx, q, dimensionReadSource{}, dimCol)
 	if err := q.Select(fmt.Sprintf(`
 		CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
 		%s AS dim_value,
@@ -2123,6 +2127,9 @@ func (s *RDBLogStore) getDimensionTokenHistogramFromMatView(ctx context.Context,
 	}
 	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
+	// Same ceiling as the raw path: bounded dimensions must not name ids the
+	// caller may not be shown, even when the aggregate is served pre-computed.
+	q = applyDimensionCeiling(ctx, q, dimensionReadSource{}, dimCol)
 	if err := q.Select(fmt.Sprintf(`
 		CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
 		%s AS dim_value,
@@ -2199,6 +2206,9 @@ func (s *RDBLogStore) getDimensionLatencyHistogramFromMatView(ctx context.Contex
 	}
 	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
+	// Same ceiling as the raw path: bounded dimensions must not name ids the
+	// caller may not be shown, even when the aggregate is served pre-computed.
+	q = applyDimensionCeiling(ctx, q, dimensionReadSource{}, dimCol)
 	if err := q.Select(fmt.Sprintf(`
 		CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
 		%s AS dim_value,
@@ -2384,6 +2394,10 @@ func (s *RDBLogStore) getUserRankingsFromMatView(ctx context.Context, filters Se
 	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
 	q = q.Where("user_id != ''")
+	// Same ceiling as the raw path in GetUserRankings: the row scope alone does
+	// not bound which user ids a caller may be shown, and the matview stores the
+	// scalar column, so it applies here unchanged.
+	q = applyDimensionCeiling(ctx, q, dimensionReadSource{}, "user_id")
 	q = q.Select(`
 		user_id,
 		SUM(count) AS total,
@@ -2424,6 +2438,7 @@ func (s *RDBLogStore) getUserRankingsFromMatView(ctx context.Context, filters Se
 		pq := s.ScopedDB(ctx).Table("mv_logs_hourly")
 		pq = s.applyMatViewFilters(pq, prevFilters)
 		pq = pq.Where("user_id != ''")
+		pq = applyDimensionCeiling(ctx, pq, dimensionReadSource{}, "user_id")
 		if err := pq.Select(`
 			user_id,
 			SUM(count) AS total,
@@ -2480,6 +2495,10 @@ func (s *RDBLogStore) getDimensionRankingsFromMatView(ctx context.Context, filte
 	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
 	q = q.Where(fmt.Sprintf("%s != ''", idCol))
+	// Same ceiling as the raw path in GetDimensionRankings. Only non-bucketed
+	// dimensions reach this reader, so the scalar column is the group key and
+	// no fan-out alias is involved.
+	q = applyDimensionCeiling(ctx, q, dimensionReadSource{}, idCol)
 	q = q.Select(fmt.Sprintf(`
 		%s AS id,
 		SUM(count) AS total,
@@ -2537,6 +2556,7 @@ func (s *RDBLogStore) getDimensionRankingsFromMatView(ctx context.Context, filte
 		pq := s.ScopedDB(ctx).Table("mv_logs_hourly")
 		pq = s.applyMatViewFilters(pq, prevFilters)
 		pq = pq.Where(fmt.Sprintf("%s != ''", idCol))
+		pq = applyDimensionCeiling(ctx, pq, dimensionReadSource{}, idCol)
 		if err := pq.Select(fmt.Sprintf(`
 			%s AS id,
 			SUM(count) AS total,
@@ -2676,6 +2696,19 @@ func (s *RDBLogStore) getDistinctKeyPairsFromMatView(ctx context.Context, idCol,
 	}
 	if query != "" {
 		q = q.Where("name ILIKE ?", "%"+query+"%")
+	}
+	// The matview projects the dimension value as "id", so the ceiling is
+	// applied to that column rather than to the underlying scalar name. Same
+	// reasoning as the raw-table path in GetDistinctKeyPairs: a dropdown lists
+	// organisation names with no row beside them, and one visible row carrying
+	// two customers would otherwise offer both.
+	if scope := queryscope.DimensionFromContext(ctx); scope != nil {
+		if allowed, bounded := scope(idCol); bounded {
+			if len(allowed) == 0 {
+				return nil, true, nil
+			}
+			q = q.Where("id IN ?", allowed)
+		}
 	}
 	if err := q.
 		Select("DISTINCT id, name").

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -2693,6 +2693,10 @@ func (s *RDBLogStore) GetUserRankings(ctx context.Context, filters SearchFilters
 	currentQuery = s.applyFilters(currentQuery, filters)
 	currentQuery = currentQuery.Where("status IN ?", terminalLogStatuses)
 	currentQuery = currentQuery.Where("user_id IS NOT NULL AND user_id != ''")
+	// The People tab groups by user_id, so it needs the same ceiling as the
+	// user ranking dimension: a caller may hold a row without being allowed to
+	// see whose it is.
+	currentQuery = applyDimensionCeiling(ctx, currentQuery, dimensionReadSource{}, "user_id")
 
 	var currentResults []struct {
 		UserID        string          `gorm:"column:user_id"`
@@ -2828,6 +2832,7 @@ func (s *RDBLogStore) GetDimensionRankings(ctx context.Context, filters SearchFi
 	currentQuery := src.base(s.ScopedDB(ctx))
 	currentQuery = s.applyFilters(currentQuery, filters)
 	currentQuery = currentQuery.Where("status IN ?", terminalLogStatuses)
+	currentQuery = applyDimensionCeiling(ctx, currentQuery, src, idCol)
 	if !src.Bucketed {
 		currentQuery = currentQuery.Where(fmt.Sprintf("%s IS NOT NULL AND %s != ''", idCol, idCol))
 	}
@@ -2885,6 +2890,10 @@ func (s *RDBLogStore) GetDimensionRankings(ctx context.Context, filters SearchFi
 			attributedQuery := src.base(s.ScopedDB(ctx))
 			attributedQuery = s.applyFilters(attributedQuery, filters)
 			attributedQuery = attributedQuery.Where("status IN ?", terminalLogStatuses)
+			// Same ceiling as the rankings themselves: this total is the sum of
+			// the rows above, so counting attributions the caller may not be
+			// shown would make it disagree with them.
+			attributedQuery = applyDimensionCeiling(ctx, attributedQuery, src, idCol)
 			var attributed int64
 			if err := attributedQuery.Count(&attributed).Error; err != nil {
 				return nil, fmt.Errorf("failed to get attributed dimension ranking totals for %s: %w", dimension, err)
@@ -3582,6 +3591,7 @@ func (s *RDBLogStore) GetDimensionCostHistogram(ctx context.Context, filters Sea
 	baseQuery := src.base(s.ScopedDB(ctx))
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
+	baseQuery = applyDimensionCeiling(ctx, baseQuery, src, dimCol)
 	baseQuery = baseQuery.Where("cost IS NOT NULL AND cost > 0")
 
 	bucketExpr := unixBucketExpr(dialect, bucketSizeSeconds)
@@ -3684,6 +3694,7 @@ func (s *RDBLogStore) GetDimensionTokenHistogram(ctx context.Context, filters Se
 	baseQuery := src.base(s.ScopedDB(ctx))
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
+	baseQuery = applyDimensionCeiling(ctx, baseQuery, src, dimCol)
 
 	bucketExpr := unixBucketExpr(dialect, bucketSizeSeconds)
 
@@ -3807,6 +3818,7 @@ func (s *RDBLogStore) GetDimensionLatencyHistogram(ctx context.Context, filters 
 	baseQuery := src.base(s.ScopedDB(ctx))
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
+	baseQuery = applyDimensionCeiling(ctx, baseQuery, src, dimCol)
 	baseQuery = baseQuery.Where("latency IS NOT NULL")
 
 	bucketExpr := unixBucketExpr(dialect, bucketSizeSeconds)
@@ -4043,6 +4055,10 @@ func (s *RDBLogStore) GetDistinctKeyPairs(ctx context.Context, idCol, nameCol st
 	if query != "" {
 		q = s.applyLikeFilter(q, nameCol, query)
 	}
+	// A filter dropdown is a list of organisation names with no log row shown
+	// beside it, so it discloses the org chart directly. The row scope alone
+	// does not bound it: one visible row carrying two customers offers both.
+	q = applyDimensionCeiling(ctx, q, dimensionReadSource{}, idCol)
 	if err := q.Order("name ASC").Limit(limit).Find(&results).Error; err != nil {
 		return nil, fmt.Errorf("failed to get distinct key pairs (%s, %s): %w", idCol, nameCol, err)
 	}
@@ -5134,4 +5150,44 @@ func (s *RDBLogStore) DeleteExpiredWebhookDeliveries(ctx context.Context) (int64
 		}
 	}
 	return totalDeleted, nil
+}
+
+// applyDimensionCeiling bounds the values a grouped organisation column may
+// take to the ones the caller is allowed to be shown.
+//
+// This is deliberately separate from ScopedDB. ScopedDB decides which rows the
+// caller receives; this decides which ids those rows are allowed to put on a
+// chart. The two coincide only when every row carries exactly one organisation
+// per dimension, and the enterprise governance plugin records the sender's
+// whole hierarchy, so a single request from someone in two teams under
+// different customers carries both customers. Such a row is legitimately
+// visible to a teammate and still must not name the second customer.
+//
+// The column depends on how the read resolved: a fanned-out read exposes each
+// of the row's ids as dim_id, while a single-owner read groups the scalar
+// column directly. Passing the wrong one is a SQL error rather than a silent
+// hole, which is the failure mode to prefer.
+//
+// Rows with no id on this dimension are always kept. They aggregate into the
+// synthetic Unassigned bucket, which names no organisation and therefore
+// discloses nothing — dropping them would understate the caller's own totals
+// and make the rollup stop reconciling.
+func applyDimensionCeiling(ctx context.Context, q *gorm.DB, src dimensionReadSource, idCol string) *gorm.DB {
+	scope := queryscope.DimensionFromContext(ctx)
+	if scope == nil {
+		return q
+	}
+	allowed, bounded := scope(idCol)
+	if !bounded {
+		return q
+	}
+	col := idCol
+	if src.FannedOut {
+		col = "dim_id"
+	}
+	unowned := fmt.Sprintf("%s IS NULL OR %s = ''", col, col)
+	if len(allowed) == 0 {
+		return q.Where(unowned)
+	}
+	return q.Where(fmt.Sprintf("%s IN ? OR %s", col, unowned), allowed)
 }

--- a/framework/queryscope/queryscope.go
+++ b/framework/queryscope/queryscope.go
@@ -38,3 +38,44 @@ func FromContext(ctx context.Context) QueryScope {
 	}
 	return nil
 }
+
+// DimensionScope bounds the VALUES a grouping dimension may take, which is a
+// different constraint from QueryScope and not implied by it.
+//
+// QueryScope decides which rows a caller may receive. That is not enough for an
+// aggregate that groups by an organisation column, because a row can be
+// legitimately visible on one dimension while carrying, on another, an id the
+// caller may not see. A user who belongs to two teams under different customers
+// produces exactly that row: a teammate may hold it — they share a team — while
+// the customer stamped on it belongs to an organisation they have no access to.
+// Grouping that row by customer names the second customer, and every ranking,
+// histogram and filter dropdown built on the same column repeats it.
+//
+// Given a scalar id column ("customer_id", "team_id", "business_unit_id",
+// "user_id", "virtual_key_id"), a DimensionScope returns the ids the caller may
+// be shown on that dimension and whether a ceiling applies at all. Returning
+// false means "unconstrained" — dimensions that describe the request rather
+// than the organisation (provider, model, alias) have no per-caller set to
+// compare against. Returning an empty slice with true means the caller may be
+// shown no id on that dimension, which is not the same thing.
+type DimensionScope func(idCol string) (allowed []string, bounded bool)
+
+// WithDimensionScope returns ctx carrying scope. Nil scope is a no-op.
+func WithDimensionScope(ctx context.Context, scope DimensionScope) context.Context {
+	if scope == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, schemas.BifrostContextKeyDimensionScope, scope)
+}
+
+// DimensionFromContext returns the dimension scope stashed on ctx, or nil when
+// none is present. Nil means no ceiling, matching FromContext's convention.
+func DimensionFromContext(ctx context.Context) DimensionScope {
+	if ctx == nil {
+		return nil
+	}
+	if v, ok := ctx.Value(schemas.BifrostContextKeyDimensionScope).(DimensionScope); ok {
+		return v
+	}
+	return nil
+}

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -1879,8 +1879,16 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 
 	// Redaction lookups are only needed for KeyPair-style dimensions; skip the
 	// extra calls when the caller didn't request them.
+	//
+	// They are also skipped when the scoped lookup above matched nothing, and
+	// that guard is load-bearing rather than an optimisation. The
+	// GetAllRedacted* store methods treat an empty id list as "no filter" and
+	// return every row in the table, unscoped - so handing them the empty
+	// result of a scoped query inverts it into a full disclosure of every key
+	// in the deployment. It fires precisely when the caller is entitled to
+	// nothing, which is the worst possible moment for it.
 	redactedSelectedKeys := make(map[string]schemas.Key)
-	if _, ok := want[filterDimSelectedKeys]; ok {
+	if _, ok := want[filterDimSelectedKeys]; ok && len(selectedKeys) > 0 {
 		selectedKeyIDs := make([]string, len(selectedKeys))
 		for i, key := range selectedKeys {
 			selectedKeyIDs[i] = key.ID
@@ -1890,7 +1898,7 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 		}
 	}
 	redactedVirtualKeys := make(map[string]tables.TableVirtualKey)
-	if _, ok := want[filterDimVirtualKeys]; ok {
+	if _, ok := want[filterDimVirtualKeys]; ok && len(virtualKeys) > 0 {
 		virtualKeyIDs := make([]string, len(virtualKeys))
 		for i, key := range virtualKeys {
 			virtualKeyIDs[i] = key.ID
@@ -1900,7 +1908,7 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 		}
 	}
 	redactedRoutingRules := make(map[string]tables.TableRoutingRule)
-	if _, ok := want[filterDimRoutingRules]; ok {
+	if _, ok := want[filterDimRoutingRules]; ok && len(routingRules) > 0 {
 		routingRuleIDs := make([]string, len(routingRules))
 		for i, rule := range routingRules {
 			routingRuleIDs[i] = rule.ID


### PR DESCRIPTION
## Summary

Aggregated queries that group by organisation dimensions (customer, team, business unit, user, virtual key) could expose organisation identifiers the caller is not permitted to see. A single log row can legitimately belong to a caller's team while simultaneously carrying an organisation id from a separate hierarchy they have no access to. Rankings, histograms, filter dropdowns, and matview lookups all grouped by that column and named the second organisation. This PR introduces a `DimensionScope` ceiling that bounds which values a grouped column may surface, independently of the row-level `QueryScope`.

## Changes

- Introduced `DimensionScope` in `framework/queryscope/queryscope.go` — a function type `func(idCol string) (allowed []string, bounded bool)` that returns the permitted ids for a given dimension column. `WithDimensionScope` and `DimensionFromContext` follow the same convention as the existing `QueryScope` helpers.
- Added `BifrostContextKeyDimensionScope` to the bifrost context key registry so the scope can be threaded through the request context.
- Added `applyDimensionCeiling` in `framework/logstore/rdb.go`, which applies the dimension scope as a SQL `IN` predicate. Rows with a null or empty id are always kept because they aggregate into the synthetic Unassigned bucket and disclose no organisation identity. Fanned-out reads use `dim_id` rather than the scalar column to match how those queries project the value.
- Applied `applyDimensionCeiling` to `GetDimensionRankings`, `GetUserRankings`, `GetDimensionCostHistogram`, `GetDimensionTokenHistogram`, `GetDimensionLatencyHistogram`, and `GetDistinctKeyPairs`, including the attributed-total sub-query inside `GetDimensionRankings` so the rollup stays consistent with the rows above it.
- Applied the same ceiling inside `getDistinctKeyPairsFromMatView` using the projected `id` column.
- Fixed a load-bearing guard in `getAvailableFilterData`: `GetAllRedacted*` store methods treat an empty id list as "no filter" and return every row in the table. The redaction lookups for selected keys, virtual keys, and routing rules are now skipped when the scoped upstream query returned nothing, preventing a full-table disclosure to a caller entitled to zero results.

## Type of change

- [x] Bug fix
- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)

## How to test

```sh
go test ./framework/logstore/... ./framework/queryscope/... ./transports/bifrost-http/...
```

Validate that:
- A caller scoped to a single customer sees only that customer's ids in rankings, histograms, and filter dropdowns.
- A caller scoped to zero ids on a dimension receives empty results from those endpoints rather than a full table dump.
- Rows with no id on the scoped dimension still appear in the Unassigned bucket.
- The attributed-total in `GetDimensionRankings` matches the sum of the returned ranked rows.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This PR closes an information-disclosure path in all aggregate and filter-dropdown endpoints. Without the ceiling, a caller with access to a single log row could observe organisation identifiers from unrelated hierarchies whenever a row carried more than one organisation id on a dimension. The fix is applied at the query layer so it cannot be bypassed by varying request parameters. The empty-list guard in `getAvailableFilterData` closes a separate inversion where a caller entitled to nothing would receive a full redacted key listing.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable