### PR TITLE
feat: add `GetMCPClientNames` to `InMemoryStore` for full client ID→name mapping across governance and config layers

### DIFF
--- a/plugins/governance/allowonallvirtualkeys_test.go
+++ b/plugins/governance/allowonallvirtualkeys_test.go
@@ -1,6 +1,7 @@
 package governance
 
 import (
+	"maps"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -12,7 +13,8 @@ import (
 
 // mockInMemoryStore is a test double for InMemoryStore.
 type mockInMemoryStore struct {
-	allowAllClients     map[string]string // clientID → clientName
+	allowAllClients     map[string]string // clientID → clientName, the clients open to every virtual key
+	clientNames         map[string]string // clientID → clientName, configured clients that are not
 	configuredProviders map[schemas.ModelProvider]configstore.ProviderConfig
 }
 
@@ -22,6 +24,15 @@ func (m *mockInMemoryStore) GetConfiguredProviders() map[schemas.ModelProvider]c
 
 func (m *mockInMemoryStore) GetMCPClientsAllowingAllVirtualKeys() map[string]string {
 	return m.allowAllClients
+}
+
+// GetMCPClientNames answers as the production store does: every configured client, of which the ones
+// open to every virtual key are a subset.
+func (m *mockInMemoryStore) GetMCPClientNames() map[string]string {
+	names := make(map[string]string, len(m.clientNames)+len(m.allowAllClients))
+	maps.Copy(names, m.clientNames)
+	maps.Copy(names, m.allowAllClients)
+	return names
 }
 
 // accessFor builds the access a key carries on its own, with the given clients open to every
@@ -143,4 +154,21 @@ func TestToolChecks_StoreWithoutOpenClients_Blocked(t *testing.T) {
 
 	assert.False(t, access.IsMCPToolAllowed("youtube-search"),
 		"no open clients means no permit for the client, so no tool is allowed")
+}
+
+// The mock has to keep the two questions apart the way the production store does: a client that is
+// configured but not open to every key is still resolvable by name.
+func TestMockInMemoryStore_ClientNamesCoverEveryConfiguredClient(t *testing.T) {
+	store := &mockInMemoryStore{
+		allowAllClients: map[string]string{"open-id": "open"},
+		clientNames:     map[string]string{"private-id": "private"},
+	}
+
+	names := store.GetMCPClientNames()
+	if names["open-id"] != "open" || names["private-id"] != "private" || len(names) != 2 {
+		t.Fatalf("GetMCPClientNames should name every configured client, got %v", names)
+	}
+	if allowAll := store.GetMCPClientsAllowingAllVirtualKeys(); len(allowAll) != 1 || allowAll["open-id"] != "open" {
+		t.Fatalf("GetMCPClientsAllowingAllVirtualKeys should stay the allow-all subset, got %v", allowAll)
+	}
 }

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -41,6 +41,7 @@ type Config struct {
 type InMemoryStore interface {
 	GetConfiguredProviders() map[schemas.ModelProvider]configstore.ProviderConfig
 	GetMCPClientsAllowingAllVirtualKeys() map[string]string // clientID → clientName
+	GetMCPClientNames() map[string]string                   // clientID → clientName, every client
 }
 
 type BaseGovernancePlugin interface {

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -5455,6 +5455,26 @@ func (c *Config) GetAllowOnAllVirtualKeysClients() map[string]string {
 	return result
 }
 
+// GetMCPClientNames returns every configured MCP client's name, keyed by client ID.
+//
+// Tool patterns are matched by client name while grants are held by client ID, so anything building a
+// grant from stored client IDs needs the mapping between them. Read-only snapshot; do not mutate.
+func (c *Config) GetMCPClientNames() map[string]string {
+	c.muMCP.RLock()
+	defer c.muMCP.RUnlock()
+
+	if c.MCPConfig == nil {
+		return nil
+	}
+	result := make(map[string]string, len(c.MCPConfig.ClientConfigs))
+	for _, client := range c.MCPConfig.ClientConfigs {
+		if client != nil && client.ID != "" && client.Name != "" {
+			result[client.ID] = client.Name
+		}
+	}
+	return result
+}
+
 // GetPluginOrder returns the names of all base plugins in their sorted placement order.
 // This method is lock-free and safe for concurrent access from hot paths.
 // Do not modify the returned slice; it is a shared snapshot and must be treated read-only.

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -308,6 +308,10 @@ func (s *GovernanceInMemoryStore) GetMCPClientsAllowingAllVirtualKeys() map[stri
 	return s.Config.GetAllowOnAllVirtualKeysClients()
 }
 
+func (s *GovernanceInMemoryStore) GetMCPClientNames() map[string]string {
+	return s.Config.GetMCPClientNames()
+}
+
 // AddMCPClient adds a new MCP client to the in-memory store
 func (s *BifrostHTTPServer) AddMCPClient(ctx context.Context, clientConfig *schemas.MCPClientConfig) error {
 	if err := s.Config.AddMCPClient(ctx, clientConfig); err != nil {


### PR DESCRIPTION
## Summary

Exposes a `GetMCPClientNames` method that returns a mapping of every configured MCP client ID to its name. This is needed because tool patterns are matched by client name while grants are held by client ID, so anything building a grant from stored client IDs requires this mapping.

## Changes

- Added `GetMCPClientNames() map[string]string` to the `InMemoryStore` interface in the governance plugin, returning all MCP clients (not just those allowing all virtual keys).
- Implemented `GetMCPClientNames` on `Config` in the bifrost-http transport, iterating over `MCPConfig.ClientConfigs` under a read lock and returning a snapshot of ID → name pairs.
- Wired `GetMCPClientNames` through `GovernanceInMemoryStore` in the server, delegating to the `Config` implementation.
- Added the corresponding mock method in the governance plugin tests to satisfy the updated interface.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/...
go test ./transports/bifrost-http/...
```

Verify that `GetMCPClientNames` returns all configured MCP clients (not just those with `allowOnAllVirtualKeys` set), and that the returned map correctly pairs client IDs to client names.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The returned map is a read-only snapshot and must not be mutated by callers. No secrets or credentials are exposed; only client IDs and names are included.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable