### PR TITLE
fix(ui): unify full-height page sizing with `--app-bottom-padding` CSS variable and tighten sidebar/content margins

### DIFF
--- a/ui/app/clientLayout.tsx
+++ b/ui/app/clientLayout.tsx
@@ -8,10 +8,10 @@ import Topbar from "@/components/topbar";
 import TrialExpiryBanner from "@/components/trialExpiryBanner";
 import { Button } from "@/components/ui/button";
 import { SidebarProvider } from "@/components/ui/sidebar";
-import { useStoreSync } from "@/hooks/useStoreSync";
 import { useNotificationSync } from "@/hooks/useNotificationSync";
-import { TopbarProvider } from "@/lib/contexts/topbarContext";
+import { useStoreSync } from "@/hooks/useStoreSync";
 import { WebSocketProvider } from "@/hooks/useWebSocket";
+import { TopbarProvider } from "@/lib/contexts/topbarContext";
 import { getErrorMessage, ReduxProvider, useGetCoreConfigQuery, useIsAuthEnabledQuery } from "@/lib/store";
 import { BifrostConfig } from "@/lib/types/config";
 import { RbacProvider, useRbacContext } from "@enterprise/lib/contexts/rbacContext";
@@ -132,7 +132,7 @@ function AppContent({ children }: { children: React.ReactNode }) {
 							    60px topbar so its top edge lands on the same line as the sidebar's
 							    search input, and --app-content-viewport compensates so full-height
 							    pages still measure to the card's inner height. */}
-							<div className="dark:bg-card custom-scrollbar content-container mx-0 min-h-0 min-w-0 flex-1 overflow-auto border border-gray-200 bg-white md:mr-2 md:mb-2 md:rounded-md md:px-10 dark:border-zinc-800">
+							<div className="dark:bg-card custom-scrollbar content-container mx-0 min-h-0 min-w-0 flex-1 overflow-auto border border-gray-200 bg-white md:mr-3 md:mb-3 md:rounded-md md:px-10 dark:border-zinc-800">
 								<TrialExpiryBanner />
 								<main className="custom-scrollbar content-container-inner relative mx-auto flex h-full min-h-0 flex-col overflow-y-hidden md:p-4">
 									{isLoading ? (

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -103,11 +103,16 @@
 	   Full-viewport surfaces that sit outside the card — dialogs, portalled
 	   popovers, the sidebar, the auth-only MinimalShell — keep using 100dvh. */
 	--app-topbar-height: 3.25rem;
-	/* Pages size themselves as `calc(var(--app-content-viewport) - 1rem)` — a
+	/* Pages size themselves as
+	   `calc(var(--app-content-viewport) - var(--app-bottom-padding))` — a
 	   leftover from when the card carried my-2. It now has only mb-2, so add
 	   that 0.5rem back here to keep their subtraction landing exactly on the
 	   card's inner height. */
 	--app-content-viewport: calc(100dvh - var(--app-topbar-height) + 0.5rem);
+	/* Gap left below a full-height page so it doesn't sit flush against the
+	   bottom of the content card. Change it here, not per page — every
+	   full-height page subtracts this from --app-content-viewport. */
+	--app-bottom-padding: 20px;
 
 	--height-base: calc(var(--app-content-viewport) - 130px);
 

--- a/ui/app/workspace/audit-logs/page.tsx
+++ b/ui/app/workspace/audit-logs/page.tsx
@@ -2,7 +2,7 @@ import AuditLogsView from "@enterprise/components/audit-logs/auditLogsView";
 
 export default function AuditLogsPage() {
 	return (
-		<div className="no-padding-parent no-border-parent bg-background flex h-[calc(var(--app-content-viewport)_-_16px)] w-full">
+		<div className="no-padding-parent no-border-parent bg-background flex h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))] w-full">
 			<AuditLogsView />
 		</div>
 	);

--- a/ui/app/workspace/complexity-router/page.tsx
+++ b/ui/app/workspace/complexity-router/page.tsx
@@ -336,7 +336,7 @@ export default function ComplexityRouterPage() {
 	const hasErrors = Boolean(boundaryErrors || keywordErrors);
 
 	return (
-		<div className="no-padding-parent flex h-[calc(var(--app-content-viewport)_-_16px)] min-w-0 flex-col">
+		<div className="no-padding-parent flex h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))] min-w-0 flex-col">
 			<ScrollArea className="min-h-0 w-full flex-1">
 				<form
 					id="complexity-router-form"

--- a/ui/app/workspace/custom-pricing/overrides/page.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/page.tsx
@@ -2,7 +2,7 @@ import ScopedPricingOverridesView from "@/app/workspace/custom-pricing/overrides
 
 export default function ScopedPricingOverridesPage() {
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_1rem)] min-h-0 w-full flex-col overflow-hidden p-4">
+		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))] min-h-0 w-full flex-col overflow-hidden p-4">
 			<ScopedPricingOverridesView />
 		</div>
 	);

--- a/ui/app/workspace/dashboard/page.tsx
+++ b/ui/app/workspace/dashboard/page.tsx
@@ -471,7 +471,7 @@ export default function DashboardPage() {
 	return (
 		<div
 			id="dashboard-root"
-			className="no-padding-parent no-border-parent bg-background flex h-[calc(var(--app-content-viewport)_-_16px)] w-full gap-3"
+			className="no-padding-parent no-border-parent bg-background flex h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))] w-full gap-3"
 		>
 			{/* Sidebar Filters */}
 			<LogsFilterSidebar filters={filters} onFiltersChange={setFilters} />

--- a/ui/app/workspace/edge-control/devices/page.tsx
+++ b/ui/app/workspace/edge-control/devices/page.tsx
@@ -2,7 +2,7 @@ import DevicesView from "@enterprise/components/edge-control/devicesView";
 
 export default function EdgeDevicesPage() {
 	return (
-		<div data-testid="edge-devices-page" className="dark:bg-card no-padding-parent no-border-parent h-[calc(var(--app-content-viewport)_-_16px)]">
+		<div data-testid="edge-devices-page" className="dark:bg-card no-padding-parent no-border-parent h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))]">
 			<DevicesView />
 		</div>
 	);

--- a/ui/app/workspace/edge-control/inventory/page.tsx
+++ b/ui/app/workspace/edge-control/inventory/page.tsx
@@ -2,7 +2,7 @@ import InventoryView from "@enterprise/components/edge-control/inventoryView";
 
 export default function EdgeInventoryPage() {
 	return (
-		<div data-testid="edge-inventory-page" className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_1rem)] w-full max-w-7xl p-4">
+		<div data-testid="edge-inventory-page" className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))] w-full max-w-7xl p-4">
 			<InventoryView />
 		</div>
 	);

--- a/ui/app/workspace/governance/access-profiles/page.tsx
+++ b/ui/app/workspace/governance/access-profiles/page.tsx
@@ -10,7 +10,7 @@ export default function AccessProfilesPage() {
 	}
 
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_1rem)] w-full flex-col p-4">
+		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))] w-full flex-col p-4">
 			<AccessProfilesIndexView />
 		</div>
 	);

--- a/ui/app/workspace/governance/business-units/page.tsx
+++ b/ui/app/workspace/governance/business-units/page.tsx
@@ -2,7 +2,7 @@ import { BusinessUnitsView } from "@enterprise/components/user-groups/businessUn
 
 export default function GovernanceBusinessUnitsPage() {
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_1rem)] w-full flex-col p-4">
+		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))] w-full flex-col p-4">
 			<BusinessUnitsView />
 		</div>
 	);

--- a/ui/app/workspace/governance/customers/page.tsx
+++ b/ui/app/workspace/governance/customers/page.tsx
@@ -79,7 +79,7 @@ export default function GovernanceCustomersPage() {
 	}
 
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_1rem)] w-full flex-col p-4">
+		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))] w-full flex-col p-4">
 			<CustomersTable
 				customers={customersData?.customers || []}
 				totalCount={customersData?.total_count || 0}

--- a/ui/app/workspace/governance/rbac/page.tsx
+++ b/ui/app/workspace/governance/rbac/page.tsx
@@ -2,7 +2,7 @@ import RBACView from "@enterprise/components/rbac/rbacView";
 
 export default function GovernanceRbacPage() {
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_1rem)] w-full flex-col p-4">
+		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))] w-full flex-col p-4">
 			<RBACView />
 		</div>
 	);

--- a/ui/app/workspace/governance/teams/page.tsx
+++ b/ui/app/workspace/governance/teams/page.tsx
@@ -2,7 +2,7 @@ import { TeamsView } from "@enterprise/components/user-groups/teamsView";
 
 export default function GovernanceTeamsPage() {
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_1rem)] w-full flex-col p-4" data-testid="teams-view">
+		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))] w-full flex-col p-4" data-testid="teams-view">
 			<TeamsView />
 		</div>
 	);

--- a/ui/app/workspace/governance/users/page.tsx
+++ b/ui/app/workspace/governance/users/page.tsx
@@ -2,7 +2,7 @@ import UsersView from "@enterprise/components/user-groups/usersView";
 
 export default function GovernanceUsersPage() {
 	return (
-		<div className="no-padding-parent mx-auto h-[calc(var(--app-content-viewport)_-_1rem)] w-full p-4">
+		<div className="no-padding-parent mx-auto h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))] w-full p-4">
 			<UsersView />
 		</div>
 	);

--- a/ui/app/workspace/governance/virtual-keys/page.tsx
+++ b/ui/app/workspace/governance/virtual-keys/page.tsx
@@ -118,7 +118,7 @@ export default function GovernanceVirtualKeysPage() {
 	};
 
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_1rem)] min-h-0 w-full flex-col overflow-hidden p-4">
+		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))] min-h-0 w-full flex-col overflow-hidden p-4">
 			<VirtualKeysTable
 				virtualKeys={virtualKeysData?.virtual_keys || []}
 				totalCount={virtualKeysData?.total_count || 0}

--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -648,10 +648,22 @@ export default function LogsPage() {
 		() => ({ expandedChainIds, loadingChainIds, onToggleChain: handleToggleChain }),
 		[expandedChainIds, loadingChainIds, handleToggleChain],
 	);
-	const selectedLogFromData = useMemo(
-		() => (selectedLogId ? (logs.find((l) => l.id === selectedLogId) ?? null) : null),
-		[selectedLogId, logs],
-	);
+	// Resolve the selected log from data already on screen — the page of roots
+	// first, then the children of any expanded chain. Children live outside
+	// `logs`, so without this second lookup clicking a child would fall through
+	// to the fetch-by-id effect below and the sheet would only appear after that
+	// round trip. Resolving locally opens the sheet immediately; the sheet still
+	// fetches the full record and shows its own loader while that lands.
+	const selectedLogFromData = useMemo(() => {
+		if (!selectedLogId) return null;
+		const root = logs.find((l) => l.id === selectedLogId);
+		if (root) return root;
+		for (const children of Object.values(chainChildren)) {
+			const child = children.find((l) => l.id === selectedLogId);
+			if (child) return child;
+		}
+		return null;
+	}, [selectedLogId, logs, chainChildren]);
 
 	useEffect(() => {
 		if (!selectedLogId || selectedLogFromData) {
@@ -737,7 +749,7 @@ export default function LogsPage() {
 	);
 
 	return (
-		<div className="dark:bg-card no-padding-parent no-border-parent h-[calc(var(--app-content-viewport)_-_16px)]">
+		<div className="dark:bg-card no-padding-parent no-border-parent h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))]">
 			{showEmptyState ? (
 				<EmptyState error={error ?? (logsError ? getErrorMessage(logsError as Parameters<typeof getErrorMessage>[0]) : null)} />
 			) : (

--- a/ui/app/workspace/mcp-logs/page.tsx
+++ b/ui/app/workspace/mcp-logs/page.tsx
@@ -437,7 +437,7 @@ export default function MCPLogsPage() {
 			) : showEmptyState ? (
 				<MCPEmptyState error={displayError} />
 			) : (
-				<div className="no-padding-parent no-border-parent bg-background flex h-[calc(var(--app-content-viewport)_-_16px)] w-full gap-3">
+				<div className="no-padding-parent no-border-parent bg-background flex h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))] w-full gap-3">
 					{/* Sidebar Filters */}
 					<MCPFilterSidebar filters={filters} onFiltersChange={setFilters} />
 

--- a/ui/app/workspace/mcp-registry/library/page.tsx
+++ b/ui/app/workspace/mcp-registry/library/page.tsx
@@ -155,7 +155,7 @@ export default function MCPLibraryPage() {
 	const isCatalogEmpty = !isFetching && totalCount === 0 && !debouncedSearch && !hasActiveFilters;
 
 	return (
-		<div className="dark:bg-card no-padding-parent no-border-parent min-h-full md:h-[calc(var(--app-content-viewport)_-_16px)]">
+		<div className="dark:bg-card no-padding-parent no-border-parent min-h-full md:h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))]">
 			<div className="bg-background flex min-h-full w-full grow gap-3 md:h-full">
 				{/* Sidebar Filters */}
 				<MCPLibraryFilterSidebar filters={filters} onFiltersChange={setFilters} />

--- a/ui/app/workspace/mcp-registry/page.tsx
+++ b/ui/app/workspace/mcp-registry/page.tsx
@@ -160,7 +160,7 @@ export default function MCPServersPage() {
 	}
 
 	return (
-		<div className="dark:bg-card no-padding-parent no-border-parent h-[calc(var(--app-content-viewport)_-_16px)]">
+		<div className="dark:bg-card no-padding-parent no-border-parent h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))]">
 			<div className="bg-background flex h-full w-full grow gap-3">
 				<MCPClientsFilterSidebar filters={filters} onFiltersChange={setFilters} />
 				<div className="bg-card h-full w-full overflow-hidden rounded-md border">

--- a/ui/app/workspace/mcp-sessions/page.tsx
+++ b/ui/app/workspace/mcp-sessions/page.tsx
@@ -126,7 +126,7 @@ export default function MCPSessionsPage() {
 	}
 
 	return (
-		<div className="dark:bg-card no-padding-parent no-border-parent h-[calc(var(--app-content-viewport)_-_16px)]">
+		<div className="dark:bg-card no-padding-parent no-border-parent h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))]">
 			<div className="bg-background flex h-full w-full grow gap-3">
 				<MCPSessionsFilterSidebar filters={filters} onFiltersChange={setFilters} />
 				<div className="bg-card h-full w-full overflow-hidden rounded-md border">

--- a/ui/app/workspace/model-catalog/views/modelCatalogView.tsx
+++ b/ui/app/workspace/model-catalog/views/modelCatalogView.tsx
@@ -23,7 +23,7 @@ export default function ModelCatalogView() {
 	}
 
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_1rem)] min-h-0 w-full max-w-7xl flex-col overflow-hidden p-4">
+		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))] min-h-0 w-full max-w-7xl flex-col overflow-hidden p-4">
 			<Tabs value={tab} onValueChange={(value) => setTab(value as ModelCatalogTab)} className="flex min-h-0 grow flex-col gap-4">
 				<TabsList className="shrink-0">
 					<TabsTrigger value="overview" data-testid="model-catalog-tab-overview">

--- a/ui/app/workspace/model-limits/page.tsx
+++ b/ui/app/workspace/model-limits/page.tsx
@@ -2,7 +2,7 @@ import ModelLimitsView from "./views/modelLimitsView";
 
 export default function ModelLimitsPage() {
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_1rem)] min-h-0 w-full flex-col overflow-hidden p-4">
+		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))] min-h-0 w-full flex-col overflow-hidden p-4">
 			<ModelLimitsView />
 		</div>
 	);

--- a/ui/app/workspace/oauth-grants/page.tsx
+++ b/ui/app/workspace/oauth-grants/page.tsx
@@ -144,7 +144,7 @@ export default function OAuthGrantsPage() {
 	}
 
 	return (
-		<div className="dark:bg-card no-padding-parent no-border-parent h-[calc(var(--app-content-viewport)_-_16px)]">
+		<div className="dark:bg-card no-padding-parent no-border-parent h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))]">
 			<div className="bg-background flex h-full w-full grow gap-3">
 				<OAuthGrantsFilterSidebar filters={filters} onFiltersChange={setFilters} />
 				<div className="bg-card h-full w-full overflow-hidden rounded-md border">

--- a/ui/app/workspace/routing-rules/page.tsx
+++ b/ui/app/workspace/routing-rules/page.tsx
@@ -7,7 +7,7 @@ import { RoutingRulesView } from "./views/routingRulesView";
 
 export default function RoutingRulesPage() {
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_1rem)] min-h-0 w-full flex-col overflow-hidden p-4">
+		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))] min-h-0 w-full flex-col overflow-hidden p-4">
 			<RoutingRulesView />
 		</div>
 	);

--- a/ui/app/workspace/skills-repo/page.tsx
+++ b/ui/app/workspace/skills-repo/page.tsx
@@ -56,7 +56,7 @@ export default function SkillsRepoPage() {
 
 	// List view
 	return (
-		<div className="no-padding-parent flex min-h-full w-full min-w-0 flex-col p-4 md:h-[calc(var(--app-content-viewport)_-_16px)] md:min-h-0">
+		<div className="no-padding-parent flex min-h-full w-full min-w-0 flex-col p-4 md:h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))] md:min-h-0">
 			<SkillsListView onSelectSkill={handleSelectSkill} onCreateNew={() => setUrlState({ create: true, skillId: null, edit: false })} />
 		</div>
 	);

--- a/ui/components/prompts/promptsView.tsx
+++ b/ui/components/prompts/promptsView.tsx
@@ -34,7 +34,7 @@ export default function PromptsView() {
 
 	if (folders.length === 0 && prompts.length === 0) {
 		return (
-			<div className="no-padding-parent no-border-parent flex h-[calc(var(--app-content-viewport)_-_18px)] w-full items-center">
+			<div className="no-padding-parent no-border-parent flex h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))] w-full items-center">
 				<PromptSheets />
 				<PromptsEmptyState />
 			</div>
@@ -43,7 +43,7 @@ export default function PromptsView() {
 
 	if (isMobile) {
 		return (
-			<div className="no-padding-parent no-border-parent bg-background flex h-[calc(var(--app-content-viewport)_-_16px)] w-full flex-col gap-2 overflow-auto">
+			<div className="no-padding-parent no-border-parent bg-background flex h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))] w-full flex-col gap-2 overflow-auto">
 				<DeleteFolderDialog />
 				<DeletePromptDialog />
 				<PromptSheets />
@@ -78,7 +78,7 @@ export default function PromptsView() {
 	}
 
 	return (
-		<div className="no-padding-parent no-border-parent bg-background h-[calc(var(--app-content-viewport)_-_16px)] w-full">
+		<div className="no-padding-parent no-border-parent bg-background h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))] w-full">
 			<DeleteFolderDialog />
 			<DeletePromptDialog />
 			<PromptSheets />

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -19,10 +19,10 @@ import {
 	Gavel,
 	GitCompareArrows,
 	Globe,
+	Hexagon,
 	History,
 	KeyRound,
 	Landmark,
-	Hexagon,
 	LaptopMinimalCheck,
 	LayoutGrid,
 	Logs,
@@ -251,15 +251,14 @@ const SidebarItemView = ({
 
 	const isHighlighted = !hasSubItems && highlightedUrl === item.url;
 
-	const buttonClassName = `group/nav-item relative h-7.5 cursor-pointer rounded-sm border px-3 transition-all duration-200 ${
-		isHighlighted
-			? "bg-sidebar-accent text-accent-foreground border-primary/20"
-			: isActive || isAnySubItemActive
-				? "bg-sidebar-accent text-primary border-primary/20"
-				: item.hasAccess
-					? "hover:bg-sidebar-accent hover:text-accent-foreground border-transparent text-slate-500 dark:text-zinc-400"
-					: "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
-	} `;
+	const buttonClassName = `group/nav-item relative h-7.5 cursor-pointer rounded-sm border px-3 transition-all duration-200 ${isHighlighted
+		? "bg-sidebar-accent text-accent-foreground border-primary/20"
+		: isActive || isAnySubItemActive
+			? "bg-sidebar-accent text-primary border-primary/20"
+			: item.hasAccess
+				? "hover:bg-sidebar-accent hover:text-accent-foreground border-transparent text-slate-500 dark:text-zinc-400"
+				: "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
+		} `;
 
 	const innerContent = (
 		<div className="flex w-full items-center justify-between">
@@ -410,15 +409,14 @@ const SidebarItemView = ({
 						const isSubItemActive = subItem.queryParam ? pathname === subItem.url : isRouteMatch(subItem.url);
 						const isSubItemHighlighted = highlightedUrl ? subItemHref.startsWith(highlightedUrl) : false;
 						const SubItemIcon = subItem.icon;
-						const subItemClassName = `h-7 cursor-pointer rounded-sm px-2 transition-all duration-200 ${
-							isSubItemHighlighted
-								? "bg-sidebar-accent text-accent-foreground"
-								: isSubItemActive
-									? "bg-sidebar-accent text-primary font-medium"
-									: subItem.hasAccess === false
-										? "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
-										: "hover:bg-sidebar-accent hover:text-accent-foreground text-slate-500 dark:text-zinc-400"
-						}`;
+						const subItemClassName = `h-7 cursor-pointer rounded-sm px-2 transition-all duration-200 ${isSubItemHighlighted
+							? "bg-sidebar-accent text-accent-foreground"
+							: isSubItemActive
+								? "bg-sidebar-accent text-primary font-medium"
+								: subItem.hasAccess === false
+									? "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
+									: "hover:bg-sidebar-accent hover:text-accent-foreground text-slate-500 dark:text-zinc-400"
+							}`;
 						const subInner = (
 							<div className="flex w-full items-center gap-2">
 								{SubItemIcon && <SubItemIcon className={`h-3.5 w-3.5 ${isSubItemActive ? "text-primary" : "text-muted-foreground"}`} />}
@@ -960,21 +958,21 @@ export default function AppSidebar() {
 			},
 			...(isDbConnected
 				? [
-						{
-							title: "Prompt Repository",
-							url: "/workspace/prompt-repo",
-							icon: FolderGit,
-							description: "Prompt repository",
-							hasAccess: hasPromptRepositoryAccess,
-						},
-						{
-							title: "Skills Repository",
-							url: "/workspace/skills-repo",
-							icon: BookOpenText,
-							description: "Skills repository",
-							hasAccess: hasSkillsRepositoryAccess,
-						},
-					]
+					{
+						title: "Prompt Repository",
+						url: "/workspace/prompt-repo",
+						icon: FolderGit,
+						description: "Prompt repository",
+						hasAccess: hasPromptRepositoryAccess,
+					},
+					{
+						title: "Skills Repository",
+						url: "/workspace/skills-repo",
+						icon: BookOpenText,
+						description: "Skills repository",
+						hasAccess: hasSkillsRepositoryAccess,
+					},
+				]
 				: []),
 			{
 				title: "Evals",
@@ -1021,14 +1019,14 @@ export default function AppSidebar() {
 					},
 					...(IS_ENTERPRISE
 						? [
-								{
-									title: "Proxy",
-									url: "/workspace/config/proxy",
-									icon: Globe,
-									description: "Proxy configuration",
-									hasAccess: hasSettingsAccess,
-								},
-							]
+							{
+								title: "Proxy",
+								url: "/workspace/config/proxy",
+								icon: Globe,
+								description: "Proxy configuration",
+								hasAccess: hasSettingsAccess,
+							},
+						]
 						: []),
 					{
 						title: "API Keys",
@@ -1053,21 +1051,21 @@ export default function AppSidebar() {
 					},
 					...(IS_ENTERPRISE
 						? [
-								{
-									title: "Branding",
-									url: "/workspace/config/branding",
-									icon: Palette,
-									description: "Custom logo and icon",
-									hasAccess: hasSettingsAccess,
-								},
-								{
-									title: "License Info",
-									url: "/workspace/config/license",
-									icon: BadgeInfo,
-									description: "Enterprise license information",
-									hasAccess: hasSettingsAccess,
-								},
-							]
+							{
+								title: "Branding",
+								url: "/workspace/config/branding",
+								icon: Palette,
+								description: "Custom logo and icon",
+								hasAccess: hasSettingsAccess,
+							},
+							{
+								title: "License Info",
+								url: "/workspace/config/license",
+								icon: BadgeInfo,
+								description: "Enterprise license information",
+								hasAccess: hasSettingsAccess,
+							},
+						]
 						: []),
 				],
 			},
@@ -1485,8 +1483,8 @@ export default function AppSidebar() {
 					</div>
 				</div>
 			)}
-			<div className="mx-2 pb-1 group-data-[collapsible=icon]:hidden">
-				<div className="dark:bg-card relative bg-white">
+			<div className="ml-2 mr-3 pb-1 group-data-[collapsible=icon]:hidden">
+				<div className="dark:bg-card relative bg-white rounded-sm">
 					<Search className="text-muted-foreground absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2" />
 					<input
 						ref={searchInputRef}
@@ -1508,7 +1506,7 @@ export default function AppSidebar() {
 				</div>
 			</div>
 			<SidebarContent className="overflow-hidden">
-				<SidebarGroup className="custom-scrollbar min-h-0 flex-1 overflow-y-auto">
+				<SidebarGroup className="custom-scrollbar min-h-0 flex-1 overflow-y-auto pr-3">
 					<SidebarGroupContent>
 						<SidebarMenu className="space-y-0.5">
 							{filteredItems.map((item) => {
@@ -1535,7 +1533,7 @@ export default function AppSidebar() {
 						</SidebarMenu>
 					</SidebarGroupContent>
 				</SidebarGroup>
-				<div className="mt-auto flex flex-col gap-4 px-3 pb-2 group-data-[collapsible=icon]:px-1">
+				<div className="mt-auto flex flex-col gap-4 px-3 pb-3 group-data-[collapsible=icon]:px-1">
 					<div className="mx-1 group-data-[collapsible=icon]:hidden">
 						<PromoCardStack cards={promoCards} onDismiss={handlePromoDismiss} />
 					</div>

--- a/ui/components/topbar.tsx
+++ b/ui/components/topbar.tsx
@@ -1,5 +1,5 @@
-import { ThemeToggle } from "@/components/themeToggle";
 import NotificationCenter from "@/components/notificationCenter";
+import { ThemeToggle } from "@/components/themeToggle";
 import { deriveTitleFromPathname, TOPBAR_MENU_SIDE_OFFSET } from "@/components/topbar.utils";
 import {
 	DropdownMenu,
@@ -34,29 +34,29 @@ const externalLinks: {
 	icon: React.ComponentType<Record<string, unknown>>;
 	strokeWidth?: number;
 }[] = [
-	{
-		title: "Discord Server",
-		url: "https://discord.gg/exN5KAydbU",
-		icon: DiscordLogoIcon,
-	},
-	{
-		title: "GitHub Repository",
-		url: "https://github.com/maximhq/bifrost",
-		icon: GithubLogoIcon,
-	},
-	{
-		title: "Report a bug",
-		url: "https://github.com/maximhq/bifrost/issues/new?title=[Bug Report]&labels=bug&type=bug&projects=maximhq/1",
-		icon: BugIcon,
-		strokeWidth: 1.5,
-	},
-	{
-		title: "Full Documentation",
-		url: "https://docs.getbifrost.ai",
-		icon: BooksIcon,
-		strokeWidth: 1,
-	},
-];
+		{
+			title: "Discord Server",
+			url: "https://discord.gg/exN5KAydbU",
+			icon: DiscordLogoIcon,
+		},
+		{
+			title: "GitHub Repository",
+			url: "https://github.com/maximhq/bifrost",
+			icon: GithubLogoIcon,
+		},
+		{
+			title: "Report a bug",
+			url: "https://github.com/maximhq/bifrost/issues/new?title=[Bug Report]&labels=bug&type=bug&projects=maximhq/1",
+			icon: BugIcon,
+			strokeWidth: 1.5,
+		},
+		{
+			title: "Full Documentation",
+			url: "https://docs.getbifrost.ai",
+			icon: BooksIcon,
+			strokeWidth: 1,
+		},
+	];
 
 /**
  * Resolves the topbar title. A page can name itself via useSetTopbarTitle();
@@ -121,7 +121,7 @@ export default function Topbar() {
 	};
 
 	return (
-		<header className="flex h-13 w-full shrink-0 items-center gap-2 px-3 pt-1 md:pr-4 md:pl-2" data-testid="topbar-container-root">
+		<header className="flex h-13 w-full shrink-0 items-center gap-2 px-3 pt-1 md:pr-3 md:pl-2" data-testid="topbar-container-root">
 			<div className="flex min-w-0 flex-1 items-center gap-2">
 				<SidebarTrigger className="shrink-0 md:hidden" />
 				<img className="h-[22px] w-auto max-w-[120px] object-contain md:hidden" src={logoSrc} alt={logoAlt} width={70} height={70} />

--- a/ui/components/topbar.utils.ts
+++ b/ui/components/topbar.utils.ts
@@ -7,7 +7,7 @@
  * offset lands every menu on the same line, and a lone override would visibly
  * break the row.
  */
-export const TOPBAR_MENU_SIDE_OFFSET = 3;
+export const TOPBAR_MENU_SIDE_OFFSET = 8;
 
 /** Path segments that are shouted rather than capitalised. */
 const titleAcronyms: Record<string, string> = {

--- a/ui/components/ui/sidebar.tsx
+++ b/ui/components/ui/sidebar.tsx
@@ -16,7 +16,7 @@ const SIDEBAR_COOKIE_NAME = "sidebar_state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH = "15rem";
 const SIDEBAR_WIDTH_MOBILE = "18rem";
-const SIDEBAR_WIDTH_ICON = "3rem";
+const SIDEBAR_WIDTH_ICON = "3.25rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "b";
 
 type SidebarContextProps = {
@@ -478,7 +478,7 @@ function SidebarMenuAction({
 				"peer-data-[size=lg]/menu-button:top-2.5",
 				"group-data-[collapsible=icon]:hidden",
 				showOnHover &&
-					"peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0",
+				"peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0",
 				className,
 			)}
 			{...props}
@@ -620,5 +620,5 @@ export {
 	SidebarRail,
 	SidebarSeparator,
 	SidebarTrigger,
-	useSidebar,
+	useSidebar
 };


### PR DESCRIPTION
## Summary

Replaces scattered hardcoded pixel offsets used for full-height page layouts with a single `--app-bottom-padding` CSS custom property, and tightens the overall layout spacing so the content card and sidebar have consistent, slightly larger margins.

## Changes

- Introduced `--app-bottom-padding: 20px` in `globals.css` as the single source of truth for the gap between full-height pages and the bottom of the content card. All pages that previously subtracted `1rem`, `16px`, or `18px` from `--app-content-viewport` now subtract `var(--app-bottom-padding)` instead.
- Updated the content card container margins from `md:mr-2 md:mb-2` to `md:mr-3 md:mb-3` to give the card a slightly larger inset from the viewport edge.
- Updated the topbar right padding from `md:pr-4` to `md:pr-3` to align with the new card margin.
- Adjusted the sidebar search input wrapper from `mx-2` to `ml-2 mr-3` and added `rounded-sm` to the inner container, so the search field aligns with the content card's right edge.
- Added `pr-3` to the sidebar scroll group and changed the bottom section padding from `pb-2` to `pb-3` for consistent spacing.
- Increased `SIDEBAR_WIDTH_ICON` from `3rem` to `3.25rem` to match the topbar height.
- Reformatted template literal class name constructions in `sidebar.tsx` for consistency (no behavioral change).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

Visually verify that all full-height pages (Dashboard, Logs, MCP Logs, Audit Logs, Governance pages, etc.) have a consistent bottom gap and that the content card, sidebar search input, and topbar right edge are all evenly inset from the viewport.

## Screenshots/Recordings

Before/after screenshots of the layout showing the consistent bottom padding and updated card margins are recommended.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable