### PR TITLE
fix: use `strings.Contains` for "together" provider normalization to handle substrings

### DIFF
--- a/framework/modelcatalog/datasheet/types.go
+++ b/framework/modelcatalog/datasheet/types.go
@@ -356,7 +356,7 @@ func makeKey(model, provider, mode string) string {
 // provider name used by the pricing catalog.
 func normalizeProvider(p string) string {
 	switch {
-	case p == "together":
+	case strings.Contains(p, "together"):
 		return "together_ai"
 	case strings.Contains(p, "vertex_ai") || p == "google-vertex":
 		return string(schemas.Vertex)


### PR DESCRIPTION
## Summary

The `normalizeProvider` function was using an exact string match for the `"together"` provider, which caused it to fail for provider strings that contain `"together"` but aren't exactly equal to it (e.g., `"together_ai"` or other variants). This fix ensures any provider string containing `"together"` is correctly normalized to `"together_ai"`.

## Changes

- Changed the `"together"` provider check from an exact equality match (`p == "together"`) to a substring match (`strings.Contains(p, "together")`) to handle provider string variants consistently.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/modelcatalog/datasheet/...
```

Verify that provider strings such as `"together"`, `"together_ai"`, or any other variant containing `"together"` are all normalized to `"together_ai"` when looked up in the pricing catalog.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable