### PR TITLE
fix: bedrock tool use ids

### DIFF
--- a/core/providers/bedrock/parallel_tool_result_ordering_test.go
+++ b/core/providers/bedrock/parallel_tool_result_ordering_test.go
@@ -18,8 +18,11 @@ package bedrock
 
 import (
 	"context"
+	"regexp"
+	"strings"
 	"testing"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -159,4 +162,179 @@ func TestParallelToolResultOrdering(t *testing.T) {
 			"iteration %d: tool_result order %v does not match tool_use order %v — Bedrock will reject this",
 			i, toolResultIDs, toolUseIDs)
 	}
+}
+
+// reportedGeminiToolUseID is the id from the OpenCode/Bedrock report: a Gemini-minted call id
+// with an embedded thought signature, replayed onto a glm-5 / kimi-2.5 turn.
+const reportedGeminiToolUseID = "d556q31u_ts_AY89a18eH3FucoBHPCdX6w7jgIhjSnIj7hU_mGofiw3SE2HL8kuMRcnfV3pGV7iUXRi_YQVYUgCH4bmcbYrS03yxWRtsPFb7KHPbp_iRinWZKPHtiyGVRlXfTsqeDBZOt3YNzKL-ycnZh0WeoLthSqnjkeZKT6idSNfd"
+
+var bedrockToolUseIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_.:-]{1,64}$`)
+
+// TestBedrockAliasToolUseID verifies the alias only rewrites ids Bedrock would reject, so
+// every id that works today stays byte-identical on the wire.
+func TestBedrockAliasToolUseID(t *testing.T) {
+	tests := []struct {
+		name       string
+		id         string
+		wantSameID bool
+	}{
+		{"anthropic id", "tooluse_RwHN0v2n5kuNuZ2qoMV3SN", true},
+		{"openai id", "call_9v2n5kuNuZ2qoMV3SNRwHN0", true},
+		{"kimi id keeps dots and colons", "functions.read:0", true},
+		{"exactly 64 chars", strings.Repeat("a", 64), true},
+		{"65 chars", strings.Repeat("a", 65), false},
+		{"gemini thought signature", reportedGeminiToolUseID, false},
+		{"unsafe characters", "call/abc 123", false},
+		{"empty", "", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := bedrockAliasToolUseID(tc.id)
+			assert.Regexp(t, bedrockToolUseIDPattern, got, "alias violates Bedrock's toolUseId constraint")
+			if tc.wantSameID {
+				assert.Equal(t, tc.id, got, "id Bedrock already accepts must pass through unchanged")
+			} else {
+				assert.Equal(t, got, bedrockAliasToolUseID(tc.id), "alias must be deterministic")
+			}
+		})
+	}
+
+	// The hash covers the full id, so ids sharing a truncated head still alias apart.
+	head := strings.Repeat("z", 70)
+	assert.NotEqual(t, bedrockAliasToolUseID(head+"_one"), bedrockAliasToolUseID(head+"_two"),
+		"ids sharing a truncated head must not collide")
+}
+
+// TestBedrockToolUseIDPairingResponsesPath verifies an over-long id is aliased identically on
+// the tool_use and its tool_result, so Bedrock can still pair them.
+func TestBedrockToolUseIDPairingResponsesPath(t *testing.T) {
+	ptr := func(s string) *string { return &s }
+	msgType := func(t schemas.ResponsesMessageType) *schemas.ResponsesMessageType { return &t }
+
+	req := &schemas.BifrostResponsesRequest{
+		Model: "zai.glm-5",
+		Input: []schemas.ResponsesMessage{
+			{
+				Type: msgType(schemas.ResponsesMessageTypeMessage),
+				Role: func(r schemas.ResponsesMessageRoleType) *schemas.ResponsesMessageRoleType { return &r }(schemas.ResponsesInputMessageRoleUser),
+				Content: &schemas.ResponsesMessageContent{
+					ContentStr: ptr("What did we do so far?"),
+				},
+			},
+			{
+				Type: msgType(schemas.ResponsesMessageTypeFunctionCall),
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					CallID:    ptr(reportedGeminiToolUseID),
+					Name:      ptr("bash"),
+					Arguments: ptr(`{"command":"ls"}`),
+				},
+			},
+			{
+				Type: msgType(schemas.ResponsesMessageTypeFunctionCallOutput),
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					CallID: ptr(reportedGeminiToolUseID),
+					Output: &schemas.ResponsesToolMessageOutputStruct{ResponsesToolCallOutputStr: ptr("build/ src/")},
+				},
+			},
+		},
+	}
+
+	bedrockReq, err := ToBedrockResponsesRequest(schemas.NewBifrostContext(context.Background(), schemas.NoDeadline), req)
+	require.NoError(t, err)
+
+	var toolUseIDs, toolResultIDs []string
+	for _, msg := range bedrockReq.Messages {
+		for _, block := range msg.Content {
+			if block.ToolUse != nil {
+				toolUseIDs = append(toolUseIDs, block.ToolUse.ToolUseID)
+			}
+			if block.ToolResult != nil {
+				toolResultIDs = append(toolResultIDs, block.ToolResult.ToolUseID)
+			}
+		}
+	}
+
+	require.Len(t, toolUseIDs, 1)
+	require.Len(t, toolResultIDs, 1)
+	assert.Regexp(t, bedrockToolUseIDPattern, toolUseIDs[0], "Bedrock rejects toolUse.toolUseId over 64 chars")
+	assert.Regexp(t, bedrockToolUseIDPattern, toolResultIDs[0], "Bedrock rejects toolResult.toolUseId over 64 chars")
+	assert.Equal(t, toolUseIDs[0], toolResultIDs[0], "tool_use and tool_result must alias to the same id")
+}
+
+// TestBedrockToolUseIDPairingChatPath is TestBedrockToolUseIDPairingResponsesPath for the
+// chat completions path, which builds toolUse/toolResult blocks through a separate converter.
+func TestBedrockToolUseIDPairingChatPath(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	req := &schemas.BifrostChatRequest{
+		Model: "zai.glm-5",
+		Input: []schemas.ChatMessage{
+			{
+				Role:    schemas.ChatMessageRoleUser,
+				Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("What did we do so far?")},
+			},
+			{
+				Role: schemas.ChatMessageRoleAssistant,
+				ChatAssistantMessage: &schemas.ChatAssistantMessage{
+					ToolCalls: []schemas.ChatAssistantMessageToolCall{
+						{
+							ID:   schemas.Ptr(reportedGeminiToolUseID),
+							Type: schemas.Ptr(string(schemas.ChatToolChoiceTypeFunction)),
+							Function: schemas.ChatAssistantMessageToolCallFunction{
+								Name:      schemas.Ptr("bash"),
+								Arguments: `{"command":"ls"}`,
+							},
+						},
+					},
+				},
+			},
+			{
+				Role:            schemas.ChatMessageRoleTool,
+				ChatToolMessage: &schemas.ChatToolMessage{ToolCallID: schemas.Ptr(reportedGeminiToolUseID)},
+				Content:         &schemas.ChatMessageContent{ContentStr: schemas.Ptr("build/ src/")},
+			},
+		},
+	}
+
+	bedrockReq, err := ToBedrockChatCompletionRequest(ctx, req)
+	require.NoError(t, err)
+
+	var toolUseID, toolResultID string
+	for _, msg := range bedrockReq.Messages {
+		for _, block := range msg.Content {
+			if block.ToolUse != nil {
+				toolUseID = block.ToolUse.ToolUseID
+			}
+			if block.ToolResult != nil {
+				toolResultID = block.ToolResult.ToolUseID
+			}
+		}
+	}
+
+	assert.Regexp(t, bedrockToolUseIDPattern, toolUseID, "Bedrock rejects toolUse.toolUseId over 64 chars")
+	assert.Regexp(t, bedrockToolUseIDPattern, toolResultID, "Bedrock rejects toolResult.toolUseId over 64 chars")
+	assert.Equal(t, toolUseID, toolResultID, "tool_use and tool_result must alias to the same id")
+}
+
+// TestBedrockAliasToolUseIDFullHashAvoidsCollision uses a real pair of 68-char ids found by
+// brute-force search: their uint32(xxhash.Sum64String(...)) values collide (the bug in the
+// previous 32-bit-truncated hash), but the full 64-bit hashes don't. If bedrockAliasToolUseID
+// ever regresses to hashing only a uint32-truncated slice, this reproduces a real duplicate
+// toolUseId — which Bedrock rejects outright, or worse, silently misattributes a tool_result.
+func TestBedrockAliasToolUseIDFullHashAvoidsCollision(t *testing.T) {
+	idA := "d556q31u_ts_AY89a18eH3FucoBHPCdX6w7jgIhjSnIj7hU_mGofiw3SE2HL8_n38390"
+	idB := "d556q31u_ts_AY89a18eH3FucoBHPCdX6w7jgIhjSnIj7hU_mGofiw3SE2HL8_n63004"
+	require.Greater(t, len(idA), 64)
+	require.Greater(t, len(idB), 64)
+
+	// Document the collision this pair exercises: same 32-bit-truncated hash, different ids.
+	require.Equal(t, uint32(xxhash.Sum64String(idA)), uint32(xxhash.Sum64String(idB)),
+		"fixture no longer demonstrates a 32-bit hash collision")
+	require.NotEqual(t, idA, idB)
+
+	aliasA := bedrockAliasToolUseID(idA)
+	aliasB := bedrockAliasToolUseID(idB)
+	assert.NotEqual(t, aliasA, aliasB, "ids with a colliding 32-bit hash must still alias apart")
+	assert.Regexp(t, bedrockToolUseIDPattern, aliasA)
+	assert.Regexp(t, bedrockToolUseIDPattern, aliasB)
 }

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -3345,7 +3345,7 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 				result := pendingResults[callID]
 				resultBlocks = append(resultBlocks, BedrockContentBlock{
 					ToolResult: &BedrockToolResult{
-						ToolUseID: callID,
+						ToolUseID: bedrockAliasToolUseID(callID),
 						Content:   result.Content,
 						Status:    schemas.Ptr(result.Status),
 					},
@@ -3385,7 +3385,7 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 				if toolCall, exists := stateManager.toolCalls[callID]; exists {
 					toolUseBlock := &BedrockContentBlock{
 						ToolUse: &BedrockToolUse{
-							ToolUseID: toolCall.CallID,
+							ToolUseID: bedrockAliasToolUseID(toolCall.CallID),
 							Name:      toolCall.ToolName,
 						},
 					}
@@ -3539,7 +3539,7 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 						if toolCall, exists := stateManager.toolCalls[callID]; exists {
 							toolUseBlock := &BedrockContentBlock{
 								ToolUse: &BedrockToolUse{
-									ToolUseID: toolCall.CallID,
+									ToolUseID: bedrockAliasToolUseID(toolCall.CallID),
 									Name:      toolCall.ToolName,
 								},
 							}
@@ -3579,7 +3579,7 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 						result := pendingResults[callID]
 						resultBlocks = append(resultBlocks, BedrockContentBlock{
 							ToolResult: &BedrockToolResult{
-								ToolUseID: callID,
+								ToolUseID: bedrockAliasToolUseID(callID),
 								Content:   result.Content,
 								Status:    schemas.Ptr(result.Status),
 							},
@@ -3620,7 +3620,7 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 					if toolCall, exists := stateManager.toolCalls[callID]; exists {
 						toolUseBlock := &BedrockContentBlock{
 							ToolUse: &BedrockToolUse{
-								ToolUseID: toolCall.CallID,
+								ToolUseID: bedrockAliasToolUseID(toolCall.CallID),
 								Name:      toolCall.ToolName,
 							},
 						}
@@ -3662,7 +3662,7 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 					result := pendingResults[callID]
 					resultBlocks = append(resultBlocks, BedrockContentBlock{
 						ToolResult: &BedrockToolResult{
-							ToolUseID: callID,
+							ToolUseID: bedrockAliasToolUseID(callID),
 							Content:   result.Content,
 							Status:    schemas.Ptr(result.Status),
 						},
@@ -3739,7 +3739,7 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 			inputBytes, _ := json.Marshal(inputMap)
 			toolUseBlock := BedrockContentBlock{
 				ToolUse: &BedrockToolUse{
-					ToolUseID: callID,
+					ToolUseID: bedrockAliasToolUseID(callID),
 					Name:      string(BedrockSystemToolNovaGrounding),
 					Input:     json.RawMessage(inputBytes),
 					Type:      "server_tool_use",
@@ -3759,7 +3759,7 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 			resultType := BedrockNovaGroundingResultType
 			toolResultBlock := BedrockContentBlock{
 				ToolResult: &BedrockToolResult{
-					ToolUseID: callID,
+					ToolUseID: bedrockAliasToolUseID(callID),
 					Type:      &resultType,
 					Status:    schemas.Ptr("success"),
 					Content:   []BedrockContentBlock{{Text: &sourcesText}},
@@ -3785,7 +3785,7 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 			inputBytes, _ := json.Marshal(map[string]string{"snippet": code})
 			toolUseBlock := BedrockContentBlock{
 				ToolUse: &BedrockToolUse{
-					ToolUseID: toolUseID,
+					ToolUseID: bedrockAliasToolUseID(toolUseID),
 					Name:      string(BedrockSystemToolNovaCodeInterpreter),
 					Input:     json.RawMessage(inputBytes),
 					Type:      "server_tool_use",
@@ -3806,7 +3806,7 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 			resultType := BedrockNovaCodeInterpreterResultType
 			toolResultBlock := BedrockContentBlock{
 				ToolResult: &BedrockToolResult{
-					ToolUseID: toolUseID,
+					ToolUseID: bedrockAliasToolUseID(toolUseID),
 					Type:      &resultType,
 					Content:   []BedrockContentBlock{{Text: &execResultStr}},
 				},

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -28,6 +28,10 @@ import (
 var awsRegionRegex = regexp.MustCompile(`^[a-z]{2,3}(?:-[a-z]+)+-\d+$`)
 var bedrockUnsafeToolNameCharRegex = regexp.MustCompile(`[^A-Za-z0-9_-]+`)
 
+// bedrockUnsafeToolUseIDCharRegex matches characters outside Bedrock's toolUseId charset
+// (^[a-zA-Z0-9_.:-]+$), which is wider than the tool-name charset above.
+var bedrockUnsafeToolUseIDCharRegex = regexp.MustCompile(`[^A-Za-z0-9_.:-]+`)
+
 // bedrockToolNameAliasKey stores Bedrock wire-name aliases on the request context.
 type bedrockToolNameAliasKey struct{}
 
@@ -339,6 +343,26 @@ func bedrockRestoreToolName(ctx context.Context, name string) string {
 		}
 	}
 	return name
+}
+
+// bedrockAliasToolUseID returns a Bedrock-safe toolUseId (<=64 chars, [a-zA-Z0-9_.:-]).
+// Deterministic, so a tool_use id and its tool_result id always alias to the same value.
+func bedrockAliasToolUseID(id string) string {
+	if id != "" && len(id) <= 64 && !bedrockUnsafeToolUseIDCharRegex.MatchString(id) {
+		return id
+	}
+
+	// Hash the full id (all 64 bits, not just a uint32-truncated slice) so two ids
+	// sharing a truncated head can't collide within a feasible search space.
+	hash := fmt.Sprintf("%016x", xxhash.Sum64String(id))
+	semantic := bedrockUnsafeToolUseIDCharRegex.ReplaceAllString(id, "_")
+	if maxSemanticLen := 64 - len(hash) - 1; len(semantic) > maxSemanticLen {
+		semantic = semantic[:maxSemanticLen]
+	}
+	if semantic == "" {
+		return hash
+	}
+	return hash + "_" + semantic
 }
 
 // convertParameters handles parameter conversion
@@ -1218,7 +1242,7 @@ func convertToolMessages(ctx context.Context, msgs []schemas.ChatMessage) (Bedro
 		}
 		toolResultBlock := BedrockContentBlock{
 			ToolResult: &BedrockToolResult{
-				ToolUseID: *msg.ChatToolMessage.ToolCallID,
+				ToolUseID: bedrockAliasToolUseID(*msg.ChatToolMessage.ToolCallID),
 				Content:   toolResultContent,
 				Status:    schemas.Ptr(status),
 			},
@@ -2323,7 +2347,7 @@ func convertToolCallToContentBlock(ctx context.Context, toolCall schemas.ChatAss
 
 	return BedrockContentBlock{
 		ToolUse: &BedrockToolUse{
-			ToolUseID: toolUseID,
+			ToolUseID: bedrockAliasToolUseID(toolUseID),
 			Name:      toolName,
 			Input:     input,
 		},


### PR DESCRIPTION
## Summary

Bedrock enforces a strict `toolUseId` constraint: at most 64 characters, matching `[a-zA-Z0-9_.:-]`. Tool call IDs minted by other providers (e.g. Gemini's thought-signature IDs like `d556q31u_ts_AY89a18eH3FucoBHPCdX6w7jgI...`) violate this constraint and cause Bedrock to reject requests. This PR introduces a deterministic aliasing function that rewrites non-conforming IDs into valid ones, while leaving already-valid IDs byte-identical on the wire.

## Changes

- Added `bedrockAliasToolUseID` in `utils.go`, which passes through any ID that already satisfies Bedrock's constraint (`≤64 chars`, safe charset). For IDs that don't, it produces a deterministic alias by prepending an 8-hex-char xxhash of the full original ID, followed by a sanitized semantic prefix — ensuring two IDs that share a truncated head cannot collide.
- Applied `bedrockAliasToolUseID` at every point in the responses and chat completion converters where a `toolUseId` or `toolResultId` is written to a Bedrock content block, covering both the responses path (`ConvertBifrostMessagesToBedrockMessages`) and the chat completions path (`convertToolCallToContentBlock`, `convertToolMessages`).
- Added `bedrockUnsafeToolUseIDCharRegex` to match characters outside Bedrock's toolUseId charset (distinct from the existing tool-name regex, since the allowed sets differ).
- Added three new test cases:
  - `TestBedrockAliasToolUseID` — unit tests for the aliasing function covering valid pass-through cases, length boundaries, unsafe characters, empty input, and collision resistance.
  - `TestBedrockToolUseIDPairingResponsesPath` — end-to-end test verifying that an over-long Gemini ID is aliased identically on both the `tool_use` and `tool_result` blocks through the responses converter.
  - `TestBedrockToolUseIDPairingChatPath` — same pairing verification through the chat completions converter.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/bedrock/... -run "TestBedrockAliasToolUseID|TestBedrockToolUseIDPairingResponsesPath|TestBedrockToolUseIDPairingChatPath|TestParallelToolResultOrdering"
```

Expected: all tests pass. Specifically verify that a Gemini-style thought-signature ID is aliased to a string matching `^[a-zA-Z0-9_.:-]{1,64}$` and that the aliased value is identical on both the `tool_use` and `tool_result` sides of a conversation turn.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

IDs that already conform to Bedrock's constraint are returned unchanged, so existing well-formed traffic is unaffected.

## Related issues

Reported case: Gemini-minted call ID `d556q31u_ts_AY89a18eH3FucoBHPCdX6w7jgIhjSnIj7hU_mGofiw3SE2HL8kuMRcnfV3pGV7iUXRi_YQVYUgCH4bmcbYrS03yxWRtsPFb7KHPbp_iRinWZKPHtiyGVRlXfTsqeDBZOt3YNzKL-ycnZh0WeoLthSqnjkeZKT6idSNfd` replayed onto a glm-5 / kimi-2.5 turn causes Bedrock to reject the request.

## Security considerations

The aliasing function is purely deterministic and local — no IDs are stored or transmitted outside the Bedrock request being constructed. The xxhash used is for collision avoidance, not cryptographic purposes.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable