### PR TITLE
Preserve Azure Responses stream errors after HTTP 200

### DIFF
--- a/core/providers/openai/errors.go
+++ b/core/providers/openai/errors.go
@@ -12,6 +12,76 @@ import (
 // ErrorConverter is a function that converts provider-specific error responses to BifrostError.
 type ErrorConverter func(resp *fasthttp.Response) *schemas.BifrostError
 
+// responsesStreamError converts either Responses API error event shape into
+// Bifrost's provider-error envelope. Responses-compatible services can report
+// an error after the HTTP headers have been committed, so the transport status
+// remains 200 and the semantic failure must be carried by the SSE event.
+//
+// The wire protocol has two shapes in use:
+//   - {"type":"error","error":{"type":...,"code":...,"message":...}}
+//   - {"type":"response.failed","response":{"error":{"code":...,"message":...}}}
+//
+// Keep the normalization here so Azure, OpenAI, and other compatible providers
+// share one behavior instead of growing provider-specific stream parsers.
+func responsesStreamError(response *schemas.BifrostResponsesStreamResponse) *schemas.BifrostError {
+	eventType := string(response.Type)
+	bifrostErr := &schemas.BifrostError{
+		Type:           schemas.Ptr(eventType),
+		IsBifrostError: false,
+		Error:          &schemas.ErrorField{},
+	}
+
+	// Preserve the legacy top-level fields first. The nested error object is
+	// preferred only when the legacy field was absent, which keeps this helper
+	// compatible with providers that emit both forms.
+	if response.Message != nil {
+		bifrostErr.Error.Message = *response.Message
+	}
+	if response.Param != nil {
+		bifrostErr.Error.Param = *response.Param
+	}
+	if response.Code != nil {
+		bifrostErr.Error.Code = response.Code
+	}
+
+	if response.Error != nil {
+		if response.Error.Type != "" {
+			bifrostErr.Error.Type = schemas.Ptr(response.Error.Type)
+		}
+		if response.Error.Message != "" && bifrostErr.Error.Message == "" {
+			bifrostErr.Error.Message = response.Error.Message
+		}
+		if response.Error.Code != "" && (bifrostErr.Error.Code == nil || *bifrostErr.Error.Code == "") {
+			bifrostErr.Error.Code = schemas.Ptr(response.Error.Code)
+		}
+	}
+
+	if response.Response != nil && response.Response.Error != nil {
+		if response.Response.Error.Type != "" && bifrostErr.Error.Type == nil {
+			bifrostErr.Error.Type = schemas.Ptr(response.Response.Error.Type)
+		}
+		if response.Response.Error.Message != "" && bifrostErr.Error.Message == "" {
+			bifrostErr.Error.Message = response.Response.Error.Message
+		}
+		if response.Response.Error.Code != "" && (bifrostErr.Error.Code == nil || *bifrostErr.Error.Code == "") {
+			bifrostErr.Error.Code = schemas.Ptr(response.Response.Error.Code)
+		}
+	}
+
+	if bifrostErr.Error.Message == "" {
+		details := eventType
+		if bifrostErr.Error.Type != nil && *bifrostErr.Error.Type != "" && *bifrostErr.Error.Type != eventType {
+			details += ", type=" + *bifrostErr.Error.Type
+		}
+		if bifrostErr.Error.Code != nil && *bifrostErr.Error.Code != "" {
+			details += ", code=" + *bifrostErr.Error.Code
+		}
+		bifrostErr.Error.Message = fmt.Sprintf("provider stream error (%s)", details)
+	}
+
+	return bifrostErr
+}
+
 // ParseOpenAIError parses OpenAI error responses.
 func ParseOpenAIError(resp *fasthttp.Response) *schemas.BifrostError {
 	var errorResp schemas.BifrostError

--- a/core/providers/openai/errors_test.go
+++ b/core/providers/openai/errors_test.go
@@ -7,6 +7,26 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+func TestResponsesStreamError_NormalizesAzureShapeAndEmptyDetails(t *testing.T) {
+	cases := []struct {
+		wire, wantMessage string
+	}{
+		{`{"type":"error","error":{"type":"too_many_requests","code":"no_capacity","message":"capacity"}}`, "capacity"},
+		{`{"type":"response.failed","response":{"error":{"code":"context_length_exceeded","message":"input is too large"}}}`, "input is too large"},
+		{`{"type":"error","error":{}}`, "provider stream error (error)"},
+	}
+	for _, tc := range cases {
+		var response schemas.BifrostResponsesStreamResponse
+		if err := schemas.Unmarshal([]byte(tc.wire), &response); err != nil {
+			t.Fatalf("unmarshal stream error: %v", err)
+		}
+		got := responsesStreamError(&response)
+		if got == nil || got.Error == nil || got.Error.Message != tc.wantMessage {
+			t.Fatalf("normalized error = %v, want message %q", got, tc.wantMessage)
+		}
+	}
+}
+
 func TestParseOpenAIError_FallbackMessageWhenProviderBodyIsNonOpenAIShape(t *testing.T) {
 	var resp fasthttp.Response
 	resp.SetStatusCode(fasthttp.StatusUnprocessableEntity)

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -1968,37 +1968,7 @@ func HandleOpenAIResponsesStreaming(
 			}
 
 			if response.Type == schemas.ResponsesStreamResponseTypeError {
-				bifrostErr := &schemas.BifrostError{
-					Type:           schemas.Ptr(string(schemas.ResponsesStreamResponseTypeError)),
-					IsBifrostError: false,
-					Error:          &schemas.ErrorField{},
-				}
-
-				if response.Message != nil {
-					bifrostErr.Error.Message = *response.Message
-				}
-				if response.Param != nil {
-					bifrostErr.Error.Param = *response.Param
-				}
-				if response.Code != nil {
-					bifrostErr.Error.Code = response.Code
-				}
-				if response.Error != nil {
-					if response.Error.Message != "" && bifrostErr.Error.Message == "" {
-						bifrostErr.Error.Message = response.Error.Message
-					}
-					if response.Error.Code != "" && (bifrostErr.Error.Code == nil || *bifrostErr.Error.Code == "") {
-						bifrostErr.Error.Code = &response.Error.Code
-					}
-				}
-				if response.Response != nil && response.Response.Error != nil {
-					if response.Response.Error.Message != "" && bifrostErr.Error.Message == "" {
-						bifrostErr.Error.Message = response.Response.Error.Message
-					}
-					if response.Response.Error.Code != "" && (bifrostErr.Error.Code == nil || *bifrostErr.Error.Code == "") {
-						bifrostErr.Error.Code = new(response.Response.Error.Code)
-					}
-				}
+				bifrostErr := responsesStreamError(&response)
 
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, []byte(jsonData), sendBackRawRequest, sendBackRawResponse, latency), responseChan, logger, postHookSpanFinalizer)
@@ -2008,15 +1978,7 @@ func HandleOpenAIResponsesStreaming(
 			// Some providers (e.g. Fireworks) send response.failed on HTTP 200 streams
 			// instead of a pre-stream 4xx. Convert to BifrostError for consistent handling.
 			if response.Type == schemas.ResponsesStreamResponseTypeFailed {
-				bifrostErr := &schemas.BifrostError{
-					Type:           schemas.Ptr(string(schemas.ResponsesStreamResponseTypeFailed)),
-					IsBifrostError: false,
-					Error:          &schemas.ErrorField{},
-				}
-				if response.Response != nil && response.Response.Error != nil {
-					bifrostErr.Error.Message = response.Response.Error.Message
-					bifrostErr.Error.Code = &response.Response.Error.Code
-				}
+				bifrostErr := responsesStreamError(&response)
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, []byte(jsonData), sendBackRawRequest, sendBackRawResponse, latency), responseChan, logger, postHookSpanFinalizer)
 				return

--- a/core/providers/openai/responseslifecycle.go
+++ b/core/providers/openai/responseslifecycle.go
@@ -317,28 +317,7 @@ func (provider *OpenAIProvider) ResponsesRetrieveStream(ctx *schemas.BifrostCont
 			}
 
 			if response.Type == schemas.ResponsesStreamResponseTypeError {
-				bifrostErr := &schemas.BifrostError{
-					Type:           schemas.Ptr(string(schemas.ResponsesStreamResponseTypeError)),
-					IsBifrostError: false,
-					Error:          &schemas.ErrorField{},
-				}
-				if response.Message != nil {
-					bifrostErr.Error.Message = *response.Message
-				}
-				if response.Param != nil {
-					bifrostErr.Error.Param = *response.Param
-				}
-				if response.Code != nil {
-					bifrostErr.Error.Code = response.Code
-				}
-				if response.Error != nil {
-					if response.Error.Message != "" && bifrostErr.Error.Message == "" {
-						bifrostErr.Error.Message = response.Error.Message
-					}
-					if response.Error.Code != "" && (bifrostErr.Error.Code == nil || *bifrostErr.Error.Code == "") {
-						bifrostErr.Error.Code = &response.Error.Code
-					}
-				}
+				bifrostErr := responsesStreamError(&response)
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, providerUtils.EnrichError(ctx, bifrostErr, nil, []byte(jsonData), sendBackRawRequest, sendBackRawResponse, latency), responseChan, provider.logger, postHookSpanFinalizer)
 				return
@@ -346,15 +325,7 @@ func (provider *OpenAIProvider) ResponsesRetrieveStream(ctx *schemas.BifrostCont
 
 			// Some providers send response.failed on HTTP 200 streams instead of a pre-stream 4xx.
 			if response.Type == schemas.ResponsesStreamResponseTypeFailed {
-				bifrostErr := &schemas.BifrostError{
-					Type:           schemas.Ptr(string(schemas.ResponsesStreamResponseTypeFailed)),
-					IsBifrostError: false,
-					Error:          &schemas.ErrorField{},
-				}
-				if response.Response != nil && response.Response.Error != nil {
-					bifrostErr.Error.Message = response.Response.Error.Message
-					bifrostErr.Error.Code = &response.Response.Error.Code
-				}
+				bifrostErr := responsesStreamError(&response)
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, providerUtils.EnrichError(ctx, bifrostErr, nil, []byte(jsonData), sendBackRawRequest, sendBackRawResponse, latency), responseChan, provider.logger, postHookSpanFinalizer)
 				return

--- a/core/providers/openai/streamtruncation_test.go
+++ b/core/providers/openai/streamtruncation_test.go
@@ -323,6 +323,56 @@ func TestResponsesStreamTruncatedBeforeCompleted(t *testing.T) {
 	assertTruncationError(t, chunks[len(chunks)-1].BifrostError)
 }
 
+// Azure/OpenAI Responses can accept a request with HTTP 200, emit lifecycle
+// events, and then report a semantic failure in a terminal SSE event. The
+// transport status is already committed, so the shared decoder must preserve
+// the nested provider details in the semantic error event.
+func TestResponsesStreamAzureStyleErrorEvent(t *testing.T) {
+	server := completeSSEServer(t,
+		`data: {"type":"response.created","sequence_number":0,"response":{"id":"r1","object":"response","created_at":1,"model":"repro-model","status":"in_progress"}}
+
+`+
+			`data: {"type":"error","sequence_number":1,"error":{"type":"too_many_requests","code":"no_capacity","message":"The service is temporarily unable to process this request."}}
+
+`)
+	defer server.Close()
+
+	provider := newStreamTestProvider(server.URL)
+	request := &schemas.BifrostResponsesRequest{
+		Provider: schemas.OpenAI,
+		Model:    "repro-model",
+		Input: []schemas.ResponsesMessage{{
+			Type:    schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("hi")},
+		}},
+	}
+	stream, bifrostErr := provider.ResponsesStream(newStreamTestContext(), passthroughPostHook, nil, testKey(), request)
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	var got *schemas.BifrostError
+	for _, chunk := range collectChunks(t, stream) {
+		if chunk.BifrostError != nil {
+			got = chunk.BifrostError
+			break
+		}
+	}
+	if got == nil || got.Error == nil {
+		t.Fatalf("expected an in-band Azure error chunk, got nil")
+	}
+	if got.Error.Type == nil || *got.Error.Type != "too_many_requests" {
+		t.Fatalf("error type = %#v, want too_many_requests", got.Error.Type)
+	}
+	if got.Error.Code == nil || *got.Error.Code != "no_capacity" {
+		t.Fatalf("error code = %#v, want no_capacity", got.Error.Code)
+	}
+	if got.Error.Message == "" {
+		t.Fatal("expected non-empty Azure stream error message")
+	}
+}
+
 // chatChunkNullDeltaFinish reproduces the terminal-chunk shape some OpenAI-compatible
 // upstreams send: "delta" is null (or absent) alongside "finish_reason", rather than
 // an empty object. ToBifrostResponsesStreamResponse must not discard finish_reason

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -1251,6 +1251,11 @@ type ResponsesResponseConversationStruct struct {
 }
 
 type ResponsesResponseError struct {
+	// Type is present on the top-level `error` stream event used by Azure
+	// OpenAI (for example, `too_many_requests`). It is optional on
+	// `response.failed`, whose response.error object normally only contains
+	// code and message.
+	Type    string `json:"type,omitempty"`
 	Code    string `json:"code"`    // The error code for the response
 	Message string `json:"message"` // A human-readable description of the error
 }


### PR DESCRIPTION
## Summary

Preserve terminal Azure Responses API errors that arrive inside an already-open HTTP 200 SSE stream.

## Root cause

Azure can accept a streaming Responses request with HTTP 200, emit normal lifecycle events, and then send a terminal `error` or `response.failed` event. The error details are nested in the event payload. Bifrost's native Responses paths did not normalize that shape consistently, so downstream callers could receive an empty model-run error even though the stream contained provider error information.

## Change

- Add one shared Responses stream-error normalizer.
- Reuse it for both create-stream and retrieve-stream Responses paths.
- Preserve nested error `type`, `code`, and `message`.
- Provide a non-empty fallback message when Azure sends empty error details.
- Add an HTTP-200 Azure-shaped SSE regression test and focused unit coverage.
- Add `ResponsesResponseError.Type` to the schema.

This keeps the outer HTTP status unchanged: a Bifrost HTTP 200 stream is not treated as a successful model completion when a terminal error event is received.

## Validation

- `go test ./providers/openai ./providers/vllm ./schemas`
- `go vet ./providers/openai ./providers/vllm ./schemas`
- `git diff --check`

ref REI-3301