### PR TITLE
fix(ui): truncate long values in log detail view and improve provider button responsiveness

### DIFF
--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -25,6 +25,7 @@ import { DottedSeparator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { TruncatedLabel } from "@/components/ui/truncatedLabel";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { ProviderIconType, RenderProviderIcon, RoutingEngineUsedIcons } from "@/lib/constants/icons";
 import {
@@ -1147,16 +1148,20 @@ export function LogDetailView({
 											<Tooltip>
 												<TooltipTrigger asChild>
 													<code
-														className="block min-w-0 cursor-pointer font-normal break-all text-blue-600 underline-offset-2 hover:underline dark:text-blue-400"
+														className="block max-w-full min-w-0 cursor-pointer truncate font-normal text-blue-600 underline-offset-2 hover:underline dark:text-blue-400"
 														onClick={() => onFilterByParentRequestId(log.parent_request_id as string)}
 													>
 														{log.parent_request_id}
 													</code>
 												</TooltipTrigger>
-												<TooltipContent sideOffset={6}>Filter this session</TooltipContent>
+												<TooltipContent sideOffset={6} className="max-w-md break-all">
+													{log.parent_request_id} · Filter this session
+												</TooltipContent>
 											</Tooltip>
 										) : (
-											<code className="block min-w-0 font-normal break-all">{log.parent_request_id}</code>
+											<TruncatedLabel className="block max-w-full min-w-0 font-normal" tooltipSide="top">
+												{log.parent_request_id}
+											</TruncatedLabel>
 										)
 									}
 								/>
@@ -1284,7 +1289,7 @@ export function LogDetailView({
 												<Link
 													to="/workspace/logs"
 													search={(prev) => ({ ...prev, offset: 0, selected_log: "", user_ids: [log.user_id] })}
-													className={`block min-w-0 cursor-pointer text-sm font-normal break-all text-blue-600 underline-offset-2 hover:underline dark:text-blue-400${log.user_name ? "" : " font-mono"}`}
+													className={`block max-w-full min-w-0 cursor-pointer truncate text-sm font-normal text-blue-600 underline-offset-2 hover:underline dark:text-blue-400${log.user_name ? "" : " font-mono"}`}
 													data-testid="logdetails-user-link"
 												>
 													{log.user_name || log.user_id}

--- a/ui/app/workspace/logs/views/logEntryDetailsView.tsx
+++ b/ui/app/workspace/logs/views/logEntryDetailsView.tsx
@@ -1,4 +1,5 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { TruncatedLabel } from "@/components/ui/truncatedLabel";
 import { cn } from "@/lib/utils";
 import { Info } from "lucide-react";
 
@@ -15,6 +16,9 @@ interface Props {
 	align?: "left" | "right";
 }
 
+const isPrimitive = (value: React.ReactNode): boolean =>
+	typeof value === "string" || typeof value === "number" || typeof value === "boolean";
+
 export default function LogEntryDetailsView(props: Props) {
 	if (props.value === null) {
 		return null;
@@ -22,13 +26,13 @@ export default function LogEntryDetailsView(props: Props) {
 	const orientation = props.orientation || "vertical";
 	return (
 		<div
-			className={cn("items-top flex flex-col gap-2", {
+			className={cn("items-top flex min-w-0 max-w-full flex-col gap-2", {
 				[`${props.className}`]: props.className !== undefined,
 				"items-start": props.align === "left" || props.align === undefined,
 				"items-end": props.align === "right",
 			})}
 		>
-			<div className={props.containerClassName}>
+			<div className={cn("min-w-0 max-w-full", props.containerClassName)}>
 				{props.label !== "" && (
 					<div className="text-muted-foreground flex shrink-0 flex-row items-center gap-1.5 pb-2 text-xs font-medium">
 						{props.label.toUpperCase().replace(/_/g, " ")}
@@ -45,16 +49,20 @@ export default function LogEntryDetailsView(props: Props) {
 					</div>
 				)}
 				<div
-					className={cn("text-md flex text-xs font-medium overflow-ellipsis transition-transform delay-75", {
+					className={cn("text-md flex min-w-0 text-xs font-medium overflow-ellipsis transition-transform delay-75", {
 						"w-full flex-col items-center gap-2": orientation === "horizontal",
 						"flex-row items-start gap-2": orientation === "vertical",
 						[`${props.valueClassName}`]: props.valueClassName !== undefined,
 						"text-end": props.align === "right",
 					})}
 				>
-					<div className="text-bifrost-gray-300 flex-1 text-sm break-all">
+					<TruncatedLabel
+						className="text-bifrost-gray-300 max-w-full min-w-0 flex-1 text-sm"
+						tooltipSide="top"
+						tooltip={isPrimitive(props.value) ? String(props.value) : undefined}
+					>
 						{typeof props.value === "boolean" ? String(props.value) : props.value}
-					</div>
+					</TruncatedLabel>
 				</div>
 			</div>
 		</div>

--- a/ui/app/workspace/providers/views/modelProviderConfig.tsx
+++ b/ui/app/workspace/providers/views/modelProviderConfig.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ModelProvider } from "@/lib/types/config";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { SettingsIcon, Trash } from "lucide-react";
@@ -31,22 +32,27 @@ export default function ModelProviderConfig({ provider, onRequestDelete }: Props
 				<Button
 					variant="outline"
 					onClick={onRequestDelete}
-					className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+					className="text-destructive hover:bg-destructive/10 hover:text-destructive size-9 px-0"
 					aria-label="Delete provider"
 					data-testid="provider-delete-btn"
 				>
 					<Trash className="h-4 w-4" />
 				</Button>
 			)}
-			<Button
-				variant="outline"
-				className="size-9 px-0 md:h-9 md:w-auto md:px-4"
-				onClick={() => setShowConfigSheet(true)}
-				aria-label={hasUpdateProviderAccess ? "Edit provider configuration" : "View provider configuration"}
-			>
-				<SettingsIcon className="h-4 w-4" />
-				<span className="hidden md:inline">{hasUpdateProviderAccess ? "Edit Provider Config" : "View Provider Config"}</span>
-			</Button>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<Button
+						variant="outline"
+						className="size-9 px-0 xl:h-9 xl:w-auto xl:px-4"
+						onClick={() => setShowConfigSheet(true)}
+						aria-label={hasUpdateProviderAccess ? "Edit provider configuration" : "View provider configuration"}
+					>
+						<SettingsIcon className="h-4 w-4" />
+						<span className="hidden xl:inline">{hasUpdateProviderAccess ? "Edit Provider Config" : "View Provider Config"}</span>
+					</Button>
+				</TooltipTrigger>
+				<TooltipContent className="xl:hidden">{hasUpdateProviderAccess ? "Edit Provider Config" : "View Provider Config"}</TooltipContent>
+			</Tooltip>
 		</div>
 	);
 

--- a/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
+++ b/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
@@ -203,14 +203,14 @@ export default function ModelProviderKeysTableView({ provider, className, header
 								<TooltipTrigger asChild>
 									<Button
 										variant="outline"
-										className="size-9 px-0 md:h-9 md:w-auto md:px-4"
+										className="size-9 px-0 xl:h-9 xl:w-auto xl:px-4"
 										disabled={isRefreshing}
 										data-testid="provider-refresh-models"
 										aria-label={isRefreshingProvider ? "Refreshing model list" : "Refresh model list"}
 										onClick={handleRefreshProviderModels}
 									>
 										<RefreshCwIcon className={cn("h-4 w-4", isRefreshingProvider && "animate-spin")} />
-										<span className="hidden md:inline">{isRefreshingProvider ? "Refreshing..." : "Refresh model list"}</span>
+										<span className="hidden xl:inline">{isRefreshingProvider ? "Refreshing..." : "Refresh model list"}</span>
 									</Button>
 								</TooltipTrigger>
 								<TooltipContent className="max-w-xs">
@@ -219,18 +219,23 @@ export default function ModelProviderKeysTableView({ provider, className, header
 							</Tooltip>
 						) : null}
 						{!isKeyless && hasUpdateProviderAccess ? (
-							<Button
-								disabled={!hasUpdateProviderAccess}
-								data-testid="add-key-btn"
-								aria-label={`Add new ${entityLabel}`}
-								className="size-9 px-0 md:h-9 md:w-auto md:px-4"
-								onClick={() => {
-									handleAddKey();
-								}}
-							>
-								<PlusIcon className="h-4 w-4" />
-								<span className="hidden md:inline">Add new {entityLabel}</span>
-							</Button>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<Button
+										disabled={!hasUpdateProviderAccess}
+										data-testid="add-key-btn"
+										aria-label={`Add new ${entityLabel}`}
+										className="size-9 px-0 xl:h-9 xl:w-auto xl:px-4"
+										onClick={() => {
+											handleAddKey();
+										}}
+									>
+										<PlusIcon className="h-4 w-4" />
+										<span className="hidden xl:inline">Add new {entityLabel}</span>
+									</Button>
+								</TooltipTrigger>
+								<TooltipContent className="xl:hidden">Add new {entityLabel}</TooltipContent>
+							</Tooltip>
 						) : null}
 					</div>
 				</CardTitle>


### PR DESCRIPTION
## Summary

Improves text truncation and tooltip behavior across the log detail view and provider configuration UI to prevent long strings from breaking layouts, and ensures icon-only buttons display tooltips at smaller viewport widths.

## Changes

- Replaced `break-all` text wrapping with `truncate` + `TruncatedLabel` for `parent_request_id` and user ID/name fields in the log detail view, so long values are clipped with an ellipsis rather than wrapping across multiple lines.
- Updated the clickable `parent_request_id` tooltip to include the full ID alongside the "Filter this session" label, so users can still read the value when it is truncated.
- Replaced the raw `div` wrapper in `LogEntryDetailsView` with `TruncatedLabel`, which shows a tooltip containing the full value when the text overflows. A helper `isPrimitive` guard ensures only string/number/boolean values are passed as the tooltip string.
- Changed the breakpoint at which button labels become visible in the provider config and keys table views from `md` to `xl`, keeping buttons icon-only at more intermediate screen sizes.
- Wrapped the "Edit/View Provider Config" button and the "Add new key" button in `Tooltip` components so their labels are accessible as tooltips when the text label is hidden below the `xl` breakpoint.
- Standardized the delete button size in `ModelProviderConfig` to match the icon-button sizing of adjacent buttons (`size-9 px-0`).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

1. Open the log detail sheet for a log entry that has a `parent_request_id`. Verify the ID is truncated with an ellipsis and hovering shows a tooltip with the full ID and "Filter this session".
2. Open a log entry where `parent_request_id` is not clickable. Verify hovering the truncated value shows the full ID in a tooltip.
3. Resize the browser window below the `xl` breakpoint on the Providers page. Verify the "Edit Provider Config", "Refresh model list", and "Add new key" buttons collapse to icon-only and display tooltips on hover.

## Screenshots/Recordings

Before/after screenshots recommended showing truncated IDs in the log detail panel and icon-only buttons at intermediate viewport widths.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable