### PR TITLE
fix: rerank integration

### DIFF
--- a/core/providers/bedrock/parallel_tool_result_ordering_test.go
+++ b/core/providers/bedrock/parallel_tool_result_ordering_test.go
@@ -18,8 +18,11 @@ package bedrock
 
 import (
 	"context"
+	"regexp"
+	"strings"
 	"testing"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -159,4 +162,179 @@ func TestParallelToolResultOrdering(t *testing.T) {
 			"iteration %d: tool_result order %v does not match tool_use order %v — Bedrock will reject this",
 			i, toolResultIDs, toolUseIDs)
 	}
+}
+
+// reportedGeminiToolUseID is the id from the OpenCode/Bedrock report: a Gemini-minted call id
+// with an embedded thought signature, replayed onto a glm-5 / kimi-2.5 turn.
+const reportedGeminiToolUseID = "d556q31u_ts_AY89a18eH3FucoBHPCdX6w7jgIhjSnIj7hU_mGofiw3SE2HL8kuMRcnfV3pGV7iUXRi_YQVYUgCH4bmcbYrS03yxWRtsPFb7KHPbp_iRinWZKPHtiyGVRlXfTsqeDBZOt3YNzKL-ycnZh0WeoLthSqnjkeZKT6idSNfd"
+
+var bedrockToolUseIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_.:-]{1,64}$`)
+
+// TestBedrockAliasToolUseID verifies the alias only rewrites ids Bedrock would reject, so
+// every id that works today stays byte-identical on the wire.
+func TestBedrockAliasToolUseID(t *testing.T) {
+	tests := []struct {
+		name       string
+		id         string
+		wantSameID bool
+	}{
+		{"anthropic id", "tooluse_RwHN0v2n5kuNuZ2qoMV3SN", true},
+		{"openai id", "call_9v2n5kuNuZ2qoMV3SNRwHN0", true},
+		{"kimi id keeps dots and colons", "functions.read:0", true},
+		{"exactly 64 chars", strings.Repeat("a", 64), true},
+		{"65 chars", strings.Repeat("a", 65), false},
+		{"gemini thought signature", reportedGeminiToolUseID, false},
+		{"unsafe characters", "call/abc 123", false},
+		{"empty", "", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := bedrockAliasToolUseID(tc.id)
+			assert.Regexp(t, bedrockToolUseIDPattern, got, "alias violates Bedrock's toolUseId constraint")
+			if tc.wantSameID {
+				assert.Equal(t, tc.id, got, "id Bedrock already accepts must pass through unchanged")
+			} else {
+				assert.Equal(t, got, bedrockAliasToolUseID(tc.id), "alias must be deterministic")
+			}
+		})
+	}
+
+	// The hash covers the full id, so ids sharing a truncated head still alias apart.
+	head := strings.Repeat("z", 70)
+	assert.NotEqual(t, bedrockAliasToolUseID(head+"_one"), bedrockAliasToolUseID(head+"_two"),
+		"ids sharing a truncated head must not collide")
+}
+
+// TestBedrockToolUseIDPairingResponsesPath verifies an over-long id is aliased identically on
+// the tool_use and its tool_result, so Bedrock can still pair them.
+func TestBedrockToolUseIDPairingResponsesPath(t *testing.T) {
+	ptr := func(s string) *string { return &s }
+	msgType := func(t schemas.ResponsesMessageType) *schemas.ResponsesMessageType { return &t }
+
+	req := &schemas.BifrostResponsesRequest{
+		Model: "zai.glm-5",
+		Input: []schemas.ResponsesMessage{
+			{
+				Type: msgType(schemas.ResponsesMessageTypeMessage),
+				Role: func(r schemas.ResponsesMessageRoleType) *schemas.ResponsesMessageRoleType { return &r }(schemas.ResponsesInputMessageRoleUser),
+				Content: &schemas.ResponsesMessageContent{
+					ContentStr: ptr("What did we do so far?"),
+				},
+			},
+			{
+				Type: msgType(schemas.ResponsesMessageTypeFunctionCall),
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					CallID:    ptr(reportedGeminiToolUseID),
+					Name:      ptr("bash"),
+					Arguments: ptr(`{"command":"ls"}`),
+				},
+			},
+			{
+				Type: msgType(schemas.ResponsesMessageTypeFunctionCallOutput),
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					CallID: ptr(reportedGeminiToolUseID),
+					Output: &schemas.ResponsesToolMessageOutputStruct{ResponsesToolCallOutputStr: ptr("build/ src/")},
+				},
+			},
+		},
+	}
+
+	bedrockReq, err := ToBedrockResponsesRequest(schemas.NewBifrostContext(context.Background(), schemas.NoDeadline), req)
+	require.NoError(t, err)
+
+	var toolUseIDs, toolResultIDs []string
+	for _, msg := range bedrockReq.Messages {
+		for _, block := range msg.Content {
+			if block.ToolUse != nil {
+				toolUseIDs = append(toolUseIDs, block.ToolUse.ToolUseID)
+			}
+			if block.ToolResult != nil {
+				toolResultIDs = append(toolResultIDs, block.ToolResult.ToolUseID)
+			}
+		}
+	}
+
+	require.Len(t, toolUseIDs, 1)
+	require.Len(t, toolResultIDs, 1)
+	assert.Regexp(t, bedrockToolUseIDPattern, toolUseIDs[0], "Bedrock rejects toolUse.toolUseId over 64 chars")
+	assert.Regexp(t, bedrockToolUseIDPattern, toolResultIDs[0], "Bedrock rejects toolResult.toolUseId over 64 chars")
+	assert.Equal(t, toolUseIDs[0], toolResultIDs[0], "tool_use and tool_result must alias to the same id")
+}
+
+// TestBedrockToolUseIDPairingChatPath is TestBedrockToolUseIDPairingResponsesPath for the
+// chat completions path, which builds toolUse/toolResult blocks through a separate converter.
+func TestBedrockToolUseIDPairingChatPath(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	req := &schemas.BifrostChatRequest{
+		Model: "zai.glm-5",
+		Input: []schemas.ChatMessage{
+			{
+				Role:    schemas.ChatMessageRoleUser,
+				Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("What did we do so far?")},
+			},
+			{
+				Role: schemas.ChatMessageRoleAssistant,
+				ChatAssistantMessage: &schemas.ChatAssistantMessage{
+					ToolCalls: []schemas.ChatAssistantMessageToolCall{
+						{
+							ID:   schemas.Ptr(reportedGeminiToolUseID),
+							Type: schemas.Ptr(string(schemas.ChatToolChoiceTypeFunction)),
+							Function: schemas.ChatAssistantMessageToolCallFunction{
+								Name:      schemas.Ptr("bash"),
+								Arguments: `{"command":"ls"}`,
+							},
+						},
+					},
+				},
+			},
+			{
+				Role:            schemas.ChatMessageRoleTool,
+				ChatToolMessage: &schemas.ChatToolMessage{ToolCallID: schemas.Ptr(reportedGeminiToolUseID)},
+				Content:         &schemas.ChatMessageContent{ContentStr: schemas.Ptr("build/ src/")},
+			},
+		},
+	}
+
+	bedrockReq, err := ToBedrockChatCompletionRequest(ctx, req)
+	require.NoError(t, err)
+
+	var toolUseID, toolResultID string
+	for _, msg := range bedrockReq.Messages {
+		for _, block := range msg.Content {
+			if block.ToolUse != nil {
+				toolUseID = block.ToolUse.ToolUseID
+			}
+			if block.ToolResult != nil {
+				toolResultID = block.ToolResult.ToolUseID
+			}
+		}
+	}
+
+	assert.Regexp(t, bedrockToolUseIDPattern, toolUseID, "Bedrock rejects toolUse.toolUseId over 64 chars")
+	assert.Regexp(t, bedrockToolUseIDPattern, toolResultID, "Bedrock rejects toolResult.toolUseId over 64 chars")
+	assert.Equal(t, toolUseID, toolResultID, "tool_use and tool_result must alias to the same id")
+}
+
+// TestBedrockAliasToolUseIDFullHashAvoidsCollision uses a real pair of 68-char ids found by
+// brute-force search: their uint32(xxhash.Sum64String(...)) values collide (the bug in the
+// previous 32-bit-truncated hash), but the full 64-bit hashes don't. If bedrockAliasToolUseID
+// ever regresses to hashing only a uint32-truncated slice, this reproduces a real duplicate
+// toolUseId — which Bedrock rejects outright, or worse, silently misattributes a tool_result.
+func TestBedrockAliasToolUseIDFullHashAvoidsCollision(t *testing.T) {
+	idA := "d556q31u_ts_AY89a18eH3FucoBHPCdX6w7jgIhjSnIj7hU_mGofiw3SE2HL8_n38390"
+	idB := "d556q31u_ts_AY89a18eH3FucoBHPCdX6w7jgIhjSnIj7hU_mGofiw3SE2HL8_n63004"
+	require.Greater(t, len(idA), 64)
+	require.Greater(t, len(idB), 64)
+
+	// Document the collision this pair exercises: same 32-bit-truncated hash, different ids.
+	require.Equal(t, uint32(xxhash.Sum64String(idA)), uint32(xxhash.Sum64String(idB)),
+		"fixture no longer demonstrates a 32-bit hash collision")
+	require.NotEqual(t, idA, idB)
+
+	aliasA := bedrockAliasToolUseID(idA)
+	aliasB := bedrockAliasToolUseID(idB)
+	assert.NotEqual(t, aliasA, aliasB, "ids with a colliding 32-bit hash must still alias apart")
+	assert.Regexp(t, bedrockToolUseIDPattern, aliasA)
+	assert.Regexp(t, bedrockToolUseIDPattern, aliasB)
 }

--- a/core/providers/bedrock/rerank.go
+++ b/core/providers/bedrock/rerank.go
@@ -151,6 +151,36 @@ func (response *BedrockRerankResponse) ToBifrostRerankResponse(documents []schem
 	return bifrostResponse
 }
 
+// ToBedrockRerankResponse converts a Bifrost rerank response into Bedrock Agent Runtime format.
+// Bedrock echoes the ranked document, which is only present when the rerank was requested
+// with ReturnDocuments enabled.
+func ToBedrockRerankResponse(bifrostResp *schemas.BifrostRerankResponse) *BedrockRerankResponse {
+	if bifrostResp == nil {
+		return nil
+	}
+
+	bedrockResp := &BedrockRerankResponse{
+		Results: make([]BedrockRerankResult, 0, len(bifrostResp.Results)),
+	}
+
+	for _, result := range bifrostResp.Results {
+		bedrockResult := BedrockRerankResult{
+			Index:          result.Index,
+			RelevanceScore: result.RelevanceScore,
+		}
+		if result.Document != nil {
+			bedrockResult.Document = &BedrockRerankResponseDocument{
+				Type:         bedrockRerankInlineDocumentTypeText,
+				TextDocument: &BedrockRerankTextValue{Text: result.Document.Text},
+			}
+		}
+
+		bedrockResp.Results = append(bedrockResp.Results, bedrockResult)
+	}
+
+	return bedrockResp
+}
+
 // ToBifrostRerankRequest converts a Bedrock Agent Runtime rerank request to Bifrost format.
 func (req *BedrockRerankRequest) ToBifrostRerankRequest(ctx *schemas.BifrostContext) *schemas.BifrostRerankRequest {
 	if req == nil {

--- a/core/providers/bedrock/rerank_test.go
+++ b/core/providers/bedrock/rerank_test.go
@@ -333,3 +333,36 @@ func TestBedrockRerankRejectsEmptyModelIdentifier(t *testing.T) {
 	require.NotNil(t, bifrostErr.Error)
 	assert.Contains(t, bifrostErr.Error.Message, "model identifier")
 }
+
+func TestToBedrockRerankResponse(t *testing.T) {
+	response := ToBedrockRerankResponse(&schemas.BifrostRerankResponse{
+		Results: []schemas.RerankResult{
+			{Index: 1, RelevanceScore: 0.92, Document: &schemas.RerankDocument{Text: "Paris is capital of France"}},
+			{Index: 0, RelevanceScore: 0.11, Document: &schemas.RerankDocument{Text: "Berlin is capital of Germany"}},
+		},
+		Model: "arn:aws:bedrock:us-east-1::foundation-model/cohere.rerank-v3-5:0",
+	})
+
+	require.NotNil(t, response)
+	require.Len(t, response.Results, 2)
+	assert.Equal(t, 1, response.Results[0].Index)
+	assert.InDelta(t, 0.92, response.Results[0].RelevanceScore, 1e-9)
+	require.NotNil(t, response.Results[0].Document)
+	assert.Equal(t, bedrockRerankInlineDocumentTypeText, response.Results[0].Document.Type)
+	require.NotNil(t, response.Results[0].Document.TextDocument)
+	assert.Equal(t, "Paris is capital of France", response.Results[0].Document.TextDocument.Text)
+	require.NotNil(t, response.Results[1].Document)
+	assert.Equal(t, "Berlin is capital of Germany", response.Results[1].Document.TextDocument.Text)
+}
+
+func TestToBedrockRerankResponseOmitsMissingDocument(t *testing.T) {
+	response := ToBedrockRerankResponse(&schemas.BifrostRerankResponse{
+		Results: []schemas.RerankResult{{Index: 0, RelevanceScore: 0.7}},
+	})
+
+	require.NotNil(t, response)
+	require.Len(t, response.Results, 1)
+	assert.Nil(t, response.Results[0].Document)
+
+	assert.Nil(t, ToBedrockRerankResponse(nil))
+}

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -3345,7 +3345,7 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 				result := pendingResults[callID]
 				resultBlocks = append(resultBlocks, BedrockContentBlock{
 					ToolResult: &BedrockToolResult{
-						ToolUseID: callID,
+						ToolUseID: bedrockAliasToolUseID(callID),
 						Content:   result.Content,
 						Status:    schemas.Ptr(result.Status),
 					},
@@ -3385,7 +3385,7 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 				if toolCall, exists := stateManager.toolCalls[callID]; exists {
 					toolUseBlock := &BedrockContentBlock{
 						ToolUse: &BedrockToolUse{
-							ToolUseID: toolCall.CallID,
+							ToolUseID: bedrockAliasToolUseID(toolCall.CallID),
 							Name:      toolCall.ToolName,
 						},
 					}
@@ -3539,7 +3539,7 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 						if toolCall, exists := stateManager.toolCalls[callID]; exists {
 							toolUseBlock := &BedrockContentBlock{
 								ToolUse: &BedrockToolUse{
-									ToolUseID: toolCall.CallID,
+									ToolUseID: bedrockAliasToolUseID(toolCall.CallID),
 									Name:      toolCall.ToolName,
 								},
 							}
@@ -3579,7 +3579,7 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 						result := pendingResults[callID]
 						resultBlocks = append(resultBlocks, BedrockContentBlock{
 							ToolResult: &BedrockToolResult{
-								ToolUseID: callID,
+								ToolUseID: bedrockAliasToolUseID(callID),
 								Content:   result.Content,
 								Status:    schemas.Ptr(result.Status),
 							},
@@ -3620,7 +3620,7 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 					if toolCall, exists := stateManager.toolCalls[callID]; exists {
 						toolUseBlock := &BedrockContentBlock{
 							ToolUse: &BedrockToolUse{
-								ToolUseID: toolCall.CallID,
+								ToolUseID: bedrockAliasToolUseID(toolCall.CallID),
 								Name:      toolCall.ToolName,
 							},
 						}
@@ -3662,7 +3662,7 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 					result := pendingResults[callID]
 					resultBlocks = append(resultBlocks, BedrockContentBlock{
 						ToolResult: &BedrockToolResult{
-							ToolUseID: callID,
+							ToolUseID: bedrockAliasToolUseID(callID),
 							Content:   result.Content,
 							Status:    schemas.Ptr(result.Status),
 						},
@@ -3739,7 +3739,7 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 			inputBytes, _ := json.Marshal(inputMap)
 			toolUseBlock := BedrockContentBlock{
 				ToolUse: &BedrockToolUse{
-					ToolUseID: callID,
+					ToolUseID: bedrockAliasToolUseID(callID),
 					Name:      string(BedrockSystemToolNovaGrounding),
 					Input:     json.RawMessage(inputBytes),
 					Type:      "server_tool_use",
@@ -3759,7 +3759,7 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 			resultType := BedrockNovaGroundingResultType
 			toolResultBlock := BedrockContentBlock{
 				ToolResult: &BedrockToolResult{
-					ToolUseID: callID,
+					ToolUseID: bedrockAliasToolUseID(callID),
 					Type:      &resultType,
 					Status:    schemas.Ptr("success"),
 					Content:   []BedrockContentBlock{{Text: &sourcesText}},
@@ -3785,7 +3785,7 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 			inputBytes, _ := json.Marshal(map[string]string{"snippet": code})
 			toolUseBlock := BedrockContentBlock{
 				ToolUse: &BedrockToolUse{
-					ToolUseID: toolUseID,
+					ToolUseID: bedrockAliasToolUseID(toolUseID),
 					Name:      string(BedrockSystemToolNovaCodeInterpreter),
 					Input:     json.RawMessage(inputBytes),
 					Type:      "server_tool_use",
@@ -3806,7 +3806,7 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 			resultType := BedrockNovaCodeInterpreterResultType
 			toolResultBlock := BedrockContentBlock{
 				ToolResult: &BedrockToolResult{
-					ToolUseID: toolUseID,
+					ToolUseID: bedrockAliasToolUseID(toolUseID),
 					Type:      &resultType,
 					Content:   []BedrockContentBlock{{Text: &execResultStr}},
 				},

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -28,6 +28,10 @@ import (
 var awsRegionRegex = regexp.MustCompile(`^[a-z]{2,3}(?:-[a-z]+)+-\d+$`)
 var bedrockUnsafeToolNameCharRegex = regexp.MustCompile(`[^A-Za-z0-9_-]+`)
 
+// bedrockUnsafeToolUseIDCharRegex matches characters outside Bedrock's toolUseId charset
+// (^[a-zA-Z0-9_.:-]+$), which is wider than the tool-name charset above.
+var bedrockUnsafeToolUseIDCharRegex = regexp.MustCompile(`[^A-Za-z0-9_.:-]+`)
+
 // bedrockToolNameAliasKey stores Bedrock wire-name aliases on the request context.
 type bedrockToolNameAliasKey struct{}
 
@@ -339,6 +343,26 @@ func bedrockRestoreToolName(ctx context.Context, name string) string {
 		}
 	}
 	return name
+}
+
+// bedrockAliasToolUseID returns a Bedrock-safe toolUseId (<=64 chars, [a-zA-Z0-9_.:-]).
+// Deterministic, so a tool_use id and its tool_result id always alias to the same value.
+func bedrockAliasToolUseID(id string) string {
+	if id != "" && len(id) <= 64 && !bedrockUnsafeToolUseIDCharRegex.MatchString(id) {
+		return id
+	}
+
+	// Hash the full id (all 64 bits, not just a uint32-truncated slice) so two ids
+	// sharing a truncated head can't collide within a feasible search space.
+	hash := fmt.Sprintf("%016x", xxhash.Sum64String(id))
+	semantic := bedrockUnsafeToolUseIDCharRegex.ReplaceAllString(id, "_")
+	if maxSemanticLen := 64 - len(hash) - 1; len(semantic) > maxSemanticLen {
+		semantic = semantic[:maxSemanticLen]
+	}
+	if semantic == "" {
+		return hash
+	}
+	return hash + "_" + semantic
 }
 
 // convertParameters handles parameter conversion
@@ -1218,7 +1242,7 @@ func convertToolMessages(ctx context.Context, msgs []schemas.ChatMessage) (Bedro
 		}
 		toolResultBlock := BedrockContentBlock{
 			ToolResult: &BedrockToolResult{
-				ToolUseID: *msg.ChatToolMessage.ToolCallID,
+				ToolUseID: bedrockAliasToolUseID(*msg.ChatToolMessage.ToolCallID),
 				Content:   toolResultContent,
 				Status:    schemas.Ptr(status),
 			},
@@ -2323,7 +2347,7 @@ func convertToolCallToContentBlock(ctx context.Context, toolCall schemas.ChatAss
 
 	return BedrockContentBlock{
 		ToolUse: &BedrockToolUse{
-			ToolUseID: toolUseID,
+			ToolUseID: bedrockAliasToolUseID(toolUseID),
 			Name:      toolName,
 			Input:     input,
 		},

--- a/core/providers/cohere/models.go
+++ b/core/providers/cohere/models.go
@@ -33,7 +33,7 @@ type CohereRerankResult struct {
 
 // CohereRerankResponse represents a Cohere rerank API response.
 type CohereRerankResponse struct {
-	ID      string               `json:"id"`
+	ID      string               `json:"id,omitempty"`
 	Results []CohereRerankResult `json:"results"`
 	Meta    *CohereRerankMeta    `json:"meta,omitempty"`
 }

--- a/core/providers/cohere/rerank.go
+++ b/core/providers/cohere/rerank.go
@@ -184,6 +184,41 @@ func (response *CohereRerankResponse) ToBifrostRerankResponse(documents []schema
 	return bifrostResponse
 }
 
+// ToCohereRerankResponse converts a Bifrost rerank response to Cohere format.
+func ToCohereRerankResponse(bifrostResp *schemas.BifrostRerankResponse) *CohereRerankResponse {
+	if bifrostResp == nil {
+		return nil
+	}
+
+	cohereResp := &CohereRerankResponse{
+		ID:      bifrostResp.ID,
+		Results: make([]CohereRerankResult, 0, len(bifrostResp.Results)),
+	}
+
+	// Cohere v2 rerank results carry only the index and the score.
+	for _, result := range bifrostResp.Results {
+		cohereResp.Results = append(cohereResp.Results, CohereRerankResult{
+			Index:          result.Index,
+			RelevanceScore: result.RelevanceScore,
+		})
+	}
+
+	if bifrostResp.Usage != nil {
+		cohereResp.Meta = &CohereRerankMeta{
+			BilledUnits: &CohereBilledUnits{
+				InputTokens:  new(bifrostResp.Usage.PromptTokens),
+				OutputTokens: new(bifrostResp.Usage.CompletionTokens),
+			},
+			Tokens: &CohereTokenUsage{
+				InputTokens:  new(bifrostResp.Usage.PromptTokens),
+				OutputTokens: new(bifrostResp.Usage.CompletionTokens),
+			},
+		}
+	}
+
+	return cohereResp
+}
+
 func formatCohereRerankDocument(doc schemas.RerankDocument) string {
 	if doc.ID == nil && len(doc.Meta) == 0 {
 		return doc.Text

--- a/core/providers/cohere/rerank_test.go
+++ b/core/providers/cohere/rerank_test.go
@@ -70,3 +70,51 @@ func TestCohereRerankResponseToBifrostRerankResponseReturnDocuments(t *testing.T
 	assert.Equal(t, "request-doc-0", response.Results[0].Document.Text)
 	assert.Equal(t, "request-doc-1", response.Results[1].Document.Text)
 }
+
+func TestToCohereRerankResponse(t *testing.T) {
+	cohereResp := ToCohereRerankResponse(&schemas.BifrostRerankResponse{
+		ID: "rerank-response-id",
+		Results: []schemas.RerankResult{
+			{Index: 1, RelevanceScore: 0.91, Document: &schemas.RerankDocument{Text: "doc-1"}},
+			{Index: 0, RelevanceScore: 0.62},
+		},
+		Model: "rerank-v3.5",
+		Usage: &schemas.BifrostLLMUsage{PromptTokens: 12, CompletionTokens: 3, TotalTokens: 15},
+	})
+
+	require.NotNil(t, cohereResp)
+	assert.Equal(t, "rerank-response-id", cohereResp.ID)
+	require.Len(t, cohereResp.Results, 2)
+	assert.Equal(t, 1, cohereResp.Results[0].Index)
+	assert.InDelta(t, 0.91, cohereResp.Results[0].RelevanceScore, 1e-9)
+	// Cohere v2 rerank results have no document field.
+	assert.Nil(t, cohereResp.Results[0].Document)
+
+	require.NotNil(t, cohereResp.Meta)
+	require.NotNil(t, cohereResp.Meta.Tokens)
+	require.NotNil(t, cohereResp.Meta.Tokens.InputTokens)
+	assert.Equal(t, 12, *cohereResp.Meta.Tokens.InputTokens)
+	require.NotNil(t, cohereResp.Meta.Tokens.OutputTokens)
+	assert.Equal(t, 3, *cohereResp.Meta.Tokens.OutputTokens)
+	require.NotNil(t, cohereResp.Meta.BilledUnits)
+	require.NotNil(t, cohereResp.Meta.BilledUnits.InputTokens)
+	assert.Equal(t, 12, *cohereResp.Meta.BilledUnits.InputTokens)
+}
+
+func TestToCohereRerankResponseOmitsEmptyIDAndMeta(t *testing.T) {
+	cohereResp := ToCohereRerankResponse(&schemas.BifrostRerankResponse{
+		Results: []schemas.RerankResult{{Index: 0, RelevanceScore: 0.5}},
+	})
+
+	require.NotNil(t, cohereResp)
+	assert.Nil(t, cohereResp.Meta)
+
+	encoded, err := json.Marshal(cohereResp)
+	require.NoError(t, err)
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(encoded, &payload))
+	assert.NotContains(t, payload, "id")
+	assert.NotContains(t, payload, "meta")
+
+	assert.Nil(t, ToCohereRerankResponse(nil))
+}

--- a/core/providers/vertex/rerank.go
+++ b/core/providers/vertex/rerank.go
@@ -189,17 +189,14 @@ func (req *VertexRankRequest) ToBifrostRerankRequest(ctx *schemas.BifrostContext
 		bifrostReq.Params.TopN = req.TopN
 	}
 
-	// Pass extra fields as ExtraParams
-	extraParams := make(map[string]interface{})
-	if req.IgnoreRecordDetailsInResponse != nil {
-		extraParams["ignore_record_details_in_response"] = *req.IgnoreRecordDetailsInResponse
+	// Set unconditionally: Discovery Engine defaults this to false, Bifrost's rerank default is true.
+	extraParams := map[string]interface{}{
+		"ignore_record_details_in_response": req.IgnoreRecordDetailsInResponse != nil && *req.IgnoreRecordDetailsInResponse,
 	}
 	if len(req.UserLabels) > 0 {
 		extraParams["user_labels"] = req.UserLabels
 	}
-	if len(extraParams) > 0 {
-		bifrostReq.Params.ExtraParams = extraParams
-	}
+	bifrostReq.Params.ExtraParams = extraParams
 
 	return bifrostReq
 }
@@ -262,6 +259,44 @@ func (response *VertexRankResponse) ToBifrostRerankResponse(documents []schemas.
 	return &schemas.BifrostRerankResponse{
 		Results: results,
 	}, nil
+}
+
+// ToVertexRankResponse converts a Bifrost rerank response to Discovery Engine rank format.
+// Records are keyed by the caller's record ID, which only survives on the result document,
+// so callers must request the rerank with ReturnDocuments enabled.
+func ToVertexRankResponse(bifrostResp *schemas.BifrostRerankResponse) (*VertexRankResponse, error) {
+	if bifrostResp == nil {
+		return nil, fmt.Errorf("bifrost rerank response is nil")
+	}
+
+	rankResponse := &VertexRankResponse{
+		Records: make([]VertexRankedRecord, 0, len(bifrostResp.Results)),
+	}
+
+	for _, result := range bifrostResp.Results {
+		if result.Document == nil {
+			return nil, fmt.Errorf("rerank result at index %d has no document: record ids cannot be restored", result.Index)
+		}
+
+		record := VertexRankedRecord{
+			Score: result.RelevanceScore,
+		}
+		if result.Document.ID != nil {
+			record.ID = *result.Document.ID
+		}
+		if result.Document.Text != "" {
+			record.Content = &result.Document.Text
+		}
+		if rawTitle, exists := result.Document.Meta["title"]; exists {
+			if title, ok := schemas.SafeExtractString(rawTitle); ok && strings.TrimSpace(title) != "" {
+				record.Title = &title
+			}
+		}
+
+		rankResponse.Records = append(rankResponse.Records, record)
+	}
+
+	return rankResponse, nil
 }
 
 func parseDiscoveryEngineErrorMessage(responseBody []byte) string {

--- a/core/providers/vertex/rerank_test.go
+++ b/core/providers/vertex/rerank_test.go
@@ -203,3 +203,57 @@ func TestVertexRankResponseToBifrostRerankResponseInvalidID(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid record id")
 }
+
+func TestToVertexRankResponse(t *testing.T) {
+	response, err := ToVertexRankResponse(&schemas.BifrostRerankResponse{
+		Results: []schemas.RerankResult{
+			{Index: 1, RelevanceScore: 0.88, Document: &schemas.RerankDocument{
+				ID: new("doc-paris"), Text: "Paris is capital of France", Meta: map[string]interface{}{"title": "Paris"},
+			}},
+			{Index: 0, RelevanceScore: 0.12, Document: &schemas.RerankDocument{
+				ID: new("doc-berlin"), Text: "Berlin is capital of Germany",
+			}},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	require.Len(t, response.Records, 2)
+
+	// Caller record IDs are restored; upstream only ever saw synthetic idx:N ids.
+	assert.Equal(t, "doc-paris", response.Records[0].ID)
+	assert.InDelta(t, 0.88, response.Records[0].Score, 1e-9)
+	require.NotNil(t, response.Records[0].Title)
+	assert.Equal(t, "Paris", *response.Records[0].Title)
+	require.NotNil(t, response.Records[0].Content)
+	assert.Equal(t, "Paris is capital of France", *response.Records[0].Content)
+
+	assert.Equal(t, "doc-berlin", response.Records[1].ID)
+	assert.Nil(t, response.Records[1].Title)
+}
+
+func TestToVertexRankResponseRequiresDocuments(t *testing.T) {
+	_, err := ToVertexRankResponse(&schemas.BifrostRerankResponse{
+		Results: []schemas.RerankResult{{Index: 0, RelevanceScore: 0.88}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no document")
+
+	_, err = ToVertexRankResponse(nil)
+	require.Error(t, err)
+}
+
+func TestVertexRankRequestToBifrostRerankRequestDefaultsIgnoreRecordDetailsToFalse(t *testing.T) {
+	t.Parallel()
+
+	// Discovery Engine defaults the flag to false, so an omitted field must not
+	// fall through to Bifrost's own default of true.
+	result := (&VertexRankRequest{
+		Query:   "capital of france",
+		Records: []VertexRankRecord{{ID: "rec-1", Content: new("Paris is the capital of France.")}},
+	}).ToBifrostRerankRequest(nil)
+
+	require.NotNil(t, result)
+	require.NotNil(t, result.Params)
+	require.NotNil(t, result.Params.ExtraParams)
+	assert.Equal(t, false, result.Params.ExtraParams["ignore_record_details_in_response"])
+}

--- a/transports/bifrost-http/integrations/bedrock.go
+++ b/transports/bifrost-http/integrations/bedrock.go
@@ -289,19 +289,22 @@ func createBedrockRerankRouteConfig(pathPrefix string, handlerStore lib.HandlerS
 		},
 		RequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*schemas.BifrostRequest, error) {
 			if bedrockReq, ok := req.(*bedrock.BedrockRerankRequest); ok {
+				rerankRequest := bedrockReq.ToBifrostRerankRequest(ctx)
+				// Bedrock echoes the ranked document in every result.
+				rerankRequest.Params.ReturnDocuments = new(true)
 				return &schemas.BifrostRequest{
-					RerankRequest: bedrockReq.ToBifrostRerankRequest(ctx),
+					RerankRequest: rerankRequest,
 				}, nil
 			}
 			return nil, errors.New("invalid rerank request type")
 		},
 		RerankResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostRerankResponse) (interface{}, error) {
-			if resp.ExtraFields.Provider == schemas.Bedrock {
-				if resp.ExtraFields.RawResponse != nil {
-					return resp.ExtraFields.RawResponse, nil
-				}
+			// Only return raw response for native Bedrock calls
+			// For cross-provider routing, always convert to Bedrock format
+			if resp.ExtraFields.RawResponse != nil && resp.ExtraFields.Provider == schemas.Bedrock {
+				return resp.ExtraFields.RawResponse, nil
 			}
-			return resp, nil
+			return bedrock.ToBedrockRerankResponse(resp), nil
 		},
 		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 			return bedrock.ToBedrockError(err)

--- a/transports/bifrost-http/integrations/bedrock_test.go
+++ b/transports/bifrost-http/integrations/bedrock_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream"
+	"github.com/bytedance/sonic"
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/providers/bedrock"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -390,6 +391,50 @@ func Test_createBedrockRerankRouteConfig(t *testing.T) {
 	assert.True(t, ok, "GetRequestTypeInstance should return *bedrock.BedrockRerankRequest")
 }
 
+func Test_createBedrockRerankResponseConverterEmitsBedrockShape(t *testing.T) {
+	handlerStore := &mockHandlerStore{}
+	route := createBedrockRerankRouteConfig("/bedrock", handlerStore)
+	require.NotNil(t, route.RerankResponseConverter)
+
+	resp := &schemas.BifrostRerankResponse{
+		Results: []schemas.RerankResult{
+			{Index: 1, RelevanceScore: 0.92, Document: &schemas.RerankDocument{Text: "Paris is capital of France"}},
+			{Index: 0, RelevanceScore: 0.11, Document: &schemas.RerankDocument{Text: "Berlin is capital of Germany"}},
+		},
+		Model: "arn:aws:bedrock:us-east-1::foundation-model/cohere.rerank-v3-5:0",
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			Provider: schemas.Bedrock,
+		},
+	}
+
+	converted, err := route.RerankResponseConverter(nil, resp)
+	require.NoError(t, err)
+
+	bedrockResp, ok := converted.(*bedrock.BedrockRerankResponse)
+	require.True(t, ok, "converter should emit *bedrock.BedrockRerankResponse")
+	require.Len(t, bedrockResp.Results, 2)
+	assert.Equal(t, 1, bedrockResp.Results[0].Index)
+	assert.InDelta(t, 0.92, bedrockResp.Results[0].RelevanceScore, 1e-9)
+	require.NotNil(t, bedrockResp.Results[0].Document)
+	require.NotNil(t, bedrockResp.Results[0].Document.TextDocument)
+	assert.Equal(t, "Paris is capital of France", bedrockResp.Results[0].Document.TextDocument.Text)
+	assert.Equal(t, "Berlin is capital of Germany", bedrockResp.Results[1].Document.TextDocument.Text)
+
+	// AWS SDKs key off camelCase relevanceScore; the Bifrost shape must not leak.
+	encoded, err := sonic.Marshal(bedrockResp)
+	require.NoError(t, err)
+	var payload map[string]interface{}
+	require.NoError(t, sonic.Unmarshal(encoded, &payload))
+	assert.NotContains(t, payload, "model")
+	assert.NotContains(t, payload, "extra_fields")
+	results, ok := payload["results"].([]interface{})
+	require.True(t, ok)
+	first, ok := results[0].(map[string]interface{})
+	require.True(t, ok)
+	assert.Contains(t, first, "relevanceScore")
+	assert.NotContains(t, first, "relevance_score")
+}
+
 func Test_createBedrockRerankResponseConverterUsesRawResponse(t *testing.T) {
 	handlerStore := &mockHandlerStore{}
 	route := createBedrockRerankRouteConfig("/bedrock", handlerStore)
@@ -405,6 +450,25 @@ func Test_createBedrockRerankResponseConverterUsesRawResponse(t *testing.T) {
 	converted, err := route.RerankResponseConverter(nil, resp)
 	require.NoError(t, err)
 	assert.Equal(t, raw, converted)
+}
+
+func Test_createBedrockRerankResponseConverterConvertsForCrossProvider(t *testing.T) {
+	handlerStore := &mockHandlerStore{}
+	route := createBedrockRerankRouteConfig("/bedrock", handlerStore)
+
+	// A Cohere-shaped raw body must never reach a Bedrock client.
+	resp := &schemas.BifrostRerankResponse{
+		Results: []schemas.RerankResult{{Index: 0, RelevanceScore: 0.5}},
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			Provider:    schemas.Cohere,
+			RawResponse: map[string]interface{}{"id": "r-123"},
+		},
+	}
+	converted, err := route.RerankResponseConverter(nil, resp)
+	require.NoError(t, err)
+	bedrockResp, ok := converted.(*bedrock.BedrockRerankResponse)
+	require.True(t, ok, "cross-provider responses must be converted, not passed through")
+	require.Len(t, bedrockResp.Results, 1)
 }
 
 func Test_createBedrockRerankRouteRequestConverter(t *testing.T) {
@@ -454,6 +518,9 @@ func Test_createBedrockRerankRouteRequestConverter(t *testing.T) {
 	require.NotNil(t, bifrostReq.RerankRequest.Params)
 	require.NotNil(t, bifrostReq.RerankRequest.Params.TopN)
 	assert.Equal(t, 1, *bifrostReq.RerankRequest.Params.TopN)
+	// Bedrock echoes the ranked document, so the route always asks for documents back.
+	require.NotNil(t, bifrostReq.RerankRequest.Params.ReturnDocuments)
+	assert.True(t, *bifrostReq.RerankRequest.Params.ReturnDocuments)
 }
 
 func Test_createBedrockRouteConfigsIncludesRerankForCompositePrefixes(t *testing.T) {

--- a/transports/bifrost-http/integrations/cohere.go
+++ b/transports/bifrost-http/integrations/cohere.go
@@ -173,12 +173,12 @@ func CreateCohereRouteConfigs(pathPrefix string) []RouteConfig {
 			return nil, errors.New("invalid rerank request type")
 		},
 		RerankResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostRerankResponse) (interface{}, error) {
-			if resp.ExtraFields.Provider == schemas.Cohere {
-				if resp.ExtraFields.RawResponse != nil {
-					return resp.ExtraFields.RawResponse, nil
-				}
+			// Only return raw response for native Cohere calls
+			// For cross-provider routing, always convert to Cohere format
+			if resp.ExtraFields.RawResponse != nil && resp.ExtraFields.Provider == schemas.Cohere {
+				return resp.ExtraFields.RawResponse, nil
 			}
-			return resp, nil
+			return cohere.ToCohereRerankResponse(resp), nil
 		},
 		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 			return err

--- a/transports/bifrost-http/integrations/cohere_test.go
+++ b/transports/bifrost-http/integrations/cohere_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/providers/cohere"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/assert"
@@ -77,6 +78,55 @@ func TestCohereRerankRouteRequestConverter(t *testing.T) {
 	assert.Equal(t, 1, *bifrostReq.RerankRequest.Params.TopN)
 }
 
+func TestCohereRerankResponseConverterEmitsCohereShape(t *testing.T) {
+	routes := CreateCohereRouteConfigs("/cohere")
+
+	var rerankRoute *RouteConfig
+	for i := range routes {
+		if routes[i].Path == "/cohere/v2/rerank" {
+			rerankRoute = &routes[i]
+			break
+		}
+	}
+	require.NotNil(t, rerankRoute)
+	require.NotNil(t, rerankRoute.RerankResponseConverter)
+
+	resp := &schemas.BifrostRerankResponse{
+		ID: "r-123",
+		Results: []schemas.RerankResult{
+			{Index: 1, RelevanceScore: 0.9},
+			{Index: 0, RelevanceScore: 0.1},
+		},
+		Model: "rerank-v3.5",
+		Usage: &schemas.BifrostLLMUsage{PromptTokens: 12, CompletionTokens: 3},
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			Provider: schemas.Cohere,
+		},
+	}
+
+	converted, err := rerankRoute.RerankResponseConverter(nil, resp)
+	require.NoError(t, err)
+
+	cohereResp, ok := converted.(*cohere.CohereRerankResponse)
+	require.True(t, ok, "converter should emit *cohere.CohereRerankResponse")
+	assert.Equal(t, "r-123", cohereResp.ID)
+	require.Len(t, cohereResp.Results, 2)
+	assert.Equal(t, 1, cohereResp.Results[0].Index)
+	assert.InDelta(t, 0.9, cohereResp.Results[0].RelevanceScore, 1e-9)
+	assert.Nil(t, cohereResp.Results[0].Document, "cohere v2 results carry no document")
+	require.NotNil(t, cohereResp.Meta)
+	require.NotNil(t, cohereResp.Meta.Tokens)
+	assert.Equal(t, 12, *cohereResp.Meta.Tokens.InputTokens)
+
+	// The wire response must not leak Bifrost-only fields.
+	encoded, err := sonic.Marshal(cohereResp)
+	require.NoError(t, err)
+	var payload map[string]interface{}
+	require.NoError(t, sonic.Unmarshal(encoded, &payload))
+	assert.NotContains(t, payload, "model")
+	assert.NotContains(t, payload, "extra_fields")
+}
+
 func TestCohereRerankResponseConverterUsesRawResponse(t *testing.T) {
 	routes := CreateCohereRouteConfigs("/cohere")
 
@@ -101,4 +151,32 @@ func TestCohereRerankResponseConverterUsesRawResponse(t *testing.T) {
 	converted, err := rerankRoute.RerankResponseConverter(nil, resp)
 	require.NoError(t, err)
 	assert.Equal(t, raw, converted)
+}
+
+func TestCohereRerankResponseConverterConvertsForCrossProvider(t *testing.T) {
+	routes := CreateCohereRouteConfigs("/cohere")
+
+	var rerankRoute *RouteConfig
+	for i := range routes {
+		if routes[i].Path == "/cohere/v2/rerank" {
+			rerankRoute = &routes[i]
+			break
+		}
+	}
+	require.NotNil(t, rerankRoute)
+
+	// A Bedrock-shaped raw body must never reach a Cohere client.
+	resp := &schemas.BifrostRerankResponse{
+		Results: []schemas.RerankResult{{Index: 0, RelevanceScore: 0.5}},
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			Provider:    schemas.Bedrock,
+			RawResponse: map[string]interface{}{"results": []interface{}{}},
+		},
+	}
+
+	converted, err := rerankRoute.RerankResponseConverter(nil, resp)
+	require.NoError(t, err)
+	cohereResp, ok := converted.(*cohere.CohereRerankResponse)
+	require.True(t, ok, "cross-provider responses must be converted, not passed through")
+	require.Len(t, cohereResp.Results, 1)
 }

--- a/transports/bifrost-http/integrations/genai.go
+++ b/transports/bifrost-http/integrations/genai.go
@@ -1045,19 +1045,19 @@ func createGenAIRerankRouteConfig(pathPrefix string) RouteConfig {
 		},
 		RequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*schemas.BifrostRequest, error) {
 			if vertexReq, ok := req.(*vertex.VertexRankRequest); ok {
+				rerankRequest := vertexReq.ToBifrostRerankRequest(ctx)
+				// Ranked records are keyed by the caller's record ID, which only the document carries.
+				rerankRequest.Params.ReturnDocuments = new(true)
 				return &schemas.BifrostRequest{
-					RerankRequest: vertexReq.ToBifrostRerankRequest(ctx),
+					RerankRequest: rerankRequest,
 				}, nil
 			}
 			return nil, errors.New("invalid rerank request type")
 		},
 		RerankResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostRerankResponse) (interface{}, error) {
-			if resp.ExtraFields.Provider == schemas.Vertex {
-				if resp.ExtraFields.RawResponse != nil {
-					return resp.ExtraFields.RawResponse, nil
-				}
-			}
-			return resp, nil
+			// No raw passthrough here, unlike other routes: ToVertexRankRequest replaces caller
+			// record IDs with synthetic ones, so the raw upstream records are not addressable.
+			return vertex.ToVertexRankResponse(resp)
 		},
 		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 			return gemini.ToGeminiError(err)

--- a/transports/bifrost-http/integrations/genai_test.go
+++ b/transports/bifrost-http/integrations/genai_test.go
@@ -225,37 +225,57 @@ func TestGenAIRerankRequestConverter(t *testing.T) {
 	assert.Equal(t, 2, *bifrostReq.RerankRequest.Params.TopN)
 }
 
-func TestGenAIRerankResponseConverterUsesRawResponse(t *testing.T) {
-	route := createGenAIRerankRouteConfig("/genai")
-	require.NotNil(t, route.RerankResponseConverter)
-
-	raw := map[string]interface{}{"records": []interface{}{}}
-	resp := &schemas.BifrostRerankResponse{
-		ExtraFields: schemas.BifrostResponseExtraFields{
-			Provider:    schemas.Vertex,
-			RawResponse: raw,
-		},
-	}
-	converted, err := route.RerankResponseConverter(nil, resp)
-	require.NoError(t, err)
-	assert.Equal(t, raw, converted)
-}
-
-func TestGenAIRerankResponseConverterFallsBackWhenNotVertex(t *testing.T) {
+func TestGenAIRerankResponseConverterRestoresCallerRecordIDs(t *testing.T) {
 	route := createGenAIRerankRouteConfig("/genai")
 	require.NotNil(t, route.RerankResponseConverter)
 
 	resp := &schemas.BifrostRerankResponse{
 		Results: []schemas.RerankResult{
-			{Index: 0, RelevanceScore: 0.9},
+			{Index: 1, RelevanceScore: 0.88, Document: &schemas.RerankDocument{
+				ID: new("doc-paris"), Text: "Paris is capital of France", Meta: map[string]interface{}{"title": "Paris"},
+			}},
+			{Index: 0, RelevanceScore: 0.12, Document: &schemas.RerankDocument{
+				ID: new("doc-berlin"), Text: "Berlin is capital of Germany",
+			}},
 		},
 		ExtraFields: schemas.BifrostResponseExtraFields{
-			Provider: schemas.Cohere,
+			Provider: schemas.Vertex,
+			// Raw carries synthetic idx:N record IDs, so it must never be returned.
+			RawResponse: map[string]interface{}{"records": []interface{}{map[string]interface{}{"id": "idx:1"}}},
 		},
 	}
+
 	converted, err := route.RerankResponseConverter(nil, resp)
 	require.NoError(t, err)
-	assert.Equal(t, resp, converted)
+
+	rankResp, ok := converted.(*vertex.VertexRankResponse)
+	require.True(t, ok, "converter should emit *vertex.VertexRankResponse")
+	require.Len(t, rankResp.Records, 2)
+	assert.Equal(t, "doc-paris", rankResp.Records[0].ID)
+	assert.InDelta(t, 0.88, rankResp.Records[0].Score, 1e-9)
+	require.NotNil(t, rankResp.Records[0].Content)
+	assert.Equal(t, "Paris is capital of France", *rankResp.Records[0].Content)
+	require.NotNil(t, rankResp.Records[0].Title)
+	assert.Equal(t, "Paris", *rankResp.Records[0].Title)
+	assert.Equal(t, "doc-berlin", rankResp.Records[1].ID)
+	assert.Nil(t, rankResp.Records[1].Title)
+}
+
+func TestGenAIRerankRequestConverterRequestsDocuments(t *testing.T) {
+	route := createGenAIRerankRouteConfig("/genai")
+	require.NotNil(t, route.RequestConverter)
+
+	bifrostCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	bifrostReq, err := route.RequestConverter(bifrostCtx, &vertex.VertexRankRequest{
+		Query:   "capital of france",
+		Records: []vertex.VertexRankRecord{{ID: "doc-paris", Content: new("Paris is capital of France")}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, bifrostReq.RerankRequest)
+	require.NotNil(t, bifrostReq.RerankRequest.Params)
+	// Ranked records are keyed by caller record ID, which only the document carries.
+	require.NotNil(t, bifrostReq.RerankRequest.Params.ReturnDocuments)
+	assert.True(t, *bifrostReq.RerankRequest.Params.ReturnDocuments)
 }
 
 func TestCreateGenAIRouteConfigsIncludesModelMetadataRoute(t *testing.T) {


### PR DESCRIPTION
## Summary

Cross-provider rerank routing previously returned raw upstream responses verbatim, which meant a Bedrock client could receive a Cohere-shaped payload (or vice versa) whenever fallback routing kicked in. This PR adds proper response converters for Bedrock, Cohere, and Vertex rerank routes so that the response is always serialized in the format the caller expects, regardless of which upstream provider actually handled the request.

## Changes

- Added `ToBedrockRerankResponse`, `ToCohereRerankResponse`, and `ToVertexRankResponse` functions that convert a `BifrostRerankResponse` back into the provider-native wire format.
- Bedrock and Cohere rerank response converters now only pass through the raw response when the provider matches; all other cases (cross-provider routing) go through the new converters.
- Vertex rerank never passes through the raw response because `ToBifrostRerankRequest` replaces caller record IDs with synthetic `idx:N` identifiers — the raw upstream records are not addressable. `ToVertexRankResponse` restores the original caller record IDs from the result documents.
- Bedrock and Vertex rerank request converters now unconditionally set `ReturnDocuments = true`: Bedrock echoes the ranked document in every result, and Vertex needs the document to recover the original record ID.
- Fixed `VertexRankRequest.ToBifrostRerankRequest` to always emit `ignore_record_details_in_response` in `ExtraParams` (defaulting to `false`), preventing Bifrost's own default of `true` from overriding Discovery Engine's intended default.
- Marked `CohereRerankResponse.ID` as `omitempty` so empty IDs are not serialized to the wire.
- Added unit tests covering correct shape emission, cross-provider conversion, raw-response passthrough, nil-safety, and the `ignore_record_details_in_response` default.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/bedrock/...
go test ./core/providers/cohere/...
go test ./core/providers/vertex/...
go test ./transports/bifrost-http/integrations/...
```

All new and existing tests should pass. To validate cross-provider routing end-to-end, configure a Bedrock rerank route with a Cohere fallback and confirm the response received by the client uses Bedrock's camelCase `relevanceScore` field rather than Cohere's schema.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. No auth, secrets, or PII handling is affected.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable