### PR TITLE
[feat]: Add tested one-click Render and Railway deployments

### DIFF
--- a/.github/workflows/deployment-template-validation.yml
+++ b/.github/workflows/deployment-template-validation.yml
@@ -1,0 +1,162 @@
+name: Deployment Template Validation
+
+on:
+  pull_request:
+    paths:
+      - "render.yaml"
+      - "deploy/render/**"
+      - "deploy/railway/**"
+      - "deploy/runtime-contract.json"
+      - "transports/config.schema.json"
+      - "transports/docker-entrypoint.sh"
+      - "transports/docker-entrypoint_test.sh"
+      - ".github/workflows/scripts/test-docker-image.sh"
+      - "transports/Dockerfile"
+      - "transports/Dockerfile.local"
+      - "docs/deployment-guides/overview.mdx"
+      - "docs/deployment-guides/runtime-contract.mdx"
+      - "docs/deployment-guides/platforms/render.mdx"
+      - "docs/deployment-guides/platforms/railway.mdx"
+      - ".github/workflows/deployment-template-validation.yml"
+      - ".github/workflows/scripts/validate-deployment-templates.py"
+      - ".github/workflows/scripts/verify-deployment-release.sh"
+      - ".github/workflows/scripts/smoke-test-published-image.sh"
+  push:
+    branches: ["main"]
+    paths:
+      - "render.yaml"
+      - "deploy/render/**"
+      - "deploy/railway/**"
+      - "deploy/runtime-contract.json"
+      - "transports/config.schema.json"
+      - "transports/docker-entrypoint.sh"
+      - "transports/docker-entrypoint_test.sh"
+      - ".github/workflows/scripts/test-docker-image.sh"
+      - "transports/Dockerfile"
+      - "transports/Dockerfile.local"
+      - "docs/deployment-guides/overview.mdx"
+      - "docs/deployment-guides/runtime-contract.mdx"
+      - "docs/deployment-guides/platforms/render.mdx"
+      - "docs/deployment-guides/platforms/railway.mdx"
+      - ".github/workflows/deployment-template-validation.yml"
+      - ".github/workflows/scripts/validate-deployment-templates.py"
+      - ".github/workflows/scripts/verify-deployment-release.sh"
+      - ".github/workflows/scripts/smoke-test-published-image.sh"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            files.pythonhosted.org:443
+            api.github.com:443
+            api.render.com:443
+            auth.docker.io:443
+            github.com:443
+            objects.githubusercontent.com:443
+            pypi.org:443
+            production.cloudflare.docker.com:443
+            registry-1.docker.io:443
+            release-assets.githubusercontent.com:443
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install validators
+        run: |
+          python3 -m pip install --disable-pip-version-check PyYAML==6.0.3 jsonschema==4.26.0
+          curl -fsSL \
+            https://github.com/render-oss/cli/releases/download/v2.22.0/cli_2.22.0_linux_amd64.zip \
+            -o /tmp/render-cli.zip
+          # Digest published in cli_2.22.0_SHA256SUMS for the pinned release.
+          echo "6cdcd11897b7bd7e673317e6f4aaf041b654d818444f3b1efec7240a835f79ec  /tmp/render-cli.zip" \
+            | sha256sum --check --strict -
+          unzip -q /tmp/render-cli.zip -d /tmp/render-cli
+          sudo install -m 0755 /tmp/render-cli/cli_v2.22.0 /usr/local/bin/render
+
+      - name: Validate repository contracts
+        run: python3 .github/workflows/scripts/validate-deployment-templates.py
+
+      - name: Validate entrypoint shell
+        run: |
+          shellcheck transports/docker-entrypoint.sh transports/docker-entrypoint_test.sh
+          sh transports/docker-entrypoint_test.sh
+
+      - name: Validate Render Blueprints
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_WORKSPACE_ID: ${{ vars.RENDER_WORKSPACE_ID }}
+        run: |
+          if [ -z "$RENDER_API_KEY" ] || [ -z "$RENDER_WORKSPACE_ID" ]; then
+            echo "::notice::Render CLI semantic validation requires RENDER_API_KEY and RENDER_WORKSPACE_ID; repository schema validation completed."
+            exit 0
+          fi
+          render blueprints validate --workspace "$RENDER_WORKSPACE_ID" render.yaml
+          render blueprints validate --workspace "$RENDER_WORKSPACE_ID" deploy/render/render-sqlite.yaml
+
+  # The published release is two artifacts: linux/amd64 and linux/arm64 are built
+  # on their own native runners and merged into one manifest list. `docker run`
+  # resolves that list to whatever the host is, so a single runner can only ever
+  # execute one of them, and an arm64 runtime stage that cannot start would pass
+  # a gate that only proved its manifest exists. Run the gate once per required
+  # platform, on a runner that executes it natively rather than under emulation —
+  # a release gate that flakes gets bypassed.
+  release-gate:
+    name: Release Gate (${{ matrix.platform }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            platform: linux/amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            auth.docker.io:443
+            github.com:443
+            production.cloudflare.docker.com:443
+            registry-1.docker.io:443
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # The strict gate lives in publish-render-sqlite-branch.yml, which refuses to
+      # publish the public one-click branch before the qualified release exists. Here
+      # it only warns on pull requests: the PR that introduces the gated runtime
+      # contract necessarily precedes the release that satisfies it.
+      - name: Verify public image release gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BIFROST_SMOKE_PLATFORM: ${{ matrix.platform }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if bash .github/workflows/scripts/verify-deployment-release.sh; then
+            exit 0
+          fi
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            echo "::warning::maximhq/bifrost:latest does not resolve to the qualified release on $BIFROST_SMOKE_PLATFORM yet; do not publish or update the public one-click templates until it does."
+            exit 0
+          fi
+          exit 1

--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -1,10 +1,17 @@
 name: Docs Validation
 
 on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs-validation.yml"
+      - ".github/workflows/scripts/check-new-broken-links.sh"
   push:
     branches: ["main"]
     paths:
       - "docs/**"
+      - ".github/workflows/docs-validation.yml"
+      - ".github/workflows/scripts/check-new-broken-links.sh"
 
 permissions:
   contents: read
@@ -29,15 +36,33 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "21"
 
-      - name: Check for broken links
-        working-directory: ./docs
+      # Compare against the branch this change is measured from: pull requests
+      # against their base, main pushes against the commit they advanced from.
+      - name: Resolve the comparison point
+        id: base
+        env:
+          BASE_REF: ${{ github.event_name == 'pull_request' && github.base_ref || github.event.before }}
         run: |
-          echo "Checking for broken links in documentation..."
-          npx --yes mintlify@latest broken-links
-          echo "✅ No broken links found"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch --no-tags origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+            echo "ref=origin/${BASE_REF}" >> "$GITHUB_OUTPUT"
+          elif [ -z "${BASE_REF}" ] || [ "${BASE_REF}" = "0000000000000000000000000000000000000000" ] || ! git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null; then
+            # Branch creation, or a force-push whose previous tip is gone: the
+            # parent commit is the only comparison point still available.
+            echo "ref=HEAD~1" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${BASE_REF}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for newly broken links
+        env:
+          COMPARE_REF: ${{ steps.base.outputs.ref }}
+        run: bash .github/workflows/scripts/check-new-broken-links.sh "$COMPARE_REF"

--- a/.github/workflows/publish-render-sqlite-branch.yml
+++ b/.github/workflows/publish-render-sqlite-branch.yml
@@ -1,0 +1,142 @@
+name: Publish Render SQLite Blueprint Branch
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "deploy/render/render-sqlite.yaml"
+      - ".github/workflows/publish-render-sqlite-branch.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: publish-render-sqlite-branch
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  # Hard release gate: the public deploy button consumes the published branch
+  # directly, so it must never advance before maximhq/bifrost:latest resolves to
+  # the qualified release. Re-run via workflow_dispatch after the release ships.
+  #
+  # Once per required platform, because the published release is two artifacts:
+  # linux/amd64 and linux/arm64 are built on their own native runners and merged
+  # into one manifest list. `docker run` resolves that list to whatever the host
+  # is, so a single runner can only ever execute one of them, and an arm64
+  # runtime stage that cannot start would pass a gate that only proved its
+  # manifest exists. Native runners rather than emulation — a release gate that
+  # flakes gets bypassed.
+  release-gate:
+    name: Release Gate (${{ matrix.platform }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            platform: linux/amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            auth.docker.io:443
+            github.com:443
+            production.cloudflare.docker.com:443
+            registry-1.docker.io:443
+
+      # This workflow force-pushes to a branch a public deploy button reads
+      # directly, and workflow_dispatch accepts any ref the caller selects, so
+      # every job refuses anything but main. See the publish job below for why
+      # the ref travels through the environment.
+      - name: Require main
+        env:
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          if [ "$WORKFLOW_REF" != "refs/heads/main" ]; then
+            echo "::error::publish-render-sqlite-branch may only run from refs/heads/main (got $WORKFLOW_REF)"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Verify public image release gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BIFROST_SMOKE_PLATFORM: ${{ matrix.platform }}
+        run: bash .github/workflows/scripts/verify-deployment-release.sh
+
+  publish:
+    needs: release-gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            auth.docker.io:443
+            github.com:443
+            production.cloudflare.docker.com:443
+            registry-1.docker.io:443
+
+      # workflow_dispatch accepts any ref the caller selects, and this job
+      # force-pushes what it checks out to a branch a public deploy button reads
+      # directly. Refuse anything but main, and check main out by the SHA that
+      # triggered the run rather than by name.
+      #
+      # The ref reaches the shell through the environment, never through
+      # expression interpolation: an interpolated `github.ref` is pasted into
+      # the script before bash parses it, so a shell-significant branch name
+      # would run before this guard could reject it.
+      - name: Require main
+        env:
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          if [ "$WORKFLOW_REF" != "refs/heads/main" ]; then
+            echo "::error::publish-render-sqlite-branch may only run from refs/heads/main (got $WORKFLOW_REF)"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Publish generated branch
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          BLOB=$(git hash-object -w deploy/render/render-sqlite.yaml)
+          TREE=$(printf '100644 blob %s\trender.yaml\n' "$BLOB" | git mktree)
+          PARENT_ARGS=()
+          if PARENT=$(git ls-remote origin refs/heads/render-sqlite | awk '{print $1}') && [ -n "$PARENT" ]; then
+            PARENT_ARGS=(-p "$PARENT")
+          fi
+          COMMIT=$(printf 'chore: publish Render SQLite Blueprint from %s\n' "$SOURCE_SHA" | git commit-tree "$TREE" "${PARENT_ARGS[@]}")
+          git push --force origin "$COMMIT:refs/heads/render-sqlite"
+
+          PUBLISHED=$(git ls-remote origin refs/heads/render-sqlite | awk '{print $1}')
+          test "$PUBLISHED" = "$COMMIT"
+          git show "$PUBLISHED:render.yaml" > /tmp/published-render.yaml
+          cmp --silent deploy/render/render-sqlite.yaml /tmp/published-render.yaml

--- a/.github/workflows/scripts/check-new-broken-links.sh
+++ b/.github/workflows/scripts/check-new-broken-links.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fail only on documentation links this change breaks.
+#
+# `mintlify broken-links` reports the whole docs tree, and the tree already has
+# broken links. Failing on the total would hand every unrelated docs pull request
+# an inherited red check, and a check that is red on arrival stops being read.
+# So run the same check against the comparison point and report the difference:
+# the rule is "no new broken links", which is enforceable from the first commit
+# and still shrinks the debt whenever someone fixes one.
+#
+# Usage: check-new-broken-links.sh <base-ref>
+
+BASE_REF=${1:?usage: check-new-broken-links.sh <base-ref>}
+# Pinned, not @latest: the two runs below are only comparable if they were
+# produced by the same tool, and resolving the tag twice leaves the check one
+# upstream publish away from diffing two different versions' output. A bump here
+# is a deliberate change with a diff to review, like any other dependency.
+MINTLIFY_VERSION=${MINTLIFY_VERSION:-4.2.810}
+REPO_ROOT=$(git rev-parse --show-toplevel)
+TEMP_ROOT=$(mktemp -d)
+BASE_TREE="$TEMP_ROOT/base-tree"
+BASE_REPORT="$TEMP_ROOT/base-report"
+HEAD_REPORT="$TEMP_ROOT/head-report"
+
+cleanup() {
+  git -C "$REPO_ROOT" worktree remove --force "$BASE_TREE" >/dev/null 2>&1 || true
+  # Keep the worktree and reports under one private mktemp directory. Deriving
+  # sibling names from the worktree path would leave those report paths
+  # unreserved until redirection and make cleanup act on paths we did not create.
+  rm -rf "$TEMP_ROOT"
+}
+trap cleanup EXIT
+
+# mintlify ends a completed run with exactly one of these verdicts: the clean
+# one exits 0, the other exits 1. Both are dropped from the compared report —
+# the tally moves whenever the count does, which would otherwise register as a
+# finding on every change, including one that only fixes links.
+CLEAN_VERDICT='^success no broken links found$'
+BROKEN_VERDICT='^found [0-9]+ broken links? in [0-9]+ files?$'
+
+# Collect the broken-link report for one docs directory, normalized so two runs
+# are comparable.
+collect() {
+  local docs_dir=$1 stderr_file=$2 output status
+  set +e
+  # Mintlify's report and verdict are stdout. Keep npm/install diagnostics on
+  # stderr out of the normalized link set: a warning that appears on only one
+  # run is not a broken documentation link and must not become a false diff.
+  output=$(cd "$docs_dir" && npx --yes "mintlify@${MINTLIFY_VERSION}" broken-links 2>"$stderr_file")
+  status=$?
+  set -e
+
+  # Strip every CSI escape sequence, not just the colour ones: the progress
+  # spinner repaints with cursor-movement codes (ESC[2K, ESC[1A, ESC[G) and its
+  # last repaint shares a line with the verdict, so a colour-only filter leaves
+  # control bytes glued to the front of the one line that has to be recognized.
+  # Then drop the spinner frames themselves — how many a run emits depends on
+  # how long it took, so they differ between two runs of the same docs tree.
+  output=$(printf '%s\n' "$output" \
+    | sed -E -e 's/\x1b\[[0-9;?]*[A-Za-z]//g' \
+             -e 's/[[:space:]]*$//' \
+             -e '/checking for broken links/d')
+
+  # A difference between two reports only means something if both sides are
+  # reports. An invocation that fails the same way twice — an incompatible
+  # release, a failed install, a crash — normalizes to two identical outputs
+  # with no links in them, which compares equal and passes the check without
+  # anything having been checked. Require the verdict only a completed run
+  # prints, and fail loudly when it is absent.
+  if ! printf '%s\n' "$output" | grep -Eq "$CLEAN_VERDICT|$BROKEN_VERDICT"; then
+    echo "ERROR: mintlify@${MINTLIFY_VERSION} broken-links did not complete in $docs_dir (exit $status)" >&2
+    echo "  Expected a run ending in 'success no broken links found' or 'found N broken links in M files'." >&2
+    printf '%s\n' "$output" | tail -20 | sed 's/^/  /' >&2
+    if [ -s "$stderr_file" ]; then
+      echo "  stderr:" >&2
+      tail -20 "$stderr_file" | sed 's/^/    /' >&2
+    fi
+    return 1
+  fi
+
+  # Normalize with one sed program rather than a grep filter: grep exits 1 when
+  # it selects nothing, and under `set -o pipefail` that fails the collection.
+  # A report holding nothing but the verdict — the shape of a docs tree with no
+  # broken links at all — would then turn the cleanest possible result into a
+  # red check with no diagnostic.
+  printf '%s\n' "$output" \
+    | sed -E -e "/${CLEAN_VERDICT}/d" \
+             -e "/${BROKEN_VERDICT}/d" \
+             -e '/^[[:space:]]*$/d' \
+    | sort -u
+}
+
+echo "Collecting broken links at ${BASE_REF}..."
+git -C "$REPO_ROOT" worktree add --detach "$BASE_TREE" "$BASE_REF" >/dev/null
+collect "$BASE_TREE/docs" "$TEMP_ROOT/base-stderr" > "$BASE_REPORT" || exit 1
+
+echo "Collecting broken links at HEAD..."
+collect "$REPO_ROOT/docs" "$TEMP_ROOT/head-stderr" > "$HEAD_REPORT" || exit 1
+
+NEW_LINKS=$(comm -13 "$BASE_REPORT" "$HEAD_REPORT" || true)
+FIXED_LINKS=$(comm -23 "$BASE_REPORT" "$HEAD_REPORT" || true)
+
+if [ -n "$FIXED_LINKS" ]; then
+  echo "Links this change fixes:"
+  printf '%s\n' "$FIXED_LINKS" | sed 's/^/  /'
+fi
+
+if [ -n "$NEW_LINKS" ]; then
+  echo "::error::this change introduces broken documentation links"
+  printf '%s\n' "$NEW_LINKS" | sed 's/^/  /'
+  exit 1
+fi
+
+PRE_EXISTING=$(wc -l < "$BASE_REPORT" | tr -d ' ')
+echo "✅ No new broken links (${PRE_EXISTING} pre-existing, unchanged by this change)"

--- a/.github/workflows/scripts/smoke-test-published-image.sh
+++ b/.github/workflows/scripts/smoke-test-published-image.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prove the *published* image carries the runtime contract the one-click
+# templates depend on.
+#
+# The image the deployment smoke tests build comes from Dockerfile.local against
+# the Go workspace; the image the release publishes comes from
+# transports/Dockerfile with GOWORK=off against the published modules. Those are
+# different builds of different module graphs, so "the smoke tests passed" says
+# nothing about the artifact operators actually pull. Tag and digest equality
+# does not close that gap either: an image built wrongly and then tagged as both
+# the release and latest satisfies every check in the gate around this one.
+#
+# What is checked here is deliberately offline and deterministic — nothing
+# depends on Bifrost reaching the network or staying up, because a release gate
+# that flakes gets bypassed. The entrypoint materializes BIFROST_CONFIG before
+# it execs Bifrost, so the volume tells us the whole story either way.
+#
+# One invocation covers one platform. `docker run` resolves a multi-platform
+# reference to the host's architecture, so the caller passes the platform it
+# means to test and the image ref for it; every required platform needs its own
+# run, preferably on a runner that executes it natively.
+#
+# Usage: smoke-test-published-image.sh <image-ref> [platform]
+
+IMAGE_REF=${1:?usage: smoke-test-published-image.sh <image-ref> [platform]}
+PLATFORM=${2:-}
+
+# The expected machine name closes the loop on the platform argument: --platform
+# alone would silently fall back to emulation, or to the host architecture for a
+# single-platform reference, and a smoke test that quietly tested amd64 twice
+# reads exactly like one that covered both.
+PLATFORM_ARGS=()
+EXPECTED_MACHINE=""
+if [ -n "$PLATFORM" ]; then
+  PLATFORM_ARGS=(--platform "$PLATFORM")
+  case "$PLATFORM" in
+    linux/amd64) EXPECTED_MACHINE=x86_64 ;;
+    linux/arm64) EXPECTED_MACHINE=aarch64 ;;
+    *)
+      echo "ERROR: unsupported platform $PLATFORM (expected linux/amd64 or linux/arm64)" >&2
+      exit 1
+      ;;
+  esac
+fi
+
+CONTAINER="bifrost-release-smoke-$$"
+VOLUME="bifrost-release-smoke-volume-$$"
+INLINE_CONFIG='{"source_of_truth":"split"}'
+
+cleanup() {
+  docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  docker volume rm "$VOLUME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "Smoke-testing $IMAGE_REF${PLATFORM:+ for $PLATFORM}"
+
+# The Blueprints hand Bifrost its configuration through BIFROST_CONFIG and drop
+# privileges on platform volumes through su-exec. A release without either
+# cannot serve them, however it was tagged.
+#
+# su-exec is run, not merely located: a binary that is present but cannot execute
+# in the published image — stale linkage against a bumped musl, a runtime stage
+# that lost a library — satisfies `command -v` and still leaves every deployment
+# that drops privileges refusing to start. Dropping privileges needs root, and
+# the image declares USER 1000:0, so this check asks for it explicitly.
+if ! docker run --rm --user 0:0 "${PLATFORM_ARGS[@]}" \
+  -e EXPECTED_MACHINE="$EXPECTED_MACHINE" --entrypoint sh "$IMAGE_REF" -c '
+  set -e
+  if [ -n "$EXPECTED_MACHINE" ] && [ "$(uname -m)" != "$EXPECTED_MACHINE" ]; then
+    echo "image runs as $(uname -m), expected $EXPECTED_MACHINE"
+    exit 1
+  fi
+  command -v su-exec >/dev/null 2>&1 || { echo "su-exec is not installed"; exit 1; }
+  dropped=$(su-exec 1000:0 id -u) || { echo "su-exec is installed but could not execute"; exit 1; }
+  [ "$dropped" = "1000" ] || { echo "su-exec dropped to UID $dropped, expected 1000"; exit 1; }
+  grep -q "materialize_inline_config" /app/docker-entrypoint.sh || { echo "entrypoint does not materialize BIFROST_CONFIG"; exit 1; }
+  grep -q "BIFROST_RUN_AS_UID" /app/docker-entrypoint.sh || { echo "entrypoint does not support privilege dropping"; exit 1; }
+'; then
+  echo "ERROR: $IMAGE_REF${PLATFORM:+ ($PLATFORM)} does not carry the deployment runtime contract" >&2
+  exit 1
+fi
+
+# Start the container the way the Railway SQLite template does: as root
+# (RAILWAY_RUN_UID=0), handing the entrypoint the unprivileged identity to drop
+# to. That is the only configuration in which the entrypoint hands what it
+# materializes to the target identity, so the ownership asserted below is
+# evidence the privilege-drop path ran, not a property of the image.
+docker volume create "$VOLUME" >/dev/null
+docker run -d --name "$CONTAINER" \
+  --user 0:0 "${PLATFORM_ARGS[@]}" \
+  -v "$VOLUME:/app/data" \
+  -e APP_HOST=127.0.0.1 \
+  -e APP_PORT=8080 \
+  -e BIFROST_CONFIG="$INLINE_CONFIG" \
+  -e BIFROST_RUN_AS_UID=1000 \
+  -e BIFROST_RUN_AS_GID=0 \
+  "$IMAGE_REF" >/dev/null
+
+# Read the result out of the volume rather than the container: the entrypoint
+# writes config.json before handing off, so this holds whether Bifrost then
+# starts, exits, or is still booting.
+materialized=""
+for _ in $(seq 1 30); do
+  if materialized=$(docker run --rm --user 0:0 "${PLATFORM_ARGS[@]}" -v "$VOLUME:/app/data" --entrypoint sh "$IMAGE_REF" -c '
+    [ -f /app/data/config.json ] || exit 1
+    printf "%s %s %s" "$(stat -c "%u:%g" /app/data/config.json)" \
+      "$(stat -c "%a" /app/data/config.json)" "$(cat /app/data/config.json)"
+  ' 2>/dev/null); then
+    break
+  fi
+  materialized=""
+  sleep 1
+done
+
+if [ -z "$materialized" ]; then
+  echo "ERROR: $IMAGE_REF did not materialize BIFROST_CONFIG at /app/data/config.json" >&2
+  docker logs "$CONTAINER" 2>&1 | tail -50 >&2 || true
+  exit 1
+fi
+
+expected="1000:0 600 $INLINE_CONFIG"
+if [ "$materialized" != "$expected" ]; then
+  echo "ERROR: $IMAGE_REF materialized '$materialized', expected '$expected'" >&2
+  exit 1
+fi
+
+echo "$IMAGE_REF${PLATFORM:+ ($PLATFORM)} materializes BIFROST_CONFIG as 1000:0 at mode 0600 and drops privileges through su-exec"

--- a/.github/workflows/scripts/test-docker-image.sh
+++ b/.github/workflows/scripts/test-docker-image.sh
@@ -17,13 +17,18 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd -P)"
 
 
 # Setup Go workspace for CI (go.work is gitignored, must be regenerated)
+# shellcheck disable=SC1091 # Resolved relative to this script at runtime.
 source "$SCRIPT_DIR/setup-go-workspace.sh"
 
 PLATFORM=${1:-linux/amd64}
 ARCH=$(echo "$PLATFORM" | cut -d'/' -f2)
 IMAGE_TAG="bifrost-test:ci-${GITHUB_SHA:-local}-${ARCH}"
 CONTAINER_NAME="bifrost-test-${ARCH}"
+PRIVDROP_CONTAINER_NAME="${CONTAINER_NAME}-privdrop"
+RO_CONFIG_CONTAINER_NAME="${CONTAINER_NAME}-ro-config"
+PRIVDROP_VOLUME_NAME="${CONTAINER_NAME}-root-volume"
 TEST_PORT=8080
+PRIVDROP_TEST_PORT=8081
 DOCKER_COMPOSE_FILE="$REPO_ROOT/tests/docker-compose.yml"
 TEMP_DIR=$(mktemp -d)
 CONFIG_FILE="$TEMP_DIR/config.json"
@@ -40,6 +45,11 @@ cleanup() {
   echo "Stopping Bifrost container..."
   docker stop "${CONTAINER_NAME}" > /dev/null 2>&1 || true
   docker rm "${CONTAINER_NAME}" > /dev/null 2>&1 || true
+  docker stop "${PRIVDROP_CONTAINER_NAME}" > /dev/null 2>&1 || true
+  docker rm "${PRIVDROP_CONTAINER_NAME}" > /dev/null 2>&1 || true
+  docker stop "${RO_CONFIG_CONTAINER_NAME}" > /dev/null 2>&1 || true
+  docker rm "${RO_CONFIG_CONTAINER_NAME}" > /dev/null 2>&1 || true
+  docker volume rm "${PRIVDROP_VOLUME_NAME}" > /dev/null 2>&1 || true
   
   # Stop docker-compose services
   echo "Stopping docker-compose services..."
@@ -66,10 +76,365 @@ docker build \
 
 echo "Build complete: ${IMAGE_TAG}"
 
-# Start docker-compose services (Postgres, Weaviate, Redis, Qdrant)
 echo ""
-echo "=== Starting docker-compose services ==="
-docker compose -f "$DOCKER_COMPOSE_FILE" up -d
+echo "=== Testing entrypoint runtime contract ==="
+
+# Each negative check asserts the entrypoint rejects an invalid configuration and
+# exits. If a regression lets the configuration through, the entrypoint execs the
+# long-running server (see the trailing exec in transports/docker-entrypoint.sh) and
+# `docker run` never returns, so every invocation is bounded by `timeout`. Without it
+# the job hangs until GitHub's default 360-minute job timeout instead of failing with
+# the diagnostic below.
+ENTRYPOINT_CHECK_TIMEOUT=60
+entrypoint_check_count=0
+
+# GNU coreutils `timeout` is present on the ubuntu runners this script targets. Keep a
+# local macOS run working (Homebrew coreutils installs it as `gtimeout`) rather than
+# failing every check with "command not found".
+if command -v timeout > /dev/null 2>&1; then
+  TIMEOUT_BIN=timeout
+elif command -v gtimeout > /dev/null 2>&1; then
+  TIMEOUT_BIN=gtimeout
+else
+  TIMEOUT_BIN=""
+  echo "WARNING: no timeout(1) found - entrypoint checks will run unbounded"
+fi
+
+# Usage: assert_entrypoint_rejects <description> <expected-substring> [docker run args...]
+assert_entrypoint_rejects() {
+  local description="$1"
+  local expected="$2"
+  shift 2
+
+  entrypoint_check_count=$((entrypoint_check_count + 1))
+  local name="${CONTAINER_NAME}-reject-${entrypoint_check_count}"
+  local output status=0
+
+  # `timeout` signals the docker CLI, not the container, so name the container and
+  # force-remove it here: the cleanup trap only knows the fixed container names.
+  local -a runner=()
+  if [ -n "$TIMEOUT_BIN" ]; then
+    runner=("$TIMEOUT_BIN" "${ENTRYPOINT_CHECK_TIMEOUT}")
+  fi
+  output=$("${runner[@]}" docker run --rm \
+    --name "${name}" \
+    --platform "${PLATFORM}" \
+    "$@" \
+    "${IMAGE_TAG}" 2>&1) || status=$?
+  docker rm -f "${name}" > /dev/null 2>&1 || true
+
+  if [ "$status" -eq 124 ]; then
+    echo "ERROR: ${description}"
+    echo "       container did not exit within ${ENTRYPOINT_CHECK_TIMEOUT}s - the entrypoint"
+    echo "       accepted the configuration and started serving instead of rejecting it"
+    echo "$output"
+    exit 1
+  fi
+  if [ "$status" -eq 0 ]; then
+    echo "ERROR: ${description}"
+    exit 1
+  fi
+  if ! grep -q "$expected" <<<"$output"; then
+    echo "ERROR: ${description} - did not fail clearly (exit ${status})"
+    echo "$output"
+    exit 1
+  fi
+}
+
+assert_entrypoint_rejects \
+  "image accepted an incomplete UID/GID configuration" \
+  "BIFROST_RUN_AS_UID and BIFROST_RUN_AS_GID must be set together" \
+  -e BIFROST_RUN_AS_UID=1000
+
+assert_entrypoint_rejects \
+  "image accepted an invalid UID/GID configuration" \
+  "must be non-negative integers" \
+  -e BIFROST_RUN_AS_UID='1000:0' \
+  -e BIFROST_RUN_AS_GID=0
+
+assert_entrypoint_rejects \
+  "image accepted root as the privilege-drop target" \
+  "BIFROST_RUN_AS_UID must be a non-zero UID" \
+  --user 0:0 \
+  -e BIFROST_RUN_AS_UID=0 \
+  -e BIFROST_RUN_AS_GID=0
+
+assert_entrypoint_rejects \
+  "image accepted privilege dropping without a root entrypoint" \
+  "require the entrypoint to start as root" \
+  -e BIFROST_RUN_AS_UID=1000 \
+  -e BIFROST_RUN_AS_GID=0
+
+docker volume create "${PRIVDROP_VOLUME_NAME}" >/dev/null
+docker run --rm \
+  --platform "${PLATFORM}" \
+  --user 0:0 \
+  --entrypoint sh \
+  -v "${PRIVDROP_VOLUME_NAME}:/app/data" \
+  "${IMAGE_TAG}" \
+  -c 'chown -R 0:0 /app/data && chmod 0700 /app/data'
+
+# shellcheck disable=SC2016 # Literal JSON schema key and env references.
+INLINE_CONFIG='{"$schema":"https://www.getbifrost.ai/schema","version":2,"source_of_truth":"split","encryption_key":"env.BIFROST_ENCRYPTION_KEY","client":{"enforce_auth_on_inference":true},"providers":{"openai":{"keys":[{"name":"CI OpenAI key","value":"env.OPENAI_API_KEY","weight":1}]}},"governance":{"auth_config":{"admin_username":"admin","admin_password":"env.BIFROST_ADMIN_PASSWORD","is_enabled":true}}}'
+docker run -d \
+  --name "${PRIVDROP_CONTAINER_NAME}" \
+  --platform "${PLATFORM}" \
+  --user 0:0 \
+  -p ${PRIVDROP_TEST_PORT}:8080 \
+  -e APP_PORT=8080 \
+  -e APP_HOST=0.0.0.0 \
+  -e BIFROST_CONFIG="${INLINE_CONFIG}" \
+  -e BIFROST_ENCRYPTION_KEY=ci-test-encryption-key-32-bytes \
+  -e BIFROST_ADMIN_PASSWORD=ci-test-admin-password \
+  -e OPENAI_API_KEY=ci-test-provider-key \
+  -e BIFROST_RUN_AS_UID=1000 \
+  -e BIFROST_RUN_AS_GID=0 \
+  -v "${PRIVDROP_VOLUME_NAME}:/app/data" \
+  "${IMAGE_TAG}" >/dev/null
+
+MAX_WAIT=60
+ELAPSED=0
+while [ $ELAPSED -lt $MAX_WAIT ]; do
+  if curl -sf "http://localhost:${PRIVDROP_TEST_PORT}/health" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+  ELAPSED=$((ELAPSED + 2))
+done
+if [ $ELAPSED -ge $MAX_WAIT ]; then
+  echo "ERROR: privilege-drop container did not become healthy"
+  docker logs "${PRIVDROP_CONTAINER_NAME}" 2>&1 | tail -100 || true
+  exit 1
+fi
+
+LOGIN_RESPONSE="$TEMP_DIR/privdrop-login.json"
+LOGIN_COOKIES="$TEMP_DIR/privdrop-login.cookies"
+LOGIN_STATUS=$(curl -sS -o "$LOGIN_RESPONSE" -w '%{http_code}' \
+  "http://localhost:${PRIVDROP_TEST_PORT}/api/session/login" \
+  -c "$LOGIN_COOKIES" \
+  -H 'Content-Type: application/json' \
+  --data '{"username":"admin","password":"ci-test-admin-password"}')
+if [ "$LOGIN_STATUS" != "200" ] || ! jq -e '.message == "Login successful"' "$LOGIN_RESPONSE" >/dev/null; then
+  echo "ERROR: generated administrator credentials failed with HTTP ${LOGIN_STATUS}"
+  cat "$LOGIN_RESPONSE"
+  exit 1
+fi
+
+VIRTUAL_KEY_RESPONSE="$TEMP_DIR/privdrop-virtual-key.json"
+VIRTUAL_KEY_STATUS=$(curl -sS -o "$VIRTUAL_KEY_RESPONSE" -w '%{http_code}' \
+  "http://localhost:${PRIVDROP_TEST_PORT}/api/governance/virtual-keys" \
+  -b "$LOGIN_COOKIES" \
+  -H 'Content-Type: application/json' \
+  --data '{"name":"CI deployment key"}')
+if [ "$VIRTUAL_KEY_STATUS" != "200" ] || ! jq -e '.message == "Virtual key created successfully"' "$VIRTUAL_KEY_RESPONSE" >/dev/null; then
+  echo "ERROR: authenticated virtual-key creation failed with HTTP ${VIRTUAL_KEY_STATUS}"
+  cat "$VIRTUAL_KEY_RESPONSE"
+  exit 1
+fi
+VIRTUAL_KEY_ID=$(jq -er '.virtual_key.id' "$VIRTUAL_KEY_RESPONSE")
+
+ANONYMOUS_STATUS=$(curl -sS -o /dev/null -w '%{http_code}' \
+  "http://localhost:${PRIVDROP_TEST_PORT}/v1/chat/completions" \
+  -H 'Content-Type: application/json' \
+  --data '{"model":"openai/gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}')
+if [ "$ANONYMOUS_STATUS" != "401" ]; then
+  echo "ERROR: anonymous inference returned HTTP ${ANONYMOUS_STATUS}, expected 401"
+  exit 1
+fi
+
+PID_UID=$(docker exec --user 0:0 "${PRIVDROP_CONTAINER_NAME}" awk '/^Uid:/{print $2}' /proc/1/status)
+if [ "$PID_UID" != "1000" ]; then
+  echo "ERROR: PID 1 runs as UID ${PID_UID}, expected 1000"
+  exit 1
+fi
+
+CONFIG_METADATA=$(docker exec --user 0:0 "${PRIVDROP_CONTAINER_NAME}" stat -c '%u:%g %a' /app/data/config.json)
+if [ "$CONFIG_METADATA" != "1000:0 600" ]; then
+  echo "ERROR: materialized config metadata is '${CONFIG_METADATA}', expected '1000:0 600'"
+  exit 1
+fi
+
+if ! PROCESS_ENV=$(docker exec --privileged --user 0:0 "${PRIVDROP_CONTAINER_NAME}" sh -c \
+  'tr "\0" "\n" </proc/1/environ'); then
+  echo "ERROR: could not inspect the Bifrost process environment"
+  exit 1
+fi
+if grep -q '^BIFROST_CONFIG=' <<<"$PROCESS_ENV"; then
+  echo "ERROR: BIFROST_CONFIG leaked into the Bifrost process environment"
+  exit 1
+fi
+
+docker restart "${PRIVDROP_CONTAINER_NAME}" >/dev/null
+ELAPSED=0
+while [ $ELAPSED -lt $MAX_WAIT ]; do
+  if curl -sf "http://localhost:${PRIVDROP_TEST_PORT}/health" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+  ELAPSED=$((ELAPSED + 2))
+done
+if [ $ELAPSED -ge $MAX_WAIT ]; then
+  echo "ERROR: privilege-drop container did not become healthy after restart"
+  docker logs "${PRIVDROP_CONTAINER_NAME}" 2>&1 | tail -100 || true
+  exit 1
+fi
+
+PERSISTED_KEY_STATUS=$(curl -sS -o /dev/null -w '%{http_code}' \
+  "http://localhost:${PRIVDROP_TEST_PORT}/api/governance/virtual-keys/${VIRTUAL_KEY_ID}" \
+  -b "$LOGIN_COOKIES")
+if [ "$PERSISTED_KEY_STATUS" != "200" ]; then
+  echo "ERROR: virtual key did not survive container restart (HTTP ${PERSISTED_KEY_STATUS})"
+  exit 1
+fi
+
+CONFIG_METADATA=$(docker exec --user 0:0 "${PRIVDROP_CONTAINER_NAME}" stat -c '%u:%g %a' /app/data/config.json)
+if [ "$CONFIG_METADATA" != "1000:0 600" ]; then
+  echo "ERROR: restarted config metadata is '${CONFIG_METADATA}', expected '1000:0 600'"
+  exit 1
+fi
+
+# Mixed ownership: /app/data itself is already 1000:0 from the first start, but
+# a database inside it is root-owned, exactly as an upgrade from a root-only
+# release leaves it. Repairing only on a top-level mismatch would skip these and
+# leave Bifrost to fail opening them, and the create-directory probe cannot see
+# them either.
+MISOWNED_FILES=$(docker exec --user 0:0 "${PRIVDROP_CONTAINER_NAME}" sh -c '
+  files=$(find /app/data -maxdepth 1 -type f ! -name config.json)
+  [ -n "$files" ] || exit 1
+  for file in $files; do
+    chown 0:0 "$file" || exit 1
+    chmod 0600 "$file" || exit 1
+  done
+  printf %s "$files"
+')
+if [ -z "$MISOWNED_FILES" ]; then
+  echo "ERROR: no data files to misown; the mixed-ownership repair case is untested"
+  exit 1
+fi
+echo "Misowned data files for the repair check:"
+echo "${MISOWNED_FILES}"
+
+DATA_DIR_OWNER=$(docker exec --user 0:0 "${PRIVDROP_CONTAINER_NAME}" stat -c '%u:%g' /app/data)
+if [ "$DATA_DIR_OWNER" != "1000:0" ]; then
+  echo "ERROR: /app/data is ${DATA_DIR_OWNER}; the mixed-ownership case needs a correctly owned parent"
+  exit 1
+fi
+
+docker restart "${PRIVDROP_CONTAINER_NAME}" >/dev/null
+ELAPSED=0
+while [ $ELAPSED -lt $MAX_WAIT ]; do
+  if curl -sf "http://localhost:${PRIVDROP_TEST_PORT}/health" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+  ELAPSED=$((ELAPSED + 2))
+done
+if [ $ELAPSED -ge $MAX_WAIT ]; then
+  echo "ERROR: container did not recover from root-owned data files inside a correctly owned /app/data"
+  docker logs "${PRIVDROP_CONTAINER_NAME}" 2>&1 | tail -100 || true
+  exit 1
+fi
+
+while IFS= read -r misowned_file; do
+  [ -n "$misowned_file" ] || continue
+  FILE_OWNER=$(docker exec --user 0:0 "${PRIVDROP_CONTAINER_NAME}" stat -c '%u:%g' "$misowned_file")
+  if [ "$FILE_OWNER" != "1000:0" ]; then
+    echo "ERROR: ${misowned_file} is owned by ${FILE_OWNER} after the repair, expected 1000:0"
+    exit 1
+  fi
+done <<<"$MISOWNED_FILES"
+
+docker stop "${PRIVDROP_CONTAINER_NAME}" >/dev/null
+docker rm "${PRIVDROP_CONTAINER_NAME}" >/dev/null
+
+# Same repair, but with config.json mounted read-only — the shape a platform
+# produces when it projects the document out of a secret store. config.json is
+# only ever read, so the repair must reach the writable data paths without
+# recursing over it: chown fails on a read-only mount, and a repair that fixed
+# everything it was supposed to would then announce itself as failed and send an
+# operator hunting a problem that does not exist.
+MOUNTED_CONFIG="$TEMP_DIR/mounted-config.json"
+printf '%s' "${INLINE_CONFIG}" > "$MOUNTED_CONFIG"
+chmod 0444 "$MOUNTED_CONFIG"
+
+MISOWNED_FILES=$(docker run --rm \
+  --platform "${PLATFORM}" \
+  --user 0:0 \
+  --entrypoint sh \
+  -v "${PRIVDROP_VOLUME_NAME}:/app/data" \
+  "${IMAGE_TAG}" \
+  -c '
+    files=$(find /app/data -maxdepth 1 -type f ! -name config.json)
+    [ -n "$files" ] || exit 1
+    for file in $files; do
+      chown 0:0 "$file" || exit 1
+    done
+    printf %s "$files"
+  ')
+if [ -z "$MISOWNED_FILES" ]; then
+  echo "ERROR: no data files to misown; the read-only config.json repair case is untested"
+  exit 1
+fi
+
+docker run -d \
+  --name "${RO_CONFIG_CONTAINER_NAME}" \
+  --platform "${PLATFORM}" \
+  --user 0:0 \
+  -e APP_PORT=8080 \
+  -e APP_HOST=0.0.0.0 \
+  -e BIFROST_ENCRYPTION_KEY=ci-test-encryption-key-32-bytes \
+  -e BIFROST_ADMIN_PASSWORD=ci-test-admin-password \
+  -e OPENAI_API_KEY=ci-test-provider-key \
+  -e BIFROST_RUN_AS_UID=1000 \
+  -e BIFROST_RUN_AS_GID=0 \
+  -v "${PRIVDROP_VOLUME_NAME}:/app/data" \
+  -v "${MOUNTED_CONFIG}:/app/data/config.json:ro" \
+  "${IMAGE_TAG}" >/dev/null
+
+REPAIR_LOGS=""
+ELAPSED=0
+while [ $ELAPSED -lt $MAX_WAIT ]; do
+  REPAIR_LOGS=$(docker logs "${RO_CONFIG_CONTAINER_NAME}" 2>&1)
+  if grep -qE '(Successfully updated|Could not update) permissions on /app/data' <<<"$REPAIR_LOGS"; then
+    break
+  fi
+  sleep 2
+  ELAPSED=$((ELAPSED + 2))
+done
+
+if ! grep -q 'Successfully updated permissions on /app/data' <<<"$REPAIR_LOGS"; then
+  echo "ERROR: the ownership repair did not report success alongside a read-only config.json"
+  echo "${REPAIR_LOGS}" | tail -50
+  exit 1
+fi
+
+while IFS= read -r misowned_file; do
+  [ -n "$misowned_file" ] || continue
+  FILE_OWNER=$(docker run --rm \
+    --platform "${PLATFORM}" \
+    --user 0:0 \
+    --entrypoint sh \
+    -v "${PRIVDROP_VOLUME_NAME}:/app/data" \
+    "${IMAGE_TAG}" \
+    -c "stat -c '%u:%g' '${misowned_file}'")
+  if [ "$FILE_OWNER" != "1000:0" ]; then
+    echo "ERROR: ${misowned_file} is owned by ${FILE_OWNER} after the repair, expected 1000:0"
+    echo "${REPAIR_LOGS}" | tail -50
+    exit 1
+  fi
+done <<<"$MISOWNED_FILES"
+
+docker stop "${RO_CONFIG_CONTAINER_NAME}" >/dev/null
+docker rm "${RO_CONFIG_CONTAINER_NAME}" >/dev/null
+docker volume rm "${PRIVDROP_VOLUME_NAME}" >/dev/null
+
+echo "Entrypoint runtime contract passed"
+
+# Start the PostgreSQL dependency used by this image smoke test. The broader
+# framework suite owns the remaining services in tests/docker-compose.yml.
+echo ""
+echo "=== Starting PostgreSQL ==="
+docker compose -f "$DOCKER_COMPOSE_FILE" up -d postgres
 
 # Wait for Postgres to be ready
 echo "Waiting for Postgres to be ready..."
@@ -281,6 +646,12 @@ if [ $HEALTH_OK -eq 0 ]; then
   echo "ERROR: Bifrost health check failed!"
   echo "Container logs:"
   docker logs "${CONTAINER_NAME}" 2>&1 | tail -100 || true
+  exit 1
+fi
+
+DEFAULT_PID_UID=$(docker exec "${CONTAINER_NAME}" awk '/^Uid:/{print $2}' /proc/1/status)
+if [ "$DEFAULT_PID_UID" != "1000" ]; then
+  echo "ERROR: default PID 1 runs as UID ${DEFAULT_PID_UID}, expected 1000"
   exit 1
 fi
 

--- a/.github/workflows/scripts/validate-deployment-templates.py
+++ b/.github/workflows/scripts/validate-deployment-templates.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Validate Bifrost's Render Blueprints and Railway template contracts."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import yaml
+from jsonschema import Draft201909Validator, Draft202012Validator, FormatChecker
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BIFROST_SCHEMA = json.loads((REPO_ROOT / "transports/config.schema.json").read_text())
+RAILWAY_SCHEMA = json.loads((REPO_ROOT / "deploy/railway/template-contract.schema.json").read_text())
+RENDER_VERIFICATION_SCHEMA = json.loads(
+    (REPO_ROOT / "deploy/render/blueprint-verification.schema.json").read_text()
+)
+# Shared with the release gate in verify-deployment-release.sh, which refuses to
+# qualify anything older. Read from one file so a bump cannot land in the gate
+# and leave the recorded verifications accepting the release it just retired.
+MINIMUM_RELEASE_TAG = json.loads((REPO_ROOT / "deploy/runtime-contract.json").read_text())["minimum_release_tag"]
+RELEASE_TAG_PATTERN = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+HOSTED_ONE_CLICK_HEADING = "## Hosted one-click choices"
+
+
+def fail(message: str) -> None:
+    raise AssertionError(message)
+
+
+def release_tuple(tag: str) -> tuple[int, ...] | None:
+    """The ordering key for a release tag, or None if it is not one."""
+    match = RELEASE_TAG_PATTERN.match(tag)
+    return tuple(int(part) for part in match.groups()) if match else None
+
+
+def verification_recorded(record: dict[str, Any], label: str) -> bool:
+    """Whether `record` carries a complete, well-formed verification.
+
+    Nothing in this repository can inspect a live Render Blueprint or Railway
+    template, so a published button rests entirely on what is written here. That
+    makes the shape of the record the only thing standing between a real
+    deployment and a claim about one, and a truthiness test is not enough: it
+    reads "soon" as a date and accepts an entry naming no release at all.
+
+    A half-filled or malformed record fails rather than quietly counting as
+    unverified. It was written by someone recording a verification, so treating
+    it as an absent one would hide the mistake and, through the both-directions
+    check below, report it as a missing documentation link instead.
+    """
+    last_verified = record.get("last_verified")
+    verified_release = record.get("verified_release")
+
+    if last_verified is None and verified_release is None:
+        return False
+    if last_verified is None or verified_release is None:
+        fail(
+            f"{label} records half a verification: last_verified and verified_release "
+            f"are set together or not at all"
+        )
+
+    try:
+        date.fromisoformat(last_verified)
+    except ValueError:
+        fail(f"{label} last_verified must be an ISO-8601 date, got {last_verified!r}")
+
+    version = release_tuple(verified_release)
+    if version is None:
+        fail(f"{label} verified_release must be a release tag like {MINIMUM_RELEASE_TAG}, got {verified_release!r}")
+    if version < release_tuple(MINIMUM_RELEASE_TAG):
+        fail(
+            f"{label} verified_release {verified_release} predates {MINIMUM_RELEASE_TAG}, the release "
+            f"that carries the deployment runtime contract. Re-verify against a qualified release."
+        )
+    return True
+
+
+def validate_json_schema(instance: Any, schema: dict[str, Any], label: str, draft: type) -> None:
+    validator = draft(schema, format_checker=FormatChecker())
+    errors = sorted(validator.iter_errors(instance), key=lambda error: list(error.absolute_path))
+    if errors:
+        details = "\n".join(
+            f"  - {'.'.join(str(part) for part in error.absolute_path) or '<root>'}: {error.message}"
+            for error in errors
+        )
+        fail(f"{label} failed schema validation:\n{details}")
+
+
+def assert_bootstrap_config(config: dict[str, Any], label: str, storage: str) -> None:
+    validate_json_schema(config, BIFROST_SCHEMA, f"{label} BIFROST_CONFIG", Draft201909Validator)
+    if config.get("source_of_truth") != "split":
+        fail(f"{label} must preserve dashboard-managed configuration with source_of_truth=split")
+    if config.get("encryption_key") != "env.BIFROST_ENCRYPTION_KEY":
+        fail(f"{label} must reference the generated encryption key")
+    if config.get("client", {}).get("enforce_auth_on_inference") is not True:
+        fail(f"{label} must reject anonymous inference")
+
+    auth = config.get("governance", {}).get("auth_config", {})
+    expected_auth = {
+        "admin_username": "admin",
+        "admin_password": "env.BIFROST_ADMIN_PASSWORD",
+        "is_enabled": True,
+    }
+    if auth != expected_auth:
+        fail(f"{label} must provision operator-managed dashboard authentication")
+
+    for store_name in ("config_store", "logs_store"):
+        store = config.get(store_name)
+        if storage == "postgres":
+            if not store or store.get("type") != "postgres" or store.get("enabled") is not True:
+                fail(f"{label} must enable PostgreSQL for {store_name}")
+            store_config = store.get("config", {})
+            if store_config.get("ssl_mode") != "require":
+                fail(f"{label} must require TLS for {store_name}")
+            if store_config.get("max_open_conns", 0) > 20:
+                fail(f"{label} exceeds the one-click PostgreSQL connection budget")
+        elif store is not None:
+            fail(f"{label} SQLite configuration must not override {store_name}")
+
+
+def env_vars(service: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    values = service.get("envVars", [])
+    return {entry["key"]: entry for entry in values}
+
+
+def validate_render(path: Path, storage: str) -> None:
+    blueprint = yaml.safe_load(path.read_text())
+    services = blueprint.get("services", [])
+    if len(services) != 1:
+        fail(f"{path} must define exactly one Bifrost service")
+    service = services[0]
+    label = str(path.relative_to(REPO_ROOT))
+
+    if service.get("runtime") != "image" or service.get("image", {}).get("url") != "docker.io/maximhq/bifrost:latest":
+        fail(f"{label} must use the public latest image")
+    if service.get("numInstances") != 1:
+        fail(f"{label} must run one OSS replica")
+    if service.get("autoDeploy") is not False:
+        fail(f"{label} image-tag updates must require an intentional manual deploy")
+    if service.get("healthCheckPath") != "/health":
+        fail(f"{label} must use /health")
+    if service.get("maxShutdownDelaySeconds") != 60:
+        fail(f"{label} must allow 60 seconds for shutdown")
+
+    variables = env_vars(service)
+    for name in ("BIFROST_ENCRYPTION_KEY", "BIFROST_ADMIN_PASSWORD"):
+        if variables.get(name, {}).get("generateValue") is not True:
+            fail(f"{label} must generate {name}")
+    config = json.loads(variables["BIFROST_CONFIG"]["value"])
+    assert_bootstrap_config(config, label, storage)
+
+    if storage == "postgres":
+        databases = blueprint.get("databases", [])
+        if len(databases) != 1:
+            fail(f"{label} must define one PostgreSQL database")
+        database = databases[0]
+        if service.get("plan") != "free" or database.get("plan") != "free":
+            fail(f"{label} PostgreSQL evaluation must use free plans")
+        if database.get("postgresMajorVersion") != "18":
+            fail(f"{label} must provision PostgreSQL 18")
+        if database.get("ipAllowList") != []:
+            fail(f"{label} database must not allow public network ranges")
+        if service.get("disk") is not None:
+            fail(f"{label} PostgreSQL service must remain ephemeral")
+    else:
+        disk = service.get("disk", {})
+        if service.get("plan") != "starter":
+            fail(f"{label} SQLite service must use the minimum disk-capable plan")
+        if disk != {"name": "bifrost-data", "mountPath": "/app/data", "sizeGB": 1}:
+            fail(f"{label} must attach a 1 GB /app/data disk")
+        if blueprint.get("databases"):
+            fail(f"{label} SQLite Blueprint must not provision PostgreSQL")
+
+
+def railway_service(contract: dict[str, Any], name: str) -> dict[str, Any]:
+    for service in contract["services"]:
+        if service["name"] == name:
+            return service
+    fail(f"Railway contract does not contain {name}")
+
+
+def validate_railway(path: Path, storage: str) -> None:
+    contract = json.loads(path.read_text())
+    label = str(path.relative_to(REPO_ROOT))
+    validate_json_schema(contract, RAILWAY_SCHEMA, label, Draft202012Validator)
+    bifrost = railway_service(contract, "Bifrost")
+
+    if contract["template"]["owner"] != "Maxim AI's Projects":
+        fail(f"{label} must remain Maxim-owned")
+
+    if bifrost["image"] != "docker.io/maximhq/bifrost:latest" or bifrost.get("image_auto_update") != "daily":
+        fail(f"{label} must track latest with daily image checks")
+    deploy = bifrost["deploy"]
+    expected = {"replicas": 1, "healthcheck_path": "/health", "draining_seconds": 60, "public_port": 8080}
+    for key, value in expected.items():
+        if deploy.get(key) != value:
+            fail(f"{label} has invalid Bifrost deploy setting {key}")
+
+    variables = bifrost["variables"]
+    if variables.get("BIFROST_CONFIG", {}).get("sensitive") is not False:
+        fail(f"{label} BIFROST_CONFIG must contain references, not secret values")
+    for name in ("BIFROST_ENCRYPTION_KEY", "BIFROST_ADMIN_PASSWORD"):
+        variable = variables.get(name, {})
+        if variable.get("value") != "${{secret()}}" or variable.get("sensitive") is not True:
+            fail(f"{label} must generate and hide {name}")
+    config = json.loads(variables["BIFROST_CONFIG"]["value"])
+    assert_bootstrap_config(config, label, storage)
+
+    if storage == "postgres":
+        postgres = railway_service(contract, "Postgres")
+        if contract["template"]["slug"] != "blue-dark":
+            fail(f"{label} must describe the existing blue-dark template")
+        if postgres["image"] != "ghcr.io/railwayapp-templates/postgres-ssl:18":
+            fail(f"{label} must provision the TLS-enabled PostgreSQL 18 image")
+        expected_postgres_variables = {
+            "POSTGRES_PASSWORD": "${{secret()}}",
+            "PGHOST": "${{RAILWAY_PRIVATE_DOMAIN}}",
+            "PGPORT": "5432",
+            "PGUSER": "${{POSTGRES_USER}}",
+            "PGPASSWORD": "${{POSTGRES_PASSWORD}}",
+            "PGDATABASE": "${{POSTGRES_DB}}",
+        }
+        for name, value in expected_postgres_variables.items():
+            if postgres["variables"].get(name, {}).get("value") != value:
+                fail(f"{label} has invalid PostgreSQL variable {name}")
+        if postgres["volumes"] != [{"mount_path": "/var/lib/postgresql/data"}]:
+            fail(f"{label} must persist PostgreSQL data")
+        if bifrost["volumes"]:
+            fail(f"{label} PostgreSQL Bifrost service must not attach a volume")
+        for variable in ("RAILWAY_RUN_UID", "BIFROST_RUN_AS_UID", "BIFROST_RUN_AS_GID"):
+            if variable in variables:
+                fail(f"{label} PostgreSQL Bifrost service must not set {variable}")
+    else:
+        expected_variables = {"RAILWAY_RUN_UID": "0", "BIFROST_RUN_AS_UID": "1000", "BIFROST_RUN_AS_GID": "0"}
+        for name, value in expected_variables.items():
+            if variables.get(name, {}).get("value") != value:
+                fail(f"{label} must set {name}={value}")
+        if bifrost["volumes"] != [{"mount_path": "/app/data"}]:
+            fail(f"{label} must attach only /app/data")
+        if deploy.get("overlap_seconds") != 0:
+            fail(f"{label} must disable overlap for the single-writer SQLite volume")
+
+
+def one_click_targets() -> list[dict[str, Any]]:
+    """Every one-click button, paired with the evidence that it may be published.
+
+    A live button is a public claim that the artifact behind it was deployed and
+    checked. Nothing in this repository can inspect a live Render Blueprint or
+    Railway template, so the claim rests on a recorded verification — and a
+    button whose record is empty must not be advertised. The relationship is
+    enforced in both directions so that verifying a template and publishing its
+    button cannot drift apart.
+    """
+    render_evidence = "deploy/render/blueprint-verification.json"
+    render = json.loads((REPO_ROOT / render_evidence).read_text())
+    validate_json_schema(render, RENDER_VERIFICATION_SCHEMA, render_evidence, Draft202012Validator)
+    render_docs = REPO_ROOT / "docs/deployment-guides/platforms/render.mdx"
+    railway_docs = REPO_ROOT / "docs/deployment-guides/platforms/railway.mdx"
+
+    targets: list[dict[str, Any]] = []
+    for name, entry in render["blueprints"].items():
+        label = f"Render {name}"
+        # Evaluated before the button URL is considered: a malformed record is a
+        # mistake worth reporting whether or not its button is published yet.
+        recorded = verification_recorded(entry, f"{label} in {render_evidence}")
+        targets.append(
+            {
+                "label": label,
+                "doc": render_docs,
+                "url": entry["button_url"],
+                # A missing button URL means there is no link to publish, and an
+                # empty one is a substring of every document — treating it as
+                # verified would satisfy the link check below against nothing.
+                "verified": bool(entry["button_url"]) and recorded,
+                "evidence": render_evidence,
+            }
+        )
+
+    for name, filename in (("PostgreSQL", "postgres"), ("SQLite", "sqlite")):
+        evidence = f"deploy/railway/{filename}.template-contract.json"
+        template = json.loads((REPO_ROOT / evidence).read_text())["template"]
+        slug = template["slug"]
+        recorded = verification_recorded(template, f"Railway {name} in {evidence}")
+        targets.append(
+            {
+                "label": f"Railway {name}",
+                "doc": railway_docs,
+                "url": f"https://railway.com/new/template/{slug}" if slug else None,
+                # An unassigned slug means the template is not published at all,
+                # so it can never be verified regardless of what is recorded.
+                "verified": bool(slug) and recorded,
+                "evidence": evidence,
+            }
+        )
+    return targets
+
+
+def validate_documentation_links() -> None:
+    targets = one_click_targets()
+    for target in targets:
+        docs = target["doc"].read_text()
+        doc_label = str(target["doc"].relative_to(REPO_ROOT))
+        if target["verified"]:
+            if target["url"] not in docs:
+                fail(f"{target['label']} is verified in {target['evidence']} but {doc_label} does not link {target['url']}")
+        elif target["url"] and target["url"] in docs:
+            fail(
+                f"{doc_label} publishes the {target['label']} one-click button while "
+                f"{target['evidence']} records no verification. Verify the live template and record "
+                f"last_verified and verified_release, or remove the button."
+            )
+
+    # The overview advertises the hosted one-click choices as a group. It may do
+    # so only while at least one of them is actually published.
+    overview = (REPO_ROOT / "docs/deployment-guides/overview.mdx").read_text()
+    verified = [target["label"] for target in targets if target["verified"]]
+    if verified and HOSTED_ONE_CLICK_HEADING not in overview:
+        fail(f"docs/deployment-guides/overview.mdx must list the published one-click choices ({', '.join(verified)})")
+    if not verified and HOSTED_ONE_CLICK_HEADING in overview:
+        fail(
+            "docs/deployment-guides/overview.mdx advertises hosted one-click choices while no template "
+            "is verified. Remove the section until a button is published."
+        )
+
+
+def main() -> int:
+    # The floor is hand-edited and shared with the release gate, which reads the
+    # same file. A malformed value here would otherwise surface as a comparison
+    # TypeError from deep inside a verification check.
+    if release_tuple(MINIMUM_RELEASE_TAG) is None:
+        fail(
+            f"deploy/runtime-contract.json minimum_release_tag must be a release tag "
+            f"like v1.6.12, got {MINIMUM_RELEASE_TAG!r}"
+        )
+
+    validate_render(REPO_ROOT / "render.yaml", "postgres")
+    validate_render(REPO_ROOT / "deploy/render/render-sqlite.yaml", "sqlite")
+    validate_railway(REPO_ROOT / "deploy/railway/postgres.template-contract.json", "postgres")
+    validate_railway(REPO_ROOT / "deploy/railway/sqlite.template-contract.json", "sqlite")
+    validate_documentation_links()
+    print("deployment template validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except (AssertionError, KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+        print(f"deployment template validation failed: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/.github/workflows/scripts/verify-deployment-release.sh
+++ b/.github/workflows/scripts/verify-deployment-release.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+repo_root=$(CDPATH='' cd -- "${script_dir}/../../.." && pwd -P)
+
+repository=${BIFROST_IMAGE_REPOSITORY:-docker.io/maximhq/bifrost}
+github_repository=${BIFROST_GITHUB_REPOSITORY:-maximhq/bifrost}
+# The release that first carried the deployment runtime contract the one-click
+# templates depend on. It is a floor, not a pin: the gate resolves the newest
+# published transports release so it keeps passing as releases advance, but it
+# must never accept a release older than the contract.
+#
+# Read from deploy/runtime-contract.json rather than written here, because
+# validate-deployment-templates.py enforces the same floor on the verifications
+# recorded for the public buttons. Two copies would let a bump raise the bar for
+# the image while the recorded verifications still pointed below it.
+minimum_release_tag=${BIFROST_MINIMUM_RELEASE_TAG:-$(jq -er '.minimum_release_tag' "${repo_root}/deploy/runtime-contract.json")}
+
+# resolve_latest_release_tag prints the newest final transports/v* release tag,
+# without its module prefix. The repository publishes one release per module, so
+# core/framework/plugins tags are filtered out here.
+#
+# The listing is reverse-chronological across every module, and plugin releases
+# dominate it, so one page of 100 need not contain a transports release at all.
+# Pages are walked until one does, then that whole page is ranked: a full
+# --paginate walk would cost one request per 100 of the repository's thousands
+# of releases on every run, for a window that already spans several transports
+# releases. release_page_limit bounds the walk so a repository that stops
+# publishing transports releases fails the gate instead of scanning forever.
+release_page_limit=${BIFROST_RELEASE_PAGE_LIMIT:-10}
+resolve_latest_release_tag() {
+  local page releases tags tag
+  for ((page = 1; page <= release_page_limit; page++)); do
+    if ! releases=$(gh api "repos/${github_repository}/releases?per_page=100&page=${page}" \
+      --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name'); then
+      echo "ERROR: could not list releases for ${github_repository}" >&2
+      return 1
+    fi
+    if [[ -z "$releases" ]]; then
+      break
+    fi
+    tags=$(printf '%s\n' "$releases" \
+      | sed -n 's|^transports/\(v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)$|\1|p')
+    if [[ -n "$tags" ]]; then
+      tag=$(printf '%s\n' "$tags" | sort -V | tail -n 1)
+      printf '%s' "$tag"
+      return 0
+    fi
+  done
+  echo "ERROR: ${github_repository} publishes no final transports/v* release in the newest ${release_page_limit} pages of its release listing" >&2
+  return 1
+}
+
+if [[ $# -gt 0 && -n "$1" ]]; then
+  release_tag=$1
+  release_source="requested release"
+else
+  release_tag=$(resolve_latest_release_tag)
+  release_source="newest public release"
+fi
+
+# The floor applies to both selection paths. An explicitly named tag is a way to
+# say which release to verify, not a way to bless one that predates the runtime
+# contract the one-click templates depend on.
+if [[ "$(printf '%s\n%s\n' "${minimum_release_tag#v}" "${release_tag#v}" | sort -V | head -n 1)" != "${minimum_release_tag#v}" ]]; then
+  echo "ERROR: ${release_source} ${release_tag} predates ${minimum_release_tag}, the release that carries the deployment runtime contract" >&2
+  exit 1
+fi
+
+release_image="${repository}:${release_tag}"
+latest_image="${repository}:latest"
+github_release_tag="transports/${release_tag}"
+
+if ! github_release=$(gh api "repos/${github_repository}/releases/tags/${github_release_tag}"); then
+  echo "ERROR: required public GitHub release does not exist: ${github_repository}@${github_release_tag}" >&2
+  exit 1
+fi
+if ! jq -e \
+  --arg expected "$github_release_tag" \
+  '.tag_name == $expected and .draft == false and .prerelease == false' \
+  <<<"$github_release" >/dev/null; then
+  echo "ERROR: ${github_repository}@${github_release_tag} is not a final public release" >&2
+  exit 1
+fi
+
+if ! release_manifest=$(docker buildx imagetools inspect "$release_image" --format '{{json .Manifest}}'); then
+  echo "ERROR: required deployment release does not exist: $release_image" >&2
+  exit 1
+fi
+if ! latest_manifest=$(docker buildx imagetools inspect "$latest_image" --format '{{json .Manifest}}'); then
+  echo "ERROR: could not inspect deployment image: $latest_image" >&2
+  exit 1
+fi
+
+release_digest=$(jq -er '.digest' <<<"$release_manifest")
+latest_digest=$(jq -er '.digest' <<<"$latest_manifest")
+if [[ "$release_digest" != "$latest_digest" ]]; then
+  echo "ERROR: $latest_image resolves to $latest_digest, not $release_image at $release_digest" >&2
+  exit 1
+fi
+
+# A single-platform release publishes no manifest list, so default the missing
+# key to an empty list and let the required-platform check below report it.
+platforms=$(jq -r '
+  (.manifests // [])[]
+  | select(.platform.os == "linux")
+  | [.platform.os, .platform.architecture]
+  | join("/")
+' <<<"$release_manifest" | sort -u)
+
+for required_platform in linux/amd64 linux/arm64; do
+  if ! grep -qx "$required_platform" <<<"$platforms"; then
+    echo "ERROR: $release_image does not include $required_platform" >&2
+    exit 1
+  fi
+done
+
+echo "$latest_image and $release_image resolve to $release_digest with linux/amd64 and linux/arm64"
+
+# Digest equality proves latest and the release tag are the same artifact; it
+# does not prove that artifact is the one the deployment tests exercised. The
+# release image is built from transports/Dockerfile with GOWORK=off against the
+# published modules, while the smoke tests build Dockerfile.local from the
+# workspace — different builds of different module graphs. Test the digest that
+# actually ships before letting a public button consume it.
+#
+# The manifest-list digest above is not that artifact: `docker run` resolves it
+# to whichever platform the host is, so this gate on an amd64 runner has never
+# executed an arm64 byte. The two platforms are separately built on their own
+# native runners and merged into the list, so an arm64 runtime stage can break
+# on its own. Test the per-platform digest, and let each required platform be
+# covered by its own run of this gate.
+host_arch=$(docker version --format '{{.Server.Arch}}')
+smoke_platform="linux/${host_arch}"
+
+# A caller that states the platform it expects to cover gets an error rather
+# than silent coverage loss: a matrix entry retargeted to a different runner
+# would otherwise re-test the platform its sibling already did, and the gate
+# would still report success for both.
+expected_platform=${BIFROST_SMOKE_PLATFORM:-}
+if [[ -n "$expected_platform" && "$expected_platform" != "$smoke_platform" ]]; then
+  echo "ERROR: BIFROST_SMOKE_PLATFORM asks for $expected_platform but this host runs $smoke_platform." >&2
+  echo "  A smoke test only covers the platform it executes natively; run this gate on a $expected_platform runner." >&2
+  exit 1
+fi
+
+if ! platform_digest=$(jq -er --arg platform "$smoke_platform" '
+  (.manifests // [])[]
+  | select((.platform.os + "/" + .platform.architecture) == $platform)
+  | .digest
+' <<<"$release_manifest" | head -n 1) || [[ -z "$platform_digest" ]]; then
+  echo "ERROR: $release_image publishes no $smoke_platform manifest for this runner to smoke-test" >&2
+  exit 1
+fi
+
+bash "${script_dir}/smoke-test-published-image.sh" "${repository}@${platform_digest}" "$smoke_platform"
+echo "Release gate passed on $smoke_platform. Each required platform is covered only by its own run of this gate."

--- a/deploy/railway/postgres.template-contract.json
+++ b/deploy/railway/postgres.template-contract.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "./template-contract.schema.json",
+  "platform": "railway",
+  "template": {
+    "name": "Bifrost + PostgreSQL",
+    "slug": "blue-dark",
+    "owner": "Maxim AI's Projects",
+    "visibility": "public",
+    "last_verified": null,
+    "verified_release": null
+  },
+  "services": [
+    {
+      "name": "Bifrost",
+      "image": "docker.io/maximhq/bifrost:latest",
+      "image_auto_update": "daily",
+      "variables": {
+        "APP_HOST": { "value": "0.0.0.0", "sensitive": false },
+        "APP_PORT": { "value": "8080", "sensitive": false },
+        "PORT": { "value": "8080", "sensitive": false },
+        "BIFROST_CONFIG": {
+          "value": "{\"$schema\":\"https://www.getbifrost.ai/schema\",\"version\":2,\"source_of_truth\":\"split\",\"encryption_key\":\"env.BIFROST_ENCRYPTION_KEY\",\"client\":{\"enforce_auth_on_inference\":true},\"governance\":{\"auth_config\":{\"admin_username\":\"admin\",\"admin_password\":\"env.BIFROST_ADMIN_PASSWORD\",\"is_enabled\":true}},\"config_store\":{\"enabled\":true,\"type\":\"postgres\",\"config\":{\"host\":\"env.PG_HOST\",\"port\":\"env.PG_PORT\",\"user\":\"env.PG_USER\",\"password\":\"env.PG_PASSWORD\",\"db_name\":\"env.PG_DATABASE\",\"ssl_mode\":\"require\",\"max_open_conns\":20,\"max_idle_conns\":5}},\"logs_store\":{\"enabled\":true,\"type\":\"postgres\",\"config\":{\"host\":\"env.PG_HOST\",\"port\":\"env.PG_PORT\",\"user\":\"env.PG_USER\",\"password\":\"env.PG_PASSWORD\",\"db_name\":\"env.PG_DATABASE\",\"ssl_mode\":\"require\",\"max_open_conns\":20,\"max_idle_conns\":5}}}",
+          "sensitive": false
+        },
+        "BIFROST_ENCRYPTION_KEY": { "value": "${{secret()}}", "sensitive": true },
+        "BIFROST_ADMIN_PASSWORD": { "value": "${{secret()}}", "sensitive": true },
+        "PG_HOST": { "value": "${{Postgres.PGHOST}}", "sensitive": false },
+        "PG_PORT": { "value": "${{Postgres.PGPORT}}", "sensitive": false },
+        "PG_USER": { "value": "${{Postgres.PGUSER}}", "sensitive": false },
+        "PG_PASSWORD": { "value": "${{Postgres.PGPASSWORD}}", "sensitive": true },
+        "PG_DATABASE": { "value": "${{Postgres.PGDATABASE}}", "sensitive": false }
+      },
+      "deploy": {
+        "replicas": 1,
+        "healthcheck_path": "/health",
+        "healthcheck_timeout_seconds": 300,
+        "draining_seconds": 60,
+        "overlap_seconds": 10,
+        "restart_policy": "ON_FAILURE",
+        "public_port": 8080
+      },
+      "volumes": []
+    },
+    {
+      "name": "Postgres",
+      "image": "ghcr.io/railwayapp-templates/postgres-ssl:18",
+      "image_auto_update": "disabled",
+      "variables": {
+        "POSTGRES_DB": { "value": "bifrost", "sensitive": false },
+        "POSTGRES_USER": { "value": "postgres", "sensitive": false },
+        "POSTGRES_PASSWORD": { "value": "${{secret()}}", "sensitive": true },
+        "PGHOST": { "value": "${{RAILWAY_PRIVATE_DOMAIN}}", "sensitive": false },
+        "PGPORT": { "value": "5432", "sensitive": false },
+        "PGUSER": { "value": "${{POSTGRES_USER}}", "sensitive": false },
+        "PGPASSWORD": { "value": "${{POSTGRES_PASSWORD}}", "sensitive": true },
+        "PGDATABASE": { "value": "${{POSTGRES_DB}}", "sensitive": false },
+        "PGDATA": { "value": "/var/lib/postgresql/data/pgdata", "sensitive": false }
+      },
+      "deploy": {
+        "replicas": 1,
+        "healthcheck_path": null,
+        "healthcheck_timeout_seconds": 300,
+        "draining_seconds": 60,
+        "overlap_seconds": 0,
+        "restart_policy": "ON_FAILURE",
+        "public_port": null
+      },
+      "volumes": [
+        { "mount_path": "/var/lib/postgresql/data" }
+      ]
+    }
+  ]
+}

--- a/deploy/railway/sqlite.template-contract.json
+++ b/deploy/railway/sqlite.template-contract.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "./template-contract.schema.json",
+  "platform": "railway",
+  "template": {
+    "name": "Bifrost + SQLite",
+    "slug": null,
+    "owner": "Maxim AI's Projects",
+    "visibility": "public",
+    "last_verified": null,
+    "verified_release": null
+  },
+  "services": [
+    {
+      "name": "Bifrost",
+      "image": "docker.io/maximhq/bifrost:latest",
+      "image_auto_update": "daily",
+      "variables": {
+        "APP_HOST": { "value": "0.0.0.0", "sensitive": false },
+        "APP_PORT": { "value": "8080", "sensitive": false },
+        "PORT": { "value": "8080", "sensitive": false },
+        "BIFROST_CONFIG": {
+          "value": "{\"$schema\":\"https://www.getbifrost.ai/schema\",\"version\":2,\"source_of_truth\":\"split\",\"encryption_key\":\"env.BIFROST_ENCRYPTION_KEY\",\"client\":{\"enforce_auth_on_inference\":true},\"governance\":{\"auth_config\":{\"admin_username\":\"admin\",\"admin_password\":\"env.BIFROST_ADMIN_PASSWORD\",\"is_enabled\":true}}}",
+          "sensitive": false
+        },
+        "BIFROST_ENCRYPTION_KEY": { "value": "${{secret()}}", "sensitive": true },
+        "BIFROST_ADMIN_PASSWORD": { "value": "${{secret()}}", "sensitive": true },
+        "RAILWAY_RUN_UID": { "value": "0", "sensitive": false },
+        "BIFROST_RUN_AS_UID": { "value": "1000", "sensitive": false },
+        "BIFROST_RUN_AS_GID": { "value": "0", "sensitive": false }
+      },
+      "deploy": {
+        "replicas": 1,
+        "healthcheck_path": "/health",
+        "healthcheck_timeout_seconds": 300,
+        "draining_seconds": 60,
+        "overlap_seconds": 0,
+        "restart_policy": "ON_FAILURE",
+        "public_port": 8080
+      },
+      "volumes": [
+        { "mount_path": "/app/data" }
+      ]
+    }
+  ]
+}

--- a/deploy/railway/template-contract.schema.json
+++ b/deploy/railway/template-contract.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.getbifrost.ai/schemas/railway-template-contract.json",
+  "title": "Bifrost Railway template contract",
+  "type": "object",
+  "required": ["platform", "template", "services"],
+  "properties": {
+    "$schema": { "type": "string" },
+    "platform": { "const": "railway" },
+    "template": {
+      "type": "object",
+      "required": ["name", "slug", "owner", "visibility", "last_verified", "verified_release"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "slug": { "type": ["string", "null"], "minLength": 1 },
+        "owner": { "type": "string", "minLength": 1 },
+        "visibility": { "const": "public" },
+        "last_verified": { "type": ["string", "null"], "format": "date" },
+        "verified_release": { "type": ["string", "null"], "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+$" }
+      },
+      "additionalProperties": false
+    },
+    "services": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "image", "variables", "deploy", "volumes"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "image": { "type": "string", "minLength": 1 },
+          "image_auto_update": { "enum": ["daily", "disabled"] },
+          "variables": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "required": ["value", "sensitive"],
+              "properties": {
+                "value": { "type": "string" },
+                "sensitive": { "type": "boolean" }
+              },
+              "additionalProperties": false
+            }
+          },
+          "deploy": {
+            "type": "object",
+            "required": ["replicas", "healthcheck_path", "healthcheck_timeout_seconds", "draining_seconds", "overlap_seconds", "restart_policy"],
+            "properties": {
+              "replicas": { "type": "integer", "minimum": 1 },
+              "healthcheck_path": { "type": ["string", "null"] },
+              "healthcheck_timeout_seconds": { "type": "integer", "minimum": 1 },
+              "draining_seconds": { "type": "integer", "minimum": 0 },
+              "overlap_seconds": { "type": "integer", "minimum": 0 },
+              "restart_policy": { "enum": ["ON_FAILURE", "ALWAYS", "NEVER"] },
+              "public_port": { "type": ["integer", "null"], "minimum": 1 }
+            },
+            "additionalProperties": false
+          },
+          "volumes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["mount_path"],
+              "properties": {
+                "mount_path": { "type": "string", "pattern": "^/" }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/deploy/render/blueprint-verification.json
+++ b/deploy/render/blueprint-verification.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "./blueprint-verification.schema.json",
+  "_comment": "Evidence for the public Render deploy buttons. A button may appear in the documentation only while its entry records a verified run; CI enforces both directions. Set last_verified (ISO-8601 date) and verified_release after deploying the Blueprint from the named branch against the qualified image and confirming the runtime contract.",
+  "blueprints": {
+    "postgres": {
+      "blueprint": "render.yaml",
+      "branch": "main",
+      "button_url": "https://render.com/deploy?repo=https://github.com/maximhq/bifrost/tree/main",
+      "last_verified": null,
+      "verified_release": null
+    },
+    "sqlite": {
+      "blueprint": "deploy/render/render-sqlite.yaml",
+      "branch": "render-sqlite",
+      "button_url": "https://render.com/deploy?repo=https://github.com/maximhq/bifrost/tree/render-sqlite",
+      "last_verified": null,
+      "verified_release": null
+    }
+  }
+}

--- a/deploy/render/blueprint-verification.schema.json
+++ b/deploy/render/blueprint-verification.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.getbifrost.ai/schemas/render-blueprint-verification.json",
+  "title": "Bifrost Render Blueprint verification record",
+  "type": "object",
+  "required": ["blueprints"],
+  "properties": {
+    "$schema": { "type": "string" },
+    "_comment": { "type": "string" },
+    "blueprints": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "required": ["blueprint", "branch", "button_url", "last_verified", "verified_release"],
+        "properties": {
+          "blueprint": { "type": "string", "minLength": 1 },
+          "branch": { "type": "string", "minLength": 1 },
+          "button_url": { "type": ["string", "null"], "minLength": 1 },
+          "last_verified": { "type": ["string", "null"], "format": "date" },
+          "verified_release": { "type": ["string", "null"], "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+$" }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/deploy/render/render-sqlite.yaml
+++ b/deploy/render/render-sqlite.yaml
@@ -1,0 +1,46 @@
+# Canonical source for the generated render-sqlite branch's root render.yaml.
+# Do not edit the generated branch directly.
+services:
+  - type: web
+    name: bifrost
+    runtime: image
+    plan: starter
+    autoDeploy: false
+    image:
+      url: docker.io/maximhq/bifrost:latest
+    numInstances: 1
+    healthCheckPath: /health
+    maxShutdownDelaySeconds: 60
+    disk:
+      name: bifrost-data
+      mountPath: /app/data
+      sizeGB: 1
+    envVars:
+      - key: APP_HOST
+        value: 0.0.0.0
+      - key: APP_PORT
+        value: "10000"
+      - key: PORT
+        value: "10000"
+      - key: BIFROST_CONFIG
+        value: |
+          {
+            "$schema": "https://www.getbifrost.ai/schema",
+            "version": 2,
+            "source_of_truth": "split",
+            "encryption_key": "env.BIFROST_ENCRYPTION_KEY",
+            "client": {
+              "enforce_auth_on_inference": true
+            },
+            "governance": {
+              "auth_config": {
+                "admin_username": "admin",
+                "admin_password": "env.BIFROST_ADMIN_PASSWORD",
+                "is_enabled": true
+              }
+            }
+          }
+      - key: BIFROST_ENCRYPTION_KEY
+        generateValue: true
+      - key: BIFROST_ADMIN_PASSWORD
+        generateValue: true

--- a/deploy/runtime-contract.json
+++ b/deploy/runtime-contract.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "The deployment runtime contract shared by the one-click templates. minimum_release_tag names the transports release that first carried it: the release gate (.github/workflows/scripts/verify-deployment-release.sh) refuses to qualify anything older, and the recorded-verification check (.github/workflows/scripts/validate-deployment-templates.py) refuses to accept a verification claiming one. Both read this file so the two cannot disagree about what qualifies. See docs/deployment-guides/runtime-contract.mdx for what the contract requires of an image.",
+  "minimum_release_tag": "v1.6.12"
+}

--- a/docs/deployment-guides/overview.mdx
+++ b/docs/deployment-guides/overview.mdx
@@ -18,8 +18,8 @@ Start with [Bifrost Deployment Requirements](/deployment-guides/runtime-contract
 | Azure Kubernetes Service | [AKS](/deployment-guides/platforms/aks) | Deploy the Helm chart to an existing AKS cluster |
 | Amazon ECS | [ECS](/deployment-guides/ecs) | Run the Bifrost image as an ECS service |
 | Google Cloud Run | [Cloud Run](/deployment-guides/platforms/cloud-run) | Run one Bifrost service with PostgreSQL-backed storage |
-| Render | [Render](/deployment-guides/platforms/render) | Run one web service with a persistent disk or PostgreSQL |
-| Railway | [Railway](/deployment-guides/platforms/railway) | Run one service with a volume or PostgreSQL |
+| Render | [Render](/deployment-guides/platforms/render) | Run one web service with a free PostgreSQL evaluation database or a durable SQLite disk |
+| Railway | [Railway](/deployment-guides/platforms/railway) | Run one Bifrost service with PostgreSQL or a persistent `/app/data` volume |
 | Fly.io | [Fly.io](/deployment-guides/fly) | Run one Machine with a Fly Volume or PostgreSQL |
 | Terraform | [Terraform module](/deployment-guides/k8s) | Create a supported cloud or Kubernetes deployment from code |
 | Docker or a VM | [Docker setup](/quickstart/gateway/setting-up#docker) | Run the image directly with a mounted data directory |

--- a/docs/deployment-guides/platforms/railway.mdx
+++ b/docs/deployment-guides/platforms/railway.mdx
@@ -1,128 +1,92 @@
 ---
 title: "Railway"
-description: "Deploy the Bifrost container as a Railway service"
+description: "Deploy Bifrost to Railway with PostgreSQL or durable SQLite"
 icon: "train"
 ---
 
-Railway can run the public Bifrost image as a long-running service. The deployment below uses PostgreSQL so configuration and logs survive service replacement.
+Railway has two Maxim-maintained template contracts for a single OSS Bifrost replica. Both use `maximhq/bifrost:latest`, generate the encryption and administrator secrets, enable dashboard authentication, and reject anonymous inference.
 
 <Note>
-**Support level: Preview.** This guide is not continuously exercised against a live Railway project.
+The contracts use the container runtime introduced in Bifrost `v1.6.12` and were validated in the repository on August 18, 2026. Publish or update the public templates only after `maximhq/bifrost:latest` resolves to a qualified multi-architecture release of `v1.6.12` or later.
 </Note>
 
-## Compatibility summary
+## Choose a deployment
 
-| Model | Compatibility | Constraint |
+| Choice | Storage | Cost and availability |
 |---|---|---|
-| Disposable one-replica evaluation | **Compatible** | Local data is not durable. |
-| One OSS replica with Railway volume and SQLite | **Preview with permission check** | SQLite is OSS-only. Railway mounts volumes as root; verify write access for container UID `1000`. |
-| One replica with external PostgreSQL 16+ | **Preview** | Fits ephemeral replacement when configuration is supplied at startup. |
-| Multiple OSS DB-managed replicas | **Not supported** | OSS live configuration does not synchronize. |
-| Enterprise mesh | **Unqualified** | The guide does not verify required peer TCP+UDP addressing; use no compatibility claim. |
+| PostgreSQL | Private PostgreSQL 18 service and persistent database volume | Railway bills compute, database, and storage usage. Bifrost can replace independently of its database. |
+| SQLite | One volume mounted at `/app/data` | Lower resource footprint, but a volume-backed deploy has a brief interruption and remains single-replica. |
 
-Bifrost Enterprise requires PostgreSQL 16 or later for both stores and does not support the SQLite alternative on this page.
+### PostgreSQL
 
-## Deploy Bifrost
+<Warning>
+The one-click button for this template is not published yet. The checked-in contract records what the template must contain, and nothing in this repository can read back what the live template currently serves; the button is enabled only once the live template has been inspected against that contract and the verification recorded.
 
-### Step 1: Create and link a Railway project
+Until then, reproduce the template manually from `deploy/railway/postgres.template-contract.json`.
+</Warning>
 
-```bash
-railway login
-railway init --name bifrost
-```
+Once verified, the Maxim-owned `blue-dark` template provisions Bifrost and PostgreSQL 18. Both stores require TLS, configuration and logs persist in PostgreSQL, and the Bifrost service has no unnecessary volume or root-user override.
 
-### Step 2: Create the Bifrost service
+The auditable dashboard contract is checked in at `deploy/railway/postgres.template-contract.json`. Railway templates are published from its dashboard because `railway.json` describes only one service and cannot create this complete multi-service template.
 
-```bash
-railway add \
-  --image docker.io/maximhq/bifrost:<BIFROST_VERSION> \
-  --variables 'APP_HOST=0.0.0.0' \
-  --variables 'APP_PORT=8080' \
-  --variables 'PORT=8080'
-```
+### SQLite
 
-Create the file that Bifrost will load:
+The Maxim-owned SQLite template is defined by `deploy/railway/sqlite.template-contract.json`. Its public button is deliberately release-gated: the assigned template slug must be recorded in that contract and on this page immediately after publication. Do not substitute an unowned or unverified community template.
 
-```bash
-cat > config.json <<'JSON'
-{
-  "$schema": "https://www.getbifrost.ai/schema",
-  "encryption_key": "env.BIFROST_ENCRYPTION_KEY",
-  "setup_token": "env.BIFROST_SETUP_TOKEN",
-  "client": {
-    "enforce_auth_on_inference": true
-  },
-  "config_store": {
-    "enabled": true,
-    "type": "postgres",
-    "config": {"host": "env.PG_HOST", "port": "5432", "user": "env.PG_USER", "password": "env.PG_PASSWORD", "db_name": "env.PG_DATABASE", "ssl_mode": "require"}
-  },
-  "logs_store": {
-    "enabled": true,
-    "type": "postgres",
-    "config": {"host": "env.PG_HOST", "port": "5432", "user": "env.PG_USER", "password": "env.PG_PASSWORD", "db_name": "env.PG_DATABASE", "ssl_mode": "require"}
-  }
-}
-JSON
-```
+The SQLite service attaches a volume at `/app/data`. Railway mounts volumes as root, so the template starts the container with `RAILWAY_RUN_UID=0`; the official entrypoint repairs the mounted directory and then launches Bifrost as `1000:0` using `BIFROST_RUN_AS_UID` and `BIFROST_RUN_AS_GID`. Bifrost—not the bootstrap shell—remains PID 1.
 
-### Step 3: Supply configuration and secrets
+## Sign in and create a credential
+
+1. Deploy the selected template and generate a public domain for the Bifrost service.
+2. Open the service's **Variables** tab and reveal the generated `BIFROST_ADMIN_PASSWORD` value.
+3. Open the public domain and sign in with username `admin` and that password.
+4. Add an LLM provider credential, then create a [virtual key](/features/governance/virtual-keys) for API clients.
+
+`BIFROST_ADMIN_PASSWORD` remains operator-managed. A password changed only in the dashboard is reset from the service variable whenever Bifrost restarts. Rotate it by changing the Railway secret and deploying the staged change.
+
+Keep `BIFROST_ENCRYPTION_KEY` stable across restarts, deployments, backups, and restores. Losing or changing it can make persisted provider credentials unreadable.
+
+## Verify
 
 ```bash
-export BIFROST_CONFIG_B64="$(base64 < config.json | tr -d '\n')"
-read -r -s -p 'PostgreSQL password: ' PG_PASSWORD; echo
-read -r -s -p 'Bifrost encryption key: ' BIFROST_ENCRYPTION_KEY; echo
-read -r -s -p 'Bifrost setup token: ' BIFROST_SETUP_TOKEN; echo
-
-printf '%s' "$BIFROST_CONFIG_B64" | railway variable set BIFROST_CONFIG_B64 --stdin
-railway variable set 'PG_HOST=<POSTGRES_HOST>'
-railway variable set 'PG_USER=<POSTGRES_USER>'
-printf '%s' "$PG_PASSWORD" | railway variable set PG_PASSWORD --stdin
-railway variable set 'PG_DATABASE=<POSTGRES_DATABASE>'
-printf '%s' "$BIFROST_ENCRYPTION_KEY" | railway variable set BIFROST_ENCRYPTION_KEY --stdin
-printf '%s' "$BIFROST_SETUP_TOKEN" | railway variable set BIFROST_SETUP_TOKEN --stdin
-```
-
-In the service settings, set the start command to:
-
-```text
-/bin/sh -c 'printf "%s" "$BIFROST_CONFIG_B64" | base64 -d > /app/data/config.json && exec /app/docker-entrypoint.sh'
-```
-
-Set the health-check path to `/health` and deploy one replica. The configuration requires authentication on inference routes. If external access is needed, generate a public domain, use the configured setup token to [create the first admin account](/quickstart/gateway/setting-up-auth), and [create a virtual key](/features/governance/virtual-keys) before sending inference traffic or sharing the hostname with clients.
-
-### Step 4: Verify
-
-```bash
-railway logs
 curl --fail --show-error https://<RAILWAY_HOSTNAME>/health
+
+curl --silent --output /dev/null --write-out '%{http_code}\n' \
+  https://<RAILWAY_HOSTNAME>/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  --data '{"model":"openai/gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}'
 ```
 
-### One-click status
+`/health` must return `200`, and anonymous inference must return `401`. Complete the [deployment verification checklist](/deployment-guides/runtime-contract#verify-the-deployment), including non-streaming, streaming, and restart-persistence checks, before adding production traffic.
 
-Railway supports **Deploy on Railway** buttons only after a project is created and published as a Railway template. Bifrost does not currently have a verified Maxim-owned template ID, so this page does not fabricate a deploy link. Image-backed Railway templates also require an explicit process for testing and publishing each new Bifrost image version.
+For the SQLite template, also open the service shell as an operator and verify the runtime and persistent files:
 
-## SQLite storage alternative (OSS only)
+```bash
+awk '/^Uid:/{print $2}' /proc/1/status
+stat -c '%u:%g %a %n' /app/data /app/data/config.json
+```
 
-This alternative is available only for OSS Bifrost. For a single-instance SQLite deployment, create `config.json` from the [SQLite configuration](/deployment-guides/runtime-contract#sqlite), encode and inject it using Step 3, remove the PostgreSQL variables, and attach a Railway volume at `/app/data`.
+PID 1 must report UID `1000`; `/app/data` and its Bifrost files must be owned by `1000:0`, and `config.json` must have mode `600`.
 
-Before using the deployment, confirm that the mounted path is writable by container UID `1000`. Railway volumes can be root-owned; if the platform configuration cannot provide safe write access, use PostgreSQL instead. Keep one replica because SQLite files are not a replica-coordination mechanism.
+## Updates, scaling, and availability
 
-## Scaling and upgrades
-
-- OSS SQLite volume: one replica.
-- PostgreSQL-backed OSS configuration: one replica.
-- File-only OSS: multiple replicas only with identical immutable config and secrets.
-- Enterprise mesh: not qualified on this page; validate required peer networking or use release-qualified broker mode.
-
-Set `RAILWAY_DEPLOYMENT_DRAINING_SECONDS` to give Bifrost time after `SIGTERM`; the platform default is not a Bifrost guarantee. Pin versioned images and use Railway deployment history or the prior tag for rollback. Database migrations are not reversed automatically.
+- Both choices run one OSS replica. Do not scale them above one; OSS live configuration is not synchronized between processes.
+- The templates configure Railway to check `maximhq/bifrost:latest` for a changed image daily.
+- For controlled production rollouts, copy the template and replace `latest` with an immutable version tag or digest.
+- Both services allow 60 seconds of deployment draining. PostgreSQL Bifrost deployments use a short overlap; SQLite overlap is disabled because only one deployment can mount the volume.
+- Railway cannot run two deployments simultaneously for a service with a volume, so SQLite redeploys have a brief outage.
+- PostgreSQL users can scale database resources and storage independently. SQLite users can resize the volume and later migrate both stores to PostgreSQL.
+- Enterprise clustering is outside these templates; follow the [Enterprise deployment guidance](/enterprise/clustering).
 
 ## Troubleshooting
 
-- `service unavailable`: verify `PORT`, `APP_PORT`, target port, and `APP_HOST` are aligned.
-- Health timeout: inspect startup migration/database logs and adjust the deployment health timeout only after correcting connectivity.
-- `/app/data` permission error: the root-owned Railway volume is not writable by UID `1000`; use a safe ownership mechanism or PostgreSQL.
-- Configuration disappears: the deployment used ephemeral local storage.
-- Stream terminates during deploy: configure sufficient draining overlap and client retry behavior.
+- **Service is unavailable:** verify `APP_PORT=8080`, `PORT=8080`, the generated public domain, and the `/health` setting.
+- **`/health` times out:** inspect startup migrations and private PostgreSQL connectivity before increasing the health-check timeout.
+- **Anonymous inference succeeds:** do not expose the project; confirm the deployed `BIFROST_CONFIG` contains `client.enforce_auth_on_inference: true` and redeploy.
+- **Login fails after restart:** reveal the current `BIFROST_ADMIN_PASSWORD` service variable and use username `admin`; rotate the variable if needed.
+- **SQLite reports a permission error:** confirm `RAILWAY_RUN_UID=0`, `BIFROST_RUN_AS_UID=1000`, and `BIFROST_RUN_AS_GID=0`. Do not solve it by leaving Bifrost running as root.
+- **Configuration disappeared:** verify the SQLite volume is mounted at `/app/data`, or that both PostgreSQL stores are healthy.
+- **A stream ends during deployment:** verify the 60-second draining setting and use client retries for interrupted requests.
+- **A changed `latest` image is not active yet:** wait for the daily image check or redeploy the Bifrost service manually.
 
-See [Bifrost Deployment Requirements](/deployment-guides/runtime-contract), its [deployment verification checklist](/deployment-guides/runtime-contract#verify-the-deployment), and [Enterprise clustering](/enterprise/clustering) for the remaining operational guidance.
+See [Bifrost Deployment Requirements](/deployment-guides/runtime-contract) for the complete container, authentication, storage, and upgrade contract.

--- a/docs/deployment-guides/platforms/render.mdx
+++ b/docs/deployment-guides/platforms/render.mdx
@@ -1,127 +1,90 @@
 ---
 title: "Render"
-description: "Deploy the Bifrost container as a Render web service"
+description: "Deploy Bifrost to Render with PostgreSQL or durable SQLite in one click"
 icon: "cloud"
 ---
 
-Render can run the versioned Bifrost image as a web service. The deployment below uses PostgreSQL so configuration and logs survive service replacement.
+Render has two Maxim-maintained Blueprints for a single OSS Bifrost replica. Both deploy `maximhq/bifrost:latest`, generate the encryption and administrator secrets, enable dashboard authentication, and reject anonymous inference.
 
 <Note>
-**Support level: Preview.** This guide is not continuously exercised against a live Render service. Render image services require `linux/amd64`, which is present in the Bifrost release manifest.
+The Blueprints use the container runtime contract introduced in Bifrost `v1.6.12`. The repository contracts were validated on August 18, 2026. Public release qualification still requires `maximhq/bifrost:latest` to resolve to a qualified multi-architecture release of `v1.6.12` or later.
 </Note>
 
-## Compatibility summary
+## Choose a deployment
 
-| Model | Compatibility | Constraint |
+| Choice | Initial cost and storage | Operational tradeoff |
 |---|---|---|
-| One OSS replica with Render persistent disk and SQLite | **Preview** | SQLite is OSS-only; the disk is single-instance and disables zero-downtime deploys. |
-| One replica with external PostgreSQL 16+ | **Preview** | Compatible with ephemeral replacement; live qualification remains required. |
-| Multiple OSS replicas with DB-managed config | **Not supported** | OSS processes do not synchronize in-memory configuration. |
-| Enterprise mesh | **Unqualified** | Render web services expose one HTTP port; peer discovery and TCP+UDP cluster networking are not documented here. |
+| PostgreSQL evaluation | Free web service and free 1 GB PostgreSQL 18 database | The web service sleeps after inactivity and the free database expires after 30 days unless upgraded. |
+| SQLite durable | Starter web service and a 1 GB persistent disk | Lowest-cost durable Render option; the attached disk makes deploys briefly unavailable. |
 
-Bifrost Enterprise requires PostgreSQL 16 or later for both stores and does not support the SQLite alternative on this page.
+### PostgreSQL evaluation
 
-See [Bifrost Deployment Requirements](/deployment-guides/runtime-contract) for the shared container values.
+<Warning>
+The one-click button for this Blueprint is not published yet. It is enabled only after the Blueprint has been deployed and verified against a qualified `maximhq/bifrost` release.
 
-## Deploy Bifrost
+Until then, deploy it manually: in the Render dashboard choose **New → Blueprint**, point it at this repository's `main` branch, and approve the generated `render.yaml`.
+</Warning>
 
-Render does not provide a CLI command that fully creates an image-backed web service. The steps below minimize dashboard work and make every Bifrost value explicit.
+Once published, the button is explicitly bound to the `main` branch and its root `render.yaml`. It provisions one Free web service and one private Free PostgreSQL 18 database. Both Bifrost stores use TLS-required PostgreSQL connections, so configuration and logs survive web-service replacement without a Bifrost disk.
 
-### Step 1: Create the Bifrost configuration
+Treat this as a 30-day evaluation. Upgrade the database before its expiry date to retain access to the data. An expired Free database has a limited upgrade grace period before Render deletes it. Upgrade the web service as well if you need it to remain awake or need production resources.
 
-```bash
-cat > config.json <<'JSON'
-{
-  "$schema": "https://www.getbifrost.ai/schema",
-  "encryption_key": "env.BIFROST_ENCRYPTION_KEY",
-  "setup_token": "env.BIFROST_SETUP_TOKEN",
-  "client": {
-    "enforce_auth_on_inference": true
-  },
-  "config_store": {
-    "enabled": true,
-    "type": "postgres",
-    "config": {"host": "env.PG_HOST", "port": "5432", "user": "env.PG_USER", "password": "env.PG_PASSWORD", "db_name": "env.PG_DATABASE", "ssl_mode": "require"}
-  },
-  "logs_store": {
-    "enabled": true,
-    "type": "postgres",
-    "config": {"host": "env.PG_HOST", "port": "5432", "user": "env.PG_USER", "password": "env.PG_PASSWORD", "db_name": "env.PG_DATABASE", "ssl_mode": "require"}
-  }
-}
-JSON
+### SQLite durable
 
-base64 < config.json | tr -d '\n'
-```
+<Warning>
+The one-click button for this Blueprint is not published yet. It is enabled only after the generated `render-sqlite` branch exists and its Blueprint has been deployed and verified against a qualified `maximhq/bifrost` release.
 
-Copy the printed base64 value. It contains no database password; the sensitive values remain separate Render secret environment variables.
+Until then, deploy it manually: copy `deploy/render/render-sqlite.yaml` into your own repository as the root `render.yaml`, then create a Render Blueprint from it.
+</Warning>
 
-### Step 2: Create the web service
+Once published, the button is explicitly bound to the generated `render-sqlite` branch. It provisions one Starter web service and mounts a 1 GB persistent disk at `/app/data`. Bifrost's SQLite configuration and logs survive restarts and redeploys.
 
-In Render, choose **New → Web Service → Existing Image**, then set:
+The canonical Blueprint lives on `main` at `deploy/render/render-sqlite.yaml`; automation publishes an orphan branch containing only the generated root `render.yaml`. Do not edit the generated branch directly.
 
-| Render field | Value |
-|---|---|
-| Image | `docker.io/maximhq/bifrost:<BIFROST_VERSION>` |
-| Health path | `/health` |
-| Docker command | `/bin/sh -c 'printf "%s" "$BIFROST_CONFIG_B64" \| base64 -d > /app/data/config.json && exec /app/docker-entrypoint.sh'` |
+## Sign in and create a credential
 
-### Step 3: Add environment variables and deploy
+1. Approve the Blueprint and wait for the Bifrost service to become live.
+2. Open the service's **Environment** page and reveal the generated `BIFROST_ADMIN_PASSWORD` secret.
+3. Open the service URL and sign in with username `admin` and that password.
+4. Add an LLM provider credential, then create a [virtual key](/features/governance/virtual-keys) for API clients.
 
-Add these values in **Environment**. Mark the password, encryption key, setup token, and encoded configuration as secret.
+`BIFROST_ADMIN_PASSWORD` is operator-managed configuration. A password changed only in the dashboard is reset from this environment variable the next time Bifrost starts. Rotate the password by changing the Render secret and redeploying the service.
 
-```text
-APP_HOST=0.0.0.0
-APP_PORT=10000
-PORT=10000
-BIFROST_CONFIG_B64=<BASE64_OUTPUT_FROM_STEP_1>
-PG_HOST=<POSTGRES_HOST>
-PG_USER=<POSTGRES_USER>
-PG_PASSWORD=<POSTGRES_PASSWORD>
-PG_DATABASE=<POSTGRES_DATABASE>
-BIFROST_ENCRYPTION_KEY=<STABLE_ENCRYPTION_KEY>
-BIFROST_SETUP_TOKEN=<SETUP_TOKEN>
-```
+The generated `BIFROST_ENCRYPTION_KEY` must remain stable. Back it up with the other deployment secrets; changing or losing it can make stored provider credentials unreadable.
 
-Deploy one instance. Render Postgres is one option; any PostgreSQL 16 or later server reachable from the service is valid. The configuration requires authentication on inference routes. Use the setup token to [create the first admin account](/quickstart/gateway/setting-up-auth), then [create a virtual key](/features/governance/virtual-keys) before sending inference traffic or sharing the public service URL with clients.
-
-### Step 4: Verify
+## Verify and warm a Free service
 
 ```bash
-curl --fail --show-error https://<RENDER_HOSTNAME>/health
+curl --fail --show-error --retry 30 --retry-all-errors --retry-delay 5 \
+  https://<RENDER_HOSTNAME>/health
+
+curl --silent --output /dev/null --write-out '%{http_code}\n' \
+  https://<RENDER_HOSTNAME>/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  --data '{"model":"openai/gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}'
 ```
 
-Inspect the Render logs if the health check does not pass. Bifrost must be able to resolve and connect to the configured PostgreSQL host during startup.
+The first command also wakes a sleeping Free web service. A cold start can take long enough that callers should retry `/health`; traffic is ready when it returns `200`. The anonymous inference request must return `401`.
 
-### One-click status
+Complete the [deployment verification checklist](/deployment-guides/runtime-contract#verify-the-deployment), including one streaming request and a restart/redeploy persistence check, before adding production traffic.
 
-Render supports a **Deploy to Render** button backed by a root `render.yaml`. Bifrost does not publish that Blueprint yet. A safe Blueprint must pin a tested Bifrost image and provide a reviewed configuration/secret flow; it would then need an automated update and smoke test for every Bifrost release. This guide therefore does not link to an unverified button.
+## Updates, scaling, and availability
 
-## SQLite storage alternative (OSS only)
-
-This alternative is available only for OSS Bifrost. For a single-instance SQLite deployment, create `config.json` from the [SQLite configuration](/deployment-guides/runtime-contract#sqlite), encode it as shown in Step 1, and keep the same Docker command. Remove the PostgreSQL environment variables, attach a paid persistent disk at `/app/data`, and keep one instance.
-
-Verify that the disk is writable by container UID `1000` before storing customer configuration. A Render disk is attached to one service instance and prevents zero-downtime replacement. Enterprise deployments must use PostgreSQL 16 or later instead.
-
-## External access
-
-Render's web-service URL and managed TLS are one optional frontend implementation. A private service plus an external gateway is also valid. The frontend must meet the shared HTTP, health, SSE, WebSocket, timeout, and forwarded-header contract.
-
-## Scaling and upgrades
-
-- OSS persistent-disk SQLite: one instance and a brief interruption during replacement.
-- PostgreSQL-backed OSS configuration: one instance.
-- File-only OSS: several instances only with identical immutable configuration and no shared SQLite.
-- Enterprise: do not claim mesh support until peer networking and the exact Enterprise release are qualified; broker mode is an advanced alternative to evaluate.
-
-For updates, deploy an immutable tag/digest and retain it in the registry for rollback. Image-backed services do not redeploy automatically merely because a tag's digest changes. Follow the [upgrade guidance](/deployment-guides/runtime-contract#upgrade-bifrost).
+- Both choices are single-replica OSS deployments. Do not scale them above one replica; OSS live configuration is not synchronized between processes.
+- A Render image-backed service does not redeploy when the digest behind `latest` changes. Use **Manual Deploy → Deploy latest reference** to pull the new digest.
+- For controlled production rollouts, replace `latest` in your copied Blueprint or service settings with an immutable version tag or digest.
+- PostgreSQL users can upgrade the database and web-service plans in place. SQLite users can resize the disk and later migrate both stores to PostgreSQL.
+- A service with a Render persistent disk cannot perform a zero-downtime replacement. Expect brief SQLite downtime during deploys.
+- Enterprise clustering is outside this one-click contract; use the [Enterprise deployment guidance](/enterprise/clustering).
 
 ## Troubleshooting
 
-- Port not detected: set both `APP_PORT=10000` and `PORT=10000`.
-- Disk deployment exits: verify `/app/data` ownership/write access for UID `1000`.
-- Configuration disappears: no persistent disk was attached and stores remained local.
-- No zero-downtime rollout: this is a documented Render disk limitation, not a Bifrost health-check failure.
-- `/health` `503`: inspect configured store connectivity, not only process state.
+- **Free service appears unavailable:** call `/health` with retries and allow the cold start to finish.
+- **Free PostgreSQL warning:** upgrade it before the 30-day expiry shown in Render; a web-service upgrade does not upgrade the database.
+- **`/health` returns `503`:** inspect startup logs and PostgreSQL connectivity. The PostgreSQL Blueprint requires TLS.
+- **Login fails after restart:** reveal the current `BIFROST_ADMIN_PASSWORD` value and sign in as `admin`; rotate that Render secret if necessary.
+- **Configuration disappeared:** verify the SQLite deployment has its disk at `/app/data`, or that both PostgreSQL store connections are healthy.
+- **New `latest` image is not running:** trigger a manual deploy. Changing the remote tag alone does not restart an image-backed Render service.
+- **SQLite deployment has a short outage:** this is expected for a disk-backed service; migrate to PostgreSQL if that tradeoff is unsuitable.
 
-Domains, managed TLS, private networking, Render Postgres, disk snapshots, alerts, and log integrations are optional platform/production features. Complete the [deployment verification checklist](/deployment-guides/runtime-contract#verify-the-deployment) and see [Enterprise clustering](/enterprise/clustering) for multinode designs.
+See [Bifrost Deployment Requirements](/deployment-guides/runtime-contract) for the complete container, authentication, storage, and upgrade contract.

--- a/docs/deployment-guides/runtime-contract.mdx
+++ b/docs/deployment-guides/runtime-contract.mdx
@@ -6,6 +6,8 @@ icon: "file-contract"
 
 This page describes the information your platform needs to run Bifrost. Use it together with the guide for [Kubernetes](/deployment-guides/helm), [EKS](/deployment-guides/platforms/eks), [GKE](/deployment-guides/platforms/gke), [AKS](/deployment-guides/platforms/aks), [ECS](/deployment-guides/ecs), or another container platform.
 
+For a single OSS replica, the [Render](/deployment-guides/platforms/render) and [Railway](/deployment-guides/platforms/railway) guides provide four one-click choices: PostgreSQL or persistent SQLite on either platform. PostgreSQL keeps state outside the Bifrost container; SQLite mounts durable `/app/data` storage and accepts brief disk-backed deployment downtime.
+
 ## What you will deploy
 
 Bifrost is distributed as a Linux container image:
@@ -103,10 +105,17 @@ The container has defaults for its basic runtime settings:
 | `LOG_LEVEL` | `info` | Process log level: `debug`, `info`, `warn`, or `error` |
 | `LOG_STYLE` | `json` | Process log format: `json` or `pretty` |
 | `GOMEMLIMIT` | Unset | Go runtime memory target; a common starting point is about 90% of the container memory limit |
+| `BIFROST_CONFIG` | Unset | Complete inline `config.json`; the entrypoint atomically writes it to `$APP_DIR/config.json` with mode `0600` on every start, then removes it from the Bifrost process environment |
+| `BIFROST_RUN_AS_UID` | Unset | Target UID for the standard Alpine image after a root-started entrypoint repairs `$APP_DIR`; must be paired with `BIFROST_RUN_AS_GID` |
+| `BIFROST_RUN_AS_GID` | Unset | Target GID paired with `BIFROST_RUN_AS_UID` |
 | `BIFROST_ENCRYPTION_KEY` | No generated value | Stable secret used to protect persisted sensitive configuration |
 | `BIFROST_SETUP_TOKEN` | Unset | Bootstrap secret used only to create the first admin account; `setup_token` in `config.json` can reference this variable |
 
 The official container entrypoint uses `APP_HOST`, `APP_PORT`, and `APP_DIR`. Use those names when configuring a container platform.
+
+`BIFROST_CONFIG` is suitable for platforms that supply configuration as an environment value instead of mounting a file. The write is atomic, occurs on every startup, and deliberately replaces the previous file so the platform definition remains authoritative. Inline configuration therefore requires the entrypoint to materialize or replace `$APP_DIR/config.json` and is incompatible with a read-only mount at that path. The file is private to its owner (`0600`), and the value is unset before Bifrost starts. Do not put provider keys directly in this JSON; use `env.VARIABLE_NAME` references so platforms can manage them as separate secrets.
+
+The standard image still starts as non-root `1000:0` when the run-as variables are absent. Set both run-as variables only when a platform mounts `/app/data` as root and can start the entrypoint as root. The entrypoint validates both values, repairs ownership of the paths Bifrost writes, confirms the target user can write them, and uses `su-exec` so Bifrost becomes PID 1 under the requested UID/GID. The repair covers the paths Bifrost opens at startup: `$APP_DIR` itself, `config.db`, `logs.db`, `logs/`, the SQLite `-wal` and `-shm` sidecars beside each database, and a rollback `-journal` left by an interrupted transaction. It stops there on purpose. When `BIFROST_CONFIG` is unset, an existing `config.json` is only read by Bifrost and left untouched by the entrypoint, so a read-only mount at that path is safe; an entry the volume brought with it — an ext4 `lost+found`, another service's mount — is not Bifrost's to hand to a different owner; and a symlink target is not followed or modified. `APP_DIR` itself must be a real directory rather than a symlink. If `config_store` or `logs_store` in `config.json` points SQLite at a path of your own, the repair does not know about that path: give it an owner the runtime user can write before Bifrost starts. An incomplete, nonnumeric, non-root, or unsupported privilege-drop configuration exits before Bifrost starts. These variables are supported by the standard Alpine image, not the Red Hat runtime image.
 
 Provider keys and integration credentials can be referenced from `config.json` with `env.VARIABLE_NAME`. For example:
 
@@ -132,6 +141,29 @@ Provider keys and integration credentials can be referenced from `config.json` w
 Keep the encryption key stable across restarts, replicas, upgrades, backups, and restores. Losing or changing it can make persisted encrypted values unreadable.
 
 Configure `setup_token` before starting a deployment that does not have an admin account. It accepts a literal value, an `env.VARIABLE_NAME` reference, or a `vault.path` reference; `BIFROST_SETUP_TOKEN` is also used when `setup_token` is absent. The token is never persisted or logged, must be identical across replicas, and is required only when [creating the first admin account](/quickstart/gateway/setting-up-auth).
+
+### One-click administrator authentication
+
+The Render and Railway one-click templates retain Bifrost 1.6-compatible authentication instead of using the 2.0 setup-token flow:
+
+```json
+{
+  "source_of_truth": "split",
+  "encryption_key": "env.BIFROST_ENCRYPTION_KEY",
+  "client": {
+    "enforce_auth_on_inference": true
+  },
+  "governance": {
+    "auth_config": {
+      "admin_username": "admin",
+      "admin_password": "env.BIFROST_ADMIN_PASSWORD",
+      "is_enabled": true
+    }
+  }
+}
+```
+
+The platforms generate `BIFROST_ADMIN_PASSWORD`; the operator reveals that secret and signs in as `admin`. The environment variable remains authoritative across restarts. A password changed only in the UI is therefore reset from `BIFROST_ADMIN_PASSWORD` on the next start. Rotate it through the platform secret and redeploy. Requiring authentication on inference routes ensures clients must use a virtual key instead of accessing the public endpoint anonymously.
 
 Use [config.json](/deployment-guides/config-json) for application configuration and [Helm Values](/deployment-guides/helm/values) for Kubernetes configuration.
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,98 @@
+# Bifrost one-click Render deployment: free PostgreSQL evaluation.
+# The free database expires 30 days after creation unless it is upgraded.
+services:
+  - type: web
+    name: bifrost
+    runtime: image
+    plan: free
+    autoDeploy: false
+    image:
+      url: docker.io/maximhq/bifrost:latest
+    numInstances: 1
+    healthCheckPath: /health
+    maxShutdownDelaySeconds: 60
+    envVars:
+      - key: APP_HOST
+        value: 0.0.0.0
+      - key: APP_PORT
+        value: "10000"
+      - key: PORT
+        value: "10000"
+      - key: BIFROST_CONFIG
+        value: |
+          {
+            "$schema": "https://www.getbifrost.ai/schema",
+            "version": 2,
+            "source_of_truth": "split",
+            "encryption_key": "env.BIFROST_ENCRYPTION_KEY",
+            "client": {
+              "enforce_auth_on_inference": true
+            },
+            "governance": {
+              "auth_config": {
+                "admin_username": "admin",
+                "admin_password": "env.BIFROST_ADMIN_PASSWORD",
+                "is_enabled": true
+              }
+            },
+            "config_store": {
+              "enabled": true,
+              "type": "postgres",
+              "config": {
+                "host": "env.PG_HOST",
+                "port": "env.PG_PORT",
+                "user": "env.PG_USER",
+                "password": "env.PG_PASSWORD",
+                "db_name": "env.PG_DATABASE",
+                "ssl_mode": "require",
+                "max_open_conns": 20,
+                "max_idle_conns": 5
+              }
+            },
+            "logs_store": {
+              "enabled": true,
+              "type": "postgres",
+              "config": {
+                "host": "env.PG_HOST",
+                "port": "env.PG_PORT",
+                "user": "env.PG_USER",
+                "password": "env.PG_PASSWORD",
+                "db_name": "env.PG_DATABASE",
+                "ssl_mode": "require",
+                "max_open_conns": 20,
+                "max_idle_conns": 5
+              }
+            }
+          }
+      - key: BIFROST_ENCRYPTION_KEY
+        generateValue: true
+      - key: BIFROST_ADMIN_PASSWORD
+        generateValue: true
+      - key: PG_HOST
+        fromDatabase:
+          name: bifrost-postgres
+          property: host
+      - key: PG_PORT
+        fromDatabase:
+          name: bifrost-postgres
+          property: port
+      - key: PG_USER
+        fromDatabase:
+          name: bifrost-postgres
+          property: user
+      - key: PG_PASSWORD
+        fromDatabase:
+          name: bifrost-postgres
+          property: password
+      - key: PG_DATABASE
+        fromDatabase:
+          name: bifrost-postgres
+          property: database
+
+databases:
+  - name: bifrost-postgres
+    plan: free
+    postgresMajorVersion: "18"
+    databaseName: bifrost
+    user: bifrost
+    ipAllowList: []

--- a/transports/Dockerfile
+++ b/transports/Dockerfile
@@ -58,8 +58,9 @@
   # musl: C standard library (required for CGO binaries)
   # libgcc: GCC runtime library
   # ca-certificates: For HTTPS connections
+  # su-exec: Drop privileges after repairing root-owned platform volumes
   RUN apk upgrade --no-cache && \
-    apk add --no-cache musl libgcc ca-certificates zlib
+    apk add --no-cache musl libgcc ca-certificates zlib su-exec
 
   # Create data directory and set up user
   COPY --from=builder /app/main .

--- a/transports/Dockerfile.local
+++ b/transports/Dockerfile.local
@@ -50,7 +50,10 @@
     go work use ./plugins/prompts && \
     go work use ./plugins/semanticcache && \
     go work use ./plugins/telemetry && \
-    go work use ./transports
+    go work use ./transports && \
+    go work edit -replace github.com/maximhq/bifrost/plugins/modelcatalogresolver=./plugins/modelcatalogresolver && \
+    grep -q 'plugins/modelcatalogresolver' go.work && \
+    test -f ./plugins/modelcatalogresolver/go.mod
 
   # Copy UI build output into transports
   COPY --from=ui-builder /app/out ./transports/bifrost-http/ui
@@ -76,8 +79,9 @@
   # musl: C standard library (required for CGO binaries)
   # libgcc: GCC runtime library
   # ca-certificates: For HTTPS connections
+  # su-exec: Drop privileges after repairing root-owned platform volumes
   RUN apk upgrade --no-cache && \
-    apk add --no-cache musl libgcc ca-certificates zlib
+    apk add --no-cache musl libgcc ca-certificates zlib su-exec
 
   # Create data directory and set up user
   COPY --from=builder /app/main .

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,5 +1,6 @@
 ## ✨ Features
 
+- **One-Click Render and Railway Deployments** - Added validated platform templates, release gates, inline runtime configuration, and safe arbitrary-UID startup for persistent volumes (thanks [@hbmartin](https://github.com/hbmartin)!)
 - **MCP Per-User OAuth** - MCP clients can hold per-user OAuth credentials and per-user headers, configurable from `config.json` as well as the UI, with a documented shared vs per-identity token lookup contract and VK/Users filters on the OAuth Grants and MCP Auth Sessions sidebars
 - **Token Exchange IDP Credentials** - New `use_idp_credentials` on `token_exchange` reuses SSO login app credentials for providers that require it, such as Microsoft Entra ID; `client_id` becomes optional when it is set (#6068, #6069)
 - **Bedrock VPC Endpoints** - AWS Bedrock keys can target VPC endpoints (#6064)

--- a/transports/docker-entrypoint.sh
+++ b/transports/docker-entrypoint.sh
@@ -2,23 +2,358 @@
 set -e
 
 APP_DIR=${APP_DIR:-/app/data}
+# Normalize trailing separators so a value such as /app/data/ cannot hide a
+# final-component symlink from the guard in ensure_app_dir.
+while [ "$APP_DIR" != "/" ] && [ "${APP_DIR%/}" != "$APP_DIR" ]; do
+    APP_DIR=${APP_DIR%/}
+done
+RUN_AS_UID=${BIFROST_RUN_AS_UID:-}
+RUN_AS_GID=${BIFROST_RUN_AS_GID:-}
+
+# Paths under APP_DIR that Bifrost opens at startup, relative to it ("." is
+# APP_DIR itself). A correctly owned APP_DIR says nothing about entries a
+# previous root-owned run left inside it, and the create-directory probe below
+# cannot see them: it creates a new directory and never touches the existing
+# databases. Both the ownership repair and the probe walk these explicitly.
+# Literal names, never patterns: they are split with pathname expansion on, and a
+# name carrying a glob character would expand somewhere it was never meant to.
+DATA_WRITE_ENTRIES=". config.db config.db-wal config.db-shm config.db-journal logs.db logs.db-wal logs.db-shm logs.db-journal logs"
+# Pattern, relative to APP_DIR, for rolled log databases whose names are not
+# fixed. The SQLite WAL sidecars and rollback journals above are exact literal
+# names: a hot -journal file may need recovery before SQLite can switch the
+# database back to WAL mode. Do not use config.db-* or logs.db-* here; those
+# patterns also match backups and other operator-owned files Bifrost never
+# opens.
+#
+# Globbed rather than "every immediate child of APP_DIR": an ext4-backed volume
+# mounts a root-owned lost+found that Bifrost never touches, and demanding it be
+# writable would refuse a perfectly good volume on every platform that provides
+# one. One list, used by both the ownership repair and the probe, so the two
+# cannot drift apart. Every reader splits it with pathname expansion off; see the
+# probe for what happens when it does not.
+DATA_WRITE_GLOBS="logs/*"
+# config.json is only read. Deployments legitimately mount it read-only, so it
+# is never required to be writable and never triggers an ownership repair.
+DATA_READ_ENTRIES="config.json"
+
+validate_run_as_config() {
+    if { [ -n "$RUN_AS_UID" ] && [ -z "$RUN_AS_GID" ]; } || { [ -z "$RUN_AS_UID" ] && [ -n "$RUN_AS_GID" ]; }; then
+        echo "Error: BIFROST_RUN_AS_UID and BIFROST_RUN_AS_GID must be set together"
+        exit 1
+    fi
+
+    if [ -z "$RUN_AS_UID" ]; then
+        return
+    fi
+
+    case "$RUN_AS_UID" in
+        *[!0-9]*)
+            echo "Error: BIFROST_RUN_AS_UID and BIFROST_RUN_AS_GID must be non-negative integers"
+            exit 1
+            ;;
+    esac
+    case "$RUN_AS_GID" in
+        *[!0-9]*)
+            echo "Error: BIFROST_RUN_AS_UID and BIFROST_RUN_AS_GID must be non-negative integers"
+            exit 1
+            ;;
+    esac
+
+    if [ "$RUN_AS_UID" = "0" ]; then
+        echo "Error: BIFROST_RUN_AS_UID must be a non-zero UID"
+        exit 1
+    fi
+
+    if [ "$(id -u)" != "0" ]; then
+        echo "Error: BIFROST_RUN_AS_UID and BIFROST_RUN_AS_GID require the entrypoint to start as root"
+        exit 1
+    fi
+
+    if ! command -v su-exec >/dev/null 2>&1; then
+        echo "Error: su-exec is required when BIFROST_RUN_AS_UID and BIFROST_RUN_AS_GID are set"
+        exit 1
+    fi
+}
+
+materialize_inline_config() {
+    if [ "${BIFROST_CONFIG+x}" != "x" ]; then
+        return
+    fi
+    if [ -z "$BIFROST_CONFIG" ]; then
+        echo "Error: BIFROST_CONFIG is set but empty"
+        exit 1
+    fi
+
+    # BIFROST_CONFIG carries the config.json document itself, not a path to one;
+    # deployments that mount a file leave it unset. Writing a path here would
+    # produce a config.json whose contents are the literal path string and start
+    # Bifrost on invalid JSON, so reject anything that is not a JSON object and
+    # name the mistake. Only the first non-blank character is ever echoed.
+    CONFIG_FIRST_CHAR=$(printf '%s' "$BIFROST_CONFIG" | tr -d '[:space:]' | cut -c1)
+    if [ "$CONFIG_FIRST_CHAR" != "{" ]; then
+        echo "Error: BIFROST_CONFIG must hold a complete inline config.json document"
+        if [ "$CONFIG_FIRST_CHAR" = "/" ]; then
+            echo "  The value looks like a filesystem path, which this variable does not accept."
+            echo "  Mount that file at $APP_DIR/config.json and leave BIFROST_CONFIG unset,"
+            echo "  or set BIFROST_CONFIG to the JSON document itself."
+        else
+            echo "  Expected a value beginning with '{'. Set it to the JSON document itself,"
+            echo "  or leave it unset and mount a config.json at $APP_DIR/config.json."
+        fi
+        exit 1
+    fi
+
+    CONFIG_PATH="$APP_DIR/config.json"
+    if ! CONFIG_TMP=$(umask 077 && mktemp "$APP_DIR/.config.json.tmp.XXXXXX"); then
+        echo "Error: Could not create a temporary config file in $APP_DIR"
+        exit 1
+    fi
+    if ! printf '%s' "$BIFROST_CONFIG" > "$CONFIG_TMP" || ! chmod 0600 "$CONFIG_TMP"; then
+        rm -f "$CONFIG_TMP"
+        echo "Error: Could not materialize BIFROST_CONFIG at $CONFIG_PATH"
+        exit 1
+    fi
+    if [ "$(id -u)" = "0" ] && [ -n "$RUN_AS_UID" ]; then
+        if ! chown "$RUN_AS_UID:$RUN_AS_GID" "$CONFIG_TMP"; then
+            rm -f "$CONFIG_TMP"
+            echo "Error: Could not set BIFROST_CONFIG ownership to $RUN_AS_UID:$RUN_AS_GID"
+            exit 1
+        fi
+    fi
+    if ! mv -f "$CONFIG_TMP" "$CONFIG_PATH"; then
+        rm -f "$CONFIG_TMP"
+        echo "Error: Could not materialize BIFROST_CONFIG at $CONFIG_PATH"
+        exit 1
+    fi
+    unset BIFROST_CONFIG
+}
+
+# The probe runs under the identity Bifrost will actually use and prints the
+# first path that identity cannot open, so the caller can name it. Creating a
+# new directory proves nothing about a root-owned config.db already sitting in a
+# correctly owned APP_DIR, so the existing entries are checked one by one.
+# shellcheck disable=SC2016 # The inner shell expands its own positional parameters.
+APP_DIR_PROBE='
+    app_dir="$1"
+    write_entries="$2"
+    write_globs="$3"
+    read_entries="$4"
+
+    probe_dir="$app_dir/.bifrost-write-test.$$"
+    if [ -e "$probe_dir" ]; then
+        probe_dir="$probe_dir.$(date +%s)"
+    fi
+    if ! mkdir "$probe_dir" 2>/dev/null; then
+        printf %s "$app_dir"
+        exit 1
+    fi
+    rmdir "$probe_dir" 2>/dev/null || true
+
+    # Read and write alone do not make a directory usable: without search
+    # permission Bifrost can neither traverse it nor create the log database
+    # inside it, and the glob below cannot even stat what it holds. Only
+    # directories are asked for it — a data file is never executable.
+    unusable_for_write() {
+        [ -e "$1" ] || return 1
+        if [ ! -r "$1" ] || [ ! -w "$1" ]; then
+            return 0
+        fi
+        [ -d "$1" ] && [ ! -x "$1" ]
+    }
+
+    for entry in $write_entries; do
+        path="$app_dir/$entry"
+        if unusable_for_write "$path"; then
+            printf %s "$path"
+            exit 1
+        fi
+    done
+    # $write_globs holds patterns, so splitting it needs pathname expansion off.
+    # Split unquoted, each word is itself expanded against the working directory
+    # before the anchored expansion below ever runs: a logs/ directory beside the
+    # process turns "logs/*" into the entries of that directory, and the loop then
+    # asks APP_DIR for those names instead of for whatever its own logs/ holds. The
+    # positional parameters are free to reuse; they were read into the four
+    # variables above.
+    set -f
+    set -- $write_globs
+    set +f
+    # $pattern stays unquoted so it expands as a glob; the quoted "$app_dir"/
+    # prefix is what keeps that expansion anchored. A glob matching nothing stays
+    # literal and unusable_for_write skips what does not exist, so an empty logs/
+    # or a database with no sidecars costs nothing here.
+    for pattern in "$@"; do
+        for path in "$app_dir"/$pattern; do
+            if unusable_for_write "$path"; then
+                printf %s "$path"
+                exit 1
+            fi
+        done
+    done
+    for entry in $read_entries; do
+        path="$app_dir/$entry"
+        if [ -e "$path" ] && [ ! -r "$path" ]; then
+            printf %s "$path"
+            exit 1
+        fi
+    done
+    exit 0
+'
+
+# UNUSABLE_PATH names the path that failed the most recent probe.
+UNUSABLE_PATH=""
 
 app_dir_writable() {
-    PROBE_DIR="$APP_DIR/.bifrost-write-test.$$"
-    if [ -e "$PROBE_DIR" ]; then
-        PROBE_DIR="$PROBE_DIR.$(date +%s)"
+    if [ -n "$RUN_AS_UID" ]; then
+        UNUSABLE_PATH=$(su-exec "$RUN_AS_UID:$RUN_AS_GID" sh -c "$APP_DIR_PROBE" sh \
+            "$APP_DIR" "$DATA_WRITE_ENTRIES" "$DATA_WRITE_GLOBS" "$DATA_READ_ENTRIES")
+        return $?
     fi
 
-    if mkdir "$PROBE_DIR" 2>/dev/null; then
-        rmdir "$PROBE_DIR" 2>/dev/null || true
+    UNUSABLE_PATH=$(sh -c "$APP_DIR_PROBE" sh \
+        "$APP_DIR" "$DATA_WRITE_ENTRIES" "$DATA_WRITE_GLOBS" "$DATA_READ_ENTRIES")
+    return $?
+}
+
+# misowned_data_paths prints every data path whose ownership differs from the
+# target identity, one per line, and nothing when they all match. config.json is
+# excluded: it is only read, and a read-only mount of it must not force a chown
+# on every start.
+misowned_data_paths() {
+    for _entry in $DATA_WRITE_ENTRIES; do
+        report_if_misowned "$APP_DIR/$_entry"
+    done
+    # Split with pathname expansion off, then expand each pattern anchored to
+    # "$APP_DIR"/: see the probe above for why each half is written this way.
+    set -f
+    # shellcheck disable=SC2086 # A list of patterns to split, not a single path.
+    set -- $DATA_WRITE_GLOBS
+    set +f
+    for _pattern in "$@"; do
+        # Expanding logs/* would traverse a top-level logs symlink before
+        # report_if_misowned could apply its final-component symlink guard. The
+        # repair deliberately leaves such a symlink alone; the write probe still
+        # checks the target because that is where Bifrost itself would write.
+        if [ "$_pattern" = "logs/*" ] && [ -L "$APP_DIR/logs" ]; then
+            continue
+        fi
+        for _path in "$APP_DIR"/$_pattern; do
+            report_if_misowned "$_path"
+        done
+    done
+}
+
+report_if_misowned() {
+    if [ ! -e "$1" ]; then
+        return
+    fi
+    # A symlink is never reported, because repair_data_path never follows one.
+    # stat reads through the link, so reporting it would name the ownership of
+    # something outside the data directory and then announce a repair that
+    # deliberately does not happen.
+    if [ -L "$1" ]; then
+        return
+    fi
+    # `|| true`: a failing stat must not abort the caller under `set -e`, and an
+    # ownership we cannot read is not evidence of a mismatch — the probe below
+    # still refuses to start on a path the target identity cannot open.
+    _uid=$(stat -c '%u' "$1" 2>/dev/null || true)
+    _gid=$(stat -c '%g' "$1" 2>/dev/null || true)
+    if [ -z "$_uid" ] || [ -z "$_gid" ]; then
+        return
+    fi
+    if [ "$_uid:$_gid" != "$TARGET_UID:$TARGET_GID" ]; then
+        printf '%s (%s:%s)\n' "$1" "$_uid" "$_gid"
+    fi
+}
+
+# repair_data_path hands one path and everything below it to the target
+# identity. A path that does not exist is not a failure: the entries are a fixed
+# list and a deployment legitimately has no logs.db yet.
+#
+# A symlink is skipped rather than followed. chmod dereferences a symlink handed
+# to it as an operand even under -R, where it skips the ones it meets during the
+# walk, so passing a glob match like logs/link would change the mode of the
+# link's target — a path outside APP_DIR entirely. GNU coreutils does exactly
+# this and BusyBox does not, which is the worst kind of difference to carry
+# between two runtime images. Bifrost never creates a symlink here, so one that
+# appears is not ours to repair, and if its target really is unusable the probe
+# still refuses to start and names it.
+repair_data_path() {
+    if [ ! -e "$1" ]; then
         return 0
     fi
+    if [ -L "$1" ]; then
+        return 0
+    fi
+    chown -R "$TARGET_UID:$TARGET_GID" "$1" 2>/dev/null && chmod -R u+rwX "$1" 2>/dev/null
+}
 
-    return 1
+# repair_data_paths repairs APP_DIR and the paths Bifrost actually opens: the
+# same DATA_WRITE_ENTRIES and DATA_WRITE_GLOBS the probe and misowned_data_paths
+# walk, so what gets repaired cannot drift from what gets checked. The exact
+# sidecar paths are repaired directly. logs/* is already covered by the one
+# recursive repair of the literal logs directory, so expanding it again would
+# repeat the full chown/chmod once per child and would traverse a logs symlink
+# before repair_data_path could reject the resulting descendant.
+#
+# Not every immediate child of APP_DIR. A volume carries entries Bifrost never
+# opens — an ext4-backed one mounts a root-owned lost+found — and a single
+# misowned database would otherwise hand all of them to the target identity
+# recursively, on a volume the probe deliberately does not require to be
+# writable. config.json is outside the write list for the reason it is never
+# required to be writable: deployments legitimately mount it read-only, chown
+# fails on a read-only mount, and a repair that fixed every path that needed
+# fixing would report itself as having failed. Any other foreign entry would
+# fail the same way, for the same wrong reason.
+repair_data_paths() {
+    _repair_status=0
+
+    if ! chown "$TARGET_UID:$TARGET_GID" "$APP_DIR" 2>/dev/null || ! chmod u+rwX "$APP_DIR" 2>/dev/null; then
+        _repair_status=1
+    fi
+
+    for _entry in $DATA_WRITE_ENTRIES; do
+        # "." is APP_DIR itself, repaired non-recursively just above; recursing
+        # from here would sweep in exactly the entries this list exists to leave
+        # alone.
+        if [ "$_entry" = "." ]; then
+            continue
+        fi
+        if ! repair_data_path "$APP_DIR/$_entry"; then
+            _repair_status=1
+        fi
+    done
+    # Split with pathname expansion off, then expand each pattern anchored to
+    # "$APP_DIR"/: see the probe above for why each half is written this way.
+    set -f
+    # shellcheck disable=SC2086 # A list of patterns to split, not a single path.
+    set -- $DATA_WRITE_GLOBS
+    set +f
+    for _pattern in "$@"; do
+        if [ "$_pattern" = "logs/*" ]; then
+            continue
+        fi
+        for _path in "$APP_DIR"/$_pattern; do
+            if ! repair_data_path "$_path"; then
+                _repair_status=1
+            fi
+        done
+    done
+
+    return "$_repair_status"
 }
 
 # Ensure APP_DIR exists when possible, but do not require CAP_CHOWN at startup.
 ensure_app_dir() {
+    # APP_DIR is the root of the privileged ownership-repair boundary. Checking
+    # only its children is insufficient when APP_DIR itself is a symlink: every
+    # apparently anchored chown/chmod would then resolve outside that boundary.
+    if [ -L "$APP_DIR" ]; then
+        echo "Error: APP_DIR must not be a symlink: $APP_DIR"
+        exit 1
+    fi
+
     mkdir -p "$APP_DIR" 2>/dev/null || true
 
     if [ ! -d "$APP_DIR" ]; then
@@ -29,15 +364,28 @@ ensure_app_dir() {
 
     CURRENT_UID=$(id -u)
     CURRENT_GID=$(id -g)
+    TARGET_UID=${RUN_AS_UID:-$CURRENT_UID}
+    TARGET_GID=${RUN_AS_GID:-$CURRENT_GID}
 
-    # Ownership repair only works as root (needs CAP_CHOWN). Stat the data dir
-    # here, inside the branch that actually uses the values.
+    materialize_inline_config
+    mkdir -p "$APP_DIR/logs" 2>/dev/null || true
+    # mkdir just created this directory, or it was already there. A symlink is
+    # left alone for the same reason repair_data_path leaves one alone: chown
+    # reads through it, and what it points at is outside APP_DIR.
+    if [ "$(id -u)" = "0" ] && [ -n "$RUN_AS_UID" ] && [ ! -L "$APP_DIR/logs" ]; then
+        chown "$RUN_AS_UID:$RUN_AS_GID" "$APP_DIR/logs" 2>/dev/null || true
+    fi
+
+    # Ownership repair only works as root (needs CAP_CHOWN). Repair APP_DIR *and*
+    # the entries inside it: a volume whose top level was fixed by an earlier
+    # run can still hold root-owned databases, and repairing only on a top-level
+    # mismatch leaves Bifrost to fail opening them later.
     if [ "$CURRENT_UID" = "0" ]; then
-        DATA_UID=$(stat -c '%u' "$APP_DIR" 2>/dev/null)
-        DATA_GID=$(stat -c '%g' "$APP_DIR" 2>/dev/null)
-        if [ "$DATA_UID:$DATA_GID" != "$CURRENT_UID:$CURRENT_GID" ]; then
-            echo "Fixing permissions on $APP_DIR (was $DATA_UID:$DATA_GID, setting to $CURRENT_UID:$CURRENT_GID)"
-            if chown -R "$CURRENT_UID:$CURRENT_GID" "$APP_DIR" 2>/dev/null && chmod -R g=rwX "$APP_DIR" 2>/dev/null; then
+        MISOWNED_PATHS=$(misowned_data_paths)
+        if [ -n "$MISOWNED_PATHS" ]; then
+            echo "Fixing permissions on $APP_DIR (setting to $TARGET_UID:$TARGET_GID); currently misowned:"
+            printf '%s\n' "$MISOWNED_PATHS" | sed 's/^/  /'
+            if repair_data_paths; then
                 echo "Successfully updated permissions on $APP_DIR"
             else
                 echo "Warning: Could not update permissions on $APP_DIR"
@@ -46,14 +394,19 @@ ensure_app_dir() {
     fi
 
     if ! app_dir_writable; then
-        DATA_UID=$(stat -c '%u' "$APP_DIR" 2>/dev/null)
-        DATA_GID=$(stat -c '%g' "$APP_DIR" 2>/dev/null)
+        UNUSABLE_PATH=${UNUSABLE_PATH:-$APP_DIR}
+        # `|| true`: under `set -e` a failing stat here would abort the script
+        # before it printed the diagnostic this branch exists to print.
+        DATA_UID=$(stat -c '%u' "$UNUSABLE_PATH" 2>/dev/null || true)
+        DATA_GID=$(stat -c '%g' "$UNUSABLE_PATH" 2>/dev/null || true)
+        DATA_UID=${DATA_UID:-unknown}
+        DATA_GID=${DATA_GID:-unknown}
         if [ "$BIFROST_SKIP_WRITE_CHECK" = "1" ]; then
-            echo "Warning: $APP_DIR is not writable by UID:GID $CURRENT_UID:$CURRENT_GID (owned by $DATA_UID:$DATA_GID)"
+            echo "Warning: $UNUSABLE_PATH is not usable by UID:GID $TARGET_UID:$TARGET_GID (owned by $DATA_UID:$DATA_GID)"
             echo "  BIFROST_SKIP_WRITE_CHECK=1 set; continuing without a writable APP_DIR."
             echo "  Only safe for read-only deployments backed by external stores (e.g. Postgres)."
         else
-            echo "Error: $APP_DIR is not writable by UID:GID $CURRENT_UID:$CURRENT_GID (owned by $DATA_UID:$DATA_GID)"
+            echo "Error: $UNUSABLE_PATH is not usable by UID:GID $TARGET_UID:$TARGET_GID (owned by $DATA_UID:$DATA_GID)"
             echo "  Bifrost needs a writable APP_DIR for config.db and logs.db before startup."
             echo "  On vanilla Kubernetes, set podSecurityContext.fsGroup (for example, 1000)."
             echo "  On OpenShift (restricted-v2), leave fsGroup unset/null so the SCC assigns an in-range GID."
@@ -63,11 +416,16 @@ ensure_app_dir() {
         fi
     fi
 
-    mkdir -p "$APP_DIR/logs" 2>/dev/null || true
-    chmod g+rwX "$APP_DIR/logs" 2>/dev/null || true
+    # Preserve group-write access for the standard and arbitrary-UID images, but
+    # never hand chmod a symlink operand: chmod would apply the mode change to
+    # its target, which may be a directory outside APP_DIR.
+    if [ ! -L "$APP_DIR/logs" ]; then
+        chmod g+rwX "$APP_DIR/logs" 2>/dev/null || true
+    fi
 }
 
 # Prepare the app directory before starting the application
+validate_run_as_config
 ensure_app_dir
 
 # Parse command line arguments and set environment variables
@@ -106,5 +464,9 @@ if [ $# -gt 1 ]; then
     parse_args "$@"
 fi
 
-# Build the command with environment variables and standard arguments
+# Build the command with environment variables and standard arguments.
+if [ -n "$RUN_AS_UID" ]; then
+    exec su-exec "$RUN_AS_UID:$RUN_AS_GID" /app/main -app-dir "$APP_DIR" -port "$APP_PORT" -host "$APP_HOST" -log-level "$LOG_LEVEL" -log-style "$LOG_STYLE"
+fi
+
 exec /app/main -app-dir "$APP_DIR" -port "$APP_PORT" -host "$APP_HOST" -log-level "$LOG_LEVEL" -log-style "$LOG_STYLE"

--- a/transports/docker-entrypoint_test.sh
+++ b/transports/docker-entrypoint_test.sh
@@ -1,0 +1,553 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
+ENTRYPOINT="$SCRIPT_DIR/docker-entrypoint.sh"
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+# Appending a non-newline sentinel before command substitution preserves any
+# trailing newlines in the file, unlike a bare $(cat ...), while avoiding cmp:
+# UBI Minimal does not include that utility in the runtime image.
+file_content_matches() {
+    [ "$(cat "$1"; printf x)" = "${2}x" ]
+}
+
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+CONFIG_DIR="$TEST_ROOT/config"
+mkdir -p "$CONFIG_DIR"
+
+set +e
+APP_DIR="$CONFIG_DIR" \
+APP_PORT=8080 \
+APP_HOST=127.0.0.1 \
+LOG_LEVEL=info \
+LOG_STYLE=json \
+BIFROST_CONFIG='{"source_of_truth":"split"}' \
+    sh "$ENTRYPOINT" >"$TEST_ROOT/materialize.out" 2>&1
+set -e
+
+[ -f "$CONFIG_DIR/config.json" ] || fail "BIFROST_CONFIG was not materialized"
+file_content_matches "$CONFIG_DIR/config.json" '{"source_of_truth":"split"}' || fail "materialized config content changed"
+[ "$(stat -c '%a' "$CONFIG_DIR/config.json" 2>/dev/null || stat -f '%Lp' "$CONFIG_DIR/config.json")" = "600" ] || fail "materialized config mode is not 0600"
+
+PAIR_DIR="$TEST_ROOT/pair"
+mkdir -p "$PAIR_DIR"
+set +e
+APP_DIR="$PAIR_DIR" \
+APP_PORT=8080 \
+APP_HOST=127.0.0.1 \
+LOG_LEVEL=info \
+LOG_STYLE=json \
+BIFROST_RUN_AS_UID=1000 \
+    sh "$ENTRYPOINT" >"$TEST_ROOT/pair.out" 2>&1
+PAIR_EXIT=$?
+set -e
+
+[ "$PAIR_EXIT" -ne 0 ] || fail "unpaired run-as setting was accepted"
+grep -q "BIFROST_RUN_AS_UID and BIFROST_RUN_AS_GID must be set together" "$TEST_ROOT/pair.out" || fail "unpaired run-as setting did not fail clearly"
+
+INVALID_DIR="$TEST_ROOT/invalid"
+mkdir -p "$INVALID_DIR"
+set +e
+APP_DIR="$INVALID_DIR" \
+APP_PORT=8080 \
+APP_HOST=127.0.0.1 \
+LOG_LEVEL=info \
+LOG_STYLE=json \
+BIFROST_RUN_AS_UID='1000:0' \
+BIFROST_RUN_AS_GID=0 \
+    sh "$ENTRYPOINT" >"$TEST_ROOT/invalid.out" 2>&1
+INVALID_EXIT=$?
+set -e
+
+[ "$INVALID_EXIT" -ne 0 ] || fail "invalid run-as setting was accepted"
+grep -q "must be non-negative integers" "$TEST_ROOT/invalid.out" || fail "invalid run-as setting did not fail clearly"
+
+ROOT_UID_DIR="$TEST_ROOT/root-uid"
+mkdir -p "$ROOT_UID_DIR"
+set +e
+APP_DIR="$ROOT_UID_DIR" \
+APP_PORT=8080 \
+APP_HOST=127.0.0.1 \
+LOG_LEVEL=info \
+LOG_STYLE=json \
+BIFROST_RUN_AS_UID=0 \
+BIFROST_RUN_AS_GID=0 \
+    sh "$ENTRYPOINT" >"$TEST_ROOT/root-uid.out" 2>&1
+ROOT_UID_EXIT=$?
+set -e
+
+[ "$ROOT_UID_EXIT" -ne 0 ] || fail "root run-as UID was accepted"
+grep -q "BIFROST_RUN_AS_UID must be a non-zero UID" "$TEST_ROOT/root-uid.out" || fail "root run-as UID did not fail clearly"
+
+PATH_CONFIG_DIR="$TEST_ROOT/path-config"
+mkdir -p "$PATH_CONFIG_DIR"
+set +e
+APP_DIR="$PATH_CONFIG_DIR" \
+APP_PORT=8080 \
+APP_HOST=127.0.0.1 \
+LOG_LEVEL=info \
+LOG_STYLE=json \
+BIFROST_CONFIG=/etc/bifrost/config.json \
+    sh "$ENTRYPOINT" >"$TEST_ROOT/path-config.out" 2>&1
+PATH_CONFIG_EXIT=$?
+set -e
+
+[ "$PATH_CONFIG_EXIT" -ne 0 ] || fail "a path-valued BIFROST_CONFIG was accepted"
+[ -f "$PATH_CONFIG_DIR/config.json" ] && fail "a path-valued BIFROST_CONFIG was written to config.json"
+grep -q "must hold a complete inline config.json document" "$TEST_ROOT/path-config.out" || fail "path-valued BIFROST_CONFIG did not fail clearly"
+grep -q "looks like a filesystem path" "$TEST_ROOT/path-config.out" || fail "path-valued BIFROST_CONFIG did not name the mistake"
+
+GARBAGE_CONFIG_DIR="$TEST_ROOT/garbage-config"
+mkdir -p "$GARBAGE_CONFIG_DIR"
+set +e
+APP_DIR="$GARBAGE_CONFIG_DIR" \
+APP_PORT=8080 \
+APP_HOST=127.0.0.1 \
+LOG_LEVEL=info \
+LOG_STYLE=json \
+BIFROST_CONFIG='not json at all' \
+    sh "$ENTRYPOINT" >"$TEST_ROOT/garbage-config.out" 2>&1
+GARBAGE_CONFIG_EXIT=$?
+set -e
+
+[ "$GARBAGE_CONFIG_EXIT" -ne 0 ] || fail "a non-JSON BIFROST_CONFIG was accepted"
+grep -q "must hold a complete inline config.json document" "$TEST_ROOT/garbage-config.out" || fail "non-JSON BIFROST_CONFIG did not fail clearly"
+
+# A JSON document may be indented or start on a later line; only the first
+# non-blank character decides.
+INDENTED_CONFIG_DIR="$TEST_ROOT/indented-config"
+mkdir -p "$INDENTED_CONFIG_DIR"
+INDENTED_CONFIG='
+  {"source_of_truth":"split"}
+'
+set +e
+APP_DIR="$INDENTED_CONFIG_DIR" \
+APP_PORT=8080 \
+APP_HOST=127.0.0.1 \
+LOG_LEVEL=info \
+LOG_STYLE=json \
+BIFROST_CONFIG="$INDENTED_CONFIG" \
+    sh "$ENTRYPOINT" >"$TEST_ROOT/indented-config.out" 2>&1
+set -e
+
+# Every case here ends in `exec /app/main`, which exists only inside the image,
+# so no run in this suite exits zero and no assertion may ask for it. Assert
+# what a rejection would change instead: the leading newline and the indentation
+# did not stop the document being materialized whole, and the diagnostic the
+# reject path prints never appeared.
+[ -f "$INDENTED_CONFIG_DIR/config.json" ] || fail "an indented BIFROST_CONFIG was rejected"
+file_content_matches "$INDENTED_CONFIG_DIR/config.json" "$INDENTED_CONFIG" || fail "indented config content changed"
+! grep -q "must hold a complete inline config.json document" "$TEST_ROOT/indented-config.out" || fail "an indented BIFROST_CONFIG was rejected"
+
+# APP_DIR is the root of every anchored repair path. A trailing slash must not
+# hide that APP_DIR itself is a symlink, or the final logs chmod and any
+# root-started ownership repair would operate through it.
+APP_DIR_LINK_TARGET="$TEST_ROOT/app-dir-link-target"
+mkdir -p "$APP_DIR_LINK_TARGET/logs"
+chmod 700 "$APP_DIR_LINK_TARGET/logs"
+APP_DIR_LINK="$TEST_ROOT/app-dir-link"
+ln -s "$APP_DIR_LINK_TARGET" "$APP_DIR_LINK"
+set +e
+APP_DIR="$APP_DIR_LINK/" \
+APP_PORT=8080 \
+APP_HOST=127.0.0.1 \
+LOG_LEVEL=info \
+LOG_STYLE=json \
+    sh "$ENTRYPOINT" >"$TEST_ROOT/app-dir-link.out" 2>&1
+APP_DIR_LINK_EXIT=$?
+set -e
+
+[ "$APP_DIR_LINK_EXIT" -ne 0 ] || fail "a symlinked APP_DIR was accepted"
+grep -q "APP_DIR must not be a symlink" "$TEST_ROOT/app-dir-link.out" || fail "a symlinked APP_DIR did not fail clearly"
+APP_DIR_LINK_LOGS_MODE=$(stat -c '%a' "$APP_DIR_LINK_TARGET/logs" 2>/dev/null || stat -f '%Lp' "$APP_DIR_LINK_TARGET/logs")
+[ "$APP_DIR_LINK_LOGS_MODE" = "700" ] || fail "a symlinked APP_DIR changed an out-of-tree logs directory (now $APP_DIR_LINK_LOGS_MODE)"
+
+# A database left behind by an earlier root-owned run sits inside an APP_DIR
+# whose own ownership is already correct, so the create-directory probe passes
+# and only a per-file check can catch it.
+UNUSABLE_DIR="$TEST_ROOT/unusable-db"
+mkdir -p "$UNUSABLE_DIR"
+: >"$UNUSABLE_DIR/config.db"
+chmod 000 "$UNUSABLE_DIR/config.db"
+set +e
+APP_DIR="$UNUSABLE_DIR" \
+APP_PORT=8080 \
+APP_HOST=127.0.0.1 \
+LOG_LEVEL=info \
+LOG_STYLE=json \
+    sh "$ENTRYPOINT" >"$TEST_ROOT/unusable-db.out" 2>&1
+UNUSABLE_EXIT=$?
+set -e
+chmod 600 "$UNUSABLE_DIR/config.db"
+
+[ "$UNUSABLE_EXIT" -ne 0 ] || fail "an unusable config.db was accepted"
+grep -q "$UNUSABLE_DIR/config.db is not usable" "$TEST_ROOT/unusable-db.out" || fail "unusable config.db was not named"
+
+# config.json is only read, and mounting it read-only is supported: it must not
+# be treated as an unusable path.
+READONLY_CONFIG_DIR="$TEST_ROOT/readonly-config"
+mkdir -p "$READONLY_CONFIG_DIR"
+printf '%s' '{"source_of_truth":"split"}' >"$READONLY_CONFIG_DIR/config.json"
+chmod 444 "$READONLY_CONFIG_DIR/config.json"
+set +e
+APP_DIR="$READONLY_CONFIG_DIR" \
+APP_PORT=8080 \
+APP_HOST=127.0.0.1 \
+LOG_LEVEL=info \
+LOG_STYLE=json \
+    sh "$ENTRYPOINT" >"$TEST_ROOT/readonly-config.out" 2>&1
+set -e
+chmod 644 "$READONLY_CONFIG_DIR/config.json"
+
+! grep -q "is not usable" "$TEST_ROOT/readonly-config.out" || fail "a read-only config.json was rejected"
+
+# Read and write permission is not enough for a directory: without search
+# permission Bifrost cannot create the log database inside logs/, and the probe
+# cannot even stat what the directory already holds.
+NO_TRAVERSE_DIR="$TEST_ROOT/no-traverse-logs"
+mkdir -p "$NO_TRAVERSE_DIR/logs"
+chmod 600 "$NO_TRAVERSE_DIR/logs"
+set +e
+APP_DIR="$NO_TRAVERSE_DIR" \
+APP_PORT=8080 \
+APP_HOST=127.0.0.1 \
+LOG_LEVEL=info \
+LOG_STYLE=json \
+    sh "$ENTRYPOINT" >"$TEST_ROOT/no-traverse-logs.out" 2>&1
+NO_TRAVERSE_EXIT=$?
+set -e
+chmod 700 "$NO_TRAVERSE_DIR/logs"
+
+[ "$NO_TRAVERSE_EXIT" -ne 0 ] || fail "a logs directory without search permission was accepted"
+grep -q "$NO_TRAVERSE_DIR/logs is not usable" "$TEST_ROOT/no-traverse-logs.out" || fail "logs directory without search permission was not named"
+
+# SQLite opens its databases in WAL mode, so it leaves -wal and -shm sidecars
+# beside them. A sidecar the target identity cannot open stops Bifrost exactly
+# like an unusable database does, and it can outlive a correctly owned database:
+# a root-owned run killed mid-flight leaves the sidecar behind, and repairing
+# only the paths with fixed names would never look at it.
+#
+# These cases exercise the probe. The ownership repair reads the same glob list,
+# but only runs as root with CAP_CHOWN, which this suite does not assume.
+SIDECAR_DIR="$TEST_ROOT/unusable-sidecar"
+mkdir -p "$SIDECAR_DIR"
+: >"$SIDECAR_DIR/config.db"
+: >"$SIDECAR_DIR/config.db-wal"
+chmod 000 "$SIDECAR_DIR/config.db-wal"
+set +e
+APP_DIR="$SIDECAR_DIR" \
+APP_PORT=8080 \
+APP_HOST=127.0.0.1 \
+LOG_LEVEL=info \
+LOG_STYLE=json \
+    sh "$ENTRYPOINT" >"$TEST_ROOT/unusable-sidecar.out" 2>&1
+SIDECAR_EXIT=$?
+set -e
+chmod 600 "$SIDECAR_DIR/config.db-wal"
+
+[ "$SIDECAR_EXIT" -ne 0 ] || fail "an unusable config.db-wal was accepted"
+grep -q "$SIDECAR_DIR/config.db-wal is not usable" "$TEST_ROOT/unusable-sidecar.out" || fail "unusable config.db-wal was not named"
+
+LOG_SIDECAR_DIR="$TEST_ROOT/unusable-log-sidecar"
+mkdir -p "$LOG_SIDECAR_DIR"
+: >"$LOG_SIDECAR_DIR/logs.db"
+: >"$LOG_SIDECAR_DIR/logs.db-shm"
+chmod 000 "$LOG_SIDECAR_DIR/logs.db-shm"
+set +e
+APP_DIR="$LOG_SIDECAR_DIR" \
+APP_PORT=8080 \
+APP_HOST=127.0.0.1 \
+LOG_LEVEL=info \
+LOG_STYLE=json \
+    sh "$ENTRYPOINT" >"$TEST_ROOT/unusable-log-sidecar.out" 2>&1
+LOG_SIDECAR_EXIT=$?
+set -e
+chmod 600 "$LOG_SIDECAR_DIR/logs.db-shm"
+
+[ "$LOG_SIDECAR_EXIT" -ne 0 ] || fail "an unusable logs.db-shm was accepted"
+grep -q "$LOG_SIDECAR_DIR/logs.db-shm is not usable" "$TEST_ROOT/unusable-log-sidecar.out" || fail "unusable logs.db-shm was not named"
+
+# A hot rollback journal can predate the configured WAL mode. SQLite must read
+# it during recovery before opening the database, so it is part of the same
+# exact startup write set without widening the match to arbitrary backups.
+JOURNAL_DIR="$TEST_ROOT/unusable-journal"
+mkdir -p "$JOURNAL_DIR"
+: >"$JOURNAL_DIR/config.db-journal"
+chmod 000 "$JOURNAL_DIR/config.db-journal"
+set +e
+APP_DIR="$JOURNAL_DIR" \
+APP_PORT=8080 \
+APP_HOST=127.0.0.1 \
+LOG_LEVEL=info \
+LOG_STYLE=json \
+    sh "$ENTRYPOINT" >"$TEST_ROOT/unusable-journal.out" 2>&1
+JOURNAL_EXIT=$?
+set -e
+chmod 600 "$JOURNAL_DIR/config.db-journal"
+
+[ "$JOURNAL_EXIT" -ne 0 ] || fail "an unusable config.db-journal was accepted"
+grep -q "$JOURNAL_DIR/config.db-journal is not usable" "$TEST_ROOT/unusable-journal.out" || fail "unusable config.db-journal was not named"
+
+LOG_JOURNAL_DIR="$TEST_ROOT/unusable-log-journal"
+mkdir -p "$LOG_JOURNAL_DIR"
+: >"$LOG_JOURNAL_DIR/logs.db-journal"
+chmod 000 "$LOG_JOURNAL_DIR/logs.db-journal"
+set +e
+APP_DIR="$LOG_JOURNAL_DIR" \
+APP_PORT=8080 \
+APP_HOST=127.0.0.1 \
+LOG_LEVEL=info \
+LOG_STYLE=json \
+    sh "$ENTRYPOINT" >"$TEST_ROOT/unusable-log-journal.out" 2>&1
+LOG_JOURNAL_EXIT=$?
+set -e
+chmod 600 "$LOG_JOURNAL_DIR/logs.db-journal"
+
+[ "$LOG_JOURNAL_EXIT" -ne 0 ] || fail "an unusable logs.db-journal was accepted"
+grep -q "$LOG_JOURNAL_DIR/logs.db-journal is not usable" "$TEST_ROOT/unusable-log-journal.out" || fail "unusable logs.db-journal was not named"
+
+# The counterpart to the glob: a volume may carry entries Bifrost never opens.
+# ext4-backed volumes mount a root-owned lost+found, and requiring it to be
+# usable would refuse a perfectly good disk on every platform that provides one.
+UNRELATED_DIR="$TEST_ROOT/unrelated-entry"
+mkdir -p "$UNRELATED_DIR/lost+found"
+chmod 000 "$UNRELATED_DIR/lost+found"
+set +e
+APP_DIR="$UNRELATED_DIR" \
+APP_PORT=8080 \
+APP_HOST=127.0.0.1 \
+LOG_LEVEL=info \
+LOG_STYLE=json \
+    sh "$ENTRYPOINT" >"$TEST_ROOT/unrelated-entry.out" 2>&1
+set -e
+chmod 700 "$UNRELATED_DIR/lost+found"
+
+! grep -q "is not usable" "$TEST_ROOT/unrelated-entry.out" || fail "an unrelated unusable entry was rejected"
+
+# The ownership repair only runs as root with CAP_CHOWN, which this suite does
+# not assume, so exercise its path selection directly: lift the repair functions
+# and the lists they walk out of the entrypoint, shadow chown and chmod with
+# recorders, and check which paths they are asked for. This is the counterpart
+# of the lost+found case above — an entry Bifrost never opens must not be
+# refused at startup, and must not be handed to the target identity either.
+REPAIR_SOURCE="$TEST_ROOT/repair-source.sh"
+sed -n \
+    -e '/^DATA_WRITE_ENTRIES=/p' \
+    -e '/^DATA_WRITE_GLOBS=/p' \
+    -e '/^repair_data_path() {/,/^}$/p' \
+    -e '/^repair_data_paths() {/,/^}$/p' \
+    "$ENTRYPOINT" >"$REPAIR_SOURCE"
+grep -q '^repair_data_paths() {' "$REPAIR_SOURCE" || fail "the repair functions could not be lifted from the entrypoint"
+
+# record_repair_calls <app_dir> <calls_file> <cwd>: run the lifted repair over
+# <app_dir> from <cwd> and record every path chown and chmod are asked for. The
+# working directory is a parameter because the glob list expands relative to it
+# unless it is split with pathname expansion off.
+record_repair_calls() {
+    : >"$2"
+    # shellcheck disable=SC2016 # The inner shell expands its own environment.
+    APP_DIR="$1" REPAIR_SOURCE="$REPAIR_SOURCE" REPAIR_CALLS="$2" sh -c '
+        set -e
+        cd "$1" || exit 1
+        TARGET_UID=1000
+        TARGET_GID=0
+        record() {
+            for _arg in "$@"; do
+                case "$_arg" in
+                    -R|u+rwX|1000:0) continue ;;
+                esac
+                printf "%s\n" "$_arg" >>"$REPAIR_CALLS"
+            done
+        }
+        chown() { record "$@"; }
+        chmod() { record "$@"; }
+        . "$REPAIR_SOURCE"
+        repair_data_paths
+    ' sh "$3"
+}
+
+REPAIR_DIR="$TEST_ROOT/repair-scope"
+mkdir -p "$REPAIR_DIR/logs" "$REPAIR_DIR/lost+found"
+: >"$REPAIR_DIR/config.db"
+: >"$REPAIR_DIR/config.db-wal"
+: >"$REPAIR_DIR/config.db-shm"
+: >"$REPAIR_DIR/config.db-journal"
+: >"$REPAIR_DIR/config.db-backup"
+: >"$REPAIR_DIR/logs.db"
+: >"$REPAIR_DIR/logs.db-wal"
+: >"$REPAIR_DIR/logs.db-shm"
+: >"$REPAIR_DIR/logs.db-journal"
+: >"$REPAIR_DIR/logs.db-backup"
+: >"$REPAIR_DIR/logs/2026-01-01.db"
+: >"$REPAIR_DIR/config.json"
+: >"$REPAIR_DIR/lost+found/#12345"
+# A symlink inside logs/ is matched by the glob, so it would reach chmod as an
+# operand — and chmod follows an operand symlink even under -R, where it skips
+# the ones it meets during the walk. Following it would put a path outside
+# APP_DIR under a recursive mode change.
+OUTSIDE_DIR="$TEST_ROOT/outside-the-data-dir"
+mkdir -p "$OUTSIDE_DIR"
+: >"$OUTSIDE_DIR/out-of-tree"
+ln -s "$OUTSIDE_DIR" "$REPAIR_DIR/logs/foreign-link"
+
+REPAIR_CALLS="$TEST_ROOT/repair-calls.txt"
+record_repair_calls "$REPAIR_DIR" "$REPAIR_CALLS" "$TEST_ROOT" \
+    || fail "the repair reported a failure on a directory it could fully repair"
+
+# The paths handed over directly. What sits inside logs/ must ride along with
+# the recursive repair of logs itself; handing a child over separately repeats
+# a recursive chown and chmod for every direct entry.
+for REPAIRED in "" /config.db /config.db-wal /config.db-shm /config.db-journal /logs.db /logs.db-wal /logs.db-shm /logs.db-journal /logs; do
+    grep -qx "$REPAIR_DIR$REPAIRED" "$REPAIR_CALLS" || fail "the repair skipped $REPAIR_DIR$REPAIRED"
+done
+! grep -q 'lost+found' "$REPAIR_CALLS" || fail "the repair reached an entry Bifrost never opens"
+! grep -qx "$REPAIR_DIR/config.json" "$REPAIR_CALLS" || fail "the repair reached a config.json a deployment may mount read-only"
+! grep -qx "$REPAIR_DIR/config.db-backup" "$REPAIR_CALLS" || fail "the repair treated config.db-backup as a SQLite sidecar"
+! grep -qx "$REPAIR_DIR/logs.db-backup" "$REPAIR_CALLS" || fail "the repair treated logs.db-backup as a SQLite sidecar"
+! grep -qx "$REPAIR_DIR/logs/foreign-link" "$REPAIR_CALLS" || fail "the repair handed a symlink to a recursive chown and chmod"
+! grep -qx "$REPAIR_DIR/logs/2026-01-01.db" "$REPAIR_CALLS" || fail "the repair traversed a log file twice instead of relying on the recursive logs repair"
+
+# The recorder proves the symlink never reaches chmod. It cannot prove why that
+# matters, because it never runs the real chmod — so run it. The repair target
+# here is this user, so chown succeeds and chmod actually executes. GNU
+# coreutils follows the operand and would take the out-of-tree file from 000 to
+# 600; BSD chmod defaults to -P and leaves it alone either way, so this case
+# does its real work on the Linux runner CI uses.
+LINK_REPAIR_DIR="$TEST_ROOT/link-repair"
+mkdir -p "$LINK_REPAIR_DIR/logs"
+LINK_TARGET_DIR="$TEST_ROOT/link-target"
+mkdir -p "$LINK_TARGET_DIR"
+: >"$LINK_TARGET_DIR/out-of-tree"
+chmod 000 "$LINK_TARGET_DIR/out-of-tree"
+ln -s "$LINK_TARGET_DIR" "$LINK_REPAIR_DIR/logs/foreign-link"
+
+# shellcheck disable=SC2016 # The inner shell expands its own environment.
+APP_DIR="$LINK_REPAIR_DIR" REPAIR_SOURCE="$REPAIR_SOURCE" sh -c '
+    set -e
+    TARGET_UID=$(id -u)
+    TARGET_GID=$(id -g)
+    . "$REPAIR_SOURCE"
+    repair_data_paths
+' || fail "the repair reported a failure on a directory it could fully repair"
+
+OUT_OF_TREE_MODE=$(stat -c '%a' "$LINK_TARGET_DIR/out-of-tree" 2>/dev/null || stat -f '%Lp' "$LINK_TARGET_DIR/out-of-tree")
+chmod 600 "$LINK_TARGET_DIR/out-of-tree"
+[ "$OUT_OF_TREE_MODE" = "0" ] || fail "the repair followed a symlink and changed the mode of a path outside APP_DIR (now $OUT_OF_TREE_MODE)"
+[ -L "$LINK_REPAIR_DIR/logs/foreign-link" ] || fail "the repair replaced a symlink inside logs/ instead of leaving it alone"
+
+# A final-component symlink guard is not enough for logs/*: pathname expansion
+# follows a symlink in the logs position and hands its ordinary descendants to
+# repair_data_path. Prove the repair never expands through that parent symlink.
+PARENT_LINK_REPAIR_DIR="$TEST_ROOT/parent-link-repair"
+mkdir -p "$PARENT_LINK_REPAIR_DIR"
+PARENT_LINK_TARGET_DIR="$TEST_ROOT/parent-link-target"
+mkdir -p "$PARENT_LINK_TARGET_DIR"
+: >"$PARENT_LINK_TARGET_DIR/out-of-tree"
+chmod 000 "$PARENT_LINK_TARGET_DIR/out-of-tree"
+ln -s "$PARENT_LINK_TARGET_DIR" "$PARENT_LINK_REPAIR_DIR/logs"
+
+# shellcheck disable=SC2016 # The inner shell expands its own environment.
+APP_DIR="$PARENT_LINK_REPAIR_DIR" REPAIR_SOURCE="$REPAIR_SOURCE" sh -c '
+    set -e
+    TARGET_UID=$(id -u)
+    TARGET_GID=$(id -g)
+    . "$REPAIR_SOURCE"
+    repair_data_paths
+' || fail "the repair reported a failure while skipping a top-level logs symlink"
+
+PARENT_LINK_TARGET_MODE=$(stat -c '%a' "$PARENT_LINK_TARGET_DIR/out-of-tree" 2>/dev/null || stat -f '%Lp' "$PARENT_LINK_TARGET_DIR/out-of-tree")
+chmod 600 "$PARENT_LINK_TARGET_DIR/out-of-tree"
+[ "$PARENT_LINK_TARGET_MODE" = "0" ] || fail "the repair expanded through the logs symlink and changed a path outside APP_DIR (now $PARENT_LINK_TARGET_MODE)"
+[ -L "$PARENT_LINK_REPAIR_DIR/logs" ] || fail "the repair replaced the top-level logs symlink instead of leaving it alone"
+
+# repair_data_paths is not the only place that changes permissions: ensure_app_dir
+# applies a final group-write chmod to logs/. Run the full entrypoint so that
+# bootstrap path is covered too, and prove a top-level logs symlink cannot carry
+# that chmod to a directory outside APP_DIR.
+ENSURE_LINK_DIR="$TEST_ROOT/link-ensure"
+mkdir -p "$ENSURE_LINK_DIR"
+ENSURE_LINK_TARGET_DIR="$TEST_ROOT/link-ensure-target"
+mkdir -p "$ENSURE_LINK_TARGET_DIR"
+chmod 700 "$ENSURE_LINK_TARGET_DIR"
+ln -s "$ENSURE_LINK_TARGET_DIR" "$ENSURE_LINK_DIR/logs"
+
+set +e
+APP_DIR="$ENSURE_LINK_DIR" \
+APP_PORT=8080 \
+APP_HOST=127.0.0.1 \
+LOG_LEVEL=info \
+LOG_STYLE=json \
+    sh "$ENTRYPOINT" >"$TEST_ROOT/link-ensure.out" 2>&1
+set -e
+
+ENSURE_LINK_TARGET_MODE=$(stat -c '%a' "$ENSURE_LINK_TARGET_DIR" 2>/dev/null || stat -f '%Lp' "$ENSURE_LINK_TARGET_DIR")
+chmod 700 "$ENSURE_LINK_TARGET_DIR"
+[ "$ENSURE_LINK_TARGET_MODE" = "700" ] || fail "ensure_app_dir followed the logs symlink and changed a directory outside APP_DIR (now $ENSURE_LINK_TARGET_MODE)"
+[ -L "$ENSURE_LINK_DIR/logs" ] || fail "ensure_app_dir replaced the logs symlink instead of leaving it alone"
+
+# The symlink guard must not remove the group-write setup for a real logs
+# directory; arbitrary-UID images rely on that permission surviving restarts.
+ENSURE_REAL_DIR="$TEST_ROOT/real-logs-ensure"
+mkdir -p "$ENSURE_REAL_DIR/logs"
+chmod 700 "$ENSURE_REAL_DIR/logs"
+set +e
+APP_DIR="$ENSURE_REAL_DIR" \
+APP_PORT=8080 \
+APP_HOST=127.0.0.1 \
+LOG_LEVEL=info \
+LOG_STYLE=json \
+    sh "$ENTRYPOINT" >"$TEST_ROOT/real-logs-ensure.out" 2>&1
+set -e
+
+ENSURE_REAL_MODE=$(stat -c '%a' "$ENSURE_REAL_DIR/logs" 2>/dev/null || stat -f '%Lp' "$ENSURE_REAL_DIR/logs")
+[ "$ENSURE_REAL_MODE" = "770" ] || fail "ensure_app_dir did not preserve group-write setup for a real logs directory (now $ENSURE_REAL_MODE)"
+
+# The pattern list contains logs/*. Split with pathname expansion on, that word
+# expands against the working directory before anything anchors it to APP_DIR:
+# a logs/ directory beside the process quietly becomes the thing "logs/*"
+# refers to. Exercise both the probe and repair from exactly such a directory.
+DECOY_CWD="$TEST_ROOT/decoy-cwd"
+mkdir -p "$DECOY_CWD/logs"
+: >"$DECOY_CWD/logs/decoy.db"
+
+DECOY_APP_DIR="$TEST_ROOT/decoy-app-dir"
+mkdir -p "$DECOY_APP_DIR/logs"
+: >"$DECOY_APP_DIR/logs/2026-01-01.db"
+chmod 000 "$DECOY_APP_DIR/logs/2026-01-01.db"
+set +e
+(
+    cd "$DECOY_CWD" || exit 1
+    APP_DIR="$DECOY_APP_DIR" \
+    APP_PORT=8080 \
+    APP_HOST=127.0.0.1 \
+    LOG_LEVEL=info \
+    LOG_STYLE=json \
+        sh "$ENTRYPOINT"
+) >"$TEST_ROOT/decoy-cwd.out" 2>&1
+DECOY_EXIT=$?
+set -e
+chmod 600 "$DECOY_APP_DIR/logs/2026-01-01.db"
+
+[ "$DECOY_EXIT" -ne 0 ] || fail "an unusable log database was accepted because the working directory held a logs/ of its own"
+grep -q "$DECOY_APP_DIR/logs/2026-01-01.db is not usable" "$TEST_ROOT/decoy-cwd.out" || fail "the unusable log database was not named"
+
+# The repair reads the same list. The exact sidecar must still be included, and
+# the logs/* word must remain intact long enough for repair_data_paths to skip
+# it in favor of the single recursive logs repair. If it expands while being
+# split, logs/decoy.db becomes an ordinary-looking pattern and is repaired a
+# second time when that same name exists under APP_DIR.
+: >"$REPAIR_DIR/logs/decoy.db"
+DECOY_REPAIR_CALLS="$TEST_ROOT/decoy-repair-calls.txt"
+record_repair_calls "$REPAIR_DIR" "$DECOY_REPAIR_CALLS" "$DECOY_CWD" \
+    || fail "the repair reported a failure on a directory it could fully repair"
+grep -qx "$REPAIR_DIR/config.db-wal" "$DECOY_REPAIR_CALLS" || fail "the repair skipped an exact SQLite sidecar"
+! grep -qx "$REPAIR_DIR/logs/decoy.db" "$DECOY_REPAIR_CALLS" || fail "the repair expanded logs/* against the working directory and repaired a log twice"
+
+echo "docker-entrypoint tests passed"


### PR DESCRIPTION
## Summary

Add production-ready one-click deployments for Render and Railway, backed by repository contracts and CI validation. The standard container entrypoint now supports inline configuration and safe arbitrary-UID startup on persistent volumes.

## Changes

- add Render and Railway templates plus machine-readable platform contracts
- validate templates, published release digests, platform smoke tests, and documentation links in CI
- materialize `BIFROST_CONFIG` atomically with private permissions and clear it before process startup
- support `BIFROST_RUN_AS_UID` and `BIFROST_RUN_AS_GID` while limiting ownership repair to runtime-owned database, sidecar, journal, and log paths
- reject symlinked `APP_DIR` roots and avoid following symlink targets during privileged repair
- document the runtime contract and platform-specific deployment flow

## Type of change

- [x] Feature
- [x] Bug fix
- [x] Documentation
- [x] Chore/CI

## Affected areas

- [x] Transports (HTTP/container runtime)
- [x] Docs
- [x] CI and deployment templates

## How to test

```sh
shellcheck transports/docker-entrypoint.sh transports/docker-entrypoint_test.sh \
  .github/workflows/scripts/check-new-broken-links.sh \
  .github/workflows/scripts/smoke-test-published-image.sh \
  .github/workflows/scripts/test-docker-image.sh \
  .github/workflows/scripts/verify-deployment-release.sh
sh transports/docker-entrypoint_test.sh
python3 .github/workflows/scripts/validate-deployment-templates.py
bash .github/workflows/scripts/check-new-broken-links.sh upstream/dev
git diff --check upstream/dev...HEAD
```

Local results: entrypoint tests passed, deployment template validation passed, and the pinned Mintlify comparison reported zero new broken links.

New runtime variables are documented in `docs/deployment-guides/runtime-contract.mdx`: `BIFROST_CONFIG`, `BIFROST_RUN_AS_UID`, and `BIFROST_RUN_AS_GID`.

## Screenshots/Recordings

Not applicable; this change has no UI surface.

## Breaking changes

- [x] No

Without the new run-as variables, the standard image keeps its existing non-root `1000:0` behavior.

## Related issues

None linked.

## Security considerations

Inline configuration is written atomically as mode `0600` and removed from the child environment. Root-started ownership repair is explicitly scoped, rejects a symlinked data root, skips symlink operands, and drops privileges with `su-exec` before launching Bifrost.

## Checklist

- [x] I read the contribution and PR guidelines
- [x] I added and ran applicable regression tests
- [x] I updated documentation and the transport changelog
- [x] I verified the applicable local CI commands
- [x] The commit and PR titles follow repository conventions
