### PR TITLE
fix: bedrock langchain embedding

### DIFF
--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -2118,15 +2118,6 @@ func (provider *BedrockProvider) Embedding(ctx *schemas.BifrostContext, key sche
 		}
 		bifrostResponse = converted
 		bifrostResponse.Model = request.Model
-		// For embeddings_by_type responses preserve the raw Bedrock payload so the
-		// invoke-endpoint converter can return all encoding variants verbatim, since
-		// the internal BifrostEmbeddingResponse only has float32 and string fields.
-		if cohereResp.ResponseType == "embeddings_by_type" {
-			var rawResponseData interface{}
-			if err := sonic.Unmarshal(rawResponse, &rawResponseData); err == nil {
-				bifrostResponse.ExtraFields.RawResponse = rawResponseData
-			}
-		}
 	}
 
 	// Bedrock Cohere embed models omit token usage from the response body and instead

--- a/core/providers/bedrock/embedding.go
+++ b/core/providers/bedrock/embedding.go
@@ -37,7 +37,7 @@ func ToBedrockTitanEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest)
 	}
 
 	// Validate that only single text input is provided for Titan models
-	if bifrostReq.Input.Text == nil && len(bifrostReq.Input.Texts) == 0 {
+	if bifrostReq.Input == nil || (bifrostReq.Input.Text == nil && len(bifrostReq.Input.Texts) == 0) {
 		return nil, fmt.Errorf("no input text provided for embedding")
 	}
 
@@ -61,11 +61,20 @@ func ToBedrockTitanEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest)
 				titanReq.Normalize = &b
 			}
 		}
-		// Forward remaining extra params (excluding normalize which is now a first-class field)
+		embeddingTypesExtracted := false
+		if rawEmbeddingTypes, exists := bifrostReq.Params.ExtraParams["embeddingTypes"]; exists {
+			if embeddingTypes, ok := schemas.SafeExtractStringSlice(rawEmbeddingTypes); ok {
+				titanReq.EmbeddingTypes = embeddingTypes
+				embeddingTypesExtracted = true
+			}
+		}
+		// Forward remaining extra params. Keep an invalid embeddingTypes value in
+		// ExtraParams so passthrough mode preserves the caller's request and lets
+		// Bedrock return its native validation error instead of silently dropping it.
 		if len(bifrostReq.Params.ExtraParams) > 0 {
 			extra := make(map[string]interface{})
 			for k, v := range bifrostReq.Params.ExtraParams {
-				if k != "normalize" {
+				if k != "normalize" && !(k == "embeddingTypes" && embeddingTypesExtracted) {
 					extra[k] = v
 				}
 			}
@@ -86,19 +95,47 @@ func (response *BedrockTitanEmbeddingResponse) ToBifrostEmbeddingResponse() *sch
 
 	bifrostResponse := &schemas.BifrostEmbeddingResponse{
 		Object: "list",
-		Data: []schemas.EmbeddingData{
-			{
-				Index:  0,
-				Object: "embedding",
-				Embedding: schemas.EmbeddingStruct{
-					EmbeddingArray: response.Embedding,
-				},
-			},
-		},
 		Usage: &schemas.BifrostLLMUsage{
 			PromptTokens: response.InputTextTokenCount,
 			TotalTokens:  response.InputTextTokenCount,
 		},
+	}
+
+	// Titan V2 always returns embeddingsByType, carrying float alone for an ordinary
+	// request. Only a genuinely multi-representation response is labelled, so the
+	// common case keeps the exact shape it had before embeddingTypes was supported.
+	if response.EmbeddingsByType != nil && response.EmbeddingsByType.Binary != nil {
+		if response.EmbeddingsByType.Float != nil {
+			bifrostResponse.Data = append(bifrostResponse.Data, schemas.EmbeddingData{
+				Index:          0,
+				Object:         "embedding",
+				Embedding:      schemas.EmbeddingStruct{EmbeddingArray: response.EmbeddingsByType.Float},
+				EncodingFormat: schemas.EmbeddingEncodingFloat,
+			})
+		}
+		if response.EmbeddingsByType.Binary != nil {
+			bifrostResponse.Data = append(bifrostResponse.Data, schemas.EmbeddingData{
+				Index:          0,
+				Object:         "embedding",
+				Embedding:      schemas.EmbeddingStruct{EmbeddingInt8Array: response.EmbeddingsByType.Binary},
+				EncodingFormat: schemas.EmbeddingEncodingBinary,
+			})
+		}
+	}
+
+	// The ordinary single-vector response, left unlabelled so it serializes exactly
+	// as before. Titan G1 only sets the top-level field; V2 repeats it under
+	// embeddingsByType.float, which is the fallback when the top level is absent.
+	if len(bifrostResponse.Data) == 0 {
+		values := response.Embedding
+		if values == nil && response.EmbeddingsByType != nil {
+			values = response.EmbeddingsByType.Float
+		}
+		bifrostResponse.Data = []schemas.EmbeddingData{{
+			Index:     0,
+			Object:    "embedding",
+			Embedding: schemas.EmbeddingStruct{EmbeddingArray: values},
+		}}
 	}
 
 	return bifrostResponse
@@ -142,7 +179,7 @@ func ToBedrockCohereEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest
 			}
 		}
 		if v, ok := extra["embedding_types"]; ok {
-			if ss, ok := v.([]string); ok {
+			if ss, ok := schemas.SafeExtractStringSlice(v); ok {
 				req.EmbeddingTypes = ss
 				delete(extra, "embedding_types")
 			}
@@ -178,6 +215,14 @@ func ToBedrockCohereEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest
 		}
 	}
 
+	// AWS requires input_type and defines no default, so an absent value would be
+	// serialized as "" and rejected. SDKs that target Titan's single-field shape
+	// (LangChain's BedrockEmbeddings) never send it; both LangChain Python clients
+	// pick search_document client-side for exactly this case, so match them.
+	if req.InputType == "" {
+		req.InputType = BedrockCohereInputTypeSearchDocument
+	}
+
 	return req, nil
 }
 
@@ -211,66 +256,63 @@ func (r *BedrockCohereEmbeddingResponse) ToBifrostEmbeddingResponse() (*schemas.
 	switch r.ResponseType {
 	case "embeddings_by_type":
 		// Object form: {"float": [[...]], "int8": [[...]], "uint8": [[...]], "binary": [[...]], "ubinary": [[...]], "base64": [...]}
-		var typed struct {
-			Float   [][]float32 `json:"float"`
-			Base64  []string    `json:"base64"`
-			Int8    [][]int8    `json:"int8"`
-			Uint8   [][]int32   `json:"uint8"` // int32 avoids []byte→base64 JSON issue
-			Binary  [][]int8    `json:"binary"`
-			Ubinary [][]int32   `json:"ubinary"` // int32 avoids []byte→base64 JSON issue
-		}
+		// Each entry is labelled with the encoding it arrived as, since int8/binary and
+		// uint8/ubinary decode into the same EmbeddingStruct field.
+		var typed BedrockCohereEmbeddingsByType
 		if err := json.Unmarshal(r.Embeddings, &typed); err != nil {
 			return nil, fmt.Errorf("error parsing embeddings_by_type: %w", err)
 		}
-		if typed.Float != nil {
-			for i, emb := range typed.Float {
-				float64Emb := make([]float64, len(emb))
-				for j, v := range emb {
-					float64Emb[j] = float64(v)
-				}
-				bifrostResponse.Data = append(bifrostResponse.Data, schemas.EmbeddingData{
-					Object:    "embedding",
-					Index:     i,
-					Embedding: schemas.EmbeddingStruct{EmbeddingArray: float64Emb},
-				})
+		for i, emb := range typed.Float {
+			float64Emb := make([]float64, len(emb))
+			for j, v := range emb {
+				float64Emb[j] = float64(v)
 			}
+			bifrostResponse.Data = append(bifrostResponse.Data, schemas.EmbeddingData{
+				Object:         "embedding",
+				Index:          i,
+				Embedding:      schemas.EmbeddingStruct{EmbeddingArray: float64Emb},
+				EncodingFormat: schemas.EmbeddingEncodingFloat,
+			})
 		}
-		if typed.Base64 != nil {
-			for i, emb := range typed.Base64 {
-				e := emb
-				bifrostResponse.Data = append(bifrostResponse.Data, schemas.EmbeddingData{
-					Object:    "embedding",
-					Index:     i,
-					Embedding: schemas.EmbeddingStruct{EmbeddingStr: &e},
-				})
-			}
+		for i, emb := range typed.Base64 {
+			e := emb
+			bifrostResponse.Data = append(bifrostResponse.Data, schemas.EmbeddingData{
+				Object:         "embedding",
+				Index:          i,
+				Embedding:      schemas.EmbeddingStruct{EmbeddingStr: &e},
+				EncodingFormat: schemas.EmbeddingEncodingBase64,
+			})
 		}
 		for i, emb := range typed.Int8 {
 			bifrostResponse.Data = append(bifrostResponse.Data, schemas.EmbeddingData{
-				Object:    "embedding",
-				Index:     i,
-				Embedding: schemas.EmbeddingStruct{EmbeddingInt8Array: emb},
+				Object:         "embedding",
+				Index:          i,
+				Embedding:      schemas.EmbeddingStruct{EmbeddingInt8Array: emb},
+				EncodingFormat: schemas.EmbeddingEncodingInt8,
 			})
 		}
 		for i, emb := range typed.Binary {
 			bifrostResponse.Data = append(bifrostResponse.Data, schemas.EmbeddingData{
-				Object:    "embedding",
-				Index:     i,
-				Embedding: schemas.EmbeddingStruct{EmbeddingInt8Array: emb},
+				Object:         "embedding",
+				Index:          i,
+				Embedding:      schemas.EmbeddingStruct{EmbeddingInt8Array: emb},
+				EncodingFormat: schemas.EmbeddingEncodingBinary,
 			})
 		}
 		for i, emb := range typed.Uint8 {
 			bifrostResponse.Data = append(bifrostResponse.Data, schemas.EmbeddingData{
-				Object:    "embedding",
-				Index:     i,
-				Embedding: schemas.EmbeddingStruct{EmbeddingInt32Array: emb},
+				Object:         "embedding",
+				Index:          i,
+				Embedding:      schemas.EmbeddingStruct{EmbeddingInt32Array: emb},
+				EncodingFormat: schemas.EmbeddingEncodingUint8,
 			})
 		}
 		for i, emb := range typed.Ubinary {
 			bifrostResponse.Data = append(bifrostResponse.Data, schemas.EmbeddingData{
-				Object:    "embedding",
-				Index:     i,
-				Embedding: schemas.EmbeddingStruct{EmbeddingInt32Array: emb},
+				Object:         "embedding",
+				Index:          i,
+				Embedding:      schemas.EmbeddingStruct{EmbeddingInt32Array: emb},
+				EncodingFormat: schemas.EmbeddingEncodingUbinary,
 			})
 		}
 

--- a/core/providers/bedrock/embedding_test.go
+++ b/core/providers/bedrock/embedding_test.go
@@ -2,6 +2,11 @@ package bedrock
 
 import (
 	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
@@ -9,6 +14,285 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestBedrockEmbeddingEncodingInvokeRoundTrip(t *testing.T) {
+	tests := []struct {
+		name             string
+		model            string
+		invokeBody       string
+		providerBody     string
+		providerResponse string
+		// expectedWire is what the native invoke route re-emits when it differs from
+		// the provider payload — the envelope is rebuilt from the canonical response,
+		// so fields the canonical schema does not carry (Cohere's id/texts) drop out.
+		expectedWire string
+	}{
+		{
+			name:       "Titan V2 default float remains unchanged",
+			model:      "amazon.titan-embed-text-v2:0",
+			invokeBody: `{"inputText":"hello","dimensions":256}`,
+			providerBody: `{
+				"inputText":"hello",
+				"dimensions":256
+			}`,
+			providerResponse: `{
+				"embedding":[0.25,0.75],
+				"inputTextTokenCount":1
+			}`,
+		},
+		{
+			name:       "Titan V2 binary",
+			model:      "amazon.titan-embed-text-v2:0",
+			invokeBody: `{"inputText":"hello","dimensions":256,"embeddingTypes":["binary"]}`,
+			providerBody: `{
+				"inputText":"hello",
+				"dimensions":256,
+				"embeddingTypes":["binary"]
+			}`,
+			providerResponse: `{
+				"embeddingsByType":{"binary":[1,0,-1]},
+				"inputTextTokenCount":1
+			}`,
+		},
+		{
+			name:       "Titan V2 float and binary",
+			model:      "amazon.titan-embed-text-v2:0",
+			invokeBody: `{"inputText":"hello","embeddingTypes":["float","binary"]}`,
+			providerBody: `{
+				"inputText":"hello",
+				"embeddingTypes":["float","binary"]
+			}`,
+			// AWS returns the top-level float vector alongside embeddingsByType
+			// whenever float is among the requested representations.
+			providerResponse: `{
+				"embedding":[0.25,0.75],
+				"embeddingsByType":{"float":[0.25,0.75],"binary":[1,0]},
+				"inputTextTokenCount":1
+			}`,
+		},
+		{
+			name:       "Cohere all typed encodings",
+			model:      "cohere.embed-v4:0",
+			invokeBody: `{"texts":["hello"],"input_type":"search_document","output_dimension":256,"embedding_types":["float","int8","uint8","binary","ubinary"]}`,
+			providerBody: `{
+				"texts":["hello"],
+				"input_type":"search_document",
+				"output_dimension":256,
+				"embedding_types":["float","int8","uint8","binary","ubinary"]
+			}`,
+			providerResponse: `{
+				"id":"embed-id",
+				"response_type":"embeddings_by_type",
+				"embeddings":{
+					"float":[[0.25,0.75]],
+					"int8":[[1,-1]],
+					"uint8":[[1,255]],
+					"binary":[[1,0]],
+					"ubinary":[[1,0]]
+				},
+				"texts":["hello"]
+			}`,
+			expectedWire: `{
+				"response_type":"embeddings_by_type",
+				"embeddings":{
+					"float":[[0.25,0.75]],
+					"int8":[[1,-1]],
+					"uint8":[[1,255]],
+					"binary":[[1,0]],
+					"ubinary":[[1,0]]
+				}
+			}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			providerRequestBody := make(chan []byte, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				providerRequestBody <- body
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(test.providerResponse))
+			}))
+			defer server.Close()
+
+			provider := newTestProviderWithServer(t, server)
+			ctx := testBedrockCtx()
+			var invokeRequest BedrockInvokeRequest
+			require.NoError(t, json.Unmarshal([]byte(test.invokeBody), &invokeRequest))
+			invokeRequest.ModelID = "bedrock/" + test.model
+
+			response, bifrostErr := provider.Embedding(
+				ctx,
+				testBedrockKey(),
+				invokeRequest.ToBifrostEmbeddingRequest(ctx),
+			)
+			require.Nil(t, bifrostErr)
+			require.NotNil(t, response)
+			assert.JSONEq(t, test.providerBody, string(<-providerRequestBody))
+			if strings.Contains(test.providerResponse, "embeddingsByType") || strings.Contains(test.providerResponse, "embeddings_by_type") {
+				assert.Nil(t, response.ExtraFields.RawResponse, "typed native payload must not bypass raw-response policy")
+				normalizedJSON, marshalErr := json.Marshal(response)
+				require.NoError(t, marshalErr)
+				assert.NotContains(t, string(normalizedJSON), "embeddingsByType")
+				assert.NotContains(t, string(normalizedJSON), "embeddings_by_type")
+
+				ctxWithRawCapture := testBedrockCtx()
+				ctxWithRawCapture.SetValue(schemas.BifrostContextKeyCaptureRawResponse, true)
+				responseWithRawCapture, rawCaptureErr := provider.Embedding(
+					ctxWithRawCapture,
+					testBedrockKey(),
+					invokeRequest.ToBifrostEmbeddingRequest(ctxWithRawCapture),
+				)
+				require.Nil(t, rawCaptureErr)
+				require.NotNil(t, responseWithRawCapture)
+				assert.JSONEq(t, test.providerBody, string(<-providerRequestBody))
+				assert.NotNil(t, responseWithRawCapture.ExtraFields.RawResponse, "explicit raw-response capture must remain supported")
+			}
+
+			expectedWire := test.expectedWire
+			if expectedWire == "" {
+				expectedWire = test.providerResponse
+			}
+
+			invokeResponse, err := ToBedrockEmbeddingInvokeResponse(ctx, response)
+			require.NoError(t, err)
+			wireResponse, err := json.Marshal(invokeResponse)
+			require.NoError(t, err)
+			assert.JSONEq(t, expectedWire, string(wireResponse))
+
+			// The envelope must survive a store-and-replay round trip: a cached
+			// response reaches this converter as plain JSON, so anything the
+			// canonical schema drops on the way out is gone on a cache hit.
+			serialized, err := json.Marshal(response)
+			require.NoError(t, err)
+			var replayed schemas.BifrostEmbeddingResponse
+			require.NoError(t, json.Unmarshal(serialized, &replayed))
+			replayedInvoke, err := ToBedrockEmbeddingInvokeResponse(ctx, &replayed)
+			require.NoError(t, err)
+			replayedWire, err := json.Marshal(replayedInvoke)
+			require.NoError(t, err)
+			assert.JSONEq(t, expectedWire, string(replayedWire), "cached response must re-emit the same native envelope")
+		})
+	}
+}
+
+func TestBedrockTitanEmbeddingResponsePreservesAllTypedEncodings(t *testing.T) {
+	response := (&BedrockTitanEmbeddingResponse{
+		EmbeddingsByType: &BedrockTitanEmbeddingsByType{
+			Float:  []float64{0.25, 0.75},
+			Binary: []int8{1, 0, -1},
+		},
+		InputTextTokenCount: 3,
+	}).ToBifrostEmbeddingResponse()
+
+	require.NotNil(t, response)
+	require.Len(t, response.Data, 2)
+	assert.Equal(t, []float64{0.25, 0.75}, response.Data[0].Embedding.EmbeddingArray)
+	assert.Equal(t, []int8{1, 0, -1}, response.Data[1].Embedding.EmbeddingInt8Array)
+	assert.Equal(t, 0, response.Data[0].Index)
+	assert.Equal(t, 0, response.Data[1].Index)
+	// The labels are what let the native invoke converter tell the two entries
+	// apart; they share an index because both describe the same input.
+	assert.Equal(t, schemas.EmbeddingEncodingFloat, response.Data[0].EncodingFormat)
+	assert.Equal(t, schemas.EmbeddingEncodingBinary, response.Data[1].EncodingFormat)
+}
+
+func TestBedrockTitanEmbeddingResponsePrefersTypedEncodingsOverLegacyFloat(t *testing.T) {
+	response := (&BedrockTitanEmbeddingResponse{
+		// Titan V2 includes this legacy float vector alongside embeddingsByType when
+		// float is one of multiple requested representations.
+		Embedding: []float64{0.5, 0.5},
+		EmbeddingsByType: &BedrockTitanEmbeddingsByType{
+			Float:  []float64{0.25, 0.75},
+			Binary: []int8{1, 0},
+		},
+		InputTextTokenCount: 3,
+	}).ToBifrostEmbeddingResponse()
+
+	require.NotNil(t, response)
+	require.Len(t, response.Data, 2)
+	assert.Equal(t, []float64{0.25, 0.75}, response.Data[0].Embedding.EmbeddingArray)
+	assert.Equal(t, []int8{1, 0}, response.Data[1].Embedding.EmbeddingInt8Array)
+}
+
+func TestToBedrockTitanEmbeddingRequestEncodingTypes(t *testing.T) {
+	text := "hello"
+	t.Run("rejects missing input without panicking", func(t *testing.T) {
+		req, err := ToBedrockTitanEmbeddingRequest(&schemas.BifrostEmbeddingRequest{})
+		require.Error(t, err)
+		assert.Nil(t, req)
+		assert.Contains(t, err.Error(), "no input")
+	})
+
+	t.Run("rejects empty input without panicking", func(t *testing.T) {
+		req, err := ToBedrockTitanEmbeddingRequest(&schemas.BifrostEmbeddingRequest{
+			Input: &schemas.EmbeddingInput{},
+		})
+		require.Error(t, err)
+		assert.Nil(t, req)
+		assert.Contains(t, err.Error(), "no input")
+	})
+
+	t.Run("accepts decoded JSON arrays", func(t *testing.T) {
+		req, err := ToBedrockTitanEmbeddingRequest(&schemas.BifrostEmbeddingRequest{
+			Input: &schemas.EmbeddingInput{Text: &text},
+			Params: &schemas.EmbeddingParameters{ExtraParams: map[string]interface{}{
+				"embeddingTypes": []interface{}{"float", "binary"},
+			}},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"float", "binary"}, req.EmbeddingTypes)
+		assert.NotContains(t, req.ExtraParams, "embeddingTypes")
+	})
+
+	t.Run("preserves invalid values for native validation", func(t *testing.T) {
+		invalid := []interface{}{"binary", float64(1)}
+		req, err := ToBedrockTitanEmbeddingRequest(&schemas.BifrostEmbeddingRequest{
+			Input: &schemas.EmbeddingInput{Text: &text},
+			Params: &schemas.EmbeddingParameters{ExtraParams: map[string]interface{}{
+				"embeddingTypes": invalid,
+			}},
+		})
+		require.NoError(t, err)
+		assert.Nil(t, req.EmbeddingTypes)
+		assert.Equal(t, invalid, req.ExtraParams["embeddingTypes"])
+	})
+}
+
+func TestBedrockTitanEmbeddingResponsePreservesLegacyEmptyEntry(t *testing.T) {
+	response := (&BedrockTitanEmbeddingResponse{InputTextTokenCount: 3}).ToBifrostEmbeddingResponse()
+	require.NotNil(t, response)
+	require.Len(t, response.Data, 1)
+	assert.Equal(t, 0, response.Data[0].Index)
+	assert.Equal(t, "embedding", response.Data[0].Object)
+	assert.Nil(t, response.Data[0].Embedding.EmbeddingArray)
+	assert.Empty(t, response.Data[0].EncodingFormat, "an ordinary single-vector response stays unlabelled")
+	assert.Equal(t, 3, response.Usage.TotalTokens)
+}
+
+func TestBedrockTitanEmbeddingResponseLeavesOrdinaryV2ResponseUnlabelled(t *testing.T) {
+	// AWS returns embeddingsByType on every Titan V2 response, carrying float alone
+	// for an ordinary request. Labelling that would change the shape of every
+	// existing Titan V2 call, so only a multi-representation response is labelled.
+	response := (&BedrockTitanEmbeddingResponse{
+		Embedding:           []float64{0.25, 0.75},
+		EmbeddingsByType:    &BedrockTitanEmbeddingsByType{Float: []float64{0.25, 0.75}},
+		InputTextTokenCount: 4,
+	}).ToBifrostEmbeddingResponse()
+
+	require.NotNil(t, response)
+	require.Len(t, response.Data, 1)
+	assert.Empty(t, response.Data[0].EncodingFormat)
+	assert.Equal(t, []float64{0.25, 0.75}, response.Data[0].Embedding.EmbeddingArray)
+
+	invokeResponse, err := ToBedrockEmbeddingInvokeResponse(testBedrockCtx(), response)
+	require.NoError(t, err)
+	wire, err := json.Marshal(invokeResponse)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"embedding":[0.25,0.75],"inputTextTokenCount":4}`, string(wire),
+		"the native envelope for an ordinary Titan V2 request must not change")
+}
 
 func TestToBedrockCohereEmbeddingRequest(t *testing.T) {
 	t.Run("returns error for nil request", func(t *testing.T) {
@@ -81,6 +365,47 @@ func TestToBedrockCohereEmbeddingRequest(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []string{"hello", "world"}, req.Texts)
 		assert.Equal(t, "search_document", req.InputType)
+	})
+
+	t.Run("defaults input_type when the caller omits it", func(t *testing.T) {
+		// AWS requires input_type and has no default, so an absent value would go out
+		// as "" and be rejected. SDKs shaped around Titan's single-field body never
+		// send it; this is what lets them reach a Cohere model at all.
+		text := "hello"
+		req, err := ToBedrockCohereEmbeddingRequest(&schemas.BifrostEmbeddingRequest{
+			Input: &schemas.EmbeddingInput{Text: &text},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, BedrockCohereInputTypeSearchDocument, req.InputType)
+	})
+
+	t.Run("caller input_type always wins over the default", func(t *testing.T) {
+		text := "hello"
+		req, err := ToBedrockCohereEmbeddingRequest(&schemas.BifrostEmbeddingRequest{
+			Input: &schemas.EmbeddingInput{Text: &text},
+			Params: &schemas.EmbeddingParameters{
+				ExtraParams: map[string]interface{}{"input_type": "search_query"},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "search_query", req.InputType)
+	})
+
+	t.Run("embedding types accept decoded JSON arrays", func(t *testing.T) {
+		text := "hello"
+		bifrostReq := &schemas.BifrostEmbeddingRequest{
+			Input: &schemas.EmbeddingInput{Text: &text},
+			Params: &schemas.EmbeddingParameters{
+				ExtraParams: map[string]interface{}{
+					"embedding_types": []interface{}{"float", "int8", "binary"},
+				},
+			},
+		}
+
+		req, err := ToBedrockCohereEmbeddingRequest(bifrostReq)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"float", "int8", "binary"}, req.EmbeddingTypes)
+		assert.NotContains(t, req.ExtraParams, "embedding_types")
 	})
 }
 

--- a/core/providers/bedrock/invoke.go
+++ b/core/providers/bedrock/invoke.go
@@ -57,7 +57,8 @@ var bedrockInvokeRequestKnownFields = map[string]bool{
 	// Embeddings
 	"inputText": true, "texts": true, "input_type": true,
 	"normalize": true, "dimensions": true,
-	"embedding_types": true, "output_dimension": true, "inputs": true,
+	"embedding_types": true, "embeddingTypes": true,
+	"output_dimension": true, "inputs": true,
 	// Internal
 	"stream": true, "extra_params": true,
 }
@@ -530,6 +531,9 @@ func (r *BedrockInvokeRequest) ToBifrostEmbeddingRequest(ctx *schemas.BifrostCon
 	}
 	if len(r.EmbeddingTypes) > 0 {
 		extraParams["embedding_types"] = r.EmbeddingTypes
+	}
+	if len(r.TitanEmbeddingTypes) > 0 {
+		extraParams["embeddingTypes"] = r.TitanEmbeddingTypes
 	}
 	if r.Truncate != nil {
 		extraParams["truncate"] = *r.Truncate
@@ -1153,17 +1157,15 @@ func ToBedrockInvokeImagesResponse(ctx *schemas.BifrostContext, resp *schemas.Bi
 }
 
 // ToBedrockEmbeddingInvokeResponse converts a BifrostEmbeddingResponse back to the native
-// Bedrock invoke API response format.
+// Bedrock invoke API response format, rebuilt entirely from the canonical response so the
+// same request produces the same envelope whether it was served live or from a cache.
 // Single-embedding (Titan) responses use: {"embedding": [...], "inputTextTokenCount": N}
 // Multi-embedding (Cohere) responses use:  {"embeddings": [[...],[...]], "response_type": "embeddings_floats"}
+// Entries carrying an EncodingFormat produce the typed envelopes instead: embeddingsByType
+// for Titan, and {"embeddings": {"<type>": ...}, "response_type": "embeddings_by_type"} for Cohere.
 func ToBedrockEmbeddingInvokeResponse(ctx *schemas.BifrostContext, resp *schemas.BifrostEmbeddingResponse) (interface{}, error) {
 	if resp == nil {
 		return nil, fmt.Errorf("bifrost embedding response is nil")
-	}
-
-	// If the provider stored the raw Bedrock response, return it verbatim
-	if resp.ExtraFields.RawResponse != nil {
-		return resp.ExtraFields.RawResponse, nil
 	}
 
 	tokenCount := 0
@@ -1187,32 +1189,99 @@ func ToBedrockEmbeddingInvokeResponse(ctx *schemas.BifrostContext, resp *schemas
 	}
 
 	if schemas.IsCohereModelFamily(ctx, model) {
-		floats := make([][]float32, 0, len(resp.Data))
-		for _, d := range resp.Data {
-			float32Emb := make([]float32, len(d.Embedding.EmbeddingArray))
-			for i, v := range d.Embedding.EmbeddingArray {
-				float32Emb[i] = float32(v)
+		return toBedrockCohereEmbeddingInvokeResponse(resp), nil
+	}
+	return toBedrockTitanEmbeddingInvokeResponse(resp, tokenCount), nil
+}
+
+// toBedrockTitanEmbeddingInvokeResponse rebuilds the Titan invoke envelope from the
+// canonical data. Entries carry the encoding they arrived as, so embeddingsByType is
+// reconstructed without holding on to the provider payload. AWS returns the top-level
+// float vector alongside embeddingsByType whenever float was among the requested
+// representations, and omits it for a binary-only request.
+func toBedrockTitanEmbeddingInvokeResponse(resp *schemas.BifrostEmbeddingResponse, tokenCount int) *BedrockInvokeEmbeddingResp {
+	out := &BedrockInvokeEmbeddingResp{InputTextTokenCount: tokenCount}
+
+	for _, d := range resp.Data {
+		switch d.EncodingFormat {
+		case schemas.EmbeddingEncodingFloat:
+			if out.EmbeddingsByType == nil {
+				out.EmbeddingsByType = &BedrockTitanEmbeddingsByType{}
 			}
-			floats = append(floats, float32Emb)
+			out.EmbeddingsByType.Float = d.Embedding.EmbeddingArray
+			out.Embedding = d.Embedding.EmbeddingArray
+		case schemas.EmbeddingEncodingBinary:
+			if out.EmbeddingsByType == nil {
+				out.EmbeddingsByType = &BedrockTitanEmbeddingsByType{}
+			}
+			out.EmbeddingsByType.Binary = d.Embedding.EmbeddingInt8Array
 		}
-		return &BedrockInvokeCohereEmbeddingResp{
-			Embeddings:   floats,
-			ResponseType: "embeddings_floats",
-		}, nil
 	}
 
-	// Titan format
-	if resp.Data[0].Embedding.EmbeddingArray == nil {
-		return &BedrockInvokeEmbeddingResp{InputTextTokenCount: tokenCount}, nil
+	// Unlabelled data means the provider sent only the legacy top-level vector
+	// (Titan G1, and V2 responses that predate embeddingsByType).
+	if out.EmbeddingsByType == nil {
+		out.Embedding = resp.Data[0].Embedding.EmbeddingArray
 	}
-	float32Emb := make([]float32, len(resp.Data[0].Embedding.EmbeddingArray))
-	for i, v := range resp.Data[0].Embedding.EmbeddingArray {
-		float32Emb[i] = float32(v)
+	return out
+}
+
+// toBedrockCohereEmbeddingInvokeResponse rebuilds the Cohere invoke envelope, picking
+// the typed shape when the entries carry encoding labels and the plain float shape
+// otherwise — matching the two response_type values Bedrock returns.
+func toBedrockCohereEmbeddingInvokeResponse(resp *schemas.BifrostEmbeddingResponse) interface{} {
+	var typed BedrockCohereEmbeddingsByType
+	isTyped := false
+	floats := make([][]float32, 0, len(resp.Data))
+
+	for _, d := range resp.Data {
+		switch d.EncodingFormat {
+		case schemas.EmbeddingEncodingFloat:
+			isTyped = true
+			typed.Float = append(typed.Float, bedrockFloat32Vector(d.Embedding.EmbeddingArray))
+		case schemas.EmbeddingEncodingBase64:
+			isTyped = true
+			if d.Embedding.EmbeddingStr != nil {
+				typed.Base64 = append(typed.Base64, *d.Embedding.EmbeddingStr)
+			}
+		case schemas.EmbeddingEncodingInt8:
+			isTyped = true
+			typed.Int8 = append(typed.Int8, d.Embedding.EmbeddingInt8Array)
+		case schemas.EmbeddingEncodingBinary:
+			isTyped = true
+			typed.Binary = append(typed.Binary, d.Embedding.EmbeddingInt8Array)
+		case schemas.EmbeddingEncodingUint8:
+			isTyped = true
+			typed.Uint8 = append(typed.Uint8, d.Embedding.EmbeddingInt32Array)
+		case schemas.EmbeddingEncodingUbinary:
+			isTyped = true
+			typed.Ubinary = append(typed.Ubinary, d.Embedding.EmbeddingInt32Array)
+		default:
+			floats = append(floats, bedrockFloat32Vector(d.Embedding.EmbeddingArray))
+		}
 	}
-	return &BedrockInvokeEmbeddingResp{
-		Embedding:           float32Emb,
-		InputTextTokenCount: tokenCount,
-	}, nil
+
+	if isTyped {
+		return &BedrockInvokeCohereTypedEmbeddingResp{
+			Embeddings:   typed,
+			ResponseType: "embeddings_by_type",
+		}
+	}
+	return &BedrockInvokeCohereEmbeddingResp{
+		Embeddings:   floats,
+		ResponseType: "embeddings_floats",
+	}
+}
+
+// bedrockFloat32Vector narrows a canonical float64 vector to the float32 precision the
+// Bedrock invoke wire format uses. An absent vector yields an empty slice, which
+// omitempty drops from the Titan envelope.
+func bedrockFloat32Vector(values []float64) []float32 {
+	out := make([]float32, len(values))
+	for i, v := range values {
+		out[i] = float32(v)
+	}
+	return out
 }
 
 // toBedrockInvokeAnthropicResponse converts BifrostResponsesResponse to Anthropic Messages API format.

--- a/core/providers/bedrock/types.go
+++ b/core/providers/bedrock/types.go
@@ -896,10 +896,11 @@ type BedrockMetadataEvent struct {
 
 // BedrockTitanEmbeddingRequest represents a Bedrock Titan embedding request
 type BedrockTitanEmbeddingRequest struct {
-	InputText   string                 `json:"inputText"`            // Required: Text to embed
-	Dimensions  *int                   `json:"dimensions,omitempty"` // Optional: 256, 512, or 1024 (titan-embed-text-v2 only)
-	Normalize   *bool                  `json:"normalize,omitempty"`  // Optional: normalize the embedding
-	ExtraParams map[string]interface{} `json:"-"`
+	InputText      string                 `json:"inputText"`                // Required: Text to embed
+	Dimensions     *int                   `json:"dimensions,omitempty"`     // Optional: 256, 512, or 1024 (titan-embed-text-v2 only)
+	Normalize      *bool                  `json:"normalize,omitempty"`      // Optional: normalize the embedding
+	EmbeddingTypes []string               `json:"embeddingTypes,omitempty"` // Optional: "float" and/or "binary" (titan-embed-text-v2 only)
+	ExtraParams    map[string]interface{} `json:"-"`
 }
 
 // GetExtraParams implements the RequestBodyWithExtraParams interface
@@ -909,8 +910,16 @@ func (req *BedrockTitanEmbeddingRequest) GetExtraParams() map[string]interface{}
 
 // BedrockTitanEmbeddingResponse represents a Bedrock Titan embedding response
 type BedrockTitanEmbeddingResponse struct {
-	Embedding           []float64 `json:"embedding"`           // The embedding vector
-	InputTextTokenCount int       `json:"inputTextTokenCount"` // Number of tokens in input
+	Embedding           []float64                     `json:"embedding"`                  // The default float embedding vector
+	EmbeddingsByType    *BedrockTitanEmbeddingsByType `json:"embeddingsByType,omitempty"` // Requested float and/or binary vectors
+	InputTextTokenCount int                           `json:"inputTextTokenCount"`        // Number of tokens in input
+}
+
+// BedrockTitanEmbeddingsByType is returned when Titan V2 embeddingTypes is set,
+// and is also how the native invoke response re-emits those representations.
+type BedrockTitanEmbeddingsByType struct {
+	Float  []float64 `json:"float,omitempty"`
+	Binary []int8    `json:"binary,omitempty"`
 }
 
 // BedrockCohereEmbeddingContentBlock represents a single content block in a mixed input
@@ -932,6 +941,11 @@ type BedrockCohereEmbeddingInput struct {
 
 // BedrockCohereEmbeddingRequest represents a Bedrock Cohere embedding request.
 // Unlike the direct Cohere API, Bedrock does not accept a "model" field in the body.
+
+// BedrockCohereInputTypeSearchDocument is the input_type applied when a caller omits
+// one. AWS requires the field and defines no default.
+const BedrockCohereInputTypeSearchDocument = "search_document"
+
 type BedrockCohereEmbeddingRequest struct {
 	InputType       string                        `json:"input_type"`                 // Required
 	Texts           []string                      `json:"texts,omitempty"`            // text-only inputs
@@ -958,6 +972,17 @@ type BedrockCohereEmbeddingResponse struct {
 	Embeddings   json.RawMessage `json:"embeddings"`
 	ResponseType string          `json:"response_type"`
 	Texts        []string        `json:"texts,omitempty"`
+}
+
+// BedrockCohereEmbeddingsByType is the "embeddings_by_type" object, used both when
+// parsing the provider response and when re-emitting it on the native invoke route.
+type BedrockCohereEmbeddingsByType struct {
+	Float   [][]float32 `json:"float,omitempty"`
+	Base64  []string    `json:"base64,omitempty"`
+	Int8    [][]int8    `json:"int8,omitempty"`
+	Uint8   [][]int32   `json:"uint8,omitempty"` // int32 avoids []byte→base64 JSON issue
+	Binary  [][]int8    `json:"binary,omitempty"`
+	Ubinary [][]int32   `json:"ubinary,omitempty"` // int32 avoids []byte→base64 JSON issue
 }
 
 const TaskTypeTextImage = "TEXT_IMAGE"
@@ -1339,14 +1364,15 @@ type BedrockInvokeRequest struct {
 
 	// ==================== EMBEDDINGS ====================
 
-	InputText       string                        `json:"inputText,omitempty"`        // Titan embed
-	Texts           []string                      `json:"texts,omitempty"`            // Cohere embed
-	InputType       *string                       `json:"input_type,omitempty"`       // Cohere embed
-	Normalize       *bool                         `json:"normalize,omitempty"`        // Titan embed v2
-	Dimensions      *int                          `json:"dimensions,omitempty"`       // Titan embed v2
-	EmbeddingTypes  []string                      `json:"embedding_types,omitempty"`  // Cohere embed: ["float","int8","uint8","binary","ubinary"]
-	OutputDimension *int                          `json:"output_dimension,omitempty"` // Cohere embed: 256, 512, 1024, 1536
-	Inputs          []BedrockCohereEmbeddingInput `json:"inputs,omitempty"`           // Cohere embed: mixed text+image inputs
+	InputText           string                        `json:"inputText,omitempty"`        // Titan embed
+	Texts               []string                      `json:"texts,omitempty"`            // Cohere embed
+	InputType           *string                       `json:"input_type,omitempty"`       // Cohere embed
+	Normalize           *bool                         `json:"normalize,omitempty"`        // Titan embed v2
+	Dimensions          *int                          `json:"dimensions,omitempty"`       // Titan embed v2
+	EmbeddingTypes      []string                      `json:"embedding_types,omitempty"`  // Cohere embed: ["float","int8","uint8","binary","ubinary"]
+	TitanEmbeddingTypes []string                      `json:"embeddingTypes,omitempty"`   // Titan V2 embed: ["float","binary"]
+	OutputDimension     *int                          `json:"output_dimension,omitempty"` // Cohere embed: 256, 512, 1024, 1536
+	Inputs              []BedrockCohereEmbeddingInput `json:"inputs,omitempty"`           // Cohere embed: mixed text+image inputs
 
 	// ==================== INTERNAL ====================
 	Stream      bool                   `json:"-"`
@@ -1360,13 +1386,25 @@ type BedrockCohereRMessage struct {
 }
 
 // BedrockInvokeEmbeddingResp is the Titan single-embedding invoke response format.
+// Embedding is omitted when only non-float representations were requested, matching
+// AWS, which drops the field for a binary-only embeddingTypes.
 type BedrockInvokeEmbeddingResp struct {
-	Embedding           []float32 `json:"embedding"`
-	InputTextTokenCount int       `json:"inputTextTokenCount"`
+	// float64 matches both the precision Titan actually returns and the type used
+	// under embeddingsByType, so the two copies of the float vector agree.
+	Embedding           []float64                     `json:"embedding,omitempty"`
+	EmbeddingsByType    *BedrockTitanEmbeddingsByType `json:"embeddingsByType,omitempty"`
+	InputTextTokenCount int                           `json:"inputTextTokenCount"`
 }
 
 // BedrockInvokeCohereEmbeddingResp is the Cohere multi-embedding invoke response format.
 type BedrockInvokeCohereEmbeddingResp struct {
 	Embeddings   [][]float32 `json:"embeddings"`
 	ResponseType string      `json:"response_type"`
+}
+
+// BedrockInvokeCohereTypedEmbeddingResp is the Cohere invoke response format once
+// embedding_types is set and Bedrock switches to the typed envelope.
+type BedrockInvokeCohereTypedEmbeddingResp struct {
+	Embeddings   BedrockCohereEmbeddingsByType `json:"embeddings"`
+	ResponseType string                        `json:"response_type"`
 }

--- a/core/schemas/embedding.go
+++ b/core/schemas/embedding.go
@@ -1,6 +1,7 @@
 package schemas
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -124,10 +125,61 @@ type EmbeddingParameters struct {
 	ExtraParams map[string]interface{} `json:"-"`
 }
 
+// Encoding names for the representations a provider can return for one input.
+const (
+	EmbeddingEncodingFloat   = "float"
+	EmbeddingEncodingInt8    = "int8"
+	EmbeddingEncodingUint8   = "uint8"
+	EmbeddingEncodingBinary  = "binary"
+	EmbeddingEncodingUbinary = "ubinary"
+	EmbeddingEncodingBase64  = "base64"
+)
+
 type EmbeddingData struct {
 	Index     int             `json:"index"`
 	Object    string          `json:"object"`    // "embedding"
 	Embedding EmbeddingStruct `json:"embedding"` // can be string, []float64, [][]float64, []int8, or []int32
+	// EncodingFormat names the representation this vector was returned as when a
+	// provider emits several for one input; int8/binary and uint8/ubinary are
+	// otherwise indistinguishable once decoded into EmbeddingStruct.
+	EncodingFormat string `json:"encoding_format,omitempty"`
+}
+
+// UnmarshalJSON routes the vector by its declared encoding. EmbeddingStruct decodes a
+// JSON number array as []float64 on the first attempt, so without this an int8 or
+// int32 representation would come back as floats — losing the distinction on any
+// path that stores the response as JSON and reads it back, such as a cache hit.
+func (d *EmbeddingData) UnmarshalJSON(data []byte) error {
+	// alias suppresses this method to avoid infinite recursion; the outer
+	// Embedding (json.RawMessage) shadows alias.Embedding so the vector is held
+	// undecoded until the encoding is known.
+	type alias EmbeddingData
+	aux := &struct {
+		*alias
+		Embedding json.RawMessage `json:"embedding"`
+	}{alias: (*alias)(d)}
+	if err := Unmarshal(data, aux); err != nil {
+		return err
+	}
+	if len(aux.Embedding) == 0 {
+		return nil
+	}
+
+	switch d.EncodingFormat {
+	case EmbeddingEncodingInt8, EmbeddingEncodingBinary:
+		var values []int8
+		if err := Unmarshal(aux.Embedding, &values); err == nil {
+			d.Embedding = EmbeddingStruct{EmbeddingInt8Array: values}
+			return nil
+		}
+	case EmbeddingEncodingUint8, EmbeddingEncodingUbinary:
+		var values []int32
+		if err := Unmarshal(aux.Embedding, &values); err == nil {
+			d.Embedding = EmbeddingStruct{EmbeddingInt32Array: values}
+			return nil
+		}
+	}
+	return d.Embedding.UnmarshalJSON(aux.Embedding)
 }
 
 type EmbeddingStruct struct {

--- a/core/schemas/serialization_test.go
+++ b/core/schemas/serialization_test.go
@@ -1800,3 +1800,59 @@ func TestSonic_ResponsesStreamCompleted_CapturesPromptCacheAndCacheWrite(t *test
 	assert.Equal(t, 80, stream.Response.Usage.InputTokensDetails.CachedWriteTokens)
 	assert.Equal(t, 1920, stream.Response.Usage.InputTokensDetails.CachedReadTokens)
 }
+
+func TestEmbeddingData_EncodingFormatSurvivesRoundTrip(t *testing.T) {
+	// A JSON number array decodes as []float64 on the first attempt, so without the
+	// encoding label an int8 or int32 representation would silently come back as
+	// floats on any store-and-replay path.
+	tests := []struct {
+		name   string
+		data   EmbeddingData
+		assert func(t *testing.T, got EmbeddingData)
+	}{
+		{
+			name: "binary stays int8",
+			data: EmbeddingData{Object: "embedding", Embedding: EmbeddingStruct{EmbeddingInt8Array: []int8{1, 0, -1}}, EncodingFormat: EmbeddingEncodingBinary},
+			assert: func(t *testing.T, got EmbeddingData) {
+				assert.Equal(t, []int8{1, 0, -1}, got.Embedding.EmbeddingInt8Array)
+				assert.Nil(t, got.Embedding.EmbeddingArray)
+			},
+		},
+		{
+			name: "ubinary stays int32",
+			data: EmbeddingData{Object: "embedding", Embedding: EmbeddingStruct{EmbeddingInt32Array: []int32{1, 255}}, EncodingFormat: EmbeddingEncodingUbinary},
+			assert: func(t *testing.T, got EmbeddingData) {
+				assert.Equal(t, []int32{1, 255}, got.Embedding.EmbeddingInt32Array)
+				assert.Nil(t, got.Embedding.EmbeddingArray)
+			},
+		},
+		{
+			name: "float stays float64",
+			data: EmbeddingData{Object: "embedding", Embedding: EmbeddingStruct{EmbeddingArray: []float64{0.25, 0.75}}, EncodingFormat: EmbeddingEncodingFloat},
+			assert: func(t *testing.T, got EmbeddingData) {
+				assert.Equal(t, []float64{0.25, 0.75}, got.Embedding.EmbeddingArray)
+			},
+		},
+		{
+			name: "unlabelled entry is unchanged",
+			data: EmbeddingData{Object: "embedding", Embedding: EmbeddingStruct{EmbeddingArray: []float64{0.25, 0.75}}},
+			assert: func(t *testing.T, got EmbeddingData) {
+				assert.Empty(t, got.EncodingFormat)
+				assert.Equal(t, []float64{0.25, 0.75}, got.Embedding.EmbeddingArray)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			serialized, err := json.Marshal(test.data)
+			require.NoError(t, err)
+
+			var got EmbeddingData
+			require.NoError(t, json.Unmarshal(serialized, &got))
+			assert.Equal(t, test.data.EncodingFormat, got.EncodingFormat)
+			assert.Equal(t, "embedding", got.Object)
+			test.assert(t, got)
+		})
+	}
+}

--- a/tests/e2e/api/HARNESS_COVERAGE_BACKLOG.md
+++ b/tests/e2e/api/HARNESS_COVERAGE_BACKLOG.md
@@ -198,7 +198,7 @@ Sources:
 ### InvokeModel API (`POST /model/{modelId}/invoke`)
 
 - [x] **Direct invoke** with Anthropic-native provider body, incl. image/tool_use/tool_result content blocks — folder 37 (#5560)
-- [ ] **Direct invoke** with Cohere-native provider body
+- [x] **Direct invoke** with Cohere-native embedding body — folder 58.C (PR #6335)
 - [x] **Invoke streaming** (`POST /model/{modelId}/invoke-with-response-stream`) — folder 36 (#5629), folder 37 (#5560)
 - [ ] **Async invocation jobs** (`POST /model-invocation-job` + list + get + stop)
 
@@ -221,17 +221,22 @@ Sources:
 Bedrock is the only provider carrying two incompatible embedding envelopes behind one name.
 `DetermineEmbeddingModelType` picks between them by substring match on the model id, so the same
 `/v1/embeddings` request behaves differently depending on whether the id contains `titan` or
-`cohere`. There is no embedding route on the `/bedrock` drop-in: `/bedrock/model/{id}/invoke`
-converts to Converse and then to Responses, so Bedrock embeddings are reachable only via
-`/v1/embeddings`, `/openai/v1/embeddings`, `/genai/.../:embedContent` and `/cohere/v2/embed`.
+`cohere`. Native InvokeModel embeddings are available through `/bedrock/model/{id}/invoke`,
+with `/langchain/model/{id}/invoke` providing the same route plus LangChain compatibility.
+Normalized embeddings remain available through `/v1/embeddings`, `/openai/v1/embeddings`,
+`/genai/.../:embedContent` and `/cohere/v2/embed`.
 
 - [x] **Titan V2 baseline** (`inputText`, one vector out, `inputTextTokenCount` to usage) - folder 53.A1
 - [x] **Titan `dimensions`** (1024 default | 512 | 256) - folder 53.A2
 - [x] **Titan array-input collapse** (no batch shape; Bifrost joins with `" \n"`, returns 1 vector) - folder 53.A3
 - [x] **Titan `normalize`** (default true; proven via L2 norm of the returned vector) - folder 53.A4 / 53.A5
 - [x] **Titan `embeddingTypes`** (camelCase; `embeddingsByType` recovered through `x-bf-send-back-raw-response`) - folder 53.A6
+- [x] **Titan native InvokeModel typed envelopes** (`binary` alone and `float` + `binary`) — folder 58.A / 58.B (PR #6335)
 - [x] **Cohere v4 `input_type`** (required by AWS; both the native `/cohere/v2/embed` route and `extra_params`) - folder 53.B1 / 53.B4
 - [x] **Cohere v4 `embedding_types`** (`embeddings_by_type` int8 parse branch) - folder 53.B2
+- [x] **Cohere v4 native InvokeModel typed envelope** (`float`, `int8`, `uint8`, `binary`, `ubinary`) — folder 58.C (PR #6335)
+- [x] **LangChain Cohere singular `embedding` alias** while preserving native plural `embeddings` — folder 58.D (PR #6335)
+- [x] **Normalized Titan dual representations without raw-response leakage** — folder 58.E (PR #6335)
 - [x] **Cohere v4 array input** (one vector per text, the arity divergence against Titan) - folder 53.B5
 - [x] **Cohere v4 `output_dimension`** (256 | 512 | 1024 | 1536) - folder 53.B6 / 53.D4
 - [x] **Usage backfill from `X-Amzn-Bedrock-Input-Token-Count`** (Cohere embed omits usage from the body; #3917) - folder 53.B7

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -107,6 +107,22 @@
           "    } else if (j.embedding && Array.isArray(j.embedding.values)) {",
           "        shape = 'genai-embedding';",
           "        hasContent = j.embedding.values.length > 0;",
+          "    } else if (j.embeddingsByType && typeof j.embeddingsByType === 'object') {",
+          "        shape = 'bedrock-titan-typed-embedding';",
+          "        var titanEmbeddingTypes = ['float', 'binary'];",
+          "        hasContent = titanEmbeddingTypes.some(function (type) {",
+          "            return Array.isArray(j.embeddingsByType[type]) && j.embeddingsByType[type].length > 0;",
+          "        });",
+          "    } else if (Array.isArray(j.embeddings)) {",
+          "        shape = 'bedrock-cohere-embedding';",
+          "        hasContent = j.embeddings.some(function (vector) { return Array.isArray(vector) && vector.length > 0; });",
+          "    } else if (j.embeddings && typeof j.embeddings === 'object') {",
+          "        shape = 'bedrock-cohere-typed-embedding';",
+          "        var cohereEmbeddingTypes = ['float', 'int8', 'uint8', 'binary', 'ubinary'];",
+          "        hasContent = cohereEmbeddingTypes.some(function (type) {",
+          "            var vectors = j.embeddings[type];",
+          "            return Array.isArray(vectors) && vectors.length > 0 && Array.isArray(vectors[0]) && vectors[0].length > 0;",
+          "        });",
           "    } else if (Array.isArray(j.embedding)) {",
           "        shape = 'bedrock-titan-embedding';",
           "        hasContent = j.embedding.length > 0;",
@@ -130349,11 +130365,11 @@
     },
     {
       "name": "53. Embeddings x provider x parameter surface",
-      "description": "Embedding coverage before this folder was one request per provider, each sending a single string and asserting nothing beyond the collection-level status check - and that check is a no-op for embeddings, because the shape branch it lands in is Array.isArray(j.data) with hasContent = j.data.length >= 0, which is true for an empty list. A provider returning zero vectors passed.\n\nThis folder pins the request parameter surface end to end: what the caller sends at the gateway, what the provider-native field is called, and what observable property of the response proves the rename survived the trip. Bedrock gets the depth because it is the only provider carrying two incompatible embedding envelopes behind one name, chosen by substring match on the model id.\n\nRoute reachability worth knowing before adding rows here: /v1/embeddings parses exactly four body fields (model, input, encoding_format, dimensions) plus fallbacks. Every other key is dropped silently unless the request carries x-bf-passthrough-extra-params: true and nests the key under \"extra_params\" (transports/bifrost-http/integrations/router.go). There is no embedding route on the /bedrock drop-in at all - /bedrock/model/{id}/invoke converts to Converse and then to Responses - so Bedrock embeddings are reachable only through /v1/embeddings, /openai/v1/embeddings, /genai/.../:embedContent and /cohere/v2/embed.\n\nSub-folder names avoid provider keywords on purpose. runners/filter-collection.mjs matches PROVIDER against ancestor folder names as well as the item body, so naming this folder after Bedrock would hand every openai/gemini/vertex/azure row to the bedrock partition.",
+      "description": "Embedding coverage before this folder was one request per provider, each sending a single string and asserting nothing beyond the collection-level status check - and that check is a no-op for embeddings, because the shape branch it lands in is Array.isArray(j.data) with hasContent = j.data.length >= 0, which is true for an empty list. A provider returning zero vectors passed.\n\nThis folder pins the request parameter surface end to end: what the caller sends at the gateway, what the provider-native field is called, and what observable property of the response proves the rename survived the trip. Bedrock gets the depth because it is the only provider carrying two incompatible embedding envelopes behind one name, chosen by substring match on the model id.\n\nRoute reachability worth knowing before adding rows here: /v1/embeddings parses exactly four body fields (model, input, encoding_format, dimensions) plus fallbacks. Every other key is dropped silently unless the request carries x-bf-passthrough-extra-params: true and nests the key under \"extra_params\" (transports/bifrost-http/integrations/router.go). Native Bedrock embeddings are also reachable through /bedrock/model/{id}/invoke and /langchain/model/{id}/invoke; normalized and SDK-compatible routes include /v1/embeddings, /openai/v1/embeddings, /genai/.../:embedContent and /cohere/v2/embed.\n\nSub-folder names avoid provider keywords on purpose. runners/filter-collection.mjs matches PROVIDER against ancestor folder names as well as the item body, so naming this folder after Bedrock would hand every openai/gemini/vertex/azure row to the bedrock partition.",
       "item": [
         {
           "name": "53.A Bedrock Titan envelope (amazon.titan-embed-*)",
-          "description": "Titan takes a single `inputText` string and returns a single vector, so Bifrost joins array input with \" \\n\" before sending (core/providers/bedrock/embedding.go ToBedrockTitanEmbeddingRequest). These rows pin the Titan-shaped request body reaching AWS and the single-vector response coming back.\n\nAWS request fields (docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-embed-text.html): inputText (required), dimensions (1024 default | 512 | 256), normalize (default true), embeddingTypes (camelCase, [\"float\"] | [\"binary\"] | both). Response: embedding, inputTextTokenCount, embeddingsByType.\n\nnormalize and embeddingTypes are not first-class fields on /v1/embeddings - only model, input, encoding_format and dimensions are parsed there. They reach the provider through x-bf-passthrough-extra-params: true plus an \"extra_params\" object, which is the door those rows use.",
+          "description": "Titan takes a single `inputText` string, so Bifrost joins array input with \" \\n\" before sending (core/providers/bedrock/embedding.go ToBedrockTitanEmbeddingRequest). The legacy/default response has one float vector; `embeddingTypes` returns one vector per requested representation. These rows pin the Titan-shaped request body reaching AWS and every requested representation coming back.\n\nAWS request fields (docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-embed-text.html): inputText (required), dimensions (1024 default | 512 | 256), normalize (default true), embeddingTypes (camelCase, [\"float\"] | [\"binary\"] | both). Response: embedding, inputTextTokenCount, embeddingsByType.\n\nnormalize and embeddingTypes are not first-class fields on /v1/embeddings - only model, input, encoding_format and dimensions are parsed there. They reach the provider through x-bf-passthrough-extra-params: true plus an \"extra_params\" object, which is the door those rows use.",
           "item": [
             {
               "name": "53.A1 bedrock/amazon.titan-embed-text-v2:0 - baseline single input",
@@ -130640,7 +130656,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"model\": \"bedrock/amazon.titan-embed-text-v2:0\",\n  \"input\": \"Hello world\",\n  \"extra_params\": {\n    \"embeddingTypes\": [\n      \"float\",\n      \"binary\"\n    ]\n  }\n}"
+                  "raw": "{\n  \"model\": \"bedrock/amazon.titan-embed-text-v2:0\",\n  \"input\": \"Hello world\",\n  \"embeddingTypes\": [\n    \"float\",\n    \"binary\"\n  ]\n}"
                 },
                 "url": {
                   "raw": "{{baseUrl}}/v1/embeddings",
@@ -130668,15 +130684,19 @@
                       "var data = j.data || [];",
                       "// AWS documents embeddingTypes (camelCase) as a Titan V2 field, and warns that the",
                       "// `embedding` field is omitted entirely when embeddingTypes contains only \"binary\".",
-                      "// This row asks for both, so the normalized float path must stay intact while the",
-                      "// binary variant is still recoverable from the raw provider payload.",
-                      "pm.test('returns 1 vector(s) - float path survives alongside binary', function () {",
+                      "// This row asks for both, so both normalized representations must survive while",
+                      "// the native AWS envelope remains recoverable from the opted-in raw payload.",
+                      "pm.test('returns both normalized float and binary representations', function () {",
                       "  pm.expect(data.length, 'wrong vector count; body: ' + pm.response.text().slice(0, 300))",
-                      "    .to.eql(1);",
+                      "    .to.eql(2);",
+                      "  var formats = [];",
                       "  for (var i = 0; i < data.length; i++) {",
                       "    pm.expect(Array.isArray(data[i].embedding), 'data[' + i + '].embedding is not an array').to.be.true;",
                       "    pm.expect(data[i].embedding.length, 'data[' + i + '].embedding is empty').to.be.above(0);",
+                      "    formats.push(data[i].encoding_format);",
                       "  }",
+                      "  formats.sort();",
+                      "  pm.expect(formats, 'expected one float and one binary representation').to.eql(['binary', 'float']);",
                       "});",
                       "pm.test('embeddingsByType.binary reached the caller via raw_response', function () {",
                       "  var raw = (j.extra_fields || {}).raw_response || {};",
@@ -136261,6 +136281,286 @@
               ]
             }
           }
+        }
+      ]
+    },
+    {
+      "name": "58. Typed embedding envelopes and SDK alias (PR #6335)",
+      "item": [
+        {
+          "name": "58.A bedrock/model Titan V2 binary-only native envelope - PR #6335",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"inputText\": \"binary-only embedding harness check\",\n  \"dimensions\": 256,\n  \"embeddingTypes\": [\n    \"binary\"\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/bedrock/model/amazon.titan-embed-text-v2:0/invoke",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "bedrock",
+                "model",
+                "amazon.titan-embed-text-v2:0",
+                "invoke"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// 400 is deliberately not guarded: rejecting this valid Titan body is a feature failure.",
+                  "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.test('Titan binary-only invoke returns the AWS embeddingsByType envelope', function () {",
+                  "  var byType = j.embeddingsByType || {};",
+                  "  pm.expect(byType, 'embeddingsByType missing; body: ' + pm.response.text().slice(0, 300)).to.have.property('binary');",
+                  "  pm.expect(Array.isArray(byType.binary), 'embeddingsByType.binary is not an array').to.be.true;",
+                  "  pm.expect(byType.binary.length, 'embeddingsByType.binary is empty').to.be.above(0);",
+                  "  for (var i = 0; i < byType.binary.length; i++) {",
+                  "    pm.expect(byType.binary[i], 'binary value outside Titan range at ' + i).to.be.within(-1, 1);",
+                  "    pm.expect(byType.binary[i] % 1, 'binary value is not an integer at ' + i).to.eql(0);",
+                  "  }",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "58.B bedrock/model Titan V2 float+binary native envelope - PR #6335",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"inputText\": \"dual representation embedding harness check\",\n  \"dimensions\": 256,\n  \"embeddingTypes\": [\n    \"float\",\n    \"binary\"\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/bedrock/model/amazon.titan-embed-text-v2:0/invoke",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "bedrock",
+                "model",
+                "amazon.titan-embed-text-v2:0",
+                "invoke"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// 400 is deliberately not guarded: rejecting this valid Titan body is a feature failure.",
+                  "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.test('Titan combined invoke preserves both AWS typed representations', function () {",
+                  "  var byType = j.embeddingsByType || {};",
+                  "  pm.expect(Array.isArray(byType.float), 'embeddingsByType.float missing; body: ' + pm.response.text().slice(0, 300)).to.be.true;",
+                  "  pm.expect(byType.float.length, 'embeddingsByType.float is empty').to.be.above(0);",
+                  "  pm.expect(Array.isArray(byType.binary), 'embeddingsByType.binary missing; body: ' + pm.response.text().slice(0, 300)).to.be.true;",
+                  "  pm.expect(byType.binary.length, 'embeddingsByType.binary is empty').to.be.above(0);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "58.C bedrock/model Cohere v4 all typed encodings native envelope - PR #6335",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"texts\": [\n    \"cohere typed embedding harness check\"\n  ],\n  \"input_type\": \"search_document\",\n  \"output_dimension\": 256,\n  \"embedding_types\": [\n    \"float\",\n    \"int8\",\n    \"uint8\",\n    \"binary\",\n    \"ubinary\"\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/bedrock/model/global.cohere.embed-v4:0/invoke",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "bedrock",
+                "model",
+                "global.cohere.embed-v4:0",
+                "invoke"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// 400 is deliberately not guarded: rejecting these documented Cohere encodings is a feature failure.",
+                  "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.test('Cohere invoke returns embeddings_by_type', function () {",
+                  "  pm.expect(j.response_type, 'unexpected response envelope: ' + pm.response.text().slice(0, 300)).to.eql('embeddings_by_type');",
+                  "});",
+                  "pm.test('Cohere invoke preserves every requested encoding', function () {",
+                  "  var embeddings = j.embeddings || {};",
+                  "  var types = ['float', 'int8', 'uint8', 'binary', 'ubinary'];",
+                  "  for (var i = 0; i < types.length; i++) {",
+                  "    var vectors = embeddings[types[i]];",
+                  "    pm.expect(Array.isArray(vectors), types[i] + ' vectors missing; body: ' + pm.response.text().slice(0, 300)).to.be.true;",
+                  "    pm.expect(vectors.length, types[i] + ' vector list is empty').to.be.above(0);",
+                  "    pm.expect(Array.isArray(vectors[0]), types[i] + ' first vector is not an array').to.be.true;",
+                  "    pm.expect(vectors[0].length, types[i] + ' first vector is empty').to.be.above(0);",
+                  "  }",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "58.D langchain/model Cohere v3 singular embedding alias - PR #6335",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"texts\": [\n    \"langchain cohere compatibility harness check\"\n  ],\n  \"input_type\": \"search_document\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/langchain/model/cohere.embed-english-v3/invoke",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "langchain",
+                "model",
+                "cohere.embed-english-v3",
+                "invoke"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// 400 is deliberately not guarded: this is the stock LangChain BedrockEmbeddings request shape.",
+                  "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "pm.test('LangChain gets the singular embedding field it reads', function () {",
+                  "  pm.expect(Array.isArray(j.embedding), 'singular embedding missing; body: ' + pm.response.text().slice(0, 300)).to.be.true;",
+                  "  pm.expect(j.embedding.length, 'singular embedding is empty').to.be.above(0);",
+                  "});",
+                  "pm.test('native plural embeddings remain intact', function () {",
+                  "  pm.expect(Array.isArray(j.embeddings), 'native embeddings list missing').to.be.true;",
+                  "  pm.expect(j.embeddings.length, 'native embeddings list is empty').to.be.above(0);",
+                  "  pm.expect(j.embedding, 'singular alias does not match embeddings[0]').to.eql(j.embeddings[0]);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "58.E bedrock/v1 Titan float+binary normalized without raw leakage - PR #6335",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-passthrough-extra-params",
+                "value": "true"
+              },
+              {
+                "key": "x-bf-send-back-raw-response",
+                "value": "false"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"bedrock/amazon.titan-embed-text-v2:0\",\n  \"input\": \"normalized dual representation harness check\",\n  \"dimensions\": 256,\n  \"embeddingTypes\": [\n    \"float\",\n    \"binary\"\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/embeddings",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "embeddings"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// 400 is deliberately not guarded: losing a requested representation is a feature failure.",
+                  "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                  "var j; try { j = pm.response.json(); } catch (e) {",
+                  "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
+                  "var data = j.data || [];",
+                  "pm.test('normalized Titan response retains float and binary vectors', function () {",
+                  "  pm.expect(data.length, 'expected two typed vectors; body: ' + pm.response.text().slice(0, 300)).to.eql(2);",
+                  "  // Each entry names the representation it came back as, so the encodings",
+                  "  // are read off the response instead of guessed from the vector values.",
+                  "  var formats = [];",
+                  "  for (var i = 0; i < data.length; i++) {",
+                  "    var vector = data[i].embedding || [];",
+                  "    pm.expect(vector.length, 'data[' + i + '].embedding is empty').to.be.above(0);",
+                  "    formats.push(data[i].encoding_format);",
+                  "  }",
+                  "  formats.sort();",
+                  "  pm.expect(formats, 'expected one float and one binary representation; body: ' + pm.response.text().slice(0, 300)).to.eql(['binary', 'float']);",
+                  "});",
+                  "pm.test('provider-native envelope never surfaces on the normalized endpoint', function () {",
+                  "  // raw_response presence is governed by the provider's send_back_raw_response",
+                  "  // config, so it is not asserted here; the envelope shape is the invariant.",
+                  "  pm.expect(j.embeddingsByType, 'provider-native envelope leaked at the top level').to.be.undefined;",
+                  "});"
+                ]
+              }
+            }
+          ]
         }
       ]
     }

--- a/tests/integrations/python/tests/test_bedrock.py
+++ b/tests/integrations/python/tests/test_bedrock.py
@@ -56,6 +56,8 @@ Invoke Endpoint — Image Generation Tests (TestBedrockInvokeEndpoint):
 29. Titan image generation via invoke (taskType=TEXT_IMAGE)
 30. Titan embeddings via invoke (inputText)
 31. Titan embeddings with params via invoke (inputText + params)
+31a. Titan binary embeddings via invoke (embeddingTypes=["binary"])
+31b. Titan float+binary embeddings via invoke (embeddingTypes=["float","binary"])
 32. Cohere embeddings via invoke (texts array)
 33. Titan inpainting via invoke (taskType=INPAINTING)
 34. Titan outpainting via invoke (taskType=OUTPAINTING)
@@ -2201,6 +2203,68 @@ class TestBedrockInvokeEndpoint:
         _assert_invoke_embedding(out)
         assert len(out["embedding"]) == 256, (
             f"Expected 256-dim embedding, got {len(out['embedding'])}"
+        )
+
+    # ------------------------------------------------------------------ #
+    # 31a. Titan binary embeddings                                        #
+    # ------------------------------------------------------------------ #
+    @skip_if_no_api_key("bedrock")
+    def test_31a_invoke_titan_binary_embeddings(self, bedrock_client):
+        """Test Case 31a: Titan Embed Text v2 returns embeddingsByType.binary."""
+        print("\n=== Test 31a: Titan binary embeddings via invoke ===")
+
+        body = {
+            "inputText": "compact binary embedding",
+            "dimensions": 256,
+            "normalize": True,
+            "embeddingTypes": ["binary"],
+        }
+
+        response = bedrock_client.invoke_model(
+            modelId="amazon.titan-embed-text-v2:0",
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps(body),
+        )
+        out = json.loads(response["body"].read())
+        binary = out.get("embeddingsByType", {}).get("binary")
+        assert isinstance(binary, list) and len(binary) > 0, (
+            f"Expected non-empty embeddingsByType.binary, got: {out}"
+        )
+        assert all(isinstance(value, int) for value in binary), (
+            "Titan binary embedding values must be integers"
+        )
+
+    # ------------------------------------------------------------------ #
+    # 31b. Titan float + binary embeddings                                #
+    # ------------------------------------------------------------------ #
+    @skip_if_no_api_key("bedrock")
+    def test_31b_invoke_titan_float_and_binary_embeddings(self, bedrock_client):
+        """Test Case 31b: Titan Embed Text v2 preserves both requested encodings."""
+        print("\n=== Test 31b: Titan float + binary embeddings via invoke ===")
+
+        body = {
+            "inputText": "dual format embedding",
+            "dimensions": 256,
+            "normalize": True,
+            "embeddingTypes": ["float", "binary"],
+        }
+
+        response = bedrock_client.invoke_model(
+            modelId="amazon.titan-embed-text-v2:0",
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps(body),
+        )
+        out = json.loads(response["body"].read())
+        typed = out.get("embeddingsByType", {})
+        float_vector = typed.get("float")
+        binary_vector = typed.get("binary")
+        assert isinstance(float_vector, list) and len(float_vector) == 256, (
+            f"Expected 256-dim embeddingsByType.float, got: {out}"
+        )
+        assert isinstance(binary_vector, list) and len(binary_vector) > 0, (
+            f"Expected non-empty embeddingsByType.binary, got: {out}"
         )
 
     # ------------------------------------------------------------------ #

--- a/transports/bifrost-http/integrations/bedrock_test.go
+++ b/transports/bifrost-http/integrations/bedrock_test.go
@@ -3,6 +3,7 @@ package integrations
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -242,6 +243,206 @@ func Test_createBedrockInvokeRouteConfig(t *testing.T) {
 	reqInstance := route.GetRequestTypeInstance(context.Background())
 	_, ok := reqInstance.(*bedrock.BedrockInvokeRequest)
 	assert.True(t, ok, "GetRequestTypeInstance should return *bedrock.BedrockInvokeRequest")
+}
+
+func TestBedrockInvokeEmbeddingResponseLangChainCohereAlias(t *testing.T) {
+	handlerStore := &mockHandlerStore{}
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	response := &schemas.BifrostEmbeddingResponse{
+		Model: "cohere.embed-english-v3",
+		Data: []schemas.EmbeddingData{
+			{
+				Index:  0,
+				Object: "embedding",
+				Embedding: schemas.EmbeddingStruct{
+					EmbeddingArray: []float64{0.25, 0.75},
+				},
+			},
+		},
+		Object: "list",
+	}
+
+	bedrockRoute := createBedrockInvokeRouteConfig("/bedrock", handlerStore)
+	bedrockResult, err := bedrockRoute.EmbeddingResponseConverter(ctx, response)
+	require.NoError(t, err)
+	bedrockJSON, err := json.Marshal(bedrockResult)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"embeddings":[[0.25,0.75]],
+		"response_type":"embeddings_floats"
+	}`, string(bedrockJSON), "native Bedrock must retain the AWS Cohere envelope")
+
+	langChainRoute := withLangChainBedrockEmbeddingCompatibility([]RouteConfig{createBedrockInvokeRouteConfig("/langchain", handlerStore)})[0]
+	langChainResult, err := langChainRoute.EmbeddingResponseConverter(ctx, response)
+	require.NoError(t, err)
+	langChainJSON, err := json.Marshal(langChainResult)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"embedding":[0.25,0.75],
+		"embeddings":[[0.25,0.75]],
+		"response_type":"embeddings_floats"
+	}`, string(langChainJSON), "LangChain needs singular embedding while native clients retain embeddings")
+}
+
+func TestBedrockInvokeTypedCohereResponseLangChainAlias(t *testing.T) {
+	handlerStore := &mockHandlerStore{}
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	response := &schemas.BifrostEmbeddingResponse{
+		Model:  "cohere.embed-v4:0",
+		Object: "list",
+		Data: []schemas.EmbeddingData{
+			{
+				Index:          0,
+				Object:         "embedding",
+				Embedding:      schemas.EmbeddingStruct{EmbeddingArray: []float64{0.25, 0.75}},
+				EncodingFormat: schemas.EmbeddingEncodingFloat,
+			},
+			{
+				Index:          0,
+				Object:         "embedding",
+				Embedding:      schemas.EmbeddingStruct{EmbeddingInt8Array: []int8{1, -1}},
+				EncodingFormat: schemas.EmbeddingEncodingInt8,
+			},
+		},
+	}
+
+	bedrockRoute := createBedrockInvokeRouteConfig("/bedrock", handlerStore)
+	bedrockResult, err := bedrockRoute.EmbeddingResponseConverter(ctx, response)
+	require.NoError(t, err)
+	bedrockJSON, err := json.Marshal(bedrockResult)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"response_type":"embeddings_by_type",
+		"embeddings":{"float":[[0.25,0.75]],"int8":[[1,-1]]}
+	}`, string(bedrockJSON), "native Bedrock must retain the typed AWS envelope")
+
+	langChainRoute := withLangChainBedrockEmbeddingCompatibility([]RouteConfig{createBedrockInvokeRouteConfig("/langchain", handlerStore)})[0]
+	result, err := langChainRoute.EmbeddingResponseConverter(ctx, response)
+	require.NoError(t, err)
+	resultJSON, err := json.Marshal(result)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"response_type":"embeddings_by_type",
+		"embedding":[0.25,0.75],
+		"embeddings":{"float":[[0.25,0.75]],"int8":[[1,-1]]}
+	}`, string(resultJSON), "the alias must expose the float representation LangChain expects")
+}
+
+func TestBedrockInvokeTypedCohereResponseWithoutFloatIsNotAliased(t *testing.T) {
+	handlerStore := &mockHandlerStore{}
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	response := &schemas.BifrostEmbeddingResponse{
+		Model:  "cohere.embed-v4:0",
+		Object: "list",
+		Data: []schemas.EmbeddingData{
+			{
+				Index:          0,
+				Object:         "embedding",
+				Embedding:      schemas.EmbeddingStruct{EmbeddingInt8Array: []int8{1, -1}},
+				EncodingFormat: schemas.EmbeddingEncodingInt8,
+			},
+		},
+	}
+
+	// LangChain's BedrockEmbeddings reads a number[] and never requests typed
+	// encodings, so an int8-only envelope has nothing meaningful to alias.
+	langChainRoute := withLangChainBedrockEmbeddingCompatibility([]RouteConfig{createBedrockInvokeRouteConfig("/langchain", handlerStore)})[0]
+	result, err := langChainRoute.EmbeddingResponseConverter(ctx, response)
+	require.NoError(t, err)
+	resultJSON, err := json.Marshal(result)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"response_type":"embeddings_by_type",
+		"embeddings":{"int8":[[1,-1]]}
+	}`, string(resultJSON))
+}
+
+func TestBedrockInvokeEmbeddingResponseLangChainLeavesTitanUnchanged(t *testing.T) {
+	handlerStore := &mockHandlerStore{}
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	response := &schemas.BifrostEmbeddingResponse{
+		Model: "amazon.titan-embed-text-v2:0",
+		Data: []schemas.EmbeddingData{
+			{
+				Index:  0,
+				Object: "embedding",
+				Embedding: schemas.EmbeddingStruct{
+					EmbeddingArray: []float64{0.25, 0.75},
+				},
+			},
+		},
+		Object: "list",
+	}
+
+	langChainRoute := withLangChainBedrockEmbeddingCompatibility([]RouteConfig{createBedrockInvokeRouteConfig("/langchain", handlerStore)})[0]
+	result, err := langChainRoute.EmbeddingResponseConverter(ctx, response)
+	require.NoError(t, err)
+	_, ok := result.(*bedrock.BedrockInvokeEmbeddingResp)
+	assert.True(t, ok)
+}
+
+func TestBedrockInvokeTypedTitanResponseLangChainLeavesEnvelopeUnchanged(t *testing.T) {
+	handlerStore := &mockHandlerStore{}
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	response := &schemas.BifrostEmbeddingResponse{
+		Model:  "amazon.titan-embed-text-v2:0",
+		Object: "list",
+		Data: []schemas.EmbeddingData{
+			{
+				Index:          0,
+				Object:         "embedding",
+				Embedding:      schemas.EmbeddingStruct{EmbeddingArray: []float64{0.25, 0.75}},
+				EncodingFormat: schemas.EmbeddingEncodingFloat,
+			},
+			{
+				Index:          0,
+				Object:         "embedding",
+				Embedding:      schemas.EmbeddingStruct{EmbeddingInt8Array: []int8{1, 0}},
+				EncodingFormat: schemas.EmbeddingEncodingBinary,
+			},
+		},
+	}
+
+	langChainRoute := withLangChainBedrockEmbeddingCompatibility([]RouteConfig{createBedrockInvokeRouteConfig("/langchain", handlerStore)})[0]
+	result, err := langChainRoute.EmbeddingResponseConverter(ctx, response)
+	require.NoError(t, err)
+	resultJSON, err := json.Marshal(result)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"embedding":[0.25,0.75],
+		"embeddingsByType":{"float":[0.25,0.75],"binary":[1,0]},
+		"inputTextTokenCount":0
+	}`, string(resultJSON), "Titan already carries the singular field AWS defines; the alias must not touch it")
+}
+
+func TestBedrockInvokeTypedCohereResponseUsesResolvedModelForAlias(t *testing.T) {
+	handlerStore := &mockHandlerStore{}
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	response := &schemas.BifrostEmbeddingResponse{
+		Object: "list",
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			ResolvedModelUsed: "cohere.embed-v4:0",
+		},
+		Data: []schemas.EmbeddingData{
+			{
+				Index:          0,
+				Object:         "embedding",
+				Embedding:      schemas.EmbeddingStruct{EmbeddingArray: []float64{0.25, 0.75}},
+				EncodingFormat: schemas.EmbeddingEncodingFloat,
+			},
+		},
+	}
+
+	langChainRoute := withLangChainBedrockEmbeddingCompatibility([]RouteConfig{createBedrockInvokeRouteConfig("/langchain", handlerStore)})[0]
+	result, err := langChainRoute.EmbeddingResponseConverter(ctx, response)
+	require.NoError(t, err)
+	resultJSON, err := json.Marshal(result)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"response_type":"embeddings_by_type",
+		"embedding":[0.25,0.75],
+		"embeddings":{"float":[[0.25,0.75]]}
+	}`, string(resultJSON), "family resolution must fall back to the resolved model")
 }
 
 func Test_createBedrockInvokeWithResponseStreamRouteConfig(t *testing.T) {

--- a/transports/bifrost-http/integrations/langchain.go
+++ b/transports/bifrost-http/integrations/langchain.go
@@ -2,6 +2,7 @@ package integrations
 
 import (
 	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/providers/bedrock"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 )
@@ -31,12 +32,76 @@ func NewLangChainRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, 
 	routes = append(routes, CreateGenAIRouteConfigs("/langchain")...)
 
 	// Add Bedrock routes to LangChain for AWS Bedrock API compatibility
-	routes = append(routes, CreateBedrockRouteConfigs("/langchain", handlerStore)...)
+	routes = append(routes, withLangChainBedrockEmbeddingCompatibility(CreateBedrockRouteConfigs("/langchain", handlerStore))...)
 
 	// Add Cohere routes to LangChain for Cohere API compatibility
 	routes = append(routes, CreateCohereRouteConfigs("/langchain")...)
 
 	return &LangChainRouter{
 		GenericRouter: NewGenericRouter(client, handlerStore, routes, nil, logger),
+	}
+}
+
+// withLangChainBedrockEmbeddingCompatibility decorates the native Bedrock
+// embedding converter with the singular field expected by LangChain's
+// BedrockEmbeddings parser. The underlying Bedrock routes remain AWS-compatible.
+func withLangChainBedrockEmbeddingCompatibility(routes []RouteConfig) []RouteConfig {
+	for i := range routes {
+		converter := routes[i].EmbeddingResponseConverter
+		if converter == nil {
+			continue
+		}
+		routes[i].EmbeddingResponseConverter = func(ctx *schemas.BifrostContext, resp *schemas.BifrostEmbeddingResponse) (interface{}, error) {
+			converted, err := converter(ctx, resp)
+			if err != nil {
+				return converted, err
+			}
+			return addLangChainCohereEmbeddingAlias(converted), nil
+		}
+	}
+	return routes
+}
+
+// langChainCohereEmbedding is the Bedrock Cohere invoke envelope plus the singular
+// "embedding" field LangChain's BedrockEmbeddings reads: that class parses
+// body.embedding for every model, while the AWS envelope only carries the plural.
+type langChainCohereEmbedding struct {
+	Embedding    []float32   `json:"embedding"`
+	Embeddings   [][]float32 `json:"embeddings"`
+	ResponseType string      `json:"response_type"`
+}
+
+// langChainCohereTypedEmbedding is the same alias over the typed encoding envelope.
+type langChainCohereTypedEmbedding struct {
+	Embedding    []float32                             `json:"embedding"`
+	Embeddings   bedrock.BedrockCohereEmbeddingsByType `json:"embeddings"`
+	ResponseType string                                `json:"response_type"`
+}
+
+// addLangChainCohereEmbeddingAlias re-emits a Cohere embedding envelope with the
+// singular alias. Only a float vector is aliased, since LangChain expects number[].
+// The native fields are carried through unchanged.
+func addLangChainCohereEmbeddingAlias(response interface{}) interface{} {
+	switch value := response.(type) {
+	case *bedrock.BedrockInvokeCohereEmbeddingResp:
+		if len(value.Embeddings) == 0 {
+			return response
+		}
+		return &langChainCohereEmbedding{
+			Embedding:    value.Embeddings[0],
+			Embeddings:   value.Embeddings,
+			ResponseType: value.ResponseType,
+		}
+	case *bedrock.BedrockInvokeCohereTypedEmbeddingResp:
+		if len(value.Embeddings.Float) == 0 {
+			return response
+		}
+		return &langChainCohereTypedEmbedding{
+			Embedding:    value.Embeddings.Float[0],
+			Embeddings:   value.Embeddings,
+			ResponseType: value.ResponseType,
+		}
+	default:
+		return response
 	}
 }


### PR DESCRIPTION
## Summary

Adds first-class support for typed embedding representations (`embeddingTypes` for Titan V2 and `embedding_types` for Cohere) across the Bedrock provider, the native invoke route, and the LangChain compatibility layer. Previously, `embeddingsByType` responses were handled by stashing the raw provider payload and returning it verbatim — bypassing the canonical schema entirely. This PR replaces that workaround with a proper round-trip path: each `EmbeddingData` entry now carries an `EncodingFormat` label that survives JSON serialization, allowing the invoke converter to reconstruct the correct native envelope from the canonical response whether it was served live or replayed from a cache.

## Changes

- **`EmbeddingData.EncodingFormat`** — new field (`float`, `int8`, `uint8`, `binary`, `ubinary`, `base64`) added to `schemas.EmbeddingData`, with a custom `UnmarshalJSON` that routes the vector into the correct typed field (`[]int8`, `[]int32`, or `[]float64`) based on the declared encoding, preventing silent float coercion on cache hits.
- **Titan V2 `embeddingTypes` support** — `ToBedrockTitanEmbeddingRequest` now promotes `embeddingTypes` from `ExtraParams` to the first-class `EmbeddingTypes` field. Invalid values are left in `ExtraParams` so Bedrock returns its own validation error rather than silently dropping them. `BedrockTitanEmbeddingResponse` gains an `EmbeddingsByType` field; `ToBifrostEmbeddingResponse` emits one labelled `EmbeddingData` entry per representation when both float and binary are present, and falls back to the legacy unlabelled single-vector shape for ordinary requests.
- **Cohere typed envelope** — `BedrockCohereEmbeddingsByType` is extracted into a named type shared between the parser and the invoke converter. `embedding_types` extraction now uses `SafeExtractStringSlice` so JSON-decoded `[]interface{}` arrays are accepted. Each `EmbeddingData` entry is labelled with its encoding.
- **`ToBedrockEmbeddingInvokeResponse` rewrite** — the raw-response passthrough is removed. Two helpers (`toBedrockTitanEmbeddingInvokeResponse`, `toBedrockCohereEmbeddingInvokeResponse`) rebuild the native envelope from the canonical data: Titan produces `embeddingsByType` when entries carry encoding labels, Cohere switches between `embeddings_floats` and `embeddings_by_type` based on the same signal. `BedrockInvokeEmbeddingResp` gains `EmbeddingsByType` and changes `Embedding` to `[]float64` with `omitempty`. A new `BedrockInvokeCohereTypedEmbeddingResp` type covers the typed Cohere envelope.
- **LangChain compatibility** — `withLangChainBedrockEmbeddingCompatibility` wraps the Bedrock invoke embedding converter to inject the singular `embedding` field LangChain's `BedrockEmbeddings` parser reads. Only a float vector is aliased; Titan responses are passed through unchanged since AWS already defines the singular field there.
- **`BedrockInvokeRequest`** — `TitanEmbeddingTypes` (`embeddingTypes`) added alongside the existing Cohere `EmbeddingTypes` (`embedding_types`), and both are registered in the known-fields map.
- **Nil-input guard** — `ToBedrockTitanEmbeddingRequest` now checks for a nil `Input` before dereferencing it.
- **Tests** — unit tests cover the `EmbeddingData` round-trip, Titan response conversion for all representation combinations, the invoke converter for both providers, and the LangChain alias logic. E2E harness folders 58.A–58.E and Python integration tests 31a–31b are added.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/... ./core/providers/bedrock/... ./transports/bifrost-http/integrations/...
```

E2E harness folders 58.A–58.E exercise the native invoke route against live AWS credentials:

- **58.A** — Titan V2 binary-only: response must contain `embeddingsByType.binary` with integer values.
- **58.B** — Titan V2 float + binary: response must contain both `embeddingsByType.float` and `embeddingsByType.binary`.
- **58.C** — Cohere v4 all typed encodings: `response_type` must be `embeddings_by_type` with all five encoding keys populated.
- **58.D** — LangChain Cohere: response must carry both singular `embedding` and plural `embeddings`, with `embedding == embeddings[0]`.
- **58.E** — Normalized Titan dual representations via `/v1/embeddings`: `data` must contain exactly two entries with `encoding_format` values `float` and `binary`; `embeddingsByType` must not appear at the top level.

Python integration tests 31a and 31b cover the same Titan cases via `boto3.invoke_model`.

## Breaking changes

- [x] Yes
- [ ] No

`BedrockInvokeEmbeddingResp.Embedding` changes from `[]float32` to `[]float64` and gains `omitempty`. Callers that type-assert the invoke response struct directly will need to update. The raw-response passthrough for `embeddings_by_type` is removed; callers that relied on `ExtraFields.RawResponse` being populated unconditionally for typed Cohere responses must opt in via `x-bf-send-back-raw-response`.

## Related issues

Closes #6335

## Security considerations

None. No auth, secrets, PII, or sandboxing changes.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable