### PR TITLE
fix: populate cost breakdown on fallback billing paths

### DIFF
--- a/framework/modelcatalog/datasheet/cost.go
+++ b/framework/modelcatalog/datasheet/cost.go
@@ -81,10 +81,25 @@ func (s *Store) CalculateCostBreakdown(result *schemas.BifrostResponse, scopes *
 // cancelled request via BifrostError.ExtraFields.BilledUsage: the
 // provider consumed tokens, so we must charge for them even though there is no
 // success response to read. It mirrors CalculateCost's compute path so success
-// and failure billing use identical rates. Returns 0 when usage is nil.
+// and failure billing use identical rates. Returns 0 when usage is nil. A thin
+// wrapper over CalculateCostBreakdownForUsage returning only the total, so both
+// paths compute cost identically.
 func (s *Store) CalculateCostForUsage(usage *schemas.BifrostLLMUsage, provider schemas.ModelProvider, model string, requestType schemas.RequestType, scopes *LookupScopes) float64 {
-	if usage == nil {
+	breakdown := s.CalculateCostBreakdownForUsage(usage, provider, model, requestType, scopes)
+	if breakdown == nil {
 		return 0
+	}
+	return breakdown.TotalCost
+}
+
+// CalculateCostBreakdownForUsage mirrors CalculateCostForUsage but returns the
+// full per-category breakdown instead of only the total, so callers billing a
+// bare usage object (failed/cancelled requests) can denormalize the input /
+// output / additional split, not just the scalar total. Returns nil when there
+// is no cost to record.
+func (s *Store) CalculateCostBreakdownForUsage(usage *schemas.BifrostLLMUsage, provider schemas.ModelProvider, model string, requestType schemas.RequestType, scopes *LookupScopes) *schemas.BifrostCost {
+	if usage == nil {
+		return nil
 	}
 
 	var lookupScopes LookupScopes
@@ -94,7 +109,7 @@ func (s *Store) CalculateCostForUsage(usage *schemas.BifrostLLMUsage, provider s
 
 	// If the provider already computed cost, trust it (matches calculateBaseCost).
 	if usage.Cost != nil && usage.Cost.TotalCost > 0 {
-		return usage.Cost.TotalCost
+		return usage.Cost
 	}
 
 	// Apply the served tier (fast mode / data residency) carried on the usage so
@@ -102,7 +117,7 @@ func (s *Store) CalculateCostForUsage(usage *schemas.BifrostLLMUsage, provider s
 	input := costInput{usage: usage}
 	input.tier = tierFromResponse(nil, usage.Speed, usage.InferenceGeo)
 
-	breakdown := s.computeCostFromInput(
+	return s.computeCostFromInput(
 		input,
 		schemas.RoutingInfo{
 			Provider:                provider,
@@ -112,10 +127,6 @@ func (s *Store) CalculateCostForUsage(usage *schemas.BifrostLLMUsage, provider s
 		normalizeStreamRequestType(requestType),
 		lookupScopes,
 	)
-	if breakdown == nil {
-		return 0
-	}
-	return breakdown.TotalCost
 }
 
 // CalculateGuardrailCost computes judge cost when no parent response is available.

--- a/framework/modelcatalog/datasheet/cost_test.go
+++ b/framework/modelcatalog/datasheet/cost_test.go
@@ -3974,6 +3974,26 @@ func TestCalculateCostForUsage_MatchesCalculateCost(t *testing.T) {
 	assert.Equal(t, respCost, usageCost, "bare-usage cost must equal full-response cost")
 }
 
+// TestCalculateCostBreakdownForUsage_CarriesSplit verifies the breakdown variant
+// returns the same total as the scalar path and carries the input/output split
+// so bare-usage billing can denormalize per category.
+func TestCalculateCostBreakdownForUsage_CarriesSplit(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("gpt-4o", "openai", "chat"): chatPricing(0.000005, 0.000015),
+	})
+
+	usage := &schemas.BifrostLLMUsage{PromptTokens: 1000, CompletionTokens: 500, TotalTokens: 1500}
+
+	bd := s.CalculateCostBreakdownForUsage(usage, schemas.OpenAI, "gpt-4o", schemas.ChatCompletionRequest, nil)
+	require.NotNil(t, bd)
+	// 1000*0.000005 input, 500*0.000015 output.
+	assert.InDelta(t, 0.005, bd.InputCost, 1e-12)
+	assert.InDelta(t, 0.0075, bd.OutputCost, 1e-12)
+	assert.InDelta(t, bd.TotalCost, bd.InputCost+bd.OutputCost+bd.AdditionalCost, 1e-12)
+	// Total matches the scalar path exactly.
+	assert.Equal(t, s.CalculateCostForUsage(usage, schemas.OpenAI, "gpt-4o", schemas.ChatCompletionRequest, nil), bd.TotalCost)
+}
+
 // TestCalculateCostForUsage_NilUsageIsZero verifies the helper bills nothing
 // when there is no usage (e.g. a failure that consumed no tokens).
 func TestCalculateCostForUsage_NilUsageIsZero(t *testing.T) {

--- a/framework/modelcatalog/pricing.go
+++ b/framework/modelcatalog/pricing.go
@@ -73,6 +73,13 @@ func (mc *ModelCatalog) CalculateCostForUsage(usage *schemas.BifrostLLMUsage, pr
 	return mc.datasheet.CalculateCostForUsage(usage, provider, model, requestType, (*datasheet.LookupScopes)(scopes))
 }
 
+// CalculateCostBreakdownForUsage computes the per-category cost breakdown from a
+// bare usage object when no full BifrostResponse is available. TotalCost equals
+// what CalculateCostForUsage returns for the same usage.
+func (mc *ModelCatalog) CalculateCostBreakdownForUsage(usage *schemas.BifrostLLMUsage, provider schemas.ModelProvider, model string, requestType schemas.RequestType, scopes *PricingLookupScopes) *schemas.BifrostCost {
+	return mc.datasheet.CalculateCostBreakdownForUsage(usage, provider, model, requestType, (*datasheet.LookupScopes)(scopes))
+}
+
 // CalculateGuardrailCost computes the aggregate cost of guardrail judge calls.
 func (mc *ModelCatalog) CalculateGuardrailCost(debug *schemas.BifrostGuardrailDebug, scopes *PricingLookupScopes) float64 {
 	return mc.datasheet.CalculateGuardrailCost(debug, (*datasheet.LookupScopes)(scopes))

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -255,15 +255,22 @@ func (p *LoggerPlugin) applyErrorBillingFromBilledUsage(ctx *schemas.BifrostCont
 		return
 	}
 	if entry.TokenUsageParsed == nil {
-		entry.TokenUsageParsed = billed
+		usageCopy := *billed
+		entry.TokenUsageParsed = &usageCopy
 		entry.PromptTokens = billed.PromptTokens
 		entry.CompletionTokens = billed.CompletionTokens
 		entry.TotalTokens = billed.TotalTokens
 	}
 	if entry.Cost == nil && p.pricingManager != nil {
 		pricingScopes := modelcatalog.PricingLookupScopesFromContext(ctx, string(entry.Provider))
-		if cost := p.pricingManager.CalculateCostForUsage(billed, schemas.ModelProvider(entry.Provider), entry.Model, requestType, pricingScopes); cost > 0 {
-			entry.Cost = &cost
+		if bd := p.pricingManager.CalculateCostBreakdownForUsage(billed, schemas.ModelProvider(entry.Provider), entry.Model, requestType, pricingScopes); bd != nil && bd.TotalCost > 0 {
+			total := bd.TotalCost
+			entry.Cost = &total
+			// Attach the breakdown to the stored usage so SerializeFields
+			// denormalizes the input/output/additional split, not just the total.
+			if entry.TokenUsageParsed != nil && entry.TokenUsageParsed.Cost == nil {
+				entry.TokenUsageParsed.Cost = bd
+			}
 		}
 	}
 }
@@ -285,21 +292,43 @@ func (p *LoggerPlugin) applyInternalCallCosts(ctx *schemas.BifrostContext, entry
 		return
 	}
 	pricingScopes := modelcatalog.PricingLookupScopesFromContext(ctx, string(entry.Provider))
-	var cost float64
+	var cacheCost, guardrailCost float64
 	if cacheDebug, ok := schemas.CacheDebugFromContext(ctx); ok {
-		cost += p.pricingManager.CalculateCacheEmbeddingCost(cacheDebug, pricingScopes)
+		cacheCost = p.pricingManager.CalculateCacheEmbeddingCost(cacheDebug, pricingScopes)
 	}
 	if guardrailDebug != nil {
-		cost += p.pricingManager.CalculateGuardrailCost(guardrailDebug, pricingScopes)
+		guardrailCost = p.pricingManager.CalculateGuardrailCost(guardrailDebug, pricingScopes)
 	}
+	cost := cacheCost + guardrailCost
 	if cost <= 0 {
 		return
 	}
 	if entry.Cost == nil {
 		entry.Cost = &cost
-		return
+	} else {
+		*entry.Cost += cost
 	}
-	*entry.Cost += cost
+
+	// Denormalize the split too: the cache embedding lookup is an input cost, the
+	// guardrail judge call an additional one. When a usage carrier exists, merge
+	// onto its breakdown (SerializeFields denormalizes from there); otherwise
+	// there is no carrier to synthesize (that would suppress the deferred-usage
+	// watcher), so write the split columns directly.
+	sidecar := &schemas.BifrostCost{TotalCost: cost}
+	if cacheCost > 0 {
+		sidecar.InputCost = cacheCost
+		sidecar.InputCostDetails = &schemas.InputCostDetails{TextCost: cacheCost}
+	}
+	if guardrailCost > 0 {
+		sidecar.AdditionalCost = guardrailCost
+		sidecar.AdditionalCostDetails = &schemas.AdditionalCostDetails{GuardrailCost: guardrailCost}
+	}
+	if entry.TokenUsageParsed != nil {
+		entry.TokenUsageParsed.Cost = entry.TokenUsageParsed.Cost.Add(sidecar)
+	} else {
+		entry.InputCost += cacheCost
+		entry.AdditionalCost += guardrailCost
+	}
 }
 
 const (

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -920,6 +920,62 @@ func TestApplyErrorBillingFromBilledUsage_ComputesCostWhenTokensAlreadyParsed(t 
 	if entry.PromptTokens != promptTokens || entry.TotalTokens != promptTokens+completionTokens {
 		t.Fatalf("token counters mutated: prompt=%d total=%d", entry.PromptTokens, entry.TotalTokens)
 	}
+	// The breakdown must ride on the usage so the denormalized split populates,
+	// not just the scalar total (Discrepancy B: failed/cancelled billing).
+	if entry.TokenUsageParsed.Cost == nil {
+		t.Fatal("expected cost breakdown attached to usage for the denormalized split")
+	}
+	if err := entry.SerializeFields(); err != nil {
+		t.Fatalf("SerializeFields: %v", err)
+	}
+	wantIn := float64(promptTokens) * 2.5e-6
+	wantOut := float64(completionTokens) * 1e-5
+	if d := entry.InputCost - wantIn; d < -1e-9 || d > 1e-9 {
+		t.Fatalf("input_cost %v != %v", entry.InputCost, wantIn)
+	}
+	if d := entry.OutputCost - wantOut; d < -1e-9 || d > 1e-9 {
+		t.Fatalf("output_cost %v != %v", entry.OutputCost, wantOut)
+	}
+}
+
+// TestApplyInternalCallCosts_DenormalizesGuardrailToAdditional guards Discrepancy
+// B for internal-only sidecar costs: a guardrail judge call with no provider
+// response must land on the additional side of the split, not just the total,
+// and must not leak into input/output.
+func TestApplyInternalCallCosts_DenormalizesGuardrailToAdditional(t *testing.T) {
+	store := newTestStore(t)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, newTestPricingManager(t), nil)
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	entry := &logstore.Log{Provider: string(schemas.OpenAI), Model: "gpt-4o"}
+	guardrail := &schemas.BifrostGuardrailDebug{
+		JudgeCalls: []schemas.BifrostGuardrailJudgeCall{{
+			JudgeProvider:    schemas.OpenAI,
+			JudgeModel:       "gpt-4o",
+			PromptTokens:     100,
+			CompletionTokens: 50,
+			TotalTokens:      150,
+		}},
+	}
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	plugin.applyInternalCallCosts(ctx, entry, guardrail)
+
+	want := float64(100)*2.5e-6 + float64(50)*1e-5
+	if entry.Cost == nil {
+		t.Fatal("expected guardrail cost on entry.Cost")
+	}
+	if d := *entry.Cost - want; d < -1e-9 || d > 1e-9 {
+		t.Fatalf("entry.Cost %v != guardrail %v", *entry.Cost, want)
+	}
+	// No usage carrier exists, so the split is written directly on the columns.
+	if d := entry.AdditionalCost - want; d < -1e-9 || d > 1e-9 {
+		t.Fatalf("additional_cost %v != guardrail %v", entry.AdditionalCost, want)
+	}
+	if entry.InputCost != 0 || entry.OutputCost != 0 {
+		t.Fatalf("guardrail-only cost must not populate input/output: in=%v out=%v", entry.InputCost, entry.OutputCost)
+	}
 }
 
 // TestApplyErrorBillingFromBilledUsage_FillsTokensAndCostWhenUnparsed pins the


### PR DESCRIPTION
## Summary

Failed and cancelled requests were only recording a scalar total cost, losing the per-category input/output/additional split. This meant that when `SerializeFields` denormalized cost columns, those fields were left empty even though a total was present. This PR introduces `CalculateCostBreakdownForUsage` to expose the full `BifrostCost` breakdown for bare-usage billing paths, and wires it through the logging plugin so both error billing and internal sidecar costs (guardrail judge calls, cache embedding lookups) correctly populate the split columns.

## Changes

- Added `CalculateCostBreakdownForUsage` to the datasheet `Store` and `ModelCatalog`, returning the full `*schemas.BifrostCost` instead of only the total. `CalculateCostForUsage` is now a thin wrapper over it.
- In `applyErrorBillingFromBilledUsage`, switched from `CalculateCostForUsage` to `CalculateCostBreakdownForUsage` and attaches the resulting breakdown to `entry.TokenUsageParsed.Cost` so `SerializeFields` can denormalize the input/output/additional split for failed/cancelled requests.
- In `applyInternalCallCosts`, separated cache and guardrail costs into named variables and built a sidecar `BifrostCost` that maps cache embedding cost to `InputCost` and guardrail judge cost to `AdditionalCost`. When a usage carrier exists the sidecar is merged onto it via `Cost.Add`; when no carrier exists the split is written directly to the log entry's cost columns.
- Added `TestCalculateCostBreakdownForUsage_CarriesSplit` to verify the breakdown variant returns the correct per-category values and that its total matches the scalar path exactly.
- Extended `TestApplyErrorBillingFromBilledUsage_ComputesCostWhenTokensAlreadyParsed` to assert the breakdown is attached to the usage and that `SerializeFields` produces correct `InputCost`/`OutputCost` columns.
- Added `TestApplyInternalCallCosts_DenormalizesGuardrailToAdditional` to verify guardrail-only sidecar cost lands on `AdditionalCost` and does not bleed into `InputCost`/`OutputCost`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/modelcatalog/datasheet/... ./plugins/logging/...
```

Expected: all existing and new tests pass. Verify that log entries for failed/cancelled requests now carry non-zero `input_cost` and `output_cost` columns in addition to the total, and that guardrail-only entries populate `additional_cost` without touching `input_cost` or `output_cost`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. Changes are limited to cost accounting and log entry population; no auth, secrets, or PII handling is affected.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable