### PR TITLE
fix: include openrouter embedding models in list models call

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -1064,6 +1064,61 @@ jobs:
             "cli-harness-${{ matrix.label }}" \
             tests/e2e/clis/reports
 
+  # vLLM provider tests - allocates two vLLM (one stable and one nightly) instances
+  # on runpod (runpodctl):
+  test-vllm:
+    needs: [check-skip, detect-changes]
+    if: needs.check-skip.outputs.should-skip != 'true' && needs.check-skip.outputs.skip-tests != 'true' && needs.detect-changes.outputs.core-needs-release == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            release-assets.githubusercontent.com:443
+            rest.runpod.io:443
+            *.proxy.runpod.net:443
+            proxy.golang.org:443
+            storage.googleapis.com:443
+            sum.golang.org:443
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version: "1.26.5"
+
+      - name: Create vLLM pods on RunPod
+        env:
+          RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
+          RUNPOD_NETWORK_VOLUME_ID: ${{ secrets.RUNPOD_NETWORK_VOLUME_ID }}
+          RUNPOD_REASONING_NETWORK_VOLUME_ID: ${{ secrets.RUNPOD_REASONING_NETWORK_VOLUME_ID }}
+        run: |
+          chmod +x ./.github/workflows/scripts/setup-vllm-runpod.sh
+          ./.github/workflows/scripts/setup-vllm-runpod.sh
+
+      - name: Run vLLM provider tests
+        run: VLLM_ENABLED=1 make test-core PROVIDER=vllm
+
+      - name: Delete vLLM pods on RunPod
+        if: always()
+        env:
+          RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
+        run: |
+          chmod +x ./.github/workflows/scripts/teardown-vllm-runpod.sh
+          ./.github/workflows/scripts/teardown-vllm-runpod.sh
+
   test-framework:
     needs: [check-skip, detect-changes]
     if: needs.check-skip.outputs.should-skip != 'true' && needs.check-skip.outputs.skip-tests != 'true' && needs.detect-changes.outputs.framework-needs-release == 'true'
@@ -2169,6 +2224,7 @@ jobs:
         approve-flaky-test-core,
         resolve-cli-versions,
         test-cli-harness,
+        test-vllm,
         test-framework,
         test-plugins,
         test-bifrost-http,
@@ -2178,7 +2234,7 @@ jobs:
         test-docker-image-amd64,
         test-docker-image-arm64,
       ]
-    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.core-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-core-integrations.result == 'success' || needs.test-core-integrations.result == 'skipped') && (needs.test-core-unit.result == 'success' || needs.test-core-unit.result == 'skipped') && (needs.test-cli-harness.result == 'success' || needs.test-cli-harness.result == 'skipped') && (needs.resolve-cli-versions.result == 'success' || needs.resolve-cli-versions.result == 'skipped') && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-api-integrations.result == 'success' || needs.test-api-integrations.result == 'skipped') && (needs.test-cost-accuracy.result == 'success' || needs.test-cost-accuracy.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped')"
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.core-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-core-integrations.result == 'success' || needs.test-core-integrations.result == 'skipped') && (needs.test-core-unit.result == 'success' || needs.test-core-unit.result == 'skipped') && (needs.test-cli-harness.result == 'success' || needs.test-cli-harness.result == 'skipped') && (needs.test-vllm.result == 'success' || needs.test-vllm.result == 'skipped') && (needs.resolve-cli-versions.result == 'success' || needs.resolve-cli-versions.result == 'skipped') && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-api-integrations.result == 'success' || needs.test-api-integrations.result == 'skipped') && (needs.test-cost-accuracy.result == 'success' || needs.test-cost-accuracy.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/scripts/setup-vllm-runpod.sh
+++ b/.github/workflows/scripts/setup-vllm-runpod.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Allocates two vLLM pods on RunPod for the test-vllm CI job and waits for
+# both to be healthy: a default vllm server pod (servers qwen3.5) and a vllm 
+# nightly server pod (servers GLM-4.7).
+#
+# Usage: ./setup-vllm-runpod.sh
+# Required env: RUNPOD_API_KEY
+# Optional env (defaults match the two terraform configs above):
+#   RUNPOD_NETWORK_VOLUME_ID, RUNPOD_REASONING_NETWORK_VOLUME_ID - persist
+#     each pod's HF cache across runs so models aren't re-downloaded every
+#     release-pipeline run - create once with `runpodctl network-volume
+#     create` and store the ids as these secrets,
+#   VLLM_IMAGE, VLLM_MODEL_NAME, VLLM_TRUST_REMOTE_CODE, VLLM_TOOL_CALL_PARSER,
+#     VLLM_REASONING_PARSER, VLLM_MAX_MODEL_LEN, VLLM_ENABLE_THINKING
+#     (default pod)
+#   VLLM_REASONING_IMAGE, VLLM_REASONING_MODEL_NAME,
+#     VLLM_REASONING_TRUST_REMOTE_CODE, VLLM_REASONING_TOOL_CALL_PARSER,
+#     VLLM_REASONING_REASONING_PARSER, VLLM_REASONING_MAX_MODEL_LEN,
+#     VLLM_REASONING_ENABLE_THINKING (reasoning pod)
+#   VLLM_READY_TIMEOUT_SECONDS, VLLM_MAX_POD_LIFETIME_MINUTES (shared)
+#
+# Exports (via $GITHUB_ENV) for later steps in the same job:
+#   RUNPOD_POD_ID, VLLM_BASE_URL, VLLM_API_KEY, VLLM_CHAT_MODEL, VLLM_TEXT_MODEL,
+#   RUNPOD_REASONING_POD_ID, VLLM_REASONING_BASE_URL, VLLM_REASONING_MODEL
+
+RUNPODCTL_VERSION="v2.7.2"
+RUNPODCTL_LINUX_AMD64_SHA256="acf5c49a3192b522e95cae92539fa6fcd8be8c48802aa26c7f3f2ec980ab4f5c"
+
+API_PORT=8000
+GPU_TYPE_ID="NVIDIA A40"
+READY_TIMEOUT_SECONDS="${VLLM_READY_TIMEOUT_SECONDS:-1200}"
+MAX_POD_LIFETIME_MINUTES="${VLLM_MAX_POD_LIFETIME_MINUTES:-120}"
+
+if [ -z "${RUNPOD_API_KEY:-}" ]; then
+  echo "::error::RUNPOD_API_KEY is not set" >&2
+  exit 1
+fi
+
+echo "🔧 Installing runpodctl ${RUNPODCTL_VERSION}..."
+RUNPODCTL_TMP="$(mktemp)"
+trap 'rm -f "$RUNPODCTL_TMP"' EXIT
+curl -sSL -o "$RUNPODCTL_TMP" "https://github.com/runpod/runpodctl/releases/download/${RUNPODCTL_VERSION}/runpodctl-linux-amd64"
+echo "${RUNPODCTL_LINUX_AMD64_SHA256}  ${RUNPODCTL_TMP}" | sha256sum -c -
+chmod +x "$RUNPODCTL_TMP"
+sudo mv "$RUNPODCTL_TMP" /usr/local/bin/runpodctl
+
+# runpodctl reads RUNPOD_API_KEY from the environment directly.
+
+TERMINATE_AFTER=$(date -u -d "+${MAX_POD_LIFETIME_MINUTES} minutes" '+%Y-%m-%dT%H:%M:%SZ')
+
+# Shared across both pods.
+VLLM_API_KEY=$(openssl rand -hex 24)
+echo "::add-mask::${VLLM_API_KEY}"
+
+# Creates one vLLM pod, echoes the pod id on success.
+# Args: name-suffix image model trust-remote-code tool-call-parser reasoning-parser
+# enable-thinking max-model-len network-volume-id-env.
+create_vllm_pod() {
+  local name_suffix="$1" image="$2" model="$3" trust_remote_code="$4" \
+    tool_call_parser="$5" reasoning_parser="$6" enable_thinking="$7" \
+    max_model_len="$8" network_volume_id="$9"
+
+  local docker_args="--model ${model} --host 0.0.0.0 --port ${API_PORT} --max-model-len ${max_model_len} --api-key ${VLLM_API_KEY} --enable-auto-tool-choice --tool-call-parser ${tool_call_parser} --reasoning-parser ${reasoning_parser} --default-chat-template-kwargs {\\\"enable_thinking\\\":${enable_thinking}}"
+  if [ "$trust_remote_code" = "true" ]; then
+    docker_args="${docker_args} --trust-remote-code"
+  fi
+
+  local create_args=(
+    pod create
+    --name "bifrost-ci-vllm-${name_suffix}-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}"
+    --image "$image"
+    --gpu-id "$GPU_TYPE_ID"
+    --gpu-count 1
+    --cloud-type SECURE
+    --container-disk-in-gb 30
+    --ports "${API_PORT}/http"
+    --docker-args "$docker_args"
+    --terminate-after "$TERMINATE_AFTER"
+    -o json
+  )
+  if [ -n "$network_volume_id" ]; then
+    echo "📦 Using persistent network volume ${network_volume_id} for the ${name_suffix} pod's HF cache" >&2
+    create_args+=(--network-volume-id "$network_volume_id" --volume-mount-path /root/.cache/huggingface)
+  else
+    create_args+=(--volume-in-gb 60 --volume-mount-path /root/.cache/huggingface)
+  fi
+
+  echo "🚀 Creating ${name_suffix} vLLM pod ($model on $GPU_TYPE_ID, auto-terminates at ${TERMINATE_AFTER} as a backstop)..." >&2
+  local create_output
+  create_output=$(runpodctl "${create_args[@]}")
+  echo "$create_output" >&2
+
+  local pod_id
+  pod_id=$(echo "$create_output" | jq -r '.id // empty')
+  if [ -z "$pod_id" ]; then
+    echo "::error::Failed to parse pod id from runpodctl output for the ${name_suffix} pod" >&2
+    exit 1
+  fi
+
+  echo "$pod_id"
+}
+
+# Waits for a pod's OpenAI-compatible endpoint to answer. Args: name-suffix base-url api-key.
+wait_for_vllm_ready() {
+  local name_suffix="$1" base_url="$2" api_key="$3"
+  echo "⏳ Waiting for the ${name_suffix} vLLM endpoint to become ready (timeout: ${READY_TIMEOUT_SECONDS}s)..."
+  local seconds_waited=0
+  until curl -sf --max-time 10 -o /dev/null -H "Authorization: Bearer ${api_key}" "${base_url}/v1/models"; do
+    if [ "$seconds_waited" -ge "$READY_TIMEOUT_SECONDS" ]; then
+      echo "::error::Timed out waiting for the ${name_suffix} vLLM endpoint to become ready" >&2
+      exit 1
+    fi
+    sleep 15
+    seconds_waited=$((seconds_waited + 15))
+    echo "  ...still waiting on ${name_suffix} pod (${seconds_waited}s elapsed)"
+  done
+  echo "✅ ${name_suffix} vLLM endpoint is ready"
+}
+
+# --- Default pod: chat/text/tool-calling scenarios (thinking off) ---
+DEFAULT_MODEL_NAME="${VLLM_MODEL_NAME:-Qwen/Qwen3.5-35B-A3B-GPTQ-Int4}"
+POD_ID=$(create_vllm_pod \
+  "default" \
+  "${VLLM_IMAGE:-vllm/vllm-openai:latest}" \
+  "$DEFAULT_MODEL_NAME" \
+  "${VLLM_TRUST_REMOTE_CODE:-false}" \
+  "${VLLM_TOOL_CALL_PARSER:-qwen3_coder}" \
+  "${VLLM_REASONING_PARSER:-qwen3}" \
+  "${VLLM_ENABLE_THINKING:-false}" \
+  "${VLLM_MAX_MODEL_LEN:-32768}" \
+  "${RUNPOD_NETWORK_VOLUME_ID:-}")
+
+# --- Reasoning pod: Reasoning scenario only (thinking on) ---
+REASONING_MODEL_NAME="${VLLM_REASONING_MODEL_NAME:-QuantTrio/GLM-4.7-Flash-AWQ}"
+REASONING_POD_ID=$(create_vllm_pod \
+  "reasoning" \
+  "${VLLM_REASONING_IMAGE:-vllm/vllm-openai:nightly}" \
+  "$REASONING_MODEL_NAME" \
+  "${VLLM_REASONING_TRUST_REMOTE_CODE:-true}" \
+  "${VLLM_REASONING_TOOL_CALL_PARSER:-glm47}" \
+  "${VLLM_REASONING_REASONING_PARSER:-glm45}" \
+  "${VLLM_REASONING_ENABLE_THINKING:-true}" \
+  "${VLLM_REASONING_MAX_MODEL_LEN:-131072}" \
+  "${RUNPOD_REASONING_NETWORK_VOLUME_ID:-}")
+
+VLLM_BASE_URL="https://${POD_ID}-${API_PORT}.proxy.runpod.net"
+VLLM_REASONING_BASE_URL="https://${REASONING_POD_ID}-${API_PORT}.proxy.runpod.net"
+echo "Default pod: ${POD_ID} -> ${VLLM_BASE_URL}"
+echo "Reasoning pod: ${REASONING_POD_ID} -> ${VLLM_REASONING_BASE_URL}"
+
+# Persist for later steps in this job (test run + teardown).
+{
+  echo "RUNPOD_POD_ID=${POD_ID}"
+  echo "VLLM_BASE_URL=${VLLM_BASE_URL}"
+  echo "VLLM_API_KEY=${VLLM_API_KEY}"
+  echo "VLLM_CHAT_MODEL=${DEFAULT_MODEL_NAME}"
+  echo "VLLM_TEXT_MODEL=${DEFAULT_MODEL_NAME}"
+  echo "RUNPOD_REASONING_POD_ID=${REASONING_POD_ID}"
+  echo "VLLM_REASONING_BASE_URL=${VLLM_REASONING_BASE_URL}"
+  echo "VLLM_REASONING_MODEL=${REASONING_MODEL_NAME}"
+} >> "$GITHUB_ENV"
+
+wait_for_vllm_ready "default" "$VLLM_BASE_URL" "$VLLM_API_KEY"
+wait_for_vllm_ready "reasoning" "$VLLM_REASONING_BASE_URL" "$VLLM_API_KEY"

--- a/.github/workflows/scripts/teardown-vllm-runpod.sh
+++ b/.github/workflows/scripts/teardown-vllm-runpod.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Deletes the RunPod vLLM pod(s) created by setup-vllm-runpod.sh.
+#
+# Usage: ./teardown-vllm-runpod.sh
+# Required env: RUNPOD_API_KEY
+# Optional env: RUNPOD_POD_ID, RUNPOD_REASONING_POD_ID (set by
+#   setup-vllm-runpod.sh via $GITHUB_ENV)
+#
+# Runs with `if: always()` in the workflow so it fires even if the test step
+# failed; --terminate-after (set at pod creation) is the backstop in case this
+# step itself never runs (e.g. the runner is killed).
+
+if [ -z "${RUNPOD_POD_ID:-}" ] && [ -z "${RUNPOD_REASONING_POD_ID:-}" ]; then
+  echo "No RUNPOD_POD_ID/RUNPOD_REASONING_POD_ID set, nothing to tear down."
+  exit 0
+fi
+
+if [ -z "${RUNPOD_API_KEY:-}" ]; then
+  echo "::error::RUNPOD_API_KEY is not set" >&2
+  exit 1
+fi
+
+if ! command -v runpodctl >/dev/null 2>&1; then
+  echo "::warning::runpodctl not found, cannot delete pods - check the RunPod console (auto-terminate-after is set as a backstop)"
+  exit 0
+fi
+
+# runpodctl reads RUNPOD_API_KEY from the environment directly.
+
+delete_pod() {
+  local name_suffix="$1" pod_id="$2"
+  if [ -z "$pod_id" ]; then
+    return 0
+  fi
+  echo "🧹 Deleting ${name_suffix} vLLM pod ${pod_id}..."
+  if runpodctl pod delete "$pod_id"; then
+    echo "✅ ${name_suffix} pod ${pod_id} deleted"
+  else
+    echo "::warning::Failed to delete ${name_suffix} pod ${pod_id} - check the RunPod console (auto-terminate-after is set as a backstop)"
+  fi
+}
+
+delete_pod "default" "${RUNPOD_POD_ID:-}"
+delete_pod "reasoning" "${RUNPOD_REASONING_POD_ID:-}"

--- a/Makefile
+++ b/Makefile
@@ -615,7 +615,7 @@ test-core: install-gotestsum $(if $(DEBUG),install-delve) ## Run core tests (Usa
 		$(ECHO) "$(YELLOW)Attach your debugger to localhost:2345$(NC)"; \
 	fi; \
 	if [ -n "$(PROVIDER)" ]; then \
-		PROVIDER_TEST_NAME=$$($(ECHO) "$(PROVIDER)" | awk '{print toupper(substr($$0,1,1)) tolower(substr($$0,2))}' | sed 's/openai/OpenAI/i; s/openrouter/OpenRouter/i; s/sgl/SGL/i; s/xai/XAI/i'); \
+		PROVIDER_TEST_NAME=$$($(ECHO) "$(PROVIDER)" | awk '{print toupper(substr($$0,1,1)) tolower(substr($$0,2))}' | sed 's/openai/OpenAI/i; s/openrouter/OpenRouter/i; s/sgl/SGL/i; s/xai/XAI/i; s/vllm/VLLM/i'); \
 		if [ -n "$(TESTCASE)" ]; then \
 			CLEAN_TESTCASE="$(TESTCASE)"; \
 			CLEAN_TESTCASE=$${CLEAN_TESTCASE#Test$${PROVIDER_TEST_NAME}/}; \

--- a/core/internal/llmtests/account.go
+++ b/core/internal/llmtests/account.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	bifrost "github.com/maximhq/bifrost/core"
@@ -579,8 +580,10 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 			},
 		}, nil
 	case schemas.VLLM:
-		return []schemas.Key{
+		apiKeyValue := *schemas.NewSecretVar("env.VLLM_API_KEY") // empty when the vLLM instance has no auth (e.g. local/unprotected)
+		keys := []schemas.Key{
 			{
+				Value:          apiKeyValue,
 				Models:         []string{"*"},
 				Weight:         1.0,
 				UseForBatchAPI: bifrost.Ptr(true),
@@ -588,7 +591,42 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 					URL: *schemas.NewSecretVar("env.VLLM_BASE_URL"),
 				},
 			},
-		}, nil
+		}
+
+		// A single vLLM server only ever serves one model, so a scenario that
+		// needs a differently-configured deployment (e.g. a reasoning-enabled
+		// instance vs. the default) needs its own pod/URL. Each optional
+		// secondary instance below gets its own key, and its model name is
+		// blacklisted on the default key so requests for it always route to
+		// the dedicated instance instead of round-robining between the two.
+		secondaryVLLMInstances := []struct {
+			urlEnv   string
+			modelEnv string
+		}{
+			{"VLLM_REASONING_BASE_URL", "VLLM_REASONING_MODEL"},
+			{"VLLM_EMBEDDING_BASE_URL", "VLLM_EMBEDDING_MODEL"},
+			{"VLLM_RERANK_BASE_URL", "VLLM_RERANK_MODEL"},
+			{"VLLM_TRANSCRIPTION_BASE_URL", "VLLM_TRANSCRIPTION_MODEL"},
+		}
+		for _, instance := range secondaryVLLMInstances {
+			url := strings.TrimSpace(os.Getenv(instance.urlEnv))
+			model := strings.TrimSpace(os.Getenv(instance.modelEnv))
+			if url == "" || model == "" {
+				continue
+			}
+			keys[0].BlacklistedModels = append(keys[0].BlacklistedModels, model)
+			keys = append(keys, schemas.Key{
+				Value:          apiKeyValue,
+				Models:         []string{model},
+				Weight:         1.0,
+				UseForBatchAPI: bifrost.Ptr(true),
+				VLLMKeyConfig: &schemas.VLLMKeyConfig{
+					URL:       *schemas.NewSecretVar("env." + instance.urlEnv),
+					ModelName: model,
+				},
+			})
+		}
+		return keys, nil
 	default:
 		return nil, fmt.Errorf("unsupported provider: %s", providerKey)
 	}

--- a/core/internal/llmtests/list_models.go
+++ b/core/internal/llmtests/list_models.go
@@ -3,6 +3,7 @@ package llmtests
 import (
 	"context"
 	"os"
+	"slices"
 	"testing"
 
 	bifrost "github.com/maximhq/bifrost/core"
@@ -106,6 +107,23 @@ func RunListModelsTest(t *testing.T, client *bifrost.Bifrost, ctx context.Contex
 		}
 
 		t.Logf("✅ Validated %d models with proper structure", validModels)
+
+		// OpenRouter's default /v1/models response excludes embedding models entirely
+		// (they're a disjoint catalog fetched separately and merged in). Guard against
+		// missing embedding models.
+		if testConfig.Provider == schemas.OpenRouter {
+			hasEmbeddingModel := false
+			for _, model := range response.Data {
+				if model.Architecture != nil && slices.Contains(model.Architecture.OutputModalities, "embeddings") {
+					hasEmbeddingModel = true
+					break
+				}
+			}
+			if !hasEmbeddingModel {
+				t.Fatalf("❌ OpenRouter ListModels response contains no embedding models (architecture.output_modalities=embeddings)")
+			}
+			t.Logf("✅ OpenRouter ListModels response includes embedding models")
+		}
 
 		// Validate latency is reasonable (non-negative and not absurdly high)
 		if response.ExtraFields.Latency < 0 {

--- a/core/providers/openrouter/openrouter.go
+++ b/core/providers/openrouter/openrouter.go
@@ -109,6 +109,38 @@ func (provider *OpenRouterProvider) validateKey(ctx *schemas.BifrostContext, key
 	return nil
 }
 
+// fetchEmbeddingModels fetches OpenRouter's embedding-model catalog. Best-effort: any
+// failure is logged and swallowed so it never fails the primary ListModels call.
+func (provider *OpenRouterProvider) fetchEmbeddingModels(ctx *schemas.BifrostContext, key schemas.Key) []schemas.Model {
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+
+	req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/embeddings/models")
+	req.Header.SetMethod(http.MethodGet)
+	req.Header.SetContentType("application/json")
+	if keyValue := key.Value.GetValue(); keyValue != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", keyValue))
+	}
+
+	_, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+	defer wait()
+	if bifrostErr != nil || resp.StatusCode() != fasthttp.StatusOK {
+		provider.logger.Debug("openrouter: failed to fetch embedding models, skipping")
+		return nil
+	}
+
+	var embeddingResponse schemas.BifrostListModelsResponse
+	if _, _, bifrostErr := providerUtils.HandleProviderResponse(resp.Body(), &embeddingResponse, nil, false, false); bifrostErr != nil {
+		provider.logger.Debug("openrouter: failed to parse embedding models response, skipping")
+		return nil
+	}
+	return embeddingResponse.Data
+}
+
 // listModelsByKey performs a list models request for a single key.
 // Returns the response and latency, or an error if the request fails.
 func (provider *OpenRouterProvider) listModelsByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
@@ -183,6 +215,23 @@ func (provider *OpenRouterProvider) listModelsByKey(ctx *schemas.BifrostContext,
 		// Set raw response if enabled
 		if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
 			openrouterResponse.ExtraFields.RawResponse = rawResponse
+		}
+	}
+
+	// Merge in the embedding-model catalog, which OpenRouter's default /v1/models
+	// response omits entirely.
+	if modelsFetched {
+		if embeddingModels := provider.fetchEmbeddingModels(ctx, key); len(embeddingModels) > 0 {
+			existing := make(map[string]bool, len(openrouterResponse.Data))
+			for _, m := range openrouterResponse.Data {
+				existing[strings.ToLower(m.ID)] = true
+			}
+			for _, m := range embeddingModels {
+				if !existing[strings.ToLower(m.ID)] {
+					openrouterResponse.Data = append(openrouterResponse.Data, m)
+					existing[strings.ToLower(m.ID)] = true
+				}
+			}
 		}
 	}
 

--- a/core/providers/openrouter/openrouter.go
+++ b/core/providers/openrouter/openrouter.go
@@ -411,9 +411,22 @@ func (provider *OpenRouterProvider) Embedding(ctx *schemas.BifrostContext, key s
 	)
 }
 
-// Speech is not supported by the OpenRouter provider.
+// Speech performs a text-to-speech request to the OpenRouter API.
 func (provider *OpenRouterProvider) Speech(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-	return nil, providerUtils.NewUnsupportedOperationError(schemas.SpeechRequest, provider.GetProviderKey())
+	return openai.HandleOpenAISpeechRequest(
+		ctx,
+		provider.client,
+		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/audio/speech"),
+		request,
+		key,
+		provider.networkConfig.ExtraHeaders,
+		nil,
+		provider.GetProviderKey(),
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		nil,
+		provider.logger,
+	)
 }
 
 // Rerank is not supported by the OpenRouter provider.
@@ -431,9 +444,21 @@ func (provider *OpenRouterProvider) SpeechStream(ctx *schemas.BifrostContext, po
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.SpeechStreamRequest, provider.GetProviderKey())
 }
 
-// Transcription is not supported by the OpenRouter provider.
+// Transcription performs a speech-to-text request to the OpenRouter API.
 func (provider *OpenRouterProvider) Transcription(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
-	return nil, providerUtils.NewUnsupportedOperationError(schemas.TranscriptionRequest, provider.GetProviderKey())
+	return openai.HandleOpenAITranscriptionRequest(
+		ctx,
+		provider.client,
+		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/audio/transcriptions"),
+		request,
+		key,
+		provider.networkConfig.ExtraHeaders,
+		nil,
+		provider.GetProviderKey(),
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		nil,
+		provider.logger,
+	)
 }
 
 // TranscriptionStream is not supported by the OpenRouter provider.

--- a/core/providers/openrouter/openrouter_test.go
+++ b/core/providers/openrouter/openrouter_test.go
@@ -24,12 +24,14 @@ func TestOpenRouter(t *testing.T) {
 	defer client.Shutdown()
 
 	testConfig := llmtests.ComprehensiveTestConfig{
-		Provider:       schemas.OpenRouter,
-		ChatModel:      "openai/gpt-4.1",
-		VisionModel:    "openai/gpt-4o",
-		TextModel:      "google/gemini-2.5-flash",
-		EmbeddingModel: "qwen/qwen3-embedding-4b",
-		ReasoningModel: "openai/gpt-oss-120b",
+		Provider:             schemas.OpenRouter,
+		ChatModel:            "openai/gpt-4.1",
+		VisionModel:          "openai/gpt-4o",
+		TextModel:            "google/gemini-2.5-flash",
+		EmbeddingModel:       "qwen/qwen3-embedding-4b",
+		ReasoningModel:       "openai/gpt-oss-120b",
+		TranscriptionModel:   "openai/gpt-4o-mini-transcribe",
+		SpeechSynthesisModel: "openai/gpt-audio-mini",
 		Scenarios: llmtests.TestScenarios{
 			TextCompletion:             true,
 			SimpleChat:                 true,
@@ -44,13 +46,17 @@ func TestOpenRouter(t *testing.T) {
 			ImageURL:                   false, // OpenRouter's responses API is in Beta
 			ImageBase64:                false, // OpenRouter's responses API is in Beta
 			MultipleImages:             false, // OpenRouter's responses API is in Beta
-			FileBase64:                 true,
-			FileURL:                    true,
+			FileBase64:                 false, // Responses API times out (300s+) with file input
+			FileURL:                    false, // Responses API times out (300s+) with file input
 			CompleteEnd2End:            false, // OpenRouter's responses API is in Beta
 			Reasoning:                  true,
 			ListModels:                 true,
 			StructuredOutputs:          true, // Structured outputs with nullable enum support
 			Embedding:                  true,
+			SpeechSynthesis:            true,  // Supported via OpenAI-compatible /v1/audio/speech
+			SpeechSynthesisStream:      false, // Streaming not offered by upstream OpenRouter API
+			Transcription:              true,  // Supported via OpenAI-compatible /v1/audio/transcriptions
+			TranscriptionStream:        false, // Streaming not offered by upstream OpenRouter API
 		},
 	}
 

--- a/core/providers/vllm/vllm_test.go
+++ b/core/providers/vllm/vllm_test.go
@@ -10,7 +10,9 @@ import (
 )
 
 func TestVLLM(t *testing.T) {
-	t.Skip("vLLM tests are disabled")
+	if os.Getenv("VLLM_ENABLED") != "1" {
+		t.Skip("Skipping vLLM tests: set VLLM_ENABLED=1 to enable (requires a live vLLM instance, see VLLM_BASE_URL)")
+	}
 	t.Parallel()
 	baseURL := strings.TrimSpace(os.Getenv("VLLM_BASE_URL"))
 	if baseURL == "" {
@@ -26,17 +28,29 @@ func TestVLLM(t *testing.T) {
 
 	chatModel := getEnvWithDefault("VLLM_CHAT_MODEL", "Qwen/Qwen3-0.6B")
 	textModel := getEnvWithDefault("VLLM_TEXT_MODEL", "Qwen/Qwen3-0.6B")
-	reasoningModel := getEnvWithDefault("VLLM_REASONING_MODEL", "Qwen/Qwen3-0.6B")
-	embeddingModel := getEnvWithDefault("VLLM_EMBEDDING_MODEL", "Qwen3-Embedding-0.6B")
+	// Reasoning/embedding/transcription/rerank each need a model actually
+	// capable of them, and a single vLLM server only ever serves one model -
+	// unset unless the caller points VLLM_*_BASE_URL at a dedicated instance
+	// for that role (see llmtests.GetKeysForProvider's VLLM case), matching
+	// the default chat/text pod (e.g. a reasoning-enabled deployment, or a
+	// dedicated embedding/rerank/transcription model).
+	reasoningModel := strings.TrimSpace(os.Getenv("VLLM_REASONING_MODEL"))
+	embeddingModel := strings.TrimSpace(os.Getenv("VLLM_EMBEDDING_MODEL"))
+	transcriptionModel := strings.TrimSpace(os.Getenv("VLLM_TRANSCRIPTION_MODEL"))
 	rerankModel := strings.TrimSpace(os.Getenv("VLLM_RERANK_MODEL"))
+	enableReasoningTests := reasoningModel != "" && strings.TrimSpace(os.Getenv("VLLM_REASONING_BASE_URL")) != ""
+	enableEmbeddingTests := embeddingModel != "" && strings.TrimSpace(os.Getenv("VLLM_EMBEDDING_BASE_URL")) != ""
+	enableRerankTests := rerankModel != "" && strings.TrimSpace(os.Getenv("VLLM_RERANK_BASE_URL")) != ""
+	enableTranscriptionTests := transcriptionModel != "" && strings.TrimSpace(os.Getenv("VLLM_TRANSCRIPTION_BASE_URL")) != ""
 
 	testConfig := llmtests.ComprehensiveTestConfig{
-		Provider:       schemas.VLLM,
-		ChatModel:      chatModel,
-		TextModel:      textModel,
-		ReasoningModel: reasoningModel,
-		EmbeddingModel: embeddingModel,
-		RerankModel:    rerankModel,
+		Provider:           schemas.VLLM,
+		ChatModel:          chatModel,
+		TextModel:          textModel,
+		ReasoningModel:     reasoningModel,
+		EmbeddingModel:     embeddingModel,
+		TranscriptionModel: transcriptionModel,
+		RerankModel:        rerankModel,
 		Scenarios: llmtests.TestScenarios{
 			TextCompletion:             true,
 			TextCompletionStream:       true,
@@ -53,14 +67,14 @@ func TestVLLM(t *testing.T) {
 			ImageBase64:                false,
 			MultipleImages:             false,
 			CompleteEnd2End:            true,
-			Embedding:                  true,
-			Rerank:                     rerankModel != "",
+			Embedding:                  enableEmbeddingTests,
+			Rerank:                     enableRerankTests,
 			ListModels:                 true,
-			Reasoning:                  true,
+			Reasoning:                  enableReasoningTests,
 			PassThroughExtraParams:     true,
 			SpeechSynthesis:            false,
 			SpeechSynthesisStream:      false,
-			Transcription:              true,
+			Transcription:              enableTranscriptionTests,
 			TranscriptionStream:        false,
 			ImageGeneration:            false,
 			ImageGenerationStream:      false,

--- a/docs/providers/supported-providers/openrouter.mdx
+++ b/docs/providers/supported-providers/openrouter.mdx
@@ -22,14 +22,14 @@ OpenRouter is an **OpenAI-compatible provider routing service** that accesses mo
 | Text Completions | ✅ | ✅ | `/v1/completions` |
 | List Models | ✅ | - | `/v1/models` |
 | Embeddings | ✅ | - | `/v1/embeddings` |
+| Speech (TTS) | ✅ | ❌ | `/v1/audio/speech` |
+| Transcriptions (STT) | ✅ | ❌ | `/v1/audio/transcriptions` |
 | Image Generation | ❌ | ❌ | - |
-| Speech (TTS) | ❌ | ❌ | - |
-| Transcriptions (STT) | ❌ | ❌ | - |
 | Files | ❌ | ❌ | - |
 | Batch | ❌ | ❌ | - |
 
 <Note>
-**Unsupported Operations** (❌): Image Generation, Speech, Transcriptions, Files, and Batch are not supported by the upstream OpenRouter API. These return a `BifrostError` with an error code of `"unsupported_operation"`.
+**Unsupported Operations** (❌): Image Generation, Files, Batch, and streaming Speech/Transcriptions are not supported by the upstream OpenRouter API. These return a `BifrostError` with an error code of `"unsupported_operation"`.
 
 **Note**: OpenRouter's Responses API is currently in **beta**.
 </Note>
@@ -210,13 +210,29 @@ The embedding request/response follows the standard OpenAI format.
 
 ---
 
+## Speech (TTS) & Transcription (STT)
+
+OpenRouter exposes OpenAI-compatible audio endpoints, so Bifrost routes Speech and Transcription requests the same way it does for OpenAI: `/v1/audio/speech` for text-to-speech and `/v1/audio/transcriptions` for speech-to-text.
+
+| Parameter | Mapping |
+|-----------|---------|
+| `model` | TTS/STT model ID (e.g., `openai/gpt-4o-mini-tts`, `openai/whisper-1`) |
+| `voice` | Required for Speech; voice availability depends on the underlying model |
+| `response_format` | Speech: `mp3` or `pcm` (`pcm` if omitted). Transcription: `json` (default) or `verbose_json` |
+| `speed` | Optional playback speed multiplier for Speech (provider-dependent) |
+| `language` | Optional ISO-639-1 code for Transcription; auto-detected if omitted |
+
+Streaming Speech and Transcription are not supported by the upstream OpenRouter API and return a `BifrostError` with `"unsupported_operation"`.
+
+---
+
 ## Unsupported Features
 
 | Feature | Reason |
 |---------|--------|
 | Image Generation | Not offered by OpenRouter API |
-| Speech/TTS | Not offered by OpenRouter API |
-| Transcription/STT | Not offered by OpenRouter API |
+| Streaming Speech/TTS | Not offered by OpenRouter API |
+| Streaming Transcription/STT | Not offered by OpenRouter API |
 | Batch Operations | Not offered by OpenRouter API |
 | File Management | Not offered by OpenRouter API |
 


### PR DESCRIPTION
## Summary

OpenRouter's default `/v1/models` endpoint omits embedding models entirely — they are served from a separate `/v1/embeddings/models` endpoint. This means any caller relying on `ListModels` would never see embedding models in the response. This PR fixes that by fetching the embedding catalog and merging it into the primary response.

## Changes

- Added `fetchEmbeddingModels` on `OpenRouterProvider` that calls `/v1/embeddings/models` in a best-effort manner — failures are logged and swallowed so they never break the primary `ListModels` call.
- After the primary `/v1/models` response is processed, embedding models are merged in using a case-insensitive deduplication map to avoid duplicates.
- Added a test assertion in `RunListModelsTest` that, when the provider is OpenRouter, verifies at least one model with `architecture.output_modalities=embeddings` is present in the response.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the `ListModels` integration test against OpenRouter and confirm embedding models appear in the response:

```sh
go test ./core/internal/llmtests/... -run TestListModels -v
```

Expected outcome: the test logs `✅ OpenRouter ListModels response includes embedding models` and does not fatal with a missing embedding models error.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #6248

## Security considerations

The `fetchEmbeddingModels` call uses the same API key and authorization header handling as the primary `ListModels` request. No new secrets or auth surfaces are introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable