### PR TITLE
feat: runware list models api

### DIFF
--- a/core/providers/runware/images.go
+++ b/core/providers/runware/images.go
@@ -2,6 +2,7 @@ package runware
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/google/uuid"
@@ -68,13 +69,17 @@ func ToRunwareImageGenerationRequest(bifrostReq *schemas.BifrostImageGenerationR
 		// input_images drives image-to-image on the generation path. A seedImage supplied through
 		// extra params is the provider-native form of the same thing and wins outright — sending
 		// both would put two input keys on a request that accepts one.
-		// Empty entries are dropped: Runware rejects a blank input key, and the edit path already
-		// filters the same way through runwareImageInput.
+		// Each entry is normalized the way the other image providers normalize theirs; empty ones are
+		// dropped, since Runware rejects a blank input key.
 		if request.SeedImage == nil {
 			inputImages := make([]string, 0, len(params.InputImages))
 			for _, img := range params.InputImages {
-				if trimmed := strings.TrimSpace(img); trimmed != "" {
-					inputImages = append(inputImages, trimmed)
+				reference, err := runwareImageReference(img)
+				if err != nil {
+					return nil, fmt.Errorf("invalid input image: %w", err)
+				}
+				if reference != "" {
+					inputImages = append(inputImages, reference)
 				}
 			}
 			if len(inputImages) > 0 {
@@ -177,16 +182,39 @@ func ToRunwareImageEditRequest(bifrostReq *schemas.BifrostImageEditRequest) (*Ru
 }
 
 // runwareImageInput resolves an input image to the reference Runware expects. A caller-supplied
-// URL passes through untouched — Runware accepts UUIDs and URLs natively, so forwarding it avoids
-// round-tripping the asset through the gateway as base64 — while raw bytes become a data URI.
+// URL is normalized rather than round-tripped through the gateway as base64; raw bytes become a
+// data URI. An unusable reference yields "", which callers treat as absent.
 func runwareImageInput(img schemas.ImageInput) string {
 	if img.URL != "" {
-		return img.URL
+		reference, err := runwareImageReference(img.URL)
+		if err != nil {
+			return ""
+		}
+		return reference
 	}
 	if len(img.Image) == 0 {
 		return ""
 	}
 	return providerUtils.FileBytesToBase64DataURL(img.Image)
+}
+
+// runwareImageReference normalizes a caller-supplied image reference. URLs and base64 payloads go
+// through the same sanitizer the other image providers use, which validates data URLs and wraps
+// bare base64 into one. A value carrying no URL scheme is left alone: Runware accepts its own asset
+// UUIDs as inputs — the ids it returns on data[].id — and those would otherwise be rejected as
+// schemeless URLs. Returns "" for an empty reference so callers can skip it.
+func runwareImageReference(image string) (string, error) {
+	trimmed := strings.TrimSpace(image)
+	if trimmed == "" {
+		return "", nil
+	}
+	if sanitized, err := schemas.SanitizeImageURL(trimmed); err == nil {
+		return sanitized, nil
+	} else if parsed, parseErr := url.Parse(trimmed); parseErr != nil || parsed.Scheme != "" {
+		// A scheme means it was meant to be a URL, so a sanitizer failure is a real error.
+		return "", err
+	}
+	return trimmed, nil
 }
 
 // runwareImageEditTaskType maps the neutral edit type onto a Runware tool task type. An empty

--- a/core/providers/runware/images_test.go
+++ b/core/providers/runware/images_test.go
@@ -755,3 +755,51 @@ func TestToRunwareImageGenerationRequest_InputImagesSkipsEmpty(t *testing.T) {
 		t.Fatalf("all-empty input_images must leave no input key, got seedImage=%v inputs=%+v", blank.SeedImage, blank.Inputs)
 	}
 }
+
+// Input images are normalized the way the other image providers normalize theirs: bare base64 is
+// wrapped into a data URI, malformed URLs are rejected, and Runware's own asset UUIDs survive —
+// those carry no scheme, so a generic URL sanitizer would otherwise reject them.
+func TestRunwareImageReference(t *testing.T) {
+	const bareBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+	for _, tc := range []struct {
+		name, in, want string
+		wantErr        bool
+	}{
+		{"asset uuid preserved", "2f670f32-dece-4c44-aef0-e62b52ca7d55", "2f670f32-dece-4c44-aef0-e62b52ca7d55", false},
+		{"https untouched", "https://example.com/a.jpg", "https://example.com/a.jpg", false},
+		{"data uri untouched", "data:image/png;base64,iVBORw0KGgo=", "data:image/png;base64,iVBORw0KGgo=", false},
+		{"bare base64 wrapped", bareBase64, "data:image/png;base64," + bareBase64, false},
+		{"whitespace trimmed", "  2f670f32-dece-4c44-aef0-e62b52ca7d55  ", "2f670f32-dece-4c44-aef0-e62b52ca7d55", false},
+		{"empty yields empty", "   ", "", false},
+		{"malformed data url errors", "data:garbage", "", true},
+		{"disallowed scheme errors", "ftp://example.com/a.jpg", "", true},
+	} {
+		got, err := runwareImageReference(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("%s: expected an error, got %q", tc.name, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("%s: got %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+// The generation path rejects a malformed reference rather than forwarding it for Runware to
+// reject, matching how replicate and runway handle input_images.
+func TestToRunwareImageGenerationRequest_InputImagesRejectsMalformed(t *testing.T) {
+	_, err := ToRunwareImageGenerationRequest(&schemas.BifrostImageGenerationRequest{
+		Model:  "runware:101@1",
+		Input:  &schemas.ImageGenerationInput{Prompt: "a cat"},
+		Params: &schemas.ImageGenerationParameters{InputImages: []string{"ftp://example.com/a.jpg"}},
+	})
+	if err == nil {
+		t.Fatalf("expected an error for a disallowed scheme")
+	}
+}

--- a/core/providers/runware/models.go
+++ b/core/providers/runware/models.go
@@ -1,6 +1,12 @@
 package runware
 
-import schemas "github.com/maximhq/bifrost/core/schemas"
+import (
+	"slices"
+	"strings"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
 
 // runware3DImageInputIsArray records, per 3D model, whether the input image goes into
 // inputs.images[] (true) or inputs.image (false). The split is per-model and comes from Runware's
@@ -236,4 +242,121 @@ func runwareVideoInputFormFor(caps schemas.ModelCaps) runwareVideoInputForm {
 		return runwareVideoInputFrameImages
 	}
 	return runwareVideoInputForms[caps.Model()]
+}
+
+// runwareModelSearchPageSize is above the documented maximum of 100, which Runware nonetheless
+// honours. It is deliberate: a modelSearch page costs ~10-20s regardless of size, so paging the
+// curated catalog at 100 would mean five sequential round trips and blow the request deadline,
+// while 500 fetches the whole set in one.
+const runwareModelSearchPageSize = 500
+
+// runwareCuratedSource limits a catalog sweep to Runware's first-party models. The unfiltered
+// catalog is dominated by community LoRA uploads (~273k of ~320k) that no Bifrost route targets.
+const runwareCuratedSource = "curated"
+
+// ToBifrostListModelsResponse converts Runware catalog pages to a Bifrost list response. The AIR is
+// the model identifier every inference task keys off, so it becomes the Bifrost model ID.
+func ToBifrostListModelsResponse(
+	models []RunwareModel,
+	providerKey schemas.ModelProvider,
+	allowedModels schemas.WhiteList,
+	blacklistedModels schemas.BlackList,
+	aliases schemas.KeyAliases,
+	unfiltered bool,
+) *schemas.BifrostListModelsResponse {
+	bifrostResponse := &schemas.BifrostListModelsResponse{
+		Data: make([]schemas.Model, 0, len(models)),
+	}
+
+	pipeline := &providerUtils.ListModelsPipeline{
+		AllowedModels:     allowedModels,
+		BlacklistedModels: blacklistedModels,
+		Aliases:           aliases,
+		Unfiltered:        unfiltered,
+		ProviderKey:       providerKey,
+		MatchFns:          providerUtils.DefaultMatchFns(),
+	}
+	if pipeline.ShouldEarlyExit() {
+		return bifrostResponse
+	}
+
+	for _, model := range models {
+		if model.AIR == "" {
+			continue
+		}
+		for _, result := range pipeline.FilterModel(model.AIR) {
+			bifrostModel := schemas.Model{
+				ID: string(providerKey) + "/" + result.ResolvedID,
+			}
+			if model.Name != "" {
+				bifrostModel.Name = &model.Name
+			}
+			if model.Comment != "" {
+				bifrostModel.Description = &model.Comment
+			}
+			if model.Creator != nil {
+				if owner := model.Creator.Name; owner != "" {
+					bifrostModel.OwnedBy = &owner
+				} else if owner := model.Creator.ID; owner != "" {
+					bifrostModel.OwnedBy = &owner
+				}
+			}
+			if model.AddedUnixTimestamp > 0 {
+				bifrostModel.Created = &model.AddedUnixTimestamp
+			}
+			// Runware describes a model's shape with capability tags rather than modality lists, so
+			// the input/output modalities are derived from its "io:<from>-to-<to>" entries.
+			if architecture := runwareModelArchitecture(model); architecture != nil {
+				bifrostModel.Architecture = architecture
+			}
+			if result.AliasValue != "" {
+				bifrostModel.Alias = &result.AliasValue
+			}
+			bifrostResponse.Data = append(bifrostResponse.Data, bifrostModel)
+		}
+	}
+
+	return bifrostResponse
+}
+
+// runwareModelArchitecture derives modality lists from a model's io: capability tags. Returns nil
+// when the entry declares none, so the field stays absent rather than empty.
+func runwareModelArchitecture(model RunwareModel) *schemas.Architecture {
+	inputs := map[string]bool{}
+	outputs := map[string]bool{}
+	for _, capability := range model.Capabilities {
+		pair, ok := strings.CutPrefix(capability, "io:")
+		if !ok {
+			continue
+		}
+		from, to, found := strings.Cut(pair, "-to-")
+		if !found {
+			continue
+		}
+		inputs[from] = true
+		outputs[to] = true
+	}
+	if len(inputs) == 0 && len(outputs) == 0 && model.Architecture == "" {
+		return nil
+	}
+	architecture := &schemas.Architecture{
+		InputModalities:  sortedKeys(inputs),
+		OutputModalities: sortedKeys(outputs),
+	}
+	if model.Architecture != "" {
+		architecture.Tokenizer = &model.Architecture
+	}
+	return architecture
+}
+
+func sortedKeys(set map[string]bool) []string {
+	if len(set) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(set))
+	for k := range set {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	return keys
 }

--- a/core/providers/runware/models_test.go
+++ b/core/providers/runware/models_test.go
@@ -1,0 +1,82 @@
+package runware
+
+import (
+	"testing"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+func catalogModels() []RunwareModel {
+	return []RunwareModel{
+		{
+			AIR:          "xai:grok-imagine@image-2.0",
+			Name:         "Grok Imagine Image 2.0",
+			Category:     "checkpoint",
+			Architecture: "grok_imagine_image_2_0",
+			Capabilities: []string{"io:text-to-image", "io:image-to-image", "form:checkpoint"},
+			Comment:      "Next-generation Grok image generation and editing",
+			Creator:      &RunwareModelCreator{ID: "xai", Name: "xAI"},
+		},
+		{
+			AIR:                "tripo:v3.1@0",
+			Name:               "Tripo 3.1",
+			Category:           "others",
+			Capabilities:       []string{"io:image-to-3d", "io:text-to-3d"},
+			AddedUnixTimestamp: 1778112000,
+		},
+		{AIR: ""}, // entries with no AIR carry no usable identifier and are skipped
+	}
+}
+
+// The AIR is the identifier every inference task keys off, so it becomes the Bifrost model ID,
+// provider-prefixed like every other provider's listing.
+func TestToBifrostListModelsResponse(t *testing.T) {
+	out := ToBifrostListModelsResponse(catalogModels(), schemas.Runware, schemas.WhiteList{"*"}, nil, nil, false)
+
+	if len(out.Data) != 2 {
+		t.Fatalf("expected 2 models (the AIR-less entry skipped), got %d", len(out.Data))
+	}
+
+	grok := out.Data[0]
+	if grok.ID != "runware/xai:grok-imagine@image-2.0" {
+		t.Fatalf("id = %q, want the provider-prefixed AIR", grok.ID)
+	}
+	if grok.Name == nil || *grok.Name != "Grok Imagine Image 2.0" {
+		t.Fatalf("name not carried: %v", grok.Name)
+	}
+	if grok.OwnedBy == nil || *grok.OwnedBy != "xAI" {
+		t.Fatalf("owned_by should come from the creator name, got %v", grok.OwnedBy)
+	}
+	if grok.Description == nil || *grok.Description == "" {
+		t.Fatalf("description not carried from comment")
+	}
+	// io: tags are the only modality signal Runware gives, so they drive the architecture block.
+	if grok.Architecture == nil {
+		t.Fatalf("expected architecture derived from io: capabilities")
+	}
+	if got := grok.Architecture.InputModalities; len(got) != 2 || got[0] != "image" || got[1] != "text" {
+		t.Fatalf("input modalities = %v, want [image text]", got)
+	}
+	if got := grok.Architecture.OutputModalities; len(got) != 1 || got[0] != "image" {
+		t.Fatalf("output modalities = %v, want [image]", got)
+	}
+	if grok.Architecture.Tokenizer == nil || *grok.Architecture.Tokenizer != "grok_imagine_image_2_0" {
+		t.Fatalf("architecture name not carried: %v", grok.Architecture.Tokenizer)
+	}
+
+	tripo := out.Data[1]
+	if tripo.Created == nil || *tripo.Created != 1778112000 {
+		t.Fatalf("created not carried: %v", tripo.Created)
+	}
+	if got := tripo.Architecture.OutputModalities; len(got) != 1 || got[0] != "3d" {
+		t.Fatalf("3d output modality = %v", got)
+	}
+}
+
+// A key's allowlist scopes the listing the same way it does for every other provider.
+func TestToBifrostListModelsResponse_RespectsKeyAllowlist(t *testing.T) {
+	out := ToBifrostListModelsResponse(catalogModels(), schemas.Runware, schemas.WhiteList{"tripo:v3.1@0"}, nil, nil, false)
+	if len(out.Data) != 1 || out.Data[0].ID != "runware/tripo:v3.1@0" {
+		t.Fatalf("allowlist not applied, got %+v", out.Data)
+	}
+}

--- a/core/providers/runware/runware.go
+++ b/core/providers/runware/runware.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bytedance/sonic"
+	"github.com/google/uuid"
 	"github.com/maximhq/bifrost/core/providers/openai"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	schemas "github.com/maximhq/bifrost/core/schemas"
@@ -69,9 +71,71 @@ func (provider *RunwareProvider) GetProviderKey() schemas.ModelProvider {
 	return schemas.Runware
 }
 
-// ListModels is not supported by the Runware provider.
+// ListModels returns Runware's curated model catalog, spanning every modality it serves — image,
+// video, 3D, audio and text.
 func (provider *RunwareProvider) ListModels(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
-	return nil, providerUtils.NewUnsupportedOperationError(schemas.ListModelsRequest, provider.GetProviderKey())
+	startTime := time.Now()
+
+	response, err := providerUtils.HandleMultipleListModelsRequests(ctx, keys, request, provider.listModelsByKey)
+	if err != nil {
+		return nil, err
+	}
+
+	response.ExtraFields.Latency = time.Since(startTime).Milliseconds()
+	return response, nil
+}
+
+// listModelsByKey sweeps Runware's catalog for one key. Runware pages a modelSearch task by offset
+// and reports totalResults inconsistently, so paging stops on the first short page rather than on a
+// count. The sweep is scoped to curated models: the full catalog is ~320k entries, the overwhelming
+// majority community LoRA uploads that no Bifrost route targets.
+func (provider *RunwareProvider) listModelsByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
+	var models []RunwareModel
+
+	for offset := 0; ; offset += runwareModelSearchPageSize {
+		searchRequest := RunwareModelSearchRequest{
+			TaskType: taskTypeModelSearch,
+			TaskUUID: uuid.New().String(),
+			Source:   runwareCuratedSource,
+			Limit:    runwareModelSearchPageSize,
+			Offset:   offset,
+		}
+		jsonData, err := providerUtils.MarshalSorted(searchRequest)
+		if err != nil {
+			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
+		}
+
+		_, respBody, _, bifrostErr := provider.sendTaskArray(ctx, key, jsonData)
+		if bifrostErr != nil {
+			return nil, bifrostErr
+		}
+
+		var searchResponse RunwareModelSearchResponse
+		if err := sonic.Unmarshal(respBody, &searchResponse); err != nil {
+			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err)
+		}
+		if len(searchResponse.Data) == 0 {
+			if msg := firstRunwareErrorMessage(searchResponse.Errors); msg != "" {
+				return nil, providerUtils.NewBifrostOperationError(msg, nil)
+			}
+			break
+		}
+
+		page := searchResponse.Data[0].Results
+		models = append(models, page...)
+		if len(page) < runwareModelSearchPageSize {
+			break
+		}
+	}
+
+	return ToBifrostListModelsResponse(
+		models,
+		provider.GetProviderKey(),
+		key.Models,
+		key.BlacklistedModels,
+		key.Aliases,
+		request.Unfiltered,
+	), nil
 }
 
 // TextCompletion is not supported by the Runware provider.

--- a/core/providers/runware/types.go
+++ b/core/providers/runware/types.go
@@ -12,6 +12,8 @@ const (
 	taskType3DInference = "3dInference"
 	// taskTypeGetResponse polls an async task (e.g. video, 3D) by its taskUUID.
 	taskTypeGetResponse = "getResponse"
+	// taskTypeModelSearch queries the model catalog; used to list models.
+	taskTypeModelSearch = "modelSearch"
 	// taskTypeUpscale enlarges an existing image; the model selects the upscaler.
 	taskTypeUpscale = "upscale"
 	// taskTypeRemoveBackground cuts the subject out onto a transparent background.
@@ -98,6 +100,62 @@ type RunwareInferenceRequest struct {
 
 func (r *RunwareInferenceRequest) GetExtraParams() map[string]interface{} {
 	return r.ExtraParams
+}
+
+// RunwareModelSearchRequest queries Runware's model catalog. The catalog spans ~320k entries once
+// community uploads are included, so listing narrows it with source "curated" — Runware's own
+// first-party set, which is what every AIR Bifrost maps natively belongs to.
+type RunwareModelSearchRequest struct {
+	TaskType string `json:"taskType"`
+	TaskUUID string `json:"taskUUID"`
+	Source   string `json:"source,omitempty"` // "curated" | "community" | "merged"
+	Limit    int    `json:"limit,omitempty"`  // 1-100, default 20
+	Offset   int    `json:"offset,omitempty"`
+}
+
+// RunwareModelSearchResponse is the envelope a modelSearch task returns.
+type RunwareModelSearchResponse struct {
+	Data   []RunwareModelSearchResult `json:"data,omitempty"`
+	Errors []RunwareError             `json:"errors,omitempty"`
+}
+
+// RunwareModelSearchResult is a single page of catalog results.
+type RunwareModelSearchResult struct {
+	TaskType string         `json:"taskType"`
+	TaskUUID string         `json:"taskUUID"`
+	Results  []RunwareModel `json:"results,omitempty"`
+	// TotalResults is the size of the whole match set, but Runware reports it inconsistently —
+	// repeated identical requests alternate between the curated and full counts. Paging stops on a
+	// short page instead of trusting it.
+	TotalResults int `json:"totalResults,omitempty"`
+}
+
+// RunwareModel is a catalog entry. The AIR is the identifier every inference task keys off.
+type RunwareModel struct {
+	AIR          string   `json:"air"`
+	Name         string   `json:"name,omitempty"`
+	Category     string   `json:"category,omitempty"` // "checkpoint" | "video" | "text" | "audio" | "others" | ...
+	Architecture string   `json:"architecture,omitempty"`
+	Capabilities []string `json:"capabilities,omitempty"` // "io:text-to-image", "op:upscale", "form:lora", ...
+	Comment      string   `json:"comment,omitempty"`
+	Version      string   `json:"version,omitempty"`
+	Source       string   `json:"source,omitempty"`
+	Private      bool     `json:"private,omitempty"`
+
+	AddedUnixTimestamp int64 `json:"addedUnixTimestamp,omitempty"`
+
+	// Present on checkpoints, absent on text and audio entries.
+	DefaultWidth  *int `json:"defaultWidth,omitempty"`
+	DefaultHeight *int `json:"defaultHeight,omitempty"`
+	DefaultSteps  *int `json:"defaultSteps,omitempty"`
+
+	Creator *RunwareModelCreator `json:"creator,omitempty"`
+}
+
+// RunwareModelCreator identifies the vendor a catalog entry belongs to.
+type RunwareModelCreator struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
 }
 
 // RunwareGetResponseRequest polls an async task by its UUID.

--- a/framework/modelcatalog/models.go
+++ b/framework/modelcatalog/models.go
@@ -19,6 +19,7 @@ import (
 var providersWithPartialListModels = map[schemas.ModelProvider]bool{
 	schemas.Perplexity: true,
 	schemas.Vertex:     true,
+	schemas.Runware:    true,
 }
 
 // GetModelsForProvider returns the effective allowed model set for the

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -174,6 +174,11 @@
           "        // An async video job is a receipt, not content: submit returns {id, status} and",
           "        // the rendered asset only exists after polling. The id IS the payload.",
           "        hasContent = !!j.id;",
+          "    } else if (typeof j.status === 'string' && typeof j.id === 'string' && (j.request_id || j.created_at)) {",
+          "        shape = 'async-job';",
+          "        // An async job is a receipt, not content: submit returns {id, status} and the result",
+          "        // only exists once the job completes. The id IS the payload.",
+          "        hasContent = !!j.id;",
           "    }",
           "    pm.expect(hasContent, 'expected non-empty content (shape=' + shape + ', body=' + JSON.stringify(j).slice(0, 200) + ')').to.be.true;",
           "  });",
@@ -132493,6 +132498,271 @@
                   }
                 }
               ]
+            },
+            {
+              "name": "runware/google:4@1 image-to-image via input_images (neutral field must reach inputs.referenceImages)",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"runware/runware:101@1\",\n  \"prompt\": \"make the scones look frosted\",\n  \"input_images\": [\n    \"https://storage.googleapis.com/generativeai-downloads/images/scones.jpg\"\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/images/generations",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "images",
+                    "generations"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('input_images is not dropped', function () {",
+                      "  // google:4@1 declares inputs.referenceImages as REQUIRED, so a dropped input_images cannot",
+                      "  // pass silently: the provider answers 'Missing required parameter'. On a seedImage model the",
+                      "  // same bug returned 200 with an unrelated image, which is why it went unnoticed.",
+                      "  pm.expect(pm.response.text(), 'input_images was dropped').to.not.include('Missing required parameter');",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "pm.test('returns an asset', function () {",
+                      "  var d = pm.response.json().data;",
+                      "  pm.expect(d, 'no data: ' + pm.response.text()).to.be.an('array').that.is.not.empty;",
+                      "  pm.expect(!!(d[0].url || d[0].b64_json), 'no asset returned').to.be.true;",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "runware/runware:101@1 input_images accepts bare base64 (normalized to a data URI)",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"runware/google:4@1\",\n  \"prompt\": \"make the scones look frosted\",\n  \"input_images\": [\n    \"iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAAAAADmVT4XAAABEklEQVR42u3O4UZDAQCA0Wsyk8xkkslMkslMJjOZTCaZZDKTZJJkMjOZmZnJzEwmSTJJkkmSTJIkyWSSJDMzmcxMkklmMjOzx+jPd57gCIKoSyzp7pHKeuV9/YoBpWpwaFg9otGO6sb0hnHjhGnSPDVtmZm1ztns8wuLjqXllVXnmsvtWff6/IFgaCMcicY241vbO7t7if2Dw6Pj5Mnp2flF6vLq+ub27v4h/Zh5en55fcvm8oX34kepXPn8+q7+/Nbqf41mqy0QIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBP470AF7D8HSZO7hZAAAAABJRU5ErkJggg==\"\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/images/generations",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "images",
+                    "generations"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('bare base64 is wrapped into a data URI before it reaches the provider', function () {",
+                      "  pm.expect(pm.response.text(), 'raw base64 forwarded unnormalized').to.not.match(/Invalid value for '(seedImage|inputs)/);",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "pm.test('returns an asset', function () {",
+                      "  var d = pm.response.json().data;",
+                      "  pm.expect(d, 'no data: ' + pm.response.text()).to.be.an('array').that.is.not.empty;",
+                      "  pm.expect(!!(d[0].url || d[0].b64_json), 'no asset returned').to.be.true;",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "runware/runware:100@1 response_format=data_uri returns an inline data URI",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"runware/runware:100@1\",\n  \"prompt\": \"a green apple on white\",\n  \"n\": 1,\n  \"size\": \"512x512\",\n  \"response_format\": \"data_uri\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/images/generations",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "images",
+                    "generations"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('data_uri maps to Runware outputType dataURI', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "  var d = pm.response.json().data;",
+                      "  pm.expect(d, 'no data: ' + pm.response.text()).to.be.an('array').that.is.not.empty;",
+                      "  pm.expect(d[0].url || '', 'expected an inline data URI').to.match(/^data:/);",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "runware/runware:100@1 async image generation submit (extra params carried by the passthrough header)",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-passthrough-extra-params",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"runware/runware:100@1\",\n  \"prompt\": \"a red apple on white\",\n  \"n\": 1,\n  \"size\": \"512x512\",\n  \"outputFormat\": \"WEBP\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/async/images/generations",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "async",
+                    "images",
+                    "generations"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('async submit is accepted', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.equal(202);",
+                      "});",
+                      "pm.test('returns an async job id', function () {",
+                      "  var j = pm.response.json();",
+                      "  pm.expect(j.id, 'no job id: ' + pm.response.text()).to.be.a('string').that.is.not.empty;",
+                      "  pm.collectionVariables.set('runwareAsyncGenJobId', j.id);",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "runware/runware:100@1 sync image generation with the passthrough header (parity baseline for the async case)",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-passthrough-extra-params",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"runware/runware:100@1\",\n  \"prompt\": \"a red apple on white\",\n  \"n\": 1,\n  \"size\": \"512x512\",\n  \"outputFormat\": \"WEBP\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/images/generations",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "images",
+                    "generations"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('extra params reach the provider on the sync route', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "  var u = (pm.response.json().data || [{}])[0].url || '';",
+                      "  if (!u) { pm.test.skip('response_format was not url', function () {}); return; }",
+                      "  pm.expect(u, 'extra param dropped on the sync route').to.match(/\\.webp($|\\?)/);",
+                      "});"
+                    ]
+                  }
+                }
+              ]
             }
           ]
         },
@@ -132978,6 +133248,247 @@
                   }
                 }
               ]
+            },
+            {
+              "name": "runware/google:4@1 image edit (referenceImages family - seedImage is rejected by these models)",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "formdata",
+                  "formdata": [
+                    {
+                      "key": "model",
+                      "value": "runware/google:4@1",
+                      "type": "text"
+                    },
+                    {
+                      "key": "image_url",
+                      "value": "https://storage.googleapis.com/generativeai-downloads/images/scones.jpg",
+                      "type": "text"
+                    },
+                    {
+                      "key": "prompt",
+                      "value": "make the scones look frosted",
+                      "type": "text"
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/images/edits",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "images",
+                    "edits"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('the input is nested under inputs.referenceImages, not sent as flat seedImage', function () {",
+                      "  var t = pm.response.text();",
+                      "  pm.expect(t, 'flat seedImage rejected by the model').to.not.include(\"Unsupported use of 'seedImage'\");",
+                      "  pm.expect(t, 'unsupported parameter').to.not.include('unsupportedParameter');",
+                      "  pm.expect(pm.response.code, 'failed: ' + t).to.be.below(400);",
+                      "});",
+                      "pm.test('returns an asset', function () {",
+                      "  var d = pm.response.json().data;",
+                      "  pm.expect(d, 'no data: ' + pm.response.text()).to.be.an('array').that.is.not.empty;",
+                      "  pm.expect(!!(d[0].url || d[0].b64_json), 'no asset returned').to.be.true;",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "runware/bfl:4@1 multi-image edit (every image reaches inputs.referenceImages[])",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "formdata",
+                  "formdata": [
+                    {
+                      "key": "model",
+                      "value": "runware/bfl:4@1",
+                      "type": "text"
+                    },
+                    {
+                      "key": "image_url[]",
+                      "value": "https://storage.googleapis.com/generativeai-downloads/images/scones.jpg",
+                      "type": "text"
+                    },
+                    {
+                      "key": "image_url[]",
+                      "value": "https://storage.googleapis.com/generativeai-downloads/images/scones.jpg",
+                      "type": "text"
+                    },
+                    {
+                      "key": "prompt",
+                      "value": "combine these into one scene",
+                      "type": "text"
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/images/edits",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "images",
+                    "edits"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('a second input image is accepted rather than dropped', function () {",
+                      "  var t = pm.response.text();",
+                      "  pm.expect(t, 'flat seedImage rejected').to.not.include(\"Unsupported use of 'seedImage'\");",
+                      "  pm.expect(pm.response.code, 'failed: ' + t).to.be.below(400);",
+                      "});",
+                      "pm.test('returns an asset', function () {",
+                      "  var d = pm.response.json().data;",
+                      "  pm.expect(d, 'no data: ' + pm.response.text()).to.be.an('array').that.is.not.empty;",
+                      "  pm.expect(!!(d[0].url || d[0].b64_json), 'no asset returned').to.be.true;",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "runware/runware:controlnet-preprocess@canny guide image via type=controlnet_preprocess",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "formdata",
+                  "formdata": [
+                    {
+                      "key": "model",
+                      "value": "runware/runware:controlnet-preprocess@canny",
+                      "type": "text"
+                    },
+                    {
+                      "key": "image_url",
+                      "value": "https://storage.googleapis.com/generativeai-downloads/images/scones.jpg",
+                      "type": "text"
+                    },
+                    {
+                      "key": "type",
+                      "value": "controlnet_preprocess",
+                      "type": "text"
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/images/edits",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "images",
+                    "edits"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('controlnet_preprocess is a recognised task type and needs no prompt', function () {",
+                      "  var t = pm.response.text();",
+                      "  pm.expect(t, 'type was unmapped so the edit fell through to imageInference').to.not.include('prompt not provided');",
+                      "  pm.expect(pm.response.code, 'failed: ' + t).to.be.below(400);",
+                      "});",
+                      "pm.test('returns an asset', function () {",
+                      "  var d = pm.response.json().data;",
+                      "  pm.expect(d, 'no data: ' + pm.response.text()).to.be.an('array').that.is.not.empty;",
+                      "  pm.expect(!!(d[0].url || d[0].b64_json), 'no asset returned').to.be.true;",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "runware/runware:101@1 async image edit submit (multipart via /v1/async/images/edits)",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "formdata",
+                  "formdata": [
+                    {
+                      "key": "model",
+                      "value": "runware/runware:101@1",
+                      "type": "text"
+                    },
+                    {
+                      "key": "image_url",
+                      "value": "https://storage.googleapis.com/generativeai-downloads/images/scones.jpg",
+                      "type": "text"
+                    },
+                    {
+                      "key": "prompt",
+                      "value": "make the background a deep blue",
+                      "type": "text"
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/async/images/edits",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "async",
+                    "images",
+                    "edits"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('async edit submit is accepted', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.equal(202);",
+                      "});",
+                      "pm.test('returns an async job id', function () {",
+                      "  var j = pm.response.json();",
+                      "  pm.expect(j.id, 'no job id: ' + pm.response.text()).to.be.a('string').that.is.not.empty;",
+                      "  pm.collectionVariables.set('runwareAsyncEditJobId', j.id);",
+                      "});"
+                    ]
+                  }
+                }
+              ]
             }
           ]
         },
@@ -133051,7 +133562,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"model\": \"runware/tencent:hunyuan-3d@3.1-rapid\",\n  \"input_reference\": \"https://storage.googleapis.com/generativeai-downloads/images/scones.jpg\",\n  \"type\": \"3d\"\n}"
+                  "raw": "{\n  \"model\": \"runware/tencent:hunyuan-3d@3.1-rapid\",\n  \"prompt\": \"a plate of scones\",\n  \"input_reference\": \"https://storage.googleapis.com/generativeai-downloads/images/scones.jpg\",\n  \"type\": \"3d\"\n}"
                 },
                 "url": {
                   "raw": "{{baseUrl}}/v1/videos",
@@ -133330,6 +133841,202 @@
                       "});",
                       "pm.test('prompt is not required for a source-driven video task', function () {",
                       "  pm.expect(pm.response.text(), 'gateway demanded a prompt').to.not.include('prompt, input_reference or video_uri');",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "runware/klingai:6@0 text-to-video (width/height must not be forced on models that declare none)",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"runware/klingai:6@0\",\n  \"prompt\": \"a red ceramic teapot, slow camera pan\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/videos",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "videos"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('no width/height default is forced onto the model', function () {",
+                      "  // A fifth of Runware's video models declare no height at all and reject the pair outright.",
+                      "  var t = pm.response.text();",
+                      "  pm.expect(t, 'dimensions forced onto a model that rejects them').to.not.match(/'(width|height)' (parameter )?is not supported/);",
+                      "  pm.expect(t, 'invalid default dimensions').to.not.include('must be an integer value between');",
+                      "  pm.expect(pm.response.code, 'failed: ' + t).to.be.below(400);",
+                      "});",
+                      "pm.test('returns a queued job', function () {",
+                      "  var j = pm.response.json();",
+                      "  pm.expect(j.id, 'no job id: ' + pm.response.text()).to.be.a('string').that.is.not.empty;",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "[EXPECT-4XX] runware/bria:51@1 typed output_format maps to Runware outputFormat (no passthrough header)",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"runware/bria:51@1\",\n  \"type\": \"background_removal\",\n  \"video_uri\": \"https://storage.googleapis.com/generativeai-downloads/video/__nonexistent__.mp4\",\n  \"output_format\": \"webm\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/videos",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "videos"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('output_format is a typed field, not an unknown extra param', function () {",
+                      "  // The source is deliberately nonexistent, so the provider must fail on the SOURCE. If the",
+                      "  // typed field had not mapped, Runware would default to MP4 and reject the format instead -",
+                      "  // and if it leaked through as snake_case it would be an unsupported parameter.",
+                      "  var t = pm.response.text();",
+                      "  pm.expect(t, 'output_format leaked through unmapped').to.not.include('output_format');",
+                      "  pm.expect(t, 'outputFormat rejected, so the typed field did not map').to.not.match(/Invalid value for 'outputFormat'/);",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "runware async image generation retrieve - extra params must survive the async path (GET /v1/async/images/generations/{job_id})",
+              "request": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{baseUrl}}/v1/async/images/generations/{{runwareAsyncGenJobId}}",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "async",
+                    "images",
+                    "generations",
+                    "{{runwareAsyncGenJobId}}"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                      "var id = pm.collectionVariables.get('runwareAsyncGenJobId');",
+                      "if (!id) { pm.test.skip('no async job id produced upstream', function () {}); return; }",
+                      "pm.test('job resolves', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "var j = pm.response.json();",
+                      "if (j.status !== 'completed') { pm.test.skip('job still ' + j.status, function () {}); return; }",
+                      "pm.test('result carries the image response', function () {",
+                      "  pm.expect(j.result, 'no result: ' + pm.response.text()).to.be.an('object');",
+                      "  pm.expect(j.result.data, 'no data in result').to.be.an('array').that.is.not.empty;",
+                      "});",
+                      "pm.test('outputFormat reached the provider (sync/async parity)', function () {",
+                      "  // The async handlers do not force the passthrough flag, so an extra param only survives",
+                      "  // when the caller sends x-bf-passthrough-extra-params. WEBP proves it was merged; a .jpg",
+                      "  // here means the param was dropped somewhere on the async path.",
+                      "  var u = j.result.data[0].url || '';",
+                      "  if (!u) { pm.test.skip('response_format was not url', function () {}); return; }",
+                      "  pm.expect(u, 'extra param dropped on the async path').to.match(/\\.webp($|\\?)/);",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "runware async image edit retrieve (GET /v1/async/images/edits/{job_id})",
+              "request": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{baseUrl}}/v1/async/images/edits/{{runwareAsyncEditJobId}}",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "async",
+                    "images",
+                    "edits",
+                    "{{runwareAsyncEditJobId}}"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                      "var id = pm.collectionVariables.get('runwareAsyncEditJobId');",
+                      "if (!id) { pm.test.skip('no async job id produced upstream', function () {}); return; }",
+                      "pm.test('job resolves', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "var j = pm.response.json();",
+                      "if (j.status !== 'completed') { pm.test.skip('job still ' + j.status, function () {}); return; }",
+                      "pm.test('the edit ran through the same conversion as the sync route', function () {",
+                      "  pm.expect(j.result, 'no result: ' + pm.response.text()).to.be.an('object');",
+                      "  pm.expect(j.result.data, 'no data in result').to.be.an('array').that.is.not.empty;",
+                      "  pm.expect(!!(j.result.data[0].url || j.result.data[0].b64_json), 'no asset returned').to.be.true;",
                       "});"
                     ]
                   }


### PR DESCRIPTION
## Summary

Runware's `ListModels` previously returned an "unsupported operation" error. This PR implements it by sweeping Runware's curated model catalog via the `modelSearch` task type, converting results into the standard `BifrostListModelsResponse` format with modality information derived from each model's `io:` capability tags.

## Changes

- Replaced the stub `ListModels` implementation with a paginated catalog sweep scoped to Runware's curated source, stopping on the first short page rather than trusting `totalResults` (which Runware reports inconsistently).
- Added `RunwareModelSearchRequest`, `RunwareModelSearchResponse`, `RunwareModelSearchResult`, `RunwareModel`, and `RunwareModelCreator` types to represent the catalog API.
- Added `ToBifrostListModelsResponse` to map catalog entries to `schemas.Model`, using the AIR as the Bifrost model ID, deriving input/output modalities from `io:<from>-to-<to>` capability tags, and populating name, description, owner, created timestamp, and architecture fields.
- Set `runwareModelSearchPageSize` to 500 (above the documented 100 maximum that Runware honours) to fetch the entire curated set in a single round trip, avoiding multiple sequential page fetches that would exceed request deadlines.
- Added `runwareCuratedSource` constant to scope sweeps away from the ~273k community LoRA uploads that dominate the unfiltered catalog.
- Added `runwareModelArchitecture` to derive `schemas.Architecture` from `io:` tags, returning `nil` when no modality information is present so the field stays absent rather than empty.
- Added tests covering provider-prefixed AIR as model ID, field mapping, modality derivation from `io:` tags, and allowlist filtering.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/runware/...
```

To validate end-to-end, configure a Runware key and call the `ListModels` route. The response should include curated models with provider-prefixed AIRs as IDs, populated modality fields derived from `io:` capability tags, and correct allowlist/blocklist filtering.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new secrets or PII handling introduced. The Runware API key is passed through the existing key management path unchanged.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable