### PR TITLE
feat: add BifrostCost support to speech, transcription and ocr usages

### DIFF
--- a/core/schemas/ocr.go
+++ b/core/schemas/ocr.go
@@ -77,6 +77,8 @@ type OCRPage struct {
 type OCRUsageInfo struct {
 	PagesProcessed int `json:"pages_processed"`
 	DocSizeBytes   int `json:"doc_size_bytes"`
+	// Cost is the per-category cost breakdown, populated when pricing is available.
+	Cost *BifrostCost `json:"cost,omitempty"`
 }
 
 // BifrostOCRResponse represents the response from an OCR request.

--- a/core/schemas/speech.go
+++ b/core/schemas/speech.go
@@ -170,4 +170,6 @@ type SpeechUsage struct {
 	// duration-based audio models (e.g. ElevenLabs sound effects) so per-second
 	// pricing can be applied; zero for token/character-billed TTS.
 	AudioSeconds int `json:"audio_seconds,omitempty"`
+	// Cost is the per-category cost breakdown, populated when pricing is available.
+	Cost *BifrostCost `json:"cost,omitempty"`
 }

--- a/core/schemas/transcriptions.go
+++ b/core/schemas/transcriptions.go
@@ -244,6 +244,8 @@ type TranscriptionUsage struct {
 	OutputTokens      *int                                 `json:"output_tokens,omitempty"`
 	TotalTokens       *int                                 `json:"total_tokens,omitempty"`
 	Seconds           *float64                             `json:"seconds,omitempty"` // For duration-based usage (fractional, e.g. 523.5)
+	// Cost is the per-category cost breakdown, populated when pricing is available.
+	Cost *BifrostCost `json:"cost,omitempty"`
 }
 
 type TranscriptionUsageInputTokenDetails struct {

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -1826,7 +1826,18 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			// provider-supplied breakdown.
 			if entry.TokenUsageParsed != nil && entry.TokenUsageParsed.Cost == nil {
 				entry.TokenUsageParsed.Cost = breakdown
+			} else if entry.TokenUsageParsed == nil {
+				// No usage carrier: OCRUsageInfo has no tokens, so OCR is never
+				// aliased into TokenUsageParsed. SerializeFields skips its cost
+				// block when TokenUsageParsed is nil, so denormalize the split
+				// directly here for the columns to reconcile to the cost column.
+				entry.InputCost = breakdown.InputCost
+				entry.OutputCost = breakdown.OutputCost
+				entry.AdditionalCost = breakdown.AdditionalCost
 			}
+			// Speech / transcription / OCR usage is not aliased into
+			// TokenUsageParsed, so write the split onto the native response too.
+			attachCostToNativeUsage(result, breakdown)
 		}
 		if bifrostErr == nil &&
 			requestType == schemas.BatchResultsRequest &&

--- a/plugins/logging/nativecost_test.go
+++ b/plugins/logging/nativecost_test.go
@@ -1,0 +1,90 @@
+package logging
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/logstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAttachCostToNativeUsage covers the speech / transcription / OCR modalities
+// whose usage object is not aliased into TokenUsageParsed, so the breakdown has
+// to be written onto the native response explicitly.
+func TestAttachCostToNativeUsage(t *testing.T) {
+	bd := &schemas.BifrostCost{InputCost: 0.002, OutputCost: 0.001, TotalCost: 0.003}
+
+	t.Run("speech", func(t *testing.T) {
+		r := &schemas.BifrostResponse{SpeechResponse: &schemas.BifrostSpeechResponse{Usage: &schemas.SpeechUsage{}}}
+		attachCostToNativeUsage(r, bd)
+		require.NotNil(t, r.SpeechResponse.Usage.Cost)
+		assert.InDelta(t, 0.003, r.SpeechResponse.Usage.Cost.TotalCost, 1e-12)
+	})
+
+	t.Run("transcription", func(t *testing.T) {
+		r := &schemas.BifrostResponse{TranscriptionResponse: &schemas.BifrostTranscriptionResponse{Usage: &schemas.TranscriptionUsage{}}}
+		attachCostToNativeUsage(r, bd)
+		require.NotNil(t, r.TranscriptionResponse.Usage.Cost)
+		assert.InDelta(t, 0.003, r.TranscriptionResponse.Usage.Cost.TotalCost, 1e-12)
+	})
+
+	t.Run("ocr", func(t *testing.T) {
+		r := &schemas.BifrostResponse{OCRResponse: &schemas.BifrostOCRResponse{UsageInfo: &schemas.OCRUsageInfo{}}}
+		attachCostToNativeUsage(r, bd)
+		require.NotNil(t, r.OCRResponse.UsageInfo.Cost)
+		assert.InDelta(t, 0.003, r.OCRResponse.UsageInfo.Cost.TotalCost, 1e-12)
+	})
+
+	t.Run("preserves provider-supplied cost", func(t *testing.T) {
+		existing := &schemas.BifrostCost{TotalCost: 9.99}
+		r := &schemas.BifrostResponse{SpeechResponse: &schemas.BifrostSpeechResponse{Usage: &schemas.SpeechUsage{Cost: existing}}}
+		attachCostToNativeUsage(r, bd)
+		assert.Same(t, existing, r.SpeechResponse.Usage.Cost)
+	})
+
+	t.Run("no usage slot is a no-op", func(t *testing.T) {
+		r := &schemas.BifrostResponse{SpeechResponse: &schemas.BifrostSpeechResponse{}}
+		attachCostToNativeUsage(r, bd)
+		assert.Nil(t, r.SpeechResponse.Usage)
+	})
+}
+
+// TestAttachCostBreakdownDenormalizesSplitWithoutUsageCarrier covers the OCR-shaped
+// case: no usage aliased into TokenUsageParsed. attachCostBreakdown must denormalize
+// the per-category split directly onto the entry columns so they reconcile to the
+// cost column (SerializeFields skips its cost block when TokenUsageParsed is nil).
+func TestAttachCostBreakdownDenormalizesSplitWithoutUsageCarrier(t *testing.T) {
+	plugin := newCostFidelityPlugin(t)
+
+	const promptTokens, completionTokens = 100, 50
+	result := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			Usage: &schemas.BifrostLLMUsage{
+				PromptTokens:     promptTokens,
+				CompletionTokens: completionTokens,
+				TotalTokens:      promptTokens + completionTokens,
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType: schemas.ChatCompletionRequest,
+				RoutingInfo: schemas.RoutingInfo{Provider: schemas.OpenAI, Model: "gpt-4o"},
+			},
+		},
+	}
+	// No usage carrier on the log entry (the OCR shape).
+	entry := &logstore.Log{Provider: string(schemas.OpenAI), Model: "gpt-4o"}
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	plugin.attachCostBreakdown(ctx, entry, result)
+
+	// gpt-4o testdata rates: input 2.5e-6/token, output 1e-5/token.
+	wantIn := float64(promptTokens) * 2.5e-6
+	wantOut := float64(completionTokens) * 1e-5
+	assert.InDelta(t, wantIn, entry.InputCost, 1e-12)
+	assert.InDelta(t, wantOut, entry.OutputCost, 1e-12)
+	assert.Zero(t, entry.AdditionalCost)
+	// The real split flowed through (both sides populated), not a lumped total.
+	assert.Positive(t, entry.InputCost)
+	assert.Positive(t, entry.OutputCost)
+}

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -599,6 +599,15 @@ func (p *LoggerPlugin) applyNonStreamingOutputToEntry(entry *logstore.Log, resul
 		} else {
 			usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
 		}
+	case result.SpeechResponse != nil && result.SpeechResponse.Usage != nil:
+		usage = &schemas.BifrostLLMUsage{
+			PromptTokens:     result.SpeechResponse.Usage.InputTokens,
+			CompletionTokens: result.SpeechResponse.Usage.OutputTokens,
+			TotalTokens:      result.SpeechResponse.Usage.TotalTokens,
+		}
+		if usage.TotalTokens == 0 {
+			usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
+		}
 	case result.ImageGenerationResponse != nil && result.ImageGenerationResponse.Usage != nil:
 		usage = &schemas.BifrostLLMUsage{}
 		usage.PromptTokens = result.ImageGenerationResponse.Usage.InputTokens
@@ -1855,16 +1864,54 @@ func normalizeLogRequestType(object string) schemas.RequestType {
 
 // attachCostBreakdown fills entry.TokenUsageParsed.Cost with the per-category
 // cost split (input / output / cache) computed from result, so log detail views
-// can surface it alongside the total. It is a no-op when pricing is
-// unavailable, usage is missing, or a breakdown is already present (e.g.
-// provider-supplied or already attached on the non-streaming path).
+// can surface it alongside the total, and also writes it onto the native typed
+// usage for modalities not aliased into TokenUsageParsed (speech, transcription,
+// OCR) so their client-facing responses carry cost too. A provider-supplied
+// breakdown already present on either target is preserved.
 func (p *LoggerPlugin) attachCostBreakdown(ctx *schemas.BifrostContext, entry *logstore.Log, result *schemas.BifrostResponse) {
-	if p.pricingManager == nil || result == nil || entry.TokenUsageParsed == nil || entry.TokenUsageParsed.Cost != nil {
+	if p.pricingManager == nil || result == nil {
 		return
 	}
 	pricingScopes := modelcatalog.PricingLookupScopesFromContext(ctx, string(entry.Provider))
-	if breakdown := p.pricingManager.CalculateCostBreakdown(result, pricingScopes); breakdown != nil {
+	breakdown := p.pricingManager.CalculateCostBreakdown(result, pricingScopes)
+	if breakdown == nil {
+		return
+	}
+	if entry.TokenUsageParsed != nil && entry.TokenUsageParsed.Cost == nil {
 		entry.TokenUsageParsed.Cost = breakdown
+	} else if entry.TokenUsageParsed == nil {
+		// No usage carrier (e.g. OCR: OCRUsageInfo has no tokens, so it is never
+		// aliased into TokenUsageParsed). SerializeFields skips its cost block when
+		// TokenUsageParsed is nil, so denormalize the split directly here for the
+		// columns to reconcile to the cost column.
+		entry.InputCost = breakdown.InputCost
+		entry.OutputCost = breakdown.OutputCost
+		entry.AdditionalCost = breakdown.AdditionalCost
+	}
+	attachCostToNativeUsage(result, breakdown)
+}
+
+// attachCostToNativeUsage writes the cost breakdown onto the native typed usage
+// for speech, transcription, and OCR responses. Unlike chat/embedding (whose
+// usage pointer is aliased into TokenUsageParsed and thus already carries cost),
+// these modalities build a separate usage object, so the client-facing response
+// would otherwise never see cost. No-op when the usage slot is absent or a
+// provider already supplied a breakdown.
+func attachCostToNativeUsage(result *schemas.BifrostResponse, breakdown *schemas.BifrostCost) {
+	if result == nil || breakdown == nil {
+		return
+	}
+	switch {
+	case result.SpeechResponse != nil && result.SpeechResponse.Usage != nil && result.SpeechResponse.Usage.Cost == nil:
+		result.SpeechResponse.Usage.Cost = breakdown
+	case result.SpeechStreamResponse != nil && result.SpeechStreamResponse.Usage != nil && result.SpeechStreamResponse.Usage.Cost == nil:
+		result.SpeechStreamResponse.Usage.Cost = breakdown
+	case result.TranscriptionResponse != nil && result.TranscriptionResponse.Usage != nil && result.TranscriptionResponse.Usage.Cost == nil:
+		result.TranscriptionResponse.Usage.Cost = breakdown
+	case result.TranscriptionStreamResponse != nil && result.TranscriptionStreamResponse.Usage != nil && result.TranscriptionStreamResponse.Usage.Cost == nil:
+		result.TranscriptionStreamResponse.Usage.Cost = breakdown
+	case result.OCRResponse != nil && result.OCRResponse.UsageInfo != nil && result.OCRResponse.UsageInfo.Cost == nil:
+		result.OCRResponse.UsageInfo.Cost = breakdown
 	}
 }
 


### PR DESCRIPTION
## Summary

Cost breakdowns were not being propagated to the native usage objects for speech, transcription, and OCR responses. Because these modalities do not alias their usage into `TokenUsageParsed`, the computed cost split was silently dropped — leaving client-facing responses without cost data and log entry columns unreconciled when no usage carrier was present.

## Changes

- Added a `Cost *BifrostCost` field to `SpeechUsage`, `TranscriptionUsage`, and `OCRUsageInfo` so these modalities can carry a per-category cost breakdown in their responses.
- Introduced `attachCostToNativeUsage` to write the computed breakdown onto speech, transcription, and OCR usage objects (both streaming and non-streaming), preserving any provider-supplied cost already present.
- Relaxed the early-return guard in `attachCostBreakdown` so it no longer bails out when `TokenUsageParsed` is nil; instead, when there is no usage carrier (e.g. OCR), it denormalizes the split directly onto the log entry's `InputCost`, `OutputCost`, and `AdditionalCost` columns so they reconcile to the cost column.
- Fixed `applyNonStreamingOutputToEntry` to alias `SpeechResponse.Usage` token counts into a `BifrostLLMUsage` struct, consistent with how other modalities are handled.
- Added `nativecost_test.go` covering `attachCostToNativeUsage` across all three modalities, the provider-supplied cost preservation case, the no-usage-slot no-op case, and the denormalization path for entries without a usage carrier.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/logging/... -run TestAttachCostToNativeUsage
go test ./plugins/logging/... -run TestAttachCostBreakdownDenormalizesSplitWithoutUsageCarrier
go test ./...
```

After running, verify that speech, transcription, and OCR responses include a populated `cost` field in their usage objects when pricing data is available, and that log entries for OCR requests have non-zero `input_cost`/`output_cost` columns.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable