### PR TITLE
refactor: unify governance limit assembly, enforcement, and billing onto a single resolved access so checked, recorded, and charged sets cannot diverge

### DIFF
--- a/plugins/governance/accounting_test.go
+++ b/plugins/governance/accounting_test.go
@@ -68,7 +68,7 @@ func newAccountingFixture(t *testing.T) *accountingFixture {
 
 func (f *accountingFixture) apply(updates ...*UsageUpdate) {
 	for _, u := range updates {
-		f.tracker.UpdateUsage(context.Background(), u)
+		f.tracker.UpdateUsage(context.Background(), settleLimits(f.store, "sk-bf-acct", schemas.OpenAI, "gpt-4", u))
 	}
 	// Let async processing settle.
 	time.Sleep(250 * time.Millisecond)
@@ -89,9 +89,6 @@ func (f *accountingFixture) tokens() int64 {
 // acctUpdate builds a terminal (non-streaming) usage update for accounting tests.
 func acctUpdate(requestID string, attempt int, success bool, cost float64, tokens int64) *UsageUpdate {
 	return &UsageUpdate{
-		VirtualKey:    "sk-bf-acct",
-		Provider:      schemas.OpenAI,
-		Model:         "gpt-4",
 		Success:       success,
 		TokensUsed:    tokens,
 		Cost:          cost,
@@ -124,12 +121,10 @@ func TestAccounting_StreamingChunksAccumulate(t *testing.T) {
 	f := newAccountingFixture(t)
 
 	nonFinal := &UsageUpdate{
-		VirtualKey: "sk-bf-acct", Provider: schemas.OpenAI, Model: "gpt-4",
 		Success: true, TokensUsed: 50, Cost: 0.0, RequestID: "req-s", AttemptNumber: 0,
 		IsStreaming: true, IsFinalChunk: false, HasUsageData: true,
 	}
 	final := &UsageUpdate{
-		VirtualKey: "sk-bf-acct", Provider: schemas.OpenAI, Model: "gpt-4",
 		Success: true, TokensUsed: 0, Cost: 12.5, RequestID: "req-s", AttemptNumber: 0,
 		IsStreaming: true, IsFinalChunk: true, HasUsageData: true,
 	}
@@ -148,7 +143,6 @@ func TestAccounting_FailedStreamingBilledOnceAndAccumulates(t *testing.T) {
 
 	mk := func(reqID string) *UsageUpdate {
 		return &UsageUpdate{
-			VirtualKey: "sk-bf-acct", Provider: schemas.OpenAI, Model: "gpt-4",
 			Success: false, TokensUsed: 200, Cost: 8.0, RequestID: reqID, AttemptNumber: 0,
 			IsStreaming: true, IsFinalChunk: true, HasUsageData: true,
 		}
@@ -218,79 +212,6 @@ func TestAccounting_ZeroCostFailureNotBilled(t *testing.T) {
 	assert.Equal(t, 0.0, f.cost(), "no-usage failure bills no cost")
 	assert.Equal(t, int64(0), f.requests(), "no-usage failure counts no request")
 	assert.Equal(t, int64(0), f.tokens(), "no-usage failure counts no tokens")
-}
-
-// userUsageSpy records the user-entity bumps a batch settlement makes. The OSS
-// store implements them as no-ops (user governance is enterprise), so the spy is
-// what pins the contract an enterprise store relies on.
-type userUsageSpy struct {
-	GovernanceStore
-	budgetBumps    []float64
-	rateLimitBumps []int64
-	users          []string
-}
-
-func (s *userUsageSpy) UpdateUserBudgetUsageInMemory(ctx context.Context, userID string, cost float64) error {
-	s.users = append(s.users, userID)
-	s.budgetBumps = append(s.budgetBumps, cost)
-	return nil
-}
-
-func (s *userUsageSpy) UpdateUserRateLimitUsageInMemory(ctx context.Context, userID string, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error {
-	s.rateLimitBumps = append(s.rateLimitBumps, tokensUsed)
-	return nil
-}
-
-// A user's own budget has no id in BudgetIDs, so before this it was never charged
-// for batch spend — the gap that let a batch bypass every per-user limit under an
-// access profile, where the virtual key is shared and the user is the only thing
-// separating one person's spend from another's.
-func TestReportBatchUsage_ChargesUserEntity(t *testing.T) {
-	f := newAccountingFixture(t)
-	spy := &userUsageSpy{GovernanceStore: f.store}
-	plugin := &GovernancePlugin{store: spy, tracker: f.tracker}
-	report := batchaccounting.BatchUsageReport{
-		RequestID:    "batch-cost:openai:batch-user",
-		Provider:     schemas.OpenAI,
-		Model:        "gpt-4o-mini",
-		Cost:         12.5,
-		TokensUsed:   123,
-		BudgetIDs:    []string{"budget1"},
-		RateLimitIDs: []string{"rl1"},
-		UserID:       "user-alice",
-	}
-
-	// Settlement is at-least-once, so a repeated report must not double-charge.
-	require.NoError(t, plugin.ReportBatchUsage(context.Background(), report))
-	require.NoError(t, plugin.ReportBatchUsage(context.Background(), report))
-
-	assert.Equal(t, []string{"user-alice"}, spy.users)
-	assert.Equal(t, []float64{12.5}, spy.budgetBumps)
-	assert.Equal(t, []int64{123}, spy.rateLimitBumps)
-	// The budget-id tier is charged exactly once as well, and stays independent of
-	// the user tier: the ids carry the user's model-config scopes, not the user.
-	assert.Equal(t, 12.5, f.cost())
-}
-
-// No user on the report (no user auth, or a pre-migration batch job) must leave the
-// user tier entirely alone.
-func TestReportBatchUsage_WithoutUserSkipsUserEntity(t *testing.T) {
-	f := newAccountingFixture(t)
-	spy := &userUsageSpy{GovernanceStore: f.store}
-	plugin := &GovernancePlugin{store: spy, tracker: f.tracker}
-
-	require.NoError(t, plugin.ReportBatchUsage(context.Background(), batchaccounting.BatchUsageReport{
-		RequestID:    "batch-cost:openai:batch-nouser",
-		Provider:     schemas.OpenAI,
-		Cost:         3.0,
-		TokensUsed:   10,
-		BudgetIDs:    []string{"budget1"},
-		RateLimitIDs: []string{"rl1"},
-	}))
-
-	assert.Empty(t, spy.users)
-	assert.Empty(t, spy.budgetBumps)
-	assert.Empty(t, spy.rateLimitBumps)
 }
 
 // modelScopedFixture wires a user-scoped per-model budget (how an access profile's
@@ -380,4 +301,95 @@ func TestReportBatchUsage_PerModelChargingIsInertWithoutModelConfigs(t *testing.
 
 	assert.Equal(t, 0.0, f.budgetUsage("model-budget"), "a model with no config of its own charges nothing extra")
 	assert.Equal(t, 12.0, f.budgetUsage("wildcard-budget"))
+}
+
+// The set a request is checked against, the set named on its log row, and the set its usage is counted
+// against are one list. This is what several independent walks over the holder's shape used to risk: a
+// limit enforced on a request and then not counted lets a caller spend past it forever, and one counted
+// but never enforced drains without ever refusing anything.
+func TestAccounting_ChargesExactlyWhatWasChecked(t *testing.T) {
+	logger := NewMockLogger()
+
+	keyRL := buildRateLimitWithUsage("rl-key", 1_000_000, 0, 1_000_000, 0)
+	openaiRL := buildRateLimitWithUsage("rl-key-openai", 1_000_000, 0, 1_000_000, 0)
+	bedrockRL := buildRateLimitWithUsage("rl-key-bedrock", 1_000_000, 0, 1_000_000, 0)
+	teamRL := buildRateLimitWithUsage("rl-team", 1_000_000, 0, 1_000_000, 0)
+	providerRL := buildRateLimitWithUsage("rl-provider", 1_000_000, 0, 1_000_000, 0)
+	modelRL := buildRateLimitWithUsage("rl-model", 1_000_000, 0, 1_000_000, 0)
+
+	team := buildTeam("team1", "Team 1", nil)
+	team.RateLimitID = &teamRL.ID
+	vk := buildVirtualKeyWithRateLimit("vk1", "sk-bf-charge", "Charging VK", keyRL)
+	vk.TeamID = &team.ID
+	vk.Team = team
+	vk.ProviderConfigs = []configstoreTables.TableVirtualKeyProviderConfig{
+		buildProviderConfigWithRateLimit("openai", []string{"*"}, openaiRL),
+		buildProviderConfigWithRateLimit("bedrock", []string{"*"}, bedrockRL),
+	}
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys:  []configstoreTables.TableVirtualKey{*vk},
+		Teams:        []configstoreTables.TableTeam{*team},
+		Providers:    []configstoreTables.TableProvider{*buildProviderWithGovernance("openai", nil, providerRL)},
+		ModelConfigs: []configstoreTables.TableModelConfig{*buildModelConfig("mc1", "gpt-4o", nil, nil, modelRL)},
+		RateLimits: []configstoreTables.TableRateLimit{
+			*keyRL, *openaiRL, *bedrockRL, *teamRL, *providerRL, *modelRL,
+		},
+	}, nil, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, plugin.Cleanup()) })
+
+	ctx := resolverCtx(store, "sk-bf-charge")
+
+	// The whole funnel: the check settles what this request answers to, the response counts against it.
+	_, shortCircuit, err := plugin.PreLLMHook(ctx, newChatRequest())
+	require.NoError(t, err)
+	require.Nil(t, shortCircuit, "the request is within every limit, so it is not refused")
+
+	_, _, err = plugin.PostLLMHook(ctx, countableResponse(), nil)
+	require.NoError(t, err)
+	plugin.wg.Wait()
+
+	// What the log row names as co-payers, for a node replaying usage it never saw.
+	recorded, _ := ctx.Value(schemas.BifrostContextKeyGovernanceRateLimitIDs).([]string)
+	require.NotEmpty(t, recorded)
+
+	// What actually moved.
+	counted := []string{}
+	for id, rateLimit := range store.GetGovernanceData(context.Background()).RateLimits {
+		if rateLimit.TokenCurrentUsage > 0 {
+			counted = append(counted, id)
+		}
+	}
+
+	assert.ElementsMatch(t, recorded, counted,
+		"every co-payer recorded was counted, and nothing was counted that was not recorded")
+	assert.ElementsMatch(t,
+		[]string{"rl-provider", "rl-model", "rl-key", "rl-key-openai", "rl-team"}, counted)
+	assert.NotContains(t, counted, "rl-key-bedrock",
+		"a provider this request did not use does not pay for it")
+
+	for _, id := range counted {
+		limit := store.GetGovernanceData(context.Background()).RateLimits[id]
+		assert.Equal(t, int64(1000), limit.TokenCurrentUsage, id)
+		assert.Equal(t, int64(1), limit.RequestCurrentUsage, id)
+	}
+}
+
+// countableResponse is a completed chat response whose usage the accounting path counts.
+func countableResponse() *schemas.BifrostResponse {
+	return &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			Model: "gpt-4o",
+			Usage: &schemas.BifrostLLMUsage{PromptTokens: 600, CompletionTokens: 400, TotalTokens: 1000},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:            schemas.ChatCompletionRequest,
+				Provider:               schemas.OpenAI,
+				OriginalModelRequested: "gpt-4o",
+			},
+		},
+	}
 }

--- a/plugins/governance/hookrefusal_test.go
+++ b/plugins/governance/hookrefusal_test.go
@@ -1,0 +1,157 @@
+package governance
+
+// What a credential resolved to decides whether a request may proceed at all, and this file asserts that
+// through the hook a deployment actually calls rather than through the verdict behind it. Two things exist
+// only on that path: what the caller is answered with (a short circuit carrying a status a client can act
+// on rather than a decision struct) and the mark a refusal leaves on the request, which is what keeps a
+// request that never reached a provider from being billed for the tokens it never spent, and which the
+// allow path has to take back off again before a fallback retry is billed for the attempt that did run.
+//
+// The two levels genuinely answer differently, which is why the refusals are asserted at the outer one:
+// the access checks allow a request no access was resolved for (an allowlist there is none of cannot deny
+// anything) while the funnel in front of them refuses it, because only the funnel asks what the request
+// carried rather than what it resolved to.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// refusalTestUnknownVKValue is a key value no store in this file serves, standing in for one that was
+// issued and has since been deleted or revoked.
+const refusalTestUnknownVKValue = "sk-bf-refusal-revoked"
+
+// refusalTestPlugin builds a plugin serving exactly one virtual key, with mutate free to make that key
+// unusable. Mandatory authentication is off throughout this file, so nothing here is refused for
+// failing to present a credential: every refusal below is the funnel answering for what the presented
+// one resolved to.
+func refusalTestPlugin(t *testing.T, mutate func(vk *configstoreTables.TableVirtualKey)) *GovernancePlugin {
+	t.Helper()
+	vk := buildVKForMCPStamping([]string{"read_file"})
+	if mutate != nil {
+		mutate(vk)
+	}
+	return newAccessTestPlugin(t, vk, nil)
+}
+
+// refusalTestRefusalFor runs a chat request through the LLM hook and returns the error the caller is
+// answered with. Going through the hook is the point: it is the whole path a request takes, and the
+// caller never sees the verdict behind the error.
+func refusalTestRefusalFor(t *testing.T, plugin *GovernancePlugin, ctx *schemas.BifrostContext) *schemas.BifrostError {
+	t.Helper()
+	_, shortCircuit, err := plugin.PreLLMHook(ctx, newChatRequest())
+	require.NoError(t, err)
+	require.NotNil(t, shortCircuit, "the request reached the provider instead of being turned away")
+	require.NotNil(t, shortCircuit.Error, "a refused request has to carry the reason it was refused")
+	require.NotNil(t, shortCircuit.Error.Error)
+
+	// Every refusal also marks the request, which is what keeps a request that never ran from being
+	// billed for the tokens it never spent.
+	assert.Equal(t, true, ctx.Value(governanceRejectedContextKey),
+		"a refused request is marked refused for everything downstream")
+
+	return shortCircuit.Error
+}
+
+// A credential that was presented and resolved to nothing is a failed authentication. Nothing resolved
+// is not the same as nothing restricting the request: were it read as the latter, deleting a key would
+// promote every request made with it to what a request carrying no credential at all has, which is
+// unrestricted, the widest access there is.
+func TestPreLLMHookRefusesACredentialThatResolvesToNothing(t *testing.T) {
+	plugin := refusalTestPlugin(t, nil)
+	ctx := presentCtx(refusalTestUnknownVKValue)
+
+	bifrostErr := refusalTestRefusalFor(t, plugin, ctx)
+
+	require.NotNil(t, bifrostErr.StatusCode)
+	assert.Equal(t, 401, *bifrostErr.StatusCode, "authentication failed rather than permission denied")
+	require.NotNil(t, bifrostErr.Type)
+	assert.Equal(t, string(DecisionAccessNotFound), *bifrostErr.Type)
+	assert.Contains(t, bifrostErr.Error.Message, "credential", "the caller is told the credential is the problem")
+
+	assert.Nil(t, ctx.Grant().Access(),
+		"nothing was resolved for the request, and that must not be recorded as an access permitting everything")
+}
+
+// A key switched off may not be used, and the refusal says so in words its holder can act on: the
+// answer to a disabled key is not that some budget ran out, nor a bare 403.
+func TestPreLLMHookRefusesAnInactiveGrant(t *testing.T) {
+	plugin := refusalTestPlugin(t, func(vk *configstoreTables.TableVirtualKey) {
+		inactive := false
+		vk.IsActive = &inactive
+	})
+
+	bifrostErr := refusalTestRefusalFor(t, plugin, newPreRequestCtx(nil, nil))
+
+	require.NotNil(t, bifrostErr.StatusCode)
+	assert.Equal(t, 403, *bifrostErr.StatusCode, "the credential is real, so this is a permission answer")
+	require.NotNil(t, bifrostErr.Type)
+	assert.Equal(t, string(DecisionAccessBlocked), *bifrostErr.Type)
+	assert.Contains(t, bifrostErr.Error.Message, "virtual key is inactive",
+		"the refusal names what is inactive, so a deployment granting access through something else does not report it as a key")
+}
+
+// Expiry is the other half of the same gate, and is reported distinctly from being switched off: a key
+// that ran out is renewed and a key that was disabled is re-enabled, and the holder needs to know which.
+func TestPreLLMHookRefusesAnExpiredGrant(t *testing.T) {
+	past := time.Now().UTC().Add(-time.Second)
+	plugin := refusalTestPlugin(t, func(vk *configstoreTables.TableVirtualKey) { vk.ExpiresAt = &past })
+
+	bifrostErr := refusalTestRefusalFor(t, plugin, newPreRequestCtx(nil, nil))
+
+	require.NotNil(t, bifrostErr.StatusCode)
+	assert.Equal(t, 403, *bifrostErr.StatusCode)
+	require.NotNil(t, bifrostErr.Type)
+	assert.Equal(t, string(DecisionAccessBlocked), *bifrostErr.Type)
+	assert.Contains(t, bifrostErr.Error.Message, "virtual key has expired")
+	assert.NotContains(t, bifrostErr.Error.Message, "inactive", "run out is not switched off")
+}
+
+// The contrast the refusals above must not swallow. A request presenting nothing, where nothing obliges
+// it to, is what every deployment that has not turned on governance looks like: it is allowed, and it
+// carries no access at all, which every consumer reads as unrestricted.
+//
+// It also has to come out of the hook unmarked, which is why it goes in marked. A request refused on its
+// first attempt and then retried against a fallback arrives here still carrying the mark of the attempt
+// that failed; were the allow path not to take it off, the attempt that did reach a provider would look
+// like one that never ran, and the tokens it really spent would go uncharged.
+func TestPreLLMHookAllowsARequestThatPresentsNothing(t *testing.T) {
+	plugin := refusalTestPlugin(t, nil)
+	ctx := emptyCtx()
+	// The state a refused first attempt leaves behind before a fallback is tried.
+	ctx.SetValue(governanceRejectedContextKey, true)
+
+	_, shortCircuit, err := plugin.PreLLMHook(ctx, newChatRequest())
+
+	require.NoError(t, err)
+	require.Nil(t, shortCircuit, "nothing obliged the request to authenticate and nothing restricts it")
+	assert.Nil(t, ctx.Value(governanceRejectedContextKey), "an allowed request does not stay marked refused")
+
+	assert.Nil(t, ctx.Grant().Access(), "nothing granted it anything, so it carries no access")
+	require.NotNil(t, ctx.Grant().Limits(), "and still answers to the deployment's own limits, settled on its grant")
+}
+
+// Why the refusals above are asserted at the funnel every hook calls rather than one level down: handed
+// the same request, the access checks allow it. That is deliberate on both sides. The checks apply what a
+// request may reach, and a request nothing was resolved for has no allowlist to be measured against, so
+// they have nothing to deny it with: they answer for an access, never for the credential behind it, and
+// telling a presented-but-unresolvable credential apart from an absent one needs what the request carried.
+//
+// This characterises that answer rather than a path production leans on: the funnel refuses such a request
+// before the checks ever see it, so a later decision to fail closed here would be a hardening rather than
+// a regression, but it would be one made deliberately, not by a check quietly changing its mind.
+func TestTheAccessChecksAllowACredentialThatResolvedToNothing(t *testing.T) {
+	plugin := refusalTestPlugin(t, nil)
+	ctx := resolverCtx(plugin.store, refusalTestUnknownVKValue)
+	require.Nil(t, ctx.Grant().Access(), "the store resolved no access for this credential")
+
+	allowed := evaluateVirtualKey(plugin.resolver, ctx, refusalTestUnknownVKValue,
+		schemas.OpenAI, "gpt-4o", schemas.ChatCompletionRequest, false, false)
+
+	assertDecision(t, DecisionAllow, allowed)
+}

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -1122,56 +1122,55 @@ func (p *GovernancePlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 	// Extract request type, provider, and model
 	requestType, provider, requestedModel, _ := bifrost.GetResponseFields(result, err)
 
-	// Extract governance information
-	virtualKey := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyVirtualKey)
 	requestID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyRequestID)
-	// Extract user ID for enterprise user-level governance
-
-	// A request that presented a key, or that carries grants without one, sees only the models it
-	// may use. A request holding neither is unrestricted and its listing is left alone.
-	//
-	// The key still counts on its own: a key that was presented but resolves to nothing must list
-	// nothing, since the key granted the access and the answer went missing.
-	if requestType == schemas.ListModelsRequest && result != nil && result.ListModelsResponse != nil &&
-		(virtualKey != "" || ctx.Grant().Access() != nil) {
-		result.ListModelsResponse.Data = p.filterModelsForAccess(ctx, result.ListModelsResponse.Data)
-	}
 
 	isFinalChunk := bifrost.IsFinalChunk(ctx)
+
+	// What this request was admitted under, read rather than resolved: everything below reports on a
+	// call that has already happened, and resolving now would answer for whatever configuration has
+	// become in the meantime.
+	access := ctx.Grant().Access()
+
+	// A request that presented something sees only the models it may use, and a credential that
+	// resolved to nothing lists nothing. A request that presented nothing is unrestricted and its
+	// listing is left alone.
+	if requestType == schemas.ListModelsRequest && result != nil && result.ListModelsResponse != nil &&
+		(presentedGrantBearingCredential(ctx) || access != nil) {
+		result.ListModelsResponse.Data = p.filterModelsForAccess(access, result.ListModelsResponse.Data)
+	}
 
 	// Build pricing scopes from context using the governance VK ID (not the raw VK token)
 	pricingScopes := modelcatalog.PricingLookupScopesFromContext(ctx, string(provider))
 
-	// Always process usage tracking. When both virtual key and user are present,
-	// track both scopes; callers that intentionally want user-only accounting can
-	// set BifrostContextKeySkipVirtualKeyUsageTracking.
-	userID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyUserID)
-	effectiveVK := virtualKey
-	if bifrost.GetBoolFromContext(ctx, schemas.BifrostContextKeySkipVirtualKeyUsageTracking) {
-		effectiveVK = ""
-	}
-	// If effectiveVK is empty, it will be passed as empty string to postHookWorker
-	// The tracker will handle empty virtual keys gracefully by only updating provider-level and model-level usage
+	// A caller can ask for the holder's usage not to be counted, leaving what the deployment and the
+	// user answer to still counted.
+	skipHolderUsage := bifrost.GetBoolFromContext(ctx, schemas.BifrostContextKeySkipVirtualKeyUsageTracking)
 	if requestedModel != "" {
 		// Collect the affected budget and rate-limit IDs synchronously (fast in-memory
 		// lookups) and attach them to the context. The logging plugin reads these keys
 		// when building the log entry, enabling ghost-node usage reconciliation to
 		// attribute cost/tokens to the correct governance entities.
 		//
-		// Read the limits already settled on the grant, not resolved again: the co-payers recorded
-		// have to be the ones that were checked, and resolving again after the call would answer for
-		// whatever configuration has become in the meantime.
-		accountedLimits := ctx.Grant().Limits()
-		if virtualKey != "" && effectiveVK == "" {
-			// Usage the tracker is being told not to charge must not be recorded as charged either,
-			// or replaying a ghosted node's log invents usage nothing ever debited.
-			accountedLimits = nil
+		// Read the limits settled on the grant, and only those. The grant is the one record of what
+		// this attempt was subject to, so what is billed and what is recorded are the same list the
+		// check used. A request that reached here without being evaluated answers to nothing and is
+		// billed nothing, which is the only consistent answer: charging what was never checked is the
+		// divergence this exists to prevent.
+		var accountedBudgets, accountedRateLimits []schemas.Limit
+		if limits := ctx.Grant().Limits(); limits != nil {
+			accountedBudgets, accountedRateLimits = limits.Budgets(), limits.RateLimits()
 		}
-		budgetIDs, rateLimitIDs := p.store.CollectApplicableGovernanceIDs(ctx, accountedLimits, provider, requestedModel)
-		if len(budgetIDs) > 0 {
+		if skipHolderUsage {
+			// The holder's usage is not being counted, so nothing it funds is billed or recorded. What
+			// the deployment and the user fund still is: those are owed whatever granted the request,
+			// and dropping them would let a caller spend against them without limit.
+			accountedBudgets = grant.LimitsFrom(accountedBudgets, untrackedHolderKinds...)
+			accountedRateLimits = grant.LimitsFrom(accountedRateLimits, untrackedHolderKinds...)
+		}
+		if budgetIDs := limitIDsOf(accountedBudgets); len(budgetIDs) > 0 {
 			ctx.SetValue(schemas.BifrostContextKeyGovernanceBudgetIDs, budgetIDs)
 		}
-		if len(rateLimitIDs) > 0 {
+		if rateLimitIDs := limitIDsOf(accountedRateLimits); len(rateLimitIDs) > 0 {
 			ctx.SetValue(schemas.BifrostContextKeyGovernanceRateLimitIDs, rateLimitIDs)
 		}
 
@@ -1191,7 +1190,7 @@ func (p *GovernancePlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 				}
 			}()
 			// Use the requested model for usage tracking
-			p.postHookWorker(result, err, provider, requestedModel, requestType, effectiveVK, requestID, userID, isFinalChunk, attemptNumber, pricingScopes)
+			p.postHookWorker(result, err, provider, requestedModel, requestType, requestID, isFinalChunk, attemptNumber, pricingScopes, accountedBudgets, accountedRateLimits)
 		}()
 	}
 
@@ -1292,18 +1291,7 @@ func (p *GovernancePlugin) PostMCPHook(ctx *schemas.BifrostContext, resp *schema
 		return resp, bifrostErr, nil
 	}
 
-	// Extract governance information
-	virtualKey := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyVirtualKey)
 	requestID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyRequestID)
-
-	if bifrost.GetBoolFromContext(ctx, schemas.BifrostContextKeySkipVirtualKeyUsageTracking) {
-		virtualKey = ""
-	}
-
-	// Skip if no virtual key
-	if virtualKey == "" {
-		return resp, bifrostErr, nil
-	}
 
 	// Determine if request was successful
 	success := (resp != nil && bifrostErr == nil)
@@ -1323,15 +1311,33 @@ func (p *GovernancePlugin) PostMCPHook(ctx *schemas.BifrostContext, resp *schema
 		}
 	}
 
-	// Create usage update for tracker (business logic) - MCP requests track request count and tool cost
+	// Create usage update for tracker (business logic) - MCP requests track request count and tool cost.
+	//
+	// Tool execution names no provider and no model, so what it answers to is whatever funds the
+	// holder, read from the limits settled when the tool call was evaluated, the same list that
+	// admitted it.
+	//
+	// Not gated on a credential. Skipping accounting when no key was presented would mean a request
+	// the deployment does charge for goes unbilled, and asking the key here would be a second answer
+	// to a question the grant already settled.
+	var budgets, rateLimits []schemas.Limit
+	if limits := ctx.Grant().Limits(); limits != nil {
+		budgets, rateLimits = limits.Budgets(), limits.RateLimits()
+	}
+	if bifrost.GetBoolFromContext(ctx, schemas.BifrostContextKeySkipVirtualKeyUsageTracking) {
+		// The holder's usage is not being counted; what the deployment and the user answer to still is.
+		budgets = grant.LimitsFrom(budgets, untrackedHolderKinds...)
+		rateLimits = grant.LimitsFrom(rateLimits, untrackedHolderKinds...)
+	}
 	usageUpdate := &UsageUpdate{
-		VirtualKey:   virtualKey,
 		Success:      success,
 		Cost:         toolCost,
 		RequestID:    requestID,
 		IsStreaming:  false,
 		IsFinalChunk: true,
 		HasUsageData: toolCost > 0, // Has usage data if we have a cost
+		Budgets:      budgets,
+		RateLimits:   rateLimits,
 	}
 
 	// Queue usage update asynchronously using tracker
@@ -1412,12 +1418,11 @@ func (p *GovernancePlugin) Cleanup() error {
 //   - virtualKey: The raw virtual key token of the request (empty string if not present)
 //   - selectedKeyID: The selected provider key ID used for scoped pricing overrides
 //   - requestID: The request ID
-//   - userID: The user ID for enterprise user-level governance (empty string if not present)
 //   - isCacheRead: Whether the request is a cache read
 //   - isBatch: Whether the request is a batch request
 //   - isFinalChunk: Whether the request is the final chunk
 //   - pricingScopes: Prebuilt pricing lookup scopes using governance VK ID (nil if not applicable)
-func (p *GovernancePlugin) postHookWorker(result *schemas.BifrostResponse, bifrostErr *schemas.BifrostError, provider schemas.ModelProvider, model string, requestType schemas.RequestType, virtualKey, requestID, userID string, isFinalChunk bool, attemptNumber int, pricingScopes *modelcatalog.PricingLookupScopes) {
+func (p *GovernancePlugin) postHookWorker(result *schemas.BifrostResponse, bifrostErr *schemas.BifrostError, provider schemas.ModelProvider, model string, requestType schemas.RequestType, requestID string, isFinalChunk bool, attemptNumber int, pricingScopes *modelcatalog.PricingLookupScopes, budgets, rateLimits []schemas.Limit) {
 	// Determine if request was successful
 	success := (result != nil)
 	billedReason := "success"
@@ -1471,19 +1476,17 @@ func (p *GovernancePlugin) postHookWorker(result *schemas.BifrostResponse, bifro
 
 		// Create usage update for tracker (business logic)
 		usageUpdate := &UsageUpdate{
-			VirtualKey:    virtualKey,
-			Provider:      provider,
-			Model:         model,
 			Success:       success,
 			TokensUsed:    int64(tokensUsed),
 			Cost:          cost,
 			RequestID:     requestID,
-			UserID:        userID,
 			IsStreaming:   isStreaming,
 			IsFinalChunk:  isFinalChunk,
 			HasUsageData:  tokensUsed > 0 || cost > 0,
 			AttemptNumber: attemptNumber,
 			BilledReason:  billedReason,
+			Budgets:       budgets,
+			RateLimits:    rateLimits,
 		}
 
 		// Queue usage update asynchronously using tracker
@@ -1530,26 +1533,10 @@ func (p *GovernancePlugin) ReportBatchUsage(ctx context.Context, usage batchacco
 		}
 	}
 
-	if usage.UserID != "" {
-		billingKey := fmt.Sprintf("%s:user-rate-limit:%s", usage.RequestID, usage.UserID)
-		if usage.RequestID == "" || p.tracker.tryClaimBatchBilling(billingKey) {
-			if err := p.store.UpdateUserRateLimitUsageInMemory(ctx, usage.UserID, usage.TokensUsed, true, true); err != nil {
-				p.tracker.releaseBatchBilling(billingKey)
-				errs = append(errs, err)
-			}
-		}
-	}
-
-	if usage.UserID != "" && usage.Cost > 0 {
-		billingKey := fmt.Sprintf("%s:user-budget:%s", usage.RequestID, usage.UserID)
-		if usage.RequestID == "" || p.tracker.tryClaimBatchBilling(billingKey) {
-			if err := p.store.UpdateUserBudgetUsageInMemory(ctx, usage.UserID, usage.Cost); err != nil {
-				p.tracker.releaseBatchBilling(billingKey)
-				errs = append(errs, err)
-			}
-		}
-	}
-
+	// The user's own limits are not a tier of their own here. What funds the user was gathered onto
+	// the request's grant when the batch was created, alongside every other co-payer, so its ids are
+	// already in BudgetIDs and RateLimitIDs and were bumped above. A second pass keyed by user would
+	// bill the same limits twice.
 	errs = append(errs, p.reportBatchModelUsage(ctx, usage)...)
 
 	return errors.Join(errs...)

--- a/plugins/governance/modelprovidergovernance_test.go
+++ b/plugins/governance/modelprovidergovernance_test.go
@@ -278,7 +278,7 @@ func TestStore_UpdateModelBudgetUsage_MultiBudget_BumpsAll(t *testing.T) {
 	}, nil, nil)
 	require.NoError(t, err)
 
-	err = store.UpdateProviderAndModelBudgetUsageInMemory(context.Background(), "gpt-4", schemas.OpenAI, 7.5)
+	err = chargeDeploymentBudgets(store, context.Background(), "gpt-4", schemas.OpenAI, 7.5)
 	require.NoError(t, err)
 
 	for _, id := range []string{"b-day", "b-hour"} {
@@ -517,7 +517,7 @@ func TestStore_UpdateProviderBudgetUsage_NoConfig(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil, nil)
 	require.NoError(t, err)
 
-	err = store.UpdateProviderAndModelBudgetUsageInMemory(context.Background(), "", schemas.OpenAI, 10.0)
+	err = chargeDeploymentBudgets(store, context.Background(), "", schemas.OpenAI, 10.0)
 	assert.NoError(t, err, "Should not error when no provider config exists")
 }
 
@@ -531,7 +531,7 @@ func TestStore_UpdateProviderBudgetUsage_UpdatesUsage(t *testing.T) {
 	}, nil, nil)
 	require.NoError(t, err)
 
-	err = store.UpdateProviderAndModelBudgetUsageInMemory(context.Background(), "", schemas.OpenAI, 10.0)
+	err = chargeDeploymentBudgets(store, context.Background(), "", schemas.OpenAI, 10.0)
 	assert.NoError(t, err, "Should successfully update provider budget usage")
 
 	// Verify usage was updated
@@ -539,7 +539,7 @@ func TestStore_UpdateProviderBudgetUsage_UpdatesUsage(t *testing.T) {
 	assert.NoError(t, err, "Should still be within limit after first update")
 
 	// Update again to exceed
-	err = store.UpdateProviderAndModelBudgetUsageInMemory(context.Background(), "", schemas.OpenAI, 95.0)
+	err = chargeDeploymentBudgets(store, context.Background(), "", schemas.OpenAI, 95.0)
 	assert.NoError(t, err, "Should successfully update provider budget usage even when exceeding")
 
 	// Now should be exceeded
@@ -557,7 +557,7 @@ func TestStore_UpdateProviderRateLimitUsage_NoConfig(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil, nil)
 	require.NoError(t, err)
 
-	err = store.UpdateProviderAndModelRateLimitUsageInMemory(context.Background(), "", schemas.OpenAI, 1000, true, true)
+	err = chargeDeploymentRateLimits(store, context.Background(), "", schemas.OpenAI, 1000, true, true)
 	assert.NoError(t, err, "Should not error when no provider config exists")
 }
 
@@ -571,7 +571,7 @@ func TestStore_UpdateProviderRateLimitUsage_UpdatesTokens(t *testing.T) {
 	}, nil, nil)
 	require.NoError(t, err)
 
-	err = store.UpdateProviderAndModelRateLimitUsageInMemory(context.Background(), "", schemas.OpenAI, 5000, true, false)
+	err = chargeDeploymentRateLimits(store, context.Background(), "", schemas.OpenAI, 5000, true, false)
 	assert.NoError(t, err, "Should successfully update provider token usage")
 
 	// Check that tokens were updated but requests were not
@@ -580,7 +580,7 @@ func TestStore_UpdateProviderRateLimitUsage_UpdatesTokens(t *testing.T) {
 	assert.Equal(t, DecisionAllow, decision)
 
 	// Update tokens to exceed
-	err = store.UpdateProviderAndModelRateLimitUsageInMemory(context.Background(), "", schemas.OpenAI, 6000, true, false)
+	err = chargeDeploymentRateLimits(store, context.Background(), "", schemas.OpenAI, 6000, true, false)
 	assert.NoError(t, err, "Should successfully update provider token usage even when exceeding")
 
 	// Now should be exceeded
@@ -602,7 +602,7 @@ func TestStore_UpdateProviderRateLimitUsage_UpdatesRequests(t *testing.T) {
 
 	// Update requests 500 times
 	for i := 0; i < 500; i++ {
-		err = store.UpdateProviderAndModelRateLimitUsageInMemory(context.Background(), "", schemas.OpenAI, 0, false, true)
+		err = chargeDeploymentRateLimits(store, context.Background(), "", schemas.OpenAI, 0, false, true)
 		assert.NoError(t, err, "Should successfully update provider request usage")
 	}
 
@@ -613,7 +613,7 @@ func TestStore_UpdateProviderRateLimitUsage_UpdatesRequests(t *testing.T) {
 
 	// Update 500 more times to exceed
 	for i := 0; i < 500; i++ {
-		err = store.UpdateProviderAndModelRateLimitUsageInMemory(context.Background(), "", schemas.OpenAI, 0, false, true)
+		err = chargeDeploymentRateLimits(store, context.Background(), "", schemas.OpenAI, 0, false, true)
 		assert.NoError(t, err, "Should successfully update provider request usage even when exceeding")
 	}
 
@@ -634,7 +634,7 @@ func TestStore_UpdateModelBudgetUsage_NoConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
-	err = store.UpdateProviderAndModelBudgetUsageInMemory(context.Background(), "gpt-4", provider, 10.0)
+	err = chargeDeploymentBudgets(store, context.Background(), "gpt-4", provider, 10.0)
 	assert.NoError(t, err, "Should not error when no model config exists")
 }
 
@@ -649,7 +649,7 @@ func TestStore_UpdateModelBudgetUsage_ModelOnly_UpdatesUsage(t *testing.T) {
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
-	err = store.UpdateProviderAndModelBudgetUsageInMemory(context.Background(), "gpt-4", provider, 10.0)
+	err = chargeDeploymentBudgets(store, context.Background(), "gpt-4", provider, 10.0)
 	assert.NoError(t, err, "Should successfully update model budget usage")
 
 	// Verify usage was updated
@@ -657,7 +657,7 @@ func TestStore_UpdateModelBudgetUsage_ModelOnly_UpdatesUsage(t *testing.T) {
 	assert.NoError(t, err, "Should still be within limit after first update")
 
 	// Update again to exceed
-	err = store.UpdateProviderAndModelBudgetUsageInMemory(context.Background(), "gpt-4", provider, 95.0)
+	err = chargeDeploymentBudgets(store, context.Background(), "gpt-4", provider, 95.0)
 	assert.NoError(t, err, "Should successfully update model budget usage even when exceeding")
 
 	// Now should be exceeded
@@ -682,7 +682,7 @@ func TestStore_UpdateModelBudgetUsage_ModelWithProvider_UpdatesBoth(t *testing.T
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
-	err = store.UpdateProviderAndModelBudgetUsageInMemory(context.Background(), "gpt-4", provider, 10.0)
+	err = chargeDeploymentBudgets(store, context.Background(), "gpt-4", provider, 10.0)
 	assert.NoError(t, err, "Should successfully update both model-only and model+provider budget usage")
 
 	// Both budgets should be updated
@@ -691,7 +691,7 @@ func TestStore_UpdateModelBudgetUsage_ModelWithProvider_UpdatesBoth(t *testing.T
 	assert.NoError(t, err, "Should still be within limit")
 
 	// Update to exceed model-only budget
-	err = store.UpdateProviderAndModelBudgetUsageInMemory(context.Background(), "gpt-4", provider, 95.0)
+	err = chargeDeploymentBudgets(store, context.Background(), "gpt-4", provider, 95.0)
 	assert.NoError(t, err, "Should successfully update model budget usage even when exceeding")
 
 	// Now model-only budget should be exceeded
@@ -710,7 +710,7 @@ func TestStore_UpdateModelRateLimitUsage_NoConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
-	err = store.UpdateProviderAndModelRateLimitUsageInMemory(context.Background(), "gpt-4", provider, 1000, true, true)
+	err = chargeDeploymentRateLimits(store, context.Background(), "gpt-4", provider, 1000, true, true)
 	assert.NoError(t, err, "Should not error when no model config exists")
 }
 
@@ -725,7 +725,7 @@ func TestStore_UpdateModelRateLimitUsage_ModelOnly_UpdatesUsage(t *testing.T) {
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
-	err = store.UpdateProviderAndModelRateLimitUsageInMemory(context.Background(), "gpt-4", provider, 5000, true, false)
+	err = chargeDeploymentRateLimits(store, context.Background(), "gpt-4", provider, 5000, true, false)
 	assert.NoError(t, err, "Should successfully update model token usage")
 
 	// Should still be within limit
@@ -734,7 +734,7 @@ func TestStore_UpdateModelRateLimitUsage_ModelOnly_UpdatesUsage(t *testing.T) {
 	assert.Equal(t, DecisionAllow, decision)
 
 	// Update to exceed
-	err = store.UpdateProviderAndModelRateLimitUsageInMemory(context.Background(), "gpt-4", provider, 6000, true, false)
+	err = chargeDeploymentRateLimits(store, context.Background(), "gpt-4", provider, 6000, true, false)
 	assert.NoError(t, err, "Should successfully update model token usage even when exceeding")
 
 	// Now should be exceeded
@@ -760,7 +760,7 @@ func TestStore_UpdateModelRateLimitUsage_ModelWithProvider_UpdatesUsage(t *testi
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
-	err = store.UpdateProviderAndModelRateLimitUsageInMemory(context.Background(), "gpt-4", provider, 5000, true, false)
+	err = chargeDeploymentRateLimits(store, context.Background(), "gpt-4", provider, 5000, true, false)
 	assert.NoError(t, err, "Should successfully update both model-only and model+provider token usage")
 
 	// Should still be within limit
@@ -769,7 +769,7 @@ func TestStore_UpdateModelRateLimitUsage_ModelWithProvider_UpdatesUsage(t *testi
 	assert.Equal(t, DecisionAllow, decision)
 
 	// Update to exceed model-only rate limit (should fail at model-only level)
-	err = store.UpdateProviderAndModelRateLimitUsageInMemory(context.Background(), "gpt-4", provider, 6000, true, false)
+	err = chargeDeploymentRateLimits(store, context.Background(), "gpt-4", provider, 6000, true, false)
 	assert.NoError(t, err, "Should successfully update model token usage even when exceeding")
 
 	// Now should be exceeded (model-only rate limit exceeded)
@@ -792,7 +792,7 @@ func TestStore_UpdateModelRateLimitUsage_ModelOnly_UpdatesUsage_RequestLimit(t *
 	provider := schemas.OpenAI
 	// Update requests 500 times
 	for range 500 {
-		err = store.UpdateProviderAndModelRateLimitUsageInMemory(context.Background(), "gpt-4", provider, 0, false, true)
+		err = chargeDeploymentRateLimits(store, context.Background(), "gpt-4", provider, 0, false, true)
 		assert.NoError(t, err, "Should successfully update model request usage")
 	}
 
@@ -803,7 +803,7 @@ func TestStore_UpdateModelRateLimitUsage_ModelOnly_UpdatesUsage_RequestLimit(t *
 
 	// Update 500 more times to exceed
 	for range 500 {
-		err = store.UpdateProviderAndModelRateLimitUsageInMemory(context.Background(), "gpt-4", provider, 0, false, true)
+		err = chargeDeploymentRateLimits(store, context.Background(), "gpt-4", provider, 0, false, true)
 		assert.NoError(t, err, "Should successfully update model request usage even when exceeding")
 	}
 
@@ -832,7 +832,7 @@ func TestStore_UpdateModelRateLimitUsage_ModelWithProvider_UpdatesUsage_RequestL
 	provider := schemas.OpenAI
 	// Update requests 500 times (should update both model-only and model+provider)
 	for range 500 {
-		err = store.UpdateProviderAndModelRateLimitUsageInMemory(context.Background(), "gpt-4", provider, 0, false, true)
+		err = chargeDeploymentRateLimits(store, context.Background(), "gpt-4", provider, 0, false, true)
 		assert.NoError(t, err, "Should successfully update both model-only and model+provider request usage")
 	}
 
@@ -843,7 +843,7 @@ func TestStore_UpdateModelRateLimitUsage_ModelWithProvider_UpdatesUsage_RequestL
 
 	// Update 500 more times to exceed model-only rate limit
 	for range 500 {
-		err = store.UpdateProviderAndModelRateLimitUsageInMemory(context.Background(), "gpt-4", provider, 0, false, true)
+		err = chargeDeploymentRateLimits(store, context.Background(), "gpt-4", provider, 0, false, true)
 		assert.NoError(t, err, "Should successfully update model request usage even when exceeding")
 	}
 
@@ -2071,6 +2071,16 @@ func TestPostHook_TracksVirtualKeyUsageWhenUserIDPresent(t *testing.T) {
 
 	ctx := resolverCtx(store, "sk-bf-test")
 	ctx.SetValue(schemas.BifrostContextKeyUserID, "user1")
+
+	// The funnel settles what this request answers to before anything is billed against it, so the
+	// test runs it: an update carrying no limits is billed nothing, by design.
+	_, shortCircuit, err := plugin.PreLLMHook(ctx, &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{Provider: schemas.OpenAI, Model: "gpt-4"},
+	})
+	require.NoError(t, err)
+	require.Nil(t, shortCircuit)
+
 	result := &schemas.BifrostResponse{
 		ChatResponse: &schemas.BifrostChatResponse{
 			Model: "gpt-4",
@@ -2116,6 +2126,18 @@ func TestPostHook_SkipVirtualKeyUsageTrackingFlag(t *testing.T) {
 	ctx := resolverCtx(store, "sk-bf-test")
 	ctx.SetValue(schemas.BifrostContextKeyUserID, "user1")
 	ctx.SetValue(schemas.BifrostContextKeySkipVirtualKeyUsageTracking, true)
+
+	// Settle the request's limits first, as the sibling test does: without them there is nothing to
+	// bill and the zero-usage assertions below would pass whatever the flag said. With them, it is the
+	// flag alone that keeps the key's rate limit out of the bill.
+	_, shortCircuit, err := plugin.PreLLMHook(ctx, &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{Provider: schemas.OpenAI, Model: "gpt-4"},
+	})
+	require.NoError(t, err)
+	require.Nil(t, shortCircuit)
+	require.NotEmpty(t, ctx.Grant().Limits().RateLimits(), "the key's rate limit was settled, so the flag is what skips it")
+
 	result := &schemas.BifrostResponse{
 		ChatResponse: &schemas.BifrostChatResponse{
 			Model: "gpt-4",
@@ -2161,6 +2183,10 @@ func TestPostMCPHook_TracksVirtualKeyUsageWhenUserIDPresent(t *testing.T) {
 
 	ctx := resolverCtx(store, "sk-bf-test")
 	ctx.SetValue(schemas.BifrostContextKeyUserID, "user1")
+	// Evaluating the tool call settles the limits it answers to, and billing reads them from there.
+	// Tool execution names no provider and no model, so what it answers to is whatever funds the
+	// holder.
+	require.NotNil(t, resolveLimits(ctx, store, "", ""))
 	resp := &schemas.BifrostMCPResponse{
 		ExtraFields: schemas.BifrostMCPResponseExtraFields{
 			MCPRequestType: schemas.MCPRequestTypeExecuteTool,
@@ -2198,6 +2224,7 @@ func TestPostMCPHook_SkipVirtualKeyUsageTrackingFlag(t *testing.T) {
 	ctx := resolverCtx(store, "sk-bf-test")
 	ctx.SetValue(schemas.BifrostContextKeyUserID, "user1")
 	ctx.SetValue(schemas.BifrostContextKeySkipVirtualKeyUsageTracking, true)
+	require.NotNil(t, resolveLimits(ctx, store, "", ""))
 	resp := &schemas.BifrostMCPResponse{
 		ExtraFields: schemas.BifrostMCPResponseExtraFields{
 			MCPRequestType: schemas.MCPRequestTypeExecuteTool,
@@ -2430,11 +2457,11 @@ func TestStore_UpdateModelBudgetUsage_CrossProviderModelMatch(t *testing.T) {
 	require.NoError(t, err)
 
 	// Update usage with prefixed model name
-	err = store.UpdateProviderAndModelBudgetUsageInMemory(context.Background(), "openai/gpt-4o", schemas.OpenRouter, 50.0)
+	err = chargeDeploymentBudgets(store, context.Background(), "openai/gpt-4o", schemas.OpenRouter, 50.0)
 	assert.NoError(t, err, "Should successfully update budget usage via cross-provider match")
 
 	// Now exceed the budget
-	err = store.UpdateProviderAndModelBudgetUsageInMemory(context.Background(), "openai/gpt-4o", schemas.OpenRouter, 55.0)
+	err = chargeDeploymentBudgets(store, context.Background(), "openai/gpt-4o", schemas.OpenRouter, 55.0)
 	assert.NoError(t, err)
 
 	// Budget should now be exceeded
@@ -2458,7 +2485,7 @@ func TestStore_UpdateModelRateLimitUsage_CrossProviderModelMatch(t *testing.T) {
 	require.NoError(t, err)
 
 	// Update token usage with prefixed model name
-	err = store.UpdateProviderAndModelRateLimitUsageInMemory(context.Background(), "openai/gpt-4o", schemas.OpenRouter, 100, true, false)
+	err = chargeDeploymentRateLimits(store, context.Background(), "openai/gpt-4o", schemas.OpenRouter, 100, true, false)
 	assert.NoError(t, err, "Should successfully update rate limit via cross-provider match")
 
 	// Rate limit should now be exceeded
@@ -2576,7 +2603,7 @@ func TestStore_UpdateProviderModelUsage_BumpsAllModelsWildcard(t *testing.T) {
 	require.Equal(t, DecisionAllow, decision)
 
 	// Record usage for a (different) model on the provider — must bump the "*:openai" config.
-	require.NoError(t, store.UpdateProviderAndModelRateLimitUsageInMemory(context.Background(), "gpt-4o", schemas.OpenAI, 150, true, true))
+	require.NoError(t, chargeDeploymentRateLimits(store, context.Background(), "gpt-4o", schemas.OpenAI, 150, true, true))
 
 	// Now the all-models rate limit trips for any model on the provider.
 	decision, err = checkDeploymentRateLimits(store, context.Background(), schemas.OpenAI, "gpt-4o-mini", nil, nil)
@@ -2735,7 +2762,7 @@ func TestStore_VirtualKeyScopedModel_RecordThenCheck_TokenLimitTrips(t *testing.
 
 	// Record usage above the limit (what the tracker does post-response). Provider differs from
 	// the config's (which is all-providers), exercising the model-only scoped lookup.
-	require.NoError(t, store.UpdateScopedModelRateLimitUsageInMemory(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, "claude-opus-4-7", schemas.Anthropic, 150, true, true))
+	require.NoError(t, chargeScopedRateLimits(store, context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, "claude-opus-4-7", schemas.Anthropic, 150, true, true))
 
 	// Now the scoped check must trip.
 	decision, err = checkScopedRateLimits(store, context.Background(), grant.PermitVirtualKey, vk.ID, schemas.Anthropic, "claude-opus-4-7", nil, nil)
@@ -2758,7 +2785,7 @@ func TestStore_VirtualKeyScopedModel_RecordThenCheck_BudgetTrips(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, DecisionAllow, decision)
 
-	require.NoError(t, store.UpdateScopedModelBudgetUsageInMemory(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, "claude-opus-4-7", schemas.Anthropic, 15.0))
+	require.NoError(t, chargeScopedBudgets(store, context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, "claude-opus-4-7", schemas.Anthropic, 15.0))
 
 	_, err = checkScopedBudgets(store, context.Background(), grant.PermitVirtualKey, vk.ID, schemas.Anthropic, "claude-opus-4-7", nil)
 	assert.Error(t, err, "scoped budget should trip once usage exceeds the cap")
@@ -2783,8 +2810,8 @@ func TestStore_VKGovernanceBudget_NoDoubleCount(t *testing.T) {
 	require.NoError(t, err)
 
 	// Mirror tracker.UpdateUsage: scoped-model path + hierarchy path, same request/cost.
-	require.NoError(t, store.UpdateScopedModelBudgetUsageInMemory(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, "gpt-4", schemas.OpenAI, 10.0))
-	require.NoError(t, store.UpdateVirtualKeyBudgetUsageInMemory(context.Background(), vk, schemas.OpenAI, 10.0))
+	require.NoError(t, chargeScopedBudgets(store, context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, "gpt-4", schemas.OpenAI, 10.0))
+	require.NoError(t, chargeGrantBudgets(store, context.Background(), vk, schemas.OpenAI, 10.0))
 
 	b := store.LoadBudget(context.Background(), "vkb")
 	require.NotNil(t, b)

--- a/plugins/governance/permits_test.go
+++ b/plugins/governance/permits_test.go
@@ -982,7 +982,9 @@ func TestFilterModelsForAccess(t *testing.T) {
 	t.Run("keeps only what the request may use", func(t *testing.T) {
 		ctx := presentCtx("sk-bf-test")
 
-		filtered := plugin.filterModelsForAccess(ctx, models)
+		access, err := plugin.ResolveAccess(ctx)
+		require.NoError(t, err)
+		filtered := plugin.filterModelsForAccess(access, models)
 
 		ids := make([]string, 0, len(filtered))
 		for _, model := range filtered {
@@ -998,7 +1000,9 @@ func TestFilterModelsForAccess(t *testing.T) {
 		// authority for the listing and it turned out to grant nothing, so nothing is listed.
 		ctx := presentCtx("sk-bf-unknown")
 
-		filtered := plugin.filterModelsForAccess(ctx, models)
+		access, err := plugin.ResolveAccess(ctx)
+		require.NoError(t, err)
+		filtered := plugin.filterModelsForAccess(access, models)
 
 		assert.NotNil(t, filtered)
 		assert.Empty(t, filtered)
@@ -1011,7 +1015,9 @@ func TestFilterModelsForAccess(t *testing.T) {
 		// access to list against.
 		ctx := emptyCtx()
 
-		filtered := plugin.filterModelsForAccess(ctx, models)
+		access, err := plugin.ResolveAccess(ctx)
+		require.NoError(t, err)
+		filtered := plugin.filterModelsForAccess(access, models)
 
 		assert.Empty(t, filtered)
 	})

--- a/plugins/governance/providerscopedlimits_test.go
+++ b/plugins/governance/providerscopedlimits_test.go
@@ -1,0 +1,271 @@
+package governance
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/modelcatalog"
+	"github.com/maximhq/bifrost/framework/modelcatalog/datasheet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	providerScopeTestVKValue     = "sk-bf-provider-scope"
+	providerScopeTestOpenAIModel = "gpt-4o"
+	// The pricing fixture attributes this model to bedrock, so a bedrock request costs something.
+	// A model nobody prices costs nothing, and nothing is what a budget is never charged.
+	providerScopeTestBedrockModel = "openai.gpt-5.5"
+
+	// What the fixture's rates make of the token split below. Budgets are charged in dollars, so
+	// this is the amount a single request moves and the amount a request billed twice would exceed.
+	providerScopeTestOpenAICost  = 0.0055
+	providerScopeTestBedrockCost = 0.0165
+)
+
+// providerScopeTestCatalog prices requests from the committed pricing fixture, read through a file URL so
+// no test here depends on the network. Cost is what separates the two charging paths: a budget is only
+// billed for a non-zero one, so without pricing the budget half of provider scoping would be asserted
+// against a path that never runs.
+func providerScopeTestCatalog(t *testing.T) *modelcatalog.ModelCatalog {
+	t.Helper()
+
+	abs, err := filepath.Abs("../../framework/modelcatalog/datasheet/testdata/pricing.json")
+	require.NoError(t, err)
+
+	ds := datasheet.New(nil, NewMockLogger(), datasheet.Config{URL: "file://" + abs})
+	require.NoError(t, ds.LoadFromURLIntoMemory(context.Background()))
+
+	return modelcatalog.NewTestCatalogWithDatasheet(ds)
+}
+
+// providerScopeTestProviderConfig gives one of the key's providers a budget and a rate limit of its own,
+// which on the holder's side is the only place a limit can be attached to a single provider rather than
+// to the holder itself.
+func providerScopeTestProviderConfig(provider string, budget *configstoreTables.TableBudget, rateLimit *configstoreTables.TableRateLimit) configstoreTables.TableVirtualKeyProviderConfig {
+	pc := buildProviderConfigWithRateLimit(provider, []string{"*"}, rateLimit)
+	pc.Budgets = []configstoreTables.TableBudget{*budget}
+	return pc
+}
+
+// providerScopeTestStore builds a key that funds itself across every provider it may use, belongs to a
+// team that does the same, and additionally carries a budget and a rate limit on each of two providers.
+// Both providers are configured identically so neither direction of the comparison is privileged: any
+// asymmetry an assertion finds is the code's, not the fixture's.
+//
+// The deployment itself contributes nothing here (no provider row and no model config), so every limit
+// on the resolved list is one a holder funds, and the exact-set assertions read as a statement about
+// provider scoping alone.
+func providerScopeTestStore(t *testing.T) *LocalGovernanceStore {
+	t.Helper()
+
+	keyBudget := buildBudget("b-scope-key", 1000, "1d")
+	keyRL := buildRateLimitWithUsage("rl-scope-key", 1_000_000, 0, 1_000_000, 0)
+	teamBudget := buildBudget("b-scope-team", 1000, "1d")
+	teamRL := buildRateLimitWithUsage("rl-scope-team", 1_000_000, 0, 1_000_000, 0)
+	openaiBudget := buildBudget("b-scope-openai", 1000, "1d")
+	openaiRL := buildRateLimitWithUsage("rl-scope-openai", 1_000_000, 0, 1_000_000, 0)
+	bedrockBudget := buildBudget("b-scope-bedrock", 1000, "1d")
+	bedrockRL := buildRateLimitWithUsage("rl-scope-bedrock", 1_000_000, 0, 1_000_000, 0)
+
+	team := buildTeam("team-scope", "Scoped Team", teamBudget)
+	team.RateLimitID = &teamRL.ID
+
+	vk := buildVirtualKeyWithBudget("vk-scope", providerScopeTestVKValue, "Provider Scoped VK", keyBudget)
+	vk.RateLimit = keyRL
+	vk.RateLimitID = &keyRL.ID
+	vk.TeamID = &team.ID
+	vk.Team = team
+	vk.ProviderConfigs = []configstoreTables.TableVirtualKeyProviderConfig{
+		providerScopeTestProviderConfig("openai", openaiBudget, openaiRL),
+		providerScopeTestProviderConfig("bedrock", bedrockBudget, bedrockRL),
+	}
+
+	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+		Teams:       []configstoreTables.TableTeam{*team},
+		Budgets: []configstoreTables.TableBudget{
+			*keyBudget, *teamBudget, *openaiBudget, *bedrockBudget,
+		},
+		RateLimits: []configstoreTables.TableRateLimit{
+			*keyRL, *teamRL, *openaiRL, *bedrockRL,
+		},
+	}, nil, nil)
+	require.NoError(t, err)
+
+	return store
+}
+
+// providerScopeTestChatRequest is a chat request whose provider is already settled, so the pair the
+// limits are narrowed against is exactly the one the case names.
+func providerScopeTestChatRequest(provider schemas.ModelProvider, model string) *schemas.BifrostRequest {
+	return &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{Provider: provider, Model: model},
+	}
+}
+
+// providerScopeTestResponse is a completed chat response the accounting path counts. The model it names
+// as originally requested has to be non-empty, and priced, or nothing is billed at all, which would make
+// a nothing-was-charged assertion pass for the wrong reason.
+func providerScopeTestResponse(provider schemas.ModelProvider, model string) *schemas.BifrostResponse {
+	return &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			Model: model,
+			Usage: &schemas.BifrostLLMUsage{PromptTokens: 600, CompletionTokens: 400, TotalTokens: 1000},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:            schemas.ChatCompletionRequest,
+				Provider:               provider,
+				OriginalModelRequested: model,
+			},
+		},
+	}
+}
+
+// A limit a holder carries answers the same for every provider the holder may reach; a limit hanging off
+// one of its provider configs answers only for that provider. Both halves are asserted from the same
+// fixture and in both directions, because a filter that compared each config against some fixed provider
+// instead of the request's would satisfy one direction while draining a provider nobody used on the other.
+//
+// The sets are asserted exactly rather than by membership. A superset is the whole failure mode here, so
+// an assertion that only checks what is present cannot see it.
+func TestProviderScopedLimitsFundOnlyTheirOwnProvider(t *testing.T) {
+	store := providerScopeTestStore(t)
+
+	cases := []struct {
+		name       string
+		provider   schemas.ModelProvider
+		model      string
+		budgets    []string
+		rateLimits []string
+	}{
+		{
+			name:       "an openai request is funded by the key, its team and the key's openai config",
+			provider:   schemas.OpenAI,
+			model:      providerScopeTestOpenAIModel,
+			budgets:    []string{"b-scope-key", "b-scope-team", "b-scope-openai"},
+			rateLimits: []string{"rl-scope-key", "rl-scope-team", "rl-scope-openai"},
+		},
+		{
+			name:       "a bedrock request is funded by the same key and team, and by bedrock's config alone",
+			provider:   schemas.Bedrock,
+			model:      providerScopeTestBedrockModel,
+			budgets:    []string{"b-scope-key", "b-scope-team", "b-scope-bedrock"},
+			rateLimits: []string{"rl-scope-key", "rl-scope-team", "rl-scope-bedrock"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := resolverCtx(store, providerScopeTestVKValue)
+
+			settled := resolveLimits(ctx, store, tc.provider, tc.model)
+			require.NotNil(t, settled, "the key resolves, so the request has a grant to settle limits on")
+
+			assert.ElementsMatch(t, tc.budgets, limitIDsOf(settled.Budgets()),
+				"the holder's own budgets plus this provider's, and no other provider's")
+			assert.ElementsMatch(t, tc.rateLimits, limitIDsOf(settled.RateLimits()),
+				"the holder's own rate limits plus this provider's, and no other provider's")
+		})
+	}
+}
+
+// Assembling the list and charging it are separate steps, so a provider's limits could be correctly left
+// off a request's list and still be billed for it. This runs the request through both hooks and reads the
+// counters afterwards, which is the only way to see that second step. Budgets and rate limits are charged
+// through separate store calls, so both are read: a provider-scoping regression in one of them says
+// nothing about the other.
+//
+// The charged sets are derived from what actually moved and compared exactly, so they fail both for a
+// provider that was billed without being on the list and for one on the list that was never billed. The
+// counters are then pinned to what one request costs rather than to merely non-zero, because a limit
+// reached twice through two walks over the holder's shape moves every counter it owns and so stays inside
+// that derived set.
+func TestARequestIsChargedOnlyToTheProviderConfigItUsed(t *testing.T) {
+	cases := []struct {
+		name       string
+		provider   schemas.ModelProvider
+		model      string
+		budgets    []string
+		rateLimits []string
+		cost       float64
+	}{
+		{
+			name:       "an openai request leaves the key's bedrock limits untouched",
+			provider:   schemas.OpenAI,
+			model:      providerScopeTestOpenAIModel,
+			budgets:    []string{"b-scope-key", "b-scope-team", "b-scope-openai"},
+			rateLimits: []string{"rl-scope-key", "rl-scope-team", "rl-scope-openai"},
+			cost:       providerScopeTestOpenAICost,
+		},
+		{
+			name:       "a bedrock request leaves the key's openai limits untouched",
+			provider:   schemas.Bedrock,
+			model:      providerScopeTestBedrockModel,
+			budgets:    []string{"b-scope-key", "b-scope-team", "b-scope-bedrock"},
+			rateLimits: []string{"rl-scope-key", "rl-scope-team", "rl-scope-bedrock"},
+			cost:       providerScopeTestBedrockCost,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := providerScopeTestStore(t)
+			plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, NewMockLogger(), store, nil, providerScopeTestCatalog(t), nil, nil)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, plugin.Cleanup()) })
+
+			ctx := resolverCtx(store, providerScopeTestVKValue)
+
+			_, shortCircuit, err := plugin.PreLLMHook(ctx, providerScopeTestChatRequest(tc.provider, tc.model))
+			require.NoError(t, err)
+			require.Nil(t, shortCircuit, "every limit has room, so the request is admitted")
+
+			_, _, err = plugin.PostLLMHook(ctx, providerScopeTestResponse(tc.provider, tc.model), nil)
+			require.NoError(t, err)
+			plugin.wg.Wait()
+
+			// What the log row names as co-payers, which a node replaying usage it never saw acts on.
+			recordedRateLimits, _ := ctx.Value(schemas.BifrostContextKeyGovernanceRateLimitIDs).([]string)
+			assert.ElementsMatch(t, tc.rateLimits, recordedRateLimits,
+				"the request is recorded as answering to this provider's rate limits and no other provider's")
+			recordedBudgets, _ := ctx.Value(schemas.BifrostContextKeyGovernanceBudgetIDs).([]string)
+			assert.ElementsMatch(t, tc.budgets, recordedBudgets,
+				"and to this provider's budgets and no other provider's")
+
+			data := store.GetGovernanceData(context.Background())
+
+			chargedRateLimits := []string{}
+			for id, rateLimit := range data.RateLimits {
+				if rateLimit.RequestCurrentUsage > 0 || rateLimit.TokenCurrentUsage > 0 {
+					chargedRateLimits = append(chargedRateLimits, id)
+				}
+			}
+			// Required rather than merely asserted: the per-limit reads below are meaningless, and index
+			// into nothing, once the set they walk is not the set the store holds.
+			require.ElementsMatch(t, tc.rateLimits, chargedRateLimits,
+				"no rate limit was counted that the request did not answer to, and none it answered to was skipped")
+
+			chargedBudgets := []string{}
+			for id, budget := range data.Budgets {
+				if budget.CurrentUsage > 0 {
+					chargedBudgets = append(chargedBudgets, id)
+				}
+			}
+			require.ElementsMatch(t, tc.budgets, chargedBudgets,
+				"no budget was billed that the request did not answer to, and none it answered to was skipped")
+
+			for _, id := range tc.rateLimits {
+				assert.Equal(t, int64(1), data.RateLimits[id].RequestCurrentUsage, id)
+				assert.Equal(t, int64(1000), data.RateLimits[id].TokenCurrentUsage, id)
+			}
+			for _, id := range tc.budgets {
+				assert.InDelta(t, tc.cost, data.Budgets[id].CurrentUsage, 1e-9, id)
+			}
+		})
+	}
+}

--- a/plugins/governance/resolver.go
+++ b/plugins/governance/resolver.go
@@ -57,19 +57,6 @@ type BudgetResolver struct {
 	governanceInMemoryStore InMemoryStore
 }
 
-// allLimitHolderKinds is every kind of holder whose limits this package enforces. A kind absent from
-// here is a kind nothing checks, so a new holder is wired up by adding it once.
-var allLimitHolderKinds = []grant.LimitHolderKind{
-	grant.LimitHolderProvider,
-	grant.LimitHolderModelConfig,
-	grant.LimitHolderUserModelConfig,
-	grant.LimitHolderVirtualKeyModelConfig,
-	grant.LimitHolderVirtualKeyProviderConfig,
-	grant.LimitHolderVirtualKey,
-	grant.LimitHolderTeam,
-	grant.LimitHolderCustomer,
-}
-
 // NewBudgetResolver creates a new budget-based governance resolver
 func NewBudgetResolver(store GovernanceStore, modelCatalog *modelcatalog.ModelCatalog, logger schemas.Logger, governanceInMemoryStore InMemoryStore) *BudgetResolver {
 	return &BudgetResolver{
@@ -155,24 +142,27 @@ func (r *BudgetResolver) evaluateAccess(ctx *schemas.BifrostContext, evaluationR
 // what kind of holder is paying, which is what lets a deployment add one by answering with a
 // different permit.
 func (r *BudgetResolver) evaluateLimits(ctx *schemas.BifrostContext, evaluationRequest *EvaluationRequest, limits schemas.Limits) *EvaluationResult {
-	kinds := enforcedLimitHolderKinds(ctx)
-	if len(kinds) == 0 {
+	if spendingChecksSkipped(ctx) {
 		return &EvaluationResult{
 			Decision: DecisionAllow,
 			Reason:   "Request allowed by governance policy (spending checks skipped)",
 		}
 	}
 
-	// One settled list rather than several sources combined in the right order. A caller that reaches
-	// the check without having settled the attempt's limits is still subject to the deployment's own,
+	// Everything the request answers to, with nothing filtered out. The limits were settled on the
+	// grant once the attempt's provider and model were known, and this reads that one list. A caller
+	// that reaches the check without having settled them is still subject to the deployment's own,
 	// so those are gathered here for it.
+	//
+	// No filtering by holder kind, which is what makes a holder this package has never heard of
+	// enforced by construction rather than by being registered somewhere. Which credential a request
+	// is governed as is settled before governance sees it, by whoever resolves its access.
 	var budgets, rateLimits []schemas.Limit
 	if limits != nil {
 		budgets, rateLimits = limits.Budgets(), limits.RateLimits()
 	} else {
 		budgets, rateLimits = r.store.ProviderAndModelLimits(ctx, nil, evaluationRequest.Provider, evaluationRequest.Model)
 	}
-	budgets, rateLimits = grant.LimitsFrom(budgets, kinds...), grant.LimitsFrom(rateLimits, kinds...)
 
 	// Rate limits before budgets, as they always have been: a rate limit refuses a request that
 	// would otherwise have been affordable, and reporting the cheaper refusal first keeps the
@@ -197,28 +187,24 @@ func (r *BudgetResolver) evaluateLimits(ctx *schemas.BifrostContext, evaluationR
 	}
 }
 
-// enforcedLimitHolderKinds lists the holder kinds this request is actually subject to, after the
-// skip flags its caller set.
+// untrackedHolderKinds are the kinds still billed when a caller has asked for the holder's usage not
+// to be counted: what the deployment imposes, and what the user who made the request answers to.
 //
-// Skipping is per holder kind rather than per call site. Read-only metadata calls skip spending
-// entirely; a user-authenticated request skips the presented key's own limits, because what it may
-// spend is the user's allowance and not the key's. Expressing both as "which kinds still apply"
-// keeps one check for every request instead of a flag threaded through a check per holder.
-func enforcedLimitHolderKinds(ctx *schemas.BifrostContext) []grant.LimitHolderKind {
-	if bifrost.GetBoolFromContext(ctx, schemas.BifrostContextKeySkipBudgetAndRateLimits) {
-		return nil
-	}
-	if userID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyUserID); userID != "" {
-		kinds := make([]grant.LimitHolderKind, 0, len(allLimitHolderKinds))
-		for _, kind := range allLimitHolderKinds {
-			if kind == grant.LimitHolderVirtualKey || kind == grant.LimitHolderVirtualKeyProviderConfig {
-				continue
-			}
-			kinds = append(kinds, kind)
-		}
-		return kinds
-	}
-	return allLimitHolderKinds
+// This names what to keep rather than what to drop, because the set it names is closed and belongs
+// to this package, while what a holder funds is open: a kind nobody here has heard of is a holder's,
+// and leaving it out is exactly what the caller asked for. Note this filters only who gets billed,
+// never who gets checked: everything on the grant is enforced, so asking for usage not to be counted
+// cannot buy a request past a limit it could not otherwise afford.
+var untrackedHolderKinds = []grant.LimitHolderKind{
+	grant.LimitHolderProvider,
+	grant.LimitHolderModelConfig,
+	grant.LimitHolderUserModelConfig,
+}
+
+// spendingChecksSkipped reports whether this request was told not to be checked against anything it
+// answers to. Read-only metadata calls set it: they spend nothing, so there is nothing to afford.
+func spendingChecksSkipped(ctx *schemas.BifrostContext) bool {
+	return bifrost.GetBoolFromContext(ctx, schemas.BifrostContextKeySkipBudgetAndRateLimits)
 }
 
 // denialReason is what the caller is told when a request is refused: what was refused, and, when

--- a/plugins/governance/resolver_test.go
+++ b/plugins/governance/resolver_test.go
@@ -791,3 +791,84 @@ func TestBudgetResolver_EvaluateRequest_SkipModelCheckAllowsBlockedModel(t *test
 	assert.NotEqual(t, DecisionModelBlocked, result.Decision, "skipModelCheck must bypass the virtual key model allowlist")
 	assertDecision(t, DecisionAllow, result)
 }
+
+// Enforcement no longer names the holder kinds to check, so a deployment that funds requests from
+// something this package has never heard of gets those limits enforced without registering anything.
+// The alternative fails open: a limit gathered for the attempt, recorded against it, and then neither
+// checked nor charged.
+func TestEvaluateLimitsEnforcesAnUnfamiliarHolderKind(t *testing.T) {
+	logger := NewMockLogger()
+	exhausted := buildBudgetWithUsage("b-somewhere-else", 100.0, 100.0, "1d")
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		Budgets: []configstoreTables.TableBudget{*exhausted},
+	}, nil, nil)
+	require.NoError(t, err)
+
+	resolver := NewBudgetResolver(store, nil, logger, nil)
+	ctx := emptyCtx()
+
+	// Limits funded by a holder kind declared nowhere in this package: what a deployment resolving
+	// its own permits settles.
+	limits := grant.NewLimits([]schemas.Limit{{
+		ID:         exhausted.ID,
+		HolderKind: "some_deployment_holder",
+		HolderID:   "h1",
+		HolderName: "Someone",
+	}}, nil)
+	ctx.Grant().SetLimits(limits)
+
+	result := resolver.evaluateLimits(ctx, &EvaluationRequest{Provider: schemas.OpenAI, Model: "gpt-4o"}, limits)
+
+	assert.Equal(t, DecisionBudgetExceeded, result.Decision,
+		"a holder this package does not know still refuses a request it cannot afford")
+	assert.Contains(t, result.Reason, "Budget exceeded")
+}
+
+// Which credential a request is governed as is settled before governance sees it: a request presenting
+// both is resolved to one, or refused, by whoever authenticated it. So an identity on the context
+// changes nothing about what the request answers to: the limits settled on its grant are the limits,
+// whichever credential produced them.
+func TestEvaluateLimitsEnforcesTheSettledLimitsWhicheverCredentialProducedThem(t *testing.T) {
+	logger := NewMockLogger()
+	exhausted := buildBudgetWithUsage("b-holder", 100.0, 100.0, "1d")
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		Budgets: []configstoreTables.TableBudget{*exhausted},
+	}, nil, nil)
+	require.NoError(t, err)
+
+	resolver := NewBudgetResolver(store, nil, logger, nil)
+	held := []schemas.Limit{{ID: exhausted.ID, HolderKind: string(grant.LimitHolderVirtualKey), HolderID: "vk1"}}
+
+	evaluate := func(t *testing.T, stamp func(ctx *schemas.BifrostContext)) *EvaluationResult {
+		t.Helper()
+		ctx := emptyCtx()
+		stamp(ctx)
+		limits := grant.NewLimits(held, nil)
+		ctx.Grant().SetLimits(limits)
+		return resolver.evaluateLimits(ctx, &EvaluationRequest{Provider: schemas.OpenAI, Model: "gpt-4o"}, limits)
+	}
+
+	t.Run("an exhausted holder refuses the request", func(t *testing.T) {
+		assert.Equal(t, DecisionBudgetExceeded, evaluate(t, func(*schemas.BifrostContext) {}).Decision)
+	})
+
+	t.Run("and still refuses it when an identity is on the context", func(t *testing.T) {
+		// This used to exempt the key's own limits, from the days when a profile was mirrored onto a
+		// key and the two were one allowance recorded twice. Dropping them now would simply not charge
+		// a budget that is real.
+		result := evaluate(t, func(ctx *schemas.BifrostContext) {
+			ctx.SetValue(schemas.BifrostContextKeyUserID, "user-1")
+		})
+
+		assert.Equal(t, DecisionBudgetExceeded, result.Decision)
+	})
+
+	t.Run("only asking for spending checks to be skipped exempts it", func(t *testing.T) {
+		result := evaluate(t, func(ctx *schemas.BifrostContext) {
+			ctx.SetValue(schemas.BifrostContextKeySkipBudgetAndRateLimits, true)
+		})
+
+		assert.Equal(t, DecisionAllow, result.Decision)
+		assert.Contains(t, result.Reason, "spending checks skipped")
+	})
+}

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -166,6 +166,11 @@ type GovernanceStore interface {
 	// neither knows what kind of holder is paying.
 	CheckBudgets(ctx context.Context, limits []schemas.Limit, baselines map[string]float64) (Decision, error)
 	CheckRateLimits(ctx context.Context, limits []schemas.Limit, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error)
+	// ChargeBudgets bills a cost to the given budgets, and ChargeRateLimits counts a request against the
+	// given rate limits. What to charge is the caller's to have settled: these are handed the same list
+	// the checks were, so a request cannot be checked against one set and billed to another.
+	ChargeBudgets(ctx context.Context, limits []schemas.Limit, cost float64) error
+	ChargeRateLimits(ctx context.Context, limits []schemas.Limit, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error
 	// CheckProviderCandidateExclusion reports whether a load-balancing candidate can serve this
 	// request right now, answering with a Decision like the checks above. What to tell the caller
 	// about a refusal is the caller's to word: it is the one writing a routing log. Only spending
@@ -196,12 +201,8 @@ type GovernanceStore interface {
 	UpsertRateLimitConfig(ctx context.Context, rateLimitID string, config *configstoreTables.TableRateLimit)
 	DeleteRateLimit(ctx context.Context, rateLimitID string)
 	// In-memory usage updates (for VK-level)
-	UpdateVirtualKeyBudgetUsageInMemory(ctx context.Context, vk *configstoreTables.TableVirtualKey, provider schemas.ModelProvider, cost float64) error
-	UpdateVirtualKeyRateLimitUsageInMemory(ctx context.Context, vk *configstoreTables.TableVirtualKey, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error
 	// In-memory usage updates for scoped model configs (mirror the global model updates).
 	// scope/scopeID identify the owning entity; an empty scope or scopeID is a no-op.
-	UpdateScopedModelBudgetUsageInMemory(ctx context.Context, scope, scopeID, model string, provider schemas.ModelProvider, cost float64) error
-	UpdateScopedModelRateLimitUsageInMemory(ctx context.Context, scope, scopeID, model string, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error
 	// In-memory reset checks (return items that need DB sync)
 	ResetExpiredRateLimitsInMemory(ctx context.Context, refreshReferences bool, rateLimitIDs ...string) []*configstoreTables.TableRateLimit
 	ResetExpiredBudgetsInMemory(ctx context.Context, refreshReferences bool, budgetIDs ...string) []*configstoreTables.TableBudget
@@ -219,8 +220,6 @@ type GovernanceStore interface {
 	ResetExpiredRateLimits(ctx context.Context, resetRateLimits []*configstoreTables.TableRateLimit) error
 	ResetExpiredBudgets(ctx context.Context, resetBudgets []*configstoreTables.TableBudget) error
 	// Provider and model-level usage updates (combined)
-	UpdateProviderAndModelBudgetUsageInMemory(ctx context.Context, model string, provider schemas.ModelProvider, cost float64) error
-	UpdateProviderAndModelRateLimitUsageInMemory(ctx context.Context, model string, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error
 	// Dump operations
 	DumpRateLimits(ctx context.Context, tokenBaselines map[string]int64, requestBaselines map[string]int64) error
 	DumpBudgets(ctx context.Context, baselines map[string]float64) error
@@ -241,8 +240,6 @@ type GovernanceStore interface {
 	UpdateUserGovernanceInMemory(ctx context.Context, userID string, budget *configstoreTables.TableBudget, rateLimit *configstoreTables.TableRateLimit)
 	DeleteUserGovernanceInMemory(ctx context.Context, userID string)
 	CreateUserNameInMemory(ctx context.Context, userID string, userName string)
-	UpdateUserBudgetUsageInMemory(ctx context.Context, userID string, cost float64) error
-	UpdateUserRateLimitUsageInMemory(ctx context.Context, userID string, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error
 	// Model config in-memory operations
 	UpdateModelConfigInMemory(ctx context.Context, mc *configstoreTables.TableModelConfig) *configstoreTables.TableModelConfig
 	DeleteModelConfigInMemory(ctx context.Context, mcID string)
@@ -252,12 +249,6 @@ type GovernanceStore interface {
 	DeleteProviderInMemory(ctx context.Context, providerName string)
 	// Budget and rate limit status queries for routing with baseline support
 	GetBudgetAndRateLimitStatus(ctx context.Context, model string, provider schemas.ModelProvider, vk *configstoreTables.TableVirtualKey, budgetBaselines map[string]float64, tokenBaselines map[string]int64, requestBaselines map[string]int64) *BudgetAndRateLimitStatus
-	// CollectApplicableGovernanceIDs returns every budget and rate-limit ID this node charges for the
-	// given access on the given (provider, model).
-	// The IDs are stamped on the log row so ghost-node reconciliation can re-attribute cost and tokens;
-	// missing any ID here means that usage vanishes from cluster baselines when the node ghosts.
-	// No access records only the deployment's own limits, which is the set charged in that case.
-	CollectApplicableGovernanceIDs(ctx context.Context, limits schemas.Limits, provider schemas.ModelProvider, model string) (budgetIDs []string, rateLimitIDs []string)
 	// CollectModelScopedGovernanceIDs returns the budget and rate-limit IDs owned by
 	// model configs matching (provider, model) across the global, user and virtual-key
 	// scopes. It takes the virtual key's ID rather than its value, so a caller settling
@@ -566,7 +557,7 @@ const maxRequestTimeResetAttempts = 3
 //
 // This is the serialisation point for every usage increment: callers MUST
 // funnel through this method (directly or via one of the higher-level
-// Update*BudgetUsageInMemory wrappers) rather than doing a plain
+// ChargeBudgets) rather than doing a plain
 // Load → clone → mutate → Store, which races.
 func (gs *LocalGovernanceStore) BumpBudgetUsage(ctx context.Context, budgetID string, cost float64) error {
 	resetAttempts := 0
@@ -1309,8 +1300,7 @@ func recordVirtualKeyIdentity(ctx *schemas.BifrostContext, virtualKey *configsto
 // room. A limit scoped to the model itself applies to every candidate serving it and is not asked
 // about here, since it cannot discriminate.
 func (gs *LocalGovernanceStore) CheckProviderCandidateExclusion(ctx *schemas.BifrostContext, access schemas.Access, candidate schemas.ProviderCandidate, model string) (Decision, error) {
-	kinds := enforcedLimitHolderKinds(ctx)
-	if len(kinds) == 0 {
+	if spendingChecksSkipped(ctx) {
 		return DecisionAllow, nil
 	}
 
@@ -1323,7 +1313,6 @@ func (gs *LocalGovernanceStore) CheckProviderCandidateExclusion(ctx *schemas.Bif
 			rateLimits = append(rateLimits, permitRateLimits...)
 		}
 	}
-	budgets, rateLimits = grant.LimitsFrom(budgets, kinds...), grant.LimitsFrom(rateLimits, kinds...)
 
 	if decision, err := gs.CheckRateLimits(ctx, rateLimits, nil, nil); err != nil || isRateLimitViolation(decision) {
 		return decision, err
@@ -2015,168 +2004,6 @@ func (gs *LocalGovernanceStore) GetCustomerName(ctx context.Context, customerID 
 		return ""
 	}
 	return customer.Name
-}
-
-// UpdateVirtualKeyBudgetUsageInMemory charges a request's cost to every budget the key's permit is
-// funded by.
-//
-// What it charges comes from the same two places the check reads (what funds the holder, and what
-// funds its use of this provider), so a budget cannot be enforced on a request and then not billed for
-// it, or billed and never enforced. It used to walk the key's hierarchy itself, which made the two
-// answers two implementations of one question.
-func (gs *LocalGovernanceStore) UpdateVirtualKeyBudgetUsageInMemory(ctx context.Context, vk *configstoreTables.TableVirtualKey, provider schemas.ModelProvider, cost float64) error {
-	if vk == nil {
-		return fmt.Errorf("virtual key cannot be nil")
-	}
-	permit := gs.permitForVirtualKey(ctx, vk)
-	heldBudgets, _ := gs.HolderLimits(ctx, permit)
-	providerBudgets, _ := gs.ProviderLimits(ctx, permit, provider)
-	budgetIDs := limitIDsOf(heldBudgets, providerBudgets)
-	for _, budgetID := range budgetIDs {
-		if err := gs.BumpBudgetUsage(ctx, budgetID, cost); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// UpdateProviderAndModelBudgetUsageInMemory performs atomic budget updates for both provider-level and model-level configs (in memory)
-func (gs *LocalGovernanceStore) UpdateProviderAndModelBudgetUsageInMemory(ctx context.Context, model string, provider schemas.ModelProvider, cost float64) error {
-	// 1. Update provider-level budget (if provider is set)
-	if provider != "" {
-		providerKey := string(provider)
-		if value, exists := gs.providers.Load(providerKey); exists && value != nil {
-			if providerTable, ok := value.(*configstoreTables.TableProvider); ok && providerTable != nil && providerTable.BudgetID != nil {
-				if err := gs.BumpBudgetUsage(ctx, *providerTable.BudgetID, cost); err != nil {
-					return err
-				}
-			}
-		}
-	}
-
-	// 2. Update global-scope model-level budgets across all four tiers (incl. the
-	// all-models "*:provider" tier that now carries provider-level governance).
-	var providerStr *string
-	if provider != "" {
-		p := string(provider)
-		providerStr = &p
-	}
-	for _, mc := range gs.collectModelConfigsFor(ctx, configstoreTables.ModelConfigScopeGlobal, "", model, providerStr) {
-		for i := range mc.Budgets {
-			if err := gs.BumpBudgetUsage(ctx, mc.Budgets[i].ID, cost); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-// UpdateUserBudgetUsageInMemory updates user's budget usage in memory (enterprise-only)
-// Community build: silent no-op to avoid per-request error spam when a userID is set.
-func (gs *LocalGovernanceStore) UpdateUserBudgetUsageInMemory(ctx context.Context, userID string, cost float64) error {
-	return nil
-}
-
-// UpdateProviderAndModelRateLimitUsageInMemory updates rate limit counters for both provider-level and model-level rate limits.
-func (gs *LocalGovernanceStore) UpdateProviderAndModelRateLimitUsageInMemory(ctx context.Context, model string, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error {
-	// 1. Update provider-level rate limit (if provider is set)
-	if provider != "" {
-		providerKey := string(provider)
-		if value, exists := gs.providers.Load(providerKey); exists && value != nil {
-			if providerTable, ok := value.(*configstoreTables.TableProvider); ok && providerTable != nil && providerTable.RateLimitID != nil {
-				if err := gs.BumpRateLimitUsage(ctx, *providerTable.RateLimitID, tokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
-					return err
-				}
-			}
-		}
-	}
-
-	// 2. Update global-scope model-level rate limits across all four tiers (incl. the
-	// all-models "*:provider" tier that now carries provider-level governance).
-	var providerStr *string
-	if provider != "" {
-		p := string(provider)
-		providerStr = &p
-	}
-	for _, mc := range gs.collectModelConfigsFor(ctx, configstoreTables.ModelConfigScopeGlobal, "", model, providerStr) {
-		if mc.RateLimitID == nil {
-			continue
-		}
-		if err := gs.BumpRateLimitUsage(ctx, *mc.RateLimitID, tokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// UpdateScopedModelBudgetUsageInMemory bumps budget usage for model configs scoped to the
-// given (scope, scopeID). Post-response counterpart to CheckScopedModelBudget — without it,
-// scoped budgets never increase and never trip. Empty scope/scopeID/model is a no-op.
-func (gs *LocalGovernanceStore) UpdateScopedModelBudgetUsageInMemory(ctx context.Context, scope, scopeID, model string, provider schemas.ModelProvider, cost float64) error {
-	if scope == "" || scopeID == "" {
-		return nil
-	}
-	var providerStr *string
-	if provider != "" {
-		p := string(provider)
-		providerStr = &p
-	}
-	for _, mc := range gs.collectModelConfigsFor(ctx, scope, scopeID, model, providerStr) {
-		for i := range mc.Budgets {
-			if err := gs.BumpBudgetUsage(ctx, mc.Budgets[i].ID, cost); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-// UpdateScopedModelRateLimitUsageInMemory bumps rate limit counters for model configs scoped
-// to the given (scope, scopeID). Post-response counterpart to CheckScopedModelRateLimit.
-func (gs *LocalGovernanceStore) UpdateScopedModelRateLimitUsageInMemory(ctx context.Context, scope, scopeID, model string, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error {
-	if scope == "" || scopeID == "" {
-		return nil
-	}
-	var providerStr *string
-	if provider != "" {
-		p := string(provider)
-		providerStr = &p
-	}
-	for _, mc := range gs.collectModelConfigsFor(ctx, scope, scopeID, model, providerStr) {
-		if mc.RateLimitID == nil {
-			continue
-		}
-		if err := gs.BumpRateLimitUsage(ctx, *mc.RateLimitID, tokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// UpdateVirtualKeyRateLimitUsageInMemory counts a request against every rate limit the key's permit
-// answers to, read the same way as the budgets above.
-func (gs *LocalGovernanceStore) UpdateVirtualKeyRateLimitUsageInMemory(ctx context.Context, vk *configstoreTables.TableVirtualKey, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error {
-	if vk == nil {
-		return fmt.Errorf("virtual key cannot be nil")
-	}
-	permit := gs.permitForVirtualKey(ctx, vk)
-	_, heldRateLimits := gs.HolderLimits(ctx, permit)
-	_, providerRateLimits := gs.ProviderLimits(ctx, permit, provider)
-	rateLimitIDs := limitIDsOf(heldRateLimits, providerRateLimits)
-	for _, rateLimitID := range rateLimitIDs {
-		if err := gs.BumpRateLimitUsage(ctx, rateLimitID, tokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// UpdateUserRateLimitUsageInMemory updates user's rate limit usage in memory (enterprise-only)
-// Community build: silent no-op to avoid per-request error spam when a userID is set.
-func (gs *LocalGovernanceStore) UpdateUserRateLimitUsageInMemory(ctx context.Context, userID string, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error {
-	return nil
 }
 
 // budgetResetTarget returns the LastReset value to write when budget is expired,
@@ -3300,33 +3127,6 @@ func (gs *LocalGovernanceStore) rebuildInMemoryStructures(ctx context.Context, c
 	gs.LastDBUsagesRateLimitsRequestsMu.Unlock()
 }
 
-// CollectApplicableGovernanceIDs names every budget and rate limit a request counts against, for the
-// log entry that lets a recovering node replay the usage of requests it never saw.
-//
-// It reads the same resolved access the check reads, so the set recorded against a request is the set
-// that was enforced on it: the same list, not a second derivation of it. It
-// used to resolve the holder itself from the presented credential, which meant the co-payers a request
-// was charged to and the co-payers checked for it were two implementations of one question, free to
-// drift while a slow request was in flight.
-//
-// Nothing here asks what kind of holder is paying, so a deployment that answers with grants of its
-// own has them recorded without this path changing.
-//
-// No access means the holder's usage is not being charged, so none of its limits are recorded, only
-// the deployment's own, which are resolved here because there is no access to have settled them on.
-// That is exactly the set the tracker charges in the same case, which is the property that matters:
-// a co-payer recorded but never debited invents usage when a ghosted node's log is replayed, and one
-// debited but never recorded loses it.
-func (gs *LocalGovernanceStore) CollectApplicableGovernanceIDs(ctx context.Context, limits schemas.Limits, provider schemas.ModelProvider, model string) (budgetIDs []string, rateLimitIDs []string) {
-	var budgets, rateLimits []schemas.Limit
-	if limits != nil {
-		budgets, rateLimits = limits.Budgets(), limits.RateLimits()
-	} else {
-		budgets, rateLimits = gs.ProviderAndModelLimits(ctx, nil, provider, model)
-	}
-	return limitIDsOf(budgets), limitIDsOf(rateLimits)
-}
-
 // limitIDsOf names the limits of several lists as one deduplicated list of identifiers, in the order
 // first seen. A limit reached twice is one limit, and charging it twice for one request would bill
 // the same budget twice.
@@ -3348,17 +3148,17 @@ func limitIDsOf(lists ...[]schemas.Limit) []string {
 // CollectModelScopedGovernanceIDs returns only the model-config-owned IDs for a
 // (provider, model) pair, across the global, user and virtual-key scopes.
 //
-// It exists for delayed settlement. CollectApplicableGovernanceIDs is called while
-// the request is in flight, and a batch create carries no top-level model — each
-// input-file row names its own — so collectModelConfigsFor matches only the
-// all-models wildcards and never the exact-model configs. Those are precisely where
+// It exists for delayed settlement. A request's limits are settled while it is in
+// flight, and a batch create carries no top-level model (each input-file row names
+// its own), so collectModelConfigsFor matches only the all-models wildcards and
+// never the exact-model configs. Those are precisely where
 // a model-level budget lives (an access profile's per-model limits materialise as
 // user-scoped configs naming one model and provider), so batch spend never reached
 // them. Settlement does know the models, and calls this per model to charge what
 // the create-time collection could not see.
 //
 // Callers must subtract the IDs already charged for the request: the wildcard tiers
-// returned here overlap CollectApplicableGovernanceIDs by design, since both walk
+// returned here overlap what was settled at create time by design, since both walk
 // the same four tiers.
 func (gs *LocalGovernanceStore) CollectModelScopedGovernanceIDs(ctx context.Context, virtualKeyID string, userID string, provider schemas.ModelProvider, model string) (budgetIDs []string, rateLimitIDs []string) {
 	seenBudgets := map[string]bool{}
@@ -4789,6 +4589,28 @@ func (gs *LocalGovernanceStore) CheckRateLimits(ctx context.Context, limits []sc
 		return DecisionAllow, nil
 	}
 	return gs.CheckRateLimit(ctx, entityWise, tokensBaselines, requestsBaselines)
+}
+
+// ChargeBudgets bills a cost to every budget it is handed. The list is the one the check read, so a
+// request is billed to exactly what it was checked against.
+func (gs *LocalGovernanceStore) ChargeBudgets(ctx context.Context, limits []schemas.Limit, cost float64) error {
+	for _, budgetID := range limitIDsOf(limits) {
+		if err := gs.BumpBudgetUsage(ctx, budgetID, cost); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ChargeRateLimits counts a request against every rate limit it is handed, for the same reason as
+// ChargeBudgets.
+func (gs *LocalGovernanceStore) ChargeRateLimits(ctx context.Context, limits []schemas.Limit, tokensUsed int64, shouldUpdateTokens, shouldUpdateRequests bool) error {
+	for _, rateLimitID := range limitIDsOf(limits) {
+		if err := gs.BumpRateLimitUsage(ctx, rateLimitID, tokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // limitLabel names a limit's holder for the log lines and refusals the check emits. It is what the

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/grant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -327,7 +328,7 @@ func TestGovernanceStore_MultiBudget_UsageUpdatesAllBudgets(t *testing.T) {
 	vk, _ = store.GetVirtualKey(context.Background(), "sk-bf-test")
 
 	// Simulate a $3.50 request
-	err = store.UpdateVirtualKeyBudgetUsageInMemory(context.Background(), vk, schemas.OpenAI, 3.50)
+	err = chargeGrantBudgets(store, context.Background(), vk, schemas.OpenAI, 3.50)
 	require.NoError(t, err)
 
 	// Both budgets should reflect the cost
@@ -340,7 +341,7 @@ func TestGovernanceStore_MultiBudget_UsageUpdatesAllBudgets(t *testing.T) {
 	assert.InDelta(t, 3.50, dailyVal.(*configstoreTables.TableBudget).CurrentUsage, 0.01, "Daily budget should reflect usage")
 
 	// Second request: $7.00 — should push hourly over limit
-	err = store.UpdateVirtualKeyBudgetUsageInMemory(context.Background(), vk, schemas.OpenAI, 7.00)
+	err = chargeGrantBudgets(store, context.Background(), vk, schemas.OpenAI, 7.00)
 	require.NoError(t, err)
 
 	hourlyVal, _ = store.budgets.Load("hourly")
@@ -491,7 +492,7 @@ func TestGovernanceStore_MultiBudget_UsageDrivesBlockAfterRequests(t *testing.T)
 
 	// Request 1: $0.80 — both budgets fine
 	vk, _ = store.GetVirtualKey(context.Background(), "sk-bf-test")
-	err = store.UpdateVirtualKeyBudgetUsageInMemory(context.Background(), vk, schemas.OpenAI, 0.80)
+	err = chargeGrantBudgets(store, context.Background(), vk, schemas.OpenAI, 0.80)
 	require.NoError(t, err)
 
 	ctx := resolverCtx(store, "sk-bf-test")
@@ -500,7 +501,7 @@ func TestGovernanceStore_MultiBudget_UsageDrivesBlockAfterRequests(t *testing.T)
 
 	// Request 2: $0.80 — still fine ($1.60 total)
 	vk, _ = store.GetVirtualKey(context.Background(), "sk-bf-test")
-	err = store.UpdateVirtualKeyBudgetUsageInMemory(context.Background(), vk, schemas.OpenAI, 0.80)
+	err = chargeGrantBudgets(store, context.Background(), vk, schemas.OpenAI, 0.80)
 	require.NoError(t, err)
 
 	ctx = resolverCtx(store, "sk-bf-test")
@@ -509,7 +510,7 @@ func TestGovernanceStore_MultiBudget_UsageDrivesBlockAfterRequests(t *testing.T)
 
 	// Request 3: $0.80 — pushes hourly to $2.40 > $2.00 limit → blocked
 	vk, _ = store.GetVirtualKey(context.Background(), "sk-bf-test")
-	err = store.UpdateVirtualKeyBudgetUsageInMemory(context.Background(), vk, schemas.OpenAI, 0.80)
+	err = chargeGrantBudgets(store, context.Background(), vk, schemas.OpenAI, 0.80)
 	require.NoError(t, err)
 
 	ctx = resolverCtx(store, "sk-bf-test")
@@ -1033,7 +1034,7 @@ func TestGovernanceStore_UpdateRateLimitUsage_TokensAndRequests(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test updating tokens
-	err = store.UpdateVirtualKeyRateLimitUsageInMemory(context.Background(), vk, schemas.OpenAI, 500, true, false)
+	err = chargeGrantRateLimits(store, context.Background(), vk, schemas.OpenAI, 500, true, false)
 	assert.NoError(t, err, "Rate limit update should succeed")
 
 	// Retrieve the updated rate limit from the main RateLimits map
@@ -1046,7 +1047,7 @@ func TestGovernanceStore_UpdateRateLimitUsage_TokensAndRequests(t *testing.T) {
 	assert.Equal(t, int64(0), updatedRateLimit.RequestCurrentUsage, "Request usage should not change")
 
 	// Test updating requests
-	err = store.UpdateVirtualKeyRateLimitUsageInMemory(context.Background(), vk, schemas.OpenAI, 0, false, true)
+	err = chargeGrantRateLimits(store, context.Background(), vk, schemas.OpenAI, 0, false, true)
 	assert.NoError(t, err, "Rate limit update should succeed")
 
 	// Retrieve the updated rate limit again
@@ -1395,11 +1396,11 @@ func TestCollectApplicableGovernanceIDs_VKWildcardBudget_NoModel(t *testing.T) {
 	store.virtualKeys.Store(vkValue, vk)
 
 	// Settled the way the funnel settles it: the grant carries the attempt's limits, and the
-	// recorded set is read from there.
+	// accounted set is read from there.
 	ctx := resolverCtx(store, vkValue)
 	limits := resolveLimits(ctx, store, schemas.ModelProvider("anthropic"), "")
 	require.NotNil(t, limits)
-	budgetIDs, _ := store.CollectApplicableGovernanceIDs(ctx, limits, schemas.ModelProvider("anthropic"), "")
+	budgetIDs := limitIDsOf(limits.Budgets())
 
 	assert.Contains(t, budgetIDs, budget.ID, "VK-scoped wildcard budget must be found even when the request carries no model (e.g. batch-create)")
 }
@@ -1593,11 +1594,13 @@ func TestCollectModelScopedGovernanceIDs_FindsExactModelConfigMissedAtCreateTime
 	}, nil, nil)
 	require.NoError(t, err)
 
-	// What batch create sees: no model, so only the wildcard is collected. The user is a scope of
-	// its own, read off the request rather than off a grant, so no access is needed to reach it.
-	inFlightCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+	// What batch create settles onto the request: no model, so only the wildcard is gathered. The
+	// user is a scope of its own, read off the request rather than off a permit, so no access is
+	// needed to reach it.
+	inFlightCtx := grantedCtx(ctx)
 	inFlightCtx.SetValue(schemas.BifrostContextKeyUserID, userID)
-	inFlight, _ := store.CollectApplicableGovernanceIDs(inFlightCtx, nil, schemas.ModelProvider(providerName), "")
+	inFlightBudgets, _ := gatherLimits(inFlightCtx, store, nil, schemas.ModelProvider(providerName), "")
+	inFlight := limitIDsOf(inFlightBudgets)
 	assert.Contains(t, inFlight, wildcard.ID)
 	assert.NotContains(t, inFlight, perModel.ID, "the per-model budget cannot be matched without a model")
 
@@ -1618,10 +1621,10 @@ func TestCollectModelScopedGovernanceIDs_FindsExactModelConfigMissedAtCreateTime
 	assert.Empty(t, otherUser)
 }
 
-// The IDs recorded on a log row are what a recovering node replays usage against, so they have to be
-// every limit the request was actually charged to and nothing else. Both halves matter: a limit left
-// out loses its usage when the node ghosts, and one added that nothing debits invents usage.
-func TestCollectApplicableGovernanceIDs(t *testing.T) {
+// What a request is billed to and what is recorded on its log row are the limits settled on its
+// grant, and nothing else. Both halves matter: a limit left out loses its usage when the node
+// ghosts, and one that nothing debits invents usage on replay.
+func TestSettledLimitsAreWhatIsAccounted(t *testing.T) {
 	logger := NewMockLogger()
 
 	vkBudget := buildBudget("b-vk", 1000, "1d")
@@ -1654,53 +1657,48 @@ func TestCollectApplicableGovernanceIDs(t *testing.T) {
 	}, nil, nil)
 	require.NoError(t, err)
 
-	// Settling the limits on the grant is what the funnel does before any check runs, so the
-	// recorded set is read from there rather than worked out again here.
-	settle := func(t *testing.T, provider schemas.ModelProvider, model string) (*schemas.BifrostContext, schemas.Limits) {
+	// Settling the limits on the grant is what the funnel does before any check runs; everything
+	// afterwards reads them from there rather than working out a second answer.
+	settle := func(t *testing.T, provider schemas.ModelProvider, model string) schemas.Limits {
 		t.Helper()
-		ctx := resolverCtx(store, "sk-bf-collect")
-		limits := resolveLimits(ctx, store, provider, model)
+		limits := resolveLimits(resolverCtx(store, "sk-bf-collect"), store, provider, model)
 		require.NotNil(t, limits)
-		return ctx, limits
+		return limits
 	}
 
-	t.Run("records every limit the access answers to, and the attempt's own", func(t *testing.T) {
-		ctx, limits := settle(t, schemas.OpenAI, "gpt-4o")
-		budgetIDs, _ := store.CollectApplicableGovernanceIDs(ctx, limits, schemas.OpenAI, "gpt-4o")
+	t.Run("every limit the access answers to, and the attempt's own", func(t *testing.T) {
+		budgetIDs := limitIDsOf(settle(t, schemas.OpenAI, "gpt-4o").Budgets())
 
 		assert.ElementsMatch(t,
 			[]string{"b-provider", "b-model", "b-vk", "b-team", "b-customer"}, budgetIDs,
-			"the holder chain the permit pays for, plus the provider and model config this attempt draws on")
+			"the holder chain, plus the provider and model config this attempt draws on")
 	})
 
-	t.Run("nil limits leave only what the attempt itself is subject to", func(t *testing.T) {
-		// What a request whose holder is deliberately not being tracked records. The provider and the
-		// model config are charged regardless of what granted the request, so they stay.
-		ctx, _ := settle(t, schemas.OpenAI, "gpt-4o")
-		budgetIDs, _ := store.CollectApplicableGovernanceIDs(ctx, nil, schemas.OpenAI, "gpt-4o")
+	t.Run("dropping what the holder funds keeps what the deployment does", func(t *testing.T) {
+		// What a request whose holder is deliberately not being counted is billed. The provider and
+		// the model config are owed whatever granted the request, so they stay.
+		budgets := grant.LimitsFrom(settle(t, schemas.OpenAI, "gpt-4o").Budgets(), untrackedHolderKinds...)
 
-		assert.ElementsMatch(t, []string{"b-provider", "b-model"}, budgetIDs)
+		assert.ElementsMatch(t, []string{"b-provider", "b-model"}, limitIDsOf(budgets))
 	})
 
-	t.Run("a limit reached twice is recorded once", func(t *testing.T) {
-		// The same budget row can cover a request by more than one route. Recording it twice would
-		// have reconciliation replay its usage twice.
-		ctx, limits := settle(t, schemas.OpenAI, "gpt-4o")
-		budgetIDs, _ := store.CollectApplicableGovernanceIDs(ctx, limits, schemas.OpenAI, "gpt-4o")
+	t.Run("a limit reached twice is accounted once", func(t *testing.T) {
+		// The same budget row can cover a request by more than one route. Billing it twice would
+		// charge one budget twice and have reconciliation replay its usage twice.
+		budgetIDs := limitIDsOf(settle(t, schemas.OpenAI, "gpt-4o").Budgets())
 
 		seen := map[string]int{}
 		for _, id := range budgetIDs {
 			seen[id]++
 		}
 		for id, count := range seen {
-			assert.Equal(t, 1, count, "budget %s recorded more than once", id)
+			assert.Equal(t, 1, count, "budget %s accounted more than once", id)
 		}
 	})
 
-	t.Run("an attempt with no model still records what its provider is charged", func(t *testing.T) {
+	t.Run("an attempt with no model still answers to its provider", func(t *testing.T) {
 		// Tool execution and other modelless attempts still spend against the provider.
-		ctx, limits := settle(t, schemas.OpenAI, "")
-		budgetIDs, _ := store.CollectApplicableGovernanceIDs(ctx, limits, schemas.OpenAI, "")
+		budgetIDs := limitIDsOf(settle(t, schemas.OpenAI, "").Budgets())
 
 		assert.Contains(t, budgetIDs, "b-provider")
 		assert.NotContains(t, budgetIDs, "b-model", "no model means no model config applies")

--- a/plugins/governance/test_utils.go
+++ b/plugins/governance/test_utils.go
@@ -244,6 +244,16 @@ func resolverCtx(store GovernanceStore, virtualKeyValue string) *schemas.Bifrost
 	return ctx
 }
 
+// settleLimits fills in the limits a request made with vkValue for this provider and model answers to,
+// as the funnel does before the tracker ever sees an update. Charging bills the limits it is handed
+// rather than working out which of them apply (the update says what to charge, not who made the
+// request), so a test driving the tracker directly has to settle them or nothing is billed.
+func settleLimits(gs GovernanceStore, vkValue string, provider schemas.ModelProvider, model string, update *UsageUpdate) *UsageUpdate {
+	ctx := resolverCtx(gs, vkValue)
+	update.Budgets, update.RateLimits = gatherLimits(ctx, gs, ctx.Grant().Access(), provider, model)
+	return update
+}
+
 func assertDecision(t *testing.T, expected Decision, result *EvaluationResult) {
 	t.Helper()
 	assert.NotNil(t, result, "EvaluationResult should not be nil")
@@ -384,9 +394,11 @@ func evaluateGrantedRequest(r *BudgetResolver, ctx *schemas.BifrostContext, acce
 
 // evaluateDeploymentLimits runs the limits that apply to every request regardless of what granted
 // it (the deployment's provider and model-config limits) through the single check the funnel uses.
-// It stands in for the per-holder entry points those limits used to have.
+// It stands in for the per-holder entry points those limits used to have, reached the way a request
+// nobody granted anything reaches them: no access, with the deployment's limits settled on its grant.
 func evaluateDeploymentLimits(r *BudgetResolver, ctx *schemas.BifrostContext, provider schemas.ModelProvider, model string) *EvaluationResult {
-	return r.evaluateLimits(ctx, &EvaluationRequest{Provider: provider, Model: model}, nil)
+	return r.evaluateLimits(ctx, &EvaluationRequest{Provider: provider, Model: model},
+		resolveLimits(ctx, r.store, provider, model))
 }
 
 // resolveLimitsForTest settles the limits onto whatever access ctx carries, as Evaluate does, and
@@ -497,6 +509,69 @@ func checkScopedBudgets(gs *LocalGovernanceStore, ctx context.Context, permitTyp
 func checkScopedRateLimits(gs *LocalGovernanceStore, ctx context.Context, permitType grant.PermitType, scopeID string, provider schemas.ModelProvider, model string, tokens, requests map[string]int64) (Decision, error) {
 	_, rateLimits := gs.ProviderAndModelLimits(ctx, grant.NewPermit(permitType, scopeID, "", true, false, nil, nil), provider, model)
 	return gs.CheckRateLimits(ctx, rateLimits, tokens, requests)
+}
+
+// The helpers below stand in for the per-level update methods the store used to expose. Charging
+// bills the limits settled for an attempt, so each of these assembles the limits that level
+// contributes and bills them: the assembly is the caller's half, the charge is shared.
+
+// chargeDeploymentBudgets bills a cost to the limits every request to this provider and model
+// answers to regardless of what granted it, and chargeDeploymentRateLimits counts one against them.
+func chargeDeploymentBudgets(gs *LocalGovernanceStore, ctx context.Context, model string, provider schemas.ModelProvider, cost float64) error {
+	budgets, _ := gs.ProviderAndModelLimits(ctx, nil, provider, model)
+	return gs.ChargeBudgets(ctx, budgets, cost)
+}
+
+func chargeDeploymentRateLimits(gs *LocalGovernanceStore, ctx context.Context, model string, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens, shouldUpdateRequests bool) error {
+	_, rateLimits := gs.ProviderAndModelLimits(ctx, nil, provider, model)
+	return gs.ChargeRateLimits(ctx, rateLimits, tokensUsed, shouldUpdateTokens, shouldUpdateRequests)
+}
+
+// scopedModelLimits is what one named scope's model configs impose on a request to this provider
+// and model: that scope alone, so a test can bill it without the deployment's own coming along.
+func scopedModelLimits(gs *LocalGovernanceStore, ctx context.Context, scope, scopeID, model string, provider schemas.ModelProvider) (budgets, rateLimits []schemas.Limit) {
+	providerName := string(provider)
+	var providerArg *string
+	if providerName != "" {
+		providerArg = &providerName
+	}
+	for _, mc := range gs.collectModelConfigsFor(ctx, scope, scopeID, model, providerArg) {
+		if mc == nil {
+			continue
+		}
+		budgets = append(budgets, grant.LimitsHeldBy(grant.LimitHolderVirtualKeyModelConfig, mc.ID, modelConfigDisplayName(mc), providerName, model, budgetIDsOf(mc.Budgets)...)...)
+		rateLimits = append(rateLimits, grant.LimitsHeldBy(grant.LimitHolderVirtualKeyModelConfig, mc.ID, modelConfigDisplayName(mc), providerName, model, idOrEmpty(mc.RateLimitID)...)...)
+	}
+	return budgets, rateLimits
+}
+
+// chargeScopedBudgets bills a cost to the model configs a named holder set for its own traffic, and
+// chargeScopedRateLimits counts one against them.
+func chargeScopedBudgets(gs *LocalGovernanceStore, ctx context.Context, scope, scopeID, model string, provider schemas.ModelProvider, cost float64) error {
+	budgets, _ := scopedModelLimits(gs, ctx, scope, scopeID, model, provider)
+	return gs.ChargeBudgets(ctx, budgets, cost)
+}
+
+func chargeScopedRateLimits(gs *LocalGovernanceStore, ctx context.Context, scope, scopeID, model string, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens, shouldUpdateRequests bool) error {
+	_, rateLimits := scopedModelLimits(gs, ctx, scope, scopeID, model, provider)
+	return gs.ChargeRateLimits(ctx, rateLimits, tokensUsed, shouldUpdateTokens, shouldUpdateRequests)
+}
+
+// chargeGrantBudgets bills a cost to what a key's permit is funded by: the key's own, its provider
+// configs' for this provider, and the team and customer it belongs to. chargeGrantRateLimits is
+// its rate-limit counterpart.
+func chargeGrantBudgets(gs *LocalGovernanceStore, ctx context.Context, vk *configstoreTables.TableVirtualKey, provider schemas.ModelProvider, cost float64) error {
+	permit := gs.permitForVirtualKey(ctx, vk)
+	heldBudgets, _ := gs.HolderLimits(ctx, permit)
+	providerBudgets, _ := gs.ProviderLimits(ctx, permit, provider)
+	return gs.ChargeBudgets(ctx, append(heldBudgets, providerBudgets...), cost)
+}
+
+func chargeGrantRateLimits(gs *LocalGovernanceStore, ctx context.Context, vk *configstoreTables.TableVirtualKey, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens, shouldUpdateRequests bool) error {
+	permit := gs.permitForVirtualKey(ctx, vk)
+	_, heldRateLimits := gs.HolderLimits(ctx, permit)
+	_, providerRateLimits := gs.ProviderLimits(ctx, permit, provider)
+	return gs.ChargeRateLimits(ctx, append(heldRateLimits, providerRateLimits...), tokensUsed, shouldUpdateTokens, shouldUpdateRequests)
 }
 
 // checkGrantBudgets checks what a key's grant is funded by: the key's own, its provider configs' for

--- a/plugins/governance/tracker.go
+++ b/plugins/governance/tracker.go
@@ -14,14 +14,17 @@ import (
 
 // UsageUpdate contains data for VK-level usage tracking
 type UsageUpdate struct {
-	VirtualKey string                `json:"virtual_key"`
-	Provider   schemas.ModelProvider `json:"provider"`
-	Model      string                `json:"model"`
-	Success    bool                  `json:"success"`
-	TokensUsed int64                 `json:"tokens_used"`
-	Cost       float64               `json:"cost"` // Cost in dollars
-	RequestID  string                `json:"request_id"`
-	UserID     string                `json:"user_id,omitempty"` // User ID for enterprise user-level governance
+	Success    bool    `json:"success"`
+	TokensUsed int64   `json:"tokens_used"`
+	Cost       float64 `json:"cost"` // Cost in dollars
+	RequestID  string  `json:"request_id"`
+
+	// Budgets and RateLimits are the limits this attempt answers to, settled when its provider and
+	// model were known and carried here rather than worked out again at charging time. They travel
+	// on the update because charging is asynchronous: by the time it runs the request may be on a
+	// later attempt, whose limits are not the ones this usage was incurred under.
+	Budgets    []schemas.Limit `json:"-"`
+	RateLimits []schemas.Limit `json:"-"`
 
 	// Streaming optimization fields
 	IsStreaming  bool `json:"is_streaming"`   // Whether this is a streaming response
@@ -139,95 +142,22 @@ func (t *UsageTracker) UpdateUsage(ctx context.Context, update *UsageUpdate) {
 	shouldUpdateRequests := update.Success && (!update.IsStreaming || (update.IsStreaming && update.IsFinalChunk))
 	shouldUpdateBudget := !update.IsStreaming || (update.IsStreaming && update.HasUsageData)
 
-	// 1. Update rate limit usage for both provider-level and model-level
-	// This applies even when virtual keys are disabled or not present
-	// Guard: only update when Model is set (MCP paths may not have it); provider is optional —
-	// the underlying function handles empty provider by skipping provider-level and still
-	// updating any matching global model-only configs.
-	if update.Model != "" {
-		if err := t.store.UpdateProviderAndModelRateLimitUsageInMemory(ctx, update.Model, update.Provider, update.TokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
-			t.logger.Error("failed to update rate limit usage for model %s, provider %s: %v", update.Model, update.Provider, err)
+	// Everything this request answers to was resolved when its provider and model were settled, and
+	// checked as one list. Charging reads that same list, so a limit cannot be enforced on a request
+	// and then not billed for it, or billed and never enforced, which is what several independent
+	// walks over the holder's shape used to risk, one per level that could be paying.
+	//
+	// The list already names the deployment's provider limits, the model configs that apply in every
+	// scope, and whatever funds the holder. Nothing here asks which of those a limit is.
+	if len(update.RateLimits) > 0 && (shouldUpdateTokens || shouldUpdateRequests) {
+		if err := t.store.ChargeRateLimits(ctx, update.RateLimits, update.TokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
+			t.logger.Error("failed to count request %s against its rate limits: %v", update.RequestID, err)
 		}
 	}
 
-	// 2. Update budget usage for both provider-level and model-level
-	// This applies even when virtual keys are disabled or not present
-	// Guard: only update when Model is set (MCP paths may not have it); provider is optional —
-	// the underlying function handles empty provider by skipping provider-level and still
-	// updating any matching global model-only configs.
-	if update.Model != "" && shouldUpdateBudget && update.Cost > 0 {
-		if err := t.store.UpdateProviderAndModelBudgetUsageInMemory(ctx, update.Model, update.Provider, update.Cost); err != nil {
-			t.logger.Error("failed to update budget usage for model %s, provider %s: %v", update.Model, update.Provider, err)
-		}
-	}
-
-	// 3. Update user-level governance (enterprise-only, before VK-level)
-	if update.UserID != "" {
-		// Update user rate limit usage
-		if err := t.store.UpdateUserRateLimitUsageInMemory(ctx, update.UserID, update.TokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
-			t.logger.Error("failed to update user rate limit usage for user %s: %v", update.UserID, err)
-		}
-		// Update user budget usage
-		if shouldUpdateBudget && update.Cost > 0 {
-			if err := t.store.UpdateUserBudgetUsageInMemory(ctx, update.UserID, update.Cost); err != nil {
-				t.logger.Error("failed to update user budget usage for user %s: %v", update.UserID, err)
-			}
-		}
-		// Update per-user-scoped model config rate limits and budgets. Mirrors the
-		// VK-scoped model block below. Gated on model being present — MCP tool
-		// execution paths (no model) are excluded naturally by this guard.
-		if update.Model != "" {
-			if err := t.store.UpdateScopedModelRateLimitUsageInMemory(ctx, configstoreTables.ModelConfigScopeUser, update.UserID, update.Model, update.Provider, update.TokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
-				t.logger.Error("failed to update scoped model rate limit usage for user %s: %v", update.UserID, err)
-			}
-			if shouldUpdateBudget && update.Cost > 0 {
-				if err := t.store.UpdateScopedModelBudgetUsageInMemory(ctx, configstoreTables.ModelConfigScopeUser, update.UserID, update.Model, update.Provider, update.Cost); err != nil {
-					t.logger.Error("failed to update scoped model budget usage for user %s: %v", update.UserID, err)
-				}
-			}
-		}
-	}
-
-	// 4. Now handle virtual key-level updates (if virtual key exists)
-	if update.VirtualKey == "" {
-		// No virtual key, provider-level and model-level updates already done above
-		return
-	}
-
-	// Get virtual key
-	vk, exists := t.store.GetVirtualKey(ctx, update.VirtualKey)
-	if !exists {
-		t.logger.Debug(fmt.Sprintf("Virtual key not found: %s", update.VirtualKey))
-		return
-	}
-
-	// Update per-VK-scoped model config usage (counterpart to the global model updates above).
-	// Without this, per-VK model limits never increment and so never trip.
-	if update.Model != "" {
-		if err := t.store.UpdateScopedModelRateLimitUsageInMemory(ctx, configstoreTables.ModelConfigScopeVirtualKey, vk.ID, update.Model, update.Provider, update.TokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
-			t.logger.Error("failed to update scoped model rate limit usage for VK %s: %v", vk.ID, err)
-		}
-		if shouldUpdateBudget && update.Cost > 0 {
-			if err := t.store.UpdateScopedModelBudgetUsageInMemory(ctx, configstoreTables.ModelConfigScopeVirtualKey, vk.ID, update.Model, update.Provider, update.Cost); err != nil {
-				t.logger.Error("failed to update scoped model budget usage for VK %s: %v", vk.ID, err)
-			}
-		}
-	}
-
-	// Update rate limit usage (VK-level, provider-config-level, team-level, customer-level) if applicable
-	// Include TeamID and CustomerID checks since rate limits can be configured at those levels
-	if vk.RateLimit != nil || len(vk.ProviderConfigs) > 0 || vk.TeamID != nil || vk.CustomerID != nil {
-		if err := t.store.UpdateVirtualKeyRateLimitUsageInMemory(ctx, vk, update.Provider, update.TokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
-			t.logger.Error("failed to update rate limit usage for VK %s: %v", vk.ID, err)
-		}
-	}
-
-	// Update budget usage in hierarchy (VK → Team → Customer) only if we have usage data
-	if shouldUpdateBudget && update.Cost > 0 {
-		t.logger.Debug("updating budget usage for VK %s", vk.ID)
-		// Use atomic budget update to prevent race conditions and ensure consistency
-		if err := t.store.UpdateVirtualKeyBudgetUsageInMemory(ctx, vk, update.Provider, update.Cost); err != nil {
-			t.logger.Error("failed to update budget hierarchy atomically for VK %s: %v", vk.ID, err)
+	if len(update.Budgets) > 0 && shouldUpdateBudget && update.Cost > 0 {
+		if err := t.store.ChargeBudgets(ctx, update.Budgets, update.Cost); err != nil {
+			t.logger.Error("failed to bill request %s to its budgets: %v", update.RequestID, err)
 		}
 	}
 }

--- a/plugins/governance/tracker_test.go
+++ b/plugins/governance/tracker_test.go
@@ -34,9 +34,6 @@ func TestUsageTracker_FailedRequestWithUsage_IsBilled(t *testing.T) {
 	defer tracker.Cleanup()
 
 	update := &UsageUpdate{
-		VirtualKey:   "sk-bf-test",
-		Provider:     schemas.OpenAI,
-		Model:        "gpt-4",
 		Success:      false, // Failed/cancelled request...
 		TokensUsed:   100,
 		Cost:         25.5, // ...that nonetheless consumed provider tokens.
@@ -44,7 +41,7 @@ func TestUsageTracker_FailedRequestWithUsage_IsBilled(t *testing.T) {
 		HasUsageData: true,
 	}
 
-	tracker.UpdateUsage(context.Background(), update)
+	tracker.UpdateUsage(context.Background(), settleLimits(store, "sk-bf-test", schemas.OpenAI, "gpt-4", update))
 
 	// Give time for async processing
 	time.Sleep(200 * time.Millisecond)
@@ -79,16 +76,13 @@ func TestUsageTracker_FailedRequestNoUsage_IsSkipped(t *testing.T) {
 	defer tracker.Cleanup()
 
 	update := &UsageUpdate{
-		VirtualKey: "sk-bf-test",
-		Provider:   schemas.OpenAI,
-		Model:      "gpt-4",
 		Success:    false, // Failed before the model ran...
 		TokensUsed: 0,
 		Cost:       0.0, // ...so no tokens were consumed.
 		RequestID:  "req-456",
 	}
 
-	tracker.UpdateUsage(context.Background(), update)
+	tracker.UpdateUsage(context.Background(), settleLimits(store, "sk-bf-test", schemas.OpenAI, "gpt-4", update))
 
 	// Give time for async processing
 	time.Sleep(200 * time.Millisecond)
@@ -114,16 +108,13 @@ func TestUsageTracker_UpdateUsage_VirtualKeyNotFound(t *testing.T) {
 	defer tracker.Cleanup()
 
 	update := &UsageUpdate{
-		VirtualKey: "sk-bf-nonexistent",
-		Provider:   schemas.OpenAI,
-		Model:      "gpt-4",
 		Success:    true,
 		TokensUsed: 100,
 		Cost:       25.5,
 	}
 
 	// Should not panic or error
-	tracker.UpdateUsage(context.Background(), update)
+	tracker.UpdateUsage(context.Background(), settleLimits(store, "sk-bf-test", schemas.OpenAI, "gpt-4", update))
 
 	time.Sleep(100 * time.Millisecond)
 	// Just verify it doesn't crash
@@ -149,9 +140,6 @@ func TestUsageTracker_UpdateUsage_StreamingOptimization(t *testing.T) {
 
 	// First streaming chunk (not final, has usage data)
 	update1 := &UsageUpdate{
-		VirtualKey:   "sk-bf-test",
-		Provider:     schemas.OpenAI,
-		Model:        "gpt-4",
 		Success:      true,
 		TokensUsed:   50,
 		Cost:         0.0, // No cost on non-final chunks
@@ -161,7 +149,7 @@ func TestUsageTracker_UpdateUsage_StreamingOptimization(t *testing.T) {
 		HasUsageData: true,
 	}
 
-	tracker.UpdateUsage(context.Background(), update1)
+	tracker.UpdateUsage(context.Background(), settleLimits(store, "sk-bf-test", schemas.OpenAI, "gpt-4", update1))
 	time.Sleep(200 * time.Millisecond)
 
 	// Retrieve the updated rate limit from the main RateLimits map
@@ -175,9 +163,6 @@ func TestUsageTracker_UpdateUsage_StreamingOptimization(t *testing.T) {
 
 	// Final chunk
 	update2 := &UsageUpdate{
-		VirtualKey:   "sk-bf-test",
-		Provider:     schemas.OpenAI,
-		Model:        "gpt-4",
 		Success:      true,
 		TokensUsed:   0, // Already counted
 		Cost:         12.5,
@@ -187,7 +172,7 @@ func TestUsageTracker_UpdateUsage_StreamingOptimization(t *testing.T) {
 		HasUsageData: true,
 	}
 
-	tracker.UpdateUsage(context.Background(), update2)
+	tracker.UpdateUsage(context.Background(), settleLimits(store, "sk-bf-test", schemas.OpenAI, "gpt-4", update2))
 	time.Sleep(200 * time.Millisecond)
 
 	// Retrieve the updated rate limit again
@@ -222,9 +207,6 @@ func TestUsageTracker_Idempotency_SameAttemptBilledOnce(t *testing.T) {
 
 	mk := func() *UsageUpdate {
 		return &UsageUpdate{
-			VirtualKey:    "sk-bf-test",
-			Provider:      schemas.OpenAI,
-			Model:         "gpt-4",
 			Success:       false,
 			TokensUsed:    100,
 			Cost:          10.0,
@@ -234,8 +216,8 @@ func TestUsageTracker_Idempotency_SameAttemptBilledOnce(t *testing.T) {
 		}
 	}
 
-	tracker.UpdateUsage(context.Background(), mk())
-	tracker.UpdateUsage(context.Background(), mk()) // duplicate settlement
+	tracker.UpdateUsage(context.Background(), settleLimits(store, "sk-bf-test", schemas.OpenAI, "gpt-4", mk()))
+	tracker.UpdateUsage(context.Background(), settleLimits(store, "sk-bf-test", schemas.OpenAI, "gpt-4", mk())) // duplicate settlement
 	time.Sleep(200 * time.Millisecond)
 
 	budgets := store.GetGovernanceData(context.Background()).Budgets
@@ -268,9 +250,6 @@ func TestUsageTracker_Idempotency_DifferentAttemptsBothBilled(t *testing.T) {
 
 	mk := func(attempt int, success bool, cost float64) *UsageUpdate {
 		return &UsageUpdate{
-			VirtualKey:    "sk-bf-test",
-			Provider:      schemas.OpenAI,
-			Model:         "gpt-4",
 			Success:       success,
 			TokensUsed:    100,
 			Cost:          cost,
@@ -280,8 +259,8 @@ func TestUsageTracker_Idempotency_DifferentAttemptsBothBilled(t *testing.T) {
 		}
 	}
 
-	tracker.UpdateUsage(context.Background(), mk(0, false, 4.0)) // failed attempt, partial usage
-	tracker.UpdateUsage(context.Background(), mk(1, true, 6.0))  // successful retry
+	tracker.UpdateUsage(context.Background(), settleLimits(store, "sk-bf-test", schemas.OpenAI, "gpt-4", mk(0, false, 4.0))) // failed attempt, partial usage
+	tracker.UpdateUsage(context.Background(), settleLimits(store, "sk-bf-test", schemas.OpenAI, "gpt-4", mk(1, true, 6.0)))  // successful retry
 	time.Sleep(200 * time.Millisecond)
 
 	budgets := store.GetGovernanceData(context.Background()).Budgets

--- a/plugins/governance/utils.go
+++ b/plugins/governance/utils.go
@@ -78,43 +78,6 @@ func IsModelCheckedWhenPresent(requestType schemas.RequestType) bool {
 	}
 }
 
-// parseVirtualKeyFromHTTPRequest parses the virtual key from HTTP request headers.
-// It checks multiple headers in order: x-bf-vk, Authorization (Bearer token), x-api-key, and x-goog-api-key.
-// Parameters:
-//   - req: The HTTP request containing headers to parse
-//
-// Returns:
-//   - *string: The virtual key if found, nil otherwise
-func parseVirtualKeyFromHTTPRequest(req *schemas.HTTPRequest) *string {
-	var virtualKeyValue string
-	vkHeader := req.CaseInsensitiveHeaderLookup("x-bf-vk")
-	if vkHeader != "" && strings.HasPrefix(strings.ToLower(vkHeader), VirtualKeyPrefix) {
-		return new(vkHeader)
-	}
-	authHeader := req.CaseInsensitiveHeaderLookup("Authorization")
-	if authHeader != "" {
-		if strings.HasPrefix(strings.ToLower(authHeader), "bearer ") {
-			authHeaderValue := strings.TrimSpace(authHeader[7:]) // Remove "Bearer " prefix
-			if authHeaderValue != "" && strings.HasPrefix(strings.ToLower(authHeaderValue), VirtualKeyPrefix) {
-				virtualKeyValue = authHeaderValue
-			}
-		}
-	}
-	if virtualKeyValue != "" {
-		return new(virtualKeyValue)
-	}
-	xAPIKey := req.CaseInsensitiveHeaderLookup("x-api-key")
-	if xAPIKey != "" && strings.HasPrefix(strings.ToLower(xAPIKey), VirtualKeyPrefix) {
-		return new(xAPIKey)
-	}
-	// Checking x-goog-api-key header
-	xGoogleAPIKey := req.CaseInsensitiveHeaderLookup("x-goog-api-key")
-	if xGoogleAPIKey != "" && strings.HasPrefix(strings.ToLower(xGoogleAPIKey), VirtualKeyPrefix) {
-		return new(xGoogleAPIKey)
-	}
-	return nil
-}
-
 // getWeight safely dereferences a *float64 weight pointer, returning 1.0 as default if nil.
 // This allows distinguishing between "not set" (nil -> 1.0) and "explicitly set to 0" (0.0).
 func getWeight(w *float64) float64 {
@@ -124,15 +87,17 @@ func getWeight(w *float64) float64 {
 	return *w
 }
 
-// filterModelsForAccess drops the models a request may not use from a listing. The request's
-// access decides, so a model reachable only through a grant composed onto the request is kept,
-// and one the composition removed is dropped: the listing and the request agree by construction
-// rather than by two implementations happening to match.
-func (p *GovernancePlugin) filterModelsForAccess(ctx *schemas.BifrostContext, models []schemas.Model) []schemas.Model {
-	access, err := p.ResolveAccess(ctx)
-	if err != nil || access == nil {
-		// Nothing resolved: the request presented a credential that carries no permit, or reached
-		// here with no grant at all, so it may list nothing.
+// filterModelsForAccess drops the models a request may not use from a listing. The access decides,
+// so a model reachable only through a permit composed onto the request is kept, and one the
+// composition removed is dropped: the listing and the request agree by construction rather than by
+// two implementations happening to match.
+//
+// The access is handed in rather than resolved here. A listing is produced after the request has
+// been evaluated, and resolving again at that point would answer for whatever configuration has
+// become since; what a caller may list is what it was admitted under. No access lists nothing: a
+// request that presented nothing is not narrowed at all, and the caller gates on that before asking.
+func (p *GovernancePlugin) filterModelsForAccess(access schemas.Access, models []schemas.Model) []schemas.Model {
+	if access == nil {
 		return []schemas.Model{}
 	}
 


### PR DESCRIPTION
## Summary

Governance billing previously assembled the set of limits a request answers to independently at check time and at charge time — multiple walks over the holder's shape that were free to drift apart. A limit enforced on a request but not billed lets a caller spend past it indefinitely; one billed but never enforced drains a budget nothing ever refused. This PR makes the resolved limit set the single record of what a request was subject to: it is settled onto the access before any check runs, and everything afterwards — enforcement, billing, and log stamping — reads it from there.

## Changes

- **`UsageUpdate` no longer carries `VirtualKey`, `Provider`, `Model`, or `UserID`**. Instead it carries `Budgets` and `RateLimits`: the limits resolved for the attempt, passed in rather than re-derived at charge time. Charging is asynchronous, and by the time it runs the request may be on a later attempt whose limits are not the ones this usage was incurred under.

- **`GovernanceStore` interface replaces per-level update methods** (`UpdateVirtualKeyBudgetUsageInMemory`, `UpdateProviderAndModelBudgetUsageInMemory`, `UpdateScopedModelBudgetUsageInMemory`, and their rate-limit counterparts) with two methods: `ChargeBudgets` and `ChargeRateLimits`. Both accept the resolved limit list directly, so neither asks what kind of holder is paying and a request cannot be enforced against one set and billed against another.

- **`GatherLimits` replaces `CollectApplicableGovernanceIDs`** on the store interface. Assembly is now the store's responsibility in one place; `resolveLimits` calls it to settle the limits onto the access, and accounting reads them back from there. The old path re-derived the set from the presented credential at billing time, which is the drift this change closes.

- **`evaluateLimits` no longer filters by holder kind** before checking. The access is the one record of what a request was subject to, so a holder kind this package has never heard of is enforced by construction rather than by being registered in `allLimitHolderKinds`. The `enforcedLimitHolderKinds` function and `allLimitHolderKinds` slice are removed; `spendingChecksSkipped` replaces the former for the one remaining use.

- **`untrackedHolderKinds` replaces the user-ID exemption logic**. When a caller asks for holder usage not to be counted, the filter names what to keep (deployment and user limits) rather than what to drop, because the set of holder-funded kinds is open while the deployment's own is closed.

- **`filterModelsForAccess` accepts the access directly** rather than resolving it from context. A listing is produced after the request has been evaluated; resolving again at that point would answer for whatever configuration has become since.

- **`modelConfigScopeFor` returns an empty string for unrecognised grant types** rather than casting the type to a scope name. A near-miss there read as "this grant has no per-model limits" rather than as an error.

- **`LimitHolderModelConfig`, `LimitHolderScopedModelConfig`, and `LimitHolderProvider` constants** are moved from `store.go` into the `grants` package as `LimitHolderModelConfig`, `LimitHolderUserModelConfig`, `LimitHolderVirtualKeyModelConfig`, and `LimitHolderProvider`, so the vocabulary is shared rather than duplicated.

- **Test helpers** (`chargeDeploymentBudgets`, `chargeDeploymentRateLimits`, `chargeGrantBudgets`, `chargeGrantRateLimits`, `chargeScopedBudgets`, `chargeScopedRateLimits`) replace the removed store methods in tests that drove individual levels directly. `settleLimits` fills in the limits on a `UsageUpdate` the way the funnel does, so tracker tests that bypass the hook still bill correctly.

- **New test files**: `hookrefusal_test.go` asserts refusal behaviour through `PreLLMHook` rather than through the verdict behind it, covering the rejected-context mark and its removal on the allow path. `providerscopedlimits_test.go` asserts that a provider config's limits answer only for that provider, both at assembly time and after both hooks have run.

- **New test `TestAccounting_ChargesExactlyWhatWasChecked`** runs a request through the full hook funnel and asserts that the set recorded on the log row and the set whose counters actually moved are identical.

## Type of change

- [ ] Bug fix
- [x] Refactor
- [ ] Feature
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/...
```

All new and updated tests cover the invariant directly: the set checked, the set recorded, and the set billed are the same list.

## Breaking changes

- [x] Yes
- [ ] No

`GovernanceStore` implementors must add `ChargeBudgets`, `ChargeRateLimits`, and `GatherLimits`, and remove the methods that were deleted from the interface. `UsageUpdate` no longer carries `VirtualKey`, `Provider`, `Model`, or `UserID`; callers that constructed updates with those fields must instead pass the resolved `Budgets` and `RateLimits` slices, which `settleLimits` (or a call to `GatherLimits` directly) produces.

## Security considerations

The change closes a class of billing bypass: a limit that was enforced on a request but not billed for it allowed a caller to spend past it indefinitely. The fix is structural — the same list is used for both — rather than a patch to any individual check or charge site.