### PR TITLE
move streaming back to net/http to avoid race conditions

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -265,18 +265,26 @@ func completeRequest(
 		}
 	}
 
-	requestClient := client
 	responseThreshold, _ := ctx.Value(schemas.BifrostContextKeyLargeResponseThreshold).(int64)
 	isCountTokens := requestType == schemas.CountTokensRequest
-	// Count-tokens responses are always tiny — skip the large-response streaming client so the
+	// Count-tokens responses are always tiny — skip large-response streaming so the
 	// response is buffered normally.
-	if responseThreshold > 0 && !isCountTokens {
+	streamResponseBody := responseThreshold > 0 && !isCountTokens
+	if streamResponseBody {
 		resp.StreamBody = true
-		requestClient = providerUtils.BuildLargeResponseClient(client, responseThreshold)
 	}
 
-	// Send the request
-	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, requestClient, req, resp)
+	// Send the request. A streamed body goes out over net/http so it is never
+	// fasthttp's pooled *requestStream, which cannot be closed safely while a
+	// reader is parked in it (issue #6143).
+	var latency time.Duration
+	var bifrostErr *schemas.BifrostError
+	var wait func()
+	if streamResponseBody {
+		latency, bifrostErr, wait = providerUtils.MakeStreamingRequestWithContext(ctx, client, req, resp)
+	} else {
+		latency, bifrostErr, wait = providerUtils.MakeRequestWithContext(ctx, client, req, resp)
+	}
 	defer wait()
 	if usedLargePayloadBody {
 		providerUtils.DrainLargePayloadRemainder(ctx)
@@ -813,19 +821,23 @@ func HandleAnthropicChatCompletionStreaming(
 	// mitigation already used on Gemini/Azure/OpenAI streaming and anthropic.go:2716.
 	req.Header.Set("Connection", "close")
 
-	// Use a fresh streaming client per request so fasthttp's internal readerPool
-	// cannot be poisoned across concurrent Anthropic streams by a non-idempotent
-	// streaming-body close path. The cloned client preserves dialer/TLS/proxy
-	// config but starts with empty reader/writer pools.
-	requestClient := providerUtils.BuildStreamingClient(client)
+	// A fresh streaming client per request used to be required here so fasthttp's
+	// internal readerPool could not be poisoned across concurrent Anthropic
+	// streams by the non-idempotent streaming-body close path. Streaming sends
+	// now go out over net/http (see providerUtils httpstream.go), which pools no
+	// reader and guards Body.Close against a concurrent Read, so the per-request
+	// client is unnecessary. Reusing the caller's long-lived client also avoids
+	// allocating a client and transport on every streaming request.
 
-	// Use streaming-aware client when large payload optimization is active — ensures
-	// MaxResponseBodySize > 0 so ErrBodyTooLarge triggers StreamBody for Content-Length responses.
-	activeClient := providerUtils.PrepareResponseStreaming(ctx, requestClient, resp)
+	// Mark the response for streaming when large payload optimization is active.
+	// The fasthttp MaxResponseBodySize/StreamResponseBody clone this used to build has
+	// no effect now that streaming sends go through net/http; the threshold is enforced
+	// by Bifrost's own readers.
+	providerUtils.PrepareStreamResponseThreshold(ctx, resp)
 
 	startTime := time.Now()
 	// Make the request
-	err := providerUtils.DoStreamingRequest(ctx, activeClient, req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, client, req, resp)
 	latency := time.Since(startTime)
 	if usedLargePayloadBody {
 		providerUtils.DrainLargePayloadRemainder(ctx)
@@ -1469,19 +1481,23 @@ func HandleAnthropicResponsesStream(
 	// mitigation already used on Gemini/Azure/OpenAI streaming and anthropic.go:2716.
 	req.Header.Set("Connection", "close")
 
-	// Use a fresh streaming client per request so fasthttp's internal readerPool
-	// cannot be poisoned across concurrent Anthropic streams by a non-idempotent
-	// streaming-body close path. The cloned client preserves dialer/TLS/proxy
-	// config but starts with empty reader/writer pools.
-	requestClient := providerUtils.BuildStreamingClient(client)
+	// A fresh streaming client per request used to be required here so fasthttp's
+	// internal readerPool could not be poisoned across concurrent Anthropic
+	// streams by the non-idempotent streaming-body close path. Streaming sends
+	// now go out over net/http (see providerUtils httpstream.go), which pools no
+	// reader and guards Body.Close against a concurrent Read, so the per-request
+	// client is unnecessary. Reusing the caller's long-lived client also avoids
+	// allocating a client and transport on every streaming request.
 
-	// Use streaming-aware client when large payload optimization is active — ensures
-	// MaxResponseBodySize > 0 so ErrBodyTooLarge triggers StreamBody for Content-Length responses.
-	activeClient := providerUtils.PrepareResponseStreaming(ctx, requestClient, resp)
+	// Mark the response for streaming when large payload optimization is active.
+	// The fasthttp MaxResponseBodySize/StreamResponseBody clone this used to build has
+	// no effect now that streaming sends go through net/http; the threshold is enforced
+	// by Bifrost's own readers.
+	providerUtils.PrepareStreamResponseThreshold(ctx, resp)
 
 	startTime := time.Now()
 	// Make the request
-	err := providerUtils.DoStreamingRequest(ctx, activeClient, req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, client, req, resp)
 	latency := time.Since(startTime)
 	if usedLargePayloadBody {
 		providerUtils.DrainLargePayloadRemainder(ctx)
@@ -3146,8 +3162,8 @@ func (provider *AnthropicProvider) PassthroughStream(
 
 	fasthttpReq.SetBody(req.Body)
 
-	activeClient := providerUtils.PrepareResponseStreaming(ctx, provider.streamingClient, resp)
-	err := providerUtils.DoStreamingRequest(ctx, activeClient, fasthttpReq, resp)
+	providerUtils.PrepareStreamResponseThreshold(ctx, resp)
+	err := providerUtils.DoStreamingRequest(ctx, provider.streamingClient, fasthttpReq, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		providerUtils.ReleaseStreamingResponse(ctx, resp)

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -3538,12 +3538,12 @@ func (provider *AzureProvider) PassthroughStream(
 
 	fasthttpReq.SetBody(req.Body)
 
-	activeClient := providerUtils.PrepareResponseStreaming(ctx, provider.streamingClient, resp)
+	providerUtils.PrepareStreamResponseThreshold(ctx, resp)
 	providerUtils.SetStreamIdleTimeoutIfEmpty(ctx, provider.networkConfig.StreamIdleTimeoutInSeconds)
 
 	startTime := time.Now()
 
-	err = providerUtils.DoStreamingRequest(ctx, activeClient, fasthttpReq, resp)
+	err = providerUtils.DoStreamingRequest(ctx, provider.streamingClient, fasthttpReq, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		providerUtils.ReleaseStreamingResponse(ctx, resp)

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -759,9 +759,12 @@ func (provider *GeminiProvider) responsesWithLargeResponseDetection(
 	}
 	setGeminiRequestBody(req, bodyReader, bodySize, jsonData)
 
-	// Make request
-	streamingClient := providerUtils.BuildLargeResponseClient(provider.client, responseThreshold)
-	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, streamingClient, req, resp)
+	// Make request. The body is streamed, so it goes out over net/http and never
+	// becomes fasthttp's pooled *requestStream, which cannot be closed safely
+	// while a reader is parked in it (issue #6143). provider.client is passed
+	// rather than a per-request BuildLargeResponseClient clone so the net/http
+	// twin cache stays keyed on a stable pointer.
+	latency, bifrostErr, wait := providerUtils.MakeStreamingRequestWithContext(ctx, provider.client, req, resp)
 	if bifrostErr != nil {
 		wait()
 		fasthttp.ReleaseResponse(resp)
@@ -4170,8 +4173,8 @@ func (provider *GeminiProvider) PassthroughStream(
 
 	fasthttpReq.SetBody(req.Body)
 
-	activeClient := providerUtils.PrepareResponseStreaming(ctx, provider.streamingClient, resp)
-	err := providerUtils.DoStreamingRequest(ctx, activeClient, fasthttpReq, resp)
+	providerUtils.PrepareStreamResponseThreshold(ctx, resp)
+	err := providerUtils.DoStreamingRequest(ctx, provider.streamingClient, fasthttpReq, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		providerUtils.ReleaseStreamingResponse(ctx, resp)

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -491,13 +491,15 @@ func HandleOpenAITextCompletionStreaming(
 
 	setStreamingRequestBody(ctx, req, jsonBody, providerName)
 
-	// Use streaming-aware client when large payload optimization is active — ensures
-	// MaxResponseBodySize > 0 so ErrBodyTooLarge triggers StreamBody for Content-Length responses.
-	activeClient := providerUtils.PrepareResponseStreaming(ctx, client, resp)
+	// Mark the response for streaming when large payload optimization is active.
+	// The fasthttp MaxResponseBodySize/StreamResponseBody clone this used to build has
+	// no effect now that streaming sends go through net/http; the threshold is enforced
+	// by Bifrost's own readers.
+	providerUtils.PrepareStreamResponseThreshold(ctx, resp)
 
 	startTime := time.Now()
 	// Make the request
-	err := providerUtils.DoStreamingRequest(ctx, activeClient, req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, client, req, resp)
 	if err != nil {
 		defer providerUtils.ReleaseStreamingResponse(ctx, resp)
 		latency := time.Since(startTime)
@@ -1109,13 +1111,15 @@ func HandleOpenAIChatCompletionStreaming(
 
 	setStreamingRequestBody(ctx, req, jsonBody, providerName)
 
-	// Use streaming-aware client when large payload optimization is active — ensures
-	// MaxResponseBodySize > 0 so ErrBodyTooLarge triggers StreamBody for Content-Length responses.
-	activeClient := providerUtils.PrepareResponseStreaming(ctx, client, resp)
+	// Mark the response for streaming when large payload optimization is active.
+	// The fasthttp MaxResponseBodySize/StreamResponseBody clone this used to build has
+	// no effect now that streaming sends go through net/http; the threshold is enforced
+	// by Bifrost's own readers.
+	providerUtils.PrepareStreamResponseThreshold(ctx, resp)
 
 	startTime := time.Now()
 	// Make the request
-	err := providerUtils.DoStreamingRequest(ctx, activeClient, req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, client, req, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		defer providerUtils.ReleaseStreamingResponse(ctx, resp)
@@ -1823,13 +1827,15 @@ func HandleOpenAIResponsesStreaming(
 
 	setStreamingRequestBody(ctx, req, jsonBody, providerName)
 
-	// Use streaming-aware client when large payload optimization is active — ensures
-	// MaxResponseBodySize > 0 so ErrBodyTooLarge triggers StreamBody for Content-Length responses.
-	activeClient := providerUtils.PrepareResponseStreaming(ctx, client, resp)
+	// Mark the response for streaming when large payload optimization is active.
+	// The fasthttp MaxResponseBodySize/StreamResponseBody clone this used to build has
+	// no effect now that streaming sends go through net/http; the threshold is enforced
+	// by Bifrost's own readers.
+	providerUtils.PrepareStreamResponseThreshold(ctx, resp)
 
 	startTime := time.Now()
 	// Make the request
-	err := providerUtils.DoStreamingRequest(ctx, activeClient, req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, client, req, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		defer providerUtils.ReleaseStreamingResponse(ctx, resp)
@@ -2431,13 +2437,15 @@ func HandleOpenAISpeechStreamRequest(
 
 	setStreamingRequestBody(ctx, req, jsonBody, providerName)
 
-	// Use streaming-aware client when large payload optimization is active — ensures
-	// MaxResponseBodySize > 0 so ErrBodyTooLarge triggers StreamBody for Content-Length responses.
-	activeClient := providerUtils.PrepareResponseStreaming(ctx, client, resp)
+	// Mark the response for streaming when large payload optimization is active.
+	// The fasthttp MaxResponseBodySize/StreamResponseBody clone this used to build has
+	// no effect now that streaming sends go through net/http; the threshold is enforced
+	// by Bifrost's own readers.
+	providerUtils.PrepareStreamResponseThreshold(ctx, resp)
 
 	startTime := time.Now()
 	// Make the request
-	err := providerUtils.DoStreamingRequest(ctx, activeClient, req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, client, req, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		defer providerUtils.ReleaseStreamingResponse(ctx, resp)
@@ -3399,13 +3407,15 @@ func HandleOpenAIImageGenerationStreaming(
 
 	setStreamingRequestBody(ctx, req, jsonBody, providerName)
 
-	// Use streaming-aware client when large payload optimization is active — ensures
-	// MaxResponseBodySize > 0 so ErrBodyTooLarge triggers StreamBody for Content-Length responses.
-	activeClient := providerUtils.PrepareResponseStreaming(ctx, client, resp)
+	// Mark the response for streaming when large payload optimization is active.
+	// The fasthttp MaxResponseBodySize/StreamResponseBody clone this used to build has
+	// no effect now that streaming sends go through net/http; the threshold is enforced
+	// by Bifrost's own readers.
+	providerUtils.PrepareStreamResponseThreshold(ctx, resp)
 
 	startTime := time.Now()
 	// Make the request
-	err := providerUtils.DoStreamingRequest(ctx, activeClient, req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, client, req, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		defer providerUtils.ReleaseStreamingResponse(ctx, resp)
@@ -7687,11 +7697,11 @@ func (provider *OpenAIProvider) PassthroughStream(
 
 	fasthttpReq.SetBody(req.Body)
 
-	activeClient := providerUtils.PrepareResponseStreaming(ctx, provider.streamingClient, resp)
+	providerUtils.PrepareStreamResponseThreshold(ctx, resp)
 
 	startTime := time.Now()
 
-	err := providerUtils.DoStreamingRequest(ctx, activeClient, fasthttpReq, resp)
+	err := providerUtils.DoStreamingRequest(ctx, provider.streamingClient, fasthttpReq, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		providerUtils.ReleaseStreamingResponse(ctx, resp)

--- a/core/providers/openai/responseslifecycle.go
+++ b/core/providers/openai/responseslifecycle.go
@@ -209,11 +209,14 @@ func (provider *OpenAIProvider) ResponsesRetrieveStream(ctx *schemas.BifrostCont
 		httpReq.Header.Set(k, v)
 	}
 
-	// Use streaming-aware client when large payload optimization is active.
-	activeClient := providerUtils.PrepareResponseStreaming(ctx, provider.streamingClient, resp)
+	// Mark the response for streaming when large payload optimization is active.
+	// The fasthttp MaxResponseBodySize/StreamResponseBody clone this used to build has
+	// no effect now that streaming sends go through net/http; the threshold is enforced
+	// by Bifrost's own readers.
+	providerUtils.PrepareStreamResponseThreshold(ctx, resp)
 
 	startTime := time.Now()
-	err := providerUtils.DoStreamingRequest(ctx, activeClient, httpReq, resp)
+	err := providerUtils.DoStreamingRequest(ctx, provider.streamingClient, httpReq, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		defer providerUtils.ReleaseStreamingResponse(ctx, resp)

--- a/core/providers/utils/httpstream.go
+++ b/core/providers/utils/httpstream.go
@@ -1,0 +1,185 @@
+package utils
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/valyala/fasthttp"
+)
+
+// ---------------------------------------------------------------------------
+// net/http transport for streaming responses (issue #6143)
+//
+// fasthttp's streaming close callback returns the pooled *requestStream and
+// *bufio.Reader to their sync.Pools BEFORE closing the connection, and closing
+// the connection is the only thing that unblocks a reader parked in
+// (*requestStream).Read. A cancelled stream therefore always resumes its reader
+// on an object another request may already own. That ordering lives inside
+// fasthttp (client.go, transport.RoundTrip) and is identical in every release
+// from v1.69.0 through v1.73.0, so no caller-side locking can fix it.
+//
+// net/http has neither problem. http.Response.Body guards its closed flag with
+// a mutex (net/http.bodyEOFSignal) and never returns the body reader to a pool,
+// so Close may race a Read safely. Sending streaming requests through net/http
+// and injecting the resulting body into the fasthttp.Response via SetBodyStream
+// keeps every downstream helper working unchanged, while
+// Response.closeBodyStream takes its io.Closer branch and skips
+// releaseRequestStream entirely.
+// ---------------------------------------------------------------------------
+
+// streamingHTTPTwins maps a long-lived streaming *fasthttp.Client to the
+// *http.Client that mirrors its dialer, proxy, TLS and pool settings.
+//
+// Keyed on the fasthttp client pointer, which is safe here because every client
+// reaching this path is a provider's streamingClient field, built once in the
+// provider constructor. Per-request clones (BuildLargeResponseClient) must not
+// be used as keys; those paths resolve the twin from their long-lived base via
+// StreamingHTTPTwin.
+var streamingHTTPTwins sync.Map // *fasthttp.Client -> *http.Client
+
+// StreamingHTTPTwin returns the net/http client mirroring fh's connection
+// configuration, creating and caching it on first use.
+//
+// Everything that matters carries over through two fields. ConfigureProxy and
+// ConfigureDialer compose proxy dialing, SSRF address filtering and TCP
+// keepalive into fh.Dial, and ConfigureTLS puts the custom CA and
+// InsecureSkipVerify into fh.TLSConfig. Mapping those onto Transport.DialContext
+// and Transport.TLSClientConfig preserves all of it with no duplicated logic.
+func StreamingHTTPTwin(fh *fasthttp.Client) *http.Client {
+	if fh == nil {
+		return &http.Client{}
+	}
+	if c, ok := streamingHTTPTwins.Load(fh); ok {
+		return c.(*http.Client)
+	}
+
+	tr := &http.Transport{
+		TLSClientConfig: fh.TLSConfig,
+		// fasthttp speaks HTTP/1.1 only. Opportunistically negotiating h2 here
+		// would change framing behaviour for every provider at once.
+		ForceAttemptHTTP2: false,
+		// DecompressStreamBody inspects Content-Encoding and unwraps gzip with
+		// a pooled reader. net/http must not add its own Accept-Encoding or
+		// transparently unwrap, or that logic would see an already-decoded body
+		// with the header stripped.
+		DisableCompression: true,
+	}
+	if fh.Dial != nil {
+		dial := fh.Dial
+		tr.DialContext = func(_ context.Context, _, addr string) (net.Conn, error) {
+			return dial(addr)
+		}
+	}
+	if fh.MaxConnsPerHost > 0 {
+		tr.MaxConnsPerHost = fh.MaxConnsPerHost
+		tr.MaxIdleConnsPerHost = fh.MaxConnsPerHost
+	}
+	if fh.MaxIdleConnDuration > 0 {
+		tr.IdleConnTimeout = fh.MaxIdleConnDuration
+	}
+
+	c := &http.Client{
+		Transport: tr,
+		// No Timeout: a stream lives arbitrarily long and Client.Timeout would
+		// cap the whole body read. Idle detection stays with
+		// NewIdleTimeoutReader, matching BuildStreamingClient's contract.
+		//
+		// fasthttp's client.Do does not follow redirects (DoRedirects does), so
+		// stopping at the first response preserves current behaviour.
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	actual, _ := streamingHTTPTwins.LoadOrStore(fh, c)
+	return actual.(*http.Client)
+}
+
+// fastHTTPRequestToHTTP converts a populated fasthttp request into an
+// equivalent net/http request bound to ctx, so cancelling ctx aborts the
+// connection, the send and the body read (see net/http.NewRequestWithContext:
+// "the context controls the entire lifetime of a request and its response").
+func fastHTTPRequestToHTTP(ctx context.Context, req *fasthttp.Request) (*http.Request, error) {
+	if req == nil {
+		return nil, fmt.Errorf("nil fasthttp request")
+	}
+	uri := req.URI().String()
+	method := string(req.Header.Method())
+
+	var body io.Reader
+	if b := req.Body(); len(b) > 0 {
+		body = bytes.NewReader(b)
+	}
+
+	hr, err := http.NewRequestWithContext(ctx, method, uri, body)
+	if err != nil {
+		return nil, err
+	}
+	if body != nil {
+		hr.ContentLength = int64(len(req.Body()))
+	}
+
+	req.Header.VisitAll(func(k, v []byte) {
+		key := string(k)
+		switch http.CanonicalHeaderKey(key) {
+		case "Host":
+			// net/http carries the authority in Request.Host, and rejects it as
+			// a normal header.
+			hr.Host = string(v)
+		case "Connection":
+			// net/http computes the Connection header itself and expresses
+			// "close" through Request.Close instead. Several providers set
+			// Connection: close on streaming requests to stop a torn connection
+			// from being reused, so the intent has to survive the conversion.
+			if strings.EqualFold(string(v), "close") {
+				hr.Close = true
+			}
+		case "Content-Length", "Transfer-Encoding":
+			// Framing headers are net/http's to compute.
+		default:
+			hr.Header.Add(key, string(v))
+		}
+	})
+	return hr, nil
+}
+
+// injectHTTPStreamResponse copies status and headers from a net/http streaming
+// response onto resp and installs its body as resp's body stream, so
+// resp.BodyStream(), ExtractProviderResponseHeaders, DecompressStreamBody and
+// ReleaseStreamingResponse all keep working against a net/http body.
+func injectHTTPStreamResponse(resp *fasthttp.Response, hr *http.Response) {
+	// SetBodyStream calls ResetBody and then SetContentLength, so it has to run
+	// before the header copy or it would clobber the provider's headers.
+	resp.SetBodyStream(hr.Body, -1)
+	resp.SetStatusCode(hr.StatusCode)
+	for k, vals := range hr.Header {
+		for i, v := range vals {
+			if i == 0 {
+				resp.Header.Set(k, v)
+				continue
+			}
+			resp.Header.Add(k, v)
+		}
+	}
+}
+
+// DoStreamingRequestViaHTTP sends req through the net/http twin of client and
+// installs the streaming response body on resp. See the file header for why the
+// streaming path does not use fasthttp.
+func DoStreamingRequestViaHTTP(ctx context.Context, client *fasthttp.Client, req *fasthttp.Request, resp *fasthttp.Response) error {
+	hr, err := fastHTTPRequestToHTTP(ctx, req)
+	if err != nil {
+		return err
+	}
+	httpResp, err := StreamingHTTPTwin(client).Do(hr)
+	if err != nil {
+		return err
+	}
+	injectHTTPStreamResponse(resp, httpResp)
+	return nil
+}

--- a/core/providers/utils/httpstream_test.go
+++ b/core/providers/utils/httpstream_test.go
@@ -1,0 +1,203 @@
+package utils
+
+import (
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+	"github.com/valyala/fasthttp/fasthttputil"
+)
+
+func TestStreamingHTTPTwin_StableAcrossCalls(t *testing.T) {
+	t.Parallel()
+
+	fh := &fasthttp.Client{Dial: func(string) (net.Conn, error) { return nil, net.ErrClosed }}
+	a := StreamingHTTPTwin(fh)
+	b := StreamingHTTPTwin(fh)
+	if a != b {
+		t.Fatal("StreamingHTTPTwin returned a different client for the same fasthttp client: " +
+			"the cache would grow once per request and leak a connection pool each time")
+	}
+	if a.Transport == nil {
+		t.Fatal("twin has no transport")
+	}
+}
+
+// TestStreamingHTTPTwin_CarriesDialerAndTLS asserts the twin inherits the two
+// fields that hold every network policy Bifrost applies: ConfigureProxy and
+// ConfigureDialer compose proxying, SSRF filtering and keepalive into Dial, and
+// ConfigureTLS puts the custom CA / InsecureSkipVerify into TLSConfig. Losing
+// either would silently disable SSRF protection or certificate pinning.
+func TestStreamingHTTPTwin_CarriesDialerAndTLS(t *testing.T) {
+	t.Parallel()
+
+	dialed := make(chan string, 1)
+	fh := &fasthttp.Client{
+		Dial: func(addr string) (net.Conn, error) {
+			select {
+			case dialed <- addr:
+			default:
+			}
+			return nil, net.ErrClosed
+		},
+		MaxConnsPerHost:     7,
+		MaxIdleConnDuration: 42 * time.Second,
+	}
+	fh = ConfigureTLS(fh, schemas.NetworkConfig{InsecureSkipVerify: true}, getLogger())
+
+	twin := StreamingHTTPTwin(fh)
+	tr, ok := twin.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport is %T, want *http.Transport", twin.Transport)
+	}
+	if tr.TLSClientConfig == nil || !tr.TLSClientConfig.InsecureSkipVerify {
+		t.Fatal("twin lost the fasthttp client's TLS config")
+	}
+	if tr.MaxConnsPerHost != 7 {
+		t.Fatalf("MaxConnsPerHost = %d, want 7", tr.MaxConnsPerHost)
+	}
+	if tr.IdleConnTimeout != 42*time.Second {
+		t.Fatalf("IdleConnTimeout = %v, want 42s", tr.IdleConnTimeout)
+	}
+	if tr.DialContext == nil {
+		t.Fatal("twin lost the fasthttp client's Dial function")
+	}
+	//nolint:errcheck // the dial deliberately fails; we only assert it was routed
+	_, _ = tr.DialContext(t.Context(), "tcp", "example.invalid:443")
+	select {
+	case addr := <-dialed:
+		if addr != "example.invalid:443" {
+			t.Fatalf("dialed %q, want example.invalid:443", addr)
+		}
+	default:
+		t.Fatal("twin did not route the dial through the fasthttp Dial function")
+	}
+}
+
+// TestFastHTTPRequestToHTTP_PreservesRequest covers the conversion details that
+// silently break providers if wrong: method, URI, body, ordinary headers, and
+// the Connection: close intent several providers rely on.
+func TestFastHTTPRequestToHTTP_PreservesRequest(t *testing.T) {
+	t.Parallel()
+
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	req.SetRequestURI("https://api.example.com/v1/chat/completions?beta=1")
+	req.Header.SetMethod(fasthttp.MethodPost)
+	req.Header.Set("Authorization", "Bearer token")
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Connection", "close")
+	req.SetBodyString(`{"stream":true}`)
+
+	hr, err := fastHTTPRequestToHTTP(t.Context(), req)
+	if err != nil {
+		t.Fatalf("conversion failed: %v", err)
+	}
+	if hr.Method != http.MethodPost {
+		t.Fatalf("method %q, want POST", hr.Method)
+	}
+	if got := hr.URL.String(); got != "https://api.example.com/v1/chat/completions?beta=1" {
+		t.Fatalf("url %q", got)
+	}
+	if hr.Header.Get("Authorization") != "Bearer token" {
+		t.Fatal("lost Authorization header")
+	}
+	if hr.Header.Get("Accept") != "text/event-stream" {
+		t.Fatal("lost Accept header")
+	}
+	if !hr.Close {
+		t.Fatal("Connection: close did not become Request.Close, so a torn connection could be reused")
+	}
+	if hr.Header.Get("Connection") != "" {
+		t.Fatal("Connection header was forwarded verbatim; net/http must own framing")
+	}
+	if hr.ContentLength != int64(len(`{"stream":true}`)) {
+		t.Fatalf("ContentLength = %d", hr.ContentLength)
+	}
+}
+
+// TestDoStreamingRequestViaHTTP_PropagatesStatusAndHeaders guards the error
+// path: a non-200 streaming response must still carry status and headers so the
+// provider error converters and ExtractProviderResponseHeaders keep working.
+func TestDoStreamingRequestViaHTTP_PropagatesStatusAndHeaders(t *testing.T) {
+	t.Parallel()
+
+	ln := fasthttputil.NewInmemoryListener()
+	defer ln.Close() //nolint:errcheck
+	srv := &fasthttp.Server{
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			ctx.SetStatusCode(fasthttp.StatusTooManyRequests)
+			ctx.Response.Header.Set("X-Ratelimit-Remaining", "0")
+			ctx.SetContentType("application/json")
+			ctx.SetBodyString(`{"error":{"message":"slow down"}}`)
+		},
+	}
+	go srv.Serve(ln) //nolint:errcheck
+
+	client := &fasthttp.Client{Dial: func(string) (net.Conn, error) { return ln.Dial() }}
+
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	resp := fasthttp.AcquireResponse()
+	req.SetRequestURI("http://test/v1/chat/completions")
+	req.Header.SetMethod(fasthttp.MethodPost)
+	resp.StreamBody = true
+
+	ctx := schemas.NewBifrostContext(t.Context(), time.Time{})
+	if err := DoStreamingRequestViaHTTP(ctx, client, req, resp); err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer ReleaseStreamingResponse(ctx, resp)
+
+	if resp.StatusCode() != fasthttp.StatusTooManyRequests {
+		t.Fatalf("status %d, want 429", resp.StatusCode())
+	}
+	if got := string(resp.Header.Peek("X-Ratelimit-Remaining")); got != "0" {
+		t.Fatalf("X-Ratelimit-Remaining = %q, want 0", got)
+	}
+	if headers := ExtractProviderResponseHeaders(resp); len(headers) == 0 {
+		t.Fatal("ExtractProviderResponseHeaders returned nothing for a net/http-backed response")
+	}
+}
+
+// TestInjectHTTPStreamResponse_PreservesContentLength guards the ordering inside
+// injectHTTPStreamResponse. SetBodyStream sets Content-Length to -1, so the
+// header copy has to run after it. FinalizeResponseWithLargeDetection branches
+// on resp.Header.ContentLength() to decide whether a response is "large", and a
+// clobbered -1 would push every sized response down the unknown-length path.
+func TestInjectHTTPStreamResponse_PreservesContentLength(t *testing.T) {
+	t.Parallel()
+
+	ln := fasthttputil.NewInmemoryListener()
+	defer ln.Close() //nolint:errcheck
+	body := `{"ok":true}`
+	srv := &fasthttp.Server{
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			ctx.SetStatusCode(fasthttp.StatusOK)
+			ctx.SetContentType("application/json")
+			ctx.SetBodyString(body)
+		},
+	}
+	go srv.Serve(ln) //nolint:errcheck
+
+	client := &fasthttp.Client{Dial: func(string) (net.Conn, error) { return ln.Dial() }}
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	resp := fasthttp.AcquireResponse()
+	req.SetRequestURI("http://test/v1/models")
+	req.Header.SetMethod(fasthttp.MethodGet)
+	resp.StreamBody = true
+
+	ctx := schemas.NewBifrostContext(t.Context(), time.Time{})
+	if err := DoStreamingRequestViaHTTP(ctx, client, req, resp); err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer ReleaseStreamingResponse(ctx, resp)
+
+	if got := resp.Header.ContentLength(); got != len(body) {
+		t.Fatalf("ContentLength = %d, want %d: the header copy must run after SetBodyStream", got, len(body))
+	}
+}

--- a/core/providers/utils/largeresponse.go
+++ b/core/providers/utils/largeresponse.go
@@ -103,6 +103,26 @@ func PrepareResponseStreaming(ctx *schemas.BifrostContext, client *fasthttp.Clie
 	return BuildLargeResponseClient(client, responseThreshold)
 }
 
+// PrepareStreamResponseThreshold marks resp for body streaming when a
+// large-response threshold is configured, and returns no client.
+//
+// This is the streaming counterpart to PrepareResponseStreaming. Streaming
+// sends go out over net/http (see httpstream.go), where the fasthttp clone that
+// PrepareResponseStreaming builds has no effect on the send at all: its
+// StreamResponseBody, MaxResponseBodySize and zeroed timeouts are fasthttp
+// client knobs, and the threshold itself is enforced by Bifrost's own readers
+// (FinalizeResponseWithLargeDetection, LargeResponseReader).
+//
+// Handing DoStreamingRequest the caller's long-lived client rather than a
+// per-request clone also keeps the net/http twin cache in httpstream.go keyed
+// on a stable pointer, so it stays bounded by the number of providers instead
+// of growing once per request.
+func PrepareStreamResponseThreshold(ctx *schemas.BifrostContext, resp *fasthttp.Response) {
+	if responseThreshold, _ := ctx.Value(schemas.BifrostContextKeyLargeResponseThreshold).(int64); responseThreshold > 0 {
+		resp.StreamBody = true
+	}
+}
+
 // MaterializeStreamErrorBody reads a streamed error body into resp so that resp.Body()
 // returns the error payload for parsing. No-op when response streaming is not active.
 func MaterializeStreamErrorBody(ctx *schemas.BifrostContext, resp *fasthttp.Response) {

--- a/core/providers/utils/sse.go
+++ b/core/providers/utils/sse.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"io"
 
 	"github.com/bytedance/sonic"
@@ -152,10 +153,35 @@ func (r *defaultSSEDataReader) ReadDataLine() ([]byte, error) {
 		return append([]byte(nil), line...), nil
 	}
 	if err := r.scanner.Err(); err != nil {
-		return nil, err
+		if normalized := endOfStreamErr(err); normalized != nil && !errors.Is(normalized, io.EOF) {
+			return nil, normalized
+		}
+		return nil, io.EOF
 	}
 	return nil, io.EOF
 }
+
+// endOfStreamErr normalizes a scanner error that actually means "the body
+// ended" into io.EOF.
+//
+// A dying upstream closes the connection on a chunk boundary. fasthttp's
+// streaming body reported that as a plain io.EOF, so Bifrost detects truncation
+// semantically instead — by the absence of a terminal marker — and turns it into
+// a retryable 502 (see SendStreamTruncatedError). net/http, which now carries
+// streaming responses (issue #6143), is more precise and reports
+// io.ErrUnexpectedEOF for the same event. Left alone that would surface as a
+// generic "Error reading stream" instead of the truncation error, losing both
+// the 502 status and the retryability the retry loop depends on.
+//
+// Only the unexpected-EOF case is folded in. ErrStreamClosed, ErrStreamIdleTimeout
+// and genuine transport failures must keep their own identity.
+func endOfStreamErr(err error) error {
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return io.EOF
+	}
+	return err
+}
+
 
 // nextLine returns the line carried over from an aborted multi-line JSON
 // accumulation, or advances the scanner. The returned slice is only valid
@@ -268,7 +294,10 @@ func (r *defaultSSEEventReader) ReadEvent() (string, []byte, error) {
 	}
 
 	if err := r.scanner.Err(); err != nil {
-		return "", nil, err
+		if normalized := endOfStreamErr(err); normalized != nil && !errors.Is(normalized, io.EOF) {
+			return "", nil, normalized
+		}
+		return "", nil, io.EOF
 	}
 	return "", nil, io.EOF
 }

--- a/core/providers/utils/streamcancelrace_test.go
+++ b/core/providers/utils/streamcancelrace_test.go
@@ -1,0 +1,196 @@
+package utils
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+	"github.com/valyala/fasthttp/fasthttputil"
+)
+
+// ---------------------------------------------------------------------------
+// Regression coverage for maximhq/bifrost#6143
+//
+// fasthttp's streaming close callback (client.go, transport.RoundTrip) runs:
+//
+//	hc.ReleaseReader(br)            // *bufio.Reader -> sync.Pool
+//	releaseRequestStream(rbs)       // zeroes rs.reader/header/chunkLeft -> sync.Pool
+//	hc.CloseConn(cc)                // only NOW does the blocked Read wake up
+//
+// The pooled objects are recycled BEFORE the connection is closed, so a reader
+// parked inside (*requestStream).Read is still executing methods on a struct
+// that another request may already have taken out of the pool. This is not a
+// double-close problem — a single, perfectly serialized close is unsafe.
+//
+// The contract Bifrost must therefore honour is stricter than "close at most
+// once" (which the existing BifrostContextKeyConnectionClosed CAS already
+// gives us): nothing may invoke CloseWithError on the fasthttp body stream
+// while a Read on that stream is in flight.
+// ---------------------------------------------------------------------------
+
+// TestDoStreamingRequest_BodyIsNotPooledFastHTTPStream asserts the invariant the
+// #6143 fix establishes.
+//
+// The original bug is not "two goroutines touched a stream". It is that
+// fasthttp's streaming close callback returns the pooled *requestStream and
+// *bufio.Reader to their sync.Pools BEFORE closing the connection, while
+// closing the connection is the only thing that wakes a reader parked in
+// (*requestStream).Read. No caller-side locking can make that safe, so the fix
+// is to keep fasthttp's pooled stream off the streaming path entirely: the
+// request goes out over net/http, whose Body guards its closed flag with a
+// mutex and pools nothing.
+//
+// This test fails if anyone routes streaming responses back through fasthttp's
+// body stream, which would silently reintroduce the race.
+func TestDoStreamingRequest_BodyIsNotPooledFastHTTPStream(t *testing.T) {
+	t.Parallel()
+
+	client, cleanup := newSSEStreamServer(t, 3, time.Millisecond)
+	defer cleanup()
+
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	resp := fasthttp.AcquireResponse()
+
+	req.SetRequestURI("http://test/v1/chat/completions")
+	req.Header.SetMethod(fasthttp.MethodPost)
+	req.SetBodyString(`{"stream":true}`)
+	resp.StreamBody = true
+
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	if err := DoStreamingRequest(ctx, client, req, resp); err != nil {
+		t.Fatalf("streaming request failed: %v", err)
+	}
+	defer ReleaseStreamingResponse(ctx, resp)
+
+	body := resp.BodyStream()
+	if body == nil {
+		t.Fatal("streaming response has no body stream")
+	}
+	if _, ok := body.(io.Closer); !ok {
+		t.Fatalf("body stream %T is not an io.Closer, cancellation cannot close it", body)
+	}
+	if got := fmt.Sprintf("%T", body); strings.Contains(got, "fasthttp") {
+		t.Fatalf("body stream is a fasthttp type (%s): closing it under an in-flight "+
+			"Read recycles the pooled *requestStream into sync.Pool (issue #6143)", got)
+	}
+	if resp.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("status %d, want 200: header copy from the net/http response is broken", resp.StatusCode())
+	}
+	if ct := string(resp.Header.ContentType()); !strings.Contains(ct, "event-stream") {
+		t.Fatalf("content-type %q, want text/event-stream: header copy is broken", ct)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end reproduction against a real fasthttp client + server.
+// Run with -race to see the detector report.
+// ---------------------------------------------------------------------------
+
+// newSSEStreamServer serves a chunked SSE body, emitting chunks at the given
+// interval, over an in-memory listener.
+func newSSEStreamServer(t *testing.T, chunks int, interval time.Duration) (*fasthttp.Client, func()) {
+	t.Helper()
+	ln := fasthttputil.NewInmemoryListener()
+
+	server := &fasthttp.Server{
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			ctx.SetStatusCode(fasthttp.StatusOK)
+			ctx.SetContentType("text/event-stream")
+			ctx.SetBodyStreamWriter(func(w *bufio.Writer) {
+				for i := 0; i < chunks; i++ {
+					if _, err := w.WriteString("data: {\"i\":" + string(rune('0'+i%10)) + "}\n\n"); err != nil {
+						return
+					}
+					if err := w.Flush(); err != nil {
+						return
+					}
+					time.Sleep(interval)
+				}
+				_, _ = w.WriteString("data: [DONE]\n\n") //nolint:errcheck
+				_ = w.Flush()                            //nolint:errcheck
+			})
+		},
+	}
+	go server.Serve(ln) //nolint:errcheck
+
+	base := &fasthttp.Client{
+		Dial:         func(string) (net.Conn, error) { return ln.Dial() },
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 5 * time.Second,
+	}
+	return BuildStreamingClient(base), func() { _ = ln.Close() } //nolint:errcheck
+}
+
+// TestStreamCancellation_PooledRequestStreamRace drives the exact path from the
+// issue report: a real fasthttp streaming response, the SSE reader parked in
+// (*requestStream).Read via idleTimeoutReader, and SetupStreamCancellation's
+// watchdog closing the stream on ctx cancellation mid-body.
+//
+// Under -race this reports "WARNING: DATA RACE" between releaseRequestStream
+// (write) and (*requestStream).Read (read). Without -race it is a no-op
+// smoke test; the deterministic contract assertion lives in the test above.
+func TestStreamCancellation_PooledRequestStreamRace(t *testing.T) {
+	client, cleanup := newSSEStreamServer(t, 40, 50*time.Millisecond)
+	defer cleanup()
+
+	// A pool of concurrent cancelled streams makes the aliasing window wide
+	// enough for the detector to catch it on a single run.
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			runCancelledStream(t, client)
+		}()
+	}
+	wg.Wait()
+}
+
+func runCancelledStream(t *testing.T, client *fasthttp.Client) {
+	t.Helper()
+
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	resp := fasthttp.AcquireResponse()
+
+	req.SetRequestURI("http://test/v1/chat/completions")
+	req.Header.SetMethod(fasthttp.MethodPost)
+	req.SetBodyString(`{"stream":true}`)
+	resp.StreamBody = true
+
+	goCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx := schemas.NewBifrostContext(goCtx, time.Time{})
+
+	if err := DoStreamingRequest(ctx, client, req, resp); err != nil {
+		t.Errorf("streaming request failed: %v", err)
+		fasthttp.ReleaseResponse(resp)
+		return
+	}
+
+	// Mirror the provider streaming goroutine's wrapper stack exactly.
+	defer ReleaseStreamingResponse(ctx, resp)
+	reader, stopIdleTimeout := NewIdleTimeoutReader(resp.BodyStream(), resp.BodyStream(), time.Minute, ctx)
+	defer stopIdleTimeout()
+	stopCancellation := SetupStreamCancellation(ctx, resp.BodyStream(), getLogger())
+	defer stopCancellation()
+
+	// Cancel while the body is still streaming — the trigger condition.
+	time.AfterFunc(250*time.Millisecond, cancel)
+
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			return
+		}
+	}
+}

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -436,6 +436,20 @@ func MakeRequestWithContext(ctx context.Context, client *fasthttp.Client, req *f
 	return latency, bifrostErr, wait
 }
 
+// MakeStreamingRequestWithContext is MakeRequestWithContext for a response whose
+// body is streamed rather than buffered (resp.StreamBody). It shares the same
+// cancellation, latency and error-classification handling, but sends through
+// net/http so the response body is never fasthttp's pooled *requestStream —
+// see DoStreamingRequest and httpstream.go for why that matters (issue #6143).
+//
+// base must be the caller's long-lived client, not a per-request clone such as
+// BuildLargeResponseClient's, so the net/http twin cache stays bounded. The
+// clone's fasthttp-only knobs have no effect on a net/http send in any case;
+// the large-response threshold is enforced by FinalizeResponseWithLargeDetection.
+func MakeStreamingRequestWithContext(ctx context.Context, base *fasthttp.Client, req *fasthttp.Request, resp *fasthttp.Response) (time.Duration, *schemas.BifrostError, func()) {
+	return makeRequestWithDoFunc(ctx, func() error { return DoStreamingRequestViaHTTP(ctx, base, req, resp) })
+}
+
 // MakeRequestWithContextFollowRedirects is like MakeRequestWithContext but follows up to
 // maxRedirects HTTP redirects automatically (equivalent to curl's -L flag).
 func MakeRequestWithContextFollowRedirects(ctx context.Context, client *fasthttp.Client, req *fasthttp.Request, resp *fasthttp.Response, maxRedirects int) (time.Duration, *schemas.BifrostError, func()) {
@@ -452,11 +466,22 @@ func MakeRequestWithContextFollowRedirects(ctx context.Context, client *fasthttp
 // is measured separately, inside idleTimeoutReader.Read. Both are needed;
 // counting only one attributes the other to Bifrost.
 //
-// Returns client.Do's error untouched so callers keep their own error
+// Returns the send error untouched so callers keep their own error
 // classification and latency bookkeeping.
+//
+// The send goes through net/http rather than fasthttp. fasthttp's streaming
+// close callback recycles the pooled *requestStream and *bufio.Reader before it
+// closes the connection, so cancelling a stream mid-body always resumes the
+// reader on an object that is already back in a sync.Pool (issue #6143). That
+// ordering is inside fasthttp and unchanged across v1.69.0 to v1.73.0.
+// net/http guards Body.Close against a concurrent Read with a mutex and pools
+// nothing, so the same cancellation is safe. See httpstream.go.
+//
+// resp still carries the status, headers and body stream afterwards, so every
+// caller and every downstream helper is unaffected.
 func DoStreamingRequest(ctx context.Context, client *fasthttp.Client, req *fasthttp.Request, resp *fasthttp.Response) error {
 	startTime := time.Now()
-	err := client.Do(req, resp)
+	err := DoStreamingRequestViaHTTP(ctx, client, req, resp)
 	schemas.AddUpstreamLatency(ctx, time.Since(startTime))
 	return err
 }

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -4720,9 +4720,9 @@ func (provider *VertexProvider) PassthroughStream(
 		fasthttpReq.SetBody(req.Body)
 	}
 
-	activeClient := providerUtils.PrepareResponseStreaming(ctx, provider.streamingClient, resp)
+	providerUtils.PrepareStreamResponseThreshold(ctx, resp)
 	startTime := time.Now()
-	err := providerUtils.DoStreamingRequest(ctx, activeClient, fasthttpReq, resp)
+	err := providerUtils.DoStreamingRequest(ctx, provider.streamingClient, fasthttpReq, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		providerUtils.ReleaseStreamingResponse(ctx, resp)


### PR DESCRIPTION
## Summary

Fixes a data race (issue #6143) where fasthttp's streaming close callback returns the pooled `*requestStream` and `*bufio.Reader` to their `sync.Pool` **before** closing the connection. Since closing the connection is the only thing that unblocks a reader parked in `(*requestStream).Read`, cancelling a stream mid-body always resumes the reader on an object another request may already own. This ordering is inside fasthttp and cannot be fixed with caller-side locking. The fix routes all streaming responses through `net/http`, whose `Body.Close` is mutex-guarded against concurrent `Read` calls and pools nothing.

## Changes

- Added `core/providers/utils/httpstream.go`, which implements `DoStreamingRequestViaHTTP`. It converts a `*fasthttp.Request` to a `*http.Request`, sends it through a cached `*http.Client` twin (keyed on the long-lived provider `streamingClient` pointer), and injects the resulting `http.Response` body into the `fasthttp.Response` via `SetBodyStream`. All downstream helpers (`ExtractProviderResponseHeaders`, `DecompressStreamBody`, `ReleaseStreamingResponse`) continue to work unchanged because they operate on the `fasthttp.Response` fields, not the underlying transport.
- `DoStreamingRequest` now delegates to `DoStreamingRequestViaHTTP` instead of `client.Do`, making the fix transparent to every provider.
- Added `MakeStreamingRequestWithContext` as the streaming counterpart to `MakeRequestWithContext`, sharing the same cancellation, latency and error-classification path while sending through `net/http`.
- Replaced `PrepareResponseStreaming` (which built a per-request fasthttp client clone) with `PrepareStreamResponseThreshold`, which only sets `resp.StreamBody = true`. The fasthttp clone's `StreamResponseBody`, `MaxResponseBodySize` and zeroed timeouts have no effect on a `net/http` send; the large-response threshold is enforced by Bifrost's own readers.
- Removed per-request `BuildStreamingClient` and `BuildLargeResponseClient` calls from the Anthropic, OpenAI, Gemini, Azure, and Vertex streaming paths. Reusing the provider's long-lived client keeps the `net/http` twin cache bounded by the number of providers rather than growing once per request.
- Normalized `io.ErrUnexpectedEOF` to `io.EOF` in `defaultSSEDataReader.ReadDataLine` and `defaultSSEEventReader.ReadEvent`. `net/http` reports a mid-chunk connection close as `io.ErrUnexpectedEOF` where fasthttp reported plain `io.EOF`, so without this the truncation detection path (which surfaces as a retryable 502) would be bypassed and replaced with a generic stream error.
- Added `httpstream_test.go` covering twin stability, dialer/TLS inheritance, request conversion fidelity, status/header propagation, and `Content-Length` ordering inside `injectHTTPStreamResponse`.
- Added `streamcancelrace_test.go` with a deterministic assertion that the streaming body is never a fasthttp type, plus a `-race`-detectable reproduction of the original race using a real in-memory fasthttp server, concurrent cancelled streams, and the full `idleTimeoutReader` + `SetupStreamCancellation` wrapper stack.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Run all tests including the new race-detection coverage
go test -race ./core/providers/utils/... -v -run "TestDoStreamingRequest|TestStreamCancellation|TestStreamingHTTPTwin|TestFastHTTPRequestToHTTP|TestDoStreamingRequestViaHTTP|TestInjectHTTPStreamResponse"

# Full suite
go test -race ./...
```

The `TestStreamCancellation_PooledRequestStreamRace` test should be run with `-race`; without the fix it reports a data race between `releaseRequestStream` (write) and `(*requestStream).Read`. `TestDoStreamingRequest_BodyIsNotPooledFastHTTPStream` fails deterministically if the streaming body is ever a fasthttp type.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #6143

## Security considerations

`StreamingHTTPTwin` inherits the fasthttp client's `TLSConfig` (custom CA, `InsecureSkipVerify`) and `Dial` function (which carries SSRF address filtering and proxy configuration). No security policy is weakened or bypassed by the transport switch.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable