### PR TITLE
chore: add `openai_config` ref to all transport provider config schemas

### DIFF
--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -4488,6 +4488,9 @@
           "minItems": 1,
           "description": "API keys for this provider"
         },
+        "openai_config": {
+          "$ref": "#/$defs/openai_config"
+        },
         "network_config": {
           "$ref": "#/$defs/network_config"
         },


### PR DESCRIPTION
Add missing open_ai config in the open ai provider. changes not done to helm since it does not have the hard additionalProperties false