### PR TITLE
feat: add per-size and joint size+quality image pricing fields for 1024×1536 and 1536×1024 resolutions

### DIFF
--- a/.github/workflows/scripts/run-migration-tests.sh
+++ b/.github/workflows/scripts/run-migration-tests.sh
@@ -2072,6 +2072,27 @@ append_dynamic_columns_postgres() {
     fi
   done
 
+  # governance_model_pricing per-size and joint size+quality per-image output rates
+  # (added via add_image_size_quality_pricing_columns)
+  for col in output_cost_per_image_above_1024_and_1536_pixels output_cost_per_image_above_1536_and_1024_pixels \
+    output_cost_per_image_above_1024_and_1024_pixels_low_quality \
+    output_cost_per_image_above_1024_and_1536_pixels_low_quality \
+    output_cost_per_image_above_1536_and_1024_pixels_low_quality \
+    output_cost_per_image_above_1024_and_1024_pixels_medium_quality \
+    output_cost_per_image_above_1024_and_1536_pixels_medium_quality \
+    output_cost_per_image_above_1536_and_1024_pixels_medium_quality \
+    output_cost_per_image_above_1024_and_1024_pixels_high_quality \
+    output_cost_per_image_above_1024_and_1536_pixels_high_quality \
+    output_cost_per_image_above_1536_and_1024_pixels_high_quality \
+    output_cost_per_image_above_1024x1024_pixels_standard_quality \
+    output_cost_per_image_above_1024x1536_pixels_standard_quality \
+    output_cost_per_image_above_1536x1024_pixels_standard_quality; do
+    if column_exists_postgres "governance_model_pricing" "$col"; then
+      echo "UPDATE governance_model_pricing SET $col = NULL WHERE id = 1;" >> "$output_file"
+      echo "UPDATE governance_model_pricing SET $col = NULL WHERE id = 2;" >> "$output_file"
+    fi
+  done
+
   # logs.redaction_mapping (added via logs_add_redaction_mapping_column)
   if column_exists_postgres "logs" "redaction_mapping"; then
     echo "UPDATE logs SET redaction_mapping = '' WHERE id = 'log-migration-test-001';" >> "$output_file"
@@ -3307,6 +3328,27 @@ append_dynamic_columns_sqlite() {
       cache_creation_input_token_cost_flex cache_creation_input_token_cost_flex_above_272k_tokens \
       cache_creation_input_token_cost_priority cache_creation_input_token_cost_fast \
       cache_creation_input_token_cost_above_1hr_fast cache_read_input_token_cost_fast inference_geo_us_multiplier; do
+      if column_exists_sqlite "$config_db" "governance_model_pricing" "$col"; then
+        echo "UPDATE governance_model_pricing SET $col = NULL WHERE id = 1;" >> "$output_file"
+        echo "UPDATE governance_model_pricing SET $col = NULL WHERE id = 2;" >> "$output_file"
+      fi
+    done
+
+    # governance_model_pricing per-size and joint size+quality per-image output rates
+    # (added via add_image_size_quality_pricing_columns)
+    for col in output_cost_per_image_above_1024_and_1536_pixels output_cost_per_image_above_1536_and_1024_pixels \
+      output_cost_per_image_above_1024_and_1024_pixels_low_quality \
+      output_cost_per_image_above_1024_and_1536_pixels_low_quality \
+      output_cost_per_image_above_1536_and_1024_pixels_low_quality \
+      output_cost_per_image_above_1024_and_1024_pixels_medium_quality \
+      output_cost_per_image_above_1024_and_1536_pixels_medium_quality \
+      output_cost_per_image_above_1536_and_1024_pixels_medium_quality \
+      output_cost_per_image_above_1024_and_1024_pixels_high_quality \
+      output_cost_per_image_above_1024_and_1536_pixels_high_quality \
+      output_cost_per_image_above_1536_and_1024_pixels_high_quality \
+      output_cost_per_image_above_1024x1024_pixels_standard_quality \
+      output_cost_per_image_above_1024x1536_pixels_standard_quality \
+      output_cost_per_image_above_1536x1024_pixels_standard_quality; do
       if column_exists_sqlite "$config_db" "governance_model_pricing" "$col"; then
         echo "UPDATE governance_model_pricing SET $col = NULL WHERE id = 1;" >> "$output_file"
         echo "UPDATE governance_model_pricing SET $col = NULL WHERE id = 2;" >> "$output_file"

--- a/docs/architecture/framework/model-catalog.mdx
+++ b/docs/architecture/framework/model-catalog.mdx
@@ -156,12 +156,26 @@ type PricingEntry struct {
     OutputCostPerImageAbove512x512PixelsPremium   *float64 `json:"output_cost_per_image_above_512_and_512_pixels_and_premium_image,omitempty"`
     OutputCostPerImageAbove1024x1024Pixels        *float64 `json:"output_cost_per_image_above_1024_and_1024_pixels,omitempty"`
     OutputCostPerImageAbove1024x1024PixelsPremium *float64 `json:"output_cost_per_image_above_1024_and_1024_pixels_and_premium_image,omitempty"`
+    OutputCostPerImageAbove1024x1536Pixels        *float64 `json:"output_cost_per_image_above_1024_and_1536_pixels,omitempty"`
+    OutputCostPerImageAbove1536x1024Pixels        *float64 `json:"output_cost_per_image_above_1536_and_1024_pixels,omitempty"`
     OutputCostPerImageAbove2048x2048Pixels        *float64 `json:"output_cost_per_image_above_2048_and_2048_pixels,omitempty"`
     OutputCostPerImageAbove4096x4096Pixels        *float64 `json:"output_cost_per_image_above_4096_and_4096_pixels,omitempty"`
     OutputCostPerImageLowQuality                  *float64 `json:"output_cost_per_image_low_quality,omitempty"`
     OutputCostPerImageMediumQuality               *float64 `json:"output_cost_per_image_medium_quality,omitempty"`
     OutputCostPerImageHighQuality                 *float64 `json:"output_cost_per_image_high_quality,omitempty"`
     OutputCostPerImageAutoQuality                 *float64 `json:"output_cost_per_image_auto_quality,omitempty"`
+    OutputCostPerImageAbove1024x1024PixelsLowQuality      *float64 `json:"output_cost_per_image_above_1024_and_1024_pixels_low_quality,omitempty"`
+    OutputCostPerImageAbove1024x1536PixelsLowQuality      *float64 `json:"output_cost_per_image_above_1024_and_1536_pixels_low_quality,omitempty"`
+    OutputCostPerImageAbove1536x1024PixelsLowQuality      *float64 `json:"output_cost_per_image_above_1536_and_1024_pixels_low_quality,omitempty"`
+    OutputCostPerImageAbove1024x1024PixelsMediumQuality   *float64 `json:"output_cost_per_image_above_1024_and_1024_pixels_medium_quality,omitempty"`
+    OutputCostPerImageAbove1024x1536PixelsMediumQuality   *float64 `json:"output_cost_per_image_above_1024_and_1536_pixels_medium_quality,omitempty"`
+    OutputCostPerImageAbove1536x1024PixelsMediumQuality   *float64 `json:"output_cost_per_image_above_1536_and_1024_pixels_medium_quality,omitempty"`
+    OutputCostPerImageAbove1024x1024PixelsHighQuality     *float64 `json:"output_cost_per_image_above_1024_and_1024_pixels_high_quality,omitempty"`
+    OutputCostPerImageAbove1024x1536PixelsHighQuality     *float64 `json:"output_cost_per_image_above_1024_and_1536_pixels_high_quality,omitempty"`
+    OutputCostPerImageAbove1536x1024PixelsHighQuality     *float64 `json:"output_cost_per_image_above_1536_and_1024_pixels_high_quality,omitempty"`
+    OutputCostPerImageAbove1024x1024PixelsStandardQuality *float64 `json:"output_cost_per_image_above_1024_and_1024_pixels_standard_quality,omitempty"`
+    OutputCostPerImageAbove1024x1536PixelsStandardQuality *float64 `json:"output_cost_per_image_above_1024_and_1536_pixels_standard_quality,omitempty"`
+    OutputCostPerImageAbove1536x1024PixelsStandardQuality *float64 `json:"output_cost_per_image_above_1536_and_1024_pixels_standard_quality,omitempty"`
     // Costs - Audio/Video
     InputCostPerAudioToken      *float64 `json:"input_cost_per_audio_token,omitempty"`
     InputCostPerAudioPerSecond  *float64 `json:"input_cost_per_audio_per_second,omitempty"`

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -84386,6 +84386,14 @@
             "type": "number",
             "minimum": 0
           },
+          "output_cost_per_image_above_1024_and_1536_pixels": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_image_above_1536_and_1024_pixels": {
+            "type": "number",
+            "minimum": 0
+          },
           "output_cost_per_image_above_2048_and_2048_pixels": {
             "type": "number",
             "minimum": 0
@@ -84407,6 +84415,54 @@
             "minimum": 0
           },
           "output_cost_per_image_auto_quality": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_image_above_1024_and_1024_pixels_low_quality": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_image_above_1024_and_1536_pixels_low_quality": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_image_above_1536_and_1024_pixels_low_quality": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_image_above_1024_and_1024_pixels_medium_quality": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_image_above_1024_and_1536_pixels_medium_quality": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_image_above_1536_and_1024_pixels_medium_quality": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_image_above_1024_and_1024_pixels_high_quality": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_image_above_1024_and_1536_pixels_high_quality": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_image_above_1536_and_1024_pixels_high_quality": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_image_above_1024_and_1024_pixels_standard_quality": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_image_above_1024_and_1536_pixels_standard_quality": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_image_above_1536_and_1024_pixels_standard_quality": {
             "type": "number",
             "minimum": 0
           },

--- a/docs/openapi/schemas/management/governance.yaml
+++ b/docs/openapi/schemas/management/governance.yaml
@@ -1846,6 +1846,12 @@ PricingPatch:
     output_cost_per_image_above_1024_and_1024_pixels_and_premium_image:
       type: number
       minimum: 0
+    output_cost_per_image_above_1024_and_1536_pixels:
+      type: number
+      minimum: 0
+    output_cost_per_image_above_1536_and_1024_pixels:
+      type: number
+      minimum: 0
     output_cost_per_image_above_2048_and_2048_pixels:
       type: number
       minimum: 0
@@ -1862,6 +1868,42 @@ PricingPatch:
       type: number
       minimum: 0
     output_cost_per_image_auto_quality:
+      type: number
+      minimum: 0
+    output_cost_per_image_above_1024_and_1024_pixels_low_quality:
+      type: number
+      minimum: 0
+    output_cost_per_image_above_1024_and_1536_pixels_low_quality:
+      type: number
+      minimum: 0
+    output_cost_per_image_above_1536_and_1024_pixels_low_quality:
+      type: number
+      minimum: 0
+    output_cost_per_image_above_1024_and_1024_pixels_medium_quality:
+      type: number
+      minimum: 0
+    output_cost_per_image_above_1024_and_1536_pixels_medium_quality:
+      type: number
+      minimum: 0
+    output_cost_per_image_above_1536_and_1024_pixels_medium_quality:
+      type: number
+      minimum: 0
+    output_cost_per_image_above_1024_and_1024_pixels_high_quality:
+      type: number
+      minimum: 0
+    output_cost_per_image_above_1024_and_1536_pixels_high_quality:
+      type: number
+      minimum: 0
+    output_cost_per_image_above_1536_and_1024_pixels_high_quality:
+      type: number
+      minimum: 0
+    output_cost_per_image_above_1024_and_1024_pixels_standard_quality:
+      type: number
+      minimum: 0
+    output_cost_per_image_above_1024_and_1536_pixels_standard_quality:
+      type: number
+      minimum: 0
+    output_cost_per_image_above_1536_and_1024_pixels_standard_quality:
       type: number
       minimum: 0
     input_cost_per_image_token:

--- a/docs/providers/custom-pricing.mdx
+++ b/docs/providers/custom-pricing.mdx
@@ -374,11 +374,31 @@ Only fields with non-zero values are applied. Cost fields are per unit in USD; m
 | `output_cost_per_image_auto_quality` | Generated image - auto quality |
 | `output_cost_per_image_above_512_and_512_pixels` | Generated image at or above 512×512 |
 | `output_cost_per_image_above_1024_and_1024_pixels` | Generated image at or above 1024×1024 |
+| `output_cost_per_image_above_1024_and_1536_pixels` | Generated image at or above 1024×1536 |
+| `output_cost_per_image_above_1536_and_1024_pixels` | Generated image at or above 1536×1024 |
 | `output_cost_per_image_above_2048_and_2048_pixels` | Generated image at or above 2048×2048 |
 | `output_cost_per_image_above_4096_and_4096_pixels` | Generated image at or above 4096×4096 |
 | `output_cost_per_image_premium_image` | Generated image - premium image |
 | `output_cost_per_image_above_512_and_512_pixels_and_premium_image` | Generated image at or above 512×512, premium image |
 | `output_cost_per_image_above_1024_and_1024_pixels_and_premium_image` | Generated image at or above 1024×1024, premium image |
+| `output_cost_per_image_above_1024_and_1024_pixels_low_quality` | Generated image at or above 1024×1024, low quality |
+| `output_cost_per_image_above_1024_and_1536_pixels_low_quality` | Generated image at or above 1024×1536, low quality |
+| `output_cost_per_image_above_1536_and_1024_pixels_low_quality` | Generated image at or above 1536×1024, low quality |
+| `output_cost_per_image_above_1024_and_1024_pixels_medium_quality` | Generated image at or above 1024×1024, medium quality |
+| `output_cost_per_image_above_1024_and_1536_pixels_medium_quality` | Generated image at or above 1024×1536, medium quality |
+| `output_cost_per_image_above_1536_and_1024_pixels_medium_quality` | Generated image at or above 1536×1024, medium quality |
+| `output_cost_per_image_above_1024_and_1024_pixels_high_quality` | Generated image at or above 1024×1024, high quality |
+| `output_cost_per_image_above_1024_and_1536_pixels_high_quality` | Generated image at or above 1024×1536, high quality |
+| `output_cost_per_image_above_1536_and_1024_pixels_high_quality` | Generated image at or above 1536×1024, high quality |
+| `output_cost_per_image_above_1024_and_1024_pixels_standard_quality` | Generated image at or above 1024×1024, standard quality |
+| `output_cost_per_image_above_1024_and_1536_pixels_standard_quality` | Generated image at or above 1024×1536, standard quality |
+| `output_cost_per_image_above_1536_and_1024_pixels_standard_quality` | Generated image at or above 1536×1024, standard quality |
+
+When several per-image rates could apply, the most specific one wins: a joint size and quality
+rate first, then a quality-only rate, then a size-only rate, then the flat `output_cost_per_image`.
+The 1024×1536 and 1536×1024 thresholds have the same pixel count, so they are matched on width
+and height rather than on the total. An image that clears both (width at least 1536 and height at
+least 1536) is billed at the 1536×1024 rate, which is checked first.
 
 ### Audio and video costs
 


### PR DESCRIPTION
## Summary

Adds support for per-size and joint size+quality image output pricing fields, enabling more granular cost tracking for image generation models that price based on both resolution and quality tier (e.g., low, medium, high, standard).

## Changes

- Added new `PricingEntry` fields for 1024×1536 and 1536×1024 size-only output costs, and joint size+quality costs across low, medium, high, and standard quality tiers for 1024×1024, 1024×1536, and 1536×1024 resolutions.
- Extended the OpenAPI schema and governance YAML to expose these new pricing fields in the `PricingPatch` object.
- Updated the custom pricing documentation to list all new fields and clarify the precedence rule: joint size+quality rates take priority over quality-only, then size-only, then the flat per-image rate. Also documents that 1024×1536 vs. 1536×1024 is matched on width and height rather than total pixel count.
- Added the new `governance_model_pricing` columns to the migration test script for both PostgreSQL and SQLite, so that existing migration tests correctly null out these columns when present.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

1. Configure a model with one or more of the new pricing fields (e.g., `output_cost_per_image_above_1024_and_1536_pixels_high_quality`) via the governance API.
2. Generate an image at 1024×1536 resolution with high quality and verify the cost is calculated using the joint size+quality rate.
3. Confirm that when only a size-only or quality-only rate is set, the correct fallback precedence is applied.
4. Run the migration tests to confirm the new columns are handled correctly in both PostgreSQL and SQLite environments.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. These are additive pricing configuration fields with no auth or PII implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable