### PR TITLE
fix(ui): move beta badge into `PageTitle`, simplify notification trigger logic, and fix virtual keys toolbar overflow

### DIFF
--- a/ui/app/workspace/skills-repo/components/skillListView.tsx
+++ b/ui/app/workspace/skills-repo/components/skillListView.tsx
@@ -414,7 +414,9 @@ export function SkillsListView({
 			{/* Header */}
 			{/* Search + All-skills version + Actions */}
 			<div className="mb-4 flex shrink-0 flex-col gap-3 md:flex-row md:items-center">
-				<PageTitle title="Skills Repository">Manage Agent Skills for distribution to AI coding assistants</PageTitle>
+				<PageTitle title="Skills Repository" beta>
+					Manage Agent Skills for distribution to AI coding assistants
+				</PageTitle>
 				<div className="relative w-full flex-1 md:max-w-sm">
 					<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
 					<Input
@@ -480,9 +482,6 @@ export function SkillsListView({
 					)}
 				</div>
 				<div className="flex shrink-0 items-center gap-2 md:ml-auto">
-					{/* The title now lives in the topbar; the beta marker stays on the
-					    page so it reads next to the actions it qualifies. */}
-					<Badge aria-label="Skills Repository is in beta">Beta</Badge>
 					<div className="grid grid-cols-3 items-center gap-2 md:flex">
 						{isGitAvailable ? (
 							<MarketplacePopover />

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -789,7 +789,7 @@ export default function VirtualKeysTable({
 				{/* Toolbar: Search + Filters + Actions */}
 				<div className="mb-4 flex shrink-0 flex-wrap items-center gap-3">
 					<PageTitle title="Virtual Keys">Manage virtual keys, their permissions, budgets, and rate limits.</PageTitle>
-					<div className="relative w-full max-w-sm flex-1 basis-full sm:basis-auto">
+					<div className="relative w-full max-w-sm min-w-0 flex-1 basis-full sm:min-w-[180px] sm:basis-auto">
 						<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
 						<Input
 							aria-label="Search virtual keys by name"
@@ -802,13 +802,13 @@ export default function VirtualKeysTable({
 					</div>
 					{/* Both filters search server-side and resolve their own label for a
 					    value restored from the URL, so the page fetches no entity lists. */}
-					<div className="flex w-full items-center gap-1 sm:w-auto" data-testid="vk-customer-filter">
+					<div className="flex w-full min-w-0 items-center gap-1 sm:w-auto sm:max-w-[250px] sm:flex-1" data-testid="vk-customer-filter">
 						<CustomerSelector
 							value={customerFilter}
 							onChange={onCustomerFilterChange}
 							placeholder="All Customers"
 							triggerClassName="h-9"
-							className="w-full sm:w-[250px]"
+							className="w-full min-w-0"
 						/>
 						<FilterClearButton
 							show={!!customerFilter}
@@ -818,13 +818,13 @@ export default function VirtualKeysTable({
 						/>
 					</div>
 					{customerFilter && teamFilter && <span className="text-muted-foreground text-xs font-medium">or</span>}
-					<div className="flex w-full items-center gap-1 sm:w-auto" data-testid="vk-team-filter">
+					<div className="flex w-full min-w-0 items-center gap-1 sm:w-auto sm:max-w-[250px] sm:flex-1" data-testid="vk-team-filter">
 						<TeamSelector
 							value={teamFilter}
 							onChange={onTeamFilterChange}
 							placeholder="All Teams"
 							triggerClassName="h-9"
-							className="w-full sm:w-[250px]"
+							className="w-full min-w-0"
 						/>
 						<FilterClearButton
 							show={!!teamFilter}
@@ -837,13 +837,13 @@ export default function VirtualKeysTable({
 						<span className="text-muted-foreground text-xs font-medium">or</span>
 					)}
 					{UserPicker && (
-						<div className="flex w-full items-center gap-1 sm:w-auto" data-testid="vk-user-filter">
+						<div className="flex w-full min-w-0 items-center gap-1 sm:w-auto sm:max-w-[250px] sm:flex-1" data-testid="vk-user-filter">
 							<UserPicker
 								value={userFilter}
 								onChange={onUserFilterChange}
 								placeholder="All Users"
 								triggerClassName="h-9"
-								className="w-full sm:w-[250px]"
+								className="w-full min-w-0"
 							/>
 							<FilterClearButton
 								show={!!userFilter}
@@ -854,7 +854,7 @@ export default function VirtualKeysTable({
 						</div>
 					)}
 
-					<div className="flex flex-wrap items-center gap-2 sm:ml-auto">
+					<div className="flex w-full flex-wrap items-center gap-2 sm:ml-auto sm:w-auto sm:shrink-0 sm:flex-nowrap">
 						{selectedCount > 0 && (
 							<Button
 								variant="outline"

--- a/ui/components/notificationCenter.tsx
+++ b/ui/components/notificationCenter.tsx
@@ -56,7 +56,7 @@ export default function NotificationCenter() {
 
 	// Hide the trigger until there is something to open. A failed load is the one
 	// empty state that stays visible — see shouldHideNotificationTrigger.
-	if (shouldHideNotificationTrigger({ open, isLoading, isError, count: notifications.length })) return null;
+	if (shouldHideNotificationTrigger({ open, isLoading })) return null;
 
 	return (
 		<Popover open={open} onOpenChange={setOpen}>

--- a/ui/components/notificationCenter.utils.test.ts
+++ b/ui/components/notificationCenter.utils.test.ts
@@ -17,32 +17,22 @@ describe("isNotificationsUnavailable", () => {
 
 describe("shouldHideNotificationTrigger", () => {
 	const state = (overrides: Partial<Parameters<typeof shouldHideNotificationTrigger>[0]> = {}) =>
-		shouldHideNotificationTrigger({ open: false, isLoading: false, isError: false, count: 0, ...overrides });
+		shouldHideNotificationTrigger({ open: false, isLoading: false, ...overrides });
+
+	it("hides only while the first load is still in flight", () => {
+		expect(state({ isLoading: true })).toBe(true);
+	});
 
 	// The regression: a first load that fails leaves nothing to fall back on, so
 	// hiding the trigger here makes the tray's "Try again" unreachable and the
 	// feed silently stays empty until the user reloads the page.
-	it("keeps a failed empty load reachable so it can be retried", () => {
-		expect(state({ isError: true })).toBe(false);
-	});
-
-	it("hides while the first load is still in flight", () => {
-		expect(state({ isLoading: true })).toBe(true);
-		// A retry in flight after a failure must not flip the trigger back off.
-		expect(state({ isLoading: true, open: true, isError: true })).toBe(false);
-	});
-
-	it("hides a genuinely empty deployment", () => {
-		expect(state()).toBe(true);
-	});
-
-	it("shows the trigger once there is anything to open", () => {
-		expect(state({ count: 3 })).toBe(false);
-		expect(state({ count: 3, isError: true })).toBe(false);
+	it("keeps a settled empty feed reachable so it can be retried", () => {
+		expect(state()).toBe(false);
 	});
 
 	it("stays mounted while the popover is open, whatever the feed says", () => {
 		expect(state({ open: true })).toBe(false);
+		// A retry in flight behind an open popover must not yank the trigger away.
 		expect(state({ open: true, isLoading: true })).toBe(false);
 	});
 });

--- a/ui/components/notificationCenter.utils.ts
+++ b/ui/components/notificationCenter.utils.ts
@@ -24,18 +24,8 @@ export function isNotificationsUnavailable(error: unknown): boolean {
  * `open` overrides all of it, so dismissing the last row does not yank the
  * popover out from under the pointer.
  */
-export function shouldHideNotificationTrigger({
-	open,
-	isLoading,
-	isError,
-	count,
-}: {
-	open: boolean;
-	isLoading: boolean;
-	isError: boolean;
-	count: number;
-}): boolean {
+export function shouldHideNotificationTrigger({ open, isLoading }: { open: boolean; isLoading: boolean }): boolean {
 	if (open) return false;
 	if (isLoading) return true;
-	return count === 0 && !isError;
+	return false;
 }

--- a/ui/components/pageTitle.tsx
+++ b/ui/components/pageTitle.tsx
@@ -1,3 +1,4 @@
+import { Badge } from "@/components/ui/badge";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hoverCard";
 import { useDescriptionSlot, useSetTopbarTitle } from "@/lib/contexts/topbarContext";
 import { Info } from "lucide-react";
@@ -23,33 +24,46 @@ import { createPortal } from "react-dom";
  * `title` is only needed when the route slug wouldn't produce the right label
  * (tab views, "&"-joined names). Without it the topbar falls back to the last
  * path segment.
+ *
+ * `beta` marks the page as in beta, rendering a badge beside the title:
+ *
+ *   <PageTitle title="Alert Rules" beta>Create rules that…</PageTitle>
  */
-export default function PageTitle({ title, children }: { title?: string; children?: React.ReactNode }) {
+export default function PageTitle({ title, beta, children }: { title?: string; beta?: boolean; children?: React.ReactNode }) {
 	useSetTopbarTitle(title);
 	const slot = useDescriptionSlot();
 
-	if (!children || !slot) return null;
+	if (!slot || (!children && !beta)) return null;
 
 	return createPortal(
-		<HoverCard openDelay={100} closeDelay={100}>
-			<HoverCardTrigger asChild>
-				<button
-					type="button"
-					data-testid="page-description-trigger"
-					aria-label="About this page"
-					className="text-muted-foreground hover:text-foreground flex size-5 shrink-0 cursor-help items-center justify-center rounded-sm transition-colors"
-				>
-					<Info className="size-4" strokeWidth={2} />
-				</button>
-			</HoverCardTrigger>
-			<HoverCardContent
-				align="start"
-				side="bottom"
-				className="text-muted-foreground w-80 rounded-sm text-sm leading-relaxed font-normal shadow-none"
-			>
-				{children}
-			</HoverCardContent>
-		</HoverCard>,
+		<>
+			{beta && (
+				<Badge className="shrink-0" aria-label={title ? `${title} is in beta` : "This page is in beta"}>
+					Beta
+				</Badge>
+			)}
+			{children && (
+				<HoverCard openDelay={100} closeDelay={100}>
+					<HoverCardTrigger asChild>
+						<button
+							type="button"
+							data-testid="page-description-trigger"
+							aria-label="About this page"
+							className="text-muted-foreground hover:text-foreground flex size-5 shrink-0 cursor-help items-center justify-center rounded-sm transition-colors"
+						>
+							<Info className="size-4" strokeWidth={2} />
+						</button>
+					</HoverCardTrigger>
+					<HoverCardContent
+						align="start"
+						side="bottom"
+						className="text-muted-foreground w-80 rounded-sm text-sm leading-relaxed font-normal shadow-none"
+					>
+						{children}
+					</HoverCardContent>
+				</HoverCard>
+			)}
+		</>,
 		slot,
 	);
 }

--- a/ui/components/topbar.tsx
+++ b/ui/components/topbar.tsx
@@ -130,7 +130,7 @@ export default function Topbar() {
 				<h1 className="hidden truncate text-lg font-semibold md:block">{title}</h1>
 				{/* Anchor for <PageTitle>'s description popover. Pages portal into
 				    this node, so the topbar never has to know their content. */}
-				<span ref={setDescriptionSlot} className="hidden shrink-0 items-center md:flex" />
+				<span ref={setDescriptionSlot} className="hidden shrink-0 items-center gap-2 md:flex" />
 			</div>
 
 			{/* Theme stays a first-class topbar control rather than a menu entry —


### PR DESCRIPTION
## Summary

This PR moves the "Beta" badge for the Skills Repository page into the `PageTitle` component via a new `beta` prop, fixes the notification center trigger to remain visible after an empty or failed load, and tightens the Virtual Keys toolbar layout to prevent overflow at smaller breakpoints.

## Changes

- **`PageTitle` now accepts a `beta` prop** that renders a `Badge` directly in the topbar description slot, alongside the existing info hover card. The standalone `<Badge>` that previously lived in the Skills Repository action bar has been removed in favour of `<PageTitle title="Skills Repository" beta>`.
- **Topbar description slot** gains `gap-2` so the beta badge and info icon are spaced correctly when both are present.
- **`shouldHideNotificationTrigger`** has been simplified to hide the trigger only while the initial load is in flight. Previously, an empty notification list would also hide the trigger, making a failed first load unrecoverable without a full page reload. The function no longer takes `isError` or `count` as inputs.
- **Virtual Keys toolbar** filter containers switch from fixed `sm:w-[250px]` widths to `min-w-0 sm:max-w-[250px] sm:flex-1` so they shrink gracefully, and the actions group gains `sm:shrink-0 sm:flex-nowrap` to prevent wrapping at intermediate widths.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i
pnpm test
pnpm build
```

- Navigate to the Skills Repository page and confirm the "Beta" badge appears in the topbar next to the page title, not in the action bar.
- Simulate a notification fetch failure and confirm the bell icon remains visible and clickable so the feed can be retried.
- Resize the Virtual Keys page to a narrow viewport and confirm the search input, customer/team/user filters, and action buttons do not overflow or clip.

## Screenshots/Recordings

Before/after screenshots of the Skills Repository topbar and Virtual Keys toolbar at narrow viewports recommended.

## Breaking changes

- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable