### PR TITLE
feat: wire in semantic cache cost to additional cost

### DIFF
--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -1954,8 +1954,8 @@ type ChatCompletionTokensDetails struct {
 // AdditionalCost == TotalCost. Flat, non-token request costs (per-request
 // surcharge, OCR per-page, container per-session) fold into the input side as
 // InputCostDetails.RequestCost. Internal sidecar costs that map to no token
-// category (guardrail judge calls, MCP tool executions) go on the additional
-// side as AdditionalCostDetails.
+// category (guardrail judge calls, MCP tool executions, semantic cache embedding
+// lookups) go on the additional side as AdditionalCostDetails.
 type BifrostCost struct {
 	InputCost             float64                `json:"input_cost,omitempty"`
 	InputCostDetails      *InputCostDetails      `json:"input_cost_details,omitempty"`
@@ -2087,8 +2087,9 @@ type OutputCostDetails struct {
 // AdditionalCost. These are internal sidecar costs with no input/output token
 // category. Extend with new fields as more such cost sources are billed.
 type AdditionalCostDetails struct {
-	GuardrailCost float64 `json:"guardrail_cost,omitempty"` // Guardrail judge-call cost
-	MCPCost       float64 `json:"mcp_cost,omitempty"`       // MCP tool-execution cost
+	GuardrailCost     float64 `json:"guardrail_cost,omitempty"`      // Guardrail judge-call cost
+	MCPCost           float64 `json:"mcp_cost,omitempty"`            // MCP tool-execution cost
+	SemanticCacheCost float64 `json:"semantic_cache_cost,omitempty"` // Semantic-cache embedding-lookup cost
 }
 
 // UnmarshalJSON implements custom JSON unmarshalling for BifrostCost. It accepts
@@ -2233,8 +2234,9 @@ func (a *AdditionalCostDetails) add(b *AdditionalCostDetails) *AdditionalCostDet
 		return a
 	}
 	return &AdditionalCostDetails{
-		GuardrailCost: a.GuardrailCost + b.GuardrailCost,
-		MCPCost:       a.MCPCost + b.MCPCost,
+		GuardrailCost:     a.GuardrailCost + b.GuardrailCost,
+		MCPCost:           a.MCPCost + b.MCPCost,
+		SemanticCacheCost: a.SemanticCacheCost + b.SemanticCacheCost,
 	}
 }
 

--- a/framework/modelcatalog/datasheet/cost.go
+++ b/framework/modelcatalog/datasheet/cost.go
@@ -295,22 +295,24 @@ func (s *Store) calculateCostWithCache(result *schemas.BifrostResponse, cacheDeb
 		if cacheDebug.HitType != nil && *cacheDebug.HitType == "direct" {
 			return nil
 		}
-		// Semantic cache hit — only the embedding lookup cost (an input cost)
+		// Semantic cache hit — only the embedding lookup cost. It's an internal
+		// sidecar cost (a separate embedding call), so it lands on the additional
+		// side, alongside guardrail/MCP, not folded into the request's input.
 		if cacheDebug.ProviderUsed != nil && cacheDebug.ModelUsed != nil && cacheDebug.InputTokens != nil {
 			c := s.computeCacheEmbeddingCost(cacheDebug, scopes)
 			if c == 0 {
 				return nil
 			}
 			return &schemas.BifrostCost{
-				InputCost:        c,
-				InputCostDetails: &schemas.InputCostDetails{TextCost: c},
-				TotalCost:        c,
+				AdditionalCost:        c,
+				AdditionalCostDetails: &schemas.AdditionalCostDetails{SemanticCacheCost: c},
+				TotalCost:             c,
 			}
 		}
 		return nil
 	}
 
-	// Cache miss — full LLM cost + embedding lookup cost (added on the input side)
+	// Cache miss — full LLM cost + embedding lookup cost (a sidecar additional cost)
 	base := s.calculateBaseCost(result, scopes)
 	embeddingCost := s.computeCacheEmbeddingCost(cacheDebug, scopes)
 	if embeddingCost == 0 {
@@ -320,16 +322,16 @@ func (s *Store) calculateCostWithCache(result *schemas.BifrostResponse, cacheDeb
 	merged := &schemas.BifrostCost{}
 	if base != nil {
 		*merged = *base
-		if base.InputCostDetails != nil {
-			d := *base.InputCostDetails
-			merged.InputCostDetails = &d
+		if base.AdditionalCostDetails != nil {
+			d := *base.AdditionalCostDetails
+			merged.AdditionalCostDetails = &d
 		}
 	}
-	if merged.InputCostDetails == nil {
-		merged.InputCostDetails = &schemas.InputCostDetails{}
+	if merged.AdditionalCostDetails == nil {
+		merged.AdditionalCostDetails = &schemas.AdditionalCostDetails{}
 	}
-	merged.InputCost += embeddingCost
-	merged.InputCostDetails.TextCost += embeddingCost
+	merged.AdditionalCost += embeddingCost
+	merged.AdditionalCostDetails.SemanticCacheCost += embeddingCost
 	merged.TotalCost += embeddingCost
 	return merged
 }
@@ -352,7 +354,13 @@ func (s *Store) computeCacheEmbeddingCost(cacheDebug *schemas.BifrostCacheDebug,
 	if pricing == nil {
 		return 0
 	}
-	return float64(*cacheDebug.InputTokens) * tieredInputRate(pricing, *cacheDebug.InputTokens, serviceTier{})
+	cost := float64(*cacheDebug.InputTokens) * tieredInputRate(pricing, *cacheDebug.InputTokens, serviceTier{})
+	// The lookup is a separate embedding call, so the embedding model's flat
+	// per-request fee applies once, mirroring the synchronous/batch paths.
+	if pricing.CostPerRequest != nil {
+		cost += *pricing.CostPerRequest
+	}
+	return cost
 }
 
 // CalculateCacheEmbeddingCost computes the semantic-cache embedding lookup cost.
@@ -1403,7 +1411,6 @@ func computeOCRCost(pricing *configstoreTables.TableModelPricing, ocrProcessedPa
 	// folds onto the input side as a request cost.
 	return totalOnlyCost(cost)
 }
-
 
 // totalOnlyCost wraps a non-token-based cost (per-page, per-session) into a
 // BifrostCost, folding it onto the input side as a flat request cost, or nil

--- a/framework/modelcatalog/datasheet/cost_test.go
+++ b/framework/modelcatalog/datasheet/cost_test.go
@@ -343,7 +343,7 @@ func TestComputeTextCost_Breakdown(t *testing.T) {
 	assert.InDelta(t, 0.0075, bd.OutputCost, 1e-12)
 	// Cache read/write are input sub-categories surfaced in the details.
 	require.NotNil(t, bd.InputCostDetails)
-	assert.InDelta(t, 0.00045, bd.InputCostDetails.CachedReadCost, 1e-12) // 1500*3e-7
+	assert.InDelta(t, 0.00045, bd.InputCostDetails.CachedReadCost, 1e-12)  // 1500*3e-7
 	assert.InDelta(t, 0.00075, bd.InputCostDetails.CachedWriteCost, 1e-12) // 200*3.75e-6
 	// Detail components sum back to the input total.
 	assert.InDelta(t, bd.InputCost,
@@ -1148,9 +1148,9 @@ func TestComputeRerankCost_BreakdownDetails(t *testing.T) {
 	require.NotNil(t, cost)
 	require.NotNil(t, cost.InputCostDetails)
 	require.NotNil(t, cost.OutputCostDetails)
-	assert.InDelta(t, 0.01, cost.InputCost, 1e-12)             // 10 * 0.001
-	assert.InDelta(t, 0.013, cost.OutputCost, 1e-12)           // 5*0.002 + 3*0.001
-	assert.InDelta(t, 0.023, cost.TotalCost, 1e-12)            // input + output
+	assert.InDelta(t, 0.01, cost.InputCost, 1e-12)   // 10 * 0.001
+	assert.InDelta(t, 0.013, cost.OutputCost, 1e-12) // 5*0.002 + 3*0.001
+	assert.InDelta(t, 0.023, cost.TotalCost, 1e-12)  // input + output
 	assert.InDelta(t, 0.01, cost.InputCostDetails.TextCost, 1e-12)
 	assert.InDelta(t, 0.01, cost.OutputCostDetails.TextCost, 1e-12)
 	assert.InDelta(t, 0.003, cost.OutputCostDetails.SearchQueriesCost, 1e-12)
@@ -1171,7 +1171,7 @@ func TestComputeSpeechCost_BreakdownDetails(t *testing.T) {
 	require.NotNil(t, cost)
 	require.NotNil(t, cost.InputCostDetails)
 	require.NotNil(t, cost.OutputCostDetails)
-	assert.InDelta(t, 0.0002, cost.InputCostDetails.TextCost, 1e-12) // 200 * 0.000001
+	assert.InDelta(t, 0.0002, cost.InputCostDetails.TextCost, 1e-12)  // 200 * 0.000001
 	assert.InDelta(t, 0.005, cost.OutputCostDetails.AudioCost, 1e-12) // 100 * 0.00005
 	assert.Zero(t, cost.OutputCostDetails.TextCost)
 }
@@ -1197,8 +1197,8 @@ func TestComputeTranscriptionCost_BreakdownDetails(t *testing.T) {
 	require.NotNil(t, cost)
 	require.NotNil(t, cost.InputCostDetails)
 	require.NotNil(t, cost.OutputCostDetails)
-	assert.InDelta(t, 0.015, cost.InputCostDetails.AudioCost, 1e-12) // 1500 * 0.00001
-	assert.InDelta(t, 0.0025, cost.InputCostDetails.TextCost, 1e-12) // 500 * 0.000005
+	assert.InDelta(t, 0.015, cost.InputCostDetails.AudioCost, 1e-12)  // 1500 * 0.00001
+	assert.InDelta(t, 0.0025, cost.InputCostDetails.TextCost, 1e-12)  // 500 * 0.000005
 	assert.InDelta(t, 0.0075, cost.OutputCostDetails.TextCost, 1e-12) // 500 * 0.000015
 	// Details reconcile with the authoritative side totals.
 	assert.InDelta(t, cost.InputCost, cost.InputCostDetails.AudioCost+cost.InputCostDetails.TextCost, 1e-12)
@@ -2041,6 +2041,184 @@ func TestCalculateCost_SemanticCacheHitNoEmbeddingInfo(t *testing.T) {
 
 	cost := s.CalculateCost(resp, nil)
 	assert.Equal(t, 0.0, cost)
+}
+
+// TestCalculateCostBreakdown_SemanticCacheHitIsAdditional verifies a semantic
+// cache hit's embedding-lookup cost lands on the additional side
+// (SemanticCacheCost), not folded into the request's input.
+func TestCalculateCostBreakdown_SemanticCacheHitIsAdditional(t *testing.T) {
+	embProvider := "openai"
+	embModel := "text-embedding-3-small"
+	embTokens := 500
+
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("gpt-4o", "openai", "chat"): {
+			Model: "gpt-4o", Provider: "openai", Mode: "chat",
+			InputCostPerToken: bifrost.Ptr(0.000005), OutputCostPerToken: bifrost.Ptr(0.000015),
+		},
+		makeKey("text-embedding-3-small", "openai", "embedding"): {
+			Model: "text-embedding-3-small", Provider: "openai", Mode: "embedding",
+			InputCostPerToken: bifrost.Ptr(0.00000002),
+		},
+	})
+
+	hitType := "semantic"
+	resp := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			Usage: &schemas.BifrostLLMUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType: schemas.ChatCompletionRequest,
+				RoutingInfo: routingInfoFor(schemas.OpenAI, "gpt-4o"),
+				CacheDebug: &schemas.BifrostCacheDebug{
+					CacheHit: true, HitType: &hitType,
+					ProviderUsed: &embProvider, ModelUsed: &embModel, InputTokens: &embTokens,
+				},
+			},
+		},
+	}
+
+	bd := s.CalculateCostBreakdown(resp, nil)
+	require.NotNil(t, bd)
+	require.NotNil(t, bd.AdditionalCostDetails)
+	// Only the embedding lookup: 500 * 0.00000002 = 0.00001, all on the additional side.
+	assert.InDelta(t, 0.00001, bd.AdditionalCost, 1e-12)
+	assert.InDelta(t, 0.00001, bd.AdditionalCostDetails.SemanticCacheCost, 1e-12)
+	assert.Zero(t, bd.InputCost)
+	assert.InDelta(t, 0.00001, bd.TotalCost, 1e-12)
+}
+
+// TestCalculateCostBreakdown_SemanticCacheMissAddsAdditional verifies a cache
+// miss prices the full LLM call plus the embedding lookup, with the lookup on
+// the additional side and the three sides reconciling to the total.
+func TestCalculateCostBreakdown_SemanticCacheMissAddsAdditional(t *testing.T) {
+	embProvider := "openai"
+	embModel := "text-embedding-3-small"
+	embTokens := 500
+
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("gpt-4o", "openai", "chat"): {
+			Model: "gpt-4o", Provider: "openai", Mode: "chat",
+			InputCostPerToken: bifrost.Ptr(0.000005), OutputCostPerToken: bifrost.Ptr(0.000015),
+		},
+		makeKey("text-embedding-3-small", "openai", "embedding"): {
+			Model: "text-embedding-3-small", Provider: "openai", Mode: "embedding",
+			InputCostPerToken: bifrost.Ptr(0.00000002),
+		},
+	})
+
+	resp := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			Usage: &schemas.BifrostLLMUsage{PromptTokens: 1000, CompletionTokens: 500, TotalTokens: 1500},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType: schemas.ChatCompletionRequest,
+				RoutingInfo: routingInfoFor(schemas.OpenAI, "gpt-4o"),
+				CacheDebug: &schemas.BifrostCacheDebug{
+					CacheHit:     false,
+					ProviderUsed: &embProvider, ModelUsed: &embModel, InputTokens: &embTokens,
+				},
+			},
+		},
+	}
+
+	bd := s.CalculateCostBreakdown(resp, nil)
+	require.NotNil(t, bd)
+	require.NotNil(t, bd.AdditionalCostDetails)
+	// Base: 1000*5e-6 + 500*1.5e-5 = 0.0125. Embedding: 500*2e-8 = 0.00001 (additional).
+	assert.InDelta(t, 0.005, bd.InputCost, 1e-12)
+	assert.InDelta(t, 0.0075, bd.OutputCost, 1e-12)
+	assert.InDelta(t, 0.00001, bd.AdditionalCost, 1e-12)
+	assert.InDelta(t, 0.00001, bd.AdditionalCostDetails.SemanticCacheCost, 1e-12)
+	assert.InDelta(t, 0.01251, bd.TotalCost, 1e-12)
+	assert.InDelta(t, bd.TotalCost, bd.InputCost+bd.OutputCost+bd.AdditionalCost, 1e-12)
+}
+
+// TestCalculateCostBreakdown_SemanticCacheHitAddsRequestSurcharge verifies the
+// embedding model's flat CostPerRequest fee is included in the semantic-cache
+// lookup cost on a hit, not just the per-token charge.
+func TestCalculateCostBreakdown_SemanticCacheHitAddsRequestSurcharge(t *testing.T) {
+	embProvider := "openai"
+	embModel := "text-embedding-3-small"
+	embTokens := 500
+
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("gpt-4o", "openai", "chat"): {
+			Model: "gpt-4o", Provider: "openai", Mode: "chat",
+			InputCostPerToken: bifrost.Ptr(0.000005), OutputCostPerToken: bifrost.Ptr(0.000015),
+		},
+		makeKey("text-embedding-3-small", "openai", "embedding"): {
+			Model: "text-embedding-3-small", Provider: "openai", Mode: "embedding",
+			InputCostPerToken: bifrost.Ptr(0.00000002), CostPerRequest: bifrost.Ptr(0.001),
+		},
+	})
+
+	hitType := "semantic"
+	resp := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			Usage: &schemas.BifrostLLMUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType: schemas.ChatCompletionRequest,
+				RoutingInfo: routingInfoFor(schemas.OpenAI, "gpt-4o"),
+				CacheDebug: &schemas.BifrostCacheDebug{
+					CacheHit: true, HitType: &hitType,
+					ProviderUsed: &embProvider, ModelUsed: &embModel, InputTokens: &embTokens,
+				},
+			},
+		},
+	}
+
+	bd := s.CalculateCostBreakdown(resp, nil)
+	require.NotNil(t, bd)
+	require.NotNil(t, bd.AdditionalCostDetails)
+	// Lookup: 500*2e-8 + 0.001 request fee = 0.00101, all on the additional side.
+	assert.InDelta(t, 0.00101, bd.AdditionalCost, 1e-12)
+	assert.InDelta(t, 0.00101, bd.AdditionalCostDetails.SemanticCacheCost, 1e-12)
+	assert.Zero(t, bd.InputCost)
+	assert.InDelta(t, 0.00101, bd.TotalCost, 1e-12)
+}
+
+// TestCalculateCostBreakdown_SemanticCacheMissAddsRequestSurcharge verifies the
+// embedding CostPerRequest fee is included in the lookup cost on a miss, on top
+// of the full LLM call, with the three sides reconciling to the total.
+func TestCalculateCostBreakdown_SemanticCacheMissAddsRequestSurcharge(t *testing.T) {
+	embProvider := "openai"
+	embModel := "text-embedding-3-small"
+	embTokens := 500
+
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("gpt-4o", "openai", "chat"): {
+			Model: "gpt-4o", Provider: "openai", Mode: "chat",
+			InputCostPerToken: bifrost.Ptr(0.000005), OutputCostPerToken: bifrost.Ptr(0.000015),
+		},
+		makeKey("text-embedding-3-small", "openai", "embedding"): {
+			Model: "text-embedding-3-small", Provider: "openai", Mode: "embedding",
+			InputCostPerToken: bifrost.Ptr(0.00000002), CostPerRequest: bifrost.Ptr(0.001),
+		},
+	})
+
+	resp := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			Usage: &schemas.BifrostLLMUsage{PromptTokens: 1000, CompletionTokens: 500, TotalTokens: 1500},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType: schemas.ChatCompletionRequest,
+				RoutingInfo: routingInfoFor(schemas.OpenAI, "gpt-4o"),
+				CacheDebug: &schemas.BifrostCacheDebug{
+					CacheHit:     false,
+					ProviderUsed: &embProvider, ModelUsed: &embModel, InputTokens: &embTokens,
+				},
+			},
+		},
+	}
+
+	bd := s.CalculateCostBreakdown(resp, nil)
+	require.NotNil(t, bd)
+	require.NotNil(t, bd.AdditionalCostDetails)
+	// Base: 1000*5e-6 + 500*1.5e-5 = 0.0125. Embedding: 500*2e-8 + 0.001 = 0.00101 (additional).
+	assert.InDelta(t, 0.005, bd.InputCost, 1e-12)
+	assert.InDelta(t, 0.0075, bd.OutputCost, 1e-12)
+	assert.InDelta(t, 0.00101, bd.AdditionalCost, 1e-12)
+	assert.InDelta(t, 0.00101, bd.AdditionalCostDetails.SemanticCacheCost, 1e-12)
+	assert.InDelta(t, 0.01351, bd.TotalCost, 1e-12)
+	assert.InDelta(t, bd.TotalCost, bd.InputCost+bd.OutputCost+bd.AdditionalCost, 1e-12)
 }
 
 // TestCalculateCostAddsGuardrailJudgeCost verifies judge cost is additive to the main request.

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -309,25 +309,22 @@ func (p *LoggerPlugin) applyInternalCallCosts(ctx *schemas.BifrostContext, entry
 		*entry.Cost += cost
 	}
 
-	// Denormalize the split too: the cache embedding lookup is an input cost, the
-	// guardrail judge call an additional one. When a usage carrier exists, merge
-	// onto its breakdown (SerializeFields denormalizes from there); otherwise
-	// there is no carrier to synthesize (that would suppress the deferred-usage
-	// watcher), so write the split columns directly.
+	// Both are additional-side sidecar costs. Merge onto the usage carrier's
+	// breakdown when one exists (SerializeFields denormalizes from it); otherwise
+	// write the additional_cost column directly. Don't synthesize a carrier: that
+	// suppresses the deferred-usage watcher.
 	sidecar := &schemas.BifrostCost{TotalCost: cost}
-	if cacheCost > 0 {
-		sidecar.InputCost = cacheCost
-		sidecar.InputCostDetails = &schemas.InputCostDetails{TextCost: cacheCost}
-	}
-	if guardrailCost > 0 {
-		sidecar.AdditionalCost = guardrailCost
-		sidecar.AdditionalCostDetails = &schemas.AdditionalCostDetails{GuardrailCost: guardrailCost}
+	if cacheCost > 0 || guardrailCost > 0 {
+		sidecar.AdditionalCost = cacheCost + guardrailCost
+		sidecar.AdditionalCostDetails = &schemas.AdditionalCostDetails{
+			SemanticCacheCost: cacheCost,
+			GuardrailCost:     guardrailCost,
+		}
 	}
 	if entry.TokenUsageParsed != nil {
 		entry.TokenUsageParsed.Cost = entry.TokenUsageParsed.Cost.Add(sidecar)
 	} else {
-		entry.InputCost += cacheCost
-		entry.AdditionalCost += guardrailCost
+		entry.AdditionalCost += cacheCost + guardrailCost
 	}
 }
 


### PR DESCRIPTION
## Summary

Semantic cache embedding-lookup costs were previously folded into the request's `InputCost`/`InputCostDetails.TextCost`. This was incorrect — the embedding call is an internal sidecar operation, not part of the request's own token usage. This PR moves semantic cache embedding costs to the `AdditionalCost`/`AdditionalCostDetails.SemanticCacheCost` field, consistent with how guardrail judge calls and MCP tool executions are handled.

## Changes

- Added `SemanticCacheCost float64` field to `AdditionalCostDetails` and included it in the `add()` merge helper.
- Updated `calculateCostWithCache` so that both semantic cache hits and cache misses record the embedding lookup cost under `AdditionalCost`/`AdditionalCostDetails.SemanticCacheCost` instead of `InputCost`/`InputCostDetails.TextCost`.
- Updated `applyInternalCallCosts` in the logging plugin to treat the cache embedding cost as an additional-side cost, merging both `cacheCost` and `guardrailCost` into a single `AdditionalCostDetails` struct rather than splitting them across input and additional sides.
- Updated the `BifrostCost` doc comment to include semantic cache embedding lookups in the list of sidecar costs that belong on the additional side.
- Added two new tests: `TestCalculateCostBreakdown_SemanticCacheHitIsAdditional` and `TestCalculateCostBreakdown_SemanticCacheMissAddsAdditional`, which verify the embedding cost lands on the additional side and that all three cost sides reconcile to the total.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/... ./framework/modelcatalog/datasheet/... ./plugins/logging/...
```

The two new tests confirm:
- A semantic cache hit records `AdditionalCost = 0.00001` and `SemanticCacheCost = 0.00001` with zero `InputCost`.
- A semantic cache miss records the full LLM cost on input/output and the embedding lookup on the additional side, with all three sides summing to `TotalCost`.

## Breaking changes

- [x] Yes
- [ ] No

Any consumers reading `InputCost` or `InputCostDetails.TextCost` to extract semantic cache embedding costs will need to read `AdditionalCost` and `AdditionalCostDetails.SemanticCacheCost` instead. The `TotalCost` value is unchanged.

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable