### PR TITLE
feat: add byte-size cap to observability batch flushing via marshaled trace size

### DIFF
--- a/framework/tracing/obsisolation_test.go
+++ b/framework/tracing/obsisolation_test.go
@@ -2,6 +2,7 @@ package tracing
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -336,6 +337,57 @@ func TestSetObservabilityPlugins_DedupesByName(t *testing.T) {
 	}
 }
 
+// TestObsSlot_SizeTriggerFlushesBeforeCount verifies the memory guard: the byte cap gates
+// delivery — traces buffer silently until their combined size crosses maxBatchBytes, at which
+// point the whole batch flushes, long before the count cap (or the timer) would. The negative
+// half (three traces stay buffered) is what distinguishes a real size cap from an
+// implementation that just flushes every trace. Content lives in both trace- and span-level
+// attributes, so trace-level byte accounting is exercised too.
+func TestObsSlot_SizeTriggerFlushesBeforeCount(t *testing.T) {
+	p := &blockingObsPlugin{name: "big"}
+	slot := &obsPluginSlot{
+		plugin:        p,
+		name:          p.name,
+		batchSize:     1_000_000, // count cap effectively unreachable
+		maxBatchBytes: 64 * 1024, // 64 KiB size cap
+		flushInterval: time.Hour, // timer never fires during the test
+		stop:          make(chan struct{}),
+	}
+	slot.start(nil)
+	defer slot.signalStop()
+
+	// ~18 KiB per trace, split across trace- and span-level attributes: three stay under the
+	// 64 KiB cap (~54 KiB), the fourth crosses it (~72 KiB).
+	bigTrace := func() *schemas.Trace {
+		return &schemas.Trace{
+			Attributes: map[string]any{"trace.big": strings.Repeat("x", 9*1024)},
+			Spans: []*schemas.Span{
+				{Name: "s", Attributes: map[string]any{"span.big": strings.Repeat("x", 9*1024)}},
+			},
+		}
+	}
+
+	// Three traces must NOT flush — the cap gates, it doesn't fire per trace. Give any wrongly
+	// triggered flush time to reach Inject before asserting nothing was delivered.
+	for range 3 {
+		slot.enqueue(bigTrace(), nil)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if got := p.started.Load(); got != 0 {
+		t.Fatalf("byte cap flushed early: %d trace(s) delivered before the cap was reached", got)
+	}
+
+	// The fourth trace crosses the cap and flushes the whole buffered batch.
+	slot.enqueue(bigTrace(), nil)
+	deadline := time.Now().Add(2 * time.Second)
+	for p.started.Load() < 4 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := p.started.Load(); got != 4 {
+		t.Fatalf("expected the byte cap to flush all 4 buffered traces, got %d", got)
+	}
+}
+
 // TestObsSlot_PostCloseEnqueueStillDelivers is the shutdown-window guarantee: a trace
 // appended after the slot has been told to stop — a producer still holding a retired slot
 // during a config reload — is flushed immediately rather than lost in a batch the timer will
@@ -346,6 +398,7 @@ func TestObsSlot_PostCloseEnqueueStillDelivers(t *testing.T) {
 		plugin:        p,
 		name:          p.name,
 		batchSize:     1000,      // never reached; only the timer or close flushes
+		maxBatchBytes: 1 << 30,   // size cap effectively disabled, so the first trace buffers
 		flushInterval: time.Hour, // never ticks during the test
 		stop:          make(chan struct{}),
 	}

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -9,13 +9,15 @@ import (
 	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
 	"github.com/maximhq/bifrost/framework/streaming"
 )
 
 const (
-	DefaultObservabilityBatchSize     = 1000             // number of traces to accumulate before flushing to a connector; the count cap is the primary trigger for busy connectors
-	DefaultObservabilityFlushInterval = 10 * time.Second // how often to flush a connector's buffer, even if the count cap hasn't been hit
+	DefaultObservabilityBatchSize     = 1000                                // number of traces to accumulate before flushing to a connector; the count cap is the primary trigger for busy connectors
+	DefaultObservabilityMaxBatchBytes = logstore.DefaultWriterMaxBatchBytes // in-memory byte size of traces to accumulate before flushing to a connector
+	DefaultObservabilityFlushInterval = 10 * time.Second                    // how often to flush a connector's buffer, even if the count/size caps haven't been hit
 
 	// flushStopTimeout bounds how long Stop waits for in-flight flushes, so a hung
 	// connector cannot block shutdown or a config reload.
@@ -32,11 +34,13 @@ type obsPluginSlot struct {
 	name   string
 
 	batchSize     int
+	maxBatchBytes int
 	flushInterval time.Duration
 
-	mu     sync.Mutex       // guards batch and closed
-	batch  []*schemas.Trace // accumulating buffer; swapped out on flush
-	closed bool             // set once the timer goroutine is stopping; late appends flush immediately
+	mu         sync.Mutex       // guards batch, batchBytes and closed
+	batch      []*schemas.Trace // accumulating buffer; swapped out on flush
+	batchBytes int              // estimated in-memory size of batch; reset when the buffer is swapped
+	closed     bool             // set once the timer goroutine is stopping; late appends flush immediately
 
 	stop    chan struct{}  // closed to tell the timer goroutine to do a final flush and exit
 	stopped sync.Once      // so stop is only closed once (reload and Stop can race)
@@ -68,8 +72,12 @@ func (s *obsPluginSlot) run(logger schemas.Logger) {
 	}
 }
 
-// enqueue appends a trace and flushes early once the buffer reaches the count cap.
+// enqueue appends a trace and flushes early once the buffer reaches either the count cap or
+// the estimated-size cap.
 func (s *obsPluginSlot) enqueue(trace *schemas.Trace, logger schemas.Logger) {
+	// Size outside the lock — the marshal is the only non-trivial work here.
+	size := marshaledTraceSize(trace)
+
 	s.mu.Lock()
 	if s.closed {
 		s.mu.Unlock()
@@ -77,14 +85,32 @@ func (s *obsPluginSlot) enqueue(trace *schemas.Trace, logger schemas.Logger) {
 		return
 	}
 	s.batch = append(s.batch, trace)
-	if len(s.batch) < s.batchSize {
+	s.batchBytes += size
+	if len(s.batch) < s.batchSize && s.batchBytes < s.maxBatchBytes {
 		s.mu.Unlock()
 		return
 	}
 	batch := s.batch
 	s.batch = nil
+	s.batchBytes = 0
 	s.mu.Unlock()
 	s.flush(batch, logger)
+}
+
+// marshaledTraceSize returns the serialized byte size of a trace, used only to decide when a
+// buffer has grown large enough to flush. Unlike a hand-rolled walk it counts exactly what a
+// connector would emit — every field, at full depth — by marshaling once here. The caller
+// passes the detached export snapshot, so this runs off the hot mutation path and cannot race
+// a late span writer. A marshal error yields 0; the count cap and timer still bound the buffer.
+func marshaledTraceSize(t *schemas.Trace) int {
+	if t == nil {
+		return 0
+	}
+	data, err := schemas.MarshalString(t)
+	if err != nil {
+		return 0
+	}
+	return len(data)
 }
 
 // take atomically swaps the current buffer out for a fresh one and returns it.
@@ -92,6 +118,7 @@ func (s *obsPluginSlot) take() []*schemas.Trace {
 	s.mu.Lock()
 	batch := s.batch
 	s.batch = nil
+	s.batchBytes = 0
 	s.mu.Unlock()
 	return batch
 }
@@ -149,10 +176,11 @@ type Tracer struct {
 	cachedHdrPatterns atomic.Pointer[[]string]
 	flushWG           sync.WaitGroup
 
-	// batchSize and flushInterval size each connector's buffer, read when the plugin slots are
-	// built. They default to the DefaultObservability* values; tests override them before
-	// SetObservabilityPlugins.
+	// batchSize, maxBatchBytes, and flushInterval size each connector's buffer, read when the
+	// plugin slots are built. They default to the DefaultObservability* values; tests override
+	// them before SetObservabilityPlugins.
 	batchSize     int
+	maxBatchBytes int
 	flushInterval time.Duration
 }
 
@@ -167,6 +195,7 @@ func NewTracer(store *TraceStore, pricingManager *modelcatalog.ModelCatalog, log
 		logger:         logger,
 		obsPlugins:     atomic.Pointer[[]*obsPluginSlot]{},
 		batchSize:      DefaultObservabilityBatchSize,
+		maxBatchBytes:  DefaultObservabilityMaxBatchBytes,
 		flushInterval:  DefaultObservabilityFlushInterval,
 	}
 }
@@ -199,6 +228,10 @@ func (t *Tracer) SetObservabilityPlugins(obsPlugins []schemas.ObservabilityPlugi
 	if batchSize <= 0 {
 		batchSize = DefaultObservabilityBatchSize
 	}
+	maxBatchBytes := t.maxBatchBytes
+	if maxBatchBytes <= 0 {
+		maxBatchBytes = DefaultObservabilityMaxBatchBytes
+	}
 	flushInterval := t.flushInterval
 	if flushInterval <= 0 {
 		flushInterval = DefaultObservabilityFlushInterval
@@ -218,6 +251,7 @@ func (t *Tracer) SetObservabilityPlugins(obsPlugins []schemas.ObservabilityPlugi
 			plugin:        plugin,
 			name:          name,
 			batchSize:     batchSize,
+			maxBatchBytes: maxBatchBytes,
 			flushInterval: flushInterval,
 			stop:          make(chan struct{}),
 		}
@@ -1020,8 +1054,8 @@ func (t *Tracer) CompleteAndFlushTrace(traceID string) {
 		// Append the snapshot to each connector's buffer and return. The snapshot is detached
 		// from the pooled trace, so it's safe to hold in the buffers after this goroutine
 		// releases the pooled object below, and safe for all connectors to share one copy
-		// (they only read it). enqueue never blocks: it appends and, at most, hands a full
-		// batch off to a new flush goroutine.
+		// (they only read it). enqueue appends the snapshot and, when a cap is reached,
+		// flushes the batch inline before returning.
 		for _, slot := range slots {
 			slot.enqueue(exportTrace, t.logger)
 		}


### PR DESCRIPTION
## Summary

Observability plugin buffers previously had only a count-based flush cap, meaning a small number of very large traces (e.g., those carrying large message payloads in span attributes) could accumulate significant memory between timer ticks. This PR adds a byte-size cap as a second flush trigger, so the buffer is flushed as soon as its estimated in-memory size exceeds a configurable threshold — regardless of trace count or timer interval.

## Changes

- Added `maxBatchBytes` field to `obsPluginSlot` and `Tracer`, defaulting to `logstore.DefaultWriterMaxBatchBytes`.
- `enqueue` now tracks `batchBytes` alongside `batch` length and flushes early when either the count cap or the byte cap is reached.
- Added `estimateTraceSize` and `estimateAttrSize` helpers that walk variable-length fields (trace/span attributes, request headers, plugin logs, span events) to produce a cheap approximate size. String and string-slice values are measured exactly; scalars fall back to a 16-byte constant.
- `take` resets `batchBytes` when swapping the buffer, keeping the accounting consistent.
- Added `TestObsSlot_SizeTriggerFlushesBeforeCount` to verify that a handful of ~20 KiB traces trip the 64 KiB byte cap well before the count cap (set to 1,000,000) or the timer (set to 1 hour) would fire.
- Updated `TestObsSlot_PostCloseEnqueueStillDelivers` to set `maxBatchBytes` to a large value so the byte cap doesn't interfere with that test's intent.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/tracing/... -run TestObsSlot_SizeTriggerFlushesBeforeCount -v
go test ./framework/tracing/... -v
```

The new test enqueues four ~20 KiB traces against a slot with a 64 KiB byte cap and a count cap of 1,000,000. It expects a flush to be triggered within 2 seconds purely from the byte cap being exceeded.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. The size estimation walks trace attribute values but does not copy or log them; no PII exposure is introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable