### PR TITLE
reasoning fix

### DIFF
--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -299,6 +299,23 @@ func reasoningPayloadAndSummary(item *schemas.ResponsesMessage) (string, bool) {
 	return encrypted, len(item.ResponsesReasoning.Summary) > 0
 }
 
+// isReasoningItem reports whether a stream item must be converted as reasoning.
+// The declared type alone is not enough: providers mislabel reasoning as a function
+// call when thinking is enabled, so an item typed as a function call that carries a
+// ResponsesReasoning payload is reasoning too. The block-type decision at
+// output_item.added and the encrypted-payload split at output_item.done both consult
+// this, because disagreeing is what left the misclassified path opening
+// redacted_thinking for summary-bearing items after the reasoning path was fixed.
+func isReasoningItem(item *schemas.ResponsesMessage) bool {
+	if item == nil || item.Type == nil {
+		return false
+	}
+	if *item.Type == schemas.ResponsesMessageTypeReasoning {
+		return true
+	}
+	return *item.Type == schemas.ResponsesMessageTypeFunctionCall && item.ResponsesReasoning != nil
+}
+
 // blockAcceptsDeltaType reports whether an Anthropic content block of blockType may
 // receive a delta of deltaType. It mirrors the validation Anthropic clients apply
 // while assembling a stream; a mismatch is not a cosmetic wire defect but a hard
@@ -2964,23 +2981,33 @@ func toAnthropicResponsesStreamEvents(ctx *schemas.BifrostContext, bifrostResp *
 						// Check if this item actually has reasoning content (misclassified)
 						// When thinking is enabled, reasoning content might be incorrectly classified as FunctionCall
 						if bifrostResp.Item.ResponsesReasoning != nil {
-							// This is actually reasoning content, not a function call
+							// This is actually reasoning content, not a function call, so it
+							// follows the same rule as the reasoning branch above: open
+							// redacted_thinking only when the encrypted payload is all the item
+							// has. Judging on "has encrypted content" alone downgraded a
+							// summary-bearing item to an atomic block, and the signature_delta
+							// that follows is the frame the client throws
+							// "Content block is not a thinking block" on. The encrypted half is
+							// not dropped -- output_item.done splits it into its own
+							// redacted_thinking block, which is why isReasoningItem has to route
+							// this shape there as well.
 							embedID := providerUtils.ShouldEmbedReasoningItemID(ctx, bifrostResp.ExtraFields.Provider, bifrostResp.ExtraFields.RoutingInfo.Model)
-							contentBlock.Type = AnthropicContentBlockTypeThinking
-							contentBlock.Thinking = schemas.Ptr("")
-							signature := ""
-							if embedID {
-								signature = providerUtils.EmbedReasoningItemID(bifrostResp.Item.ID, "")
-							}
-							contentBlock.Signature = &signature
-							// Check if there's encrypted content for redacted_thinking
-							if bifrostResp.Item.ResponsesReasoning.EncryptedContent != nil && *bifrostResp.Item.ResponsesReasoning.EncryptedContent != "" {
+							encrypted, hasSummary := reasoningPayloadAndSummary(bifrostResp.Item)
+							if encrypted != "" && !hasSummary {
 								contentBlock.Type = AnthropicContentBlockTypeRedactedThinking
-								data := *bifrostResp.Item.ResponsesReasoning.EncryptedContent
+								data := encrypted
 								if embedID {
 									data = providerUtils.EmbedReasoningItemID(bifrostResp.Item.ID, data)
 								}
 								contentBlock.Data = &data
+							} else {
+								contentBlock.Type = AnthropicContentBlockTypeThinking
+								contentBlock.Thinking = schemas.Ptr("")
+								signature := ""
+								if embedID {
+									signature = providerUtils.EmbedReasoningItemID(bifrostResp.Item.ID, "")
+								}
+								contentBlock.Signature = &signature
 							}
 						} else {
 							// A real function call. It always opens as tool_use: the
@@ -3419,9 +3446,7 @@ func toAnthropicResponsesStreamEvents(ctx *schemas.BifrostContext, bifrostResp *
 			})
 
 			return events
-		} else if bifrostResp.Item != nil &&
-			bifrostResp.Item.Type != nil &&
-			*bifrostResp.Item.Type == schemas.ResponsesMessageTypeReasoning {
+		} else if isReasoningItem(bifrostResp.Item) {
 
 			// Reasoning complete. Close the block opened at output_item.added, then --
 			// when that block was a thinking block and the finished item carries an

--- a/core/providers/anthropic/streamblocktype_test.go
+++ b/core/providers/anthropic/streamblocktype_test.go
@@ -272,3 +272,278 @@ func TestAnthropicStreamEgress_FunctionCallNeverOpensAsThinking(t *testing.T) {
 		}
 	}
 }
+
+// reasoningAddedFrame builds the single output_item.added frame that opens a
+// reasoning item, with the summary and encrypted_content already attached or not.
+// The block type chosen on this frame is the whole decision under test: it is fixed
+// the moment the block opens and every later delta has to be legal against it.
+func reasoningAddedFrame(summary, encrypted string) *schemas.BifrostResponsesStreamResponse {
+	reasoningID := "rs_1"
+	reasoningType := schemas.ResponsesMessageTypeReasoning
+
+	reasoning := &schemas.ResponsesReasoning{}
+	if summary != "" {
+		reasoning.Summary = []schemas.ResponsesReasoningSummary{{
+			Type: schemas.ResponsesReasoningContentBlockTypeSummaryText,
+			Text: summary,
+		}}
+	}
+	if encrypted != "" {
+		reasoning.EncryptedContent = schemas.Ptr(encrypted)
+	}
+
+	return &schemas.BifrostResponsesStreamResponse{
+		Type:        schemas.ResponsesStreamResponseTypeOutputItemAdded,
+		OutputIndex: schemas.Ptr(0),
+		Item: &schemas.ResponsesMessage{
+			ID:                 &reasoningID,
+			Type:               &reasoningType,
+			ResponsesReasoning: reasoning,
+		},
+		ExtraFields: schemas.BifrostResponseExtraFields{Provider: schemas.OpenAI},
+	}
+}
+
+// firstBlockStart returns the type opened by the first content_block_start, or ""
+// when the frames opened no block at all.
+func firstBlockStart(events []*AnthropicStreamEvent) AnthropicContentBlockType {
+	for _, event := range events {
+		if event != nil && event.Type == AnthropicStreamEventTypeContentBlockStart && event.ContentBlock != nil {
+			return event.ContentBlock.Type
+		}
+	}
+	return ""
+}
+
+// TestAnthropicStreamEgress_ReasoningBlockTypeMatrix pins the block-type decision
+// across every combination of (encrypted payload present) x (visible summary
+// present). Only the redacted-only quadrant may open as redacted_thinking: that
+// block is atomic, its payload rides in `data` on the start frame and no delta ever
+// follows it. Every other quadrant is or may become incremental, and the deltas that
+// follow are only legal against a thinking block.
+//
+// The live SDK repro cannot cover this. It only trips the bug when the upstream
+// model happens to emit a visible summary, so a green run is indistinguishable from
+// a run that never reached the trigger -- which is exactly what 8/8 attempts against
+// a local gateway did, every one returning redacted-only reasoning.
+func TestAnthropicStreamEgress_ReasoningBlockTypeMatrix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		summary   string
+		encrypted string
+		want      AnthropicContentBlockType
+	}{
+		{
+			name:      "summary and payload opens thinking so summary deltas are legal",
+			summary:   "Ranking the sources by recency.",
+			encrypted: streamTestEncrypted,
+			want:      AnthropicContentBlockTypeThinking,
+		},
+		{
+			name:      "payload only is atomic and opens redacted_thinking",
+			encrypted: streamTestEncrypted,
+			want:      AnthropicContentBlockTypeRedactedThinking,
+		},
+		{
+			name:    "summary only opens thinking",
+			summary: "Ranking the sources by recency.",
+			want:    AnthropicContentBlockTypeThinking,
+		},
+		{
+			name: "empty reasoning opens thinking because deltas may still arrive",
+			want: AnthropicContentBlockTypeThinking,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			frames := []*schemas.BifrostResponsesStreamResponse{reasoningAddedFrame(tt.summary, tt.encrypted)}
+			if got := firstBlockStart(driveAnthropicEgress(t, frames)); got != tt.want {
+				t.Errorf("reasoning item opened as %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAnthropicStreamEgress_LateSummaryNeverLandsOnRedactedBlock covers the ordering
+// the block-type matrix cannot: an item that arrives at output_item.added carrying
+// encrypted_content and NO summary yet, whose summary text then streams in
+// afterwards. Judged on the added frame alone that item looks redacted-only, so
+// opening redacted_thinking there is locally reasonable and globally wrong -- the
+// summary deltas that follow are thinking_delta, which the client silently discards
+// against a redacted block. That failure is quiet: no abort, no error, the user just
+// loses the reasoning text.
+//
+// Passing requires the summary to remain visible, either by opening the block as
+// thinking or by routing the late summary into its own thinking block.
+func TestAnthropicStreamEgress_LateSummaryNeverLandsOnRedactedBlock(t *testing.T) {
+	t.Parallel()
+
+	reasoningID := "rs_1"
+
+	// Added with the payload only; the summary shows up two frames later.
+	frames := []*schemas.BifrostResponsesStreamResponse{
+		reasoningAddedFrame("", streamTestEncrypted),
+		{
+			Type:        schemas.ResponsesStreamResponseTypeReasoningSummaryTextDelta,
+			OutputIndex: schemas.Ptr(0),
+			ItemID:      &reasoningID,
+			Delta:       schemas.Ptr("Ranking the sources "),
+			ExtraFields: schemas.BifrostResponseExtraFields{Provider: schemas.OpenAI},
+		},
+		{
+			Type:        schemas.ResponsesStreamResponseTypeReasoningSummaryTextDelta,
+			OutputIndex: schemas.Ptr(0),
+			ItemID:      &reasoningID,
+			Delta:       schemas.Ptr("by recency."),
+			ExtraFields: schemas.BifrostResponseExtraFields{Provider: schemas.OpenAI},
+		},
+	}
+
+	openBlocks := map[int]AnthropicContentBlockType{}
+	var visible strings.Builder
+
+	for _, event := range driveAnthropicEgress(t, frames) {
+		if event == nil || event.Index == nil {
+			continue
+		}
+		index := *event.Index
+
+		switch event.Type {
+		case AnthropicStreamEventTypeContentBlockStart:
+			if event.ContentBlock != nil {
+				openBlocks[index] = event.ContentBlock.Type
+			}
+		case AnthropicStreamEventTypeContentBlockDelta:
+			if event.Delta == nil || event.Delta.Type != AnthropicStreamDeltaTypeThinking {
+				continue
+			}
+			if blockType := openBlocks[index]; blockType != AnthropicContentBlockTypeThinking {
+				t.Errorf("thinking_delta targets block %d opened as %q; the client discards it and the reasoning text is lost", index, blockType)
+				continue
+			}
+			if event.Delta.Thinking != nil {
+				visible.WriteString(*event.Delta.Thinking)
+			}
+		case AnthropicStreamEventTypeContentBlockStop:
+			delete(openBlocks, index)
+		}
+	}
+
+	if got := visible.String(); got != "Ranking the sources by recency." {
+		t.Errorf("late summary did not survive into a thinking block: got %q", got)
+	}
+}
+
+// TestAnthropicStreamEgress_SignatureDeltaOnlyTargetsThinking isolates the single
+// delta/block pairing the client throws on rather than tolerates -- signature_delta
+// against redacted_thinking -- which is the frame that surfaced to users as
+// "Content block is not a thinking block". blockAcceptsDelta folds this in with the
+// tolerated mismatches; asserting it separately keeps the hard-abort case from being
+// masked if that helper is ever loosened.
+func TestAnthropicStreamEgress_SignatureDeltaOnlyTargetsThinking(t *testing.T) {
+	t.Parallel()
+
+	openBlocks := map[int]AnthropicContentBlockType{}
+
+	for _, event := range driveAnthropicEgress(t, openAIReasoningStreamFrames()) {
+		if event == nil || event.Index == nil {
+			continue
+		}
+		index := *event.Index
+
+		switch event.Type {
+		case AnthropicStreamEventTypeContentBlockStart:
+			if event.ContentBlock != nil {
+				openBlocks[index] = event.ContentBlock.Type
+			}
+		case AnthropicStreamEventTypeContentBlockDelta:
+			if event.Delta == nil || event.Delta.Type != AnthropicStreamDeltaTypeSignature {
+				continue
+			}
+			if blockType := openBlocks[index]; blockType != AnthropicContentBlockTypeThinking {
+				t.Errorf("signature_delta targets block %d opened as %q; the client throws \"Content block is not a thinking block\" and aborts the turn", index, blockType)
+			}
+		case AnthropicStreamEventTypeContentBlockStop:
+			delete(openBlocks, index)
+		}
+	}
+}
+
+// TestAnthropicStreamEgress_MisclassifiedReasoningUsesSameBlockRule covers the
+// sibling of the reasoning branch: an item typed as a function call that actually
+// carries reasoning (providers mislabel these when thinking is enabled). It reaches
+// a separate block-type decision that must follow the same rule -- redacted_thinking
+// only when the payload is all there is -- because the summary and signature deltas
+// that follow are indistinguishable from the ones the reasoning branch emits.
+//
+// Judging on "has encrypted content" alone reopens the original defect on this path:
+// a summary-bearing item opens redacted_thinking, and the signature_delta that
+// follows is the frame the client throws "Content block is not a thinking block" on.
+func TestAnthropicStreamEgress_MisclassifiedReasoningUsesSameBlockRule(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		summary   string
+		encrypted string
+		want      AnthropicContentBlockType
+	}{
+		{
+			name:      "summary and payload opens thinking",
+			summary:   "Ranking the sources by recency.",
+			encrypted: streamTestEncrypted,
+			want:      AnthropicContentBlockTypeThinking,
+		},
+		{
+			name:      "payload only is atomic and opens redacted_thinking",
+			encrypted: streamTestEncrypted,
+			want:      AnthropicContentBlockTypeRedactedThinking,
+		},
+		{
+			name:    "summary only opens thinking",
+			summary: "Ranking the sources by recency.",
+			want:    AnthropicContentBlockTypeThinking,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			callID := "call_1"
+			functionType := schemas.ResponsesMessageTypeFunctionCall
+
+			reasoning := &schemas.ResponsesReasoning{}
+			if tt.summary != "" {
+				reasoning.Summary = []schemas.ResponsesReasoningSummary{{
+					Type: schemas.ResponsesReasoningContentBlockTypeSummaryText,
+					Text: tt.summary,
+				}}
+			}
+			if tt.encrypted != "" {
+				reasoning.EncryptedContent = schemas.Ptr(tt.encrypted)
+			}
+
+			frames := []*schemas.BifrostResponsesStreamResponse{{
+				Type:         schemas.ResponsesStreamResponseTypeOutputItemAdded,
+				OutputIndex:  schemas.Ptr(0),
+				ContentIndex: schemas.Ptr(0),
+				Item: &schemas.ResponsesMessage{
+					ID:                 &callID,
+					Type:               &functionType,
+					ResponsesReasoning: reasoning,
+				},
+				ExtraFields: schemas.BifrostResponseExtraFields{Provider: schemas.OpenAI},
+			}}
+
+			if got := firstBlockStart(driveAnthropicEgress(t, frames)); got != tt.want {
+				t.Errorf("misclassified reasoning item opened as %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a bug where reasoning stream items carrying both an encrypted payload and a visible summary were incorrectly opened as `redacted_thinking` blocks instead of `thinking` blocks. This caused downstream Anthropic SDK clients to throw "Content block is not a thinking block" when a `signature_delta` arrived against the wrong block type, or to silently discard summary text when `thinking_delta` frames landed on a `redacted_thinking` block.

## Changes

- Introduced `isReasoningItem` to centralize the check for whether a stream item should be treated as reasoning. Previously, the `output_item.done` path used a direct type comparison while the `output_item.added` path used a separate inline check, allowing the two to diverge and leave misclassified items on the wrong routing path.
- Fixed the block-type decision for both the native reasoning branch and the misclassified-function-call branch (providers mislabel reasoning as a function call when thinking is enabled). Both now apply the same rule: open `redacted_thinking` only when the encrypted payload is the sole content; open `thinking` in every other case, including when a summary is present alongside the encrypted payload.
- Replaced the ad-hoc encrypted-content check with `reasoningPayloadAndSummary`, which already encodes the correct split, making the two call sites consistent.
- Added four test cases covering the full decision matrix:
  - `TestAnthropicStreamEgress_ReasoningBlockTypeMatrix` — pins the block type across all combinations of encrypted payload and visible summary for natively typed reasoning items.
  - `TestAnthropicStreamEgress_LateSummaryNeverLandsOnRedactedBlock` — covers the ordering edge where the summary arrives after the `output_item.added` frame, ensuring summary deltas are never silently dropped.
  - `TestAnthropicStreamEgress_SignatureDeltaOnlyTargetsThinking` — isolates the hard-abort pairing (`signature_delta` against `redacted_thinking`) separately from the tolerated mismatches in `blockAcceptsDelta`.
  - `TestAnthropicStreamEgress_MisclassifiedReasoningUsesSameBlockRule` — verifies the function-call-typed reasoning path follows the identical block-type rule.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/anthropic/... -run "TestAnthropicStreamEgress_ReasoningBlockTypeMatrix|TestAnthropicStreamEgress_LateSummaryNeverLandsOnRedactedBlock|TestAnthropicStreamEgress_SignatureDeltaOnlyTargetsThinking|TestAnthropicStreamEgress_MisclassifiedReasoningUsesSameBlockRule" -v
```

All four new tests should pass. The `SignatureDeltaOnlyTargetsThinking` test will also catch any future regression where the block-type decision is loosened and the hard-abort frame is re-introduced.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable