### PR TITLE
fix: restructuring of replayed thinking blocks

### DIFF
--- a/core/providers/anthropic/attemptprovider_test.go
+++ b/core/providers/anthropic/attemptprovider_test.go
@@ -1,0 +1,66 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// attemptProvider is what every ShouldEmbedReasoningItemID call site in
+// responses.go reads, so its two branches decide whether a reasoning item's id is
+// smuggled into its signature/data. Both branches are load-bearing:
+//
+//   - RoutingInfo.Provider is the non-deprecated field and core populates it on every
+//     stream chunk, so it must win when set.
+//   - ExtraFields.Provider is the wider field: syncDeprecatedFromRoutingInfo only
+//     backfills it when RoutingInfo.Provider is non-empty, so frames built outside
+//     core's pipeline carry only the deprecated one. Dropping the fallback would stop
+//     embedding ids on exactly those frames, and silently -- nothing errors, the two
+//     halves of a reasoning item just stop merging on re-ingest.
+func TestStreamAttemptProvider(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		extra schemas.BifrostResponseExtraFields
+		want  schemas.ModelProvider
+	}{
+		{
+			name: "routing info wins when set",
+			extra: schemas.BifrostResponseExtraFields{
+				Provider:    schemas.Anthropic,
+				RoutingInfo: schemas.RoutingInfo{Provider: schemas.OpenAI},
+			},
+			want: schemas.OpenAI,
+		},
+		{
+			name: "falls back to the deprecated field when routing info is empty",
+			extra: schemas.BifrostResponseExtraFields{
+				Provider: schemas.OpenAI,
+			},
+			want: schemas.OpenAI,
+		},
+		{
+			name: "both agree",
+			extra: schemas.BifrostResponseExtraFields{
+				Provider:    schemas.OpenAI,
+				RoutingInfo: schemas.RoutingInfo{Provider: schemas.OpenAI},
+			},
+			want: schemas.OpenAI,
+		},
+		{
+			name:  "neither set",
+			extra: schemas.BifrostResponseExtraFields{},
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := attemptProvider(tt.extra); got != tt.want {
+				t.Errorf("attemptProvider = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/core/providers/anthropic/latesummaryupgrade_test.go
+++ b/core/providers/anthropic/latesummaryupgrade_test.go
@@ -1,0 +1,108 @@
+package anthropic
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// A reasoning item that looked redacted-only at output_item.added and then streamed
+// summary text is reopened as a thinking block mid-stream
+// (upgradeLateSummaryToThinkingBlock). That reopened block reads as "opened as
+// thinking" to the split at output_item.done, which would otherwise emit the
+// encrypted payload a second time -- once in `data` on the block that was closed,
+// once as a fresh redacted_thinking block.
+//
+// Duplicating it is not cosmetic: the client replays both halves next turn, so the
+// same signed reasoning state is submitted twice under one item.
+//
+// This drives the full lifecycle (added -> deltas -> done), which
+// TestAnthropicStreamEgress_LateSummaryNeverLandsOnRedactedBlock deliberately does
+// not: that test isolates the delta/block pairing.
+func TestAnthropicStreamEgress_LateSummaryDoesNotDuplicateEncryptedPayload(t *testing.T) {
+	t.Parallel()
+
+	reasoningID := "rs_1"
+	reasoningType := schemas.ResponsesMessageTypeReasoning
+
+	summaryDelta := func(text string) *schemas.BifrostResponsesStreamResponse {
+		return &schemas.BifrostResponsesStreamResponse{
+			Type:        schemas.ResponsesStreamResponseTypeReasoningSummaryTextDelta,
+			OutputIndex: schemas.Ptr(0),
+			ItemID:      &reasoningID,
+			Delta:       schemas.Ptr(text),
+			ExtraFields: schemas.BifrostResponseExtraFields{Provider: schemas.OpenAI},
+		}
+	}
+
+	frames := []*schemas.BifrostResponsesStreamResponse{
+		reasoningAddedFrame("", streamTestEncrypted),
+		summaryDelta("Ranking the sources "),
+		summaryDelta("by recency."),
+		{
+			Type:        schemas.ResponsesStreamResponseTypeOutputItemDone,
+			OutputIndex: schemas.Ptr(0),
+			Item: &schemas.ResponsesMessage{
+				ID:   &reasoningID,
+				Type: &reasoningType,
+				ResponsesReasoning: &schemas.ResponsesReasoning{
+					Summary: []schemas.ResponsesReasoningSummary{{
+						Type: schemas.ResponsesReasoningContentBlockTypeSummaryText,
+						Text: "Ranking the sources by recency.",
+					}},
+					EncryptedContent: schemas.Ptr(streamTestEncrypted),
+				},
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{Provider: schemas.OpenAI},
+		},
+	}
+
+	var redactedPayloads []string
+	openBlocks := map[int]AnthropicContentBlockType{}
+	var visible strings.Builder
+
+	for _, event := range driveAnthropicEgress(t, frames) {
+		if event == nil || event.Index == nil {
+			continue
+		}
+		index := *event.Index
+
+		switch event.Type {
+		case AnthropicStreamEventTypeContentBlockStart:
+			if event.ContentBlock == nil {
+				t.Fatalf("content_block_start at index %d carried no content_block", index)
+			}
+			openBlocks[index] = event.ContentBlock.Type
+			if event.ContentBlock.Type == AnthropicContentBlockTypeRedactedThinking && event.ContentBlock.Data != nil {
+				redactedPayloads = append(redactedPayloads, *event.ContentBlock.Data)
+			}
+		case AnthropicStreamEventTypeContentBlockDelta:
+			if event.Delta == nil || event.Delta.Type != AnthropicStreamDeltaTypeThinking {
+				continue
+			}
+			if blockType := openBlocks[index]; blockType != AnthropicContentBlockTypeThinking {
+				t.Errorf("thinking_delta targets block %d opened as %q", index, blockType)
+				continue
+			}
+			if event.Delta.Thinking != nil {
+				visible.WriteString(*event.Delta.Thinking)
+			}
+		case AnthropicStreamEventTypeContentBlockStop:
+			delete(openBlocks, index)
+		}
+	}
+
+	if got := visible.String(); got != "Ranking the sources by recency." {
+		t.Errorf("late summary lost: thinking block accumulated %q", got)
+	}
+	if len(redactedPayloads) != 1 {
+		t.Fatalf("encrypted payload must be delivered exactly once, got %d redacted_thinking blocks: %q", len(redactedPayloads), redactedPayloads)
+	}
+	if !strings.Contains(redactedPayloads[0], streamTestEncrypted) {
+		t.Errorf("redacted_thinking data %q does not carry the encrypted payload", redactedPayloads[0])
+	}
+	if len(openBlocks) != 0 {
+		t.Errorf("every content_block_start must be closed, left open: %v", openBlocks)
+	}
+}

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -222,6 +222,14 @@ type anthropicToResponsesStreamState struct {
 	// blockIndexByItem.
 	blockTypes []AnthropicContentBlockType
 
+	// reasoningPayloadSentByItem marks reasoning items whose encrypted payload has
+	// already reached the client, on the redacted_thinking block opened for them at
+	// output_item.added. Set only by upgradeLateSummaryToThinkingBlock, which closes
+	// that block when the item turns out to have visible reasoning after all. The
+	// split at output_item.done consults this so the payload is not sent twice: once
+	// in `data` on the closed block and again as a fresh redacted_thinking block.
+	reasoningPayloadSentByItem map[string]bool
+
 	// codeExecServerClosedByItem marks code_interpreter_call items whose
 	// server_tool_use block was already closed early on code.done (python/bash,
 	// where the input reconstructs from the neutral Code and the block must close
@@ -282,6 +290,116 @@ func (s *anthropicToResponsesStreamState) blockType(index int) AnthropicContentB
 		return ""
 	}
 	return s.blockTypes[index]
+}
+
+// attemptProvider reports the provider that handled this attempt.
+//
+// ExtraFields.Provider is deprecated in favour of RoutingInfo.Provider, and core
+// populates RoutingInfo on every stream chunk (postHookRunner -> PopulateRoutingInfo
+// in core/bifrost.go). But the sync that backfills the deprecated field is
+// conditional -- syncDeprecatedFromRoutingInfo only copies when info.Provider is
+// non-empty -- so the deprecated field is the WIDER of the two: it is still set on
+// frames built outside that path (a provider driven directly as a library, and the
+// stream fixtures in this package), where RoutingInfo.Provider is empty.
+//
+// Reading RoutingInfo first honours the deprecation; the fallback keeps those frames
+// working. Every ShouldEmbedReasoningItemID call site in this file must go through
+// here, because they all decide whether the SAME item's id is smuggled into its
+// signature/data. If they disagree, one reasoning item's thinking half and encrypted
+// half end up under different ids and no longer merge on re-ingest (reasoningIndexByID
+// in the grouped ingress converter).
+//
+// ToAnthropicResponsesResponse's ResolveModelCaps lookup reads through here too, for
+// the forward-looking half of the same reason rather than a present bug: an empty
+// provider makes CapabilitiesFor return no record and every capability predicate falls
+// back to name detection, so the fallback is what keeps that lookup working on frames
+// core never routed.
+func attemptProvider(extra schemas.BifrostResponseExtraFields) schemas.ModelProvider {
+	if extra.RoutingInfo.Provider != "" {
+		return extra.RoutingInfo.Provider
+	}
+	return extra.Provider //nolint:staticcheck // SA1019: deliberate fallback, see above
+}
+
+// markReasoningPayloadSent records that key's encrypted reasoning payload already
+// reached the client, so output_item.done does not emit it a second time.
+func (s *anthropicToResponsesStreamState) markReasoningPayloadSent(key string) {
+	if key == "" {
+		return
+	}
+	if s.reasoningPayloadSentByItem == nil {
+		s.reasoningPayloadSentByItem = make(map[string]bool)
+	}
+	s.reasoningPayloadSentByItem[key] = true
+}
+
+// reasoningPayloadSent reports whether key's encrypted reasoning payload has already
+// been delivered (see markReasoningPayloadSent).
+func (s *anthropicToResponsesStreamState) reasoningPayloadSent(key string) bool {
+	return key != "" && s.reasoningPayloadSentByItem[key]
+}
+
+// upgradeLateSummaryToThinkingBlock handles a reasoning item that looked
+// redacted-only at output_item.added -- encrypted payload, no summary -- and then
+// starts streaming summary text anyway.
+//
+// Judged on the added frame alone, opening redacted_thinking there is right:
+// redacted_thinking is atomic, it carries its payload in `data` on the start frame,
+// and nothing more is expected. But a thinking_delta landing on a redacted block is
+// silently discarded by Anthropic clients, and a signature_delta against one is the
+// frame Claude Code aborts the turn on ("Content block is not a thinking block").
+// Either way the visible reasoning is lost with no error to explain it.
+//
+// enforceStreamBlockTypes cannot rescue this: it only drops the offending delta,
+// which trades a silent loss for a slightly quieter one. The fix is to close the
+// redacted block -- its payload already shipped, which is what markReasoningPayloadSent
+// records -- and reopen the item as a thinking block that the deltas can legally land
+// on. Splitting the two halves across two blocks is exactly what the non-streaming
+// converter does (convertBifrostReasoningToAnthropicThinking); this is the streaming
+// equivalent, discovered one frame later.
+//
+// It returns the prefix events to emit ahead of the delta, plus the index the delta
+// must now target. When no upgrade is needed it returns (nil, idx) unchanged.
+func upgradeLateSummaryToThinkingBlock(
+	ctx *schemas.BifrostContext,
+	state *anthropicToResponsesStreamState,
+	bifrostResp *schemas.BifrostResponsesStreamResponse,
+	key string,
+	idx *int,
+) ([]*AnthropicStreamEvent, *int) {
+	if idx == nil || state.blockType(*idx) != AnthropicContentBlockTypeRedactedThinking {
+		return nil, idx
+	}
+
+	events := []*AnthropicStreamEvent{{
+		Type:  AnthropicStreamEventTypeContentBlockStop,
+		Index: idx,
+	}}
+	state.markReasoningPayloadSent(key)
+
+	// Re-point the item's key at the new block so the deltas that follow, and the
+	// content_block_stop at output_item.done, resolve to it instead of the closed one.
+	newIdx := state.allocBlockIndex(key)
+
+	// Same signature seeding as the thinking branch at output_item.added: when the id
+	// is being smuggled through the signature, the reopened block carries it too, so a
+	// client replaying this turn folds the thinking half back together with the
+	// redacted half (see reasoningIndexByID in the ingress converter).
+	signature := ""
+	if providerUtils.ShouldEmbedReasoningItemID(ctx, attemptProvider(bifrostResp.ExtraFields), bifrostResp.ExtraFields.RoutingInfo.Model) {
+		signature = providerUtils.EmbedReasoningItemID(bifrostResp.ItemID, "")
+	}
+	events = append(events, &AnthropicStreamEvent{
+		Type:  AnthropicStreamEventTypeContentBlockStart,
+		Index: newIdx,
+		ContentBlock: &AnthropicContentBlock{
+			Type:      AnthropicContentBlockTypeThinking,
+			Thinking:  schemas.Ptr(""),
+			Signature: &signature,
+		},
+	})
+
+	return events, newIdx
 }
 
 // reasoningPayloadAndSummary reports a reasoning item's encrypted payload (empty
@@ -2945,7 +3063,7 @@ func toAnthropicResponsesStreamEvents(ctx *schemas.BifrostContext, bifrostResp *
 						// embedID gates smuggling the real OpenAI reasoning item id into
 						// signature/data (see providerUtils.ShouldEmbedReasoningItemID and
 						// convertBifrostReasoningToAnthropicThinking for why).
-						embedID := providerUtils.ShouldEmbedReasoningItemID(ctx, bifrostResp.ExtraFields.Provider, bifrostResp.ExtraFields.RoutingInfo.Model)
+						embedID := providerUtils.ShouldEmbedReasoningItemID(ctx, attemptProvider(bifrostResp.ExtraFields), bifrostResp.ExtraFields.RoutingInfo.Model)
 						encrypted, hasSummary := reasoningPayloadAndSummary(bifrostResp.Item)
 						// Redacted-only reasoning (encrypted payload, nothing visible) is an
 						// atomic block: the payload rides in `data` on this very frame and no
@@ -2991,7 +3109,7 @@ func toAnthropicResponsesStreamEvents(ctx *schemas.BifrostContext, bifrostResp *
 							// not dropped -- output_item.done splits it into its own
 							// redacted_thinking block, which is why isReasoningItem has to route
 							// this shape there as well.
-							embedID := providerUtils.ShouldEmbedReasoningItemID(ctx, bifrostResp.ExtraFields.Provider, bifrostResp.ExtraFields.RoutingInfo.Model)
+							embedID := providerUtils.ShouldEmbedReasoningItemID(ctx, attemptProvider(bifrostResp.ExtraFields), bifrostResp.ExtraFields.RoutingInfo.Model)
 							encrypted, hasSummary := reasoningPayloadAndSummary(bifrostResp.Item)
 							if encrypted != "" && !hasSummary {
 								contentBlock.Type = AnthropicContentBlockTypeRedactedThinking
@@ -3147,8 +3265,17 @@ func toAnthropicResponsesStreamEvents(ctx *schemas.BifrostContext, bifrostResp *
 		}
 
 	case schemas.ResponsesStreamResponseTypeReasoningSummaryTextDelta:
+		state := getOrCreateAnthropicToResponsesStreamState(ctx)
+		key := reverseStreamItemKey(bifrostResp)
+		idx := state.blockIndexFor(key)
+
+		// A delta arriving for a block opened as redacted_thinking means the item had
+		// visible reasoning after all. Close it and reopen as thinking, else this delta
+		// is discarded (thinking_delta) or aborts the turn (signature_delta).
+		prefix, idx := upgradeLateSummaryToThinkingBlock(ctx, state, bifrostResp, key, idx)
+
 		streamResp.Type = AnthropicStreamEventTypeContentBlockDelta
-		streamResp.Index = getOrCreateAnthropicToResponsesStreamState(ctx).blockIndexFor(reverseStreamItemKey(bifrostResp))
+		streamResp.Index = idx
 
 		// Check if this is a signature delta or text delta
 		if bifrostResp.Signature != nil {
@@ -3163,6 +3290,10 @@ func toAnthropicResponsesStreamEvents(ctx *schemas.BifrostContext, bifrostResp *
 				Type:     AnthropicStreamDeltaTypeThinking,
 				Thinking: bifrostResp.Delta,
 			}
+		}
+
+		if len(prefix) > 0 {
+			return append(prefix, streamResp)
 		}
 
 	case schemas.ResponsesStreamResponseTypeOutputTextAnnotationAdded:
@@ -3465,7 +3596,8 @@ func toAnthropicResponsesStreamEvents(ctx *schemas.BifrostContext, bifrostResp *
 			// redacted_thinking is atomic on the wire, carrying its payload in `data`
 			// on the start frame, which is why it never receives deltas.
 			state := getOrCreateAnthropicToResponsesStreamState(ctx)
-			idx := state.blockIndexFor(reverseStreamItemKey(bifrostResp))
+			key := reverseStreamItemKey(bifrostResp)
+			idx := state.blockIndexFor(key)
 			events := []*AnthropicStreamEvent{{
 				Type:  AnthropicStreamEventTypeContentBlockStop,
 				Index: idx,
@@ -3473,9 +3605,13 @@ func toAnthropicResponsesStreamEvents(ctx *schemas.BifrostContext, bifrostResp *
 
 			encrypted, _ := reasoningPayloadAndSummary(bifrostResp.Item)
 			openedAsThinking := idx != nil && state.blockType(*idx) == AnthropicContentBlockTypeThinking
-			if encrypted != "" && openedAsThinking {
+			// An item upgraded mid-stream (upgradeLateSummaryToThinkingBlock) also reads
+			// as "opened as thinking" here, because its key now points at the reopened
+			// block -- but its payload already went out in `data` on the redacted block
+			// that was closed. Emitting it again would duplicate the reasoning state.
+			if encrypted != "" && openedAsThinking && !state.reasoningPayloadSent(key) {
 				data := encrypted
-				if providerUtils.ShouldEmbedReasoningItemID(ctx, bifrostResp.ExtraFields.Provider, bifrostResp.ExtraFields.RoutingInfo.Model) {
+				if providerUtils.ShouldEmbedReasoningItemID(ctx, attemptProvider(bifrostResp.ExtraFields), bifrostResp.ExtraFields.RoutingInfo.Model) {
 					data = providerUtils.EmbedReasoningItemID(bifrostResp.Item.ID, data)
 				}
 				redactedIdx := state.allocBlockIndex("")
@@ -4644,7 +4780,7 @@ func ToAnthropicResponsesResponse(ctx *schemas.BifrostContext, bifrostResp *sche
 	var contentBlocks []AnthropicContentBlock
 	if bifrostResp.Output != nil {
 		anthropicMessages, _ := ConvertBifrostMessagesToAnthropicMessages(ctx, bifrostResp.Output, false,
-			schemas.ResolveModelCaps(bifrostResp.ExtraFields.Provider, bifrostResp.Model))
+			schemas.ResolveModelCaps(attemptProvider(bifrostResp.ExtraFields), bifrostResp.Model))
 		// Extract content blocks from the converted messages
 		for _, msg := range anthropicMessages {
 			if msg.Content.ContentBlocks != nil {
@@ -5560,6 +5696,66 @@ func convertSingleAnthropicMessageToBifrostMessagesGrouped(msg *AnthropicMessage
 	return []schemas.ResponsesMessage{}
 }
 
+// anthropicToolUseBlockToResponsesMessage converts one tool_use / server_tool_use /
+// mcp_tool_use block into the Responses item it maps to. Extracted so the grouped
+// converter can emit tool calls at the position they occupied in the turn instead of
+// replaying them all from a buffer at the end (see flushPendingToolUses).
+func anthropicToolUseBlockToResponsesMessage(toolBlock *AnthropicContentBlock, isOutputMessage bool) schemas.ResponsesMessage {
+	bifrostMsg := schemas.ResponsesMessage{
+		Type:         schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+		Status:       schemas.Ptr("completed"),
+		CacheControl: toolBlock.CacheControl,
+		ResponsesToolMessage: &schemas.ResponsesToolMessage{
+			CallID: toolBlock.ID,
+			Name:   toolBlock.Name,
+		},
+	}
+	if isOutputMessage {
+		bifrostMsg.ID = schemas.Ptr("fc_" + schemas.GetRandomString(50))
+	}
+
+	// Check for computer tool use
+	if toolBlock.Name != nil && *toolBlock.Name == string(AnthropicToolNameComputer) {
+		bifrostMsg.Type = schemas.Ptr(schemas.ResponsesMessageTypeComputerCall)
+		bifrostMsg.ResponsesToolMessage.Name = nil
+		var inputMap map[string]interface{}
+		if err := sonic.Unmarshal(toolBlock.Input, &inputMap); err == nil {
+			bifrostMsg.ResponsesToolMessage.Action = &schemas.ResponsesToolMessageActionStruct{
+				ResponsesComputerToolCallAction: convertAnthropicToResponsesComputerAction(inputMap),
+			}
+		}
+	} else if toolBlock.Name != nil && *toolBlock.Name == string(AnthropicToolNameWebSearch) {
+		bifrostMsg.Type = schemas.Ptr(schemas.ResponsesMessageTypeWebSearchCall)
+		bifrostMsg.ResponsesToolMessage.Name = nil
+		if q := providerUtils.GetJSONField(toolBlock.Input, "query"); q.Exists() && q.Type == gjson.String {
+			query := q.Str
+			bifrostMsg.ResponsesToolMessage.Action = &schemas.ResponsesToolMessageActionStruct{
+				ResponsesWebSearchToolCallAction: &schemas.ResponsesWebSearchToolCallAction{
+					Type:    "search",
+					Query:   schemas.Ptr(query),
+					Queries: []string{query},
+				},
+			}
+		}
+	} else if toolBlock.Name != nil && *toolBlock.Name == string(AnthropicToolNameWebFetch) {
+		bifrostMsg.Type = schemas.Ptr(schemas.ResponsesMessageTypeWebFetchCall)
+		bifrostMsg.ResponsesToolMessage.Name = nil
+		if u := providerUtils.GetJSONField(toolBlock.Input, "url"); u.Exists() && u.Type == gjson.String {
+			bifrostMsg.ResponsesToolMessage.Action = &schemas.ResponsesToolMessageActionStruct{
+				ResponsesWebFetchToolCallAction: &schemas.ResponsesWebFetchToolCallAction{
+					URL: u.Str,
+				},
+			}
+		}
+	} else {
+		if len(toolBlock.Input) > 0 {
+			bifrostMsg.ResponsesToolMessage.Arguments = schemas.Ptr(string(toolBlock.Input))
+		}
+	}
+
+	return bifrostMsg
+}
+
 // Helper function to convert Anthropic content blocks to Bifrost ResponsesMessages, grouping text and tool_use blocks
 func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []AnthropicContentBlock, role *schemas.ResponsesMessageRoleType, isOutputMessage bool) []schemas.ResponsesMessage {
 	var bifrostMessages []schemas.ResponsesMessage
@@ -5573,8 +5769,57 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 	// appending a second one with a duplicate id.
 	reasoningIndexByID := map[string]int{}
 
+	// Consecutive text blocks coalesce into one message item, and consecutive
+	// tool_use blocks stay grouped -- that is what "grouped" means here. But the
+	// runs must be flushed the moment a block of another kind arrives, so the
+	// emitted items keep the order the client sent.
+	//
+	// Buffering both runs to the end of the turn (as this used to) reorders an
+	// interleaved-thinking turn: [thinking, text, tool_use, thinking, text, tool_use]
+	// came out as [reasoning, reasoning, message, function_call, function_call],
+	// moving the second thinking block in front of the tool call it was produced
+	// after. Anthropic drops the "assistant turn begins with a thinking block" rule
+	// for adaptive thinking, so that relocation is a modification of a signed block,
+	// not a normalization -- and Bedrock rejects the replay for it (issue #6342).
+	flushAccumulatedText := func() {
+		if len(accumulatedTextContent) == 0 {
+			return
+		}
+		if isOutputMessage {
+			bifrostMessages = append(bifrostMessages, schemas.ResponsesMessage{
+				ID:   schemas.Ptr("msg_" + schemas.GetRandomString(50)),
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+				Role: role,
+				Content: &schemas.ResponsesMessageContent{
+					ContentBlocks: accumulatedTextContent,
+				},
+			})
+		}
+		accumulatedTextContent = nil
+	}
+	flushPendingToolUses := func() {
+		for _, toolBlock := range pendingToolUseBlocks {
+			bifrostMessages = append(bifrostMessages, anthropicToolUseBlockToResponsesMessage(toolBlock, isOutputMessage))
+		}
+		pendingToolUseBlocks = nil
+	}
+
 	// Process content blocks
 	for _, block := range contentBlocks {
+		// Close off whichever run this block is not part of, so both land in
+		// wire order relative to each other and to every other block type.
+		if block.Type != AnthropicContentBlockTypeText {
+			flushAccumulatedText()
+		}
+		switch block.Type {
+		case AnthropicContentBlockTypeToolUse,
+			AnthropicContentBlockTypeServerToolUse,
+			AnthropicContentBlockTypeMCPToolUse:
+			// still inside the tool_use run
+		default:
+			flushPendingToolUses()
+		}
+
 		switch block.Type {
 		case AnthropicContentBlockTypeText:
 			if block.Text != nil {
@@ -5735,64 +5980,84 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 			}
 
 		case AnthropicContentBlockTypeToolResult:
-			// Convert tool result to function call output message
+			// Convert tool result to function call output message.
+			//
+			// `content` is OPTIONAL on an Anthropic tool_result block -- only `type`
+			// and `tool_use_id` are required (platform.claude.com/docs/en/api/messages,
+			// ToolResultBlockParam). A void tool, a tool that returned nothing, and an
+			// is_error result with no body all arrive with no `content` key.
+			//
+			// This used to gate the whole conversion on `block.Content != nil` and drop
+			// those blocks silently. Anthropic and Bedrock Converse both carry tool
+			// results on a user turn, so a dropped result deletes the user turn that
+			// separated two assistant turns -- and Bedrock's merge-consecutive-same-role
+			// pass then fuses every assistant turn into one, relocating each replayed
+			// thinking block to a content index it never occupied. That is issue #6342:
+			// a 15-message replay reaching Bedrock as [user, assistant(19 blocks)] and
+			// coming back as a non-retryable "`thinking` ... blocks in the latest
+			// assistant message cannot be modified".
+			//
+			// A missing body now behaves exactly like the already-supported empty-content
+			// array: an output struct with no content, which Bedrock emits as
+			// `"content": []` (required by ToolResultBlock, and already the shape the
+			// empty-array path ships today).
 			if block.ToolUseID != nil {
-				if block.Content != nil {
-					bifrostMsg := schemas.ResponsesMessage{
-						Type:         schemas.Ptr(schemas.ResponsesMessageTypeFunctionCallOutput),
-						Status:       schemas.Ptr("completed"),
-						CacheControl: block.CacheControl,
-						ResponsesToolMessage: &schemas.ResponsesToolMessage{
-							CallID: block.ToolUseID,
-						},
-					}
-					// Initialize the nested struct before any writes
-					bifrostMsg.ResponsesToolMessage.Output = &schemas.ResponsesToolMessageOutputStruct{}
+				bifrostMsg := schemas.ResponsesMessage{
+					Type:         schemas.Ptr(schemas.ResponsesMessageTypeFunctionCallOutput),
+					Status:       schemas.Ptr("completed"),
+					CacheControl: block.CacheControl,
+					ResponsesToolMessage: &schemas.ResponsesToolMessage{
+						CallID: block.ToolUseID,
+					},
+				}
+				// Initialize the nested struct before any writes
+				bifrostMsg.ResponsesToolMessage.Output = &schemas.ResponsesToolMessageOutputStruct{}
 
-					if block.Content.ContentStr != nil {
-						bifrostMsg.ResponsesToolMessage.Output.ResponsesToolCallOutputStr = block.Content.ContentStr
-					} else if block.Content.ContentBlocks != nil {
-						var toolMsgContentBlocks []schemas.ResponsesMessageContentBlock
-						for _, contentBlock := range block.Content.ContentBlocks {
-							switch contentBlock.Type {
-							case AnthropicContentBlockTypeText:
-								if contentBlock.Text != nil {
-									var blockType schemas.ResponsesMessageContentBlockType
-									if isOutputMessage {
-										blockType = schemas.ResponsesOutputMessageContentTypeText
-									} else {
-										blockType = schemas.ResponsesInputMessageContentBlockTypeText
-									}
-									toolMsgContentBlocks = append(toolMsgContentBlocks, schemas.ResponsesMessageContentBlock{
-										Type:         blockType,
-										Text:         contentBlock.Text,
-										CacheControl: contentBlock.CacheControl,
-									})
+				if block.Content == nil {
+					// No body to convert; the is_error handling below still applies.
+				} else if block.Content.ContentStr != nil {
+					bifrostMsg.ResponsesToolMessage.Output.ResponsesToolCallOutputStr = block.Content.ContentStr
+				} else if block.Content.ContentBlocks != nil {
+					var toolMsgContentBlocks []schemas.ResponsesMessageContentBlock
+					for _, contentBlock := range block.Content.ContentBlocks {
+						switch contentBlock.Type {
+						case AnthropicContentBlockTypeText:
+							if contentBlock.Text != nil {
+								var blockType schemas.ResponsesMessageContentBlockType
+								if isOutputMessage {
+									blockType = schemas.ResponsesOutputMessageContentTypeText
+								} else {
+									blockType = schemas.ResponsesInputMessageContentBlockTypeText
 								}
-							case AnthropicContentBlockTypeImage:
-								if contentBlock.Source != nil && contentBlock.Source.SourceObj != nil {
-									toolMsgContentBlocks = append(toolMsgContentBlocks, contentBlock.toBifrostResponsesImageBlock())
-								}
-							case AnthropicContentBlockTypeDocument:
-								// A tool returning a PDF (Claude Code's Read tool, for one)
-								// nests a document block here. Dropping it leaves the
-								// function_call_output with an empty content array, which
-								// OpenAI rejects outright:
-								// "Missing required parameter: 'input[N].content[0]'".
-								if contentBlock.Source != nil && contentBlock.Source.SourceObj != nil {
-									toolMsgContentBlocks = append(toolMsgContentBlocks, contentBlock.toBifrostResponsesDocumentBlock())
-								}
+								toolMsgContentBlocks = append(toolMsgContentBlocks, schemas.ResponsesMessageContentBlock{
+									Type:         blockType,
+									Text:         contentBlock.Text,
+									CacheControl: contentBlock.CacheControl,
+								})
+							}
+						case AnthropicContentBlockTypeImage:
+							if contentBlock.Source != nil && contentBlock.Source.SourceObj != nil {
+								toolMsgContentBlocks = append(toolMsgContentBlocks, contentBlock.toBifrostResponsesImageBlock())
+							}
+						case AnthropicContentBlockTypeDocument:
+							// A tool returning a PDF (Claude Code's Read tool, for one)
+							// nests a document block here. Dropping it leaves the
+							// function_call_output with an empty content array, which
+							// OpenAI rejects outright:
+							// "Missing required parameter: 'input[N].content[0]'".
+							if contentBlock.Source != nil && contentBlock.Source.SourceObj != nil {
+								toolMsgContentBlocks = append(toolMsgContentBlocks, contentBlock.toBifrostResponsesDocumentBlock())
 							}
 						}
-						bifrostMsg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks = toolMsgContentBlocks
 					}
-					// Handle is_error from Anthropic
-					if block.IsError != nil && *block.IsError {
-						bifrostMsg.Status = schemas.Ptr("incomplete")
-					}
-
-					bifrostMessages = append(bifrostMessages, bifrostMsg)
+					bifrostMsg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks = toolMsgContentBlocks
 				}
+				// Handle is_error from Anthropic
+				if block.IsError != nil && *block.IsError {
+					bifrostMsg.Status = schemas.Ptr("incomplete")
+				}
+
+				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}
 
 		case AnthropicContentBlockTypeServerToolUse:
@@ -5821,80 +6086,9 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 		}
 	}
 
-	// Flush any remaining pending blocks
-	if len(accumulatedTextContent) > 0 {
-		bifrostMsg := schemas.ResponsesMessage{
-			Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
-			Role: role,
-		}
-		if isOutputMessage {
-			bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
-			bifrostMsg.Content = &schemas.ResponsesMessageContent{
-				ContentBlocks: accumulatedTextContent,
-			}
-			bifrostMessages = append(bifrostMessages, bifrostMsg)
-		}
-	}
-
-	// Emit any accumulated tool_use blocks as function_calls
-	if len(pendingToolUseBlocks) > 0 {
-		for _, toolBlock := range pendingToolUseBlocks {
-			bifrostMsg := schemas.ResponsesMessage{
-				Type:         schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
-				Status:       schemas.Ptr("completed"),
-				CacheControl: toolBlock.CacheControl,
-				ResponsesToolMessage: &schemas.ResponsesToolMessage{
-					CallID: toolBlock.ID,
-					Name:   toolBlock.Name,
-				},
-			}
-			if isOutputMessage {
-				bifrostMsg.ID = schemas.Ptr("fc_" + schemas.GetRandomString(50))
-			}
-
-			// Check for computer tool use
-			if toolBlock.Name != nil && *toolBlock.Name == string(AnthropicToolNameComputer) {
-				bifrostMsg.Type = schemas.Ptr(schemas.ResponsesMessageTypeComputerCall)
-				bifrostMsg.ResponsesToolMessage.Name = nil
-				var inputMap map[string]interface{}
-				if err := sonic.Unmarshal(toolBlock.Input, &inputMap); err == nil {
-					bifrostMsg.ResponsesToolMessage.Action = &schemas.ResponsesToolMessageActionStruct{
-						ResponsesComputerToolCallAction: convertAnthropicToResponsesComputerAction(inputMap),
-					}
-				}
-			} else if toolBlock.Name != nil && *toolBlock.Name == string(AnthropicToolNameWebSearch) {
-				bifrostMsg.Type = schemas.Ptr(schemas.ResponsesMessageTypeWebSearchCall)
-				bifrostMsg.ResponsesToolMessage.Name = nil
-				if q := providerUtils.GetJSONField(toolBlock.Input, "query"); q.Exists() && q.Type == gjson.String {
-					query := q.Str
-					bifrostMsg.ResponsesToolMessage.Action = &schemas.ResponsesToolMessageActionStruct{
-						ResponsesWebSearchToolCallAction: &schemas.ResponsesWebSearchToolCallAction{
-							Type:    "search",
-							Query:   schemas.Ptr(query),
-							Queries: []string{query},
-						},
-					}
-				}
-			} else if toolBlock.Name != nil && *toolBlock.Name == string(AnthropicToolNameWebFetch) {
-				bifrostMsg.Type = schemas.Ptr(schemas.ResponsesMessageTypeWebFetchCall)
-				bifrostMsg.ResponsesToolMessage.Name = nil
-				if u := providerUtils.GetJSONField(toolBlock.Input, "url"); u.Exists() && u.Type == gjson.String {
-					bifrostMsg.ResponsesToolMessage.Action = &schemas.ResponsesToolMessageActionStruct{
-						ResponsesWebFetchToolCallAction: &schemas.ResponsesWebFetchToolCallAction{
-							URL: u.Str,
-						},
-					}
-				}
-			} else {
-				if len(toolBlock.Input) > 0 {
-					bifrostMsg.ResponsesToolMessage.Arguments = schemas.Ptr(string(toolBlock.Input))
-				}
-			}
-
-			bifrostMessages = append(bifrostMessages, bifrostMsg)
-		}
-	}
-
+	// Flush whatever the last run left buffered.
+	flushAccumulatedText()
+	flushPendingToolUses()
 	return bifrostMessages
 }
 
@@ -6180,64 +6374,84 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 				}
 			}
 		case AnthropicContentBlockTypeToolResult:
-			// Convert tool result to function call output message
+			// Convert tool result to function call output message.
+			//
+			// `content` is OPTIONAL on an Anthropic tool_result block -- only `type`
+			// and `tool_use_id` are required (platform.claude.com/docs/en/api/messages,
+			// ToolResultBlockParam). A void tool, a tool that returned nothing, and an
+			// is_error result with no body all arrive with no `content` key.
+			//
+			// This used to gate the whole conversion on `block.Content != nil` and drop
+			// those blocks silently. Anthropic and Bedrock Converse both carry tool
+			// results on a user turn, so a dropped result deletes the user turn that
+			// separated two assistant turns -- and Bedrock's merge-consecutive-same-role
+			// pass then fuses every assistant turn into one, relocating each replayed
+			// thinking block to a content index it never occupied. That is issue #6342:
+			// a 15-message replay reaching Bedrock as [user, assistant(19 blocks)] and
+			// coming back as a non-retryable "`thinking` ... blocks in the latest
+			// assistant message cannot be modified".
+			//
+			// A missing body now behaves exactly like the already-supported empty-content
+			// array: an output struct with no content, which Bedrock emits as
+			// `"content": []` (required by ToolResultBlock, and already the shape the
+			// empty-array path ships today).
 			if block.ToolUseID != nil {
-				if block.Content != nil {
-					bifrostMsg := schemas.ResponsesMessage{
-						Type:         schemas.Ptr(schemas.ResponsesMessageTypeFunctionCallOutput),
-						Status:       schemas.Ptr("completed"),
-						CacheControl: block.CacheControl,
-						ResponsesToolMessage: &schemas.ResponsesToolMessage{
-							CallID: block.ToolUseID,
-						},
-					}
-					// Initialize the nested struct before any writes
-					bifrostMsg.ResponsesToolMessage.Output = &schemas.ResponsesToolMessageOutputStruct{}
+				bifrostMsg := schemas.ResponsesMessage{
+					Type:         schemas.Ptr(schemas.ResponsesMessageTypeFunctionCallOutput),
+					Status:       schemas.Ptr("completed"),
+					CacheControl: block.CacheControl,
+					ResponsesToolMessage: &schemas.ResponsesToolMessage{
+						CallID: block.ToolUseID,
+					},
+				}
+				// Initialize the nested struct before any writes
+				bifrostMsg.ResponsesToolMessage.Output = &schemas.ResponsesToolMessageOutputStruct{}
 
-					if block.Content.ContentStr != nil {
-						bifrostMsg.ResponsesToolMessage.Output.ResponsesToolCallOutputStr = block.Content.ContentStr
-					} else if block.Content.ContentBlocks != nil {
-						var toolMsgContentBlocks []schemas.ResponsesMessageContentBlock
-						for _, contentBlock := range block.Content.ContentBlocks {
-							switch contentBlock.Type {
-							case AnthropicContentBlockTypeText:
-								if contentBlock.Text != nil {
-									var blockType schemas.ResponsesMessageContentBlockType
-									if isOutputMessage {
-										blockType = schemas.ResponsesOutputMessageContentTypeText
-									} else {
-										blockType = schemas.ResponsesInputMessageContentBlockTypeText
-									}
-									toolMsgContentBlocks = append(toolMsgContentBlocks, schemas.ResponsesMessageContentBlock{
-										Type:         blockType,
-										Text:         contentBlock.Text,
-										CacheControl: contentBlock.CacheControl,
-									})
+				if block.Content == nil {
+					// No body to convert; the is_error handling below still applies.
+				} else if block.Content.ContentStr != nil {
+					bifrostMsg.ResponsesToolMessage.Output.ResponsesToolCallOutputStr = block.Content.ContentStr
+				} else if block.Content.ContentBlocks != nil {
+					var toolMsgContentBlocks []schemas.ResponsesMessageContentBlock
+					for _, contentBlock := range block.Content.ContentBlocks {
+						switch contentBlock.Type {
+						case AnthropicContentBlockTypeText:
+							if contentBlock.Text != nil {
+								var blockType schemas.ResponsesMessageContentBlockType
+								if isOutputMessage {
+									blockType = schemas.ResponsesOutputMessageContentTypeText
+								} else {
+									blockType = schemas.ResponsesInputMessageContentBlockTypeText
 								}
-							case AnthropicContentBlockTypeImage:
-								if contentBlock.Source != nil && contentBlock.Source.SourceObj != nil {
-									toolMsgContentBlocks = append(toolMsgContentBlocks, contentBlock.toBifrostResponsesImageBlock())
-								}
-							case AnthropicContentBlockTypeDocument:
-								// A tool returning a PDF (Claude Code's Read tool, for one)
-								// nests a document block here. Dropping it leaves the
-								// function_call_output with an empty content array, which
-								// OpenAI rejects outright:
-								// "Missing required parameter: 'input[N].content[0]'".
-								if contentBlock.Source != nil && contentBlock.Source.SourceObj != nil {
-									toolMsgContentBlocks = append(toolMsgContentBlocks, contentBlock.toBifrostResponsesDocumentBlock())
-								}
+								toolMsgContentBlocks = append(toolMsgContentBlocks, schemas.ResponsesMessageContentBlock{
+									Type:         blockType,
+									Text:         contentBlock.Text,
+									CacheControl: contentBlock.CacheControl,
+								})
+							}
+						case AnthropicContentBlockTypeImage:
+							if contentBlock.Source != nil && contentBlock.Source.SourceObj != nil {
+								toolMsgContentBlocks = append(toolMsgContentBlocks, contentBlock.toBifrostResponsesImageBlock())
+							}
+						case AnthropicContentBlockTypeDocument:
+							// A tool returning a PDF (Claude Code's Read tool, for one)
+							// nests a document block here. Dropping it leaves the
+							// function_call_output with an empty content array, which
+							// OpenAI rejects outright:
+							// "Missing required parameter: 'input[N].content[0]'".
+							if contentBlock.Source != nil && contentBlock.Source.SourceObj != nil {
+								toolMsgContentBlocks = append(toolMsgContentBlocks, contentBlock.toBifrostResponsesDocumentBlock())
 							}
 						}
-						bifrostMsg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks = toolMsgContentBlocks
 					}
-					// Handle is_error from Anthropic
-					if block.IsError != nil && *block.IsError {
-						bifrostMsg.Status = schemas.Ptr("incomplete")
-					}
-
-					bifrostMessages = append(bifrostMessages, bifrostMsg)
+					bifrostMsg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks = toolMsgContentBlocks
 				}
+				// Handle is_error from Anthropic
+				if block.IsError != nil && *block.IsError {
+					bifrostMsg.Status = schemas.Ptr("incomplete")
+				}
+
+				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}
 
 		case AnthropicContentBlockTypeServerToolUse:

--- a/core/providers/anthropic/toolresultnocontent_test.go
+++ b/core/providers/anthropic/toolresultnocontent_test.go
@@ -1,0 +1,134 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// Anthropic's Messages API marks `content` optional on a tool_result block --
+// only `type` and `tool_use_id` are required
+// (https://platform.claude.com/docs/en/api/messages, ToolResultBlockParam).
+// A void tool, a tool that returned nothing, and an is_error result with no
+// body all legitimately arrive with no `content` key at all.
+//
+// Both Responses-surface converters used to gate the whole conversion on
+// `block.Content != nil`, so those blocks were dropped on the floor rather than
+// becoming a function_call_output. Losing the tool result loses the entire user
+// turn that carried it, which is what wedges a Bedrock replay: with no user turn
+// between them, every assistant turn merges into one (see
+// TestAnthropicIngressBedrockReplayKeepsTurnBoundaries in the bedrock package).
+//
+// The empty-content-array shape is already covered by
+// TestConvertToolResultWithEmptyContent; this asserts the absent/null/is_error
+// shapes behave identically to it.
+func TestConvertToolResultWithoutContentField(t *testing.T) {
+	cases := []struct {
+		name    string
+		block   AnthropicContentBlock
+		isError bool
+	}{
+		{
+			name: "content key absent",
+			block: AnthropicContentBlock{
+				Type:      AnthropicContentBlockTypeToolResult,
+				ToolUseID: schemas.Ptr("toolu_void"),
+			},
+		},
+		{
+			name: "is_error with no content",
+			block: AnthropicContentBlock{
+				Type:      AnthropicContentBlockTypeToolResult,
+				ToolUseID: schemas.Ptr("toolu_failed"),
+				IsError:   schemas.Ptr(true),
+			},
+			isError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			role := schemas.ResponsesInputMessageRoleUser
+			blocks := []AnthropicContentBlock{tc.block}
+
+			// keepToolsGrouped path (every `bedrock/` request takes this one).
+			grouped := convertAnthropicContentBlocksToResponsesMessagesGrouped(blocks, &role, false)
+			assertSingleFunctionCallOutput(t, "grouped", grouped, *tc.block.ToolUseID)
+
+			// Default path (native Anthropic, Vertex, Azure ingress).
+			ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+			plain := convertAnthropicContentBlocksToResponsesMessages(ctx, blocks, &role, false, "")
+			assertSingleFunctionCallOutput(t, "default", plain, *tc.block.ToolUseID)
+		})
+	}
+}
+
+func assertSingleFunctionCallOutput(t *testing.T, path string, msgs []schemas.ResponsesMessage, wantCallID string) {
+	t.Helper()
+
+	if len(msgs) != 1 {
+		t.Fatalf("%s path: a content-less tool_result must still convert to one function_call_output, got %d messages", path, len(msgs))
+	}
+	msg := msgs[0]
+	if msg.Type == nil || *msg.Type != schemas.ResponsesMessageTypeFunctionCallOutput {
+		t.Fatalf("%s path: expected type function_call_output, got %v", path, msg.Type)
+	}
+	if msg.ResponsesToolMessage == nil || msg.ResponsesToolMessage.CallID == nil {
+		t.Fatalf("%s path: converted message carries no call id", path)
+	}
+	if *msg.ResponsesToolMessage.CallID != wantCallID {
+		t.Fatalf("%s path: expected call id %q, got %q", path, wantCallID, *msg.ResponsesToolMessage.CallID)
+	}
+	if msg.ResponsesToolMessage.Output == nil {
+		t.Fatalf("%s path: output struct must be non-nil so downstream converters emit a tool result", path)
+	}
+	if _, err := schemas.MarshalSorted(msgs); err != nil {
+		t.Fatalf("%s path: converted messages must marshal, got: %v", path, err)
+	}
+}
+
+// The grouped converter used to buffer every text block and every tool_use block
+// to the end of the turn while emitting thinking blocks in place. For an
+// interleaved turn that reordered the stream into
+// [reasoning, reasoning, message(text+text), function_call, function_call],
+// which relocates the second thinking block in front of the tool call it was
+// produced after. Items must come out in wire order, with only *consecutive*
+// text blocks coalesced.
+func TestGroupedConverterPreservesInterleavedBlockOrder(t *testing.T) {
+	role := schemas.ResponsesInputMessageRoleAssistant
+	blocks := []AnthropicContentBlock{
+		{Type: AnthropicContentBlockTypeThinking, Thinking: schemas.Ptr("t0"), Signature: schemas.Ptr("SIG_0")},
+		{Type: AnthropicContentBlockTypeText, Text: schemas.Ptr("step 0")},
+		{Type: AnthropicContentBlockTypeToolUse, ID: schemas.Ptr("toolu_0"), Name: schemas.Ptr("get_weather"), Input: []byte(`{"city":"sf"}`)},
+		{Type: AnthropicContentBlockTypeThinking, Thinking: schemas.Ptr("t1"), Signature: schemas.Ptr("SIG_1")},
+		{Type: AnthropicContentBlockTypeText, Text: schemas.Ptr("step 1")},
+		{Type: AnthropicContentBlockTypeToolUse, ID: schemas.Ptr("toolu_1"), Name: schemas.Ptr("get_weather"), Input: []byte(`{"city":"la"}`)},
+	}
+
+	msgs := convertAnthropicContentBlocksToResponsesMessagesGrouped(blocks, &role, true)
+
+	want := []schemas.ResponsesMessageType{
+		schemas.ResponsesMessageTypeReasoning,
+		schemas.ResponsesMessageTypeMessage,
+		schemas.ResponsesMessageTypeFunctionCall,
+		schemas.ResponsesMessageTypeReasoning,
+		schemas.ResponsesMessageTypeMessage,
+		schemas.ResponsesMessageTypeFunctionCall,
+	}
+	got := make([]schemas.ResponsesMessageType, 0, len(msgs))
+	for _, m := range msgs {
+		if m.Type == nil {
+			got = append(got, "<nil>")
+			continue
+		}
+		got = append(got, *m.Type)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("item order: want %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("item order: want %v, got %v", want, got)
+		}
+	}
+}

--- a/core/providers/bedrock/anthropicingressreplay_test.go
+++ b/core/providers/bedrock/anthropicingressreplay_test.go
@@ -1,0 +1,349 @@
+package bedrock_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/providers/anthropic"
+	"github.com/maximhq/bifrost/core/providers/bedrock"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/require"
+)
+
+// Wire-level reproduction of issue #6342.
+//
+// A client on the Anthropic-native ingress (`POST /anthropic/v1/messages`) with a
+// `bedrock/` model prefix never takes the Anthropic passthrough -- isClaudeModel in
+// transports/bifrost-http/integrations/anthropic.go excludes schemas.Bedrock -- so the
+// request is converted Anthropic -> Bifrost Responses -> Bedrock Converse.
+//
+// Converse has no message-level tool role: a tool result rides a user turn. So every
+// dropped tool result also deletes the user turn that separated two assistant turns,
+// and ConvertBifrostMessagesToBedrockMessages' "merge consecutive messages with the
+// same role" pass then fuses them. With every tool result dropped, a 15-message replay
+// collapses to [user, assistant] and every replayed thinking block lands in one
+// oversized assistant message at a content index it never occupied upstream. Bedrock
+// rejects that non-retryably:
+//
+//	messages.1.content.5: `thinking` or `redacted_thinking` blocks in the latest
+//	assistant message cannot be modified.
+//
+// which is unrecoverable -- the client replays the same history on every retry.
+//
+// `content` is optional on an Anthropic tool_result block (only `type` and
+// `tool_use_id` are required; see platform.claude.com/docs/en/api/messages,
+// ToolResultBlockParam), so a void tool or an errored tool with no body produces
+// exactly this payload.
+func TestAnthropicIngressBedrockReplayKeepsTurnBoundaries(t *testing.T) {
+	// The reporter's conversation: one user turn, then 7 assistant tool-call steps,
+	// each answered by a tool result. Steps 0, 3, 4, 5 and 6 carry a signed thinking
+	// block, matching their convertToModelMessages dump.
+	thinkingOnStep := map[int]bool{0: true, 3: true, 4: true, 5: true, 6: true}
+
+	messages := []map[string]any{
+		{"role": "user", "content": []map[string]any{{"type": "text", "text": "run the tool"}}},
+	}
+	for step := 0; step < 7; step++ {
+		var assistantBlocks []map[string]any
+		if thinkingOnStep[step] {
+			assistantBlocks = append(assistantBlocks, map[string]any{
+				"type":      "thinking",
+				"thinking":  fmt.Sprintf("deliberating on step %d", step),
+				"signature": fmt.Sprintf("ErUBCkYIBxgCKkA_signature_%d", step),
+			})
+		}
+		assistantBlocks = append(assistantBlocks,
+			map[string]any{"type": "text", "text": fmt.Sprintf("calling the tool, step %d", step)},
+			map[string]any{
+				"type":  "tool_use",
+				"id":    fmt.Sprintf("toolu_01Step%02d", step),
+				"name":  "get_weather",
+				"input": map[string]any{"city": "san francisco"},
+			},
+		)
+		messages = append(messages, map[string]any{"role": "assistant", "content": assistantBlocks})
+		// A tool_result with no `content` key -- legal, and what a void or errored
+		// tool produces.
+		messages = append(messages, map[string]any{"role": "user", "content": []map[string]any{{
+			"type":        "tool_result",
+			"tool_use_id": fmt.Sprintf("toolu_01Step%02d", step),
+		}}})
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"model":      "bedrock/us.anthropic.claude-opus-4-8",
+		"max_tokens": 4096,
+		"thinking":   map[string]any{"type": "adaptive"},
+		"tools": []map[string]any{{
+			"name":         "get_weather",
+			"description":  "look up the weather",
+			"input_schema": map[string]any{"type": "object", "properties": map[string]any{"city": map[string]any{"type": "string"}}},
+		}},
+		"messages": messages,
+	})
+	require.NoError(t, err)
+
+	var ingressReq anthropic.AnthropicMessageRequest
+	require.NoError(t, json.Unmarshal(body, &ingressReq))
+	require.Len(t, ingressReq.Messages, 15, "fixture must reproduce the reporter's 15-message replay")
+
+	ctx := &schemas.BifrostContext{}
+	bifrostReq := ingressReq.ToBifrostResponsesRequest(ctx)
+	require.NotNil(t, bifrostReq)
+
+	converseReq, err := bedrock.ToBedrockResponsesRequest(ctx, bifrostReq)
+	require.NoError(t, err)
+
+	// 1. Turn boundaries survive: 15 in, 15 out, strictly alternating.
+	require.Equalf(t, len(ingressReq.Messages), len(converseReq.Messages),
+		"every tool result must keep its user turn; collapsing turns merges the assistant messages behind them (converse roles: %s)",
+		converseRoles(converseReq.Messages))
+
+	for i, msg := range converseReq.Messages {
+		wantRole := bedrock.BedrockMessageRoleUser
+		if i%2 == 1 {
+			wantRole = bedrock.BedrockMessageRoleAssistant
+		}
+		require.Equalf(t, wantRole, msg.Role, "message %d role", i)
+	}
+
+	// 2. Every replayed thinking block stays in its own assistant turn, at content
+	//    index 0, with its signature byte-for-byte intact. Bedrock verifies each
+	//    signature against the block it signed, so a block that moved turn or index
+	//    is a modified block.
+	seenSignatures := 0
+	for step := 0; step < 7; step++ {
+		msg := converseReq.Messages[step*2+1]
+		if !thinkingOnStep[step] {
+			for j, block := range msg.Content {
+				require.Nilf(t, block.ReasoningContent,
+					"step %d had no thinking block upstream, but content.%d is reasoning", step, j)
+			}
+			continue
+		}
+
+		require.NotNilf(t, msg.Content[0].ReasoningContent,
+			"step %d: thinking block must stay first in its own assistant turn", step)
+		require.NotNil(t, msg.Content[0].ReasoningContent.ReasoningText)
+		require.NotNilf(t, msg.Content[0].ReasoningContent.ReasoningText.Signature,
+			"step %d: replay signature dropped", step)
+		require.Equalf(t, fmt.Sprintf("ErUBCkYIBxgCKkA_signature_%d", step),
+			*msg.Content[0].ReasoningContent.ReasoningText.Signature,
+			"step %d: replay signature altered", step)
+		seenSignatures++
+
+		// Exactly one reasoning block per turn -- no other turn's thinking migrated in.
+		reasoningInTurn := 0
+		for _, block := range msg.Content {
+			if block.ReasoningContent != nil {
+				reasoningInTurn++
+			}
+		}
+		require.Equalf(t, 1, reasoningInTurn, "step %d: expected exactly one reasoning block in the turn", step)
+	}
+	require.Equal(t, 5, seenSignatures, "all five signed thinking blocks must be asserted")
+
+	// 3. Each tool result is answered in the turn immediately after its call.
+	for step := 0; step < 7; step++ {
+		userMsg := converseReq.Messages[step*2+2]
+		require.Lenf(t, userMsg.Content, 1, "step %d: tool-result turn must hold exactly its own result", step)
+		require.NotNilf(t, userMsg.Content[0].ToolResult, "step %d: tool result dropped", step)
+		require.Equalf(t, fmt.Sprintf("toolu_01Step%02d", step),
+			userMsg.Content[0].ToolResult.ToolUseID, "step %d: tool result paired with the wrong call", step)
+	}
+}
+
+// converseRoles renders just the role sequence, so a collapse failure reads as
+// "user,assistant" instead of a page of content-block pointers.
+func converseRoles(messages []bedrock.BedrockMessage) string {
+	roles := make([]string, 0, len(messages))
+	for _, m := range messages {
+		roles = append(roles, fmt.Sprintf("%s(%d)", m.Role, len(m.Content)))
+	}
+	return strings.Join(roles, ",")
+}
+
+// Interleaved thinking (issue #6342, second defect). On adaptive-thinking models
+// Claude reasons *between* tool calls inside a single assistant turn, so one
+// assistant message can be [thinking, text, tool_use, thinking, text, tool_use].
+//
+// Anthropic drops the "assistant turn must begin with a thinking block" rule for
+// adaptive thinking (platform.claude.com/docs/en/build-with-claude/extended-thinking,
+// "Turn structure in manual mode"), so hoisting every thinking block to the front of
+// the turn is not a harmless normalization -- it relocates a signed block the client
+// replayed verbatim, which is the same "blocks must remain as they were" violation
+// that wedges the conversation.
+//
+// The turn must arrive at Bedrock in the order the client sent it, whichever order
+// that is. Both orders are covered because they exercise different flush sites in
+// ConvertBifrostMessagesToBedrockMessages: text-then-tool_use lets the reasoning ride
+// into the assistant message being built, while tool_use-then-text has a tool call
+// AND buffered reasoning pending at the same time, which is the case that used to
+// emit the tool use in front of the reasoning block that preceded it.
+func TestAnthropicIngressBedrockPreservesInterleavedThinkingOrder(t *testing.T) {
+	think := func(step int) map[string]any {
+		return map[string]any{
+			"type":      "thinking",
+			"thinking":  fmt.Sprintf("deliberating on step %d", step),
+			"signature": fmt.Sprintf("ErUBCkYIBxgCKkA_signature_%d", step),
+		}
+	}
+	text := func(step int) map[string]any {
+		return map[string]any{"type": "text", "text": fmt.Sprintf("calling the tool, step %d", step)}
+	}
+	toolUse := func(step int) map[string]any {
+		return map[string]any{
+			"type":  "tool_use",
+			"id":    fmt.Sprintf("toolu_01Step%02d", step),
+			"name":  "get_weather",
+			"input": map[string]any{"city": "san francisco"},
+		}
+	}
+
+	tests := []struct {
+		name  string
+		order func(step int) []map[string]any
+		want  []string
+	}{
+		{
+			name:  "thinking, text, tool_use",
+			order: func(step int) []map[string]any { return []map[string]any{think(step), text(step), toolUse(step)} },
+			want: []string{
+				"reasoning:ErUBCkYIBxgCKkA_signature_0",
+				"text:calling the tool, step 0",
+				"toolUse:toolu_01Step00",
+				"reasoning:ErUBCkYIBxgCKkA_signature_1",
+				"text:calling the tool, step 1",
+				"toolUse:toolu_01Step01",
+			},
+		},
+		{
+			name:  "thinking, tool_use, text",
+			order: func(step int) []map[string]any { return []map[string]any{think(step), toolUse(step), text(step)} },
+			want: []string{
+				"reasoning:ErUBCkYIBxgCKkA_signature_0",
+				"toolUse:toolu_01Step00",
+				"text:calling the tool, step 0",
+				"reasoning:ErUBCkYIBxgCKkA_signature_1",
+				"toolUse:toolu_01Step01",
+				"text:calling the tool, step 1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var assistantBlocks []map[string]any
+			for step := 0; step < 2; step++ {
+				assistantBlocks = append(assistantBlocks, tt.order(step)...)
+			}
+
+			body, err := json.Marshal(map[string]any{
+				"model":      "bedrock/us.anthropic.claude-opus-4-8",
+				"max_tokens": 4096,
+				"thinking":   map[string]any{"type": "adaptive"},
+				"tools": []map[string]any{{
+					"name":         "get_weather",
+					"description":  "look up the weather",
+					"input_schema": map[string]any{"type": "object"},
+				}},
+				"messages": []map[string]any{
+					{"role": "user", "content": []map[string]any{{"type": "text", "text": "run the tool twice"}}},
+					{"role": "assistant", "content": assistantBlocks},
+					{"role": "user", "content": []map[string]any{
+						{"type": "tool_result", "tool_use_id": "toolu_01Step00", "content": "sunny"},
+						{"type": "tool_result", "tool_use_id": "toolu_01Step01", "content": "windy"},
+					}},
+				},
+			})
+			require.NoError(t, err)
+
+			var ingressReq anthropic.AnthropicMessageRequest
+			require.NoError(t, json.Unmarshal(body, &ingressReq))
+
+			ctx := &schemas.BifrostContext{}
+			converseReq, err := bedrock.ToBedrockResponsesRequest(ctx, ingressReq.ToBifrostResponsesRequest(ctx))
+			require.NoError(t, err)
+
+			require.Len(t, converseReq.Messages, 3, "roles: %s", converseRoles(converseReq.Messages))
+			turn := converseReq.Messages[1]
+			require.Equal(t, bedrock.BedrockMessageRoleAssistant, turn.Role)
+
+			got := make([]string, 0, len(turn.Content))
+			for _, block := range turn.Content {
+				switch {
+				case block.ReasoningContent != nil && block.ReasoningContent.ReasoningText != nil:
+					sig := ""
+					if block.ReasoningContent.ReasoningText.Signature != nil {
+						sig = *block.ReasoningContent.ReasoningText.Signature
+					}
+					got = append(got, "reasoning:"+sig)
+				case block.Text != nil:
+					got = append(got, "text:"+*block.Text)
+				case block.ToolUse != nil:
+					got = append(got, "toolUse:"+block.ToolUse.ToolUseID)
+				default:
+					got = append(got, "other")
+				}
+			}
+			require.Equal(t, tt.want, got, "interleaved turn must reach Bedrock in the order the client sent it")
+		})
+	}
+}
+
+// Converse accepts only success|error on toolResult.status
+// (docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolResultBlock.html),
+// while Bifrost's Responses surface marks a failed tool result "incomplete". The
+// egress switch used to let "incomplete" fall through to its default and report the
+// failure to the model as a success -- so Bedrock could not read back what its own
+// ingress had written (TestConverseToolErrorReachesChatSurface pins the other half).
+//
+// This matters directly for issue #6342: `is_error: true` with no body is one of the
+// three tool_result shapes that used to be dropped entirely, so fixing the drop is
+// what starts routing these results through this switch.
+func TestAnthropicIngressBedrockToolErrorKeepsErrorStatus(t *testing.T) {
+	body, err := json.Marshal(map[string]any{
+		"model":      "bedrock/us.anthropic.claude-opus-4-8",
+		"max_tokens": 4096,
+		"tools": []map[string]any{{
+			"name":         "run",
+			"description":  "run a command",
+			"input_schema": map[string]any{"type": "object"},
+		}},
+		"messages": []map[string]any{
+			{"role": "user", "content": []map[string]any{{"type": "text", "text": "run it"}}},
+			{"role": "assistant", "content": []map[string]any{
+				{"type": "text", "text": "running"},
+				{"type": "tool_use", "id": "toolu_failed", "name": "run", "input": map[string]any{}},
+			}},
+			// is_error with no content: legal, and one of the shapes that used to be dropped.
+			{"role": "user", "content": []map[string]any{
+				{"type": "tool_result", "tool_use_id": "toolu_failed", "is_error": true},
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	var ingressReq anthropic.AnthropicMessageRequest
+	require.NoError(t, json.Unmarshal(body, &ingressReq))
+
+	ctx := &schemas.BifrostContext{}
+	converseReq, err := bedrock.ToBedrockResponsesRequest(ctx, ingressReq.ToBifrostResponsesRequest(ctx))
+	require.NoError(t, err)
+
+	require.Len(t, converseReq.Messages, 3, "roles: %s", converseRoles(converseReq.Messages))
+
+	var result *bedrock.BedrockToolResult
+	for _, block := range converseReq.Messages[2].Content {
+		if block.ToolResult != nil {
+			result = block.ToolResult
+			break
+		}
+	}
+	require.NotNil(t, result, "content-less is_error tool_result must still reach Converse")
+	require.Equal(t, "toolu_failed", result.ToolUseID)
+	require.NotNil(t, result.Status, "Converse requires a readable status for a failed tool call")
+	require.Equal(t, "error", *result.Status, "is_error must not be reported to the model as a success")
+}

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -3434,9 +3434,23 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 			seenNonSystemMessage = true
 		}
 
-		// If we're processing a non-reasoning message and have pending reasoning blocks,
-		// flush them into the previous assistant message (if it exists)
-		if msgType != schemas.ResponsesMessageTypeReasoning && len(pendingReasoningContentBlocks) > 0 {
+		// Buffered reasoning belongs to the assistant turn that is still being built,
+		// so the three item types that build one consume it themselves and are skipped
+		// here: an assistant `message` prepends it to its own content, and
+		// function_call / function_call_output prepend it to the toolUse message they
+		// flush. Relocating it into the PREVIOUS assistant message for those types
+		// moved an interleaved thinking block in front of the tool call it was produced
+		// after -- a modification of a signed block that Bedrock rejects (issue #6342).
+		//
+		// Everything else (a user turn, a server-tool call, an unhandled type) has
+		// nothing to attach the reasoning to going forward, so the historical fallback
+		// still applies: fold it into the last assistant message rather than lose it.
+		consumesPendingReasoning := msgType == schemas.ResponsesMessageTypeReasoning ||
+			msgType == schemas.ResponsesMessageTypeFunctionCall ||
+			msgType == schemas.ResponsesMessageTypeFunctionCallOutput ||
+			(msgType == schemas.ResponsesMessageTypeMessage && msg.Role != nil &&
+				*msg.Role == schemas.ResponsesInputMessageRoleAssistant)
+		if !consumesPendingReasoning && len(pendingReasoningContentBlocks) > 0 {
 			if len(bedrockMessages) > 0 && bedrockMessages[len(bedrockMessages)-1].Role == BedrockMessageRoleAssistant {
 				// Prepend reasoning blocks to the last assistant message
 				lastMsg := &bedrockMessages[len(bedrockMessages)-1]
@@ -3467,10 +3481,19 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 				resultContent := []BedrockContentBlock{}
 				status := "success"
 				if msg.Status != nil && *msg.Status != "" {
-					// Validate status is one of the allowed values
+					// Converse accepts only success|error on toolResult.status
+					// (docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolResultBlock.html).
+					// "incomplete" is the canonical Responses status for a failed tool
+					// result -- it is what the Anthropic ingress writes for is_error and
+					// what this provider's own Converse ingress writes for status "error"
+					// (see convertSingleBedrockMessageToBifrostMessages). Letting it fall
+					// through to the default reported a failed tool call to the model as a
+					// success, so Bedrock could not read back what Bedrock had written.
 					switch *msg.Status {
 					case "success", "error":
 						status = *msg.Status
+					case "incomplete":
+						status = "error"
 					default:
 						// Default to success for unknown status values
 						status = "success"
@@ -3614,47 +3637,17 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 			role := *msg.Role
 
 			// Always flush pending tool calls and results before processing a new message
-			// This ensures tool calls and results are properly paired
-			if stateManager.HasPendingToolCalls() {
-				callIDs := stateManager.EmitPendingToolCalls()
-				// Create assistant message with tool calls
-				var toolUseBlocks []BedrockContentBlock
-				for _, callID := range callIDs {
-					if toolCall, exists := stateManager.toolCalls[callID]; exists {
-						toolUseBlock := &BedrockContentBlock{
-							ToolUse: &BedrockToolUse{
-								ToolUseID: bedrockAliasToolUseID(toolCall.CallID),
-								Name:      toolCall.ToolName,
-							},
-						}
-						// Preserve original key ordering of tool arguments for prompt caching.
-						var input json.RawMessage
-						var buf bytes.Buffer
-						if err := json.Compact(&buf, []byte(toolCall.Arguments)); err == nil {
-							input = buf.Bytes()
-						} else {
-							input = json.RawMessage("{}")
-						}
-						toolUseBlock.ToolUse.Input = input
-						toolUseBlocks = append(toolUseBlocks, *toolUseBlock)
-						// Preserve the cache breakpoint Claude Code placed on this tool call, else the
-						// next turn can't match the prefix and collapses to the tools/system floor.
-						if toolCall.CacheControl != nil {
-							toolUseBlocks = append(toolUseBlocks, BedrockContentBlock{
-								CachePoint: newBedrockCachePoint(toolCall.CacheControl.TTL),
-							})
-						}
-					}
-				}
-
-				if len(toolUseBlocks) > 0 {
-					bedrockMessages = append(bedrockMessages, BedrockMessage{
-						Role:    BedrockMessageRoleAssistant,
-						Content: toolUseBlocks,
-					})
-					stateManager.MarkToolCallsEmitted(callIDs, len(bedrockMessages)-1)
-				}
-			}
+			// This ensures tool calls and results are properly paired.
+			//
+			// Routed through flushPendingToolCalls rather than a private copy of it:
+			// the copy that used to live here was identical except that it did NOT
+			// prepend pendingReasoningContentBlocks, so a turn ordered
+			// [thinking, tool_use, text] -- which reaches this branch with a tool call
+			// AND buffered reasoning pending at the same time -- emitted the tool use
+			// in front of the signed reasoning block that preceded it upstream. That is
+			// the same relocation of a replayed thinking block that issue #6342 is
+			// about, just one flush site further along.
+			flushPendingToolCalls()
 
 			// Emit any pending results after tool calls
 			if stateManager.HasPendingResults() {
@@ -3712,11 +3705,26 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 						bedrockMsg.Content = append(pendingServerToolBlocks, bedrockMsg.Content...)
 						pendingServerToolBlocks = nil
 					}
+					// Buffered reasoning belongs at the front of THIS assistant message,
+					// not folded back into the previous one. Doing it here is what keeps
+					// an interleaved turn in wire order once the tool-call batch before
+					// it has already been flushed (see the reasoning case above).
+					if bedrockMsg.Role == BedrockMessageRoleAssistant && len(pendingReasoningContentBlocks) > 0 {
+						bedrockMsg.Content = append(pendingReasoningContentBlocks, bedrockMsg.Content...)
+						pendingReasoningContentBlocks = nil
+					}
 					bedrockMessages = append(bedrockMessages, *bedrockMsg)
 				}
 			}
 
 		case schemas.ResponsesMessageTypeReasoning:
+			// A reasoning item arriving while tool calls are still buffered means the
+			// model thought AFTER those calls (interleaved thinking). Emit them first so
+			// the new reasoning lands behind them in the turn instead of being hoisted
+			// in front of them. flushPendingToolCalls consumes whatever reasoning was
+			// already pending, which is the reasoning that genuinely preceded the calls.
+			flushPendingToolCalls()
+
 			// Handle reasoning as content in next assistant message
 			// For now, just add to pending content blocks
 			reasoningBlocks := convertBifrostReasoningToBedrockReasoning(&msg)

--- a/core/schemas/emptytooloutputmux_test.go
+++ b/core/schemas/emptytooloutputmux_test.go
@@ -1,0 +1,101 @@
+package schemas
+
+import (
+	"testing"
+)
+
+// OpenAI's Chat Completions API requires `content` on a role:"tool" message -- it is
+// the tool's result, so unlike an assistant message it has no meaning without one.
+//
+// A function_call_output can legitimately carry no body. Anthropic marks `content`
+// optional on a tool_result block (only `type` and `tool_use_id` are required), so a
+// void tool, an errored tool with no body, and an explicit empty content array all
+// produce a ResponsesToolMessageOutputStruct with neither field set.
+//
+// ToChatMessages used to leave cm.Content nil for those, and `omitempty` then dropped
+// the key entirely -- the tool message went out as
+// {"role":"tool","tool_call_id":"..."} with no content at all.
+//
+// Fixed here rather than at the Anthropic ingress on purpose. This is the layer that
+// owns the chat wire contract, so one fix covers every producer of an empty tool
+// output; seeding an empty string back at the ingress would also rewrite the Bedrock
+// Converse wire from `"content":[]` to `"content":[{"text":""}]`, and an empty text
+// block is a shape Anthropic rejects.
+func TestToChatMessages_EmptyToolOutputCarriesEmptyStringContent(t *testing.T) {
+	fcoType := ResponsesMessageTypeFunctionCallOutput
+
+	newFCO := func(output *ResponsesToolMessageOutputStruct) ResponsesMessage {
+		return ResponsesMessage{
+			Type: &fcoType,
+			ResponsesToolMessage: &ResponsesToolMessage{
+				CallID: Ptr("toolu_empty"),
+				Output: output,
+			},
+		}
+	}
+
+	tests := []struct {
+		name string
+		msg  ResponsesMessage
+	}{
+		{
+			name: "output struct with neither field set",
+			msg:  newFCO(&ResponsesToolMessageOutputStruct{}),
+		},
+		{
+			name: "output blocks present but empty",
+			msg:  newFCO(&ResponsesToolMessageOutputStruct{ResponsesFunctionToolCallOutputBlocks: []ResponsesMessageContentBlock{}}),
+		},
+		{
+			name: "no output struct at all",
+			msg:  newFCO(nil),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chatMessages := ToChatMessages([]ResponsesMessage{tt.msg})
+
+			if len(chatMessages) != 1 {
+				t.Fatalf("expected 1 chat message, got %d", len(chatMessages))
+			}
+			cm := chatMessages[0]
+			if cm.Role != ChatMessageRoleTool {
+				t.Fatalf("expected role tool, got %q", cm.Role)
+			}
+			if cm.Content == nil || cm.Content.ContentStr == nil {
+				t.Fatalf("tool message must carry content; OpenAI rejects a tool message without it. got Content=%+v", cm.Content)
+			}
+			if *cm.Content.ContentStr != "" {
+				t.Errorf("empty tool output must become an empty string, got %q", *cm.Content.ContentStr)
+			}
+		})
+	}
+}
+
+// A tool output that DOES carry a body must be untouched by the empty-output
+// backfill above.
+func TestToChatMessages_NonEmptyToolOutputUnchanged(t *testing.T) {
+	fcoType := ResponsesMessageTypeFunctionCallOutput
+
+	chatMessages := ToChatMessages([]ResponsesMessage{{
+		Type: &fcoType,
+		ResponsesToolMessage: &ResponsesToolMessage{
+			CallID: Ptr("toolu_ok"),
+			Output: &ResponsesToolMessageOutputStruct{
+				ResponsesToolCallOutputStr: Ptr("72 degrees and sunny"),
+			},
+		},
+	}})
+
+	if len(chatMessages) != 1 {
+		t.Fatalf("expected 1 chat message, got %d", len(chatMessages))
+	}
+	cm := chatMessages[0]
+	if cm.Content == nil || cm.Content.ContentStr == nil {
+		t.Fatal("expected content to survive")
+	}
+	if *cm.Content.ContentStr != "72 degrees and sunny" {
+		t.Errorf("tool output altered: got %q", *cm.Content.ContentStr)
+	}
+}

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -975,6 +975,26 @@ func ToChatMessages(rms []ResponsesMessage) []ChatMessage {
 			attachPendingReasoning(cm.ChatAssistantMessage)
 		}
 
+		// A role:"tool" message carries a tool's result, so unlike an assistant
+		// message it has no meaning without content -- OpenAI's Chat Completions API
+		// requires the field. A function_call_output can legitimately carry no body
+		// though: Anthropic marks `content` optional on a tool_result block, so a void
+		// tool, an errored tool with no body, and an explicit empty content array all
+		// arrive here with nothing to convert. Left alone, ChatMessageContent's
+		// omitempty then drops the key entirely and the tool message goes out as
+		// {"role":"tool","tool_call_id":"..."}.
+		//
+		// Backfilled here, after the content conversion above, rather than at any one
+		// ingress: this is the layer that owns the chat wire contract, so it covers
+		// every producer of an empty tool output at once. Seeding the empty string
+		// further upstream would also rewrite the Bedrock Converse wire from
+		// `"content":[]` to `"content":[{"text":""}]`, and an empty text block is a
+		// shape Anthropic rejects.
+		if cm.Role == ChatMessageRoleTool &&
+			(cm.Content == nil || (cm.Content.ContentStr == nil && len(cm.Content.ContentBlocks) == 0)) {
+			cm.Content = &ChatMessageContent{ContentStr: Ptr("")}
+		}
+
 		chatMessages = append(chatMessages, cm)
 	}
 


### PR DESCRIPTION
## Summary

Fixes issue #6342, where replaying a conversation through the Anthropic ingress with a `bedrock/` model prefix caused Bedrock to reject the request with a non-retryable error: `` `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified ``. Two root causes combined to produce this: content-less `tool_result` blocks were silently dropped, collapsing user turns and causing Bedrock's same-role merge pass to fuse all assistant turns into one oversized message; and the grouped converter buffered all text and tool-use blocks to the end of the turn, reordering interleaved thinking blocks in front of the tool calls they were produced after.

## Changes

- **Content-less `tool_result` blocks are no longer dropped.** The Anthropic Messages API marks `content` optional on `ToolResultBlockParam` — only `type` and `tool_use_id` are required. A void tool, a tool that returned nothing, and an `is_error` result with no body all arrive with no `content` key. Both Responses-surface converters (`convertAnthropicContentBlocksToResponsesMessagesGrouped` and `convertAnthropicContentBlocksToResponsesMessages`) previously gated the entire conversion on `block.Content != nil`, silently dropping those blocks. Each dropped result also deleted the user turn carrying it, which caused Bedrock's consecutive-same-role merge to fuse every assistant turn into one.

- **Interleaved block order is preserved in the grouped converter.** The converter previously buffered all accumulated text blocks and all tool-use blocks to the end of the turn, emitting thinking blocks in place. For a turn shaped `[thinking, text, tool_use, thinking, text, tool_use]` this produced `[reasoning, reasoning, message, function_call, function_call]`, hoisting the second thinking block in front of the tool call it was produced after. Flush helpers (`flushAccumulatedText`, `flushPendingToolUses`) are now called eagerly whenever a block of a different kind arrives, preserving wire order while still coalescing consecutive same-kind blocks.

- **`anthropicToolUseBlockToResponsesMessage` extracted.** The tool-use-to-Responses-item conversion logic is factored into a standalone function so the grouped converter can emit tool calls at the position they occupied in the turn rather than replaying them all from a buffer at the end.

- **`"incomplete"` status maps to `"error"` on Bedrock Converse.** Converse accepts only `success` or `error` on `toolResult.status`. `"incomplete"` is the canonical Responses status for a failed tool result (written by the Anthropic ingress for `is_error` and by the Bedrock ingress for `status: error`). The previous `switch` had no case for it, so it fell through to the default and reported a failed tool call to the model as a success.

- **Pending reasoning is consumed by the item that owns it, not folded back.** In `ConvertBifrostMessagesToBedrockMessages`, buffered reasoning blocks are now consumed by the assistant `message`, `function_call`, or `function_call_output` item that follows them, rather than being folded into the previous assistant message. This keeps an interleaved thinking block in the same turn as the tool call it preceded. A `flushPendingToolCalls()` call is also added before a new reasoning item is appended, so that tool calls produced before the next thinking block are emitted first.

- **Tests added** covering: content-less and `is_error` tool results on both converter paths; interleaved block order through the grouped converter; a full 15-message Bedrock replay asserting turn boundaries, per-turn thinking block placement, and signature integrity; interleaved thinking order through the full Anthropic → Bedrock pipeline; and `is_error` status propagation to Converse.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
go test ./core/providers/anthropic/... ./core/providers/bedrock/...
```

The new tests in `core/providers/anthropic/toolresultnocontent_test.go` and `core/providers/bedrock/anthropicingressreplay_test.go` directly reproduce the failure conditions from issue #6342 and assert the corrected behaviour.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #6342

## Security considerations

None. Changes are confined to message-format conversion logic with no effect on authentication, secrets, or PII handling.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable