### PR TITLE
fix: handle dashboard auth, budget-reset dialog, and stale MCP state in e2e tests

### DIFF
--- a/tests/e2e/core/fixtures/base.fixture.ts
+++ b/tests/e2e/core/fixtures/base.fixture.ts
@@ -1,4 +1,5 @@
 import { test as base, expect } from "@playwright/test";
+import { waitForNetworkIdle } from "../utils/test-helpers";
 import { SidebarPage } from "../pages/sidebar.page";
 import { ProvidersPage } from "../../features/providers/pages/providers.page";
 import { VirtualKeysPage } from "../../features/virtual-keys/pages/virtual-keys.page";
@@ -21,6 +22,8 @@ import { ModelLimitsPage } from "../../features/model-limits/pages/model-limits.
  */
 type BifrostFixtures = {
 	closeDevProfiler: void;
+	handleLoginRedirect: void;
+	skipAutoLogin: boolean;
 	sidebarPage: SidebarPage;
 	providersPage: ProvidersPage;
 	virtualKeysPage: VirtualKeysPage;
@@ -66,6 +69,47 @@ export const test = base.extend<BifrostFixtures>({
 						.catch(() => {});
 				},
 				{ noWaitAfter: true },
+			);
+			await use();
+		},
+		{ auto: true },
+	],
+
+	skipAutoLogin: [false, { option: true }],
+
+	handleLoginRedirect: [
+		async ({ page, skipAutoLogin }, use) => {
+			// Any test can hit an auth wall: dashboard auth redirects to /login (via a
+			// baseApi 401 handler) whenever the session is missing/expired. Transparently
+			// complete the login flow whenever that happens so feature tests don't each
+			// need their own auth handling.
+			if (skipAutoLogin) {
+				await use();
+				return;
+			}
+			await page.addLocatorHandler(
+				page.locator("#username"),
+				async () => {
+					const username = process.env.BIFROST_ADMIN_USERNAME;
+					const password = process.env.BIFROST_ADMIN_PASSWORD;
+					if (!username || !password) {
+						throw new Error(
+							"Redirected to /login but BIFROST_ADMIN_USERNAME/BIFROST_ADMIN_PASSWORD are not set.",
+						);
+					}
+					// The login form always redirects to /workspace on success, ignoring
+					// ?goto=; capture it here and navigate back so the test lands on the
+					// page it originally asked for.
+					const goto = new URL(page.url()).searchParams.get("goto");
+					await page.locator("#username").fill(username);
+					await page.locator("#password").fill(password);
+					await page.getByRole("button", { name: /Sign in/i }).click();
+					await page.waitForURL((url) => !url.pathname.startsWith("/login"), { timeout: 15000 });
+					if (goto) {
+						await page.goto(goto);
+					}
+					await waitForNetworkIdle(page);
+				},
 			);
 			await use();
 		},

--- a/tests/e2e/features/model-limits/pages/model-limits.page.ts
+++ b/tests/e2e/features/model-limits/pages/model-limits.page.ts
@@ -73,6 +73,23 @@ export class ModelLimitsPage extends BasePage {
     await actionsBtn.click()
   }
 
+  private async preserveBudgetUsageIfPrompted(): Promise<void> {
+    const dialog = this.page.getByTestId('model-limit-budget-reset-dialog')
+    const dialogVisible = dialog.waitFor({ state: 'visible', timeout: 5000 }).then(() => 'dialog' as const)
+    const sheetClosed = this.sheet.waitFor({ state: 'hidden', timeout: 5000 }).then(() => 'sheet' as const)
+
+    let winner: 'dialog' | 'sheet'
+    try {
+      winner = await Promise.race([dialogVisible, sheetClosed])
+    } catch {
+      return
+    }
+    if (winner !== 'dialog') return
+
+    await this.page.getByTestId('model-limit-budget-reset-dialog-preserve-btn').click()
+    await dialog.waitFor({ state: 'hidden', timeout: 3000 })
+  }
+
   private async waitForSheetClosedAfterSave(): Promise<void> {
     const closed = await expect(this.sheet)
       .not.toBeVisible({ timeout: 5000 })
@@ -182,6 +199,7 @@ export class ModelLimitsPage extends BasePage {
     const saveBtn = this.page.getByRole('button', { name: /Save Changes|Create Limit/i })
     await expect(saveBtn).toBeEnabled({ timeout: 10000 })
     await saveBtn.click()
+    await this.preserveBudgetUsageIfPrompted()
     await this.waitForSheetClosedAfterSave()
     await expect(this.getModelLimitRow(modelName, provider)).toBeVisible({ timeout: 15000 })
   }

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -2,7 +2,7 @@
  * Single global setup for all E2E tests.
  * 1. Builds test plugin (plugins) and copies to /tmp.
  * 2. Builds and starts MCP test servers (HTTP/SSE on 3001, STDIO test-tools-server).
- * 3. Ensures TestClient001 MCP client exists and is connected (create or reconnect as needed).
+ * 3. Ensures TestClient001 MCP client exists and is healthy (create or reconnect as needed).
  * 4. Sends a POST /v1/responses request to validate the proxy with MCP.
  * Returns a teardown function that stops MCP servers.
  */
@@ -182,13 +182,24 @@ async function ensureTestClient001AndSendResponses(baseUrl: string): Promise<voi
     throw new Error(`MCP client "${TEST_MCP_CLIENT_NAME}" not found after create.`)
   }
   clientId = clientAfter.config.client_id
-  if (clientAfter.state !== 'connected') {
-    console.log(`MCP client "${TEST_MCP_CLIENT_NAME}" not connected; reloading via POST /api/mcp/client/${clientId}/reconnect...`)
+  // 'connected' was renamed to 'healthy' (core/schemas/mcp.go) to also cover
+  // per-call auth types that never hold a single shared connection.
+  if (clientAfter.state !== 'healthy') {
+    console.log(`MCP client "${TEST_MCP_CLIENT_NAME}" not healthy (state=${clientAfter.state}); reloading via POST /api/mcp/client/${clientId}/reconnect...`)
     const reconnectRes = await httpRequest(baseUrl, 'POST', `/api/mcp/client/${encodeURIComponent(clientId)}/reconnect`)
     if (reconnectRes.statusCode < 200 || reconnectRes.statusCode >= 300) {
-      throw new Error(
-        `POST /api/mcp/client/.../reconnect failed: ${reconnectRes.statusCode} ${reconnectRes.body}. Ensure MCP server is running and reload Bifrost if needed.`
-      )
+      // A plain "http" client with no needs_session_stickiness defaults to
+      // per-call connections, which have no persistent connection to
+      // reconnect and go straight to healthy at creation time instead — the
+      // reconnect call above was only ever needed for sticky clients that
+      // failed to connect. Only a genuine reconnect failure should fail setup.
+      const isPerCallNotApplicable = /per-call connections/.test(reconnectRes.body)
+      if (!isPerCallNotApplicable) {
+        throw new Error(
+          `POST /api/mcp/client/.../reconnect failed: ${reconnectRes.statusCode} ${reconnectRes.body}. Ensure MCP server is running and reload Bifrost if needed.`
+        )
+      }
+      console.log(`MCP client "${TEST_MCP_CLIENT_NAME}" uses per-call connections; reconnect not applicable, continuing.`)
     }
   }
 
@@ -199,12 +210,12 @@ async function ensureTestClient001AndSendResponses(baseUrl: string): Promise<voi
   const parsed2 = JSON.parse(listRes2.body) as { clients?: MCPClientItem[] } | MCPClientItem[]
   const list2 = (Array.isArray(parsed2) ? parsed2 : (parsed2.clients ?? [])).filter((c) => c.config?.name === TEST_MCP_CLIENT_NAME)
   const client = list2[0]
-  if (!client || client.state !== 'connected') {
+  if (!client || client.state !== 'healthy') {
     throw new Error(
-      `MCP client "${TEST_MCP_CLIENT_NAME}" is not connected after create/reconnect. Reload the MCP server and ensure it is running, then re-run global setup.`
+      `MCP client "${TEST_MCP_CLIENT_NAME}" is not healthy after create/reconnect (state=${client?.state}). Reload the MCP server and ensure it is running, then re-run global setup.`
     )
   }
-  console.log(`✓ MCP client "${TEST_MCP_CLIENT_NAME}" is connected`)  
+  console.log(`✓ MCP client "${TEST_MCP_CLIENT_NAME}" is healthy`)
 }
 
 async function runPluginSetup(): Promise<void> {


### PR DESCRIPTION
## Summary

This PR improves E2E test reliability by transparently handling auth redirects during tests and aligning the test infrastructure with a renamed MCP client state (`connected` → `healthy`). It also adds handling for a budget reset dialog that can appear when saving model limits.

## Changes

- Added a `handleLoginRedirect` auto-fixture that intercepts any redirect to `/login` during a test, completes the login flow using `BIFROST_ADMIN_USERNAME`/`BIFROST_ADMIN_PASSWORD`, and navigates back to the originally requested page. This prevents individual feature tests from needing their own auth handling.
- Added `preserveBudgetUsageIfPrompted` to `ModelLimitsPage` to automatically dismiss the budget reset dialog (by clicking "preserve") when it appears after saving a model limit, preventing test failures caused by this intermittent dialog.
- Updated `global-setup.ts` to check for `healthy` instead of `connected` as the expected MCP client state, reflecting a rename in `core/schemas/mcp.go`. Also added graceful handling for per-call connection clients where a reconnect call is not applicable, rather than failing setup.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Run the E2E test suite against an environment where the session may be expired or missing:

```sh
cd tests/e2e
BIFROST_ADMIN_USERNAME=<user> BIFROST_ADMIN_PASSWORD=<pass> npx playwright test
```

- Verify that tests which previously failed due to auth redirects now complete successfully.
- Verify that model limit tests pass even when the budget reset dialog appears.
- Verify that global setup completes without error when the MCP client is in `healthy` state or uses per-call connections.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

`BIFROST_ADMIN_USERNAME` and `BIFROST_ADMIN_PASSWORD` are consumed only within the test fixture and are never logged or exposed beyond the login flow.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable