### PR TITLE
docs: add `claimsSyncMode` provisioning source section to all SCIM provider guides

### DIFF
--- a/docs/enterprise/setting-up-entra/scim.mdx
+++ b/docs/enterprise/setting-up-entra/scim.mdx
@@ -94,9 +94,10 @@ bifrost:
         groups:
           attributeType: "group"        # "user" (SCIM User attribute) or "group" (match SCIM Group)
           attributeValue: "displayName"
+      claimsSyncMode: "both"                                # provisioning source: "both" (SCIM + login claims) or "scim" (SCIM only - ignore login claims)
 ```
 
-The same keys (`provisioningToken`, `claimScimAttributes`) apply directly under `scim_config.config` in a raw `config.json`.
+The same keys (`provisioningToken`, `claimScimAttributes`, `claimsSyncMode`) apply directly under `scim_config.config` in a raw `config.json`.
 
 </Step>
 
@@ -107,6 +108,21 @@ The same keys (`provisioningToken`, `claimScimAttributes`) apply directly under 
 </Warning>
 
 Then use this token as the **Secret Token** and your deployment's SCIM endpoint as the **Tenant URL** in [Step 2](#step-2-configure-entra-provisioning) below.
+
+---
+
+### Provisioning source
+
+The provider configuration includes a **Provisioning source** setting that controls whether IdP login claims still provision users, or whether SCIM is the sole source of truth:
+
+| Option | Config value | Behavior |
+| --- | --- | --- |
+| **SCIM and login claims** (default) | `both` | Both SCIM and IdP login / token-refresh claims create and update users, roles, teams, and business units. |
+| **SCIM only - ignore login claims** | `scim` | SCIM is the sole source of truth. OIDC claims will be ignored and will never create or update users from claims - new users must be pushed by SCIM. Users not already provisioned by SCIM are denied access at login. |
+
+Choose **SCIM only** when provisioning must be fully controlled by your IdP's SCIM app and login-time claim changes should never alter membership. Leave it on the default **SCIM and login claims** if users are also provisioned just-in-time on first login.
+
+This maps to the `claimsSyncMode` config key (`both` or `scim`) and is inert when SCIM is disabled - claims always sync then.
 
 ---
 

--- a/docs/enterprise/setting-up-generic-oidc/scim.mdx
+++ b/docs/enterprise/setting-up-generic-oidc/scim.mdx
@@ -92,9 +92,10 @@ bifrost:
         groups:
           attributeType: "group"        # "user" (SCIM User attribute) or "group" (match SCIM Group)
           attributeValue: "displayName"
+      claimsSyncMode: "both"                                # provisioning source: "both" (SCIM + login claims) or "scim" (SCIM only - ignore login claims)
 ```
 
-The same keys (`provisioningToken`, `claimScimAttributes`) apply directly under `scim_config.config` in a raw `config.json`.
+The same keys (`provisioningToken`, `claimScimAttributes`, `claimsSyncMode`) apply directly under `scim_config.config` in a raw `config.json`.
 
 </Step>
 
@@ -105,6 +106,21 @@ The same keys (`provisioningToken`, `claimScimAttributes`) apply directly under 
 </Warning>
 
 Then use this token as the **Bearer Token** and your deployment's SCIM endpoint as the **SCIM Base URL** in [Step 2](#step-2-configure-your-idp-to-push-scim-to-bifrost) below.
+
+---
+
+### Provisioning source
+
+The provider configuration includes a **Provisioning source** setting that controls whether IdP login claims still provision users, or whether SCIM is the sole source of truth:
+
+| Option | Config value | Behavior |
+| --- | --- | --- |
+| **SCIM and login claims** (default) | `both` | Both SCIM and IdP login / token-refresh claims create and update users, roles, teams, and business units. |
+| **SCIM only - ignore login claims** | `scim` | SCIM is the sole source of truth. OIDC claims will be ignored and will never create or update users from claims - new users must be pushed by SCIM. Users not already provisioned by SCIM are denied access at login. |
+
+Choose **SCIM only** when provisioning must be fully controlled by your IdP's SCIM app and login-time claim changes should never alter membership. Leave it on the default **SCIM and login claims** if users are also provisioned just-in-time on first login.
+
+This maps to the `claimsSyncMode` config key (`both` or `scim`) and is inert when SCIM is disabled - claims always sync then.
 
 ---
 

--- a/docs/enterprise/setting-up-google-workspace/scim.mdx
+++ b/docs/enterprise/setting-up-google-workspace/scim.mdx
@@ -85,6 +85,21 @@ To control which Google Workspace groups are synced as Bifrost teams, configure 
 
 ---
 
+### Provisioning source
+
+The provider configuration includes a **Provisioning source** setting that controls whether IdP login claims still provision users, or whether SCIM is the sole source of truth:
+
+| Option | Config value | Behavior |
+| --- | --- | --- |
+| **SCIM and login claims** (default) | `both` | Both SCIM and IdP login / token-refresh claims create and update users, roles, teams, and business units. |
+| **SCIM only - ignore login claims** | `scim` | SCIM is the sole source of truth. Login and token refresh never create or update users from claims - new users must be pushed by SCIM, and an unknown user signing in is denied with a message to contact their administrator. |
+
+Choose **SCIM only** when provisioning must be fully controlled by your IdP's SCIM app and login-time claim changes should never alter membership. Leave it on the default **SCIM and login claims** if users are also provisioned just-in-time on first login.
+
+This maps to the `claimsSyncMode` config key (`both` or `scim`) and is inert when SCIM is disabled - claims always sync then.
+
+---
+
 ## Step 3: Trigger and verify sync
 
 <Steps>

--- a/docs/enterprise/setting-up-okta/scim.mdx
+++ b/docs/enterprise/setting-up-okta/scim.mdx
@@ -95,9 +95,10 @@ bifrost:
         groups:
           attributeType: "group"        # "user" (SCIM User attribute) or "group" (match SCIM Group)
           attributeValue: "displayName"
+      claimsSyncMode: "both"                                # provisioning source: "both" (SCIM + login claims) or "scim" (SCIM only - ignore login claims)
 ```
 
-The same keys (`provisioningToken`, `claimScimAttributes`) apply directly under `scim_config.config` in a raw `config.json`.
+The same keys (`provisioningToken`, `claimScimAttributes`, `claimsSyncMode`) apply directly under `scim_config.config` in a raw `config.json`.
 
 </Step>
 
@@ -108,6 +109,21 @@ The same keys (`provisioningToken`, `claimScimAttributes`) apply directly under 
 </Warning>
 
 Then use this token as the **API Token** and your deployment's SCIM endpoint as the **SCIM 2.0 Base URL** in [Step 3](#step-3-configure-the-scim-app) - the rest of the Okta setup is identical.
+
+---
+
+### Provisioning source
+
+The provider configuration includes a **Provisioning source** setting that controls whether IdP login claims still provision users, or whether SCIM is the sole source of truth:
+
+| Option | Config value | Behavior |
+| --- | --- | --- |
+| **SCIM and login claims** (default) | `both` | Both SCIM and IdP login / token-refresh claims create and update users, roles, teams, and business units. |
+| **SCIM only - ignore login claims** | `scim` | SCIM is the sole source of truth. OIDC claims will be ignored and will never create or update users from claims - new users must be pushed by SCIM. Users not already provisioned by SCIM are denied access at login. |
+
+Choose **SCIM only** when provisioning must be fully controlled by your IdP's SCIM app and login-time claim changes should never alter membership. Leave it on the default **SCIM and login claims** if users are also provisioned just-in-time on first login.
+
+This maps to the `claimsSyncMode` config key (`both` or `scim`) and is inert when SCIM is disabled - claims always sync then.
 
 ---
 


### PR DESCRIPTION
### TL;DR

Documents the new `claimsSyncMode` configuration option across all SCIM provider setup guides 

### What changed?

A new `claimsSyncMode` config key is now documented in the SCIM setup guides for all supported providers. It accepts two values:

- `both` (default) — SCIM and IdP login/token-refresh claims both create and update users, roles, teams, and business units.
- `scim` — SCIM is the sole provisioning source; login-time OIDC claims are ignored and will never create or update users. Unknown users signing in are denied and directed to contact their administrator.

Each guide now includes a **Provisioning source** section with a reference table, guidance on when to use each option, and a note that the setting is inert when SCIM is disabled.

### How to test?

- Review the updated SCIM docs for Entra, Generic OIDC, Google Workspace, and Okta to confirm the new section renders correctly and the config snippet includes the `claimsSyncMode` comment.
- Verify the reference table and guidance text are consistent across all four guides.

### Why make this change?

Users needed documentation explaining how to control whether login-time claims can provision users alongside SCIM, or whether SCIM should be the exclusive source of truth. This is important for organizations that require strict IdP-controlled provisioning and want to prevent ad-hoc user creation at login time.