### PR TITLE
docs(complexity): OpenAPI, Helm, and feature doc coverage for the LLM fallback classifier

### DIFF
--- a/docs/features/governance/complexity-router.mdx
+++ b/docs/features/governance/complexity-router.mdx
@@ -16,7 +16,7 @@ complexity_tier in ["MEDIUM", "COMPLEX"]
 
 This lets you route simple greetings to a fast, cheap model and deep reasoning tasks to a frontier model automatically, with no changes to your application code.
 
-Classification runs only when a routing rule actually references `complexity_tier`, so requests that never touch a complexity rule pay no embedding cost. When classification is unavailable or the request resembles no reference phrase closely enough, Bifrost leaves `complexity_tier` unknown and keeps the request on its existing routing path instead of guessing.
+Classification runs only when a routing rule actually references `complexity_tier`, so requests that never touch a complexity rule pay no embedding cost. Once semantic classification is configured, a request it cannot confidently match — a near miss, a timeout, an in-progress warmup — leaves `complexity_tier` unpublished. You can optionally configure an **LLM fallback classifier** to step in for exactly those requests — see [LLM fallback classifier](#llm-fallback-classifier). The fallback engages only after semantic classification has actually run; without semantic classification configured at all, Bifrost keeps the request on its existing routing path instead of guessing.
 
 <Note>
 Complexity classification is **semantic** (embedding-based). The older lexical keyword scorer is retired. See [Lexical keyword classifier (retired)](#lexical-keyword-classifier-retired) for details and migration guidance.
@@ -57,6 +57,26 @@ With semantic classification configured, every tier must contain at least one ph
 
 ---
 
+## LLM fallback classifier
+
+By default, a request that matches no reference phrase confidently simply carries no `complexity_tier`. If you'd rather have a second opinion than let those requests fall through, set semantic classification's `fallback` to `llm` and configure a chat model to name the tier instead.
+
+The LLM fallback runs **only after** semantic classification produces no tier — never as the primary classifier, and never in parallel with it. It never sees a request that semantic classification already resolved.
+
+<Warning>
+The cost of this classifier is latency, paid on every request it runs for. A request that reaches the fallback waits on one full chat completion from the configured model before it is routed. Pick a small, fast model, and use `timeout` to cap the wait — a timed-out classification skips complexity routing for that request, exactly like an unmatched semantic request without a fallback.
+</Warning>
+
+The fallback model is asked to answer with one of the three tier names, guided by a prompt you can edit (`prompt`, or **Fallback Classification Prompt** on the Complexity Router page). Bifrost always appends a fixed, non-editable section stating the tier names and the required JSON response shape, so your edits refine *what the tiers mean* to the model but can never break the response contract. Leaving `prompt` empty uses Bifrost's shipped default guidance.
+
+`message_history_count` behaves the same way it does for semantic classification: it controls how many of the most recent user messages (oldest first) are sent to the fallback model, independent of the semantic classifier's own `message_history_count`.
+
+<Note>
+An LLM-classified turn carries no similarity score — a chat completion has no equivalent of embedding-distance, and a synthetic one would invite comparisons against thresholds tuned for your vector backend. `complexity_score` is therefore absent on rows where `complexity_mechanism` is `llm`. See [Observability](#observability).
+</Note>
+
+---
+
 ## Configuration
 
 Semantic classification requires an embedding provider and model. The provider must have an enabled key in **Model Providers**. The UI warns you if the saved provider has no usable key.
@@ -67,9 +87,10 @@ Semantic classification requires an embedding provider and model. The provider m
 Navigate to **Complexity Router** in the sidebar.
 
 - **Phrase to Tier Mapping**: add a phrase by typing it and pressing **Enter** in a tier's input; remove one with the × on its chip. Counts are shown per tier.
-- **Edit embedding configuration**: opens the embedding sheet (provider, model, similarity floor, history window, timeout, budgets, and phrase storage: **Embedded** keeps phrase vectors in Bifrost's own memory; **Vector Store** keeps them in the configured vector store so they survive restarts, falling back to Embedded when none is available).
+- **Edit embedding configuration**: opens the embedding sheet (provider, model, similarity floor, history window, timeout, budgets, and phrase storage: **Embedded** keeps phrase vectors in Bifrost's own memory; **Vector Store** keeps them in the configured vector store so they survive restarts, falling back to Embedded when none is available). Setting **When no phrase matches confidently** to **LLM classifier** reveals a **Fallback classifier** section further down the same sheet — provider, model, timeout, history window, and budgets for the fallback model. Setting it back to **None** hides that section again; its settings are preserved either way.
+- When the fallback is on, a **Fallback Classification Prompt** section appears on the main page below the phrase lists, with a **Reset to default** button. The model itself is configured in the embedding sheet; only the prompt text lives here, since it needs room to iterate.
 - The **Classifier status** badge in the header shows whether the classifier is ready to serve (see [Classifier status and warmup](#classifier-status-and-warmup)).
-- Click **Save changes** to apply (hot-reloaded, no restart), **Discard changes** to revert unsaved edits, or **Restore defaults** to restore the built-in reference phrases. Restore defaults keeps the embedding configuration.
+- Click **Save changes** to apply (hot-reloaded, no restart), **Discard changes** to revert unsaved edits, or **Restore defaults** to restore the built-in reference phrases. Restore defaults keeps the embedding and fallback configuration.
 
 ![Embedding configuration](../../media/ui-complexity-router-embedding-configuration.png)
 
@@ -93,7 +114,8 @@ curl -X PUT http://localhost:8080/api/routing/complexity-analyzer-config \
       "min_similarity": 0,
       "message_history_count": 1,
       "count_toward_budgets": false,
-      "vector_store": "embedded"
+      "vector_store": "embedded",
+      "fallback": "none"
     },
     "keywords": {
       "simple_keywords": ["what is a mutex?", "fix the grammar in this sentence."],
@@ -102,7 +124,30 @@ curl -X PUT http://localhost:8080/api/routing/complexity-analyzer-config \
     }
   }'
 
-# Check classifier status
+# Enable the LLM fallback classifier: set semantic.fallback to "llm" and add an llm block
+curl -X PUT http://localhost:8080/api/routing/complexity-analyzer-config \
+  -H "Content-Type: application/json" \
+  -d '{
+    "semantic": {
+      "provider": "openai",
+      "embedding_model": "text-embedding-3-small",
+      "fallback": "llm"
+    },
+    "llm": {
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "timeout": "4s",
+      "message_history_count": 1,
+      "count_toward_budgets": false
+    },
+    "keywords": {
+      "simple_keywords": ["what is a mutex?", "fix the grammar in this sentence."],
+      "medium_keywords": ["add api-key auth: hash the keys, reject revoked ones, and never log them."],
+      "complex_keywords": ["balance testing, prescribing rules, and staffing against rising resistant infections."]
+    }
+  }'
+
+# Check classifier status (includes llm readiness and the default prompt when llm is configured)
 curl http://localhost:8080/api/routing/complexity-analyzer-status
 
 # Restore built-in reference phrases (embedding configuration is preserved)
@@ -125,7 +170,16 @@ Reference-phrase lists are stored in the existing `keywords` fields (`simple_key
         "min_similarity": 0,
         "message_history_count": 1,
         "count_toward_budgets": false,
-        "vector_store": "embedded"
+        "vector_store": "embedded",
+        "fallback": "llm"
+      },
+      "llm": {
+        "provider": "openai",
+        "model": "gpt-4o-mini",
+        "timeout": "4s",
+        "prompt": "",
+        "message_history_count": 1,
+        "count_toward_budgets": false
       },
       "keywords": {
         "simple_keywords": ["what is a mutex?", "fix the grammar in this sentence."],
@@ -144,8 +198,15 @@ Reference-phrase lists are stored in the existing `keywords` fields (`simple_key
 | `semantic.timeout` | duration | `1.5s` | Ceiling on the inline embedding call; exceeding it skips tier routing for that request |
 | `semantic.min_similarity` | number | `0` | Similarity floor. Below it no tier is published. `0` accepts the nearest eligible match |
 | `semantic.message_history_count` | integer | `1` | Number of recent user messages joined into the embedded text (1–10) |
-| `semantic.count_toward_budgets` | boolean | `false` | Count embedding usage toward virtual-key budgets |
+| `semantic.count_toward_budgets` | boolean | `false` | Count embedding usage toward virtual-key budgets (record-only, never enforced) |
 | `semantic.vector_store` | string | `embedded` | `embedded` uses Bifrost's built-in in-memory store and re-embeds phrases on restart. `vector_store` uses the configured top-level `vector_store`; if none is configured, it safely uses Embedded instead. |
+| `semantic.fallback` | string | `none` | What answers when semantic classification produces no tier: `none` records the request as skipped; `llm` asks the model configured in `llm` below. Requires `llm` to be set |
+| `llm.provider` | string | Required when `fallback` is `llm` | Provider used to run the classification chat completion; must have an enabled key |
+| `llm.model` | string | Required when `fallback` is `llm` | Chat model asked to name the tier. Pick a small, fast one — every fallback classification waits on one completion |
+| `llm.timeout` | duration | `4s` | Ceiling on the classification completion; exceeding it skips tier routing for that request |
+| `llm.prompt` | string | Shipped default guidance | Replaces the shipped classification guidance (max 4,000 characters). The tier-name and response-format reinforcement is appended by Bifrost regardless and cannot be edited |
+| `llm.message_history_count` | integer | `1` | Number of recent user messages sent to the classifier, oldest first (1–10) |
+| `llm.count_toward_budgets` | boolean | `false` | Count classification completion cost toward virtual-key budgets (record-only, never enforced) |
 | `keywords.simple_keywords` | string[] | 50 built-in phrases | Reference phrases for the Simple tier |
 | `keywords.medium_keywords` | string[] | 50 built-in phrases | Reference phrases for the Medium tier |
 | `keywords.complex_keywords` | string[] | 50 built-in phrases | Reference phrases for the Complex tier |
@@ -177,6 +238,13 @@ The badge in the UI header and `GET /api/routing/complexity-analyzer-status` rep
 | `failed` | The desired configuration failed to warm. When `serving_previous` is true, the previous generation keeps serving while you fix the problem |
 
 The status response never contains phrases, embeddings, or provider secrets.
+
+The same response always also carries the LLM fallback classifier's own status, whether or not it is configured:
+
+| Field | Values | Meaning |
+|---|---|---|
+| `llm.state` | `disabled`, `ready` | `disabled` means no `llm` block is configured; `ready` means it is. Unlike semantic classification, the LLM fallback has no warmup — it makes its first provider call on the first classification it runs, so it is ready as soon as it is saved. |
+| `llm_default_prompt` | string | The shipped classification guidance, served so a configuration client (like the **Fallback Classification Prompt** editor) can seed itself and offer a reset without holding a copy that drifts from the gateway's. Present regardless of whether an `llm` block is configured. |
 
 ---
 
@@ -303,15 +371,21 @@ When a routing rule references `complexity_tier`, the classification outcome is 
 | Field | Values | Meaning |
 |---|---|---|
 | `complexity_tier` | `SIMPLE`, `MEDIUM`, `COMPLEX` | The tier the request was classified into |
-| `complexity_mechanism` | `semantic`, `skipped` | How the tier was produced. `semantic` means an embedding match produced the tier; `skipped` means a rule demanded a tier but classification produced none (classifier not configured or not ready, unsupported input, embedding failure/timeout, or a match below `min_similarity`) |
-| `complexity_score` | 0.0 – 1.0 | The similarity score of the nearest reference phrase |
+| `complexity_mechanism` | `semantic`, `llm`, `skipped` | How the tier was produced. `semantic` means an embedding match produced the tier; `llm` means the fallback chat model named the tier after semantic classification produced none; `skipped` means a rule demanded a tier but neither produced one (classifier not configured or not ready, unsupported input, failure/timeout, or a match below `min_similarity`) |
+| `complexity_score` | 0.0 – 1.0 | The similarity score of the nearest reference phrase. Never set when `complexity_mechanism` is `llm` — a chat completion has no equivalent similarity score |
 
 The routing decision logs also record the matched reference phrase alongside the tier and similarity, so you can tell a genuine match from an accidental one. Long phrases are truncated to 120 characters in the log line.
 
-For example, a successful match is recorded as:
+For example, a successful semantic match is recorded as:
 
 ```text
 Semantic complexity: tier=MEDIUM similarity=0.62 matched="produce a customer-facing incident summary from an already established cause and remediation."
+```
+
+A tier produced by the LLM fallback is recorded as:
+
+```text
+LLM complexity: tier=COMPLEX
 ```
 
 These fields are only set when a routing rule actually referenced `complexity_tier`; requests that never touched a complexity rule carry no complexity fields.
@@ -325,7 +399,7 @@ curl "http://localhost:8080/api/logs?complexity_tiers=COMPLEX&complexity_mechani
 ```
 
 <Note>
-The raw `complexity_score` is displayed but not filterable; tier and mechanism are the supported filter dimensions. The mechanism filter offers `semantic` and `skipped`. Legacy `REASONING` tiers remain available in the logs filter.
+The raw `complexity_score` is displayed but not filterable; tier and mechanism are the supported filter dimensions. The mechanism filter offers `semantic`, `llm`, and `skipped`. Legacy `REASONING` tiers remain available in the logs filter.
 </Note>
 
 ### In telemetry
@@ -337,6 +411,11 @@ Semantic routing's own embedding overhead is tracked separately with two Prometh
 - `bifrost_routing_embedding_requests_total`
 - `bifrost_routing_embedding_cost_total` (USD; recorded whether or not `count_toward_budgets` is set)
 
+The LLM fallback classifier's own completion overhead is tracked separately too, with two Prometheus counters labeled by the fallback provider and model (no `phase` label — the fallback has no warmup):
+
+- `bifrost_routing_llm_requests_total`
+- `bifrost_routing_llm_cost_total` (USD; recorded whether or not `count_toward_budgets` is set)
+
 See [Telemetry](../telemetry) and [Prometheus](../observability/prometheus) for the full attribute and label reference.
 
 ---
@@ -345,13 +424,23 @@ See [Telemetry](../telemetry) and [Prometheus](../observability/prometheus) for 
 
 ### No tier is ever published (everything is `skipped`)
 
-The most common cause is that semantic classification is not configured or not ready. Check the classifier status badge or `GET /api/routing/complexity-analyzer-status`:
+The most common cause is that semantic classification is not configured. Without a configured semantic classifier, no fallback runs either — the LLM fallback only ever engages after semantic classification has actually been invoked, never as a substitute for missing semantic configuration. Check the classifier status badge or `GET /api/routing/complexity-analyzer-status`:
 
 - `disabled`: set an embedding provider and model, and make sure the provider has an enabled key.
 - `warming`: warmup is embedding the reference phrases. If `serving_previous` is true, the last good generation remains available while it runs.
 - `failed`: check server logs for the provider or vector-store failure. If `serving_previous` is true, the last good generation is still serving while you fix the configuration.
 
+If semantic classification is configured and ready, but individual requests still land as skipped (a near miss, a timeout), consider configuring the [LLM fallback classifier](#llm-fallback-classifier) instead of leaving those requests unclassified.
+
 Also verify a routing rule actually references `complexity_tier`; classification runs lazily and never runs otherwise.
+
+### Setting `fallback` to `llm` is rejected
+
+Semantic classification's `fallback` field requires a companion `llm` block with at least `provider` and `model` set — the update endpoint rejects `fallback: "llm"` without one. Configure the LLM fallback classifier (Web UI: the **Fallback classifier** section inside the embedding sheet; API/config.json: the `llm` block) before or in the same request that sets `fallback` to `llm`.
+
+### LLM fallback times out or never runs
+
+Check `llm.state` on `GET /api/routing/complexity-analyzer-status`: `disabled` means no `llm` block is saved. If it's `ready` but classifications still show `complexity_mechanism: skipped`, check `llm.timeout` — the fallback model may be too slow for the configured budget. Provider errors and timeouts are recorded in the routing decision logs alongside the cause.
 
 ### Rule not matching when complexity_tier is set
 
@@ -361,7 +450,7 @@ If classification is unavailable for a request (unsupported input, mixed-modal c
 
 ### Which request types are supported
 
-Complexity routing currently runs only for **text-bearing** request families. Supported inputs include:
+Complexity routing currently runs only for **text-bearing** request families. This applies identically to the LLM fallback classifier — it shares the same input extraction as semantic classification, so a request semantic classification cannot analyze reaches the fallback in the same unclassifiable state. Supported inputs include:
 
 - Chat Completions and other messages-style requests with text-only user content
 - Text Completions requests using `prompt`

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -68640,10 +68640,8 @@
       "get": {
         "operationId": "getComplexityAnalyzerConfig",
         "summary": "Get complexity analyzer config",
-        "description": "Returns the full complexity analyzer runtime config, including the semantic embedding configuration and per-tier reference phrase lists. Returns built-in defaults if none have been configured.",
-        "tags": [
-          "Routing"
-        ],
+        "description": "Returns the full complexity analyzer runtime config, including the semantic embedding configuration, the llm fallback classifier configuration, and per-tier reference phrase lists. Returns built-in defaults if none have been configured.",
+        "tags": ["Routing"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -68782,6 +68780,63 @@
                             "vector_store"
                           ],
                           "description": "Where reference-phrase embeddings live. `embedded` (default) uses the\nbuilt-in in-memory store, so phrases are re-embedded on every restart.\n`vector_store` uses the top-level `vector_store` when one is configured\nand falls back to the embedded store otherwise.\n"
+                        },
+                        "fallback": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "llm"
+                          ],
+                          "description": "What answers when semantic classification produces no tier (a match\nbelow `min_similarity`, a timeout, or an unfinished warmup). `none`\n(the default) records the request as skipped. `llm` asks the chat\nmodel configured in the analyzer's `llm` block, which is required\nwhen this is set.\n"
+                        }
+                      }
+                    },
+                    "llm": {
+                      "type": "object",
+                      "description": "Chat-completion (LLM) fallback classifier settings. The block is inert\nunless `semantic.fallback` selects `llm`; the classifier runs only after\nsemantic classification produces no tier. Tier names (SIMPLE, MEDIUM,\nCOMPLEX) and the response format are fixed: the gateway always appends a\nnon-editable reinforcement stating them.\n",
+                      "additionalProperties": false,
+                      "required": [
+                        "provider",
+                        "model"
+                      ],
+                      "properties": {
+                        "provider": {
+                          "type": "string",
+                          "minLength": 1,
+                          "description": "Provider used to run the classification chat completion (must have an enabled key)"
+                        },
+                        "model": {
+                          "type": "string",
+                          "minLength": 1,
+                          "description": "Chat model asked to name the tier. Every fallback classification waits on one completion from this model, so pick a small, fast one."
+                        },
+                        "timeout": {
+                          "description": "Per-request classification timeout. Accepts a duration string (\"2s\") or milliseconds as a number. Default 4s. On timeout no complexity tier is published and the request is recorded as skipped.",
+                          "oneOf": [
+                            {
+                              "type": "string",
+                              "pattern": "^[0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h)$"
+                            },
+                            {
+                              "type": "number",
+                              "exclusiveMinimum": 0
+                            }
+                          ]
+                        },
+                        "prompt": {
+                          "type": "string",
+                          "maxLength": 4000,
+                          "description": "Replaces the shipped classification guidance (max 4000 characters); empty means the shipped guidance is used. The tier-name and response-format reinforcement is appended by the gateway either way and cannot be edited."
+                        },
+                        "message_history_count": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "maximum": 10,
+                          "description": "How many of the most recent user messages are given to the classifier, oldest first (default 1, the latest message only). Only user turns count; system prompts and assistant replies are never sent."
+                        },
+                        "count_toward_budgets": {
+                          "type": "boolean",
+                          "description": "Whether classification completion cost counts toward virtual-key budgets (record-only, never enforced; default false)"
                         }
                       }
                     }
@@ -68815,10 +68870,8 @@
       "put": {
         "operationId": "updateComplexityAnalyzerConfig",
         "summary": "Update complexity analyzer config",
-        "description": "Replaces the full complexity analyzer runtime config and hot-reloads the routing plugin. Changing the embedding configuration or reference phrases triggers a background re-warm of the classifier; unchanged phrases are not re-embedded.",
-        "tags": [
-          "Routing"
-        ],
+        "description": "Replaces the full complexity analyzer runtime config and hot-reloads the routing plugin. Changing the embedding configuration or reference phrases triggers a background re-warm of the classifier; unchanged phrases are not re-embedded. Setting semantic.fallback to llm requires the llm block to be present.",
+        "tags": ["Routing"],
         "requestBody": {
           "required": true,
           "content": {
@@ -68951,6 +69004,63 @@
                           "vector_store"
                         ],
                         "description": "Where reference-phrase embeddings live. `embedded` (default) uses the\nbuilt-in in-memory store, so phrases are re-embedded on every restart.\n`vector_store` uses the top-level `vector_store` when one is configured\nand falls back to the embedded store otherwise.\n"
+                      },
+                      "fallback": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "llm"
+                        ],
+                        "description": "What answers when semantic classification produces no tier (a match\nbelow `min_similarity`, a timeout, or an unfinished warmup). `none`\n(the default) records the request as skipped. `llm` asks the chat\nmodel configured in the analyzer's `llm` block, which is required\nwhen this is set.\n"
+                      }
+                    }
+                  },
+                  "llm": {
+                    "type": "object",
+                    "description": "Chat-completion (LLM) fallback classifier settings. The block is inert\nunless `semantic.fallback` selects `llm`; the classifier runs only after\nsemantic classification produces no tier. Tier names (SIMPLE, MEDIUM,\nCOMPLEX) and the response format are fixed: the gateway always appends a\nnon-editable reinforcement stating them.\n",
+                    "additionalProperties": false,
+                    "required": [
+                      "provider",
+                      "model"
+                    ],
+                    "properties": {
+                      "provider": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Provider used to run the classification chat completion (must have an enabled key)"
+                      },
+                      "model": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Chat model asked to name the tier. Every fallback classification waits on one completion from this model, so pick a small, fast one."
+                      },
+                      "timeout": {
+                        "description": "Per-request classification timeout. Accepts a duration string (\"2s\") or milliseconds as a number. Default 4s. On timeout no complexity tier is published and the request is recorded as skipped.",
+                        "oneOf": [
+                          {
+                            "type": "string",
+                            "pattern": "^[0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h)$"
+                          },
+                          {
+                            "type": "number",
+                            "exclusiveMinimum": 0
+                          }
+                        ]
+                      },
+                      "prompt": {
+                        "type": "string",
+                        "maxLength": 4000,
+                        "description": "Replaces the shipped classification guidance (max 4000 characters); empty means the shipped guidance is used. The tier-name and response-format reinforcement is appended by the gateway either way and cannot be edited."
+                      },
+                      "message_history_count": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 10,
+                        "description": "How many of the most recent user messages are given to the classifier, oldest first (default 1, the latest message only). Only user turns count; system prompts and assistant replies are never sent."
+                      },
+                      "count_toward_budgets": {
+                        "type": "boolean",
+                        "description": "Whether classification completion cost counts toward virtual-key budgets (record-only, never enforced; default false)"
                       }
                     }
                   }
@@ -69097,6 +69207,63 @@
                             "vector_store"
                           ],
                           "description": "Where reference-phrase embeddings live. `embedded` (default) uses the\nbuilt-in in-memory store, so phrases are re-embedded on every restart.\n`vector_store` uses the top-level `vector_store` when one is configured\nand falls back to the embedded store otherwise.\n"
+                        },
+                        "fallback": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "llm"
+                          ],
+                          "description": "What answers when semantic classification produces no tier (a match\nbelow `min_similarity`, a timeout, or an unfinished warmup). `none`\n(the default) records the request as skipped. `llm` asks the chat\nmodel configured in the analyzer's `llm` block, which is required\nwhen this is set.\n"
+                        }
+                      }
+                    },
+                    "llm": {
+                      "type": "object",
+                      "description": "Chat-completion (LLM) fallback classifier settings. The block is inert\nunless `semantic.fallback` selects `llm`; the classifier runs only after\nsemantic classification produces no tier. Tier names (SIMPLE, MEDIUM,\nCOMPLEX) and the response format are fixed: the gateway always appends a\nnon-editable reinforcement stating them.\n",
+                      "additionalProperties": false,
+                      "required": [
+                        "provider",
+                        "model"
+                      ],
+                      "properties": {
+                        "provider": {
+                          "type": "string",
+                          "minLength": 1,
+                          "description": "Provider used to run the classification chat completion (must have an enabled key)"
+                        },
+                        "model": {
+                          "type": "string",
+                          "minLength": 1,
+                          "description": "Chat model asked to name the tier. Every fallback classification waits on one completion from this model, so pick a small, fast one."
+                        },
+                        "timeout": {
+                          "description": "Per-request classification timeout. Accepts a duration string (\"2s\") or milliseconds as a number. Default 4s. On timeout no complexity tier is published and the request is recorded as skipped.",
+                          "oneOf": [
+                            {
+                              "type": "string",
+                              "pattern": "^[0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h)$"
+                            },
+                            {
+                              "type": "number",
+                              "exclusiveMinimum": 0
+                            }
+                          ]
+                        },
+                        "prompt": {
+                          "type": "string",
+                          "maxLength": 4000,
+                          "description": "Replaces the shipped classification guidance (max 4000 characters); empty means the shipped guidance is used. The tier-name and response-format reinforcement is appended by the gateway either way and cannot be edited."
+                        },
+                        "message_history_count": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "maximum": 10,
+                          "description": "How many of the most recent user messages are given to the classifier, oldest first (default 1, the latest message only). Only user turns count; system prompts and assistant replies are never sent."
+                        },
+                        "count_toward_budgets": {
+                          "type": "boolean",
+                          "description": "Whether classification completion cost counts toward virtual-key budgets (record-only, never enforced; default false)"
                         }
                       }
                     }
@@ -69142,10 +69309,8 @@
       "post": {
         "operationId": "resetComplexityAnalyzerConfig",
         "summary": "Reset complexity analyzer config",
-        "description": "Restores the built-in reference phrase lists and hot-reloads the routing plugin. The saved embedding provider, model, and storage configuration are preserved.",
-        "tags": [
-          "Routing"
-        ],
+        "description": "Restores the built-in reference phrase lists and hot-reloads the routing plugin. The saved embedding provider, model, storage configuration, and llm fallback configuration are preserved.",
+        "tags": ["Routing"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -69284,79 +69449,65 @@
                             "vector_store"
                           ],
                           "description": "Where reference-phrase embeddings live. `embedded` (default) uses the\nbuilt-in in-memory store, so phrases are re-embedded on every restart.\n`vector_store` uses the top-level `vector_store` when one is configured\nand falls back to the embedded store otherwise.\n"
+                        },
+                        "fallback": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "llm"
+                          ],
+                          "description": "What answers when semantic classification produces no tier (a match\nbelow `min_similarity`, a timeout, or an unfinished warmup). `none`\n(the default) records the request as skipped. `llm` asks the chat\nmodel configured in the analyzer's `llm` block, which is required\nwhen this is set.\n"
                         }
                       }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BifrostError"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "Config store not available",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BifrostError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/routing/complexity-analyzer-status": {
-      "get": {
-        "operationId": "getComplexityAnalyzerStatus",
-        "summary": "Get complexity classifier status",
-        "description": "Returns the runtime status of the semantic complexity classifier (disabled, warming, ready, or failed), including warmup progress and whether a previous generation is still serving.",
-        "tags": [
-          "Routing"
-        ],
-        "responses": {
-          "200": {
-            "description": "Complexity classifier status retrieved successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "description": "Runtime status of the semantic complexity classifier. Never contains phrases, embeddings, or provider secrets.",
-                  "properties": {
-                    "state": {
-                      "type": "string",
-                      "enum": [
-                        "disabled",
-                        "warming",
-                        "ready",
-                        "failed"
+                    },
+                    "llm": {
+                      "type": "object",
+                      "description": "Chat-completion (LLM) fallback classifier settings. The block is inert\nunless `semantic.fallback` selects `llm`; the classifier runs only after\nsemantic classification produces no tier. Tier names (SIMPLE, MEDIUM,\nCOMPLEX) and the response format are fixed: the gateway always appends a\nnon-editable reinforcement stating them.\n",
+                      "additionalProperties": false,
+                      "required": [
+                        "provider",
+                        "model"
                       ],
-                      "description": "disabled = no embedding configuration; warming = reference phrases are being embedded; ready = serving the current configuration; failed = the desired configuration failed to warm"
-                    },
-                    "loaded": {
-                      "type": "integer",
-                      "description": "Reference phrases embedded so far in the current warmup"
-                    },
-                    "total": {
-                      "type": "integer",
-                      "description": "Total reference phrases to embed in the current warmup"
-                    },
-                    "serving_previous": {
-                      "type": "boolean",
-                      "description": "When true with state=failed, the previous generation is still serving while the new one failed to warm"
-                    },
-                    "error": {
-                      "type": "string",
-                      "description": "Warmup failure detail when state=failed"
+                      "properties": {
+                        "provider": {
+                          "type": "string",
+                          "minLength": 1,
+                          "description": "Provider used to run the classification chat completion (must have an enabled key)"
+                        },
+                        "model": {
+                          "type": "string",
+                          "minLength": 1,
+                          "description": "Chat model asked to name the tier. Every fallback classification waits on one completion from this model, so pick a small, fast one."
+                        },
+                        "timeout": {
+                          "description": "Per-request classification timeout. Accepts a duration string (\"2s\") or milliseconds as a number. Default 4s. On timeout no complexity tier is published and the request is recorded as skipped.",
+                          "oneOf": [
+                            {
+                              "type": "string",
+                              "pattern": "^[0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h)$"
+                            },
+                            {
+                              "type": "number",
+                              "exclusiveMinimum": 0
+                            }
+                          ]
+                        },
+                        "prompt": {
+                          "type": "string",
+                          "maxLength": 4000,
+                          "description": "Replaces the shipped classification guidance (max 4000 characters); empty means the shipped guidance is used. The tier-name and response-format reinforcement is appended by the gateway either way and cannot be edited."
+                        },
+                        "message_history_count": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "maximum": 10,
+                          "description": "How many of the most recent user messages are given to the classifier, oldest first (default 1, the latest message only). Only user turns count; system prompts and assistant replies are never sent."
+                        },
+                        "count_toward_budgets": {
+                          "type": "boolean",
+                          "description": "Whether classification completion cost counts toward virtual-key budgets (record-only, never enforced; default false)"
+                        }
+                      }
                     }
                   }
                 }
@@ -69701,10 +69852,8 @@
         "operationId": "getComplexityAnalyzerConfigLegacy",
         "deprecated": true,
         "summary": "Get complexity analyzer config (deprecated path)",
-        "description": "Returns the full complexity analyzer runtime config, including the semantic embedding configuration and per-tier reference phrase lists. Returns built-in defaults if none have been configured. Deprecated, use /api/routing/complexity-analyzer-config instead. This path is kept for backwards compatibility and behaves identically.",
-        "tags": [
-          "Routing"
-        ],
+        "description": "Returns the full complexity analyzer runtime config, including the semantic embedding configuration, the llm fallback classifier configuration, and per-tier reference phrase lists. Returns built-in defaults if none have been configured. Deprecated, use /api/routing/complexity-analyzer-config instead. This path is kept for backwards compatibility and behaves identically.",
+        "tags": ["Routing"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -69843,6 +69992,63 @@
                             "vector_store"
                           ],
                           "description": "Where reference-phrase embeddings live. `embedded` (default) uses the\nbuilt-in in-memory store, so phrases are re-embedded on every restart.\n`vector_store` uses the top-level `vector_store` when one is configured\nand falls back to the embedded store otherwise.\n"
+                        },
+                        "fallback": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "llm"
+                          ],
+                          "description": "What answers when semantic classification produces no tier (a match\nbelow `min_similarity`, a timeout, or an unfinished warmup). `none`\n(the default) records the request as skipped. `llm` asks the chat\nmodel configured in the analyzer's `llm` block, which is required\nwhen this is set.\n"
+                        }
+                      }
+                    },
+                    "llm": {
+                      "type": "object",
+                      "description": "Chat-completion (LLM) fallback classifier settings. The block is inert\nunless `semantic.fallback` selects `llm`; the classifier runs only after\nsemantic classification produces no tier. Tier names (SIMPLE, MEDIUM,\nCOMPLEX) and the response format are fixed: the gateway always appends a\nnon-editable reinforcement stating them.\n",
+                      "additionalProperties": false,
+                      "required": [
+                        "provider",
+                        "model"
+                      ],
+                      "properties": {
+                        "provider": {
+                          "type": "string",
+                          "minLength": 1,
+                          "description": "Provider used to run the classification chat completion (must have an enabled key)"
+                        },
+                        "model": {
+                          "type": "string",
+                          "minLength": 1,
+                          "description": "Chat model asked to name the tier. Every fallback classification waits on one completion from this model, so pick a small, fast one."
+                        },
+                        "timeout": {
+                          "description": "Per-request classification timeout. Accepts a duration string (\"2s\") or milliseconds as a number. Default 4s. On timeout no complexity tier is published and the request is recorded as skipped.",
+                          "oneOf": [
+                            {
+                              "type": "string",
+                              "pattern": "^[0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h)$"
+                            },
+                            {
+                              "type": "number",
+                              "exclusiveMinimum": 0
+                            }
+                          ]
+                        },
+                        "prompt": {
+                          "type": "string",
+                          "maxLength": 4000,
+                          "description": "Replaces the shipped classification guidance (max 4000 characters); empty means the shipped guidance is used. The tier-name and response-format reinforcement is appended by the gateway either way and cannot be edited."
+                        },
+                        "message_history_count": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "maximum": 10,
+                          "description": "How many of the most recent user messages are given to the classifier, oldest first (default 1, the latest message only). Only user turns count; system prompts and assistant replies are never sent."
+                        },
+                        "count_toward_budgets": {
+                          "type": "boolean",
+                          "description": "Whether classification completion cost counts toward virtual-key budgets (record-only, never enforced; default false)"
                         }
                       }
                     }
@@ -69877,10 +70083,8 @@
         "operationId": "updateComplexityAnalyzerConfigLegacy",
         "deprecated": true,
         "summary": "Update complexity analyzer config (deprecated path)",
-        "description": "Replaces the full complexity analyzer runtime config and hot-reloads the routing plugin. Changing the embedding configuration or reference phrases triggers a background re-warm of the classifier; unchanged phrases are not re-embedded. Deprecated, use /api/routing/complexity-analyzer-config instead. This path is kept for backwards compatibility and behaves identically.",
-        "tags": [
-          "Routing"
-        ],
+        "description": "Replaces the full complexity analyzer runtime config and hot-reloads the routing plugin. Changing the embedding configuration or reference phrases triggers a background re-warm of the classifier; unchanged phrases are not re-embedded. Setting semantic.fallback to llm requires the llm block to be present. Deprecated, use /api/routing/complexity-analyzer-config instead. This path is kept for backwards compatibility and behaves identically.",
+        "tags": ["Routing"],
         "requestBody": {
           "required": true,
           "content": {
@@ -70013,6 +70217,63 @@
                           "vector_store"
                         ],
                         "description": "Where reference-phrase embeddings live. `embedded` (default) uses the\nbuilt-in in-memory store, so phrases are re-embedded on every restart.\n`vector_store` uses the top-level `vector_store` when one is configured\nand falls back to the embedded store otherwise.\n"
+                      },
+                      "fallback": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "llm"
+                        ],
+                        "description": "What answers when semantic classification produces no tier (a match\nbelow `min_similarity`, a timeout, or an unfinished warmup). `none`\n(the default) records the request as skipped. `llm` asks the chat\nmodel configured in the analyzer's `llm` block, which is required\nwhen this is set.\n"
+                      }
+                    }
+                  },
+                  "llm": {
+                    "type": "object",
+                    "description": "Chat-completion (LLM) fallback classifier settings. The block is inert\nunless `semantic.fallback` selects `llm`; the classifier runs only after\nsemantic classification produces no tier. Tier names (SIMPLE, MEDIUM,\nCOMPLEX) and the response format are fixed: the gateway always appends a\nnon-editable reinforcement stating them.\n",
+                    "additionalProperties": false,
+                    "required": [
+                      "provider",
+                      "model"
+                    ],
+                    "properties": {
+                      "provider": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Provider used to run the classification chat completion (must have an enabled key)"
+                      },
+                      "model": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Chat model asked to name the tier. Every fallback classification waits on one completion from this model, so pick a small, fast one."
+                      },
+                      "timeout": {
+                        "description": "Per-request classification timeout. Accepts a duration string (\"2s\") or milliseconds as a number. Default 4s. On timeout no complexity tier is published and the request is recorded as skipped.",
+                        "oneOf": [
+                          {
+                            "type": "string",
+                            "pattern": "^[0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h)$"
+                          },
+                          {
+                            "type": "number",
+                            "exclusiveMinimum": 0
+                          }
+                        ]
+                      },
+                      "prompt": {
+                        "type": "string",
+                        "maxLength": 4000,
+                        "description": "Replaces the shipped classification guidance (max 4000 characters); empty means the shipped guidance is used. The tier-name and response-format reinforcement is appended by the gateway either way and cannot be edited."
+                      },
+                      "message_history_count": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 10,
+                        "description": "How many of the most recent user messages are given to the classifier, oldest first (default 1, the latest message only). Only user turns count; system prompts and assistant replies are never sent."
+                      },
+                      "count_toward_budgets": {
+                        "type": "boolean",
+                        "description": "Whether classification completion cost counts toward virtual-key budgets (record-only, never enforced; default false)"
                       }
                     }
                   }
@@ -70159,6 +70420,63 @@
                             "vector_store"
                           ],
                           "description": "Where reference-phrase embeddings live. `embedded` (default) uses the\nbuilt-in in-memory store, so phrases are re-embedded on every restart.\n`vector_store` uses the top-level `vector_store` when one is configured\nand falls back to the embedded store otherwise.\n"
+                        },
+                        "fallback": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "llm"
+                          ],
+                          "description": "What answers when semantic classification produces no tier (a match\nbelow `min_similarity`, a timeout, or an unfinished warmup). `none`\n(the default) records the request as skipped. `llm` asks the chat\nmodel configured in the analyzer's `llm` block, which is required\nwhen this is set.\n"
+                        }
+                      }
+                    },
+                    "llm": {
+                      "type": "object",
+                      "description": "Chat-completion (LLM) fallback classifier settings. The block is inert\nunless `semantic.fallback` selects `llm`; the classifier runs only after\nsemantic classification produces no tier. Tier names (SIMPLE, MEDIUM,\nCOMPLEX) and the response format are fixed: the gateway always appends a\nnon-editable reinforcement stating them.\n",
+                      "additionalProperties": false,
+                      "required": [
+                        "provider",
+                        "model"
+                      ],
+                      "properties": {
+                        "provider": {
+                          "type": "string",
+                          "minLength": 1,
+                          "description": "Provider used to run the classification chat completion (must have an enabled key)"
+                        },
+                        "model": {
+                          "type": "string",
+                          "minLength": 1,
+                          "description": "Chat model asked to name the tier. Every fallback classification waits on one completion from this model, so pick a small, fast one."
+                        },
+                        "timeout": {
+                          "description": "Per-request classification timeout. Accepts a duration string (\"2s\") or milliseconds as a number. Default 4s. On timeout no complexity tier is published and the request is recorded as skipped.",
+                          "oneOf": [
+                            {
+                              "type": "string",
+                              "pattern": "^[0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h)$"
+                            },
+                            {
+                              "type": "number",
+                              "exclusiveMinimum": 0
+                            }
+                          ]
+                        },
+                        "prompt": {
+                          "type": "string",
+                          "maxLength": 4000,
+                          "description": "Replaces the shipped classification guidance (max 4000 characters); empty means the shipped guidance is used. The tier-name and response-format reinforcement is appended by the gateway either way and cannot be edited."
+                        },
+                        "message_history_count": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "maximum": 10,
+                          "description": "How many of the most recent user messages are given to the classifier, oldest first (default 1, the latest message only). Only user turns count; system prompts and assistant replies are never sent."
+                        },
+                        "count_toward_budgets": {
+                          "type": "boolean",
+                          "description": "Whether classification completion cost counts toward virtual-key budgets (record-only, never enforced; default false)"
                         }
                       }
                     }
@@ -70205,10 +70523,8 @@
         "operationId": "resetComplexityAnalyzerConfigLegacy",
         "deprecated": true,
         "summary": "Reset complexity analyzer config (deprecated path)",
-        "description": "Restores the built-in reference phrase lists and hot-reloads the routing plugin. The saved embedding provider, model, and storage configuration are preserved. Deprecated, use /api/routing/complexity-analyzer-config/reset instead. This path is kept for backwards compatibility and behaves identically.",
-        "tags": [
-          "Routing"
-        ],
+        "description": "Restores the built-in reference phrase lists and hot-reloads the routing plugin. The saved embedding provider, model, storage configuration, and llm fallback configuration are preserved. Deprecated, use /api/routing/complexity-analyzer-config/reset instead. This path is kept for backwards compatibility and behaves identically.",
+        "tags": ["Routing"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -70347,6 +70663,63 @@
                             "vector_store"
                           ],
                           "description": "Where reference-phrase embeddings live. `embedded` (default) uses the\nbuilt-in in-memory store, so phrases are re-embedded on every restart.\n`vector_store` uses the top-level `vector_store` when one is configured\nand falls back to the embedded store otherwise.\n"
+                        },
+                        "fallback": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "llm"
+                          ],
+                          "description": "What answers when semantic classification produces no tier (a match\nbelow `min_similarity`, a timeout, or an unfinished warmup). `none`\n(the default) records the request as skipped. `llm` asks the chat\nmodel configured in the analyzer's `llm` block, which is required\nwhen this is set.\n"
+                        }
+                      }
+                    },
+                    "llm": {
+                      "type": "object",
+                      "description": "Chat-completion (LLM) fallback classifier settings. The block is inert\nunless `semantic.fallback` selects `llm`; the classifier runs only after\nsemantic classification produces no tier. Tier names (SIMPLE, MEDIUM,\nCOMPLEX) and the response format are fixed: the gateway always appends a\nnon-editable reinforcement stating them.\n",
+                      "additionalProperties": false,
+                      "required": [
+                        "provider",
+                        "model"
+                      ],
+                      "properties": {
+                        "provider": {
+                          "type": "string",
+                          "minLength": 1,
+                          "description": "Provider used to run the classification chat completion (must have an enabled key)"
+                        },
+                        "model": {
+                          "type": "string",
+                          "minLength": 1,
+                          "description": "Chat model asked to name the tier. Every fallback classification waits on one completion from this model, so pick a small, fast one."
+                        },
+                        "timeout": {
+                          "description": "Per-request classification timeout. Accepts a duration string (\"2s\") or milliseconds as a number. Default 4s. On timeout no complexity tier is published and the request is recorded as skipped.",
+                          "oneOf": [
+                            {
+                              "type": "string",
+                              "pattern": "^[0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h)$"
+                            },
+                            {
+                              "type": "number",
+                              "exclusiveMinimum": 0
+                            }
+                          ]
+                        },
+                        "prompt": {
+                          "type": "string",
+                          "maxLength": 4000,
+                          "description": "Replaces the shipped classification guidance (max 4000 characters); empty means the shipped guidance is used. The tier-name and response-format reinforcement is appended by the gateway either way and cannot be edited."
+                        },
+                        "message_history_count": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "maximum": 10,
+                          "description": "How many of the most recent user messages are given to the classifier, oldest first (default 1, the latest message only). Only user turns count; system prompts and assistant replies are never sent."
+                        },
+                        "count_toward_budgets": {
+                          "type": "boolean",
+                          "description": "Whether classification completion cost counts toward virtual-key budgets (record-only, never enforced; default false)"
                         }
                       }
                     }
@@ -82268,6 +82641,95 @@
             "ManagementBearerAuth": []
           }
         ]
+      }
+    },
+    "/api/routing/complexity-analyzer-status": {
+      "get": {
+        "operationId": "getComplexityAnalyzerStatus",
+        "summary": "Get complexity classifier status",
+        "description": "Returns the runtime status of the semantic complexity classifier (disabled, warming, ready, or failed), including warmup progress and whether a previous generation is still serving. When the llm fallback block is configured, also returns its readiness and the shipped default classification prompt.",
+        "tags": [
+          "Routing"
+        ],
+        "responses": {
+          "200": {
+            "description": "Complexity classifier status retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Runtime status of the semantic complexity classifier and, when configured, the LLM fallback classifier. Never contains phrases, embeddings, or provider secrets.",
+                  "properties": {
+                    "state": {
+                      "type": "string",
+                      "enum": [
+                        "disabled",
+                        "warming",
+                        "ready",
+                        "failed"
+                      ],
+                      "description": "disabled = no embedding configuration; warming = reference phrases are being embedded; ready = serving the current configuration; failed = the desired configuration failed to warm"
+                    },
+                    "loaded": {
+                      "type": "integer",
+                      "description": "Reference phrases embedded so far in the current warmup"
+                    },
+                    "total": {
+                      "type": "integer",
+                      "description": "Total reference phrases to embed in the current warmup"
+                    },
+                    "serving_previous": {
+                      "type": "boolean",
+                      "description": "When true with state=failed, the previous generation is still serving while the new one failed to warm"
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Warmup failure detail when state=failed"
+                    },
+                    "llm": {
+                      "type": "object",
+                      "description": "Always present in the response. state is disabled when no llm block is configured.",
+                      "properties": {
+                        "state": {
+                          "type": "string",
+                          "enum": [
+                            "disabled",
+                            "ready"
+                          ],
+                          "description": "disabled = no llm configuration; ready = the llm block is configured. The classifier has no warmup, so it is ready as soon as it is saved."
+                        }
+                      }
+                    },
+                    "llm_default_prompt": {
+                      "type": "string",
+                      "description": "The shipped classification guidance, served so a configuration client can seed its prompt editor and offer a reset without holding a copy that drifts from the gateway's. Always present in the response, regardless of whether an llm block is configured."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Config store not available",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
       }
     }
   },

--- a/docs/openapi/paths/management/routing.yaml
+++ b/docs/openapi/paths/management/routing.yaml
@@ -173,7 +173,7 @@ complexity:
   get:
     operationId: getComplexityAnalyzerConfig
     summary: Get complexity analyzer config
-    description: Returns the full complexity analyzer runtime config, including the semantic embedding configuration and per-tier reference phrase lists. Returns built-in defaults if none have been configured.
+    description: Returns the full complexity analyzer runtime config, including the semantic embedding configuration, the llm fallback classifier configuration, and per-tier reference phrase lists. Returns built-in defaults if none have been configured.
     tags:
       - Routing
     security:
@@ -193,7 +193,7 @@ complexity:
   put:
     operationId: updateComplexityAnalyzerConfig
     summary: Update complexity analyzer config
-    description: Replaces the full complexity analyzer runtime config and hot-reloads the routing plugin. Changing the embedding configuration or reference phrases triggers a background re-warm of the classifier; unchanged phrases are not re-embedded.
+    description: Replaces the full complexity analyzer runtime config and hot-reloads the routing plugin. Changing the embedding configuration or reference phrases triggers a background re-warm of the classifier; unchanged phrases are not re-embedded. Setting semantic.fallback to llm requires the llm block to be present.
     tags:
       - Routing
     requestBody:
@@ -222,7 +222,7 @@ complexity-reset:
   post:
     operationId: resetComplexityAnalyzerConfig
     summary: Reset complexity analyzer config
-    description: Restores the built-in reference phrase lists and hot-reloads the routing plugin. The saved embedding provider, model, and storage configuration are preserved.
+    description: Restores the built-in reference phrase lists and hot-reloads the routing plugin. The saved embedding provider, model, storage configuration, and llm fallback configuration are preserved.
     tags:
       - Routing
     security:
@@ -411,7 +411,7 @@ complexity-status:
   get:
     operationId: getComplexityAnalyzerStatus
     summary: Get complexity classifier status
-    description: Returns the runtime status of the semantic complexity classifier (disabled, warming, ready, or failed), including warmup progress and whether a previous generation is still serving.
+    description: Returns the runtime status of the semantic complexity classifier (disabled, warming, ready, or failed), including warmup progress and whether a previous generation is still serving. When the llm fallback block is configured, also returns its readiness and the shipped default classification prompt.
     tags:
       - Routing
     responses:
@@ -431,7 +431,7 @@ complexity-legacy:
     operationId: getComplexityAnalyzerConfigLegacy
     deprecated: true
     summary: Get complexity analyzer config (deprecated path)
-    description: Returns the full complexity analyzer runtime config, including the semantic embedding configuration and per-tier reference phrase lists. Returns built-in defaults if none have been configured. Deprecated, use /api/routing/complexity-analyzer-config instead. This path is kept for backwards compatibility and behaves identically.
+    description: Returns the full complexity analyzer runtime config, including the semantic embedding configuration, the llm fallback classifier configuration, and per-tier reference phrase lists. Returns built-in defaults if none have been configured. Deprecated, use /api/routing/complexity-analyzer-config instead. This path is kept for backwards compatibility and behaves identically.
     tags:
       - Routing
     security:
@@ -452,7 +452,7 @@ complexity-legacy:
     operationId: updateComplexityAnalyzerConfigLegacy
     deprecated: true
     summary: Update complexity analyzer config (deprecated path)
-    description: Replaces the full complexity analyzer runtime config and hot-reloads the routing plugin. Changing the embedding configuration or reference phrases triggers a background re-warm of the classifier; unchanged phrases are not re-embedded. Deprecated, use /api/routing/complexity-analyzer-config instead. This path is kept for backwards compatibility and behaves identically.
+    description: Replaces the full complexity analyzer runtime config and hot-reloads the routing plugin. Changing the embedding configuration or reference phrases triggers a background re-warm of the classifier; unchanged phrases are not re-embedded. Setting semantic.fallback to llm requires the llm block to be present. Deprecated, use /api/routing/complexity-analyzer-config instead. This path is kept for backwards compatibility and behaves identically.
     tags:
       - Routing
     requestBody:
@@ -482,7 +482,7 @@ complexity-reset-legacy:
     operationId: resetComplexityAnalyzerConfigLegacy
     deprecated: true
     summary: Reset complexity analyzer config (deprecated path)
-    description: Restores the built-in reference phrase lists and hot-reloads the routing plugin. The saved embedding provider, model, and storage configuration are preserved. Deprecated, use /api/routing/complexity-analyzer-config/reset instead. This path is kept for backwards compatibility and behaves identically.
+    description: Restores the built-in reference phrase lists and hot-reloads the routing plugin. The saved embedding provider, model, storage configuration, and llm fallback configuration are preserved. Deprecated, use /api/routing/complexity-analyzer-config/reset instead. This path is kept for backwards compatibility and behaves identically.
     tags:
       - Routing
     security:

--- a/docs/openapi/schemas/management/governance.yaml
+++ b/docs/openapi/schemas/management/governance.yaml
@@ -2315,9 +2315,60 @@ ComplexitySemanticConfig:
         built-in in-memory store, so phrases are re-embedded on every restart.
         `vector_store` uses the top-level `vector_store` when one is configured
         and falls back to the embedded store otherwise.
+    fallback:
+      type: string
+      enum: [none, llm]
+      description: |
+        What answers when semantic classification produces no tier (a match
+        below `min_similarity`, a timeout, or an unfinished warmup). `none`
+        (the default) records the request as skipped. `llm` asks the chat
+        model configured in the analyzer's `llm` block, which is required
+        when this is set.
+
+ComplexityLLMConfig:
+  type: object
+  description: |
+    Chat-completion (LLM) fallback classifier settings. The block is inert
+    unless `semantic.fallback` selects `llm`; the classifier runs only after
+    semantic classification produces no tier. Tier names (SIMPLE, MEDIUM,
+    COMPLEX) and the response format are fixed: the gateway always appends a
+    non-editable reinforcement stating them.
+  additionalProperties: false
+  required:
+    - provider
+    - model
+  properties:
+    provider:
+      type: string
+      minLength: 1
+      description: Provider used to run the classification chat completion (must have an enabled key)
+    model:
+      type: string
+      minLength: 1
+      description: Chat model asked to name the tier. Every fallback classification waits on one completion from this model, so pick a small, fast one.
+    timeout:
+      description: Per-request classification timeout. Accepts a duration string ("2s") or milliseconds as a number. Default 4s. On timeout no complexity tier is published and the request is recorded as skipped.
+      oneOf:
+        - type: string
+          pattern: '^[0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h)$'
+        - type: number
+          exclusiveMinimum: 0
+    prompt:
+      type: string
+      maxLength: 4000
+      description: Replaces the shipped classification guidance (max 4000 characters); empty means the shipped guidance is used. The tier-name and response-format reinforcement is appended by the gateway either way and cannot be edited.
+    message_history_count:
+      type: integer
+      minimum: 1
+      maximum: 10
+      description: How many of the most recent user messages are given to the classifier, oldest first (default 1, the latest message only). Only user turns count; system prompts and assistant replies are never sent.
+    count_toward_budgets:
+      type: boolean
+      description: Whether classification completion cost counts toward virtual-key budgets (record-only, never enforced; default false)
+
 ComplexitySemanticStatus:
   type: object
-  description: Runtime status of the semantic complexity classifier. Never contains phrases, embeddings, or provider secrets.
+  description: Runtime status of the semantic complexity classifier and, when configured, the LLM fallback classifier. Never contains phrases, embeddings, or provider secrets.
   properties:
     state:
       type: string
@@ -2335,6 +2386,17 @@ ComplexitySemanticStatus:
     error:
       type: string
       description: Warmup failure detail when state=failed
+    llm:
+      type: object
+      description: Always present in the response. state is disabled when no llm block is configured.
+      properties:
+        state:
+          type: string
+          enum: [disabled, ready]
+          description: disabled = no llm configuration; ready = the llm block is configured. The classifier has no warmup, so it is ready as soon as it is saved.
+    llm_default_prompt:
+      type: string
+      description: The shipped classification guidance, served so a configuration client can seed its prompt editor and offer a reset without holding a copy that drifts from the gateway's. Always present in the response, regardless of whether an llm block is configured.
 
 ComplexityAnalyzerConfig:
   type: object
@@ -2349,3 +2411,5 @@ ComplexityAnalyzerConfig:
       $ref: '#/ComplexityKeywordConfig'
     semantic:
       $ref: '#/ComplexitySemanticConfig'
+    llm:
+      $ref: '#/ComplexityLLMConfig'

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -2186,7 +2186,7 @@
             },
             "complexityAnalyzerConfig": {
               "type": ["object", "null"],
-              "description": "Runtime configuration for complexity_tier CEL routing. Renders into governance.complexity_analyzer_config in config.json. Semantic (embedding-based) classification is the only mechanism — without the semantic block no complexity_tier is published.",
+              "description": "Runtime configuration for complexity_tier CEL routing. Renders into governance.complexity_analyzer_config in config.json. Semantic (embedding-based) classification is the primary mechanism — without the semantic block no complexity_tier is published. The optional llm block is a chat-completion fallback engaged only when semantic.fallback is 'llm'.",
               "properties": {
                 "semantic": {
                   "type": "object",
@@ -2235,9 +2235,60 @@
                       "type": "string",
                       "enum": ["embedded", "vector_store"],
                       "description": "Where phrase embeddings are stored: 'embedded' uses the built-in chromem store; 'vector_store' uses the configured top-level vectorStore and falls back to embedded when none is configured (default: embedded)."
+                    },
+                    "fallback": {
+                      "type": "string",
+                      "enum": ["none", "llm"],
+                      "description": "What answers when semantic classification produces no tier (a match below min_similarity, a timeout, an unfinished warmup): 'none' (default) records the request as skipped; 'llm' asks the chat model configured in the sibling llm block, which is required when this is set."
                     }
                   },
                   "required": ["provider", "embedding_model"],
+                  "additionalProperties": false
+                },
+                "llm": {
+                  "type": "object",
+                  "description": "Chat-completion (LLM) fallback classifier settings. Inert unless semantic.fallback selects 'llm'; the classifier runs only after semantic classification produces no tier. Tier names and the response format are fixed and always appended by the gateway.",
+                  "properties": {
+                    "provider": {
+                      "type": "string",
+                      "minLength": 1,
+                      "description": "Provider used to run the classification chat completion (must have an enabled key)"
+                    },
+                    "model": {
+                      "type": "string",
+                      "minLength": 1,
+                      "description": "Chat model asked to name the tier. Every fallback classification waits on one completion from this model, so pick a small, fast one."
+                    },
+                    "timeout": {
+                      "description": "Per-request classification timeout (duration string like '2s', or milliseconds as a number; default: 4s). On timeout no tier is published for that request.",
+                      "oneOf": [
+                        {
+                          "type": "string",
+                          "pattern": "^[0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h)$"
+                        },
+                        {
+                          "type": "number",
+                          "exclusiveMinimum": 0
+                        }
+                      ]
+                    },
+                    "prompt": {
+                      "type": "string",
+                      "maxLength": 4000,
+                      "description": "Replaces the shipped classification guidance (max 4000 characters); empty means the shipped guidance is used. The gateway always appends a fixed tier-name and response-format reinforcement."
+                    },
+                    "message_history_count": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 10,
+                      "description": "How many of the most recent user messages are given to the classifier, oldest first (default: 1, the latest message only)."
+                    },
+                    "count_toward_budgets": {
+                      "type": "boolean",
+                      "description": "Record classification completion cost against governance budgets (record-only, never enforced; default: false)"
+                    }
+                  },
+                  "required": ["provider", "model"],
                   "additionalProperties": false
                 },
                 "tier_boundaries": {

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -924,8 +924,16 @@ bifrost:
       #   timeout: "1.5s"                  # Ceiling on the inline embedding call; exceeding it skips tier routing for that request
       #   min_similarity: 0                # Similarity floor for the nearest reference phrase; 0 accepts the nearest phrase unconditionally
       #   message_history_count: 1         # Recent user messages joined into the embedded text (1 = latest only)
-      #   count_toward_budgets: false      # Count embedding usage toward virtual-key budgets
+      #   count_toward_budgets: false      # Count embedding usage toward virtual-key budgets (record-only, never enforced)
       #   vector_store: "embedded"         # embedded (in-memory, re-embeds on restart) | vector_store (configured vectorStore, falls back to embedded when none is configured)
+      #   fallback: "none"                 # none (default, records skipped) | llm (asks the llm block below when semantic produces no tier; requires llm to be set)
+      # llm:                                # Chat-completion fallback classifier — inert unless semantic.fallback is "llm"
+      #   provider: "openai"               # Provider used for the classification chat completion (must have an enabled key in bifrost.providers)
+      #   model: "gpt-4o-mini"             # Small, fast chat model — every fallback classification waits on one completion from it
+      #   timeout: "4s"                    # Per-request classification timeout; on timeout no tier is published and the request is recorded as skipped
+      #   prompt: ""                       # Replaces the shipped classification guidance (max 4000 chars); empty uses the shipped guidance
+      #   message_history_count: 1         # Recent user messages sent to the classifier, oldest first (1 = latest only)
+      #   count_toward_budgets: false      # Count classification completion cost toward virtual-key budgets (record-only, never enforced)
       # keywords:                          # Required when complexityAnalyzerConfig is non-null; in split mode these phrases merge with stored defaults
       #   simple_keywords: ["what is a mutex?", "fix the grammar in this sentence."]
       #   medium_keywords: ["add api-key auth: hash the keys, reject revoked ones, and never log them."]


### PR DESCRIPTION
## Summary

Adds an optional LLM fallback classifier to the Complexity Router. When semantic (embedding-based) classification produces no tier — because no reference phrase matched confidently enough, the classifier timed out, or warmup is incomplete — the fallback asks a configured chat model to name the tier instead. Without a fallback, those requests continue to be recorded as `skipped` with no change in behavior.

## Changes

- Documented the new `semantic.fallback` field (`none` | `llm`) and the companion `llm` block (`provider`, `model`, `timeout`, `prompt`, `message_history_count`, `count_toward_budgets`) in the Complexity Router reference page.
- Clarified that the LLM fallback runs strictly after semantic classification produces no tier — never as the primary classifier and never in parallel.
- Added a note that `complexity_score` is absent when `complexity_mechanism` is `llm`, since a chat completion has no equivalent of embedding-distance.
- Documented the new `llm.state` and `llm_default_prompt` fields on the status endpoint, present only when the `llm` block is configured.
- Added new Prometheus counters (`bifrost_routing_llm_requests_total`, `bifrost_routing_llm_cost_total`) for fallback classifier overhead.
- Documented UI surface: the **When no phrase matches confidently** toggle in the embedding sheet reveals a **Fallback classifier** section; the **Fallback Classification Prompt** editor with a **Reset to default** button appears on the main page when the fallback is enabled.
- Added troubleshooting entries for `fallback: "llm"` being rejected without a companion `llm` block, and for diagnosing fallback timeouts via `llm.state` on the status endpoint.
- Updated the mechanism filter note to include `llm` alongside `semantic` and `skipped`.
- Clarified that the LLM fallback shares the same input extraction as semantic classification, so requests semantic classification cannot analyze reach the fallback in the same unclassifiable state.
- Updated OpenAPI descriptions for the config GET/PUT, reset, and status endpoints to reflect the new `llm` block and fallback behavior.
- Added `ComplexityLLMConfig` schema and extended `ComplexitySemanticConfig` with `fallback` and `ComplexitySemanticStatus` with `llm` and `llm_default_prompt`.
- Extended the Helm chart values schema and `values.yaml` with the `llm` block and `semantic.fallback` field; updated the `complexityAnalyzerConfig` description to reflect that semantic is the primary classifier and `llm` is optional.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Enable the LLM fallback via the API and confirm it activates only when semantic classification produces no tier:

```sh
# Configure semantic classification with the LLM fallback enabled
curl -X PUT http://localhost:8080/api/routing/complexity-analyzer-config \
  -H "Content-Type: application/json" \
  -d '{
    "semantic": {
      "provider": "openai",
      "embedding_model": "text-embedding-3-small",
      "fallback": "llm"
    },
    "llm": {
      "provider": "openai",
      "model": "gpt-4o-mini",
      "timeout": "4s",
      "message_history_count": 1,
      "count_toward_budgets": false
    },
    "keywords": {
      "simple_keywords": ["what is a mutex?"],
      "medium_keywords": ["add api-key auth: hash the keys, reject revoked ones, and never log them."],
      "complex_keywords": ["balance testing, prescribing rules, and staffing against rising resistant infections."]
    }
  }'

# Confirm llm.state is "ready" and llm_default_prompt is present
curl http://localhost:8080/api/routing/complexity-analyzer-status

# Send a request that won't match any reference phrase closely and verify
# complexity_mechanism is "llm" in the routing decision log
```

Verify that setting `fallback: "llm"` without an `llm` block is rejected with a validation error.

Verify that resetting phrases preserves the `llm` block and `semantic.fallback`.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The LLM fallback sends a portion of user message history to a configured provider. The number of messages forwarded is controlled by `llm.message_history_count` (default 1). System prompts and assistant replies are never sent. No provider secrets are exposed through the status endpoint.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable