### PR TITLE
fix: adds split cost calculation to Clickhouse and recalculation flows

### DIFF
--- a/framework/logstore/clickhousestore.go
+++ b/framework/logstore/clickhousestore.go
@@ -401,7 +401,7 @@ func (s *ClickHouseLogStore) Update(ctx context.Context, id string, entry any) e
 // BulkUpdateCost backfills costs by reading each chunk of rows, patching cost,
 // and re-inserting. Reading the full row is required because the re-insert must
 // reproduce every column (the ReplacingMergeTree dedup key includes timestamp).
-func (s *ClickHouseLogStore) BulkUpdateCost(ctx context.Context, updates map[string]float64) error {
+func (s *ClickHouseLogStore) BulkUpdateCost(ctx context.Context, updates map[string]CostUpdate) error {
 	if len(updates) == 0 {
 		return nil
 	}
@@ -425,8 +425,12 @@ func (s *ClickHouseLogStore) BulkUpdateCost(ctx context.Context, updates map[str
 				return nil
 			}
 			for _, r := range rows {
-				cost := updates[r.ID]
+				u := updates[r.ID]
+				cost := u.Total
 				r.Cost = &cost
+				r.InputCost = u.Input
+				r.OutputCost = u.Output
+				r.AdditionalCost = u.Additional
 			}
 			return s.chReinsert(ctx, &rows)
 		}(); err != nil {

--- a/framework/logstore/clickhousestore_test.go
+++ b/framework/logstore/clickhousestore_test.go
@@ -439,24 +439,30 @@ func TestClickHouseBulkUpdateCost(t *testing.T) {
 	ctx := context.Background()
 	ts := time.Now().UTC().Truncate(time.Millisecond)
 
-	updates := map[string]float64{}
+	updates := map[string]CostUpdate{}
 	for i := 0; i < 5; i++ {
 		id := fmt.Sprintf("ch-cost-%d", i)
 		require.NoError(t, store.CreateIfNotExists(ctx, chTestLog(id, ts.Add(time.Duration(i)*time.Millisecond))))
-		updates[id] = float64(i) * 0.1
+		total := float64(i) * 0.1
+		updates[id] = CostUpdate{Total: total, Input: total * 0.6, Output: total * 0.3, Additional: total * 0.1}
 	}
 	// Unknown ids must be ignored, not error.
-	updates["ch-cost-missing"] = 9.9
+	updates["ch-cost-missing"] = CostUpdate{Total: 9.9, Input: 9.9}
 
 	require.NoError(t, store.BulkUpdateCost(ctx, updates))
 	require.NoError(t, store.BulkUpdateCost(ctx, nil)) // no-op
 
 	for i := 0; i < 5; i++ {
 		id := fmt.Sprintf("ch-cost-%d", i)
+		total := float64(i) * 0.1
 		found, err := store.FindByID(ctx, id)
 		require.NoError(t, err)
 		require.NotNil(t, found.Cost, "cost missing for %s", id)
-		assert.InDelta(t, float64(i)*0.1, *found.Cost, 1e-9)
+		assert.InDelta(t, total, *found.Cost, 1e-9)
+		// The per-category split is reprice too, reconciling to the total.
+		assert.InDelta(t, total*0.6, found.InputCost, 1e-9)
+		assert.InDelta(t, total*0.3, found.OutputCost, 1e-9)
+		assert.InDelta(t, total*0.1, found.AdditionalCost, 1e-9)
 		assert.Equal(t, int64(1), chCountRows(t, store.db, "logs", id))
 	}
 }

--- a/framework/logstore/hybrid.go
+++ b/framework/logstore/hybrid.go
@@ -976,9 +976,10 @@ func (h *HybridLogStore) GetDimensionLatencyHistogram(ctx context.Context, filte
 	return h.inner.GetDimensionLatencyHistogram(ctx, filters, bucketSizeSeconds, dimension)
 }
 
-// BulkUpdateCost delegates to the inner store and updates the cost column
-// for each (logID -> cost) pair in a single round trip.
-func (h *HybridLogStore) BulkUpdateCost(ctx context.Context, updates map[string]float64) error {
+// BulkUpdateCost delegates to the inner store and updates the cost columns
+// (total + input/output/additional split) for each (logID -> CostUpdate) pair
+// in a single round trip.
+func (h *HybridLogStore) BulkUpdateCost(ctx context.Context, updates map[string]CostUpdate) error {
 	return h.inner.BulkUpdateCost(ctx, updates)
 }
 

--- a/framework/logstore/logstoreparity_test.go
+++ b/framework/logstore/logstoreparity_test.go
@@ -1016,7 +1016,7 @@ func TestLogStoreParity(t *testing.T) {
 		})
 		t.Run("bulk_update_cost", func(t *testing.T) {
 			runOnAll(t, stores, func(ctx context.Context, s LogStore) error {
-				return s.BulkUpdateCost(ctx, map[string]float64{"p1": 0.9, "p4": 2.9})
+				return s.BulkUpdateCost(ctx, map[string]CostUpdate{"p1": {Total: 0.9, Input: 0.9}, "p4": {Total: 2.9, Input: 2.9}})
 			})
 			assertParity(t, stores, 1e-6, func(ctx context.Context, s LogStore) (any, error) {
 				var costs []map[string]any

--- a/framework/logstore/payload.go
+++ b/framework/logstore/payload.go
@@ -189,7 +189,7 @@ type BillingPayloadBackfill struct {
 //
 // Safe because pricing is the last thing that reads these: the recalc job keeps only
 // the ID, timestamp and computed cost afterwards, and the rows are never written back
-// (BulkUpdateCost takes an id → cost map).
+// (BulkUpdateCost takes an id → CostUpdate map).
 func ReleaseBillingPayloads(logs []*Log) {
 	for _, l := range logs {
 		if l != nil {

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -623,7 +623,7 @@ func (s *RDBLogStore) Update(ctx context.Context, id string, entry any) error {
 
 // BulkUpdateCost updates log costs in bulk, using a PostgreSQL-specific batched
 // VALUES update when available and per-row updates for other dialects.
-func (s *RDBLogStore) BulkUpdateCost(ctx context.Context, updates map[string]float64) error {
+func (s *RDBLogStore) BulkUpdateCost(ctx context.Context, updates map[string]CostUpdate) error {
 	if len(updates) == 0 {
 		return nil
 	}
@@ -633,9 +633,13 @@ func (s *RDBLogStore) BulkUpdateCost(ctx context.Context, updates map[string]flo
 	}
 
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		for id, cost := range updates {
-			costValue := cost
-			if err := tx.Model(&Log{}).Where("id = ?", id).Update("cost", costValue).Error; err != nil {
+		for id, u := range updates {
+			if err := tx.Model(&Log{}).Where("id = ?", id).Updates(map[string]interface{}{
+				"cost":            u.Total,
+				"input_cost":      u.Input,
+				"output_cost":     u.Output,
+				"additional_cost": u.Additional,
+			}).Error; err != nil {
 				return err
 			}
 		}
@@ -781,31 +785,41 @@ func serializeLogUpdateEntry(entry any) (any, error) {
 // buildBulkUpdateCostPostgresSQL builds a deterministic UPDATE ... FROM
 // (VALUES ...) statement and argument list for a chunk of PostgreSQL log cost
 // updates.
-func buildBulkUpdateCostPostgresSQL(ids []string, updates map[string]float64) (string, []interface{}) {
+func buildBulkUpdateCostPostgresSQL(ids []string, updates map[string]CostUpdate) (string, []interface{}) {
 	var sqlBuilder strings.Builder
-	args := make([]interface{}, 0, len(ids)*2)
+	const colsPerRow = 5
+	args := make([]interface{}, 0, len(ids)*colsPerRow)
 
-	sqlBuilder.WriteString("UPDATE logs SET cost = v.cost FROM (VALUES ")
+	// Reprice the total and the per-category split together so the denormalized
+	// columns stay reconciled to the cost column.
+	sqlBuilder.WriteString("UPDATE logs SET cost = v.cost, input_cost = v.input_cost, output_cost = v.output_cost, additional_cost = v.additional_cost FROM (VALUES ")
 	for i, id := range ids {
 		if i > 0 {
 			sqlBuilder.WriteString(",")
 		}
-		argOffset := i * 2
+		argOffset := i * colsPerRow
 		sqlBuilder.WriteString("($")
 		sqlBuilder.WriteString(strconv.Itoa(argOffset + 1))
 		sqlBuilder.WriteString("::text,$")
 		sqlBuilder.WriteString(strconv.Itoa(argOffset + 2))
+		sqlBuilder.WriteString("::float8,$")
+		sqlBuilder.WriteString(strconv.Itoa(argOffset + 3))
+		sqlBuilder.WriteString("::float8,$")
+		sqlBuilder.WriteString(strconv.Itoa(argOffset + 4))
+		sqlBuilder.WriteString("::float8,$")
+		sqlBuilder.WriteString(strconv.Itoa(argOffset + 5))
 		sqlBuilder.WriteString("::float8)")
-		args = append(args, id, updates[id])
+		u := updates[id]
+		args = append(args, id, u.Total, u.Input, u.Output, u.Additional)
 	}
-	sqlBuilder.WriteString(") AS v(id, cost) WHERE logs.id = v.id")
+	sqlBuilder.WriteString(") AS v(id, cost, input_cost, output_cost, additional_cost) WHERE logs.id = v.id")
 
 	return sqlBuilder.String(), args
 }
 
 // bulkUpdateCostPostgres applies chunked PostgreSQL bulk cost updates to avoid
 // issuing one UPDATE per log row.
-func (s *RDBLogStore) bulkUpdateCostPostgres(ctx context.Context, updates map[string]float64) error {
+func (s *RDBLogStore) bulkUpdateCostPostgres(ctx context.Context, updates map[string]CostUpdate) error {
 	ids := make([]string, 0, len(updates))
 	for id := range updates {
 		ids = append(ids, id)

--- a/framework/logstore/rdb_perf_test.go
+++ b/framework/logstore/rdb_perf_test.go
@@ -497,14 +497,14 @@ func TestMCPToolLogCreateSerializesFields(t *testing.T) {
 }
 
 func TestBuildBulkUpdateCostPostgresSQL(t *testing.T) {
-	updates := map[string]float64{
-		"log-a": 1.25,
-		"log-b": 2.5,
+	updates := map[string]CostUpdate{
+		"log-a": {Total: 1.25, Input: 1.0, Output: 0.2, Additional: 0.05},
+		"log-b": {Total: 2.5, Input: 2.0, Output: 0.4, Additional: 0.1},
 	}
 
 	query, args := buildBulkUpdateCostPostgresSQL([]string{"log-a", "log-b"}, updates)
-	wantQuery := "UPDATE logs SET cost = v.cost FROM (VALUES ($1::text,$2::float8),($3::text,$4::float8)) AS v(id, cost) WHERE logs.id = v.id"
-	wantArgs := []interface{}{"log-a", 1.25, "log-b", 2.5}
+	wantQuery := "UPDATE logs SET cost = v.cost, input_cost = v.input_cost, output_cost = v.output_cost, additional_cost = v.additional_cost FROM (VALUES ($1::text,$2::float8,$3::float8,$4::float8,$5::float8),($6::text,$7::float8,$8::float8,$9::float8,$10::float8)) AS v(id, cost, input_cost, output_cost, additional_cost) WHERE logs.id = v.id"
+	wantArgs := []interface{}{"log-a", 1.25, 1.0, 0.2, 0.05, "log-b", 2.5, 2.0, 0.4, 0.1}
 
 	if query != wantQuery {
 		t.Fatalf("query mismatch\n got: %s\nwant: %s", query, wantQuery)
@@ -626,20 +626,28 @@ func TestBulkUpdateCostSQLiteFallback(t *testing.T) {
 		}
 	}
 
-	if err := store.BulkUpdateCost(context.Background(), map[string]float64{
-		"log-a": 1.5,
-		"log-b": 2.5,
+	if err := store.BulkUpdateCost(context.Background(), map[string]CostUpdate{
+		"log-a": {Total: 1.5, Input: 1.0, Output: 0.4, Additional: 0.1},
+		"log-b": {Total: 2.5, Input: 2.0, Output: 0.5},
 	}); err != nil {
 		t.Fatalf("BulkUpdateCost() error = %v", err)
 	}
 
-	for id, wantCost := range map[string]float64{"log-a": 1.5, "log-b": 2.5} {
+	wantSplit := map[string]CostUpdate{
+		"log-a": {Total: 1.5, Input: 1.0, Output: 0.4, Additional: 0.1},
+		"log-b": {Total: 2.5, Input: 2.0, Output: 0.5},
+	}
+	for id, want := range wantSplit {
 		logEntry, err := store.FindByID(context.Background(), id)
 		if err != nil {
 			t.Fatalf("FindByID(%s) error = %v", id, err)
 		}
-		if logEntry.Cost == nil || *logEntry.Cost != wantCost {
-			t.Fatalf("cost mismatch for %s: got %v want %v", id, logEntry.Cost, wantCost)
+		if logEntry.Cost == nil || *logEntry.Cost != want.Total {
+			t.Fatalf("cost mismatch for %s: got %v want %v", id, logEntry.Cost, want.Total)
+		}
+		if logEntry.InputCost != want.Input || logEntry.OutputCost != want.Output || logEntry.AdditionalCost != want.Additional {
+			t.Fatalf("split mismatch for %s: got in=%v out=%v add=%v want in=%v out=%v add=%v",
+				id, logEntry.InputCost, logEntry.OutputCost, logEntry.AdditionalCost, want.Input, want.Output, want.Additional)
 		}
 	}
 }

--- a/framework/logstore/store.go
+++ b/framework/logstore/store.go
@@ -19,6 +19,37 @@ const (
 	LogStoreTypeClickHouse LogStoreType = "clickhouse"
 )
 
+// CostUpdate is the repriced cost for a single log row, applied in bulk by
+// BulkUpdateCost. It carries the per-category split alongside the total so a
+// reprice keeps the denormalized input/output/additional cost columns in sync
+// with the cost column (they otherwise go stale on recompute). Input + Output +
+// Additional == Total, mirroring schemas.BifrostCost.
+type CostUpdate struct {
+	Total      float64
+	Input      float64
+	Output     float64
+	Additional float64
+}
+
+// CostUpdateFromBreakdown builds a CostUpdate from a cost breakdown, falling back
+// to attributing an unsplit total to the input side (mirrors the SerializeFields
+// reconciliation for opaque provider totals).
+func CostUpdateFromBreakdown(bd *schemas.BifrostCost) CostUpdate {
+	if bd == nil {
+		return CostUpdate{}
+	}
+	u := CostUpdate{
+		Total:      bd.TotalCost,
+		Input:      bd.InputCost,
+		Output:     bd.OutputCost,
+		Additional: bd.AdditionalCost,
+	}
+	if u.Input == 0 && u.Output == 0 && u.Additional == 0 && u.Total > 0 {
+		u.Input = u.Total
+	}
+	return u
+}
+
 // LogStore is the interface for the log store.
 type LogStore interface {
 	Ping(ctx context.Context) error
@@ -95,7 +126,7 @@ type LogStore interface {
 	// timestamp but greater log ID are included to avoid skipping same-timestamp rows.
 	GetNodeUsageAfter(ctx context.Context, nodeID string, cursor NodeUsageCursor) (*NodeUsageAggregate, error)
 	Update(ctx context.Context, id string, entry any) error
-	BulkUpdateCost(ctx context.Context, updates map[string]float64) error
+	BulkUpdateCost(ctx context.Context, updates map[string]CostUpdate) error
 	Flush(ctx context.Context, since time.Time) error
 	Close(ctx context.Context) error
 	DeleteLog(ctx context.Context, id string) error

--- a/plugins/logging/costfidelity_test.go
+++ b/plugins/logging/costfidelity_test.go
@@ -634,9 +634,9 @@ func (s *legacyOffloadedStore) HydrateBillingChunk(_ context.Context, logs []*lo
 	return result, nil
 }
 
-func (s *legacyOffloadedStore) BulkUpdateCost(_ context.Context, updates map[string]float64) error {
+func (s *legacyOffloadedStore) BulkUpdateCost(_ context.Context, updates map[string]logstore.CostUpdate) error {
 	for id, c := range updates {
-		s.costs[id] = c
+		s.costs[id] = c.Total
 	}
 	return nil
 }

--- a/plugins/logging/costrecalc.go
+++ b/plugins/logging/costrecalc.go
@@ -197,7 +197,7 @@ func (p *LoggerPlugin) RunCostRecalcJob(ctx context.Context, metaJSON string, ch
 			return snapshot(), err
 		}
 
-		costUpdates := make(map[string]float64, len(batch))
+		costUpdates := make(map[string]logstore.CostUpdate, len(batch))
 		gotPositiveCost := make([]bool, len(batch))
 		batchSkipped := 0
 		batchUnpriceable := 0
@@ -214,14 +214,14 @@ func (p *LoggerPlugin) RunCostRecalcJob(ctx context.Context, metaJSON string, ch
 			}
 			if cost <= 0 {
 				if outcomes[i].knownZeroCost {
-					costUpdates[logEntry.ID] = cost
+					costUpdates[logEntry.ID] = logstore.CostUpdate{}
 				} else {
 					batchSkipped++
 					p.logger.Debug("skipping cost recalculation for log %s: resolved cost is zero", logEntry.ID)
 				}
 				continue
 			}
-			costUpdates[logEntry.ID] = cost
+			costUpdates[logEntry.ID] = logstore.CostUpdateFromBreakdown(outcomes[i].breakdown)
 			gotPositiveCost[i] = true
 		}
 

--- a/plugins/logging/costrecalc_test.go
+++ b/plugins/logging/costrecalc_test.go
@@ -21,6 +21,7 @@ type fakeRecalcStore struct {
 	logstore.LogStore
 	logs              []logstore.Log // pre-sorted by (timestamp, id)
 	cost              map[string]float64
+	split             map[string]logstore.CostUpdate // full per-category update per id
 	hasCost           map[string]bool
 	updateCount       map[string]int // successful BulkUpdateCost touches per id
 	searchCalls       int
@@ -34,6 +35,7 @@ func newFakeRecalcStore(logs []logstore.Log) *fakeRecalcStore {
 	return &fakeRecalcStore{
 		logs:        logs,
 		cost:        make(map[string]float64),
+		split:       make(map[string]logstore.CostUpdate),
 		hasCost:     make(map[string]bool),
 		updateCount: make(map[string]int),
 	}
@@ -89,13 +91,14 @@ func (s *fakeRecalcStore) SearchLogs(_ context.Context, f logstore.SearchFilters
 	return &logstore.SearchResult{Logs: page}, nil
 }
 
-func (s *fakeRecalcStore) BulkUpdateCost(_ context.Context, updates map[string]float64) error {
+func (s *fakeRecalcStore) BulkUpdateCost(_ context.Context, updates map[string]logstore.CostUpdate) error {
 	s.bulkCalls++
 	if s.failBulkOnCall != 0 && s.bulkCalls == s.failBulkOnCall {
 		return fmt.Errorf("simulated bulk update failure")
 	}
 	for id, c := range updates {
-		s.cost[id] = c
+		s.cost[id] = c.Total
+		s.split[id] = c
 		s.hasCost[id] = true
 		s.updateCount[id]++
 	}
@@ -184,6 +187,35 @@ func window(base time.Time) logstore.SearchFilters {
 	start := base.Add(-time.Hour)
 	end := base.Add(time.Hour)
 	return logstore.SearchFilters{StartTime: &start, EndTime: &end}
+}
+
+// TestRunCostRecalcJob_BackfillsCostSplit verifies recompute refreshes the
+// denormalized input/output/additional columns, not just the total, so the split
+// reconciles to the cost column after a reprice.
+func TestRunCostRecalcJob_BackfillsCostSplit(t *testing.T) {
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	store := newFakeRecalcStore([]logstore.Log{positiveLog("split-1", base)})
+	p := newRecalcPlugin(t, store)
+
+	if _, _, err := runJob(t, p, CostRecalcJobMeta{Filters: window(base), MissingCostOnly: false, Total: 1}); err != nil {
+		t.Fatalf("RunCostRecalcJob error = %v", err)
+	}
+
+	u, ok := store.split["split-1"]
+	if !ok {
+		t.Fatal("expected a cost update for split-1")
+	}
+	// gpt-4o testdata rates: input 2.5e-6/token, output 1e-5/token (100 prompt, 50 completion).
+	wantIn, wantOut := 100*2.5e-6, 50*1e-5
+	if d := u.Input - wantIn; d < -1e-12 || d > 1e-12 {
+		t.Fatalf("input cost %v != %v", u.Input, wantIn)
+	}
+	if d := u.Output - wantOut; d < -1e-12 || d > 1e-12 {
+		t.Fatalf("output cost %v != %v", u.Output, wantOut)
+	}
+	if d := u.Total - (u.Input + u.Output + u.Additional); d < -1e-12 || d > 1e-12 {
+		t.Fatalf("split does not reconcile to total: total=%v in=%v out=%v add=%v", u.Total, u.Input, u.Output, u.Additional)
+	}
 }
 
 // TestCalculateCostForLog_BedrockMantleChatStreamUsesResponsesPricing pins the

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -1541,7 +1541,7 @@ func (p *LoggerPlugin) RecalculateCostsWithProgress(ctx context.Context, filters
 			return nil, err
 		}
 
-		costUpdates := make(map[string]float64, len(searchResult.Logs))
+		costUpdates := make(map[string]logstore.CostUpdate, len(searchResult.Logs))
 		batchDebugUpdated := 0
 		stillMissingInBatch := 0
 
@@ -1559,7 +1559,7 @@ func (p *LoggerPlugin) RecalculateCostsWithProgress(ctx context.Context, filters
 			}
 			if cost <= 0 {
 				if outcomes[i].knownZeroCost {
-					costUpdates[logEntry.ID] = cost
+					costUpdates[logEntry.ID] = logstore.CostUpdate{}
 				} else {
 					result.Skipped++
 					p.logger.Debug("skipping cost recalculation for log %s: resolved cost is zero", logEntry.ID)
@@ -1572,18 +1572,24 @@ func (p *LoggerPlugin) RecalculateCostsWithProgress(ctx context.Context, filters
 			if outcomes[i].batchDebugUpdate != "" {
 				// A repriced batch aggregate row needs cost and batch_debug written
 				// together so model_breakdowns never disagrees with the row's own
-				// cost — BulkUpdateCost only ever writes the cost column, so this one
-				// row goes through a dedicated update instead of the bulk path below.
+				// cost, and batch_debug can only be written through a dedicated update
+				// (BulkUpdateCost writes cost and the split columns, but not
+				// batch_debug). This row carries a scalar total only, so derive the
+				// split columns from it the same way CostUpdateFromBreakdown does.
+				update := logstore.CostUpdateFromBreakdown(&schemas.BifrostCost{TotalCost: cost})
 				if err := p.store.Update(ctx, logEntry.ID, map[string]any{
-					"cost":        cost,
-					"batch_debug": outcomes[i].batchDebugUpdate,
+					"cost":            update.Total,
+					"input_cost":      update.Input,
+					"output_cost":     update.Output,
+					"additional_cost": update.Additional,
+					"batch_debug":     outcomes[i].batchDebugUpdate,
 				}); err != nil {
 					return nil, fmt.Errorf("failed to update batch cost for log %s: %w", logEntry.ID, err)
 				}
 				batchDebugUpdated++
 				continue
 			}
-			costUpdates[logEntry.ID] = cost
+			costUpdates[logEntry.ID] = logstore.CostUpdateFromBreakdown(outcomes[i].breakdown)
 		}
 
 		if len(costUpdates) > 0 {
@@ -1655,14 +1661,17 @@ var errPricingInputsUnavailable = errors.New("pricing inputs unavailable")
 // reason the row was left alone.
 type billingOutcome struct {
 	cost float64
-	err  error
+	// breakdown is the per-category split for the same reprice; nil when the row
+	// priced to zero or errored. Recompute denormalizes it into the split columns.
+	breakdown *schemas.BifrostCost
+	err       error
 	// knownZeroCost is captured while the row's payload is still hydrated, because it
 	// is derived from CacheDebugParsed and ReleaseBillingPayloads clears that. Callers
 	// run after the release, so they cannot re-derive it.
 	knownZeroCost bool
 	// batchDebugUpdate is the serialized batch_debug JSON to persist alongside cost,
 	// set only for a batch aggregate row repriced via calculateBatchAggregateCost.
-	// BulkUpdateCost only ever touches the cost column, so without this the row's
+	// BulkUpdateCost cannot write batch_debug, so without this the row's
 	// model_breakdowns would stay stuck showing the pre-recalculation (unpriced)
 	// state even after cost is fixed.
 	batchDebugUpdate string
@@ -1726,9 +1735,15 @@ func (p *LoggerPlugin) priceLogsInChunks(ctx context.Context, batch []logstore.L
 				continue
 			}
 			if isBatchAggregateRow(&batch[i]) {
+				// Batch aggregate rows reprice per model and carry only a scalar
+				// total (no input/output split), persisted via the batchDebugUpdate
+				// path below.
 				outcomes[i].cost, outcomes[i].batchDebugUpdate, outcomes[i].err = p.calculateBatchAggregateCost(&batch[i])
 			} else {
-				outcomes[i].cost, outcomes[i].err = p.calculateCostForLog(&batch[i])
+				outcomes[i].breakdown, outcomes[i].err = p.calculateCostBreakdownForLog(&batch[i])
+				if outcomes[i].breakdown != nil {
+					outcomes[i].cost = outcomes[i].breakdown.TotalCost
+				}
 			}
 			// Must be read here, before the release below drops cache_debug.
 			outcomes[i].knownZeroCost = isKnownZeroCostLog(&batch[i])
@@ -1915,16 +1930,30 @@ func attachCostToNativeUsage(result *schemas.BifrostResponse, breakdown *schemas
 	}
 }
 
+// calculateCostForLog reprices a stored log row and returns the total. Thin
+// wrapper over calculateCostBreakdownForLog for callers that only need the scalar.
 func (p *LoggerPlugin) calculateCostForLog(logEntry *logstore.Log) (float64, error) {
+	bd, err := p.calculateCostBreakdownForLog(logEntry)
+	if bd == nil {
+		return 0, err
+	}
+	return bd.TotalCost, err
+}
+
+// calculateCostBreakdownForLog reprices a stored log row and returns the full
+// per-category breakdown, so recompute can refresh the denormalized input/output/
+// additional cost columns, not just the total. Returns (nil, nil) for a provably
+// zero-cost row (e.g. a direct cache hit).
+func (p *LoggerPlugin) calculateCostBreakdownForLog(logEntry *logstore.Log) (*schemas.BifrostCost, error) {
 	if logEntry == nil {
-		return 0, fmt.Errorf("log entry cannot be nil")
+		return nil, fmt.Errorf("log entry cannot be nil")
 	}
 
 	if (logEntry.TokenUsageParsed == nil && logEntry.TokenUsage != "") ||
 		(logEntry.CacheDebugParsed == nil && logEntry.CacheDebug != "") ||
 		(logEntry.GuardrailDebugParsed == nil && logEntry.GuardrailDebug != "") {
 		if err := logEntry.DeserializeFields(); err != nil {
-			return 0, fmt.Errorf("failed to deserialize fields for log %s: %w", logEntry.ID, err)
+			return nil, fmt.Errorf("failed to deserialize fields for log %s: %w", logEntry.ID, err)
 		}
 	}
 
@@ -1934,15 +1963,17 @@ func (p *LoggerPlugin) calculateCostForLog(logEntry *logstore.Log) (float64, err
 
 	// If no cache hit, guardrail call, or usage, we can't calculate cost.
 	if usage == nil && (cacheDebug == nil || !cacheDebug.CacheHit) && guardrailDebug == nil {
-		return 0, fmt.Errorf("token usage not available for log %s", logEntry.ID)
+		return nil, fmt.Errorf("%w: token usage not available for log %s", errPricingInputsUnavailable, logEntry.ID)
 	}
 
 	// A direct cache hit was served without an LLM call, so pricing returns zero
 	// regardless of the token breakdown (see calculateCostWithCache). Short-circuiting
 	// ahead of the degraded gate keeps a provably-free row from being reported
-	// unpriceable and revisited by every MissingCostOnly pass.
-	if isKnownZeroCostLog(logEntry) {
-		return 0, nil
+	// unpriceable and revisited by every MissingCostOnly pass. A guardrail judge
+	// call is billed separately (AdditionalCost) even on a cache hit, so fall
+	// through when one ran instead of discarding that charge.
+	if isKnownZeroCostLog(logEntry) && guardrailDebug == nil {
+		return nil, nil
 	}
 
 	// Refuse to price a usage stub rebuilt from denormalized columns. It lacks the
@@ -1954,13 +1985,13 @@ func (p *LoggerPlugin) calculateCostForLog(logEntry *logstore.Log) (float64, err
 	// failed). Erroring makes the recalc job count it as skipped instead of
 	// writing a number that is wrong by multiples.
 	if logEntry.IsUsageDegraded() {
-		return 0, fmt.Errorf("%w: log %s", errPricingInputsUnavailable, logEntry.ID)
+		return nil, fmt.Errorf("%w: log %s", errPricingInputsUnavailable, logEntry.ID)
 	}
 
 	requestType := normalizeLogRequestType(logEntry.Object)
 	if requestType == "" && (cacheDebug == nil || !cacheDebug.CacheHit) && guardrailDebug == nil {
 		p.logger.Warn("skipping cost calculation for log %s: object type is empty (timestamp: %s)", logEntry.ID, logEntry.Timestamp)
-		return 0, fmt.Errorf("object type is empty for log %s", logEntry.ID)
+		return nil, fmt.Errorf("%w: object type is empty for log %s", errPricingInputsUnavailable, logEntry.ID)
 	}
 
 	// Build a minimal BifrostResponse matching the request type so that
@@ -2062,7 +2093,7 @@ func (p *LoggerPlugin) calculateCostForLog(logEntry *logstore.Log) (float64, err
 	}
 
 	scopes := pricingScopesForLog(logEntry)
-	return p.pricingManager.CalculateCost(resp, &scopes), nil
+	return p.pricingManager.CalculateCostBreakdown(resp, &scopes), nil
 }
 
 // servedTier carries the billing tier a log row was served at, read back from the


### PR DESCRIPTION
## Summary

`BulkUpdateCost` previously accepted a `map[string]float64` carrying only the total cost per log row. This meant that after a reprice, the denormalized `input_cost`, `output_cost`, and `additional_cost` columns went stale while the `cost` column was refreshed. This PR introduces a `CostUpdate` struct that carries the full per-category split alongside the total, and threads it through every layer so a reprice keeps all four cost columns reconciled.

## Changes

- Introduced `CostUpdate` struct in `logstore/store.go` with `Total`, `Input`, `Output`, and `Additional` fields, mirroring `schemas.BifrostCost`.
- Added `CostUpdateFromBreakdown` helper that builds a `CostUpdate` from a `*schemas.BifrostCost`, falling back to attributing an unsplit total to the input side for opaque provider totals.
- Changed `BulkUpdateCost` signature across `LogStore` interface, `RDBLogStore`, `ClickHouseLogStore`, and `HybridLogStore` from `map[string]float64` to `map[string]CostUpdate`.
- Updated the PostgreSQL bulk `UPDATE ... FROM (VALUES ...)` path in `buildBulkUpdateCostPostgresSQL` to include `input_cost`, `output_cost`, and `additional_cost` columns alongside `cost`, expanding from 2 to 5 args per row.
- Updated the SQLite/generic fallback path in `RDBLogStore` to issue a multi-column `Updates` call instead of a single-column `Update`.
- Updated the ClickHouse re-insert path to patch `InputCost`, `OutputCost`, and `AdditionalCost` fields on each row before reinsertion.
- Refactored `calculateCostForLog` into a thin wrapper over a new `calculateCostBreakdownForLog` that returns `*schemas.BifrostCost` instead of a scalar, so `priceLogsInChunks` can capture the full breakdown and pass it to `CostUpdateFromBreakdown`.
- Updated `billingOutcome` to carry a `breakdown *schemas.BifrostCost` field populated during pricing, used by both `RunCostRecalcJob` and `RecalculateCostsWithProgress` when building the cost update map.
- Updated all test fakes (`fakeRecalcStore`, `legacyOffloadedStore`) and test assertions to use `CostUpdate`, and added `TestRunCostRecalcJob_BackfillsCostSplit` to verify the split reconciles to the total after a reprice.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/logstore/... ./plugins/logging/...
```

The new `TestRunCostRecalcJob_BackfillsCostSplit` test verifies that after a reprice, `input_cost + output_cost + additional_cost` reconciles to `cost`. `TestClickHouseBulkUpdateCost` and `TestBulkUpdateCostSQLiteFallback` verify the split is persisted and read back correctly for each store backend. `TestBuildBulkUpdateCostPostgresSQL` pins the generated SQL to include all four cost columns.

## Breaking changes

- [x] Yes
- [ ] No

The `LogStore` interface method `BulkUpdateCost` has changed its parameter type from `map[string]float64` to `map[string]CostUpdate`. Any external implementation of `LogStore` must be updated to match the new signature.

## Related issues

## Security considerations

None. This change only affects internal cost column writes and does not touch authentication, secrets, or PII handling.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable