### PR TITLE
refactor: replace `*TableVirtualKey` in routing rule evaluation with a `GovernanceScope` struct read off the resolved access context, eliminating a duplicate credential walk

### DIFF
--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/batchaccounting"
 	"github.com/maximhq/bifrost/framework/configstore"
-	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/grant"
 	"github.com/maximhq/bifrost/framework/mcpcatalog"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
@@ -57,7 +56,6 @@ type BaseGovernancePlugin interface {
 	GetGovernanceStore() GovernanceStore
 	// Routing collaboration: the routing plugin calls these after evaluating routing rules,
 	// so the allowlist and the load balancer both act on the post-rule provider/model.
-	GetVirtualKey(ctx context.Context, vkValue string) (*configstoreTables.TableVirtualKey, bool)
 	// ResolveAccess answers what a request may reach, resolving it once and recording it on the
 	// request's grant so every later reader sees the same answer. A request context that carries no
 	// grant is a wiring fault, and is reported as one.
@@ -65,7 +63,7 @@ type BaseGovernancePlugin interface {
 	// request context concretely because resolution reads request-scoped values off it, which a
 	// plain context.Context carrying the same request cannot provide.
 	ResolveAccess(ctx *schemas.BifrostContext) (schemas.Access, error)
-	GetBudgetAndRateLimitStatus(ctx context.Context, model string, provider schemas.ModelProvider, vk *configstoreTables.TableVirtualKey, budgetBaselines map[string]float64, tokenBaselines map[string]int64, requestBaselines map[string]int64) *BudgetAndRateLimitStatus
+	GetBudgetAndRateLimitStatus(ctx *schemas.BifrostContext, provider schemas.ModelProvider, model string, budgetBaselines map[string]float64, tokenBaselines map[string]int64, requestBaselines map[string]int64) *BudgetAndRateLimitStatus
 	PublishRoutingAllowlist(ctx *schemas.BifrostContext, modelStr string)
 	LoadBalanceProvider(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) error
 }
@@ -357,16 +355,16 @@ func (p *GovernancePlugin) HTTPTransportStreamChunkHook(ctx *schemas.BifrostCont
 	return chunk, nil
 }
 
-// GetVirtualKey resolves a virtual key by its value. Exposed so the routing plugin can build
-// the rule scope chain from the same key this plugin governs.
-func (p *GovernancePlugin) GetVirtualKey(ctx context.Context, vkValue string) (*configstoreTables.TableVirtualKey, bool) {
-	return p.store.GetVirtualKey(ctx, vkValue)
-}
-
-// GetBudgetAndRateLimitStatus reports live budget and rate limit usage for a provider/model
-// pair. Exposed so routing rules can test budget_used, tokens_used and request.
-func (p *GovernancePlugin) GetBudgetAndRateLimitStatus(ctx context.Context, model string, provider schemas.ModelProvider, vk *configstoreTables.TableVirtualKey, budgetBaselines map[string]float64, tokenBaselines map[string]int64, requestBaselines map[string]int64) *BudgetAndRateLimitStatus {
-	return p.store.GetBudgetAndRateLimitStatus(ctx, model, provider, vk, budgetBaselines, tokenBaselines, requestBaselines)
+// GetBudgetAndRateLimitStatus reports how close a request is to the limits it answers to, for a
+// provider and model pair. Exposed so routing rules can test budget_used, tokens_used and request
+// counts.
+//
+// It reads the request's access off its grant rather than taking a credential: what governs a
+// request is what granted it, and a rule asking "how much room is left" wants the answer for every
+// holder paying, which for a caller granted access by something other than a key is not answerable
+// from a key at all. Nothing is passed, so nothing can be passed wrongly.
+func (p *GovernancePlugin) GetBudgetAndRateLimitStatus(ctx *schemas.BifrostContext, provider schemas.ModelProvider, model string, budgetBaselines map[string]float64, tokenBaselines map[string]int64, requestBaselines map[string]int64) *BudgetAndRateLimitStatus {
+	return p.store.GetBudgetAndRateLimitStatus(ctx, provider, model, budgetBaselines, tokenBaselines, requestBaselines)
 }
 
 // LoadBalanceProvider picks a weighted provider among those the request may reach for req.Model

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -248,7 +248,10 @@ type GovernanceStore interface {
 	UpdateProviderInMemory(ctx context.Context, provider *configstoreTables.TableProvider) *configstoreTables.TableProvider
 	DeleteProviderInMemory(ctx context.Context, providerName string)
 	// Budget and rate limit status queries for routing with baseline support
-	GetBudgetAndRateLimitStatus(ctx context.Context, model string, provider schemas.ModelProvider, vk *configstoreTables.TableVirtualKey, budgetBaselines map[string]float64, tokenBaselines map[string]int64, requestBaselines map[string]int64) *BudgetAndRateLimitStatus
+	// GetBudgetAndRateLimitStatus reports how close the request is to what it answers to for a
+	// provider and model pair, read from the access on its grant. Routing asks this before an attempt's
+	// limits are settled, one pair at a time, so it gathers rather than reads the settled set.
+	GetBudgetAndRateLimitStatus(ctx *schemas.BifrostContext, provider schemas.ModelProvider, model string, budgetBaselines map[string]float64, tokenBaselines map[string]int64, requestBaselines map[string]int64) *BudgetAndRateLimitStatus
 	// CollectModelScopedGovernanceIDs returns the budget and rate-limit IDs owned by
 	// model configs matching (provider, model) across the global, user and virtual-key
 	// scopes. It takes the virtual key's ID rather than its value, so a caller settling
@@ -1851,22 +1854,6 @@ func modelConfigStoreKey(scope, scopeID, modelKey string, provider *string) stri
 		return base
 	}
 	return fmt.Sprintf("%s:%s:%s", scope, scopeID, base)
-}
-
-// modelConfigScope is one level of the model-config scope chain (name + target ID).
-type modelConfigScope struct {
-	name string
-	id   string
-}
-
-// nonGlobalModelConfigScopeChain returns the non-global scopes that apply to a request
-// made with the given virtual key, most specific first. The global scope is intentionally
-// excluded because it is enforced separately, and unconditionally, by ProviderAndModelLimits.
-func nonGlobalModelConfigScopeChain(vk *configstoreTables.TableVirtualKey) []modelConfigScope {
-	if vk == nil {
-		return nil
-	}
-	return []modelConfigScope{{name: configstoreTables.ModelConfigScopeVirtualKey, id: vk.ID}}
 }
 
 // findScopedModelOnlyConfig looks up a model-only config (no provider) within a specific
@@ -4213,175 +4200,47 @@ func (gs *LocalGovernanceStore) updateRateLimitReferences(ctx context.Context, r
 	})
 }
 
-// GetBudgetAndRateLimitStatus returns the current budget and rate limit status for provider and model combination
-// Accounts for baseline usage from remote nodes when calculating percentages
-func (gs *LocalGovernanceStore) GetBudgetAndRateLimitStatus(ctx context.Context, model string, provider schemas.ModelProvider, vk *configstoreTables.TableVirtualKey, budgetBaselines map[string]float64, tokenBaselines map[string]int64, requestBaselines map[string]int64) *BudgetAndRateLimitStatus {
-	// Prevent nil pointer dereferences
-	if budgetBaselines == nil {
-		budgetBaselines = map[string]float64{}
-	}
-	if tokenBaselines == nil {
-		tokenBaselines = map[string]int64{}
-	}
-	if requestBaselines == nil {
-		requestBaselines = map[string]int64{}
+// GetBudgetAndRateLimitStatus implements GovernanceStore. It gathers what the request would answer to
+// for the pair, from the store and the access on its grant, and reports the fullest budget and rate
+// limit among them. A request with no access still answers to the deployment's own limits.
+func (gs *LocalGovernanceStore) GetBudgetAndRateLimitStatus(ctx *schemas.BifrostContext, provider schemas.ModelProvider, model string, budgetBaselines map[string]float64, tokenBaselines map[string]int64, requestBaselines map[string]int64) *BudgetAndRateLimitStatus {
+	budgets, rateLimits := gatherLimits(ctx, gs, ctx.Grant().Access(), provider, model)
+	status := &BudgetAndRateLimitStatus{}
+
+	for _, limit := range budgets {
+		budget := gs.LoadBudget(ctx, limit.ID)
+		if budget == nil {
+			continue
+		}
+		maxLimit := budget.EffectiveMaxLimit()
+		if maxLimit <= 0 {
+			continue
+		}
+		if percent := (budget.CurrentUsage + budgetBaselines[budget.ID]) / maxLimit * 100; percent > status.BudgetPercentUsed {
+			status.BudgetPercentUsed = percent
+		}
 	}
 
-	result := &BudgetAndRateLimitStatus{
-		BudgetPercentUsed:           0,
-		RateLimitTokenPercentUsed:   0,
-		RateLimitRequestPercentUsed: 0,
-	}
-
-	var providerStr *string
-	if provider != "" {
-		p := string(provider)
-		providerStr = &p
-	}
-
-	// applyModelConfig folds a model config's rate-limit and budgets into the running max.
-	applyModelConfig := func(modelConfig *configstoreTables.TableModelConfig) {
-		if modelConfig.RateLimitID != nil {
-			if rateLimitValue, ok := gs.rateLimits.Load(*modelConfig.RateLimitID); ok && rateLimitValue != nil {
-				if rateLimit, ok := rateLimitValue.(*configstoreTables.TableRateLimit); ok && rateLimit != nil {
-					if rateLimit.TokenMaxLimit != nil && *rateLimit.TokenMaxLimit > 0 {
-						tokenPercent := float64(rateLimit.TokenCurrentUsage+tokenBaselines[rateLimit.ID]) / float64(*rateLimit.TokenMaxLimit) * 100
-						if tokenPercent > result.RateLimitTokenPercentUsed {
-							result.RateLimitTokenPercentUsed = tokenPercent
-						}
-					}
-					// Calculate request percent used
-					if rateLimit.RequestMaxLimit != nil && *rateLimit.RequestMaxLimit > 0 {
-						requestPercent := float64(rateLimit.RequestCurrentUsage+requestBaselines[rateLimit.ID]) / float64(*rateLimit.RequestMaxLimit) * 100
-						if requestPercent > result.RateLimitRequestPercentUsed {
-							result.RateLimitRequestPercentUsed = requestPercent
-						}
-					}
-				}
+	for _, limit := range rateLimits {
+		rateLimit := gs.LoadRateLimit(ctx, limit.ID)
+		if rateLimit == nil {
+			continue
+		}
+		if rateLimit.TokenMaxLimit != nil && *rateLimit.TokenMaxLimit > 0 {
+			used := float64(rateLimit.TokenCurrentUsage+tokenBaselines[rateLimit.ID]) / float64(*rateLimit.TokenMaxLimit) * 100
+			if used > status.RateLimitTokenPercentUsed {
+				status.RateLimitTokenPercentUsed = used
 			}
 		}
-		// Get budget status (max percent across the config's budgets)
-		for bi := range modelConfig.Budgets {
-			if budgetValue, ok := gs.budgets.Load(modelConfig.Budgets[bi].ID); ok && budgetValue != nil {
-				if budget, ok := budgetValue.(*configstoreTables.TableBudget); ok && budget != nil {
-					if effectiveMaxLimit := budget.EffectiveMaxLimit(); effectiveMaxLimit > 0 {
-						budgetPercent := float64(budget.CurrentUsage+budgetBaselines[budget.ID]) / effectiveMaxLimit * 100
-						if budgetPercent > result.BudgetPercentUsed {
-							result.BudgetPercentUsed = budgetPercent
-						}
-					}
-				}
+		if rateLimit.RequestMaxLimit != nil && *rateLimit.RequestMaxLimit > 0 {
+			used := float64(rateLimit.RequestCurrentUsage+requestBaselines[rateLimit.ID]) / float64(*rateLimit.RequestMaxLimit) * 100
+			if used > status.RateLimitRequestPercentUsed {
+				status.RateLimitRequestPercentUsed = used
 			}
 		}
 	}
 
-	// Model-level (global scope), all tiers incl. the "*:provider" / "*:nil" wildcards
-	// that carry provider-level governance after the provider-governance migration.
-	if model != "" {
-		for _, modelConfig := range gs.collectModelConfigsFor(ctx, configstoreTables.ModelConfigScopeGlobal, "", model, providerStr) {
-			applyModelConfig(modelConfig)
-		}
-	}
-
-	// VK-scoped model configs. The per-VK provider budget set via the model limits UI now
-	// lives here (scope=virtual_key, model="*"); before the provider-governance migration it
-	// was read from vk.ProviderConfigs below. Mirror the scope walk enforcement uses.
-	if model != "" && vk != nil {
-		for _, scope := range nonGlobalModelConfigScopeChain(vk) {
-			for _, modelConfig := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, providerStr) {
-				applyModelConfig(modelConfig)
-			}
-		}
-	}
-
-	// Check global provider-specific rate limits and budgets
-	providerValue, ok := gs.providers.Load(string(provider))
-	if ok && providerValue != nil {
-		if providerTable, ok := providerValue.(*configstoreTables.TableProvider); ok && providerTable != nil {
-			// Get rate limit status
-			if providerTable.RateLimitID != nil {
-				if rateLimitValue, ok := gs.rateLimits.Load(*providerTable.RateLimitID); ok && rateLimitValue != nil {
-					if rateLimit, ok := rateLimitValue.(*configstoreTables.TableRateLimit); ok && rateLimit != nil {
-						// Calculate token percent used
-						if rateLimit.TokenMaxLimit != nil && *rateLimit.TokenMaxLimit > 0 {
-							tokenPercent := float64(rateLimit.TokenCurrentUsage+tokenBaselines[rateLimit.ID]) / float64(*rateLimit.TokenMaxLimit) * 100
-							if tokenPercent > result.RateLimitTokenPercentUsed {
-								result.RateLimitTokenPercentUsed = tokenPercent
-							}
-						}
-						// Calculate request percent used
-						if rateLimit.RequestMaxLimit != nil && *rateLimit.RequestMaxLimit > 0 {
-							requestPercent := float64(rateLimit.RequestCurrentUsage+requestBaselines[rateLimit.ID]) / float64(*rateLimit.RequestMaxLimit) * 100
-							if requestPercent > result.RateLimitRequestPercentUsed {
-								result.RateLimitRequestPercentUsed = requestPercent
-							}
-						}
-					}
-				}
-			}
-			// Get budget status
-			if providerTable.BudgetID != nil {
-				if budgetValue, ok := gs.budgets.Load(*providerTable.BudgetID); ok && budgetValue != nil {
-					if budget, ok := budgetValue.(*configstoreTables.TableBudget); ok && budget != nil {
-						if effectiveMaxLimit := budget.EffectiveMaxLimit(); effectiveMaxLimit > 0 {
-							budgetPercent := float64(budget.CurrentUsage+budgetBaselines[budget.ID]) / effectiveMaxLimit * 100
-							if budgetPercent > result.BudgetPercentUsed {
-								result.BudgetPercentUsed = budgetPercent
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-
-	// Check virtual key level provider-specific rate limits and budgets
-	// NO LONGER NEEDED - provider budgets are now handled in model configs under the virtual key scope. Keeping this code here for now, but it can be removed.
-	if vk != nil {
-		if vk.ProviderConfigs != nil {
-			for _, pc := range vk.ProviderConfigs {
-				if pc.Provider == string(provider) {
-					// Get rate limit status
-					if pc.RateLimit != nil {
-						// Look up canonical rate limit from gs.rateLimits
-						if rateLimitValue, ok := gs.rateLimits.Load(pc.RateLimit.ID); ok && rateLimitValue != nil {
-							if rateLimit, ok := rateLimitValue.(*configstoreTables.TableRateLimit); ok && rateLimit != nil {
-								// Calculate token percent used
-								if rateLimit.TokenMaxLimit != nil && *rateLimit.TokenMaxLimit > 0 {
-									tokenPercent := float64(rateLimit.TokenCurrentUsage+tokenBaselines[rateLimit.ID]) / float64(*rateLimit.TokenMaxLimit) * 100
-									if tokenPercent > result.RateLimitTokenPercentUsed {
-										result.RateLimitTokenPercentUsed = tokenPercent
-									}
-								}
-								// Calculate request percent used
-								if rateLimit.RequestMaxLimit != nil && *rateLimit.RequestMaxLimit > 0 {
-									requestPercent := float64(rateLimit.RequestCurrentUsage+requestBaselines[rateLimit.ID]) / float64(*rateLimit.RequestMaxLimit) * 100
-									if requestPercent > result.RateLimitRequestPercentUsed {
-										result.RateLimitRequestPercentUsed = requestPercent
-									}
-								}
-							}
-						}
-					}
-					// Get budget status from multi-budgets
-					for _, b := range pc.Budgets {
-						if budgetValue, ok := gs.budgets.Load(b.ID); ok && budgetValue != nil {
-							if budget, ok := budgetValue.(*configstoreTables.TableBudget); ok && budget != nil {
-								if effectiveMaxLimit := budget.EffectiveMaxLimit(); effectiveMaxLimit > 0 {
-									budgetPercent := float64(budget.CurrentUsage+budgetBaselines[budget.ID]) / effectiveMaxLimit * 100
-									if budgetPercent > result.BudgetPercentUsed {
-										result.BudgetPercentUsed = budgetPercent
-									}
-								}
-							}
-						}
-					}
-					break
-				}
-			}
-		}
-	}
-	return result
+	return status
 }
 
 // GlobalProviderLimits reports the deployment's own limits on a provider: unscoped to any holder,

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -1263,16 +1263,43 @@ func TestGovernanceStore_RateLimitStatus(t *testing.T) {
 	store.providers.Store("openai", providerConfig)
 
 	// Get status
-	status := store.GetBudgetAndRateLimitStatus(context.Background(), "", schemas.ModelProvider("openai"), nil, nil, nil, nil)
+	status := store.GetBudgetAndRateLimitStatus(emptyCtx(), schemas.ModelProvider("openai"), "", nil, nil, nil)
 
 	assert.NotNil(t, status)
 	assert.Equal(t, 50.0, status.RateLimitTokenPercentUsed)
 
 	// Update usage to exhausted state
 	rl.TokenCurrentUsage = 1000
-	status = store.GetBudgetAndRateLimitStatus(context.Background(), "", schemas.ModelProvider("openai"), nil, nil, nil, nil)
+	status = store.GetBudgetAndRateLimitStatus(emptyCtx(), schemas.ModelProvider("openai"), "", nil, nil, nil)
 
 	assert.Equal(t, 100.0, status.RateLimitTokenPercentUsed)
+}
+
+// Routing can ask for status on a request nothing has resolved access for yet. That is not an error
+// and must not panic: the deployment's own limits still apply, and there is simply no holder to add.
+func TestGovernanceStore_StatusWithNoResolvedAccess(t *testing.T) {
+	logger := NewMockLogger()
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil, nil)
+	require.NoError(t, err)
+
+	limit := int64(1000)
+	rateLimitID := "provider:openai:ratelimit"
+	store.rateLimits.Store(rateLimitID, &configstoreTables.TableRateLimit{
+		ID:                rateLimitID,
+		TokenMaxLimit:     &limit,
+		TokenCurrentUsage: 500,
+	})
+	store.providers.Store("openai", &configstoreTables.TableProvider{Name: "openai", RateLimitID: &rateLimitID})
+
+	ctx := emptyCtx()
+	require.Nil(t, ctx.Grant().Access(), "nothing resolved on this request")
+
+	var status *BudgetAndRateLimitStatus
+	require.NotPanics(t, func() {
+		status = store.GetBudgetAndRateLimitStatus(ctx, schemas.ModelProvider("openai"), "gpt-4o", nil, nil, nil)
+	})
+	require.NotNil(t, status)
+	assert.Equal(t, 50.0, status.RateLimitTokenPercentUsed, "the deployment's provider limit applies whoever is asking")
 }
 
 // TestGovernanceStore_BudgetStatus tests budget status calculation
@@ -1298,14 +1325,14 @@ func TestGovernanceStore_BudgetStatus(t *testing.T) {
 	store.providers.Store("openai", providerConfig)
 
 	// Get status
-	status := store.GetBudgetAndRateLimitStatus(context.Background(), "", schemas.ModelProvider("openai"), nil, nil, nil, nil)
+	status := store.GetBudgetAndRateLimitStatus(emptyCtx(), schemas.ModelProvider("openai"), "", nil, nil, nil)
 
 	assert.NotNil(t, status)
 	assert.Equal(t, 60.0, status.BudgetPercentUsed)
 
 	// Update usage to exhausted state
 	budget.CurrentUsage = 100.0
-	status = store.GetBudgetAndRateLimitStatus(context.Background(), "", schemas.ModelProvider("openai"), nil, nil, nil, nil)
+	status = store.GetBudgetAndRateLimitStatus(emptyCtx(), schemas.ModelProvider("openai"), "", nil, nil, nil)
 
 	assert.Equal(t, 100.0, status.BudgetPercentUsed)
 }
@@ -1338,7 +1365,7 @@ func TestGetBudgetAndRateLimitStatus_VKScopedModelConfig(t *testing.T) {
 
 	store.virtualKeys.Store(vkValue, vk)
 
-	status := store.GetBudgetAndRateLimitStatus(context.Background(), "gpt-5", schemas.ModelProvider(providerName), vk, nil, nil, nil)
+	status := store.GetBudgetAndRateLimitStatus(resolverCtx(store, vkValue), schemas.ModelProvider(providerName), "gpt-5", nil, nil, nil)
 
 	require.NotNil(t, status)
 	assert.Greater(t, status.BudgetPercentUsed, 100.0, "VK-scoped model budget at 120%% must be visible to routing status")
@@ -1364,8 +1391,11 @@ func TestGetBudgetAndRateLimitStatus_VKScopedModelConfig_NoMatchOtherProvider(t 
 
 	store.virtualKeys.Store(vkValue, vk)
 
-	// Query for anthropic — should not see the openai-scoped budget.
-	status := store.GetBudgetAndRateLimitStatus(context.Background(), "claude-3-5-sonnet", schemas.ModelProvider("anthropic"), vk, nil, nil, nil)
+	// Query for anthropic — should not see the openai-scoped budget. resolverCtx resolves real
+	// access for the VK so gatherLimits actually reaches the VK-scoped model config; emptyCtx
+	// leaves access nil, which short-circuits gatherLimits before it ever consults VK-scoped
+	// configs, so the assertion below would pass even if provider isolation were broken.
+	status := store.GetBudgetAndRateLimitStatus(resolverCtx(store, vkValue), schemas.ModelProvider("anthropic"), "claude-3-5-sonnet", nil, nil, nil)
 
 	require.NotNil(t, status)
 	assert.Equal(t, 0.0, status.BudgetPercentUsed, "openai VK-scoped budget must not appear for anthropic requests")
@@ -1420,7 +1450,7 @@ func TestGetBudgetAndRateLimitStatus_GlobalModelConfig(t *testing.T) {
 	}, nil, nil)
 	require.NoError(t, err)
 
-	status := store.GetBudgetAndRateLimitStatus(context.Background(), "gpt-5", schemas.ModelProvider(providerName), nil, nil, nil, nil)
+	status := store.GetBudgetAndRateLimitStatus(emptyCtx(), schemas.ModelProvider(providerName), "gpt-5", nil, nil, nil)
 
 	require.NotNil(t, status)
 	assert.Equal(t, 75.0, status.BudgetPercentUsed, "global model+provider budget must be visible to routing status")
@@ -1822,5 +1852,138 @@ func TestResolveLimits(t *testing.T) {
 		ids := limitIDsOf(settled.Budgets())
 		assert.Contains(t, ids, "b-provider")
 		assert.NotContains(t, ids, "b-model", "no model means no model config applies")
+	})
+}
+
+// Routing asks for this before a request's limits have been settled onto its grant, so the status cannot
+// read the settled set: gatherLimits assembles from the store and the access each time. Every source a
+// request can answer to has to be reachable that way, or routing prefers a provider that is out of money.
+//
+// Each case loads exactly one source at 40% and asserts the status reports 40: a source that is not
+// reached reports 0, so this fails for whichever one is missed rather than only for the total.
+func TestGetBudgetAndRateLimitStatusReachesEverySource(t *testing.T) {
+	const vkValue = "sk-bf-status"
+
+	newStore := func(t *testing.T, build func(vk *configstoreTables.TableVirtualKey, cfg *configstore.GovernanceConfig)) *LocalGovernanceStore {
+		t.Helper()
+		vk := buildVirtualKey("vk1", vkValue, "Status VK", true)
+		vk.ProviderConfigs = []configstoreTables.TableVirtualKeyProviderConfig{
+			buildProviderConfig("openai", []string{"*"}),
+		}
+		cfg := &configstore.GovernanceConfig{}
+		build(vk, cfg)
+		cfg.VirtualKeys = []configstoreTables.TableVirtualKey{*vk}
+		store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, cfg, nil, nil)
+		require.NoError(t, err)
+		return store
+	}
+
+	// 40 used of 100, distinct from 0 so a source that is never reached is visible.
+	fortyPercent := func(id string) *configstoreTables.TableBudget {
+		return buildBudgetWithUsage(id, 100.0, 40.0, "1d")
+	}
+
+	cases := []struct {
+		name  string
+		build func(vk *configstoreTables.TableVirtualKey, cfg *configstore.GovernanceConfig)
+	}{
+		{
+			name: "the deployment's own provider budget",
+			build: func(_ *configstoreTables.TableVirtualKey, cfg *configstore.GovernanceConfig) {
+				budget := fortyPercent("b-provider")
+				cfg.Providers = []configstoreTables.TableProvider{*buildProviderWithGovernance("openai", budget, nil)}
+				cfg.Budgets = append(cfg.Budgets, *budget)
+			},
+		},
+		{
+			name: "a global model config",
+			build: func(_ *configstoreTables.TableVirtualKey, cfg *configstore.GovernanceConfig) {
+				budget := fortyPercent("b-model")
+				cfg.ModelConfigs = []configstoreTables.TableModelConfig{*buildModelConfig("mc1", "gpt-4o", nil, budget, nil)}
+				cfg.Budgets = append(cfg.Budgets, *budget)
+			},
+		},
+		{
+			name: "a model config the key scoped to itself",
+			build: func(vk *configstoreTables.TableVirtualKey, cfg *configstore.GovernanceConfig) {
+				budget := fortyPercent("b-vk-model")
+				cfg.ModelConfigs = []configstoreTables.TableModelConfig{
+					*buildVKScopedModelConfig("mc-vk", "gpt-4o", nil, vk.ID, budget, nil),
+				}
+				cfg.Budgets = append(cfg.Budgets, *budget)
+			},
+		},
+		{
+			name: "the key's own budget",
+			build: func(vk *configstoreTables.TableVirtualKey, cfg *configstore.GovernanceConfig) {
+				budget := fortyPercent("b-key")
+				vk.Budgets = []configstoreTables.TableBudget{*budget}
+				cfg.Budgets = append(cfg.Budgets, *budget)
+			},
+		},
+		{
+			name: "the key's provider config",
+			build: func(vk *configstoreTables.TableVirtualKey, cfg *configstore.GovernanceConfig) {
+				budget := fortyPercent("b-key-openai")
+				vk.ProviderConfigs = []configstoreTables.TableVirtualKeyProviderConfig{
+					buildProviderConfigWithBudgets("openai", []string{"*"}, []configstoreTables.TableBudget{*budget}),
+				}
+				cfg.Budgets = append(cfg.Budgets, *budget)
+			},
+		},
+		{
+			name: "the team the key belongs to",
+			build: func(vk *configstoreTables.TableVirtualKey, cfg *configstore.GovernanceConfig) {
+				budget := fortyPercent("b-team")
+				team := buildTeam("team1", "Team 1", budget)
+				vk.TeamID = &team.ID
+				vk.Team = team
+				cfg.Teams = []configstoreTables.TableTeam{*team}
+				cfg.Budgets = append(cfg.Budgets, *budget)
+			},
+		},
+		{
+			name: "the customer above that team",
+			build: func(vk *configstoreTables.TableVirtualKey, cfg *configstore.GovernanceConfig) {
+				budget := fortyPercent("b-customer")
+				customer := buildCustomer("cust1", "Customer 1", budget)
+				team := buildTeam("team1", "Team 1", nil)
+				team.CustomerID = &customer.ID
+				team.Customer = customer
+				vk.TeamID = &team.ID
+				vk.Team = team
+				cfg.Teams = []configstoreTables.TableTeam{*team}
+				cfg.Customers = []configstoreTables.TableCustomer{*customer}
+				cfg.Budgets = append(cfg.Budgets, *budget)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newStore(t, tc.build)
+
+			status := store.GetBudgetAndRateLimitStatus(resolverCtx(store, vkValue), schemas.OpenAI, "gpt-4o", nil, nil, nil)
+
+			require.NotNil(t, status)
+			assert.Equal(t, 40.0, status.BudgetPercentUsed,
+				"this source is not reached, so routing would prefer a provider that is out of money")
+		})
+	}
+
+	t.Run("the tightest constraint is what routing sees", func(t *testing.T) {
+		// Not a sum and not the last one read: a request is refused by whichever limit is closest to its
+		// cap, so that is the number a rule preferring a provider with room has to be given.
+		store := newStore(t, func(vk *configstoreTables.TableVirtualKey, cfg *configstore.GovernanceConfig) {
+			loose := buildBudgetWithUsage("b-provider", 100.0, 10.0, "1d")
+			tight := buildBudgetWithUsage("b-key", 100.0, 90.0, "1d")
+			cfg.Providers = []configstoreTables.TableProvider{*buildProviderWithGovernance("openai", loose, nil)}
+			vk.Budgets = []configstoreTables.TableBudget{*tight}
+			cfg.Budgets = append(cfg.Budgets, *loose, *tight)
+		})
+
+		status := store.GetBudgetAndRateLimitStatus(resolverCtx(store, vkValue), schemas.OpenAI, "gpt-4o", nil, nil, nil)
+
+		assert.Equal(t, 90.0, status.BudgetPercentUsed)
 	})
 }

--- a/plugins/routing/main.go
+++ b/plugins/routing/main.go
@@ -16,10 +16,8 @@ import (
 	"sync"
 	"sync/atomic"
 
-	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
-	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/plugins/routing/complexity"
 	"github.com/maximhq/bifrost/plugins/routing/rules"
 )
@@ -36,6 +34,9 @@ const PluginName = "routing"
 // through this same call.
 type Governance interface {
 	rules.GovernanceStore
+	// ResolveAccess answers what the request may reach, and is what routing reads a request's
+	// governance scope from: the identifiers it needs are stamped when the access is resolved.
+	ResolveAccess(ctx *schemas.BifrostContext) (schemas.Access, error)
 	PublishRoutingAllowlist(ctx *schemas.BifrostContext, modelStr string)
 	LoadBalanceProvider(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) error
 }
@@ -188,7 +189,7 @@ func (p *RoutingPlugin) PreRequestHook(ctx *schemas.BifrostContext, req *schemas
 		return nil
 	}
 
-	virtualKey, ok := p.resolveVirtualKey(ctx)
+	scope, ok := p.resolveGovernanceScope(ctx)
 	if !ok {
 		return nil
 	}
@@ -200,7 +201,7 @@ func (p *RoutingPlugin) PreRequestHook(ctx *schemas.BifrostContext, req *schemas
 	// reads metadata.Model when it rewrites the model field in the body prefix, so
 	// mutating it here is what propagates the routing decision to the upstream call.
 	if metadata, _ := ctx.Value(schemas.BifrostContextKeyLargePayloadMetadata).(*schemas.LargePayloadMetadata); metadata != nil && metadata.Model != "" {
-		newModel, err := p.routeLargePayloadModel(ctx, virtualKey, metadata.Model, req.RequestType)
+		newModel, err := p.routeLargePayloadModel(ctx, scope, metadata.Model, req.RequestType)
 		if err != nil {
 			return err
 		}
@@ -210,7 +211,7 @@ func (p *RoutingPlugin) PreRequestHook(ctx *schemas.BifrostContext, req *schemas
 		return nil
 	}
 
-	if _, err := p.applyRoutingRules(ctx, req, virtualKey); err != nil {
+	if _, err := p.applyRoutingRules(ctx, req, scope); err != nil {
 		return err
 	}
 
@@ -228,7 +229,7 @@ func (p *RoutingPlugin) PreRequestHook(ctx *schemas.BifrostContext, req *schemas
 // rule evaluation and virtual key materialization as the main PreRequestHook path, and returns the resolved
 // model (provider-prefixed when a provider was selected, plain model otherwise). Used by the
 // large-payload branch where req.Model is empty because the body wasn't parsed.
-func (p *RoutingPlugin) routeLargePayloadModel(ctx *schemas.BifrostContext, virtualKey *configstoreTables.TableVirtualKey, modelIn string, requestType schemas.RequestType) (string, error) {
+func (p *RoutingPlugin) routeLargePayloadModel(ctx *schemas.BifrostContext, scope rules.GovernanceScope, modelIn string, requestType schemas.RequestType) (string, error) {
 	// Parse a provider-prefixed model string the same way the transport does for
 	// body-having requests, so an explicit prefix like "openai/gpt-4o" lands in
 	// ChatRequest.Provider and rule evaluation honors the caller's routing intent.
@@ -238,7 +239,7 @@ func (p *RoutingPlugin) routeLargePayloadModel(ctx *schemas.BifrostContext, virt
 		ChatRequest: &schemas.BifrostChatRequest{Provider: providerIn, Model: parsedModel},
 	}
 
-	if _, err := p.applyRoutingRules(ctx, synthetic, virtualKey); err != nil {
+	if _, err := p.applyRoutingRules(ctx, synthetic, scope); err != nil {
 		return modelIn, err
 	}
 
@@ -265,7 +266,7 @@ func (p *RoutingPlugin) routeLargePayloadModel(ctx *schemas.BifrostContext, virt
 // req.Provider/req.Model/req.Fallbacks when a rule matches, returning the matched
 // rules.Decision, or nil when no rule matched. A deployment with no rules configured pays a
 // single map check here and falls through to the virtual key's own provider selection.
-func (p *RoutingPlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, virtualKey *configstoreTables.TableVirtualKey) (*rules.Decision, error) {
+func (p *RoutingPlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, scope rules.GovernanceScope) (*rules.Decision, error) {
 	if !p.rules.HasRules(ctx) {
 		return nil, nil
 	}
@@ -318,19 +319,18 @@ func (p *RoutingPlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *sche
 	}
 
 	routingCtx := &rules.EvaluationContext{
-		VirtualKey:               virtualKey,
-		UserID:                   bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyUserID),
+		Scope:                    scope,
 		Provider:                 provider,
 		Model:                    model,
 		RequestType:              requestType,
 		Headers:                  headers,
 		QueryParams:              queryParams,
-		BudgetAndRateLimitStatus: p.governance.GetBudgetAndRateLimitStatus(ctx, model, provider, virtualKey, nil, nil, nil),
+		BudgetAndRateLimitStatus: p.governance.GetBudgetAndRateLimitStatus(ctx, provider, model, nil, nil, nil),
 		ComputeComplexity:        computeComplexity,
 	}
 
-	p.logger.Debug("[Routing] Built routing context: provider=%s, model=%s, requestType=%s, vk=%v",
-		provider, model, requestType, virtualKey != nil)
+	p.logger.Debug("[Routing] Built routing context: provider=%s, model=%s, requestType=%s, vk=%s",
+		provider, model, requestType, scope.VirtualKeyID)
 
 	// Evaluate routing rules
 	decision, err := p.engine.EvaluateRoutingRules(ctx, routingCtx)

--- a/plugins/routing/routingpin_test.go
+++ b/plugins/routing/routingpin_test.go
@@ -55,7 +55,7 @@ func TestApplyRoutingRules_PinnedKeyReachesContext(t *testing.T) {
 	pluginName := PluginName
 	scoped := root.WithPluginScope(&pluginName)
 
-	decision, err := plugin.applyRoutingRules(scoped, req, nil)
+	decision, err := plugin.applyRoutingRules(scoped, req, rules.GovernanceScope{})
 	require.NoError(t, err)
 	require.NotNil(t, decision)
 	assert.Equal(t, pinnedKeyID, decision.KeyID)

--- a/plugins/routing/rules/engine.go
+++ b/plugins/routing/rules/engine.go
@@ -1,7 +1,6 @@
 package rules
 
 import (
-	"context"
 	"fmt"
 	"math/rand/v2"
 	"regexp"
@@ -37,11 +36,27 @@ type Decision struct {
 	MatchedRuleName string   // Name of the rule that matched
 }
 
+// GovernanceScope is who a request is governed as: the identifiers the access it carries was resolved
+// under, stamped on the context at that moment. Rules match on them as scopes and read them as variables.
+//
+// Identifiers rather than the credential row they came from. A rule asks which key, team or customer a
+// request belongs to, never anything else about them, and a request granted access by something other
+// than a key has those answers too, which a credential row could not have supplied.
+//
+// An empty field means the request has no such scope, which is what a rule scoped to one must not match.
+type GovernanceScope struct {
+	VirtualKeyID   string
+	VirtualKeyName string
+	UserID         string
+	TeamID         string
+	TeamName       string
+	CustomerID     string
+	CustomerName   string
+}
+
 // EvaluationContext holds all data needed for routing rule evaluation
-// Reuses existing configstore table types for VirtualKey, Team, Customer
 type EvaluationContext struct {
-	VirtualKey               *configstoreTables.TableVirtualKey   // nil if no VK
-	UserID                   string                               // Resolved calling user id; empty when the request carries no user identity
+	Scope                    GovernanceScope                      // who the request is governed as
 	Provider                 schemas.ModelProvider                // Current provider
 	Model                    string                               // Current model
 	RequestType              string                               // Request type (e.g., "chat_completion", "embedding"); streaming requests carry a distinct "_stream" suffix (e.g., "chat_completion_stream")
@@ -60,8 +75,7 @@ type EvaluationContext struct {
 // evaluating them against a missing governance store would silently answer those variables
 // with zero values instead of real usage.
 type GovernanceStore interface {
-	GetVirtualKey(ctx context.Context, vkValue string) (*configstoreTables.TableVirtualKey, bool)
-	GetBudgetAndRateLimitStatus(ctx context.Context, model string, provider schemas.ModelProvider, vk *configstoreTables.TableVirtualKey, budgetBaselines map[string]float64, tokenBaselines map[string]int64, requestBaselines map[string]int64) *governance.BudgetAndRateLimitStatus
+	GetBudgetAndRateLimitStatus(ctx *schemas.BifrostContext, provider schemas.ModelProvider, model string, budgetBaselines map[string]float64, tokenBaselines map[string]int64, requestBaselines map[string]int64) *governance.BudgetAndRateLimitStatus
 }
 
 type Engine struct {
@@ -123,7 +137,7 @@ func (re *Engine) EvaluateRoutingRules(ctx *schemas.BifrostContext, routingCtx *
 
 	// Build scope chain once — it's based on the immutable VirtualKey and user
 	// identity and won't change across chain steps.
-	scopeChain := buildScopeChain(routingCtx.VirtualKey, routingCtx.UserID)
+	scopeChain := buildScopeChain(routingCtx.Scope)
 
 	// Cache rules per scope upfront to avoid redundant store lookups when rules chain
 	// and we re-evaluate the scope hierarchy on subsequent steps.
@@ -169,7 +183,7 @@ func (re *Engine) EvaluateRoutingRules(ctx *schemas.BifrostContext, routingCtx *
 		iterCtx.Model = currentModel
 		// Refresh budget/rate-limit status for the current provider/model so chained
 		// rules that test budget_used, tokens_used, or request see fresh data.
-		iterCtx.BudgetAndRateLimitStatus = re.governance.GetBudgetAndRateLimitStatus(ctx, currentModel, currentProvider, routingCtx.VirtualKey, nil, nil, nil)
+		iterCtx.BudgetAndRateLimitStatus = re.governance.GetBudgetAndRateLimitStatus(ctx, currentProvider, currentModel, nil, nil, nil)
 
 		variables, err := extractRoutingVariables(&iterCtx)
 		if err != nil {
@@ -369,61 +383,28 @@ func selectWeightedTarget(targets []configstoreTables.TableRoutingTarget) (confi
 	return valid[len(valid)-1], true
 }
 
-// buildScopeChain builds the scope evaluation chain based on organizational hierarchy
-// Returns scope levels in precedence order (highest to lowest)
-// VirtualKey > User > Team > Customer > Global
-func buildScopeChain(virtualKey *configstoreTables.TableVirtualKey, userID string) []ScopeLevel {
+// buildScopeChain orders the scopes a request matches rules at, most specific first:
+// VirtualKey > User > Team > Customer > Global. First match within an iteration wins.
+//
+// A scope is present when the request has an identifier for it, and every identifier arrives the same
+// way: the user level is independent of the others, so a session-authenticated request carrying no
+// credential still matches user-scoped rules.
+func buildScopeChain(scope GovernanceScope) []ScopeLevel {
 	var chain []ScopeLevel
-
-	// VirtualKey level (highest precedence)
-	if virtualKey != nil {
-		chain = append(chain, ScopeLevel{
-			ScopeName: "virtual_key",
-			ScopeID:   virtualKey.ID,
-		})
-	}
-
-	// User level: the resolved calling user. Independent of VK presence so
-	// session-authenticated requests without a virtual key still match
-	// user-scoped rules.
-	if userID != "" {
-		chain = append(chain, ScopeLevel{
-			ScopeName: "user",
-			ScopeID:   userID,
-		})
-	}
-
-	if virtualKey != nil {
-		// Team level
-		if virtualKey.Team != nil {
-			chain = append(chain, ScopeLevel{
-				ScopeName: "team",
-				ScopeID:   virtualKey.Team.ID,
-			})
-
-			// Customer level (from Team)
-			if virtualKey.Team.Customer != nil {
-				chain = append(chain, ScopeLevel{
-					ScopeName: "customer",
-					ScopeID:   virtualKey.Team.Customer.ID,
-				})
-			}
-		} else if virtualKey.Customer != nil {
-			// Customer level (VK attached directly to customer, no Team)
-			chain = append(chain, ScopeLevel{
-				ScopeName: "customer",
-				ScopeID:   virtualKey.Customer.ID,
-			})
+	appendScope := func(name, id string) {
+		if id == "" {
+			return
 		}
+		chain = append(chain, ScopeLevel{ScopeName: name, ScopeID: id})
 	}
 
-	// Global level (lowest precedence)
-	chain = append(chain, ScopeLevel{
-		ScopeName: "global",
-		ScopeID:   "",
-	})
+	appendScope("virtual_key", scope.VirtualKeyID)
+	appendScope("user", scope.UserID)
+	appendScope("team", scope.TeamID)
+	appendScope("customer", scope.CustomerID)
 
-	return chain
+	// Global level (lowest precedence), and the only one every request matches at.
+	return append(chain, ScopeLevel{ScopeName: "global", ScopeID: ""})
 }
 
 // evaluateCELExpression evaluates a compiled CEL program with given variables
@@ -501,43 +482,16 @@ func extractRoutingVariables(ctx *EvaluationContext) (map[string]interface{}, er
 	}
 	variables["params"] = normalizedParams
 
-	// Extract VirtualKey context if available
-	if ctx.VirtualKey != nil {
-		variables["virtual_key_id"] = ctx.VirtualKey.ID
-		variables["virtual_key_name"] = ctx.VirtualKey.Name
-	} else {
-		variables["virtual_key_id"] = ""
-		variables["virtual_key_name"] = ""
-	}
-
-	// Resolved calling user id; empty when the request carries no user identity
-	variables["user_id"] = ctx.UserID
-
-	// Extract Team context if available (from VirtualKey)
-	if ctx.VirtualKey != nil && ctx.VirtualKey.Team != nil {
-		variables["team_id"] = ctx.VirtualKey.Team.ID
-		variables["team_name"] = ctx.VirtualKey.Team.Name
-	} else {
-		variables["team_id"] = ""
-		variables["team_name"] = ""
-	}
-
-	// Extract Customer context if available (from Team or directly from VirtualKey)
-	if ctx.VirtualKey != nil {
-		if ctx.VirtualKey.Team != nil && ctx.VirtualKey.Team.Customer != nil {
-			variables["customer_id"] = ctx.VirtualKey.Team.Customer.ID
-			variables["customer_name"] = ctx.VirtualKey.Team.Customer.Name
-		} else if ctx.VirtualKey.Customer != nil {
-			variables["customer_id"] = ctx.VirtualKey.Customer.ID
-			variables["customer_name"] = ctx.VirtualKey.Customer.Name
-		} else {
-			variables["customer_id"] = ""
-			variables["customer_name"] = ""
-		}
-	} else {
-		variables["customer_id"] = ""
-		variables["customer_name"] = ""
-	}
+	// Who the request is governed as. Absent scopes are the empty string, which is what a rule comparing
+	// against one has always seen: the branching this replaced existed only to reach through a
+	// credential row for the same six values.
+	variables["virtual_key_id"] = ctx.Scope.VirtualKeyID
+	variables["virtual_key_name"] = ctx.Scope.VirtualKeyName
+	variables["user_id"] = ctx.Scope.UserID
+	variables["team_id"] = ctx.Scope.TeamID
+	variables["team_name"] = ctx.Scope.TeamName
+	variables["customer_id"] = ctx.Scope.CustomerID
+	variables["customer_name"] = ctx.Scope.CustomerName
 
 	// Populate budget and rate limit variables for current provider/model combination
 	if ctx.BudgetAndRateLimitStatus != nil {

--- a/plugins/routing/rules/engine_test.go
+++ b/plugins/routing/rules/engine_test.go
@@ -16,9 +16,38 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// withUser adds the calling user to a scope, for tests that vary the user independently of the credential.
+func withUser(scope GovernanceScope, userID string) GovernanceScope {
+	scope.UserID = userID
+	return scope
+}
+
+// scopeOf is the governance scope a virtual key resolves to. Production reads these identifiers off the
+// context, where resolving the request's access stamped them; a test that wants "a key under a team under
+// a customer" is clearest saying so as rows, so this mirrors that mapping in one place.
+func scopeOf(vk *configstoreTables.TableVirtualKey) GovernanceScope {
+	if vk == nil {
+		return GovernanceScope{}
+	}
+	scope := GovernanceScope{VirtualKeyID: vk.ID, VirtualKeyName: vk.Name}
+	if vk.Team != nil {
+		scope.TeamID, scope.TeamName = vk.Team.ID, vk.Team.Name
+		if vk.Team.Customer != nil {
+			scope.CustomerID, scope.CustomerName = vk.Team.Customer.ID, vk.Team.Customer.Name
+		}
+	}
+	// A customer the key names directly wins over the one reached through its team, which is the order
+	// resolving the access stamps them in; a helper that disagreed would have tests assert a scope no
+	// request ever carries.
+	if vk.Customer != nil {
+		scope.CustomerID, scope.CustomerName = vk.Customer.ID, vk.Customer.Name
+	}
+	return scope
+}
+
 // TestBuildScopeChain_GlobalOnly tests scope chain with no VirtualKey
 func TestBuildScopeChain_GlobalOnly(t *testing.T) {
-	chain := buildScopeChain(nil, "")
+	chain := buildScopeChain(GovernanceScope{})
 
 	require.Equal(t, 1, len(chain))
 	assert.Equal(t, "global", chain[0].ScopeName)
@@ -32,7 +61,7 @@ func TestBuildScopeChain_VirtualKeyOnly(t *testing.T) {
 		Name: "test-vk",
 	}
 
-	chain := buildScopeChain(vk, "")
+	chain := buildScopeChain(scopeOf(vk))
 
 	require.Equal(t, 2, len(chain))
 	assert.Equal(t, "virtual_key", chain[0].ScopeName)
@@ -54,7 +83,7 @@ func TestBuildScopeChain_WithTeam(t *testing.T) {
 		Team: team,
 	}
 
-	chain := buildScopeChain(vk, "")
+	chain := buildScopeChain(scopeOf(vk))
 
 	require.Equal(t, 3, len(chain))
 	assert.Equal(t, "virtual_key", chain[0].ScopeName)
@@ -83,7 +112,7 @@ func TestBuildScopeChain_FullHierarchy(t *testing.T) {
 		Team: team,
 	}
 
-	chain := buildScopeChain(vk, "")
+	chain := buildScopeChain(scopeOf(vk))
 
 	require.Equal(t, 4, len(chain))
 	assert.Equal(t, "virtual_key", chain[0].ScopeName)
@@ -99,7 +128,7 @@ func TestBuildScopeChain_FullHierarchy(t *testing.T) {
 // TestBuildScopeChain_UserOnly verifies a session-authenticated request with
 // no virtual key still gets a user level ahead of global.
 func TestBuildScopeChain_UserOnly(t *testing.T) {
-	chain := buildScopeChain(nil, "user-1")
+	chain := buildScopeChain(GovernanceScope{UserID: "user-1"})
 
 	require.Equal(t, 2, len(chain))
 	assert.Equal(t, "user", chain[0].ScopeName)
@@ -114,7 +143,7 @@ func TestBuildScopeChain_FullHierarchyWithUser(t *testing.T) {
 	team := &configstoreTables.TableTeam{ID: "team-456", Name: "premium-team", Customer: customer}
 	vk := &configstoreTables.TableVirtualKey{ID: "vk-123", Name: "test-vk", Team: team}
 
-	chain := buildScopeChain(vk, "user-1")
+	chain := buildScopeChain(withUser(scopeOf(vk), "user-1"))
 
 	require.Equal(t, 5, len(chain))
 	assert.Equal(t, "virtual_key", chain[0].ScopeName)
@@ -410,7 +439,7 @@ func TestEvaluateRoutingRules_ScopePrecedence(t *testing.T) {
 	}
 
 	ctx := &EvaluationContext{
-		VirtualKey:  vk,
+		Scope:       scopeOf(vk),
 		Provider:    schemas.OpenAI,
 		Model:       "gpt-4o",
 		Headers:     map[string]string{},
@@ -1476,9 +1505,9 @@ func TestExtractRoutingVariables_WithVirtualKey(t *testing.T) {
 	}
 
 	ctx := &EvaluationContext{
-		VirtualKey: vk,
-		Provider:   schemas.OpenAI,
-		Model:      "gpt-4o",
+		Scope:    scopeOf(vk),
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4o",
 	}
 
 	variables, err := extractRoutingVariables(ctx)
@@ -1504,9 +1533,9 @@ func TestExtractRoutingVariables_WithTeam(t *testing.T) {
 	}
 
 	ctx := &EvaluationContext{
-		VirtualKey: vk,
-		Provider:   schemas.OpenAI,
-		Model:      "gpt-4o",
+		Scope:    scopeOf(vk),
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4o",
 	}
 
 	variables, err := extractRoutingVariables(ctx)
@@ -1537,9 +1566,9 @@ func TestExtractRoutingVariables_WithCustomer(t *testing.T) {
 	}
 
 	ctx := &EvaluationContext{
-		VirtualKey: vk,
-		Provider:   schemas.OpenAI,
-		Model:      "gpt-4o",
+		Scope:    scopeOf(vk),
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4o",
 	}
 
 	variables, err := extractRoutingVariables(ctx)
@@ -1654,7 +1683,7 @@ func TestBuildRoutingContext(t *testing.T) {
 	params := map[string]string{"org": "test"}
 
 	ctx := &EvaluationContext{
-		VirtualKey:               vk,
+		Scope:                    scopeOf(vk),
 		Provider:                 schemas.OpenAI,
 		Model:                    "gpt-4o",
 		Headers:                  headers,
@@ -1662,7 +1691,7 @@ func TestBuildRoutingContext(t *testing.T) {
 		BudgetAndRateLimitStatus: &governance.BudgetAndRateLimitStatus{},
 	}
 
-	assert.Equal(t, vk, ctx.VirtualKey)
+	assert.Equal(t, scopeOf(vk), ctx.Scope)
 	assert.Equal(t, schemas.OpenAI, ctx.Provider)
 	assert.Equal(t, "gpt-4o", ctx.Model)
 	assert.Equal(t, headers, ctx.Headers)
@@ -1689,7 +1718,7 @@ func TestExtractRoutingVariables_ComplexHierarchy(t *testing.T) {
 	}
 
 	ctx := &EvaluationContext{
-		VirtualKey:  vk,
+		Scope:       scopeOf(vk),
 		Provider:    schemas.OpenAI,
 		Model:       "gpt-4o",
 		Headers:     map[string]string{"X-Tier": "premium", "X-Org": "acme"},
@@ -1960,7 +1989,7 @@ func TestEvaluateRoutingRules_UserScopedRule(t *testing.T) {
 		return &EvaluationContext{
 			Provider:    schemas.OpenAI,
 			Model:       "gpt-4o",
-			UserID:      userID,
+			Scope:       GovernanceScope{UserID: userID},
 			Headers:     map[string]string{},
 			QueryParams: map[string]string{},
 		}
@@ -2020,8 +2049,7 @@ func TestEvaluateRoutingRules_VirtualKeyPreemptsUser(t *testing.T) {
 	require.NoError(t, store.UpsertRule(context.Background(), vkRule))
 
 	decision, err := engine.EvaluateRoutingRules(bgCtx, &EvaluationContext{
-		VirtualKey:  &configstoreTables.TableVirtualKey{ID: "vk-123", Name: "test-vk"},
-		UserID:      "user-1",
+		Scope:       withUser(scopeOf(&configstoreTables.TableVirtualKey{ID: "vk-123", Name: "test-vk"}), "user-1"),
 		Provider:    schemas.OpenAI,
 		Model:       "gpt-4o",
 		Headers:     map[string]string{},
@@ -2059,7 +2087,7 @@ func TestEvaluateRoutingRules_UserIDCELVariable(t *testing.T) {
 	decision, err := engine.EvaluateRoutingRules(bgCtx, &EvaluationContext{
 		Provider:    schemas.OpenAI,
 		Model:       "gpt-4o",
-		UserID:      "user-1",
+		Scope:       GovernanceScope{UserID: "user-1"},
 		Headers:     map[string]string{},
 		QueryParams: map[string]string{},
 	})
@@ -2070,10 +2098,37 @@ func TestEvaluateRoutingRules_UserIDCELVariable(t *testing.T) {
 	decision, err = engine.EvaluateRoutingRules(bgCtx, &EvaluationContext{
 		Provider:    schemas.OpenAI,
 		Model:       "gpt-4o",
-		UserID:      "someone-else",
+		Scope:       GovernanceScope{UserID: "someone-else"},
 		Headers:     map[string]string{},
 		QueryParams: map[string]string{},
 	})
 	require.NoError(t, err)
 	assert.Nil(t, decision, "user_id CEL predicate must not match a different user")
+}
+
+// A key can sit under a team that belongs to one customer and name a different customer directly. Which
+// of them a request belongs to is governance's answer, and routing has to match rules at the same one:
+// deriving it a second time is how a customer-scoped rule came to fire for a customer that was not paying.
+//
+// The direct customer wins, because that is what resolving the access stamps.
+func TestBuildScopeChain_DirectCustomerWinsOverTheTeams(t *testing.T) {
+	teamsCustomer := &configstoreTables.TableCustomer{ID: "cust-team", Name: "Team's Customer"}
+	team := &configstoreTables.TableTeam{ID: "team-1", Name: "team", CustomerID: &teamsCustomer.ID, Customer: teamsCustomer}
+	vk := &configstoreTables.TableVirtualKey{
+		ID: "vk-123", Name: "test-vk",
+		Team:     team,
+		Customer: &configstoreTables.TableCustomer{ID: "cust-direct", Name: "Direct Customer"},
+	}
+
+	chain := buildScopeChain(scopeOf(vk))
+
+	var customerScope string
+	for _, level := range chain {
+		if level.ScopeName == "customer" {
+			customerScope = level.ScopeID
+		}
+	}
+	assert.Equal(t, "cust-direct", customerScope,
+		"the customer the request is charged to is the one its rules must match at")
+	assert.Equal(t, "team-1", chain[1].ScopeID, "and the team is still in the chain")
 }

--- a/plugins/routing/rules/test_utils.go
+++ b/plugins/routing/rules/test_utils.go
@@ -83,12 +83,7 @@ func NewMockGovernanceStore() *MockGovernanceStore {
 	return &MockGovernanceStore{VirtualKeys: map[string]*configstoreTables.TableVirtualKey{}}
 }
 
-func (m *MockGovernanceStore) GetVirtualKey(ctx context.Context, vkValue string) (*configstoreTables.TableVirtualKey, bool) {
-	vk, ok := m.VirtualKeys[vkValue]
-	return vk, ok
-}
-
-func (m *MockGovernanceStore) GetBudgetAndRateLimitStatus(ctx context.Context, model string, provider schemas.ModelProvider, vk *configstoreTables.TableVirtualKey, budgetBaselines map[string]float64, tokenBaselines map[string]int64, requestBaselines map[string]int64) *governance.BudgetAndRateLimitStatus {
+func (m *MockGovernanceStore) GetBudgetAndRateLimitStatus(ctx *schemas.BifrostContext, provider schemas.ModelProvider, model string, budgetBaselines map[string]float64, tokenBaselines map[string]int64, requestBaselines map[string]int64) *governance.BudgetAndRateLimitStatus {
 	return m.Status
 }
 

--- a/plugins/routing/test_utils.go
+++ b/plugins/routing/test_utils.go
@@ -5,11 +5,15 @@ import (
 	"github.com/maximhq/bifrost/plugins/routing/rules"
 )
 
-// MockGovernance stands in for the governance plugin. It serves the canned virtual key and
-// usage state its embedded store provides, and records the provider materialization calls the
-// routing hook makes so tests can assert what model they were handed.
+// MockGovernance stands in for the governance plugin. It serves the canned access and usage state its
+// embedded store provides, and records the provider materialization calls the routing hook makes so tests
+// can assert what model they were handed.
 type MockGovernance struct {
 	*rules.MockGovernanceStore
+
+	// Access is what ResolveAccess answers with. Nil stands for a request nothing granted anything,
+	// which routing rules see as unscoped.
+	Access schemas.Access
 
 	// AllowlistModels records the model passed to each PublishRoutingAllowlist call, in order.
 	AllowlistModels []string
@@ -23,7 +27,15 @@ type MockGovernance struct {
 }
 
 func NewMockGovernance() *MockGovernance {
-	return &MockGovernance{MockGovernanceStore: rules.NewMockGovernanceStore()}
+	// No access by default: the shape a request that presented nothing carries, which is what most
+	// routing tests are exercising.
+	return &MockGovernance{
+		MockGovernanceStore: rules.NewMockGovernanceStore(),
+	}
+}
+
+func (m *MockGovernance) ResolveAccess(_ *schemas.BifrostContext) (schemas.Access, error) {
+	return m.Access, nil
 }
 
 func (m *MockGovernance) PublishRoutingAllowlist(_ *schemas.BifrostContext, modelStr string) {

--- a/plugins/routing/utils.go
+++ b/plugins/routing/utils.go
@@ -2,30 +2,41 @@ package routing
 
 import (
 	"context"
-	"time"
 
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
-	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/plugins/routing/complexity"
+	"github.com/maximhq/bifrost/plugins/routing/rules"
 )
 
-// resolveVirtualKey loads the virtual key named on the request. Returns ok=false when the
-// request carries a virtual key that is unusable (unknown, inactive or expired), which skips
-// rule evaluation the same way the downstream governance checks skip such a request.
-// A request with no virtual key at all resolves to (nil, true): rules scoped to the user or
-// to global still apply.
-func (p *RoutingPlugin) resolveVirtualKey(ctx *schemas.BifrostContext) (*configstoreTables.TableVirtualKey, bool) {
-	virtualKeyValue := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyVirtualKey)
-	if virtualKeyValue == "" {
-		return nil, true
+// resolveGovernanceScope reports who the request is governed as, for matching rules and reading rule
+// variables. Returns ok=false when the request carries a credential that may not be used (unknown,
+// inactive or expired), which skips rule evaluation the same way the downstream governance checks refuse
+// such a request.
+//
+// The scope is read off the context, where resolving the request's access stamped it. Nothing here loads
+// a credential: a rule asks which key, team or customer a request belongs to, and a request granted
+// access by something other than a key has those answers too.
+func (p *RoutingPlugin) resolveGovernanceScope(ctx *schemas.BifrostContext) (rules.GovernanceScope, bool) {
+	access, err := p.governance.ResolveAccess(ctx)
+	if err != nil {
+		// A request nothing settled who it is: governance refuses it downstream, and there is no
+		// scope to match rules against here.
+		return rules.GovernanceScope{}, false
 	}
-	virtualKey, found := p.governance.GetVirtualKey(ctx, virtualKeyValue)
-	if !found || virtualKey == nil || !virtualKey.IsActiveValue() || virtualKey.IsExpiredAt(time.Now().UTC()) {
-		return nil, false
+	if access == nil {
+		return rules.GovernanceScope{}, true
 	}
-	return virtualKey, true
+	return rules.GovernanceScope{
+		VirtualKeyID:   bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceVirtualKeyID),
+		VirtualKeyName: bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceVirtualKeyName),
+		UserID:         bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyUserID),
+		TeamID:         bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceTeamID),
+		TeamName:       bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceTeamName),
+		CustomerID:     bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceCustomerID),
+		CustomerName:   bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceCustomerName),
+	}, true
 }
 
 // resolveAnalyzerConfigFromStoreOrArg prefers an explicitly configured analyzer config over

--- a/transports/bifrost-http/handlers/realtime_client_secrets_test.go
+++ b/transports/bifrost-http/handlers/realtime_client_secrets_test.go
@@ -10,7 +10,6 @@ import (
 	bifrost "github.com/maximhq/bifrost/core"
 	openaiProvider "github.com/maximhq/bifrost/core/providers/openai"
 	"github.com/maximhq/bifrost/core/schemas"
-	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/kvstore"
 	"github.com/maximhq/bifrost/plugins/governance"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
@@ -534,11 +533,7 @@ func (m *mockRealtimeMintingGovernancePlugin) GetGovernanceStore() governance.Go
 	return nil
 }
 
-func (m *mockRealtimeMintingGovernancePlugin) GetVirtualKey(_ context.Context, _ string) (*configstoreTables.TableVirtualKey, bool) {
-	return nil, false
-}
-
-func (m *mockRealtimeMintingGovernancePlugin) GetBudgetAndRateLimitStatus(_ context.Context, _ string, _ schemas.ModelProvider, _ *configstoreTables.TableVirtualKey, _ map[string]float64, _ map[string]int64, _ map[string]int64) *governance.BudgetAndRateLimitStatus {
+func (m *mockRealtimeMintingGovernancePlugin) GetBudgetAndRateLimitStatus(_ *schemas.BifrostContext, _ schemas.ModelProvider, _ string, _ map[string]float64, _ map[string]int64, _ map[string]int64) *governance.BudgetAndRateLimitStatus {
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Routing rule evaluation was deriving governance scope (virtual key, team, customer) by loading the credential row itself and walking its associations — a fourth implementation of "which limits apply" that could disagree with the three others in the enforcement path. This PR replaces that with reading the identifiers already stamped on the context when the request's access was resolved, and routes `GetBudgetAndRateLimitStatus` through `GatherLimits` so the same assembly enforcement uses is what routing reads.

## Changes

- `resolveVirtualKey` is replaced by `resolveGovernanceScope`, which reads governance identifiers off the context rather than loading a credential row. A request granted access by something other than a virtual key now carries the correct scope for rule matching without any special-casing.
- `GetVirtualKey` is removed from `BaseGovernancePlugin` and `GovernanceStore`; routing no longer needs to load a credential to build a scope chain.
- `GetBudgetAndRateLimitStatus` now takes a `*schemas.BifrostContext` instead of a raw `context.Context` plus an explicit `*TableVirtualKey`. It reads the request's effective access off the context and delegates to `GatherLimits`, eliminating a hand-rolled scope walk that could miss or double-count limits relative to enforcement.
- `EvaluationContext.VirtualKey` and `UserID` are replaced by a `GovernanceScope` struct carrying the six identifier strings (virtual key, user, team, customer). `buildScopeChain` and `extractRoutingVariables` read from it directly instead of dereferencing a credential row.
- `ResolveEffectiveAccess` is added to the routing plugin's `Governance` interface so the scope can be resolved through the same path governance uses.
- A new test suite `TestGetBudgetAndRateLimitStatusReachesEverySource` verifies that every limit source a request can answer to — provider budget, global model config, VK-scoped model config, key budget, key provider config, team, and customer — is reachable through the new path, and that the tightest constraint is what routing sees.
- A new test `TestBuildScopeChain_DirectCustomerWinsOverTheTeams` pins the resolution order when a key names a customer directly and also belongs to a team with its own customer.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/... ./plugins/routing/... ./transports/bifrost-http/...
```

The new `TestGetBudgetAndRateLimitStatusReachesEverySource` cases each load exactly one budget source at 40% and assert the status reports 40. A source that is not reached by the new path reports 0, making the failure local to whichever source is missed rather than only visible in an aggregate.

## Breaking changes

- [x] Yes

`BaseGovernancePlugin`, `GovernanceStore`, and the routing `Governance` interface have changed signatures. Any external implementation of these interfaces must:
- Remove `GetVirtualKey`.
- Update `GetBudgetAndRateLimitStatus` to accept `(ctx *schemas.BifrostContext, provider schemas.ModelProvider, model string, ...)` instead of `(ctx context.Context, model string, provider schemas.ModelProvider, vk *TableVirtualKey, ...)`.
- Add `ResolveEffectiveAccess(ctx *schemas.BifrostContext) *grants.EffectiveAccess` to governance implementations used by the routing plugin.

## Security considerations

Routing previously loaded the credential row to derive scope, which meant a request granted access by a non-key grant could be evaluated against an empty or mismatched scope. Reading identifiers off the context ensures rule matching and budget status always reflect the same access that enforcement acts on.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable