### PR TITLE
feat(streaming): add RawStreamTextCodec and paused buffer transform for native SSE redaction

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6713,10 +6713,11 @@ func clearAnthropicPassthroughForNonNativeProvider(ctx *schemas.BifrostContext, 
 		schemas.IsAnthropicModelFamily(ctx, model) {
 		return
 	}
-	// The rewriter is valid only while the matching Anthropic-native body is
-	// forwarded; converted and fallback requests must not inherit it.
+	// Native redaction codecs are valid only while the matching Anthropic body
+	// and response stream are forwarded; converted fallbacks must not inherit them.
 	ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, false)
 	ctx.ClearValue(schemas.BifrostContextKeyRawRequestBodyTextRewriter)
+	ctx.ClearValue(schemas.BifrostContextKeyRawStreamTextCodec)
 	ctx.SetValue(schemas.BifrostContextKeySendBackRawResponse, false)
 	ctx.SetValue(schemas.BifrostContextKeyPassthroughOverridesPresent, false)
 	ctx.ClearValue(schemas.BifrostContextKeyURLPath)

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -283,6 +283,7 @@ const (
 	BifrostContextKeyURLPath                             BifrostContextKey = "bifrost-extra-url-path"                 // string
 	BifrostContextKeyUseRawRequestBody                   BifrostContextKey = "bifrost-use-raw-request-body"
 	BifrostContextKeyRawRequestBodyTextRewriter          BifrostContextKey = "bifrost-raw-request-body-text-rewriter"           // RawRequestBodyTextRewriter (set by native integrations because raw passthrough bypasses normalized runtime redaction)
+	BifrostContextKeyRawStreamTextCodec                  BifrostContextKey = "bifrost-raw-stream-text-codec"                    // RawStreamTextCodec (set by native integrations whose client response forwards provider-native stream events)
 	BifrostContextKeyChangeRequestType                   BifrostContextKey = "bifrost-change-request-type"                      // RequestType (set by plugins to trigger request type conversion in core, e.g. text->chat or chat->responses)
 	BifrostContextKeySendBackRawRequest                  BifrostContextKey = "bifrost-send-back-raw-request"                    // bool (per-request override — read by bifrost.go, never overwritten)
 	BifrostContextKeySendBackRawResponse                 BifrostContextKey = "bifrost-send-back-raw-response"                   // bool (per-request override — read by bifrost.go, never overwritten)

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -637,6 +637,22 @@ type streamBufferClearer interface {
 	ClearPausedStreamBuffer(traceID string) error
 }
 
+// PausedStreamBufferTransformResult contains rewritten chunks and the leading count safe to replay.
+type PausedStreamBufferTransformResult struct {
+	Chunks       []*BifrostStreamChunk
+	ReleaseCount int
+}
+
+// PausedStreamBufferTransform rewrites a shallow snapshot of chunks captured by one pause epoch.
+// Implementations must use copy-on-write and return the same number of chunks in the same order.
+// ReleaseCount lets the gate replay an approved prefix while keeping an unevaluated suffix paused.
+type PausedStreamBufferTransform func(chunks []*BifrostStreamChunk) (PausedStreamBufferTransformResult, error)
+
+// streamBufferTransformer is an optional tracer capability for atomically rewriting paused client chunks.
+type streamBufferTransformer interface {
+	TransformPausedStreamBuffer(traceID string, transform PausedStreamBufferTransform) error
+}
+
 // ClearPausedStreamBuffer drops chunks buffered while the active stream is paused.
 func (bc *BifrostContext) ClearPausedStreamBuffer() error {
 	tr, _ := bc.Value(BifrostContextKeyTracer).(Tracer)
@@ -649,6 +665,24 @@ func (bc *BifrostContext) ClearPausedStreamBuffer() error {
 		return fmt.Errorf("stream tracer does not support buffer clearing")
 	}
 	return clearer.ClearPausedStreamBuffer(tid)
+}
+
+// TransformPausedStreamBuffer atomically rewrites chunks captured since the latest pause.
+// The current PostLLMHook chunk has not reached the gate yet and is therefore not included.
+func (bc *BifrostContext) TransformPausedStreamBuffer(transform PausedStreamBufferTransform) error {
+	if transform == nil {
+		return fmt.Errorf("paused stream buffer transform is nil")
+	}
+	tr, _ := bc.Value(BifrostContextKeyTracer).(Tracer)
+	tid, _ := bc.Value(BifrostContextKeyTraceID).(string)
+	if tr == nil || tid == "" {
+		return fmt.Errorf("stream tracer or trace ID is missing")
+	}
+	transformer, ok := any(tr).(streamBufferTransformer)
+	if !ok {
+		return fmt.Errorf("stream tracer does not support buffer transformation")
+	}
+	return transformer.TransformPausedStreamBuffer(tid, transform)
 }
 
 // EndStream terminates the active streaming response. Any buffered chunks are

--- a/core/schemas/redaction.go
+++ b/core/schemas/redaction.go
@@ -12,6 +12,22 @@ import (
 // slice because implementations may mutate the input in place; any rewrite error is unsafe to forward.
 type RawRequestBodyTextRewriter func(rawBody []byte, replacements map[string]string) ([]byte, error)
 
+// RawStreamTextEvent identifies guardrail-visible text carried by one provider-native stream event.
+type RawStreamTextEvent struct {
+	TargetID string
+	Text     string
+}
+
+// RawStreamTextCodec inspects and rewrites text in one provider-native raw stream event.
+// Integrations own this contract because only they know which raw event fields mirror
+// normalized assistant text; unrelated reasoning, tool, and lifecycle fields stay opaque.
+type RawStreamTextCodec interface {
+	// Inspect returns the event's text and opaque provider target identity when it is eligible.
+	Inspect(rawResponse string) (event RawStreamTextEvent, eligible bool, err error)
+	// Rewrite returns a copy of an eligible raw event with only its text field replaced.
+	Rewrite(rawResponse string, text string) (string, error)
+}
+
 // RedactionPhase identifies which request lifecycle phase produced a redaction finding.
 type RedactionPhase string
 

--- a/core/utils.go
+++ b/core/utils.go
@@ -423,6 +423,7 @@ func ClearContextForInternalRequest(ctx *schemas.BifrostContext) {
 	// Body transport.
 	ctx.ClearValue(schemas.BifrostContextKeyUseRawRequestBody)
 	ctx.ClearValue(schemas.BifrostContextKeyRawRequestBodyTextRewriter)
+	ctx.ClearValue(schemas.BifrostContextKeyRawStreamTextCodec)
 	ctx.ClearValue(schemas.BifrostContextKeySendBackRawRequest)
 	ctx.ClearValue(schemas.BifrostContextKeySendBackRawResponse)
 	ctx.ClearValue(schemas.BifrostContextKeyPassthroughOverridesPresent)

--- a/framework/streaming/accumulator.go
+++ b/framework/streaming/accumulator.go
@@ -439,6 +439,8 @@ func (a *Accumulator) cleanupStreamAccumulator(requestID string, forceEndGate bo
 		}
 		acc.gateReplayBuf = nil
 		acc.gateReplayBufBytes = 0
+		acc.gateTransformStart = 0
+		acc.gateApprovedPrefix = 0
 	}
 
 	// Return all chunks to the pool before deleting

--- a/framework/streaming/gate.go
+++ b/framework/streaming/gate.go
@@ -68,6 +68,18 @@ func (a *Accumulator) ClearPausedStreamBuffer(traceID string) error {
 	return v.(*StreamAccumulator).ClearPausedBuffer()
 }
 
+// TransformPausedStreamBuffer atomically rewrites chunks captured by the latest pause epoch.
+func (a *Accumulator) TransformPausedStreamBuffer(traceID string, transform schemas.PausedStreamBufferTransform) error {
+	if traceID == "" {
+		return fmt.Errorf("trace ID is empty")
+	}
+	v, ok := a.streamAccumulators.Load(traceID)
+	if !ok {
+		return fmt.Errorf("stream accumulator not found")
+	}
+	return v.(*StreamAccumulator).TransformPausedBuffer(transform)
+}
+
 // EndStream is the Tracer-level entry point for terminating a stream.
 // Any buffered chunks are flushed first; then if err is non-nil it is delivered
 // as a terminal error chunk. After EndStream, further provider chunks are dropped.
@@ -222,7 +234,7 @@ func (a *Accumulator) GateSend(traceID string, chunk *schemas.BifrostStreamChunk
 	return sa.GateSend(chunk, isFinal, isHardErr, ch, ctx)
 }
 
-// Pause transitions the gate from Active to Paused. Idempotent.
+// Pause transitions the gate from Active to Paused and revokes buffered replay permission. Idempotent.
 func (sa *StreamAccumulator) Pause() {
 	sa.mu.Lock()
 	defer sa.mu.Unlock()
@@ -233,6 +245,11 @@ func (sa *StreamAccumulator) Pause() {
 	sa.gateReplayEventInterval = 0
 	sa.gateState = StreamStatePaused
 	sa.gatePausedAt = sa.gateSeq
+	sa.gatePauseEpoch++
+	// Keep an older replay backlog outside the new transform scope, but do not
+	// let it cross the new pause until a transform commits or Resume is called.
+	sa.gateTransformStart = len(sa.gateReplayBuf)
+	sa.gateApprovedPrefix = 0
 }
 
 // Resume transitions the gate from Paused back to Active and wakes the flusher
@@ -310,6 +327,8 @@ func (sa *StreamAccumulator) ClearPausedBuffer() error {
 	}
 	sa.gateReplayBuf = nil
 	sa.gateReplayBufBytes = 0
+	sa.gateTransformStart = 0
+	sa.gateApprovedPrefix = 0
 	// Dropping the buffer also discards the pacing armed for that buffer.
 	sa.gateReplayEventInterval = 0
 	// A terminal chunk buffered while paused no longer exists; keeping the
@@ -317,6 +336,77 @@ func (sa *StreamAccumulator) ClearPausedBuffer() error {
 	// and silently drop the caller's replacement terminal chunk.
 	sa.gatePendingTerminal = false
 	if sa.gateCond != nil {
+		sa.gateCond.Broadcast()
+	}
+	return nil
+}
+
+// TransformPausedBuffer transactionally replaces the current pause epoch's chunk pointers.
+// The callback runs without the gate mutex, and the result is installed only when the
+// paused epoch and its buffered suffix are unchanged. Callbacks must use copy-on-write.
+func (sa *StreamAccumulator) TransformPausedBuffer(transform schemas.PausedStreamBufferTransform) error {
+	if transform == nil {
+		return fmt.Errorf("paused stream buffer transform is nil")
+	}
+
+	sa.mu.Lock()
+	if sa.gateState != StreamStatePaused {
+		sa.mu.Unlock()
+		return fmt.Errorf("stream gate is not paused")
+	}
+	epoch := sa.gatePauseEpoch
+	start := sa.gateTransformStart
+	if start < 0 || start > len(sa.gateReplayBuf) || sa.gateApprovedPrefix > start {
+		sa.mu.Unlock()
+		return fmt.Errorf("paused stream buffer transform scope is invalid")
+	}
+	original := append([]*schemas.BifrostStreamChunk(nil), sa.gateReplayBuf[start:]...)
+	sa.mu.Unlock()
+
+	result, err := transform(original)
+	if err != nil {
+		return err
+	}
+	if len(result.Chunks) != len(original) {
+		return fmt.Errorf("paused stream buffer transform changed chunk count from %d to %d", len(original), len(result.Chunks))
+	}
+	if result.ReleaseCount < 0 || result.ReleaseCount > len(original) {
+		return fmt.Errorf("paused stream buffer transform release count %d is outside [0,%d]", result.ReleaseCount, len(original))
+	}
+
+	var originalBytes, transformedBytes int64
+	for i := range original {
+		originalBytes += chunkBytes(original[i])
+		transformedBytes += chunkBytes(result.Chunks[i])
+	}
+
+	sa.mu.Lock()
+	defer sa.mu.Unlock()
+	if sa.gateState != StreamStatePaused || sa.gatePauseEpoch != epoch {
+		return fmt.Errorf("paused stream buffer changed during transformation")
+	}
+	currentStart := sa.gateTransformStart
+	if currentStart < 0 || currentStart > start || sa.gateApprovedPrefix > currentStart || len(sa.gateReplayBuf) != currentStart+len(original) {
+		return fmt.Errorf("paused stream buffer changed during transformation")
+	}
+	for i := range original {
+		if sa.gateReplayBuf[currentStart+i] != original[i] {
+			return fmt.Errorf("paused stream buffer changed during transformation")
+		}
+	}
+	nextBytes := sa.gateReplayBufBytes - originalBytes + transformedBytes
+	if nextBytes < 0 {
+		nextBytes = 0
+	}
+	if nextBytes > gateReplayBufMaxBytes {
+		return fmt.Errorf("transformed paused stream buffer exceeds %d bytes", gateReplayBufMaxBytes)
+	}
+	copy(sa.gateReplayBuf[currentStart:], result.Chunks)
+	sa.gateReplayBufBytes = nextBytes
+	nextBoundary := currentStart + result.ReleaseCount
+	sa.gateTransformStart = nextBoundary
+	sa.gateApprovedPrefix = nextBoundary
+	if sa.gateApprovedPrefix > 0 && sa.gateCond != nil {
 		sa.gateCond.Broadcast()
 	}
 	return nil
@@ -470,11 +560,18 @@ func (sa *StreamAccumulator) GateSend(chunk *schemas.BifrostStreamChunk, isFinal
 
 // drainBufferLocked drains gateReplayBuf to gateFlusherCh in order. MUST be
 // called with sa.mu held. Releases sa.mu while sending; reacquires before
-// returning. Stops draining if state transitions to Paused or ctx is done.
+// returning. While paused, it drains only the approved prefix and leaves the
+// current unevaluated suffix held. It also stops when ctx is done.
 func (sa *StreamAccumulator) drainBufferLocked() {
-	for sa.gateState != StreamStatePaused && len(sa.gateReplayBuf) > 0 {
+	for len(sa.gateReplayBuf) > 0 && (sa.gateState != StreamStatePaused || sa.gateApprovedPrefix > 0) {
 		chunk := sa.gateReplayBuf[0]
 		sa.gateReplayBuf = sa.gateReplayBuf[1:]
+		if sa.gateTransformStart > 0 {
+			sa.gateTransformStart--
+		}
+		if sa.gateApprovedPrefix > 0 {
+			sa.gateApprovedPrefix--
+		}
 		// Decrement bytes per-chunk so the counter stays accurate even if
 		// the loop exits mid-drain (Pause). Clamp at zero to absorb any
 		// rounding drift between MarshalJSON sizes captured on append vs.
@@ -495,6 +592,8 @@ func (sa *StreamAccumulator) drainBufferLocked() {
 			// Delivery or pacing was canceled; abandon the remaining buffer.
 			sa.gateReplayBuf = nil
 			sa.gateReplayBufBytes = 0
+			sa.gateTransformStart = 0
+			sa.gateApprovedPrefix = 0
 			// Canceled replay is terminal, so its interval is no longer applicable.
 			sa.gateReplayEventInterval = 0
 			sa.gateState = StreamStateEnded
@@ -504,6 +603,8 @@ func (sa *StreamAccumulator) drainBufferLocked() {
 	if len(sa.gateReplayBuf) == 0 {
 		sa.gateReplayBuf = nil // release backing array
 		sa.gateReplayBufBytes = 0
+		sa.gateTransformStart = 0
+		sa.gateApprovedPrefix = 0
 		// Pacing belongs to this buffer and must not survive a completed replay.
 		sa.gateReplayEventInterval = 0
 	}
@@ -533,7 +634,7 @@ func (sa *StreamAccumulator) gateFlusher() {
 	for {
 		// Wait while paused (chunks may continue to arrive), or while active
 		// with empty buffer (no work). Wake on Ended or buffered-while-active.
-		for sa.gateState != StreamStateEnded && (sa.gateState == StreamStatePaused || len(sa.gateReplayBuf) == 0) {
+		for sa.gateState != StreamStateEnded && (len(sa.gateReplayBuf) == 0 || (sa.gateState == StreamStatePaused && sa.gateApprovedPrefix == 0)) {
 			sa.gateCond.Wait()
 		}
 		// Drain whatever is buffered (state is Active or Ended here).

--- a/framework/streaming/gate_test.go
+++ b/framework/streaming/gate_test.go
@@ -3,6 +3,7 @@ package streaming
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -432,6 +433,273 @@ func TestGate_ClearPausedStreamBufferDropsBufferedTerminal(t *testing.T) {
 	}
 	if sa.gateState != StreamStateEnded {
 		t.Fatalf("expected Ended after replacement terminal, got %v", sa.gateState)
+	}
+}
+
+// TestGate_TransformPausedStreamBufferReplaysCopies verifies a successful transform replaces only client-facing buffered pointers.
+func TestGate_TransformPausedStreamBufferReplaysCopies(t *testing.T) {
+	a := newTestAccumulator(t)
+	traceID := "trace-transform-paused"
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	r := newRecorder(8)
+	defer r.close()
+	chunks := makeChunks(2)
+
+	a.PauseStream(traceID)
+	for _, chunk := range chunks {
+		if !a.GateSend(traceID, chunk, false, false, r.ch, ctx) {
+			t.Fatal("paused GateSend returned false")
+		}
+	}
+	err := a.TransformPausedStreamBuffer(traceID, func(buffered []*schemas.BifrostStreamChunk) (schemas.PausedStreamBufferTransformResult, error) {
+		rewritten := make([]*schemas.BifrostStreamChunk, len(buffered))
+		for i, chunk := range buffered {
+			chunkCopy := *chunk
+			responseCopy := *chunk.BifrostChatResponse
+			responseCopy.ID += "-redacted"
+			chunkCopy.BifrostChatResponse = &responseCopy
+			rewritten[i] = &chunkCopy
+		}
+		return schemas.PausedStreamBufferTransformResult{Chunks: rewritten, ReleaseCount: len(rewritten)}, nil
+	})
+	if err != nil {
+		t.Fatalf("TransformPausedStreamBuffer() error = %v", err)
+	}
+	for i, chunk := range chunks {
+		if chunk.BifrostChatResponse.ID != fmt.Sprintf("chunk-%d", i) {
+			t.Fatalf("provider-original chunk %d was mutated: %q", i, chunk.BifrostChatResponse.ID)
+		}
+	}
+
+	a.ResumeStream(traceID)
+	if !r.waitFor(2, time.Second) {
+		t.Fatal("transformed chunks were not replayed")
+	}
+	got, _ := r.snapshot()
+	for i, chunk := range got {
+		if chunk.BifrostChatResponse.ID != fmt.Sprintf("chunk-%d-redacted", i) {
+			t.Errorf("replayed chunk %d ID = %q", i, chunk.BifrostChatResponse.ID)
+		}
+		if chunk == chunks[i] {
+			t.Errorf("replayed chunk %d reused provider-original pointer", i)
+		}
+	}
+}
+
+// TestGate_TransformPausedStreamBufferReleasesOnlyApprovedPrefix verifies an unevaluated suffix remains paused.
+func TestGate_TransformPausedStreamBufferReleasesOnlyApprovedPrefix(t *testing.T) {
+	a := newTestAccumulator(t)
+	traceID := "trace-transform-prefix"
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	r := newRecorder(8)
+	defer r.close()
+	chunks := makeChunks(3)
+
+	a.PauseStream(traceID)
+	for _, chunk := range chunks {
+		if !a.GateSend(traceID, chunk, false, false, r.ch, ctx) {
+			t.Fatal("paused GateSend returned false")
+		}
+	}
+	err := a.TransformPausedStreamBuffer(traceID, func(buffered []*schemas.BifrostStreamChunk) (schemas.PausedStreamBufferTransformResult, error) {
+		return schemas.PausedStreamBufferTransformResult{Chunks: buffered, ReleaseCount: 2}, nil
+	})
+	if err != nil {
+		t.Fatalf("TransformPausedStreamBuffer() error = %v", err)
+	}
+	if !r.waitFor(2, time.Second) {
+		t.Fatal("approved prefix was not replayed")
+	}
+	time.Sleep(20 * time.Millisecond)
+	got, _ := r.snapshot()
+	if len(got) != 2 || got[0] != chunks[0] || got[1] != chunks[1] {
+		t.Fatalf("replayed prefix = %#v, want first two chunks only", got)
+	}
+
+	err = a.TransformPausedStreamBuffer(traceID, func(buffered []*schemas.BifrostStreamChunk) (schemas.PausedStreamBufferTransformResult, error) {
+		if len(buffered) != 1 || buffered[0] != chunks[2] {
+			t.Fatalf("next transform snapshot = %#v, want held suffix", buffered)
+		}
+		return schemas.PausedStreamBufferTransformResult{Chunks: buffered, ReleaseCount: 1}, nil
+	})
+	if err != nil {
+		t.Fatalf("second TransformPausedStreamBuffer() error = %v", err)
+	}
+	if !r.waitFor(3, time.Second) {
+		t.Fatal("held suffix was not replayed after approval")
+	}
+	a.ResumeStream(traceID)
+}
+
+// TestGate_TransformPausedStreamBufferFailureKeepsOriginals verifies callback failure cannot partially change replay state.
+func TestGate_TransformPausedStreamBufferFailureKeepsOriginals(t *testing.T) {
+	a := newTestAccumulator(t)
+	traceID := "trace-transform-failure"
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	r := newRecorder(4)
+	defer r.close()
+	chunk := makeChunks(1)[0]
+
+	a.PauseStream(traceID)
+	if !a.GateSend(traceID, chunk, false, false, r.ch, ctx) {
+		t.Fatal("paused GateSend returned false")
+	}
+	err := a.TransformPausedStreamBuffer(traceID, func(buffered []*schemas.BifrostStreamChunk) (schemas.PausedStreamBufferTransformResult, error) {
+		return schemas.PausedStreamBufferTransformResult{}, fmt.Errorf("forced transform failure")
+	})
+	if err == nil {
+		t.Fatal("TransformPausedStreamBuffer() error = nil")
+	}
+	a.ResumeStream(traceID)
+	if !r.waitFor(1, time.Second) {
+		t.Fatal("original chunk was not replayed")
+	}
+	got, _ := r.snapshot()
+	if got[0] != chunk {
+		t.Fatalf("failure replaced original chunk pointer")
+	}
+}
+
+// TestGate_TransformPausedStreamBufferRejectsConcurrentAppend verifies a stale snapshot is never installed over newer chunks.
+func TestGate_TransformPausedStreamBufferRejectsConcurrentAppend(t *testing.T) {
+	a := newTestAccumulator(t)
+	traceID := "trace-transform-concurrent"
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	r := newRecorder(4)
+	defer r.close()
+	chunks := makeChunks(2)
+
+	a.PauseStream(traceID)
+	if !a.GateSend(traceID, chunks[0], false, false, r.ch, ctx) {
+		t.Fatal("first paused GateSend returned false")
+	}
+	callbackStarted := make(chan struct{})
+	continueTransform := make(chan struct{})
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- a.TransformPausedStreamBuffer(traceID, func(buffered []*schemas.BifrostStreamChunk) (schemas.PausedStreamBufferTransformResult, error) {
+			close(callbackStarted)
+			<-continueTransform
+			return schemas.PausedStreamBufferTransformResult{Chunks: buffered}, nil
+		})
+	}()
+	<-callbackStarted
+	if !a.GateSend(traceID, chunks[1], false, false, r.ch, ctx) {
+		t.Fatal("concurrent paused GateSend returned false")
+	}
+	close(continueTransform)
+	if err := <-errCh; err == nil {
+		t.Fatal("TransformPausedStreamBuffer() error = nil after concurrent append")
+	}
+
+	a.ResumeStream(traceID)
+	if !r.waitFor(2, time.Second) {
+		t.Fatal("original chunks were not replayed")
+	}
+	got, _ := r.snapshot()
+	if got[0] != chunks[0] || got[1] != chunks[1] {
+		t.Fatalf("concurrent failure changed buffered pointers")
+	}
+}
+
+// TestGate_TransformPausedStreamBufferScopesLatestPause verifies an older replay backlog is excluded from a new pause epoch.
+func TestGate_TransformPausedStreamBufferScopesLatestPause(t *testing.T) {
+	sa := &StreamAccumulator{
+		gateState:          StreamStateActive,
+		gateReplayBuf:      makeChunks(2),
+		gateReplayBufBytes: 1,
+	}
+	sa.Pause()
+	if sa.gateTransformStart != 2 || sa.gateApprovedPrefix != 0 {
+		t.Fatalf("new pause boundaries = (%d, %d), want transform start 2 and approved prefix 0", sa.gateTransformStart, sa.gateApprovedPrefix)
+	}
+	latest := makeChunks(1)[0]
+	sa.gateReplayBuf = append(sa.gateReplayBuf, latest)
+
+	seen := 0
+	err := sa.TransformPausedBuffer(func(buffered []*schemas.BifrostStreamChunk) (schemas.PausedStreamBufferTransformResult, error) {
+		seen = len(buffered)
+		return schemas.PausedStreamBufferTransformResult{Chunks: buffered, ReleaseCount: 1}, nil
+	})
+	if err != nil {
+		t.Fatalf("TransformPausedBuffer() error = %v", err)
+	}
+	if seen != 1 {
+		t.Fatalf("transform saw %d chunks, want only the latest pause suffix", seen)
+	}
+	if sa.gateTransformStart != 3 || sa.gateApprovedPrefix != 3 {
+		t.Fatalf("committed boundaries = (%d, %d), want 3 old-plus-new chunks approved", sa.gateTransformStart, sa.gateApprovedPrefix)
+	}
+}
+
+// TestGate_PauseDuringDrainStopsReplay verifies a new pause revokes delivery for buffered chunks not already in flight.
+func TestGate_PauseDuringDrainStopsReplay(t *testing.T) {
+	a := newTestAccumulator(t)
+	traceID := "trace-pause-during-drain"
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	ch := make(chan *schemas.BifrostStreamChunk)
+	chunks := makeChunks(3)
+
+	a.PauseStream(traceID)
+	for _, chunk := range chunks {
+		if !a.GateSend(traceID, chunk, false, false, ch, ctx) {
+			t.Fatal("paused GateSend returned false")
+		}
+	}
+	sa := mustGet(t, a, traceID)
+	defer func() {
+		cancel()
+		a.EndStream(traceID, nil)
+		sa.WaitForFlusher()
+	}()
+
+	a.ResumeStream(traceID)
+	deadline := time.Now().Add(time.Second)
+	for {
+		sa.mu.Lock()
+		buffered := len(sa.gateReplayBuf)
+		sa.mu.Unlock()
+		if buffered == 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("flusher did not begin draining; buffered=%d", buffered)
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	a.PauseStream(traceID)
+	if got := <-ch; got != chunks[0] {
+		t.Fatalf("first delivered chunk = %p, want %p", got, chunks[0])
+	}
+	select {
+	case got := <-ch:
+		t.Fatalf("chunk %p escaped after the second pause", got)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// TestGate_TransformPausedStreamBufferEnforcesCap verifies replacement growth cannot bypass the replay limit.
+func TestGate_TransformPausedStreamBufferEnforcesCap(t *testing.T) {
+	sa := &StreamAccumulator{gateState: StreamStateActive}
+	sa.Pause()
+	original := makeChunks(1)[0]
+	sa.gateReplayBuf = append(sa.gateReplayBuf, original)
+	originalBytes := chunkBytes(original)
+	sa.gateReplayBufBytes = gateReplayBufMaxBytes - 1
+
+	err := sa.TransformPausedBuffer(func(buffered []*schemas.BifrostStreamChunk) (schemas.PausedStreamBufferTransformResult, error) {
+		chunkCopy := *buffered[0]
+		responseCopy := *buffered[0].BifrostChatResponse
+		responseCopy.ID = strings.Repeat("x", int(originalBytes)+2)
+		chunkCopy.BifrostChatResponse = &responseCopy
+		return schemas.PausedStreamBufferTransformResult{Chunks: []*schemas.BifrostStreamChunk{&chunkCopy}}, nil
+	})
+	if err == nil {
+		t.Fatal("TransformPausedBuffer() error = nil for oversized replacement")
+	}
+	if sa.gateReplayBuf[0] != original {
+		t.Fatal("oversized replacement changed the buffered chunk")
 	}
 }
 

--- a/framework/streaming/types.go
+++ b/framework/streaming/types.go
@@ -167,6 +167,13 @@ type StreamAccumulator struct {
 	// (purely for diagnostics — the buffered chunks themselves drive replay).
 	gateState    StreamState
 	gatePausedAt int // -1 if never paused
+	// gatePauseEpoch changes on every Active -> Paused transition. gateTransformStart
+	// excludes an older replay backlog from the current transform scope without allowing
+	// that backlog to drain through the new pause. A successful transform advances both
+	// boundaries; draining decrements them as leading chunks leave the buffer.
+	gatePauseEpoch     uint64
+	gateTransformStart int
+	gateApprovedPrefix int // leading buffered chunks allowed to drain while paused
 	// gatePendingTerminal is set when an isFinal or isHardErr chunk arrived
 	// while Paused. The flusher consumes this flag after Resume drains the
 	// buffer and transitions the gate to Ended.

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -664,6 +664,14 @@ func (t *Tracer) ClearPausedStreamBuffer(traceID string) error {
 	return t.accumulator.ClearPausedStreamBuffer(traceID)
 }
 
+// TransformPausedStreamBuffer forwards atomic rewrites of paused client chunks to the streaming accumulator.
+func (t *Tracer) TransformPausedStreamBuffer(traceID string, transform schemas.PausedStreamBufferTransform) error {
+	if t == nil || t.accumulator == nil {
+		return errors.New("stream accumulator is not configured")
+	}
+	return t.accumulator.TransformPausedStreamBuffer(traceID, transform)
+}
+
 // EndStream terminates the streaming response. Any buffered chunks are flushed
 // first; if err is non-nil it is then delivered as a terminal error chunk. After
 // EndStream, all further provider chunks are dropped (PostLLMHook still fires).

--- a/framework/tracing/tracer_test.go
+++ b/framework/tracing/tracer_test.go
@@ -77,6 +77,34 @@ func TestTracer_CompleteAndFlushTraceInjectsObservabilityPlugins(t *testing.T) {
 	}
 }
 
+// TestTracer_TransformPausedStreamBufferForwardsToAccumulator verifies the production tracer exposes the gate transformation capability.
+func TestTracer_TransformPausedStreamBufferForwardsToAccumulator(t *testing.T) {
+	store := NewTraceStore(5*time.Minute, nil)
+	defer store.Stop()
+
+	tracer := NewTracer(store, nil, nil)
+	defer tracer.Stop()
+
+	const traceID = "trace-transform-paused"
+	tracer.PauseStream(traceID)
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyTracer, tracer)
+	ctx.SetValue(schemas.BifrostContextKeyTraceID, traceID)
+
+	called := false
+	err := ctx.TransformPausedStreamBuffer(func(chunks []*schemas.BifrostStreamChunk) (schemas.PausedStreamBufferTransformResult, error) {
+		called = true
+		return schemas.PausedStreamBufferTransformResult{Chunks: chunks}, nil
+	})
+	if err != nil {
+		t.Fatalf("TransformPausedStreamBuffer() error = %v", err)
+	}
+	if !called {
+		t.Fatal("TransformPausedStreamBuffer() did not reach the streaming accumulator")
+	}
+}
+
 func TestTracer_CompleteAndFlushTraceRedactsContentBeforeInject(t *testing.T) {
 	store := NewTraceStore(5*time.Minute, nil)
 	defer store.Stop()

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/tidwall/sjson"
 	"github.com/valyala/fasthttp"
 )
 
@@ -311,6 +312,7 @@ func checkAnthropicPassthrough(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.Bif
 
 	var provider schemas.ModelProvider
 	var model string
+	isMessagesRequest := false
 
 	switch r := req.(type) {
 	case *anthropic.AnthropicTextRequest:
@@ -318,6 +320,7 @@ func checkAnthropicPassthrough(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.Bif
 
 	case *anthropic.AnthropicMessageRequest:
 		provider, model = schemas.ParseModelString(r.Model, "")
+		isMessagesRequest = true
 	}
 
 	headers := extractHeadersFromRequest(ctx)
@@ -345,11 +348,23 @@ func checkAnthropicPassthrough(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.Bif
 				bifrostCtx.SetValue(schemas.BifrostContextKeyExtraHeaders, passthroughHeaders)
 			}
 		}
-		if provider == schemas.Vertex && (hasPromptCachingScopeBetaHeader(headers) || hasFastModeBetaHeader(headers)) {
+		// These providers convert output_config.format through Bifrost, including
+		// their client-facing response events, so raw request and response text
+		// rewriters do not apply.
+		if (provider == schemas.Vertex || provider == schemas.BedrockMantle || provider == schemas.Azure) && hasOutputConfigFormat(req) {
 			bifrostCtx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, false)
 			return nil
 		}
-		if (provider == schemas.Vertex || provider == schemas.BedrockMantle || provider == schemas.Azure) && hasOutputConfigFormat(req) {
+		if isMessagesRequest {
+			// Native Messages response forwarding is independent of raw request
+			// serialization. Vertex beta modes serialize the normalized request but
+			// still return Anthropic SSE that Guardrails must synchronize.
+			bifrostCtx.SetValue(
+				schemas.BifrostContextKeyRawStreamTextCodec,
+				schemas.RawStreamTextCodec(anthropicRawStreamTextCodec{}),
+			)
+		}
+		if provider == schemas.Vertex && (hasPromptCachingScopeBetaHeader(headers) || hasFastModeBetaHeader(headers)) {
 			bifrostCtx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, false)
 			return nil
 		}
@@ -361,6 +376,46 @@ func checkAnthropicPassthrough(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.Bif
 		)
 	}
 	return nil
+}
+
+// anthropicRawStreamTextCodec owns Anthropic's native text-delta JSON shape.
+type anthropicRawStreamTextCodec struct{}
+
+// Inspect returns text only for assistant content_block_delta text_delta events.
+func (anthropicRawStreamTextCodec) Inspect(rawResponse string) (schemas.RawStreamTextEvent, bool, error) {
+	if !gjson.Valid(rawResponse) {
+		return schemas.RawStreamTextEvent{}, false, fmt.Errorf("anthropic raw stream event is not valid JSON")
+	}
+	if gjson.Get(rawResponse, "type").String() != "content_block_delta" ||
+		gjson.Get(rawResponse, "delta.type").String() != "text_delta" {
+		return schemas.RawStreamTextEvent{}, false, nil
+	}
+	index := gjson.Get(rawResponse, "index")
+	if !index.Exists() || index.Type != gjson.Number || index.Int() < 0 {
+		return schemas.RawStreamTextEvent{}, false, fmt.Errorf("anthropic text_delta event has invalid index")
+	}
+	text := gjson.Get(rawResponse, "delta.text")
+	if !text.Exists() || text.Type != gjson.String {
+		return schemas.RawStreamTextEvent{}, false, fmt.Errorf("anthropic text_delta event has invalid delta.text")
+	}
+	return schemas.RawStreamTextEvent{
+		TargetID: strconv.FormatInt(index.Int(), 10),
+		Text:     text.String(),
+	}, true, nil
+}
+
+// Rewrite replaces only delta.text on an eligible Anthropic raw stream event.
+func (codec anthropicRawStreamTextCodec) Rewrite(rawResponse string, text string) (string, error) {
+	if _, eligible, err := codec.Inspect(rawResponse); err != nil {
+		return "", err
+	} else if !eligible {
+		return "", fmt.Errorf("anthropic raw stream event is not an eligible text_delta")
+	}
+	rewritten, err := sjson.Set(rawResponse, "delta.text", text)
+	if err != nil {
+		return "", fmt.Errorf("rewrite anthropic text_delta: %w", err)
+	}
+	return rewritten, nil
 }
 
 // rewriteAnthropicRawRequestBody applies runtime replacements only to Anthropic fields mirrored as mutable normalized text.

--- a/transports/bifrost-http/integrations/anthropic_test.go
+++ b/transports/bifrost-http/integrations/anthropic_test.go
@@ -11,6 +11,68 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+// TestAnthropicRawStreamTextCodecRewritesOnlyTextDelta verifies the codec preserves provider-native event structure.
+func TestAnthropicRawStreamTextCodecRewritesOnlyTextDelta(t *testing.T) {
+	codec := anthropicRawStreamTextCodec{}
+	raw := `{"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"Contact alice@example.com"},"usage":{"output_tokens":4}}`
+	event, eligible, err := codec.Inspect(raw)
+	if err != nil {
+		t.Fatalf("Inspect() error = %v", err)
+	}
+	if !eligible || event.TargetID != "2" || event.Text != "Contact alice@example.com" {
+		t.Fatalf("Inspect() = (%+v, %v), want target 2 text event", event, eligible)
+	}
+
+	rewritten, err := codec.Rewrite(raw, "Contact [EMAIL]\nnext")
+	if err != nil {
+		t.Fatalf("Rewrite() error = %v", err)
+	}
+	if got := gjson.Get(rewritten, "delta.text").String(); got != "Contact [EMAIL]\nnext" {
+		t.Errorf("delta.text = %q", got)
+	}
+	if got := gjson.Get(rewritten, "type").String(); got != "content_block_delta" {
+		t.Errorf("type = %q", got)
+	}
+	if got := gjson.Get(rewritten, "usage.output_tokens").Int(); got != 4 {
+		t.Errorf("usage.output_tokens = %d", got)
+	}
+	if got := gjson.Get(raw, "delta.text").String(); got != "Contact alice@example.com" {
+		t.Errorf("provider-original raw event changed to %q", got)
+	}
+}
+
+// TestAnthropicRawStreamTextCodecIgnoresNonTextEvents verifies reasoning, tool JSON, and lifecycle events remain opaque.
+func TestAnthropicRawStreamTextCodecIgnoresNonTextEvents(t *testing.T) {
+	codec := anthropicRawStreamTextCodec{}
+	cases := []string{
+		`{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"alice@example.com"}}`,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"signature_delta","signature":"alice@example.com"}}`,
+		`{"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"email\":\"alice@example.com\"}"}}`,
+		`{"type":"content_block_stop","index":2}`,
+		`{"type":"message_stop"}`,
+	}
+	for _, raw := range cases {
+		if event, eligible, err := codec.Inspect(raw); err != nil || eligible {
+			t.Errorf("Inspect(%s) = (%+v, %v, %v), want ineligible", raw, event, eligible, err)
+		}
+	}
+}
+
+// TestAnthropicRawStreamTextCodecRejectsMalformedEligibleEvents verifies malformed native text events cannot be synchronized.
+func TestAnthropicRawStreamTextCodecRejectsMalformedEligibleEvents(t *testing.T) {
+	codec := anthropicRawStreamTextCodec{}
+	cases := []string{
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta"}}`,
+		`{"type":"content_block_delta","index":"zero","delta":{"type":"text_delta","text":"hello"}}`,
+		`{"type":`,
+	}
+	for _, raw := range cases {
+		if _, _, err := codec.Inspect(raw); err == nil {
+			t.Errorf("Inspect(%q) error = nil", raw)
+		}
+	}
+}
+
 // TestRewriteAnthropicRawRequestBodyRedactsOnlyContentFields verifies native redaction covers conversation content without touching request metadata or tool arguments.
 func TestRewriteAnthropicRawRequestBodyRedactsOnlyContentFields(t *testing.T) {
 	rawBody := []byte(`{
@@ -280,13 +342,81 @@ func TestCheckAnthropicPassthrough_OutputConfigEscapeHatch(t *testing.T) {
 				t.Errorf("expected UseRawRequestBody to stay true for %s, got false", tc.model)
 			}
 			_, hasRewriter := bifrostCtx.Value(schemas.BifrostContextKeyRawRequestBodyTextRewriter).(schemas.RawRequestBodyTextRewriter)
+			_, hasStreamCodec := bifrostCtx.Value(schemas.BifrostContextKeyRawStreamTextCodec).(schemas.RawStreamTextCodec)
 			if tc.wantRawOff && hasRewriter {
 				t.Errorf("expected raw request body text rewriter to remain unset for %s", tc.model)
 			}
 			if !tc.wantRawOff && !hasRewriter {
 				t.Errorf("expected Anthropic raw request body text rewriter for %s", tc.model)
 			}
+			if tc.wantRawOff && hasStreamCodec {
+				t.Errorf("expected raw stream text codec to remain unset for %s", tc.model)
+			}
+			if !tc.wantRawOff && !hasStreamCodec {
+				t.Errorf("expected Anthropic raw stream text codec for %s", tc.model)
+			}
 		})
+	}
+}
+
+// TestCheckAnthropicPassthrough_VertexBetaKeepsNativeResponseCodec verifies
+// request-only Vertex escape hatches do not disable native Messages response rewriting.
+func TestCheckAnthropicPassthrough_VertexBetaKeepsNativeResponseCodec(t *testing.T) {
+	betaHeaders := []string{
+		anthropic.AnthropicPromptCachingScopeBetaHeader,
+		anthropic.AnthropicFastModeBetaHeader,
+	}
+
+	for _, betaHeader := range betaHeaders {
+		t.Run(betaHeader, func(t *testing.T) {
+			reqCtx := &fasthttp.RequestCtx{}
+			reqCtx.Request.Header.SetMethod(fasthttp.MethodPost)
+			reqCtx.Request.Header.Set("user-agent", "claude-code/1.0")
+			reqCtx.Request.Header.Set("x-api-key", "sk-ant-test")
+			reqCtx.Request.Header.Set(anthropic.AnthropicBetaHeader, betaHeader)
+
+			bifrostCtx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+			defer cancel()
+
+			req := &anthropic.AnthropicMessageRequest{
+				Model:     "vertex/claude-opus-4-6",
+				MaxTokens: 1024,
+			}
+			if err := checkAnthropicPassthrough(reqCtx, bifrostCtx, req); err != nil {
+				t.Fatalf("checkAnthropicPassthrough() error = %v", err)
+			}
+
+			if useRaw, _ := bifrostCtx.Value(schemas.BifrostContextKeyUseRawRequestBody).(bool); useRaw {
+				t.Fatal("Vertex beta request kept raw request-body passthrough enabled")
+			}
+			if sendRaw, _ := bifrostCtx.Value(schemas.BifrostContextKeySendBackRawResponse).(bool); !sendRaw {
+				t.Fatal("Vertex beta request disabled native response forwarding")
+			}
+			if _, ok := bifrostCtx.Value(schemas.BifrostContextKeyRawRequestBodyTextRewriter).(schemas.RawRequestBodyTextRewriter); ok {
+				t.Fatal("Vertex beta request registered a raw request-body rewriter")
+			}
+			if _, ok := bifrostCtx.Value(schemas.BifrostContextKeyRawStreamTextCodec).(schemas.RawStreamTextCodec); !ok {
+				t.Fatal("Vertex beta request did not register the native response codec")
+			}
+		})
+	}
+}
+
+// TestCheckAnthropicPassthroughLegacyCompleteOmitsStreamCodec verifies only Messages streams register the native SSE codec.
+func TestCheckAnthropicPassthroughLegacyCompleteOmitsStreamCodec(t *testing.T) {
+	reqCtx := &fasthttp.RequestCtx{}
+	reqCtx.Request.Header.SetMethod(fasthttp.MethodPost)
+	reqCtx.Request.Header.Set("user-agent", "claude-code/1.0")
+	reqCtx.Request.Header.Set("x-api-key", "sk-ant-test")
+	bifrostCtx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	req := &anthropic.AnthropicTextRequest{Model: "anthropic/claude-haiku-4-5"}
+	if err := checkAnthropicPassthrough(reqCtx, bifrostCtx, req); err != nil {
+		t.Fatalf("checkAnthropicPassthrough() error = %v", err)
+	}
+	if _, ok := bifrostCtx.Value(schemas.BifrostContextKeyRawStreamTextCodec).(schemas.RawStreamTextCodec); ok {
+		t.Fatal("legacy complete request registered a Messages raw stream codec")
 	}
 }
 

--- a/transports/go.mod
+++ b/transports/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.18.0
+	github.com/tidwall/sjson v1.2.5
 	github.com/valyala/fasthttp v1.71.0
 	go.uber.org/automaxprocs v1.6.0
 	golang.org/x/sync v0.21.0
@@ -196,7 +197,6 @@ require (
 	github.com/stretchr/objx v0.5.3 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
-	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/weaviate/weaviate v1.38.0 // indirect

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -3116,7 +3116,11 @@ export function LogDetailView({
 												)
 											) : msg.output !== undefined ? (
 												<CollapsibleCode
-													text={typeof msg.output === "string" ? msg.output : JSON.stringify(msg.output, null, 2)}
+													text={
+														typeof msg.output === "string"
+															? applyRedactionMapping(msg.output, mapping)
+															: JSON.stringify(applyRedactionMappingToValue(msg.output, mapping), null, 2)
+													}
 													preview={3}
 												/>
 											) : Array.isArray(msg.tools) && msg.tools.length > 0 ? (


### PR DESCRIPTION
## Summary

Introduces a `RawStreamTextCodec` interface and a `TransformPausedStreamBuffer` gate operation so that guardrails can atomically rewrite provider-native SSE text events held in the stream gate's paused buffer. Previously, only request body redaction was synchronized with the native passthrough path; response stream events had no equivalent mechanism. This closes the gap for Anthropic Messages streams forwarded directly to clients such as Claude Code.

## Changes

- **`RawStreamTextCodec` interface** (`core/schemas/redaction.go`): Defines `Inspect` and `Rewrite` methods that integrations implement to identify and rewrite text-carrying fields in raw provider stream events without touching opaque fields (reasoning, tool JSON, lifecycle events).

- **`BifrostContextKeyRawStreamTextCodec` context key** (`core/schemas/bifrost.go`): Carries the codec through the request lifecycle. Cleared alongside the request body rewriter in `clearAnthropicPassthroughForNonNativeProvider` and `ClearContextForInternalRequest` so converted or fallback requests never inherit a stale codec.

- **`TransformPausedStreamBuffer` gate operation** (`framework/streaming/gate.go`, `types.go`): Atomically replaces chunk pointers in the current pause epoch's buffered suffix. The callback runs outside the gate mutex; the result is installed only when the epoch and buffered suffix are unchanged (optimistic concurrency). A `ReleaseCount` field lets a transform approve a leading prefix for immediate drain while keeping an unevaluated suffix paused. `gatePauseEpoch` and `gateApprovedPrefix` fields track this state across multiple transform calls and across `drainBufferLocked` iterations.

- **`BifrostContext.TransformPausedStreamBuffer`** (`core/schemas/context.go`): Exposes the gate operation through the context, mirroring the existing `ClearPausedStreamBuffer` pattern. Also adds `PausedStreamBufferTransform` and `PausedStreamBufferTransformResult` types and the `streamBufferTransformer` capability interface.

- **Tracer forwarding** (`framework/tracing/tracer.go`): `Tracer.TransformPausedStreamBuffer` delegates to the streaming accumulator, satisfying the `streamBufferTransformer` interface.

- **Anthropic Messages codec** (`transports/bifrost-http/integrations/anthropic.go`): `anthropicRawStreamTextCodec` implements `RawStreamTextCodec` for `content_block_delta / text_delta` events. Registered on the context only for `AnthropicMessageRequest` (not legacy complete). `sjson` promoted from indirect to direct dependency for the `Rewrite` path.

- **`drainBufferLocked` and cleanup paths** updated to respect `gateApprovedPrefix`, ensuring the flusher wakes and drains only approved chunks while a paused suffix remains held, and that the prefix counter is zeroed on buffer clear or context cancellation.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Core
go test ./core/...

# Streaming gate
go test ./framework/streaming/...

# Tracing
go test ./framework/tracing/...

# Anthropic integration
go test ./transports/bifrost-http/integrations/...

# Full transport suite
cd transports && go test ./...
```

Key scenarios covered by new tests:
- `TestGate_TransformPausedStreamBufferReplaysCopies`: successful transform replaces buffered pointers and replays rewritten chunks after resume.
- `TestGate_TransformPausedStreamBufferReleasesOnlyApprovedPrefix`: partial `ReleaseCount` drains an approved prefix while keeping the suffix paused for a subsequent transform call.
- `TestGate_TransformPausedStreamBufferFailureKeepsOriginals`: callback error leaves original pointers intact.
- `TestGate_TransformPausedStreamBufferRejectsConcurrentAppend`: stale snapshot is rejected when a new chunk arrives between snapshot and install.
- `TestGate_TransformPausedStreamBufferScopesLatestPause`: pre-pause backlog is excluded from the transform scope.
- `TestGate_TransformPausedStreamBufferEnforcesCap`: oversized replacement is rejected without mutating the buffer.
- `TestAnthropicRawStreamTextCodec*`: codec correctly identifies, ignores, and rejects various Anthropic SSE event shapes.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

- The codec's `Inspect`/`Rewrite` contract is intentionally narrow: only `content_block_delta / text_delta` events are eligible, so reasoning (`thinking_delta`), tool arguments (`input_json_delta`), and lifecycle events remain opaque and are never rewritten.
- `TransformPausedStreamBuffer` validates epoch and pointer identity before installing results, preventing a race from silently corrupting buffered chunks.
- Oversized replacements are rejected before the buffer is mutated, preserving the existing `gateReplayBufMaxBytes` cap.
- The codec and rewriter are cleared from context on fallback or internal requests, preventing PII-handling logic from leaking across provider boundaries.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable