### PR TITLE
fix: rerank compatibility and integration tests

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -1370,11 +1370,12 @@ func (bifrost *Bifrost) RerankRequest(ctx *schemas.BifrostContext, req *schemas.
 		}
 	}
 	for i, doc := range req.Documents {
-		if strings.TrimSpace(doc.Text) == "" {
+		// A document carries either prose or a structured body; only an empty pair is unrankable.
+		if strings.TrimSpace(doc.Text) == "" && len(doc.Data) == 0 {
 			return nil, &schemas.BifrostError{
 				IsBifrostError: false,
 				Error: &schemas.ErrorField{
-					Message: fmt.Sprintf("document text is empty at index %d", i),
+					Message: fmt.Sprintf("document has no text or data at index %d", i),
 				},
 				ExtraFields: schemas.BifrostErrorExtraFields{
 					RequestType:            schemas.RerankRequest,

--- a/core/go.mod
+++ b/core/go.mod
@@ -29,7 +29,6 @@ require (
 	go.starlark.net v0.0.0-20260102030733-3fee463870c9
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/text v0.39.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -77,4 +76,5 @@ require (
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/core/providers/bedrock/models.go
+++ b/core/providers/bedrock/models.go
@@ -12,6 +12,7 @@ type BedrockRerankRequest struct {
 	Queries                []BedrockRerankQuery          `json:"queries"`
 	Sources                []BedrockRerankSource         `json:"sources"`
 	RerankingConfiguration BedrockRerankingConfiguration `json:"rerankingConfiguration"`
+	NextToken              *string                       `json:"nextToken,omitempty"`
 }
 
 // GetExtraParams implements RequestBodyWithExtraParams.
@@ -23,6 +24,7 @@ const (
 	bedrockRerankQueryTypeText            = "TEXT"
 	bedrockRerankSourceTypeInline         = "INLINE"
 	bedrockRerankInlineDocumentTypeText   = "TEXT"
+	bedrockRerankInlineDocumentTypeJSON   = "JSON"
 	bedrockRerankConfigurationTypeBedrock = "BEDROCK_RERANKING_MODEL"
 )
 
@@ -37,8 +39,9 @@ type BedrockRerankSource struct {
 }
 
 type BedrockRerankInlineSource struct {
-	Type         string                 `json:"type"`
-	TextDocument BedrockRerankTextValue `json:"textDocument"`
+	Type         string                  `json:"type"`
+	TextDocument *BedrockRerankTextValue `json:"textDocument,omitempty"`
+	JSONDocument map[string]interface{}  `json:"jsonDocument,omitempty"`
 }
 
 type BedrockRerankTextRef struct {
@@ -79,6 +82,7 @@ type BedrockRerankResult struct {
 type BedrockRerankResponseDocument struct {
 	Type         string                  `json:"type,omitempty"`
 	TextDocument *BedrockRerankTextValue `json:"textDocument,omitempty"`
+	JSONDocument map[string]interface{}  `json:"jsonDocument,omitempty"`
 }
 
 func (response *BedrockListModelsResponse) ToBifrostListModelsResponse(providerKey schemas.ModelProvider, allowedModels schemas.WhiteList, blacklistedModels schemas.BlackList, aliases schemas.KeyAliases, unfiltered bool) *schemas.BifrostListModelsResponse {

--- a/core/providers/bedrock/rerank.go
+++ b/core/providers/bedrock/rerank.go
@@ -66,20 +66,28 @@ func ToBedrockRerankRequest(bifrostReq *schemas.BifrostRerankRequest, modelARN s
 	}
 
 	for i, doc := range bifrostReq.Documents {
+		inlineSource := BedrockRerankInlineSource{
+			Type:         bedrockRerankInlineDocumentTypeText,
+			TextDocument: &BedrockRerankTextValue{Text: doc.Text},
+		}
+		// Bedrock ranks structured bodies natively, so a JSON document goes over as-is.
+		if doc.Text == "" && len(doc.Data) > 0 {
+			inlineSource = BedrockRerankInlineSource{
+				Type:         bedrockRerankInlineDocumentTypeJSON,
+				JSONDocument: doc.Data,
+			}
+		}
 		bedrockReq.Sources[i] = BedrockRerankSource{
-			Type: bedrockRerankSourceTypeInline,
-			InlineDocumentSource: BedrockRerankInlineSource{
-				Type: bedrockRerankInlineDocumentTypeText,
-				TextDocument: BedrockRerankTextValue{
-					Text: doc.Text,
-				},
-			},
+			Type:                 bedrockRerankSourceTypeInline,
+			InlineDocumentSource: inlineSource,
 		}
 	}
 
 	if bifrostReq.Params == nil {
 		return bedrockReq, nil
 	}
+
+	bedrockReq.NextToken = bifrostReq.Params.NextToken
 
 	if bifrostReq.Params.TopN != nil {
 		topN := *bifrostReq.Params.TopN
@@ -92,12 +100,14 @@ func ToBedrockRerankRequest(bifrostReq *schemas.BifrostRerankRequest, modelARN s
 		bedrockReq.RerankingConfiguration.BedrockRerankingConfiguration.NumberOfResults = schemas.Ptr(topN)
 	}
 
+	// Bedrock validates this map against a per-model allowlist and rejects the whole request on
+	// an unknown key: COHERE_RERANK accepts only max_tokens_per_doc. Priority has no Bedrock
+	// equivalent, so it is dropped rather than forwarded - sending it 400s a request that
+	// succeeds on Cohere, which would break fallback chains. ExtraParams stays a passthrough:
+	// the caller opted into those keys explicitly.
 	additionalFields := make(map[string]interface{})
 	if bifrostReq.Params.MaxTokensPerDoc != nil {
 		additionalFields["max_tokens_per_doc"] = *bifrostReq.Params.MaxTokensPerDoc
-	}
-	if bifrostReq.Params.Priority != nil {
-		additionalFields["priority"] = *bifrostReq.Params.Priority
 	}
 	for k, v := range bifrostReq.Params.ExtraParams {
 		additionalFields[k] = v
@@ -116,7 +126,8 @@ func (response *BedrockRerankResponse) ToBifrostRerankResponse(documents []schem
 	}
 
 	bifrostResponse := &schemas.BifrostRerankResponse{
-		Results: make([]schemas.RerankResult, 0, len(response.Results)),
+		Results:   make([]schemas.RerankResult, 0, len(response.Results)),
+		NextToken: response.NextToken,
 	}
 
 	for _, result := range response.Results {
@@ -124,9 +135,14 @@ func (response *BedrockRerankResponse) ToBifrostRerankResponse(documents []schem
 			Index:          result.Index,
 			RelevanceScore: result.RelevanceScore,
 		}
-		if result.Document != nil && result.Document.TextDocument != nil {
-			rerankResult.Document = &schemas.RerankDocument{
-				Text: result.Document.TextDocument.Text,
+		if result.Index >= 0 && result.Index < len(documents) {
+			rerankResult.ID = documents[result.Index].ID
+		}
+		if result.Document != nil {
+			if result.Document.TextDocument != nil {
+				rerankResult.Document = &schemas.RerankDocument{Text: result.Document.TextDocument.Text}
+			} else if len(result.Document.JSONDocument) > 0 {
+				rerankResult.Document = &schemas.RerankDocument{Data: result.Document.JSONDocument}
 			}
 		}
 		bifrostResponse.Results = append(bifrostResponse.Results, rerankResult)
@@ -152,15 +168,16 @@ func (response *BedrockRerankResponse) ToBifrostRerankResponse(documents []schem
 }
 
 // ToBedrockRerankResponse converts a Bifrost rerank response into Bedrock Agent Runtime format.
-// Bedrock echoes the ranked document, which is only present when the rerank was requested
-// with ReturnDocuments enabled.
+// The live Rerank API returns only index and score per result, so a document is echoed back only
+// when the canonical response actually carries one.
 func ToBedrockRerankResponse(bifrostResp *schemas.BifrostRerankResponse) *BedrockRerankResponse {
 	if bifrostResp == nil {
 		return nil
 	}
 
 	bedrockResp := &BedrockRerankResponse{
-		Results: make([]BedrockRerankResult, 0, len(bifrostResp.Results)),
+		Results:   make([]BedrockRerankResult, 0, len(bifrostResp.Results)),
+		NextToken: bifrostResp.NextToken,
 	}
 
 	for _, result := range bifrostResp.Results {
@@ -169,9 +186,17 @@ func ToBedrockRerankResponse(bifrostResp *schemas.BifrostRerankResponse) *Bedroc
 			RelevanceScore: result.RelevanceScore,
 		}
 		if result.Document != nil {
-			bedrockResult.Document = &BedrockRerankResponseDocument{
-				Type:         bedrockRerankInlineDocumentTypeText,
-				TextDocument: &BedrockRerankTextValue{Text: result.Document.Text},
+			switch {
+			case len(result.Document.Data) > 0:
+				bedrockResult.Document = &BedrockRerankResponseDocument{
+					Type:         bedrockRerankInlineDocumentTypeJSON,
+					JSONDocument: result.Document.Data,
+				}
+			default:
+				bedrockResult.Document = &BedrockRerankResponseDocument{
+					Type:         bedrockRerankInlineDocumentTypeText,
+					TextDocument: &BedrockRerankTextValue{Text: result.Document.Text},
+				}
 			}
 		}
 
@@ -203,10 +228,17 @@ func (req *BedrockRerankRequest) ToBifrostRerankRequest(ctx *schemas.BifrostCont
 
 	// Convert sources to documents
 	for _, source := range req.Sources {
-		bifrostReq.Documents = append(bifrostReq.Documents, schemas.RerankDocument{
-			Text: source.InlineDocumentSource.TextDocument.Text,
-		})
+		doc := schemas.RerankDocument{}
+		if source.InlineDocumentSource.TextDocument != nil {
+			doc.Text = source.InlineDocumentSource.TextDocument.Text
+		}
+		if len(source.InlineDocumentSource.JSONDocument) > 0 {
+			doc.Data = source.InlineDocumentSource.JSONDocument
+		}
+		bifrostReq.Documents = append(bifrostReq.Documents, doc)
 	}
+
+	bifrostReq.Params.NextToken = req.NextToken
 
 	// Extract TopN from NumberOfResults
 	if req.RerankingConfiguration.BedrockRerankingConfiguration.NumberOfResults != nil {

--- a/core/providers/bedrock/rerank_test.go
+++ b/core/providers/bedrock/rerank_test.go
@@ -44,8 +44,30 @@ func TestToBedrockRerankRequest(t *testing.T) {
 	fields := req.RerankingConfiguration.BedrockRerankingConfiguration.ModelConfiguration.AdditionalModelRequestFields
 	require.NotNil(t, fields)
 	assert.Equal(t, maxTokensPerDoc, fields["max_tokens_per_doc"])
-	assert.Equal(t, priority, fields["priority"])
 	assert.Equal(t, "END", fields["truncate"])
+
+	// Bedrock rejects the whole request on an unknown additional field: COHERE_RERANK allows
+	// only max_tokens_per_doc. Forwarding priority 400s a request that succeeds on Cohere.
+	assert.NotContains(t, fields, "priority",
+		"priority has no Bedrock equivalent and must be dropped, not forwarded")
+}
+
+func TestToBedrockRerankRequestNextToken(t *testing.T) {
+	req, err := ToBedrockRerankRequest(&schemas.BifrostRerankRequest{
+		Model:     "arn:aws:bedrock:us-east-1::foundation-model/cohere.rerank-v3-5:0",
+		Query:     "capital of france",
+		Documents: []schemas.RerankDocument{{Text: "Paris is the capital of France."}},
+		Params:    &schemas.RerankParameters{NextToken: schemas.Ptr("cursor-1")},
+	}, "arn:aws:bedrock:us-east-1::foundation-model/cohere.rerank-v3-5:0")
+	require.NoError(t, err)
+
+	// nextToken is a top-level request field. Landing in additionalModelRequestFields instead
+	// makes Bedrock reject the request outright.
+	require.NotNil(t, req.NextToken)
+	assert.Equal(t, "cursor-1", *req.NextToken)
+	assert.NotContains(t,
+		req.RerankingConfiguration.BedrockRerankingConfiguration.ModelConfiguration.AdditionalModelRequestFields,
+		"next_token")
 }
 
 func TestBedrockRerankResponseToBifrostRerankResponse(t *testing.T) {
@@ -146,14 +168,14 @@ func TestBedrockRerankRequestToBifrostRerankRequest(t *testing.T) {
 				Type: bedrockRerankSourceTypeInline,
 				InlineDocumentSource: BedrockRerankInlineSource{
 					Type:         bedrockRerankInlineDocumentTypeText,
-					TextDocument: BedrockRerankTextValue{Text: "Paris is the capital of France."},
+					TextDocument: &BedrockRerankTextValue{Text: "Paris is the capital of France."},
 				},
 			},
 			{
 				Type: bedrockRerankSourceTypeInline,
 				InlineDocumentSource: BedrockRerankInlineSource{
 					Type:         bedrockRerankInlineDocumentTypeText,
-					TextDocument: BedrockRerankTextValue{Text: "Berlin is the capital of Germany."},
+					TextDocument: &BedrockRerankTextValue{Text: "Berlin is the capital of Germany."},
 				},
 			},
 		},

--- a/core/providers/cohere/errors.go
+++ b/core/providers/cohere/errors.go
@@ -23,3 +23,26 @@ func parseCohereError(resp *fasthttp.Response) *schemas.BifrostError {
 	}
 	return bifrostErr
 }
+
+// CohereErrorResponse is the body Cohere returns on a failed request. Verified against the live
+// v2 API, which replies with a flat {"id", "message"} on 400, 401 and 404 alike.
+type CohereErrorResponse struct {
+	ID      string `json:"id,omitempty"`
+	Message string `json:"message"`
+}
+
+// ToCohereError converts a Bifrost error into Cohere's error wire shape.
+func ToCohereError(bifrostErr *schemas.BifrostError) *CohereErrorResponse {
+	if bifrostErr == nil {
+		return nil
+	}
+
+	errorResponse := &CohereErrorResponse{}
+	if bifrostErr.EventID != nil {
+		errorResponse.ID = *bifrostErr.EventID
+	}
+	if bifrostErr.Error != nil {
+		errorResponse.Message = bifrostErr.Error.Message
+	}
+	return errorResponse
+}

--- a/core/providers/cohere/models.go
+++ b/core/providers/cohere/models.go
@@ -1,21 +1,70 @@
 package cohere
 
 import (
-	"encoding/json"
 	"strings"
+
+	"github.com/bytedance/sonic"
 
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
+// CohereRerankDocument is Cohere's overloaded document field. Requests accept a bare string or an
+// object; only the object's "text" is ranked, every other key rides along. Responses always use
+// the object form, so this always marshals as an object and only unmarshalling is lenient.
+type CohereRerankDocument struct {
+	Text     string                 `json:"text"`
+	ID       *string                `json:"id,omitempty"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// UnmarshalJSON accepts a bare string or an object, folding any key other than "text" and "id"
+// into Metadata so passthrough fields survive a round trip.
+func (d *CohereRerankDocument) UnmarshalJSON(data []byte) error {
+	var text string
+	if err := sonic.Unmarshal(data, &text); err == nil {
+		*d = CohereRerankDocument{Text: text}
+		return nil
+	}
+
+	var fields map[string]interface{}
+	if err := sonic.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+
+	*d = CohereRerankDocument{}
+	if text, ok := fields["text"].(string); ok {
+		d.Text = text
+	}
+	if id, ok := fields["id"].(string); ok {
+		d.ID = &id
+	}
+	metadata := make(map[string]interface{})
+	if nested, ok := fields["metadata"].(map[string]interface{}); ok {
+		for k, v := range nested {
+			metadata[k] = v
+		}
+	}
+	for k, v := range fields {
+		if k != "text" && k != "id" && k != "metadata" {
+			metadata[k] = v
+		}
+	}
+	if len(metadata) > 0 {
+		d.Metadata = metadata
+	}
+	return nil
+}
+
 // CohereRerankRequest represents a Cohere rerank API request.
 type CohereRerankRequest struct {
 	Model           string                 `json:"model"`
 	Query           string                 `json:"query"`
-	Documents       []string               `json:"documents"`
+	Documents       []CohereRerankDocument `json:"documents"`
 	TopN            *int                   `json:"top_n,omitempty"`
 	MaxTokensPerDoc *int                   `json:"max_tokens_per_doc,omitempty"`
 	Priority        *int                   `json:"priority,omitempty"`
+	ReturnDocuments *bool                  `json:"return_documents,omitempty"`
 	ExtraParams     map[string]interface{} `json:"-"`
 }
 
@@ -26,9 +75,9 @@ func (r *CohereRerankRequest) GetExtraParams() map[string]interface{} {
 
 // CohereRerankResult represents a single result from Cohere rerank.
 type CohereRerankResult struct {
-	Index          int             `json:"index"`
-	RelevanceScore float64         `json:"relevance_score"`
-	Document       json.RawMessage `json:"document,omitempty"`
+	Index          int                   `json:"index"`
+	RelevanceScore float64               `json:"relevance_score"`
+	Document       *CohereRerankDocument `json:"document,omitempty"`
 }
 
 // CohereRerankResponse represents a Cohere rerank API response.
@@ -40,9 +89,11 @@ type CohereRerankResponse struct {
 
 // CohereRerankMeta represents metadata in Cohere rerank response.
 type CohereRerankMeta struct {
-	APIVersion  *CohereEmbeddingAPIVersion `json:"api_version,omitempty"`
-	BilledUnits *CohereBilledUnits         `json:"billed_units,omitempty"`
-	Tokens      *CohereTokenUsage          `json:"tokens,omitempty"`
+	APIVersion   *CohereEmbeddingAPIVersion `json:"api_version,omitempty"`
+	BilledUnits  *CohereBilledUnits         `json:"billed_units,omitempty"`
+	Tokens       *CohereTokenUsage          `json:"tokens,omitempty"`
+	CachedTokens *int                       `json:"cached_tokens,omitempty"`
+	Warnings     []string                   `json:"warnings,omitempty"`
 }
 
 func (response *CohereListModelsResponse) ToBifrostListModelsResponse(providerKey schemas.ModelProvider, allowedModels schemas.WhiteList, blacklistedModels schemas.BlackList, aliases schemas.KeyAliases, unfiltered bool) *schemas.BifrostListModelsResponse {

--- a/core/providers/cohere/rerank.go
+++ b/core/providers/cohere/rerank.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/schemas"
-	"gopkg.in/yaml.v3"
 )
 
 // ToCohereRerankRequest converts a Bifrost rerank request to Cohere format
@@ -19,10 +18,13 @@ func ToCohereRerankRequest(bifrostReq *schemas.BifrostRerankRequest) *CohereRera
 		Query: bifrostReq.Query,
 	}
 
-	// Cohere v2 expects documents as a list of strings.
-	documents := make([]string, len(bifrostReq.Documents))
+	documents := make([]CohereRerankDocument, len(bifrostReq.Documents))
 	for i, doc := range bifrostReq.Documents {
-		documents[i] = formatCohereRerankDocument(doc)
+		documents[i] = CohereRerankDocument{
+			Text:     rerankDocumentText(doc),
+			ID:       doc.ID,
+			Metadata: doc.Meta,
+		}
 	}
 	cohereReq.Documents = documents
 
@@ -30,6 +32,7 @@ func ToCohereRerankRequest(bifrostReq *schemas.BifrostRerankRequest) *CohereRera
 		cohereReq.TopN = bifrostReq.Params.TopN
 		cohereReq.MaxTokensPerDoc = bifrostReq.Params.MaxTokensPerDoc
 		cohereReq.Priority = bifrostReq.Params.Priority
+		cohereReq.ReturnDocuments = bifrostReq.Params.ReturnDocuments
 		cohereReq.ExtraParams = bifrostReq.Params.ExtraParams
 	}
 
@@ -51,10 +54,11 @@ func (req *CohereRerankRequest) ToBifrostRerankRequest(ctx *schemas.BifrostConte
 		Params:   &schemas.RerankParameters{},
 	}
 
-	// Convert documents
 	for _, doc := range req.Documents {
 		bifrostReq.Documents = append(bifrostReq.Documents, schemas.RerankDocument{
-			Text: doc,
+			Text: doc.Text,
+			ID:   doc.ID,
+			Meta: doc.Metadata,
 		})
 	}
 
@@ -66,6 +70,9 @@ func (req *CohereRerankRequest) ToBifrostRerankRequest(ctx *schemas.BifrostConte
 	}
 	if req.Priority != nil {
 		bifrostReq.Params.Priority = req.Priority
+	}
+	if req.ReturnDocuments != nil {
+		bifrostReq.Params.ReturnDocuments = req.ReturnDocuments
 	}
 	if req.ExtraParams != nil {
 		bifrostReq.Params.ExtraParams = req.ExtraParams
@@ -84,53 +91,24 @@ func (response *CohereRerankResponse) ToBifrostRerankResponse(documents []schema
 		ID: response.ID,
 	}
 
-	// Convert results
 	for _, result := range response.Results {
 		rerankResult := schemas.RerankResult{
 			Index:          result.Index,
 			RelevanceScore: result.RelevanceScore,
 		}
-
-		// Convert document if present
-		if len(result.Document) > 0 {
-			var docMap map[string]interface{}
-			if err := sonic.Unmarshal(result.Document, &docMap); err == nil {
-				doc := &schemas.RerankDocument{}
-				populated := false
-				if text, ok := docMap["text"].(string); ok {
-					doc.Text = text
-					populated = true
-				}
-				if id, ok := docMap["id"].(string); ok {
-					doc.ID = &id
-					populated = true
-				}
-				// Collect metadata: unwrap "metadata"/"meta" keys to avoid nesting
-				meta := make(map[string]interface{})
-				if rawMeta, ok := docMap["metadata"].(map[string]interface{}); ok {
-					for k, v := range rawMeta {
-						meta[k] = v
-					}
-				} else if rawMeta, ok := docMap["meta"].(map[string]interface{}); ok {
-					for k, v := range rawMeta {
-						meta[k] = v
-					}
-				}
-				for k, v := range docMap {
-					if k != "text" && k != "id" && k != "metadata" && k != "meta" {
-						meta[k] = v
-					}
-				}
-				if len(meta) > 0 {
-					doc.Meta = meta
-					populated = true
-				}
-				if populated {
-					rerankResult.Document = doc
-				}
+		if result.Index >= 0 && result.Index < len(documents) {
+			rerankResult.ID = documents[result.Index].ID
+		}
+		if result.Document != nil {
+			rerankResult.Document = &schemas.RerankDocument{
+				Text: result.Document.Text,
+				ID:   result.Document.ID,
+				Meta: result.Document.Metadata,
+			}
+			if rerankResult.ID == nil {
+				rerankResult.ID = result.Document.ID
 			}
 		}
-
 		bifrostResponse.Results = append(bifrostResponse.Results, rerankResult)
 	}
 	sort.SliceStable(bifrostResponse.Results, func(i, j int) bool {
@@ -172,11 +150,23 @@ func (response *CohereRerankResponse) ToBifrostRerankResponse(documents []schema
 				hasTokenUsage = true
 			}
 		}
-		if hasTokenUsage {
+
+		// Rerank bills in search units, not tokens; carry them so cost calculation has an input.
+		var searchUnits *int
+		if response.Meta.BilledUnits != nil && response.Meta.BilledUnits.SearchUnits != nil {
+			searchUnits = response.Meta.BilledUnits.SearchUnits
+		}
+
+		if hasTokenUsage || searchUnits != nil {
 			bifrostResponse.Usage = &schemas.BifrostLLMUsage{
 				PromptTokens:     promptTokens,
 				CompletionTokens: completionTokens,
 				TotalTokens:      promptTokens + completionTokens,
+			}
+			if searchUnits != nil {
+				bifrostResponse.Usage.CompletionTokensDetails = &schemas.ChatCompletionTokensDetails{
+					NumSearchQueries: searchUnits,
+				}
 			}
 		}
 	}
@@ -195,47 +185,57 @@ func ToCohereRerankResponse(bifrostResp *schemas.BifrostRerankResponse) *CohereR
 		Results: make([]CohereRerankResult, 0, len(bifrostResp.Results)),
 	}
 
-	// Cohere v2 rerank results carry only the index and the score.
 	for _, result := range bifrostResp.Results {
-		cohereResp.Results = append(cohereResp.Results, CohereRerankResult{
+		cohereResult := CohereRerankResult{
 			Index:          result.Index,
 			RelevanceScore: result.RelevanceScore,
-		})
+		}
+		if result.Document != nil {
+			cohereResult.Document = &CohereRerankDocument{
+				Text:     rerankDocumentText(*result.Document),
+				ID:       result.Document.ID,
+				Metadata: result.Document.Meta,
+			}
+		}
+		cohereResp.Results = append(cohereResp.Results, cohereResult)
 	}
 
 	if bifrostResp.Usage != nil {
-		cohereResp.Meta = &CohereRerankMeta{
-			BilledUnits: &CohereBilledUnits{
-				InputTokens:  new(bifrostResp.Usage.PromptTokens),
-				OutputTokens: new(bifrostResp.Usage.CompletionTokens),
-			},
-			Tokens: &CohereTokenUsage{
-				InputTokens:  new(bifrostResp.Usage.PromptTokens),
-				OutputTokens: new(bifrostResp.Usage.CompletionTokens),
-			},
+		billedUnits := &CohereBilledUnits{}
+		hasBilledUnits := false
+		if bifrostResp.Usage.CompletionTokensDetails != nil && bifrostResp.Usage.CompletionTokensDetails.NumSearchQueries != nil {
+			billedUnits.SearchUnits = bifrostResp.Usage.CompletionTokensDetails.NumSearchQueries
+			hasBilledUnits = true
+		}
+		if bifrostResp.Usage.PromptTokens > 0 || bifrostResp.Usage.CompletionTokens > 0 {
+			billedUnits.InputTokens = new(bifrostResp.Usage.PromptTokens)
+			billedUnits.OutputTokens = new(bifrostResp.Usage.CompletionTokens)
+			hasBilledUnits = true
+			cohereResp.Meta = &CohereRerankMeta{
+				Tokens: &CohereTokenUsage{
+					InputTokens:  new(bifrostResp.Usage.PromptTokens),
+					OutputTokens: new(bifrostResp.Usage.CompletionTokens),
+				},
+			}
+		}
+		if hasBilledUnits {
+			if cohereResp.Meta == nil {
+				cohereResp.Meta = &CohereRerankMeta{}
+			}
+			cohereResp.Meta.BilledUnits = billedUnits
 		}
 	}
 
 	return cohereResp
 }
 
-func formatCohereRerankDocument(doc schemas.RerankDocument) string {
-	if doc.ID == nil && len(doc.Meta) == 0 {
+// rerankDocumentText renders a document as the prose Cohere ranks. A structured body is encoded
+// so its content still reaches the ranker on a provider with no native JSON document support.
+func rerankDocumentText(doc schemas.RerankDocument) string {
+	if doc.Text != "" || len(doc.Data) == 0 {
 		return doc.Text
 	}
-
-	// Keep metadata/id available by encoding a structured string document.
-	documentPayload := map[string]interface{}{
-		"text": doc.Text,
-	}
-	if doc.ID != nil {
-		documentPayload["id"] = *doc.ID
-	}
-	if len(doc.Meta) > 0 {
-		documentPayload["metadata"] = doc.Meta
-	}
-
-	encoded, err := yaml.Marshal(documentPayload)
+	encoded, err := sonic.Marshal(doc.Data)
 	if err != nil {
 		return doc.Text
 	}

--- a/core/providers/cohere/rerank_test.go
+++ b/core/providers/cohere/rerank_test.go
@@ -16,12 +16,12 @@ func TestCohereRerankResponseToBifrostRerankResponse(t *testing.T) {
 			{
 				Index:          1,
 				RelevanceScore: 0.62,
-				Document: json.RawMessage(`{"text":"provider-doc-1","id":"doc-1","topic":"geography"}`),
+				Document: &CohereRerankDocument{Text: "provider-doc-1", ID: schemas.Ptr("doc-1"), Metadata: map[string]interface{}{"topic": "geography"}},
 			},
 			{
 				Index:          0,
 				RelevanceScore: 0.91,
-				Document: json.RawMessage(`{"text":"provider-doc-0"}`),
+				Document: &CohereRerankDocument{Text: "provider-doc-0"},
 			},
 		},
 	}).ToBifrostRerankResponse(nil, false)
@@ -51,12 +51,12 @@ func TestCohereRerankResponseToBifrostRerankResponseReturnDocuments(t *testing.T
 			{
 				Index:          1,
 				RelevanceScore: 0.62,
-				Document: json.RawMessage(`{"text":"provider-doc-1"}`),
+				Document: &CohereRerankDocument{Text: "provider-doc-1"},
 			},
 			{
 				Index:          0,
 				RelevanceScore: 0.91,
-				Document: json.RawMessage(`{"text":"provider-doc-0"}`),
+				Document: &CohereRerankDocument{Text: "provider-doc-0"},
 			},
 		},
 	}).ToBifrostRerankResponse(requestDocs, true)
@@ -87,8 +87,10 @@ func TestToCohereRerankResponse(t *testing.T) {
 	require.Len(t, cohereResp.Results, 2)
 	assert.Equal(t, 1, cohereResp.Results[0].Index)
 	assert.InDelta(t, 0.91, cohereResp.Results[0].RelevanceScore, 1e-9)
-	// Cohere v2 rerank results have no document field.
-	assert.Nil(t, cohereResp.Results[0].Document)
+	// Cohere echoes the document back when the caller asked for documents.
+	require.NotNil(t, cohereResp.Results[0].Document)
+	assert.Equal(t, "doc-1", cohereResp.Results[0].Document.Text)
+	assert.Nil(t, cohereResp.Results[1].Document)
 
 	require.NotNil(t, cohereResp.Meta)
 	require.NotNil(t, cohereResp.Meta.Tokens)
@@ -117,4 +119,28 @@ func TestToCohereRerankResponseOmitsEmptyIDAndMeta(t *testing.T) {
 	assert.NotContains(t, payload, "meta")
 
 	assert.Nil(t, ToCohereRerankResponse(nil))
+}
+
+func TestToCohereRerankResponseDocumentIsAlwaysAnObject(t *testing.T) {
+	// Cohere returns results[].document as an object even for a plain-string request
+	// document. Emitting a bare string here breaks the official SDK, which parses the
+	// field into a typed document.
+	cohereResp := ToCohereRerankResponse(&schemas.BifrostRerankResponse{
+		Results: []schemas.RerankResult{
+			{Index: 0, RelevanceScore: 0.9, Document: &schemas.RerankDocument{Text: "doc-0"}},
+		},
+	})
+
+	encoded, err := json.Marshal(cohereResp)
+	require.NoError(t, err)
+
+	var payload struct {
+		Results []struct {
+			Document map[string]interface{} `json:"document"`
+		} `json:"results"`
+	}
+	require.NoError(t, json.Unmarshal(encoded, &payload))
+	require.Len(t, payload.Results, 1)
+	require.NotNil(t, payload.Results[0].Document, "document must serialize as an object, not a string")
+	assert.Equal(t, "doc-0", payload.Results[0].Document["text"])
 }

--- a/core/providers/cohere/types.go
+++ b/core/providers/cohere/types.go
@@ -405,6 +405,8 @@ type CohereBilledUnits struct {
 	OutputTokens    *int `json:"output_tokens,omitempty"`   // Number of billed output tokens
 	SearchUnits     *int `json:"search_units,omitempty"`    // Number of billed search units
 	Classifications *int `json:"classifications,omitempty"` // Number of billed classification units
+	Images          *int `json:"images,omitempty"`          // Number of billed images
+	ImageTokens     *int `json:"image_tokens,omitempty"`    // Number of billed image tokens
 }
 
 // CohereTokenUsage represents detailed token usage

--- a/core/providers/vertex/rerank.go
+++ b/core/providers/vertex/rerank.go
@@ -32,8 +32,10 @@ func buildVertexRankingConfig(projectID, rankingConfigOverride string) (string, 
 }
 
 func getVertexRerankOptions(projectID string, params *schemas.RerankParameters) (*vertexRerankOptions, error) {
+	// Record details are Vertex's name for returning the document back, so it maps onto the
+	// neutral ReturnDocuments flag rather than a provider-specific extra param.
 	options := &vertexRerankOptions{
-		IgnoreRecordDetailsInResponse: true,
+		IgnoreRecordDetailsInResponse: params == nil || params.ReturnDocuments == nil || !*params.ReturnDocuments,
 	}
 
 	if params == nil || params.ExtraParams == nil {
@@ -61,14 +63,6 @@ func getVertexRerankOptions(projectID string, params *schemas.RerankParameters) 
 		return nil, err
 	}
 	options.RankingConfig = rankingConfig
-
-	if rawIgnoreRecordDetails, exists := extraParams["ignore_record_details_in_response"]; exists {
-		ignoreRecordDetailsInResponse, ok := schemas.SafeExtractBool(rawIgnoreRecordDetails)
-		if !ok {
-			return nil, fmt.Errorf("invalid ignore_record_details_in_response: expected bool")
-		}
-		options.IgnoreRecordDetailsInResponse = ignoreRecordDetailsInResponse
-	}
 
 	if rawUserLabels, exists := extraParams["user_labels"]; exists {
 		userLabels, ok := schemas.SafeExtractStringMap(rawUserLabels)
@@ -104,6 +98,11 @@ func ToVertexRankRequest(bifrostReq *schemas.BifrostRerankRequest, options *vert
 	for i, doc := range bifrostReq.Documents {
 		recordID := fmt.Sprintf("%s%d", vertexSyntheticRecordPrefix, i)
 		content := doc.Text
+		if content == "" && len(doc.Data) > 0 {
+			if encoded, err := sonic.Marshal(doc.Data); err == nil {
+				content = string(encoded)
+			}
+		}
 		record := VertexRankRecord{
 			ID:      recordID,
 			Content: &content,
@@ -153,12 +152,12 @@ func (req *VertexRankRequest) ToBifrostRerankRequest(ctx *schemas.BifrostContext
 		return nil
 	}
 
+	// Leave the provider empty like the other rerank converters so the route's header and the
+	// modelcatalogresolver decide it; pinning Vertex here made /genai/v1/rank single-provider.
 	var provider schemas.ModelProvider
 	var model string
 	if req.Model != nil {
-		provider, model = schemas.ParseModelString(*req.Model, schemas.Vertex)
-	} else {
-		provider = schemas.Vertex
+		provider, model = schemas.ParseModelString(*req.Model, "")
 	}
 
 	bifrostReq := &schemas.BifrostRerankRequest{
@@ -189,14 +188,12 @@ func (req *VertexRankRequest) ToBifrostRerankRequest(ctx *schemas.BifrostContext
 		bifrostReq.Params.TopN = req.TopN
 	}
 
-	// Set unconditionally: Discovery Engine defaults this to false, Bifrost's rerank default is true.
-	extraParams := map[string]interface{}{
-		"ignore_record_details_in_response": req.IgnoreRecordDetailsInResponse != nil && *req.IgnoreRecordDetailsInResponse,
-	}
+	// Discovery Engine defaults to returning record details, so an omitted flag means documents come back.
+	bifrostReq.Params.ReturnDocuments = new(req.IgnoreRecordDetailsInResponse == nil || !*req.IgnoreRecordDetailsInResponse)
+
 	if len(req.UserLabels) > 0 {
-		extraParams["user_labels"] = req.UserLabels
+		bifrostReq.Params.ExtraParams = map[string]interface{}{"user_labels": req.UserLabels}
 	}
-	bifrostReq.Params.ExtraParams = extraParams
 
 	return bifrostReq
 }
@@ -239,6 +236,7 @@ func (response *VertexRankResponse) ToBifrostRerankResponse(documents []schemas.
 		result := schemas.RerankResult{
 			Index:          index,
 			RelevanceScore: record.Score,
+			ID:             documents[index].ID,
 		}
 
 		if returnDocuments {
@@ -262,8 +260,8 @@ func (response *VertexRankResponse) ToBifrostRerankResponse(documents []schemas.
 }
 
 // ToVertexRankResponse converts a Bifrost rerank response to Discovery Engine rank format.
-// Records are keyed by the caller's record ID, which only survives on the result document,
-// so callers must request the rerank with ReturnDocuments enabled.
+// Records are keyed by the caller's record ID, which rides on the result as identity; title and
+// content appear only when the caller asked for documents back.
 func ToVertexRankResponse(bifrostResp *schemas.BifrostRerankResponse) (*VertexRankResponse, error) {
 	if bifrostResp == nil {
 		return nil, fmt.Errorf("bifrost rerank response is nil")
@@ -274,22 +272,24 @@ func ToVertexRankResponse(bifrostResp *schemas.BifrostRerankResponse) (*VertexRa
 	}
 
 	for _, result := range bifrostResp.Results {
-		if result.Document == nil {
-			return nil, fmt.Errorf("rerank result at index %d has no document: record ids cannot be restored", result.Index)
-		}
-
 		record := VertexRankedRecord{
 			Score: result.RelevanceScore,
 		}
-		if result.Document.ID != nil {
+		switch {
+		case result.ID != nil:
+			record.ID = *result.ID
+		case result.Document != nil && result.Document.ID != nil:
 			record.ID = *result.Document.ID
 		}
-		if result.Document.Text != "" {
-			record.Content = &result.Document.Text
-		}
-		if rawTitle, exists := result.Document.Meta["title"]; exists {
-			if title, ok := schemas.SafeExtractString(rawTitle); ok && strings.TrimSpace(title) != "" {
-				record.Title = &title
+
+		if result.Document != nil {
+			if result.Document.Text != "" {
+				record.Content = &result.Document.Text
+			}
+			if rawTitle, exists := result.Document.Meta["title"]; exists {
+				if title, ok := schemas.SafeExtractString(rawTitle); ok && strings.TrimSpace(title) != "" {
+					record.Title = &title
+				}
 			}
 		}
 

--- a/core/providers/vertex/rerank_test.go
+++ b/core/providers/vertex/rerank_test.go
@@ -89,9 +89,10 @@ func TestGetVertexRerankOptions(t *testing.T) {
 	t.Parallel()
 
 	options, err := getVertexRerankOptions("project-x", &schemas.RerankParameters{
+		// Returning documents is Bifrost's neutral spelling of "do not ignore record details".
+		ReturnDocuments: new(true),
 		ExtraParams: map[string]interface{}{
-			"ranking_config":                    "custom_rank",
-			"ignore_record_details_in_response": false,
+			"ranking_config": "custom_rank",
 			"user_labels": map[string]interface{}{
 				"env": "test",
 			},
@@ -101,6 +102,23 @@ func TestGetVertexRerankOptions(t *testing.T) {
 	assert.Equal(t, "projects/project-x/locations/global/rankingConfigs/custom_rank", options.RankingConfig)
 	assert.False(t, options.IgnoreRecordDetailsInResponse)
 	assert.Equal(t, map[string]string{"env": "test"}, options.UserLabels)
+}
+
+func TestGetVertexRerankOptionsReturnDocumentsUnset(t *testing.T) {
+	t.Parallel()
+
+	// A nil ReturnDocuments only reaches here from the canonical rerank route, where "unset"
+	// means the caller did not ask for documents - the same default Cohere and Bedrock apply.
+	// The /genai/v1/rank route never passes nil: ToBifrostRerankRequest resolves an omitted
+	// ignoreRecordDetailsInResponse into an explicit ReturnDocuments first. Fetching record
+	// details here would be discarded by Rerank, which attaches documents only on an explicit
+	// ReturnDocuments.
+	for _, params := range []*schemas.RerankParameters{nil, {}, {ReturnDocuments: new(false)}} {
+		options, err := getVertexRerankOptions("project-x", params)
+		require.NoError(t, err)
+		assert.True(t, options.IgnoreRecordDetailsInResponse,
+			"documents must not be fetched unless the caller asked for them: %+v", params)
+	}
 }
 
 func TestVertexRankResponseToBifrostRerankResponse(t *testing.T) {
@@ -156,7 +174,9 @@ func TestVertexRankRequestToBifrostRerankRequest(t *testing.T) {
 	result := req.ToBifrostRerankRequest(bifrostCtx)
 
 	require.NotNil(t, result)
-	assert.Equal(t, schemas.Vertex, result.Provider)
+	// Provider resolution is deferred to the route header and the modelcatalogresolver plugin,
+	// matching the Cohere and Bedrock rerank converters.
+	assert.Equal(t, schemas.ModelProvider(""), result.Provider)
 	assert.Equal(t, "semantic-ranker-default@latest", result.Model)
 	assert.Equal(t, "capital of france", result.Query)
 	require.Len(t, result.Documents, 2)
@@ -179,9 +199,10 @@ func TestVertexRankRequestToBifrostRerankRequest(t *testing.T) {
 	require.NotNil(t, result.Params.TopN)
 	assert.Equal(t, 5, *result.Params.TopN)
 
-	// ExtraParams
+	// ignoreRecordDetailsInResponse maps onto the neutral ReturnDocuments flag.
+	require.NotNil(t, result.Params.ReturnDocuments)
+	assert.False(t, *result.Params.ReturnDocuments)
 	require.NotNil(t, result.Params.ExtraParams)
-	assert.Equal(t, true, result.Params.ExtraParams["ignore_record_details_in_response"])
 	assert.Equal(t, map[string]string{"env": "test"}, result.Params.ExtraParams["user_labels"])
 }
 
@@ -231,22 +252,28 @@ func TestToVertexRankResponse(t *testing.T) {
 	assert.Nil(t, response.Records[1].Title)
 }
 
-func TestToVertexRankResponseRequiresDocuments(t *testing.T) {
-	_, err := ToVertexRankResponse(&schemas.BifrostRerankResponse{
-		Results: []schemas.RerankResult{{Index: 0, RelevanceScore: 0.88}},
+func TestToVertexRankResponseIdentityWithoutDocuments(t *testing.T) {
+	// ignoreRecordDetailsInResponse means no document comes back, but the record id is identity
+	// rather than detail, so it must still address the caller's record.
+	response, err := ToVertexRankResponse(&schemas.BifrostRerankResponse{
+		Results: []schemas.RerankResult{{Index: 0, RelevanceScore: 0.88, ID: new("doc-paris")}},
 	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no document")
+	require.NoError(t, err)
+	require.Len(t, response.Records, 1)
+	assert.Equal(t, "doc-paris", response.Records[0].ID)
+	assert.InDelta(t, 0.88, response.Records[0].Score, 1e-9)
+	assert.Nil(t, response.Records[0].Title)
+	assert.Nil(t, response.Records[0].Content)
 
 	_, err = ToVertexRankResponse(nil)
 	require.Error(t, err)
 }
 
-func TestVertexRankRequestToBifrostRerankRequestDefaultsIgnoreRecordDetailsToFalse(t *testing.T) {
+func TestVertexRankRequestToBifrostRerankRequestDefaultsToReturningDocuments(t *testing.T) {
 	t.Parallel()
 
-	// Discovery Engine defaults the flag to false, so an omitted field must not
-	// fall through to Bifrost's own default of true.
+	// Discovery Engine returns record details by default, so an omitted flag must mean
+	// documents come back rather than falling through to Bifrost's own default.
 	result := (&VertexRankRequest{
 		Query:   "capital of france",
 		Records: []VertexRankRecord{{ID: "rec-1", Content: new("Paris is the capital of France.")}},
@@ -254,6 +281,6 @@ func TestVertexRankRequestToBifrostRerankRequestDefaultsIgnoreRecordDetailsToFal
 
 	require.NotNil(t, result)
 	require.NotNil(t, result.Params)
-	require.NotNil(t, result.Params.ExtraParams)
-	assert.Equal(t, false, result.Params.ExtraParams["ignore_record_details_in_response"])
+	require.NotNil(t, result.Params.ReturnDocuments)
+	assert.True(t, *result.Params.ReturnDocuments)
 }

--- a/core/schemas/rerank.go
+++ b/core/schemas/rerank.go
@@ -1,10 +1,43 @@
 package schemas
 
+import "github.com/bytedance/sonic"
+
 // RerankDocument represents a document to be reranked.
+//
+// Text carries prose content. Data carries a structured body for providers that rank JSON
+// natively; providers without native support serialize it into text. Meta rides along as
+// passthrough metadata and is not ranked.
 type RerankDocument struct {
 	Text string                 `json:"text"`
+	Data map[string]interface{} `json:"data,omitempty"`
 	ID   *string                `json:"id,omitempty"`
 	Meta map[string]interface{} `json:"meta,omitempty"`
+}
+
+// rerankDocumentFields mirrors RerankDocument without the custom unmarshaler, so the object
+// branch below can decode without recursing.
+type rerankDocumentFields struct {
+	Text string                 `json:"text"`
+	Data map[string]interface{} `json:"data,omitempty"`
+	ID   *string                `json:"id,omitempty"`
+	Meta map[string]interface{} `json:"meta,omitempty"`
+}
+
+// UnmarshalJSON accepts either a bare string or an object. Every rerank API in the wild takes
+// `documents: ["a", "b"]`, so the canonical route accepts that form and normalizes it.
+func (d *RerankDocument) UnmarshalJSON(data []byte) error {
+	var text string
+	if err := sonic.Unmarshal(data, &text); err == nil {
+		*d = RerankDocument{Text: text}
+		return nil
+	}
+
+	var fields rerankDocumentFields
+	if err := sonic.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	*d = RerankDocument(fields)
+	return nil
 }
 
 // RerankParameters contains optional parameters for a rerank request.
@@ -13,6 +46,7 @@ type RerankParameters struct {
 	MaxTokensPerDoc *int                   `json:"max_tokens_per_doc,omitempty"`
 	Priority        *int                   `json:"priority,omitempty"`
 	ReturnDocuments *bool                  `json:"return_documents,omitempty"`
+	NextToken       *string                `json:"next_token,omitempty"`
 	ExtraParams     map[string]interface{} `json:"-"`
 }
 
@@ -33,9 +67,14 @@ func (r *BifrostRerankRequest) GetRawRequestBody() []byte {
 }
 
 // RerankResult represents a single reranked document with its relevance score.
+//
+// Index addresses the document by position. ID carries the caller's document identifier when the
+// request supplied one; it is identity rather than content, so it survives even when documents are
+// not returned. Document carries the content back and is set only when ReturnDocuments is on.
 type RerankResult struct {
 	Index          int             `json:"index"`
 	RelevanceScore float64         `json:"relevance_score"`
+	ID             *string         `json:"id,omitempty"`
 	Document       *RerankDocument `json:"document,omitempty"`
 }
 
@@ -45,5 +84,6 @@ type BifrostRerankResponse struct {
 	Results     []RerankResult             `json:"results"`
 	Model       string                     `json:"model"`
 	Usage       *BifrostLLMUsage           `json:"usage,omitempty"`
+	NextToken   *string                    `json:"next_token,omitempty"`
 	ExtraFields BifrostResponseExtraFields `json:"extra_fields"`
 }

--- a/tests/e2e/api/HARNESS_COVERAGE_BACKLOG.md
+++ b/tests/e2e/api/HARNESS_COVERAGE_BACKLOG.md
@@ -82,7 +82,7 @@ Sources:
 - [ ] **Models list** (`GET /v1/models`)
 - [ ] **Containers API** (`POST /v1/containers` for code-interpreter sandboxes)
 - [ ] **Videos API** (`POST /v1/videos` for Sora)
-- [ ] **Rerank** (`POST /v1/rerank`)
+- [x] **Rerank** (`POST /v1/rerank`) - folder 56, cross-provider across cohere/bedrock/vertex
 
 ---
 

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -114,6 +114,10 @@
           "        shape = 'rerank';",
           "        // A rerank response ranks the documents it was given; it generates no text, so the ranked list IS the content. Matched on index + a relevance score rather than on `results` alone, which is too generic to claim off other shapes. This branch went missing until now because no rerank row had ever returned 2xx: every bedrock row was rejected pre-flight for not naming its model as an ARN, and every vertex row 403s on discoveryengine IAM - and the content check is gated on code < 400, so it never ran.",
           "        hasContent = j.results.length > 0;",
+          "    } else if (Array.isArray(j.records) && j.records.length > 0 && j.records[0] && typeof j.records[0].id === 'string' && typeof j.records[0].score === 'number') {",
+          "        shape = 'rerank-records';",
+          "        // Discovery Engine's rank API is ID-keyed: it answers with records[] carrying id + score, not results[] with index + relevance_score, so the rerank branch above never claims it. Like that branch, the ranked list IS the content - a rank call generates no text. Matched on id + score rather than on `records` alone, which is too generic to claim off other shapes. This went missing because /genai/v1/rank only started returning the real Discovery Engine shape once the rank response converter landed; before that it leaked Bifrost's canonical results[] and was claimed by the rerank branch.",
+          "        hasContent = j.records.length > 0;",
           "    } else if (Array.isArray(j.predictions)) {",
           "        shape = 'vertex-predictions';",
           "        hasContent = j.predictions.length > 0;",
@@ -128718,10 +128722,11 @@
                       "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
                       "var j; try { j = pm.response.json(); } catch (e) {",
                       "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
-                      "pm.test('rerank returned ranked results', function () {",
-                      "  var r = j.results || j.data || [];",
-                      "  pm.expect(r.length, 'no results: ' + pm.response.text().slice(0, 400)).to.be.above(0);",
-                      "  pm.expect(r[0]).to.have.property('index');",
+                      "pm.test('rank returned ranked records', function () {",
+                      "  var r = j.records || [];",
+                      "  pm.expect(r.length, 'no records (Discovery Engine returns records[], not results[]): ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                      "  pm.expect(r[0], 'record must be keyed by id').to.have.property('id');",
+                      "  pm.expect(r[0], 'record must carry score').to.have.property('score');",
                       "});"
                     ]
                   }
@@ -128763,10 +128768,11 @@
                       "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
                       "var j; try { j = pm.response.json(); } catch (e) {",
                       "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
-                      "pm.test('rerank returned ranked results', function () {",
-                      "  var r = j.results || j.data || [];",
-                      "  pm.expect(r.length, 'no results: ' + pm.response.text().slice(0, 400)).to.be.above(0);",
-                      "  pm.expect(r[0]).to.have.property('index');",
+                      "pm.test('rank returned ranked records', function () {",
+                      "  var r = j.records || [];",
+                      "  pm.expect(r.length, 'no records (Discovery Engine returns records[], not results[]): ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                      "  pm.expect(r[0], 'record must be keyed by id').to.have.property('id');",
+                      "  pm.expect(r[0], 'record must carry score').to.have.property('score');",
                       "});"
                     ]
                   }
@@ -133694,6 +133700,1348 @@
             }
           },
           "response": []
+        }
+      ]
+    },
+    {
+      "name": "56. Rerank Wire Shapes and Neutral Schema (PR #6328)",
+      "description": "Rerank had route x provider reachability coverage in 48.6, but nothing pinned the wire shape or the neutral schema. The old assertions accepted `j.results || j.data` and only checked for an `index` field, so a Bedrock response carrying snake_case relevance_score (which AWS SDKs deserialize as 0.0) passed, and the /genai/v1/rank cases passed only while the route leaked Bifrost's canonical shape.\n\nThis folder completes the matrix and pins behaviour:\n- POST /v1/rerank across cohere, bedrock and vertex (the canonical route had zero cases)\n- the three drop-in routes served by the cohere provider (no prior coverage)\n- per-route wire shape: snake_case on /cohere, camelCase on /bedrock, records[] on /genai, and no canonical model/extra_fields leaking into a provider-shaped body\n- neutral schema: string|object documents, structured `data` bodies, result id identity, document echo as an object, ignoreRecordDetailsInResponse, and search-unit usage\n\nRanking assertions require the one relevant document to rank first rather than just checking for a 200, because a provider that drops document content still answers 200 with meaningless scores.",
+      "item": [
+        {
+          "name": "56. /v1/rerank string documents -> cohere/rerank-v3.5 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"cohere/rerank-v3.5\",\n  \"query\": \"What is the capital of France?\",\n  \"documents\": [\n    \"Paris is the capital and most populous city of France.\",\n    \"Carrots are orange root vegetables rich in beta carotene.\",\n    \"Berlin is the capital of Germany and its largest city.\"\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/rerank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "rerank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "// Plain-string documents are the form every rerank SDK sends; they were rejected",
+                  "// before RerankDocument gained a string|object unmarshaller.",
+                  "pm.test('results are ranked, not merely returned', function () {",
+                  "  var r = j.results || [];",
+                  "  pm.expect(r.length, 'no results: ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                  "  pm.expect(r[0], 'result must carry an index').to.have.property('index');",
+                  "  pm.expect(r[0], 'expected relevance_score on the wire').to.have.property('relevance_score');",
+                  "  pm.expect(r[0].index, 'the only relevant document must rank first').to.eql(0);",
+                  "  if (r.length > 1) { pm.expect(r[0].relevance_score, 'top and bottom scores indistinguishable').to.be.above(r[r.length - 1].relevance_score); }",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. /v1/rerank string documents -> bedrock/cohere.rerank-v3-5:0 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"bedrock/cohere.rerank-v3-5:0\",\n  \"query\": \"What is the capital of France?\",\n  \"documents\": [\n    \"Paris is the capital and most populous city of France.\",\n    \"Carrots are orange root vegetables rich in beta carotene.\",\n    \"Berlin is the capital of Germany and its largest city.\"\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/rerank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "rerank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "// Plain-string documents are the form every rerank SDK sends; they were rejected",
+                  "// before RerankDocument gained a string|object unmarshaller.",
+                  "pm.test('results are ranked, not merely returned', function () {",
+                  "  var r = j.results || [];",
+                  "  pm.expect(r.length, 'no results: ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                  "  pm.expect(r[0], 'result must carry an index').to.have.property('index');",
+                  "  pm.expect(r[0], 'expected relevance_score on the wire').to.have.property('relevance_score');",
+                  "  pm.expect(r[0].index, 'the only relevant document must rank first').to.eql(0);",
+                  "  if (r.length > 1) { pm.expect(r[0].relevance_score, 'top and bottom scores indistinguishable').to.be.above(r[r.length - 1].relevance_score); }",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. /v1/rerank string documents -> vertex/semantic-ranker-default-004 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"vertex/semantic-ranker-default-004\",\n  \"query\": \"What is the capital of France?\",\n  \"documents\": [\n    \"Paris is the capital and most populous city of France.\",\n    \"Carrots are orange root vegetables rich in beta carotene.\",\n    \"Berlin is the capital of Germany and its largest city.\"\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/rerank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "rerank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "// Plain-string documents are the form every rerank SDK sends; they were rejected",
+                  "// before RerankDocument gained a string|object unmarshaller.",
+                  "pm.test('results are ranked, not merely returned', function () {",
+                  "  var r = j.results || [];",
+                  "  pm.expect(r.length, 'no results: ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                  "  pm.expect(r[0], 'result must carry an index').to.have.property('index');",
+                  "  pm.expect(r[0], 'expected relevance_score on the wire').to.have.property('relevance_score');",
+                  "  pm.expect(r[0].index, 'the only relevant document must rank first').to.eql(0);",
+                  "  if (r.length > 1) { pm.expect(r[0].relevance_score, 'top and bottom scores indistinguishable').to.be.above(r[r.length - 1].relevance_score); }",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. /cohere/v2/rerank wire shape -> cohere/rerank-v3.5 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"cohere/rerank-v3.5\",\n  \"query\": \"What is the capital of France?\",\n  \"documents\": [\n    \"Paris is the capital and most populous city of France.\",\n    \"Carrots are orange root vegetables rich in beta carotene.\",\n    \"Berlin is the capital of Germany and its largest city.\"\n  ],\n  \"top_n\": 3\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/cohere/v2/rerank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "cohere",
+                "v2",
+                "rerank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "pm.test('results are ranked, not merely returned', function () {",
+                  "  var r = j.results || [];",
+                  "  pm.expect(r.length, 'no results: ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                  "  pm.expect(r[0], 'result must carry an index').to.have.property('index');",
+                  "  pm.expect(r[0], 'expected relevance_score on the wire').to.have.property('relevance_score');",
+                  "  pm.expect(r[0], 'relevanceScore must not appear on this route').to.not.have.property('relevanceScore');",
+                  "  pm.expect(r[0].index, 'the only relevant document must rank first').to.eql(0);",
+                  "  if (r.length > 1) { pm.expect(r[0].relevance_score, 'top and bottom scores indistinguishable').to.be.above(r[r.length - 1].relevance_score); }",
+                  "});",
+                  "pm.test('response is Cohere-shaped, with no Bifrost fields leaking', function () {",
+                  "  pm.expect(j, 'canonical Bifrost model field leaked').to.not.have.property('model');",
+                  "  pm.expect(j, 'canonical Bifrost extra_fields leaked').to.not.have.property('extra_fields');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. /bedrock/rerank camelCase wire shape -> cohere/rerank-v3.5 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"queries\": [\n    {\n      \"type\": \"TEXT\",\n      \"textQuery\": {\n        \"text\": \"What is the capital of France?\"\n      }\n    }\n  ],\n  \"sources\": [\n    {\n      \"type\": \"INLINE\",\n      \"inlineDocumentSource\": {\n        \"type\": \"TEXT\",\n        \"textDocument\": {\n          \"text\": \"Paris is the capital and most populous city of France.\"\n        }\n      }\n    },\n    {\n      \"type\": \"INLINE\",\n      \"inlineDocumentSource\": {\n        \"type\": \"TEXT\",\n        \"textDocument\": {\n          \"text\": \"Carrots are orange root vegetables rich in beta carotene.\"\n        }\n      }\n    },\n    {\n      \"type\": \"INLINE\",\n      \"inlineDocumentSource\": {\n        \"type\": \"TEXT\",\n        \"textDocument\": {\n          \"text\": \"Berlin is the capital of Germany and its largest city.\"\n        }\n      }\n    }\n  ],\n  \"rerankingConfiguration\": {\n    \"type\": \"BEDROCK_RERANKING_MODEL\",\n    \"bedrockRerankingConfiguration\": {\n      \"modelConfiguration\": {\n        \"modelArn\": \"cohere/rerank-v3.5\"\n      }\n    }\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/bedrock/rerank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "bedrock",
+                "rerank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "// AWS SDKs match response keys case-insensitively but not punctuation-insensitively, so a",
+                  "// snake_case body deserializes every score as 0.0 instead of raising. Pin the casing.",
+                  "pm.test('results are ranked, not merely returned', function () {",
+                  "  var r = j.results || [];",
+                  "  pm.expect(r.length, 'no results: ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                  "  pm.expect(r[0], 'result must carry an index').to.have.property('index');",
+                  "  pm.expect(r[0], 'expected relevanceScore on the wire').to.have.property('relevanceScore');",
+                  "  pm.expect(r[0], 'relevance_score must not appear on this route').to.not.have.property('relevance_score');",
+                  "  pm.expect(r[0].index, 'the only relevant document must rank first').to.eql(0);",
+                  "  if (r.length > 1) { pm.expect(r[0].relevanceScore, 'top and bottom scores indistinguishable').to.be.above(r[r.length - 1].relevanceScore); }",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. /genai/v1/rank caller record ids -> cohere/rerank-v3.5 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"cohere/rerank-v3.5\",\n  \"query\": \"What is the capital of France?\",\n  \"records\": [\n    {\n      \"id\": \"record-0\",\n      \"title\": \"Doc 0\",\n      \"content\": \"Paris is the capital and most populous city of France.\"\n    },\n    {\n      \"id\": \"record-1\",\n      \"title\": \"Doc 1\",\n      \"content\": \"Carrots are orange root vegetables rich in beta carotene.\"\n    },\n    {\n      \"id\": \"record-2\",\n      \"title\": \"Doc 2\",\n      \"content\": \"Berlin is the capital of Germany and its largest city.\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/genai/v1/rank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "genai",
+                "v1",
+                "rank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "pm.test('ranked records keep the caller ids, never synthetic ones', function () {",
+                  "  var r = j.records || [];",
+                  "  pm.expect(r.length, 'no records: ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                  "  pm.expect(r[0].id, 'expected the caller record id').to.eql('record-0');",
+                  "  for (var i = 0; i < r.length; i++) {",
+                  "    pm.expect(r[i].id, 'upstream synthetic id leaked to the client').to.not.match(/^idx:/);",
+                  "  }",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. /v1/rerank object documents round-trip -> cohere/rerank-v3.5 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"cohere/rerank-v3.5\",\n  \"query\": \"What is the capital of France?\",\n  \"documents\": [\n    {\n      \"text\": \"Paris is the capital and most populous city of France.\",\n      \"id\": \"doc-0\",\n      \"metadata\": {\n        \"position\": 0\n      }\n    },\n    {\n      \"text\": \"Carrots are orange root vegetables rich in beta carotene.\",\n      \"id\": \"doc-1\",\n      \"metadata\": {\n        \"position\": 1\n      }\n    },\n    {\n      \"text\": \"Berlin is the capital of Germany and its largest city.\",\n      \"id\": \"doc-2\",\n      \"metadata\": {\n        \"position\": 2\n      }\n    }\n  ],\n  \"return_documents\": true\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/rerank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "rerank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "pm.test('results are ranked, not merely returned', function () {",
+                  "  var r = j.results || [];",
+                  "  pm.expect(r.length, 'no results: ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                  "  pm.expect(r[0], 'result must carry an index').to.have.property('index');",
+                  "  pm.expect(r[0], 'expected relevance_score on the wire').to.have.property('relevance_score');",
+                  "  pm.expect(r[0].index, 'the only relevant document must rank first').to.eql(0);",
+                  "  if (r.length > 1) { pm.expect(r[0].relevance_score, 'top and bottom scores indistinguishable').to.be.above(r[r.length - 1].relevance_score); }",
+                  "});",
+                  "pm.test('document identity survives the round trip', function () {",
+                  "  var top = (j.results || [])[0];",
+                  "  pm.expect(top.id, 'result must carry the caller document id as identity').to.eql('doc-0');",
+                  "  pm.expect(top.document, 'return_documents did not echo the document').to.be.an('object');",
+                  "  pm.expect(top.document.text).to.be.a('string');",
+                  "  pm.expect(top.document.id).to.eql('doc-0');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. /v1/rerank structured data documents -> cohere/rerank-v3.5 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"cohere/rerank-v3.5\",\n  \"query\": \"What is the capital of France?\",\n  \"documents\": [\n    {\n      \"data\": {\n        \"title\": \"France\",\n        \"body\": \"Paris is the capital and most populous city of France.\"\n      }\n    },\n    {\n      \"data\": {\n        \"title\": \"Carrots\",\n        \"body\": \"Carrots are orange root vegetables rich in beta carotene.\"\n      }\n    },\n    {\n      \"data\": {\n        \"title\": \"Germany\",\n        \"body\": \"Berlin is the capital of Germany and its largest city.\"\n      }\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/rerank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "rerank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "// A provider that dropped the structured body would still answer 200 with flat scores,",
+                  "// so the ordering assertion is what proves the content reached the model.",
+                  "pm.test('results are ranked, not merely returned', function () {",
+                  "  var r = j.results || [];",
+                  "  pm.expect(r.length, 'no results: ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                  "  pm.expect(r[0], 'result must carry an index').to.have.property('index');",
+                  "  pm.expect(r[0], 'expected relevance_score on the wire').to.have.property('relevance_score');",
+                  "  pm.expect(r[0].index, 'the only relevant document must rank first').to.eql(0);",
+                  "  if (r.length > 1) { pm.expect(r[0].relevance_score, 'top and bottom scores indistinguishable').to.be.above(r[r.length - 1].relevance_score); }",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. /v1/rerank reports search units -> cohere/rerank-v3.5 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"cohere/rerank-v3.5\",\n  \"query\": \"What is the capital of France?\",\n  \"documents\": [\n    \"Paris is the capital and most populous city of France.\",\n    \"Carrots are orange root vegetables rich in beta carotene.\",\n    \"Berlin is the capital of Germany and its largest city.\"\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/rerank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "rerank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "// Rerank bills in search units rather than tokens; without this the request costs nothing.",
+                  "pm.test('usage carries a billable unit', function () {",
+                  "  pm.expect(j.usage, 'no usage block: ' + pm.response.text().slice(0, 300)).to.be.an('object');",
+                  "  var d = j.usage.completion_tokens_details || {};",
+                  "  pm.expect(d.num_search_queries, 'search units missing, rerank would bill zero').to.be.above(0);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. /cohere/v2/rerank cross-provider document echo -> bedrock/cohere.rerank-v3-5:0 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"bedrock/cohere.rerank-v3-5:0\",\n  \"query\": \"What is the capital of France?\",\n  \"documents\": [\n    {\n      \"text\": \"Paris is the capital and most populous city of France.\",\n      \"id\": \"doc-0\",\n      \"metadata\": {\n        \"position\": 0\n      }\n    },\n    {\n      \"text\": \"Carrots are orange root vegetables rich in beta carotene.\",\n      \"id\": \"doc-1\",\n      \"metadata\": {\n        \"position\": 1\n      }\n    },\n    {\n      \"text\": \"Berlin is the capital of Germany and its largest city.\",\n      \"id\": \"doc-2\",\n      \"metadata\": {\n        \"position\": 2\n      }\n    }\n  ],\n  \"return_documents\": true\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/cohere/v2/rerank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "cohere",
+                "v2",
+                "rerank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "pm.test('results are ranked, not merely returned', function () {",
+                  "  var r = j.results || [];",
+                  "  pm.expect(r.length, 'no results: ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                  "  pm.expect(r[0], 'result must carry an index').to.have.property('index');",
+                  "  pm.expect(r[0], 'expected relevance_score on the wire').to.have.property('relevance_score');",
+                  "  pm.expect(r[0], 'relevanceScore must not appear on this route').to.not.have.property('relevanceScore');",
+                  "  pm.expect(r[0].index, 'the only relevant document must rank first').to.eql(0);",
+                  "  if (r.length > 1) { pm.expect(r[0].relevance_score, 'top and bottom scores indistinguishable').to.be.above(r[r.length - 1].relevance_score); }",
+                  "});",
+                  "// Cohere always returns document as an object. Emitting a bare string here breaks the",
+                  "// official SDK, which parses the field into a typed document.",
+                  "pm.test('document is echoed as an object, not a bare string', function () {",
+                  "  var top = (j.results || [])[0];",
+                  "  pm.expect(top.document, 'document must be an object').to.be.an('object');",
+                  "  pm.expect(top.document.id, 'id must survive cross-provider backfill').to.eql('doc-0');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. /cohere/v2/rerank error shape -> cohere/rerank-v3.5 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"cohere/rerank-v3.5\",\n  \"query\": \"\",\n  \"documents\": [\n    \"Paris is the capital and most populous city of France.\",\n    \"Carrots are orange root vegetables rich in beta carotene.\",\n    \"Berlin is the capital of Germany and its largest city.\"\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/cohere/v2/rerank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "cohere",
+                "v2",
+                "rerank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// No 4xx guard here: a 4xx IS the signature under test. Only infra noise is skipped.",
+                  "if ([429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.test('errors are Cohere-shaped, not a Bifrost envelope', function () {",
+                  "  pm.expect(pm.response.code, 'an empty query must be rejected').to.be.at.least(400);",
+                  "  pm.expect(j.message, 'expected Cohere {message}: ' + pm.response.text().slice(0, 300)).to.be.a('string');",
+                  "  pm.expect(j, 'Bifrost error envelope leaked').to.not.have.property('is_bifrost_error');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. /bedrock/rerank jsonDocument sources -> bedrock/cohere.rerank-v3-5:0 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"queries\": [\n    {\n      \"type\": \"TEXT\",\n      \"textQuery\": {\n        \"text\": \"What is the capital of France?\"\n      }\n    }\n  ],\n  \"sources\": [\n    {\n      \"type\": \"INLINE\",\n      \"inlineDocumentSource\": {\n        \"type\": \"JSON\",\n        \"jsonDocument\": {\n          \"title\": \"France\",\n          \"body\": \"Paris is the capital and most populous city of France.\"\n        }\n      }\n    },\n    {\n      \"type\": \"INLINE\",\n      \"inlineDocumentSource\": {\n        \"type\": \"JSON\",\n        \"jsonDocument\": {\n          \"title\": \"Carrots\",\n          \"body\": \"Carrots are orange root vegetables rich in beta carotene.\"\n        }\n      }\n    },\n    {\n      \"type\": \"INLINE\",\n      \"inlineDocumentSource\": {\n        \"type\": \"JSON\",\n        \"jsonDocument\": {\n          \"title\": \"Germany\",\n          \"body\": \"Berlin is the capital of Germany and its largest city.\"\n        }\n      }\n    }\n  ],\n  \"rerankingConfiguration\": {\n    \"type\": \"BEDROCK_RERANKING_MODEL\",\n    \"bedrockRerankingConfiguration\": {\n      \"modelConfiguration\": {\n        \"modelArn\": \"bedrock/cohere.rerank-v3-5:0\"\n      }\n    }\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/bedrock/rerank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "bedrock",
+                "rerank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "// JSON document sources were previously dropped to empty strings: a silent 200 with a",
+                  "// confident ranking over blank text. The ordering assertion is the only way to catch that.",
+                  "pm.test('results are ranked, not merely returned', function () {",
+                  "  var r = j.results || [];",
+                  "  pm.expect(r.length, 'no results: ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                  "  pm.expect(r[0], 'result must carry an index').to.have.property('index');",
+                  "  pm.expect(r[0], 'expected relevanceScore on the wire').to.have.property('relevanceScore');",
+                  "  pm.expect(r[0], 'relevance_score must not appear on this route').to.not.have.property('relevance_score');",
+                  "  pm.expect(r[0].index, 'the only relevant document must rank first').to.eql(0);",
+                  "  if (r.length > 1) { pm.expect(r[0].relevanceScore, 'top and bottom scores indistinguishable').to.be.above(r[r.length - 1].relevanceScore); }",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. /genai/v1/rank ignoreRecordDetailsInResponse -> bedrock/cohere.rerank-v3-5:0 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"bedrock/cohere.rerank-v3-5:0\",\n  \"query\": \"What is the capital of France?\",\n  \"records\": [\n    {\n      \"id\": \"record-0\",\n      \"title\": \"Doc 0\",\n      \"content\": \"Paris is the capital and most populous city of France.\"\n    },\n    {\n      \"id\": \"record-1\",\n      \"title\": \"Doc 1\",\n      \"content\": \"Carrots are orange root vegetables rich in beta carotene.\"\n    },\n    {\n      \"id\": \"record-2\",\n      \"title\": \"Doc 2\",\n      \"content\": \"Berlin is the capital of Germany and its largest city.\"\n    }\n  ],\n  \"ignoreRecordDetailsInResponse\": true\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/genai/v1/rank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "genai",
+                "v1",
+                "rank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "pm.test('details are suppressed but identity survives', function () {",
+                  "  var r = j.records || [];",
+                  "  pm.expect(r.length, 'no records: ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                  "  for (var i = 0; i < r.length; i++) {",
+                  "    pm.expect(r[i], 'content leaked despite suppression').to.not.have.property('content');",
+                  "    pm.expect(r[i], 'title leaked despite suppression').to.not.have.property('title');",
+                  "    pm.expect(r[i].id, 'id is identity, not a detail - it must survive').to.be.a('string');",
+                  "    pm.expect(r[i].score).to.be.a('number');",
+                  "  }",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. litellm drop-in prefix, cohere dialect -> cohere/rerank-v3.5 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"cohere/rerank-v3.5\",\n  \"query\": \"What is the capital of France?\",\n  \"documents\": [\n    \"Paris is the capital and most populous city of France.\",\n    \"Carrots are orange root vegetables rich in beta carotene.\",\n    \"Berlin is the capital of Germany and its largest city.\"\n  ],\n  \"top_n\": 3\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/litellm/v2/rerank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "litellm",
+                "v2",
+                "rerank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "pm.test('drop-in prefix resolves to the right dialect and ranks', function () {",
+                  "  var r = j.results || [];",
+                  "  pm.expect(r.length, 'no results: ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                  "  pm.expect(r[0], 'expected relevance_score on this dialect').to.have.property('relevance_score');",
+                  "  pm.expect(r[0], 'relevanceScore must not appear on this dialect').to.not.have.property('relevanceScore');",
+                  "  pm.expect(r[0].index, 'the only relevant document must rank first').to.eql(0);",
+                  "  pm.expect(j, 'canonical Bifrost model field leaked').to.not.have.property('model');",
+                  "  pm.expect(j, 'canonical Bifrost extra_fields leaked').to.not.have.property('extra_fields');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. litellm drop-in prefix, bedrock dialect -> bedrock/cohere.rerank-v3-5:0 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"queries\": [\n    {\n      \"type\": \"TEXT\",\n      \"textQuery\": {\n        \"text\": \"What is the capital of France?\"\n      }\n    }\n  ],\n  \"sources\": [\n    {\n      \"type\": \"INLINE\",\n      \"inlineDocumentSource\": {\n        \"type\": \"TEXT\",\n        \"textDocument\": {\n          \"text\": \"Paris is the capital and most populous city of France.\"\n        }\n      }\n    },\n    {\n      \"type\": \"INLINE\",\n      \"inlineDocumentSource\": {\n        \"type\": \"TEXT\",\n        \"textDocument\": {\n          \"text\": \"Carrots are orange root vegetables rich in beta carotene.\"\n        }\n      }\n    },\n    {\n      \"type\": \"INLINE\",\n      \"inlineDocumentSource\": {\n        \"type\": \"TEXT\",\n        \"textDocument\": {\n          \"text\": \"Berlin is the capital of Germany and its largest city.\"\n        }\n      }\n    }\n  ],\n  \"rerankingConfiguration\": {\n    \"type\": \"BEDROCK_RERANKING_MODEL\",\n    \"bedrockRerankingConfiguration\": {\n      \"modelConfiguration\": {\n        \"modelArn\": \"bedrock/cohere.rerank-v3-5:0\"\n      }\n    }\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/litellm/rerank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "litellm",
+                "rerank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "pm.test('drop-in prefix resolves to the right dialect and ranks', function () {",
+                  "  var r = j.results || [];",
+                  "  pm.expect(r.length, 'no results: ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                  "  pm.expect(r[0], 'expected relevanceScore on this dialect').to.have.property('relevanceScore');",
+                  "  pm.expect(r[0], 'relevance_score must not appear on this dialect').to.not.have.property('relevance_score');",
+                  "  pm.expect(r[0].index, 'the only relevant document must rank first').to.eql(0);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. litellm drop-in prefix, rank dialect -> vertex/semantic-ranker-default-004 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"vertex/semantic-ranker-default-004\",\n  \"query\": \"What is the capital of France?\",\n  \"records\": [\n    {\n      \"id\": \"record-0\",\n      \"title\": \"Doc 0\",\n      \"content\": \"Paris is the capital and most populous city of France.\"\n    },\n    {\n      \"id\": \"record-1\",\n      \"title\": \"Doc 1\",\n      \"content\": \"Carrots are orange root vegetables rich in beta carotene.\"\n    },\n    {\n      \"id\": \"record-2\",\n      \"title\": \"Doc 2\",\n      \"content\": \"Berlin is the capital of Germany and its largest city.\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/litellm/v1/rank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "litellm",
+                "v1",
+                "rank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "pm.test('drop-in prefix resolves to the rank dialect', function () {",
+                  "  var r = j.records || [];",
+                  "  pm.expect(r.length, 'no records (rank returns records[], not results[]): ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                  "  pm.expect(r[0].id, 'caller record id must be preserved').to.eql('record-0');",
+                  "  pm.expect(r[0]).to.have.property('score');",
+                  "  pm.expect(j, 'canonical Bifrost results[] leaked into the rank dialect').to.not.have.property('results');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. langchain drop-in prefix, cohere dialect -> bedrock/cohere.rerank-v3-5:0 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"bedrock/cohere.rerank-v3-5:0\",\n  \"query\": \"What is the capital of France?\",\n  \"documents\": [\n    \"Paris is the capital and most populous city of France.\",\n    \"Carrots are orange root vegetables rich in beta carotene.\",\n    \"Berlin is the capital of Germany and its largest city.\"\n  ],\n  \"top_n\": 3\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/langchain/v2/rerank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "langchain",
+                "v2",
+                "rerank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "pm.test('drop-in prefix resolves to the right dialect and ranks', function () {",
+                  "  var r = j.results || [];",
+                  "  pm.expect(r.length, 'no results: ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                  "  pm.expect(r[0], 'expected relevance_score on this dialect').to.have.property('relevance_score');",
+                  "  pm.expect(r[0], 'relevanceScore must not appear on this dialect').to.not.have.property('relevanceScore');",
+                  "  pm.expect(r[0].index, 'the only relevant document must rank first').to.eql(0);",
+                  "  pm.expect(j, 'canonical Bifrost model field leaked').to.not.have.property('model');",
+                  "  pm.expect(j, 'canonical Bifrost extra_fields leaked').to.not.have.property('extra_fields');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. langchain drop-in prefix, bedrock dialect -> vertex/semantic-ranker-default-004 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"queries\": [\n    {\n      \"type\": \"TEXT\",\n      \"textQuery\": {\n        \"text\": \"What is the capital of France?\"\n      }\n    }\n  ],\n  \"sources\": [\n    {\n      \"type\": \"INLINE\",\n      \"inlineDocumentSource\": {\n        \"type\": \"TEXT\",\n        \"textDocument\": {\n          \"text\": \"Paris is the capital and most populous city of France.\"\n        }\n      }\n    },\n    {\n      \"type\": \"INLINE\",\n      \"inlineDocumentSource\": {\n        \"type\": \"TEXT\",\n        \"textDocument\": {\n          \"text\": \"Carrots are orange root vegetables rich in beta carotene.\"\n        }\n      }\n    },\n    {\n      \"type\": \"INLINE\",\n      \"inlineDocumentSource\": {\n        \"type\": \"TEXT\",\n        \"textDocument\": {\n          \"text\": \"Berlin is the capital of Germany and its largest city.\"\n        }\n      }\n    }\n  ],\n  \"rerankingConfiguration\": {\n    \"type\": \"BEDROCK_RERANKING_MODEL\",\n    \"bedrockRerankingConfiguration\": {\n      \"modelConfiguration\": {\n        \"modelArn\": \"vertex/semantic-ranker-default-004\"\n      }\n    }\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/langchain/rerank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "langchain",
+                "rerank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "pm.test('drop-in prefix resolves to the right dialect and ranks', function () {",
+                  "  var r = j.results || [];",
+                  "  pm.expect(r.length, 'no results: ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                  "  pm.expect(r[0], 'expected relevanceScore on this dialect').to.have.property('relevanceScore');",
+                  "  pm.expect(r[0], 'relevance_score must not appear on this dialect').to.not.have.property('relevance_score');",
+                  "  pm.expect(r[0].index, 'the only relevant document must rank first').to.eql(0);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. langchain drop-in prefix, rank dialect -> cohere/rerank-v3.5 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"cohere/rerank-v3.5\",\n  \"query\": \"What is the capital of France?\",\n  \"records\": [\n    {\n      \"id\": \"record-0\",\n      \"title\": \"Doc 0\",\n      \"content\": \"Paris is the capital and most populous city of France.\"\n    },\n    {\n      \"id\": \"record-1\",\n      \"title\": \"Doc 1\",\n      \"content\": \"Carrots are orange root vegetables rich in beta carotene.\"\n    },\n    {\n      \"id\": \"record-2\",\n      \"title\": \"Doc 2\",\n      \"content\": \"Berlin is the capital of Germany and its largest city.\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/langchain/v1/rank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "langchain",
+                "v1",
+                "rank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "pm.test('drop-in prefix resolves to the rank dialect', function () {",
+                  "  var r = j.records || [];",
+                  "  pm.expect(r.length, 'no records (rank returns records[], not results[]): ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                  "  pm.expect(r[0].id, 'caller record id must be preserved').to.eql('record-0');",
+                  "  pm.expect(r[0]).to.have.property('score');",
+                  "  pm.expect(j, 'canonical Bifrost results[] leaked into the rank dialect').to.not.have.property('results');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. pydanticai drop-in prefix, cohere dialect -> vertex/semantic-ranker-default-004 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"vertex/semantic-ranker-default-004\",\n  \"query\": \"What is the capital of France?\",\n  \"documents\": [\n    \"Paris is the capital and most populous city of France.\",\n    \"Carrots are orange root vegetables rich in beta carotene.\",\n    \"Berlin is the capital of Germany and its largest city.\"\n  ],\n  \"top_n\": 3\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/pydanticai/v2/rerank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "pydanticai",
+                "v2",
+                "rerank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "pm.test('drop-in prefix resolves to the right dialect and ranks', function () {",
+                  "  var r = j.results || [];",
+                  "  pm.expect(r.length, 'no results: ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                  "  pm.expect(r[0], 'expected relevance_score on this dialect').to.have.property('relevance_score');",
+                  "  pm.expect(r[0], 'relevanceScore must not appear on this dialect').to.not.have.property('relevanceScore');",
+                  "  pm.expect(r[0].index, 'the only relevant document must rank first').to.eql(0);",
+                  "  pm.expect(j, 'canonical Bifrost model field leaked').to.not.have.property('model');",
+                  "  pm.expect(j, 'canonical Bifrost extra_fields leaked').to.not.have.property('extra_fields');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. pydanticai drop-in prefix, bedrock dialect -> cohere/rerank-v3.5 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"queries\": [\n    {\n      \"type\": \"TEXT\",\n      \"textQuery\": {\n        \"text\": \"What is the capital of France?\"\n      }\n    }\n  ],\n  \"sources\": [\n    {\n      \"type\": \"INLINE\",\n      \"inlineDocumentSource\": {\n        \"type\": \"TEXT\",\n        \"textDocument\": {\n          \"text\": \"Paris is the capital and most populous city of France.\"\n        }\n      }\n    },\n    {\n      \"type\": \"INLINE\",\n      \"inlineDocumentSource\": {\n        \"type\": \"TEXT\",\n        \"textDocument\": {\n          \"text\": \"Carrots are orange root vegetables rich in beta carotene.\"\n        }\n      }\n    },\n    {\n      \"type\": \"INLINE\",\n      \"inlineDocumentSource\": {\n        \"type\": \"TEXT\",\n        \"textDocument\": {\n          \"text\": \"Berlin is the capital of Germany and its largest city.\"\n        }\n      }\n    }\n  ],\n  \"rerankingConfiguration\": {\n    \"type\": \"BEDROCK_RERANKING_MODEL\",\n    \"bedrockRerankingConfiguration\": {\n      \"modelConfiguration\": {\n        \"modelArn\": \"cohere/rerank-v3.5\"\n      }\n    }\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/pydanticai/rerank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "pydanticai",
+                "rerank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "pm.test('drop-in prefix resolves to the right dialect and ranks', function () {",
+                  "  var r = j.results || [];",
+                  "  pm.expect(r.length, 'no results: ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                  "  pm.expect(r[0], 'expected relevanceScore on this dialect').to.have.property('relevanceScore');",
+                  "  pm.expect(r[0], 'relevance_score must not appear on this dialect').to.not.have.property('relevance_score');",
+                  "  pm.expect(r[0].index, 'the only relevant document must rank first').to.eql(0);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. pydanticai drop-in prefix, rank dialect -> bedrock/cohere.rerank-v3-5:0 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"bedrock/cohere.rerank-v3-5:0\",\n  \"query\": \"What is the capital of France?\",\n  \"records\": [\n    {\n      \"id\": \"record-0\",\n      \"title\": \"Doc 0\",\n      \"content\": \"Paris is the capital and most populous city of France.\"\n    },\n    {\n      \"id\": \"record-1\",\n      \"title\": \"Doc 1\",\n      \"content\": \"Carrots are orange root vegetables rich in beta carotene.\"\n    },\n    {\n      \"id\": \"record-2\",\n      \"title\": \"Doc 2\",\n      \"content\": \"Berlin is the capital of Germany and its largest city.\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/pydanticai/v1/rank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "pydanticai",
+                "v1",
+                "rank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "pm.test('drop-in prefix resolves to the rank dialect', function () {",
+                  "  var r = j.records || [];",
+                  "  pm.expect(r.length, 'no records (rank returns records[], not results[]): ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                  "  pm.expect(r[0].id, 'caller record id must be preserved').to.eql('record-0');",
+                  "  pm.expect(r[0]).to.have.property('score');",
+                  "  pm.expect(j, 'canonical Bifrost results[] leaked into the rank dialect').to.not.have.property('results');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. cursor drop-in prefix, cohere dialect -> cohere/rerank-v3.5 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"cohere/rerank-v3.5\",\n  \"query\": \"What is the capital of France?\",\n  \"documents\": [\n    \"Paris is the capital and most populous city of France.\",\n    \"Carrots are orange root vegetables rich in beta carotene.\",\n    \"Berlin is the capital of Germany and its largest city.\"\n  ],\n  \"top_n\": 3\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/cursor/v2/rerank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "cursor",
+                "v2",
+                "rerank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "pm.test('drop-in prefix resolves to the right dialect and ranks', function () {",
+                  "  var r = j.results || [];",
+                  "  pm.expect(r.length, 'no results: ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                  "  pm.expect(r[0], 'expected relevance_score on this dialect').to.have.property('relevance_score');",
+                  "  pm.expect(r[0], 'relevanceScore must not appear on this dialect').to.not.have.property('relevanceScore');",
+                  "  pm.expect(r[0].index, 'the only relevant document must rank first').to.eql(0);",
+                  "  pm.expect(j, 'canonical Bifrost model field leaked').to.not.have.property('model');",
+                  "  pm.expect(j, 'canonical Bifrost extra_fields leaked').to.not.have.property('extra_fields');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. cursor drop-in prefix, bedrock dialect -> bedrock/cohere.rerank-v3-5:0 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"queries\": [\n    {\n      \"type\": \"TEXT\",\n      \"textQuery\": {\n        \"text\": \"What is the capital of France?\"\n      }\n    }\n  ],\n  \"sources\": [\n    {\n      \"type\": \"INLINE\",\n      \"inlineDocumentSource\": {\n        \"type\": \"TEXT\",\n        \"textDocument\": {\n          \"text\": \"Paris is the capital and most populous city of France.\"\n        }\n      }\n    },\n    {\n      \"type\": \"INLINE\",\n      \"inlineDocumentSource\": {\n        \"type\": \"TEXT\",\n        \"textDocument\": {\n          \"text\": \"Carrots are orange root vegetables rich in beta carotene.\"\n        }\n      }\n    },\n    {\n      \"type\": \"INLINE\",\n      \"inlineDocumentSource\": {\n        \"type\": \"TEXT\",\n        \"textDocument\": {\n          \"text\": \"Berlin is the capital of Germany and its largest city.\"\n        }\n      }\n    }\n  ],\n  \"rerankingConfiguration\": {\n    \"type\": \"BEDROCK_RERANKING_MODEL\",\n    \"bedrockRerankingConfiguration\": {\n      \"modelConfiguration\": {\n        \"modelArn\": \"bedrock/cohere.rerank-v3-5:0\"\n      }\n    }\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/cursor/rerank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "cursor",
+                "rerank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "pm.test('drop-in prefix resolves to the right dialect and ranks', function () {",
+                  "  var r = j.results || [];",
+                  "  pm.expect(r.length, 'no results: ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                  "  pm.expect(r[0], 'expected relevanceScore on this dialect').to.have.property('relevanceScore');",
+                  "  pm.expect(r[0], 'relevance_score must not appear on this dialect').to.not.have.property('relevance_score');",
+                  "  pm.expect(r[0].index, 'the only relevant document must rank first').to.eql(0);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. cursor drop-in prefix, rank dialect -> vertex/semantic-ranker-default-004 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"vertex/semantic-ranker-default-004\",\n  \"query\": \"What is the capital of France?\",\n  \"records\": [\n    {\n      \"id\": \"record-0\",\n      \"title\": \"Doc 0\",\n      \"content\": \"Paris is the capital and most populous city of France.\"\n    },\n    {\n      \"id\": \"record-1\",\n      \"title\": \"Doc 1\",\n      \"content\": \"Carrots are orange root vegetables rich in beta carotene.\"\n    },\n    {\n      \"id\": \"record-2\",\n      \"title\": \"Doc 2\",\n      \"content\": \"Berlin is the capital of Germany and its largest city.\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/cursor/v1/rank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "cursor",
+                "v1",
+                "rank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "pm.test('drop-in prefix resolves to the rank dialect', function () {",
+                  "  var r = j.records || [];",
+                  "  pm.expect(r.length, 'no records (rank returns records[], not results[]): ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                  "  pm.expect(r[0].id, 'caller record id must be preserved').to.eql('record-0');",
+                  "  pm.expect(r[0]).to.have.property('score');",
+                  "  pm.expect(j, 'canonical Bifrost results[] leaked into the rank dialect').to.not.have.property('results');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. /v1/rerank priority is dropped for bedrock -> bedrock/cohere.rerank-v3-5:0 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"bedrock/cohere.rerank-v3-5:0\",\n  \"query\": \"What is the capital of France?\",\n  \"documents\": [\n    \"Paris is the capital and most populous city of France.\",\n    \"Carrots are orange root vegetables rich in beta carotene.\",\n    \"Berlin is the capital of Germany and its largest city.\"\n  ],\n  \"priority\": 1\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/rerank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "rerank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "// priority is a Cohere concept with no Bedrock equivalent. Forwarding it 400s a request",
+                  "// that succeeds on Cohere, which silently breaks fallback chains.",
+                  "pm.test('canonical params survive routing to bedrock', function () {",
+                  "  pm.expect(pm.response.text(), 'priority leaked into additionalModelRequestFields').to.not.include('additionalModelRequestField');",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "  var r = j.results || [];",
+                  "  pm.expect(r.length, 'no results: ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                  "  pm.expect(r[0].index, 'the only relevant document must rank first').to.eql(0);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "56. /v1/rerank next_token is a first-class param -> bedrock/cohere.rerank-v3-5:0 - PR #6328",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"bedrock/cohere.rerank-v3-5:0\",\n  \"query\": \"What is the capital of France?\",\n  \"documents\": [\n    \"Paris is the capital and most populous city of France.\",\n    \"Carrots are orange root vegetables rich in beta carotene.\",\n    \"Berlin is the capital of Germany and its largest city.\"\n  ],\n  \"next_token\": \"harness-cursor-probe\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/rerank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "rerank"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "// next_token must bind to RerankParameters. When it is not a known field it falls through",
+                  "// to ExtraParams and is forwarded as a model request field, which Bedrock rejects.",
+                  "pm.test('canonical params survive routing to bedrock', function () {",
+                  "  pm.expect(pm.response.text(), 'next_token leaked into additionalModelRequestFields').to.not.include('additionalModelRequestField');",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text().slice(0, 400)).to.be.below(400);",
+                  "  var r = j.results || [];",
+                  "  pm.expect(r.length, 'no results: ' + pm.response.text().slice(0, 400)).to.be.above(0);",
+                  "  pm.expect(r[0].index, 'the only relevant document must rank first').to.eql(0);",
+                  "});"
+                ]
+              }
+            }
+          ]
         }
       ]
     }

--- a/tests/integrations/python/README.md
+++ b/tests/integrations/python/README.md
@@ -87,6 +87,26 @@ Our test suite covers 30 comprehensive scenarios for each integration:
 16. **Transcription Error Handling** - Invalid audio format and model error handling
 17. **Voice & Format Testing** - Multiple voices and audio format validation
 
+### Rerank Tests (Cohere, Bedrock, Vertex)
+Reranking takes a query plus documents and returns them ordered by relevance. The parameterized
+provider-SDK tests run cross-provider — a request shaped for one provider must come back in that
+provider's wire shape no matter which provider actually served it. Cases that pin a single
+provider's own behaviour (`return_documents`, error shapes, the LangChain compressors) stay
+fixed to that provider.
+
+- **Cohere SDK** (`test_cohere.py`) — cross-provider: string documents, object documents carrying
+  id/metadata, `top_n`. Cohere-only: `return_documents`, Cohere-shaped errors
+- **AWS SDK** (`test_bedrock.py`) — cross-provider: inline TEXT sources, inline JSON sources,
+  `numberOfResults`
+- **LangChain** (`test_langchain.py`) — `CohereRerank` and `BedrockRerank` document compressors,
+  each fixed to its own provider
+- **Discovery Engine** (`test_google.py`) — cross-provider: `/genai/v1/rank`, caller record-id
+  restoration and `ignoreRecordDetailsInResponse`
+
+Assertions check the ranking itself, not just a 200: a provider that drops document content still
+returns success with meaningless scores, so the shared helper asserts the relevant document
+outranks the irrelevant one.
+
 ### Embeddings Tests (OpenAI)
 18. **Single Text Embedding** - Basic text-to-vector conversion
 19. **Batch Text Embeddings** - Multiple text embeddings in single request

--- a/tests/integrations/python/config.yml
+++ b/tests/integrations/python/config.yml
@@ -159,6 +159,9 @@ providers:
     file: "gemini-2.5-flash"
     thinking: "gemini-2.5-pro"
     embeddings: "gemini-embedding-001"
+    # Discovery Engine's ranker is not part of Vertex's discoverable model catalog, so it is
+    # named with an explicit provider prefix to route deterministically.
+    rerank: "vertex/semantic-ranker-default@latest"
     image_generation: "imagen-4.0-generate-001"
     image_edit: "imagen-3.0-capability-001"
     imagen: "imagen-4.0-generate-001"
@@ -185,6 +188,7 @@ providers:
     thinking: "us.anthropic.claude-opus-4-5-20251101-v1:0"
     text_completion: "mistral.mistral-7b-instruct-v0:2"
     embeddings: "global.cohere.embed-v4:0"
+    rerank: "cohere.rerank-v3-5:0"
     image_generation: "amazon.titan-image-generator-v2:0"
     image_variation: "amazon.titan-image-generator-v2:0"
     batch_inline: "anthropic.claude-3-5-sonnet-20240620-v1:0"
@@ -207,6 +211,7 @@ providers:
     vision: "command-a-vision-07-2025"
     tools: "command-a-03-2025"
     embeddings: "embed-v4.0"
+    rerank: "rerank-v3.5"
     streaming: "command-a-03-2025"
     count_tokens: "command-a-03-2025"
     alternatives:
@@ -302,6 +307,7 @@ provider_scenarios:
     video_generation: false # disabled for now because of long running operations
 
   azure:
+    rerank: false  # Azure hosts Cohere rerank models, but Bifrost's azure provider does not implement rerank yet
     simple_chat: true
     multi_turn_conversation: true
     streaming: true
@@ -457,6 +463,7 @@ provider_scenarios:
     context_caching: true  # Gemini context caching (Caches API) via Bifrost passthrough
 
   vertex:
+    rerank: true
     simple_chat: true
     multi_turn_conversation: true
     streaming: true
@@ -502,6 +509,7 @@ provider_scenarios:
     count_tokens: false
 
   bedrock:
+    rerank: true
     simple_chat: true
     multi_turn_conversation: true
     streaming: true
@@ -547,6 +555,7 @@ provider_scenarios:
     count_tokens: true  # Bedrock supports token counting via CountTokens API
 
   cohere:
+    rerank: true
     simple_chat: true
     multi_turn_conversation: true
     streaming: true
@@ -662,6 +671,7 @@ scenario_capabilities:
   transcription: "transcription"
   transcription_streaming: "transcription"
   embeddings: "embeddings"
+  rerank: "rerank"
   image_generation: "image_generation"  # Uses image_generation model
   image_edit: "image_edit"  # Uses image_edit model
   imagen: "imagen"  # Uses imagen model (Gemini/Vertex)

--- a/tests/integrations/python/pyproject.toml
+++ b/tests/integrations/python/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "google-genai>=1.50.0",
     "pydantic-ai>=0.1.0",
     "boto3>=1.34.0",
+    "cohere>=5.13.0",
     # Testing utilities
     "websocket-client>=1.6.0",
     "httpx>=0.25.0",
@@ -46,6 +47,7 @@ dependencies = [
     "langchain>=1.1.0",
     "langchain-community>=0.4.1",
     "langchain-aws>=1.1.0",
+    "langchain-cohere>=0.4.0",
     "pytest-xdist>=3.8.0",
     "pyasn1>=0.6.4",
 ]

--- a/tests/integrations/python/tests/test_bedrock.py
+++ b/tests/integrations/python/tests/test_bedrock.py
@@ -88,6 +88,9 @@ import botocore.exceptions
 import pytest
 
 from .utils.common import (
+    RERANK_DOCUMENTS,
+    RERANK_QUERY,
+    assert_valid_rerank_results,
     BASE64_IMAGE_LARGE,
     BASE64_TITAN_MASK_IMAGE,
     CALCULATOR_TOOL,
@@ -3491,3 +3494,132 @@ class TestBedrockGuardrail:
             f"  ✓ outputAssessments type correct — stopReason={response['stopReason']}, "
             f"outputAssessments keys={list(output_assessments.keys())}"
         )
+
+
+def get_provider_rerank_client(provider: str) -> boto3.client:
+    """Create bedrock-agent-runtime client with x-model-provider header for given provider"""
+    base_url = get_integration_url("bedrock")
+    config = get_config()
+    integration_settings = config.get_integration_settings("bedrock")
+    region = integration_settings.get("region", "us-west-2")
+
+    client = boto3.client(
+        "bedrock-agent-runtime",
+        region_name=region,
+        endpoint_url=base_url,
+    )
+
+    client.meta.events.register("before-send", create_provider_header_handler(provider))
+    return client
+
+
+def bedrock_reranking_configuration(model: str, number_of_results: int = None) -> Dict[str, Any]:
+    """Build Bedrock's rerankingConfiguration block.
+
+    Bifrost expands a bare model id into a foundation-model ARN, so tests pass whatever
+    identifier the provider is configured with.
+    """
+    bedrock_config: Dict[str, Any] = {"modelConfiguration": {"modelArn": model}}
+    if number_of_results is not None:
+        bedrock_config["numberOfResults"] = number_of_results
+
+    return {
+        "type": "BEDROCK_RERANKING_MODEL",
+        "bedrockRerankingConfiguration": bedrock_config,
+    }
+
+
+def bedrock_rerank_pairs(response: Dict[str, Any]) -> List[tuple]:
+    """Normalize a Bedrock rerank response into (index, score) tuples.
+
+    Bedrock uses camelCase relevanceScore. AWS SDKs match response keys case-insensitively
+    but not punctuation-insensitively, so a snake_case body would silently deserialize every
+    score as 0.0 rather than raising - hence the explicit key assertion.
+    """
+    results = response["results"]
+    for result in results:
+        assert "relevanceScore" in result, (
+            f"expected camelCase relevanceScore, got keys {list(result)}"
+        )
+    return [(r["index"], r["relevanceScore"]) for r in results]
+
+
+class TestBedrockRerank:
+    """Rerank via the AWS SDK (bedrock-agent-runtime) through Bifrost."""
+
+    @pytest.mark.parametrize(
+        "provider,model", get_cross_provider_params_for_scenario("rerank")
+    )
+    def test_26_rerank_text_documents(self, provider, model):
+        """Inline TEXT document sources - the common Bedrock rerank shape."""
+        client = get_provider_rerank_client(provider)
+
+        response = client.rerank(
+            queries=[{"type": "TEXT", "textQuery": {"text": RERANK_QUERY}}],
+            sources=[
+                {
+                    "type": "INLINE",
+                    "inlineDocumentSource": {
+                        "type": "TEXT",
+                        "textDocument": {"text": document},
+                    },
+                }
+                for document in RERANK_DOCUMENTS
+            ],
+            rerankingConfiguration=bedrock_reranking_configuration(model),
+        )
+
+        assert_valid_rerank_results(bedrock_rerank_pairs(response))
+
+    @pytest.mark.parametrize(
+        "provider,model", get_cross_provider_params_for_scenario("rerank")
+    )
+    def test_27_rerank_json_documents(self, provider, model):
+        """Inline JSON document sources.
+
+        A provider that drops the structured body still returns 200, so this asserts the
+        relevant document separates from the irrelevant one - which only happens if the
+        JSON content actually reached the model.
+        """
+        client = get_provider_rerank_client(provider)
+
+        response = client.rerank(
+            queries=[{"type": "TEXT", "textQuery": {"text": RERANK_QUERY}}],
+            sources=[
+                {
+                    "type": "INLINE",
+                    "inlineDocumentSource": {
+                        "type": "JSON",
+                        "jsonDocument": {"position": index, "body": document},
+                    },
+                }
+                for index, document in enumerate(RERANK_DOCUMENTS)
+            ],
+            rerankingConfiguration=bedrock_reranking_configuration(model),
+        )
+
+        assert_valid_rerank_results(bedrock_rerank_pairs(response))
+
+    @pytest.mark.parametrize(
+        "provider,model", get_cross_provider_params_for_scenario("rerank")
+    )
+    def test_28_rerank_number_of_results(self, provider, model):
+        """numberOfResults truncates the ranking, Bedrock's spelling of top_n."""
+        client = get_provider_rerank_client(provider)
+
+        response = client.rerank(
+            queries=[{"type": "TEXT", "textQuery": {"text": RERANK_QUERY}}],
+            sources=[
+                {
+                    "type": "INLINE",
+                    "inlineDocumentSource": {
+                        "type": "TEXT",
+                        "textDocument": {"text": document},
+                    },
+                }
+                for document in RERANK_DOCUMENTS
+            ],
+            rerankingConfiguration=bedrock_reranking_configuration(model, number_of_results=2),
+        )
+
+        assert_valid_rerank_results(bedrock_rerank_pairs(response), expected_count=2)

--- a/tests/integrations/python/tests/test_cohere.py
+++ b/tests/integrations/python/tests/test_cohere.py
@@ -1,0 +1,180 @@
+"""
+Cohere Integration Tests - Cross-Provider Support
+
+🌉 CROSS-PROVIDER TESTING:
+This test suite uses the official Cohere SDK (ClientV2) against Bifrost's /cohere routes.
+Tests run against every provider that declares the `rerank` scenario, routed with the
+x-model-provider header, so a Cohere-shaped request served by Bedrock or Vertex must still
+come back in Cohere's wire shape.
+
+Covered scenarios:
+1. Rerank with plain string documents - Cross-provider
+2. Rerank with object documents carrying id/metadata - Cross-provider
+3. top_n truncation - Cross-provider
+4. return_documents echo - Cohere
+5. Error shape on an invalid request - Cohere
+
+Note: Tests automatically skip for providers that don't support rerank.
+"""
+
+import os
+
+import cohere
+import pytest
+
+from .utils.common import (
+    RERANK_DOCUMENTS,
+    RERANK_QUERY,
+    Config,
+    assert_valid_rerank_results,
+    rerank_documents_as_objects,
+    skip_if_no_api_key,
+)
+from .utils.config_loader import get_integration_url
+from .utils.parametrize import (
+    format_provider_model,
+    get_cross_provider_params_for_scenario,
+)
+
+
+@pytest.fixture
+def cohere_client():
+    """Cohere ClientV2 pointed at Bifrost.
+
+    The SDK appends the version path (/v2/rerank) to base_url, so it is configured with
+    the bare integration URL.
+    """
+    return cohere.ClientV2(
+        api_key=os.getenv("COHERE_API_KEY", "dummy-key"),
+        base_url=get_integration_url("cohere"),
+    )
+
+
+@pytest.fixture
+def test_config():
+    """Test configuration"""
+    return Config()
+
+
+def provider_options(provider: str, **extra_body):
+    """Route the call to `provider` and pass through any non-SDK body params."""
+    options = {"additional_headers": {"x-model-provider": provider}}
+    if extra_body:
+        options["additional_body_parameters"] = extra_body
+    return options
+
+
+def result_pairs(response):
+    """Normalize a Cohere rerank response into (index, score) tuples."""
+    return [(r.index, r.relevance_score) for r in response.results]
+
+
+class TestCohereRerank:
+    """Rerank via the Cohere SDK through Bifrost."""
+
+    @pytest.mark.parametrize(
+        "provider,model", get_cross_provider_params_for_scenario("rerank")
+    )
+    def test_01_rerank_string_documents(self, cohere_client, provider, model):
+        """Plain string documents - the form every rerank SDK sends."""
+        skip_if_no_api_key(provider)
+
+        response = cohere_client.rerank(
+            model=model,
+            query=RERANK_QUERY,
+            documents=RERANK_DOCUMENTS,
+            request_options=provider_options(provider),
+        )
+
+        assert response.results, f"no results from {format_provider_model(provider, model)}"
+        assert_valid_rerank_results(result_pairs(response))
+
+    @pytest.mark.parametrize(
+        "provider,model", get_cross_provider_params_for_scenario("rerank")
+    )
+    def test_02_rerank_object_documents(self, cohere_client, provider, model):
+        """Object documents: Cohere ranks only `text`, other keys ride along.
+
+        Documents are requested back so the id and metadata are actually checked - asserting
+        the ranking alone would pass even if a converter kept `text` and dropped the rest.
+        """
+        skip_if_no_api_key(provider)
+
+        documents = rerank_documents_as_objects()
+        response = cohere_client.rerank(
+            model=model,
+            query=RERANK_QUERY,
+            documents=documents,
+            request_options=provider_options(provider, return_documents=True),
+        )
+
+        assert_valid_rerank_results(result_pairs(response))
+
+        for result in response.results:
+            assert result.document == documents[result.index], (
+                f"document at index {result.index} did not round-trip: "
+                f"got {result.document!r}, sent {documents[result.index]!r}"
+            )
+
+    @pytest.mark.parametrize(
+        "provider,model", get_cross_provider_params_for_scenario("rerank")
+    )
+    def test_03_rerank_top_n(self, cohere_client, provider, model):
+        """top_n truncates the ranking without disturbing the ordering."""
+        skip_if_no_api_key(provider)
+
+        response = cohere_client.rerank(
+            model=model,
+            query=RERANK_QUERY,
+            documents=RERANK_DOCUMENTS,
+            top_n=2,
+            request_options=provider_options(provider),
+        )
+
+        assert_valid_rerank_results(result_pairs(response), expected_count=2)
+
+    def test_04_rerank_return_documents(self, cohere_client):
+        """return_documents echoes the document back on each result.
+
+        The v2 SDK has no return_documents parameter, so it is passed through as an
+        additional body parameter the way a raw Cohere caller would send it.
+        """
+        skip_if_no_api_key("cohere")
+
+        response = cohere_client.rerank(
+            model="rerank-v3.5",
+            query=RERANK_QUERY,
+            documents=RERANK_DOCUMENTS,
+            request_options=provider_options("cohere", return_documents=True),
+        )
+
+        assert_valid_rerank_results(result_pairs(response))
+        top = response.results[0]
+        assert top.document is not None, "return_documents did not echo the document"
+
+        # The v2 SDK does not model the document field, so it arrives untyped. Cohere always
+        # returns it as an object, never a bare string - a string here means Bifrost collapsed
+        # the shape and the typed SDKs would break on it.
+        document = top.document
+        assert isinstance(document, dict), (
+            f"document must be an object, got {type(document).__name__}: {document!r}"
+        )
+        assert document["text"] == RERANK_DOCUMENTS[0]
+
+    def test_05_rerank_error_shape(self, cohere_client):
+        """An invalid request surfaces as a Cohere SDK error, not a raw gateway error."""
+        skip_if_no_api_key("cohere")
+
+        with pytest.raises(Exception) as exc_info:
+            cohere_client.rerank(
+                model="rerank-v3.5",
+                query="",
+                documents=RERANK_DOCUMENTS,
+                request_options=provider_options("cohere"),
+            )
+
+        # The Cohere SDK only raises its typed errors when the body carries Cohere's
+        # {"message": ...} shape, so this asserts Bifrost converted the error too.
+        assert isinstance(exc_info.value, cohere.core.ApiError), (
+            f"expected a Cohere ApiError, got {type(exc_info.value).__name__}: {exc_info.value}"
+        )

--- a/tests/integrations/python/tests/test_google.py
+++ b/tests/integrations/python/tests/test_google.py
@@ -70,6 +70,9 @@ from google.genai.types import HttpOptions
 from PIL import Image
 
 from .utils.common import (
+    RERANK_DOCUMENTS,
+    RERANK_QUERY,
+    assert_valid_rerank_results,
     BASE64_IMAGE,
     # Batch API utilities
     BATCH_INLINE_PROMPTS,
@@ -120,7 +123,7 @@ from .utils.common import (
     stage_vertex_batch_input,
     skip_if_no_api_key,
 )
-from .utils.config_loader import get_config, get_model
+from .utils.config_loader import get_config, get_integration_url, get_model
 from .utils.parametrize import (
     format_provider_model,
     get_cross_provider_params_for_scenario,
@@ -3953,3 +3956,76 @@ def extract_google_function_calls(response: Any) -> List[Dict[str, Any]]:
                 continue
 
     return function_calls
+
+
+class TestGoogleRerank:
+    """Rerank via Bifrost's /genai/v1/rank route (Vertex Discovery Engine shape).
+
+    Discovery Engine's rank API is ID-keyed rather than index-keyed, so these assert the
+    caller's own record ids come back rather than the synthetic ids Bifrost uses upstream.
+    The google-genai SDK has no binding for this endpoint, so it is driven over HTTP.
+    """
+
+    @staticmethod
+    def _rank(provider: str, model: str, payload_extra: Dict[str, Any] = None) -> Dict[str, Any]:
+        payload = {
+            "model": model,
+            "query": RERANK_QUERY,
+            "records": [
+                {"id": f"record-{index}", "title": f"Doc {index}", "content": document}
+                for index, document in enumerate(RERANK_DOCUMENTS)
+            ],
+        }
+        payload.update(payload_extra or {})
+
+        response = requests.post(
+            f"{get_integration_url('google')}/v1/rank",
+            json=payload,
+            headers={"x-model-provider": provider},
+            timeout=60,
+        )
+        assert response.status_code == 200, (
+            f"rank failed for {provider}: {response.status_code} {response.text[:300]}"
+        )
+        return response.json()
+
+    @staticmethod
+    def _pairs(body: Dict[str, Any]) -> List[tuple]:
+        """Normalize ranked records into (index, score), recovering index from the record id."""
+        records = body["records"]
+        for record in records:
+            assert record["id"].startswith("record-"), (
+                f"caller record id was not restored, got {record['id']!r} "
+                "(upstream synthetic ids must never reach the client)"
+            )
+        return [(int(r["id"].split("-")[1]), r["score"]) for r in records]
+
+    @pytest.mark.parametrize(
+        "provider,model", get_cross_provider_params_for_scenario("rerank")
+    )
+    def test_rank_returns_caller_record_ids(self, provider, model):
+        """Records come back keyed by the caller's ids, with details by default."""
+        body = self._rank(provider, model)
+
+        assert_valid_rerank_results(self._pairs(body))
+
+        top = body["records"][0]
+        assert top.get("content"), "record details are returned unless suppressed"
+
+    @pytest.mark.parametrize(
+        "provider,model", get_cross_provider_params_for_scenario("rerank")
+    )
+    def test_rank_ignore_record_details(self, provider, model):
+        """ignoreRecordDetailsInResponse drops title/content but keeps id and score.
+
+        The id is identity rather than detail, so suppressing details must not cost the
+        caller the ability to map a result back to the record they sent.
+        """
+        body = self._rank(provider, model, {"ignoreRecordDetailsInResponse": True})
+
+        assert_valid_rerank_results(self._pairs(body))
+
+        for record in body["records"]:
+            assert "content" not in record, f"content leaked despite suppression: {record}"
+            assert "title" not in record, f"title leaked despite suppression: {record}"
+            assert record["id"] and record["score"] is not None

--- a/tests/integrations/python/tests/test_langchain.py
+++ b/tests/integrations/python/tests/test_langchain.py
@@ -111,6 +111,9 @@ except ImportError:
 
 
 from .utils.common import (
+    RERANK_DOCUMENTS,
+    RERANK_QUERY,
+    assert_valid_rerank_results,
     CALCULATOR_TOOL,
     EMBEDDINGS_MULTIPLE_TEXTS,
     EMBEDDINGS_SIMILAR_TEXTS,
@@ -1696,3 +1699,74 @@ class TestLangChainStandardEmbeddings(TestLangChainOpenAIEmbeddings):
     """Run LangChain's standard embeddings tests"""
 
     pass
+
+
+class TestLangChainRerank:
+    """Rerank via LangChain document compressors through Bifrost.
+
+    LangChain wraps each provider's rerank API in a BaseDocumentCompressor, so these
+    exercise the same Bifrost routes through a third abstraction layer: whatever the
+    compressor returns must still be a correctly ordered ranking.
+    """
+
+    @staticmethod
+    def _documents():
+        from langchain_core.documents import Document
+
+        return [Document(page_content=text) for text in RERANK_DOCUMENTS]
+
+    @staticmethod
+    def _pairs(compressed):
+        """Normalize compressed documents into (index, score) tuples.
+
+        LangChain drops the provider's index and keeps relevance_score in metadata, so the
+        original position is recovered by matching page_content.
+        """
+        return [
+            (
+                RERANK_DOCUMENTS.index(document.page_content),
+                document.metadata["relevance_score"],
+            )
+            for document in compressed
+        ]
+
+    def test_20_cohere_rerank_compressor(self, test_config):
+        """langchain_cohere.CohereRerank against Bifrost's /cohere routes."""
+        from langchain_cohere import CohereRerank
+
+        compressor = CohereRerank(
+            base_url=get_integration_url("cohere"),
+            cohere_api_key=os.getenv("COHERE_API_KEY", "dummy-key"),
+            model=get_config().get_provider_model("cohere", "rerank"),
+            top_n=2,
+        )
+
+        compressed = compressor.compress_documents(self._documents(), RERANK_QUERY)
+
+        assert_valid_rerank_results(self._pairs(compressed), expected_count=2)
+
+    def test_21_bedrock_rerank_compressor(self, test_config):
+        """langchain_aws.BedrockRerank against Bifrost's /bedrock routes."""
+        from langchain_aws import BedrockRerank
+
+        config = get_config()
+        region = config.get_integration_settings("bedrock").get("region", "us-west-2")
+
+        # BedrockRerank exposes endpoint_url as an output field only, so Bifrost is reached
+        # by handing it a pre-built client rather than an endpoint override.
+        client = boto3.client(
+            "bedrock-agent-runtime",
+            region_name=region,
+            endpoint_url=get_integration_url("bedrock"),
+        )
+
+        compressor = BedrockRerank(
+            client=client,
+            model_arn=config.get_provider_model("bedrock", "rerank"),
+            region_name=region,
+            top_n=2,
+        )
+
+        compressed = compressor.compress_documents(self._documents(), RERANK_QUERY)
+
+        assert_valid_rerank_results(self._pairs(compressed), expected_count=2)

--- a/tests/integrations/python/tests/utils/common.py
+++ b/tests/integrations/python/tests/utils/common.py
@@ -3756,3 +3756,87 @@ def run_openai_base_url_client_secret_request(
         }
     finally:
         client.close()
+
+
+# ============================================================================
+# Rerank helpers
+# ============================================================================
+
+# A rerank call takes a query plus documents and returns them ordered by relevance.
+# The corpus is deliberately unambiguous so the expected ordering is stable across
+# providers and model versions: only one document answers the query.
+RERANK_QUERY = "What is the capital of France?"
+
+RERANK_DOCUMENTS = [
+    "Paris is the capital and most populous city of France.",
+    "Carrots are orange root vegetables rich in beta carotene.",
+    "Berlin is the capital of Germany and its largest city.",
+]
+
+# Index into RERANK_DOCUMENTS that any working reranker must rank first.
+RERANK_RELEVANT_INDEX = 0
+
+# Index of the document with no relationship to the query at all.
+RERANK_IRRELEVANT_INDEX = 1
+
+
+def assert_valid_rerank_results(
+    pairs: List[tuple],
+    expected_count: Optional[int] = None,
+    expected_top_index: int = RERANK_RELEVANT_INDEX,
+):
+    """Assert a reranking is well-formed and actually ranked.
+
+    Args:
+        pairs: (index, score) tuples normalized from a provider's wire shape, in
+            the order the provider returned them.
+        expected_count: number of results expected, when top_n was supplied.
+        expected_top_index: index into RERANK_DOCUMENTS that must rank first.
+
+    Checking only that a call returned 200 would pass even if every score were
+    zero, so this also asserts the ordering carries real signal.
+    """
+    assert pairs, "rerank returned no results"
+
+    if expected_count is not None:
+        assert len(pairs) == expected_count, (
+            f"expected {expected_count} results, got {len(pairs)}"
+        )
+
+    for index, score in pairs:
+        assert isinstance(index, int), f"result index must be an int, got {type(index)}"
+        assert 0 <= index < len(RERANK_DOCUMENTS), f"result index {index} out of range"
+        assert isinstance(score, (int, float)), (
+            f"relevance score must be numeric, got {type(score)}"
+        )
+
+    indices = [index for index, _ in pairs]
+    assert len(indices) == len(set(indices)), f"duplicate indices in results: {indices}"
+
+    scores = [score for _, score in pairs]
+    assert scores == sorted(scores, reverse=True), (
+        f"results are not ordered by descending relevance: {scores}"
+    )
+
+    # A provider that dropped the document content still returns 200 with all-zero
+    # scores, so assert the ranking separated the relevant document from the rest.
+    assert indices[0] == expected_top_index, (
+        f"expected document {expected_top_index} to rank first, got {indices[0]} "
+        f"(scores: {scores})"
+    )
+    if len(scores) > 1:
+        assert scores[0] > scores[-1], (
+            f"top and bottom scores are indistinguishable: {scores}"
+        )
+
+
+def rerank_documents_as_objects() -> List[Dict[str, Any]]:
+    """RERANK_DOCUMENTS in Cohere's object form, carrying id and metadata.
+
+    Cohere ranks only the ``text`` field; every other key rides along and is
+    echoed back untouched, which is what lets Bifrost round-trip document ids.
+    """
+    return [
+        {"text": text, "id": f"doc-{i}", "metadata": {"position": i}}
+        for i, text in enumerate(RERANK_DOCUMENTS)
+    ]

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -216,6 +216,7 @@ var rerankParamsKnownFields = map[string]bool{
 	"max_tokens_per_doc": true,
 	"priority":           true,
 	"return_documents":   true,
+	"next_token":         true,
 }
 
 var ocrParamsKnownFields = map[string]bool{
@@ -1213,8 +1214,8 @@ func prepareRerankRequest(ctx *fasthttp.RequestCtx, config *lib.Config) (*Rerank
 		return nil, nil, fmt.Errorf("documents are required for rerank")
 	}
 	for i, doc := range req.Documents {
-		if strings.TrimSpace(doc.Text) == "" {
-			return nil, nil, fmt.Errorf("document text is required for rerank at index %d", i)
+		if strings.TrimSpace(doc.Text) == "" && len(doc.Data) == 0 {
+			return nil, nil, fmt.Errorf("document text or data is required for rerank at index %d", i)
 		}
 	}
 	if req.RerankParameters == nil {

--- a/transports/bifrost-http/integrations/bedrock.go
+++ b/transports/bifrost-http/integrations/bedrock.go
@@ -289,11 +289,8 @@ func createBedrockRerankRouteConfig(pathPrefix string, handlerStore lib.HandlerS
 		},
 		RequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*schemas.BifrostRequest, error) {
 			if bedrockReq, ok := req.(*bedrock.BedrockRerankRequest); ok {
-				rerankRequest := bedrockReq.ToBifrostRerankRequest(ctx)
-				// Bedrock echoes the ranked document in every result.
-				rerankRequest.Params.ReturnDocuments = new(true)
 				return &schemas.BifrostRequest{
-					RerankRequest: rerankRequest,
+					RerankRequest: bedrockReq.ToBifrostRerankRequest(ctx),
 				}, nil
 			}
 			return nil, errors.New("invalid rerank request type")

--- a/transports/bifrost-http/integrations/bedrock_test.go
+++ b/transports/bifrost-http/integrations/bedrock_test.go
@@ -489,7 +489,7 @@ func Test_createBedrockRerankRouteRequestConverter(t *testing.T) {
 				Type: "INLINE",
 				InlineDocumentSource: bedrock.BedrockRerankInlineSource{
 					Type:         "TEXT",
-					TextDocument: bedrock.BedrockRerankTextValue{Text: "Paris is capital of France"},
+					TextDocument: &bedrock.BedrockRerankTextValue{Text: "Paris is capital of France"},
 				},
 			},
 		},
@@ -518,9 +518,8 @@ func Test_createBedrockRerankRouteRequestConverter(t *testing.T) {
 	require.NotNil(t, bifrostReq.RerankRequest.Params)
 	require.NotNil(t, bifrostReq.RerankRequest.Params.TopN)
 	assert.Equal(t, 1, *bifrostReq.RerankRequest.Params.TopN)
-	// Bedrock echoes the ranked document, so the route always asks for documents back.
-	require.NotNil(t, bifrostReq.RerankRequest.Params.ReturnDocuments)
-	assert.True(t, *bifrostReq.RerankRequest.Params.ReturnDocuments)
+	// The live Rerank API returns no document, so the route must not force documents on.
+	assert.Nil(t, bifrostReq.RerankRequest.Params.ReturnDocuments)
 }
 
 func Test_createBedrockRouteConfigsIncludesRerankForCompositePrefixes(t *testing.T) {

--- a/transports/bifrost-http/integrations/cohere.go
+++ b/transports/bifrost-http/integrations/cohere.go
@@ -102,7 +102,7 @@ func CreateCohereRouteConfigs(pathPrefix string) []RouteConfig {
 			return resp, nil
 		},
 		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
-			return err
+			return cohere.ToCohereError(err)
 		},
 		StreamConfig: &StreamConfig{
 			ChatStreamResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostChatResponse) (string, interface{}, error) {
@@ -114,7 +114,7 @@ func CreateCohereRouteConfigs(pathPrefix string) []RouteConfig {
 				return "", resp, nil
 			},
 			ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
-				return err
+				return cohere.ToCohereError(err)
 			},
 		},
 	})
@@ -148,7 +148,7 @@ func CreateCohereRouteConfigs(pathPrefix string) []RouteConfig {
 			return resp, nil
 		},
 		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
-			return err
+			return cohere.ToCohereError(err)
 		},
 	})
 
@@ -181,7 +181,7 @@ func CreateCohereRouteConfigs(pathPrefix string) []RouteConfig {
 			return cohere.ToCohereRerankResponse(resp), nil
 		},
 		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
-			return err
+			return cohere.ToCohereError(err)
 		},
 	})
 
@@ -214,7 +214,7 @@ func CreateCohereRouteConfigs(pathPrefix string) []RouteConfig {
 			return resp, nil
 		},
 		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
-			return err
+			return cohere.ToCohereError(err)
 		},
 	})
 

--- a/transports/bifrost-http/integrations/cohere_test.go
+++ b/transports/bifrost-http/integrations/cohere_test.go
@@ -55,7 +55,7 @@ func TestCohereRerankRouteRequestConverter(t *testing.T) {
 	req := &cohere.CohereRerankRequest{
 		Model:     "rerank-v3.5",
 		Query:     "what is bifrost?",
-		Documents: []string{"doc1", "doc2"},
+		Documents: []cohere.CohereRerankDocument{{Text: "doc1"}, {Text: "doc2"}},
 		TopN:      &topN,
 	}
 
@@ -113,7 +113,7 @@ func TestCohereRerankResponseConverterEmitsCohereShape(t *testing.T) {
 	require.Len(t, cohereResp.Results, 2)
 	assert.Equal(t, 1, cohereResp.Results[0].Index)
 	assert.InDelta(t, 0.9, cohereResp.Results[0].RelevanceScore, 1e-9)
-	assert.Nil(t, cohereResp.Results[0].Document, "cohere v2 results carry no document")
+	assert.Nil(t, cohereResp.Results[0].Document, "no document echoed when the canonical response carries none")
 	require.NotNil(t, cohereResp.Meta)
 	require.NotNil(t, cohereResp.Meta.Tokens)
 	assert.Equal(t, 12, *cohereResp.Meta.Tokens.InputTokens)

--- a/transports/bifrost-http/integrations/genai.go
+++ b/transports/bifrost-http/integrations/genai.go
@@ -1045,11 +1045,8 @@ func createGenAIRerankRouteConfig(pathPrefix string) RouteConfig {
 		},
 		RequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*schemas.BifrostRequest, error) {
 			if vertexReq, ok := req.(*vertex.VertexRankRequest); ok {
-				rerankRequest := vertexReq.ToBifrostRerankRequest(ctx)
-				// Ranked records are keyed by the caller's record ID, which only the document carries.
-				rerankRequest.Params.ReturnDocuments = new(true)
 				return &schemas.BifrostRequest{
-					RerankRequest: rerankRequest,
+					RerankRequest: vertexReq.ToBifrostRerankRequest(ctx),
 				}, nil
 			}
 			return nil, errors.New("invalid rerank request type")
@@ -1061,6 +1058,12 @@ func createGenAIRerankRouteConfig(pathPrefix string) RouteConfig {
 		},
 		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 			return gemini.ToGeminiError(err)
+		},
+		// Resolve the provider from x-model-provider (Vertex by default) so the route can be
+		// served cross-provider like /cohere/v2/rerank and /bedrock/rerank.
+		PreCallback: func(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, req interface{}) error {
+			bifrostCtx.SetValue(bifrostContextKeyProvider, getProviderFromHeader(ctx, schemas.Vertex))
+			return nil
 		},
 	}
 }

--- a/transports/bifrost-http/integrations/genai_test.go
+++ b/transports/bifrost-http/integrations/genai_test.go
@@ -25,7 +25,8 @@ func TestCreateGenAIRerankRouteConfig(t *testing.T) {
 	assert.NotNil(t, route.RequestConverter)
 	assert.NotNil(t, route.RerankResponseConverter)
 	assert.NotNil(t, route.ErrorConverter)
-	assert.Nil(t, route.PreCallback)
+	// The route resolves x-model-provider so it can be served cross-provider.
+	assert.NotNil(t, route.PreCallback)
 
 	// Verify request instance type
 	reqInstance := route.GetRequestTypeInstance(context.Background())
@@ -214,7 +215,8 @@ func TestGenAIRerankRequestConverter(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, bifrostReq)
 	require.NotNil(t, bifrostReq.RerankRequest)
-	assert.Equal(t, schemas.Vertex, bifrostReq.RerankRequest.Provider)
+	// Provider resolution is deferred to the route header and the modelcatalogresolver plugin.
+	assert.Equal(t, schemas.ModelProvider(""), bifrostReq.RerankRequest.Provider)
 	assert.Equal(t, "semantic-ranker-default@latest", bifrostReq.RerankRequest.Model)
 	assert.Equal(t, "capital of france", bifrostReq.RerankRequest.Query)
 	require.Len(t, bifrostReq.RerankRequest.Documents, 2)


### PR DESCRIPTION
## Summary

Extends the rerank pipeline to support structured (JSON) documents alongside plain-text ones, adds a provider-neutral `ReturnDocuments` flag and `NextToken` pagination field, propagates caller document IDs through every result, and wires cross-provider routing to the `/genai/v1/rank` endpoint. Cohere error responses are now shaped to Cohere's wire format, and the Bedrock and Vertex routes no longer force `ReturnDocuments` on unconditionally.

## Changes

- **`RerankDocument`** gains a `Data map[string]interface{}` field for structured bodies; its `UnmarshalJSON` accepts a bare string or an object so existing callers sending `["a","b"]` continue to work without changes.
- **`RerankResult`** gains a top-level `ID *string` field so a caller's document identifier survives even when `ReturnDocuments` is off.
- **`RerankParameters`** gains `NextToken *string` for paginated Bedrock rerank calls.
- **Bedrock rerank**: inline sources are emitted as `JSON` type when `doc.Data` is populated and `doc.Text` is empty; `NextToken` is forwarded in both directions; `ToBifrostRerankResponse` restores caller IDs from the input document slice and handles `JSONDocument` on the response; `ToVertexRankResponse` no longer errors when a result carries no document.
- **Cohere rerank**: `CohereRerankDocument` replaces the previous `json.RawMessage` / `[]string` approach with a typed struct whose `UnmarshalJSON` accepts a bare string or an object; `ReturnDocuments` is forwarded; search units are carried in `CompletionTokensDetails.NumSearchQueries`; `ToCohereRerankResponse` now echoes documents back; `CohereRerankMeta` gains `CachedTokens` and `Warnings`; `CohereBilledUnits` gains `Images` and `ImageTokens`.
- **Cohere errors**: `ToCohereError` converts a `BifrostError` into Cohere's `{"id","message"}` wire shape; all Cohere route error converters now use it instead of returning the raw Bifrost error.
- **Vertex rerank**: `IgnoreRecordDetailsInResponse` is derived from the neutral `ReturnDocuments` flag rather than a provider-specific extra param; `ToBifrostRerankRequest` no longer pins the provider to `Vertex`, deferring resolution to the route header; caller IDs are restored on results; `ToVertexRankResponse` emits the record ID from `result.ID` or `result.Document.ID` and no longer requires a document to be present.
- **`/genai/v1/rank` route**: a `PreCallback` reads `x-model-provider` so the endpoint can be served cross-provider; the route no longer forces `ReturnDocuments = true`.
- **Bedrock route**: `ReturnDocuments` is no longer forced on; the converter passes through whatever the request carries.
- **Validation**: empty-document checks in both `bifrost.go` and the HTTP handler now require both `Text` and `Data` to be absent before rejecting a document.
- **`gopkg.in/yaml.v3`** moved from a direct to an indirect dependency; the YAML-based document encoding in the Cohere path is replaced with JSON via `sonic`.
- **Integration tests**: new `TestCohereRerank`, `TestBedrockRerank`, `TestGoogleRerank`, and `TestLangChainRerank` suites cover string documents, object documents, `top_n`/`numberOfResults`, `return_documents`, `ignoreRecordDetailsInResponse`, and cross-provider routing; shared helpers `assert_valid_rerank_results` and `rerank_documents_as_objects` are added to `common.py`; `cohere>=5.13.0` and `langchain-cohere>=0.4.0` are added as test dependencies.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./core/... ./transports/...

# Integration tests (requires provider credentials)
cd tests/integrations/python
uv run pytest tests/test_cohere.py tests/test_bedrock.py tests/test_google.py tests/test_langchain.py -k "rerank" -v
```

Rerank model entries must be present in `config.yml` for each provider under the `rerank` key. The `COHERE_API_KEY` environment variable is required for Cohere tests; Bedrock and Vertex use ambient AWS/GCP credentials.

## Breaking changes

- [x] Yes
- [ ] No

`BedrockRerankInlineSource.TextDocument` changed from a value type (`BedrockRerankTextValue`) to a pointer (`*BedrockRerankTextValue`). Callers constructing this struct directly must update their initialization. The Bedrock and Vertex routes no longer unconditionally set `ReturnDocuments = true`; providers that relied on documents always being present in results will now receive them only when the upstream response carries them or the caller explicitly requests them.

## Related issues

## Security considerations

No new auth surfaces, secrets, or PII handling introduced. Structured document bodies (`Data`) are passed through to providers as-is; callers are responsible for the content they submit.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable