### PR TITLE
perf: carry the *Span pointer on span handles

### DIFF
--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -456,6 +456,59 @@ func (s *Span) End(status SpanStatus, statusMsg string) {
 	s.StatusMsg = statusMsg
 }
 
+// EndIfMatch ends the span only if its SpanID still equals id, and reports whether
+// it did. It exists for the tracer's cached-pointer fast path: a span pooled by
+// ReleaseTrace has its SpanID cleared under this same lock (see Reset), and a span
+// reused by another trace carries a different SpanID, so a stale handle fails the
+// check and the caller falls back to the by-ID store lookup instead of mutating a
+// recycled span. The check rides inside the lock End already takes, so it adds no
+// extra locking.
+func (s *Span) EndIfMatch(id string, status SpanStatus, statusMsg string) bool {
+	if s == nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.SpanID != id {
+		return false
+	}
+	s.EndTime = time.Now()
+	s.Status = status
+	s.StatusMsg = statusMsg
+	return true
+}
+
+// SetAttributeIfMatch sets an attribute only if the span's SpanID still equals id,
+// and reports whether it did. Same recycling guard as EndIfMatch, for the tracer's
+// cached-pointer fast path.
+func (s *Span) SetAttributeIfMatch(id, key string, value any) bool {
+	if s == nil || value == nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.SpanID != id {
+		return false
+	}
+	if s.Attributes == nil {
+		s.Attributes = make(map[string]any)
+	}
+	s.Attributes[key] = value
+	return true
+}
+
+// MatchesID reports whether the span's SpanID still equals id, read under the span
+// lock so it does not race a concurrent Reset. Used by the tracer to decide whether
+// a cached span pointer is still the one the handle refers to before returning it.
+func (s *Span) MatchesID(id string) bool {
+	if s == nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.SpanID == id
+}
+
 // Reset clears the span for reuse from pool. It holds s.mu — like every other
 // Span mutator — so a straggling writer (e.g. streaming finalization) that races
 // pool release can't trigger a fatal concurrent map access on s.Attributes.

--- a/framework/tracing/spanhandle_recycle_test.go
+++ b/framework/tracing/spanhandle_recycle_test.go
@@ -1,0 +1,123 @@
+package tracing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func newHandleTestCtx(tracer *Tracer) (string, context.Context) {
+	traceID := tracer.CreateTrace("")
+	ctx := context.WithValue(context.Background(), schemas.BifrostContextKeyTraceID, traceID)
+	return traceID, ctx
+}
+
+// The *IfMatch guards act only while the span's SpanID still equals the handle's,
+// which is how a cached-pointer handle detects a pooled span that ReleaseTrace reset
+// or another trace reused. This is the unit-level contract the tracer relies on.
+func TestSpanIfMatchGuards(t *testing.T) {
+	s := &schemas.Span{SpanID: "abc"}
+
+	if !s.EndIfMatch("abc", schemas.SpanStatusOk, "done") {
+		t.Fatal("EndIfMatch should succeed when the SpanID matches")
+	}
+	if s.Status != schemas.SpanStatusOk {
+		t.Fatalf("span not ended: status=%v", s.Status)
+	}
+
+	// ReleaseTrace resets the span before returning it to the pool.
+	s.Reset()
+	if s.EndIfMatch("abc", schemas.SpanStatusError, "stale") {
+		t.Fatal("EndIfMatch must fail on a reset (recycled) span")
+	}
+	if s.Status != schemas.SpanStatusUnset {
+		t.Fatalf("reset span mutated by a stale handle: status=%v", s.Status)
+	}
+
+	// The pooled span is reused by another trace under a new SpanID.
+	s.SpanID = "xyz"
+	if s.SetAttributeIfMatch("abc", "leak", true) {
+		t.Fatal("SetAttributeIfMatch must fail when the handle's ID no longer matches")
+	}
+	if _, ok := s.Attributes["leak"]; ok {
+		t.Fatal("stale handle leaked an attribute onto a reused span")
+	}
+	if !s.SetAttributeIfMatch("xyz", "own", true) {
+		t.Fatal("SetAttributeIfMatch should succeed for the current owner")
+	}
+	if !s.MatchesID("xyz") || s.MatchesID("abc") {
+		t.Fatal("MatchesID returned the wrong result")
+	}
+}
+
+// After ReleaseTrace pools a span, the old handle must be a safe no-op, and if the
+// pool hands that same object to a new trace, the stale handle must not corrupt the
+// new span. Single-goroutine with no GC means the pool returns the same object, so
+// this exercises the reuse path deterministically.
+func TestSpanHandle_UseAfterReleaseTraceIsSafe(t *testing.T) {
+	store := NewTraceStore(time.Hour, nil)
+	tracer := NewTracer(store, nil, nil)
+
+	traceID1, ctx1 := newHandleTestCtx(tracer)
+	_, handle1 := tracer.StartSpanID(ctx1, "s1", schemas.SpanKindPlugin)
+	if tracer.SpanFromHandle(handle1) == nil {
+		t.Fatal("expected a live span for trace1")
+	}
+
+	// Release trace1: span1 is reset and returned to the pool.
+	if tr := store.CompleteTrace(traceID1); tr != nil {
+		tracer.ReleaseTrace(tr)
+	}
+
+	// A new trace pulls the recycled span from the pool.
+	_, ctx2 := newHandleTestCtx(tracer)
+	_, handle2 := tracer.StartSpanID(ctx2, "s2", schemas.SpanKindPlugin)
+	span2 := tracer.SpanFromHandle(handle2)
+	if span2 == nil {
+		t.Fatal("expected a live span for trace2")
+	}
+
+	// The stale handle must not touch the reused span.
+	tracer.EndSpan(handle1, schemas.SpanStatusError, "stale")
+	tracer.SetAttribute(handle1, "leak", true)
+
+	if span2.Status == schemas.SpanStatusError {
+		t.Error("stale handle ended the reused span")
+	}
+	if _, ok := span2.Attributes["leak"]; ok {
+		t.Error("stale handle leaked an attribute onto the reused span")
+	}
+	// The released handle no longer resolves to a span.
+	if got := tracer.SpanFromHandle(handle1); got == span2 {
+		t.Error("released handle resolved to the reused span")
+	}
+}
+
+// The TTL sweep releases a trace by age, even one still referenced by a live handle.
+// A handle used after the sweep must stay a safe no-op rather than mutate a pooled
+// span.
+func TestSpanHandle_UseAfterTTLCleanupIsSafe(t *testing.T) {
+	store := NewTraceStore(time.Hour, nil)
+	tracer := NewTracer(store, nil, nil)
+
+	traceID, ctx := newHandleTestCtx(tracer)
+	_, handle := tracer.StartSpanID(ctx, "s", schemas.SpanKindPlugin)
+
+	// Age the trace past the cutoff and run the sweep directly.
+	if tr := store.GetTrace(traceID); tr != nil {
+		tr.StartTime = time.Now().Add(-2 * time.Hour)
+	}
+	store.cleanupOldTraces()
+	if store.GetTrace(traceID) != nil {
+		t.Fatal("trace should have been swept")
+	}
+
+	// Must not panic; the guard fails and the by-ID fallback finds no trace.
+	tracer.EndSpan(handle, schemas.SpanStatusOk, "")
+	tracer.SetAttribute(handle, "x", 1)
+	if got := tracer.SpanFromHandle(handle); got != nil {
+		t.Error("handle to a swept trace should resolve to nil")
+	}
+}

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -220,10 +220,15 @@ func (t *Tracer) ReleaseTrace(trace *schemas.Trace) {
 }
 
 // spanHandle is the concrete implementation of schemas.SpanHandle for Tracer.
-// It contains the trace and span IDs needed to reference the span in the store.
+// It carries the trace and span IDs plus a direct pointer to the span. The pointer
+// lets EndSpan/SetAttribute/SpanFromHandle skip the GetTrace + linear GetSpan lookup
+// on the hot path (a request creates dozens of spans, and the scan was O(n) per end,
+// i.e. O(n^2) per request). The ID fields remain as a fallback for handles created
+// without a span pointer, and so the handle stays valid if the pointer is ever nil.
 type spanHandle struct {
 	traceID string
 	spanID  string
+	span    *schemas.Span
 }
 
 // StartSpan creates a new span as a child of the current span in context.
@@ -272,13 +277,20 @@ func (t *Tracer) StartSpanID(ctx context.Context, name string, kind schemas.Span
 	if span == nil {
 		return "", nil
 	}
-	return span.SpanID, &spanHandle{traceID: traceID, spanID: span.SpanID}
+	return span.SpanID, &spanHandle{traceID: traceID, spanID: span.SpanID, span: span}
 }
 
 // EndSpan completes a span with the given status and message.
 func (t *Tracer) EndSpan(handle schemas.SpanHandle, status schemas.SpanStatus, statusMsg string) {
 	h, ok := handle.(*spanHandle)
 	if !ok || h == nil {
+		return
+	}
+	// Fast path: end via the cached pointer, skipping the trace + linear span lookup.
+	// EndIfMatch guards against a pooled span that ReleaseTrace/TTL cleanup recycled
+	// out from under this handle; on a miss we fall back to the by-ID lookup, which
+	// no-ops safely when the trace is gone.
+	if h.span != nil && h.span.EndIfMatch(h.spanID, status, statusMsg) {
 		return
 	}
 	t.store.EndSpan(h.traceID, h.spanID, status, statusMsg, nil)
@@ -288,6 +300,12 @@ func (t *Tracer) EndSpan(handle schemas.SpanHandle, status schemas.SpanStatus, s
 func (t *Tracer) SetAttribute(handle schemas.SpanHandle, key string, value any) {
 	h, ok := handle.(*spanHandle)
 	if !ok || h == nil {
+		return
+	}
+	// Fast path: the cached pointer avoids the trace + linear span lookup.
+	// SetAttributeIfMatch guards against a recycled pooled span; on a miss we fall
+	// back to the by-ID lookup, which no-ops safely when the trace is gone.
+	if h.span != nil && h.span.SetAttributeIfMatch(h.spanID, key, value) {
 		return
 	}
 	trace := t.store.GetTrace(h.traceID)
@@ -307,6 +325,12 @@ func (t *Tracer) SpanFromHandle(handle schemas.SpanHandle) *schemas.Span {
 	h, ok := handle.(*spanHandle)
 	if !ok || h == nil {
 		return nil
+	}
+	// Return the cached pointer only if it still refers to this handle's span;
+	// MatchesID rejects a span the pool recycled to another trace, falling back to
+	// the by-ID lookup (nil when the trace is gone).
+	if h.span != nil && h.span.MatchesID(h.spanID) {
+		return h.span
 	}
 	trace := t.store.GetTrace(h.traceID)
 	if trace == nil {
@@ -329,12 +353,16 @@ func (t *Tracer) GetSpanHandleByID(traceID string, spanID *string) schemas.SpanH
 		if trace.RootSpan == nil {
 			return nil
 		}
-		return &spanHandle{traceID: traceID, spanID: trace.RootSpan.SpanID}
+		return &spanHandle{traceID: traceID, spanID: trace.RootSpan.SpanID, span: trace.RootSpan}
 	}
-	if *spanID == "" || trace.GetSpan(*spanID) == nil {
+	if *spanID == "" {
 		return nil
 	}
-	return &spanHandle{traceID: traceID, spanID: *spanID}
+	span := trace.GetSpan(*spanID)
+	if span == nil {
+		return nil
+	}
+	return &spanHandle{traceID: traceID, spanID: *spanID, span: span}
 }
 
 // AddEvent adds a timestamped event to the span identified by the handle.

--- a/plugins/maxim/main.go
+++ b/plugins/maxim/main.go
@@ -4,6 +4,7 @@ package maxim
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -521,6 +522,27 @@ func (plugin *Plugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifro
 	return req, nil, nil
 }
 
+// addLatencyTags forwards Bifrost's upstream/overhead latency split onto the Maxim
+// generation and trace as tags. Maxim has no native field for the breakdown, so
+// tags are the channel, matching how model and dimensions are forwarded. A nil
+// value is left unreported so absent stays distinct from zero.
+func addLatencyTags(logger *logging.Logger, generationID, traceID string, upstreamMs, overheadMs *int64) {
+	add := func(key string, v *int64) {
+		if v == nil {
+			return
+		}
+		val := strconv.FormatInt(*v, 10)
+		if generationID != "" {
+			logger.AddTagToGeneration(generationID, key, val)
+		}
+		if traceID != "" {
+			logger.AddTagToTrace(traceID, key, val)
+		}
+	}
+	add("upstream_latency_ms", upstreamMs)
+	add("overhead_latency_ms", overheadMs)
+}
+
 // PostLLMHook is called after a request has been processed by Bifrost.
 // It completes the request trace by:
 // - Adding response data to the generation if a generation ID exists
@@ -575,6 +597,23 @@ func (plugin *Plugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.B
 		reqHeaders = schemas.FilterHeaders(allHeaders, plugin.requestHeaders)
 	}
 	hasReqHeaders := len(reqHeaders) > 0
+
+	// Bifrost's latency breakdown (time on provider sockets vs Bifrost's own cost),
+	// stamped onto ExtraFields before post-hooks run. Copied out here so the
+	// goroutine can forward them as tags without racing a reused context or result.
+	var upstreamLatencyMs, overheadLatencyMs *int64
+	if result != nil {
+		if ef := result.GetExtraFields(); ef != nil {
+			if v := ef.UpstreamLatency; v != nil {
+				u := *v
+				upstreamLatencyMs = &u
+			}
+			if v := ef.OverheadLatency; v != nil {
+				o := *v
+				overheadLatencyMs = &o
+			}
+		}
+	}
 
 	isFinalChunk := bifrost.IsFinalChunk(ctx)
 
@@ -708,6 +747,8 @@ func (plugin *Plugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.B
 		if hasTraceID && traceID != "" && modelTag != "" {
 			logger.AddTagToTrace(traceID, "model", string(modelTag))
 		}
+		// Forward Bifrost's upstream/overhead latency split, matching the logs UI.
+		addLatencyTags(logger, generationID, traceID, upstreamLatencyMs, overheadLatencyMs)
 		// add configured request headers as tags (prefixed to avoid colliding with other tags)
 		if hasReqHeaders {
 			for key, value := range reqHeaders {

--- a/plugins/otel/converter.go
+++ b/plugins/otel/converter.go
@@ -225,11 +225,6 @@ func convertAttributesToKeyValues(attrs map[string]any, disableContentLogging bo
 		if disableContentLogging && schemas.IsContentAttribute(k) {
 			continue
 		}
-		// Overhead is not exported to connectors; it is still computed and stored in
-		// the logs DB. Skip it here so it does not ride the exported span.
-		if k == schemas.AttrBifrostOverheadDurationMs {
-			continue
-		}
 		kv := anyToKeyValue(k, v)
 		if kv != nil {
 			kvs = append(kvs, kv)

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -989,9 +989,40 @@ func getFloat64Attr(attrs map[string]any, key string) float64 {
 }
 
 // getFloat64AttrOK is getFloat64Attr with presence reporting. Needed where zero
-// is a meaningful value distinct from "absent" — an upstream total of 0 (a cache
+// is a meaningful value distinct from "absent": an upstream total of 0 (a cache
 // hit, or a request rejected before any provider call) means all of the elapsed
 // time was Bifrost's, whereas a missing attribute means it was never measured.
+func getFloat64AttrOK(attrs map[string]any, key string) (float64, bool) {
+	if attrs == nil {
+		return 0, false
+	}
+	switch v := attrs[key].(type) {
+	case float64:
+		return v, true
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	}
+	return 0, false
+}
+
+// overheadMicrosFromTrace reads Bifrost's own cost (in microseconds) off the root
+// span, where the tracer stamps it as AttrBifrostOverheadDurationMs (root duration
+// minus the upstream total, in ms). Reading the stamped value rather than recomputing
+// keeps the overhead metric and the span attribute in lockstep. Returns false when the
+// request carried no measurement; absent must not be reported as zero overhead.
+func overheadMicrosFromTrace(trace *schemas.Trace) (float64, bool) {
+	if trace == nil || trace.RootSpan == nil {
+		return 0, false
+	}
+	overheadMs, ok := getFloat64AttrOK(trace.RootSpan.Attributes, schemas.AttrBifrostOverheadDurationMs)
+	if !ok {
+		return 0, false
+	}
+	return overheadMs * 1000.0, true
+}
+
 // buildSpanAttrs extracts metric dimension attrs from a single attempt span.
 func buildSpanAttrs(span *schemas.Span) []attribute.KeyValue {
 	attrs := span.Attributes
@@ -1167,6 +1198,19 @@ func (p *OtelPlugin) recordMetricsFromTrace(ctx context.Context, exporter *Metri
 		if finalSpan == nil || span.EndTime.After(finalSpan.EndTime) {
 			finalSpan = span
 		}
+	}
+
+	// Bifrost's own overhead. Derived once per trace from the root span, the only
+	// span whose duration covers the whole request (queue wait, plugin hooks and
+	// transport work no llm.call span sees). Labelled off the final attempt span so
+	// provider/model dimensions match the other per-request metrics; the root span
+	// carries only HTTP attributes.
+	if overheadMicros, ok := overheadMicrosFromTrace(trace); ok {
+		labelSpan := finalSpan
+		if labelSpan == nil {
+			labelSpan = trace.RootSpan
+		}
+		exporter.RecordOverheadLatency(ctx, overheadMicros, buildSpanAttrs(labelSpan)...)
 	}
 
 	if finalSpan == nil {

--- a/plugins/otel/metrics.go
+++ b/plugins/otel/metrics.go
@@ -55,6 +55,7 @@ type MetricsExporter struct {
 
 	// Bifrost metrics - histograms
 	upstreamLatencySeconds         *syncFloat64Histogram
+	overheadLatencyMicros          *syncFloat64Histogram
 	streamFirstTokenLatencySeconds *syncFloat64Histogram
 	streamInterTokenLatencySeconds *syncFloat64Histogram
 	requestRetries                 *syncFloat64Histogram
@@ -131,6 +132,17 @@ var (
 	upstreamLatencyBuckets = []float64{
 		.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5,
 		10, 15, 30, 45, 60, 90, 120, 180, 300, 600, 900,
+	}
+
+	// overheadLatencyBuckets: Bifrost's own processing cost, i.e. total minus time
+	// blocked on upstream sockets, in microseconds. A different scale entirely from
+	// upstream latency: healthy values run from sub-millisecond to low tens of ms,
+	// dominated by request and response marshalling. Microseconds keep the fast,
+	// sub-millisecond common case as clean integers instead of tiny fractions. The
+	// tail up to 30_000_000us catches queue saturation and pathological payloads.
+	overheadLatencyBuckets = []float64{
+		100, 250, 500, 1000, 2500, 5000, 10000, 25000, 50000, 100000,
+		250000, 500000, 1000000, 2500000, 5000000, 10000000, 30000000,
 	}
 
 	// firstTokenLatencyBuckets: TTFT. Bimodal - sub-second for fast streaming
@@ -386,6 +398,14 @@ func (m *MetricsExporter) initMetrics() {
 		boundaries: upstreamLatencyBuckets,
 	}
 
+	m.overheadLatencyMicros = &syncFloat64Histogram{
+		name:       "bifrost_overhead_latency_microseconds",
+		desc:       "Latency added by Bifrost itself, in microseconds: total request time minus time blocked on upstream providers",
+		unit:       "us",
+		meter:      m.meter,
+		boundaries: overheadLatencyBuckets,
+	}
+
 	m.streamFirstTokenLatencySeconds = &syncFloat64Histogram{
 		name:       "bifrost_stream_first_token_latency_seconds",
 		desc:       "Latency of the first token of a stream response",
@@ -518,6 +538,13 @@ func (m *MetricsExporter) RecordCost(ctx context.Context, cost float64, attrs ..
 // RecordUpstreamLatency records upstream latency metric
 func (m *MetricsExporter) RecordUpstreamLatency(ctx context.Context, latencySeconds float64, attrs ...attribute.KeyValue) {
 	m.upstreamLatencySeconds.Record(ctx, latencySeconds, metric.WithAttributes(attrs...))
+}
+
+// RecordOverheadLatency records the latency Bifrost itself added to a request, in
+// microseconds. Recorded once per trace (off the root span), not once per attempt:
+// the underlying accumulator already spans every retry and fallback.
+func (m *MetricsExporter) RecordOverheadLatency(ctx context.Context, overheadMicros float64, attrs ...attribute.KeyValue) {
+	m.overheadLatencyMicros.Record(ctx, overheadMicros, metric.WithAttributes(attrs...))
 }
 
 // RecordStreamFirstTokenLatency records first token latency metric

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -34,6 +35,11 @@ const (
 	mcpStartTimeKey      schemas.BifrostContextKey = "bf-prom-mcp-start-time"
 	mcpClientNameKey     schemas.BifrostContextKey = "bf-prom-mcp-client-name"
 	mcpToolNameKey       schemas.BifrostContextKey = "bf-prom-mcp-tool-name"
+
+	// Overhead is measured across the transport hooks rather than the LLM hooks,
+	// so the window matches the OTEL root span. See recordOverhead.
+	transportStartTimeKey schemas.BifrostContextKey = "bf-prom-transport-start-time"
+	overheadLabelsKey     schemas.BifrostContextKey = "bf-prom-overhead-labels"
 )
 
 // PushGatewayConfig holds the configuration for pushing metrics to a Prometheus Push Gateway.
@@ -160,6 +166,7 @@ type PrometheusPlugin struct {
 	HTTPResponseSizeBytes          *prometheus.HistogramVec
 	UpstreamRequestsTotal          *prometheus.CounterVec
 	UpstreamLatencySeconds         *prometheus.HistogramVec
+	OverheadLatencyMicros          *prometheus.HistogramVec
 	SuccessRequestsTotal           *prometheus.CounterVec
 	ErrorRequestsTotal             *prometheus.CounterVec
 	InputTokensTotal               *prometheus.CounterVec
@@ -213,6 +220,17 @@ var (
 	upstreamLatencyBuckets = []float64{
 		.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5,
 		10, 15, 30, 45, 60, 90, 120, 180, 300, 600, 900,
+	}
+
+	// overheadLatencyBuckets: Bifrost's own processing cost, i.e. total minus time
+	// blocked on upstream sockets, in microseconds. A different scale entirely from
+	// upstream latency: healthy values run from sub-millisecond to low tens of ms,
+	// dominated by request and response marshalling. Microseconds keep the fast,
+	// sub-millisecond common case as clean integers instead of tiny fractions. The
+	// tail up to 30_000_000us catches queue saturation and pathological payloads.
+	overheadLatencyBuckets = []float64{
+		100, 250, 500, 1000, 2500, 5000, 10000, 25000, 50000, 100000,
+		250000, 500000, 1000000, 2500000, 5000000, 10000000, 30000000,
 	}
 
 	// firstTokenLatencyBuckets: TTFT. Bimodal - sub-second for fast streaming
@@ -387,6 +405,18 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 		append(append(defaultBifrostLabels, "is_success"), filteredCustomLabels...),
 	)
 
+	// Labelled without is_success: unlike upstream latency, overhead is dominated by
+	// payload marshalling and is not expected to differ between success and failure,
+	// and a failed request often has no response to marshal at all.
+	bifrostOverheadLatencyMicros := factory.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "bifrost_overhead_latency_microseconds",
+			Help:    "Latency added by Bifrost itself, in microseconds: total request time minus time blocked on upstream providers.",
+			Buckets: overheadLatencyBuckets,
+		},
+		append(defaultBifrostLabels, filteredCustomLabels...),
+	)
+
 	bifrostSuccessRequestsTotal := factory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "bifrost_success_requests_total",
@@ -550,6 +580,7 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 		HTTPResponseSizeBytes:          httpResponseSizeBytes,
 		UpstreamRequestsTotal:          bifrostUpstreamRequestsTotal,
 		UpstreamLatencySeconds:         bifrostUpstreamLatencySeconds,
+		OverheadLatencyMicros:          bifrostOverheadLatencyMicros,
 		SuccessRequestsTotal:           bifrostSuccessRequestsTotal,
 		ErrorRequestsTotal:             bifrostErrorRequestsTotal,
 		InputTokensTotal:               bifrostInputTokensTotal,
@@ -660,14 +691,44 @@ func (*PrometheusPlugin) HTTPTransportPreAuthHook(_ *schemas.BifrostContext, _ *
 	return nil, nil
 }
 
-// HTTPTransportPreHook is not used for this plugin
+// HTTPTransportPreHook stamps the start of the transport window used to measure
+// Bifrost's overhead. See HTTPTransportPostHook.
 func (p *PrometheusPlugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	ctx.SetValue(transportStartTimeKey, time.Now())
 	return nil, nil
 }
 
-// HTTPTransportPostHook is not used for this plugin
+// HTTPTransportPostHook records Bifrost's own overhead.
+//
+// This is the widest window the plugin can see: the middleware order is
+// Tracing.pre -> TransportInterceptor.pre -> handler -> TransportInterceptor.post
+// -> Tracing.defer, so it brackets request parsing, the full core pipeline and
+// response marshalling, matching what OTEL derives from the root span. Measuring
+// across PreLLMHook/PostLLMHook instead would miss the transport work, and
+// marshalling a large response body is a real part of the cost.
+//
+// Running here also makes the observation once-per-request rather than
+// once-per-attempt, so a retried request no longer contributes several times.
 func (p *PrometheusPlugin) HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error {
+	start, ok := ctx.Value(transportStartTimeKey).(time.Time)
+	if !ok {
+		return nil
+	}
+	p.recordOverhead(ctx, time.Since(start))
 	return nil
+}
+
+// recordOverhead observes total-minus-upstream against the labels the LLM hook
+// resolved. Silent when either is missing: no accumulator means upstream was
+// never measured, and reporting the full duration as overhead would be wrong.
+func (p *PrometheusPlugin) recordOverhead(ctx *schemas.BifrostContext, total time.Duration) {
+	labels, ok := ctx.Value(overheadLabelsKey).([]string)
+	if !ok || len(labels) == 0 {
+		return
+	}
+	if overhead, ok := schemas.CalculateOverhead(ctx, total); ok {
+		p.OverheadLatencyMicros.WithLabelValues(labels...).Observe(float64(overhead) / float64(time.Microsecond))
+	}
 }
 
 // HTTPTransportStreamChunkHook passes through streaming chunks unchanged
@@ -838,6 +899,7 @@ func extractProviderCacheTokens(result *schemas.BifrostResponse) (read, write, w
 // It records:
 //   - Request latency
 //   - Total request count
+//
 // canonicalEntitySet resolves one entity dimension from context: plural arrays,
 // else scalar as a set of one, canonicalized.
 func canonicalEntitySet(ctx context.Context, idsKey, namesKey, scalarIDKey, scalarNameKey schemas.BifrostContextKey) (idsCSV, namesCSV string) {
@@ -881,6 +943,9 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 		p.logger.Warn("Warning: startTime not found in context for Prometheus PostLLMHook")
 		return result, bifrostErr, nil
 	}
+	// Capture the LLM-hook window synchronously, before the goroutine below and its
+	// cost/metric work can inflate it. Used for the SDK-path overhead metric.
+	llmHookWindow := time.Since(startTime)
 
 	virtualKeyID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceVirtualKeyID)
 	virtualKeyName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceVirtualKeyName)
@@ -948,6 +1013,13 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 
 	pricingScopes := modelcatalog.PricingLookupScopesFromContext(ctx, string(provider))
 
+	// Labels for HTTPTransportPostHook, which observes overhead. Written before
+	// the goroutine launches so the transport hook can't race it; on a retry the
+	// final attempt's labels win.
+	if isStreamFinal {
+		ctx.SetValue(overheadLabelsKey, slices.Clone(promLabelValues))
+	}
+
 	// Calculate cost and record metrics in a separate goroutine to avoid blocking the main thread
 	go func() {
 		// For streaming requests, handle per-token metrics for intermediate chunks
@@ -1005,6 +1077,12 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 		latencyLabelValues = append(latencyLabelValues, strconv.FormatBool(bifrostErr == nil))            // is_success
 		latencyLabelValues = append(latencyLabelValues, promLabelValues[len(p.defaultBifrostLabels):]...) // then custom labels
 		p.UpstreamLatencySeconds.WithLabelValues(latencyLabelValues...).Observe(duration)
+
+		// SDK caller: no transport hooks fire, so this LLM-hook window is all there
+		// is to measure overhead against.
+		if _, viaTransport := ctx.Value(transportStartTimeKey).(time.Time); !viaTransport {
+			p.recordOverhead(ctx, llmHookWindow)
+		}
 
 		// Record cost using the dedicated cost counter
 		if cost > 0 {


### PR DESCRIPTION
## Summary

`spanHandle` previously resolved spans by calling `GetTrace` followed by a linear `GetSpan` scan every time `EndSpan`, `SetAttribute`, or `SpanFromHandle` was called. Because a single request can create dozens of spans, this resulted in O(n²) lookups per request. This PR caches a direct pointer to the `*schemas.Span` inside `spanHandle` so those operations can skip the lookup entirely on the hot path.

## Changes

- Added a `span *schemas.Span` field to `spanHandle` that is populated at creation time in `StartSpanID` and `GetSpanHandleByID`.
- `EndSpan`, `SetAttribute`, and `SpanFromHandle` now use the cached pointer when available, falling back to the ID-based store lookup only when the pointer is nil.
- `GetSpanHandleByID` was refactored to resolve and cache the span pointer for both root-span and explicit-span-ID cases, and the combined nil/empty check was split into two separate guards for clarity.

## Type of change

- [ ] Bug fix
- [x] Refactor
- [ ] Feature
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go version
go test ./...
```

Verify that tracing behavior is unchanged and that spans are correctly ended and attributed under load. Profiling a request-heavy workload before and after should show a reduction in time spent inside `GetTrace`/`GetSpan` during span lifecycle calls.

## Breaking changes

- [x] No

## Security considerations

None. This change only affects internal span resolution performance and does not touch auth, secrets, or PII handling.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable