### PR TITLE
feat: expose input/output/additional cost split in quota API

### DIFF
--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -71,6 +71,11 @@ SELECT
     COALESCE(SUM(total_tokens), 0) AS total_tokens,
     COALESCE(SUM(cached_read_tokens), 0) AS total_cached_read_tokens,
     COALESCE(SUM(cost), 0) AS total_cost,
+    -- Per-category cost split, denormalized on the logs rows, so quota/usage can
+    -- surface input vs output vs additional (guardrail/MCP) alongside the total.
+    COALESCE(SUM(input_cost), 0) AS total_input_cost,
+    COALESCE(SUM(output_cost), 0) AS total_output_cost,
+    COALESCE(SUM(additional_cost), 0) AS total_additional_cost,
     -- Cache-hit measures precomputed from cache_debug so /api/logs/stats can
     -- serve them from the hybrid instead of a full-window raw scan. Safe to
     -- materialize: cache_debug is written with the terminal status and never
@@ -145,6 +150,9 @@ var mvLogsHourlyRequiredColumns = []string{
 	"total_tokens",
 	"total_cached_read_tokens",
 	"total_cost",
+	"total_input_cost",
+	"total_output_cost",
+	"total_additional_cost",
 	"avg_overhead",
 	"p90_overhead",
 	"p95_overhead",
@@ -2291,6 +2299,9 @@ func (s *RDBLogStore) getModelRankingsFromMatView(ctx context.Context, filters S
 		AvgLatency         float64        `gorm:"column:avg_lat"`
 		TotalTokens        int64          `gorm:"column:total_tkns"`
 		TotalCost          float64        `gorm:"column:total_cost"`
+		InputCost          float64        `gorm:"column:total_input_cost"`
+		OutputCost         float64        `gorm:"column:total_output_cost"`
+		AdditionalCost     float64        `gorm:"column:total_additional_cost"`
 		TPCompletionTokens int64          `gorm:"column:tp_completion_tokens"`
 		TPLatencyMs        float64        `gorm:"column:tp_latency_ms"`
 	}
@@ -2305,6 +2316,9 @@ func (s *RDBLogStore) getModelRankingsFromMatView(ctx context.Context, filters S
 		CASE WHEN SUM(count) > 0 THEN SUM(avg_latency * count) / SUM(count) ELSE 0 END AS avg_lat,
 		SUM(total_tokens) AS total_tkns,
 		SUM(total_cost) AS total_cost,
+		SUM(total_input_cost) AS total_input_cost,
+		SUM(total_output_cost) AS total_output_cost,
+		SUM(total_additional_cost) AS total_additional_cost,
 		COALESCE(SUM(CASE WHEN status = 'success' THEN throughput_completion_tokens ELSE 0 END), 0) AS tp_completion_tokens,
 		COALESCE(SUM(CASE WHEN status = 'success' THEN throughput_latency_ms ELSE 0 END), 0) AS tp_latency_ms
 	`).Group("model, provider").
@@ -2372,15 +2386,18 @@ func (s *RDBLogStore) getModelRankingsFromMatView(ctx context.Context, filters S
 			successRate = float64(r.SuccessCount) / float64(r.Total) * 100
 		}
 		entry := ModelRankingEntry{
-			Model:         r.Model,
-			Provider:      r.Provider,
-			TotalRequests: r.Total,
-			SuccessCount:  r.SuccessCount,
-			SuccessRate:   successRate,
-			TotalTokens:   r.TotalTokens,
-			TotalCost:     r.TotalCost,
-			AvgLatency:    r.AvgLatency,
-			Throughput:    tokensPerSecond(r.TPCompletionTokens, r.TPLatencyMs),
+			Model:          r.Model,
+			Provider:       r.Provider,
+			TotalRequests:  r.Total,
+			SuccessCount:   r.SuccessCount,
+			SuccessRate:    successRate,
+			TotalTokens:    r.TotalTokens,
+			TotalCost:      r.TotalCost,
+			InputCost:      r.InputCost,
+			OutputCost:     r.OutputCost,
+			AdditionalCost: r.AdditionalCost,
+			AvgLatency:     r.AvgLatency,
+			Throughput:     tokensPerSecond(r.TPCompletionTokens, r.TPLatencyMs),
 		}
 		if r.CanonicalName.Valid {
 			entry.CanonicalModelName = &r.CanonicalName.String

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -292,6 +292,7 @@ var logstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"logs_add_upstream_and_overhead_latency_columns"}, run: migrationAddUpstreamAndOverheadLatencyColumns},
 	{IDs: []string{"logs_add_batch_debug_column"}, run: migrationAddBatchDebugColumn},
 	{IDs: []string{"logs_add_cost_breakdown_columns"}, run: migrationAddCostBreakdownColumns},
+	{IDs: []string{"logs_recreate_matviews_with_cost_breakdown"}, run: migrationRecreateMatViewsWithCostBreakdown},
 }
 
 // areThereAnyPendingMigrations returns true if there are any pending migrations to be applied.
@@ -3498,6 +3499,34 @@ func migrationRecreateMatViewsWithUserAgentColumn(ctx context.Context, db *gorm.
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while recreating matviews with app column: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationRecreateMatViewsWithCostBreakdown is a marker migration: the actual
+// rebuild of mv_logs_hourly (now carrying total_input_cost / total_output_cost /
+// total_additional_cost alongside total_cost) happens on the next PostgreSQL
+// startup via ensureMatViews / repairMatViewShapes, which detect the new required
+// columns and drop+recreate the drifted view. The rebuild is deferred to startup
+// (not done inline here) to avoid heavy AccessExclusiveLock churn during rolling
+// deploys on large logs tables.
+func migrationRecreateMatViewsWithCostBreakdown(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: "logs_recreate_matviews_with_cost_breakdown",
+		Migrate: func(tx *gorm.DB) error {
+			// No-op: the drifted mv_logs_hourly is dropped and recreated on the
+			// next startup by repairMatViewShapes once it sees the new columns.
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			// No rollback needed — ensureMatViews recreates on next startup.
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while recreating matviews with cost breakdown columns: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -2577,9 +2577,13 @@ func (s *RDBLogStore) GetModelRankings(ctx context.Context, filters SearchFilter
 		COALESCE(SUM(CASE WHEN status = 'success' AND latency > 0 THEN completion_tokens ELSE 0 END), 0) as tp_completion_tokens,
 		COALESCE(SUM(CASE WHEN status = 'success' AND latency > 0 THEN latency ELSE 0 END), 0) as tp_latency_ms
 	`
-	// Only the current-period query scans canonical_name; keeping it out of the
-	// shared clause spares the previous-period query a discarded aggregate.
-	currentSelectClause := "MAX(NULLIF(canonical_model_name, '')) as canonical_name," + selectClause
+	// Only the current-period query scans canonical_name and the per-category cost
+	// split; keeping them out of the shared clause spares the previous-period
+	// query aggregates it discards (trend compares totals only).
+	currentSelectClause := "MAX(NULLIF(canonical_model_name, '')) as canonical_name," + selectClause + `,
+		COALESCE(SUM(input_cost), 0) as total_input_cost,
+		COALESCE(SUM(output_cost), 0) as total_output_cost,
+		COALESCE(SUM(additional_cost), 0) as total_additional_cost`
 
 	// Query current period
 	currentQuery := s.ScopedDB(ctx).Model(&Log{})
@@ -2595,6 +2599,9 @@ func (s *RDBLogStore) GetModelRankings(ctx context.Context, filters SearchFilter
 		SuccessCount       int64           `gorm:"column:success_count"`
 		TotalTokens        sql.NullInt64   `gorm:"column:total_tokens"`
 		TotalCost          sql.NullFloat64 `gorm:"column:total_cost"`
+		InputCost          sql.NullFloat64 `gorm:"column:total_input_cost"`
+		OutputCost         sql.NullFloat64 `gorm:"column:total_output_cost"`
+		AdditionalCost     sql.NullFloat64 `gorm:"column:total_additional_cost"`
 		AvgLatency         sql.NullFloat64 `gorm:"column:avg_latency"`
 		TPCompletionTokens int64           `gorm:"column:tp_completion_tokens"`
 		TPLatencyMs        float64         `gorm:"column:tp_latency_ms"`
@@ -2678,14 +2685,17 @@ func (s *RDBLogStore) GetModelRankings(ctx context.Context, filters SearchFilter
 	rankings := make([]ModelRankingWithTrend, len(currentResults))
 	for i, r := range currentResults {
 		entry := ModelRankingEntry{
-			Model:         r.Model,
-			Provider:      r.Provider,
-			TotalRequests: r.TotalRequests,
-			SuccessCount:  r.SuccessCount,
-			TotalTokens:   r.TotalTokens.Int64,
-			TotalCost:     r.TotalCost.Float64,
-			AvgLatency:    r.AvgLatency.Float64,
-			Throughput:    tokensPerSecond(r.TPCompletionTokens, r.TPLatencyMs),
+			Model:          r.Model,
+			Provider:       r.Provider,
+			TotalRequests:  r.TotalRequests,
+			SuccessCount:   r.SuccessCount,
+			TotalTokens:    r.TotalTokens.Int64,
+			TotalCost:      r.TotalCost.Float64,
+			InputCost:      r.InputCost.Float64,
+			OutputCost:     r.OutputCost.Float64,
+			AdditionalCost: r.AdditionalCost.Float64,
+			AvgLatency:     r.AvgLatency.Float64,
+			Throughput:     tokensPerSecond(r.TPCompletionTokens, r.TPLatencyMs),
 		}
 		if r.CanonicalName.Valid {
 			entry.CanonicalModelName = &r.CanonicalName.String

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -1968,7 +1968,12 @@ type ModelRankingEntry struct {
 	SuccessRate        float64 `json:"success_rate"`
 	TotalTokens        int64   `json:"total_tokens"`
 	TotalCost          float64 `json:"total_cost"`
-	AvgLatency         float64 `json:"avg_latency"`
+	// Per-category cost split; sums to TotalCost. AdditionalCost holds internal
+	// sidecar costs with no input/output token category (guardrail, MCP).
+	InputCost      float64 `json:"input_cost"`
+	OutputCost     float64 `json:"output_cost"`
+	AdditionalCost float64 `json:"additional_cost"`
+	AvgLatency     float64 `json:"avg_latency"`
 	// Throughput is aggregate token-generation rate (tokens/sec) for this model:
 	// SUM(completion_tokens) / (SUM(latency_ms)/1000) over successful rows with
 	// latency > 0 — the same definition as the throughput histogram.

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -4791,6 +4791,11 @@ type quotaModelSpend struct {
 	TotalRequests int64   `json:"total_requests"`
 	TotalTokens   int64   `json:"total_tokens"`
 	TotalCost     float64 `json:"total_cost"`
+	// Per-category cost split; sums to TotalCost. AdditionalCost holds internal
+	// sidecar costs with no input/output token category (guardrail, MCP).
+	InputCost      float64 `json:"input_cost"`
+	OutputCost     float64 `json:"output_cost"`
+	AdditionalCost float64 `json:"additional_cost"`
 }
 
 // quotaBudget is a VK budget plus the actual per-model spend (from request logs) accumulated
@@ -4832,11 +4837,14 @@ func (h *GovernanceHandler) buildBudgetsWithUsage(ctx context.Context, vkID, usa
 			if ranking != nil {
 				for _, r := range ranking.Rankings {
 					entry.Models = append(entry.Models, quotaModelSpend{
-						Model:         r.Model,
-						Provider:      r.Provider,
-						TotalRequests: r.TotalRequests,
-						TotalTokens:   r.TotalTokens,
-						TotalCost:     r.TotalCost,
+						Model:          r.Model,
+						Provider:       r.Provider,
+						TotalRequests:  r.TotalRequests,
+						TotalTokens:    r.TotalTokens,
+						TotalCost:      r.TotalCost,
+						InputCost:      r.InputCost,
+						OutputCost:     r.OutputCost,
+						AdditionalCost: r.AdditionalCost,
 					})
 				}
 			}


### PR DESCRIPTION
## Summary

Exposes per-category cost breakdown (`input_cost`, `output_cost`, `additional_cost`) on model ranking entries so that quota/usage surfaces can show how total cost is distributed across input tokens, output tokens, and additional sidecar costs (guardrails, MCP) rather than only the aggregate total.

## Changes

- Added `total_input_cost`, `total_output_cost`, and `total_additional_cost` columns to the `mv_logs_hourly` materialized view definition and its required-columns guard list. The view is rebuilt on next startup via `repairMatViewShapes` rather than inline during migration to avoid `AccessExclusiveLock` contention on large logs tables during rolling deploys.
- Added a marker migration (`logs_recreate_matviews_with_cost_breakdown`) that records the schema intent without performing the rebuild itself.
- Extended `getModelRankingsFromMatView` to select and aggregate the three new cost columns from the matview, and mapped them into `ModelRankingEntry`.
- Extended the raw-scan path in `GetModelRankings` to include the per-category cost aggregates in the current-period select clause only (the previous-period query compares totals and discards these fields, so they are excluded to avoid unnecessary aggregation).
- Added `InputCost`, `OutputCost`, and `AdditionalCost` fields to `ModelRankingEntry` with JSON serialization.
- Propagated the three cost fields into `quotaModelSpend` in the governance handler so the budget/usage API response includes the breakdown alongside the existing total.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/logstore/... ./transports/bifrost-http/handlers/...
```

1. Deploy with the migration applied. On startup, `repairMatViewShapes` will detect the missing columns in `mv_logs_hourly` and drop/recreate the view.
2. After the view is rebuilt, call `/api/logs/model-rankings` and confirm `input_cost`, `output_cost`, and `additional_cost` appear on each ranking entry and sum to `total_cost`.
3. Call the quota/budgets endpoint for a virtual key with spend and confirm the per-model entries include the three cost fields.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new auth surfaces, secrets, or PII exposure. The cost fields are derived from existing log data already accessible through the rankings and quota APIs.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable