### PR TITLE
feat(integrations): support native raw request redaction

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6713,7 +6713,10 @@ func clearAnthropicPassthroughForNonNativeProvider(ctx *schemas.BifrostContext, 
 		schemas.IsAnthropicModelFamily(ctx, model) {
 		return
 	}
+	// The rewriter is valid only while the matching Anthropic-native body is
+	// forwarded; converted and fallback requests must not inherit it.
 	ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, false)
+	ctx.ClearValue(schemas.BifrostContextKeyRawRequestBodyTextRewriter)
 	ctx.SetValue(schemas.BifrostContextKeySendBackRawResponse, false)
 	ctx.SetValue(schemas.BifrostContextKeyPassthroughOverridesPresent, false)
 	ctx.ClearValue(schemas.BifrostContextKeyURLPath)

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -180,10 +180,11 @@ type anthropicToResponsesStreamState struct {
 	nextBlockIndex   int
 	blockIndexByItem map[string]int
 
-	// emittedTextByBlock holds bounded progress for text actually emitted to a
-	// normalized Anthropic client. Responses output_text.done is cumulative, so
-	// this lets the converter recover only its missing suffix without retaining a
-	// second full copy of the streamed response.
+	// emittedTextByBlock holds bounded progress for text that actually reached a
+	// normalized Anthropic client. Responses output_text.done is cumulative, while
+	// Anthropic clients assemble incremental content_block_delta events, so the
+	// converter needs this state to recover only a verified missing suffix without
+	// retaining a second full copy of the streamed response.
 	emittedTextByBlock map[int]*emittedTextProgress
 
 	// blockIndexMisses records non-empty item keys for which blockIndexFor was
@@ -247,13 +248,17 @@ type anthropicToResponsesStreamState struct {
 	codeExecServerClosedByItem map[string]bool
 }
 
-// emittedTextProgress records the byte length and SHA-256 state of one emitted text prefix.
+// emittedTextProgress records one Anthropic text block's wire-visible prefix.
+// emittedBytes locates the possible terminal suffix, while prefixHasher proves
+// that output_text.done still extends the exact bytes already sent. Keeping only
+// the count and digest makes the bookkeeping bounded regardless of output size.
 type emittedTextProgress struct {
 	emittedBytes int
 	prefixHasher hash.Hash
 }
 
-// recordEmittedText advances one block's bounded text progress.
+// recordEmittedText advances one block's bounded progress after a text delta is
+// known to be client-visible.
 func (s *anthropicToResponsesStreamState) recordEmittedText(blockIndex int, text string) {
 	if text == "" {
 		return
@@ -270,7 +275,9 @@ func (s *anthropicToResponsesStreamState) recordEmittedText(blockIndex int, text
 	progress.emittedBytes += len(text)
 }
 
-// recordEmittedTextEvents tracks text deltas that survived protocol validation and will reach the client.
+// recordEmittedTextEvents tracks only text deltas that survived protocol
+// validation and will reach the normalized client. Raw passthrough frames remain
+// authoritative, so the converter must neither track nor later supplement them.
 func (s *anthropicToResponsesStreamState) recordEmittedTextEvents(events []*AnthropicStreamEvent) {
 	if s.passthrough {
 		return
@@ -284,7 +291,11 @@ func (s *anthropicToResponsesStreamState) recordEmittedTextEvents(events []*Anth
 	}
 }
 
-// missingTerminalText returns the append-only suffix absent from prior emitted deltas.
+// missingTerminalText returns the append-only suffix not present in prior
+// client-visible deltas. Responses output_text.done carries cumulative text, so
+// the emitted prefix must match byte-for-byte before the remainder can safely be
+// converted into an Anthropic delta; a shorter or divergent aggregate is rejected
+// instead of duplicating or guessing client-visible content.
 func (s *anthropicToResponsesStreamState) missingTerminalText(blockIndex int, aggregate string) (string, bool) {
 	emittedBytes := 0
 	if progress := s.emittedTextByBlock[blockIndex]; progress != nil {
@@ -301,7 +312,8 @@ func (s *anthropicToResponsesStreamState) missingTerminalText(blockIndex int, ag
 	return missing, missing != ""
 }
 
-// clearEmittedTextProgress releases one content block's terminal-text bookkeeping.
+// clearEmittedTextProgress releases terminal-text bookkeeping once
+// output_item.done closes the corresponding Anthropic content block.
 func (s *anthropicToResponsesStreamState) clearEmittedTextProgress(key string) {
 	if key == "" || s.blockIndexByItem == nil || s.emittedTextByBlock == nil {
 		return
@@ -3316,6 +3328,10 @@ func toAnthropicResponsesStreamEvents(ctx *schemas.BifrostContext, bifrostResp *
 		}
 
 	case schemas.ResponsesStreamResponseTypeOutputTextDone:
+		// Runtime redaction may hold every output_text.delta and release the safe
+		// cumulative text only in output_text.done. Anthropic has no equivalent
+		// cumulative text event, so emit only the verified suffix before the block
+		// closes; passthrough streams keep their raw upstream frames authoritative.
 		state := getOrCreateAnthropicToResponsesStreamState(ctx)
 		if state.passthrough || bifrostResp.Text == nil || *bifrostResp.Text == "" {
 			return nil

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -1,10 +1,12 @@
 package anthropic
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"hash"
 	"maps"
 	"math"
 	"strings"
@@ -178,6 +180,12 @@ type anthropicToResponsesStreamState struct {
 	nextBlockIndex   int
 	blockIndexByItem map[string]int
 
+	// emittedTextByBlock holds bounded progress for text actually emitted to a
+	// normalized Anthropic client. Responses output_text.done is cumulative, so
+	// this lets the converter recover only its missing suffix without retaining a
+	// second full copy of the streamed response.
+	emittedTextByBlock map[int]*emittedTextProgress
+
 	// blockIndexMisses records non-empty item keys for which blockIndexFor was
 	// asked for an index that allocBlockIndex never assigned — i.e. a
 	// content_block_stop/_delta referencing a block whose content_block_start was
@@ -237,6 +245,70 @@ type anthropicToResponsesStreamState struct {
 	// Code can't carry and never spawns nested blocks, so it is left open here and
 	// closed at output_item.done from the verbatim carry input instead.
 	codeExecServerClosedByItem map[string]bool
+}
+
+// emittedTextProgress records the byte length and SHA-256 state of one emitted text prefix.
+type emittedTextProgress struct {
+	emittedBytes int
+	prefixHasher hash.Hash
+}
+
+// recordEmittedText advances one block's bounded text progress.
+func (s *anthropicToResponsesStreamState) recordEmittedText(blockIndex int, text string) {
+	if text == "" {
+		return
+	}
+	if s.emittedTextByBlock == nil {
+		s.emittedTextByBlock = make(map[int]*emittedTextProgress)
+	}
+	progress := s.emittedTextByBlock[blockIndex]
+	if progress == nil {
+		progress = &emittedTextProgress{prefixHasher: sha256.New()}
+		s.emittedTextByBlock[blockIndex] = progress
+	}
+	_, _ = progress.prefixHasher.Write([]byte(text))
+	progress.emittedBytes += len(text)
+}
+
+// recordEmittedTextEvents tracks text deltas that survived protocol validation and will reach the client.
+func (s *anthropicToResponsesStreamState) recordEmittedTextEvents(events []*AnthropicStreamEvent) {
+	if s.passthrough {
+		return
+	}
+	for _, event := range events {
+		if event == nil || event.Type != AnthropicStreamEventTypeContentBlockDelta || event.Index == nil ||
+			event.Delta == nil || event.Delta.Type != AnthropicStreamDeltaTypeText || event.Delta.Text == nil {
+			continue
+		}
+		s.recordEmittedText(*event.Index, *event.Delta.Text)
+	}
+}
+
+// missingTerminalText returns the append-only suffix absent from prior emitted deltas.
+func (s *anthropicToResponsesStreamState) missingTerminalText(blockIndex int, aggregate string) (string, bool) {
+	emittedBytes := 0
+	if progress := s.emittedTextByBlock[blockIndex]; progress != nil {
+		emittedBytes = progress.emittedBytes
+		if emittedBytes > len(aggregate) {
+			return "", false
+		}
+		aggregatePrefixHash := sha256.Sum256([]byte(aggregate[:emittedBytes]))
+		if !bytes.Equal(progress.prefixHasher.Sum(nil), aggregatePrefixHash[:]) {
+			return "", false
+		}
+	}
+	missing := aggregate[emittedBytes:]
+	return missing, missing != ""
+}
+
+// clearEmittedTextProgress releases one content block's terminal-text bookkeeping.
+func (s *anthropicToResponsesStreamState) clearEmittedTextProgress(key string) {
+	if key == "" || s.blockIndexByItem == nil || s.emittedTextByBlock == nil {
+		return
+	}
+	if blockIndex, ok := s.blockIndexByItem[key]; ok {
+		delete(s.emittedTextByBlock, blockIndex)
+	}
 }
 
 // allocBlockIndex assigns and returns the next Anthropic content-block index. A
@@ -549,8 +621,8 @@ func anthropicNativeEffortFrom(ctx *schemas.BifrostContext) (anthropicNativeEffo
 
 // SetResponsesStreamPassthrough marks this request's Anthropic reverse stream
 // conversion as running on the Claude Code passthrough path (raw upstream frames
-// interleaved with converted ones). The converter reads state.passthrough only for
-// collapsed server-tool result blocks that must still consume an upstream index.
+// interleaved with converted ones). The converter keeps raw upstream text
+// authoritative while still consuming indices for collapsed server-tool results.
 func SetResponsesStreamPassthrough(ctx *schemas.BifrostContext) {
 	getOrCreateAnthropicToResponsesStreamState(ctx).passthrough = true
 }
@@ -2784,7 +2856,10 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 	if len(events) == 0 || ctx == nil {
 		return events
 	}
-	return enforceStreamBlockTypes(getOrCreateAnthropicToResponsesStreamState(ctx), events)
+	state := getOrCreateAnthropicToResponsesStreamState(ctx)
+	events = enforceStreamBlockTypes(state, events)
+	state.recordEmittedTextEvents(events)
+	return events
 }
 
 // enforceStreamBlockTypes tracks the type each content_block_start opens and drops
@@ -3240,6 +3315,26 @@ func toAnthropicResponsesStreamEvents(ctx *schemas.BifrostContext, bifrostResp *
 			}
 		}
 
+	case schemas.ResponsesStreamResponseTypeOutputTextDone:
+		state := getOrCreateAnthropicToResponsesStreamState(ctx)
+		if state.passthrough || bifrostResp.Text == nil || *bifrostResp.Text == "" {
+			return nil
+		}
+		blockIndex, ok := state.blockIndexByItem[reverseStreamItemKey(bifrostResp)]
+		if !ok || state.blockType(blockIndex) != AnthropicContentBlockTypeText {
+			return nil
+		}
+		missing, ok := state.missingTerminalText(blockIndex, *bifrostResp.Text)
+		if !ok {
+			return nil
+		}
+		streamResp.Type = AnthropicStreamEventTypeContentBlockDelta
+		streamResp.Index = schemas.Ptr(blockIndex)
+		streamResp.Delta = &AnthropicStreamDelta{
+			Type: AnthropicStreamDeltaTypeText,
+			Text: schemas.Ptr(missing),
+		}
+
 	case schemas.ResponsesStreamResponseTypeFunctionCallArgumentsDelta:
 		// Skip WebSearch tool argument deltas - they will be sent synthetically in output_item.done
 		if bifrostResp.ItemID != nil {
@@ -3314,6 +3409,7 @@ func toAnthropicResponsesStreamEvents(ctx *schemas.BifrostContext, bifrostResp *
 		return nil
 
 	case schemas.ResponsesStreamResponseTypeOutputItemDone:
+		getOrCreateAnthropicToResponsesStreamState(ctx).clearEmittedTextProgress(reverseStreamItemKey(bifrostResp))
 		// Handle WebSearch tool completion with sanitization and synthetic delta generation
 		if bifrostResp.Item != nil &&
 			bifrostResp.Item.Type != nil &&

--- a/core/providers/anthropic/terminaltextstream_test.go
+++ b/core/providers/anthropic/terminaltextstream_test.go
@@ -1,0 +1,195 @@
+package anthropic
+
+import (
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// terminalTextItemAdded builds a text output-item start for reverse stream conversion.
+func terminalTextItemAdded(itemID string, outputIndex int) *schemas.BifrostResponsesStreamResponse {
+	return &schemas.BifrostResponsesStreamResponse{
+		Type:        schemas.ResponsesStreamResponseTypeOutputItemAdded,
+		OutputIndex: schemas.Ptr(outputIndex),
+		Item: &schemas.ResponsesMessage{
+			ID:   schemas.Ptr(itemID),
+			Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+		},
+	}
+}
+
+// terminalTextDelta builds one normalized output-text delta.
+func terminalTextDelta(itemID string, outputIndex int, text string) *schemas.BifrostResponsesStreamResponse {
+	return &schemas.BifrostResponsesStreamResponse{
+		Type:        schemas.ResponsesStreamResponseTypeOutputTextDelta,
+		ItemID:      schemas.Ptr(itemID),
+		OutputIndex: schemas.Ptr(outputIndex),
+		Delta:       schemas.Ptr(text),
+	}
+}
+
+// terminalTextDone builds the cumulative normalized output-text terminal event.
+func terminalTextDone(itemID string, outputIndex int, text string) *schemas.BifrostResponsesStreamResponse {
+	return &schemas.BifrostResponsesStreamResponse{
+		Type:        schemas.ResponsesStreamResponseTypeOutputTextDone,
+		ItemID:      schemas.Ptr(itemID),
+		OutputIndex: schemas.Ptr(outputIndex),
+		Text:        schemas.Ptr(text),
+	}
+}
+
+// terminalTextItemDone builds the output-item terminal event that closes the Anthropic block.
+func terminalTextItemDone(itemID string, outputIndex int) *schemas.BifrostResponsesStreamResponse {
+	return &schemas.BifrostResponsesStreamResponse{
+		Type:        schemas.ResponsesStreamResponseTypeOutputItemDone,
+		OutputIndex: schemas.Ptr(outputIndex),
+		Item: &schemas.ResponsesMessage{
+			ID:   schemas.Ptr(itemID),
+			Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+		},
+	}
+}
+
+// convertTerminalTextEvents runs normalized events through the Bifrost-to-Anthropic converter.
+func convertTerminalTextEvents(ctx *schemas.BifrostContext, responses ...*schemas.BifrostResponsesStreamResponse) []*AnthropicStreamEvent {
+	var events []*AnthropicStreamEvent
+	for _, response := range responses {
+		events = append(events, ToAnthropicResponsesStreamResponse(ctx, response)...)
+	}
+	return events
+}
+
+// terminalTextDeltas reconstructs client-visible text from Anthropic text deltas only.
+func terminalTextDeltas(events []*AnthropicStreamEvent) string {
+	var text string
+	for _, event := range events {
+		if event.Type == AnthropicStreamEventTypeContentBlockDelta &&
+			event.Delta != nil && event.Delta.Type == AnthropicStreamDeltaTypeText && event.Delta.Text != nil {
+			text += *event.Delta.Text
+		}
+	}
+	return text
+}
+
+// TestTerminalTextStreamEmitsOnlyMissingSuffix verifies held and partially released output is completed once.
+func TestTerminalTextStreamEmitsOnlyMissingSuffix(t *testing.T) {
+	tests := []struct {
+		name         string
+		deltas       []string
+		aggregate    string
+		want         string
+		wantTerminal string
+	}{
+		{name: "short held reply", deltas: []string{"", ""}, aggregate: "OK", want: "OK", wantTerminal: "OK"},
+		{name: "partially released reply", deltas: []string{"First sentence. "}, aggregate: "First sentence. Final sentence.", want: "First sentence. Final sentence.", wantTerminal: "Final sentence."},
+		{name: "normal stream", deltas: []string{"O", "K"}, aggregate: "OK", want: "OK", wantTerminal: ""},
+		{name: "redaction changes byte length", deltas: []string{"Contact [EMAIL]. "}, aggregate: "Contact [EMAIL]. Done.", want: "Contact [EMAIL]. Done.", wantTerminal: "Done."},
+		{name: "unicode prefix", deltas: []string{"Hello 世界. "}, aggregate: "Hello 世界. Done.", want: "Hello 世界. Done.", wantTerminal: "Done."},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := schemas.NewBifrostContext(nil, time.Time{})
+			responses := []*schemas.BifrostResponsesStreamResponse{terminalTextItemAdded("msg_1", 0)}
+			for _, delta := range test.deltas {
+				responses = append(responses, terminalTextDelta("msg_1", 0, delta))
+			}
+
+			beforeTerminal := convertTerminalTextEvents(ctx, responses...)
+			terminalEvents := convertTerminalTextEvents(ctx, terminalTextDone("msg_1", 0, test.aggregate))
+			allEvents := append(beforeTerminal, terminalEvents...)
+			if got := terminalTextDeltas(allEvents); got != test.want {
+				t.Fatalf("reconstructed text = %q, want %q", got, test.want)
+			}
+			if got := terminalTextDeltas(terminalEvents); got != test.wantTerminal {
+				t.Fatalf("terminal text delta = %q, want %q", got, test.wantTerminal)
+			}
+		})
+	}
+}
+
+// TestTerminalTextStreamTracksBlocksIndependently verifies interleaved text items do not share progress.
+func TestTerminalTextStreamTracksBlocksIndependently(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	events := convertTerminalTextEvents(ctx,
+		terminalTextItemAdded("msg_1", 0),
+		terminalTextDelta("msg_1", 0, "First "),
+		terminalTextItemAdded("msg_2", 1),
+		terminalTextDelta("msg_2", 1, "Second "),
+		terminalTextDone("msg_1", 0, "First done."),
+		terminalTextDone("msg_2", 1, "Second done."),
+	)
+
+	wantByBlock := map[int]string{0: "First done.", 1: "Second done."}
+	gotByBlock := make(map[int]string)
+	for _, event := range events {
+		if event.Type == AnthropicStreamEventTypeContentBlockDelta && event.Index != nil &&
+			event.Delta != nil && event.Delta.Type == AnthropicStreamDeltaTypeText && event.Delta.Text != nil {
+			gotByBlock[*event.Index] += *event.Delta.Text
+		}
+	}
+	for index, want := range wantByBlock {
+		if got := gotByBlock[index]; got != want {
+			t.Errorf("block %d text = %q, want %q", index, got, want)
+		}
+	}
+}
+
+// TestTerminalTextStreamRejectsNonAppendOnlyAggregate verifies unsafe terminal aggregates never synthesize guessed text.
+func TestTerminalTextStreamRejectsNonAppendOnlyAggregate(t *testing.T) {
+	tests := []struct {
+		name      string
+		aggregate string
+	}{
+		{name: "shorter", aggregate: "Fir"},
+		{name: "prefix mismatch", aggregate: "Changed sentence. Final."},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := schemas.NewBifrostContext(nil, time.Time{})
+			convertTerminalTextEvents(ctx,
+				terminalTextItemAdded("msg_1", 0),
+				terminalTextDelta("msg_1", 0, "First sentence. "),
+			)
+			if events := convertTerminalTextEvents(ctx, terminalTextDone("msg_1", 0, test.aggregate)); len(events) != 0 {
+				t.Fatalf("unsafe aggregate emitted events: %#v", events)
+			}
+		})
+	}
+
+	t.Run("unopened block", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+		if events := convertTerminalTextEvents(ctx, terminalTextDone("msg_missing", 0, "OK")); len(events) != 0 {
+			t.Fatalf("unopened block emitted events: %#v", events)
+		}
+	})
+}
+
+// TestTerminalTextStreamPassthroughNeverSynthesizes verifies raw Claude Code frames remain authoritative.
+func TestTerminalTextStreamPassthroughNeverSynthesizes(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	SetResponsesStreamPassthrough(ctx)
+	convertTerminalTextEvents(ctx, terminalTextItemAdded("msg_1", 0))
+
+	if events := convertTerminalTextEvents(ctx, terminalTextDone("msg_1", 0, "OK")); len(events) != 0 {
+		t.Fatalf("passthrough output_text.done synthesized events: %#v", events)
+	}
+}
+
+// TestTerminalTextStreamDeltaPrecedesStop verifies the recovered suffix is emitted before its block closes.
+func TestTerminalTextStreamDeltaPrecedesStop(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	convertTerminalTextEvents(ctx, terminalTextItemAdded("msg_1", 0))
+	terminalEvents := convertTerminalTextEvents(ctx, terminalTextDone("msg_1", 0, "OK"))
+	stopEvents := convertTerminalTextEvents(ctx, terminalTextItemDone("msg_1", 0))
+	events := append(terminalEvents, stopEvents...)
+
+	if len(events) != 2 || events[0].Type != AnthropicStreamEventTypeContentBlockDelta || events[1].Type != AnthropicStreamEventTypeContentBlockStop {
+		t.Fatalf("terminal event order = %#v, want text delta then block stop", events)
+	}
+	if progress := getOrCreateAnthropicToResponsesStreamState(ctx).emittedTextByBlock; len(progress) != 0 {
+		t.Fatalf("emitted text progress leaked after block stop: %#v", progress)
+	}
+}

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -223,6 +223,31 @@ func SetJSONField(data []byte, path string, value interface{}) ([]byte, error) {
 	return sjson.SetBytes(data, path, value)
 }
 
+// setJSONStringFieldInPlaceOptions enables SJSON's owned-buffer fast path.
+// Keep this immutable because provider requests can be rewritten concurrently.
+var setJSONStringFieldInPlaceOptions = sjson.Options{
+	// Optimistic tells SJSON that the path already exists, enabling its faster
+	// direct search-and-replace path; it does not permit mutation by itself.
+	Optimistic: true,
+	// ReplaceInPlace permits SJSON to reuse and mutate caller-owned bytes when
+	// the replacement fits; otherwise SJSON returns a newly allocated buffer.
+	ReplaceInPlace: true,
+}
+
+// SetJSONStringFieldInPlace updates an existing JSON string in caller-owned bytes.
+// It is currently used only for native raw-request redaction on passthrough
+// integrations such as Claude Code/Anthropic and Gemini GenAI. Callers must use
+// the returned slice because SJSON may reuse the input or allocate a new buffer.
+// This reduces allocations and GC pressure, but each field still requires a path
+// search and may shift trailing bytes; this is not a bulk update.
+func SetJSONStringFieldInPlace(data []byte, path string, value string) ([]byte, error) {
+	encodedValue, err := sonic.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("marshal JSON string field: %w", err)
+	}
+	return sjson.SetRawBytesOptions(data, path, encodedValue, &setJSONStringFieldInPlaceOptions)
+}
+
 // SetRawJSONField sets a field in JSON bytes to an already-encoded JSON document,
 // inserting it verbatim instead of re-marshaling it.
 func SetRawJSONField(data []byte, path string, value []byte) ([]byte, error) {

--- a/core/providers/utils/utilsjson_test.go
+++ b/core/providers/utils/utilsjson_test.go
@@ -1,10 +1,12 @@
 package utils
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 func TestSetJSONField(t *testing.T) {
@@ -44,10 +46,10 @@ func TestSetJSONField(t *testing.T) {
 			expected: `{"betas":["a","b"]}`,
 		},
 		{
-			name:  "preserves_existing_fields",
-			data:  []byte(`{"a":1,"b":2}`),
-			path:  "c",
-			value: 3,
+			name:     "preserves_existing_fields",
+			data:     []byte(`{"a":1,"b":2}`),
+			path:     "c",
+			value:    3,
 			expected: `{"a":1,"b":2,"c":3}`,
 		},
 	}
@@ -59,6 +61,43 @@ func TestSetJSONField(t *testing.T) {
 			assert.Equal(t, tt.expected, string(result), "exact byte-level ordering must match")
 		})
 	}
+}
+
+// TestSetJSONStringFieldInPlace verifies owned-buffer reuse without sacrificing JSON string encoding or allocation fallback.
+func TestSetJSONStringFieldInPlace(t *testing.T) {
+	t.Run("shorter replacement reuses owned bytes", func(t *testing.T) {
+		data := []byte(`{"message":"alice@example.com","metadata":"keep"}`)
+		result, err := SetJSONStringFieldInPlace(data, "message", "[EMAIL]")
+
+		require.NoError(t, err)
+		require.NotEmpty(t, result)
+		assert.Equal(t, "[EMAIL]", gjson.GetBytes(result, "message").String())
+		assert.Equal(t, "keep", gjson.GetBytes(result, "metadata").String())
+		assert.True(t, &data[0] == &result[0], "a shorter replacement should reuse the owned backing array")
+	})
+
+	t.Run("escaped and unicode replacement remains valid JSON", func(t *testing.T) {
+		data := []byte(`{"message":"a sufficiently long original string","metadata":"keep"}`)
+		replacement := `["EMAIL"] \\ 日本`
+		result, err := SetJSONStringFieldInPlace(data, "message", replacement)
+
+		require.NoError(t, err)
+		assert.True(t, gjson.ValidBytes(result))
+		assert.Equal(t, replacement, gjson.GetBytes(result, "message").String())
+		assert.Equal(t, "keep", gjson.GetBytes(result, "metadata").String())
+	})
+
+	t.Run("longer replacement allocates without mutating input", func(t *testing.T) {
+		data := []byte(`{"message":"x","metadata":"keep"}`)
+		original := bytes.Clone(data)
+		result, err := SetJSONStringFieldInPlace(data, "message", "a replacement longer than the original")
+
+		require.NoError(t, err)
+		require.NotEmpty(t, result)
+		assert.Equal(t, "a replacement longer than the original", gjson.GetBytes(result, "message").String())
+		assert.Equal(t, original, data, "allocation fallback must not partially mutate the input")
+		assert.False(t, &data[0] == &result[0], "a growing replacement cannot reuse the original backing array")
+	})
 }
 
 func TestDeleteJSONField(t *testing.T) {

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -282,6 +282,7 @@ const (
 	BifrostContextKeyPassthroughHeaders                  BifrostContextKey = "bifrost-anthropic-passthrough-headers"  // map[string][]string (the caller's raw request headers, captured for Anthropic OAuth passthrough where their token is the upstream credential; ONLY the Anthropic provider may forward these — every other provider authenticates with its own configured credentials. Reserved: set by the transport, never by a plugin)
 	BifrostContextKeyURLPath                             BifrostContextKey = "bifrost-extra-url-path"                 // string
 	BifrostContextKeyUseRawRequestBody                   BifrostContextKey = "bifrost-use-raw-request-body"
+	BifrostContextKeyRawRequestBodyTextRewriter          BifrostContextKey = "bifrost-raw-request-body-text-rewriter"           // RawRequestBodyTextRewriter (set by native integrations because raw passthrough bypasses normalized runtime redaction)
 	BifrostContextKeyChangeRequestType                   BifrostContextKey = "bifrost-change-request-type"                      // RequestType (set by plugins to trigger request type conversion in core, e.g. text->chat or chat->responses)
 	BifrostContextKeySendBackRawRequest                  BifrostContextKey = "bifrost-send-back-raw-request"                    // bool (per-request override — read by bifrost.go, never overwritten)
 	BifrostContextKeySendBackRawResponse                 BifrostContextKey = "bifrost-send-back-raw-response"                   // bool (per-request override — read by bifrost.go, never overwritten)

--- a/core/schemas/redaction.go
+++ b/core/schemas/redaction.go
@@ -6,6 +6,12 @@ import (
 	"strings"
 )
 
+// RawRequestBodyTextRewriter synchronizes runtime literal replacements into provider-native JSON.
+// Integrations implement this contract because only they know which native fields correspond to
+// guardrail-visible normalized text. Callers must pass owned rawBody bytes and use only the returned
+// slice because implementations may mutate the input in place; any rewrite error is unsafe to forward.
+type RawRequestBodyTextRewriter func(rawBody []byte, replacements map[string]string) ([]byte, error)
+
 // RedactionPhase identifies which request lifecycle phase produced a redaction finding.
 type RedactionPhase string
 

--- a/core/utils.go
+++ b/core/utils.go
@@ -422,6 +422,7 @@ func ClearContextForInternalRequest(ctx *schemas.BifrostContext) {
 	ctx.ClearValue(schemas.BifrostContextKeySkipKeySelection)
 	// Body transport.
 	ctx.ClearValue(schemas.BifrostContextKeyUseRawRequestBody)
+	ctx.ClearValue(schemas.BifrostContextKeyRawRequestBodyTextRewriter)
 	ctx.ClearValue(schemas.BifrostContextKeySendBackRawRequest)
 	ctx.ClearValue(schemas.BifrostContextKeySendBackRawResponse)
 	ctx.ClearValue(schemas.BifrostContextKeyPassthroughOverridesPresent)

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -303,9 +303,9 @@ func hydrateAnthropicRequestFromLargePayloadMetadata(bifrostCtx *schemas.Bifrost
 	}
 }
 
-// checkAnthropicPassthrough pre-callback checks if the request is for a claude model.
-// If it is, it attaches the raw request body for direct use by the provider.
-// It also checks for anthropic oauth headers and sets the bifrost context.
+// checkAnthropicPassthrough configures provider-native forwarding for Claude Code requests.
+// Alongside the required auth, path, and raw-response settings, it registers an
+// Anthropic-owned text rewriter so raw request bytes cannot bypass runtime redaction.
 func checkAnthropicPassthrough(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, req any) error {
 	hydrateAnthropicRequestFromLargePayloadMetadata(bifrostCtx, req)
 
@@ -352,6 +352,117 @@ func checkAnthropicPassthrough(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.Bif
 		if (provider == schemas.Vertex || provider == schemas.BedrockMantle || provider == schemas.Azure) && hasOutputConfigFormat(req) {
 			bifrostCtx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, false)
 			return nil
+		}
+		// Raw passthrough preserves native-only fields but skips normalized request
+		// serialization, so Guardrails needs an integration-owned path rewriter.
+		bifrostCtx.SetValue(
+			schemas.BifrostContextKeyRawRequestBodyTextRewriter,
+			schemas.RawRequestBodyTextRewriter(rewriteAnthropicRawRequestBody),
+		)
+	}
+	return nil
+}
+
+// rewriteAnthropicRawRequestBody applies runtime replacements only to Anthropic fields mirrored as mutable normalized text.
+// Keeping the allowlist here preserves native metadata and other fields Guardrails did not inspect.
+func rewriteAnthropicRawRequestBody(rawBody []byte, replacements map[string]string) ([]byte, error) {
+	return rewriteRawRequestTextFields(rawBody, replacements, collectAnthropicRawRequestTextPaths)
+}
+
+// anthropicRawContentScope controls which native content-block text fields are guardrail-visible.
+type anthropicRawContentScope uint8
+
+const (
+	anthropicRawContentScopeSystem anthropicRawContentScope = iota
+	anthropicRawContentScopeMessage
+	anthropicRawContentScopeToolResult
+)
+
+// collectAnthropicRawRequestTextPaths enumerates Anthropic fields mirrored into mutable Bifrost request text.
+func collectAnthropicRawRequestTextPaths(root gjson.Result, replacements map[string]string) ([]string, error) {
+	paths := make([]string, 0)
+	if err := appendRawRequestStringPath(&paths, root.Get("prompt"), "prompt"); err != nil {
+		return nil, err
+	}
+	if err := collectAnthropicRawContentPaths(&paths, root.Get("system"), "system", anthropicRawContentScopeSystem); err != nil {
+		return nil, err
+	}
+
+	messages := root.Get("messages")
+	if !messages.Exists() || messages.Type == gjson.Null {
+		return paths, nil
+	}
+	if !messages.IsArray() {
+		return nil, fmt.Errorf("raw Anthropic request messages must be an array")
+	}
+	var collectErr error
+	messages.ForEach(func(index, message gjson.Result) bool {
+		messagePath := rawRequestArrayPath("messages", int(index.Int()))
+		collectErr = collectAnthropicRawContentPaths(
+			&paths,
+			message.Get("content"),
+			rawRequestObjectPath(messagePath, "content"),
+			anthropicRawContentScopeMessage,
+		)
+		return collectErr == nil
+	})
+	return paths, collectErr
+}
+
+// collectAnthropicRawContentPaths handles the string, block-array, and single-block Anthropic content union.
+func collectAnthropicRawContentPaths(paths *[]string, content gjson.Result, path string, scope anthropicRawContentScope) error {
+	if !content.Exists() || content.Type == gjson.Null {
+		return nil
+	}
+	if content.Type == gjson.String {
+		*paths = append(*paths, path)
+		return nil
+	}
+	if content.IsObject() {
+		return collectAnthropicRawContentBlockPaths(paths, content, path, scope)
+	}
+	if !content.IsArray() {
+		return fmt.Errorf("raw Anthropic content path %q must be a string, object, or array", path)
+	}
+
+	var collectErr error
+	content.ForEach(func(index, block gjson.Result) bool {
+		collectErr = collectAnthropicRawContentBlockPaths(paths, block, rawRequestArrayPath(path, int(index.Int())), scope)
+		return collectErr == nil
+	})
+	return collectErr
+}
+
+// collectAnthropicRawContentBlockPaths selects only block fields represented as mutable normalized text.
+func collectAnthropicRawContentBlockPaths(paths *[]string, block gjson.Result, path string, scope anthropicRawContentScope) error {
+	if !block.IsObject() {
+		return fmt.Errorf("raw Anthropic content block at %q must be an object", path)
+	}
+	blockType := block.Get("type")
+	if !blockType.Exists() || blockType.Type == gjson.Null {
+		return nil
+	}
+	if blockType.Type != gjson.String {
+		return fmt.Errorf("raw Anthropic content block type at %q must be a string", path)
+	}
+
+	switch scope {
+	case anthropicRawContentScopeSystem, anthropicRawContentScopeToolResult:
+		if blockType.String() == string(anthropic.AnthropicContentBlockTypeText) {
+			return appendRawRequestStringPath(paths, block.Get("text"), rawRequestObjectPath(path, "text"))
+		}
+		return nil
+	case anthropicRawContentScopeMessage:
+		switch anthropic.AnthropicContentBlockType(blockType.String()) {
+		case anthropic.AnthropicContentBlockTypeText:
+			return appendRawRequestStringPath(paths, block.Get("text"), rawRequestObjectPath(path, "text"))
+		case anthropic.AnthropicContentBlockTypeToolResult, anthropic.AnthropicContentBlockTypeMCPToolResult:
+			return collectAnthropicRawContentPaths(
+				paths,
+				block.Get("content"),
+				rawRequestObjectPath(path, "content"),
+				anthropicRawContentScopeToolResult,
+			)
 		}
 	}
 	return nil

--- a/transports/bifrost-http/integrations/anthropic_test.go
+++ b/transports/bifrost-http/integrations/anthropic_test.go
@@ -7,8 +7,98 @@ import (
 
 	"github.com/maximhq/bifrost/core/providers/anthropic"
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/tidwall/gjson"
 	"github.com/valyala/fasthttp"
 )
+
+// TestRewriteAnthropicRawRequestBodyRedactsOnlyContentFields verifies native redaction covers conversation content without touching request metadata or tool arguments.
+func TestRewriteAnthropicRawRequestBodyRedactsOnlyContentFields(t *testing.T) {
+	rawBody := []byte(`{
+		"model":"claude-sonnet-4-5",
+		"prompt":"legacy alice@example.com",
+		"system":[{"type":"text","text":"system alice@example.com"}],
+		"messages":[
+			{"role":"user","content":"first alice@example.com"},
+			{"role":"assistant","content":[
+				{"type":"thinking","thinking":"reason alice@example.com","signature":"alice@example.com"},
+				{"type":"redacted_thinking","data":"alice@example.com"},
+				{"type":"compaction","content":"summary alice@example.com"},
+				{"type":"text","text":"answer alice@example.com"},
+				{"type":"tool_use","id":"call_1","name":"lookup","input":{"email":"alice@example.com"}}
+			]},
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"call_1","content":"tool alice@example.com"},
+				{"type":"mcp_tool_result","tool_use_id":"call_2","content":[{"type":"text","text":"nested alice@example.com"}]}
+			]}
+		],
+		"metadata":{"user_id":"alice@example.com"},
+		"tools":[{"name":"lookup","description":"alice@example.com","input_schema":{"type":"object"}}]
+	}`)
+
+	got, err := rewriteAnthropicRawRequestBody(rawBody, map[string]string{"alice@example.com": "[EMAIL]"})
+	if err != nil {
+		t.Fatalf("rewriteAnthropicRawRequestBody() error = %v", err)
+	}
+
+	redactedPaths := []string{
+		"prompt",
+		"system.0.text",
+		"messages.0.content",
+		"messages.1.content.3.text",
+		"messages.2.content.0.content",
+		"messages.2.content.1.content.0.text",
+	}
+	for _, path := range redactedPaths {
+		if value := gjson.GetBytes(got, path).String(); strings.Contains(value, "alice@example.com") || !strings.Contains(value, "[EMAIL]") {
+			t.Errorf("%s = %q, want redacted content", path, value)
+		}
+	}
+
+	untouchedPaths := map[string]string{
+		"messages.1.content.0.thinking":    "reason alice@example.com",
+		"messages.1.content.0.signature":   "alice@example.com",
+		"messages.1.content.1.data":        "alice@example.com",
+		"messages.1.content.2.content":     "summary alice@example.com",
+		"messages.1.content.4.input.email": "alice@example.com",
+		"metadata.user_id":                 "alice@example.com",
+		"tools.0.description":              "alice@example.com",
+	}
+	for path, expected := range untouchedPaths {
+		if value := gjson.GetBytes(got, path).String(); value != expected {
+			t.Errorf("%s = %q, want untouched %q", path, value, expected)
+		}
+	}
+}
+
+// TestRewriteAnthropicRawRequestBodyRejectsUnmappedLiteral verifies a normalized runtime mutation cannot silently leave native content unredacted.
+func TestRewriteAnthropicRawRequestBodyRejectsUnmappedLiteral(t *testing.T) {
+	_, err := rewriteAnthropicRawRequestBody(
+		[]byte(`{"messages":[{"role":"user","content":"hello"}]}`),
+		map[string]string{"alice@example.com": "[EMAIL]"},
+	)
+	if err == nil {
+		t.Fatal("rewriteAnthropicRawRequestBody() error = nil, want unmapped literal error")
+	}
+}
+
+// TestRewriteAnthropicRawRequestBodyRejectsMalformedJSON verifies native rewrites never repair or forward a malformed body.
+func TestRewriteAnthropicRawRequestBodyRejectsMalformedJSON(t *testing.T) {
+	_, err := rewriteAnthropicRawRequestBody([]byte(`{"messages":`), map[string]string{"alice@example.com": "[EMAIL]"})
+	if err == nil {
+		t.Fatal("rewriteAnthropicRawRequestBody() error = nil, want malformed JSON error")
+	}
+}
+
+// TestRewriteAnthropicRawRequestBodyRejectsDuplicateKeys prevents parser precedence from selecting an unredacted duplicate value.
+func TestRewriteAnthropicRawRequestBodyRejectsDuplicateKeys(t *testing.T) {
+	_, err := rewriteAnthropicRawRequestBody(
+		[]byte(`{"messages":[{"role":"user","content":"alice@example.com","content":"alice@example.com"}]}`),
+		map[string]string{"alice@example.com": "[EMAIL]"},
+	)
+	if err == nil {
+		t.Fatal("rewriteAnthropicRawRequestBody() error = nil, want duplicate-key error")
+	}
+}
 
 // TestMustConvertInPassthrough pins the passthrough routing decision that fixes
 // the Claude Code advisor/server-tool streaming bug: server tools (advisor,
@@ -188,6 +278,13 @@ func TestCheckAnthropicPassthrough_OutputConfigEscapeHatch(t *testing.T) {
 			}
 			if !tc.wantRawOff && !useRaw {
 				t.Errorf("expected UseRawRequestBody to stay true for %s, got false", tc.model)
+			}
+			_, hasRewriter := bifrostCtx.Value(schemas.BifrostContextKeyRawRequestBodyTextRewriter).(schemas.RawRequestBodyTextRewriter)
+			if tc.wantRawOff && hasRewriter {
+				t.Errorf("expected raw request body text rewriter to remain unset for %s", tc.model)
+			}
+			if !tc.wantRawOff && !hasRewriter {
+				t.Errorf("expected Anthropic raw request body text rewriter for %s", tc.model)
 			}
 		})
 	}

--- a/transports/bifrost-http/integrations/genai.go
+++ b/transports/bifrost-http/integrations/genai.go
@@ -1396,7 +1396,9 @@ func getLargeRequestTypeDetectionThreshold(ctx *fasthttp.RequestCtx) int64 {
 	return schemas.DefaultLargePayloadRequestThresholdBytes
 }
 
-// extractAndSetModelAndRequestType extracts model and request type from URL and request object and sets it in the request
+// extractAndSetModelAndRequestType derives GenAI routing flags and configures native Gemini passthrough.
+// GeminiGenerationRequest and GeminiCountTokensRequest also register a path-aware rewriter because
+// their raw bytes otherwise bypass runtime guardrail mutations made to the normalized request.
 func extractAndSetModelAndRequestType(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, req interface{}) error {
 	model := ctx.UserValue("model")
 	if model == nil {
@@ -1496,7 +1498,7 @@ func extractAndSetModelAndRequestType(ctx *fasthttp.RequestCtx, bifrostCtx *sche
 		}
 		if !r.IsEmbedding && explicitGemini {
 			setGenAIRawRequestBodyFromRequest(ctx, bifrostCtx)
-			bifrostCtx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+			enableGenAIRawRequestBodyRedaction(bifrostCtx)
 		}
 
 		return nil
@@ -1506,7 +1508,7 @@ func extractAndSetModelAndRequestType(ctx *fasthttp.RequestCtx, bifrostCtx *sche
 		}
 		if explicitGemini {
 			setGenAIRawRequestBodyFromRequest(ctx, bifrostCtx)
-			bifrostCtx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+			enableGenAIRawRequestBodyRedaction(bifrostCtx)
 		}
 		return nil
 	case *gemini.GeminiEmbeddingRequest:
@@ -1541,6 +1543,145 @@ func setGenAIRawRequestBodyFromRequest(ctx *fasthttp.RequestCtx, bifrostCtx *sch
 	if body := ctx.Request.Body(); len(body) > 0 {
 		bifrostCtx.SetValue(genAIRawRequestBodyContextKey, copyBytes(body))
 	}
+}
+
+// enableGenAIRawRequestBodyRedaction couples Gemini raw passthrough with its native content rewriter.
+// The two settings must travel together so provider-specific fields are preserved without bypassing runtime redaction.
+func enableGenAIRawRequestBodyRedaction(bifrostCtx *schemas.BifrostContext) {
+	bifrostCtx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+	bifrostCtx.SetValue(
+		schemas.BifrostContextKeyRawRequestBodyTextRewriter,
+		schemas.RawRequestBodyTextRewriter(rewriteGenAIRawRequestBody),
+	)
+}
+
+// rewriteGenAIRawRequestBody applies runtime replacements only to Gemini fields mirrored as mutable normalized text.
+// Keeping the allowlist here preserves configuration and other native fields Guardrails did not inspect.
+func rewriteGenAIRawRequestBody(rawBody []byte, replacements map[string]string) ([]byte, error) {
+	return rewriteRawRequestTextFields(rawBody, replacements, collectGenAIRawRequestTextPaths)
+}
+
+// collectGenAIRawRequestTextPaths enumerates flat and countTokens-enveloped Gemini content fields.
+func collectGenAIRawRequestTextPaths(root gjson.Result, replacements map[string]string) ([]string, error) {
+	paths := make([]string, 0)
+	if err := collectGenAIGenerationTextPaths(&paths, root, "", replacements); err != nil {
+		return nil, err
+	}
+	for _, envelopeKey := range []string{"generateContentRequest", "generate_content_request"} {
+		envelope := root.Get(envelopeKey)
+		if !envelope.Exists() || envelope.Type == gjson.Null {
+			continue
+		}
+		if !envelope.IsObject() {
+			return nil, fmt.Errorf("raw Gemini countTokens envelope %q must be an object", envelopeKey)
+		}
+		if err := collectGenAIGenerationTextPaths(&paths, envelope, rawRequestObjectPath("", envelopeKey), replacements); err != nil {
+			return nil, err
+		}
+	}
+	return paths, nil
+}
+
+// collectGenAIGenerationTextPaths selects Gemini generation fields mirrored into mutable Bifrost request text.
+func collectGenAIGenerationTextPaths(paths *[]string, request gjson.Result, path string, replacements map[string]string) error {
+	if !request.IsObject() {
+		return fmt.Errorf("raw Gemini generation request at %q must be an object", path)
+	}
+	for _, systemKey := range []string{"systemInstruction", "system_instruction"} {
+		if err := collectGenAIContentTextPaths(
+			paths,
+			request.Get(systemKey),
+			rawRequestObjectPath(path, systemKey),
+			false,
+			replacements,
+		); err != nil {
+			return err
+		}
+	}
+
+	contents := request.Get("contents")
+	if contents.Exists() && contents.Type != gjson.Null {
+		if !contents.IsArray() {
+			return fmt.Errorf("raw Gemini contents at %q must be an array", rawRequestObjectPath(path, "contents"))
+		}
+		var collectErr error
+		contentsPath := rawRequestObjectPath(path, "contents")
+		contents.ForEach(func(index, content gjson.Result) bool {
+			collectErr = collectGenAIContentTextPaths(
+				paths,
+				content,
+				rawRequestArrayPath(contentsPath, int(index.Int())),
+				true,
+				replacements,
+			)
+			return collectErr == nil
+		})
+		if collectErr != nil {
+			return collectErr
+		}
+	}
+
+	instances := request.Get("instances")
+	if !instances.Exists() || instances.Type == gjson.Null {
+		return nil
+	}
+	if !instances.IsArray() {
+		return fmt.Errorf("raw Gemini instances at %q must be an array", rawRequestObjectPath(path, "instances"))
+	}
+	instancesPath := rawRequestObjectPath(path, "instances")
+	var collectErr error
+	instances.ForEach(func(index, instance gjson.Result) bool {
+		instancePath := rawRequestArrayPath(instancesPath, int(index.Int()))
+		collectErr = appendRawRequestStringPath(paths, instance.Get("prompt"), rawRequestObjectPath(instancePath, "prompt"))
+		return collectErr == nil
+	})
+	return collectErr
+}
+
+// collectGenAIContentTextPaths selects text parts and supported function-response JSON values from one Gemini content object.
+func collectGenAIContentTextPaths(paths *[]string, content gjson.Result, path string, includeFunctionResponses bool, replacements map[string]string) error {
+	if !content.Exists() || content.Type == gjson.Null {
+		return nil
+	}
+	if !content.IsObject() {
+		return fmt.Errorf("raw Gemini content at %q must be an object", path)
+	}
+	parts := content.Get("parts")
+	if !parts.Exists() || parts.Type == gjson.Null {
+		return nil
+	}
+	if !parts.IsArray() {
+		return fmt.Errorf("raw Gemini content parts at %q must be an array", rawRequestObjectPath(path, "parts"))
+	}
+
+	partsPath := rawRequestObjectPath(path, "parts")
+	var collectErr error
+	parts.ForEach(func(index, part gjson.Result) bool {
+		partPath := rawRequestArrayPath(partsPath, int(index.Int()))
+		if collectErr = appendRawRequestStringPath(paths, part.Get("text"), rawRequestObjectPath(partPath, "text")); collectErr != nil {
+			return false
+		}
+		if !includeFunctionResponses {
+			return true
+		}
+		functionResponse := part.Get("functionResponse")
+		if !functionResponse.Exists() || functionResponse.Type == gjson.Null {
+			return true
+		}
+		functionResponsePath := rawRequestObjectPath(partPath, "functionResponse")
+		if !functionResponse.IsObject() {
+			collectErr = fmt.Errorf("raw Gemini function response at %q must be an object", functionResponsePath)
+			return false
+		}
+		collectErr = appendRawRequestJSONLeafPaths(
+			paths,
+			functionResponse.Get("response"),
+			rawRequestObjectPath(functionResponsePath, "response"),
+			replacements,
+		)
+		return collectErr == nil
+	})
+	return collectErr
 }
 
 func copyBytes(in []byte) []byte {

--- a/transports/bifrost-http/integrations/genai_test.go
+++ b/transports/bifrost-http/integrations/genai_test.go
@@ -2,6 +2,7 @@ package integrations
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/bytedance/sonic"
@@ -10,8 +11,83 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 	"github.com/valyala/fasthttp"
 )
+
+// TestRewriteGenAIRawRequestBodyRedactsOnlyContentFields verifies Gemini redaction covers native text and function-result values without touching metadata or function-call arguments.
+func TestRewriteGenAIRawRequestBodyRedactsOnlyContentFields(t *testing.T) {
+	rawBody := []byte(`{
+		"systemInstruction":{"parts":[{"text":"system alice@example.com"}]},
+		"contents":[
+			{"role":"user","parts":[{"text":"first alice@example.com"}]},
+			{"role":"model","parts":[
+				{"thought":true,"text":"reason alice@example.com","thoughtSignature":"alice@example.com"},
+				{"functionCall":{"name":"lookup","args":{"email":"alice@example.com"}}}
+			]},
+			{"role":"user","parts":[{"functionResponse":{"name":"lookup","response":{"output":"tool alice@example.com","nested.value":{"contact:key":"alice@example.com"}}}}]}
+		],
+		"instances":[{"prompt":"image alice@example.com"}],
+		"labels":{"owner":"alice@example.com"},
+		"tools":[{"functionDeclarations":[{"name":"lookup","description":"alice@example.com"}]}]
+	}`)
+
+	got, err := rewriteGenAIRawRequestBody(rawBody, map[string]string{"alice@example.com": "[EMAIL]"})
+	require.NoError(t, err)
+
+	redactedPaths := []string{
+		"systemInstruction.parts.0.text",
+		"contents.0.parts.0.text",
+		"contents.1.parts.0.text",
+		"contents.2.parts.0.functionResponse.response.output",
+		`contents.2.parts.0.functionResponse.response.nested\.value.contact:key`,
+		"instances.0.prompt",
+	}
+	for _, path := range redactedPaths {
+		value := gjson.GetBytes(got, path).String()
+		assert.NotContains(t, value, "alice@example.com", path)
+		assert.Contains(t, value, "[EMAIL]", path)
+	}
+
+	untouchedPaths := []string{
+		"contents.1.parts.0.thoughtSignature",
+		"contents.1.parts.1.functionCall.args.email",
+		"labels.owner",
+		"tools.0.functionDeclarations.0.description",
+	}
+	for _, path := range untouchedPaths {
+		assert.Equal(t, "alice@example.com", gjson.GetBytes(got, path).String(), path)
+	}
+	assert.True(t, strings.Contains(string(got), `"labels":{"owner":"alice@example.com"}`))
+}
+
+// TestRewriteGenAIRawRequestBodySupportsCountTokensEnvelope verifies both documented envelope spelling and snake-case system instructions use the same content allowlist.
+func TestRewriteGenAIRawRequestBodySupportsCountTokensEnvelope(t *testing.T) {
+	rawBody := []byte(`{"generate_content_request":{"system_instruction":{"parts":[{"text":"system alice@example.com"}]},"contents":[{"parts":[{"text":"user alice@example.com"}]}]}}`)
+
+	got, err := rewriteGenAIRawRequestBody(rawBody, map[string]string{"alice@example.com": "[EMAIL]"})
+	require.NoError(t, err)
+	assert.Equal(t, "system [EMAIL]", gjson.GetBytes(got, "generate_content_request.system_instruction.parts.0.text").String())
+	assert.Equal(t, "user [EMAIL]", gjson.GetBytes(got, "generate_content_request.contents.0.parts.0.text").String())
+}
+
+// TestRewriteGenAIRawRequestBodyRejectsUnmappedLiteral verifies a normalized runtime mutation cannot silently leave Gemini content unredacted.
+func TestRewriteGenAIRawRequestBodyRejectsUnmappedLiteral(t *testing.T) {
+	_, err := rewriteGenAIRawRequestBody(
+		[]byte(`{"contents":[{"parts":[{"text":"hello"}]}]}`),
+		map[string]string{"alice@example.com": "[EMAIL]"},
+	)
+	require.Error(t, err)
+}
+
+// TestRewriteGenAIRawRequestBodyRejectsSensitiveObjectKeys verifies unsupported key mutation fails closed inside a function-result subtree.
+func TestRewriteGenAIRawRequestBodyRejectsSensitiveObjectKeys(t *testing.T) {
+	_, err := rewriteGenAIRawRequestBody(
+		[]byte(`{"contents":[{"parts":[{"functionResponse":{"response":{"alice@example.com":"value"}}}]}]}`),
+		map[string]string{"alice@example.com": "[EMAIL]"},
+	)
+	require.ErrorContains(t, err, "unsupported JSON object key")
+}
 
 func TestCreateGenAIRerankRouteConfig(t *testing.T) {
 	route := createGenAIRerankRouteConfig("/genai")
@@ -75,6 +151,8 @@ func TestExtractAndSetModelAndRequestTypePreservesRawBodyForGenerateContent(t *t
 
 	assert.Equal(t, true, bifrostCtx.Value(schemas.BifrostContextKeyUseRawRequestBody))
 	assert.Equal(t, rawBody, bifrostCtx.Value(genAIRawRequestBodyContextKey))
+	_, hasRewriter := bifrostCtx.Value(schemas.BifrostContextKeyRawRequestBodyTextRewriter).(schemas.RawRequestBodyTextRewriter)
+	assert.True(t, hasRewriter)
 }
 
 func TestExtractAndSetModelAndRequestTypeNoRawPassthroughWithoutExplicitGemini(t *testing.T) {
@@ -96,6 +174,7 @@ func TestExtractAndSetModelAndRequestTypeNoRawPassthroughWithoutExplicitGemini(t
 
 	assert.Nil(t, bifrostCtx.Value(schemas.BifrostContextKeyUseRawRequestBody))
 	assert.Nil(t, bifrostCtx.Value(genAIRawRequestBodyContextKey))
+	assert.Nil(t, bifrostCtx.Value(schemas.BifrostContextKeyRawRequestBodyTextRewriter))
 }
 
 func TestExtractAndSetModelAndRequestTypeDoesNotRawPassthroughEmbedding(t *testing.T) {

--- a/transports/bifrost-http/integrations/rawrequestredaction.go
+++ b/transports/bifrost-http/integrations/rawrequestredaction.go
@@ -1,0 +1,195 @@
+package integrations
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/tidwall/gjson"
+)
+
+// rawRequestTextPathCollector returns the integration-owned JSON string paths that correspond to mutable normalized text.
+type rawRequestTextPathCollector func(root gjson.Result, replacements map[string]string) ([]string, error)
+
+// rewriteRawRequestTextFields applies literal replacements only to paths selected by the native integration.
+// It consumes caller-owned rawBody bytes so repeated field updates can reuse the same backing array, then
+// verifies every requested literal was found and every patched value persisted before returning the body.
+func rewriteRawRequestTextFields(rawBody []byte, replacements map[string]string, collect rawRequestTextPathCollector) ([]byte, error) {
+	if len(replacements) == 0 {
+		return rawBody, nil
+	}
+	if len(rawBody) == 0 {
+		return nil, fmt.Errorf("raw request body is empty")
+	}
+	if !gjson.ValidBytes(rawBody) {
+		return nil, fmt.Errorf("raw request body is not valid JSON")
+	}
+	root := gjson.ParseBytes(rawBody)
+	if err := validateRawRequestUniqueObjectKeys(root); err != nil {
+		return nil, err
+	}
+	if collect == nil {
+		return nil, fmt.Errorf("raw request body text path collector is unavailable")
+	}
+
+	paths, err := collect(root, replacements)
+	if err != nil {
+		return nil, err
+	}
+
+	found := make(map[string]bool, len(replacements))
+	expected := make(map[string]string)
+	seenPaths := make(map[string]struct{}, len(paths))
+	patched := rawBody
+	for _, path := range paths {
+		if _, seen := seenPaths[path]; seen {
+			continue
+		}
+		seenPaths[path] = struct{}{}
+
+		field := gjson.GetBytes(patched, path)
+		if !field.Exists() || field.Type != gjson.String {
+			return nil, fmt.Errorf("raw request content path %q is no longer a string", path)
+		}
+		original := field.String()
+		for literal := range replacements {
+			if literal != "" && strings.Contains(original, literal) {
+				found[literal] = true
+			}
+		}
+
+		redacted := schemas.ApplyLiteralReplacements(original, replacements)
+		if redacted == original {
+			continue
+		}
+		// In-place SJSON updates avoid allocating one full raw body per changed field.
+		// They still perform one path search and may shift JSON bytes for every field;
+		// this is deliberately an allocation optimization rather than a bulk patcher.
+		patched, err = providerUtils.SetJSONStringFieldInPlace(patched, path, redacted)
+		if err != nil {
+			return nil, fmt.Errorf("redact raw request content path %q: %w", path, err)
+		}
+		expected[path] = redacted
+	}
+
+	for literal := range replacements {
+		if literal != "" && !found[literal] {
+			return nil, fmt.Errorf("one or more runtime redaction literals were not found in an integration-owned content path")
+		}
+	}
+	if !gjson.ValidBytes(patched) {
+		return nil, fmt.Errorf("redacted raw request body is not valid JSON")
+	}
+	for path, want := range expected {
+		field := gjson.GetBytes(patched, path)
+		if !field.Exists() || field.Type != gjson.String || field.String() != want {
+			return nil, fmt.Errorf("redacted raw request content path %q failed verification", path)
+		}
+	}
+	return patched, nil
+}
+
+// validateRawRequestUniqueObjectKeys rejects ambiguous objects whose first and last values can differ across JSON parsers.
+func validateRawRequestUniqueObjectKeys(value gjson.Result) error {
+	switch {
+	case value.IsObject():
+		seen := make(map[string]struct{})
+		var validationErr error
+		value.ForEach(func(key, child gjson.Result) bool {
+			keyText := key.String()
+			if _, exists := seen[keyText]; exists {
+				validationErr = fmt.Errorf("raw request body contains duplicate JSON object keys")
+				return false
+			}
+			seen[keyText] = struct{}{}
+			validationErr = validateRawRequestUniqueObjectKeys(child)
+			return validationErr == nil
+		})
+		return validationErr
+	case value.IsArray():
+		var validationErr error
+		value.ForEach(func(_, child gjson.Result) bool {
+			validationErr = validateRawRequestUniqueObjectKeys(child)
+			return validationErr == nil
+		})
+		return validationErr
+	default:
+		return nil
+	}
+}
+
+// appendRawRequestStringPath adds an optional JSON string field to the integration-owned path set.
+func appendRawRequestStringPath(paths *[]string, field gjson.Result, path string) error {
+	if !field.Exists() || field.Type == gjson.Null {
+		return nil
+	}
+	if field.Type != gjson.String {
+		return fmt.Errorf("raw request content path %q must be a string", path)
+	}
+	*paths = append(*paths, path)
+	return nil
+}
+
+// appendRawRequestJSONLeafPaths adds string values below an integration-owned JSON content subtree.
+func appendRawRequestJSONLeafPaths(paths *[]string, value gjson.Result, path string, replacements map[string]string) error {
+	switch {
+	case !value.Exists() || value.Type == gjson.Null:
+		return nil
+	case value.Type == gjson.String:
+		*paths = append(*paths, path)
+		return nil
+	case value.IsArray():
+		var collectErr error
+		value.ForEach(func(index, child gjson.Result) bool {
+			collectErr = appendRawRequestJSONLeafPaths(paths, child, rawRequestArrayPath(path, int(index.Int())), replacements)
+			return collectErr == nil
+		})
+		return collectErr
+	case value.IsObject():
+		var collectErr error
+		value.ForEach(func(key, child gjson.Result) bool {
+			if containsRuntimeLiteral(key.String(), replacements) {
+				collectErr = fmt.Errorf("a runtime redaction literal appears in an unsupported JSON object key at %q", path)
+				return false
+			}
+			collectErr = appendRawRequestJSONLeafPaths(paths, child, rawRequestObjectPath(path, key.String()), replacements)
+			return collectErr == nil
+		})
+		return collectErr
+	default:
+		if containsRuntimeLiteral(value.Raw, replacements) {
+			return fmt.Errorf("a runtime redaction literal appears in an unsupported non-string JSON value at %q", path)
+		}
+		return nil
+	}
+}
+
+// containsRuntimeLiteral reports whether text contains any non-empty replacement key.
+func containsRuntimeLiteral(text string, replacements map[string]string) bool {
+	for literal := range replacements {
+		if literal != "" && strings.Contains(text, literal) {
+			return true
+		}
+	}
+	return false
+}
+
+// rawRequestObjectPath appends one escaped object key to a GJSON/SJSON path.
+func rawRequestObjectPath(path, key string) string {
+	escaped := strings.ReplaceAll(gjson.Escape(key), ":", `\:`)
+	if path == "" {
+		return escaped
+	}
+	return path + "." + escaped
+}
+
+// rawRequestArrayPath appends one array index to a GJSON/SJSON path.
+func rawRequestArrayPath(path string, index int) string {
+	indexText := strconv.Itoa(index)
+	if path == "" {
+		return indexText
+	}
+	return path + "." + indexText
+}


### PR DESCRIPTION
## Summary

Raw passthrough mode forwards provider-native request bytes directly to the upstream API, bypassing the normalized request serialization path where runtime guardrail redactions are applied. This PR closes that gap by introducing a `RawRequestBodyTextRewriter` contract that integrations must register alongside any raw passthrough activation, ensuring runtime literal replacements are applied to the native JSON before it is forwarded.

## Changes

- Introduced `RawRequestBodyTextRewriter` as a typed function in `core/schemas/redaction.go` and a corresponding context key `BifrostContextKeyRawRequestBodyTextRewriter` in `core/schemas/bifrost.go`.
- Added `rewriteRawRequestTextFields` in a new `rawrequestredaction.go` file, which validates JSON integrity (including duplicate-key rejection), collects integration-owned text paths, applies literal replacements, and verifies every replacement literal was found and every patched value persisted.
- Implemented `rewriteAnthropicRawRequestBody` for the Anthropic integration, covering `prompt`, `system`, and `messages` content fields (text, thinking, compaction, tool-result, and MCP tool-result blocks) while explicitly excluding signatures, tool-call arguments, metadata, and tool descriptions.
- Implemented `rewriteGenAIRawRequestBody` for the Gemini integration, covering `systemInstruction`/`system_instruction`, `contents` (text parts and function-response JSON leaf values), `instances[].prompt`, and the `generateContentRequest`/`generate_content_request` countTokens envelope, while excluding function-call arguments, labels, and tool declarations.
- `checkAnthropicPassthrough` now registers the Anthropic rewriter when raw passthrough is enabled; `extractAndSetModelAndRequestType` delegates to a new `enableGenAIRawRequestBodyRedaction` helper that sets both the raw-body flag and the Gemini rewriter atomically.
- `clearAnthropicPassthroughForNonNativeProvider` and `ClearContextForInternalRequest` both clear the rewriter key so converted, fallback, and nested requests cannot inherit a stale integration callback.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/... ./transports/bifrost-http/integrations/...
```

Key scenarios covered by new tests:

- `TestRewriteAnthropicRawRequestBodyRedactsOnlyContentFields` — confirms redaction reaches all Anthropic content fields and leaves signatures, tool arguments, metadata, and tool descriptions untouched.
- `TestRewriteAnthropicRawRequestBodyRejectsUnmappedLiteral` — confirms a replacement literal absent from any integration-owned path is treated as an error rather than silently skipped.
- `TestRewriteAnthropicRawRequestBodyRejectsMalformedJSON` and `TestRewriteAnthropicRawRequestBodyRejectsDuplicateKeys` — confirm the rewriter fails closed on structurally invalid input.
- Equivalent tests for the Gemini integration, including the countTokens envelope and function-response subtree key-mutation rejection.
- `TestClearContextForInternalRequestClearsRawBodyRewriter` — confirms nested requests cannot inherit the rewriter.
- `TestClearAnthropicPassthroughForNonNativeProvider` extended to assert the rewriter is cleared for non-native providers.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Raw passthrough previously forwarded provider-native bytes without applying runtime guardrail redactions (e.g. PII literal replacements). Any replacement that Guardrails applied to the normalized request was invisible to the bytes actually sent upstream. The rewriter closes this gap by requiring integrations to enumerate exactly which native fields correspond to guardrail-visible text, failing the request if a replacement literal cannot be located in those fields. Duplicate JSON keys, malformed JSON, and object-key mutations are all rejected to prevent parser-precedence attacks from selecting an unredacted value.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)