### PR TITLE
[fix]: flatten multi-block system prompts to string content for chat providers

### DIFF
--- a/core/providers/anthropic/systemflatten_test.go
+++ b/core/providers/anthropic/systemflatten_test.go
@@ -86,8 +86,8 @@ func TestMultiBlockSystemToChatRequest(t *testing.T) {
 	}
 }
 
-// One text block already collapsed to string content before the fix; multi-block user
-// messages must keep their content array (image/file parts depend on it).
+// One text block already collapsed to string content before the fix. Shape coverage
+// that does not involve the Anthropic ingress lives in core/schemas/systemflatten_test.go.
 func TestSystemFlattenShapes(t *testing.T) {
 	buildChat := func(t *testing.T, bodyJSON string) *schemas.BifrostChatRequest {
 		t.Helper()
@@ -114,61 +114,4 @@ func TestSystemFlattenShapes(t *testing.T) {
 		}
 	})
 
-	t.Run("multi-block developer message flattens to string", func(t *testing.T) {
-		devRole := schemas.ResponsesInputMessageRoleDeveloper
-		chatMessages := schemas.ToChatMessages([]schemas.ResponsesMessage{
-			{
-				Role: &devRole,
-				Content: &schemas.ResponsesMessageContent{
-					ContentBlocks: []schemas.ResponsesMessageContentBlock{
-						{Type: schemas.ResponsesInputMessageContentBlockTypeText, Text: schemas.Ptr("dev block A")},
-						{Type: schemas.ResponsesInputMessageContentBlockTypeText, Text: schemas.Ptr("dev block B")},
-					},
-				},
-			},
-		})
-		if len(chatMessages) != 1 {
-			t.Fatalf("expected 1 chat message, got %d", len(chatMessages))
-		}
-		dev := chatMessages[0]
-		if dev.Role != schemas.ChatMessageRoleDeveloper {
-			t.Fatalf("expected developer role, got %s", dev.Role)
-		}
-		if dev.Content == nil || dev.Content.ContentStr == nil {
-			t.Fatalf("expected multi-block developer message to flatten to string content, got: %+v", dev.Content)
-		}
-		if want := "dev block A\n\ndev block B"; *dev.Content.ContentStr != want {
-			t.Errorf("flattened developer prompt mismatch:\ngot:  %q\nwant: %q", *dev.Content.ContentStr, want)
-		}
-	})
-
-	t.Run("multi-block user message keeps content array", func(t *testing.T) {
-		// Flattening applies to system/developer roles only: user messages keep their
-		// content array through ToChatMessages (image/file parts depend on it).
-		userRole := schemas.ResponsesInputMessageRoleUser
-		chatMessages := schemas.ToChatMessages([]schemas.ResponsesMessage{
-			{
-				Role: &userRole,
-				Content: &schemas.ResponsesMessageContent{
-					ContentBlocks: []schemas.ResponsesMessageContentBlock{
-						{Type: schemas.ResponsesInputMessageContentBlockTypeText, Text: schemas.Ptr("part one")},
-						{Type: schemas.ResponsesInputMessageContentBlockTypeText, Text: schemas.Ptr("part two")},
-					},
-				},
-			},
-		})
-		if len(chatMessages) != 1 {
-			t.Fatalf("expected 1 chat message, got %d", len(chatMessages))
-		}
-		user := chatMessages[0]
-		if user.Role != schemas.ChatMessageRoleUser {
-			t.Fatalf("expected user role, got %s", user.Role)
-		}
-		if user.Content == nil || user.Content.ContentBlocks == nil {
-			t.Fatalf("expected multi-block user message to keep content array, got: %+v", user.Content)
-		}
-		if len(user.Content.ContentBlocks) != 2 {
-			t.Fatalf("expected 2 user content blocks, got %d", len(user.Content.ContentBlocks))
-		}
-	})
 }

--- a/core/providers/anthropic/systemflatten_test.go
+++ b/core/providers/anthropic/systemflatten_test.go
@@ -114,6 +114,34 @@ func TestSystemFlattenShapes(t *testing.T) {
 		}
 	})
 
+	t.Run("multi-block developer message flattens to string", func(t *testing.T) {
+		devRole := schemas.ResponsesInputMessageRoleDeveloper
+		chatMessages := schemas.ToChatMessages([]schemas.ResponsesMessage{
+			{
+				Role: &devRole,
+				Content: &schemas.ResponsesMessageContent{
+					ContentBlocks: []schemas.ResponsesMessageContentBlock{
+						{Type: schemas.ResponsesInputMessageContentBlockTypeText, Text: schemas.Ptr("dev block A")},
+						{Type: schemas.ResponsesInputMessageContentBlockTypeText, Text: schemas.Ptr("dev block B")},
+					},
+				},
+			},
+		})
+		if len(chatMessages) != 1 {
+			t.Fatalf("expected 1 chat message, got %d", len(chatMessages))
+		}
+		dev := chatMessages[0]
+		if dev.Role != schemas.ChatMessageRoleDeveloper {
+			t.Fatalf("expected developer role, got %s", dev.Role)
+		}
+		if dev.Content == nil || dev.Content.ContentStr == nil {
+			t.Fatalf("expected multi-block developer message to flatten to string content, got: %+v", dev.Content)
+		}
+		if want := "dev block A\n\ndev block B"; *dev.Content.ContentStr != want {
+			t.Errorf("flattened developer prompt mismatch:\ngot:  %q\nwant: %q", *dev.Content.ContentStr, want)
+		}
+	})
+
 	t.Run("multi-block user message keeps content array", func(t *testing.T) {
 		// Flattening applies to system/developer roles only: user messages keep their
 		// content array through ToChatMessages (image/file parts depend on it).

--- a/core/providers/anthropic/systemflatten_test.go
+++ b/core/providers/anthropic/systemflatten_test.go
@@ -1,0 +1,146 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/providers/openai"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// Regression test for issue #6245: an Anthropic-format request with a multi-block
+// top-level `system` field (what Claude Code sends) must reach chat-style providers
+// (e.g. ollama, which routes Responses through ToChatRequest) as exactly ONE system
+// message at position 0 with plain string content. OpenAI-compatible servers like
+// ollama expand a content-parts array into one message per part, so a multi-part
+// system message becomes [system, system, system] upstream and is rejected with
+// "system message must be at the beginning".
+func TestMultiBlockSystemToChatRequest(t *testing.T) {
+	rawReq := []byte(`{
+		"model": "ollama/llama3.1",
+		"max_tokens": 512,
+		"system": [
+			{"type": "text", "text": "You are Claude Code, Anthropic's official CLI for Claude."},
+			{"type": "text", "text": "Block B: follow the project conventions.", "cache_control": {"type": "ephemeral"}},
+			{"type": "text", "text": "Block C: answer concisely."}
+		],
+		"messages": [
+			{"role": "user", "content": "hello"}
+		]
+	}`)
+
+	var anthropicReq AnthropicMessageRequest
+	if err := json.Unmarshal(rawReq, &anthropicReq); err != nil {
+		t.Fatalf("failed to unmarshal anthropic request: %v", err)
+	}
+
+	// Ingress conversion (what /anthropic/v1/messages does), then the responses→chat
+	// fallback used by chat-style providers (core/providers/ollama/ollama.go).
+	chatReq := anthropicReq.ToBifrostResponsesRequest(nil).ToChatRequest()
+
+	dumpChat, _ := json.MarshalIndent(chatReq.Input, "", "  ")
+
+	chatSysCount := 0
+	for _, m := range chatReq.Input {
+		if m.Role == schemas.ChatMessageRoleSystem {
+			chatSysCount++
+		}
+	}
+	if chatSysCount != 1 {
+		t.Errorf("expected exactly 1 system message in chat request, got %d:\n%s", chatSysCount, dumpChat)
+	}
+	if len(chatReq.Input) == 0 || chatReq.Input[0].Role != schemas.ChatMessageRoleSystem {
+		t.Fatalf("expected system message at position 0, got messages:\n%s", dumpChat)
+	}
+	if len(chatReq.Input) != 2 {
+		t.Errorf("expected 2 chat messages total (system + user), got %d", len(chatReq.Input))
+	}
+
+	sys := chatReq.Input[0]
+	if sys.Content == nil || sys.Content.ContentStr == nil {
+		t.Fatalf("expected multi-block system prompt to be flattened to string content, got:\n%s", dumpChat)
+	}
+	want := "You are Claude Code, Anthropic's official CLI for Claude.\n\nBlock B: follow the project conventions.\n\nBlock C: answer concisely."
+	if *sys.Content.ContentStr != want {
+		t.Errorf("flattened system prompt mismatch:\ngot:  %q\nwant: %q", *sys.Content.ContentStr, want)
+	}
+
+	// The outbound openai-compatible payload must carry the same single string prompt.
+	wireMessages := openai.ConvertBifrostMessagesToOpenAIMessages(chatReq.Input)
+	dumpWire, err := json.Marshal(wireMessages[0])
+	if err != nil {
+		t.Fatalf("marshal wire message: %v", err)
+	}
+	var wireSys struct {
+		Role    string `json:"role"`
+		Content any    `json:"content"`
+	}
+	if err := json.Unmarshal(dumpWire, &wireSys); err != nil {
+		t.Fatalf("unmarshal wire message: %v", err)
+	}
+	if wireSys.Role != "system" {
+		t.Errorf("expected wire role system, got %q", wireSys.Role)
+	}
+	if _, isString := wireSys.Content.(string); !isString {
+		t.Errorf("expected wire system content to be a string, got %T: %s", wireSys.Content, dumpWire)
+	}
+}
+
+// One text block already collapsed to string content before the fix; multi-block user
+// messages must keep their content array (image/file parts depend on it).
+func TestSystemFlattenShapes(t *testing.T) {
+	buildChat := func(t *testing.T, bodyJSON string) *schemas.BifrostChatRequest {
+		t.Helper()
+		var req AnthropicMessageRequest
+		if err := json.Unmarshal([]byte(bodyJSON), &req); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		return req.ToBifrostResponsesRequest(nil).ToChatRequest()
+	}
+
+	t.Run("single system block stays plain string", func(t *testing.T) {
+		chatReq := buildChat(t, `{
+			"model": "ollama/llama3.1",
+			"max_tokens": 512,
+			"system": [{"type":"text","text":"only block"}],
+			"messages": [{"role": "user", "content": "hello"}]
+		}`)
+		sys := chatReq.Input[0]
+		if sys.Role != schemas.ChatMessageRoleSystem {
+			t.Fatalf("expected system first, got %s", sys.Role)
+		}
+		if sys.Content == nil || sys.Content.ContentStr == nil || *sys.Content.ContentStr != "only block" {
+			t.Fatalf("expected single-block system to be plain string content, got: %+v", sys.Content)
+		}
+	})
+
+	t.Run("multi-block user message keeps content array", func(t *testing.T) {
+		// Flattening applies to system/developer roles only: user messages keep their
+		// content array through ToChatMessages (image/file parts depend on it).
+		userRole := schemas.ResponsesInputMessageRoleUser
+		chatMessages := schemas.ToChatMessages([]schemas.ResponsesMessage{
+			{
+				Role: &userRole,
+				Content: &schemas.ResponsesMessageContent{
+					ContentBlocks: []schemas.ResponsesMessageContentBlock{
+						{Type: schemas.ResponsesInputMessageContentBlockTypeText, Text: schemas.Ptr("part one")},
+						{Type: schemas.ResponsesInputMessageContentBlockTypeText, Text: schemas.Ptr("part two")},
+					},
+				},
+			},
+		})
+		if len(chatMessages) != 1 {
+			t.Fatalf("expected 1 chat message, got %d", len(chatMessages))
+		}
+		user := chatMessages[0]
+		if user.Role != schemas.ChatMessageRoleUser {
+			t.Fatalf("expected user role, got %s", user.Role)
+		}
+		if user.Content == nil || user.Content.ContentBlocks == nil {
+			t.Fatalf("expected multi-block user message to keep content array, got: %+v", user.Content)
+		}
+		if len(user.Content.ContentBlocks) != 2 {
+			t.Fatalf("expected 2 user content blocks, got %d", len(user.Content.ContentBlocks))
+		}
+	})
+}

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -715,8 +715,6 @@ func (cm *ChatMessage) ToResponsesMessages() []ResponsesMessage {
 	return messages
 }
 
-// ToChatMessages converts a slice of ResponsesMessages back to ChatMessages
-// This handles the aggregation of function_call messages back into assistant messages with tool calls
 // flattenSystemTextBlocks joins multi-block all-text system/developer content into a
 // single string prompt. Chat-style providers reached via this conversion (e.g. ollama's
 // OpenAI-compatible server) expand a content-parts array into one message per part,
@@ -728,16 +726,21 @@ func flattenSystemTextBlocks(role ChatMessageRole, blocks []ResponsesMessageCont
 	if len(blocks) < 2 {
 		return "", false
 	}
-	texts := make([]string, len(blocks))
-	for i, block := range blocks {
+	texts := make([]string, 0, len(blocks))
+	for _, block := range blocks {
 		if (block.Type != ResponsesInputMessageContentBlockTypeText && block.Type != ResponsesOutputMessageContentTypeText) || block.Text == nil {
 			return "", false
 		}
-		texts[i] = *block.Text
+		if strings.TrimSpace(*block.Text) == "" {
+			continue
+		}
+		texts = append(texts, *block.Text)
 	}
 	return strings.Join(texts, "\n\n"), true
 }
 
+// ToChatMessages converts a slice of ResponsesMessages back to ChatMessages
+// This handles the aggregation of function_call messages back into assistant messages with tool calls
 func ToChatMessages(rms []ResponsesMessage) []ChatMessage {
 	if len(rms) == 0 {
 		return []ChatMessage{}

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -717,6 +717,27 @@ func (cm *ChatMessage) ToResponsesMessages() []ResponsesMessage {
 
 // ToChatMessages converts a slice of ResponsesMessages back to ChatMessages
 // This handles the aggregation of function_call messages back into assistant messages with tool calls
+// flattenSystemTextBlocks joins multi-block all-text system/developer content into a
+// single string prompt. Chat-style providers reached via this conversion (e.g. ollama's
+// OpenAI-compatible server) expand a content-parts array into one message per part,
+// which breaks upstreams that require a single leading system message.
+func flattenSystemTextBlocks(role ChatMessageRole, blocks []ResponsesMessageContentBlock) (string, bool) {
+	if role != ChatMessageRoleSystem && role != ChatMessageRoleDeveloper {
+		return "", false
+	}
+	if len(blocks) < 2 {
+		return "", false
+	}
+	texts := make([]string, len(blocks))
+	for i, block := range blocks {
+		if (block.Type != ResponsesInputMessageContentBlockTypeText && block.Type != ResponsesOutputMessageContentTypeText) || block.Text == nil {
+			return "", false
+		}
+		texts[i] = *block.Text
+	}
+	return strings.Join(texts, "\n\n"), true
+}
+
 func ToChatMessages(rms []ResponsesMessage) []ChatMessage {
 	if len(rms) == 0 {
 		return []ChatMessage{}
@@ -897,7 +918,11 @@ func ToChatMessages(rms []ResponsesMessage) []ChatMessage {
 
 		// Convert content (skip for refusal messages since refusal is already extracted)
 		if rm.Content != nil && (rm.Type == nil || *rm.Type != ResponsesMessageTypeRefusal) {
-			if rm.Content.ContentStr != nil ||
+			if joined, ok := flattenSystemTextBlocks(cm.Role, rm.Content.ContentBlocks); ok {
+				cm.Content = &ChatMessageContent{
+					ContentStr: &joined,
+				}
+			} else if rm.Content.ContentStr != nil ||
 				(len(rm.Content.ContentBlocks) == 1 &&
 					(rm.Content.ContentBlocks[0].Type == ResponsesInputMessageContentBlockTypeText || rm.Content.ContentBlocks[0].Type == ResponsesOutputMessageContentTypeText)) {
 				if rm.Content.ContentStr != nil {

--- a/core/schemas/systemflatten_test.go
+++ b/core/schemas/systemflatten_test.go
@@ -1,0 +1,104 @@
+package schemas
+
+import (
+	"testing"
+)
+
+// Regression tests for issue #6245: flattenSystemTextBlocks (via ToChatMessages) must
+// join multi-block system/developer text content into a single string prompt, and must
+// leave every other shape untouched. The Anthropic ingress path is covered in
+// core/providers/anthropic/systemflatten_test.go.
+func TestFlattenSystemTextBlocksShapes(t *testing.T) {
+	t.Run("multi-block developer message flattens to string", func(t *testing.T) {
+		devRole := ResponsesInputMessageRoleDeveloper
+		chatMessages := ToChatMessages([]ResponsesMessage{
+			{
+				Role: &devRole,
+				Content: &ResponsesMessageContent{
+					ContentBlocks: []ResponsesMessageContentBlock{
+						{Type: ResponsesInputMessageContentBlockTypeText, Text: Ptr("dev block A")},
+						{Type: ResponsesInputMessageContentBlockTypeText, Text: Ptr("dev block B")},
+					},
+				},
+			},
+		})
+		if len(chatMessages) != 1 {
+			t.Fatalf("expected 1 chat message, got %d", len(chatMessages))
+		}
+		dev := chatMessages[0]
+		if dev.Role != ChatMessageRoleDeveloper {
+			t.Fatalf("expected developer role, got %s", dev.Role)
+		}
+		if dev.Content == nil || dev.Content.ContentStr == nil {
+			t.Fatalf("expected multi-block developer message to flatten to string content, got: %+v", dev.Content)
+		}
+		if want := "dev block A\n\ndev block B"; *dev.Content.ContentStr != want {
+			t.Errorf("flattened developer prompt mismatch:\ngot:  %q\nwant: %q", *dev.Content.ContentStr, want)
+		}
+	})
+
+	t.Run("empty text blocks are skipped when joining", func(t *testing.T) {
+		sysRole := ResponsesInputMessageRoleSystem
+		chatMessages := ToChatMessages([]ResponsesMessage{
+			{
+				Role: &sysRole,
+				Content: &ResponsesMessageContent{
+					ContentBlocks: []ResponsesMessageContentBlock{
+						{Type: ResponsesInputMessageContentBlockTypeText, Text: Ptr("block A")},
+						{Type: ResponsesInputMessageContentBlockTypeText, Text: Ptr("   ")},
+						{Type: ResponsesInputMessageContentBlockTypeText, Text: Ptr("block B")},
+					},
+				},
+			},
+		})
+		if len(chatMessages) != 1 {
+			t.Fatalf("expected 1 chat message, got %d", len(chatMessages))
+		}
+		sys := chatMessages[0]
+		if sys.Content == nil || sys.Content.ContentStr == nil {
+			t.Fatalf("expected flattened string content, got: %+v", sys.Content)
+		}
+		if want := "block A\n\nblock B"; *sys.Content.ContentStr != want {
+			t.Errorf("expected empty block skipped in join:\ngot:  %q\nwant: %q", *sys.Content.ContentStr, want)
+		}
+	})
+
+	t.Run("multi-block user message keeps content array", func(t *testing.T) {
+		// Flattening applies to system/developer roles only: user messages keep their
+		// content array through ToChatMessages (image/file parts depend on it).
+		userRole := ResponsesInputMessageRoleUser
+		chatMessages := ToChatMessages([]ResponsesMessage{
+			{
+				Role: &userRole,
+				Content: &ResponsesMessageContent{
+					ContentBlocks: []ResponsesMessageContentBlock{
+						{Type: ResponsesInputMessageContentBlockTypeText, Text: Ptr("part one")},
+						{Type: ResponsesInputMessageContentBlockTypeText, Text: Ptr("part two")},
+					},
+				},
+			},
+		})
+		if len(chatMessages) != 1 {
+			t.Fatalf("expected 1 chat message, got %d", len(chatMessages))
+		}
+		user := chatMessages[0]
+		if user.Role != ChatMessageRoleUser {
+			t.Fatalf("expected user role, got %s", user.Role)
+		}
+		if user.Content == nil || user.Content.ContentBlocks == nil {
+			t.Fatalf("expected multi-block user message to keep content array, got: %+v", user.Content)
+		}
+		blocks := user.Content.ContentBlocks
+		if len(blocks) != 2 {
+			t.Fatalf("expected 2 user content blocks, got %d", len(blocks))
+		}
+		for i, want := range []string{"part one", "part two"} {
+			if blocks[i].Type != ChatContentBlockTypeText {
+				t.Errorf("block %d: expected text type, got %q", i, blocks[i].Type)
+			}
+			if blocks[i].Text == nil || *blocks[i].Text != want {
+				t.Errorf("block %d: expected text %q, got %+v", i, want, blocks[i].Text)
+			}
+		}
+	})
+}

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -136765,6 +136765,82 @@
           ]
         }
       ]
+    },
+    {
+      "name": "59. Multi-Block System Flatten to Chat Providers (#6245 / PR #6367)",
+      "description": "Issue #6245: an Anthropic-format request with a multi-block top-level `system` field (what Claude Code sends) reaches chat-style providers via ToChatRequest/ToChatMessages. Before the fix the content-parts array survived the hop, and OpenAI-compatible upstreams (e.g. ollama) expand a parts array into one message per part, so a 3-block system message became [system, system, system] and was rejected with 'system message must be at the beginning'. The fix flattens multi-block all-text system/developer content to a single string on the Responses-to-Chat conversion. This case pins the wire shape through a real chat-fallback provider (deepseek routes Responses through ToChatRequest unless use_anthropic_endpoints is set): the outbound request must carry exactly one system message, at position 0, with plain string content joining all three blocks.",
+      "item": [
+        {
+          "name": "deepseek/deepseek-v4-flash multi-block system flattens to one string system message - #6245",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-send-back-raw-request",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"deepseek/deepseek-v4-flash\",\n  \"max_tokens\": 64,\n  \"system\": [\n    {\n      \"type\": \"text\",\n      \"text\": \"You are a helpful assistant.\"\n    },\n    {\n      \"type\": \"text\",\n      \"text\": \"Answer concisely.\",\n      \"cache_control\": {\n        \"type\": \"ephemeral\"\n      }\n    },\n    {\n      \"type\": \"text\",\n      \"text\": \"Respond in English.\"\n    }\n  ],\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Say hello in one word.\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "anthropic",
+                "v1",
+                "messages"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('deepseek multi-block system: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var body = pm.response.json() || {};",
+                  "var ef = body.extra_fields || {};",
+                  "var rr = ef.raw_request;",
+                  "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                  "pm.test('deepseek multi-block system: raw_request captured', function () {",
+                  "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                  "});",
+                  "if (!rr || typeof rr !== 'object') { return; }",
+                  "var msgs = rr.messages || [];",
+                  "var sys = msgs.filter(function (m) { return m.role === 'system'; });",
+                  "pm.test('deepseek multi-block system: exactly one system message on the wire', function () {",
+                  "  pm.expect(sys.length, 'messages: ' + JSON.stringify(msgs)).to.eql(1);",
+                  "});",
+                  "pm.test('deepseek multi-block system: system message is first', function () {",
+                  "  pm.expect(msgs.length, 'no messages in raw_request').to.be.above(0);",
+                  "  pm.expect(msgs[0].role, 'messages: ' + JSON.stringify(msgs)).to.eql('system');",
+                  "});",
+                  "if (sys.length === 0) { return; }",
+                  "pm.test('deepseek multi-block system: content flattened to a single string', function () {",
+                  "  pm.expect(typeof sys[0].content, 'system content: ' + JSON.stringify(sys[0].content)).to.eql('string');",
+                  "  pm.expect(sys[0].content).to.include('You are a helpful assistant.');",
+                  "  pm.expect(sys[0].content).to.include('Answer concisely.');",
+                  "  pm.expect(sys[0].content).to.include('Respond in English.');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Claude Code can't talk to an ollama provider through Bifrost at all. Every request fails with `system message must be at the beginning`.

The trigger is the shape of the system prompt. Claude Code always sends the top-level `system` field as 3 text blocks. Bifrost keeps those blocks as a content-parts array on the outbound chat-completions payload, and ollama's OpenAI-compat layer expands each part of a content array into its own message with the same role. So one system message with 3 parts becomes `[system, system, system, user]` inside ollama, and its renderer rejects it. One block works because `ToChatMessages` already collapses a single text block to plain string content. Two or more blocks fall off that cliff.

I traced this end to end: Bifrost itself never splits the message (the ingress builds one system message with N blocks, and `ToChatRequest` keeps it as one message). The array shape is the problem, and a plain string system prompt is the only shape every openai-compat server accepts.

## Changes

- `core/schemas/mux.go`: `ToChatMessages` now flattens multi-block all-text system/developer content into a single string prompt (blocks joined with `\n\n`), generalizing the existing single-block collapse.
- Gated on role and all-text blocks only. User messages keep their content arrays, since image/file parts depend on them.
- The fix sits in the generic responses→chat converter rather than the ollama provider: `ToChatRequest` is the fallback path for every chat-style provider (ollama, deepseek, groq, etc.) and none of them benefit from a parts array on a system message. This path already drops per-block `cache_control` today, and a string system prompt has nowhere to carry it anyway, so nothing is lost there.
- `core/providers/anthropic/systemflatten_test.go`: regression test covering the full ingress→chat path with a 3-block Claude Code-shaped request, plus the single-block shape. The main test fails without the converter change.
- `core/schemas/systemflatten_test.go`: the provider-agnostic `ToChatMessages` shape guards (developer-role flatten, empty-block skip, multi-block user message keeps its array with values and order asserted).
- `tests/e2e/api/collections/provider-harness.json`: folder 59 pins the wire shape end to end through deepseek (a real chat-fallback provider in the harness): a 3-block Anthropic `system` must reach the upstream as exactly one leading system message with string content, asserted via `x-bf-send-back-raw-request`.
- Review follow-ups also folded in: blocks whose trimmed text is empty are skipped when joining (no doubled separators), and the `ToChatMessages` doc comment sits back above its declaration.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go test -run 'TestMultiBlockSystemToChatRequest|TestSystemFlattenShapes' -v ./providers/anthropic/
go test -run TestFlattenSystemTextBlocksShapes -v ./schemas/
go test ./schemas/ ./providers/anthropic/ ./providers/openai/ ./providers/ollama/
```

Harness case (live, paid):

```sh
make run-provider-harness-test PROVIDER=deepseek FEATURE="multi-block system"
```

Or live: point Claude Code at Bifrost's `/anthropic` endpoint with an ollama provider behind it. Before this change the first request fails with `system message must be at the beginning`; after it, requests go through.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #6245

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable

