### PR TITLE
fix: build fix for scimAPI fallback

### DIFF
--- a/ui/app/_fallbacks/enterprise/lib/store/apis/scimApi.ts
+++ b/ui/app/_fallbacks/enterprise/lib/store/apis/scimApi.ts
@@ -22,7 +22,7 @@ export const useGetSCIMProvidersQuery = (
 	_args?: undefined,
 	_opts?: { skip?: boolean },
 ): {
-	data: unknown[] | undefined;
+	data: { enabled: boolean }[] | undefined;
 	isLoading: boolean;
 	isError: boolean;
 	error: null;


### PR DESCRIPTION
## Summary

Improves type safety for the SCIM providers fallback query hook by replacing the generic `unknown[]` return type with a typed `{ enabled: boolean }[]` shape.

## Changes

- The `data` return type of `useGetSCIMProvidersQuery` in the enterprise fallback was changed from `unknown[]` to `{ enabled: boolean }[]`, ensuring consumers can safely access the `enabled` property without additional type assertions or runtime checks.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable