### PR TITLE
feat(http): serve aggregate GET /v1/models from the ModelCatalog

### DIFF
--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -892,9 +892,16 @@ func (h *CompletionHandler) listModels(ctx *fasthttp.RequestCtx) {
 		bifrostListModelsReq.ExtraParams = extraParams
 	}
 
-	// If provider is empty, list all models from all providers
+	// If provider is empty, list all models from all providers.
+	// Prefer the in-memory ModelCatalog for the aggregate listing: the live
+	// fan-out shares each provider's inference worker queue and can block for
+	// minutes behind in-flight generations (see list_models_catalog.go).
 	if provider == "" {
-		resp, bifrostErr = h.client.ListAllModels(bifrostCtx, bifrostListModelsReq)
+		if catalogResp := h.listModelsFromCatalog(ctx, bifrostCtx); catalogResp != nil {
+			resp, bifrostErr = catalogResp, nil
+		} else {
+			resp, bifrostErr = h.client.ListAllModels(bifrostCtx, bifrostListModelsReq)
+		}
 	} else {
 		resp, bifrostErr = h.client.ListModelsRequest(bifrostCtx, bifrostListModelsReq)
 	}

--- a/transports/bifrost-http/handlers/list_models_catalog.go
+++ b/transports/bifrost-http/handlers/list_models_catalog.go
@@ -1,0 +1,159 @@
+package handlers
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	governanceplugin "github.com/maximhq/bifrost/plugins/governance"
+	"github.com/valyala/fasthttp"
+)
+
+// listModelsFromCatalog serves GET /v1/models (without a ?provider= scope) from
+// the in-memory ModelCatalog instead of a live provider fan-out.
+//
+// Rationale: ListAllModels issues a runtime list-models call per provider and
+// waits for all of them. Those calls share the provider's inference worker
+// queue, so on a provider with low concurrency (e.g. a local llama.cpp slot
+// reservation) the listing blocks behind in-flight generations — measured at
+// 700s+ on a busy GPU, which every OpenAI-compatible client experiences as an
+// empty model dropdown. The ModelCatalog already holds the same model set
+// (populated by boot-time discovery and refreshed on provider/key changes),
+// so the aggregate listing can be answered from memory.
+//
+// Returns nil when the catalog cannot answer the request, in which case the
+// caller falls back to the live fan-out. That happens when:
+//   - the catalog is not configured,
+//   - the client asked for live results (?source=live),
+//   - the client uses pagination (page_token/page_size), which the catalog
+//     does not model.
+func (h *CompletionHandler) listModelsFromCatalog(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext) *schemas.BifrostListModelsResponse {
+	if h.config == nil || h.config.ModelCatalog == nil {
+		return nil
+	}
+	if strings.EqualFold(strings.TrimSpace(string(ctx.QueryArgs().Peek("source"))), "live") {
+		return nil
+	}
+	if len(ctx.QueryArgs().Peek("page_token")) > 0 || len(ctx.QueryArgs().Peek("page_size")) > 0 {
+		return nil
+	}
+	// Any other query parameter is a provider-specific list-models feature
+	// (search, ordering, …) that only the live path understands.
+	for k := range ctx.QueryArgs().All() {
+		switch string(k) {
+		case "provider", "source", "page_token", "page_size":
+		default:
+			return nil
+		}
+	}
+
+	providers := h.catalogProvidersForRequest(bifrostCtx)
+	if providers == nil {
+		return nil
+	}
+
+	modelFilter, ok := h.virtualKeyModelFilter(ctx)
+	if !ok {
+		// Virtual-key resolution hit a store error; let the live path handle
+		// (and surface) it instead of answering 200 with a misleading list.
+		return nil
+	}
+
+	data := make([]schemas.Model, 0, 64)
+	for _, provider := range providers {
+		for _, model := range h.config.ModelCatalog.GetModelsForProvider(provider) {
+			if modelFilter != nil && !modelFilter(provider, model) {
+				continue
+			}
+			data = append(data, schemas.Model{ID: string(provider) + "/" + model})
+		}
+	}
+	if len(data) == 0 {
+		// An empty catalog usually means boot-time discovery has not (yet)
+		// populated it; let the live fan-out answer rather than serving an
+		// empty 200 that reads as "no models".
+		return nil
+	}
+	sort.Slice(data, func(i, j int) bool { return data[i].ID < data[j].ID })
+
+	return &schemas.BifrostListModelsResponse{Data: data}
+}
+
+// catalogProvidersForRequest resolves the provider set the catalog listing
+// should cover: the virtual key's providers when the request carries one
+// (stamped on the context by applyListModelsVirtualKeyProviderFilter),
+// otherwise every configured provider. Returns nil when the configured
+// provider set cannot be resolved, signalling the caller to fall back.
+func (h *CompletionHandler) catalogProvidersForRequest(bifrostCtx *schemas.BifrostContext) []schemas.ModelProvider {
+	if bifrostCtx != nil {
+		if raw := bifrostCtx.Value(schemas.BifrostContextKeyAvailableProviders); raw != nil {
+			if available, ok := raw.([]schemas.ModelProvider); ok && len(available) > 0 {
+				return available
+			}
+			return nil
+		}
+	}
+	providers, err := h.client.GetConfiguredProviders()
+	if err != nil {
+		return nil
+	}
+	return providers
+}
+
+// virtualKeyModelFilter returns a predicate applying the virtual key's
+// per-provider allowed_models to catalog entries, mirroring the governance
+// plugin's filtering on the live path (which this handler bypasses). A nil
+// (nil, true) means "no filtering" — the request carries no virtual key at
+// all; (nil, false) means the caller must fall back to the live path (store
+// lookup failed, or the key is unknown/inactive and the live path's
+// governance enforcement should answer).
+// Wildcard semantics follow schemas.WhiteList/BlackList: allowed ["*"] permits
+// every catalog model of that provider, an empty allowed list denies all
+// (deny-by-default), and blacklisted entries are excluded first.
+func (h *CompletionHandler) virtualKeyModelFilter(ctx *fasthttp.RequestCtx) (func(schemas.ModelProvider, string) bool, bool) {
+	vkValue := governanceplugin.ParseVirtualKeyFromFastHTTPRequest(ctx)
+	if vkValue == nil || strings.TrimSpace(*vkValue) == "" {
+		return nil, true
+	}
+	if h.config == nil || h.config.ConfigStore == nil {
+		// A keyed request we cannot verify: fall back to the live path rather
+		// than serving the full catalog unfiltered.
+		return nil, false
+	}
+	vk, err := h.config.ConfigStore.GetVirtualKeyByValue(ctx, strings.TrimSpace(*vkValue))
+	if err != nil {
+		// Store error: signal the caller to fall back to the live path, which
+		// surfaces the failure instead of answering 200 with a misleading list.
+		return nil, false
+	}
+	if vk == nil || vk.IsActive == nil || !*vk.IsActive {
+		// Unknown or inactive key: defer to the live path so its governance
+		// enforcement (per-provider rejection) applies unchanged, instead of
+		// answering with the full unfiltered catalog.
+		return nil, false
+	}
+
+	type modelScope struct {
+		allowed     schemas.WhiteList
+		blacklisted schemas.BlackList
+	}
+	scopeByProvider := make(map[schemas.ModelProvider]modelScope, len(vk.ProviderConfigs))
+	for _, pc := range vk.ProviderConfigs {
+		provider := schemas.ModelProvider(strings.TrimSpace(pc.Provider))
+		if provider == "" {
+			continue
+		}
+		scopeByProvider[provider] = modelScope{allowed: pc.AllowedModels, blacklisted: pc.BlacklistedModels}
+	}
+
+	return func(provider schemas.ModelProvider, model string) bool {
+		scope, ok := scopeByProvider[provider]
+		if !ok {
+			return false
+		}
+		if scope.blacklisted.IsBlocked(model) {
+			return false
+		}
+		return scope.allowed.IsAllowed(model)
+	}, true
+}


### PR DESCRIPTION
## Problem

The aggregate `GET /v1/models` listing fans out live `ListModels` requests to every provider configured on the caller's virtual key, through the same worker queues as inference traffic. On deployments with a low-concurrency provider (e.g. a local llama.cpp custom provider with concurrency 1), a single long-running generation blocks the fan-out for its full duration.

Measured on v1.6.11: `/v1/models` took **738–769 s** (and returned 504 through most proxies) while one chat completion was in flight on the busy provider. Clients that populate a model dropdown from `/v1/models` (pgAdmin, various OpenAI-compatible UIs) effectively see an empty list whenever the gateway is doing work.

Meanwhile `GET /api/models` answers in ~0.16 s from the in-memory ModelCatalog — the data is already there.

## Change

Serve the aggregate listing from the ModelCatalog, applying the same virtual-key scoping the live path enforces (per-provider `allowed_models` incl. `*` wildcard, `blacklisted_models` checked first). Model IDs keep the `provider/model` format the live aggregate path returns.

The live fan-out is fully preserved as a fallback; the catalog path steps aside (returns to the existing code path) for:

- `?provider=` — explicit single-provider listing, unchanged
- `?source=live` — explicit opt-out
- `page_token` / `page_size` — pagination semantics stay live
- any unknown query parameter
- governance store errors, unknown/inactive virtual keys, a nil ConfigStore, or an empty catalog (fail-open to previous behavior)

## Trade-off

Catalog freshness is boot-time discovery + refresh on provider/key changes — identical to what `GET /api/models` already serves, so the dashboard and `/v1/models` now agree.

## Validation

- `go build` / `go vet` / handler tests green on the v1.6.11 tag and current main
- Running in production on our gateway since 2026-08-19: `/v1/models` with a scoped virtual key returns 416 models in 0.3 s during full GPU saturation (previously 738–769 s / 504); scope enforcement verified (in-scope 200 / out-of-scope 403 / no key 401)