### PR TITLE
chore: update flake for 1.26.7

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,13 +17,13 @@
         "aarch64-darwin" # 64-bit ARM macOS
       ];
 
-      # Temporary workaround until nixpkgs includes Go 1.26.6.
-      go_1_26_6_overlay = final: prev: {
+      # Temporary workaround until nixpkgs includes Go 1.26.7.
+      go_1_26_7_overlay = final: prev: {
         go_1_26 = prev.go_1_26.overrideAttrs (oldAttrs: rec {
-          version = "1.26.6";
+          version = "1.26.7";
           src = final.fetchurl {
             url = "https://go.dev/dl/go${version}.src.tar.gz";
-            sha256 = "a0721c54c688901448d77ad9b3ec7ea7c474730755ff891382e92ecb93ff2cb1";
+            sha256 = "0ed24eac755105085b89fe9cabc2742b91a0ad7b94b59d3ad364918ebc8956ad";
           };
         });
         go = final.go_1_26;
@@ -39,7 +39,7 @@
             # Provides a system-specific, configured Nixpkgs
             pkgs = import inputs.nixpkgs {
               inherit system;
-              overlays = [ go_1_26_6_overlay ];
+              overlays = [ go_1_26_7_overlay ];
               # Enable using unfree packages
               config.allowUnfree = true;
             };

--- a/ui/app/_fallbacks/enterprise/lib/store/apis/scimApi.ts
+++ b/ui/app/_fallbacks/enterprise/lib/store/apis/scimApi.ts
@@ -22,7 +22,7 @@ export const useGetSCIMProvidersQuery = (
 	_args?: undefined,
 	_opts?: { skip?: boolean },
 ): {
-	data: unknown[] | undefined;
+	data: { enabled: boolean }[] | undefined;
 	isLoading: boolean;
 	isError: boolean;
 	error: null;


### PR DESCRIPTION
## Summary

Bumps the Go version overlay in the Nix flake from 1.26.6 to 1.26.7 to keep the development environment up to date with the latest Go patch release.

## Changes

- Updated the Nix overlay to use Go 1.26.7, replacing the previous 1.26.6 pin
- Updated the source tarball SHA256 hash to match the 1.26.7 release

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
nix develop
go version
# Expected: go version go1.26.7 ...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

Go patch releases often include security fixes. Staying current on patch versions reduces exposure to known vulnerabilities in the Go toolchain.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable