### PR TITLE
feat(integrations): support native raw request redaction

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6660,6 +6660,7 @@ func clearAnthropicPassthroughForNonNativeProvider(ctx *schemas.BifrostContext, 
 		return
 	}
 	ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, false)
+	ctx.ClearValue(schemas.BifrostContextKeyRawRequestBodyTextRewriter)
 	ctx.SetValue(schemas.BifrostContextKeySendBackRawResponse, false)
 	ctx.SetValue(schemas.BifrostContextKeyPassthroughOverridesPresent, false)
 }

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -2968,6 +2968,11 @@ func TestClearAnthropicPassthroughForNonNativeProvider(t *testing.T) {
 			for _, k := range flagKeys {
 				ctx.SetValue(k, true)
 			}
+			ctx.SetValue(schemas.BifrostContextKeyRawRequestBodyTextRewriter, schemas.RawRequestBodyTextRewriter(
+				func(rawBody []byte, _ map[string]string) ([]byte, error) {
+					return rawBody, nil
+				},
+			))
 
 			clearAnthropicPassthroughForNonNativeProvider(ctx, tt.baseProvider)
 
@@ -2978,7 +2983,28 @@ func TestClearAnthropicPassthroughForNonNativeProvider(t *testing.T) {
 					t.Errorf("flag %v = %v, want %v", k, got, want)
 				}
 			}
+
+			_, hasRewriter := ctx.Value(schemas.BifrostContextKeyRawRequestBodyTextRewriter).(schemas.RawRequestBodyTextRewriter)
+			if hasRewriter == tt.wantCleared {
+				t.Errorf("raw request body rewriter present = %v, want %v", hasRewriter, !tt.wantCleared)
+			}
 		})
+	}
+}
+
+// TestClearContextForInternalRequestClearsRawBodyRewriter verifies nested requests cannot inherit integration callbacks.
+func TestClearContextForInternalRequestClearsRawBodyRewriter(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyRawRequestBodyTextRewriter, schemas.RawRequestBodyTextRewriter(
+		func(rawBody []byte, _ map[string]string) ([]byte, error) {
+			return rawBody, nil
+		},
+	))
+
+	ClearContextForInternalRequest(ctx)
+
+	if got := ctx.Value(schemas.BifrostContextKeyRawRequestBodyTextRewriter); got != nil {
+		t.Fatalf("raw request body rewriter = %v, want nil", got)
 	}
 }
 

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -282,6 +282,7 @@ const (
 	BifrostContextKeyPassthroughHeaders                  BifrostContextKey = "bifrost-anthropic-passthrough-headers"  // map[string][]string (the caller's raw request headers, captured for Anthropic OAuth passthrough where their token is the upstream credential; ONLY the Anthropic provider may forward these — every other provider authenticates with its own configured credentials. Reserved: set by the transport, never by a plugin)
 	BifrostContextKeyURLPath                             BifrostContextKey = "bifrost-extra-url-path"                 // string
 	BifrostContextKeyUseRawRequestBody                   BifrostContextKey = "bifrost-use-raw-request-body"
+	BifrostContextKeyRawRequestBodyTextRewriter          BifrostContextKey = "bifrost-raw-request-body-text-rewriter"           // RawRequestBodyTextRewriter (set by native integrations that own raw-body text paths)
 	BifrostContextKeyChangeRequestType                   BifrostContextKey = "bifrost-change-request-type"                      // RequestType (set by plugins to trigger request type conversion in core, e.g. text->chat or chat->responses)
 	BifrostContextKeySendBackRawRequest                  BifrostContextKey = "bifrost-send-back-raw-request"                    // bool (per-request override — read by bifrost.go, never overwritten)
 	BifrostContextKeySendBackRawResponse                 BifrostContextKey = "bifrost-send-back-raw-response"                   // bool (per-request override — read by bifrost.go, never overwritten)

--- a/core/schemas/redaction.go
+++ b/core/schemas/redaction.go
@@ -6,6 +6,9 @@ import (
 	"strings"
 )
 
+// RawRequestBodyTextRewriter applies runtime literal replacements to integration-owned text fields in a native JSON request body.
+type RawRequestBodyTextRewriter func(rawBody []byte, replacements map[string]string) ([]byte, error)
+
 // RedactionPhase identifies which request lifecycle phase produced a redaction finding.
 type RedactionPhase string
 

--- a/core/utils.go
+++ b/core/utils.go
@@ -417,6 +417,7 @@ func ClearContextForInternalRequest(ctx *schemas.BifrostContext) {
 	ctx.ClearValue(schemas.BifrostContextKeySkipKeySelection)
 	// Body transport.
 	ctx.ClearValue(schemas.BifrostContextKeyUseRawRequestBody)
+	ctx.ClearValue(schemas.BifrostContextKeyRawRequestBodyTextRewriter)
 	ctx.ClearValue(schemas.BifrostContextKeySendBackRawRequest)
 	ctx.ClearValue(schemas.BifrostContextKeySendBackRawResponse)
 	ctx.ClearValue(schemas.BifrostContextKeyPassthroughOverridesPresent)

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -353,6 +353,118 @@ func checkAnthropicPassthrough(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.Bif
 			bifrostCtx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, false)
 			return nil
 		}
+		bifrostCtx.SetValue(
+			schemas.BifrostContextKeyRawRequestBodyTextRewriter,
+			schemas.RawRequestBodyTextRewriter(rewriteAnthropicRawRequestBody),
+		)
+	}
+	return nil
+}
+
+// rewriteAnthropicRawRequestBody applies runtime replacements to Anthropic-native content fields.
+func rewriteAnthropicRawRequestBody(rawBody []byte, replacements map[string]string) ([]byte, error) {
+	return rewriteRawRequestTextFields(rawBody, replacements, collectAnthropicRawRequestTextPaths)
+}
+
+// anthropicRawContentScope controls which native content-block text fields are guardrail-visible.
+type anthropicRawContentScope uint8
+
+const (
+	anthropicRawContentScopeSystem anthropicRawContentScope = iota
+	anthropicRawContentScopeMessage
+	anthropicRawContentScopeToolResult
+)
+
+// collectAnthropicRawRequestTextPaths enumerates Anthropic fields mirrored into mutable Bifrost request text.
+func collectAnthropicRawRequestTextPaths(root gjson.Result, replacements map[string]string) ([]string, error) {
+	paths := make([]string, 0)
+	if err := appendRawRequestStringPath(&paths, root.Get("prompt"), "prompt"); err != nil {
+		return nil, err
+	}
+	if err := collectAnthropicRawContentPaths(&paths, root.Get("system"), "system", anthropicRawContentScopeSystem); err != nil {
+		return nil, err
+	}
+
+	messages := root.Get("messages")
+	if !messages.Exists() || messages.Type == gjson.Null {
+		return paths, nil
+	}
+	if !messages.IsArray() {
+		return nil, fmt.Errorf("raw Anthropic request messages must be an array")
+	}
+	var collectErr error
+	messages.ForEach(func(index, message gjson.Result) bool {
+		messagePath := rawRequestArrayPath("messages", int(index.Int()))
+		collectErr = collectAnthropicRawContentPaths(
+			&paths,
+			message.Get("content"),
+			rawRequestObjectPath(messagePath, "content"),
+			anthropicRawContentScopeMessage,
+		)
+		return collectErr == nil
+	})
+	return paths, collectErr
+}
+
+// collectAnthropicRawContentPaths handles the string, block-array, and single-block Anthropic content union.
+func collectAnthropicRawContentPaths(paths *[]string, content gjson.Result, path string, scope anthropicRawContentScope) error {
+	if !content.Exists() || content.Type == gjson.Null {
+		return nil
+	}
+	if content.Type == gjson.String {
+		*paths = append(*paths, path)
+		return nil
+	}
+	if content.IsObject() {
+		return collectAnthropicRawContentBlockPaths(paths, content, path, scope)
+	}
+	if !content.IsArray() {
+		return fmt.Errorf("raw Anthropic content path %q must be a string, object, or array", path)
+	}
+
+	var collectErr error
+	content.ForEach(func(index, block gjson.Result) bool {
+		collectErr = collectAnthropicRawContentBlockPaths(paths, block, rawRequestArrayPath(path, int(index.Int())), scope)
+		return collectErr == nil
+	})
+	return collectErr
+}
+
+// collectAnthropicRawContentBlockPaths selects only block fields represented as mutable normalized text.
+func collectAnthropicRawContentBlockPaths(paths *[]string, block gjson.Result, path string, scope anthropicRawContentScope) error {
+	if !block.IsObject() {
+		return fmt.Errorf("raw Anthropic content block at %q must be an object", path)
+	}
+	blockType := block.Get("type")
+	if !blockType.Exists() || blockType.Type == gjson.Null {
+		return nil
+	}
+	if blockType.Type != gjson.String {
+		return fmt.Errorf("raw Anthropic content block type at %q must be a string", path)
+	}
+
+	switch scope {
+	case anthropicRawContentScopeSystem, anthropicRawContentScopeToolResult:
+		if blockType.String() == string(anthropic.AnthropicContentBlockTypeText) {
+			return appendRawRequestStringPath(paths, block.Get("text"), rawRequestObjectPath(path, "text"))
+		}
+		return nil
+	case anthropicRawContentScopeMessage:
+		switch anthropic.AnthropicContentBlockType(blockType.String()) {
+		case anthropic.AnthropicContentBlockTypeText:
+			return appendRawRequestStringPath(paths, block.Get("text"), rawRequestObjectPath(path, "text"))
+		case anthropic.AnthropicContentBlockTypeThinking:
+			return appendRawRequestStringPath(paths, block.Get("thinking"), rawRequestObjectPath(path, "thinking"))
+		case anthropic.AnthropicContentBlockTypeCompaction:
+			return appendRawRequestStringPath(paths, block.Get("content"), rawRequestObjectPath(path, "content"))
+		case anthropic.AnthropicContentBlockTypeToolResult, anthropic.AnthropicContentBlockTypeMCPToolResult:
+			return collectAnthropicRawContentPaths(
+				paths,
+				block.Get("content"),
+				rawRequestObjectPath(path, "content"),
+				anthropicRawContentScopeToolResult,
+			)
+		}
 	}
 	return nil
 }

--- a/transports/bifrost-http/integrations/anthropic_test.go
+++ b/transports/bifrost-http/integrations/anthropic_test.go
@@ -7,8 +7,94 @@ import (
 
 	"github.com/maximhq/bifrost/core/providers/anthropic"
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/tidwall/gjson"
 	"github.com/valyala/fasthttp"
 )
+
+// TestRewriteAnthropicRawRequestBodyRedactsOnlyContentFields verifies native redaction covers conversation content without touching request metadata or tool arguments.
+func TestRewriteAnthropicRawRequestBodyRedactsOnlyContentFields(t *testing.T) {
+	rawBody := []byte(`{
+		"model":"claude-sonnet-4-5",
+		"prompt":"legacy alice@example.com",
+		"system":[{"type":"text","text":"system alice@example.com"}],
+		"messages":[
+			{"role":"user","content":"first alice@example.com"},
+			{"role":"assistant","content":[
+				{"type":"thinking","thinking":"reason alice@example.com","signature":"alice@example.com"},
+				{"type":"text","text":"answer alice@example.com"},
+				{"type":"tool_use","id":"call_1","name":"lookup","input":{"email":"alice@example.com"}}
+			]},
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"call_1","content":"tool alice@example.com"},
+				{"type":"mcp_tool_result","tool_use_id":"call_2","content":[{"type":"text","text":"nested alice@example.com"}]}
+			]}
+		],
+		"metadata":{"user_id":"alice@example.com"},
+		"tools":[{"name":"lookup","description":"alice@example.com","input_schema":{"type":"object"}}]
+	}`)
+
+	got, err := rewriteAnthropicRawRequestBody(rawBody, map[string]string{"alice@example.com": "[EMAIL]"})
+	if err != nil {
+		t.Fatalf("rewriteAnthropicRawRequestBody() error = %v", err)
+	}
+
+	redactedPaths := []string{
+		"prompt",
+		"system.0.text",
+		"messages.0.content",
+		"messages.1.content.0.thinking",
+		"messages.1.content.1.text",
+		"messages.2.content.0.content",
+		"messages.2.content.1.content.0.text",
+	}
+	for _, path := range redactedPaths {
+		if value := gjson.GetBytes(got, path).String(); strings.Contains(value, "alice@example.com") || !strings.Contains(value, "[EMAIL]") {
+			t.Errorf("%s = %q, want redacted content", path, value)
+		}
+	}
+
+	untouchedPaths := []string{
+		"messages.1.content.0.signature",
+		"messages.1.content.2.input.email",
+		"metadata.user_id",
+		"tools.0.description",
+	}
+	for _, path := range untouchedPaths {
+		if value := gjson.GetBytes(got, path).String(); value != "alice@example.com" {
+			t.Errorf("%s = %q, want untouched literal", path, value)
+		}
+	}
+}
+
+// TestRewriteAnthropicRawRequestBodyRejectsUnmappedLiteral verifies a normalized runtime mutation cannot silently leave native content unredacted.
+func TestRewriteAnthropicRawRequestBodyRejectsUnmappedLiteral(t *testing.T) {
+	_, err := rewriteAnthropicRawRequestBody(
+		[]byte(`{"messages":[{"role":"user","content":"hello"}]}`),
+		map[string]string{"alice@example.com": "[EMAIL]"},
+	)
+	if err == nil {
+		t.Fatal("rewriteAnthropicRawRequestBody() error = nil, want unmapped literal error")
+	}
+}
+
+// TestRewriteAnthropicRawRequestBodyRejectsMalformedJSON verifies native rewrites never repair or forward a malformed body.
+func TestRewriteAnthropicRawRequestBodyRejectsMalformedJSON(t *testing.T) {
+	_, err := rewriteAnthropicRawRequestBody([]byte(`{"messages":`), map[string]string{"alice@example.com": "[EMAIL]"})
+	if err == nil {
+		t.Fatal("rewriteAnthropicRawRequestBody() error = nil, want malformed JSON error")
+	}
+}
+
+// TestRewriteAnthropicRawRequestBodyRejectsDuplicateKeys prevents parser precedence from selecting an unredacted duplicate value.
+func TestRewriteAnthropicRawRequestBodyRejectsDuplicateKeys(t *testing.T) {
+	_, err := rewriteAnthropicRawRequestBody(
+		[]byte(`{"messages":[{"role":"user","content":"alice@example.com","content":"alice@example.com"}]}`),
+		map[string]string{"alice@example.com": "[EMAIL]"},
+	)
+	if err == nil {
+		t.Fatal("rewriteAnthropicRawRequestBody() error = nil, want duplicate-key error")
+	}
+}
 
 // TestMustConvertInPassthrough pins the passthrough routing decision that fixes
 // the Claude Code advisor/server-tool streaming bug: server tools (advisor,
@@ -188,6 +274,13 @@ func TestCheckAnthropicPassthrough_OutputConfigEscapeHatch(t *testing.T) {
 			}
 			if !tc.wantRawOff && !useRaw {
 				t.Errorf("expected UseRawRequestBody to stay true for %s, got false", tc.model)
+			}
+			_, hasRewriter := bifrostCtx.Value(schemas.BifrostContextKeyRawRequestBodyTextRewriter).(schemas.RawRequestBodyTextRewriter)
+			if tc.wantRawOff && hasRewriter {
+				t.Errorf("expected raw request body text rewriter to remain unset for %s", tc.model)
+			}
+			if !tc.wantRawOff && !hasRewriter {
+				t.Errorf("expected Anthropic raw request body text rewriter for %s", tc.model)
 			}
 		})
 	}

--- a/transports/bifrost-http/integrations/genai.go
+++ b/transports/bifrost-http/integrations/genai.go
@@ -1494,7 +1494,7 @@ func extractAndSetModelAndRequestType(ctx *fasthttp.RequestCtx, bifrostCtx *sche
 		}
 		if !r.IsEmbedding && explicitGemini {
 			setGenAIRawRequestBodyFromRequest(ctx, bifrostCtx)
-			bifrostCtx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+			enableGenAIRawRequestBodyRedaction(bifrostCtx)
 		}
 
 		return nil
@@ -1504,7 +1504,7 @@ func extractAndSetModelAndRequestType(ctx *fasthttp.RequestCtx, bifrostCtx *sche
 		}
 		if explicitGemini {
 			setGenAIRawRequestBodyFromRequest(ctx, bifrostCtx)
-			bifrostCtx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+			enableGenAIRawRequestBodyRedaction(bifrostCtx)
 		}
 		return nil
 	case *gemini.GeminiEmbeddingRequest:
@@ -1539,6 +1539,143 @@ func setGenAIRawRequestBodyFromRequest(ctx *fasthttp.RequestCtx, bifrostCtx *sch
 	if body := ctx.Request.Body(); len(body) > 0 {
 		bifrostCtx.SetValue(genAIRawRequestBodyContextKey, copyBytes(body))
 	}
+}
+
+// enableGenAIRawRequestBodyRedaction enables native passthrough with the matching Gemini content rewriter.
+func enableGenAIRawRequestBodyRedaction(bifrostCtx *schemas.BifrostContext) {
+	bifrostCtx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+	bifrostCtx.SetValue(
+		schemas.BifrostContextKeyRawRequestBodyTextRewriter,
+		schemas.RawRequestBodyTextRewriter(rewriteGenAIRawRequestBody),
+	)
+}
+
+// rewriteGenAIRawRequestBody applies runtime replacements to Gemini-native content fields.
+func rewriteGenAIRawRequestBody(rawBody []byte, replacements map[string]string) ([]byte, error) {
+	return rewriteRawRequestTextFields(rawBody, replacements, collectGenAIRawRequestTextPaths)
+}
+
+// collectGenAIRawRequestTextPaths enumerates flat and countTokens-enveloped Gemini content fields.
+func collectGenAIRawRequestTextPaths(root gjson.Result, replacements map[string]string) ([]string, error) {
+	paths := make([]string, 0)
+	if err := collectGenAIGenerationTextPaths(&paths, root, "", replacements); err != nil {
+		return nil, err
+	}
+	for _, envelopeKey := range []string{"generateContentRequest", "generate_content_request"} {
+		envelope := root.Get(envelopeKey)
+		if !envelope.Exists() || envelope.Type == gjson.Null {
+			continue
+		}
+		if !envelope.IsObject() {
+			return nil, fmt.Errorf("raw Gemini countTokens envelope %q must be an object", envelopeKey)
+		}
+		if err := collectGenAIGenerationTextPaths(&paths, envelope, rawRequestObjectPath("", envelopeKey), replacements); err != nil {
+			return nil, err
+		}
+	}
+	return paths, nil
+}
+
+// collectGenAIGenerationTextPaths selects Gemini generation fields mirrored into mutable Bifrost request text.
+func collectGenAIGenerationTextPaths(paths *[]string, request gjson.Result, path string, replacements map[string]string) error {
+	if !request.IsObject() {
+		return fmt.Errorf("raw Gemini generation request at %q must be an object", path)
+	}
+	for _, systemKey := range []string{"systemInstruction", "system_instruction"} {
+		if err := collectGenAIContentTextPaths(
+			paths,
+			request.Get(systemKey),
+			rawRequestObjectPath(path, systemKey),
+			false,
+			replacements,
+		); err != nil {
+			return err
+		}
+	}
+
+	contents := request.Get("contents")
+	if contents.Exists() && contents.Type != gjson.Null {
+		if !contents.IsArray() {
+			return fmt.Errorf("raw Gemini contents at %q must be an array", rawRequestObjectPath(path, "contents"))
+		}
+		var collectErr error
+		contentsPath := rawRequestObjectPath(path, "contents")
+		contents.ForEach(func(index, content gjson.Result) bool {
+			collectErr = collectGenAIContentTextPaths(
+				paths,
+				content,
+				rawRequestArrayPath(contentsPath, int(index.Int())),
+				true,
+				replacements,
+			)
+			return collectErr == nil
+		})
+		if collectErr != nil {
+			return collectErr
+		}
+	}
+
+	instances := request.Get("instances")
+	if !instances.Exists() || instances.Type == gjson.Null {
+		return nil
+	}
+	if !instances.IsArray() {
+		return fmt.Errorf("raw Gemini instances at %q must be an array", rawRequestObjectPath(path, "instances"))
+	}
+	instancesPath := rawRequestObjectPath(path, "instances")
+	var collectErr error
+	instances.ForEach(func(index, instance gjson.Result) bool {
+		instancePath := rawRequestArrayPath(instancesPath, int(index.Int()))
+		collectErr = appendRawRequestStringPath(paths, instance.Get("prompt"), rawRequestObjectPath(instancePath, "prompt"))
+		return collectErr == nil
+	})
+	return collectErr
+}
+
+// collectGenAIContentTextPaths selects text parts and supported function-response JSON values from one Gemini content object.
+func collectGenAIContentTextPaths(paths *[]string, content gjson.Result, path string, includeFunctionResponses bool, replacements map[string]string) error {
+	if !content.Exists() || content.Type == gjson.Null {
+		return nil
+	}
+	if !content.IsObject() {
+		return fmt.Errorf("raw Gemini content at %q must be an object", path)
+	}
+	parts := content.Get("parts")
+	if !parts.Exists() || parts.Type == gjson.Null {
+		return nil
+	}
+	if !parts.IsArray() {
+		return fmt.Errorf("raw Gemini content parts at %q must be an array", rawRequestObjectPath(path, "parts"))
+	}
+
+	partsPath := rawRequestObjectPath(path, "parts")
+	var collectErr error
+	parts.ForEach(func(index, part gjson.Result) bool {
+		partPath := rawRequestArrayPath(partsPath, int(index.Int()))
+		if collectErr = appendRawRequestStringPath(paths, part.Get("text"), rawRequestObjectPath(partPath, "text")); collectErr != nil {
+			return false
+		}
+		if !includeFunctionResponses {
+			return true
+		}
+		functionResponse := part.Get("functionResponse")
+		if !functionResponse.Exists() || functionResponse.Type == gjson.Null {
+			return true
+		}
+		functionResponsePath := rawRequestObjectPath(partPath, "functionResponse")
+		if !functionResponse.IsObject() {
+			collectErr = fmt.Errorf("raw Gemini function response at %q must be an object", functionResponsePath)
+			return false
+		}
+		collectErr = appendRawRequestJSONLeafPaths(
+			paths,
+			functionResponse.Get("response"),
+			rawRequestObjectPath(functionResponsePath, "response"),
+			replacements,
+		)
+		return collectErr == nil
+	})
+	return collectErr
 }
 
 func copyBytes(in []byte) []byte {

--- a/transports/bifrost-http/integrations/genai_test.go
+++ b/transports/bifrost-http/integrations/genai_test.go
@@ -2,6 +2,7 @@ package integrations
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/bytedance/sonic"
@@ -10,8 +11,83 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 	"github.com/valyala/fasthttp"
 )
+
+// TestRewriteGenAIRawRequestBodyRedactsOnlyContentFields verifies Gemini redaction covers native text and function-result values without touching metadata or function-call arguments.
+func TestRewriteGenAIRawRequestBodyRedactsOnlyContentFields(t *testing.T) {
+	rawBody := []byte(`{
+		"systemInstruction":{"parts":[{"text":"system alice@example.com"}]},
+		"contents":[
+			{"role":"user","parts":[{"text":"first alice@example.com"}]},
+			{"role":"model","parts":[
+				{"thought":true,"text":"reason alice@example.com","thoughtSignature":"alice@example.com"},
+				{"functionCall":{"name":"lookup","args":{"email":"alice@example.com"}}}
+			]},
+			{"role":"user","parts":[{"functionResponse":{"name":"lookup","response":{"output":"tool alice@example.com","nested.value":{"contact:key":"alice@example.com"}}}}]}
+		],
+		"instances":[{"prompt":"image alice@example.com"}],
+		"labels":{"owner":"alice@example.com"},
+		"tools":[{"functionDeclarations":[{"name":"lookup","description":"alice@example.com"}]}]
+	}`)
+
+	got, err := rewriteGenAIRawRequestBody(rawBody, map[string]string{"alice@example.com": "[EMAIL]"})
+	require.NoError(t, err)
+
+	redactedPaths := []string{
+		"systemInstruction.parts.0.text",
+		"contents.0.parts.0.text",
+		"contents.1.parts.0.text",
+		"contents.2.parts.0.functionResponse.response.output",
+		`contents.2.parts.0.functionResponse.response.nested\.value.contact:key`,
+		"instances.0.prompt",
+	}
+	for _, path := range redactedPaths {
+		value := gjson.GetBytes(got, path).String()
+		assert.NotContains(t, value, "alice@example.com", path)
+		assert.Contains(t, value, "[EMAIL]", path)
+	}
+
+	untouchedPaths := []string{
+		"contents.1.parts.0.thoughtSignature",
+		"contents.1.parts.1.functionCall.args.email",
+		"labels.owner",
+		"tools.0.functionDeclarations.0.description",
+	}
+	for _, path := range untouchedPaths {
+		assert.Equal(t, "alice@example.com", gjson.GetBytes(got, path).String(), path)
+	}
+	assert.True(t, strings.Contains(string(got), `"labels":{"owner":"alice@example.com"}`))
+}
+
+// TestRewriteGenAIRawRequestBodySupportsCountTokensEnvelope verifies both documented envelope spelling and snake-case system instructions use the same content allowlist.
+func TestRewriteGenAIRawRequestBodySupportsCountTokensEnvelope(t *testing.T) {
+	rawBody := []byte(`{"generate_content_request":{"system_instruction":{"parts":[{"text":"system alice@example.com"}]},"contents":[{"parts":[{"text":"user alice@example.com"}]}]}}`)
+
+	got, err := rewriteGenAIRawRequestBody(rawBody, map[string]string{"alice@example.com": "[EMAIL]"})
+	require.NoError(t, err)
+	assert.Equal(t, "system [EMAIL]", gjson.GetBytes(got, "generate_content_request.system_instruction.parts.0.text").String())
+	assert.Equal(t, "user [EMAIL]", gjson.GetBytes(got, "generate_content_request.contents.0.parts.0.text").String())
+}
+
+// TestRewriteGenAIRawRequestBodyRejectsUnmappedLiteral verifies a normalized runtime mutation cannot silently leave Gemini content unredacted.
+func TestRewriteGenAIRawRequestBodyRejectsUnmappedLiteral(t *testing.T) {
+	_, err := rewriteGenAIRawRequestBody(
+		[]byte(`{"contents":[{"parts":[{"text":"hello"}]}]}`),
+		map[string]string{"alice@example.com": "[EMAIL]"},
+	)
+	require.Error(t, err)
+}
+
+// TestRewriteGenAIRawRequestBodyRejectsSensitiveObjectKeys verifies unsupported key mutation fails closed inside a function-result subtree.
+func TestRewriteGenAIRawRequestBodyRejectsSensitiveObjectKeys(t *testing.T) {
+	_, err := rewriteGenAIRawRequestBody(
+		[]byte(`{"contents":[{"parts":[{"functionResponse":{"response":{"alice@example.com":"value"}}}]}]}`),
+		map[string]string{"alice@example.com": "[EMAIL]"},
+	)
+	require.ErrorContains(t, err, "unsupported JSON object key")
+}
 
 func TestCreateGenAIRerankRouteConfig(t *testing.T) {
 	route := createGenAIRerankRouteConfig("/genai")
@@ -75,6 +151,8 @@ func TestExtractAndSetModelAndRequestTypePreservesRawBodyForGenerateContent(t *t
 
 	assert.Equal(t, true, bifrostCtx.Value(schemas.BifrostContextKeyUseRawRequestBody))
 	assert.Equal(t, rawBody, bifrostCtx.Value(genAIRawRequestBodyContextKey))
+	_, hasRewriter := bifrostCtx.Value(schemas.BifrostContextKeyRawRequestBodyTextRewriter).(schemas.RawRequestBodyTextRewriter)
+	assert.True(t, hasRewriter)
 }
 
 func TestExtractAndSetModelAndRequestTypeNoRawPassthroughWithoutExplicitGemini(t *testing.T) {
@@ -96,6 +174,7 @@ func TestExtractAndSetModelAndRequestTypeNoRawPassthroughWithoutExplicitGemini(t
 
 	assert.Nil(t, bifrostCtx.Value(schemas.BifrostContextKeyUseRawRequestBody))
 	assert.Nil(t, bifrostCtx.Value(genAIRawRequestBodyContextKey))
+	assert.Nil(t, bifrostCtx.Value(schemas.BifrostContextKeyRawRequestBodyTextRewriter))
 }
 
 func TestExtractAndSetModelAndRequestTypeDoesNotRawPassthroughEmbedding(t *testing.T) {

--- a/transports/bifrost-http/integrations/rawrequestredaction.go
+++ b/transports/bifrost-http/integrations/rawrequestredaction.go
@@ -1,0 +1,190 @@
+package integrations
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/tidwall/gjson"
+)
+
+// rawRequestTextPathCollector returns the integration-owned JSON string paths eligible for runtime redaction.
+type rawRequestTextPathCollector func(root gjson.Result, replacements map[string]string) ([]string, error)
+
+// rewriteRawRequestTextFields applies literal replacements only to paths selected by the native integration.
+func rewriteRawRequestTextFields(rawBody []byte, replacements map[string]string, collect rawRequestTextPathCollector) ([]byte, error) {
+	if len(replacements) == 0 {
+		return rawBody, nil
+	}
+	if len(rawBody) == 0 {
+		return nil, fmt.Errorf("raw request body is empty")
+	}
+	if !gjson.ValidBytes(rawBody) {
+		return nil, fmt.Errorf("raw request body is not valid JSON")
+	}
+	root := gjson.ParseBytes(rawBody)
+	if err := validateRawRequestUniqueObjectKeys(root); err != nil {
+		return nil, err
+	}
+	if collect == nil {
+		return nil, fmt.Errorf("raw request body text path collector is unavailable")
+	}
+
+	paths, err := collect(root, replacements)
+	if err != nil {
+		return nil, err
+	}
+
+	found := make(map[string]bool, len(replacements))
+	expected := make(map[string]string)
+	seenPaths := make(map[string]struct{}, len(paths))
+	patched := rawBody
+	for _, path := range paths {
+		if _, seen := seenPaths[path]; seen {
+			continue
+		}
+		seenPaths[path] = struct{}{}
+
+		field := gjson.GetBytes(patched, path)
+		if !field.Exists() || field.Type != gjson.String {
+			return nil, fmt.Errorf("raw request content path %q is no longer a string", path)
+		}
+		original := field.String()
+		for literal := range replacements {
+			if literal != "" && strings.Contains(original, literal) {
+				found[literal] = true
+			}
+		}
+
+		redacted := schemas.ApplyLiteralReplacements(original, replacements)
+		if redacted == original {
+			continue
+		}
+		patched, err = providerUtils.SetJSONField(patched, path, redacted)
+		if err != nil {
+			return nil, fmt.Errorf("redact raw request content path %q: %w", path, err)
+		}
+		expected[path] = redacted
+	}
+
+	for literal := range replacements {
+		if literal != "" && !found[literal] {
+			return nil, fmt.Errorf("one or more runtime redaction literals were not found in an integration-owned content path")
+		}
+	}
+	if !gjson.ValidBytes(patched) {
+		return nil, fmt.Errorf("redacted raw request body is not valid JSON")
+	}
+	for path, want := range expected {
+		field := gjson.GetBytes(patched, path)
+		if !field.Exists() || field.Type != gjson.String || field.String() != want {
+			return nil, fmt.Errorf("redacted raw request content path %q failed verification", path)
+		}
+	}
+	return patched, nil
+}
+
+// validateRawRequestUniqueObjectKeys rejects ambiguous objects whose first and last values can differ across JSON parsers.
+func validateRawRequestUniqueObjectKeys(value gjson.Result) error {
+	switch {
+	case value.IsObject():
+		seen := make(map[string]struct{})
+		var validationErr error
+		value.ForEach(func(key, child gjson.Result) bool {
+			keyText := key.String()
+			if _, exists := seen[keyText]; exists {
+				validationErr = fmt.Errorf("raw request body contains duplicate JSON object keys")
+				return false
+			}
+			seen[keyText] = struct{}{}
+			validationErr = validateRawRequestUniqueObjectKeys(child)
+			return validationErr == nil
+		})
+		return validationErr
+	case value.IsArray():
+		var validationErr error
+		value.ForEach(func(_, child gjson.Result) bool {
+			validationErr = validateRawRequestUniqueObjectKeys(child)
+			return validationErr == nil
+		})
+		return validationErr
+	default:
+		return nil
+	}
+}
+
+// appendRawRequestStringPath adds an optional JSON string field to the integration-owned path set.
+func appendRawRequestStringPath(paths *[]string, field gjson.Result, path string) error {
+	if !field.Exists() || field.Type == gjson.Null {
+		return nil
+	}
+	if field.Type != gjson.String {
+		return fmt.Errorf("raw request content path %q must be a string", path)
+	}
+	*paths = append(*paths, path)
+	return nil
+}
+
+// appendRawRequestJSONLeafPaths adds string values below an integration-owned JSON content subtree.
+func appendRawRequestJSONLeafPaths(paths *[]string, value gjson.Result, path string, replacements map[string]string) error {
+	switch {
+	case !value.Exists() || value.Type == gjson.Null:
+		return nil
+	case value.Type == gjson.String:
+		*paths = append(*paths, path)
+		return nil
+	case value.IsArray():
+		var collectErr error
+		value.ForEach(func(index, child gjson.Result) bool {
+			collectErr = appendRawRequestJSONLeafPaths(paths, child, rawRequestArrayPath(path, int(index.Int())), replacements)
+			return collectErr == nil
+		})
+		return collectErr
+	case value.IsObject():
+		var collectErr error
+		value.ForEach(func(key, child gjson.Result) bool {
+			if containsRuntimeLiteral(key.String(), replacements) {
+				collectErr = fmt.Errorf("a runtime redaction literal appears in an unsupported JSON object key at %q", path)
+				return false
+			}
+			collectErr = appendRawRequestJSONLeafPaths(paths, child, rawRequestObjectPath(path, key.String()), replacements)
+			return collectErr == nil
+		})
+		return collectErr
+	default:
+		if containsRuntimeLiteral(value.Raw, replacements) {
+			return fmt.Errorf("a runtime redaction literal appears in an unsupported non-string JSON value at %q", path)
+		}
+		return nil
+	}
+}
+
+// containsRuntimeLiteral reports whether text contains any non-empty replacement key.
+func containsRuntimeLiteral(text string, replacements map[string]string) bool {
+	for literal := range replacements {
+		if literal != "" && strings.Contains(text, literal) {
+			return true
+		}
+	}
+	return false
+}
+
+// rawRequestObjectPath appends one escaped object key to a GJSON/SJSON path.
+func rawRequestObjectPath(path, key string) string {
+	escaped := strings.ReplaceAll(gjson.Escape(key), ":", `\:`)
+	if path == "" {
+		return escaped
+	}
+	return path + "." + escaped
+}
+
+// rawRequestArrayPath appends one array index to a GJSON/SJSON path.
+func rawRequestArrayPath(path string, index int) string {
+	indexText := strconv.Itoa(index)
+	if path == "" {
+		return indexText
+	}
+	return path + "." + indexText
+}


### PR DESCRIPTION
## Summary
- add a request-scoped raw-body text rewriter contract
- rewrite only Anthropic and Gemini integration-owned content paths with GJSON/SJSON
- cover prior conversation turns, system/reasoning text, and supported tool-result text
- fail closed for malformed or duplicate JSON, missing literals, and ambiguous rewrites
- clear the callback whenever native raw passthrough is disabled or an internal request is derived

## Validation
- core: go test . -count=1
- core: go test ./schemas -count=1
- transports: go test ./bifrost-http/integrations -count=1
- go vet on core, schemas, and HTTP integrations
- git diff --cached --check

## Stack
- stacked on #6159
- consumed by the companion Bifrost Enterprise Guardrails PR