### PR TITLE
[fix]: skip default reasoning_with_tool_calls marker for capability-empty datasheet rows

### DIFF
--- a/framework/modelcatalog/datasheet/costonlyparams_test.go
+++ b/framework/modelcatalog/datasheet/costonlyparams_test.go
@@ -15,8 +15,11 @@ import (
 // (should_drop_params) then stripped tools / tool_choice / temperature / everything
 // else from requests to that model.
 func TestCostOnlyRowProducesNoParamAllowlist(t *testing.T) {
-	// Hosted-datasheet shape reported in the issue for gemini-3.6-flash:
-	// pricing keys only, none of which map to ModelCapabilities fields.
+	// Hosted-datasheet shape reported in the issue: pricing keys only, none of
+	// which map to ModelCapabilities fields. The issue's original row
+	// (gemini-3.6-flash) has since been fixed upstream; claude-opus-4-7-20260416
+	// ({"deprecation_date": "2027-04-16"}) still reproduces on the live feed and
+	// parses to the same empty ModelCapabilities.
 	costOnlyRow := json.RawMessage(`{
 		"input_cost_per_token_batches": 0.000000075,
 		"output_cost_per_token_batches": 0.0000003
@@ -41,12 +44,33 @@ func TestCostOnlyRowProducesNoParamAllowlist(t *testing.T) {
 		// happens, mirroring the real datasheet where thousands of populated
 		// rows sit alongside the cost-only gemini-3.6-flash row.
 		s.applyModelParameters(map[string]json.RawMessage{
-			"gemini-3.6-flash": costOnlyRow,
-			"gpt-4o":           json.RawMessage(`{"supports_function_calling":true,"supports_tool_choice":true}`),
+			"claude-opus-4-7-20260416": costOnlyRow,
+			"gpt-4o":                   json.RawMessage(`{"supports_function_calling":true,"supports_tool_choice":true}`),
 		})
 
-		if got := s.GetSupportedParameters("gemini-3.6-flash"); got != nil {
-			t.Errorf("GetSupportedParameters(gemini-3.6-flash) = %v, want nil (unknown) — compat treats any non-nil list as a complete allowlist and drops tools/tool_choice", got)
+		if got := s.GetSupportedParameters("claude-opus-4-7-20260416"); got != nil {
+			t.Errorf("GetSupportedParameters(claude-opus-4-7-20260416) = %v, want nil (unknown) — compat treats any non-nil list as a complete allowlist and drops tools/tool_choice", got)
+		}
+	})
+
+	t.Run("explicit-false-only row keeps an authoritative allowlist", func(t *testing.T) {
+		// A row saying only {"supports_function_calling": false} IS a statement
+		// about the parameter surface: it must keep a non-nil allowlist (with the
+		// default marker) so compat still drops tools, instead of degrading to
+		// "unknown, do not drop".
+		var caps schemas.ModelCapabilities
+		if err := json.Unmarshal(json.RawMessage(`{"supports_function_calling":false}`), &caps); err != nil {
+			t.Fatalf("unmarshal explicit-false-only row: %v", err)
+		}
+		got := extractSupportedParams(&caps)
+		if len(got) == 0 {
+			t.Fatalf("extractSupportedParams(explicit-false-only row) = empty, want the default reasoning_with_tool_calls marker so the allowlist stays authoritative")
+		}
+		if !slices.Contains(got, "reasoning_with_tool_calls") {
+			t.Errorf("extractSupportedParams(explicit-false-only row) = %v, want reasoning_with_tool_calls present", got)
+		}
+		if slices.Contains(got, "tools") {
+			t.Errorf("extractSupportedParams(explicit-false-only row) = %v, want tools absent", got)
 		}
 	})
 

--- a/framework/modelcatalog/datasheet/costonlyparams_test.go
+++ b/framework/modelcatalog/datasheet/costonlyparams_test.go
@@ -82,5 +82,14 @@ func TestCostOnlyRowProducesNoParamAllowlist(t *testing.T) {
 		if got := extractSupportedParams(&explicitFalse); slices.Contains(got, "reasoning_with_tool_calls") {
 			t.Errorf("extractSupportedParams(explicit false) = %v, want reasoning_with_tool_calls absent", got)
 		}
+
+		// Explicit false must also override a marker sourced from model_parameters ids.
+		var falseWithParamID schemas.ModelCapabilities
+		if err := json.Unmarshal(json.RawMessage(`{"model_parameters":[{"id":"reasoning_with_tool_calls"}],"supports_reasoning_with_tool_calls":false}`), &falseWithParamID); err != nil {
+			t.Fatalf("unmarshal explicit-false row with param id: %v", err)
+		}
+		if got := extractSupportedParams(&falseWithParamID); slices.Contains(got, "reasoning_with_tool_calls") {
+			t.Errorf("extractSupportedParams(explicit false + model_parameters id) = %v, want reasoning_with_tool_calls absent", got)
+		}
 	})
 }

--- a/framework/modelcatalog/datasheet/costonlyparams_test.go
+++ b/framework/modelcatalog/datasheet/costonlyparams_test.go
@@ -1,0 +1,86 @@
+package datasheet
+
+import (
+	"encoding/json"
+	"slices"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// Regression test for issue #6276: a datasheet row that declares ONLY pricing (no
+// capability flags, no model_parameters) must not produce a supported-parameters
+// allowlist. The default "reasoning_with_tool_calls" marker used to be added even to
+// capability-empty rows, turning them into a one-element allowlist; the compat plugin
+// (should_drop_params) then stripped tools / tool_choice / temperature / everything
+// else from requests to that model.
+func TestCostOnlyRowProducesNoParamAllowlist(t *testing.T) {
+	// Hosted-datasheet shape reported in the issue for gemini-3.6-flash:
+	// pricing keys only, none of which map to ModelCapabilities fields.
+	costOnlyRow := json.RawMessage(`{
+		"input_cost_per_token_batches": 0.000000075,
+		"output_cost_per_token_batches": 0.0000003
+	}`)
+
+	t.Run("extractSupportedParams on a capability-empty row", func(t *testing.T) {
+		var caps schemas.ModelCapabilities
+		if err := json.Unmarshal(costOnlyRow, &caps); err != nil {
+			t.Fatalf("unmarshal cost-only row: %v", err)
+		}
+		if !IsEmptyModelCapabilities(&caps) {
+			t.Fatalf("precondition: cost-only row should parse to empty ModelCapabilities")
+		}
+		if got := extractSupportedParams(&caps); len(got) != 0 {
+			t.Errorf("extractSupportedParams(cost-only row) = %v, want empty — a row declaring no request parameters must not synthesize an allowlist", got)
+		}
+	})
+
+	t.Run("applyModelParameters end-to-end", func(t *testing.T) {
+		s := &Store{}
+		// A second, genuinely populated row keeps applied > 0 so the index swap
+		// happens, mirroring the real datasheet where thousands of populated
+		// rows sit alongside the cost-only gemini-3.6-flash row.
+		s.applyModelParameters(map[string]json.RawMessage{
+			"gemini-3.6-flash": costOnlyRow,
+			"gpt-4o":           json.RawMessage(`{"supports_function_calling":true,"supports_tool_choice":true}`),
+		})
+
+		if got := s.GetSupportedParameters("gemini-3.6-flash"); got != nil {
+			t.Errorf("GetSupportedParameters(gemini-3.6-flash) = %v, want nil (unknown) — compat treats any non-nil list as a complete allowlist and drops tools/tool_choice", got)
+		}
+	})
+
+	t.Run("populated row keeps the default marker", func(t *testing.T) {
+		// Backward-compat contract from #4630: rows declaring real capabilities but
+		// lacking the reasoning_with_tool_calls flag still get the default marker.
+		var caps schemas.ModelCapabilities
+		if err := json.Unmarshal(json.RawMessage(`{"supports_function_calling":true}`), &caps); err != nil {
+			t.Fatalf("unmarshal populated row: %v", err)
+		}
+		got := extractSupportedParams(&caps)
+		if !slices.Contains(got, "reasoning_with_tool_calls") {
+			t.Errorf("extractSupportedParams(populated row) = %v, want it to include the default reasoning_with_tool_calls marker", got)
+		}
+		if !slices.Contains(got, "tools") {
+			t.Errorf("extractSupportedParams(populated row) = %v, want it to include tools", got)
+		}
+	})
+
+	t.Run("explicit flag is honored regardless of other capabilities", func(t *testing.T) {
+		var explicitTrue schemas.ModelCapabilities
+		if err := json.Unmarshal(json.RawMessage(`{"supports_reasoning_with_tool_calls":true}`), &explicitTrue); err != nil {
+			t.Fatalf("unmarshal explicit-true row: %v", err)
+		}
+		if got := extractSupportedParams(&explicitTrue); !slices.Contains(got, "reasoning_with_tool_calls") {
+			t.Errorf("extractSupportedParams(explicit true) = %v, want reasoning_with_tool_calls present", got)
+		}
+
+		var explicitFalse schemas.ModelCapabilities
+		if err := json.Unmarshal(json.RawMessage(`{"supports_function_calling":true,"supports_reasoning_with_tool_calls":false}`), &explicitFalse); err != nil {
+			t.Fatalf("unmarshal explicit-false row: %v", err)
+		}
+		if got := extractSupportedParams(&explicitFalse); slices.Contains(got, "reasoning_with_tool_calls") {
+			t.Errorf("extractSupportedParams(explicit false) = %v, want reasoning_with_tool_calls absent", got)
+		}
+	})
+}

--- a/framework/modelcatalog/datasheet/types.go
+++ b/framework/modelcatalog/datasheet/types.go
@@ -515,9 +515,6 @@ func extractSupportedParams(parsed *schemas.ModelCapabilities) []string {
 	if parsed.SupportsReasoning != nil && *parsed.SupportsReasoning {
 		addParam("reasoning")
 	}
-	if parsed.SupportsReasoningWithToolCalls == nil || *parsed.SupportsReasoningWithToolCalls {
-		addParam("reasoning_with_tool_calls")
-	}
 	if parsed.SupportsNoneReasoningEffort != nil && *parsed.SupportsNoneReasoningEffort {
 		addParam("supports_none_reasoning_effort")
 	}
@@ -537,6 +534,20 @@ func extractSupportedParams(parsed *schemas.ModelCapabilities) []string {
 	if parsed.SupportsWebSearch != nil && *parsed.SupportsWebSearch {
 		addParam("web_search")
 		addParam("web_search_options")
+	}
+
+	// reasoning_with_tool_calls defaults on for rows that lack the flag, so models
+	// missing it don't get reasoning stripped when tools are present. Restrict the
+	// default to rows that declared at least one capability: for a capability-empty
+	// (e.g. cost-only) row the marker alone would otherwise become a one-element
+	// allowlist, and compat with should_drop_params would strip every other
+	// parameter (tools, tool_choice, ...) from requests.
+	if parsed.SupportsReasoningWithToolCalls != nil {
+		if *parsed.SupportsReasoningWithToolCalls {
+			addParam("reasoning_with_tool_calls")
+		}
+	} else if len(supported) > 0 {
+		addParam("reasoning_with_tool_calls")
 	}
 
 	return supported

--- a/framework/modelcatalog/datasheet/types.go
+++ b/framework/modelcatalog/datasheet/types.go
@@ -536,12 +536,32 @@ func extractSupportedParams(parsed *schemas.ModelCapabilities) []string {
 		addParam("web_search_options")
 	}
 
+	// declaredParamSurface reports whether the row said anything at all about the
+	// request-parameter surface, including explicit "supports X: false". That is a
+	// different set from "produced a parameter name above": a row carrying only
+	// explicit-false flags produces no names but IS making an authoritative
+	// statement, and must keep a (possibly empty-of-tools) allowlist rather than
+	// degrade to "unknown, do not drop".
+	declaredParamSurface := len(parsed.ModelParameters) > 0 ||
+		parsed.SupportsAssistantPrefill != nil ||
+		parsed.SupportsFunctionCalling != nil ||
+		parsed.SupportsParallelFunctionCalling != nil ||
+		parsed.SupportsToolChoice != nil ||
+		parsed.SupportsReasoning != nil ||
+		parsed.SupportsResponseSchema != nil ||
+		parsed.SupportsNoneReasoningEffort != nil ||
+		parsed.SupportsServiceTier != nil ||
+		parsed.SupportsPromptCaching != nil ||
+		parsed.SupportsWebSearch != nil
+
 	// reasoning_with_tool_calls defaults on for rows that lack the flag, so models
 	// missing it don't get reasoning stripped when tools are present. Restrict the
-	// default to rows that declared at least one capability: for a capability-empty
-	// (e.g. cost-only) row the marker alone would otherwise become a one-element
-	// allowlist, and compat with should_drop_params would strip every other
-	// parameter (tools, tool_choice, ...) from requests.
+	// default to rows that declared a parameter surface: for a row that said
+	// nothing about parameters (cost-only, deprecation-only, mode-only) the marker
+	// alone would otherwise become a one-element allowlist, and compat with
+	// should_drop_params would strip every other parameter (tools, tool_choice,
+	// ...) from requests. This block must stay last in the function: the explicit
+	// false below removes the marker regardless of how it was added above.
 	if parsed.SupportsReasoningWithToolCalls != nil {
 		if *parsed.SupportsReasoningWithToolCalls {
 			addParam("reasoning_with_tool_calls")
@@ -552,7 +572,7 @@ func extractSupportedParams(parsed *schemas.ModelCapabilities) []string {
 				return p == "reasoning_with_tool_calls"
 			})
 		}
-	} else if len(supported) > 0 {
+	} else if declaredParamSurface {
 		addParam("reasoning_with_tool_calls")
 	}
 

--- a/framework/modelcatalog/datasheet/types.go
+++ b/framework/modelcatalog/datasheet/types.go
@@ -545,6 +545,12 @@ func extractSupportedParams(parsed *schemas.ModelCapabilities) []string {
 	if parsed.SupportsReasoningWithToolCalls != nil {
 		if *parsed.SupportsReasoningWithToolCalls {
 			addParam("reasoning_with_tool_calls")
+		} else {
+			// Explicit false wins even when a model_parameters id already added
+			// the marker via the default case above.
+			supported = slices.DeleteFunc(supported, func(p string) bool {
+				return p == "reasoning_with_tool_calls"
+			})
 		}
 	} else if len(supported) > 0 {
 		addParam("reasoning_with_tool_calls")


### PR DESCRIPTION
## Summary

A datasheet row that declares only pricing silently kills tool calling for that model.

The issue's original row (`gemini-3.6-flash`) carried two cost keys and nothing else. `extractSupportedParams` still added the default `reasoning_with_tool_calls` marker to it, which turned an otherwise empty capability list into a one-element allowlist. `applyModelParameters` stores any non-empty list, the compat plugin treats a non-nil list as authoritative, and with `should_drop_params: true` it stripped `tools`, `tool_choice`, and everything else from requests to that model. The model supports function calling fine; Bifrost just never asked.

That row has since been fixed upstream; `claude-opus-4-7-20260416` (`{"deprecation_date": "2027-04-16"}`, no capability fields) still reproduces on the live feed today, along with four other rows.

This PR fixes the code half of #6276. The hosted row itself still needs its capability flags added, but after this change an incomplete row degrades to "unknown, don't drop" instead of an allowlist of one marker.

## Changes

- `framework/modelcatalog/datasheet/types.go`: the default `reasoning_with_tool_calls` marker (from #4630) is now only added when the row declared a parameter surface at all: any `model_parameters` entry or any non-nil `supports_*` flag that maps to a request parameter, explicit false included. A row saying only `"supports_function_calling": false` is making an authoritative statement and keeps its allowlist; a row saying nothing about parameters (cost-only, deprecation-only, mode-only) degrades to "unknown, don't drop".
- An explicit `supports_reasoning_with_tool_calls` value is honored either way, true or false, including false overriding a marker sourced from a `model_parameters` id.
- No compat-side change needed: capability-empty rows now produce an empty list, `applyModelParameters` only stores non-empty lists, `GetSupportedParameters` returns nil, and compat's existing `!= nil` guard already skips dropping for nil.
- Populated rows lacking the flag keep the backward-compatible default from #4630 unchanged.
- `framework/modelcatalog/datasheet/costonlyparams_test.go`: regression tests for the cost-only row (unit and end-to-end through `applyModelParameters`), the explicit-false-only row keeping an authoritative allowlist, the populated-row default, and both explicit flag values. The first two fail without the fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

The change itself is in Framework (model catalog); the visible behavior change is in the compat plugin's drop decisions.

## How to test

```sh
cd framework
go test -run TestCostOnlyRowProducesNoParamAllowlist -v ./modelcatalog/datasheet/
go test ./modelcatalog/...
cd .. && go test ./plugins/compat/
```

Or live: with the default public `model_parameters_url` and `should_drop_params: true`, send a chat request to `claude-opus-4-7-20260416` with one function tool. Before this change `tools` and `tool_choice` are dropped before the request leaves Bifrost; after it they pass through. (The issue's original row, `gemini-3.6-flash`, no longer reproduces since its upstream row gained capability flags.)

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

Cost-only rows also disappear from `/v1/models` `supported_parameters` and the qualified-key suffix index; those entries carried no real data.

## Related issues

Fixes the parser half of #6276. Datasheet row updates for the remaining capability-empty rows (`claude-opus-4-7-20260416` and friends) are maintainer-side.

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable

