### PR TITLE
feat: add `HTTPTransportPreAuthHook` phase that runs before transport authentication, moving `HTTPTransportPreHook` to run after

### DIFF
--- a/core/schemas/plugin.go
+++ b/core/schemas/plugin.go
@@ -170,7 +170,10 @@ func ReleaseHTTPResponse(resp *HTTPResponse) {
 // PostHooks are executed in the reverse order of PreHooks.
 //
 // Execution order:
-// 1. HTTPTransportPreHook (HTTP transport only, once per request, executed in registration order)
+// 0. HTTPTransportPreAuthHook (HTTP transport only, once per request, executed in registration order,
+//    before the transport's authentication middlewares)
+// 1. HTTPTransportPreHook (HTTP transport only, once per request, executed in registration order,
+//    after the transport's authentication middlewares)
 // 2. PreRequestHook (once per request, executed in registration order)
 // 3. PreLLMHook (executed in registration order, runs again on each fallback attempt)
 // 4. Provider call
@@ -179,7 +182,8 @@ func ReleaseHTTPResponse(resp *HTTPResponse) {
 // 6a. HTTPTransportStreamChunkHook (for streaming responses, called per-chunk in reverse order)
 //
 // Per-request vs per-attempt phases:
-// - HTTPTransportPreHook, PreRequestHook, HTTPTransportPostHook run ONCE per top-level request.
+// - HTTPTransportPreAuthHook, HTTPTransportPreHook, PreRequestHook, HTTPTransportPostHook run
+//   ONCE per top-level request.
 // - PreLLMHook, PostLLMHook run ONCE PER ATTEMPT: the primary provider call, plus once per
 //   fallback attempt. Mutations a PreLLMHook makes to the request only carry to later
 //   fallbacks where prepareFallbackRequest happens to share pointers (shallow copy) —
@@ -218,7 +222,40 @@ type BasePlugin interface {
 type HTTPTransportPlugin interface {
 	BasePlugin
 
-	// HTTPTransportPreHook is called at the HTTP transport layer before requests enter Bifrost core.
+	// HTTPTransportPreAuthHook is called at the HTTP transport layer before the transport's
+	// authentication middlewares run, so mutations made here are visible to authentication.
+	// Implement it with a body only when the plugin's job is to supply or translate the
+	// credentials authentication reads — deriving a virtual key from an upstream identity
+	// header, say. Every other kind of work belongs in HTTPTransportPreHook, which runs after
+	// authentication and can therefore see the resolved caller identity. Plugins with nothing
+	// to do before authentication return (nil, nil).
+	// Only invoked when using HTTP transport (bifrost-http), not when using Bifrost as a Go SDK
+	// directly. Like the other transport hooks it takes serializable types; native .so plugins
+	// join the phase by exporting an HTTPTransportPreAuthHook symbol.
+	//
+	// req carries the same fields HTTPTransportPreHook receives — Method, Path, Headers, Query,
+	// PathParams and Body — and the same mutations apply, so moving a hook between the two
+	// phases is a rename. Note the cost: the body is snapshotted before the caller is known, so
+	// a request authentication goes on to reject has already been copied.
+	//
+	// Mutating Method or Path is rejected (the request is failed with 409) — routing has
+	// already been resolved by the time this runs.
+	//
+	// This hook has no post-hook counterpart: HTTPTransportPostHook pairs with
+	// HTTPTransportPreHook, and a request rejected by authentication runs neither. A plugin
+	// that must observe every request, including rejected ones, should not rely on this phase
+	// for its bookkeeping.
+	//
+	// Return values:
+	// - (nil, nil): Continue to authentication, request modifications are applied
+	// - (*HTTPResponse, nil): Short-circuit with this response, skip authentication and the handler
+	// - (nil, error): Short-circuit with error response
+	HTTPTransportPreAuthHook(ctx *BifrostContext, req *HTTPRequest) (*HTTPResponse, error)
+
+	// HTTPTransportPreHook is called at the HTTP transport layer before requests enter Bifrost core,
+	// after the transport has authenticated the request — so the resolved caller identity is already
+	// on ctx. A plugin that needs to run BEFORE authentication (typically to supply the credentials
+	// authentication reads) belongs in HTTPTransportPreAuthHook instead.
 	// It receives a serializable HTTPRequest and allows plugins to modify it in-place.
 	// Only invoked when using HTTP transport (bifrost-http), not when using Bifrost as a Go SDK directly.
 	// Works with both native .so plugins and WASM plugins due to serializable types.

--- a/docs/enterprise/migration-guides/v2.0.0.mdx
+++ b/docs/enterprise/migration-guides/v2.0.0.mdx
@@ -3,7 +3,7 @@ title: "Migrating to Enterprise v2.0.0"
 description: "Breaking changes and migration instructions for the Enterprise v2.0.0 release"
 ---
 
-Enterprise v2.0.0 is built on top of OSS `2.0.0-prerelease3` and inherits both breaking changes from that release. This page summarizes the inherited changes, the Enterprise license requirement, and how the changes interact with SCIM-based authentication.
+Enterprise v2.0.0 is built on top of OSS `2.0.0-prerelease3` and inherits both breaking changes from that release. This page summarizes the inherited changes, the Enterprise license requirement, the plugin transport-hook change, and how the changes interact with SCIM-based authentication.
 
 <Warning>
 **A provisioned Bifrost Enterprise license is required for v2.0.0.** Before migrating, contact the Bifrost team to obtain your `license.bif` file. Set the entire contents of this file as the value of the `BIFROST_LICENSE` environment variable on every node running Bifrost. Complete this configuration before upgrading to avoid interrupting your deployment.
@@ -35,6 +35,29 @@ This is **not an additional breaking change**: no action is required, and nothin
 </Note>
 
 The practical implication: under SCIM, protection for the custom-plugin-path endpoint rests entirely on `SCIMController.Middleware()`'s own fail-closed behavior, rather than on the layered, defense-in-depth check that non-SCIM deployments get in addition to their own auth middleware. If you rely on SCIM for dashboard authentication, treat `SCIMController.Middleware()`'s correctness as the sole safeguard for this endpoint rather than assuming the OSS-documented check is also active.
+
+---
+
+## Plugin Transport Hooks: New Pre-Auth Phase
+
+OSS v2.0.0 adds `HTTPTransportPreAuthHook`, which runs before the transport authenticates a request, and moves `HTTPTransportPreHook` to run after authentication (see [Breaking Change 4](/migration-guides/v2.0.0#breaking-change-4-httptransportprehook-now-runs-after-authentication)). On Enterprise the ordering half of that change is not new — `HTTPTransportPreHook` has run after the SCIM and API-key middlewares since the release that introduced the desktop agent. What is new is a phase that runs *before* them.
+
+**Who is affected:** any custom plugin that supplies a credential — deriving a virtual key from an upstream identity header, rewriting an `Authorization` header — from `HTTPTransportPreHook`.
+
+On Enterprise this has been silently ineffective for SCIM deployments, and the symptom depends on whether an identity provider is configured:
+
+| Deployment | Credential injected from `HTTPTransportPreHook` |
+|---|---|
+| Identity provider configured, `enforce_auth_on_inference` on | Never seen. Inference auth rejects the request with `401` before the plugin runs |
+| No identity provider | Still works. The injected key is not seen by the auth middlewares, but it does reach governance downstream, which validates it |
+
+The second row is why this often looks like an SSO-specific bug: the same plugin binary works on a deployment without an IdP and fails on one with it.
+
+**How to fix it:** rename the function to `HTTPTransportPreAuthHook`. It receives the same `*HTTPRequest` — headers, query, path params and body — and applies the same mutations, so the hook body does not change. After the rename the plugin behaves identically with or without an identity provider.
+
+<Note>
+**Ordering with large payloads.** The request-body snapshot now happens in the pre-auth phase, so the large-payload threshold middleware moved ahead of it. A body above `large_payload.request_threshold_bytes` is still skipped rather than copied, exactly as before. No configuration change is required.
+</Note>
 
 ---
 

--- a/docs/migration-guides/v2.0.0.mdx
+++ b/docs/migration-guides/v2.0.0.mdx
@@ -3,7 +3,7 @@ title: "Migrating to v2.0.0"
 description: "Breaking changes and migration instructions for the v2.0.0 release"
 ---
 
-v2.0.0 hardens custom plugin loading against server-side request forgery (SSRF), closes a path that let an unauthenticated caller register a custom native plugin when dashboard auth is disabled or unconfigured, and moves all governance APIs under a single `/api/governance` namespace. This page covers the three breaking changes in this release and how to migrate.
+v2.0.0 hardens custom plugin loading against server-side request forgery (SSRF), closes a path that let an unauthenticated caller register a custom native plugin when dashboard auth is disabled or unconfigured, moves all governance APIs under a single `/api/governance` namespace, and moves the plugin `HTTPTransportPreHook` phase to run after the transport authenticates the request. This page covers the four breaking changes in this release and how to migrate.
 
 <Note>
 **Running Bifrost Enterprise?** This page covers the OSS behavior only. See the [Enterprise v2.0.0 Migration Guide](/enterprise/migration-guides/v2.0.0) for how these changes interact with SCIM-based authentication.
@@ -179,6 +179,69 @@ The canonical Team `customer_id` field retains the Open Source budget-hierarchy 
 
 ---
 
+## Breaking Change 4: `HTTPTransportPreHook` Now Runs After Authentication
+
+**What changed:** the plugin HTTP transport pipeline gained a phase. `HTTPTransportPreAuthHook` now runs *before* the transport's authentication middlewares, and `HTTPTransportPreHook` — which used to hold that position — runs *after* them.
+
+```
+before:  HTTPTransportPreHook → auth → handler
+after:   HTTPTransportPreAuthHook → auth → HTTPTransportPreHook → handler
+```
+
+**Who is affected:** any custom plugin that writes a credential from `HTTPTransportPreHook` — a virtual key on `x-bf-vk`, an `Authorization` header, an `x-api-key` — typically to derive one from an upstream identity header.
+
+<Warning>
+**Whether this breaks the plugin depends on what authenticates inference in your deployment, and neither outcome reports an error.**
+
+- **Authentication rejects the request** — Enterprise with an identity provider configured and `enforce_auth_on_inference` enabled. Authentication runs first, so `HTTPTransportPreHook` never executes and the credential is never written.
+- **Authentication permits the request** — every Open Source deployment, because inference auth is a deliberate pass-through, and Enterprise without an identity provider. The hook still runs, and the header it writes is still visible to components downstream of it, so governance validates the key and the plugin keeps working.
+
+The second case is why this can look deployment-specific: the same plugin binary keeps working on one gateway and stops on another. In both cases the credential is now written after the point that authenticates it, so move that work to `HTTPTransportPreAuthHook` — the only phase where a credential is guaranteed to be in place before authentication reads it.
+</Warning>
+
+**How to fix it:** rename the function. `HTTPTransportPreAuthHook` receives the same `*HTTPRequest` — headers, query, path params and body — and applies the same mutations, so nothing inside the hook body changes.
+
+**Before** (v1.x — credential injected from the pre-hook):
+```go
+func HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	if userID := req.Headers["x-my-idp-user"]; userID != "" {
+		req.Headers["x-bf-vk"] = virtualKeyFor(userID)
+	}
+	return nil, nil
+}
+```
+
+**After** (v2.0 — same body, new phase):
+```go
+func HTTPTransportPreAuthHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	if userID := req.Headers["x-my-idp-user"]; userID != "" {
+		req.Headers["x-bf-vk"] = virtualKeyFor(userID)
+	}
+	return nil, nil
+}
+```
+
+A plugin may export both hooks; they are independent phases. `HTTPTransportPreAuthHook` runs once per request. `HTTPTransportPreHook` runs once per request too, but only for requests that reach it: a pre-auth hook that short-circuits, or authentication rejecting the request, skips it.
+
+**Plugins that do not touch credentials need no behavioural change** — and gain something. Because authentication has already run, `HTTPTransportPreHook` now sees the resolved caller identity on `ctx`. They do still need the new method to compile, as the Note below explains.
+
+Two differences between the phases are worth knowing:
+
+| | `HTTPTransportPreAuthHook` | `HTTPTransportPreHook` |
+|---|---|---|
+| Runs for a request authentication rejects | Yes | No |
+| Post-hook counterpart | None | `HTTPTransportPostHook` |
+
+A plugin that must observe *every* request, including rejected ones, should not rely on `HTTPTransportPreHook` for that bookkeeping.
+
+<Note>
+`HTTPTransportPreAuthHook` is part of the `HTTPTransportPlugin` interface, so Go plugins compiled against v2.0 must define it. Plugins with nothing to do before authentication return `(nil, nil)`. Native `.so` plugins are unaffected unless they opt in: the symbol is looked up optionally, and a plugin that never exports it is skipped by the phase.
+</Note>
+
+See the [Plugin Migration Guide](/plugins/migration-guide) for the full hook contract.
+
+---
+
 ## Migration Checklist
 
 <Steps>
@@ -192,6 +255,10 @@ For any internal URL found above, add the host (or its CIDR) to `server.plugin_d
 
 <Step title="Confirm dashboard auth is configured before creating a custom-path plugin">
 If dashboard auth is disabled or unconfigured, `POST /api/plugins` and `PUT /api/plugins/{name}` will now reject any request that sets a custom `path`. Enable dashboard authentication first if you need to register a plugin with a custom binary path.
+</Step>
+
+<Step title="Move credential work in custom plugins to `HTTPTransportPreAuthHook`">
+Grep your plugins for writes to `x-bf-vk`, `Authorization`, `x-api-key`, `x-goog-api-key`, or `api-key` inside `HTTPTransportPreHook`. Any you find must move to `HTTPTransportPreAuthHook` — the rename is the whole migration, and the failure mode if you miss one is silent.
 </Step>
 
 <Step title="Move governance API callers to canonical `/api/governance` paths">

--- a/docs/plugins/getting-started.mdx
+++ b/docs/plugins/getting-started.mdx
@@ -52,7 +52,8 @@ This generates a `.so` file that exports specific functions matching Bifrost's p
   <Tab title="v1.4.x+">
     - `Init(config any) error` - Initialize the plugin with configuration
     - `GetName() string` - Return the plugin name
-    - `HTTPTransportPreHook()` - Intercept HTTP requests before they enter Bifrost core (HTTP transport only)
+    - `HTTPTransportPreAuthHook()` <sup>v2.0+</sup> - Intercept HTTP requests before the transport authenticates them; the seam for supplying credentials (HTTP transport only)
+    - `HTTPTransportPreHook()` - Intercept HTTP requests after authentication, before they enter Bifrost core (HTTP transport only)
     - `HTTPTransportPostHook()` - Intercept HTTP responses after they exit Bifrost core (HTTP transport only)
     - `PreRequestHook()` <sup>v1.6.x+</sup> - Once-per-request routing phase: decide provider/model/fallbacks
     - `PreLLMHook()` - Intercept requests before they reach providers (runs per provider attempt)
@@ -91,12 +92,13 @@ Plugins execute in a specific order:
 
 <Tabs>
   <Tab title="v1.4.x+">
-    1. `HTTPTransportPreHook` - Intercept HTTP requests (HTTP transport only)
-    2. `PreRequestHook` <sup>v1.6.x+</sup> - **Once per request**, before any provider call. Routing decisions (provider/model/fallbacks) happen here and propagate to every attempt.
-    3. `PreLLMHook`/`PreMCPHook` - Per provider attempt, registration order, can short-circuit requests
-    4. Provider call (if not short-circuited)
-    5. `PostLLMHook`/`PostMCPHook` - Per provider attempt, reverse order of PreHooks
-    6. `HTTPTransportPostHook` - Intercept HTTP responses (HTTP transport only, reverse order)
+    1. `HTTPTransportPreAuthHook` <sup>v2.0+</sup> - Intercept HTTP requests before authentication (HTTP transport only)
+    2. `HTTPTransportPreHook` - Intercept HTTP requests after authentication (HTTP transport only)
+    3. `PreRequestHook` <sup>v1.6.x+</sup> - **Once per request**, before any provider call. Routing decisions (provider/model/fallbacks) happen here and propagate to every attempt.
+    4. `PreLLMHook`/`PreMCPHook` - Per provider attempt, registration order, can short-circuit requests
+    5. Provider call (if not short-circuited)
+    6. `PostLLMHook`/`PostMCPHook` - Per provider attempt, reverse order of PreHooks
+    7. `HTTPTransportPostHook` - Intercept HTTP responses (HTTP transport only, reverse order)
   </Tab>
   <Tab title="v1.3.x">
     1. `TransportInterceptor` - Modifies raw HTTP requests (HTTP transport only)

--- a/docs/plugins/migration-guide.mdx
+++ b/docs/plugins/migration-guide.mdx
@@ -1,8 +1,78 @@
 ---
 title: "Plugin Migration Guide"
-description: "How to migrate your Bifrost plugins from v1.3.x to v1.4.x"
+description: "How to migrate your Bifrost plugins across HTTP transport hook changes"
 icon: "arrow-up-right-dots"
 ---
+
+## v1.x to v2.0: `HTTPTransportPreHook` moved after authentication
+
+In v1.x, `HTTPTransportPreHook` ran before the transport authenticated the request, so a plugin could
+put a credential on the request and have it authenticated. In v2.0 it runs **after** authentication, and
+a new `HTTPTransportPreAuthHook` occupies the earlier position.
+
+<Warning>
+If your plugin writes a credential - a virtual key, an `Authorization` header, an `x-api-key` - from
+`HTTPTransportPreHook`, that credential is now written after the point that authenticates it, and
+nothing errors either way. Where authentication rejects the request the hook never runs at all; where
+it permits the request the hook still runs and the header still reaches components downstream of it,
+so the plugin can appear to keep working on one deployment and stop on another. Move that work to
+`HTTPTransportPreAuthHook`.
+</Warning>
+
+### Does this affect my plugin?
+
+Two separate questions, and the answers differ.
+
+**Does it need the new method to compile?** Every Go implementation of `schemas.HTTPTransportPlugin`
+does, because `HTTPTransportPreAuthHook` is part of that interface. A plugin with nothing to do before
+authentication returns `(nil, nil)`. Native `.so` plugins are the exception: the symbol is looked up
+optionally, so a plugin that never exports it keeps loading and is skipped by the phase.
+
+**Does its behaviour need to move?** Only if it touches credentials. A plugin that logs, rewrites a
+body, adds a tracing header, or short-circuits on a business rule stays exactly where it is - and gains
+something: `HTTPTransportPreHook` now sees the resolved caller identity on `ctx`, because authentication
+has already run.
+
+### Migration
+
+Rename the function. The pre-auth phase receives the same `*HTTPRequest` - body included - and applies the same mutations, so nothing inside the hook has to change:
+
+**Before (v1.x):**
+
+```go
+func HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	if userID := req.Headers["x-my-idp-user"]; userID != "" {
+		req.Headers["x-bf-vk"] = virtualKeyFor(userID)
+	}
+	return nil, nil
+}
+```
+
+**After (v2.0):**
+
+```go
+func HTTPTransportPreAuthHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	if userID := req.Headers["x-my-idp-user"]; userID != "" {
+		req.Headers["x-bf-vk"] = virtualKeyFor(userID)
+	}
+	return nil, nil
+}
+```
+
+A plugin may export both hooks. They are independent phases. `HTTPTransportPreAuthHook` runs once per
+request; `HTTPTransportPreHook` runs once per request too, but only for requests that reach it — a
+pre-auth hook that short-circuits, or authentication rejecting the request, skips it.
+
+### What the pre-auth phase does not give you
+
+| | `HTTPTransportPreAuthHook` | `HTTPTransportPreHook` |
+|---|---|---|
+| Runs | Before authentication | After authentication |
+| Caller identity on `ctx` | Not yet resolved | Resolved |
+| `req` shape | Headers, query, path params, body | Same |
+| Post-hook counterpart | None | `HTTPTransportPostHook` |
+| Runs for a request authentication rejects | Yes | No |
+| Mutating `req.Method` / `req.Path` | `409` | `409` |
 
 ## Overview
 

--- a/docs/plugins/writing-go-plugin.mdx
+++ b/docs/plugins/writing-go-plugin.mdx
@@ -492,13 +492,40 @@ Both methods are inert rather than fatal when no model catalog is wired - `GetMo
 
 <Tabs>
   <Tab title="v1.5.x+">
+#### `HTTPTransportPreAuthHook(ctx, req)` <sup>v2.0+</sup>
+
+**HTTP transport only.** Intercepts requests BEFORE the transport authenticates them, so anything this
+hook changes is what authentication sees. Implement it only when the plugin's job is to supply or
+translate a credential:
+- Derive a virtual key from an upstream identity header
+- Rewrite or normalise an `Authorization` header before it is validated
+- Reject a request outright with a custom response
+- Native .so plugins join the phase by exporting an `HTTPTransportPreAuthHook` symbol
+
+Key points:
+- Receives serializable `*HTTPRequest` (not raw fasthttp)
+- Carries the same request shape as `HTTPTransportPreHook` - headers, query, path params and body - and the same mutations apply, so a hook can move between the two phases by renaming
+- Modifying `req.Method` or `req.Path` fails the request with `409`
+- Return `(nil, nil)` to continue to authentication, request modifications applied
+- Return `(*HTTPResponse, nil)` to short-circuit with response
+- Return `(nil, error)` to short-circuit with error
+- No post-hook counterpart: `HTTPTransportPostHook` pairs with `HTTPTransportPreHook`, and a request rejected by authentication runs neither
+
 #### `HTTPTransportPreHook(ctx, req)`
 
-**HTTP transport only.** Intercepts requests BEFORE they enter Bifrost core. Use this to:
+**HTTP transport only.** Intercepts requests BEFORE they enter Bifrost core and AFTER the transport has
+authenticated them, so the resolved caller identity is already on `ctx`. Use this to:
 - Modify request headers, body, or query params in-place
 - Short-circuit with a custom response
 - Store values in `BifrostContext` for use in other hooks
 - Works with both native .so and WASM plugins
+
+<Warning>
+**Changed in v2.0.** This hook used to run before authentication. A credential written here is now set
+too late to be authenticated against - move that work to `HTTPTransportPreAuthHook`. Nothing errors
+either way: where authentication rejects the request this hook never runs, and where it permits the
+request the hook runs and its header still reaches components downstream of it.
+</Warning>
 
 Key points:
 - Receives serializable `*HTTPRequest` (not raw fasthttp)

--- a/framework/plugins/main.go
+++ b/framework/plugins/main.go
@@ -65,7 +65,7 @@ func AsHTTPTransportPlugin(plugin schemas.BasePlugin) schemas.HTTPTransportPlugi
 	// Check if it's a DynamicPlugin first
 	if dp, ok := plugin.(*DynamicPlugin); ok {
 		// Only return as HTTPTransportPlugin if it actually has HTTP transport hooks
-		if dp.httpTransportPreHook != nil || dp.httpTransportPostHook != nil {
+		if dp.httpTransportPreAuthHook != nil || dp.httpTransportPreHook != nil || dp.httpTransportPostHook != nil {
 			return dp
 		}
 		return nil

--- a/framework/plugins/soloader.go
+++ b/framework/plugins/soloader.go
@@ -90,6 +90,14 @@ func (l *SharedObjectPluginLoader) LoadPlugin(path string, config any) (schemas.
 		return nil, fmt.Errorf("failed to cast Cleanup to func() error\nSee docs for more information: https://docs.getbifrost.ai/plugins/writing-go-plugin")
 	}
 
+	// Optional: HTTPTransportPreAuthHook — runs before the transport authenticates the
+	// request. Plugins predating the hook simply don't export it and are skipped.
+	if sym, err := pluginObj.Lookup("HTTPTransportPreAuthHook"); err == nil {
+		if dp.httpTransportPreAuthHook, ok = sym.(func(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error)); !ok {
+			return nil, fmt.Errorf("failed to cast HTTPTransportPreAuthHook to expected signature")
+		}
+	}
+
 	// Optional: HTTPTransportPreHook
 	if sym, err := pluginObj.Lookup("HTTPTransportPreHook"); err == nil {
 		if dp.httpTransportPreHook, ok = sym.(func(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error)); !ok {

--- a/framework/plugins/soplugin.go
+++ b/framework/plugins/soplugin.go
@@ -21,6 +21,11 @@ type DynamicPlugin struct {
 	getName func() string
 	cleanup func() error
 
+	// HTTPTransportPlugin, pre-auth phase (optional). Forward-compat: new .so plugins can export
+	// HTTPTransportPreAuthHook to run before the transport authenticates the request.
+	// Plugins predating the hook leave it nil and are skipped by the pre-auth phase.
+	httpTransportPreAuthHook func(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error)
+
 	// HTTPTransportPlugin (optional)
 	httpTransportPreHook         func(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error)
 	httpTransportPostHook        func(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error
@@ -57,6 +62,16 @@ func (dp *DynamicPlugin) GetName() string {
 // Cleanup is invoked by core/bifrost.go during plugin unload, reload, and shutdown (BasePlugin interface)
 func (dp *DynamicPlugin) Cleanup() error {
 	return dp.cleanup()
+}
+
+// HTTPTransportPreAuthHook intercepts HTTP requests at the transport layer before the transport
+// authenticates them (HTTPTransportPlugin interface). Same dispatch as the other optional
+// hooks: typed symbol if exported, else no-op.
+func (dp *DynamicPlugin) HTTPTransportPreAuthHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	if dp.httpTransportPreAuthHook == nil {
+		return nil, nil // No-op if not implemented
+	}
+	return dp.httpTransportPreAuthHook(ctx, req)
 }
 
 // HTTPTransportPreHook intercepts HTTP requests at the transport layer before entering Bifrost core (HTTPTransportPlugin interface)

--- a/plugins/compat/main.go
+++ b/plugins/compat/main.go
@@ -78,6 +78,12 @@ func (p *CompatPlugin) GetName() string {
 	return PluginName
 }
 
+// HTTPTransportPreAuthHook is a no-op: this plugin does no credential work, so it has
+// nothing to do before the transport authenticates the request (HTTPTransportPlugin interface).
+func (*CompatPlugin) HTTPTransportPreAuthHook(_ *schemas.BifrostContext, _ *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	return nil, nil
+}
+
 // HTTPTransportPreHook is not used for this plugin
 func (p *CompatPlugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
 	return nil, nil

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -322,6 +322,12 @@ func (p *GovernancePlugin) UpdateEnforceAuthOnInference(enforceAuthOnInference b
 	p.isVkMandatory = new(enforceAuthOnInference)
 }
 
+// HTTPTransportPreAuthHook is a no-op: this plugin does no credential work, so it has
+// nothing to do before the transport authenticates the request (HTTPTransportPlugin interface).
+func (*GovernancePlugin) HTTPTransportPreAuthHook(_ *schemas.BifrostContext, _ *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	return nil, nil
+}
+
 // HTTPTransportPreHook is retained as a no-op so governance still satisfies the
 // HTTPTransportPlugin interface (used by the enterprise wrapper's 503 gate delegation).
 // All routing now flows through PreRequestHook: body-having requests via handleRequest,

--- a/plugins/jsonparser/main.go
+++ b/plugins/jsonparser/main.go
@@ -83,6 +83,12 @@ func (p *JsonParserPlugin) GetName() string {
 	return PluginName
 }
 
+// HTTPTransportPreAuthHook is a no-op: this plugin does no credential work, so it has
+// nothing to do before the transport authenticates the request (HTTPTransportPlugin interface).
+func (*JsonParserPlugin) HTTPTransportPreAuthHook(_ *schemas.BifrostContext, _ *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	return nil, nil
+}
+
 // HTTPTransportPreHook is not used for this plugin
 func (p *JsonParserPlugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
 	return nil, nil

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -1052,6 +1052,12 @@ func (p *LoggerPlugin) GetName() string {
 	return PluginName
 }
 
+// HTTPTransportPreAuthHook is a no-op: this plugin does no credential work, so it has
+// nothing to do before the transport authenticates the request (HTTPTransportPlugin interface).
+func (*LoggerPlugin) HTTPTransportPreAuthHook(_ *schemas.BifrostContext, _ *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	return nil, nil
+}
+
 // HTTPTransportPreHook is not used for this plugin
 func (p *LoggerPlugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
 	return nil, nil

--- a/plugins/maxim/main.go
+++ b/plugins/maxim/main.go
@@ -164,6 +164,12 @@ func (plugin *Plugin) GetName() string {
 	return PluginName
 }
 
+// HTTPTransportPreAuthHook is a no-op: this plugin does no credential work, so it has
+// nothing to do before the transport authenticates the request (HTTPTransportPlugin interface).
+func (*Plugin) HTTPTransportPreAuthHook(_ *schemas.BifrostContext, _ *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	return nil, nil
+}
+
 // HTTPTransportPreHook is not used for this plugin
 func (plugin *Plugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
 	return nil, nil

--- a/plugins/mocker/main.go
+++ b/plugins/mocker/main.go
@@ -480,6 +480,12 @@ func (p *MockerPlugin) GetName() string {
 	return PluginName
 }
 
+// HTTPTransportPreAuthHook is a no-op: this plugin does no credential work, so it has
+// nothing to do before the transport authenticates the request (HTTPTransportPlugin interface).
+func (*MockerPlugin) HTTPTransportPreAuthHook(_ *schemas.BifrostContext, _ *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	return nil, nil
+}
+
 // HTTPTransportPreHook is not used for this plugin
 func (p *MockerPlugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
 	return nil, nil

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -719,6 +719,12 @@ func (p *OtelPlugin) RedactConfig(raw map[string]any) (map[string]any, error) {
 	return result, nil
 }
 
+// HTTPTransportPreAuthHook is a no-op: this plugin does no credential work, so it has
+// nothing to do before the transport authenticates the request (HTTPTransportPlugin interface).
+func (*OtelPlugin) HTTPTransportPreAuthHook(_ *schemas.BifrostContext, _ *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	return nil, nil
+}
+
 // HTTPTransportPreHook is not used for this plugin
 func (p *OtelPlugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
 	return nil, nil

--- a/plugins/prompts/main.go
+++ b/plugins/prompts/main.go
@@ -177,6 +177,12 @@ func (p *Plugin) GetName() string {
 	return PluginName
 }
 
+// HTTPTransportPreAuthHook is a no-op: this plugin does no credential work, so it has
+// nothing to do before the transport authenticates the request (HTTPTransportPlugin interface).
+func (*Plugin) HTTPTransportPreAuthHook(_ *schemas.BifrostContext, _ *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	return nil, nil
+}
+
 // HTTPTransportPreHook copies x-bf-prompt-id and x-bf-prompt-version from the incoming HTTP request
 // into BifrostContext so the default header resolver and PreLLMHook can read them.
 func (p *Plugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {

--- a/plugins/semanticcache/main.go
+++ b/plugins/semanticcache/main.go
@@ -315,6 +315,12 @@ func (plugin *Plugin) GetName() string {
 	return PluginName
 }
 
+// HTTPTransportPreAuthHook is a no-op: this plugin does no credential work, so it has
+// nothing to do before the transport authenticates the request (HTTPTransportPlugin interface).
+func (*Plugin) HTTPTransportPreAuthHook(_ *schemas.BifrostContext, _ *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	return nil, nil
+}
+
 // HTTPTransportPreHook is not used by the semantic cache plugin.
 func (plugin *Plugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
 	return nil, nil

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -654,6 +654,12 @@ func (p *PrometheusPlugin) RedactConfig(raw map[string]any) (map[string]any, err
 	return result, nil
 }
 
+// HTTPTransportPreAuthHook is a no-op: this plugin does no credential work, so it has
+// nothing to do before the transport authenticates the request (HTTPTransportPlugin interface).
+func (*PrometheusPlugin) HTTPTransportPreAuthHook(_ *schemas.BifrostContext, _ *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	return nil, nil
+}
+
 // HTTPTransportPreHook is not used for this plugin
 func (p *PrometheusPlugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
 	return nil, nil

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -388,6 +388,81 @@ func newDecompressReader(r io.Reader, encoding string) (io.Reader, func(), error
 	}
 }
 
+// TransportPreAuthInterceptorMiddleware runs the pre-auth phase of the plugin pipeline.
+// It converts the fasthttp request to a serializable HTTPRequest, runs every plugin implementing
+// HTTPTransportPreAuthHook, and applies modifications back to the fasthttp context — so the
+// authentication middlewares that run next observe them. This is the seam for plugins whose job is
+// to supply or translate the credentials authentication reads (deriving a virtual key from an
+// upstream identity header, say). Everything else belongs in TransportInterceptorMiddleware, which
+// runs after authentication and can see the resolved caller.
+//
+// The phase carries the same request shape as TransportInterceptorMiddleware, body included, so a
+// hook can move between the two by renaming. That means the body is snapshotted before the caller
+// is authenticated: a request authentication goes on to reject has already been copied once here.
+// Large payloads are still skipped — fasthttpToHTTPRequest honours the large-payload threshold, so
+// the threshold middleware must run before this one.
+//
+// There is no post-hook counterpart. HTTPTransportPostHook pairs with HTTPTransportPreHook, and a
+// request rejected by authentication runs neither.
+func TransportPreAuthInterceptorMiddleware(config *lib.Config) schemas.BifrostHTTPMiddleware {
+	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+		return func(ctx *fasthttp.RequestCtx) {
+			plugins := config.GetLoadedHTTPTransportPlugins()
+			if len(plugins) == 0 {
+				next(ctx)
+				return
+			}
+			// Get or create BifrostContext from fasthttp context
+			bifrostCtx := getBifrostContextFromFastHTTP(ctx)
+			// Transport hooks run before the inference path stamps the catalog, so stamp it
+			// here too — otherwise ctx.GetModelInfo would be nil in HTTPTransportPreAuthHook
+			// but populated in every other hook.
+			if config.ModelCatalog != nil {
+				bifrostCtx.SetValue(schemas.BifrostContextKeyModelCatalog, config.ModelCatalog)
+			}
+			// Acquire pooled request
+			req := schemas.AcquireHTTPRequest()
+			defer schemas.ReleaseHTTPRequest(req)
+			fasthttpToHTTPRequest(ctx, req)
+			// Run plugin pre-auth interceptors
+			for _, plugin := range plugins {
+				pluginName := plugin.GetName()
+				pluginCtx := bifrostCtx.WithPluginScope(&pluginName)
+				resp, err := plugin.HTTPTransportPreAuthHook(pluginCtx, req)
+				pluginCtx.ReleasePluginScope()
+				if err != nil {
+					// Short-circuit with error — drain plugin logs before returning
+					appendTransportPluginLogs(ctx, bifrostCtx.DrainPluginLogs())
+					ctx.SetStatusCode(fasthttp.StatusInternalServerError)
+					ctx.SetBodyString(err.Error())
+					return
+				}
+				if resp != nil {
+					// Short-circuit with response — drain plugin logs before returning
+					appendTransportPluginLogs(ctx, bifrostCtx.DrainPluginLogs())
+					applyHTTPResponseToCtx(ctx, resp)
+					return
+				}
+				// If we got here, the plugin may have modified req in-place
+			}
+			// Drain pre-auth plugin logs and store on fasthttp context for trace attachment
+			appendTransportPluginLogs(ctx, bifrostCtx.DrainPluginLogs())
+			// Apply modifications back to fasthttp context. A plugin that rewrote the method
+			// or path has already been failed with 409; running the rest of the chain would
+			// serve a response the transport just rejected.
+			if !applyHTTPRequestToCtx(ctx, req) {
+				return
+			}
+			// Adding user values so later middlewares, hooks and handlers observe anything
+			// a pre-auth plugin stashed on the context.
+			for key, value := range bifrostCtx.GetUserValues() {
+				ctx.SetUserValue(key, value)
+			}
+			next(ctx)
+		}
+	}
+}
+
 // TransportInterceptorMiddleware runs all plugin HTTP transport interceptors.
 // It converts the fasthttp request to a serializable HTTPRequest, runs all plugin interceptors,
 // and applies any modifications back to the fasthttp context.
@@ -419,29 +494,27 @@ func TransportInterceptorMiddleware(config *lib.Config) schemas.BifrostHTTPMiddl
 				pluginCtx.ReleasePluginScope()
 				if err != nil {
 					// Short-circuit with error — drain plugin logs before returning
-					if logs := bifrostCtx.DrainPluginLogs(); len(logs) > 0 {
-						ctx.SetUserValue(schemas.BifrostContextKeyTransportPluginLogs, logs)
-					}
+					appendTransportPluginLogs(ctx, bifrostCtx.DrainPluginLogs())
 					ctx.SetStatusCode(fasthttp.StatusInternalServerError)
 					ctx.SetBodyString(err.Error())
 					return
 				}
 				if resp != nil {
 					// Short-circuit with response — drain plugin logs before returning
-					if logs := bifrostCtx.DrainPluginLogs(); len(logs) > 0 {
-						ctx.SetUserValue(schemas.BifrostContextKeyTransportPluginLogs, logs)
-					}
+					appendTransportPluginLogs(ctx, bifrostCtx.DrainPluginLogs())
 					applyHTTPResponseToCtx(ctx, resp)
 					return
 				}
 				// If we got here, the plugin may have modified req in-place
 			}
 			// Drain pre-hook plugin logs and store on fasthttp context for trace attachment
-			if preHookLogs := bifrostCtx.DrainPluginLogs(); len(preHookLogs) > 0 {
-				ctx.SetUserValue(schemas.BifrostContextKeyTransportPluginLogs, preHookLogs)
+			appendTransportPluginLogs(ctx, bifrostCtx.DrainPluginLogs())
+			// Apply modifications back to fasthttp context. A plugin that rewrote the method
+			// or path has already been failed with 409; running the handler anyway would
+			// serve a response the transport just rejected.
+			if !applyHTTPRequestToCtx(ctx, req) {
+				return
 			}
-			// Apply modifications back to fasthttp context
-			applyHTTPRequestToCtx(ctx, req)
 			// Adding user values
 			for key, value := range bifrostCtx.GetUserValues() {
 				ctx.SetUserValue(key, value)
@@ -528,27 +601,15 @@ func runTransportPostHooks(ctx *fasthttp.RequestCtx, plugins []schemas.HTTPTrans
 		if err != nil {
 			logger.Warn("error in HTTPTransportPostHook for plugin %s: %s", pluginName, err.Error())
 			// Drain plugin logs before returning on error
-			if postHookLogs := bifrostCtx.DrainPluginLogs(); len(postHookLogs) > 0 {
-				if existing, ok := ctx.UserValue(schemas.BifrostContextKeyTransportPluginLogs).([]schemas.PluginLogEntry); ok {
-					ctx.SetUserValue(schemas.BifrostContextKeyTransportPluginLogs, append(existing, postHookLogs...))
-				} else {
-					ctx.SetUserValue(schemas.BifrostContextKeyTransportPluginLogs, postHookLogs)
-				}
-			}
+			appendTransportPluginLogs(ctx, bifrostCtx.DrainPluginLogs())
 			if shouldApplyShortCircuit {
 				applyHTTPResponseToCtx(ctx, httpResp)
 			}
 			return fmt.Errorf("transport post-hook plugin %s: %w", pluginName, err)
 		}
 	}
-	// Drain post-hook plugin logs and merge with pre-hook logs
-	if postHookLogs := bifrostCtx.DrainPluginLogs(); len(postHookLogs) > 0 {
-		if existing, ok := ctx.UserValue(schemas.BifrostContextKeyTransportPluginLogs).([]schemas.PluginLogEntry); ok {
-			ctx.SetUserValue(schemas.BifrostContextKeyTransportPluginLogs, append(existing, postHookLogs...))
-		} else {
-			ctx.SetUserValue(schemas.BifrostContextKeyTransportPluginLogs, postHookLogs)
-		}
-	}
+	// Drain post-hook plugin logs and merge with the earlier phases' logs
+	appendTransportPluginLogs(ctx, bifrostCtx.DrainPluginLogs())
 	if shouldApplyShortCircuit {
 		applyHTTPResponseToCtx(ctx, httpResp)
 	}
@@ -665,12 +726,14 @@ func fasthttpToHTTPRequest(ctx *fasthttp.RequestCtx, req *schemas.HTTPRequest) {
 }
 
 // applyHTTPRequestToCtx applies modifications from HTTPRequest back to fasthttp context.
-func applyHTTPRequestToCtx(ctx *fasthttp.RequestCtx, req *schemas.HTTPRequest) {
+// Reports false when a plugin rewrote the method or path: the request has already been
+// failed with 409 and the caller must stop.
+func applyHTTPRequestToCtx(ctx *fasthttp.RequestCtx, req *schemas.HTTPRequest) bool {
 	// If path/method is different, throw error
 	if req.Method != string(ctx.Method()) || req.Path != string(ctx.Path()) {
 		logger.Error("request method/path mismatch: %s %s != %s %s", req.Method, req.Path, string(ctx.Method()), string(ctx.Path()))
 		SendError(ctx, fasthttp.StatusConflict, "request method/path was modified by a plugin, this is not allowed")
-		return
+		return false
 	}
 	// Apply headers
 	for key, value := range req.Headers {
@@ -684,6 +747,22 @@ func applyHTTPRequestToCtx(ctx *fasthttp.RequestCtx, req *schemas.HTTPRequest) {
 	if req.Body != nil {
 		ctx.Request.SetBody(req.Body)
 	}
+	return true
+}
+
+// appendTransportPluginLogs accumulates transport-layer plugin logs on the fasthttp context
+// for trace attachment. Every phase (pre-auth, pre-hook, post-hook) drains into the same slot,
+// so this appends rather than overwrites — otherwise a later phase would drop the earlier
+// phases' logs.
+func appendTransportPluginLogs(ctx *fasthttp.RequestCtx, logs []schemas.PluginLogEntry) {
+	if len(logs) == 0 {
+		return
+	}
+	if existing, ok := ctx.UserValue(schemas.BifrostContextKeyTransportPluginLogs).([]schemas.PluginLogEntry); ok {
+		ctx.SetUserValue(schemas.BifrostContextKeyTransportPluginLogs, append(existing, logs...))
+		return
+	}
+	ctx.SetUserValue(schemas.BifrostContextKeyTransportPluginLogs, logs)
 }
 
 // applyHTTPResponseToCtx writes a short-circuit response to fasthttp context.

--- a/transports/bifrost-http/handlers/middlewares_test.go
+++ b/transports/bifrost-http/handlers/middlewares_test.go
@@ -2465,3 +2465,214 @@ func TestTracingMiddleware_AccessLogIncludesRequestID(t *testing.T) {
 		t.Error("expected access log to include a non-empty trace_id")
 	}
 }
+
+// fakePreAuthPlugin is a minimal HTTPTransportPlugin whose pre-auth hook is supplied per test;
+// the remaining transport hooks are inert.
+type fakePreAuthPlugin struct {
+	name string
+	hook func(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error)
+}
+
+func (p *fakePreAuthPlugin) GetName() string { return p.name }
+
+func (p *fakePreAuthPlugin) Cleanup() error { return nil }
+
+func (p *fakePreAuthPlugin) HTTPTransportPreAuthHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	return p.hook(ctx, req)
+}
+
+func (p *fakePreAuthPlugin) HTTPTransportPreHook(_ *schemas.BifrostContext, _ *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	return nil, nil
+}
+
+func (p *fakePreAuthPlugin) HTTPTransportPostHook(_ *schemas.BifrostContext, _ *schemas.HTTPRequest, _ *schemas.HTTPResponse) error {
+	return nil
+}
+
+func (p *fakePreAuthPlugin) HTTPTransportStreamChunkHook(_ *schemas.BifrostContext, _ *schemas.HTTPRequest, chunk *schemas.BifrostStreamChunk) (*schemas.BifrostStreamChunk, error) {
+	return chunk, nil
+}
+
+// preAuthTestConfig builds a Config whose transport plugin cache holds the given plugins.
+func preAuthTestConfig(plugins ...schemas.HTTPTransportPlugin) *lib.Config {
+	config := &lib.Config{}
+	config.HTTPTransportPlugins.Store(&plugins)
+	return config
+}
+
+// preAuthTestCtx builds a request context carrying a body, so tests can assert the body is
+// neither delivered to the hook nor disturbed by the phase.
+func preAuthTestCtx() *fasthttp.RequestCtx {
+	var req fasthttp.Request
+	req.Header.SetMethod("POST")
+	req.SetRequestURI("/v1/chat/completions?stream=false")
+	req.SetBodyString(`{"model":"gpt-4"}`)
+	// Init rather than a zero value: the middleware derives a BifrostContext from the
+	// request context, and Done() panics on an uninitialized RequestCtx.
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Init(&req, nil, nil)
+	return ctx
+}
+
+// TestTransportPreAuthInterceptorMiddleware_HeaderVisibleToNext asserts the whole point of the
+// phase: a credential a plugin writes is on the request before the next middleware runs.
+func TestTransportPreAuthInterceptorMiddleware_HeaderVisibleToNext(t *testing.T) {
+	config := preAuthTestConfig(&fakePreAuthPlugin{
+		name: "vk-injector",
+		hook: func(_ *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+			req.Headers["x-bf-vk"] = "sk-bf-injected"
+			req.Query["injected"] = "yes"
+			return nil, nil
+		},
+	})
+
+	var seenVK, seenQuery string
+	handler := TransportPreAuthInterceptorMiddleware(config)(func(ctx *fasthttp.RequestCtx) {
+		seenVK = string(ctx.Request.Header.Peek("x-bf-vk"))
+		seenQuery = string(ctx.Request.URI().QueryArgs().Peek("injected"))
+	})
+
+	ctx := preAuthTestCtx()
+	handler(ctx)
+
+	if seenVK != "sk-bf-injected" {
+		t.Errorf("expected next middleware to see the injected virtual key, got %q", seenVK)
+	}
+	if seenQuery != "yes" {
+		t.Errorf("expected next middleware to see the injected query param, got %q", seenQuery)
+	}
+}
+
+// TestTransportPreAuthInterceptorMiddleware_BodyIsModifiable asserts the pre-auth phase carries
+// the same request shape as the post-auth phase: the hook reads the body and its rewrite lands on
+// the request, so a hook can move between the two phases by renaming.
+func TestTransportPreAuthInterceptorMiddleware_BodyIsModifiable(t *testing.T) {
+	var hookSawBody string
+	config := preAuthTestConfig(&fakePreAuthPlugin{
+		name: "body-rewriter",
+		hook: func(_ *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+			hookSawBody = string(req.Body)
+			req.Body = []byte(`{"model":"rewritten"}`)
+			return nil, nil
+		},
+	})
+
+	var handlerBody string
+	handler := TransportPreAuthInterceptorMiddleware(config)(func(ctx *fasthttp.RequestCtx) {
+		handlerBody = string(ctx.Request.Body())
+	})
+
+	ctx := preAuthTestCtx()
+	handler(ctx)
+
+	if hookSawBody != `{"model":"gpt-4"}` {
+		t.Errorf("expected the pre-auth hook to receive the request body, got %q", hookSawBody)
+	}
+	if handlerBody != `{"model":"rewritten"}` {
+		t.Errorf("expected the rewritten body to reach the handler, got %q", handlerBody)
+	}
+}
+
+// TestTransportPreAuthInterceptorMiddleware_ShortCircuitResponse asserts a plugin can answer the
+// request itself, and that authentication and the handler never run.
+func TestTransportPreAuthInterceptorMiddleware_ShortCircuitResponse(t *testing.T) {
+	config := preAuthTestConfig(&fakePreAuthPlugin{
+		name: "denier",
+		hook: func(_ *schemas.BifrostContext, _ *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+			return &schemas.HTTPResponse{
+				StatusCode: fasthttp.StatusUnauthorized,
+				Headers:    map[string]string{"WWW-Authenticate": "Bearer"},
+				Body:       []byte("denied"),
+			}, nil
+		},
+	})
+
+	nextCalled := false
+	handler := TransportPreAuthInterceptorMiddleware(config)(func(_ *fasthttp.RequestCtx) {
+		nextCalled = true
+	})
+
+	ctx := preAuthTestCtx()
+	handler(ctx)
+
+	if nextCalled {
+		t.Error("expected the chain to stop at the short-circuiting plugin")
+	}
+	if ctx.Response.StatusCode() != fasthttp.StatusUnauthorized {
+		t.Errorf("expected status %d, got %d", fasthttp.StatusUnauthorized, ctx.Response.StatusCode())
+	}
+	if got := string(ctx.Response.Body()); got != "denied" {
+		t.Errorf("expected the plugin's body, got %q", got)
+	}
+}
+
+// TestTransportPreAuthInterceptorMiddleware_PluginError asserts a hook error fails the request
+// rather than letting it continue unauthenticated.
+func TestTransportPreAuthInterceptorMiddleware_PluginError(t *testing.T) {
+	config := preAuthTestConfig(&fakePreAuthPlugin{
+		name: "broken",
+		hook: func(_ *schemas.BifrostContext, _ *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+			return nil, context.DeadlineExceeded
+		},
+	})
+
+	nextCalled := false
+	handler := TransportPreAuthInterceptorMiddleware(config)(func(_ *fasthttp.RequestCtx) {
+		nextCalled = true
+	})
+
+	ctx := preAuthTestCtx()
+	handler(ctx)
+
+	if nextCalled {
+		t.Error("expected the chain to stop after a plugin error")
+	}
+	if ctx.Response.StatusCode() != fasthttp.StatusInternalServerError {
+		t.Errorf("expected status %d, got %d", fasthttp.StatusInternalServerError, ctx.Response.StatusCode())
+	}
+}
+
+// TestTransportPreAuthInterceptorMiddleware_PathMutationRejected asserts routing cannot be
+// rewritten from the pre-auth phase — the request is failed rather than served on a path the
+// router never matched.
+func TestTransportPreAuthInterceptorMiddleware_PathMutationRejected(t *testing.T) {
+	SetLogger(&mockLogger{})
+	config := preAuthTestConfig(&fakePreAuthPlugin{
+		name: "rerouter",
+		hook: func(_ *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+			req.Path = "/v1/embeddings"
+			return nil, nil
+		},
+	})
+
+	nextCalled := false
+	handler := TransportPreAuthInterceptorMiddleware(config)(func(_ *fasthttp.RequestCtx) {
+		nextCalled = true
+	})
+
+	ctx := preAuthTestCtx()
+	handler(ctx)
+
+	if nextCalled {
+		t.Error("expected the chain to stop after a rejected path mutation")
+	}
+	if ctx.Response.StatusCode() != fasthttp.StatusConflict {
+		t.Errorf("expected status %d, got %d", fasthttp.StatusConflict, ctx.Response.StatusCode())
+	}
+}
+
+// TestTransportPreAuthInterceptorMiddleware_NoPlugins asserts the phase is a pass-through when
+// nothing implements the hook, which is the common case.
+func TestTransportPreAuthInterceptorMiddleware_NoPlugins(t *testing.T) {
+	nextCalled := false
+	handler := TransportPreAuthInterceptorMiddleware(preAuthTestConfig())(func(_ *fasthttp.RequestCtx) {
+		nextCalled = true
+	})
+
+	ctx := preAuthTestCtx()
+	handler(ctx)
+
+	if !nextCalled {
+		t.Error("expected the request to pass straight through when no plugin implements the hook")
+	}
+}

--- a/transports/bifrost-http/handlers/realtime_client_secrets_test.go
+++ b/transports/bifrost-http/handlers/realtime_client_secrets_test.go
@@ -493,6 +493,10 @@ func (m *mockRealtimeMintingGovernancePlugin) EvaluateGovernanceRequest(ctx *sch
 	return &governance.EvaluationResult{Decision: governance.DecisionAllow}, nil
 }
 
+func (m *mockRealtimeMintingGovernancePlugin) HTTPTransportPreAuthHook(_ *schemas.BifrostContext, _ *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	return nil, nil
+}
+
 func (m *mockRealtimeMintingGovernancePlugin) HTTPTransportPreHook(_ *schemas.BifrostContext, _ *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
 	return nil, nil
 }

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -2617,6 +2617,10 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 		return fmt.Errorf("failed to initialize routes: %v", err)
 	}
 	// Registering inference routes
+	// The pre-auth plugin phase runs immediately before the auth middlewares so a plugin can
+	// supply or translate the credentials they read (see schemas.HTTPTransportPreAuthHook).
+	// Skipped entirely when no transport plugin is loaded.
+	inferenceMiddlewares = append(inferenceMiddlewares, handlers.TransportPreAuthInterceptorMiddleware(s.Config))
 	if ctx.Value(schemas.BifrostContextKeyIsEnterprise) == nil && s.AuthMiddleware != nil {
 		inferenceMiddlewares = append(inferenceMiddlewares, s.AuthMiddleware.InferenceMiddleware())
 	}
@@ -2632,10 +2636,12 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	tracer.SetObservabilityPlugins(observabilityPlugins)
 	s.Client.SetTracer(tracer)
 	s.TracingMiddleware = handlers.NewTracingMiddleware(tracer)
-	// TransportInterceptor must be inside TracingMiddleware so that the tracing defer
-	// runs AFTER transport post-hooks (capturing HTTPTransportPostHook plugin logs).
-	// Order: Tracing.pre → TransportInterceptor.pre → handler → TransportInterceptor.post → Tracing.defer
-	inferenceMiddlewares = append([]schemas.BifrostHTTPMiddleware{handlers.TransportInterceptorMiddleware(s.Config)}, inferenceMiddlewares...)
+	// TransportInterceptor runs AFTER the auth middlewares so HTTPTransportPreHook observes an
+	// authenticated request, and inside TracingMiddleware so the tracing defer runs AFTER
+	// transport post-hooks (capturing HTTPTransportPostHook plugin logs).
+	// Order: Tracing.pre → PreAuthInterceptor → auth → TransportInterceptor.pre → handler →
+	//        TransportInterceptor.post → Tracing.defer
+	inferenceMiddlewares = append(inferenceMiddlewares, handlers.TransportInterceptorMiddleware(s.Config))
 	inferenceMiddlewares = append([]schemas.BifrostHTTPMiddleware{s.TracingMiddleware.Middleware()}, inferenceMiddlewares...)
 
 	err = s.RegisterInferenceRoutes(s.Ctx, inferenceMiddlewares...)


### PR DESCRIPTION
## Summary

The plugin HTTP transport pipeline gains a new `HTTPTransportPreAuthHook` phase that runs before the transport's authentication middlewares. Previously, `HTTPTransportPreHook` ran before authentication, meaning plugins could supply credentials that authentication would then validate. In v2.0, `HTTPTransportPreHook` was silently moved to run after authentication, breaking any plugin that writes a virtual key or rewrites an `Authorization` header from that hook — the credential is set too late to be seen by auth, the request proceeds unauthenticated, and nothing in the logs indicates why. `HTTPTransportPreAuthHook` restores the pre-authentication seam explicitly and intentionally.

## Changes

- Added `HTTPTransportPreAuthHook` to the `HTTPTransportPlugin` interface in `core/schemas/plugin.go`, with full contract documentation covering return values, body snapshotting cost, the absence of a post-hook counterpart, and the restriction on mutating `Method` or `Path`.
- Implemented `TransportPreAuthInterceptorMiddleware` in `transports/bifrost-http/handlers/middlewares.go`, which converts the fasthttp request to a serializable `HTTPRequest`, runs every plugin's `HTTPTransportPreAuthHook`, applies mutations back to the fasthttp context, and short-circuits on error or a non-nil response — mirroring the existing `TransportInterceptorMiddleware` structure.
- Registered `TransportPreAuthInterceptorMiddleware` in the inference middleware chain immediately before the auth middlewares, and moved `TransportInterceptorMiddleware` to run after them. The full order is now: `Tracing.pre → PreAuthInterceptor → auth → TransportInterceptor → handler → TransportInterceptor.post → Tracing.defer`.
- Changed `applyHTTPRequestToCtx` to return a `bool` so callers can stop the chain when a plugin illegally rewrites the method or path, rather than silently continuing.
- Extracted `appendTransportPluginLogs` as a shared helper so all three phases (pre-auth, pre-hook, post-hook) accumulate logs into the same fasthttp context slot without overwriting each other.
- Added no-op `HTTPTransportPreAuthHook` implementations to all first-party plugins (`compat`, `governance`, `jsonparser`, `logging`, `maxim`, `mocker`, `otel`, `prompts`, `semanticcache`, `telemetry`) to satisfy the updated interface.
- Updated `DynamicPlugin` (`.so` loader) to look up `HTTPTransportPreAuthHook` optionally — plugins that predate the hook simply don't export the symbol and are skipped by the phase.
- Updated `AsHTTPTransportPlugin` to recognise a plugin as an `HTTPTransportPlugin` when it exports `httpTransportPreAuthHook`, even if it exports neither of the existing hooks.
- Added tests covering: header and query mutations visible to the next middleware, body read and rewrite, short-circuit response, plugin error, path mutation rejection, and the no-plugin pass-through case.
- Updated OSS and Enterprise v2.0.0 migration guides and plugin documentation (`getting-started.mdx`, `writing-go-plugin.mdx`, `migration-guide.mdx`) to describe the new phase, the silent failure mode, and the rename-only migration path.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./transports/bifrost-http/handlers/... -run TestTransportPreAuthInterceptorMiddleware
go test ./...
```

To validate end-to-end: write a plugin that exports `HTTPTransportPreAuthHook` and sets `x-bf-vk` from an upstream identity header. Deploy with an identity provider configured and `enforce_auth_on_inference` enabled. Confirm the request is authenticated rather than rejected with `401`. Then rename the export back to `HTTPTransportPreHook` and confirm the request is rejected — verifying the phase boundary is real.

## Breaking changes

- [x] Yes
- [ ] No

`HTTPTransportPlugin` now requires `HTTPTransportPreAuthHook`. Go plugins compiled against v2.0 must implement it; returning `(nil, nil)` is sufficient for plugins with no credential work. Native `.so` plugins are unaffected unless they opt in — the symbol is looked up optionally.

Any plugin that wrote a credential from `HTTPTransportPreHook` must rename that function to `HTTPTransportPreAuthHook`. The failure mode without the rename is silent: the plugin runs and returns cleanly, but the credential is written after authentication has already run and is ignored. See the v2.0.0 migration guide for the full checklist.

## Related issues

See [Breaking Change 4 in the v2.0.0 migration guide](/migration-guides/v2.0.0#breaking-change-4-httptransportprehook-now-runs-after-authentication) and the [Enterprise v2.0.0 migration guide](/enterprise/migration-guides/v2.0.0) for the SCIM-specific context.

## Security considerations

The pre-auth phase snapshots the request body before the caller is authenticated. A request that authentication goes on to reject has already had its body copied once. Large payloads are still skipped — `fasthttpToHTTPRequest` honours the large-payload threshold, so the threshold middleware must run before `TransportPreAuthInterceptorMiddleware`. No configuration change is required; the ordering is enforced in `server.go`.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable