### PR TITLE
feat: add grant implementation for per-request identity, access, and limits

### DIFF
--- a/.claude/skills/resolve-pr-comments-stack/SKILL.md
+++ b/.claude/skills/resolve-pr-comments-stack/SKILL.md
@@ -10,7 +10,9 @@ Systematically resolve unresolved review comments (CodeRabbit, Greptile, human r
 across every branch in a Graphite stack, working bottom-up in a single checkout. Each
 branch's fixes are committed into that branch via `gt modify` before moving to the next,
 so the stack stays restacked and consistent throughout — no branch is left dirty, and no
-branch is worked on out of dependency order.
+branch is worked on out of dependency order. Nothing in this pass changes the user's tree
+or branches without their say-so: every code edit and reply is approved per comment, and
+every `gt modify` (or `gt restack`) is approved per branch, before it runs.
 
 This is the stack-wide orchestration layer. The per-PR triage logic (fetch threads,
 classify FIX/REPLY/SKIP, apply) is the same as the single-PR `resolve-pr-comments` skill;
@@ -169,13 +171,37 @@ and the tests above are green:
 go vet ./<affected packages>/...         # go build ./... can report a false success
 go test ./<affected packages>/... -race  # -race for concurrency-sensitive changes
 git status --short                       # must show only the files this branch's fixes touched
+```
+
+**Then stop and ask before amending.** `gt modify` rewrites the branch's tip commit and
+restacks every descendant, which is the user's tree to change, not yours. Show them what is
+about to go in (the `git status --short` output, a one-line summary of each fix, and the
+test result), then ask with `AskUserQuestion`, once per branch, offering:
+
+1. **Run `gt modify -a` now** (Recommended): you amend the tip, preserving its message, and
+   move on to the next branch.
+2. **I'll amend it myself**: do nothing to the tree. Wait for the user to say it is done,
+   then confirm `git status --short` is empty before the next `gt checkout`. If it is not
+   empty, ask again; never checkout over a dirty tree.
+3. **Stop the pass here**: leave the changes uncommitted in the working tree, report what is
+   pending on this branch, and end the pass.
+
+Only after option 1 is chosen:
+
+```bash
 gt modify -a                             # amend the tip, PRESERVING its existing message
 ```
 
 `gt modify` amends the branch's tip with the staged changes and auto-restacks every
-descendant branch — this is the correct persistence mechanism for a stack pass, not a plain
+descendant branch, which is the correct persistence mechanism for a stack pass: not a plain
 `git commit` (which wouldn't restack) and not leaving changes uncommitted (which would carry
-into the next `gt checkout` and corrupt it).
+into the next `gt checkout` and corrupt it). Correct mechanism or not, it never runs without
+that per-branch approval, and approval on one branch does not carry over to the next. That
+approval covers the automatic restack too, when it lands with no conflict: rewriting a
+descendant's tip SHA is a mechanical side effect of the one approved amend, not a second
+action, so there is nothing separate to ask about: the descendant's own file content
+never changes. A conflicted restack is the one case that stops being mechanical, and it is
+gated on its own, separately, below.
 
 **Use `gt modify -a`, not `gt modify -a -m "..."`.** The tip commit is the *author's*, not
 yours; `-m` silently rewrites its message, so a branch whose tip is `cli test improvements`
@@ -217,8 +243,9 @@ gh pr view <number> --json headRefOid --jq .headRefOid   # must equal `git rev-p
 
 If a remote head does not match its local tip, publication was incomplete — commonly because
 `gt submit` reported branches it could not restack. Do not verify only the branches that went
-out. Run `gt restack` (a local operation, so this one is yours), routing any conflict through
-the gated recovery flow below, then tell the user to re-run `gt submit --stack` and redo the
+out. Run `gt restack` (local, but it rewrites branch tips, so ask first exactly as for
+`gt modify`), routing any conflict through the gated recovery flow below, then tell the user
+to re-run `gt submit --stack` and redo the
 verification for every branch, since the restack changed their SHAs.
 
 Only once every remote head matches is it meaningful to re-fetch threads.
@@ -251,13 +278,15 @@ summary, not as an error to retry. Then move to the next branch.
    stash pops conflict. Use `gt modify` to persist per-branch instead of stashing to move
    between branches.
 4. **No worktrees for this pass.** One feature/pass at a time in the main checkout.
-5. **`gt modify`, not ad hoc `git commit`, between branches** — even though the general rule
-   elsewhere is "don't commit without asking," a stack-wide comment pass is the documented
-   exception: leaving many branches simultaneously dirty isn't viable, and `gt modify` is the
-   stack-native persistence step, not a scope-creeping commit. Always `gt modify -a` without
-   `-m`, so the tip's existing message survives. This exception covers `gt modify` in the
-   normal loop **only** — resolving a restack conflict is gated (see *If `gt modify` hits a
-   restack conflict*), and publishing is never yours at all (Hard Rule 8).
+5. **`gt modify`, not ad hoc `git commit`, between branches, and only with approval.**
+   `gt modify` is the stack-native persistence step (a plain `git commit` wouldn't restack,
+   and leaving branches dirty corrupts the next checkout), but it is still a commit on the
+   user's branch, and the general rule "don't commit without asking" applies to it in full.
+   Ask once per branch before every `gt modify` (see *Committing the branch*); if the user
+   would rather amend themselves, wait for them. Always `gt modify -a` without `-m`, so the
+   tip's existing message survives. Resolving a restack conflict is gated separately (see
+   *If `gt modify` hits a restack conflict*), and publishing is never yours at all (Hard
+   Rule 8).
 6. **No FIX lands without a test that was red first**, and no branch is committed without
    running the tests that cover what changed (see *Every FIX is TDD*). "It compiles" and
    "`go vet` is clean" are not test runs. The only exception is code that genuinely cannot
@@ -281,8 +310,8 @@ stops being mechanical: you are about to hand-edit files on a branch whose comme
 never asked to touch, and `gt continue` then rewrites that branch and everything above it.
 Before editing anything, show the user the conflicted branch, the exact files, and how you
 intend to resolve each region, and wait. This is separate from the per-comment gate — that
-one approved a fix, not a rewrite of a descendant branch. `gt modify` in the normal loop
-stays ungated per Hard Rule 5; conflict recovery does not.
+one approved a fix, and the per-branch `gt modify` approval covered amending this branch's
+tip, not hand-resolving files on a descendant.
 
 1. Stay on the conflicted branch with the operation paused — the conflict markers are
    already in the working tree. `gt abort` only cancels the operation entirely.
@@ -323,8 +352,9 @@ stays ungated per Hard Rule 5; conflict recovery does not.
   buys it no shortcut. Present the finding and your proposed action, and wait for an explicit
   FIX/REPLY/SKIP. That applies even when a later branch clearly did fix it: the reply citing
   that later PR number is still a reply, so it is posted only after approval. If the decision
-  is FIX, it runs red-green TDD and persists with `gt modify -a` like everything else, and
-  any restack conflict goes through the gated recovery flow. If the pass is published
+  is FIX, it runs red-green TDD and persists through the same per-branch `gt modify -a`
+  approval as everything else, and any restack conflict goes through the gated recovery
+  flow. If the pass is published
   afterwards, re-verify the affected remote heads.
 
 ## Step 2: Final summary

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -84,6 +84,7 @@ type BifrostContext struct {
 	userValues            map[any]any
 	valuesMu              sync.RWMutex
 	blockRestrictedWrites atomic.Bool
+	grant                 atomic.Pointer[Grant] // what the request has been granted; installed by the transport, root contexts only
 
 	// Plugin scoping fields
 	pluginScope   *string                        // Non-nil when this is a scoped plugin context
@@ -192,6 +193,67 @@ func (bc *BifrostContext) Root() *BifrostContext {
 		bc = bc.valueDelegate
 	}
 	return bc
+}
+
+// SetGrant installs what this request has been granted, so that Grant hands it out for the life of
+// the request. Whoever builds the request context installs it, because core declares the shape of
+// a Grant and never constructs one. Installing nothing is refused, and reported.
+func (bc *BifrostContext) SetGrant(g Grant) bool {
+	if bc == nil || g == nil {
+		return false
+	}
+	bc.Root().grant.Store(&g)
+	return true
+}
+
+// Grant returns what this request has been granted: who it is made by, what it may reach, and what
+// pays for it. There is one per request, reached from every context of that request: a
+// plugin-scoped context answers with its root's, and a context derived from another request's
+// context shares that request's. Nil when nothing was installed on this request or any it derives
+// from, which is what a request nothing governs sees.
+//
+// It is handed out as installed, with no guard on writes. A plugin that needs to change what a
+// request is attributed to, may reach, or answers to does so through the same sections everything
+// else reads, and a deployment that wants a section left alone says so in the plugin order it
+// chooses.
+func (bc *BifrostContext) Grant() Grant {
+	if bc == nil {
+		return nil
+	}
+	root := bc.Root()
+	if g := root.grant.Load(); g != nil {
+		return *g
+	}
+	ancestor := root.inheritedGrant()
+	if ancestor == nil {
+		return nil
+	}
+	// Remembered here so the next read does not walk the chain again. Shared, not copied: a
+	// request and the contexts derived from it are one request, with one answer.
+	root.grant.CompareAndSwap(nil, &ancestor)
+	if g := root.grant.Load(); g != nil {
+		return *g
+	}
+	return nil
+}
+
+// inheritedGrant finds the grant of the nearest ancestor request context that has one. Only
+// BifrostContext parents are walked: a pooled transport context is never read through (see
+// Value), and a foreign context has nothing to offer.
+func (bc *BifrostContext) inheritedGrant() Grant {
+	parent := bc.parent
+	for parent != nil {
+		ancestor, ok := parent.(*BifrostContext)
+		if !ok {
+			return nil
+		}
+		ancestor = ancestor.Root()
+		if g := ancestor.grant.Load(); g != nil {
+			return *g
+		}
+		parent = ancestor.parent
+	}
+	return nil
 }
 
 // BlockRestrictedWrites returns true if restricted writes are blocked.

--- a/core/schemas/grant.go
+++ b/core/schemas/grant.go
@@ -1,0 +1,313 @@
+package schemas
+
+// What a request has been granted: who it is made by, what it may reach, and what pays for it.
+//
+// Every request carries one Grant, reached through its context. It is an envelope of sections that
+// settle at different points as the request moves through the gateway. The Identity settles first,
+// when the transport authenticates whatever the request presented. The Access settles once the
+// permits the caller holds have been resolved, before anything decides where the request goes, and
+// holds for the whole request: a fallback changes the provider, not the caller. The Limits settle
+// per attempt, once the provider and model it will use are known, and are replaced whole for the
+// next attempt. Each section is replaced rather than edited in place, so anything holding an
+// earlier answer keeps reading it.
+//
+// This file declares the shapes and nothing else. What implements them, and where permits come
+// from, is decided by whoever wires the gateway; core reads the answers and drives when each
+// section is settled. A request that carries no Grant, or a Grant with no Access, is one nothing
+// governs: it presented no credential and nothing granted it anything, so it reaches every
+// provider, model, key and tool the deployment has, and a consumer that narrows something leaves
+// it alone. That is a different thing from access that permits nothing, and consumers must tell
+// the two apart.
+
+// Grant is what a request has been granted, carried on its context for the life of the request.
+//
+// A nil section means not settled, which every reader has to tell apart from settled-and-empty: no
+// access resolved is not access that permits nothing, and no limits resolved is not an attempt that
+// answers to none.
+//
+// Any layer may replace a section, plugins included: a deployment that governs requests its own
+// way changes what a request is attributed to, may reach, or answers to through the same sections
+// everything else reads. Writes report whether they landed. Recording nothing is a no-op: a section
+// can be replaced by a later answer but never emptied by one, because a reader cannot tell an
+// emptied section from one that was never settled.
+type Grant interface {
+	// Identity is who the request is made by, or nil when nothing has settled it.
+	Identity() Identity
+	// Access is what the request may reach, or nil when nothing has resolved it: a request that
+	// carries no permit, which nothing governs, or a path that runs before resolution.
+	Access() Access
+	// Limits is what the current attempt answers to, or nil until its provider and model are
+	// settled and its limits resolved.
+	Limits() Limits
+
+	// SetIdentity records who the request is made by.
+	SetIdentity(identity Identity) bool
+	// SetAccess records what the request may reach, so everything downstream reads one answer
+	// rather than resolving its own.
+	SetAccess(access Access) bool
+	// SetLimits records what the current attempt answers to, replacing what the previous attempt
+	// answered to.
+	SetLimits(limits Limits) bool
+}
+
+// Identity is who a request is made by and where they sit in the organization, as resolved for
+// this request.
+//
+// It is settled in two steps by two layers. The transport records what was presented, which is all
+// it can know. Resolving the request's access then fills in what that resolves to: the key row, the
+// user it belongs to, and the teams, business units and customers above them. Everything downstream
+// that attributes the request, whether to a log row, a routing rule or a budget, reads it from here
+// rather than looking any of it up again.
+//
+// Teams, Customers and BusinessUnits are every one the identity reaches, for attribution that fans
+// out across an organization. Each list is ordered with the one the request is attributed to first:
+// the team a key is attached to, the customer that key names directly, the user's primary team.
+type Identity interface {
+	// Credential is what the request is authenticated by. A request that presented a key alongside
+	// an already verified identity still has one: whichever the deployment's precedence chose, with
+	// the other recorded as the resolved fact it stands for (see User and VirtualKey). Its Kind is
+	// empty when the request presented nothing.
+	Credential() Credential
+	// Presented reports whether the request presented anything at all. That is a different question
+	// from whether what it presented resolved to something: a credential that resolves to nothing
+	// is refused, while a request that presented nothing carries no access at all and is left to
+	// the mandatory-auth check to admit or refuse.
+	Presented() bool
+
+	// User is the user the request is attributed to: the one who authenticated, or the one who
+	// holds the key that was presented. Nil when no user is known.
+	User() *UserRef
+	// VirtualKey is the key the request was made with, once the presented value has resolved to a
+	// row. Nil when no key was presented or it resolved to nothing.
+	VirtualKey() *EntityRef
+
+	// Teams, Customers and BusinessUnits are every one the identity reaches, the attributed one
+	// first. Empty when unknown.
+	Teams() []EntityRef
+	Customers() []EntityRef
+	BusinessUnits() []EntityRef
+
+	// Project is the scope the request named and was admitted to. Nil when the request named no
+	// project, or named one it may not use; the two are told apart by reading the request itself.
+	Project() *EntityRef
+}
+
+// Permit is what one source confers: a named bundle of access.
+//
+// (Type, ID) is a permit's identity: it names the source whose access this is, and is what
+// attribution refers to. Name is for display in refusals and logs; renaming a source changes Name,
+// never its identity.
+//
+// What pays for exercising it is not here. A permit describes what may be reached; what that costs
+// is gathered by whoever holds the budgets, keyed by the permit's identity, once the provider and
+// model an attempt will use are known (see Access.PermitsForModel).
+//
+// The slices a permit hands out are its own and must be read, not modified. Permits are told apart
+// by identity, so an implementation has to be comparable: a pointer, as the one that ships is.
+type Permit interface {
+	// Type is the kind of source the permit comes from, as the resolver that built it names kinds.
+	Type() string
+	ID() string
+	Name() string
+	IsActive() bool
+	IsExpired() bool
+
+	// ProviderPermits is every provider the permit allows, with what each allows.
+	ProviderPermits() []ProviderPermit
+	// MCPPermits is every MCP client the permit allows tools of.
+	MCPPermits() []MCPPermit
+}
+
+// Access is an attempt's resolved access: the permits the caller holds, the permit scoping the
+// request, and the mode composing the two. It is built once per attempt and never mutated, so every
+// consumer of that attempt sees one answer.
+//
+// The caller's permits are read as one: what any of them permits, the caller may reach, any key
+// any of them allows may serve it, and every one of them that permits it pays for it (see
+// PermitsForModel). There is one scoping permit at most, composed under one mode.
+//
+// Either side may be empty. No caller permits means the caller holds no access of their own, which
+// is not the same as holding a permit that permits nothing. No scoping permit means the mode is
+// irrelevant and the answer is what the caller's permits permit.
+type Access interface {
+	// Bases returns the permits the caller holds, in attribution order. Empty when they hold none.
+	Bases() []Permit
+	// Scoping returns the permit scoping this request, or nil when nothing scopes it.
+	Scoping() Permit
+	// Mode returns the composition mode governing this request, as the resolver that built it names
+	// modes. It is meaningless when nothing scopes the request.
+	Mode() string
+	// IsScoped reports whether a scoping permit applies to this request.
+	IsScoped() bool
+
+	// IsProviderAllowed reports whether the request may use provider at all.
+	IsProviderAllowed(provider string) bool
+	// IsModelAllowed reports whether the request may use model on provider. Blacklisted models
+	// lose to nothing: a permit that blacklists the model does not permit it, whatever its
+	// allowed-models list says. An empty model asks about the provider alone.
+	IsModelAllowed(provider string, model string) bool
+	// IsMCPToolAllowed reports whether the request may execute toolPattern, which is either
+	// "<client>-<tool>" or the "<client>-*" wildcard standing for every tool of a client. A
+	// wildcard is permitted when the client is granted any tool at all; narrowing a wildcard down
+	// to the tools actually granted is MCPToolIncludeList's job.
+	IsMCPToolAllowed(toolPattern string) bool
+
+	// PermitsForModel returns the permits the request answers to for model on provider: every one
+	// of the caller's permits that permits the pair, then the scoping permit whenever the request
+	// is scoped. Nil when the request may not use the pair at all. An empty model asks about the
+	// provider alone.
+	//
+	// This is the attribution rule, and what the pair costs is gathered against every permit named
+	// here. The caller's permits are read as one, so each of them that permits the pair covers the
+	// request and each is charged; there is no affording something because a different budget has
+	// room. The scoping permit is named whether or not it was the one that admitted the pair,
+	// because the request happens inside the scope and is that scope's spend.
+	PermitsForModel(provider string, model string) []Permit
+
+	// KeysForModel returns the provider keys the request may use for model on provider, and whether
+	// that list is restrictive at all: any key any of the caller's permitting permits allows,
+	// composed with the scoping permit's under the mode. restricted is false when every key of the
+	// provider is allowed, in which case keyIDs is nil; when restricted is true, only keyIDs may be
+	// used and an empty list allows none.
+	KeysForModel(provider string, model string) (keyIDs []string, restricted bool)
+	// ProvidersForModel returns every provider permit the request may serve model from, in
+	// evaluation order: the caller's permits first, each in full and in their order, then providers
+	// gained purely through the scoping permit. Weight is passed through untouched: filtering
+	// unweighted candidates, and applying budget and rate-limit exclusions, is the caller's decision.
+	ProvidersForModel(model string) []ProviderCandidate
+	// GrantedProvidersForModel returns the providers that permit model, for consumers that gate on the
+	// provider rather than on the exact model: routing layers and model listings. Model names are
+	// matched by name here, since those consumers sit on top of the model resolution their own
+	// layers already run. An empty model means "no model to filter on", which keeps every granted
+	// provider.
+	GrantedProvidersForModel(model string) []string
+
+	// MCPToolIncludeList returns the tool patterns the request may execute, as "<client>-<tool>"
+	// entries and "<client>-*" wildcards for clients granted every tool. An empty result means no
+	// tool may be executed.
+	MCPToolIncludeList() []string
+	// NarrowMCPToolIncludeList narrows a tool list the caller asked for down to what this access
+	// permits, so a request-supplied include list can only ever narrow the access, never widen it.
+	// The result is never nil: an empty list permits no tool, which downstream has to tell apart
+	// from no list having been supplied at all. A request with no access is not narrowed at all,
+	// which is the caller's to notice before asking.
+	NarrowMCPToolIncludeList(requested []string) []string
+
+	// DeniedPermitsForModel returns the permits that refused model on provider, so the refusal can name them.
+	// An empty model asks about the provider alone. Nil when the request is allowed.
+	DeniedPermitsForModel(provider string, model string) []Permit
+	// DeniedPermitsForMCPTool is DeniedPermitsForModel for an MCP tool pattern.
+	DeniedPermitsForMCPTool(toolPattern string) []Permit
+}
+
+// Limits is what an attempt answers to once its provider and model are settled: every budget and
+// every rate limit, whoever holds them, already selected for that pair. What is checked, what is
+// named as a co-payer on the log row, and what is charged all read the same list, so they cannot
+// disagree about which limits an attempt was subject to. Either list is nil when nothing of that
+// kind applies.
+type Limits interface {
+	Budgets() []Limit
+	RateLimits() []Limit
+}
+
+// ProviderPermit is permission to use one provider, with the model and key restrictions that come
+// with it. It mirrors the semantics of a virtual key's provider config, expressed independently of
+// any particular source.
+//
+// The lists have the semantics of the configuration lists they are built from: a list holding only
+// "*" is unrestricted, an empty list holds nothing, and membership ignores case. Key IDs are the
+// exception, matched exactly by whoever selects a key.
+type ProviderPermit struct {
+	Provider          string   // provider name, as configured
+	AllowedModels     []string // ["*"] allows all models; empty allows none (deny by default)
+	BlacklistedModels []string // blocked models; wins over AllowedModels
+	KeyIDs            []string // ["*"] allows all keys of the provider; empty allows none.
+	//                             Composes with the other side's list, but only where that side also
+	//                             authorizes the request for the provider: a permit the request is not
+	//                             proceeding on does not get to say which keys serve it.
+	Weight *float64 // load-balancing weight; nil means the provider is not a load-balancing
+	//                  candidate. Unlike the permissions, this does not compose: there is no
+	//                  meaningful intersection of two preferences, so a scoping permit that
+	//                  expresses one wins as the more specific context.
+}
+
+// MCPPermit is permission to execute tools of one MCP client.
+type MCPPermit struct {
+	Client string // stable client identifier; identifies the client across renames and
+	//                decides which permit applies to a client
+	ClientName string   // client name, as used in "<client>-<tool>" tool patterns
+	Tools      []string // ["*"] allows every tool of the client; empty allows none
+}
+
+// ProviderCandidate is one way a request could be served: a provider, with the weight and keys it
+// would operate under. One per provider permit, so a request holding two for the same provider has
+// two candidates that may carry different weights and keys.
+//
+// Which permit offered the candidate is not restated here: a candidate is offered only by a permit
+// that permits the model on its provider, and every such permit pays for the pair, so what the
+// candidate costs is gathered against Access.PermitsForModel, given its provider and the model.
+type ProviderCandidate struct {
+	Provider string
+	Weight   *float64 // nil means the candidate has no weight assigned
+	KeyIDs   []string // ["*"] allows all keys of the provider; per candidate, so two permits for
+	//                   one provider can carry different keys. Consumers stamping a key restriction
+	//                   for the request use Access.KeysForModel instead: it answers for the request, not
+	//                   per candidate.
+}
+
+// Limit is one budget or one rate limit a request answers to: what to load when enforcing it, and
+// whose it is.
+//
+// ID is an identifier, never the record. A budget's usage is live and replaced in place as
+// requests spend, so a copy taken when the permit was built would answer from a balance that has
+// since moved; whoever enforces a limit loads it by ID at the moment it enforces.
+//
+// HolderKind, HolderID and HolderName say where the limit came from, because a refusal has to be
+// able to name what refused. "The key's monthly budget" and "your team's" are different answers to
+// the user, and a bare identifier cannot tell them apart. HolderID also keeps two limits of the
+// same kind distinct, which matters when one holder carries several.
+//
+// Which requests a limit applies to is not recorded on it. It is settled by where the limit comes
+// from and by when it is gathered, since a request can fail over to another provider or have its
+// model re-resolved by a routing rule. So a limit that has been gathered for an attempt is one to
+// enforce; there is nothing further to match it against.
+type Limit struct {
+	ID string
+
+	HolderKind string
+	HolderID   string
+	HolderName string
+
+	// What the limit was gathered for, when it is scoped to a provider or a model. Empty when it is
+	// scoped to neither: an empty name is never a real provider or model, so nothing else is needed
+	// to say "unscoped". Descriptive only, nothing selects on them, so that a limit which is
+	// recorded on a log row or named in a refusal can say what it was scoped to.
+	Provider string
+	Model    string
+}
+
+// Credential is what the request presented to say who it is. Kind names what it was, in the
+// vocabulary of whoever authenticates requests; an empty Kind means nothing was presented.
+//
+// Value is whatever identifies the credential to the layer that resolves it: the key itself for a
+// virtual key, which is looked up by value, and an identifier for kinds that were verified when they
+// were accepted, such as an API key's id or a session's subject. It is not a display value and must
+// not be logged as one.
+type Credential struct {
+	Kind  string
+	Value string
+}
+
+// EntityRef names something in the organization by identifier and display name. The identifier is
+// the identity; the name is for logs and refusals, and renaming the entity changes only that.
+type EntityRef struct {
+	ID   string
+	Name string
+}
+
+// UserRef is the person a request is attributed to.
+type UserRef struct {
+	ID    string
+	Name  string
+	Email string
+}

--- a/framework/grant/access.go
+++ b/framework/grant/access.go
@@ -1,0 +1,648 @@
+package grant
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// CompositionMode is how a scoping permit combines with the permits the caller holds. These are
+// the values a schemas.Access reports from Mode.
+type CompositionMode string
+
+const (
+	// Intersect permits what the caller's permits and the scoping permit both permit.
+	Intersect CompositionMode = "intersect"
+	// Union permits what either of them permits.
+	Union CompositionMode = "union"
+)
+
+// ModelMatcher decides whether model, as the request names it, is one of allowed on provider.
+// Whoever resolves a request's access supplies it, because deciding that needs the deployment's own
+// view of the provider: how it names models, and which provider-prefixed or cross-provider entries
+// in allowed stand for the same model. Without one, entries are matched by name.
+type ModelMatcher func(provider, model string, allowed []string) bool
+
+// Access is the one implementation of schemas.Access: the fold of the permits a request carries.
+//
+// Per attempt rather than per request, because a request that fails over resolves again for each
+// provider it tries. Configuration can change between two slow calls, and the attempt running
+// second has to answer to what is in force when it runs.
+//
+// The caller's permits are a list because a caller can hold several at once, and they are read as
+// one, as if they were a single permit holding all of their provider and MCP permits: what any of
+// them permits, the caller may reach; any key any of them allows may serve the request; and every
+// one of them that permits the pair pays for it (see PermitsForModel). Their order is the order the
+// resolver gave them, and is the order candidates and refusals are reported in.
+//
+// There is one scoping slot, not a list. A request is scoped by at most one thing at a time, and
+// composing under one mode is what keeps every answer here decidable.
+type Access struct {
+	bases   []schemas.Permit
+	scoping schemas.Permit
+	mode    CompositionMode
+	matcher ModelMatcher
+}
+
+// NewAccess folds the permits the caller holds together with the permit scoping this request,
+// under one composition mode.
+//
+// A request composes under exactly one mode. Choosing it belongs to whoever resolved the permits:
+// that layer knows what it asked and what answered. Passing no scoping permit leaves the mode
+// irrelevant and the answer is the caller's permits alone. Nil entries in bases are dropped, so a
+// resolver that found nothing for one source does not have to say so twice.
+func NewAccess(bases []schemas.Permit, scoping schemas.Permit, mode CompositionMode, matcher ModelMatcher) *Access {
+	held := make([]schemas.Permit, 0, len(bases))
+	for _, base := range bases {
+		if !isNilPermit(base) {
+			held = append(held, base)
+		}
+	}
+	if isNilPermit(scoping) {
+		scoping = nil
+	}
+	return &Access{
+		bases:   held,
+		scoping: scoping,
+		mode:    mode,
+		matcher: matcher,
+	}
+}
+
+// Bases implements schemas.Access.
+func (a *Access) Bases() []schemas.Permit {
+	if a == nil {
+		return nil
+	}
+	return slices.Clone(a.bases)
+}
+
+// Scoping implements schemas.Access.
+func (a *Access) Scoping() schemas.Permit {
+	if a == nil {
+		return nil
+	}
+	return a.scoping
+}
+
+// Mode implements schemas.Access.
+func (a *Access) Mode() string {
+	if a == nil {
+		return ""
+	}
+	return string(a.mode)
+}
+
+// IsScoped implements schemas.Access.
+func (a *Access) IsScoped() bool {
+	return a != nil && a.scoping != nil
+}
+
+// IsProviderAllowed implements schemas.Access.
+func (a *Access) IsProviderAllowed(provider string) bool {
+	if a == nil {
+		return false
+	}
+	base := a.anyBase(func(p schemas.Permit) bool { return allowsProvider(p, provider) })
+	if a.scoping == nil {
+		return base
+	}
+	return a.compose(base, allowsProvider(a.scoping, provider))
+}
+
+// IsModelAllowed implements schemas.Access.
+func (a *Access) IsModelAllowed(provider string, model string) bool {
+	if a == nil {
+		return false
+	}
+	base := a.anyBase(func(p schemas.Permit) bool { return a.permitAllowsModel(p, provider, model) })
+	if a.scoping == nil {
+		return base
+	}
+	return a.compose(base, a.permitAllowsModel(a.scoping, provider, model))
+}
+
+// IsMCPToolAllowed implements schemas.Access.
+func (a *Access) IsMCPToolAllowed(toolPattern string) bool {
+	if a == nil || toolPattern == "" {
+		return false
+	}
+	base := a.anyBase(func(p schemas.Permit) bool { return allowsTool(p, toolPattern) })
+	if a.scoping == nil {
+		return base
+	}
+	return a.compose(base, allowsTool(a.scoping, toolPattern))
+}
+
+// PermitsForModel implements schemas.Access.
+func (a *Access) PermitsForModel(provider string, model string) []schemas.Permit {
+	if a == nil || !a.IsModelAllowed(provider, model) {
+		return nil
+	}
+	permits := make([]schemas.Permit, 0, len(a.bases)+1)
+	for _, base := range a.bases {
+		if a.permitAllowsModel(base, provider, model) {
+			permits = append(permits, base)
+		}
+	}
+	if a.scoping != nil {
+		permits = append(permits, a.scoping)
+	}
+	return permits
+}
+
+// KeysForModel implements schemas.Access.
+//
+// The caller's side is the union of every key restriction its permitting permits hold for the
+// provider, across all of their provider permits for it: the caller's permits are read as one, and
+// a request served by any of them may use any key any of them allows. That is composed with the
+// scoping permit's restriction only where the scoping permit also authorizes the pair. A scoping
+// permit that narrows a request to two of the provider's keys has to mean it, and taking the
+// caller's list instead would hand the request a key the scope refused; but a permit the request is
+// not proceeding on has no say, which is why the model is asked for.
+//
+// The result is a plain []string rather than any list type of the permit's own: it is handed
+// straight to consumers that type-assert []string, where a named slice type would fail the
+// assertion silently and read as "no restriction at all".
+func (a *Access) KeysForModel(provider string, model string) (keyIDs []string, restricted bool) {
+	if a == nil || !a.IsModelAllowed(provider, model) {
+		// The request cannot proceed on this provider, so there is no key restriction to report.
+		return nil, false
+	}
+	callerKeys, callerHolds := a.unionKeysHeldBy(a.bases, provider, model)
+	var scopeKeys []string
+	scopeHolds := false
+	if a.scoping != nil {
+		scopeKeys, scopeHolds = a.unionKeysHeldBy([]schemas.Permit{a.scoping}, provider, model)
+	}
+	var granted []string
+	switch {
+	case callerHolds && scopeHolds:
+		granted = composeKeyIDs(callerKeys, scopeKeys, a.mode)
+	case callerHolds:
+		granted = callerKeys
+	case scopeHolds:
+		// The request proceeds on the scoping permit alone, so its restriction is the whole of it.
+		granted = scopeKeys
+	default:
+		// Neither side holds a provider permit, so there is no restriction to report. That is a
+		// different answer from a permit whose restriction happens to name no key, which must not
+		// read as "every key is allowed", so it is decided here, on whether a provider permit was
+		// found at all, rather than on whether the list came back empty.
+		return nil, false
+	}
+	if listIsUnrestricted(granted) {
+		return nil, false
+	}
+	// A copy, and always non-nil: a consumer must not be able to edit the permit through the answer,
+	// and an empty restriction allows no key, which is not "no restriction at all".
+	keyIDs = make([]string, 0, len(granted))
+	keyIDs = append(keyIDs, granted...)
+	return keyIDs, true
+}
+
+// unionKeysHeldBy is the union of the key restrictions that permits which authorize model on
+// provider hold for that provider, and whether any of them holds one at all. A permit that does not
+// authorize the pair has no say.
+func (a *Access) unionKeysHeldBy(permits []schemas.Permit, provider string, model string) (keys []string, holds bool) {
+	for _, permit := range permits {
+		if !a.permitAllowsModel(permit, provider, model) {
+			continue
+		}
+		for _, pp := range permit.ProviderPermits() {
+			if pp.Provider != provider {
+				continue
+			}
+			holds = true
+			keys = composeKeyIDs(keys, pp.KeyIDs, Union)
+		}
+	}
+	return keys, holds
+}
+
+// ProvidersForModel implements schemas.Access. Model names resolve through the matcher here. Unlike
+// GrantedProvidersForModel, this is the decision itself rather than a gate over one, so cross-provider
+// naming and provider-prefixed entries must resolve exactly as the deployment resolves them.
+func (a *Access) ProvidersForModel(model string) []schemas.ProviderCandidate {
+	if a == nil || model == "" {
+		return nil
+	}
+
+	candidates := make([]schemas.ProviderCandidate, 0, a.providerPermitCount())
+	a.eachProviderPermit(func(owner schemas.Permit, pp *schemas.ProviderPermit, isBase bool) bool {
+		provider := pp.Provider
+		// Three separate questions, none of which implies another. Whether the composed access
+		// permits the pair at all:
+		if !a.IsModelAllowed(provider, model) {
+			return false
+		}
+		// Whether *this* permit permits it: under a union the other side may be the one authorizing
+		// the request, and a permit that blacklists the model must not serve it. One blacklisting
+		// provider permit blocks the provider for that model across the whole permit, so a
+		// permissive one cannot reopen it:
+		if blacklistsModel(owner, provider, model) {
+			return false
+		}
+		// And whether this provider permit in particular permits it, so a permit holding several for
+		// a provider only offers the ones that can serve the model:
+		if !a.permitsModel(pp, model) {
+			return false
+		}
+		// Weight does not compose, because it is a preference rather than a permission and there is
+		// no meaningful intersection of two preferences. Instead the scoping permit wins where it
+		// expresses one: it is the more specific context, so a scope that wants a provider preferred
+		// differently inside it says so and is obeyed. Where it expresses none, the candidate's own
+		// weight stands.
+		selectedWeight := pp.Weight
+		if isBase && a.scoping != nil {
+			if scoped := weightedProviderPermitFor(a.scoping, provider); scoped != nil {
+				selectedWeight = scoped.Weight
+			}
+		}
+		// Only the permits that actually permit model on this provider have a say. A permit that is
+		// not authorizing this request does not get to restrict which of the provider's keys serve
+		// it; under a union that is the whole point, since the request is proceeding on the other
+		// side's authority alone. So the composition is the exception here, not the rule: the
+		// candidate's own keys stand unless the scoping permit both authorizes the model and holds
+		// the provider. A candidate offered through the scoping permit alone composes with nothing,
+		// because it is offered only where none of the caller's permits could serve the model. Per
+		// candidate the keys are this provider permit's own; KeysForModel is where the caller's
+		// permits are read as one.
+		selectedKeyIDs := pp.KeyIDs
+		if isBase && a.scoping != nil && a.permitAllowsModel(a.scoping, provider, model) {
+			if scoped := providerPermitFor(a.scoping, provider); scoped != nil {
+				selectedKeyIDs = composeKeyIDs(pp.KeyIDs, scoped.KeyIDs, a.mode)
+			}
+		}
+		// A copy, as in KeysForModel: selectedKeyIDs is the permit's own slice whenever nothing composed
+		// it, and a consumer editing the candidate must not edit the permit through it.
+		candidates = append(candidates, schemas.ProviderCandidate{
+			Provider: provider,
+			Weight:   selectedWeight,
+			KeyIDs:   slices.Clone(selectedKeyIDs),
+		})
+		return true
+	})
+
+	if len(candidates) == 0 {
+		return nil
+	}
+	return candidates
+}
+
+// GrantedProvidersForModel implements schemas.Access. Because this gate cannot ask ProvidersForModel
+// anything, the composition it needs is re-derived by name below.
+func (a *Access) GrantedProvidersForModel(model string) []string {
+	if a == nil {
+		return nil
+	}
+
+	allowed := make([]string, 0, a.providerPermitCount())
+	if a.IsScoped() && a.mode != Union && a.mode != Intersect {
+		// Unrecognized mode: permit nothing, as everywhere else.
+		return allowed
+	}
+	intersecting := a.IsScoped() && a.mode == Intersect
+
+	seen := make(map[string]struct{})
+	a.eachProviderPermit(func(_ schemas.Permit, pp *schemas.ProviderPermit, isBase bool) bool {
+		if _, dup := seen[pp.Provider]; dup {
+			return true
+		}
+		if !providerPermitAllowsModel(pp, model) {
+			return false
+		}
+		if intersecting {
+			// A scoping permit cannot widen an intersection, and what the caller holds must also be
+			// permitted by the scoping permit.
+			if !isBase || !allowsModelByName(a.scoping, pp.Provider, model) {
+				return false
+			}
+		}
+		seen[pp.Provider] = struct{}{}
+		allowed = append(allowed, pp.Provider)
+		return true
+	})
+	return allowed
+}
+
+// eachProviderPermit visits the provider permits the request could be served from: every provider
+// permit of every one of the caller's permits, in order, then the scoping permit's for providers
+// none of them could serve. The coarse provider gate and candidate selection walk it identically
+// rather than each keeping its own copy of the rule.
+//
+// The caller's permits do not shadow one another: they are read as one permit, and within one
+// permit two provider permits for the same provider are both offered, which is what lets a holder
+// run a provider under two weights or key sets. Only the scoping permit is shadowed, and only for
+// providers the caller's permits actually served, which accept reports. Shadowing on merely
+// *holding* a provider would lose it whenever the caller holds it but cannot serve this particular
+// request; under a union that is a request the access permits, through the scoping permit, with
+// nothing left to serve it.
+func (a *Access) eachProviderPermit(accept func(owner schemas.Permit, pp *schemas.ProviderPermit, isBase bool) bool) {
+	served := make(map[string]struct{})
+	for _, base := range a.bases {
+		eachProviderPermit(base, func(pp *schemas.ProviderPermit) bool {
+			if accept(base, pp, true) {
+				served[pp.Provider] = struct{}{}
+			}
+			return true
+		})
+	}
+	eachProviderPermit(a.scoping, func(pp *schemas.ProviderPermit) bool {
+		if _, done := served[pp.Provider]; done {
+			return true
+		}
+		accept(a.scoping, pp, false)
+		return true
+	})
+}
+
+// providerPermitCount is how many provider permits the request holds across every permit, for
+// sizing results.
+func (a *Access) providerPermitCount() int {
+	count := 0
+	for _, base := range a.bases {
+		count += len(base.ProviderPermits())
+	}
+	if a.scoping != nil {
+		count += len(a.scoping.ProviderPermits())
+	}
+	return count
+}
+
+// MCPToolIncludeList implements schemas.Access.
+//
+// The caller's permits are read as one, so their entries are merged in order before the scoping
+// permit is composed on: a tool any of them grants, the caller may execute.
+func (a *Access) MCPToolIncludeList() []string {
+	if a == nil {
+		return nil
+	}
+
+	merged := newUniqueEntries(0)
+	for _, base := range a.bases {
+		for _, entry := range mcpEntries(base) {
+			merged.add(entry)
+		}
+	}
+	base := merged.list()
+	if !a.IsScoped() {
+		return base
+	}
+	return a.composeMCPEntries(base, mcpEntries(a.scoping))
+}
+
+// NarrowMCPToolIncludeList implements schemas.Access.
+//
+// A "<client>-*" wildcard is kept as a wildcard only when the access grants that client every
+// tool, because downstream a wildcard reads as every tool of the client; otherwise it is replaced by
+// the specific tools the access grants for that client, which may be none. A specific entry is kept
+// when the access permits it. Empty entries and repeats are dropped. No access at all permits
+// nothing.
+func (a *Access) NarrowMCPToolIncludeList(requested []string) []string {
+	kept := newUniqueEntries(len(requested))
+	granted := a.MCPToolIncludeList()
+	grantedSet := make(map[string]struct{}, len(granted))
+	for _, entry := range granted {
+		grantedSet[entry] = struct{}{}
+	}
+	for _, entry := range requested {
+		if entry == "" {
+			continue
+		}
+		clientName, isWildcard := strings.CutSuffix(entry, "-"+Wildcard)
+		if !isWildcard {
+			if a.IsMCPToolAllowed(entry) {
+				kept.add(entry)
+			}
+			continue
+		}
+		if _, everyTool := grantedSet[entry]; everyTool {
+			kept.add(entry)
+			continue
+		}
+		for _, grantedEntry := range granted {
+			if strings.HasPrefix(grantedEntry, clientName+"-") {
+				kept.add(grantedEntry)
+			}
+		}
+	}
+	return kept.list()
+}
+
+// composeMCPEntries folds the caller's tool patterns with the scoping permit's under the request's
+// mode, the counterpart of compose for verdicts and composeKeyIDs for provider keys. An
+// unrecognized mode permits nothing, as everywhere else.
+//
+// The scoping permit is read off the receiver rather than passed in, because scoped has to be that
+// permit's own expansion: narrowing asks the permit questions its expansion cannot answer, so a
+// caller free to supply entries from elsewhere could quietly widen access.
+func (a *Access) composeMCPEntries(base, scoped []string) []string {
+	switch a.mode {
+	case Union:
+		merged := newUniqueEntries(len(base) + len(scoped))
+		for _, entry := range base {
+			merged.add(entry)
+		}
+		for _, entry := range scoped {
+			merged.add(entry)
+		}
+		return merged.list()
+	case Intersect:
+		// A wildcard is passed through only when both sides hold one, because downstream a
+		// "<client>-*" entry reads as every tool of that client. Which side carries the wildcard
+		// decides how the other is consulted, and this is why narrowing needs the permit and not
+		// just its entries: an unrestricted client expands to a bare "<client>-*", so testing a
+		// specific entry for membership in that expansion would drop every tool the scoping permit
+		// in fact permits. The permit is asked instead. In the other direction there is nothing to
+		// ask: a wildcard has to be replaced by the scoping permit's specific entries for the
+		// client, which only the expansion lists.
+		scopedSet := make(map[string]struct{}, len(scoped))
+		for _, entry := range scoped {
+			scopedSet[entry] = struct{}{}
+		}
+		kept := newUniqueEntries(len(base))
+		for _, entry := range base {
+			clientName, isWildcard := strings.CutSuffix(entry, "-"+Wildcard)
+			if !isWildcard {
+				if allowsTool(a.scoping, entry) {
+					kept.add(entry)
+				}
+				continue
+			}
+			if _, unrestrictedOnBothSides := scopedSet[entry]; unrestrictedOnBothSides {
+				kept.add(entry)
+				continue
+			}
+			for _, scopedEntry := range scoped {
+				if strings.HasPrefix(scopedEntry, clientName+"-") {
+					kept.add(scopedEntry)
+				}
+			}
+		}
+		return kept.list()
+	}
+	return []string{}
+}
+
+// DeniedPermitsForModel implements schemas.Access.
+//
+// What is named is whatever refused and whose permission would have changed the answer. The
+// caller's permits are read as one, so when none of them permits the pair all of them refused and
+// all are named: a caller holding two profiles is told that neither permits the model, not that one
+// of them does not. Under an intersection, when one of them permits it and the scoping permit does
+// not, the scoping permit alone stands in the way and alone is named. Under a union both sides must
+// have refused, and both are named. A caller holding no permit at all has nothing to be named.
+func (a *Access) DeniedPermitsForModel(provider string, model string) []schemas.Permit {
+	if a == nil {
+		return nil
+	}
+	return a.deniedBy(func(p schemas.Permit) bool { return a.permitAllowsModel(p, provider, model) })
+}
+
+// DeniedPermitsForMCPTool implements schemas.Access.
+func (a *Access) DeniedPermitsForMCPTool(toolPattern string) []schemas.Permit {
+	if a == nil {
+		return nil
+	}
+	return a.deniedBy(func(p schemas.Permit) bool { return allowsTool(p, toolPattern) })
+}
+
+// deniedBy identifies which permits refused, given a verdict per permit.
+func (a *Access) deniedBy(permits func(schemas.Permit) bool) []schemas.Permit {
+	baseAllows := a.anyBase(permits)
+	if a.scoping == nil {
+		if baseAllows {
+			return nil
+		}
+		return a.refusingBases()
+	}
+	scopingAllows := permits(a.scoping)
+	if a.compose(baseAllows, scopingAllows) {
+		return nil
+	}
+	if baseAllows {
+		return []schemas.Permit{a.scoping}
+	}
+	refused := a.refusingBases()
+	if a.mode == Union && !scopingAllows {
+		refused = append(refused, a.scoping)
+	}
+	return refused
+}
+
+// refusingBases is every permit the caller holds, for naming when none of them permitted. Nil when
+// they hold none.
+func (a *Access) refusingBases() []schemas.Permit {
+	if len(a.bases) == 0 {
+		return nil
+	}
+	return slices.Clone(a.bases)
+}
+
+// anyBase reports whether any of the caller's permits satisfies permits. The caller's permits are
+// read as one everywhere, and this is the one place that reading is written down.
+func (a *Access) anyBase(permits func(schemas.Permit) bool) bool {
+	for _, base := range a.bases {
+		if permits(base) {
+			return true
+		}
+	}
+	return false
+}
+
+// compose applies the request's composition mode between the two sides' verdicts. It is only
+// meaningful with a scoping permit; callers answer the unscoped case with the caller's permits
+// alone. An unrecognized mode permits nothing.
+func (a *Access) compose(baseAllows, scopingAllows bool) bool {
+	switch a.mode {
+	case Union:
+		return baseAllows || scopingAllows
+	case Intersect:
+		return baseAllows && scopingAllows
+	}
+	return false
+}
+
+// composeKeyIDs folds two key restrictions under a composition mode. Order follows the first
+// argument, so the result is stable.
+//
+// The wildcard is the universe rather than an entry: it stands for every key the provider has, so
+// intersecting with it yields the other side untouched and unioning with it is unrestricted. An
+// unrecognized mode permits nothing, as everywhere else.
+func composeKeyIDs(first, second []string, mode CompositionMode) []string {
+	switch mode {
+	case Intersect:
+		if listIsUnrestricted(first) {
+			return second
+		}
+		if listIsUnrestricted(second) {
+			return first
+		}
+		shared := make([]string, 0, len(first))
+		for _, keyID := range first {
+			if slices.Contains(second, keyID) {
+				shared = append(shared, keyID)
+			}
+		}
+		return shared
+	case Union:
+		if listIsUnrestricted(first) || listIsUnrestricted(second) {
+			return []string{Wildcard}
+		}
+		merged := make([]string, 0, len(first)+len(second))
+		merged = append(merged, first...)
+		for _, keyID := range second {
+			if !slices.Contains(merged, keyID) {
+				merged = append(merged, keyID)
+			}
+		}
+		return merged
+	}
+	return []string{}
+}
+
+// permitAllowsModel reports whether the permit permits model on provider: blacklisted by no
+// provider permit of that provider, and allowed by at least one. A permit that is not there permits
+// nothing. An empty model asks about the provider alone.
+func (a *Access) permitAllowsModel(p schemas.Permit, provider string, model string) bool {
+	if isNilPermit(p) {
+		return false
+	}
+	if model == "" {
+		return allowsProvider(p, provider)
+	}
+	if blacklistsModel(p, provider, model) {
+		return false
+	}
+	pps := p.ProviderPermits()
+	for i := range pps {
+		pp := &pps[i]
+		if pp.Provider != provider {
+			continue
+		}
+		if a.permitsModel(pp, model) {
+			return true
+		}
+	}
+	return false
+}
+
+// permitsModel applies one provider permit's allowed-models rule, through the matcher when there is
+// one and by name otherwise.
+func (a *Access) permitsModel(pp *schemas.ProviderPermit, model string) bool {
+	if a.matcher == nil {
+		return listAllows(pp.AllowedModels, model)
+	}
+	return a.matcher(pp.Provider, model, pp.AllowedModels)
+}
+
+// Compile-time checks that this package implements the shapes core declares.
+var (
+	_ schemas.Grant    = (*Grant)(nil)
+	_ schemas.Identity = (*Identity)(nil)
+	_ schemas.Permit   = (*Permit)(nil)
+	_ schemas.Access   = (*Access)(nil)
+	_ schemas.Limits   = (*Limits)(nil)
+)

--- a/framework/grant/entries.go
+++ b/framework/grant/entries.go
@@ -1,0 +1,35 @@
+package grant
+
+// uniqueEntries accumulates tool patterns in the order they were first added, dropping repeats.
+//
+// The list and the record of what is already in it are one value, so no caller can hold a record
+// that belongs to a different list. Keeping them apart is a silent bug rather than a loud one: a
+// function accumulating two lists at once would go on collapsing entries against the wrong set
+// and hand back a tool list that permits the wrong thing.
+type uniqueEntries struct {
+	entries []string
+	seen    map[string]struct{}
+}
+
+// newUniqueEntries starts an empty accumulator sized for capacity entries.
+func newUniqueEntries(capacity int) *uniqueEntries {
+	return &uniqueEntries{
+		entries: make([]string, 0, capacity),
+		seen:    make(map[string]struct{}, capacity),
+	}
+}
+
+// add appends entry unless it is already present.
+func (u *uniqueEntries) add(entry string) {
+	if _, dup := u.seen[entry]; dup {
+		return
+	}
+	u.seen[entry] = struct{}{}
+	u.entries = append(u.entries, entry)
+}
+
+// list returns what was accumulated, never nil: an empty tool list permits nothing, which a
+// consumer has to be able to tell apart from nothing having been resolved at all.
+func (u *uniqueEntries) list() []string {
+	return u.entries
+}

--- a/framework/grant/grant.go
+++ b/framework/grant/grant.go
@@ -1,0 +1,100 @@
+package grant
+
+import (
+	"reflect"
+	"sync/atomic"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// Grant is the envelope a request carries its sections in. See schemas.Grant for what each
+// section is and when it settles.
+//
+// Each section is held behind an atomic pointer and replaced whole. A consumer that read a section
+// keeps the answer it read, so two readers of one attempt never see a torn or partially updated
+// value, and a section being replaced cannot change a decision that was already made against it.
+type Grant struct {
+	identity atomic.Pointer[schemas.Identity]
+	access   atomic.Pointer[schemas.Access]
+	limits   atomic.Pointer[schemas.Limits]
+}
+
+// New returns an empty grant.
+func New() *Grant {
+	return &Grant{}
+}
+
+// Identity implements schemas.Grant.
+func (g *Grant) Identity() schemas.Identity {
+	if g == nil {
+		return nil
+	}
+	if p := g.identity.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+// Access implements schemas.Grant.
+func (g *Grant) Access() schemas.Access {
+	if g == nil {
+		return nil
+	}
+	if a := g.access.Load(); a != nil {
+		return *a
+	}
+	return nil
+}
+
+// Limits implements schemas.Grant.
+func (g *Grant) Limits() schemas.Limits {
+	if g == nil {
+		return nil
+	}
+	if l := g.limits.Load(); l != nil {
+		return *l
+	}
+	return nil
+}
+
+// SetIdentity implements schemas.Grant. Recording nothing is a no-op, as the interface says.
+func (g *Grant) SetIdentity(identity schemas.Identity) bool {
+	if g == nil || isNil(identity) {
+		return false
+	}
+	g.identity.Store(&identity)
+	return true
+}
+
+// SetAccess implements schemas.Grant. Recording nothing is a no-op, as the interface says.
+func (g *Grant) SetAccess(access schemas.Access) bool {
+	if g == nil || isNil(access) {
+		return false
+	}
+	g.access.Store(&access)
+	return true
+}
+
+// SetLimits implements schemas.Grant. Recording nothing is a no-op, as the interface says.
+func (g *Grant) SetLimits(limits schemas.Limits) bool {
+	if g == nil || isNil(limits) {
+		return false
+	}
+	g.limits.Store(&limits)
+	return true
+}
+
+// isNil reports whether an interface value is nil, including one that holds a nil pointer. A
+// section holding a nil pointer would read as settled while answering nothing, which is exactly
+// the confusion a nil section exists to prevent, so setters refuse it as they refuse a bare nil.
+func isNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.Ptr, reflect.Map, reflect.Slice, reflect.Func, reflect.Interface:
+		return rv.IsNil()
+	}
+	return false
+}

--- a/framework/grant/identity.go
+++ b/framework/grant/identity.go
@@ -1,0 +1,130 @@
+package grant
+
+import (
+	"slices"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// CredentialKind names what a request presented to say who it is: one of the things this gateway
+// identifies a caller by. These are the values a schemas.Credential carries in Kind. A raw provider
+// key is not among them: it selects which key serves the request and says nothing about who made it.
+type CredentialKind string
+
+const (
+	// CredentialVirtualKey marks a virtual key.
+	CredentialVirtualKey CredentialKind = "virtual_key"
+	// CredentialSessionToken marks a dashboard session token.
+	CredentialSessionToken CredentialKind = "session_token"
+	// CredentialIdentityToken marks a token the identity provider issued for the user.
+	CredentialIdentityToken CredentialKind = "idp_jwt"
+	// CredentialMCPToken marks a token this deployment's own authorization server issued to an MCP
+	// client.
+	CredentialMCPToken CredentialKind = "mcp_jwt"
+	// CredentialAPIKey marks a management API key.
+	CredentialAPIKey CredentialKind = "api_key"
+)
+
+// NewCredential is a schemas.Credential of the given kind.
+func NewCredential(kind CredentialKind, value string) schemas.Credential {
+	return schemas.Credential{Kind: string(kind), Value: value}
+}
+
+// Identity is the one implementation of schemas.Identity. It is built whole and never edited: a
+// layer that learns more about the caller builds the replacement from what the getters return plus
+// what it learned, which is what lets a request's context hand a identity out without a lock.
+type Identity struct {
+	credential schemas.Credential
+
+	user       *schemas.UserRef
+	virtualKey *schemas.EntityRef
+
+	teams         []schemas.EntityRef
+	customers     []schemas.EntityRef
+	businessUnits []schemas.EntityRef
+
+	project *schemas.EntityRef
+}
+
+// NewIdentity builds a Identity. See schemas.Identity for what each value means. The lists are
+// copied, so a caller that keeps its slices cannot alter what the request is attributed to.
+func NewIdentity(
+	credential schemas.Credential,
+	user *schemas.UserRef,
+	virtualKey *schemas.EntityRef,
+	teams []schemas.EntityRef,
+	customers []schemas.EntityRef,
+	businessUnits []schemas.EntityRef,
+	project *schemas.EntityRef,
+) *Identity {
+	return &Identity{
+		credential:    credential,
+		user:          user,
+		virtualKey:    virtualKey,
+		teams:         slices.Clone(teams),
+		customers:     slices.Clone(customers),
+		businessUnits: slices.Clone(businessUnits),
+		project:       project,
+	}
+}
+
+// Credential implements schemas.Identity.
+func (p *Identity) Credential() schemas.Credential {
+	if p == nil {
+		return schemas.Credential{}
+	}
+	return p.credential
+}
+
+// Presented implements schemas.Identity.
+func (p *Identity) Presented() bool {
+	return p != nil && p.credential.Kind != ""
+}
+
+// User implements schemas.Identity.
+func (p *Identity) User() *schemas.UserRef {
+	if p == nil {
+		return nil
+	}
+	return p.user
+}
+
+// VirtualKey implements schemas.Identity.
+func (p *Identity) VirtualKey() *schemas.EntityRef {
+	if p == nil {
+		return nil
+	}
+	return p.virtualKey
+}
+
+// Teams implements schemas.Identity.
+func (p *Identity) Teams() []schemas.EntityRef {
+	if p == nil {
+		return nil
+	}
+	return p.teams
+}
+
+// Customers implements schemas.Identity.
+func (p *Identity) Customers() []schemas.EntityRef {
+	if p == nil {
+		return nil
+	}
+	return p.customers
+}
+
+// BusinessUnits implements schemas.Identity.
+func (p *Identity) BusinessUnits() []schemas.EntityRef {
+	if p == nil {
+		return nil
+	}
+	return p.businessUnits
+}
+
+// Project implements schemas.Identity.
+func (p *Identity) Project() *schemas.EntityRef {
+	if p == nil {
+		return nil
+	}
+	return p.project
+}

--- a/framework/grant/limit.go
+++ b/framework/grant/limit.go
@@ -1,0 +1,202 @@
+package grant
+
+import (
+	"slices"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// LimitHolderKind identifies what kind of entity a limit hangs off. These are the values a
+// schemas.Limit carries in HolderKind. An open string, like PermitType, so a deployment resolving a
+// holder of its own can name it without this package changing. The kinds that do exist are named
+// below rather than wherever each is resolved, because telling one limit from another is a single
+// vocabulary and a reader should not have to know which layer introduced a kind.
+type LimitHolderKind string
+
+// Every kind of limit holder, declared together and grouped by holder. Within a holder the kinds
+// run from the widest scope to the narrowest: the holder's own limits, spent by every request it
+// makes; its per-provider limits, spent only by requests that provider serves; and its per-model
+// limits, spent only by requests for that model.
+//
+// Once resolved for an attempt, a request's limits are one flat list, and these are what tell them
+// apart afterwards: a refusal has to say whether it was your key's budget or your team's, and a
+// caller looking at several limits of the same shape needs to know which is which.
+//
+// Nothing registers or enumerates them. Enforcement covers every kind, so a limit carrying any of
+// these is checked and charged by the same path, and a deployment that resolves a holder of its own
+// declares its kind here and is enforced by construction.
+const (
+	// Held by a virtual key.
+	LimitHolderVirtualKey               LimitHolderKind = "vk"
+	LimitHolderVirtualKeyProviderConfig LimitHolderKind = "vk_provider_config"
+	LimitHolderVirtualKeyModelConfig    LimitHolderKind = "vk_model_config"
+
+	// Held by a profile attached to a caller.
+	LimitHolderAccessProfile               LimitHolderKind = "access_profile"
+	LimitHolderAccessProfileProviderConfig LimitHolderKind = "access_profile_provider_config"
+
+	// Held by the user a request is attributed to. Kept apart from the key's kinds because a caller
+	// can be told to stop counting a request against the key that granted it while still counting
+	// it against the user who made it; one kind covering both would make that unexpressible.
+	//
+	// This kind covers two different origins that share the user's scope: a per-model limit
+	// assigned to the user directly, and one a deployment derived from something the user holds and
+	// stored against them. They are not the same money and they do not share a lifecycle, since
+	// detaching whatever produced the derived one removes it while the directly assigned one
+	// survives, but at this level they are indistinguishable, so a refusal naming this kind cannot
+	// say which of the two ran out. Telling them apart needs whatever recorded the derivation,
+	// which is the deployment's to know; a deployment that wants the distinction in its refusals
+	// declares a kind for it.
+	LimitHolderUserModelConfig LimitHolderKind = "user_model_config"
+
+	// Held by the organization above the caller. Spent by every request made under anything they
+	// contain.
+	LimitHolderTeam         LimitHolderKind = "team"
+	LimitHolderBusinessUnit LimitHolderKind = "business_unit"
+	LimitHolderCustomer     LimitHolderKind = "customer"
+
+	// Held by a project, which is not part of the organization above the caller. A project is a
+	// scope a request opts into rather than a container the caller sits inside, so what it funds
+	// is spent by whoever names it and by nobody else: a caller's own limits and their
+	// organization's are untouched by it, and the same caller reaching the same model outside the
+	// project answers to none of these.
+	LimitHolderProject               LimitHolderKind = "project"
+	LimitHolderProjectProviderConfig LimitHolderKind = "project_provider_config"
+	LimitHolderProjectModelConfig    LimitHolderKind = "project_model_config"
+
+	// Held by no one in the organization. A provider's limits are the deployment's own, and a model
+	// config's are scoped to a (model, provider) pattern. Neither is anybody's allowance, so a
+	// refusal naming one of these is telling the caller about the deployment rather than about
+	// themselves.
+	LimitHolderProvider    LimitHolderKind = "provider"
+	LimitHolderModelConfig LimitHolderKind = "model_config"
+)
+
+// LimitsHeldBy names the limits one holder imposes, from the identifiers of the records that
+// enforce them. provider and model are recorded on each for description, empty when the limit is
+// scoped to neither; see schemas.Limit for why nothing selects on them.
+//
+// Identifiers rather than records, for the reason on schemas.Limit, and it is also what keeps this
+// package out of the business of what a budget row looks like: whoever reads those rows already
+// knows their shape, and all this needs from them is an identity. Records without one are skipped,
+// since a limit that cannot be loaded cannot be enforced.
+func LimitsHeldBy(kind LimitHolderKind, holderID, holderName, provider, model string, ids ...string) []schemas.Limit {
+	if len(ids) == 0 {
+		return nil
+	}
+	limits := make([]schemas.Limit, 0, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		limits = append(limits, schemas.Limit{
+			ID:         id,
+			HolderKind: string(kind),
+			HolderID:   holderID,
+			HolderName: holderName,
+			Provider:   provider,
+			Model:      model,
+		})
+	}
+	if len(limits) == 0 {
+		return nil
+	}
+	return limits
+}
+
+// LimitsFrom keeps the limits held by any of kinds, and is how a caller that enforces one holder's
+// limits asks about exactly that holder.
+//
+// It exists because "does anything govern this?" and "does this holder govern this?" are different
+// questions, and a request's limits come from several holders at once. A check written against one
+// holder, a key's budgets say, must gate on that holder's own limits, or it fires on a team's
+// budget and then reports on the key's, which passes while the team is exhausted. Passing no kinds
+// keeps nothing, since asking about no holder is asking about nothing.
+func LimitsFrom(limits []schemas.Limit, kinds ...LimitHolderKind) []schemas.Limit {
+	if len(limits) == 0 || len(kinds) == 0 {
+		return nil
+	}
+	held := make([]schemas.Limit, 0, len(limits))
+	for _, limit := range limits {
+		if slices.Contains(kinds, LimitHolderKind(limit.HolderKind)) {
+			held = append(held, limit)
+		}
+	}
+	if len(held) == 0 {
+		return nil
+	}
+	return held
+}
+
+// Limits is the one implementation of schemas.Limits.
+//
+// Resolving them is the caller's to do and its answer is taken as given. Which holders are charged
+// is a question about how a deployment is configured, and this package would have to learn what a
+// project, a team or a model config is in order to have an opinion. So it holds the answer without
+// deriving it.
+//
+// One limit reached twice is still one limit, so what is held is deduplicated. That is not an
+// opinion about which holders are charged; it is that charging one budget twice for a single request
+// is never what a deployment meant, however its holders overlap. A team or customer reached through
+// two permits, or a customer named directly as well as through its team, arrives twice and must not
+// be billed twice.
+type Limits struct {
+	budgets    []schemas.Limit
+	rateLimits []schemas.Limit
+}
+
+// NewLimits holds the limits an attempt answers to. Both lists are copied as well as deduplicated,
+// so a caller that keeps its slice cannot alter what the attempt is held to.
+func NewLimits(budgets, rateLimits []schemas.Limit) *Limits {
+	return &Limits{
+		budgets:    dedupedLimits(budgets),
+		rateLimits: dedupedLimits(rateLimits),
+	}
+}
+
+// Budgets implements schemas.Limits. A copy, not the internal slice: enforcement, billing, and
+// logging all read the same settled Limits for one attempt, and a caller sorting or overwriting
+// what it got back must not change what the next reader sees.
+func (l *Limits) Budgets() []schemas.Limit {
+	if l == nil {
+		return nil
+	}
+	return slices.Clone(l.budgets)
+}
+
+// RateLimits implements schemas.Limits. See Budgets for why this returns a copy.
+func (l *Limits) RateLimits() []schemas.Limit {
+	if l == nil {
+		return nil
+	}
+	return slices.Clone(l.rateLimits)
+}
+
+// dedupedLimits keeps the first occurrence of each limit, in the order given. First rather than
+// last because the order is the order refusals report in, what the deployment imposes before what
+// the holder is funded by, and a limit reached again later has already been accounted for.
+//
+// A limit without an ID is dropped rather than kept: whoever enforces a limit loads it by ID, so
+// one that names no record cannot be enforced, and treating every unnamed limit as the same limit
+// would silently collapse distinct ones. The same rule LimitsHeldBy applies when it builds them.
+func dedupedLimits(limits []schemas.Limit) []schemas.Limit {
+	if len(limits) == 0 {
+		return nil
+	}
+	deduped := make([]schemas.Limit, 0, len(limits))
+	seen := make(map[string]struct{}, len(limits))
+	for _, limit := range limits {
+		if limit.ID == "" {
+			continue
+		}
+		if _, already := seen[limit.ID]; already {
+			continue
+		}
+		seen[limit.ID] = struct{}{}
+		deduped = append(deduped, limit)
+	}
+	if len(deduped) == 0 {
+		return nil
+	}
+	return deduped
+}

--- a/framework/grant/lists.go
+++ b/framework/grant/lists.go
@@ -1,0 +1,39 @@
+package grant
+
+import "strings"
+
+// Wildcard marks an unrestricted list: every value is allowed, or every value is blocked, depending
+// on which kind of list carries it.
+const Wildcard = "*"
+
+// The lists a permit carries have the semantics of the configuration lists they are built from. A
+// list holding only the wildcard is unrestricted, an empty list holds nothing, and membership
+// ignores case. Key IDs are the one exception, matched exactly by whoever selects a key; nothing
+// here is used for them.
+
+// listIsUnrestricted reports whether list holds only the wildcard.
+func listIsUnrestricted(list []string) bool {
+	return len(list) == 1 && list[0] == Wildcard
+}
+
+// listContains reports whether list names value, ignoring case.
+func listContains(list []string, value string) bool {
+	for _, entry := range list {
+		if strings.EqualFold(entry, value) {
+			return true
+		}
+	}
+	return false
+}
+
+// listAllows reads list as an allow list: everything when it is unrestricted, otherwise what it
+// names. An empty allow list permits nothing.
+func listAllows(list []string, value string) bool {
+	return listIsUnrestricted(list) || listContains(list, value)
+}
+
+// listBlocks reads list as a block list: everything when it holds the wildcard, otherwise what it
+// names. An empty block list refuses nothing.
+func listBlocks(list []string, value string) bool {
+	return listIsUnrestricted(list) || listContains(list, value)
+}

--- a/framework/grant/permit.go
+++ b/framework/grant/permit.go
@@ -1,0 +1,365 @@
+package grant
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// PermitType identifies what kind of source a permit's access comes from. These are the values a
+// schemas.Permit reports from Type. An open string: kinds are declared by whoever resolves permits
+// of that kind, so this package needs no list of them.
+type PermitType string
+
+// The permit kinds this package names. The type stays open, so these are not the only kinds that
+// can exist. They are the ones PrettyString can render, which is why they are declared here rather
+// than wherever permits of each kind are resolved: a refusal has to read the same whichever kind it
+// names.
+const (
+	// PermitVirtualKey marks permits whose access comes from a virtual key.
+	PermitVirtualKey PermitType = "vk"
+	// PermitAccessProfile marks permits whose access comes from a profile attached to a caller.
+	PermitAccessProfile PermitType = "access_profile"
+	// PermitProject marks permits whose access comes from a project a request names. A project is
+	// not something the caller belongs to but something the request opts into, so it grants
+	// alongside whatever the caller already holds rather than instead of it. PrettyString needs no
+	// case for it: the identifier already reads as prose, which is the only reason the others have
+	// one.
+	PermitProject PermitType = "project"
+)
+
+// PrettyString names the permit kind as a refusal should say it. Refusals are read by whoever made
+// the request, so "your virtual key has expired" is the answer and "vk" is not.
+//
+// A kind it does not know renders as itself. That is not a good message, but it is better than an
+// empty one: a refusal that loses its subject cannot be acted on at all.
+func (t PermitType) PrettyString() string {
+	switch t {
+	case PermitVirtualKey:
+		return "virtual key"
+	case PermitAccessProfile:
+		return "access profile"
+	default:
+		return string(t)
+	}
+}
+
+// Permit is the one implementation of schemas.Permit.
+//
+// It is a snapshot for one attempt. The provider permits carry a copy of the configuration they
+// came from, so a source reloaded mid-attempt cannot change what that attempt has already resolved.
+// A later attempt builds its own and picks the reload up.
+type Permit struct {
+	permitType PermitType
+	id         string
+	name       string
+	isActive   bool
+	isExpired  bool
+
+	providerPermits []schemas.ProviderPermit
+	mcpPermits      []schemas.MCPPermit
+}
+
+// NewPermit builds a Permit. See schemas.Permit for what each value means. The lists are deep
+// copied, down to each entry's own slices and its Weight pointer, so a resolver that keeps its
+// slices (or the value behind a Weight pointer) cannot alter what an attempt was admitted under.
+func NewPermit(
+	permitType PermitType,
+	id string,
+	name string,
+	isActive bool,
+	isExpired bool,
+	providerPermits []schemas.ProviderPermit,
+	mcpPermits []schemas.MCPPermit,
+) *Permit {
+	return &Permit{
+		permitType:      permitType,
+		id:              id,
+		name:            name,
+		isActive:        isActive,
+		isExpired:       isExpired,
+		providerPermits: cloneProviderPermits(providerPermits),
+		mcpPermits:      cloneMCPPermits(mcpPermits),
+	}
+}
+
+// cloneProviderPermits deep-copies each entry: slices.Clone on the outer slice only copies the
+// struct values, and AllowedModels, BlacklistedModels, KeyIDs, and the value behind Weight would
+// otherwise still alias the source's own slices and pointer.
+func cloneProviderPermits(providerPermits []schemas.ProviderPermit) []schemas.ProviderPermit {
+	cloned := slices.Clone(providerPermits)
+	for i := range cloned {
+		cloned[i].AllowedModels = slices.Clone(cloned[i].AllowedModels)
+		cloned[i].BlacklistedModels = slices.Clone(cloned[i].BlacklistedModels)
+		cloned[i].KeyIDs = slices.Clone(cloned[i].KeyIDs)
+		if cloned[i].Weight != nil {
+			weight := *cloned[i].Weight
+			cloned[i].Weight = &weight
+		}
+	}
+	return cloned
+}
+
+// cloneMCPPermits deep-copies each entry's Tools slice, for the same reason cloneProviderPermits
+// copies each entry's nested slices.
+func cloneMCPPermits(mcpPermits []schemas.MCPPermit) []schemas.MCPPermit {
+	cloned := slices.Clone(mcpPermits)
+	for i := range cloned {
+		cloned[i].Tools = slices.Clone(cloned[i].Tools)
+	}
+	return cloned
+}
+
+// Type implements schemas.Permit.
+func (p *Permit) Type() string {
+	if p == nil {
+		return ""
+	}
+	return string(p.permitType)
+}
+
+// ID implements schemas.Permit.
+func (p *Permit) ID() string {
+	if p == nil {
+		return ""
+	}
+	return p.id
+}
+
+// Name implements schemas.Permit.
+func (p *Permit) Name() string {
+	if p == nil {
+		return ""
+	}
+	return p.name
+}
+
+// IsActive implements schemas.Permit.
+func (p *Permit) IsActive() bool {
+	return p != nil && p.isActive
+}
+
+// IsExpired implements schemas.Permit.
+func (p *Permit) IsExpired() bool {
+	return p != nil && p.isExpired
+}
+
+// ProviderPermits implements schemas.Permit. A copy, not the permit's own slice: the permit is a
+// snapshot for the whole attempt, read by every consumer that asks what it permits, and a caller
+// mutating what it got back must not change what the next reader sees.
+func (p *Permit) ProviderPermits() []schemas.ProviderPermit {
+	if p == nil {
+		return nil
+	}
+	return cloneProviderPermits(p.providerPermits)
+}
+
+// MCPPermits implements schemas.Permit. See ProviderPermits for why this returns a copy.
+func (p *Permit) MCPPermits() []schemas.MCPPermit {
+	if p == nil {
+		return nil
+	}
+	return cloneMCPPermits(p.mcpPermits)
+}
+
+// The rules below are written against schemas.Permit rather than *Permit, so the fold asks every
+// permit it holds the same questions whichever implementation answers them.
+
+// isNilPermit reports whether p is nothing at all, including an interface holding a nil pointer.
+func isNilPermit(p schemas.Permit) bool {
+	return isNil(p)
+}
+
+// allowsProvider reports whether the permit permits provider at all. A permit with no provider
+// permit permits none (deny by default), and so does a permit that is not there.
+func allowsProvider(p schemas.Permit, provider string) bool {
+	if isNilPermit(p) {
+		return false
+	}
+	for _, pp := range p.ProviderPermits() {
+		if pp.Provider == provider {
+			return true
+		}
+	}
+	return false
+}
+
+// blacklistsModel reports whether any of the permit's provider permits for provider blocks model.
+// One blocking provider permit blocks the provider for that model outright.
+func blacklistsModel(p schemas.Permit, provider string, model string) bool {
+	if isNilPermit(p) {
+		return false
+	}
+	for _, pp := range p.ProviderPermits() {
+		if pp.Provider == provider && listBlocks(pp.BlacklistedModels, model) {
+			return true
+		}
+	}
+	return false
+}
+
+// allowsTool reports whether the permit permits toolPattern. The MCP permit that holds a client
+// decides for that client: a client with a permit here is never widened by another permit of the
+// same source.
+//
+// A client is identified by its stable id, the same as mcpEntries: a rename can leave two entries
+// for the same client under different names, and the first one still has to be the one that
+// decides, not whichever one the pattern's current name happens to match.
+func allowsTool(p schemas.Permit, toolPattern string) bool {
+	if isNilPermit(p) {
+		return false
+	}
+	handledClients := make(map[string]struct{})
+	for _, mp := range p.MCPPermits() {
+		clientName := mp.ClientName
+		if clientName == "" {
+			continue
+		}
+		clientKey := mp.Client
+		if clientKey == "" {
+			clientKey = clientName
+		}
+		if _, handled := handledClients[clientKey]; handled {
+			continue
+		}
+		handledClients[clientKey] = struct{}{}
+		if toolPattern != clientName+"-"+Wildcard && !strings.HasPrefix(toolPattern, clientName+"-") {
+			continue
+		}
+		if toolPattern == clientName+"-"+Wildcard {
+			return len(mp.Tools) > 0
+		}
+		if listIsUnrestricted(mp.Tools) {
+			return true
+		}
+		return listContains(mp.Tools, strings.TrimPrefix(toolPattern, clientName+"-"))
+	}
+	return false
+}
+
+// allowsModelByName is the name-matching counterpart of Access.permitAllowsModel, for the coarse
+// provider gates that must not resolve model names.
+//
+// blacklistsModel is checked first, across every provider-permit entry for provider, before any
+// entry gets to allow the model: a permit can hold more than one provider-permit entry for the
+// same provider (two provider configs on one key, for instance), and one entry allowing what a
+// later entry blacklists must not let the model through first.
+func allowsModelByName(p schemas.Permit, provider string, model string) bool {
+	if isNilPermit(p) {
+		return false
+	}
+	if model != "" && blacklistsModel(p, provider, model) {
+		return false
+	}
+	for _, pp := range p.ProviderPermits() {
+		if pp.Provider != provider {
+			continue
+		}
+		if model == "" {
+			return true
+		}
+		if providerPermitAllowsModel(&pp, model) {
+			return true
+		}
+	}
+	return false
+}
+
+// providerPermitAllowsModel applies one provider permit's model rules by name only, resolving
+// nothing. An empty model means there is nothing to filter on, which keeps the permit.
+func providerPermitAllowsModel(pp *schemas.ProviderPermit, model string) bool {
+	if model == "" {
+		return true
+	}
+	return listAllows(pp.AllowedModels, model) && !listBlocks(pp.BlacklistedModels, model)
+}
+
+// weightedProviderPermitFor returns the permit's first provider permit for provider that sets a
+// weight, or nil when none does.
+func weightedProviderPermitFor(p schemas.Permit, provider string) *schemas.ProviderPermit {
+	if isNilPermit(p) {
+		return nil
+	}
+	pps := p.ProviderPermits()
+	for i := range pps {
+		pp := &pps[i]
+		if pp.Provider == provider && pp.Weight != nil {
+			return pp
+		}
+	}
+	return nil
+}
+
+// providerPermitFor returns the permit's first provider permit for provider, or nil when it holds
+// none.
+func providerPermitFor(p schemas.Permit, provider string) *schemas.ProviderPermit {
+	if isNilPermit(p) {
+		return nil
+	}
+	pps := p.ProviderPermits()
+	for i := range pps {
+		if pps[i].Provider == provider {
+			return &pps[i]
+		}
+	}
+	return nil
+}
+
+// eachProviderPermit visits the permit's provider permits. A provider named by nothing but
+// whitespace is skipped: no comparison anywhere would match it, so it could only ever be selected
+// and then fail downstream. visit returns false to stop, which this reports back.
+func eachProviderPermit(p schemas.Permit, visit func(pp *schemas.ProviderPermit) bool) bool {
+	if isNilPermit(p) {
+		return true
+	}
+	pps := p.ProviderPermits()
+	for i := range pps {
+		pp := &pps[i]
+		if strings.TrimSpace(pp.Provider) == "" {
+			continue
+		}
+		if !visit(pp) {
+			return false
+		}
+	}
+	return true
+}
+
+// mcpEntries returns the tool patterns a permit permits, in MCP permit order, with duplicates
+// collapsed. The first MCP permit holding a client decides for that client.
+func mcpEntries(p schemas.Permit) []string {
+	if isNilPermit(p) {
+		return []string{}
+	}
+	mps := p.MCPPermits()
+	entries := newUniqueEntries(len(mps))
+	handledClients := make(map[string]struct{})
+	for _, mp := range mps {
+		if mp.ClientName == "" {
+			continue
+		}
+		clientKey := mp.Client
+		if clientKey == "" {
+			clientKey = mp.ClientName
+		}
+		if _, handled := handledClients[clientKey]; handled {
+			continue
+		}
+		handledClients[clientKey] = struct{}{}
+		if len(mp.Tools) == 0 {
+			continue
+		}
+		if listIsUnrestricted(mp.Tools) {
+			entries.add(mp.ClientName + "-" + Wildcard)
+			continue
+		}
+		for _, tool := range mp.Tools {
+			if tool == "" {
+				continue
+			}
+			entries.add(mp.ClientName + "-" + tool)
+		}
+	}
+	return entries.list()
+}


### PR DESCRIPTION
## Summary

Introduces a `grants` package that models access as composable, named permission bundles. Rather than each consumer (routing, key selection, model listings, MCP tool filtering) independently deriving what a request may reach, access is resolved once per attempt into an `EffectiveAccess` value and stored on the context. Every downstream consumer reads that single answer.

## Changes

- Added `framework/grants/grants.go`: defines the core `Grant`, `ProviderConfigGrant`, `MCPConfigGrant`, and `Limit` types, along with grant-level permission methods (`allowsProvider`, `allowsTool`, `blacklistsModel`, etc.) and limit helpers (`LimitsHeldBy`, `LimitsFrom`).

- Added `framework/grants/access.go`: defines `EffectiveAccess`, which folds a base grant (what the caller holds) and a scoping grant together under one of two composition modes — `intersect` or `union`. Exposes the composed answers for provider access (`IsProviderAllowed`, `IsModelAllowed`), key selection (`KeysFor`), provider routing (`ProvidersFor`, `GrantedProvidersFor`), MCP tools (`MCPIncludeList`, `IsMCPToolAllowed`), and limit resolution (`WithResolvedLimits`, `ResolvedBudgets`, `ResolvedRateLimits`). Limits always apply from both slots regardless of composition mode — a union that widens access does not widen what the request is charged against.

- Added `framework/grants/context.go`: provides `EffectiveAccessFromContext` and `RecordEffectiveAccess` as the single sanctioned path for reading and writing the resolved access on a `BifrostContext`, keeping the type assertion and the nil-means-unresolved invariant in one place.

- Added `framework/grants/entries.go`: a small `uniqueEntries` helper that accumulates tool patterns in insertion order without duplicates, used by MCP tool list composition.

- Added `BifrostContextKeyGovernanceEffectiveAccess` to the context key registry in `core/schemas/bifrost.go`, so the key is declared alongside every other context key rather than privately inside the grants package.

Notable design decisions:
- `EffectiveAccess` is per-attempt rather than per-request, because configuration can change between failover attempts and each attempt must answer to what is in force when it runs.
- `WithResolvedLimits` returns a copy rather than mutating, so consumers holding an earlier answer continue reading it correctly.
- Limits are deduplicated on resolution to prevent a holder reached through both slots from being charged twice.
- Weight does not compose — the scoping grant wins where it expresses a preference, as the more specific context.
- Key restrictions compose only when both slots authorize the request for the provider; a grant not authorizing the request does not get to restrict which keys serve it.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go version
go test ./...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

`EffectiveAccess` is resolved once and stored on the context; consumers must not bypass `EffectiveAccessFromContext` and derive their own answer, as that would allow access decisions to diverge. The nil-means-unresolved invariant in `RecordEffectiveAccess` ensures a request carrying no grant cannot be mistaken for one that was resolved and permits nothing.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable