### PR TITLE
gemini inmessage system role bug fix

### DIFF
--- a/core/providers/anthropic/attemptprovider_test.go
+++ b/core/providers/anthropic/attemptprovider_test.go
@@ -1,0 +1,66 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// attemptProvider is what every ShouldEmbedReasoningItemID call site in
+// responses.go reads, so its two branches decide whether a reasoning item's id is
+// smuggled into its signature/data. Both branches are load-bearing:
+//
+//   - RoutingInfo.Provider is the non-deprecated field and core populates it on every
+//     stream chunk, so it must win when set.
+//   - ExtraFields.Provider is the wider field: syncDeprecatedFromRoutingInfo only
+//     backfills it when RoutingInfo.Provider is non-empty, so frames built outside
+//     core's pipeline carry only the deprecated one. Dropping the fallback would stop
+//     embedding ids on exactly those frames, and silently -- nothing errors, the two
+//     halves of a reasoning item just stop merging on re-ingest.
+func TestStreamAttemptProvider(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		extra schemas.BifrostResponseExtraFields
+		want  schemas.ModelProvider
+	}{
+		{
+			name: "routing info wins when set",
+			extra: schemas.BifrostResponseExtraFields{
+				Provider:    schemas.Anthropic,
+				RoutingInfo: schemas.RoutingInfo{Provider: schemas.OpenAI},
+			},
+			want: schemas.OpenAI,
+		},
+		{
+			name: "falls back to the deprecated field when routing info is empty",
+			extra: schemas.BifrostResponseExtraFields{
+				Provider: schemas.OpenAI,
+			},
+			want: schemas.OpenAI,
+		},
+		{
+			name: "both agree",
+			extra: schemas.BifrostResponseExtraFields{
+				Provider:    schemas.OpenAI,
+				RoutingInfo: schemas.RoutingInfo{Provider: schemas.OpenAI},
+			},
+			want: schemas.OpenAI,
+		},
+		{
+			name:  "neither set",
+			extra: schemas.BifrostResponseExtraFields{},
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := attemptProvider(tt.extra); got != tt.want {
+				t.Errorf("attemptProvider = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/core/providers/anthropic/latesummaryupgrade_test.go
+++ b/core/providers/anthropic/latesummaryupgrade_test.go
@@ -1,0 +1,108 @@
+package anthropic
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// A reasoning item that looked redacted-only at output_item.added and then streamed
+// summary text is reopened as a thinking block mid-stream
+// (upgradeLateSummaryToThinkingBlock). That reopened block reads as "opened as
+// thinking" to the split at output_item.done, which would otherwise emit the
+// encrypted payload a second time -- once in `data` on the block that was closed,
+// once as a fresh redacted_thinking block.
+//
+// Duplicating it is not cosmetic: the client replays both halves next turn, so the
+// same signed reasoning state is submitted twice under one item.
+//
+// This drives the full lifecycle (added -> deltas -> done), which
+// TestAnthropicStreamEgress_LateSummaryNeverLandsOnRedactedBlock deliberately does
+// not: that test isolates the delta/block pairing.
+func TestAnthropicStreamEgress_LateSummaryDoesNotDuplicateEncryptedPayload(t *testing.T) {
+	t.Parallel()
+
+	reasoningID := "rs_1"
+	reasoningType := schemas.ResponsesMessageTypeReasoning
+
+	summaryDelta := func(text string) *schemas.BifrostResponsesStreamResponse {
+		return &schemas.BifrostResponsesStreamResponse{
+			Type:        schemas.ResponsesStreamResponseTypeReasoningSummaryTextDelta,
+			OutputIndex: schemas.Ptr(0),
+			ItemID:      &reasoningID,
+			Delta:       schemas.Ptr(text),
+			ExtraFields: schemas.BifrostResponseExtraFields{Provider: schemas.OpenAI},
+		}
+	}
+
+	frames := []*schemas.BifrostResponsesStreamResponse{
+		reasoningAddedFrame("", streamTestEncrypted),
+		summaryDelta("Ranking the sources "),
+		summaryDelta("by recency."),
+		{
+			Type:        schemas.ResponsesStreamResponseTypeOutputItemDone,
+			OutputIndex: schemas.Ptr(0),
+			Item: &schemas.ResponsesMessage{
+				ID:   &reasoningID,
+				Type: &reasoningType,
+				ResponsesReasoning: &schemas.ResponsesReasoning{
+					Summary: []schemas.ResponsesReasoningSummary{{
+						Type: schemas.ResponsesReasoningContentBlockTypeSummaryText,
+						Text: "Ranking the sources by recency.",
+					}},
+					EncryptedContent: schemas.Ptr(streamTestEncrypted),
+				},
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{Provider: schemas.OpenAI},
+		},
+	}
+
+	var redactedPayloads []string
+	openBlocks := map[int]AnthropicContentBlockType{}
+	var visible strings.Builder
+
+	for _, event := range driveAnthropicEgress(t, frames) {
+		if event == nil || event.Index == nil {
+			continue
+		}
+		index := *event.Index
+
+		switch event.Type {
+		case AnthropicStreamEventTypeContentBlockStart:
+			if event.ContentBlock == nil {
+				t.Fatalf("content_block_start at index %d carried no content_block", index)
+			}
+			openBlocks[index] = event.ContentBlock.Type
+			if event.ContentBlock.Type == AnthropicContentBlockTypeRedactedThinking && event.ContentBlock.Data != nil {
+				redactedPayloads = append(redactedPayloads, *event.ContentBlock.Data)
+			}
+		case AnthropicStreamEventTypeContentBlockDelta:
+			if event.Delta == nil || event.Delta.Type != AnthropicStreamDeltaTypeThinking {
+				continue
+			}
+			if blockType := openBlocks[index]; blockType != AnthropicContentBlockTypeThinking {
+				t.Errorf("thinking_delta targets block %d opened as %q", index, blockType)
+				continue
+			}
+			if event.Delta.Thinking != nil {
+				visible.WriteString(*event.Delta.Thinking)
+			}
+		case AnthropicStreamEventTypeContentBlockStop:
+			delete(openBlocks, index)
+		}
+	}
+
+	if got := visible.String(); got != "Ranking the sources by recency." {
+		t.Errorf("late summary lost: thinking block accumulated %q", got)
+	}
+	if len(redactedPayloads) != 1 {
+		t.Fatalf("encrypted payload must be delivered exactly once, got %d redacted_thinking blocks: %q", len(redactedPayloads), redactedPayloads)
+	}
+	if !strings.Contains(redactedPayloads[0], streamTestEncrypted) {
+		t.Errorf("redacted_thinking data %q does not carry the encrypted payload", redactedPayloads[0])
+	}
+	if len(openBlocks) != 0 {
+		t.Errorf("every content_block_start must be closed, left open: %v", openBlocks)
+	}
+}

--- a/core/providers/anthropic/rawrequestecho_test.go
+++ b/core/providers/anthropic/rawrequestecho_test.go
@@ -1,0 +1,63 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The /anthropic/v1/messages route dropped extra_fields on the way out, so
+// x-bf-send-back-raw-request produced nothing for callers on that surface even when the
+// setting was enabled. The raw capture is populated on the Bifrost response
+// (BifrostResponseExtraFields.RawRequest) but AnthropicMessageResponse had no field to
+// carry it, unlike BifrostChatResponse which serializes extra_fields directly.
+//
+// The echo must appear ONLY when a raw capture is actually present, so a default
+// response on this route stays byte-identical to Anthropic's documented shape.
+
+func responsesRespWithRaw(rawReq interface{}) *schemas.BifrostResponsesResponse {
+	return &schemas.BifrostResponsesResponse{
+		ID:    schemas.Ptr("resp_1"),
+		Model: "gemini-3.7-flash",
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			Provider:   schemas.Gemini,
+			RawRequest: rawReq,
+		},
+	}
+}
+
+func TestToAnthropicResponsesResponse_EchoesRawRequestWhenCaptured(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	raw := map[string]interface{}{"contents": []interface{}{
+		map[string]interface{}{"role": "user", "parts": []interface{}{map[string]interface{}{"text": "hi"}}},
+	}}
+
+	out := ToAnthropicResponsesResponse(ctx, responsesRespWithRaw(raw))
+	require.NotNil(t, out)
+	require.NotNil(t, out.ExtraFields, "extra_fields must be carried when a raw request was captured")
+	assert.NotNil(t, out.ExtraFields.RawRequest, "raw_request must survive to the Anthropic wire shape")
+
+	// It must actually serialize - a field that marshals away is no better than a dropped one.
+	encoded, err := json.Marshal(out)
+	require.NoError(t, err)
+	assert.Contains(t, string(encoded), "\"extra_fields\"")
+	assert.Contains(t, string(encoded), "\"raw_request\"")
+}
+
+// Without a capture, the response must stay byte-conformant to Anthropic's schema.
+func TestToAnthropicResponsesResponse_NoExtraFieldsWithoutCapture(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	out := ToAnthropicResponsesResponse(ctx, responsesRespWithRaw(nil))
+	require.NotNil(t, out)
+	assert.Nil(t, out.ExtraFields, "extra_fields must be absent when nothing was captured")
+
+	encoded, err := json.Marshal(out)
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "extra_fields",
+		"a default response on this route must stay byte-identical to Anthropic's shape")
+}

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -222,6 +222,14 @@ type anthropicToResponsesStreamState struct {
 	// blockIndexByItem.
 	blockTypes []AnthropicContentBlockType
 
+	// reasoningPayloadSentByItem marks reasoning items whose encrypted payload has
+	// already reached the client, on the redacted_thinking block opened for them at
+	// output_item.added. Set only by upgradeLateSummaryToThinkingBlock, which closes
+	// that block when the item turns out to have visible reasoning after all. The
+	// split at output_item.done consults this so the payload is not sent twice: once
+	// in `data` on the closed block and again as a fresh redacted_thinking block.
+	reasoningPayloadSentByItem map[string]bool
+
 	// codeExecServerClosedByItem marks code_interpreter_call items whose
 	// server_tool_use block was already closed early on code.done (python/bash,
 	// where the input reconstructs from the neutral Code and the block must close
@@ -282,6 +290,116 @@ func (s *anthropicToResponsesStreamState) blockType(index int) AnthropicContentB
 		return ""
 	}
 	return s.blockTypes[index]
+}
+
+// attemptProvider reports the provider that handled this attempt.
+//
+// ExtraFields.Provider is deprecated in favour of RoutingInfo.Provider, and core
+// populates RoutingInfo on every stream chunk (postHookRunner -> PopulateRoutingInfo
+// in core/bifrost.go). But the sync that backfills the deprecated field is
+// conditional -- syncDeprecatedFromRoutingInfo only copies when info.Provider is
+// non-empty -- so the deprecated field is the WIDER of the two: it is still set on
+// frames built outside that path (a provider driven directly as a library, and the
+// stream fixtures in this package), where RoutingInfo.Provider is empty.
+//
+// Reading RoutingInfo first honours the deprecation; the fallback keeps those frames
+// working. Every ShouldEmbedReasoningItemID call site in this file must go through
+// here, because they all decide whether the SAME item's id is smuggled into its
+// signature/data. If they disagree, one reasoning item's thinking half and encrypted
+// half end up under different ids and no longer merge on re-ingest (reasoningIndexByID
+// in the grouped ingress converter).
+//
+// ToAnthropicResponsesResponse's ResolveModelCaps lookup reads through here too, for
+// the forward-looking half of the same reason rather than a present bug: an empty
+// provider makes CapabilitiesFor return no record and every capability predicate falls
+// back to name detection, so the fallback is what keeps that lookup working on frames
+// core never routed.
+func attemptProvider(extra schemas.BifrostResponseExtraFields) schemas.ModelProvider {
+	if extra.RoutingInfo.Provider != "" {
+		return extra.RoutingInfo.Provider
+	}
+	return extra.Provider //nolint:staticcheck // SA1019: deliberate fallback, see above
+}
+
+// markReasoningPayloadSent records that key's encrypted reasoning payload already
+// reached the client, so output_item.done does not emit it a second time.
+func (s *anthropicToResponsesStreamState) markReasoningPayloadSent(key string) {
+	if key == "" {
+		return
+	}
+	if s.reasoningPayloadSentByItem == nil {
+		s.reasoningPayloadSentByItem = make(map[string]bool)
+	}
+	s.reasoningPayloadSentByItem[key] = true
+}
+
+// reasoningPayloadSent reports whether key's encrypted reasoning payload has already
+// been delivered (see markReasoningPayloadSent).
+func (s *anthropicToResponsesStreamState) reasoningPayloadSent(key string) bool {
+	return key != "" && s.reasoningPayloadSentByItem[key]
+}
+
+// upgradeLateSummaryToThinkingBlock handles a reasoning item that looked
+// redacted-only at output_item.added -- encrypted payload, no summary -- and then
+// starts streaming summary text anyway.
+//
+// Judged on the added frame alone, opening redacted_thinking there is right:
+// redacted_thinking is atomic, it carries its payload in `data` on the start frame,
+// and nothing more is expected. But a thinking_delta landing on a redacted block is
+// silently discarded by Anthropic clients, and a signature_delta against one is the
+// frame Claude Code aborts the turn on ("Content block is not a thinking block").
+// Either way the visible reasoning is lost with no error to explain it.
+//
+// enforceStreamBlockTypes cannot rescue this: it only drops the offending delta,
+// which trades a silent loss for a slightly quieter one. The fix is to close the
+// redacted block -- its payload already shipped, which is what markReasoningPayloadSent
+// records -- and reopen the item as a thinking block that the deltas can legally land
+// on. Splitting the two halves across two blocks is exactly what the non-streaming
+// converter does (convertBifrostReasoningToAnthropicThinking); this is the streaming
+// equivalent, discovered one frame later.
+//
+// It returns the prefix events to emit ahead of the delta, plus the index the delta
+// must now target. When no upgrade is needed it returns (nil, idx) unchanged.
+func upgradeLateSummaryToThinkingBlock(
+	ctx *schemas.BifrostContext,
+	state *anthropicToResponsesStreamState,
+	bifrostResp *schemas.BifrostResponsesStreamResponse,
+	key string,
+	idx *int,
+) ([]*AnthropicStreamEvent, *int) {
+	if idx == nil || state.blockType(*idx) != AnthropicContentBlockTypeRedactedThinking {
+		return nil, idx
+	}
+
+	events := []*AnthropicStreamEvent{{
+		Type:  AnthropicStreamEventTypeContentBlockStop,
+		Index: idx,
+	}}
+	state.markReasoningPayloadSent(key)
+
+	// Re-point the item's key at the new block so the deltas that follow, and the
+	// content_block_stop at output_item.done, resolve to it instead of the closed one.
+	newIdx := state.allocBlockIndex(key)
+
+	// Same signature seeding as the thinking branch at output_item.added: when the id
+	// is being smuggled through the signature, the reopened block carries it too, so a
+	// client replaying this turn folds the thinking half back together with the
+	// redacted half (see reasoningIndexByID in the ingress converter).
+	signature := ""
+	if providerUtils.ShouldEmbedReasoningItemID(ctx, attemptProvider(bifrostResp.ExtraFields), bifrostResp.ExtraFields.RoutingInfo.Model) {
+		signature = providerUtils.EmbedReasoningItemID(bifrostResp.ItemID, "")
+	}
+	events = append(events, &AnthropicStreamEvent{
+		Type:  AnthropicStreamEventTypeContentBlockStart,
+		Index: newIdx,
+		ContentBlock: &AnthropicContentBlock{
+			Type:      AnthropicContentBlockTypeThinking,
+			Thinking:  schemas.Ptr(""),
+			Signature: &signature,
+		},
+	})
+
+	return events, newIdx
 }
 
 // reasoningPayloadAndSummary reports a reasoning item's encrypted payload (empty
@@ -2945,7 +3063,7 @@ func toAnthropicResponsesStreamEvents(ctx *schemas.BifrostContext, bifrostResp *
 						// embedID gates smuggling the real OpenAI reasoning item id into
 						// signature/data (see providerUtils.ShouldEmbedReasoningItemID and
 						// convertBifrostReasoningToAnthropicThinking for why).
-						embedID := providerUtils.ShouldEmbedReasoningItemID(ctx, bifrostResp.ExtraFields.Provider, bifrostResp.ExtraFields.RoutingInfo.Model)
+						embedID := providerUtils.ShouldEmbedReasoningItemID(ctx, attemptProvider(bifrostResp.ExtraFields), bifrostResp.ExtraFields.RoutingInfo.Model)
 						encrypted, hasSummary := reasoningPayloadAndSummary(bifrostResp.Item)
 						// Redacted-only reasoning (encrypted payload, nothing visible) is an
 						// atomic block: the payload rides in `data` on this very frame and no
@@ -2991,7 +3109,7 @@ func toAnthropicResponsesStreamEvents(ctx *schemas.BifrostContext, bifrostResp *
 							// not dropped -- output_item.done splits it into its own
 							// redacted_thinking block, which is why isReasoningItem has to route
 							// this shape there as well.
-							embedID := providerUtils.ShouldEmbedReasoningItemID(ctx, bifrostResp.ExtraFields.Provider, bifrostResp.ExtraFields.RoutingInfo.Model)
+							embedID := providerUtils.ShouldEmbedReasoningItemID(ctx, attemptProvider(bifrostResp.ExtraFields), bifrostResp.ExtraFields.RoutingInfo.Model)
 							encrypted, hasSummary := reasoningPayloadAndSummary(bifrostResp.Item)
 							if encrypted != "" && !hasSummary {
 								contentBlock.Type = AnthropicContentBlockTypeRedactedThinking
@@ -3147,8 +3265,17 @@ func toAnthropicResponsesStreamEvents(ctx *schemas.BifrostContext, bifrostResp *
 		}
 
 	case schemas.ResponsesStreamResponseTypeReasoningSummaryTextDelta:
+		state := getOrCreateAnthropicToResponsesStreamState(ctx)
+		key := reverseStreamItemKey(bifrostResp)
+		idx := state.blockIndexFor(key)
+
+		// A delta arriving for a block opened as redacted_thinking means the item had
+		// visible reasoning after all. Close it and reopen as thinking, else this delta
+		// is discarded (thinking_delta) or aborts the turn (signature_delta).
+		prefix, idx := upgradeLateSummaryToThinkingBlock(ctx, state, bifrostResp, key, idx)
+
 		streamResp.Type = AnthropicStreamEventTypeContentBlockDelta
-		streamResp.Index = getOrCreateAnthropicToResponsesStreamState(ctx).blockIndexFor(reverseStreamItemKey(bifrostResp))
+		streamResp.Index = idx
 
 		// Check if this is a signature delta or text delta
 		if bifrostResp.Signature != nil {
@@ -3163,6 +3290,10 @@ func toAnthropicResponsesStreamEvents(ctx *schemas.BifrostContext, bifrostResp *
 				Type:     AnthropicStreamDeltaTypeThinking,
 				Thinking: bifrostResp.Delta,
 			}
+		}
+
+		if len(prefix) > 0 {
+			return append(prefix, streamResp)
 		}
 
 	case schemas.ResponsesStreamResponseTypeOutputTextAnnotationAdded:
@@ -3465,7 +3596,8 @@ func toAnthropicResponsesStreamEvents(ctx *schemas.BifrostContext, bifrostResp *
 			// redacted_thinking is atomic on the wire, carrying its payload in `data`
 			// on the start frame, which is why it never receives deltas.
 			state := getOrCreateAnthropicToResponsesStreamState(ctx)
-			idx := state.blockIndexFor(reverseStreamItemKey(bifrostResp))
+			key := reverseStreamItemKey(bifrostResp)
+			idx := state.blockIndexFor(key)
 			events := []*AnthropicStreamEvent{{
 				Type:  AnthropicStreamEventTypeContentBlockStop,
 				Index: idx,
@@ -3473,9 +3605,13 @@ func toAnthropicResponsesStreamEvents(ctx *schemas.BifrostContext, bifrostResp *
 
 			encrypted, _ := reasoningPayloadAndSummary(bifrostResp.Item)
 			openedAsThinking := idx != nil && state.blockType(*idx) == AnthropicContentBlockTypeThinking
-			if encrypted != "" && openedAsThinking {
+			// An item upgraded mid-stream (upgradeLateSummaryToThinkingBlock) also reads
+			// as "opened as thinking" here, because its key now points at the reopened
+			// block -- but its payload already went out in `data` on the redacted block
+			// that was closed. Emitting it again would duplicate the reasoning state.
+			if encrypted != "" && openedAsThinking && !state.reasoningPayloadSent(key) {
 				data := encrypted
-				if providerUtils.ShouldEmbedReasoningItemID(ctx, bifrostResp.ExtraFields.Provider, bifrostResp.ExtraFields.RoutingInfo.Model) {
+				if providerUtils.ShouldEmbedReasoningItemID(ctx, attemptProvider(bifrostResp.ExtraFields), bifrostResp.ExtraFields.RoutingInfo.Model) {
 					data = providerUtils.EmbedReasoningItemID(bifrostResp.Item.ID, data)
 				}
 				redactedIdx := state.allocBlockIndex("")
@@ -4644,7 +4780,7 @@ func ToAnthropicResponsesResponse(ctx *schemas.BifrostContext, bifrostResp *sche
 	var contentBlocks []AnthropicContentBlock
 	if bifrostResp.Output != nil {
 		anthropicMessages, _ := ConvertBifrostMessagesToAnthropicMessages(ctx, bifrostResp.Output, false,
-			schemas.ResolveModelCaps(bifrostResp.ExtraFields.Provider, bifrostResp.Model))
+			schemas.ResolveModelCaps(attemptProvider(bifrostResp.ExtraFields), bifrostResp.Model))
 		// Extract content blocks from the converted messages
 		for _, msg := range anthropicMessages {
 			if msg.Content.ContentBlocks != nil {
@@ -5560,6 +5696,66 @@ func convertSingleAnthropicMessageToBifrostMessagesGrouped(msg *AnthropicMessage
 	return []schemas.ResponsesMessage{}
 }
 
+// anthropicToolUseBlockToResponsesMessage converts one tool_use / server_tool_use /
+// mcp_tool_use block into the Responses item it maps to. Extracted so the grouped
+// converter can emit tool calls at the position they occupied in the turn instead of
+// replaying them all from a buffer at the end (see flushPendingToolUses).
+func anthropicToolUseBlockToResponsesMessage(toolBlock *AnthropicContentBlock, isOutputMessage bool) schemas.ResponsesMessage {
+	bifrostMsg := schemas.ResponsesMessage{
+		Type:         schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+		Status:       schemas.Ptr("completed"),
+		CacheControl: toolBlock.CacheControl,
+		ResponsesToolMessage: &schemas.ResponsesToolMessage{
+			CallID: toolBlock.ID,
+			Name:   toolBlock.Name,
+		},
+	}
+	if isOutputMessage {
+		bifrostMsg.ID = schemas.Ptr("fc_" + schemas.GetRandomString(50))
+	}
+
+	// Check for computer tool use
+	if toolBlock.Name != nil && *toolBlock.Name == string(AnthropicToolNameComputer) {
+		bifrostMsg.Type = schemas.Ptr(schemas.ResponsesMessageTypeComputerCall)
+		bifrostMsg.ResponsesToolMessage.Name = nil
+		var inputMap map[string]interface{}
+		if err := sonic.Unmarshal(toolBlock.Input, &inputMap); err == nil {
+			bifrostMsg.ResponsesToolMessage.Action = &schemas.ResponsesToolMessageActionStruct{
+				ResponsesComputerToolCallAction: convertAnthropicToResponsesComputerAction(inputMap),
+			}
+		}
+	} else if toolBlock.Name != nil && *toolBlock.Name == string(AnthropicToolNameWebSearch) {
+		bifrostMsg.Type = schemas.Ptr(schemas.ResponsesMessageTypeWebSearchCall)
+		bifrostMsg.ResponsesToolMessage.Name = nil
+		if q := providerUtils.GetJSONField(toolBlock.Input, "query"); q.Exists() && q.Type == gjson.String {
+			query := q.Str
+			bifrostMsg.ResponsesToolMessage.Action = &schemas.ResponsesToolMessageActionStruct{
+				ResponsesWebSearchToolCallAction: &schemas.ResponsesWebSearchToolCallAction{
+					Type:    "search",
+					Query:   schemas.Ptr(query),
+					Queries: []string{query},
+				},
+			}
+		}
+	} else if toolBlock.Name != nil && *toolBlock.Name == string(AnthropicToolNameWebFetch) {
+		bifrostMsg.Type = schemas.Ptr(schemas.ResponsesMessageTypeWebFetchCall)
+		bifrostMsg.ResponsesToolMessage.Name = nil
+		if u := providerUtils.GetJSONField(toolBlock.Input, "url"); u.Exists() && u.Type == gjson.String {
+			bifrostMsg.ResponsesToolMessage.Action = &schemas.ResponsesToolMessageActionStruct{
+				ResponsesWebFetchToolCallAction: &schemas.ResponsesWebFetchToolCallAction{
+					URL: u.Str,
+				},
+			}
+		}
+	} else {
+		if len(toolBlock.Input) > 0 {
+			bifrostMsg.ResponsesToolMessage.Arguments = schemas.Ptr(string(toolBlock.Input))
+		}
+	}
+
+	return bifrostMsg
+}
+
 // Helper function to convert Anthropic content blocks to Bifrost ResponsesMessages, grouping text and tool_use blocks
 func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []AnthropicContentBlock, role *schemas.ResponsesMessageRoleType, isOutputMessage bool) []schemas.ResponsesMessage {
 	var bifrostMessages []schemas.ResponsesMessage
@@ -5573,8 +5769,57 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 	// appending a second one with a duplicate id.
 	reasoningIndexByID := map[string]int{}
 
+	// Consecutive text blocks coalesce into one message item, and consecutive
+	// tool_use blocks stay grouped -- that is what "grouped" means here. But the
+	// runs must be flushed the moment a block of another kind arrives, so the
+	// emitted items keep the order the client sent.
+	//
+	// Buffering both runs to the end of the turn (as this used to) reorders an
+	// interleaved-thinking turn: [thinking, text, tool_use, thinking, text, tool_use]
+	// came out as [reasoning, reasoning, message, function_call, function_call],
+	// moving the second thinking block in front of the tool call it was produced
+	// after. Anthropic drops the "assistant turn begins with a thinking block" rule
+	// for adaptive thinking, so that relocation is a modification of a signed block,
+	// not a normalization -- and Bedrock rejects the replay for it (issue #6342).
+	flushAccumulatedText := func() {
+		if len(accumulatedTextContent) == 0 {
+			return
+		}
+		if isOutputMessage {
+			bifrostMessages = append(bifrostMessages, schemas.ResponsesMessage{
+				ID:   schemas.Ptr("msg_" + schemas.GetRandomString(50)),
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+				Role: role,
+				Content: &schemas.ResponsesMessageContent{
+					ContentBlocks: accumulatedTextContent,
+				},
+			})
+		}
+		accumulatedTextContent = nil
+	}
+	flushPendingToolUses := func() {
+		for _, toolBlock := range pendingToolUseBlocks {
+			bifrostMessages = append(bifrostMessages, anthropicToolUseBlockToResponsesMessage(toolBlock, isOutputMessage))
+		}
+		pendingToolUseBlocks = nil
+	}
+
 	// Process content blocks
 	for _, block := range contentBlocks {
+		// Close off whichever run this block is not part of, so both land in
+		// wire order relative to each other and to every other block type.
+		if block.Type != AnthropicContentBlockTypeText {
+			flushAccumulatedText()
+		}
+		switch block.Type {
+		case AnthropicContentBlockTypeToolUse,
+			AnthropicContentBlockTypeServerToolUse,
+			AnthropicContentBlockTypeMCPToolUse:
+			// still inside the tool_use run
+		default:
+			flushPendingToolUses()
+		}
+
 		switch block.Type {
 		case AnthropicContentBlockTypeText:
 			if block.Text != nil {
@@ -5735,64 +5980,84 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 			}
 
 		case AnthropicContentBlockTypeToolResult:
-			// Convert tool result to function call output message
+			// Convert tool result to function call output message.
+			//
+			// `content` is OPTIONAL on an Anthropic tool_result block -- only `type`
+			// and `tool_use_id` are required (platform.claude.com/docs/en/api/messages,
+			// ToolResultBlockParam). A void tool, a tool that returned nothing, and an
+			// is_error result with no body all arrive with no `content` key.
+			//
+			// This used to gate the whole conversion on `block.Content != nil` and drop
+			// those blocks silently. Anthropic and Bedrock Converse both carry tool
+			// results on a user turn, so a dropped result deletes the user turn that
+			// separated two assistant turns -- and Bedrock's merge-consecutive-same-role
+			// pass then fuses every assistant turn into one, relocating each replayed
+			// thinking block to a content index it never occupied. That is issue #6342:
+			// a 15-message replay reaching Bedrock as [user, assistant(19 blocks)] and
+			// coming back as a non-retryable "`thinking` ... blocks in the latest
+			// assistant message cannot be modified".
+			//
+			// A missing body now behaves exactly like the already-supported empty-content
+			// array: an output struct with no content, which Bedrock emits as
+			// `"content": []` (required by ToolResultBlock, and already the shape the
+			// empty-array path ships today).
 			if block.ToolUseID != nil {
-				if block.Content != nil {
-					bifrostMsg := schemas.ResponsesMessage{
-						Type:         schemas.Ptr(schemas.ResponsesMessageTypeFunctionCallOutput),
-						Status:       schemas.Ptr("completed"),
-						CacheControl: block.CacheControl,
-						ResponsesToolMessage: &schemas.ResponsesToolMessage{
-							CallID: block.ToolUseID,
-						},
-					}
-					// Initialize the nested struct before any writes
-					bifrostMsg.ResponsesToolMessage.Output = &schemas.ResponsesToolMessageOutputStruct{}
+				bifrostMsg := schemas.ResponsesMessage{
+					Type:         schemas.Ptr(schemas.ResponsesMessageTypeFunctionCallOutput),
+					Status:       schemas.Ptr("completed"),
+					CacheControl: block.CacheControl,
+					ResponsesToolMessage: &schemas.ResponsesToolMessage{
+						CallID: block.ToolUseID,
+					},
+				}
+				// Initialize the nested struct before any writes
+				bifrostMsg.ResponsesToolMessage.Output = &schemas.ResponsesToolMessageOutputStruct{}
 
-					if block.Content.ContentStr != nil {
-						bifrostMsg.ResponsesToolMessage.Output.ResponsesToolCallOutputStr = block.Content.ContentStr
-					} else if block.Content.ContentBlocks != nil {
-						var toolMsgContentBlocks []schemas.ResponsesMessageContentBlock
-						for _, contentBlock := range block.Content.ContentBlocks {
-							switch contentBlock.Type {
-							case AnthropicContentBlockTypeText:
-								if contentBlock.Text != nil {
-									var blockType schemas.ResponsesMessageContentBlockType
-									if isOutputMessage {
-										blockType = schemas.ResponsesOutputMessageContentTypeText
-									} else {
-										blockType = schemas.ResponsesInputMessageContentBlockTypeText
-									}
-									toolMsgContentBlocks = append(toolMsgContentBlocks, schemas.ResponsesMessageContentBlock{
-										Type:         blockType,
-										Text:         contentBlock.Text,
-										CacheControl: contentBlock.CacheControl,
-									})
+				if block.Content == nil {
+					// No body to convert; the is_error handling below still applies.
+				} else if block.Content.ContentStr != nil {
+					bifrostMsg.ResponsesToolMessage.Output.ResponsesToolCallOutputStr = block.Content.ContentStr
+				} else if block.Content.ContentBlocks != nil {
+					var toolMsgContentBlocks []schemas.ResponsesMessageContentBlock
+					for _, contentBlock := range block.Content.ContentBlocks {
+						switch contentBlock.Type {
+						case AnthropicContentBlockTypeText:
+							if contentBlock.Text != nil {
+								var blockType schemas.ResponsesMessageContentBlockType
+								if isOutputMessage {
+									blockType = schemas.ResponsesOutputMessageContentTypeText
+								} else {
+									blockType = schemas.ResponsesInputMessageContentBlockTypeText
 								}
-							case AnthropicContentBlockTypeImage:
-								if contentBlock.Source != nil && contentBlock.Source.SourceObj != nil {
-									toolMsgContentBlocks = append(toolMsgContentBlocks, contentBlock.toBifrostResponsesImageBlock())
-								}
-							case AnthropicContentBlockTypeDocument:
-								// A tool returning a PDF (Claude Code's Read tool, for one)
-								// nests a document block here. Dropping it leaves the
-								// function_call_output with an empty content array, which
-								// OpenAI rejects outright:
-								// "Missing required parameter: 'input[N].content[0]'".
-								if contentBlock.Source != nil && contentBlock.Source.SourceObj != nil {
-									toolMsgContentBlocks = append(toolMsgContentBlocks, contentBlock.toBifrostResponsesDocumentBlock())
-								}
+								toolMsgContentBlocks = append(toolMsgContentBlocks, schemas.ResponsesMessageContentBlock{
+									Type:         blockType,
+									Text:         contentBlock.Text,
+									CacheControl: contentBlock.CacheControl,
+								})
+							}
+						case AnthropicContentBlockTypeImage:
+							if contentBlock.Source != nil && contentBlock.Source.SourceObj != nil {
+								toolMsgContentBlocks = append(toolMsgContentBlocks, contentBlock.toBifrostResponsesImageBlock())
+							}
+						case AnthropicContentBlockTypeDocument:
+							// A tool returning a PDF (Claude Code's Read tool, for one)
+							// nests a document block here. Dropping it leaves the
+							// function_call_output with an empty content array, which
+							// OpenAI rejects outright:
+							// "Missing required parameter: 'input[N].content[0]'".
+							if contentBlock.Source != nil && contentBlock.Source.SourceObj != nil {
+								toolMsgContentBlocks = append(toolMsgContentBlocks, contentBlock.toBifrostResponsesDocumentBlock())
 							}
 						}
-						bifrostMsg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks = toolMsgContentBlocks
 					}
-					// Handle is_error from Anthropic
-					if block.IsError != nil && *block.IsError {
-						bifrostMsg.Status = schemas.Ptr("incomplete")
-					}
-
-					bifrostMessages = append(bifrostMessages, bifrostMsg)
+					bifrostMsg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks = toolMsgContentBlocks
 				}
+				// Handle is_error from Anthropic
+				if block.IsError != nil && *block.IsError {
+					bifrostMsg.Status = schemas.Ptr("incomplete")
+				}
+
+				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}
 
 		case AnthropicContentBlockTypeServerToolUse:
@@ -5821,80 +6086,9 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 		}
 	}
 
-	// Flush any remaining pending blocks
-	if len(accumulatedTextContent) > 0 {
-		bifrostMsg := schemas.ResponsesMessage{
-			Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
-			Role: role,
-		}
-		if isOutputMessage {
-			bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
-			bifrostMsg.Content = &schemas.ResponsesMessageContent{
-				ContentBlocks: accumulatedTextContent,
-			}
-			bifrostMessages = append(bifrostMessages, bifrostMsg)
-		}
-	}
-
-	// Emit any accumulated tool_use blocks as function_calls
-	if len(pendingToolUseBlocks) > 0 {
-		for _, toolBlock := range pendingToolUseBlocks {
-			bifrostMsg := schemas.ResponsesMessage{
-				Type:         schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
-				Status:       schemas.Ptr("completed"),
-				CacheControl: toolBlock.CacheControl,
-				ResponsesToolMessage: &schemas.ResponsesToolMessage{
-					CallID: toolBlock.ID,
-					Name:   toolBlock.Name,
-				},
-			}
-			if isOutputMessage {
-				bifrostMsg.ID = schemas.Ptr("fc_" + schemas.GetRandomString(50))
-			}
-
-			// Check for computer tool use
-			if toolBlock.Name != nil && *toolBlock.Name == string(AnthropicToolNameComputer) {
-				bifrostMsg.Type = schemas.Ptr(schemas.ResponsesMessageTypeComputerCall)
-				bifrostMsg.ResponsesToolMessage.Name = nil
-				var inputMap map[string]interface{}
-				if err := sonic.Unmarshal(toolBlock.Input, &inputMap); err == nil {
-					bifrostMsg.ResponsesToolMessage.Action = &schemas.ResponsesToolMessageActionStruct{
-						ResponsesComputerToolCallAction: convertAnthropicToResponsesComputerAction(inputMap),
-					}
-				}
-			} else if toolBlock.Name != nil && *toolBlock.Name == string(AnthropicToolNameWebSearch) {
-				bifrostMsg.Type = schemas.Ptr(schemas.ResponsesMessageTypeWebSearchCall)
-				bifrostMsg.ResponsesToolMessage.Name = nil
-				if q := providerUtils.GetJSONField(toolBlock.Input, "query"); q.Exists() && q.Type == gjson.String {
-					query := q.Str
-					bifrostMsg.ResponsesToolMessage.Action = &schemas.ResponsesToolMessageActionStruct{
-						ResponsesWebSearchToolCallAction: &schemas.ResponsesWebSearchToolCallAction{
-							Type:    "search",
-							Query:   schemas.Ptr(query),
-							Queries: []string{query},
-						},
-					}
-				}
-			} else if toolBlock.Name != nil && *toolBlock.Name == string(AnthropicToolNameWebFetch) {
-				bifrostMsg.Type = schemas.Ptr(schemas.ResponsesMessageTypeWebFetchCall)
-				bifrostMsg.ResponsesToolMessage.Name = nil
-				if u := providerUtils.GetJSONField(toolBlock.Input, "url"); u.Exists() && u.Type == gjson.String {
-					bifrostMsg.ResponsesToolMessage.Action = &schemas.ResponsesToolMessageActionStruct{
-						ResponsesWebFetchToolCallAction: &schemas.ResponsesWebFetchToolCallAction{
-							URL: u.Str,
-						},
-					}
-				}
-			} else {
-				if len(toolBlock.Input) > 0 {
-					bifrostMsg.ResponsesToolMessage.Arguments = schemas.Ptr(string(toolBlock.Input))
-				}
-			}
-
-			bifrostMessages = append(bifrostMessages, bifrostMsg)
-		}
-	}
-
+	// Flush whatever the last run left buffered.
+	flushAccumulatedText()
+	flushPendingToolUses()
 	return bifrostMessages
 }
 
@@ -6180,64 +6374,84 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 				}
 			}
 		case AnthropicContentBlockTypeToolResult:
-			// Convert tool result to function call output message
+			// Convert tool result to function call output message.
+			//
+			// `content` is OPTIONAL on an Anthropic tool_result block -- only `type`
+			// and `tool_use_id` are required (platform.claude.com/docs/en/api/messages,
+			// ToolResultBlockParam). A void tool, a tool that returned nothing, and an
+			// is_error result with no body all arrive with no `content` key.
+			//
+			// This used to gate the whole conversion on `block.Content != nil` and drop
+			// those blocks silently. Anthropic and Bedrock Converse both carry tool
+			// results on a user turn, so a dropped result deletes the user turn that
+			// separated two assistant turns -- and Bedrock's merge-consecutive-same-role
+			// pass then fuses every assistant turn into one, relocating each replayed
+			// thinking block to a content index it never occupied. That is issue #6342:
+			// a 15-message replay reaching Bedrock as [user, assistant(19 blocks)] and
+			// coming back as a non-retryable "`thinking` ... blocks in the latest
+			// assistant message cannot be modified".
+			//
+			// A missing body now behaves exactly like the already-supported empty-content
+			// array: an output struct with no content, which Bedrock emits as
+			// `"content": []` (required by ToolResultBlock, and already the shape the
+			// empty-array path ships today).
 			if block.ToolUseID != nil {
-				if block.Content != nil {
-					bifrostMsg := schemas.ResponsesMessage{
-						Type:         schemas.Ptr(schemas.ResponsesMessageTypeFunctionCallOutput),
-						Status:       schemas.Ptr("completed"),
-						CacheControl: block.CacheControl,
-						ResponsesToolMessage: &schemas.ResponsesToolMessage{
-							CallID: block.ToolUseID,
-						},
-					}
-					// Initialize the nested struct before any writes
-					bifrostMsg.ResponsesToolMessage.Output = &schemas.ResponsesToolMessageOutputStruct{}
+				bifrostMsg := schemas.ResponsesMessage{
+					Type:         schemas.Ptr(schemas.ResponsesMessageTypeFunctionCallOutput),
+					Status:       schemas.Ptr("completed"),
+					CacheControl: block.CacheControl,
+					ResponsesToolMessage: &schemas.ResponsesToolMessage{
+						CallID: block.ToolUseID,
+					},
+				}
+				// Initialize the nested struct before any writes
+				bifrostMsg.ResponsesToolMessage.Output = &schemas.ResponsesToolMessageOutputStruct{}
 
-					if block.Content.ContentStr != nil {
-						bifrostMsg.ResponsesToolMessage.Output.ResponsesToolCallOutputStr = block.Content.ContentStr
-					} else if block.Content.ContentBlocks != nil {
-						var toolMsgContentBlocks []schemas.ResponsesMessageContentBlock
-						for _, contentBlock := range block.Content.ContentBlocks {
-							switch contentBlock.Type {
-							case AnthropicContentBlockTypeText:
-								if contentBlock.Text != nil {
-									var blockType schemas.ResponsesMessageContentBlockType
-									if isOutputMessage {
-										blockType = schemas.ResponsesOutputMessageContentTypeText
-									} else {
-										blockType = schemas.ResponsesInputMessageContentBlockTypeText
-									}
-									toolMsgContentBlocks = append(toolMsgContentBlocks, schemas.ResponsesMessageContentBlock{
-										Type:         blockType,
-										Text:         contentBlock.Text,
-										CacheControl: contentBlock.CacheControl,
-									})
+				if block.Content == nil {
+					// No body to convert; the is_error handling below still applies.
+				} else if block.Content.ContentStr != nil {
+					bifrostMsg.ResponsesToolMessage.Output.ResponsesToolCallOutputStr = block.Content.ContentStr
+				} else if block.Content.ContentBlocks != nil {
+					var toolMsgContentBlocks []schemas.ResponsesMessageContentBlock
+					for _, contentBlock := range block.Content.ContentBlocks {
+						switch contentBlock.Type {
+						case AnthropicContentBlockTypeText:
+							if contentBlock.Text != nil {
+								var blockType schemas.ResponsesMessageContentBlockType
+								if isOutputMessage {
+									blockType = schemas.ResponsesOutputMessageContentTypeText
+								} else {
+									blockType = schemas.ResponsesInputMessageContentBlockTypeText
 								}
-							case AnthropicContentBlockTypeImage:
-								if contentBlock.Source != nil && contentBlock.Source.SourceObj != nil {
-									toolMsgContentBlocks = append(toolMsgContentBlocks, contentBlock.toBifrostResponsesImageBlock())
-								}
-							case AnthropicContentBlockTypeDocument:
-								// A tool returning a PDF (Claude Code's Read tool, for one)
-								// nests a document block here. Dropping it leaves the
-								// function_call_output with an empty content array, which
-								// OpenAI rejects outright:
-								// "Missing required parameter: 'input[N].content[0]'".
-								if contentBlock.Source != nil && contentBlock.Source.SourceObj != nil {
-									toolMsgContentBlocks = append(toolMsgContentBlocks, contentBlock.toBifrostResponsesDocumentBlock())
-								}
+								toolMsgContentBlocks = append(toolMsgContentBlocks, schemas.ResponsesMessageContentBlock{
+									Type:         blockType,
+									Text:         contentBlock.Text,
+									CacheControl: contentBlock.CacheControl,
+								})
+							}
+						case AnthropicContentBlockTypeImage:
+							if contentBlock.Source != nil && contentBlock.Source.SourceObj != nil {
+								toolMsgContentBlocks = append(toolMsgContentBlocks, contentBlock.toBifrostResponsesImageBlock())
+							}
+						case AnthropicContentBlockTypeDocument:
+							// A tool returning a PDF (Claude Code's Read tool, for one)
+							// nests a document block here. Dropping it leaves the
+							// function_call_output with an empty content array, which
+							// OpenAI rejects outright:
+							// "Missing required parameter: 'input[N].content[0]'".
+							if contentBlock.Source != nil && contentBlock.Source.SourceObj != nil {
+								toolMsgContentBlocks = append(toolMsgContentBlocks, contentBlock.toBifrostResponsesDocumentBlock())
 							}
 						}
-						bifrostMsg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks = toolMsgContentBlocks
 					}
-					// Handle is_error from Anthropic
-					if block.IsError != nil && *block.IsError {
-						bifrostMsg.Status = schemas.Ptr("incomplete")
-					}
-
-					bifrostMessages = append(bifrostMessages, bifrostMsg)
+					bifrostMsg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks = toolMsgContentBlocks
 				}
+				// Handle is_error from Anthropic
+				if block.IsError != nil && *block.IsError {
+					bifrostMsg.Status = schemas.Ptr("incomplete")
+				}
+
+				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}
 
 		case AnthropicContentBlockTypeServerToolUse:

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -4773,6 +4773,12 @@ func ToAnthropicResponsesResponse(ctx *schemas.BifrostContext, bifrostResp *sche
 		anthropicResp.ID = *bifrostResp.ID
 	}
 
+	// Carry Bifrost's extra_fields only when a raw capture is present. See the field's
+	// doc on AnthropicMessageResponse: this route's whole purpose is byte-conformance
+	// with Anthropic's Messages schema, so the extension appears exclusively for callers
+	// who asked for the capture and is absent for everyone else.
+	anthropicResp.ExtraFields = rawCaptureExtraFields(bifrostResp.ExtraFields)
+
 	// Convert usage information using common converter (handles iterations recursively)
 	anthropicResp.Usage = ConvertBifrostUsageToAnthropicUsage(bifrostResp.Usage)
 
@@ -9361,4 +9367,23 @@ func generateSyntheticInputJSONDeltas(argumentsJSON string, contentIndex *int) [
 	}
 
 	return events
+}
+
+// rawCaptureExtraFields returns the extra fields to echo on Anthropic-shaped responses, or
+// nil when the caller did not request a raw capture.
+//
+// The gate is the presence of RawRequest/RawResponse rather than a context flag, because
+// those are exactly what the send_back_raw_request / send_back_raw_response settings (and
+// the x-bf-send-back-raw-request header) populate. Reading the values themselves keeps the
+// echo correct no matter which of those switches turned it on, and keeps it off when a
+// provider silently declined to capture anything.
+//
+// The returned pointer aliases a copy, so a caller mutating the echo cannot reach back into
+// the BifrostResponse the rest of the pipeline (logging, tracing, plugins) still reads.
+func rawCaptureExtraFields(extra schemas.BifrostResponseExtraFields) *schemas.BifrostResponseExtraFields {
+	if extra.RawRequest == nil && extra.RawResponse == nil {
+		return nil
+	}
+	echo := extra
+	return &echo
 }

--- a/core/providers/anthropic/toolresultnocontent_test.go
+++ b/core/providers/anthropic/toolresultnocontent_test.go
@@ -1,0 +1,134 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// Anthropic's Messages API marks `content` optional on a tool_result block --
+// only `type` and `tool_use_id` are required
+// (https://platform.claude.com/docs/en/api/messages, ToolResultBlockParam).
+// A void tool, a tool that returned nothing, and an is_error result with no
+// body all legitimately arrive with no `content` key at all.
+//
+// Both Responses-surface converters used to gate the whole conversion on
+// `block.Content != nil`, so those blocks were dropped on the floor rather than
+// becoming a function_call_output. Losing the tool result loses the entire user
+// turn that carried it, which is what wedges a Bedrock replay: with no user turn
+// between them, every assistant turn merges into one (see
+// TestAnthropicIngressBedrockReplayKeepsTurnBoundaries in the bedrock package).
+//
+// The empty-content-array shape is already covered by
+// TestConvertToolResultWithEmptyContent; this asserts the absent/null/is_error
+// shapes behave identically to it.
+func TestConvertToolResultWithoutContentField(t *testing.T) {
+	cases := []struct {
+		name    string
+		block   AnthropicContentBlock
+		isError bool
+	}{
+		{
+			name: "content key absent",
+			block: AnthropicContentBlock{
+				Type:      AnthropicContentBlockTypeToolResult,
+				ToolUseID: schemas.Ptr("toolu_void"),
+			},
+		},
+		{
+			name: "is_error with no content",
+			block: AnthropicContentBlock{
+				Type:      AnthropicContentBlockTypeToolResult,
+				ToolUseID: schemas.Ptr("toolu_failed"),
+				IsError:   schemas.Ptr(true),
+			},
+			isError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			role := schemas.ResponsesInputMessageRoleUser
+			blocks := []AnthropicContentBlock{tc.block}
+
+			// keepToolsGrouped path (every `bedrock/` request takes this one).
+			grouped := convertAnthropicContentBlocksToResponsesMessagesGrouped(blocks, &role, false)
+			assertSingleFunctionCallOutput(t, "grouped", grouped, *tc.block.ToolUseID)
+
+			// Default path (native Anthropic, Vertex, Azure ingress).
+			ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+			plain := convertAnthropicContentBlocksToResponsesMessages(ctx, blocks, &role, false, "")
+			assertSingleFunctionCallOutput(t, "default", plain, *tc.block.ToolUseID)
+		})
+	}
+}
+
+func assertSingleFunctionCallOutput(t *testing.T, path string, msgs []schemas.ResponsesMessage, wantCallID string) {
+	t.Helper()
+
+	if len(msgs) != 1 {
+		t.Fatalf("%s path: a content-less tool_result must still convert to one function_call_output, got %d messages", path, len(msgs))
+	}
+	msg := msgs[0]
+	if msg.Type == nil || *msg.Type != schemas.ResponsesMessageTypeFunctionCallOutput {
+		t.Fatalf("%s path: expected type function_call_output, got %v", path, msg.Type)
+	}
+	if msg.ResponsesToolMessage == nil || msg.ResponsesToolMessage.CallID == nil {
+		t.Fatalf("%s path: converted message carries no call id", path)
+	}
+	if *msg.ResponsesToolMessage.CallID != wantCallID {
+		t.Fatalf("%s path: expected call id %q, got %q", path, wantCallID, *msg.ResponsesToolMessage.CallID)
+	}
+	if msg.ResponsesToolMessage.Output == nil {
+		t.Fatalf("%s path: output struct must be non-nil so downstream converters emit a tool result", path)
+	}
+	if _, err := schemas.MarshalSorted(msgs); err != nil {
+		t.Fatalf("%s path: converted messages must marshal, got: %v", path, err)
+	}
+}
+
+// The grouped converter used to buffer every text block and every tool_use block
+// to the end of the turn while emitting thinking blocks in place. For an
+// interleaved turn that reordered the stream into
+// [reasoning, reasoning, message(text+text), function_call, function_call],
+// which relocates the second thinking block in front of the tool call it was
+// produced after. Items must come out in wire order, with only *consecutive*
+// text blocks coalesced.
+func TestGroupedConverterPreservesInterleavedBlockOrder(t *testing.T) {
+	role := schemas.ResponsesInputMessageRoleAssistant
+	blocks := []AnthropicContentBlock{
+		{Type: AnthropicContentBlockTypeThinking, Thinking: schemas.Ptr("t0"), Signature: schemas.Ptr("SIG_0")},
+		{Type: AnthropicContentBlockTypeText, Text: schemas.Ptr("step 0")},
+		{Type: AnthropicContentBlockTypeToolUse, ID: schemas.Ptr("toolu_0"), Name: schemas.Ptr("get_weather"), Input: []byte(`{"city":"sf"}`)},
+		{Type: AnthropicContentBlockTypeThinking, Thinking: schemas.Ptr("t1"), Signature: schemas.Ptr("SIG_1")},
+		{Type: AnthropicContentBlockTypeText, Text: schemas.Ptr("step 1")},
+		{Type: AnthropicContentBlockTypeToolUse, ID: schemas.Ptr("toolu_1"), Name: schemas.Ptr("get_weather"), Input: []byte(`{"city":"la"}`)},
+	}
+
+	msgs := convertAnthropicContentBlocksToResponsesMessagesGrouped(blocks, &role, true)
+
+	want := []schemas.ResponsesMessageType{
+		schemas.ResponsesMessageTypeReasoning,
+		schemas.ResponsesMessageTypeMessage,
+		schemas.ResponsesMessageTypeFunctionCall,
+		schemas.ResponsesMessageTypeReasoning,
+		schemas.ResponsesMessageTypeMessage,
+		schemas.ResponsesMessageTypeFunctionCall,
+	}
+	got := make([]schemas.ResponsesMessageType, 0, len(msgs))
+	for _, m := range msgs {
+		if m.Type == nil {
+			got = append(got, "<nil>")
+			continue
+		}
+		got = append(got, *m.Type)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("item order: want %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("item order: want %v, got %v", want, got)
+		}
+	}
+}

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -1849,6 +1849,18 @@ type AnthropicMessageResponse struct {
 	// omitempty when absent; a present-but-null value (no divergence) is conveyed by a
 	// non-nil pointer with a nil CacheMissReason — see schemas.CacheDiagnostics.
 	Diagnostics *schemas.CacheDiagnostics `json:"diagnostics,omitempty"`
+
+	// ExtraFields carries Bifrost's own response metadata (raw_request, raw_response,
+	// routing info, latency) on this route, mirroring the extra_fields member that
+	// BifrostChatResponse and BifrostResponsesResponse serialize directly.
+	//
+	// Anthropic's Messages schema has no such member, so this is a Bifrost extension and
+	// is populated ONLY when a raw capture is actually present -- i.e. when the provider
+	// config enables send_back_raw_request/response, or a request sets
+	// x-bf-send-back-raw-request with allow_per_request_raw_override on. Without a
+	// capture it stays nil and omitempty keeps the response byte-identical to the
+	// documented Anthropic shape, so ordinary clients never see a non-conformant field.
+	ExtraFields *schemas.BifrostResponseExtraFields `json:"extra_fields,omitempty"`
 }
 
 // AnthropicTextResponse represents the response structure from Anthropic's text completion API

--- a/core/providers/bedrock/anthropicingressreplay_test.go
+++ b/core/providers/bedrock/anthropicingressreplay_test.go
@@ -1,0 +1,349 @@
+package bedrock_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/providers/anthropic"
+	"github.com/maximhq/bifrost/core/providers/bedrock"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/require"
+)
+
+// Wire-level reproduction of issue #6342.
+//
+// A client on the Anthropic-native ingress (`POST /anthropic/v1/messages`) with a
+// `bedrock/` model prefix never takes the Anthropic passthrough -- isClaudeModel in
+// transports/bifrost-http/integrations/anthropic.go excludes schemas.Bedrock -- so the
+// request is converted Anthropic -> Bifrost Responses -> Bedrock Converse.
+//
+// Converse has no message-level tool role: a tool result rides a user turn. So every
+// dropped tool result also deletes the user turn that separated two assistant turns,
+// and ConvertBifrostMessagesToBedrockMessages' "merge consecutive messages with the
+// same role" pass then fuses them. With every tool result dropped, a 15-message replay
+// collapses to [user, assistant] and every replayed thinking block lands in one
+// oversized assistant message at a content index it never occupied upstream. Bedrock
+// rejects that non-retryably:
+//
+//	messages.1.content.5: `thinking` or `redacted_thinking` blocks in the latest
+//	assistant message cannot be modified.
+//
+// which is unrecoverable -- the client replays the same history on every retry.
+//
+// `content` is optional on an Anthropic tool_result block (only `type` and
+// `tool_use_id` are required; see platform.claude.com/docs/en/api/messages,
+// ToolResultBlockParam), so a void tool or an errored tool with no body produces
+// exactly this payload.
+func TestAnthropicIngressBedrockReplayKeepsTurnBoundaries(t *testing.T) {
+	// The reporter's conversation: one user turn, then 7 assistant tool-call steps,
+	// each answered by a tool result. Steps 0, 3, 4, 5 and 6 carry a signed thinking
+	// block, matching their convertToModelMessages dump.
+	thinkingOnStep := map[int]bool{0: true, 3: true, 4: true, 5: true, 6: true}
+
+	messages := []map[string]any{
+		{"role": "user", "content": []map[string]any{{"type": "text", "text": "run the tool"}}},
+	}
+	for step := 0; step < 7; step++ {
+		var assistantBlocks []map[string]any
+		if thinkingOnStep[step] {
+			assistantBlocks = append(assistantBlocks, map[string]any{
+				"type":      "thinking",
+				"thinking":  fmt.Sprintf("deliberating on step %d", step),
+				"signature": fmt.Sprintf("ErUBCkYIBxgCKkA_signature_%d", step),
+			})
+		}
+		assistantBlocks = append(assistantBlocks,
+			map[string]any{"type": "text", "text": fmt.Sprintf("calling the tool, step %d", step)},
+			map[string]any{
+				"type":  "tool_use",
+				"id":    fmt.Sprintf("toolu_01Step%02d", step),
+				"name":  "get_weather",
+				"input": map[string]any{"city": "san francisco"},
+			},
+		)
+		messages = append(messages, map[string]any{"role": "assistant", "content": assistantBlocks})
+		// A tool_result with no `content` key -- legal, and what a void or errored
+		// tool produces.
+		messages = append(messages, map[string]any{"role": "user", "content": []map[string]any{{
+			"type":        "tool_result",
+			"tool_use_id": fmt.Sprintf("toolu_01Step%02d", step),
+		}}})
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"model":      "bedrock/us.anthropic.claude-opus-4-8",
+		"max_tokens": 4096,
+		"thinking":   map[string]any{"type": "adaptive"},
+		"tools": []map[string]any{{
+			"name":         "get_weather",
+			"description":  "look up the weather",
+			"input_schema": map[string]any{"type": "object", "properties": map[string]any{"city": map[string]any{"type": "string"}}},
+		}},
+		"messages": messages,
+	})
+	require.NoError(t, err)
+
+	var ingressReq anthropic.AnthropicMessageRequest
+	require.NoError(t, json.Unmarshal(body, &ingressReq))
+	require.Len(t, ingressReq.Messages, 15, "fixture must reproduce the reporter's 15-message replay")
+
+	ctx := &schemas.BifrostContext{}
+	bifrostReq := ingressReq.ToBifrostResponsesRequest(ctx)
+	require.NotNil(t, bifrostReq)
+
+	converseReq, err := bedrock.ToBedrockResponsesRequest(ctx, bifrostReq)
+	require.NoError(t, err)
+
+	// 1. Turn boundaries survive: 15 in, 15 out, strictly alternating.
+	require.Equalf(t, len(ingressReq.Messages), len(converseReq.Messages),
+		"every tool result must keep its user turn; collapsing turns merges the assistant messages behind them (converse roles: %s)",
+		converseRoles(converseReq.Messages))
+
+	for i, msg := range converseReq.Messages {
+		wantRole := bedrock.BedrockMessageRoleUser
+		if i%2 == 1 {
+			wantRole = bedrock.BedrockMessageRoleAssistant
+		}
+		require.Equalf(t, wantRole, msg.Role, "message %d role", i)
+	}
+
+	// 2. Every replayed thinking block stays in its own assistant turn, at content
+	//    index 0, with its signature byte-for-byte intact. Bedrock verifies each
+	//    signature against the block it signed, so a block that moved turn or index
+	//    is a modified block.
+	seenSignatures := 0
+	for step := 0; step < 7; step++ {
+		msg := converseReq.Messages[step*2+1]
+		if !thinkingOnStep[step] {
+			for j, block := range msg.Content {
+				require.Nilf(t, block.ReasoningContent,
+					"step %d had no thinking block upstream, but content.%d is reasoning", step, j)
+			}
+			continue
+		}
+
+		require.NotNilf(t, msg.Content[0].ReasoningContent,
+			"step %d: thinking block must stay first in its own assistant turn", step)
+		require.NotNil(t, msg.Content[0].ReasoningContent.ReasoningText)
+		require.NotNilf(t, msg.Content[0].ReasoningContent.ReasoningText.Signature,
+			"step %d: replay signature dropped", step)
+		require.Equalf(t, fmt.Sprintf("ErUBCkYIBxgCKkA_signature_%d", step),
+			*msg.Content[0].ReasoningContent.ReasoningText.Signature,
+			"step %d: replay signature altered", step)
+		seenSignatures++
+
+		// Exactly one reasoning block per turn -- no other turn's thinking migrated in.
+		reasoningInTurn := 0
+		for _, block := range msg.Content {
+			if block.ReasoningContent != nil {
+				reasoningInTurn++
+			}
+		}
+		require.Equalf(t, 1, reasoningInTurn, "step %d: expected exactly one reasoning block in the turn", step)
+	}
+	require.Equal(t, 5, seenSignatures, "all five signed thinking blocks must be asserted")
+
+	// 3. Each tool result is answered in the turn immediately after its call.
+	for step := 0; step < 7; step++ {
+		userMsg := converseReq.Messages[step*2+2]
+		require.Lenf(t, userMsg.Content, 1, "step %d: tool-result turn must hold exactly its own result", step)
+		require.NotNilf(t, userMsg.Content[0].ToolResult, "step %d: tool result dropped", step)
+		require.Equalf(t, fmt.Sprintf("toolu_01Step%02d", step),
+			userMsg.Content[0].ToolResult.ToolUseID, "step %d: tool result paired with the wrong call", step)
+	}
+}
+
+// converseRoles renders just the role sequence, so a collapse failure reads as
+// "user,assistant" instead of a page of content-block pointers.
+func converseRoles(messages []bedrock.BedrockMessage) string {
+	roles := make([]string, 0, len(messages))
+	for _, m := range messages {
+		roles = append(roles, fmt.Sprintf("%s(%d)", m.Role, len(m.Content)))
+	}
+	return strings.Join(roles, ",")
+}
+
+// Interleaved thinking (issue #6342, second defect). On adaptive-thinking models
+// Claude reasons *between* tool calls inside a single assistant turn, so one
+// assistant message can be [thinking, text, tool_use, thinking, text, tool_use].
+//
+// Anthropic drops the "assistant turn must begin with a thinking block" rule for
+// adaptive thinking (platform.claude.com/docs/en/build-with-claude/extended-thinking,
+// "Turn structure in manual mode"), so hoisting every thinking block to the front of
+// the turn is not a harmless normalization -- it relocates a signed block the client
+// replayed verbatim, which is the same "blocks must remain as they were" violation
+// that wedges the conversation.
+//
+// The turn must arrive at Bedrock in the order the client sent it, whichever order
+// that is. Both orders are covered because they exercise different flush sites in
+// ConvertBifrostMessagesToBedrockMessages: text-then-tool_use lets the reasoning ride
+// into the assistant message being built, while tool_use-then-text has a tool call
+// AND buffered reasoning pending at the same time, which is the case that used to
+// emit the tool use in front of the reasoning block that preceded it.
+func TestAnthropicIngressBedrockPreservesInterleavedThinkingOrder(t *testing.T) {
+	think := func(step int) map[string]any {
+		return map[string]any{
+			"type":      "thinking",
+			"thinking":  fmt.Sprintf("deliberating on step %d", step),
+			"signature": fmt.Sprintf("ErUBCkYIBxgCKkA_signature_%d", step),
+		}
+	}
+	text := func(step int) map[string]any {
+		return map[string]any{"type": "text", "text": fmt.Sprintf("calling the tool, step %d", step)}
+	}
+	toolUse := func(step int) map[string]any {
+		return map[string]any{
+			"type":  "tool_use",
+			"id":    fmt.Sprintf("toolu_01Step%02d", step),
+			"name":  "get_weather",
+			"input": map[string]any{"city": "san francisco"},
+		}
+	}
+
+	tests := []struct {
+		name  string
+		order func(step int) []map[string]any
+		want  []string
+	}{
+		{
+			name:  "thinking, text, tool_use",
+			order: func(step int) []map[string]any { return []map[string]any{think(step), text(step), toolUse(step)} },
+			want: []string{
+				"reasoning:ErUBCkYIBxgCKkA_signature_0",
+				"text:calling the tool, step 0",
+				"toolUse:toolu_01Step00",
+				"reasoning:ErUBCkYIBxgCKkA_signature_1",
+				"text:calling the tool, step 1",
+				"toolUse:toolu_01Step01",
+			},
+		},
+		{
+			name:  "thinking, tool_use, text",
+			order: func(step int) []map[string]any { return []map[string]any{think(step), toolUse(step), text(step)} },
+			want: []string{
+				"reasoning:ErUBCkYIBxgCKkA_signature_0",
+				"toolUse:toolu_01Step00",
+				"text:calling the tool, step 0",
+				"reasoning:ErUBCkYIBxgCKkA_signature_1",
+				"toolUse:toolu_01Step01",
+				"text:calling the tool, step 1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var assistantBlocks []map[string]any
+			for step := 0; step < 2; step++ {
+				assistantBlocks = append(assistantBlocks, tt.order(step)...)
+			}
+
+			body, err := json.Marshal(map[string]any{
+				"model":      "bedrock/us.anthropic.claude-opus-4-8",
+				"max_tokens": 4096,
+				"thinking":   map[string]any{"type": "adaptive"},
+				"tools": []map[string]any{{
+					"name":         "get_weather",
+					"description":  "look up the weather",
+					"input_schema": map[string]any{"type": "object"},
+				}},
+				"messages": []map[string]any{
+					{"role": "user", "content": []map[string]any{{"type": "text", "text": "run the tool twice"}}},
+					{"role": "assistant", "content": assistantBlocks},
+					{"role": "user", "content": []map[string]any{
+						{"type": "tool_result", "tool_use_id": "toolu_01Step00", "content": "sunny"},
+						{"type": "tool_result", "tool_use_id": "toolu_01Step01", "content": "windy"},
+					}},
+				},
+			})
+			require.NoError(t, err)
+
+			var ingressReq anthropic.AnthropicMessageRequest
+			require.NoError(t, json.Unmarshal(body, &ingressReq))
+
+			ctx := &schemas.BifrostContext{}
+			converseReq, err := bedrock.ToBedrockResponsesRequest(ctx, ingressReq.ToBifrostResponsesRequest(ctx))
+			require.NoError(t, err)
+
+			require.Len(t, converseReq.Messages, 3, "roles: %s", converseRoles(converseReq.Messages))
+			turn := converseReq.Messages[1]
+			require.Equal(t, bedrock.BedrockMessageRoleAssistant, turn.Role)
+
+			got := make([]string, 0, len(turn.Content))
+			for _, block := range turn.Content {
+				switch {
+				case block.ReasoningContent != nil && block.ReasoningContent.ReasoningText != nil:
+					sig := ""
+					if block.ReasoningContent.ReasoningText.Signature != nil {
+						sig = *block.ReasoningContent.ReasoningText.Signature
+					}
+					got = append(got, "reasoning:"+sig)
+				case block.Text != nil:
+					got = append(got, "text:"+*block.Text)
+				case block.ToolUse != nil:
+					got = append(got, "toolUse:"+block.ToolUse.ToolUseID)
+				default:
+					got = append(got, "other")
+				}
+			}
+			require.Equal(t, tt.want, got, "interleaved turn must reach Bedrock in the order the client sent it")
+		})
+	}
+}
+
+// Converse accepts only success|error on toolResult.status
+// (docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolResultBlock.html),
+// while Bifrost's Responses surface marks a failed tool result "incomplete". The
+// egress switch used to let "incomplete" fall through to its default and report the
+// failure to the model as a success -- so Bedrock could not read back what its own
+// ingress had written (TestConverseToolErrorReachesChatSurface pins the other half).
+//
+// This matters directly for issue #6342: `is_error: true` with no body is one of the
+// three tool_result shapes that used to be dropped entirely, so fixing the drop is
+// what starts routing these results through this switch.
+func TestAnthropicIngressBedrockToolErrorKeepsErrorStatus(t *testing.T) {
+	body, err := json.Marshal(map[string]any{
+		"model":      "bedrock/us.anthropic.claude-opus-4-8",
+		"max_tokens": 4096,
+		"tools": []map[string]any{{
+			"name":         "run",
+			"description":  "run a command",
+			"input_schema": map[string]any{"type": "object"},
+		}},
+		"messages": []map[string]any{
+			{"role": "user", "content": []map[string]any{{"type": "text", "text": "run it"}}},
+			{"role": "assistant", "content": []map[string]any{
+				{"type": "text", "text": "running"},
+				{"type": "tool_use", "id": "toolu_failed", "name": "run", "input": map[string]any{}},
+			}},
+			// is_error with no content: legal, and one of the shapes that used to be dropped.
+			{"role": "user", "content": []map[string]any{
+				{"type": "tool_result", "tool_use_id": "toolu_failed", "is_error": true},
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	var ingressReq anthropic.AnthropicMessageRequest
+	require.NoError(t, json.Unmarshal(body, &ingressReq))
+
+	ctx := &schemas.BifrostContext{}
+	converseReq, err := bedrock.ToBedrockResponsesRequest(ctx, ingressReq.ToBifrostResponsesRequest(ctx))
+	require.NoError(t, err)
+
+	require.Len(t, converseReq.Messages, 3, "roles: %s", converseRoles(converseReq.Messages))
+
+	var result *bedrock.BedrockToolResult
+	for _, block := range converseReq.Messages[2].Content {
+		if block.ToolResult != nil {
+			result = block.ToolResult
+			break
+		}
+	}
+	require.NotNil(t, result, "content-less is_error tool_result must still reach Converse")
+	require.Equal(t, "toolu_failed", result.ToolUseID)
+	require.NotNil(t, result.Status, "Converse requires a readable status for a failed tool call")
+	require.Equal(t, "error", *result.Status, "is_error must not be reported to the model as a success")
+}

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -3434,9 +3434,23 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 			seenNonSystemMessage = true
 		}
 
-		// If we're processing a non-reasoning message and have pending reasoning blocks,
-		// flush them into the previous assistant message (if it exists)
-		if msgType != schemas.ResponsesMessageTypeReasoning && len(pendingReasoningContentBlocks) > 0 {
+		// Buffered reasoning belongs to the assistant turn that is still being built,
+		// so the three item types that build one consume it themselves and are skipped
+		// here: an assistant `message` prepends it to its own content, and
+		// function_call / function_call_output prepend it to the toolUse message they
+		// flush. Relocating it into the PREVIOUS assistant message for those types
+		// moved an interleaved thinking block in front of the tool call it was produced
+		// after -- a modification of a signed block that Bedrock rejects (issue #6342).
+		//
+		// Everything else (a user turn, a server-tool call, an unhandled type) has
+		// nothing to attach the reasoning to going forward, so the historical fallback
+		// still applies: fold it into the last assistant message rather than lose it.
+		consumesPendingReasoning := msgType == schemas.ResponsesMessageTypeReasoning ||
+			msgType == schemas.ResponsesMessageTypeFunctionCall ||
+			msgType == schemas.ResponsesMessageTypeFunctionCallOutput ||
+			(msgType == schemas.ResponsesMessageTypeMessage && msg.Role != nil &&
+				*msg.Role == schemas.ResponsesInputMessageRoleAssistant)
+		if !consumesPendingReasoning && len(pendingReasoningContentBlocks) > 0 {
 			if len(bedrockMessages) > 0 && bedrockMessages[len(bedrockMessages)-1].Role == BedrockMessageRoleAssistant {
 				// Prepend reasoning blocks to the last assistant message
 				lastMsg := &bedrockMessages[len(bedrockMessages)-1]
@@ -3467,10 +3481,19 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 				resultContent := []BedrockContentBlock{}
 				status := "success"
 				if msg.Status != nil && *msg.Status != "" {
-					// Validate status is one of the allowed values
+					// Converse accepts only success|error on toolResult.status
+					// (docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolResultBlock.html).
+					// "incomplete" is the canonical Responses status for a failed tool
+					// result -- it is what the Anthropic ingress writes for is_error and
+					// what this provider's own Converse ingress writes for status "error"
+					// (see convertSingleBedrockMessageToBifrostMessages). Letting it fall
+					// through to the default reported a failed tool call to the model as a
+					// success, so Bedrock could not read back what Bedrock had written.
 					switch *msg.Status {
 					case "success", "error":
 						status = *msg.Status
+					case "incomplete":
+						status = "error"
 					default:
 						// Default to success for unknown status values
 						status = "success"
@@ -3614,47 +3637,17 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 			role := *msg.Role
 
 			// Always flush pending tool calls and results before processing a new message
-			// This ensures tool calls and results are properly paired
-			if stateManager.HasPendingToolCalls() {
-				callIDs := stateManager.EmitPendingToolCalls()
-				// Create assistant message with tool calls
-				var toolUseBlocks []BedrockContentBlock
-				for _, callID := range callIDs {
-					if toolCall, exists := stateManager.toolCalls[callID]; exists {
-						toolUseBlock := &BedrockContentBlock{
-							ToolUse: &BedrockToolUse{
-								ToolUseID: bedrockAliasToolUseID(toolCall.CallID),
-								Name:      toolCall.ToolName,
-							},
-						}
-						// Preserve original key ordering of tool arguments for prompt caching.
-						var input json.RawMessage
-						var buf bytes.Buffer
-						if err := json.Compact(&buf, []byte(toolCall.Arguments)); err == nil {
-							input = buf.Bytes()
-						} else {
-							input = json.RawMessage("{}")
-						}
-						toolUseBlock.ToolUse.Input = input
-						toolUseBlocks = append(toolUseBlocks, *toolUseBlock)
-						// Preserve the cache breakpoint Claude Code placed on this tool call, else the
-						// next turn can't match the prefix and collapses to the tools/system floor.
-						if toolCall.CacheControl != nil {
-							toolUseBlocks = append(toolUseBlocks, BedrockContentBlock{
-								CachePoint: newBedrockCachePoint(toolCall.CacheControl.TTL),
-							})
-						}
-					}
-				}
-
-				if len(toolUseBlocks) > 0 {
-					bedrockMessages = append(bedrockMessages, BedrockMessage{
-						Role:    BedrockMessageRoleAssistant,
-						Content: toolUseBlocks,
-					})
-					stateManager.MarkToolCallsEmitted(callIDs, len(bedrockMessages)-1)
-				}
-			}
+			// This ensures tool calls and results are properly paired.
+			//
+			// Routed through flushPendingToolCalls rather than a private copy of it:
+			// the copy that used to live here was identical except that it did NOT
+			// prepend pendingReasoningContentBlocks, so a turn ordered
+			// [thinking, tool_use, text] -- which reaches this branch with a tool call
+			// AND buffered reasoning pending at the same time -- emitted the tool use
+			// in front of the signed reasoning block that preceded it upstream. That is
+			// the same relocation of a replayed thinking block that issue #6342 is
+			// about, just one flush site further along.
+			flushPendingToolCalls()
 
 			// Emit any pending results after tool calls
 			if stateManager.HasPendingResults() {
@@ -3712,11 +3705,26 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 						bedrockMsg.Content = append(pendingServerToolBlocks, bedrockMsg.Content...)
 						pendingServerToolBlocks = nil
 					}
+					// Buffered reasoning belongs at the front of THIS assistant message,
+					// not folded back into the previous one. Doing it here is what keeps
+					// an interleaved turn in wire order once the tool-call batch before
+					// it has already been flushed (see the reasoning case above).
+					if bedrockMsg.Role == BedrockMessageRoleAssistant && len(pendingReasoningContentBlocks) > 0 {
+						bedrockMsg.Content = append(pendingReasoningContentBlocks, bedrockMsg.Content...)
+						pendingReasoningContentBlocks = nil
+					}
 					bedrockMessages = append(bedrockMessages, *bedrockMsg)
 				}
 			}
 
 		case schemas.ResponsesMessageTypeReasoning:
+			// A reasoning item arriving while tool calls are still buffered means the
+			// model thought AFTER those calls (interleaved thinking). Emit them first so
+			// the new reasoning lands behind them in the turn instead of being hoisted
+			// in front of them. flushPendingToolCalls consumes whatever reasoning was
+			// already pending, which is the reasoning that genuinely preceded the calls.
+			flushPendingToolCalls()
+
 			// Handle reasoning as content in next assistant message
 			// For now, just add to pending content blocks
 			reasoningBlocks := convertBifrostReasoningToBedrockReasoning(&msg)

--- a/core/providers/gemini/chat.go
+++ b/core/providers/gemini/chat.go
@@ -110,8 +110,14 @@ func ToGeminiChatCompletionRequestWithImageURLSchemes(ctx *schemas.BifrostContex
 			}
 		}
 	}
-	// Convert chat completion messages to Gemini format
-	contents, systemInstruction, err := convertBifrostMessagesToGemini(bifrostReq.Input, allowedImageURLSchemes...)
+	// Convert chat completion messages to Gemini format.
+	//
+	// The trailing-assistant trim is the Chat Completions counterpart of the one in
+	// convertResponsesMessagesToGeminiContents: Gemini answers 400 for any conversation whose
+	// last turn is role:"model", regardless of which Bifrost API shaped it. See
+	// trimTrailingAssistantPrefill for why prefill is the only trailing model turn dropped.
+	input := trimTrailingChatAssistantPrefill(bifrostReq.Input, schemas.ResolveModelCaps(bifrostReq.Provider, capModel))
+	contents, systemInstruction, err := convertBifrostMessagesToGemini(input, allowedImageURLSchemes...)
 	if err != nil {
 		return nil, err
 	}
@@ -691,4 +697,33 @@ func createErrorResponse(response *GenerateContentResponse, finishReason string,
 	}
 
 	return errorResp
+}
+
+// isChatAssistantPrefillMessage reports whether msg is a plain assistant text turn, the Chat
+// Completions analogue of isAssistantPrefillMessage. A message carrying tool calls, reasoning, or
+// audio is not a prefill: it is history the model must see replayed, so it is never trimmed.
+func isChatAssistantPrefillMessage(msg *schemas.ChatMessage) bool {
+	if msg.Role != schemas.ChatMessageRoleAssistant {
+		return false
+	}
+	if a := msg.ChatAssistantMessage; a != nil {
+		if len(a.ToolCalls) > 0 || a.Audio != nil || a.Reasoning != nil || len(a.ReasoningDetails) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// trimTrailingChatAssistantPrefill drops the trailing run of assistant prefill turns so the
+// conversation ends on a user or tool turn. See trimTrailingAssistantPrefill for the rationale
+// and for the datasheet opt-out.
+func trimTrailingChatAssistantPrefill(messages []schemas.ChatMessage, caps schemas.ModelCaps) []schemas.ChatMessage {
+	if caps.SupportsAssistantPrefill(false) {
+		return messages
+	}
+	trimmed := len(messages)
+	for trimmed > 0 && isChatAssistantPrefillMessage(&messages[trimmed-1]) {
+		trimmed--
+	}
+	return messages[:trimmed]
 }

--- a/core/providers/gemini/claudecodeprefill_test.go
+++ b/core/providers/gemini/claudecodeprefill_test.go
@@ -1,0 +1,434 @@
+package gemini
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/providers/anthropic"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression tests for issue #6334: Claude Code traffic on /anthropic/v1/messages routed to
+// Gemini/Vertex fails with an upstream HTTP 400.
+//
+// Two normalizations that the Bedrock converter already performs are missing on the Gemini
+// path (ToGeminiResponsesRequest -> convertResponsesMessagesToGeminiContents):
+//
+//  1. A trailing assistant turn (Claude Code's prefill) is mapped straight to a Gemini
+//     role:"model" content. Gemini's Content.role is documented as "Must be either 'user'
+//     or 'model'" for multi-turn conversations, and generateContent rejects a history whose
+//     final turn is "model" with 400 ("Please ensure that multiturn requests ends with a
+//     user role or a function response"). Bedrock trims this in ToBedrockResponsesRequest.
+//
+//  2. A mid-conversation role:"system" turn is hoisted into systemInstruction rather than
+//     inlined in place. Gemini has no message-level system role, so the Bedrock/Anthropic
+//     fallback is to render it as a user turn wrapped in <system-reminder> (see
+//     convertBifrostSystemReminderToBedrockUserMessage / inlineMidConversationSystem).
+//     Hoisting moves the text ahead of every message and collapses the cached prefix.
+
+// buildGeminiRequestFromAnthropic mirrors the transport path: Anthropic Messages ingress ->
+// Bifrost Responses -> Gemini generateContent.
+func buildGeminiRequestFromAnthropic(t *testing.T, msgs []anthropic.AnthropicMessage, system *anthropic.AnthropicContent) *GeminiGenerationRequest {
+	t.Helper()
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	in := &anthropic.AnthropicMessageRequest{
+		Model:     "gemini/gemini-3.7-flash",
+		MaxTokens: 1024,
+		Messages:  msgs,
+		System:    system,
+	}
+
+	bifrostReq := in.ToBifrostResponsesRequest(ctx)
+	require.NotNil(t, bifrostReq)
+	bifrostReq.Provider = schemas.Gemini
+
+	out, err := ToGeminiResponsesRequest(ctx, bifrostReq)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	return out
+}
+
+func anthropicTextMessage(role anthropic.AnthropicMessageRole, text string) anthropic.AnthropicMessage {
+	return anthropic.AnthropicMessage{
+		Role:    role,
+		Content: anthropic.AnthropicContent{ContentStr: schemas.Ptr(text)},
+	}
+}
+
+// A trailing assistant prefill must not reach Gemini as the final role:"model" turn.
+func TestGeminiResponses_TrailingAssistantPrefillIsTrimmed(t *testing.T) {
+	out := buildGeminiRequestFromAnthropic(t, []anthropic.AnthropicMessage{
+		anthropicTextMessage(anthropic.AnthropicMessageRoleUser, "What is 2+2?"),
+		anthropicTextMessage(anthropic.AnthropicMessageRoleAssistant, "The answer is"),
+	}, nil)
+
+	require.NotEmpty(t, out.Contents, "expected at least one content turn")
+	last := out.Contents[len(out.Contents)-1]
+	assert.NotEqual(t, "model", last.Role,
+		"Gemini rejects a conversation ending on a model turn; the trailing assistant prefill must be trimmed")
+}
+
+// Consecutive trailing assistant turns must all be trimmed, not just the last one.
+func TestGeminiResponses_MultipleTrailingAssistantTurnsTrimmed(t *testing.T) {
+	out := buildGeminiRequestFromAnthropic(t, []anthropic.AnthropicMessage{
+		anthropicTextMessage(anthropic.AnthropicMessageRoleUser, "What is 2+2?"),
+		anthropicTextMessage(anthropic.AnthropicMessageRoleAssistant, "Let me think."),
+		anthropicTextMessage(anthropic.AnthropicMessageRoleAssistant, "The answer is"),
+	}, nil)
+
+	require.NotEmpty(t, out.Contents, "expected at least one content turn")
+	last := out.Contents[len(out.Contents)-1]
+	assert.NotEqual(t, "model", last.Role,
+		"every trailing model turn must be trimmed, not only the final one")
+}
+
+// A mid-conversation system turn must be inlined in place as a user turn, not hoisted into
+// systemInstruction ahead of the whole conversation.
+func TestGeminiResponses_MidConversationSystemInlinedAsUserTurn(t *testing.T) {
+	const leadingSystem = "You are Claude Code."
+	const reminder = "The user opened a new file."
+
+	out := buildGeminiRequestFromAnthropic(t, []anthropic.AnthropicMessage{
+		anthropicTextMessage(anthropic.AnthropicMessageRoleUser, "Hello"),
+		anthropicTextMessage(anthropic.AnthropicMessageRoleAssistant, "Hi there."),
+		anthropicTextMessage(anthropic.AnthropicMessageRoleSystem, reminder),
+		anthropicTextMessage(anthropic.AnthropicMessageRoleUser, "What changed?"),
+	}, &anthropic.AnthropicContent{ContentStr: schemas.Ptr(leadingSystem)})
+
+	// The leading system prompt still belongs in systemInstruction.
+	require.NotNil(t, out.SystemInstruction, "leading system prompt must stay in systemInstruction")
+	var systemText strings.Builder
+	for _, p := range out.SystemInstruction.Parts {
+		systemText.WriteString(p.Text)
+	}
+	assert.Contains(t, systemText.String(), leadingSystem)
+	assert.NotContains(t, systemText.String(), reminder,
+		"a mid-conversation system turn must not be hoisted into systemInstruction; hoisting moves it ahead of the conversation and invalidates the cached prefix")
+
+	// It must appear as a user turn, in place, inside contents.
+	found := false
+	for _, c := range out.Contents {
+		for _, p := range c.Parts {
+			if strings.Contains(p.Text, reminder) {
+				found = true
+				assert.Equal(t, "user", c.Role,
+					"an inlined mid-conversation system reminder must be carried as a user turn")
+			}
+		}
+	}
+	assert.True(t, found, "mid-conversation system reminder must be inlined into contents as a user turn")
+}
+
+// The trim must not eat a trailing turn that carries a thought signature. Gemini's thinking guide
+// requires thought blocks to be resent exactly as received, so a signed reasoning turn is history,
+// not a prefill.
+func TestGeminiResponses_TrailingReasoningTurnIsNotTrimmed(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	reasoningType := schemas.ResponsesMessageTypeReasoning
+	assistantRole := schemas.ResponsesInputMessageRoleAssistant
+	userRole := schemas.ResponsesInputMessageRoleUser
+
+	bifrostReq := &schemas.BifrostResponsesRequest{
+		Provider: schemas.Gemini,
+		Model:    "gemini-3.7-flash",
+		Input: []schemas.ResponsesMessage{
+			{
+				Role: &userRole,
+				Content: &schemas.ResponsesMessageContent{
+					ContentStr: schemas.Ptr("Think about this."),
+				},
+			},
+			{
+				Role: &assistantRole,
+				Type: &reasoningType,
+				ResponsesReasoning: &schemas.ResponsesReasoning{
+					Summary: []schemas.ResponsesReasoningSummary{{
+						Type: "summary_text",
+						Text: "Working through it.",
+					}},
+				},
+			},
+		},
+	}
+
+	out, err := ToGeminiResponsesRequest(ctx, bifrostReq)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	var reasoningText string
+	for _, c := range out.Contents {
+		for _, p := range c.Parts {
+			reasoningText += p.Text
+		}
+	}
+	assert.Contains(t, reasoningText, "Working through it.",
+		"a trailing reasoning turn must survive the prefill trim; Gemini requires thought blocks to be replayed verbatim")
+}
+
+// A trailing assistant turn holding a function call is an unanswered tool round, not a prefill.
+func TestGeminiResponses_TrailingFunctionCallIsNotTrimmed(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	callType := schemas.ResponsesMessageTypeFunctionCall
+	userRole := schemas.ResponsesInputMessageRoleUser
+
+	bifrostReq := &schemas.BifrostResponsesRequest{
+		Provider: schemas.Gemini,
+		Model:    "gemini-3.7-flash",
+		Input: []schemas.ResponsesMessage{
+			{
+				Role: &userRole,
+				Content: &schemas.ResponsesMessageContent{
+					ContentStr: schemas.Ptr("What is the weather?"),
+				},
+			},
+			{
+				Type: &callType,
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					Name:      schemas.Ptr("get_weather"),
+					CallID:    schemas.Ptr("call_1"),
+					Arguments: schemas.Ptr(`{"city":"SF"}`),
+				},
+			},
+		},
+	}
+
+	out, err := ToGeminiResponsesRequest(ctx, bifrostReq)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	found := false
+	for _, c := range out.Contents {
+		for _, p := range c.Parts {
+			if p.FunctionCall != nil && p.FunctionCall.Name == "get_weather" {
+				found = true
+			}
+		}
+	}
+	assert.True(t, found, "a trailing function call must survive the prefill trim")
+}
+
+// Chat Completions path parity: the same trailing prefill must be trimmed there too.
+func TestGeminiChat_TrailingAssistantPrefillIsTrimmed(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	bifrostReq := &schemas.BifrostChatRequest{
+		Provider: schemas.Gemini,
+		Model:    "gemini-3.7-flash",
+		Input: []schemas.ChatMessage{
+			{
+				Role: schemas.ChatMessageRoleUser,
+				Content: &schemas.ChatMessageContent{
+					ContentStr: schemas.Ptr("What is 2+2?"),
+				},
+			},
+			{
+				Role: schemas.ChatMessageRoleAssistant,
+				Content: &schemas.ChatMessageContent{
+					ContentStr: schemas.Ptr("The answer is"),
+				},
+			},
+		},
+	}
+
+	out, err := ToGeminiChatCompletionRequest(ctx, bifrostReq)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.NotEmpty(t, out.Contents)
+	assert.NotEqual(t, "model", out.Contents[len(out.Contents)-1].Role,
+		"the Chat Completions path must trim the trailing prefill too")
+}
+
+// An assistant turn carrying tool calls is history the model must see replayed, not a prefill.
+func TestGeminiChat_TrailingAssistantToolCallIsNotTrimmed(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	bifrostReq := &schemas.BifrostChatRequest{
+		Provider: schemas.Gemini,
+		Model:    "gemini-3.7-flash",
+		Input: []schemas.ChatMessage{
+			{
+				Role: schemas.ChatMessageRoleUser,
+				Content: &schemas.ChatMessageContent{
+					ContentStr: schemas.Ptr("What is the weather?"),
+				},
+			},
+			{
+				Role: schemas.ChatMessageRoleAssistant,
+				ChatAssistantMessage: &schemas.ChatAssistantMessage{
+					ToolCalls: []schemas.ChatAssistantMessageToolCall{{
+						ID:   schemas.Ptr("call_1"),
+						Type: schemas.Ptr("function"),
+						Function: schemas.ChatAssistantMessageToolCallFunction{
+							Name:      schemas.Ptr("get_weather"),
+							Arguments: `{"city":"SF"}`,
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	out, err := ToGeminiChatCompletionRequest(ctx, bifrostReq)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	found := false
+	for _, c := range out.Contents {
+		for _, p := range c.Parts {
+			if p.FunctionCall != nil && p.FunctionCall.Name == "get_weather" {
+				found = true
+			}
+		}
+	}
+	assert.True(t, found, "a trailing assistant tool call must survive the prefill trim")
+}
+
+// ── Review findings on PR #6363 (CodeRabbit) ──────────────────────────────────
+
+// assistantMessageWithBlocks builds a trailing assistant turn of type "message" whose
+// content is carried as blocks rather than a plain string.
+func assistantMessageWithBlocks(blocks []schemas.ResponsesMessageContentBlock) schemas.ResponsesMessage {
+	msgType := schemas.ResponsesMessageTypeMessage
+	role := schemas.ResponsesInputMessageRoleAssistant
+	return schemas.ResponsesMessage{
+		Role:    &role,
+		Type:    &msgType,
+		Content: &schemas.ResponsesMessageContent{ContentBlocks: blocks},
+	}
+}
+
+func geminiRequestWithTrailingAssistant(t *testing.T, trailing schemas.ResponsesMessage) *GeminiGenerationRequest {
+	t.Helper()
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	userRole := schemas.ResponsesInputMessageRoleUser
+	out, err := ToGeminiResponsesRequest(ctx, &schemas.BifrostResponsesRequest{
+		Provider: schemas.Gemini,
+		Model:    "gemini-3.7-flash",
+		Input: []schemas.ResponsesMessage{
+			{Role: &userRole, Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("Think about this.")}},
+			trailing,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	return out
+}
+
+// A trailing assistant message whose blocks include a reasoning block is model history,
+// not a prefill: convertContentBlockToGeminiPart turns it into Part{Thought:true}, and
+// Gemini requires thought blocks to be replayed verbatim.
+func TestGeminiResponses_TrailingAssistantReasoningBlockIsNotTrimmed(t *testing.T) {
+	out := geminiRequestWithTrailingAssistant(t, assistantMessageWithBlocks(
+		[]schemas.ResponsesMessageContentBlock{{
+			Type: schemas.ResponsesOutputMessageContentTypeReasoning,
+			Text: schemas.Ptr("Deliberating carefully."),
+		}},
+	))
+
+	var seen string
+	for _, c := range out.Contents {
+		for _, p := range c.Parts {
+			seen += p.Text
+		}
+	}
+	assert.Contains(t, seen, "Deliberating carefully.",
+		"an assistant message carrying a reasoning block is thought history and must survive the prefill trim")
+}
+
+// Same hazard by a second route: a plain TEXT block carrying a signature becomes a
+// Part.ThoughtSignature, so trimming it drops a signature Gemini needs replayed.
+func TestGeminiResponses_TrailingAssistantSignedTextBlockIsNotTrimmed(t *testing.T) {
+	sig := base64.StdEncoding.EncodeToString([]byte("thought-sig-6334"))
+	out := geminiRequestWithTrailingAssistant(t, assistantMessageWithBlocks(
+		[]schemas.ResponsesMessageContentBlock{{
+			Type:      schemas.ResponsesInputMessageContentBlockTypeText,
+			Text:      schemas.Ptr("Partial answer"),
+			Signature: schemas.Ptr(sig),
+		}},
+	))
+
+	found := false
+	for _, c := range out.Contents {
+		for _, p := range c.Parts {
+			if len(p.ThoughtSignature) > 0 {
+				found = true
+			}
+		}
+	}
+	assert.True(t, found,
+		"a signed assistant text block carries a thought signature and must survive the prefill trim")
+}
+
+// ContentStr and ContentBlocks are mutually exclusive sources: when ContentStr is
+// non-nil it is the sole source, matching convertBifrostSystemReminderToBedrockUserMessage.
+func TestInlineGeminiSystemReminder_ContentStrIsSoleSource(t *testing.T) {
+	msg := schemas.ResponsesMessage{
+		Content: &schemas.ResponsesMessageContent{
+			ContentStr: schemas.Ptr(""),
+			ContentBlocks: []schemas.ResponsesMessageContentBlock{{
+				Type: schemas.ResponsesInputMessageContentBlockTypeText,
+				Text: schemas.Ptr("block text that must not be read"),
+			}},
+		},
+	}
+
+	content, err := inlineGeminiSystemReminder(&msg)
+	require.NoError(t, err)
+
+	var seen string
+	if content != nil {
+		for _, p := range content.Parts {
+			seen += p.Text
+		}
+	}
+	assert.NotContains(t, seen, "block text that must not be read",
+		"ContentBlocks must not be read when ContentStr is non-nil; the two are mutually exclusive")
+}
+
+// Mirrors the harness anti-over-trim guard at unit level. Asserting only that
+// "get_weather" appears somewhere in contents is vacuous: the trailing tool_result
+// becomes a functionResponse carrying the same name, so the assertion would hold even
+// if the assistant tool_use turn had been trimmed. The invariant that actually
+// distinguishes the two is a MODEL turn carrying a functionCall.
+func TestGeminiResponses_TrailingToolUseKeepsModelFunctionCallTurn(t *testing.T) {
+	out := buildGeminiRequestFromAnthropic(t, []anthropic.AnthropicMessage{
+		anthropicTextMessage(anthropic.AnthropicMessageRoleUser, "What is the weather in SF?"),
+		{
+			Role: anthropic.AnthropicMessageRoleAssistant,
+			Content: anthropic.AnthropicContent{ContentBlocks: []anthropic.AnthropicContentBlock{{
+				Type:  anthropic.AnthropicContentBlockTypeToolUse,
+				ID:    schemas.Ptr("toolu_bf6334"),
+				Name:  schemas.Ptr("get_weather"),
+				Input: json.RawMessage(`{"city":"SF"}`),
+			}}},
+		},
+		{
+			Role: anthropic.AnthropicMessageRoleUser,
+			Content: anthropic.AnthropicContent{ContentBlocks: []anthropic.AnthropicContentBlock{{
+				Type:      anthropic.AnthropicContentBlockTypeToolResult,
+				ToolUseID: schemas.Ptr("toolu_bf6334"),
+				Content:   &anthropic.AnthropicContent{ContentStr: schemas.Ptr("sunny, 20C")},
+			}}},
+		},
+	}, nil)
+
+	// Keyed on functionCall vs functionResponse, NOT on role: Gemini's Content.role is
+	// omitempty and this converter leaves the function-call turn's role unset, so a
+	// role=="model" check would fail for a reason unrelated to trimming.
+	var toolCall *Part
+	for _, c := range out.Contents {
+		for _, p := range c.Parts {
+			if p.FunctionCall != nil && p.FunctionCall.Name == "get_weather" {
+				toolCall = p
+			}
+		}
+	}
+	require.NotNil(t, toolCall,
+		"the functionCall must survive; matching get_weather anywhere would also match the tool_result functionResponse")
+}

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -4074,6 +4074,127 @@ func convertResponsesToolChoiceToGemini(toolChoice *schemas.ResponsesToolChoice)
 // responses, where a tool returns images/files nested in functionResponse.parts). provider
 // distinguishes Vertex AI from the Gemini Developer API, which differ in how multimodal
 // function responses must be referenced (see the FunctionCallOutput handling below).
+// isAssistantPrefillMessage reports whether msg is a plain assistant text turn -- the shape
+// Claude Code sends as a prefill, and the only trailing model turn that is safe to drop.
+//
+// Reasoning items and function calls are deliberately excluded even though they also render as
+// role:"model". Gemini's thinking guide requires thought blocks to survive replay verbatim ("You
+// MUST always resend all thought blocks exactly as they were received from the model",
+// https://ai.google.dev/gemini-api/docs/thinking), and a trailing function call is a turn the
+// caller still owes a functionResponse for -- neither is a prefill, and silently deleting either
+// would corrupt the history rather than repair it.
+func isAssistantPrefillMessage(msg *schemas.ResponsesMessage) bool {
+	if msg.Role == nil || *msg.Role != schemas.ResponsesInputMessageRoleAssistant {
+		return false
+	}
+	if msg.ResponsesToolMessage != nil || msg.ResponsesReasoning != nil {
+		return false
+	}
+	if msg.Type != nil && *msg.Type != schemas.ResponsesMessageTypeMessage {
+		return false
+	}
+	// The type and the standalone-reasoning check above are not sufficient: a turn typed
+	// "message" can still smuggle thought history in through its content blocks. A
+	// reasoning block becomes Part{Thought: true}, and a plain TEXT block carrying a
+	// signature becomes Part.ThoughtSignature -- both in convertContentBlockToGeminiPart.
+	// Either one makes the turn history Gemini requires replayed verbatim, not a prefill.
+	//
+	// So the allowance is a whitelist rather than a blacklist: only unsigned text blocks
+	// qualify, and any other block type (reasoning, refusal, compaction, fallback, image,
+	// file) disqualifies the turn. Erring this way costs at most an untrimmed turn --
+	// which Gemini answers with the 400 the caller already had -- while the opposite
+	// error silently deletes history and is unrecoverable.
+	if msg.Content != nil {
+		for _, block := range msg.Content.ContentBlocks {
+			if block.Signature != nil {
+				return false
+			}
+			switch block.Type {
+			case schemas.ResponsesInputMessageContentBlockTypeText,
+				schemas.ResponsesOutputMessageContentTypeText:
+			default:
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// trimTrailingAssistantPrefill drops the trailing run of assistant prefill turns so the
+// conversation ends on a user turn. Returns messages unchanged when the model declares prefill
+// support via the datasheet (ModelCaps.SupportsAssistantPrefill), which no Gemini model does
+// today -- the hook exists so a future model can opt back in without a code change.
+func trimTrailingAssistantPrefill(messages []schemas.ResponsesMessage, caps schemas.ModelCaps) []schemas.ResponsesMessage {
+	if caps.SupportsAssistantPrefill(false) {
+		return messages
+	}
+	trimmed := len(messages)
+	for trimmed > 0 && isAssistantPrefillMessage(&messages[trimmed-1]) {
+		trimmed--
+	}
+	return messages[:trimmed]
+}
+
+// inlineGeminiSystemReminder renders a mid-conversation role:"system" turn as a user turn wrapped
+// in the <system-reminder> envelope Claude Code uses, keeping it at its original position in the
+// conversation.
+//
+// Gemini has no message-level system role -- Content.role must be "user" or "model" -- so such a
+// turn has to become one or the other. The alternative, hoisting it into systemInstruction, is
+// what this replaces: systemInstruction renders ahead of every message, so a reminder that
+// arrives at turn 40 is presented as though it had been said at turn 0, and growing that block
+// mid-conversation invalidates the cached prefix behind it. This mirrors Bedrock's
+// convertBifrostSystemReminderToBedrockUserMessage and the native Anthropic fallback in
+// inlineMidConversationSystem, both of which measured the hoist as a prompt-cache collapse.
+//
+// The trade is the same one those converters accepted: a user turn is not the operator channel a
+// system turn is, so instruction adherence is weaker. The text originates from the caller's own
+// system role, so nothing attacker-controlled is laundered by the change.
+//
+// Returns nil when the message yields no text, so the caller skips the append.
+func inlineGeminiSystemReminder(msg *schemas.ResponsesMessage, allowedImageURLSchemes ...string) (*Content, error) {
+	if msg.Content == nil {
+		return nil, nil
+	}
+
+	wrap := func(text string) string {
+		return "<system-reminder>\n" + text + "\n</system-reminder>\n"
+	}
+
+	content := &Content{Role: "user"}
+	// ContentStr and ContentBlocks are mutually exclusive sources: whenever ContentStr is
+	// non-nil it is the sole source, matching convertBifrostSystemReminderToBedrockUserMessage.
+	// Gating the block loop on a non-EMPTY string instead would let a caller that set
+	// ContentStr to "" fall through and have its blocks read as well, emitting the reminder
+	// from a source the caller did not select.
+	if msg.Content.ContentStr != nil {
+		if *msg.Content.ContentStr != "" {
+			content.Parts = append(content.Parts, &Part{Text: wrap(*msg.Content.ContentStr)})
+		}
+	} else {
+		for _, block := range msg.Content.ContentBlocks {
+			part, err := convertContentBlockToGeminiPart(block, allowedImageURLSchemes...)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert system message content block: %w", err)
+			}
+			if part == nil {
+				continue
+			}
+			// Only text is wrapped; a non-text block (image, file) has no envelope to carry and is
+			// passed through as-is rather than dropped.
+			if part.Text != "" {
+				part.Text = wrap(part.Text)
+			}
+			content.Parts = append(content.Parts, part)
+		}
+	}
+
+	if len(content.Parts) == 0 {
+		return nil, nil
+	}
+	return content, nil
+}
+
 func convertResponsesMessagesToGeminiContents(messages []schemas.ResponsesMessage, model string, provider schemas.ModelProvider, allowedImageURLSchemes ...string) ([]Content, *Content, error) {
 	if len(allowedImageURLSchemes) == 0 {
 		allowedImageURLSchemes = defaultGeminiImageURLSchemes
@@ -4081,6 +4202,20 @@ func convertResponsesMessagesToGeminiContents(messages []schemas.ResponsesMessag
 
 	isVertex := provider == schemas.Vertex
 	caps := schemas.ResolveModelCaps(provider, model)
+
+	// Gemini rejects a conversation whose final turn is role:"model" -- generateContent answers
+	// 400 with "Please ensure that multiturn requests ends with a user role or a function
+	// response". Content.role is documented as "Must be either 'user' or 'model'", and Gemini
+	// exposes no assistant-prefill mechanism to continue from, so a trailing model turn has no
+	// valid meaning on this wire at all.
+	//
+	// Claude Code routinely ends its message array with an assistant prefill, so /anthropic
+	// traffic pointed at Gemini/Vertex fails on every such turn. Bedrock trims the same shape in
+	// ToBedrockResponsesRequest; this is that trim for Gemini. The gate differs: Bedrock keys on
+	// IsAnthropicModelFamily because a Bedrock target may be a Claude model, which is never true
+	// here, so the default is a flat false and only a datasheet record can turn it back on.
+	messages = trimTrailingAssistantPrefill(messages, caps)
+
 	// if only system / developer message is there, convert it to user message (since openai allows it)
 	if len(messages) == 1 && messages[0].Role != nil && (*messages[0].Role == schemas.ResponsesInputMessageRoleSystem || *messages[0].Role == schemas.ResponsesInputMessageRoleDeveloper) {
 		content := Content{Role: "user"}
@@ -4128,7 +4263,20 @@ func convertResponsesMessagesToGeminiContents(messages []schemas.ResponsesMessag
 	// According to Gemini docs, all function responses must be in a single message
 	var pendingFunctionResponseParts []*Part
 
+	// Set once the leading system prompt ends (first non-system message). Only the leading run is
+	// hoisted into systemInstruction; a system turn that arrives after the conversation has
+	// started is inlined in place instead -- see inlineGeminiSystemReminder.
+	seenNonSystemMessage := false
+
 	for i, msg := range messages {
+		isSystemMessage := msg.Role != nil &&
+			(*msg.Role == schemas.ResponsesInputMessageRoleSystem || *msg.Role == schemas.ResponsesInputMessageRoleDeveloper)
+		// Recorded before the branches below, all of which `continue`, so a reasoning or tool
+		// item still closes the leading system run.
+		if !isSystemMessage {
+			seenNonSystemMessage = true
+		}
+
 		// Standalone reasoning messages carry the model's thought blocks. Their
 		// SIGNATURE is picked up by the look-ahead on the preceding function
 		// call, so only the text is emitted here - sending the signature again
@@ -4171,8 +4319,31 @@ func convertResponsesMessagesToGeminiContents(messages []schemas.ResponsesMessag
 			continue
 		}
 
-		// Handle system messages separately
-		if msg.Role != nil && (*msg.Role == schemas.ResponsesInputMessageRoleSystem || *msg.Role == schemas.ResponsesInputMessageRoleDeveloper) {
+		// A mid-conversation system turn is inlined at its original position as a user turn.
+		// Hoisting it would move it ahead of the whole conversation and invalidate the cached
+		// prefix behind it.
+		if isSystemMessage && seenNonSystemMessage {
+			inlined, err := inlineGeminiSystemReminder(&msg, allowedImageURLSchemes...)
+			if err != nil {
+				return nil, nil, err
+			}
+			if inlined != nil {
+				// Flush first: the reminder is a user turn of its own and must not be filed
+				// behind function responses that precede it.
+				if len(pendingFunctionResponseParts) > 0 {
+					contents = append(contents, Content{
+						Parts: pendingFunctionResponseParts,
+						Role:  "user",
+					})
+					pendingFunctionResponseParts = nil
+				}
+				contents = append(contents, *inlined)
+			}
+			continue
+		}
+
+		// Handle the leading system prompt separately
+		if isSystemMessage {
 			if systemInstruction == nil {
 				systemInstruction = &Content{}
 			}

--- a/core/schemas/emptytooloutputmux_test.go
+++ b/core/schemas/emptytooloutputmux_test.go
@@ -1,0 +1,101 @@
+package schemas
+
+import (
+	"testing"
+)
+
+// OpenAI's Chat Completions API requires `content` on a role:"tool" message -- it is
+// the tool's result, so unlike an assistant message it has no meaning without one.
+//
+// A function_call_output can legitimately carry no body. Anthropic marks `content`
+// optional on a tool_result block (only `type` and `tool_use_id` are required), so a
+// void tool, an errored tool with no body, and an explicit empty content array all
+// produce a ResponsesToolMessageOutputStruct with neither field set.
+//
+// ToChatMessages used to leave cm.Content nil for those, and `omitempty` then dropped
+// the key entirely -- the tool message went out as
+// {"role":"tool","tool_call_id":"..."} with no content at all.
+//
+// Fixed here rather than at the Anthropic ingress on purpose. This is the layer that
+// owns the chat wire contract, so one fix covers every producer of an empty tool
+// output; seeding an empty string back at the ingress would also rewrite the Bedrock
+// Converse wire from `"content":[]` to `"content":[{"text":""}]`, and an empty text
+// block is a shape Anthropic rejects.
+func TestToChatMessages_EmptyToolOutputCarriesEmptyStringContent(t *testing.T) {
+	fcoType := ResponsesMessageTypeFunctionCallOutput
+
+	newFCO := func(output *ResponsesToolMessageOutputStruct) ResponsesMessage {
+		return ResponsesMessage{
+			Type: &fcoType,
+			ResponsesToolMessage: &ResponsesToolMessage{
+				CallID: Ptr("toolu_empty"),
+				Output: output,
+			},
+		}
+	}
+
+	tests := []struct {
+		name string
+		msg  ResponsesMessage
+	}{
+		{
+			name: "output struct with neither field set",
+			msg:  newFCO(&ResponsesToolMessageOutputStruct{}),
+		},
+		{
+			name: "output blocks present but empty",
+			msg:  newFCO(&ResponsesToolMessageOutputStruct{ResponsesFunctionToolCallOutputBlocks: []ResponsesMessageContentBlock{}}),
+		},
+		{
+			name: "no output struct at all",
+			msg:  newFCO(nil),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chatMessages := ToChatMessages([]ResponsesMessage{tt.msg})
+
+			if len(chatMessages) != 1 {
+				t.Fatalf("expected 1 chat message, got %d", len(chatMessages))
+			}
+			cm := chatMessages[0]
+			if cm.Role != ChatMessageRoleTool {
+				t.Fatalf("expected role tool, got %q", cm.Role)
+			}
+			if cm.Content == nil || cm.Content.ContentStr == nil {
+				t.Fatalf("tool message must carry content; OpenAI rejects a tool message without it. got Content=%+v", cm.Content)
+			}
+			if *cm.Content.ContentStr != "" {
+				t.Errorf("empty tool output must become an empty string, got %q", *cm.Content.ContentStr)
+			}
+		})
+	}
+}
+
+// A tool output that DOES carry a body must be untouched by the empty-output
+// backfill above.
+func TestToChatMessages_NonEmptyToolOutputUnchanged(t *testing.T) {
+	fcoType := ResponsesMessageTypeFunctionCallOutput
+
+	chatMessages := ToChatMessages([]ResponsesMessage{{
+		Type: &fcoType,
+		ResponsesToolMessage: &ResponsesToolMessage{
+			CallID: Ptr("toolu_ok"),
+			Output: &ResponsesToolMessageOutputStruct{
+				ResponsesToolCallOutputStr: Ptr("72 degrees and sunny"),
+			},
+		},
+	}})
+
+	if len(chatMessages) != 1 {
+		t.Fatalf("expected 1 chat message, got %d", len(chatMessages))
+	}
+	cm := chatMessages[0]
+	if cm.Content == nil || cm.Content.ContentStr == nil {
+		t.Fatal("expected content to survive")
+	}
+	if *cm.Content.ContentStr != "72 degrees and sunny" {
+		t.Errorf("tool output altered: got %q", *cm.Content.ContentStr)
+	}
+}

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -975,6 +975,26 @@ func ToChatMessages(rms []ResponsesMessage) []ChatMessage {
 			attachPendingReasoning(cm.ChatAssistantMessage)
 		}
 
+		// A role:"tool" message carries a tool's result, so unlike an assistant
+		// message it has no meaning without content -- OpenAI's Chat Completions API
+		// requires the field. A function_call_output can legitimately carry no body
+		// though: Anthropic marks `content` optional on a tool_result block, so a void
+		// tool, an errored tool with no body, and an explicit empty content array all
+		// arrive here with nothing to convert. Left alone, ChatMessageContent's
+		// omitempty then drops the key entirely and the tool message goes out as
+		// {"role":"tool","tool_call_id":"..."}.
+		//
+		// Backfilled here, after the content conversion above, rather than at any one
+		// ingress: this is the layer that owns the chat wire contract, so it covers
+		// every producer of an empty tool output at once. Seeding the empty string
+		// further upstream would also rewrite the Bedrock Converse wire from
+		// `"content":[]` to `"content":[{"text":""}]`, and an empty text block is a
+		// shape Anthropic rejects.
+		if cm.Role == ChatMessageRoleTool &&
+			(cm.Content == nil || (cm.Content.ContentStr == nil && len(cm.Content.ContentBlocks) == 0)) {
+			cm.Content = &ChatMessageContent{ContentStr: Ptr("")}
+		}
+
 		chatMessages = append(chatMessages, cm)
 	}
 

--- a/framework/modelcatalog/datasheet/types.go
+++ b/framework/modelcatalog/datasheet/types.go
@@ -499,8 +499,11 @@ func extractSupportedParams(parsed *schemas.ModelCapabilities) []string {
 	}
 
 	if parsed.SupportsAssistantPrefill != nil && *parsed.SupportsAssistantPrefill {
-		// Not an actual request parameter; if present, trailing assistant messages
-		// for anthropic and bedrock's anthropic models will not be trimmed.
+		// Not an actual request parameter; if present, trailing assistant messages are
+		// left in place instead of being trimmed. Read by anthropic and by bedrock's
+		// anthropic models, and by gemini/vertex -- where the default is the opposite
+		// (no model supports prefill, so the trim is on unless a record turns it off),
+		// because Gemini rejects any conversation ending on a role:"model" turn.
 		addParam("assistant_prefill")
 	}
 	if parsed.SupportsFunctionCalling != nil && *parsed.SupportsFunctionCalling {

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -135044,6 +135044,518 @@
           ]
         }
       ]
+    },
+    {
+      "name": "57. Claude Code turn normalization - assistant prefill trim + mid-conversation system inlining (#6334)",
+      "description": "Claude Code sends two shapes that Gemini/Vertex cannot accept verbatim, and until #6334 the Gemini egress\nconverter (core/providers/gemini/responses.go) normalized neither, so /anthropic/v1/messages traffic pointed at\ngemini/vertex failed upstream with HTTP 400.\n\n1. TRAILING ASSISTANT PREFILL. Claude Code routinely ends its messages array with a role:\"assistant\" turn for the\n   model to continue. Bifrost mapped it to a Gemini role:\"model\" content. Gemini's Content.role is documented as\n   \"Must be either 'user' or 'model'\" and generateContent rejects a history whose final turn is \"model\"\n   (\"Please ensure that multiturn requests ends with a user role or a function response\"). Gemini exposes no\n   prefill mechanism at all, so the turn is trimmed. Bedrock has done this since #3517.\n\n2. MID-CONVERSATION SYSTEM TURN. Claude Code injects runtime state as role:\"system\" entries inside messages.\n   Gemini has no message-level system role, so Bifrost hoisted them into systemInstruction - which renders ahead\n   of every message, presenting a turn-40 reminder as though it were said at turn 0, and invalidating the cached\n   prefix behind it on every injection. They are now inlined in place as user turns wrapped in\n   <system-reminder>, matching convertBifrostSystemReminderToBedrockUserMessage (#4068) and the native Anthropic\n   fallback inlineMidConversationSystem.\n\nEvery case asserts the OUTBOUND provider payload via x-bf-send-back-raw-request rather than merely checking that\nthe call did not 400. A \"no 400\" assertion would pass on a provider that silently tolerated the bad shape and\nwould tell us nothing about which normalization ran; raw_request pins the converter itself.\n\nFIXTURE CONSTRAINTS - do not \"tidy\" these bodies:\n - Case B needs TWO consecutive trailing assistant turns. A fix that drops only messages[len-1] passes case A\n   and still fails case B.\n - Case E needs a leading top-level `system` AND a later role:\"system\" entry. Without the leading one the case\n   cannot distinguish \"inlined correctly\" from \"system handling dropped entirely\".\n - Case G is the anti-over-trim guard: its trailing assistant turn carries tool_use, which is unanswered history\n   rather than a prefill and must survive. A trim that keys only on role:\"assistant\" passes A-C and breaks G.\n - A 400 is NOT guarded away in these scripts - a 400 IS the regression signature here.",
+      "item": [
+        {
+          "name": "gemini/gemini-3.7-flash /anthropic/v1/messages trailing assistant prefill is trimmed - #6334",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('gemini prefill: 2xx (Gemini 400s on an illegal turn sequence)', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var body = pm.response.json() || {};",
+                  "var rr = (body.extra_fields || {}).raw_request;",
+                  "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                  "pm.test('gemini prefill: raw_request captured', function () {",
+                  "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                  "});",
+                  "if (!rr || typeof rr !== 'object') { return; }",
+                  "var contents = rr.contents || [];",
+                  "var dump = JSON.stringify(contents);",
+                  "pm.test('gemini prefill: conversation does not end on a model turn', function () {",
+                  "  pm.expect(contents.length, 'contents empty: ' + dump).to.be.above(0);",
+                  "  pm.expect(contents[contents.length - 1].role, 'contents: ' + dump).to.not.eql('model');",
+                  "});",
+                  "pm.test('gemini prefill: the assistant prefill never reached the wire', function () {",
+                  "  pm.expect(dump).to.not.include('The answer is');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-send-back-raw-request",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"gemini/gemini-3.7-flash\",\n  \"max_tokens\": 64,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What is 2+2? Answer with just the number.\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"The answer is\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "anthropic",
+                "v1",
+                "messages"
+              ]
+            }
+          }
+        },
+        {
+          "name": "gemini/gemini-3.7-flash /anthropic/v1/messages consecutive trailing prefills are all trimmed - #6334",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('gemini multi-prefill: 2xx (Gemini 400s on an illegal turn sequence)', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var body = pm.response.json() || {};",
+                  "var rr = (body.extra_fields || {}).raw_request;",
+                  "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                  "pm.test('gemini multi-prefill: raw_request captured', function () {",
+                  "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                  "});",
+                  "if (!rr || typeof rr !== 'object') { return; }",
+                  "var contents = rr.contents || [];",
+                  "var dump = JSON.stringify(contents);",
+                  "pm.test('gemini multi-prefill: conversation does not end on a model turn', function () {",
+                  "  pm.expect(contents.length, 'contents empty: ' + dump).to.be.above(0);",
+                  "  pm.expect(contents[contents.length - 1].role, 'contents: ' + dump).to.not.eql('model');",
+                  "});",
+                  "pm.test('gemini multi-prefill: the assistant prefill never reached the wire', function () {",
+                  "  pm.expect(dump).to.not.include('The answer is');",
+                  "});",
+                  "pm.test('gemini multi-prefill: the earlier prefill went too', function () {",
+                  "  pm.expect(dump).to.not.include('Let me think.');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-send-back-raw-request",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"gemini/gemini-3.7-flash\",\n  \"max_tokens\": 64,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What is 2+2? Answer with just the number.\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"Let me think.\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"The answer is\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "anthropic",
+                "v1",
+                "messages"
+              ]
+            }
+          }
+        },
+        {
+          "name": "vertex/gemini-2.5-pro /anthropic/v1/messages trailing assistant prefill is trimmed - #6334",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('vertex prefill: 2xx (Gemini 400s on an illegal turn sequence)', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var body = pm.response.json() || {};",
+                  "var rr = (body.extra_fields || {}).raw_request;",
+                  "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                  "pm.test('vertex prefill: raw_request captured', function () {",
+                  "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                  "});",
+                  "if (!rr || typeof rr !== 'object') { return; }",
+                  "var contents = rr.contents || [];",
+                  "var dump = JSON.stringify(contents);",
+                  "pm.test('vertex prefill: conversation does not end on a model turn', function () {",
+                  "  pm.expect(contents.length, 'contents empty: ' + dump).to.be.above(0);",
+                  "  pm.expect(contents[contents.length - 1].role, 'contents: ' + dump).to.not.eql('model');",
+                  "});",
+                  "pm.test('vertex prefill: the assistant prefill never reached the wire', function () {",
+                  "  pm.expect(dump).to.not.include('The answer is');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-send-back-raw-request",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"vertex/gemini-2.5-pro\",\n  \"max_tokens\": 64,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What is 2+2? Answer with just the number.\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"The answer is\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "anthropic",
+                "v1",
+                "messages"
+              ]
+            }
+          }
+        },
+        {
+          "name": "gemini/gemini-3.7-flash /anthropic/v1/messages streaming trailing prefill does not 400 - #6334",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('gemini prefill stream: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "var text = pm.response.text() || '';",
+                  "pm.test('gemini prefill stream: the stream actually carried data', function () {",
+                  "  pm.expect(text.length, 'empty body - the negative checks below would pass vacuously').to.be.above(0);",
+                  "  pm.expect(text, 'no SSE data frame in body: ' + text.slice(0, 800)).to.include('data:');",
+                  "});",
+                  "pm.test('gemini prefill stream: no turn-order refusal in the stream', function () {",
+                  "  var low = String(text).toLowerCase();",
+                  "  pm.expect(low, 'stream body: ' + String(text).slice(0, 800)).to.not.include('ends with a user role');",
+                  "  pm.expect(low, 'stream body: ' + String(text).slice(0, 800)).to.not.include('last turn cannot be model');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-send-back-raw-request",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"gemini/gemini-3.7-flash\",\n  \"max_tokens\": 64,\n  \"stream\": true,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What is 2+2? Answer with just the number.\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"The answer is\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "anthropic",
+                "v1",
+                "messages"
+              ]
+            }
+          }
+        },
+        {
+          "name": "gemini/gemini-3.7-flash /anthropic/v1/messages mid-conversation system turn is inlined as a user turn - #6334",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('gemini mid-conv system: 2xx (Gemini 400s on an illegal turn sequence)', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var body = pm.response.json() || {};",
+                  "var rr = (body.extra_fields || {}).raw_request;",
+                  "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                  "pm.test('gemini mid-conv system: raw_request captured', function () {",
+                  "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                  "});",
+                  "if (!rr || typeof rr !== 'object') { return; }",
+                  "var contents = rr.contents || [];",
+                  "var dump = JSON.stringify(contents);",
+                  "var sysInstr = JSON.stringify(rr.systemInstruction || rr.system_instruction || {});",
+                  "pm.test('gemini mid-conv system: reminder is NOT hoisted into systemInstruction', function () {",
+                  "  pm.expect(sysInstr, 'systemInstruction: ' + sysInstr).to.not.include('The user just opened src/main.go.');",
+                  "});",
+                  "pm.test('gemini mid-conv system: leading system prompt still hoisted', function () {",
+                  "  pm.expect(sysInstr, 'systemInstruction: ' + sysInstr).to.include('terse assistant');",
+                  "});",
+                  "pm.test('gemini mid-conv system: reminder inlined in contents as a user turn', function () {",
+                  "  var hit = null;",
+                  "  for (var i = 0; i < contents.length; i++) {",
+                  "    if (JSON.stringify(contents[i]).indexOf('The user just opened src/main.go.') !== -1) { hit = contents[i]; }",
+                  "  }",
+                  "  pm.expect(hit, 'reminder absent from contents: ' + dump).to.not.eql(null);",
+                  "  pm.expect(hit.role, 'contents: ' + dump).to.eql('user');",
+                  "});",
+                  "pm.test('gemini mid-conv system: reminder keeps its <system-reminder> envelope', function () {",
+                  "  pm.expect(dump, 'contents: ' + dump).to.include('system-reminder');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-send-back-raw-request",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"gemini/gemini-3.7-flash\",\n  \"max_tokens\": 64,\n  \"system\": \"You are a terse assistant.\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Hello\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"Hi.\"\n    },\n    {\n      \"role\": \"system\",\n      \"content\": \"The user just opened src/main.go.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"What file am I in? Answer with the path only.\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "anthropic",
+                "v1",
+                "messages"
+              ]
+            }
+          }
+        },
+        {
+          "name": "gemini/gemini-3.7-flash /v1/chat/completions trailing assistant prefill is trimmed - #6334",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('gemini chat prefill: 2xx (Gemini 400s on an illegal turn sequence)', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var body = pm.response.json() || {};",
+                  "var rr = (body.extra_fields || {}).raw_request;",
+                  "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                  "pm.test('gemini chat prefill: raw_request captured', function () {",
+                  "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                  "});",
+                  "if (!rr || typeof rr !== 'object') { return; }",
+                  "var contents = rr.contents || [];",
+                  "var dump = JSON.stringify(contents);",
+                  "pm.test('gemini chat prefill: conversation does not end on a model turn', function () {",
+                  "  pm.expect(contents.length, 'contents empty: ' + dump).to.be.above(0);",
+                  "  pm.expect(contents[contents.length - 1].role, 'contents: ' + dump).to.not.eql('model');",
+                  "});",
+                  "pm.test('gemini chat prefill: the assistant prefill never reached the wire', function () {",
+                  "  pm.expect(dump).to.not.include('The answer is');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-send-back-raw-request",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"gemini/gemini-3.7-flash\",\n  \"max_tokens\": 64,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What is 2+2? Answer with just the number.\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"The answer is\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
+        },
+        {
+          "name": "gemini/gemini-3.7-flash /anthropic/v1/messages trailing assistant tool_use is NOT trimmed - #6334",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('gemini tool_use guard: 2xx (Gemini 400s on an illegal turn sequence)', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var body = pm.response.json() || {};",
+                  "var rr = (body.extra_fields || {}).raw_request;",
+                  "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                  "pm.test('gemini tool_use guard: raw_request captured', function () {",
+                  "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                  "});",
+                  "if (!rr || typeof rr !== 'object') { return; }",
+                  "var contents = rr.contents || [];",
+                  "var dump = JSON.stringify(contents);",
+                  "pm.test('gemini tool_use guard: the trailing tool round survived the prefill trim', function () {",
+                  "  var modelCall = null;",
+                  "  for (var i = 0; i < contents.length; i++) {",
+                  "    var parts = contents[i].parts || [];",
+                  "    for (var j = 0; j < parts.length; j++) {",
+                  "      if (parts[j].functionCall && parts[j].functionCall.name === 'get_weather') { modelCall = parts[j]; }",
+                  "    }",
+                  "  }",
+                  "  pm.expect(modelCall, 'no functionCall survived - a substring match on get_weather would also match the tool_result functionResponse. contents: ' + dump).to.not.eql(null);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-send-back-raw-request",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"gemini/gemini-3.7-flash\",\n  \"max_tokens\": 128,\n  \"tools\": [\n    {\n      \"name\": \"get_weather\",\n      \"description\": \"Get weather for a city\",\n      \"input_schema\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"city\": {\n            \"type\": \"string\"\n          }\n        },\n        \"required\": [\n          \"city\"\n        ]\n      }\n    }\n  ],\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What is the weather in SF?\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": [\n        {\n          \"type\": \"tool_use\",\n          \"id\": \"toolu_bf6334\",\n          \"name\": \"get_weather\",\n          \"input\": {\n            \"city\": \"SF\"\n          }\n        }\n      ]\n    },\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"tool_result\",\n          \"tool_use_id\": \"toolu_bf6334\",\n          \"content\": \"sunny, 20C\"\n        }\n      ]\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "anthropic",
+                "v1",
+                "messages"
+              ]
+            }
+          }
+        },
+        {
+          "name": "bedrock/global.anthropic.claude-opus-4-7 /anthropic/v1/messages mid-conversation system turn is inlined, not hoisted - #6334",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('bedrock mid-conv system: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var body = pm.response.json() || {};",
+                  "var rr = (body.extra_fields || {}).raw_request;",
+                  "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                  "pm.test('bedrock mid-conv system: raw_request captured', function () {",
+                  "  pm.expect(rr, 'raw_request missing').to.be.an('object');",
+                  "});",
+                  "if (!rr || typeof rr !== 'object') { return; }",
+                  "var msgs = JSON.stringify(rr.messages || []);",
+                  "var sys = JSON.stringify(rr.system || []);",
+                  "pm.test('bedrock mid-conv system: reminder is NOT hoisted into the system block', function () {",
+                  "  pm.expect(sys, 'system: ' + sys).to.not.include('The user just opened src/main.go.');",
+                  "});",
+                  "pm.test('bedrock mid-conv system: reminder inlined into messages with its envelope', function () {",
+                  "  pm.expect(msgs, 'messages: ' + msgs).to.include('The user just opened src/main.go.');",
+                  "  pm.expect(msgs, 'messages: ' + msgs).to.include('system-reminder');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-send-back-raw-request",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"bedrock/global.anthropic.claude-opus-4-7\",\n  \"max_tokens\": 64,\n  \"system\": \"You are a terse assistant.\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Hello\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"Hi.\"\n    },\n    {\n      \"role\": \"system\",\n      \"content\": \"The user just opened src/main.go.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"What file am I in? Answer with the path only.\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "anthropic",
+                "v1",
+                "messages"
+              ]
+            }
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fixes HTTP 400 errors from Gemini/Vertex when Claude Code traffic is routed through `/anthropic/v1/messages`. Two conversation shapes that Claude Code routinely produces were passed to Gemini verbatim without normalization, causing upstream rejections on every such request.

Closes #6334

## Changes

- **Trailing assistant prefill trim (Responses path):** `convertResponsesMessagesToGeminiContents` now calls `trimTrailingAssistantPrefill` before building the `contents` array. Gemini rejects any conversation whose final turn is `role:"model"` with a 400. Claude Code ends its message array with a plain assistant text turn as a prefill; that turn is now dropped before the request reaches the wire. Reasoning items and function calls are explicitly excluded from the trim — Gemini requires thought blocks to be replayed verbatim, and a trailing function call is an unanswered tool round, not a prefill.
- **Trailing assistant prefill trim (Chat Completions path):** `ToGeminiChatCompletionRequestWithImageURLSchemes` now applies the same trim via `trimTrailingChatAssistantPrefill` and `isChatAssistantPrefillMessage`, giving the `/v1/chat/completions` surface parity with the Responses path.
- **Mid-conversation system turn inlining:** Previously, any `role:"system"` message inside the conversation was hoisted into `systemInstruction`, which renders ahead of every message. A system reminder injected at turn 40 was therefore presented as though it had been said at turn 0, and growing `systemInstruction` mid-conversation invalidated the cached prefix behind it. System turns that arrive after the first non-system message are now inlined in place as `role:"user"` turns wrapped in a `<system-reminder>` envelope, matching the behavior of `convertBifrostSystemReminderToBedrockUserMessage` and `inlineMidConversationSystem` on the Bedrock and native Anthropic paths. Only the leading run of system messages is still hoisted.
- **`extra_fields`** **propagation on** **`/anthropic/v1/messages`:** `AnthropicMessageResponse` gains an `ExtraFields` field (omitempty) so that `x-bf-send-back-raw-request` results are visible to callers on that route. The field is populated only when a raw capture is actually present; without one it stays nil and the response remains byte-identical to Anthropic's documented shape. `rawCaptureExtraFields` gates on the presence of `RawRequest`/`RawResponse` rather than a context flag, so it honors all three switches that can enable capture.
- **Datasheet comment update:** The `SupportsAssistantPrefill` comment in `extractSupportedParams` now documents that Gemini/Vertex also reads this flag, and that the default for those providers is the opposite of Anthropic/Bedrock — the trim is on unless a datasheet record explicitly turns it off.
- **Tests:** Unit tests cover the prefill trim (single and consecutive trailing turns), the reasoning/function-call anti-over-trim guards, the mid-conversation system inlining, and the `extra_fields` echo behavior for both the present and absent capture cases. E2E Postman cases assert the outbound Gemini payload via `x-bf-send-back-raw-request` for all scenarios across Gemini, Vertex, and Bedrock targets.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
go test ./core/providers/gemini/... ./core/providers/anthropic/...
```

For end-to-end validation, run the Postman collection in `tests/e2e/api/collections/provider-harness.json` against a live Bifrost instance with Gemini, Vertex, and Bedrock credentials configured. Collection item 57 covers all cases. Each test asserts the outbound `contents` array via `raw_request` — a 400 from the provider is the regression signature and is not suppressed in the scripts.

## Breaking changes

- [x] No

## Related issues

Closes #6334

## Security considerations

Mid-conversation system turns are inlined as user turns. The text originates from the caller's own system role, so nothing attacker-controlled is laundered by the role change. The trade-off (weaker operator-channel semantics) is the same one the Bedrock and native Anthropic converters already accepted.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable