### PR TITLE
onbaording checklist fixes

### DIFF
--- a/ui/hooks/useOnboardingChecklist.ts
+++ b/ui/hooks/useOnboardingChecklist.ts
@@ -64,6 +64,13 @@ export function useOnboardingChecklist({ skip = false }: { skip?: boolean } = {}
 
 	const authConfig = bifrostConfig?.auth_config;
 	const clientConfig = bifrostConfig?.client_config;
+	// Enterprise SSO satisfies dashboard auth on its own. An identity-provider
+	// record holds the OIDC credentials (clientId/clientSecret/tenantId), and the
+	// server installs SCIMController.Middleware() in place of the OSS
+	// AuthMiddleware whenever one is enabled, so admin_username/admin_password
+	// are never set on these deployments and would strand this step forever.
+	// Mirrors the server's own gate: SCIMConfig != nil && SCIMConfig.Enabled.
+	const ssoGatesDashboard = IS_ENTERPRISE && (scimProviders?.some((provider) => provider.enabled) ?? false);
 
 	const steps: OnboardingStep[] = useMemo(() => {
 		// Order: 1) Security, 2) Provider Setup, 3) Everything Else.
@@ -82,7 +89,9 @@ export function useOnboardingChecklist({ skip = false }: { skip?: boolean } = {}
 				title: "Set up dashboard auth",
 				route: "/workspace/config/security",
 				section: "Security",
-				complete: !!authConfig?.is_enabled && authValueSet(authConfig?.admin_username) && authValueSet(authConfig?.admin_password),
+				complete:
+					ssoGatesDashboard ||
+					(!!authConfig?.is_enabled && authValueSet(authConfig?.admin_username) && authValueSet(authConfig?.admin_password)),
 			},
 			{
 				id: "enforce-inference-auth",
@@ -125,7 +134,7 @@ export function useOnboardingChecklist({ skip = false }: { skip?: boolean } = {}
 				]
 			: [];
 		return [...common, ...enterprise];
-	}, [allKeys, clientConfig, authConfig, scimProviders, modelConfigsResponse, vksResponse]);
+	}, [allKeys, clientConfig, authConfig, ssoGatesDashboard, scimProviders, modelConfigsResponse, vksResponse]);
 
 	return { bifrostConfig, steps, skippedIds, checklistReady, isDismissedForAll };
 }


### PR DESCRIPTION
## Summary

When Enterprise SSO is configured with an enabled SCIM/OIDC identity provider, the "Set up dashboard auth" onboarding step was never completing because `admin_username`/`admin_password` are never set on SSO deployments. This left the checklist permanently stuck on that step for Enterprise users relying on SSO for dashboard authentication.

## Changes

- Added `ssoGatesDashboard` — a boolean that is `true` when running in Enterprise mode and at least one SCIM provider is enabled. This mirrors the server-side gate (`SCIMConfig != nil && SCIMConfig.Enabled`) where `SCIMController.Middleware()` replaces the OSS `AuthMiddleware`.
- The "Set up dashboard auth" step is now marked complete if `ssoGatesDashboard` is `true`, bypassing the `admin_username`/`admin_password` check that would otherwise never be satisfied on SSO deployments.
- Added `ssoGatesDashboard` to the `useMemo` dependency array to ensure the step reacts correctly to provider changes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Deploy an Enterprise instance and configure an OIDC/SCIM identity provider, setting it to `enabled: true`.
2. Navigate to the onboarding checklist.
3. Verify the "Set up dashboard auth" step is marked complete without requiring `admin_username`/`admin_password` to be set.
4. Disable the SSO provider and confirm the step reverts to requiring the username/password credentials.

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This change only affects the onboarding checklist UI completion state. The actual authentication enforcement is handled server-side by `SCIMController.Middleware()`, which this change mirrors. No auth logic is bypassed — the step is only visually marked complete when SSO is already handling authentication at the server level.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable