### PR TITLE
autodetect harness level session ids

### DIFF
--- a/core/schemas/useragents.go
+++ b/core/schemas/useragents.go
@@ -3,6 +3,7 @@ package schemas
 import (
 	"regexp"
 	"strings"
+	"unicode/utf8"
 )
 
 // UserAgentIdentifiers lists substrings that may appear in User-Agent for a given integration.
@@ -39,6 +40,54 @@ var (
 	// QwenCodeCLI identifies requests from Qwen Code clients.
 	QwenCodeCLI = UserAgentIdentifiers{"qwen-code", "qwencode", "qwen"}
 )
+
+// MaxSessionIDLength caps every caller-asserted session identifier Bifrost
+// ingests, counted in runes rather than bytes so the limit means the same thing
+// for a non-ASCII identifier as for an ASCII one.
+//
+// Session IDs become KV lookup keys and exported trace attributes, and the
+// OpenTelemetry attribute value length limit defaults to unlimited
+// (https://opentelemetry.io/docs/specs/otel/common/#attribute-limits), so
+// nothing downstream bounds a caller-controlled value for us. Every ingestion
+// path (x-bf-session-id, the baggage session-id member, x-bf-mcp-session-id, and
+// the harness headers below) goes through NormalizeSessionID.
+const MaxSessionIDLength = 255
+
+// NormalizeSessionID trims a caller-asserted session identifier and reports
+// whether it is usable: non-empty and no longer than MaxSessionIDLength runes.
+// Every session ingestion path shares it so one rule governs what can become a
+// KV lookup key or an exported trace attribute.
+func NormalizeSessionID(value string) (string, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" || utf8.RuneCountInString(value) > MaxSessionIDLength {
+		return "", false
+	}
+	return value, true
+}
+
+// HarnessSessionHeaders lists the headers coding harnesses use to carry their
+// own session identifier, in priority order. Bifrost falls back to these when
+// x-bf-session-id is absent, so harness traffic gets provider key stickiness and
+// OTEL session grouping without the caller renaming anything.
+//
+// Claude Code documents x-claude-code-session-id for exactly this purpose and
+// classifies it as a header a gateway may consume rather than forward:
+// https://code.claude.com/docs/en/llm-gateway-protocol#request-headers
+// That reference also treats x-claude-code-* as an open list that grows with
+// releases, so revisit this table when Claude Code ships new attribution headers.
+//
+// Only headers a harness verifiably sends belong here. Deliberately absent:
+// x-parent-session-id (OpenCode) would collapse every sub-agent onto its
+// parent's key, and x-qwen-code-session-id was designed but never shipped.
+var HarnessSessionHeaders = []string{
+	"x-claude-code-session-id", // Claude Code, and wrappers that spawn it (e.g. Conductor)
+	"x-session-affinity",       // OpenCode
+	"x-session-id",             // OpenCode sends this alongside the above; also the generic convention
+	"session-id",               // Codex CLI
+	"session_id",               // Codex CLI, builds predating the dashed rename
+	"thread-id",                // Codex CLI thread: coarser, only when no session header is sent
+	"conversation_id",          // Codex CLI, builds predating the dashed rename
+}
 
 // UserAgentAppMatcher maps a detected application label to User-Agent identifiers.
 type UserAgentAppMatcher struct {

--- a/docs/features/observability/otel.mdx
+++ b/docs/features/observability/otel.mdx
@@ -137,6 +137,8 @@ Because all requests in a session share one trace, very long-lived sessions prod
 
 To send a session ID, pass the [`x-bf-session-id`](/providers/request-options) header on each request you want grouped together.
 
+Requests from a coding harness need no Bifrost-specific header: when `x-bf-session-id` is absent, Bifrost adopts the harness's own session header (Claude Code, Codex CLI, and OpenCode are recognized). That populates `session.id` on every request in the run; enable `group_traces_by_session` to collapse the run into a single trace. See [Coding Harness Headers](/providers/request-options#session-stickiness-session-id) for the full list.
+
 ---
 
 ## Setup

--- a/docs/providers/request-options.mdx
+++ b/docs/providers/request-options.mdx
@@ -14,7 +14,7 @@ Bifrost provides request options that control behavior, enable features, and pas
 | `BifrostContextKeyAPIKeyName`              | `x-bf-api-key`                                       | `string`              | Explicit API key name selection                                                                                                       |
 | `BifrostContextKeyAPIKeyID`                | `x-bf-api-key-id`                                    | `string`              | Explicit API key ID selection (takes priority over name)                                                                              |
 | `BifrostContextKeyDirectKey`               | `x-bf-direct-key` (+ `Authorization` / `x-api-key` / `x-goog-api-key`) | `schemas.Key`         | Use a caller-supplied raw provider key directly, bypassing the registered key pool. On the gateway, requires `allow_direct_keys` server-side |
-| `BifrostContextKeySessionID`               | `x-bf-session-id`                                    | `string`              | Session ID for key stickiness (requires KV store)                                                                                     |
+| `BifrostContextKeySessionID`               | `x-bf-session-id` (falls back to coding-harness session headers) | `string`              | Session ID for key stickiness (requires KV store)                                                                                     |
 | `BifrostContextKeySessionTTL`              | `x-bf-session-ttl`                                   | `time.Duration`       | Session-to-key cache TTL (duration string or seconds)                                                                                 |
 | `BifrostContextKeyRequestID`               | `x-request-id`                                       | `string`              | Custom request ID for tracking                                                                                                        |
 | `BifrostContextKeySendBackRawRequest`      | `x-bf-send-back-raw-request`                         | `bool`                | Include raw provider request in the response                                                                                          |
@@ -235,6 +235,26 @@ On the first request for a session ID, Bifrost selects a key and caches the bind
 **Retry and Fallback Behavior:**
 - **Retries**: Session stickiness persists across retry attempts. If a request fails and is retried, the same sticky key is used.
 - **Fallbacks**: When falling back to a different provider (e.g., from OpenAI to Anthropic), session stickiness is disabled and a new key is selected for the fallback provider. This ensures availability when the primary provider's keys are exhausted or failing.
+
+**Coding Harness Headers:**
+
+Coding harnesses already send a session identifier on every request under their own header name. When `x-bf-session-id` is absent, Bifrost adopts the first of these it finds, so pointing a harness at Bifrost gives you session stickiness and session-grouped traces with no configuration:
+
+| Header                      | Sent by                                                          |
+| --------------------------- | ---------------------------------------------------------------- |
+| `x-claude-code-session-id`  | Claude Code, and tools that run it (for example Conductor)        |
+| `x-session-affinity`        | OpenCode                                                          |
+| `x-session-id`              | OpenCode (alongside the above), and clients using the generic convention |
+| `session-id`                | Codex CLI                                                         |
+| `session_id`                | Codex CLI, builds predating its dashed-header rename              |
+| `thread-id`                 | Codex CLI thread, used only when no session header is sent        |
+| `conversation_id`           | Codex CLI, builds predating its dashed-header rename              |
+
+The list is ordered: the first non-empty header whose value is at most 255 runes wins, so a blank or over-long header is skipped and the next one is tried.
+
+An explicit `x-bf-session-id` always overrides all of them, so you can group requests your own way regardless of what the client sends. It also decides the outcome when it is unusable: a request that sends an `x-bf-session-id` longer than 255 runes gets no session at all rather than falling back to a harness header, because silently grouping it under a session you did not ask for is worse than leaving it ungrouped.
+
+Claude Code documents `x-claude-code-session-id` in its [gateway protocol reference](https://code.claude.com/docs/en/llm-gateway-protocol#request-headers), where it is listed as a header a gateway may consume for attribution rather than forward upstream. Subagent requests carry the same session ID as their parent, so an agent run with parallel subagents stays on one key.
 
 <Tabs>
 <Tab title="Gateway (cURL)">

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -1344,7 +1344,11 @@ func (m *TracingMiddleware) Middleware() schemas.BifrostHTTPMiddleware {
 				// asynchronously and must never observe later mutations.
 				tracer.SetTraceAttribute(traceID, schemas.TraceAttrDimensions, maps.Clone(dimensions))
 			}
-			if sessionID := strings.TrimSpace(string(ctx.Request.Header.Peek("x-bf-session-id"))); sessionID != "" {
+			// Resolved rather than peeked: this middleware runs before context
+			// conversion, so it repeats the same x-bf-session-id-then-harness-header
+			// lookup ConvertToBifrostContext does. Both read the same headers with
+			// the same priority list, so key stickiness and session.id agree.
+			if sessionID := lib.ResolveSessionIDFromRequest(&ctx.Request.Header); sessionID != "" {
 				tracer.SetTraceAttribute(traceID, schemas.TraceAttrSessionID, sessionID)
 			}
 			// Only trace ID goes into context (lightweight, no bloat)

--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -87,15 +88,91 @@ func ParseSessionIDFromBaggage(header string) string {
 		if key != "session-id" || value == "" {
 			continue
 		}
-		if len(value) > 255 {
+		sessionID, ok := schemas.NormalizeSessionID(value)
+		if !ok {
 			if logger != nil {
-				logger.Warn("session-id exceeds 255 chars, ignoring: length=%d, prefix=%s", len(value), value[:255])
+				// Length only, never the value: baggage is caller-controlled.
+				logger.Warn("baggage session-id exceeds %d runes, ignoring: length=%d", schemas.MaxSessionIDLength, utf8.RuneCountInString(value))
 			}
 			continue
 		}
-		return value
+		return sessionID
 	}
 	return ""
+}
+
+// ResolveHarnessSessionID returns the first non-empty header from
+// schemas.HarnessSessionHeaders, in that list's priority order. Coding harnesses
+// (Claude Code, Codex CLI, OpenCode) already send a session identifier on every
+// request under their own header name; honoring it means their traffic gets key
+// stickiness and OTEL session grouping without the caller setting x-bf-session-id.
+//
+// headers must be keyed by lowercased header name. Values are trimmed and
+// rejected past schemas.MaxSessionIDLength so no ingestion path can plant an
+// oversized KV lookup key or trace attribute. Callers are responsible for
+// preferring an explicit x-bf-session-id over this result.
+func ResolveHarnessSessionID(headers map[string]string) string {
+	if len(headers) == 0 {
+		return ""
+	}
+	for _, name := range schemas.HarnessSessionHeaders {
+		raw := headers[name]
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		sessionID, ok := schemas.NormalizeSessionID(raw)
+		if !ok {
+			if logger != nil {
+				// Don't echo the value: harness session headers are caller-controlled.
+				logger.Warn("%s exceeds %d runes, ignoring: length=%d", name, schemas.MaxSessionIDLength, utf8.RuneCountInString(strings.TrimSpace(raw)))
+			}
+			continue
+		}
+		return sessionID
+	}
+	return ""
+}
+
+// ResolveSessionIDFromHeaders returns the session ID for a request from a
+// lowercased header map. An explicit x-bf-session-id decides the outcome
+// whenever the caller sends one: if it is valid it wins, and if it is oversized
+// the request gets no session at all rather than silently adopting a harness
+// header, because substituting a different session identity for the one the
+// caller asked for is worse than having none. Only when no explicit header is
+// present do the harness headers apply.
+func ResolveSessionIDFromHeaders(headers map[string]string) string {
+	if raw := headers["x-bf-session-id"]; strings.TrimSpace(raw) != "" {
+		sessionID, ok := schemas.NormalizeSessionID(raw)
+		if !ok {
+			if logger != nil {
+				// Length only, never the value: x-bf-session-id is caller-controlled.
+				logger.Warn("x-bf-session-id exceeds %d runes, ignoring: length=%d", schemas.MaxSessionIDLength, utf8.RuneCountInString(strings.TrimSpace(raw)))
+			}
+			return ""
+		}
+		return sessionID
+	}
+	return ResolveHarnessSessionID(headers)
+}
+
+// ResolveSessionIDFromRequest is ResolveSessionIDFromHeaders for callers that
+// hold a fasthttp header rather than the lowercased header map
+// ConvertToBifrostContext builds, notably the tracing middleware, which runs
+// before context conversion.
+//
+// Keys are lowercased during iteration rather than read with Peek so the result
+// never depends on fasthttp header-name normalization, which does not fold the
+// underscore forms Codex CLI still sends.
+func ResolveSessionIDFromRequest(h *fasthttp.RequestHeader) string {
+	if h == nil {
+		return ""
+	}
+	headers := make(map[string]string, h.Len())
+	h.All()(func(key, value []byte) bool {
+		headers[strings.ToLower(string(key))] = string(value)
+		return true
+	})
+	return ResolveSessionIDFromHeaders(headers)
 }
 
 // ConvertToBifrostContext converts a FastHTTP RequestCtx to a Bifrost context,
@@ -144,7 +221,9 @@ func ParseSessionIDFromBaggage(header string) string {
 //   - This allows callers to send arbitrary context metadata without needing to extend the public schema
 //
 // 8. Session Stickiness Headers:
-//   - x-bf-session-id: Session identifier for key binding (reuse same key across requests)
+//   - x-bf-session-id: Session identifier for key binding (reuse same key across requests).
+//     When absent, falls back to the coding-harness session headers listed in
+//     schemas.HarnessSessionHeaders (Claude Code, Codex CLI, OpenCode).
 //   - x-bf-session-ttl: Per-request TTL override (duration string e.g. "30m" or seconds integer)
 //
 // 9. Raw Capture Headers (per-request override of provider config; accepts "true" or "false"):
@@ -336,16 +415,17 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, store HandlerStore) (*sch
 		// Handle MCP session ID header (x-bf-mcp-session-id): a client-issued
 		// opaque identifier used for session-mode per-user OAuth flows. Any
 		// non-empty string the caller can re-present on subsequent /mcp calls.
-		// 255-char cap matches ParseSessionIDFromBaggage so both ingestion
-		// paths reject oversized lookup keys consistently.
+		// schemas.NormalizeSessionID applies the same cap as every other session
+		// ingestion path, so none of them can accept a lookup key the others reject.
 		if keyStr == "x-bf-mcp-session-id" {
-			if v := strings.TrimSpace(string(value)); v != "" {
-				if len(v) > 255 {
-					// Don't echo any of the value — x-bf-mcp-session-id is a
+			if raw := strings.TrimSpace(string(value)); raw != "" {
+				v, ok := schemas.NormalizeSessionID(raw)
+				if !ok {
+					// Don't echo any of the value: x-bf-mcp-session-id is a
 					// re-presentable lookup key for session-mode OAuth; the
 					// length alone is enough for debugging.
 					if logger != nil {
-						logger.Warn("x-bf-mcp-session-id exceeds 255 chars, ignoring: length=%d (skipped last %d chars)", len(v), len(v)-255)
+						logger.Warn("x-bf-mcp-session-id exceeds %d runes, ignoring: length=%d", schemas.MaxSessionIDLength, utf8.RuneCountInString(raw))
 					}
 					return true
 				}
@@ -446,11 +526,11 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, store HandlerStore) (*sch
 			}
 			return true
 		}
-		// Session stickiness: session ID for key binding
+		// Session stickiness: session ID for key binding. Consumed here so the
+		// header is not forwarded to the provider by the direct-forwarding path
+		// below; the value itself is resolved once after this loop, by the same
+		// function the tracing middleware calls, so the two cannot disagree.
 		if keyStr == "x-bf-session-id" {
-			if valueStr := strings.TrimSpace(string(value)); valueStr != "" {
-				bifrostCtx.SetValue(schemas.BifrostContextKeySessionID, valueStr)
-			}
 			return true
 		}
 		// Session stickiness: per-request TTL override (duration string or seconds integer)
@@ -642,6 +722,21 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, store HandlerStore) (*sch
 		return true
 	})
 	bifrostCtx.SetValue(schemas.BifrostContextKeyRequestHeaders, allHeaders)
+
+	// Session stickiness: an explicit x-bf-session-id wins, otherwise the
+	// harness's own session header applies, so Claude Code / Codex CLI /
+	// OpenCode traffic gets key stickiness without the caller renaming anything.
+	//
+	// This deliberately runs after the header loop rather than inside it: that
+	// loop is a single pass with early returns, and header order is not
+	// guaranteed, so a harness header arriving first would otherwise beat
+	// x-bf-session-id. allHeaders is already built and already lowercased, so
+	// this costs no extra header iteration, and routing both the explicit and
+	// the harness case through one resolver keeps stickiness and the OTEL
+	// session.id trace attribute in agreement.
+	if sessionID := ResolveSessionIDFromHeaders(allHeaders); sessionID != "" {
+		bifrostCtx.SetValue(schemas.BifrostContextKeySessionID, sessionID)
+	}
 
 	// Collect all request query params for downstream use (e.g., governance routing CEL rules
 	// that read params["..."]). Keys are lowercased for case-insensitive lookup.

--- a/transports/bifrost-http/lib/ctx_test.go
+++ b/transports/bifrost-http/lib/ctx_test.go
@@ -2,7 +2,9 @@ package lib
 
 import (
 	"context"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/kvstore"
@@ -660,5 +662,281 @@ func TestConvertToBifrostContext_AsyncWebhookHeader(t *testing.T) {
 				t.Fatalf("context webhook endpoint = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// sessionIDFromContext is a helper for the harness-fallback tests below.
+func sessionIDFromContext(t *testing.T, ctx *fasthttp.RequestCtx) string {
+	t.Helper()
+	bifrostCtx, cancel := ConvertToBifrostContext(ctx, testHandlerStore{})
+	defer cancel()
+	sessionID, _ := bifrostCtx.Value(schemas.BifrostContextKeySessionID).(string)
+	return sessionID
+}
+
+func TestConvertToBifrostContext_HarnessSessionHeaderFallback(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string]string
+		want    string
+	}{
+		{
+			name:    "claude code",
+			headers: map[string]string{"x-claude-code-session-id": "cc-1"},
+			want:    "cc-1",
+		},
+		{
+			name:    "opencode session affinity",
+			headers: map[string]string{"x-session-affinity": "oc-1"},
+			want:    "oc-1",
+		},
+		{
+			name:    "generic x-session-id",
+			headers: map[string]string{"x-session-id": "generic-1"},
+			want:    "generic-1",
+		},
+		{
+			name:    "codex dashed",
+			headers: map[string]string{"session-id": "cx-1"},
+			want:    "cx-1",
+		},
+		{
+			name:    "codex underscored",
+			headers: map[string]string{"session_id": "cx-2"},
+			want:    "cx-2",
+		},
+		{
+			name:    "codex thread id",
+			headers: map[string]string{"thread-id": "cx-3"},
+			want:    "cx-3",
+		},
+		{
+			name:    "codex conversation id",
+			headers: map[string]string{"conversation_id": "cx-4"},
+			want:    "cx-4",
+		},
+		{
+			name:    "header name is case insensitive",
+			headers: map[string]string{"X-Claude-Code-Session-Id": "cc-2"},
+			want:    "cc-2",
+		},
+		{
+			name:    "value is trimmed",
+			headers: map[string]string{"x-claude-code-session-id": "  cc-3  "},
+			want:    "cc-3",
+		},
+		{
+			name:    "whitespace only does not shadow lower priority header",
+			headers: map[string]string{"x-claude-code-session-id": "   ", "session-id": "cx-5"},
+			want:    "cx-5",
+		},
+		{
+			name:    "no session headers at all",
+			headers: map[string]string{"user-agent": "claude-cli/2.1.0"},
+			want:    "",
+		},
+		{
+			name:    "baggage session-id member is not a session id",
+			headers: map[string]string{"baggage": "session-id=bg-1"},
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &fasthttp.RequestCtx{}
+			for k, v := range tt.headers {
+				ctx.Request.Header.Set(k, v)
+			}
+			if got := sessionIDFromContext(t, ctx); got != tt.want {
+				t.Fatalf("session id = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConvertToBifrostContext_ExplicitSessionIDBeatsHarnessHeader(t *testing.T) {
+	// Set the harness header first: the header loop in ConvertToBifrostContext is
+	// a single pass with early returns, so this ordering is the regression guard
+	// against resolving the fallback inline instead of after the loop.
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("x-claude-code-session-id", "harness")
+	ctx.Request.Header.Set("session-id", "codex")
+	ctx.Request.Header.Set("x-bf-session-id", "explicit")
+
+	if got := sessionIDFromContext(t, ctx); got != "explicit" {
+		t.Fatalf("session id = %q, want %q", got, "explicit")
+	}
+}
+
+func TestConvertToBifrostContext_HarnessSessionHeaderPriority(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	// Deliberately set in reverse priority order.
+	ctx.Request.Header.Set("conversation_id", "cx-conversation")
+	ctx.Request.Header.Set("thread-id", "cx-thread")
+	ctx.Request.Header.Set("session_id", "cx-underscore")
+	ctx.Request.Header.Set("session-id", "cx-dash")
+	ctx.Request.Header.Set("x-session-id", "generic")
+	ctx.Request.Header.Set("x-session-affinity", "opencode")
+	ctx.Request.Header.Set("x-claude-code-session-id", "claude-code")
+
+	if got := sessionIDFromContext(t, ctx); got != "claude-code" {
+		t.Fatalf("session id = %q, want %q", got, "claude-code")
+	}
+}
+
+func TestConvertToBifrostContext_OversizedHarnessSessionHeaderRejected(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("x-claude-code-session-id", strings.Repeat("a", schemas.MaxSessionIDLength+1))
+	ctx.Request.Header.Set("session-id", "cx-1")
+
+	// The oversized value is dropped, not truncated, and must not shadow the next
+	// candidate: it would otherwise become a KV lookup key and a trace attribute.
+	if got := sessionIDFromContext(t, ctx); got != "cx-1" {
+		t.Fatalf("session id = %q, want %q", got, "cx-1")
+	}
+}
+
+func TestConvertToBifrostContext_OversizedExplicitSessionIDRejected(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("x-bf-session-id", strings.Repeat("a", schemas.MaxSessionIDLength+1))
+	ctx.Request.Header.Set("x-claude-code-session-id", "cc-1")
+
+	// The caller asserted an explicit session; when that value is unusable the
+	// request gets no session rather than silently adopting a different identity.
+	if got := sessionIDFromContext(t, ctx); got != "" {
+		t.Fatalf("session id = %q, want empty", got)
+	}
+}
+
+func TestConvertToBifrostContext_MultiByteSessionIDCountedInRunes(t *testing.T) {
+	// MaxSessionIDLength counts runes, so this value is legal at 255 runes even
+	// though it is 765 bytes.
+	want := strings.Repeat("\u754c", schemas.MaxSessionIDLength)
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("x-bf-session-id", want)
+
+	if got := sessionIDFromContext(t, ctx); got != want {
+		t.Fatalf("session id runes = %d, want %d", utf8.RuneCountInString(got), schemas.MaxSessionIDLength)
+	}
+
+	over := &fasthttp.RequestCtx{}
+	over.Request.Header.Set("x-bf-session-id", strings.Repeat("\u754c", schemas.MaxSessionIDLength+1))
+	if got := sessionIDFromContext(t, over); got != "" {
+		t.Fatalf("session id = %q, want empty for %d runes", got, schemas.MaxSessionIDLength+1)
+	}
+}
+
+func TestConvertToBifrostContext_MaxLengthHarnessSessionHeaderAccepted(t *testing.T) {
+	want := strings.Repeat("a", schemas.MaxSessionIDLength)
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("x-claude-code-session-id", want)
+
+	if got := sessionIDFromContext(t, ctx); got != want {
+		t.Fatalf("session id length = %d, want %d", len(got), len(want))
+	}
+}
+
+func TestResolveSessionIDFromRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string]string
+		want    string
+	}{
+		{name: "no headers", headers: nil, want: ""},
+		{name: "explicit only", headers: map[string]string{"x-bf-session-id": "explicit"}, want: "explicit"},
+		{name: "harness only", headers: map[string]string{"x-claude-code-session-id": "cc-1"}, want: "cc-1"},
+		{
+			name:    "explicit wins",
+			headers: map[string]string{"x-claude-code-session-id": "cc-1", "x-bf-session-id": "explicit"},
+			want:    "explicit",
+		},
+		{
+			name:    "blank explicit falls through to harness",
+			headers: map[string]string{"x-bf-session-id": "  ", "session-id": "cx-1"},
+			want:    "cx-1",
+		},
+		{
+			// An asserted-but-oversized explicit header yields no session at all.
+			// Falling through would silently group the request under a session
+			// identity the caller never asked for.
+			name: "oversized explicit does not fall through to harness",
+			headers: map[string]string{
+				"x-bf-session-id": strings.Repeat("a", schemas.MaxSessionIDLength+1),
+				"session-id":      "cx-1",
+			},
+			want: "",
+		},
+		{
+			name:    "explicit at the rune limit is accepted",
+			headers: map[string]string{"x-bf-session-id": strings.Repeat("a", schemas.MaxSessionIDLength)},
+			want:    strings.Repeat("a", schemas.MaxSessionIDLength),
+		},
+		{
+			// The cap counts runes, so a multi-byte value at the limit is legal
+			// even though its byte length is far over it.
+			name:    "multi-byte explicit at the rune limit is accepted",
+			headers: map[string]string{"x-bf-session-id": strings.Repeat("\u754c", schemas.MaxSessionIDLength)},
+			want:    strings.Repeat("\u754c", schemas.MaxSessionIDLength),
+		},
+		{
+			name:    "priority order holds",
+			headers: map[string]string{"thread-id": "cx-thread", "x-session-affinity": "opencode"},
+			want:    "opencode",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &fasthttp.RequestCtx{}
+			for k, v := range tt.headers {
+				ctx.Request.Header.Set(k, v)
+			}
+			if got := ResolveSessionIDFromRequest(&ctx.Request.Header); got != tt.want {
+				t.Fatalf("ResolveSessionIDFromRequest() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	t.Run("nil header", func(t *testing.T) {
+		if got := ResolveSessionIDFromRequest(nil); got != "" {
+			t.Fatalf("ResolveSessionIDFromRequest(nil) = %q, want empty", got)
+		}
+	})
+}
+
+// TestSessionIDResolutionIsConsistent pins the invariant that key stickiness
+// (ConvertToBifrostContext) and the OTEL session.id trace attribute
+// (ResolveSessionIDFromRequest, called from the tracing middleware) never
+// disagree: they run at different points in the request lifecycle.
+func TestSessionIDResolutionIsConsistent(t *testing.T) {
+	headerSets := []map[string]string{
+		{"x-bf-session-id": "explicit"},
+		{"x-claude-code-session-id": "cc-1"},
+		{"x-session-affinity": "oc-1"},
+		{"x-session-id": "generic-1"},
+		{"x-session-affinity": "oc-1", "x-session-id": "oc-1"},
+		{"session-id": "cx-1"},
+		{"session_id": "cx-2"},
+		{"conversation_id": "cx-3"},
+		{"x-bf-session-id": "explicit", "session-id": "cx-1"},
+		{"x-claude-code-session-id": "cc-1", "thread-id": "cx-thread"},
+		{"user-agent": "codex-cli/1.0"},
+		{"x-bf-session-id": strings.Repeat("a", schemas.MaxSessionIDLength+1), "session-id": "cx-1"},
+		{"x-claude-code-session-id": strings.Repeat("a", schemas.MaxSessionIDLength+1), "session-id": "cx-1"},
+		{"x-bf-session-id": strings.Repeat("\u754c", schemas.MaxSessionIDLength)},
+		{"x-bf-session-id": strings.Repeat("\u754c", schemas.MaxSessionIDLength+1), "session-id": "cx-1"},
+	}
+
+	for _, headers := range headerSets {
+		ctx := &fasthttp.RequestCtx{}
+		for k, v := range headers {
+			ctx.Request.Header.Set(k, v)
+		}
+		fromMiddleware := ResolveSessionIDFromRequest(&ctx.Request.Header)
+		fromContext := sessionIDFromContext(t, ctx)
+		if fromMiddleware != fromContext {
+			t.Fatalf("headers %v: middleware resolved %q but context resolved %q", headers, fromMiddleware, fromContext)
+		}
 	}
 }

--- a/ui/app/workspace/providers/page.tsx
+++ b/ui/app/workspace/providers/page.tsx
@@ -21,7 +21,7 @@ import { KnownProvider, ModelProviderName, ProviderStatus } from "@/lib/types/co
 import { cn } from "@/lib/utils";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { useNavigate } from "@tanstack/react-router";
-import { AlertCircle, ArrowLeft } from "lucide-react";
+import { AlertCircle, ArrowLeft, Server } from "lucide-react";
 import { useQueryState } from "nuqs";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -202,69 +202,84 @@ export default function Providers() {
 					setShowCustomProviderSheet(false);
 				}}
 			/>
-			<div className={cn("w-full flex-col md:flex md:max-h-[calc(var(--app-content-viewport)_-_70px)] md:w-[300px]", mobileDetailOpen ? "hidden" : "flex")}>
+			<div
+				className={cn(
+					"w-full flex-col md:flex md:h-[calc(var(--app-content-viewport)_-_70px)] md:w-[300px]",
+					mobileDetailOpen ? "hidden" : "flex",
+				)}
+			>
 				<TooltipProvider>
-					<div className="custom-scrollbar flex-1 overflow-y-auto">
-						<div className="rounded-md bg-zinc-50/50 md:p-4 dark:bg-zinc-800/20">
-							{/* Configured Providers (standard with keys + custom) */}
-							{configuredProviders.length > 0 && (
-								<div className="mb-4">
-									<div className="text-muted-foreground mb-2 text-xs font-medium">Configured Providers</div>
-									{configuredProviders.map((p) => {
-										const isCustom = !ProviderNames.includes(p.name as KnownProvider);
-										const label = isCustom ? p.name : ProviderLabels[p.name as keyof typeof ProviderLabels];
-										return (
-											<div
-												key={p.name}
-												data-testid={`provider-item-${p.name.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}`}
-												className={cn(
-													"mb-1 flex h-8 w-full min-w-0 cursor-pointer items-center gap-2 rounded-sm border px-3 text-sm",
-													selectedProvider?.name === p.name
-														? "bg-secondary opacity-100 hover:opacity-100"
-														: "hover:bg-secondary cursor-pointer border-transparent opacity-100 hover:border",
-												)}
-												onClick={(e) => {
-													e.preventDefault();
-													e.stopPropagation();
-													if (providerFormIsDirty) {
-														setPendingRedirection(p.name);
-														setShowRedirectionDialog(true);
-														return;
-													}
-													setProvider(p.name);
-													if (isMobile) setMobileDetailOpen(true);
-												}}
-											>
-												<RenderProviderIcon
-													provider={(isCustom ? p.custom_provider_config?.base_provider_type : p.name) as ProviderIconType}
-													size="sm"
-													className="h-4 w-4 shrink-0"
-												/>
-												<TruncatedLabel className="flex-1 text-sm">{label}</TruncatedLabel>
-												<KeyDiscoveryFailedBadge provider={p} />
-												<ProviderStatusBadge status={p.provider_status} />
-												{isCustom && (
-													<Badge variant="secondary" className="text-muted-foreground ml-auto shrink-0 px-1.5 py-0.5 text-[10px] font-bold">
-														CUSTOM
-													</Badge>
-												)}
-											</div>
-										);
-									})}
+					<div className="flex min-h-0 flex-1 flex-col rounded-md bg-zinc-50/50 md:p-4 dark:bg-zinc-800/20">
+						{/* Pinned lane title */}
+						<div className="text-muted-foreground mb-2 shrink-0 text-xs font-medium">Configured Providers</div>
+
+						{/* Configured providers (standard with keys + custom): the only scrolling region */}
+						<div className="custom-scrollbar min-h-0 flex-1 overflow-y-auto">
+							{configuredProviders.length > 0 ? (
+								configuredProviders.map((p) => {
+									const isCustom = !ProviderNames.includes(p.name as KnownProvider);
+									const label = isCustom ? p.name : ProviderLabels[p.name as keyof typeof ProviderLabels];
+									return (
+										<div
+											key={p.name}
+											data-testid={`provider-item-${p.name.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}`}
+											className={cn(
+												"mb-1 flex h-8 w-full min-w-0 cursor-pointer items-center gap-2 rounded-sm border px-3 text-sm",
+												selectedProvider?.name === p.name
+													? "bg-secondary opacity-100 hover:opacity-100"
+													: "hover:bg-secondary cursor-pointer border-transparent opacity-100 hover:border",
+											)}
+											onClick={(e) => {
+												e.preventDefault();
+												e.stopPropagation();
+												if (providerFormIsDirty) {
+													setPendingRedirection(p.name);
+													setShowRedirectionDialog(true);
+													return;
+												}
+												setProvider(p.name);
+												if (isMobile) setMobileDetailOpen(true);
+											}}
+										>
+											<RenderProviderIcon
+												provider={(isCustom ? p.custom_provider_config?.base_provider_type : p.name) as ProviderIconType}
+												size="sm"
+												className="h-4 w-4 shrink-0"
+											/>
+											<TruncatedLabel className="flex-1 text-sm">{label}</TruncatedLabel>
+											<KeyDiscoveryFailedBadge provider={p} />
+											<ProviderStatusBadge status={p.provider_status} />
+											{isCustom && (
+												<Badge variant="secondary" className="text-muted-foreground ml-auto shrink-0 px-1.5 py-0.5 text-[10px] font-bold">
+													CUSTOM
+												</Badge>
+											)}
+										</div>
+									);
+								})
+							) : (
+								<div
+									data-testid="providers-lane-empty"
+									className="flex h-full flex-col items-center justify-center gap-2 px-4 py-8 text-center"
+								>
+									<Server className="text-muted-foreground h-8 w-8" strokeWidth={1} />
+									<div className="text-muted-foreground text-xs">No providers configured yet</div>
 								</div>
 							)}
-							{hasProviderCreateAccess ? (
-								<div className="pb-4">
-									<AddProviderDropdown
-										disabled={!hasProviderCreateAccess}
-										existingInSidebar={existingInSidebarNames}
-										knownProviders={knownProviders}
-										onSelectKnownProvider={handleSelectKnownProvider}
-										onAddCustomProvider={() => setShowCustomProviderSheet(true)}
-									/>
-								</div>
-							) : null}
 						</div>
+
+						{/* Pinned add action */}
+						{hasProviderCreateAccess ? (
+							<div className="shrink-0 pt-3">
+								<AddProviderDropdown
+									disabled={!hasProviderCreateAccess}
+									existingInSidebar={existingInSidebarNames}
+									knownProviders={knownProviders}
+									onSelectKnownProvider={handleSelectKnownProvider}
+									onAddCustomProvider={() => setShowCustomProviderSheet(true)}
+								/>
+							</div>
+						) : null}
 					</div>
 				</TooltipProvider>
 			</div>


### PR DESCRIPTION
## Summary

Coding harnesses (Claude Code, Codex CLI, OpenCode) already send a session identifier on every request under their own header names. Previously, Bifrost only recognized `x-bf-session-id`, so harness traffic missed out on provider key stickiness and OTEL session grouping unless callers explicitly renamed their headers. This PR adds automatic fallback: when `x-bf-session-id` is absent, Bifrost adopts the first recognized harness session header it finds, in a defined priority order.

## Changes

- Added `MaxSessionIDLength = 255` constant to `core/schemas/useragents.go` and replaced all inline `255` literals with it so the cap is enforced consistently across every ingestion path (`x-bf-session-id`, baggage `session-id`, `x-bf-mcp-session-id`, and harness headers).
- Added `HarnessSessionHeaders` to `core/schemas/useragents.go`, listing the headers Claude Code, Codex CLI, and OpenCode send, in priority order, with inline rationale for what was deliberately excluded (`x-parent-session-id`, `x-qwen-code-session-id`).
- Added `ResolveHarnessSessionID(headers map[string]string)` in `transports/bifrost-http/lib/ctx.go` to walk the priority list and return the first non-empty, length-valid value.
- Added `ResolveSessionIDFromRequest(h *fasthttp.RequestHeader)` for callers that hold a raw fasthttp header (notably the tracing middleware, which runs before context conversion). It builds a lowercased header map itself so underscore-named Codex CLI headers are found regardless of fasthttp normalization.
- Updated `ConvertToBifrostContext` to run the harness fallback after the main header loop rather than inline, ensuring an explicit `x-bf-session-id` always wins even if a harness header appears first in the wire order.
- Updated the tracing middleware to call `ResolveSessionIDFromRequest` instead of peeking `x-bf-session-id` directly, so the `session.id` trace attribute and the key-stickiness session ID always agree.
- Fixed the providers sidebar in the UI: the configured-providers list is now the only scrolling region, the "Configured Providers" label and the "Add Provider" button are pinned outside the scroll area, and an empty-state illustration is shown when no providers are configured.
- Updated `docs/features/observability/otel.mdx` and `docs/providers/request-options.mdx` to document the harness fallback behavior and the full header priority table.

Notable design decisions:
- The fallback runs after the header loop rather than inside it to avoid a race where a harness header arriving before `x-bf-session-id` in iteration order would shadow the explicit value.
- Oversized harness session values are dropped (not truncated) and the next candidate in the priority list is tried, preventing an attacker-controlled value from becoming a KV lookup key or trace attribute.
- `x-parent-session-id` (OpenCode) is explicitly excluded because it would collapse every sub-agent onto its parent's key. `x-qwen-code-session-id` is excluded because it was designed but never shipped.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
go test ./transports/bifrost-http/lib/... -run TestConvertToBifrostContext_HarnessSessionHeaderFallback
go test ./transports/bifrost-http/lib/... -run TestConvertToBifrostContext_ExplicitSessionIDBeatsHarnessHeader
go test ./transports/bifrost-http/lib/... -run TestConvertToBifrostContext_HarnessSessionHeaderPriority
go test ./transports/bifrost-http/lib/... -run TestConvertToBifrostContext_OversizedHarnessSessionHeaderRejected
go test ./transports/bifrost-http/lib/... -run TestConvertToBifrostContext_MaxLengthHarnessSessionHeaderAccepted
go test ./transports/bifrost-http/lib/... -run TestResolveSessionIDFromRequest
go test ./transports/bifrost-http/lib/... -run TestSessionIDResolutionIsConsistent
go test ./...
```

To validate end-to-end: point a Claude Code or Codex CLI session at a Bifrost gateway without setting `x-bf-session-id`. Confirm that successive requests within the same agent run land on the same provider key and appear under a single `session.id` in the OTEL trace output.

## Screenshots/Recordings

**Providers sidebar — empty state (new)**

The sidebar now shows a "No providers configured yet" illustration when the list is empty, and the "Add Provider" button stays pinned at the bottom rather than scrolling away.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Harness session header values are caller-controlled and flow into KV lookup keys and exported trace attributes. All ingestion paths enforce `MaxSessionIDLength = 255`; values exceeding this are dropped entirely (not truncated) and the next priority candidate is tried. Header values are never echoed in log output when they exceed the length cap.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable