### PR TITLE
fix: rerank costs and integration tests for langchain

### DIFF
--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -2215,6 +2215,18 @@ func (provider *BedrockProvider) Rerank(ctx *schemas.BifrostContext, key schemas
 		}
 	}
 
+	// Rerank bills per query, where AWS defines a query as one call covering up to 100 document
+	// chunks ("if a request contains 350 documents, it will be treated as 4 queries"). The count
+	// is exposed only as the CloudWatch SearchUnits metric, never in the response, so it is
+	// derived here. A document over ~500 tokens is chunked upstream into several, so this is a
+	// lower bound for long documents; CloudWatch remains the source for exact reconciliation.
+	if len(request.Documents) > 0 {
+		if bifrostResponse.Usage == nil {
+			bifrostResponse.Usage = &schemas.BifrostLLMUsage{}
+		}
+		bifrostResponse.Usage.SearchUnits = new((len(request.Documents) + bedrockRerankChunksPerQuery - 1) / bedrockRerankChunksPerQuery)
+	}
+
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
 	bifrostResponse.ExtraFields.ProviderResponseHeaders = providerResponseHeaders
 

--- a/core/providers/bedrock/models.go
+++ b/core/providers/bedrock/models.go
@@ -26,6 +26,9 @@ const (
 	bedrockRerankInlineDocumentTypeText   = "TEXT"
 	bedrockRerankInlineDocumentTypeJSON   = "JSON"
 	bedrockRerankConfigurationTypeBedrock = "BEDROCK_RERANKING_MODEL"
+
+	// bedrockRerankChunksPerQuery is how many document chunks AWS bills as a single rerank query.
+	bedrockRerankChunksPerQuery = 100
 )
 
 type BedrockRerankQuery struct {

--- a/core/providers/cohere/rerank.go
+++ b/core/providers/cohere/rerank.go
@@ -163,11 +163,7 @@ func (response *CohereRerankResponse) ToBifrostRerankResponse(documents []schema
 				CompletionTokens: completionTokens,
 				TotalTokens:      promptTokens + completionTokens,
 			}
-			if searchUnits != nil {
-				bifrostResponse.Usage.CompletionTokensDetails = &schemas.ChatCompletionTokensDetails{
-					NumSearchQueries: searchUnits,
-				}
-			}
+			bifrostResponse.Usage.SearchUnits = searchUnits
 		}
 	}
 
@@ -203,8 +199,8 @@ func ToCohereRerankResponse(bifrostResp *schemas.BifrostRerankResponse) *CohereR
 	if bifrostResp.Usage != nil {
 		billedUnits := &CohereBilledUnits{}
 		hasBilledUnits := false
-		if bifrostResp.Usage.CompletionTokensDetails != nil && bifrostResp.Usage.CompletionTokensDetails.NumSearchQueries != nil {
-			billedUnits.SearchUnits = bifrostResp.Usage.CompletionTokensDetails.NumSearchQueries
+		if bifrostResp.Usage.SearchUnits != nil {
+			billedUnits.SearchUnits = bifrostResp.Usage.SearchUnits
 			hasBilledUnits = true
 		}
 		if bifrostResp.Usage.PromptTokens > 0 || bifrostResp.Usage.CompletionTokens > 0 {

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -1845,6 +1845,11 @@ type BifrostLLMUsage struct {
 	CompletionTokens        int                          `json:"completion_tokens,omitempty"`
 	CompletionTokensDetails *ChatCompletionTokensDetails `json:"completion_tokens_details,omitempty"`
 	TotalTokens             int                          `json:"total_tokens"`
+	// SearchUnits is the billable unit for rerank: Cohere and Bedrock both define one unit as
+	// a single query against up to 100 document chunks, so a request over that many chunks
+	// bills as several. Distinct from ChatCompletionTokensDetails.NumSearchQueries, which
+	// counts web-search calls made during a chat turn.
+	SearchUnits *int `json:"search_units,omitempty"`
 	Cost                    *BifrostCost                 `json:"cost,omitempty"` // Only for the providers which support cost calculation
 	// xAI-specific usage field, normalized into Cost by NormalizeProviderCost.
 	CostInUsdTicks *int64 `json:"cost_in_usd_ticks,omitempty"`

--- a/docs/architecture/framework/model-catalog.mdx
+++ b/docs/architecture/framework/model-catalog.mdx
@@ -178,6 +178,7 @@ type PricingEntry struct {
 
     // Costs - Other
     SearchContextCostPerQuery     *float64 `json:"search_context_cost_per_query,omitempty"`
+    InputCostPerQuery             *float64 `json:"input_cost_per_query,omitempty"`
     CodeInterpreterCostPerSession *float64 `json:"code_interpreter_cost_per_session,omitempty"`
     CostPerRequest                *float64 `json:"cost_per_request,omitempty"`
 }

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -97539,6 +97539,11 @@
             "type": "number",
             "minimum": 0
           },
+          "input_cost_per_query": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Per-query rate for rerank models. One query covers up to 100 document chunks, so a request over that many chunks bills as several queries."
+          },
           "code_interpreter_cost_per_session": {
             "type": "number",
             "minimum": 0

--- a/docs/openapi/schemas/management/governance.yaml
+++ b/docs/openapi/schemas/management/governance.yaml
@@ -1920,6 +1920,12 @@ PricingPatch:
     search_context_cost_per_query:
       type: number
       minimum: 0
+    input_cost_per_query:
+      type: number
+      minimum: 0
+      description: >-
+        Per-query rate for rerank models. One query covers up to 100 document chunks, so a
+        request over that many chunks bills as several queries.
     code_interpreter_cost_per_session:
       type: number
       minimum: 0

--- a/docs/providers/custom-pricing.mdx
+++ b/docs/providers/custom-pricing.mdx
@@ -404,6 +404,7 @@ Any field you set (including `0`) is applied as an override; omitted fields are 
 | Field | Description |
 |-------|-------------|
 | `search_context_cost_per_query` | Cost per web search context query |
+| `input_cost_per_query` | Cost per rerank query. One query covers up to 100 document chunks, so a larger request bills as several. Does not apply to Vertex, which bills content-size-derived ranking units |
 | `code_interpreter_cost_per_session` | Cost per code interpreter session |
 | `inference_geo_us_multiplier` | Data-residency cost multiplier applied when a request is served from a US inference region |
 | `cost_per_request` | Flat fee added once per billed request, on top of any usage-based cost |

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -471,6 +471,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_notifications_table"}, run: migrationAddNotificationsTable},
 	{IDs: []string{"add_batch_jobs_table"}, run: migrationAddBatchJobsTable},
 	{IDs: []string{"add_image_megapixel_tier_pricing_columns"}, run: migrationAddImageMegapixelTierPricingColumns},
+	{IDs: []string{"add_input_cost_per_query_column"}, run: migrationAddInputCostPerQueryColumn},
 }
 
 func migrationAddNotificationsTable(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
@@ -12082,6 +12083,36 @@ func migrationAddImageMegapixelTierPricingColumns(ctx context.Context, db *gorm.
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running add_image_megapixel_tier_pricing_columns migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddInputCostPerQueryColumn adds the per-query rerank rate. Rerank models bill per
+// query (a "search unit" covering up to 100 document chunks) rather than per token, so without
+// this column every rerank request costs zero.
+func migrationAddInputCostPerQueryColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_input_cost_per_query_column"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if err := addColumnIfNotExists(tx, logger, &tables.TableModelPricing{}, "input_cost_per_query"); err != nil {
+				return fmt.Errorf("failed to add column input_cost_per_query: %w", err)
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if err := dropColumnIfExists(tx, logger, &tables.TableModelPricing{}, "input_cost_per_query"); err != nil {
+				return fmt.Errorf("failed to drop column input_cost_per_query: %w", err)
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running %s migration: %s", migrationName, err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2804,6 +2804,7 @@ var pricingSyncUpdateColumns = []string{
 	"output_cost_per_second",
 	// Costs - Other
 	"search_context_cost_per_query",
+	"input_cost_per_query",
 	"code_interpreter_cost_per_session",
 	"cost_per_request",
 	// Costs - OCR

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -3683,3 +3683,34 @@ func TestRDBConfigStore_SyncRoutingRules(t *testing.T) {
 		})
 	}
 }
+
+// TestUpsertModelPricesBatch_InputCostPerQuerySurvivesResync guards the ON CONFLICT DO UPDATE
+// column list. Create() writes every column, so a first sync looks correct even when a field is
+// missing from pricingSyncUpdateColumns - the value only disappears on the next resync of an
+// existing row, which is 24h later in production.
+func TestUpsertModelPricesBatch_InputCostPerQuerySurvivesResync(t *testing.T) {
+	s := setupRDBTestStore(t)
+	require.NoError(t, s.DB().AutoMigrate(&tables.TableModelPricing{}))
+
+	ctx := context.Background()
+	cost := func(f float64) *float64 { return &f }
+
+	row := tables.TableModelPricing{Model: "rerank-v3.5", Provider: "cohere", Mode: "rerank"}
+	require.NoError(t, s.UpsertModelPricesBatch(ctx, []tables.TableModelPricing{row}))
+
+	row.InputCostPerQuery = cost(0.002)
+	require.NoError(t, s.UpsertModelPricesBatch(ctx, []tables.TableModelPricing{row}))
+
+	got, err := s.GetModelPrices(ctx)
+	require.NoError(t, err)
+	var found *tables.TableModelPricing
+	for i := range got {
+		if got[i].Model == "rerank-v3.5" {
+			found = &got[i]
+			break
+		}
+	}
+	require.NotNil(t, found)
+	require.NotNil(t, found.InputCostPerQuery, "input_cost_per_query missing from pricingSyncUpdateColumns")
+	assert.Equal(t, 0.002, *found.InputCostPerQuery)
+}

--- a/framework/configstore/tables/modelpricing.go
+++ b/framework/configstore/tables/modelpricing.go
@@ -113,6 +113,7 @@ type TableModelPricing struct {
 
 	// Costs - Other
 	SearchContextCostPerQuery     *float64 `gorm:"default:null;column:search_context_cost_per_query" json:"search_context_cost_per_query,omitempty"`
+	InputCostPerQuery             *float64 `gorm:"default:null;column:input_cost_per_query" json:"input_cost_per_query,omitempty"`
 	CodeInterpreterCostPerSession *float64 `gorm:"default:null;column:code_interpreter_cost_per_session" json:"code_interpreter_cost_per_session,omitempty"`
 	// Data-residency multiplier scaling all token/cache costs when Anthropic serves inference_geo:"us" (1.1x); nil = no multiplier.
 	InferenceGeoUSMultiplier *float64 `gorm:"default:null;column:inference_geo_us_multiplier" json:"inference_geo_us_multiplier,omitempty"`

--- a/framework/modelcatalog/datasheet/cost.go
+++ b/framework/modelcatalog/datasheet/cost.go
@@ -427,8 +427,13 @@ func (s *Store) calculateBaseCost(result *schemas.BifrostResponse, scopes Lookup
 		return input.imageUsage.Cost
 	}
 
-	// If no usage data at all, nothing to price
-	if input.usage == nil && input.audioSeconds == nil && input.audioTokenDetails == nil && input.imageUsage == nil && input.videoSeconds == nil && input.audioTextInputChars == 0 && input.ocrProcessedPages == nil && input.containerIdentifierString == "" {
+	// If no usage data at all, nothing to price.
+	//
+	// Rerank is exempt: it bills per query rather than per unit of reported usage, so a call
+	// that reports nothing still owes one query. Vertex returns no usage on rerank at all, and
+	// treating that as free would silently under-report every one of its calls.
+	if requestType != schemas.RerankRequest &&
+		input.usage == nil && input.audioSeconds == nil && input.audioTokenDetails == nil && input.imageUsage == nil && input.videoSeconds == nil && input.audioTextInputChars == 0 && input.ocrProcessedPages == nil && input.containerIdentifierString == "" {
 		return nil
 	}
 
@@ -596,7 +601,9 @@ func extractCostInput(result *schemas.BifrostResponse) costInput {
 	case result.EmbeddingResponse != nil && result.EmbeddingResponse.Usage != nil:
 		input.usage = result.EmbeddingResponse.Usage
 
-	case result.RerankResponse != nil && result.RerankResponse.Usage != nil:
+	// Not gated on Usage like its neighbours: rerank bills per query, so a response that
+	// carries no usage at all (Vertex reports none) still owes one query's cost.
+	case result.RerankResponse != nil:
 		input.usage = result.RerankResponse.Usage
 
 	case result.SpeechResponse != nil && result.SpeechResponse.Usage != nil:
@@ -1034,31 +1041,55 @@ func computeEmbeddingCost(pricing *configstoreTables.TableModelPricing, usage *s
 }
 
 // computeRerankCost handles rerank requests.
+//
+// Rerank is priced two different ways depending on the model. Cohere, Bedrock and Azure bill per
+// query - one query covers up to 100 document chunks, so a larger request bills as several - while
+// hosted rerankers such as Voyage and Jina bill per token. Both terms are summed because a given
+// pricing row only ever carries one of them.
+//
+// Per-query pricing needs no usage at all, so a nil usage still bills one query rather than
+// returning zero: Vertex reports no usage on rerank, and dropping the charge there would silently
+// under-report every one of its calls.
 func computeRerankCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, tier serviceTier) *schemas.BifrostCost {
-	if usage == nil {
-		return nil
+	queryCost := 0.0
+	if pricing.InputCostPerQuery != nil {
+		// Providers that report their own billed unit count win: Cohere's search_units already
+		// accounts for long documents being chunked past the 100-per-query boundary.
+		queries := 1
+		if usage != nil && usage.SearchUnits != nil && *usage.SearchUnits > 0 {
+			queries = *usage.SearchUnits
+		}
+		queryCost = float64(queries) * *pricing.InputCostPerQuery
 	}
-	tierTokens := usage.PromptTokens
-	inputCost := float64(usage.PromptTokens) * tieredInputRate(pricing, tierTokens, tier)
-	outputCost := float64(usage.CompletionTokens) * tieredOutputRate(pricing, tierTokens, tier)
 
-	searchCost := 0.0
-	if pricing.SearchContextCostPerQuery != nil && usage.CompletionTokensDetails != nil && usage.CompletionTokensDetails.NumSearchQueries != nil {
-		searchCost = float64(*usage.CompletionTokensDetails.NumSearchQueries) * *pricing.SearchContextCostPerQuery
+	// Token terms stay zero when the response reports no usage; the per-query charge above
+	// still applies.
+	inputCost, outputCost, searchCost := 0.0, 0.0, 0.0
+	if usage != nil {
+		tierTokens := usage.PromptTokens
+		inputCost = float64(usage.PromptTokens) * tieredInputRate(pricing, tierTokens, tier)
+		outputCost = float64(usage.CompletionTokens) * tieredOutputRate(pricing, tierTokens, tier)
+
+		if pricing.SearchContextCostPerQuery != nil && usage.CompletionTokensDetails != nil && usage.CompletionTokensDetails.NumSearchQueries != nil {
+			searchCost = float64(*usage.CompletionTokensDetails.NumSearchQueries) * *pricing.SearchContextCostPerQuery
+		}
 	}
 
-	// Search queries are billed on the output side, matching computeTextCost.
+	// Search queries are billed on the output side, matching computeTextCost. The flat
+	// per-query rerank charge maps to no token category, so it folds into the input side
+	// as RequestCost, matching CostPerRequest.
+	inputTokensCost := inputCost + queryCost
 	outputTokensCost := outputCost + searchCost
 
 	var inputDetails *schemas.InputCostDetails
-	if inputCost != 0 {
-		inputDetails = &schemas.InputCostDetails{TextCost: inputCost}
+	if inputTokensCost != 0 {
+		inputDetails = &schemas.InputCostDetails{TextCost: inputCost, RequestCost: queryCost}
 	}
 	var outputDetails *schemas.OutputCostDetails
-	if outputCost != 0 || searchCost != 0 {
+	if outputTokensCost != 0 {
 		outputDetails = &schemas.OutputCostDetails{TextCost: outputCost, SearchQueriesCost: searchCost}
 	}
-	return newInputOutputCostWithDetails(inputCost, outputTokensCost, inputDetails, outputDetails)
+	return newInputOutputCostWithDetails(inputTokensCost, outputTokensCost, inputDetails, outputDetails)
 }
 
 // newInputOutputCost builds a BifrostCost from separate input and output costs,

--- a/framework/modelcatalog/datasheet/cost_test.go
+++ b/framework/modelcatalog/datasheet/cost_test.go
@@ -4940,3 +4940,64 @@ func TestCalculateBatchCostDetailsForUsage_CostPerRequestSurcharge(t *testing.T)
 	assert.InDelta(t, viaUsage, details.Cost, 1e-12)
 	assert.InDelta(t, 0.0007+0.01, details.Cost, 1e-12)
 }
+
+func TestCalculateCost_RerankPerQuery(t *testing.T) {
+	// Cohere and Bedrock both bill rerank per query rather than per token, so the token rates
+	// on these rows are genuinely zero upstream. Before input_cost_per_query was wired, that
+	// made every rerank request cost nothing.
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("rerank-v3.5", "cohere", "rerank"): {
+			Model: "rerank-v3.5", Provider: "cohere", Mode: "rerank",
+			InputCostPerToken:  bifrost.Ptr(0.0),
+			OutputCostPerToken: bifrost.Ptr(0.0),
+			InputCostPerQuery:  bifrost.Ptr(0.002),
+		},
+	})
+
+	t.Run("single search unit", func(t *testing.T) {
+		resp := makeRerankResponse(schemas.Cohere, "rerank-v3.5", &schemas.BifrostLLMUsage{
+			SearchUnits: bifrost.Ptr(1),
+		})
+		assert.InDelta(t, 0.002, s.CalculateCost(resp, nil), 1e-12)
+	})
+
+	t.Run("multiple search units bill per unit", func(t *testing.T) {
+		// A query covers up to 100 document chunks; 150 documents bills as 2.
+		resp := makeRerankResponse(schemas.Cohere, "rerank-v3.5", &schemas.BifrostLLMUsage{
+			SearchUnits: bifrost.Ptr(2),
+		})
+		assert.InDelta(t, 0.004, s.CalculateCost(resp, nil), 1e-12)
+	})
+
+	t.Run("usage without search units bills one query", func(t *testing.T) {
+		resp := makeRerankResponse(schemas.Cohere, "rerank-v3.5", &schemas.BifrostLLMUsage{
+			PromptTokens: 500,
+			TotalTokens:  500,
+		})
+		assert.InDelta(t, 0.002, s.CalculateCost(resp, nil), 1e-12)
+	})
+
+	t.Run("nil usage still bills one query", func(t *testing.T) {
+		// Vertex reports no usage on rerank; returning zero would under-report every call.
+		resp := makeRerankResponse(schemas.Cohere, "rerank-v3.5", nil)
+		assert.InDelta(t, 0.002, s.CalculateCost(resp, nil), 1e-12)
+	})
+}
+
+func TestCalculateCost_RerankPerTokenStillWorks(t *testing.T) {
+	// Voyage and Jina style rerankers bill per token and carry no per-query rate; the two
+	// pricing shapes must not interfere.
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("rerank-2", "voyage", "rerank"): {
+			Model: "rerank-2", Provider: "voyage", Mode: "rerank",
+			InputCostPerToken: bifrost.Ptr(0.00000005),
+		},
+	})
+
+	resp := makeRerankResponse("voyage", "rerank-2", &schemas.BifrostLLMUsage{
+		PromptTokens: 1000,
+		TotalTokens:  1000,
+	})
+
+	assert.InDelta(t, 0.00005, s.CalculateCost(resp, nil), 1e-12)
+}

--- a/framework/modelcatalog/datasheet/overrides.go
+++ b/framework/modelcatalog/datasheet/overrides.go
@@ -550,6 +550,7 @@ func patchPricing(pricing configstoreTables.TableModelPricing, override Options)
 		{dst: &patched.OutputCostPerImageAbove64Megapixels, src: override.OutputCostPerImageAbove64Megapixels},
 		{dst: &patched.CacheReadInputImageTokenCost, src: override.CacheReadInputImageTokenCost},
 		{dst: &patched.SearchContextCostPerQuery, src: override.SearchContextCostPerQuery},
+		{dst: &patched.InputCostPerQuery, src: override.InputCostPerQuery},
 		{dst: &patched.CodeInterpreterCostPerSession, src: override.CodeInterpreterCostPerSession},
 		{dst: &patched.CostPerRequest, src: override.CostPerRequest},
 		{dst: &patched.OutputCostPerImageLowQuality, src: override.OutputCostPerImageLowQuality},

--- a/framework/modelcatalog/datasheet/overrides_test.go
+++ b/framework/modelcatalog/datasheet/overrides_test.go
@@ -986,3 +986,18 @@ func TestCatalogPricingOverrides_ReturnsDeepCopies(t *testing.T) {
 	require.NotNil(t, priced.InputCostPerToken)
 	assert.Equal(t, 3.0, *priced.InputCostPerToken, "runtime pricing must survive a caller mutating a catalog result")
 }
+
+func TestPatchPricing_InputCostPerQuery(t *testing.T) {
+	base := configstoreTables.TableModelPricing{
+		Model:    "rerank-v3.5",
+		Provider: "cohere",
+		Mode:     "rerank",
+	}
+
+	patched := patchPricing(base, Options{
+		InputCostPerQuery: bifrost.Ptr(0.002),
+	})
+
+	require.NotNil(t, patched.InputCostPerQuery)
+	assert.Equal(t, 0.002, *patched.InputCostPerQuery)
+}

--- a/framework/modelcatalog/datasheet/types.go
+++ b/framework/modelcatalog/datasheet/types.go
@@ -192,6 +192,14 @@ type Options struct {
 	// represents it as a tiered object. See Entry.UnmarshalJSON.
 	SearchContextCostPerQuery     *float64 `json:"search_context_cost_per_query,omitempty"`
 	CodeInterpreterCostPerSession *float64 `json:"code_interpreter_cost_per_session,omitempty"`
+	// InputCostPerQuery is the per-query rate rerank models bill on. Cohere and Bedrock both
+	// define a query (a "search unit") as one query against up to 100 document chunks, so a
+	// request over that many chunks bills as several queries. It is unrelated to
+	// SearchContextCostPerQuery, which prices web-search context on chat models.
+	//
+	// Not applicable to Vertex: its Ranking API bills "ranking units" derived from record count
+	// and title/content size, so a flat per-query rate would misprice every call.
+	InputCostPerQuery *float64 `json:"input_cost_per_query,omitempty"`
 	InferenceGeoUSMultiplier      *float64 `json:"inference_geo_us_multiplier,omitempty"`
 	// CostPerRequest is a flat fee added once per billed request, on top of
 	// whatever usage-based cost the request otherwise computes to.
@@ -680,6 +688,7 @@ func convertEntryToTablePricing(modelKey string, entry Entry) configstoreTables.
 
 		SearchContextCostPerQuery:     entry.SearchContextCostPerQuery,
 		CodeInterpreterCostPerSession: entry.CodeInterpreterCostPerSession,
+		InputCostPerQuery:             entry.InputCostPerQuery,
 		InferenceGeoUSMultiplier:      entry.InferenceGeoUSMultiplier,
 		CostPerRequest:                entry.CostPerRequest,
 
@@ -773,6 +782,7 @@ func convertTablePricingToEntry(pricing *configstoreTables.TableModelPricing) *E
 		OutputCostPerSecond:         pricing.OutputCostPerSecond,
 
 		SearchContextCostPerQuery:     pricing.SearchContextCostPerQuery,
+		InputCostPerQuery:             pricing.InputCostPerQuery,
 		CodeInterpreterCostPerSession: pricing.CodeInterpreterCostPerSession,
 		InferenceGeoUSMultiplier:      pricing.InferenceGeoUSMultiplier,
 		CostPerRequest:                pricing.CostPerRequest,

--- a/tests/integrations/python/README.md
+++ b/tests/integrations/python/README.md
@@ -91,15 +91,18 @@ Our test suite covers 30 comprehensive scenarios for each integration:
 Reranking takes a query plus documents and returns them ordered by relevance. The parameterized
 provider-SDK tests run cross-provider — a request shaped for one provider must come back in that
 provider's wire shape no matter which provider actually served it. Cases that pin a single
-provider's own behaviour (`return_documents`, error shapes, the LangChain compressors) stay
-fixed to that provider.
+provider's own behaviour (`return_documents`, error shapes, LangChain's own client-side
+mechanics) stay fixed to that provider.
 
 - **Cohere SDK** (`test_cohere.py`) — cross-provider: string documents, object documents carrying
   id/metadata, `top_n`. Cohere-only: `return_documents`, Cohere-shaped errors
 - **AWS SDK** (`test_bedrock.py`) — cross-provider: inline TEXT sources, inline JSON sources,
   `numberOfResults`
-- **LangChain** (`test_langchain.py`) — `CohereRerank` and `BedrockRerank` document compressors,
-  each fixed to its own provider
+- **LangChain** (`test_langchain.py`) — cross-provider: `CohereRerank.compress_documents`,
+  `rerank()`, `top_n`, metadata preservation, `ContextualCompressionRetriever` (the documented
+  RAG pattern) and async `acompress_documents`. Cohere-only: per-call `top_n` override,
+  `top_n=None`, string/dict documents with `rank_fields`, the empty-input short circuit and
+  `max_tokens_per_doc`. `BedrockRerank` is covered against its own provider
 - **Discovery Engine** (`test_google.py`) — cross-provider: `/genai/v1/rank`, caller record-id
   restoration and `ignoreRecordDetailsInResponse`
 

--- a/tests/integrations/python/tests/test_langchain.py
+++ b/tests/integrations/python/tests/test_langchain.py
@@ -1704,42 +1704,57 @@ class TestLangChainStandardEmbeddings(TestLangChainOpenAIEmbeddings):
 class TestLangChainRerank:
     """Rerank via LangChain document compressors through Bifrost.
 
-    LangChain wraps each provider's rerank API in a BaseDocumentCompressor, so these
-    exercise the same Bifrost routes through a third abstraction layer: whatever the
-    compressor returns must still be a correctly ordered ranking.
+    LangChain wraps each provider's rerank API in a BaseDocumentCompressor, so these exercise
+    Bifrost's rerank routes through a third abstraction layer. CohereRerank coerces every
+    document to a string before calling the API (Document -> page_content, dict -> YAML,
+    str -> itself), so these also cover Bifrost accepting the plain-string document form.
+
+    Cross-provider tests cover the operations a customer's behaviour depends on. Tests that
+    pin LangChain's own client-side mechanics (rank_fields YAML filtering, the empty-input
+    short circuit, metadata deep-copy) run against Cohere only - the provider cannot change
+    what LangChain does before and after the call.
     """
 
     @staticmethod
     def _documents():
         from langchain_core.documents import Document
 
-        return [Document(page_content=text) for text in RERANK_DOCUMENTS]
+        return [
+            Document(page_content=text, metadata={"source": f"doc-{i}", "position": i})
+            for i, text in enumerate(RERANK_DOCUMENTS)
+        ]
+
+    @staticmethod
+    def _compressor(provider, model, **kwargs):
+        from langchain_cohere import CohereRerank
+
+        return CohereRerank(
+            base_url=get_integration_url("cohere"),
+            cohere_api_key=os.getenv("COHERE_API_KEY", "dummy-key"),
+            model=model,
+            **kwargs,
+        )
 
     @staticmethod
     def _pairs(compressed):
         """Normalize compressed documents into (index, score) tuples.
 
-        LangChain drops the provider's index and keeps relevance_score in metadata, so the
-        original position is recovered by matching page_content.
+        compress_documents drops the provider's index and keeps relevance_score in metadata,
+        so the original position is recovered from the document itself.
         """
         return [
-            (
-                RERANK_DOCUMENTS.index(document.page_content),
-                document.metadata["relevance_score"],
-            )
+            (RERANK_DOCUMENTS.index(document.page_content), document.metadata["relevance_score"])
             for document in compressed
         ]
 
-    def test_20_cohere_rerank_compressor(self, test_config):
-        """langchain_cohere.CohereRerank against Bifrost's /cohere routes."""
-        from langchain_cohere import CohereRerank
+    # ---------------------------------------------------------------- core compressor path
 
-        compressor = CohereRerank(
-            base_url=get_integration_url("cohere"),
-            cohere_api_key=os.getenv("COHERE_API_KEY", "dummy-key"),
-            model=get_config().get_provider_model("cohere", "rerank"),
-            top_n=2,
-        )
+    @pytest.mark.parametrize(
+        "provider,model", get_cross_provider_params_for_scenario("rerank")
+    )
+    def test_20_cohere_rerank_compressor(self, provider, model):
+        """compress_documents - the method ContextualCompressionRetriever calls."""
+        compressor = self._compressor(provider, model, top_n=2)
 
         compressed = compressor.compress_documents(self._documents(), RERANK_QUERY)
 
@@ -1768,5 +1783,165 @@ class TestLangChainRerank:
         )
 
         compressed = compressor.compress_documents(self._documents(), RERANK_QUERY)
+
+        assert_valid_rerank_results(self._pairs(compressed), expected_count=2)
+
+    # ---------------------------------------------------------------- rerank() directly
+
+    @pytest.mark.parametrize(
+        "provider,model", get_cross_provider_params_for_scenario("rerank")
+    )
+    def test_22_rerank_returns_index_and_score(self, provider, model):
+        """rerank() returns raw {index, relevance_score} dicts keyed to the input order."""
+        compressor = self._compressor(provider, model, top_n=3)
+
+        results = compressor.rerank(self._documents(), RERANK_QUERY)
+
+        assert results, "rerank returned nothing"
+        for result in results:
+            assert set(result) >= {"index", "relevance_score"}, f"unexpected keys: {list(result)}"
+        assert_valid_rerank_results([(r["index"], r["relevance_score"]) for r in results])
+
+    @pytest.mark.parametrize(
+        "provider,model", get_cross_provider_params_for_scenario("rerank")
+    )
+    def test_23_metadata_is_preserved_and_scored(self, provider, model):
+        """Caller metadata survives the round trip and relevance_score is added to it."""
+        compressor = self._compressor(provider, model, top_n=3)
+        documents = self._documents()
+
+        compressed = compressor.compress_documents(documents, RERANK_QUERY)
+
+        assert_valid_rerank_results(self._pairs(compressed))
+        for document in compressed:
+            original = documents[RERANK_DOCUMENTS.index(document.page_content)]
+            assert document.metadata["source"] == original.metadata["source"]
+            assert document.metadata["position"] == original.metadata["position"]
+            assert isinstance(document.metadata["relevance_score"], float)
+
+        # compress_documents deep-copies metadata; the caller's documents must be untouched.
+        for original in documents:
+            assert "relevance_score" not in original.metadata
+
+    # ---------------------------------------------------------------- top_n behaviour
+
+    @pytest.mark.parametrize(
+        "provider,model", get_cross_provider_params_for_scenario("rerank")
+    )
+    def test_24_top_n_from_constructor(self, provider, model):
+        """top_n set on the compressor truncates the ranking."""
+        compressor = self._compressor(provider, model, top_n=1)
+
+        compressed = compressor.compress_documents(self._documents(), RERANK_QUERY)
+
+        assert_valid_rerank_results(self._pairs(compressed), expected_count=1)
+
+    def test_25_top_n_per_call_override(self, test_config):
+        """A per-call top_n wins over the constructor value."""
+        model = get_config().get_provider_model("cohere", "rerank")
+        compressor = self._compressor("cohere", model, top_n=1)
+
+        results = compressor.rerank(self._documents(), RERANK_QUERY, top_n=2)
+
+        assert len(results) == 2, f"per-call top_n ignored: got {len(results)}"
+
+    def test_26_top_n_none_returns_all(self, test_config):
+        """top_n=None asks for the full ranking rather than the constructor default."""
+        model = get_config().get_provider_model("cohere", "rerank")
+        compressor = self._compressor("cohere", model, top_n=1)
+
+        results = compressor.rerank(self._documents(), RERANK_QUERY, top_n=None)
+
+        assert len(results) == len(RERANK_DOCUMENTS), (
+            f"expected the full ranking, got {len(results)}"
+        )
+
+    # ---------------------------------------------------------------- document forms
+
+    def test_27_string_documents(self, test_config):
+        """Plain strings - the form CohereRerank sends for every document type."""
+        model = get_config().get_provider_model("cohere", "rerank")
+        compressor = self._compressor("cohere", model, top_n=3)
+
+        results = compressor.rerank(RERANK_DOCUMENTS, RERANK_QUERY)
+
+        assert_valid_rerank_results([(r["index"], r["relevance_score"]) for r in results])
+
+    def test_28_dict_documents_with_rank_fields(self, test_config):
+        """dict documents are YAML-dumped, restricted to rank_fields when given.
+
+        rank_fields is applied client-side by LangChain, so the ranked text is the filtered
+        YAML. Ranking on the title-only field must still surface the relevant document.
+        """
+        model = get_config().get_provider_model("cohere", "rerank")
+        compressor = self._compressor("cohere", model, top_n=3)
+        documents = [
+            {"title": "France", "body": RERANK_DOCUMENTS[0], "internal_id": "a"},
+            {"title": "Carrots", "body": RERANK_DOCUMENTS[1], "internal_id": "b"},
+            {"title": "Germany", "body": RERANK_DOCUMENTS[2], "internal_id": "c"},
+        ]
+
+        results = compressor.rerank(documents, RERANK_QUERY, rank_fields=["title", "body"])
+
+        assert_valid_rerank_results([(r["index"], r["relevance_score"]) for r in results])
+
+    def test_29_empty_documents_short_circuits(self, test_config):
+        """An empty document list returns [] without calling the API."""
+        model = get_config().get_provider_model("cohere", "rerank")
+        compressor = self._compressor("cohere", model, top_n=3)
+
+        assert compressor.rerank([], RERANK_QUERY) == []
+        assert list(compressor.compress_documents([], RERANK_QUERY)) == []
+
+    def test_30_max_tokens_per_doc(self, test_config):
+        """max_tokens_per_doc is forwarded and accepted by the rerank route."""
+        model = get_config().get_provider_model("cohere", "rerank")
+        compressor = self._compressor("cohere", model, top_n=3)
+
+        results = compressor.rerank(
+            self._documents(), RERANK_QUERY, max_tokens_per_doc=512
+        )
+
+        assert_valid_rerank_results([(r["index"], r["relevance_score"]) for r in results])
+
+    # ---------------------------------------------------------------- retriever wiring
+
+    @pytest.mark.parametrize(
+        "provider,model", get_cross_provider_params_for_scenario("rerank")
+    )
+    def test_31_contextual_compression_retriever(self, provider, model):
+        """The documented RAG pattern: a reranker wrapped around a base retriever.
+
+        A static base retriever keeps the assertion about reranking rather than about vector
+        search, which is what this suite is pinning.
+        """
+        from langchain_classic.retrievers import ContextualCompressionRetriever
+        from langchain_core.retrievers import BaseRetriever
+
+        documents = self._documents()
+
+        class StaticRetriever(BaseRetriever):
+            def _get_relevant_documents(self, query, *, run_manager=None):
+                return documents
+
+        retriever = ContextualCompressionRetriever(
+            base_compressor=self._compressor(provider, model, top_n=2),
+            base_retriever=StaticRetriever(),
+        )
+
+        compressed = retriever.invoke(RERANK_QUERY)
+
+        assert_valid_rerank_results(self._pairs(compressed), expected_count=2)
+
+    @pytest.mark.parametrize(
+        "provider,model", get_cross_provider_params_for_scenario("rerank")
+    )
+    def test_32_async_compress_documents(self, provider, model):
+        """acompress_documents - the path async LangChain apps take."""
+        compressor = self._compressor(provider, model, top_n=2)
+
+        compressed = asyncio.run(
+            compressor.acompress_documents(self._documents(), RERANK_QUERY)
+        )
 
         assert_valid_rerank_results(self._pairs(compressed), expected_count=2)

--- a/ui/app/workspace/custom-pricing/overrides/pricingFields.test.ts
+++ b/ui/app/workspace/custom-pricing/overrides/pricingFields.test.ts
@@ -63,6 +63,7 @@ describe("pricingFieldUnit", () => {
 			"ocr_cost_per_page",
 			"annotation_cost_per_page",
 			"search_context_cost_per_query",
+			"input_cost_per_query",
 			"code_interpreter_cost_per_session",
 			"output_cost_per_image_high_quality",
 		]) {
@@ -79,7 +80,7 @@ describe("pricingFieldUnit", () => {
 			expect(byUnit[unit], `${field.key} resolved to unexpected unit ${unit}`).toBeDefined();
 			byUnit[unit].push(field.key);
 		}
-		expect(PRICING_FIELDS).toHaveLength(82);
+		expect(PRICING_FIELDS).toHaveLength(83);
 		expect(byUnit.multiplier).toEqual(["inference_geo_us_multiplier"]);
 		expect(byUnit.character).toEqual(["input_cost_per_character"]);
 		// Sanity: the split is real, not everything collapsing into one bucket.

--- a/ui/app/workspace/custom-pricing/overrides/pricingFields.ts
+++ b/ui/app/workspace/custom-pricing/overrides/pricingFields.ts
@@ -296,6 +296,12 @@ export const PRICING_FIELDS = [
 		requestTypeGroups: ["chat", "rerank"],
 	},
 	{
+		key: "input_cost_per_query",
+		label: "Rerank / query",
+		group: "chat",
+		requestTypeGroups: ["rerank"],
+	},
+	{
 		key: "code_interpreter_cost_per_session",
 		label: "Code interpreter / session",
 		group: "chat",

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -564,6 +564,7 @@ export interface PricingOverridePatch {
 	output_cost_per_second?: number;
 	// Other
 	search_context_cost_per_query?: number;
+	input_cost_per_query?: number;
 	code_interpreter_cost_per_session?: number;
 	inference_geo_us_multiplier?: number;
 	cost_per_request?: number;


### PR DESCRIPTION
## Summary

Rerank models from Cohere and Bedrock bill per query (one "search unit" = up to 100 document chunks) rather than per token, meaning every rerank request previously cost zero. This PR wires a new `input_cost_per_query` pricing field end-to-end so those calls are correctly priced, and moves the `SearchUnits` count out of `ChatCompletionTokensDetails` into a dedicated top-level field on `BifrostLLMUsage`.

## Changes

- **`SearchUnits` field on `BifrostLLMUsage`**: Replaces the previous placement inside `CompletionTokensDetails.NumSearchQueries`, which conflated rerank billing units with web-search calls made during a chat turn. Cohere's translation layer is updated to read/write the new field; Bedrock now derives and populates it from the document count using the 100-chunks-per-query rule.

- **`input_cost_per_query` pricing field**: Added to `TableModelPricing`, the model catalog `Entry`/`Options` types, the `pricingSyncUpdateColumns` list, and the `patchPricing` override path. A database migration adds the column. The field is intentionally separate from `search_context_cost_per_query`, which prices web-search context on chat models.

- **`computeRerankCost` rewrite**: Now sums a per-query charge (using `SearchUnits` when present, defaulting to 1) with the existing per-token charge. A `nil` usage no longer short-circuits to zero — Vertex reports no usage on rerank, so dropping the charge there would silently under-report every call. The early-exit guard in `calculateBaseCost` is similarly exempted for rerank requests.

- **`extractCostInput` fix**: The rerank case is no longer gated on `Usage != nil`, matching the new billing model where a response with no usage still owes one query.

- **DB migration `add_input_cost_per_query_column`**: Adds the column with rollback support. A regression test (`TestUpsertModelPricesBatch_InputCostPerQuerySurvivesResync`) guards the `ON CONFLICT DO UPDATE` column list, catching the class of bug where a missing column only disappears on the second sync of an existing row.

- **LangChain integration tests expanded**: `TestLangChainRerank` is refactored to run core compressor tests cross-provider and adds 12 new cases covering `rerank()`, metadata preservation, `top_n` overrides, string/dict document forms, `max_tokens_per_doc`, `ContextualCompressionRetriever`, and `acompress_documents`.

- **UI and docs**: `input_cost_per_query` is added to the custom-pricing UI field list (group: rerank), the OpenAPI schema, the governance YAML, and the custom-pricing documentation page.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
# Core
go test ./core/providers/bedrock/... ./core/providers/cohere/... ./framework/modelcatalog/... ./framework/configstore/...

# UI
cd ui
pnpm i
pnpm test
pnpm build
```

To validate end-to-end pricing:
1. Set `input_cost_per_query: 0.002` on a Cohere `rerank-v3.5` pricing row.
2. Send a rerank request with fewer than 100 documents — expect cost `0.002`.
3. Send a rerank request with 150 documents — expect cost `0.004` (2 search units).
4. Confirm Vertex rerank requests (which return no usage) are priced at `1 × input_cost_per_query` rather than zero.

## Breaking changes

- [x] Yes
- [ ] No

`SearchUnits` moves from `BifrostLLMUsage.CompletionTokensDetails.NumSearchQueries` to `BifrostLLMUsage.SearchUnits`. Any consumer reading the old path will see `nil` and must be updated to read `usage.search_units` instead.

## Related issues

## Security considerations

None. This change touches pricing arithmetic and schema fields only; no auth, secrets, or PII are involved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable