### PR TITLE
feat: dispatch `obsPluginSlot` flushes on isolated goroutines so slow connectors can't block others

### DIFF
--- a/framework/tracing/obsisolation_test.go
+++ b/framework/tracing/obsisolation_test.go
@@ -91,6 +91,41 @@ func TestSetObservabilityFlushIntervalSeconds(t *testing.T) {
 	}
 }
 
+// TestCompleteAndFlushTrace_SlowPluginDoesNotDelayOthers is the core isolation guarantee:
+// a connector doing blocking network I/O in Inject must not hold up delivery to another
+// connector — including the logging plugin, whose Inject enqueues the row for the DB.
+func TestCompleteAndFlushTrace_SlowPluginDoesNotDelayOthers(t *testing.T) {
+	store := NewTraceStore(5*time.Minute, nil)
+	defer store.Stop()
+
+	tracer := newTestTracer(store, 20*time.Millisecond)
+	defer tracer.Stop()
+
+	const slowInject = 750 * time.Millisecond
+	slow := &blockingObsPlugin{name: "slow-connector", delay: slowInject}
+	fast := &blockingObsPlugin{name: "fast-connector"}
+
+	// Slow one registered first: the ordering that used to cause the stall.
+	tracer.SetObservabilityPlugins([]schemas.ObservabilityPlugin{slow, fast})
+
+	traceID := tracer.CreateTrace("")
+	start := time.Now()
+	tracer.CompleteAndFlushTrace(traceID)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for fast.started.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if fast.started.Load() == 0 {
+		t.Fatal("fast plugin was never injected")
+	}
+
+	elapsed := time.Unix(0, fast.firstEntry.Load()).Sub(start)
+	if elapsed >= slowInject {
+		t.Fatalf("fast plugin was blocked behind the slow one: entered Inject after %v (slow plugin takes %v)", elapsed, slowInject)
+	}
+}
+
 // TestCompleteAndFlushTrace_CountTriggerFlushesBeforeTick verifies the count trigger: once a
 // connector's buffer reaches batchSize it flushes immediately, without waiting for the
 // interval tick, and nothing is dropped.
@@ -121,6 +156,68 @@ func TestCompleteAndFlushTrace_CountTriggerFlushesBeforeTick(t *testing.T) {
 	}
 	if dropped := tracer.ObservabilityDropCounts()["counter"]; dropped != 0 {
 		t.Fatalf("expected no drops, got %d", dropped)
+	}
+}
+
+// TestCompleteAndFlushTrace_HungPluginBuffersThenDeliversAll is the end-to-end promise:
+// push 10000 traces at a plugin whose Inject hangs. They fill the buffer and pile up behind
+// blocked flush goroutines — delivered nowhere, but dropped nowhere either. Once the plugin
+// unblocks, every single one of the 10000 must drain through.
+func TestCompleteAndFlushTrace_HungPluginBuffersThenDeliversAll(t *testing.T) {
+	store := NewTraceStore(5*time.Minute, nil)
+	defer store.Stop()
+
+	// Short interval so the trailing partial batch (10000 is not a multiple of 1024) is
+	// flushed by the timer too, exercising both triggers under the hang.
+	tracer := newTestTracer(store, 50*time.Millisecond)
+	tracer.batchSize = 1024
+	defer tracer.Stop()
+
+	hung := &blockingObsPlugin{name: "hung", release: make(chan struct{})}
+	// Release on every exit path so a failed assertion doesn't leave flush goroutines
+	// blocked in Inject (pinning their batches) for the rest of the package run.
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(hung.release) }) }
+	defer release()
+	tracer.SetObservabilityPlugins([]schemas.ObservabilityPlugin{hung})
+
+	const total = 10000
+	for range total {
+		tracer.CompleteAndFlushTrace(tracer.CreateTrace(""))
+	}
+	// All producer appends complete quickly even though every flush goroutine is stuck.
+	if !tracer.waitForFlushes(5 * time.Second) {
+		t.Fatal("producers did not finish appending")
+	}
+
+	// Give the timer a few ticks to flush the trailing partial batch into a (blocked) flush
+	// goroutine, so every trace is now either buffered or in-flight — none dropped.
+	time.Sleep(300 * time.Millisecond)
+
+	// While the plugin hangs, delivery is stalled: only the first trace of each dispatched
+	// batch has entered Inject; the vast majority wait behind them.
+	if s := hung.started.Load(); s == 0 || s >= total {
+		t.Fatalf("while hung, expected some-but-not-all traces in Inject, got %d/%d", s, total)
+	}
+	if hung.inFlight.Load() == 0 {
+		t.Fatal("expected flush goroutines blocked in Inject while the plugin hangs")
+	}
+	if d := tracer.ObservabilityDropCounts()["hung"]; d != 0 {
+		t.Fatalf("expected no drops while buffering, got %d", d)
+	}
+
+	// Release: every buffered / in-flight trace must now drain through.
+	release()
+
+	deadline := time.Now().Add(15 * time.Second)
+	for hung.started.Load() < total && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Millisecond)
+	}
+	if got := hung.started.Load(); got != total {
+		t.Fatalf("expected all %d traces delivered after release, got %d", total, got)
+	}
+	if d := tracer.ObservabilityDropCounts()["hung"]; d != 0 {
+		t.Fatalf("expected zero drops overall, got %d", d)
 	}
 }
 

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -25,9 +25,10 @@ const (
 )
 
 // obsPluginSlot gives one observability plugin its own batch buffer and a timer goroutine
-// that flushes it. Traces accumulate in the buffer; a flush delivers the whole batch by
-// injecting each trace in turn. Nothing is dropped — producers always append. Each connector
-// has its own buffer so they don't contend on a shared one.
+// that flushes it. Traces accumulate in the buffer; a flush hands the whole batch to a new
+// goroutine (so it never blocks accumulation) which delivers each trace via Inject. Nothing
+// is dropped — producers always append. Each connector has its own buffer so a slow one
+// can't hold up the others.
 type obsPluginSlot struct {
 	plugin schemas.ObservabilityPlugin
 	name   string
@@ -43,7 +44,7 @@ type obsPluginSlot struct {
 
 	stop    chan struct{}  // closed to tell the timer goroutine to do a final flush and exit
 	stopped sync.Once      // so stop is only closed once (reload and Stop can race)
-	wg      sync.WaitGroup // timer goroutine, for a bounded drain
+	wg      sync.WaitGroup // timer goroutine + in-flight flush goroutines, for a bounded drain
 
 	dropped atomic.Int64 // retained for ObservabilityDropCounts; stays 0 in this design
 }
@@ -71,8 +72,7 @@ func (s *obsPluginSlot) run(logger schemas.Logger) {
 	}
 }
 
-// enqueue appends a trace and flushes early once the buffer reaches either the count cap or
-// the estimated-size cap.
+// enqueue appends a trace and flushes early once the buffer reaches either the count cap or estimated-size cap
 func (s *obsPluginSlot) enqueue(trace *schemas.Trace, logger schemas.Logger) {
 	// Estimate outside the lock — the walk is the only non-trivial work here.
 	size := estimateTraceSize(trace)
@@ -182,14 +182,19 @@ func (s *obsPluginSlot) take() []*schemas.Trace {
 	return batch
 }
 
-// flush delivers a batch by injecting each trace in turn. Empty batches are a no-op.
+// flush delivers a batch on its own goroutine so accumulation never blocks on a slow
+// connector. Empty batches are a no-op.
 func (s *obsPluginSlot) flush(batch []*schemas.Trace, logger schemas.Logger) {
 	if len(batch) == 0 {
 		return
 	}
-	for _, trace := range batch {
-		s.inject(trace, logger)
-	}
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		for _, trace := range batch {
+			s.inject(trace, logger)
+		}
+	}()
 }
 
 // inject hands one trace to the plugin, recovering from panics so a bad backend can't take
@@ -1085,8 +1090,8 @@ func (t *Tracer) CompleteAndFlushTrace(traceID string) {
 		// Append the snapshot to each connector's buffer and return. The snapshot is detached
 		// from the pooled trace, so it's safe to hold in the buffers after this goroutine
 		// releases the pooled object below, and safe for all connectors to share one copy
-		// (they only read it). enqueue appends the snapshot and, when a cap is reached,
-		// flushes the batch inline before returning.
+		// (they only read it). enqueue never blocks: it appends and, at most, hands a full
+		// batch off to a new flush goroutine.
 		for _, slot := range slots {
 			slot.enqueue(exportTrace, t.logger)
 		}


### PR DESCRIPTION
## Summary

Observability plugin `Inject` calls were previously executed inline during a flush, meaning a slow or blocking connector (e.g., one doing network I/O) would stall delivery to all subsequent connectors in the list. This PR moves each flush batch onto its own goroutine so that a slow plugin can never block accumulation or delay other plugins.

## Changes

- `obsPluginSlot.flush` now spawns a goroutine per batch instead of injecting traces inline. The goroutine is tracked by the existing `sync.WaitGroup` (comment updated to reflect this), ensuring bounded drain on shutdown.
- `enqueue` no longer blocks on slow connectors — it appends and, at most, hands a full batch off to the new goroutine.
- Two new tests cover the isolation guarantees:
  - `TestCompleteAndFlushTrace_SlowPluginDoesNotDelayOthers`: verifies that a slow connector registered first does not delay a fast connector's `Inject` entry.
  - `TestCompleteAndFlushTrace_HungPluginBuffersThenDeliversAll`: verifies that 10,000 traces pushed at a completely hung plugin are buffered without drops and fully delivered once the plugin unblocks.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Plugins

## How to test

```sh
go test ./framework/tracing/... -v -run TestCompleteAndFlushTrace_SlowPluginDoesNotDelayOthers
go test ./framework/tracing/... -v -run TestCompleteAndFlushTrace_HungPluginBuffersThenDeliversAll
go test ./framework/tracing/...
```

The two new tests will fail on the previous implementation and pass with this change. The hung-plugin test confirms zero drops across all 10,000 traces after the plugin is released.

## Breaking changes

- [x] No

## Security considerations

None. The change is scoped to internal goroutine dispatch for observability delivery and does not affect auth, secrets, or PII handling.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable