### PR TITLE
fix: adds batch types in filters and make batch id column take full width

### DIFF
--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -1659,31 +1659,33 @@ export function LogDetailView({
 									<DottedSeparator />
 									<div className="space-y-4">
 										<BlockHeader title="Batch Details" />
-										<div className="grid w-full grid-cols-3 md:grid-cols-1 items-start justify-between gap-4">
-											{batchDebug.batch_id && (
-												<LogEntryDetailsView
-													className="w-full"
-													label="Batch ID"
-													value={
-														<span className="flex items-center gap-1">
-															<code className="font-mono text-xs">{batchDebug.batch_id}</code>
-															<CopyInlineButton text={batchDebug.batch_id} testId="logdetails-copy-batch-id-button" />
-														</span>
-													}
-												/>
-											)}
-											{batchDebug.request_counts && (
-												<>
-													<LogEntryDetailsView className="w-full" label="Total Requests" value={String(batchDebug.request_counts.total)} />
-													{batchRequestStates(batchDebug.request_counts).map(([label, count]) => (
-														<LogEntryDetailsView key={label} className="w-full" label={label} value={String(count)} />
-													))}
-												</>
-											)}
-											{batchDebug.accounting?.cost != null && (
-												<LogEntryDetailsView className="w-full" label="Batch Cost" value={formatCost(batchDebug.accounting.cost)} />
-											)}
-										</div>
+										{batchDebug.batch_id && (
+											<LogEntryDetailsView
+												className="w-full"
+												label="Batch ID"
+												value={
+													<span className="flex items-center gap-1">
+														<code className="font-mono text-xs">{batchDebug.batch_id}</code>
+														<CopyInlineButton text={batchDebug.batch_id} testId="logdetails-copy-batch-id-button" />
+													</span>
+												}
+											/>
+										)}
+										{(batchDebug.request_counts || batchDebug.accounting?.cost != null) && (
+											<div className="grid w-full grid-cols-1 md:grid-cols-3 items-start justify-between gap-4">
+												{batchDebug.request_counts && (
+													<>
+														<LogEntryDetailsView className="w-full" label="Total Requests" value={String(batchDebug.request_counts.total)} />
+														{batchRequestStates(batchDebug.request_counts).map(([label, count]) => (
+															<LogEntryDetailsView key={label} className="w-full" label={label} value={String(count)} />
+														))}
+													</>
+												)}
+												{batchDebug.accounting?.cost != null && (
+													<LogEntryDetailsView className="w-full" label="Batch Cost" value={formatCost(batchDebug.accounting.cost)} />
+												)}
+											</div>
+										)}
 									</div>
 								</>
 							)}

--- a/ui/lib/constants/logs.ts
+++ b/ui/lib/constants/logs.ts
@@ -93,6 +93,13 @@ export const RequestTypes = [
 	"video_remix",
 	"count_tokens",
 	"compaction",
+    // Batch operations
+	"batch_create",
+	"batch_list",
+	"batch_retrieve",
+	"batch_cancel",
+	"batch_delete",
+	"batch_results",
 	// Container operations
 	"container_create",
 	"container_list",

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -337,6 +337,7 @@ export type RequestType =
 	| "batch_list"
 	| "batch_retrieve"
 	| "batch_cancel"
+	| "batch_delete"
 	| "batch_results"
 	| "file_upload"
 	| "file_list"


### PR DESCRIPTION
## Summary

Improves the layout of the Batch Details section in the log detail view and adds missing batch operation request types to constants and type definitions.

## Changes

- Restructured the Batch Details layout so that the Batch ID renders outside the grid, displayed on its own row, while request counts and cost are grouped together in a responsive grid only when at least one of those values is present
- Fixed the responsive grid column order — previously `grid-cols-3 md:grid-cols-1` (3 columns on mobile, 1 on desktop), now correctly `grid-cols-1 md:grid-cols-3`
- Added `batch_create`, `batch_list`, `batch_retrieve`, `batch_cancel`, `batch_delete`, and `batch_results` to the `RequestTypes` constants array
- Added `batch_delete` to the `RequestType` union type, which was previously missing

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Navigate to a log entry for a batch request and open the detail view. Verify:
- The Batch ID appears on its own row above the grid
- Request counts and cost appear in a grid that is 1 column on mobile and 3 columns on desktop
- Batch operation types (`batch_create`, `batch_list`, etc.) are correctly recognized and displayed in log filters

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

Before/after screenshots of the Batch Details panel recommended to confirm layout fix.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable