### PR TITLE
feat: per-phase overhead breakdown - instrument, compute, persist, display

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -63,6 +63,7 @@ type ChannelMessage struct {
 	Response       chan *schemas.BifrostResponse
 	ResponseStream chan chan *schemas.BifrostStreamChunk
 	Err            chan schemas.BifrostError
+	queueSpan      schemas.SpanHandle // "queue-wait" span opened at enqueue, closed when a worker dequeues (or on release if the send never landed)
 }
 
 // Bifrost manages providers and maintains specified open channels for concurrent processing.
@@ -3908,6 +3909,8 @@ func (bifrost *Bifrost) UpdateProvider(providerKey schemas.ModelProvider) error 
 			default:
 				// newPq is full — cancel this message and all remaining in oldPq.
 				cancelMsg := func(r *ChannelMessage) {
+					// Cancelling instead of transferring: close its queue-wait span.
+					bifrost.endQueueWaitSpan(r)
 					prov, mod, _ := r.BifrostRequest.GetRequestFields()
 					select {
 					case r.Err <- schemas.BifrostError{
@@ -5547,6 +5550,9 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 	msg := bifrost.getChannelMessage(*preReq)
 	msg.Context = ctx
 
+	// Open the queue-wait span; the worker closes it when it dequeues the message.
+	startQueueWaitSpan(ctx, tracer, msg)
+
 	// If the queue is closing, check whether the provider was updated (new queue
 	// available) or removed. On update, transparently re-route to the new queue
 	// so in-flight producers don't get spurious errors. On removal, error out.
@@ -5888,6 +5894,9 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 
 	msg := bifrost.getChannelMessage(*preReq)
 	msg.Context = ctx
+
+	// Open the queue-wait span; the worker closes it when it dequeues the message.
+	startQueueWaitSpan(ctx, tracer, msg)
 
 	// If the queue is closing, check whether the provider was updated (new queue
 	// available) or removed. On update, transparently re-route to the new queue
@@ -6391,14 +6400,20 @@ func executeRequestWithRetries[T any](
 			exportHeaderAttributes(passthrough)
 		}
 
-		// Populate LLM request attributes (messages, parameters, etc.)
-		if req != nil {
-			tracer.PopulateLLMRequestAttributes(handle, req)
-		}
-
-		// Update context with span ID (no valueCtx alloc; StartSpanID returned it).
+		// Make the LLM call the active span before attribute-population so that phase
+		// nests inside it rather than the preceding span (no valueCtx alloc; StartSpanID
+		// returned spanID).
 		if spanID != "" {
 			ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
+		}
+
+		// Populate LLM request attributes (messages, parameters, etc.). Timed as an
+		// "attribute-population" span: writing a large prompt's messages onto the span
+		// is real, payload-scaled work that otherwise hides in the core bucket.
+		if req != nil {
+			_, attrHandle := tracer.StartSpanID(ctx, "attribute-population", schemas.SpanKindInternal)
+			tracer.PopulateLLMRequestAttributes(handle, req)
+			tracer.EndSpan(attrHandle, schemas.SpanStatusOk, "")
 		}
 
 		// Record stream start time for TTFT calculation (only for streaming requests)
@@ -6481,11 +6496,15 @@ func executeRequestWithRetries[T any](
 					}
 				}
 				resp.PopulateExtraFields(requestType, providerKey, model, resolvedModelUsed)
+				_, attrHandle := tracer.StartSpanID(ctx, "attribute-population", schemas.SpanKindInternal)
 				tracer.PopulateLLMResponseAttributes(ctx, handle, resp, bifrostError)
+				tracer.EndSpan(attrHandle, schemas.SpanStatusOk, "")
 			} else if bifrostError != nil {
 				// Failed stream requests carry a chan result and miss the cast above;
 				// stamp error attributes explicitly so spans don't report unknown.
+				_, attrHandle := tracer.StartSpanID(ctx, "attribute-population", schemas.SpanKindInternal)
 				tracer.PopulateLLMResponseAttributes(ctx, handle, nil, bifrostError)
+				tracer.EndSpan(attrHandle, schemas.SpanStatusOk, "")
 			}
 
 			// End span with appropriate status
@@ -6682,12 +6701,15 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 		select {
 		case r := <-pq.queue:
 			req = r
+			bifrost.endQueueWaitSpan(req)
 		case <-pq.done:
 			// Provider is shutting down. Drain any buffered requests and send
 			// back errors so callers are not left blocked on their response channel.
 			for {
 				select {
 				case r := <-pq.queue:
+					// Draining a still-open queue-wait span: close it before discarding.
+					bifrost.endQueueWaitSpan(r)
 					provKey, mod, _ := r.GetRequestFields()
 					select {
 					case r.Err <- schemas.BifrostError{
@@ -8282,6 +8304,28 @@ func (bifrost *Bifrost) releasePluginPipeline(pipeline *PluginPipeline) {
 
 // POOL & RESOURCE MANAGEMENT
 
+// startQueueWaitSpan opens a nil-safe "queue-wait" internal span measuring how long
+// the message sits in the provider queue before a worker dequeues it. The handle is
+// stored on the message; endQueueWaitSpan closes it on dequeue, and
+// releaseChannelMessage closes it if the send never reached a worker. When no trace
+// is active StartSpanID returns a nil handle, so the phase simply folds into core.
+func startQueueWaitSpan(ctx *schemas.BifrostContext, tracer schemas.Tracer, msg *ChannelMessage) {
+	if tracer == nil {
+		return
+	}
+	_, msg.queueSpan = tracer.StartSpanID(ctx, "queue-wait", schemas.SpanKindInternal)
+}
+
+// endQueueWaitSpan closes the queue-wait span once (nil-safe, idempotent): it clears
+// the handle so a later releaseChannelMessage does not double-close it.
+func (bifrost *Bifrost) endQueueWaitSpan(msg *ChannelMessage) {
+	if msg == nil || msg.queueSpan == nil {
+		return
+	}
+	bifrost.getTracer().EndSpan(msg.queueSpan, schemas.SpanStatusOk, "")
+	msg.queueSpan = nil
+}
+
 // getChannelMessage gets a ChannelMessage from the pool and configures it with the request.
 // It also gets response and error channels from their respective pools.
 func (bifrost *Bifrost) getChannelMessage(req schemas.BifrostRequest) *ChannelMessage {
@@ -8338,6 +8382,8 @@ func (bifrost *Bifrost) drainQueueWithErrors(pq *ProviderQueue) {
 	for {
 		select {
 		case r := <-pq.queue:
+			// Draining a still-open queue-wait span: close it before discarding.
+			bifrost.endQueueWaitSpan(r)
 			provKey, mod, _ := r.GetRequestFields()
 			select {
 			case r.Err <- schemas.BifrostError{
@@ -8362,6 +8408,10 @@ func (bifrost *Bifrost) drainQueueWithErrors(pq *ProviderQueue) {
 
 // releaseChannelMessage returns a ChannelMessage and its channels to their respective pools.
 func (bifrost *Bifrost) releaseChannelMessage(msg *ChannelMessage) {
+	// Close the queue-wait span if the message never reached a worker (send failed
+	// on a shutdown/drop path). No-op when the worker already closed it.
+	bifrost.endQueueWaitSpan(msg)
+
 	// Drain any undelivered values before pooling so an idle pooled channel
 	// doesn't pin a full response/error until its next reuse. getChannelMessage
 	// drains again on acquire as defense in depth.
@@ -8402,6 +8452,7 @@ func (bifrost *Bifrost) releaseChannelMessage(msg *ChannelMessage) {
 	msg.Response = nil
 	msg.ResponseStream = nil
 	msg.Err = nil
+	msg.queueSpan = nil
 	bifrost.channelMessagePool.Put(msg)
 }
 

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -544,12 +544,16 @@ func HandleAnthropicChatCompletionRequest(
 	response := AcquireAnthropicMessageResponse()
 	defer ReleaseAnthropicMessageResponse(response)
 
-	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, response, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, config.ShouldSendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, config.ShouldSendBackRawResponse))
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, responseBody, response, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, config.ShouldSendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, config.ShouldSendBackRawResponse))
 	if bifrostErr != nil {
 		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, config.ShouldSendBackRawRequest, config.ShouldSendBackRawResponse, latency)
 	}
 	// Create final response
+	convTracer, convHandle := providerUtils.StartResponseConvertorSpan(ctx)
 	bifrostResponse := response.ToBifrostChatResponse(ctx)
+	if convTracer != nil {
+		convTracer.EndSpan(convHandle, schemas.SpanStatusOk, "")
+	}
 
 	// Set ExtraFields
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -1239,15 +1239,30 @@ func (provider *BedrockProvider) ChatCompletion(ctx *schemas.BifrostContext, key
 	bedrockResponse := acquireBedrockChatResponse()
 	defer releaseBedrockChatResponse(bedrockResponse)
 
-	// Parse the response using the new Bedrock type
+	// Parse the response using the new Bedrock type. Timed as the "response-parse"
+	// overhead phase, matching HandleProviderResponseCtx on the other completion paths.
+	parseTracer, parseHandle := providerUtils.StartResponseParseSpan(ctx)
 	if err := sonic.Unmarshal(responseBody, bedrockResponse); err != nil {
+		if parseTracer != nil {
+			parseTracer.EndSpan(parseHandle, schemas.SpanStatusError, err.Error())
+		}
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("failed to parse bedrock response", err), jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
+	}
+	if parseTracer != nil {
+		parseTracer.EndSpan(parseHandle, schemas.SpanStatusOk, "")
 	}
 
 	// Convert using the new response converter
+	convTracer, convHandle := providerUtils.StartResponseConvertorSpan(ctx)
 	bifrostResponse, err := bedrockResponse.ToBifrostChatResponse(ctx, request.Model)
 	if err != nil {
+		if convTracer != nil {
+			convTracer.EndSpan(convHandle, schemas.SpanStatusError, err.Error())
+		}
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("failed to convert bedrock response", err), jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
+	}
+	if convTracer != nil {
+		convTracer.EndSpan(convHandle, schemas.SpanStatusOk, "")
 	}
 
 	// Override finish reason for structured output (Converse API only)
@@ -1730,9 +1745,17 @@ func (provider *BedrockProvider) Responses(ctx *schemas.BifrostContext, key sche
 	bedrockResponse := acquireBedrockChatResponse()
 	defer releaseBedrockChatResponse(bedrockResponse)
 
-	// Parse the response using the new Bedrock type
+	// Parse the response using the new Bedrock type. Timed as the "response-parse"
+	// overhead phase, matching HandleProviderResponseCtx on the other completion paths.
+	parseTracer, parseHandle := providerUtils.StartResponseParseSpan(ctx)
 	if err := sonic.Unmarshal(responseBody, bedrockResponse); err != nil {
+		if parseTracer != nil {
+			parseTracer.EndSpan(parseHandle, schemas.SpanStatusError, err.Error())
+		}
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("failed to parse bedrock response", err), jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
+	}
+	if parseTracer != nil {
+		parseTracer.EndSpan(parseHandle, schemas.SpanStatusOk, "")
 	}
 
 	// Convert using the new response converter
@@ -2195,7 +2218,7 @@ func (provider *BedrockProvider) Rerank(ctx *schemas.BifrostContext, key schemas
 	}
 
 	response := &BedrockRerankResponse{}
-	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(rawResponseBody, response, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, rawResponseBody, response, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 	if bifrostErr != nil {
 		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, rawResponseBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 	}

--- a/core/providers/cohere/cohere.go
+++ b/core/providers/cohere/cohere.go
@@ -379,12 +379,16 @@ func (provider *CohereProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 	response := acquireCohereResponse()
 	defer releaseCohereResponse(response)
 
-	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, response, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, responseBody, response, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 	if bifrostErr != nil {
 		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 	}
 
+	convTracer, convHandle := providerUtils.StartResponseConvertorSpan(ctx)
 	bifrostResponse := response.ToBifrostChatResponse(request.Model)
+	if convTracer != nil {
+		convTracer.EndSpan(convHandle, schemas.SpanStatusOk, "")
+	}
 
 	// Set ExtraFields
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -314,7 +314,11 @@ func (provider *GeminiProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 		}, nil
 	}
 
+	convTracer, convHandle := providerUtils.StartResponseConvertorSpan(ctx)
 	bifrostResponse := geminiResponse.ToBifrostChatResponse()
+	if convTracer != nil {
+		convTracer.EndSpan(convHandle, schemas.SpanStatusOk, "")
+	}
 
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
 	bifrostResponse.ExtraFields.ProviderResponseHeaders = providerResponseHeaders
@@ -1282,7 +1286,7 @@ func (provider *GeminiProvider) Embedding(ctx *schemas.BifrostContext, key schem
 
 	// Parse Gemini's batch embedding response
 	var geminiResponse GeminiEmbeddingResponse
-	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(body, &geminiResponse, jsonData,
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, body, &geminiResponse, jsonData,
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 	if bifrostErr != nil {

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -924,7 +924,7 @@ func HandleOpenAIChatCompletionRequest(
 	if customResponseHandler != nil {
 		rawRequest, rawResponse, bifrostErr = customResponseHandler(body, response, jsonData, sendBackRawRequest, sendBackRawResponse)
 	} else {
-		rawRequest, rawResponse, bifrostErr = providerUtils.HandleProviderResponse(body, response, jsonData, sendBackRawRequest, sendBackRawResponse)
+		rawRequest, rawResponse, bifrostErr = providerUtils.HandleProviderResponseCtx(ctx, body, response, jsonData, sendBackRawRequest, sendBackRawResponse)
 	}
 
 	if bifrostErr != nil {

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -1609,6 +1609,36 @@ func MergeExtraParamsIntoJSON(jsonBody []byte, extraParams map[string]interface{
 	return compact.Bytes(), nil
 }
 
+// startPhaseSpan opens a nil-safe internal child span marking a Bifrost overhead
+// phase (request marshalling, response parsing) so the log detail view can attribute
+// core overhead. Both returns are nil when no trace is active; EndSpan is nil-safe,
+// so callers guard only on the tracer. StartSpanID avoids a per-span context alloc.
+func startPhaseSpan(ctx context.Context, name string) (schemas.Tracer, schemas.SpanHandle) {
+	t, ok := ctx.Value(schemas.BifrostContextKeyTracer).(schemas.Tracer)
+	if !ok || t == nil {
+		return nil, nil
+	}
+	_, h := t.StartSpanID(ctx, name, schemas.SpanKindInternal)
+	return t, h
+}
+
+// StartResponseConvertorSpan opens a nil-safe "convertor" span for the provider->Bifrost
+// response mapping (ToBifrost*Response). It shares the "convertor" bucket with the
+// request-side conversion so total conversion time is attributed together, instead of
+// the response half folding into core. Symmetric to the request path: response-parse
+// times the JSON decode, this times the struct->unified mapping. Wrapped at the primary
+// chat call sites; secondary response paths fold into core. EndSpan is nil-safe.
+func StartResponseConvertorSpan(ctx context.Context) (schemas.Tracer, schemas.SpanHandle) {
+	return startPhaseSpan(ctx, "convertor")
+}
+
+// StartResponseParseSpan opens the "response-parse" overhead phase span for providers
+// that unmarshal the response body directly (e.g. Bedrock Converse) rather than through
+// HandleProviderResponseCtx. Nil-safe: returns a nil tracer when no trace is active.
+func StartResponseParseSpan(ctx context.Context) (schemas.Tracer, schemas.SpanHandle) {
+	return startPhaseSpan(ctx, "response-parse")
+}
+
 // CheckContextAndGetRequestBody checks if the raw request body should be used, and returns it if it exists.
 func CheckContextAndGetRequestBody(ctx context.Context, request RequestBodyGetter, requestConverter RequestBodyConverter) ([]byte, *schemas.BifrostError) {
 	if IsLargePayloadPassthroughEnabled(ctx) {
@@ -1617,17 +1647,32 @@ func CheckContextAndGetRequestBody(ctx context.Context, request RequestBodyGette
 
 	rawBody, ok := CheckAndGetRawRequestBody(ctx, request)
 	if !ok {
+		// The converting path splits into two non-overlapping overhead phases so their
+		// costs are attributed separately (and never double-counted): "convertor" for
+		// the Bifrost->provider format conversion, then "request-marshal" for the JSON
+		// encode. The raw-body passthrough branch does neither.
+		ct, chdl := startPhaseSpan(ctx, "convertor")
 		convertedBody, err := requestConverter()
 		if err != nil {
+			if ct != nil {
+				ct.EndSpan(chdl, schemas.SpanStatusError, err.Error())
+			}
 			return nil, NewBifrostOperationError(schemas.ErrRequestBodyConversion, err)
+		}
+		if ct != nil {
+			ct.EndSpan(chdl, schemas.SpanStatusOk, "")
 		}
 		if convertedBody == nil {
 			return nil, NewBifrostOperationError("request body is not provided", nil)
 		}
 
+		mt, mhdl := startPhaseSpan(ctx, "request-marshal")
 		// Indenting is removed to reduce data on wire
 		jsonBody, err := MarshalProviderRequest(convertedBody)
 		if err != nil {
+			if mt != nil {
+				mt.EndSpan(mhdl, schemas.SpanStatusError, err.Error())
+			}
 			return nil, NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
 		}
 		// Merge ExtraParams into the JSON if passthrough is enabled
@@ -1638,9 +1683,15 @@ func CheckContextAndGetRequestBody(ctx context.Context, request RequestBodyGette
 				// tool schemas and other order-sensitive JSON structures.
 				jsonBody, err = MergeExtraParamsIntoJSON(jsonBody, extraParams)
 				if err != nil {
+					if mt != nil {
+						mt.EndSpan(mhdl, schemas.SpanStatusError, err.Error())
+					}
 					return nil, NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
 				}
 			}
+		}
+		if mt != nil {
+			mt.EndSpan(mhdl, schemas.SpanStatusOk, "")
 		}
 		return jsonBody, nil
 	} else {
@@ -1835,6 +1886,31 @@ func EnrichError(
 	}
 
 	return bifrostErr
+}
+
+// HandleProviderResponseCtx is HandleProviderResponse with a context, so the JSON
+// parse is timed as the "response-parse" overhead phase for the log detail view.
+// Used at the primary completion call sites (chat / responses / text) where parse
+// time is on the latency hot path; the ctx-less HandleProviderResponse remains for
+// the many secondary sites (files, batches, containers) whose parse time is not
+// worth a span and simply folds into the "core" bucket.
+func HandleProviderResponseCtx[T any](ctx context.Context, responseBody []byte, response *T, requestBody []byte, sendBackRawRequest bool, sendBackRawResponse bool) (rawRequest interface{}, rawResponse interface{}, bifrostErr *schemas.BifrostError) {
+	if t, h := startPhaseSpan(ctx, "response-parse"); t != nil {
+		// Inspect the named bifrostErr so a failed parse ends the span as an error
+		// instead of appearing as successful overhead work.
+		defer func() {
+			if bifrostErr != nil {
+				msg := "response parse failed"
+				if bifrostErr.Error != nil && bifrostErr.Error.Message != "" {
+					msg = bifrostErr.Error.Message
+				}
+				t.EndSpan(h, schemas.SpanStatusError, msg)
+				return
+			}
+			t.EndSpan(h, schemas.SpanStatusOk, "")
+		}()
+	}
+	return HandleProviderResponse(responseBody, response, requestBody, sendBackRawRequest, sendBackRawResponse)
 }
 
 // HandleProviderResponse handles common response parsing logic for provider responses.

--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -456,6 +456,59 @@ func (s *Span) End(status SpanStatus, statusMsg string) {
 	s.StatusMsg = statusMsg
 }
 
+// EndIfMatch ends the span only if its SpanID still equals id, and reports whether
+// it did. It exists for the tracer's cached-pointer fast path: a span pooled by
+// ReleaseTrace has its SpanID cleared under this same lock (see Reset), and a span
+// reused by another trace carries a different SpanID, so a stale handle fails the
+// check and the caller falls back to the by-ID store lookup instead of mutating a
+// recycled span. The check rides inside the lock End already takes, so it adds no
+// extra locking.
+func (s *Span) EndIfMatch(id string, status SpanStatus, statusMsg string) bool {
+	if s == nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.SpanID != id {
+		return false
+	}
+	s.EndTime = time.Now()
+	s.Status = status
+	s.StatusMsg = statusMsg
+	return true
+}
+
+// SetAttributeIfMatch sets an attribute only if the span's SpanID still equals id,
+// and reports whether it did. Same recycling guard as EndIfMatch, for the tracer's
+// cached-pointer fast path.
+func (s *Span) SetAttributeIfMatch(id, key string, value any) bool {
+	if s == nil || value == nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.SpanID != id {
+		return false
+	}
+	if s.Attributes == nil {
+		s.Attributes = make(map[string]any)
+	}
+	s.Attributes[key] = value
+	return true
+}
+
+// MatchesID reports whether the span's SpanID still equals id, read under the span
+// lock so it does not race a concurrent Reset. Used by the tracer to decide whether
+// a cached span pointer is still the one the handle refers to before returning it.
+func (s *Span) MatchesID(id string) bool {
+	if s == nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.SpanID == id
+}
+
 // Reset clears the span for reuse from pool. It holds s.mu — like every other
 // Span mutator — so a straggling writer (e.g. streaming finalization) that races
 // pool release can't trigger a fatal concurrent map access on s.Attributes.

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -293,6 +293,7 @@ var logstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"logs_add_batch_debug_column"}, run: migrationAddBatchDebugColumn},
 	{IDs: []string{"logs_add_cost_breakdown_columns"}, run: migrationAddCostBreakdownColumns},
 	{IDs: []string{"logs_recreate_matviews_with_cost_breakdown"}, run: migrationRecreateMatViewsWithCostBreakdown},
+	{IDs: []string{"logs_add_overhead_breakdown_column"}, run: migrationAddOverheadBreakdownColumn},
 }
 
 // areThereAnyPendingMigrations returns true if there are any pending migrations to be applied.
@@ -667,6 +668,31 @@ func migrationAddUpstreamAndOverheadLatencyColumns(ctx context.Context, db *gorm
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while adding upstream/overhead latency columns: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddOverheadBreakdownColumn adds the overhead_breakdown column to the
+// logs table. It holds the per-span self-time decomposition of Bifrost overhead.
+func migrationAddOverheadBreakdownColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "logs_add_overhead_breakdown_column"
+	logger.Info("[logstore] starting migration %s", migrationName)
+	defer logger.Info("[logstore] finished migration %s", migrationName)
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			return addColumnIfNotExists(tx, logger, &Log{}, "overhead_breakdown")
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			return dropColumnIfExists(tx, logger, &Log{}, "overhead_breakdown")
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while adding overhead_breakdown column: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -169,6 +169,18 @@ func (u *UserAgentMapping) BeforeCreate(tx *gorm.DB) error {
 	return nil
 }
 
+// OverheadBucket is one slice of the Bifrost overhead, attributed to a span (or
+// group of spans) by self-time: the span's own wall duration minus the wall
+// duration of its direct children. Self-times across the whole span tree are
+// non-overlapping and sum to the root duration, so summing the overhead-side
+// buckets gives an independent measure of overhead that does not rely on the
+// upstream socket accumulator. DurationUs is microseconds (overhead runs small).
+type OverheadBucket struct {
+	Name       string  `json:"name"` // e.g. "key.selection", "plugin.governance", "mcp", "core"
+	Kind       string  `json:"kind"` // originating span kind, for grouping/coloring
+	DurationUs float64 `json:"duration_us"`
+}
+
 // Log represents a complete log entry for a request/response cycle
 // This is the GORM model with appropriate tags
 type Log struct {
@@ -244,6 +256,7 @@ type Log struct {
 	Latency                 *float64  `gorm:"index:idx_logs_latency" json:"latency,omitempty"`
 	UpstreamLatency         *float64  `gorm:"index:idx_logs_upstream_latency" json:"upstream_latency,omitempty"` // Provider socket time across all attempts, ms; nil = unmeasured
 	OverheadLatency         *float64  `gorm:"index:idx_logs_overhead_latency" json:"overhead_latency,omitempty"` // Bifrost overhead (total minus upstream), ms; nil = unmeasured
+	OverheadBreakdown       string    `gorm:"type:text" json:"-"`                                                // JSON serialized []OverheadBucket: per-span self-time decomposition of overhead
 	TokenUsage              string    `gorm:"type:text" json:"-"`                                                // JSON serialized *schemas.LLMUsage
 	// Denormalized cost split for per-category quota aggregation. input + output +
 	// additional reconcile to the cost column. Additional holds internal sidecar
@@ -354,6 +367,7 @@ type Log struct {
 	VideoListOutputParsed       *schemas.BifrostVideoListResponse       `gorm:"-" json:"video_list_output,omitempty"`
 	VideoDeleteOutputParsed     *schemas.BifrostVideoDeleteResponse     `gorm:"-" json:"video_delete_output,omitempty"`
 	AttemptTrailParsed          []schemas.KeyAttemptRecord              `gorm:"-" json:"attempt_trail,omitempty"`
+	OverheadBreakdownParsed     []OverheadBucket                        `gorm:"-" json:"overhead_breakdown,omitempty"`
 	BudgetIDsParsed             []string                                `gorm:"-" json:"budget_ids,omitempty"`
 	RateLimitIDsParsed          []string                                `gorm:"-" json:"rate_limit_ids,omitempty"`
 	TeamIDsParsed               []string                                `gorm:"-" json:"team_ids,omitempty"`
@@ -724,6 +738,16 @@ func (l *Log) SerializeFields() error {
 		l.AttemptTrail = ""
 	}
 
+	if len(l.OverheadBreakdownParsed) > 0 {
+		if data, err := sonic.Marshal(l.OverheadBreakdownParsed); err != nil {
+			return err
+		} else {
+			l.OverheadBreakdown = string(data)
+		}
+	} else {
+		l.OverheadBreakdown = ""
+	}
+
 	if l.MetadataParsed != nil {
 		data, err := sonic.Marshal(l.MetadataParsed)
 		if err != nil {
@@ -1050,6 +1074,12 @@ func (l *Log) DeserializeFields() error {
 	if l.AttemptTrail != "" {
 		if err := sonic.Unmarshal([]byte(l.AttemptTrail), &l.AttemptTrailParsed); err != nil {
 			l.AttemptTrailParsed = nil
+		}
+	}
+
+	if l.OverheadBreakdown != "" {
+		if err := sonic.Unmarshal([]byte(l.OverheadBreakdown), &l.OverheadBreakdownParsed); err != nil {
+			l.OverheadBreakdownParsed = nil
 		}
 	}
 

--- a/framework/tracing/spanhandle_recycle_test.go
+++ b/framework/tracing/spanhandle_recycle_test.go
@@ -1,0 +1,123 @@
+package tracing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func newHandleTestCtx(tracer *Tracer) (string, context.Context) {
+	traceID := tracer.CreateTrace("")
+	ctx := context.WithValue(context.Background(), schemas.BifrostContextKeyTraceID, traceID)
+	return traceID, ctx
+}
+
+// The *IfMatch guards act only while the span's SpanID still equals the handle's,
+// which is how a cached-pointer handle detects a pooled span that ReleaseTrace reset
+// or another trace reused. This is the unit-level contract the tracer relies on.
+func TestSpanIfMatchGuards(t *testing.T) {
+	s := &schemas.Span{SpanID: "abc"}
+
+	if !s.EndIfMatch("abc", schemas.SpanStatusOk, "done") {
+		t.Fatal("EndIfMatch should succeed when the SpanID matches")
+	}
+	if s.Status != schemas.SpanStatusOk {
+		t.Fatalf("span not ended: status=%v", s.Status)
+	}
+
+	// ReleaseTrace resets the span before returning it to the pool.
+	s.Reset()
+	if s.EndIfMatch("abc", schemas.SpanStatusError, "stale") {
+		t.Fatal("EndIfMatch must fail on a reset (recycled) span")
+	}
+	if s.Status != schemas.SpanStatusUnset {
+		t.Fatalf("reset span mutated by a stale handle: status=%v", s.Status)
+	}
+
+	// The pooled span is reused by another trace under a new SpanID.
+	s.SpanID = "xyz"
+	if s.SetAttributeIfMatch("abc", "leak", true) {
+		t.Fatal("SetAttributeIfMatch must fail when the handle's ID no longer matches")
+	}
+	if _, ok := s.Attributes["leak"]; ok {
+		t.Fatal("stale handle leaked an attribute onto a reused span")
+	}
+	if !s.SetAttributeIfMatch("xyz", "own", true) {
+		t.Fatal("SetAttributeIfMatch should succeed for the current owner")
+	}
+	if !s.MatchesID("xyz") || s.MatchesID("abc") {
+		t.Fatal("MatchesID returned the wrong result")
+	}
+}
+
+// After ReleaseTrace pools a span, the old handle must be a safe no-op, and if the
+// pool hands that same object to a new trace, the stale handle must not corrupt the
+// new span. Single-goroutine with no GC means the pool returns the same object, so
+// this exercises the reuse path deterministically.
+func TestSpanHandle_UseAfterReleaseTraceIsSafe(t *testing.T) {
+	store := NewTraceStore(time.Hour, nil)
+	tracer := NewTracer(store, nil, nil)
+
+	traceID1, ctx1 := newHandleTestCtx(tracer)
+	_, handle1 := tracer.StartSpanID(ctx1, "s1", schemas.SpanKindPlugin)
+	if tracer.SpanFromHandle(handle1) == nil {
+		t.Fatal("expected a live span for trace1")
+	}
+
+	// Release trace1: span1 is reset and returned to the pool.
+	if tr := store.CompleteTrace(traceID1); tr != nil {
+		tracer.ReleaseTrace(tr)
+	}
+
+	// A new trace pulls the recycled span from the pool.
+	_, ctx2 := newHandleTestCtx(tracer)
+	_, handle2 := tracer.StartSpanID(ctx2, "s2", schemas.SpanKindPlugin)
+	span2 := tracer.SpanFromHandle(handle2)
+	if span2 == nil {
+		t.Fatal("expected a live span for trace2")
+	}
+
+	// The stale handle must not touch the reused span.
+	tracer.EndSpan(handle1, schemas.SpanStatusError, "stale")
+	tracer.SetAttribute(handle1, "leak", true)
+
+	if span2.Status == schemas.SpanStatusError {
+		t.Error("stale handle ended the reused span")
+	}
+	if _, ok := span2.Attributes["leak"]; ok {
+		t.Error("stale handle leaked an attribute onto the reused span")
+	}
+	// The released handle no longer resolves to a span.
+	if got := tracer.SpanFromHandle(handle1); got == span2 {
+		t.Error("released handle resolved to the reused span")
+	}
+}
+
+// The TTL sweep releases a trace by age, even one still referenced by a live handle.
+// A handle used after the sweep must stay a safe no-op rather than mutate a pooled
+// span.
+func TestSpanHandle_UseAfterTTLCleanupIsSafe(t *testing.T) {
+	store := NewTraceStore(time.Hour, nil)
+	tracer := NewTracer(store, nil, nil)
+
+	traceID, ctx := newHandleTestCtx(tracer)
+	_, handle := tracer.StartSpanID(ctx, "s", schemas.SpanKindPlugin)
+
+	// Age the trace past the cutoff and run the sweep directly.
+	if tr := store.GetTrace(traceID); tr != nil {
+		tr.StartTime = time.Now().Add(-2 * time.Hour)
+	}
+	store.cleanupOldTraces()
+	if store.GetTrace(traceID) != nil {
+		t.Fatal("trace should have been swept")
+	}
+
+	// Must not panic; the guard fails and the by-ID fallback finds no trace.
+	tracer.EndSpan(handle, schemas.SpanStatusOk, "")
+	tracer.SetAttribute(handle, "x", 1)
+	if got := tracer.SpanFromHandle(handle); got != nil {
+		t.Error("handle to a swept trace should resolve to nil")
+	}
+}

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -220,10 +220,15 @@ func (t *Tracer) ReleaseTrace(trace *schemas.Trace) {
 }
 
 // spanHandle is the concrete implementation of schemas.SpanHandle for Tracer.
-// It contains the trace and span IDs needed to reference the span in the store.
+// It carries the trace and span IDs plus a direct pointer to the span. The pointer
+// lets EndSpan/SetAttribute/SpanFromHandle skip the GetTrace + linear GetSpan lookup
+// on the hot path (a request creates dozens of spans, and the scan was O(n) per end,
+// i.e. O(n^2) per request). The ID fields remain as a fallback for handles created
+// without a span pointer, and so the handle stays valid if the pointer is ever nil.
 type spanHandle struct {
 	traceID string
 	spanID  string
+	span    *schemas.Span
 }
 
 // StartSpan creates a new span as a child of the current span in context.
@@ -272,13 +277,20 @@ func (t *Tracer) StartSpanID(ctx context.Context, name string, kind schemas.Span
 	if span == nil {
 		return "", nil
 	}
-	return span.SpanID, &spanHandle{traceID: traceID, spanID: span.SpanID}
+	return span.SpanID, &spanHandle{traceID: traceID, spanID: span.SpanID, span: span}
 }
 
 // EndSpan completes a span with the given status and message.
 func (t *Tracer) EndSpan(handle schemas.SpanHandle, status schemas.SpanStatus, statusMsg string) {
 	h, ok := handle.(*spanHandle)
 	if !ok || h == nil {
+		return
+	}
+	// Fast path: end via the cached pointer, skipping the trace + linear span lookup.
+	// EndIfMatch guards against a pooled span that ReleaseTrace/TTL cleanup recycled
+	// out from under this handle; on a miss we fall back to the by-ID lookup, which
+	// no-ops safely when the trace is gone.
+	if h.span != nil && h.span.EndIfMatch(h.spanID, status, statusMsg) {
 		return
 	}
 	t.store.EndSpan(h.traceID, h.spanID, status, statusMsg, nil)
@@ -288,6 +300,12 @@ func (t *Tracer) EndSpan(handle schemas.SpanHandle, status schemas.SpanStatus, s
 func (t *Tracer) SetAttribute(handle schemas.SpanHandle, key string, value any) {
 	h, ok := handle.(*spanHandle)
 	if !ok || h == nil {
+		return
+	}
+	// Fast path: the cached pointer avoids the trace + linear span lookup.
+	// SetAttributeIfMatch guards against a recycled pooled span; on a miss we fall
+	// back to the by-ID lookup, which no-ops safely when the trace is gone.
+	if h.span != nil && h.span.SetAttributeIfMatch(h.spanID, key, value) {
 		return
 	}
 	trace := t.store.GetTrace(h.traceID)
@@ -307,6 +325,12 @@ func (t *Tracer) SpanFromHandle(handle schemas.SpanHandle) *schemas.Span {
 	h, ok := handle.(*spanHandle)
 	if !ok || h == nil {
 		return nil
+	}
+	// Return the cached pointer only if it still refers to this handle's span;
+	// MatchesID rejects a span the pool recycled to another trace, falling back to
+	// the by-ID lookup (nil when the trace is gone).
+	if h.span != nil && h.span.MatchesID(h.spanID) {
+		return h.span
 	}
 	trace := t.store.GetTrace(h.traceID)
 	if trace == nil {
@@ -329,12 +353,16 @@ func (t *Tracer) GetSpanHandleByID(traceID string, spanID *string) schemas.SpanH
 		if trace.RootSpan == nil {
 			return nil
 		}
-		return &spanHandle{traceID: traceID, spanID: trace.RootSpan.SpanID}
+		return &spanHandle{traceID: traceID, spanID: trace.RootSpan.SpanID, span: trace.RootSpan}
 	}
-	if *spanID == "" || trace.GetSpan(*spanID) == nil {
+	if *spanID == "" {
 		return nil
 	}
-	return &spanHandle{traceID: traceID, spanID: *spanID}
+	span := trace.GetSpan(*spanID)
+	if span == nil {
+		return nil
+	}
+	return &spanHandle{traceID: traceID, spanID: *spanID, span: span}
 }
 
 // AddEvent adds a timestamped event to the span identified by the handle.

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -2053,6 +2054,9 @@ func (p *LoggerPlugin) Inject(_ context.Context, trace *schemas.Trace) error {
 		upstreamMs, upOK = traceAttrFloatMs(trace.RootSpan.Attributes, schemas.AttrBifrostUpstreamDurationMs)
 		overheadMs, ovOK = traceAttrFloatMs(trace.RootSpan.Attributes, schemas.AttrBifrostOverheadDurationMs)
 	}
+	// Per-span self-time decomposition of overhead, attached to the same terminal
+	// row that receives the overhead number below.
+	overheadBreakdown := computeOverheadBreakdown(trace, overheadMs, ovOK)
 
 	p.logger.Debug("Inject: enqueuing %d log entries", len(pending.entries))
 	// Upstream/overhead are request-level: put them on one row per trace, not all.
@@ -2098,6 +2102,9 @@ func (p *LoggerPlugin) Inject(_ context.Context, trace *schemas.Trace) error {
 				total := upstreamMs + overheadMs
 				entry.Latency = &total
 			}
+			if len(overheadBreakdown) > 0 {
+				entry.OverheadBreakdownParsed = overheadBreakdown
+			}
 		} else if upOK || ovOK {
 			entry.UpstreamLatency = nil
 			entry.OverheadLatency = nil
@@ -2118,6 +2125,169 @@ func serializePluginLogs(logs []schemas.PluginLogEntry) string {
 		return ""
 	}
 	return string(data)
+}
+
+// spanWall is a span's wall-clock duration, guarding against unfinished spans
+// (zero or non-monotonic EndTime) which would otherwise read as huge negatives.
+func spanWall(s *schemas.Span) time.Duration {
+	if s.EndTime.IsZero() || !s.EndTime.After(s.StartTime) {
+		return 0
+	}
+	return s.EndTime.Sub(s.StartTime)
+}
+
+// spanOverlap is the duration of child that falls inside parent's time window. For a
+// genuinely nested child this equals the child's wall duration, so self-time is
+// unchanged; for a child re-parented by ID but running outside the parent (a
+// sequential sibling in wall-clock terms) it is zero. Guards unfinished spans.
+func spanOverlap(parent, child *schemas.Span) time.Duration {
+	if parent.EndTime.IsZero() || !parent.EndTime.After(parent.StartTime) {
+		return 0
+	}
+	if child.EndTime.IsZero() || !child.EndTime.After(child.StartTime) {
+		return 0
+	}
+	start := child.StartTime
+	if parent.StartTime.After(start) {
+		start = parent.StartTime
+	}
+	end := child.EndTime
+	if parent.EndTime.Before(end) {
+		end = parent.EndTime
+	}
+	if !end.After(start) {
+		return 0
+	}
+	return end.Sub(start)
+}
+
+// isOverheadSpanKind reports whether a span's self-time counts as attributable
+// Bifrost overhead. Only spans that tightly bracket Bifrost's own code qualify:
+// plugin hooks and internal operations (key.selection, etc). Deliberately excluded:
+//   - llm.call/retry/fallback and the media provider kinds: the upstream side.
+//   - the root http.request span: its self-time is the glue between child spans,
+//     which for streaming also contains response-body socket reads that happen
+//     outside any child span. That time is real upstream (and is already in the
+//     upstream accumulator), so counting it here would double-report it as overhead.
+//
+// Excluded spans still subtract from their parent's self-time via childDur, so their
+// time is removed from any bucket rather than mislabeled. The gap between the summed
+// buckets and the stamped overhead number is surfaced as the reconciliation line.
+func isOverheadSpanKind(kind schemas.SpanKind) bool {
+	switch kind {
+	case schemas.SpanKindPlugin, schemas.SpanKindInternal:
+		return true
+	default:
+		return false
+	}
+}
+
+// overheadBucketName maps an overhead-side span to its breakdown bucket.
+func overheadBucketName(s *schemas.Span) string {
+	if s.Kind == schemas.SpanKindPlugin {
+		// plugin.<name>.<phase> -> plugin.<name>, collapsing the hook phases.
+		n := strings.TrimPrefix(s.Name, "plugin.")
+		if i := strings.LastIndex(n, "."); i > 0 {
+			n = n[:i]
+		}
+		return "plugin." + n
+	}
+	return s.Name // key.selection and other internal spans keep their name
+}
+
+// computeOverheadBreakdown decomposes Bifrost overhead across spans by self-time:
+// each span's own wall duration minus the wall duration of its direct children.
+// Self-times across the tree are non-overlapping and sum to the root duration, so
+// summing the overhead-side buckets is an independent measure of overhead that does
+// not depend on the upstream socket accumulator. Only overhead-side spans produce a
+// bucket; provider/upstream spans still subtract from their parent's self-time.
+//
+// The remaining overhead (the stamped total, minus the measured plugin/internal
+// self-time) is attributed to a final "core" bucket: transport parsing, routing, and
+// request/response marshalling that Bifrost does outside any plugin span. It is
+// derived from overheadMs (which already excludes upstream), not from the root
+// span's self-time, so it never picks up streaming socket reads. Buckets are
+// returned with microsecond values, measured spans first (chronological) then core.
+func computeOverheadBreakdown(trace *schemas.Trace, overheadMs float64, overheadOK bool) []logstore.OverheadBucket {
+	if trace == nil || len(trace.Spans) == 0 {
+		return nil
+	}
+	// Sum direct-children time per parent, over ALL spans (upstream ones too), so
+	// excluded child spans are still removed from their parent's self-time. Only the
+	// portion of a child that temporally OVERLAPS its parent counts: a child
+	// re-parented for trace-hierarchy reasons but running outside the parent's window
+	// (e.g. llm.call is linked under key.selection but starts after it ends) then
+	// correctly subtracts nothing, instead of driving the parent's self-time negative.
+	spanByID := make(map[string]*schemas.Span, len(trace.Spans))
+	for _, s := range trace.Spans {
+		if s != nil && s.SpanID != "" {
+			spanByID[s.SpanID] = s
+		}
+	}
+	childDur := make(map[string]time.Duration, len(trace.Spans))
+	for _, s := range trace.Spans {
+		if s == nil || s.ParentID == "" {
+			continue
+		}
+		parent := spanByID[s.ParentID]
+		if parent == nil {
+			continue
+		}
+		childDur[s.ParentID] += spanOverlap(parent, s)
+	}
+
+	type agg struct {
+		dur   time.Duration
+		kind  schemas.SpanKind
+		first time.Time
+	}
+	buckets := make(map[string]*agg)
+	for _, s := range trace.Spans {
+		if s == nil || !isOverheadSpanKind(s.Kind) {
+			continue
+		}
+		self := spanWall(s) - childDur[s.SpanID]
+		if self <= 0 {
+			continue
+		}
+		name := overheadBucketName(s)
+		b := buckets[name]
+		if b == nil {
+			b = &agg{kind: s.Kind, first: s.StartTime}
+			buckets[name] = b
+		}
+		b.dur += self
+		if s.StartTime.Before(b.first) {
+			b.first = s.StartTime
+		}
+	}
+	out := make([]logstore.OverheadBucket, 0, len(buckets)+1)
+	var measuredNs int64
+	for name, b := range buckets {
+		measuredNs += b.dur.Nanoseconds()
+		out = append(out, logstore.OverheadBucket{
+			Name:       name,
+			Kind:       string(b.kind),
+			DurationUs: float64(b.dur.Nanoseconds()) / 1000.0,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return buckets[out[i].Name].first.Before(buckets[out[j].Name].first)
+	})
+
+	// Attribute whatever overhead is left over to Bifrost core. Skip when the
+	// measured spans already exceed the total (upstream over-counting): a negative
+	// core is a diagnostic signal, not a bucket, and is surfaced in the UI footer.
+	if overheadOK {
+		coreUs := overheadMs*1000.0 - float64(measuredNs)/1000.0
+		if coreUs > 0.5 {
+			out = append(out, logstore.OverheadBucket{Name: "core", Kind: "core", DurationUs: coreUs})
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // traceAttrFloatMs reads a millisecond span attribute, tolerating int/int64/float64.

--- a/plugins/logging/overhead_breakdown_test.go
+++ b/plugins/logging/overhead_breakdown_test.go
@@ -1,0 +1,198 @@
+package logging
+
+import (
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// span builds a finished span at the given millisecond offsets from base.
+func span(base time.Time, id, parent, name string, kind schemas.SpanKind, startMs, endMs int) *schemas.Span {
+	return &schemas.Span{
+		SpanID:    id,
+		ParentID:  parent,
+		Name:      name,
+		Kind:      kind,
+		StartTime: base.Add(time.Duration(startMs) * time.Millisecond),
+		EndTime:   base.Add(time.Duration(endMs) * time.Millisecond),
+	}
+}
+
+func bucketMap(t *testing.T, trace *schemas.Trace, overheadMs float64, ovOK bool) map[string]float64 {
+	t.Helper()
+	out := map[string]float64{}
+	for _, b := range computeOverheadBreakdown(trace, overheadMs, ovOK) {
+		out[b.Name] = b.DurationUs
+	}
+	return out
+}
+
+// A typical chat trace: root wraps key.selection, one plugin's pre/post hooks, and
+// the llm.call. Overhead decomposes into key.selection and one collapsed plugin
+// bucket. The llm.call is upstream, and the root http.request self-time is
+// deliberately not bucketed (it can hide streaming socket reads).
+func TestComputeOverheadBreakdown_ChatPath(t *testing.T) {
+	base := time.Now()
+	trace := &schemas.Trace{Spans: []*schemas.Span{
+		span(base, "root", "", "/v1/chat/completions", schemas.SpanKindHTTPRequest, 0, 100),
+		span(base, "keysel", "root", "key.selection", schemas.SpanKindInternal, 1, 3),
+		span(base, "pre", "root", "plugin.governance.prehook", schemas.SpanKindPlugin, 3, 8),
+		span(base, "llm", "root", "chat gpt-4o", schemas.SpanKindLLMCall, 8, 95),
+		span(base, "post", "root", "plugin.governance.posthook", schemas.SpanKindPlugin, 95, 96),
+	}}
+
+	// Total overhead 12ms; measured plugin/internal spans are 8ms, so 4ms lands in core.
+	got := bucketMap(t, trace, 12, true)
+
+	if len(got) != 3 {
+		t.Fatalf("expected 3 buckets (key.selection, plugin.governance, core), got %v", got)
+	}
+	if got["key.selection"] != 2000 {
+		t.Errorf("key.selection = %v us, want 2000", got["key.selection"])
+	}
+	// prehook 5ms + posthook 1ms, collapsed to one plugin bucket
+	if got["plugin.governance"] != 6000 {
+		t.Errorf("plugin.governance = %v us, want 6000", got["plugin.governance"])
+	}
+	// 12ms overhead - 8ms measured = 4ms attributed to core
+	if got["core"] != 4000 {
+		t.Errorf("core = %v us, want 4000", got["core"])
+	}
+	// llm.call (upstream) and the root http.request span are not overhead buckets
+	if _, ok := got["chat gpt-4o"]; ok {
+		t.Error("llm.call span must not appear as an overhead bucket")
+	}
+	if _, ok := got["/v1/chat/completions"]; ok {
+		t.Error("root http.request span must not appear as an overhead bucket")
+	}
+}
+
+// When overhead exceeds the measured plugin spans but no plugin/internal spans were
+// captured at all, the whole overhead is attributed to core.
+func TestComputeOverheadBreakdown_CoreOnly(t *testing.T) {
+	base := time.Now()
+	trace := &schemas.Trace{Spans: []*schemas.Span{
+		span(base, "root", "", "/v1/chat/completions", schemas.SpanKindHTTPRequest, 0, 100),
+		span(base, "llm", "root", "chat gpt-4o", schemas.SpanKindLLMCall, 5, 95),
+	}}
+
+	got := bucketMap(t, trace, 3, true)
+	if len(got) != 1 || got["core"] != 3000 {
+		t.Errorf("expected a single core bucket of 3000 us, got %v", got)
+	}
+}
+
+// When measured spans exceed the computed overhead (upstream over-counting), no
+// negative core bucket is emitted; only the measured spans remain.
+func TestComputeOverheadBreakdown_NoNegativeCore(t *testing.T) {
+	base := time.Now()
+	trace := &schemas.Trace{Spans: []*schemas.Span{
+		span(base, "root", "", "/v1/chat/completions", schemas.SpanKindHTTPRequest, 0, 100),
+		span(base, "pre", "root", "plugin.governance.prehook", schemas.SpanKindPlugin, 0, 10),
+	}}
+
+	// Overhead 5ms < measured 10ms: core would be negative, so it is omitted.
+	got := bucketMap(t, trace, 5, true)
+	if len(got) != 1 || got["plugin.governance"] != 10000 {
+		t.Errorf("expected only plugin.governance=10000, got %v", got)
+	}
+	if _, ok := got["core"]; ok {
+		t.Error("core bucket must not be emitted when it would be negative")
+	}
+}
+
+// The named core phases (transport in/out, request-marshal, response-parse) are
+// internal spans that bucket by name; the two transport spans aggregate into one.
+func TestComputeOverheadBreakdown_CorePhases(t *testing.T) {
+	base := time.Now()
+	trace := &schemas.Trace{Spans: []*schemas.Span{
+		span(base, "root", "", "/v1/chat/completions", schemas.SpanKindHTTPRequest, 0, 100),
+		span(base, "tin", "root", "transport", schemas.SpanKindInternal, 0, 2),
+		span(base, "llm", "root", "chat gpt-4o", schemas.SpanKindLLMCall, 2, 90),
+		span(base, "marshal", "llm", "request-marshal", schemas.SpanKindInternal, 2, 5),
+		span(base, "parse", "llm", "response-parse", schemas.SpanKindInternal, 80, 89),
+		span(base, "tout", "root", "transport", schemas.SpanKindInternal, 95, 98),
+	}}
+
+	got := bucketMap(t, trace, 0, false)
+	if got["transport"] != 5000 { // 2ms in + 3ms out, aggregated
+		t.Errorf("transport = %v us, want 5000 (aggregated)", got["transport"])
+	}
+	if got["request-marshal"] != 3000 {
+		t.Errorf("request-marshal = %v us, want 3000", got["request-marshal"])
+	}
+	if got["response-parse"] != 9000 {
+		t.Errorf("response-parse = %v us, want 9000", got["response-parse"])
+	}
+}
+
+// A plugin span that itself contains a nested child (e.g. an MCP round-trip) counts
+// only its self-time: the plugin's own wall duration minus the child's.
+func TestComputeOverheadBreakdown_SelfTimeExcludesChildren(t *testing.T) {
+	base := time.Now()
+	trace := &schemas.Trace{Spans: []*schemas.Span{
+		span(base, "root", "", "/v1/chat/completions", schemas.SpanKindHTTPRequest, 0, 100),
+		span(base, "pre", "root", "plugin.mcp.prehook", schemas.SpanKindPlugin, 0, 40),
+		// MCP round-trip nested under the plugin: subtracted from the plugin's self-time.
+		span(base, "tool", "pre", "mcp.execute", schemas.SpanKindMCPTool, 5, 35),
+	}}
+
+	// No overhead total supplied: only measured self-time, no core bucket.
+	got := bucketMap(t, trace, 0, false)
+	// plugin wall 40ms minus 30ms child = 10ms self-time.
+	if got["plugin.mcp"] != 10000 {
+		t.Errorf("plugin.mcp = %v us, want 10000", got["plugin.mcp"])
+	}
+	if _, ok := got["core"]; ok {
+		t.Error("no core bucket without an overhead total")
+	}
+}
+
+// key.selection is re-parented as llm.call's parent for trace-hierarchy reasons
+// (core/bifrost.go), yet llm.call starts only after key.selection ends. Its wall must
+// NOT be subtracted from key.selection's self-time, so key.selection still surfaces
+// as its own bucket instead of collapsing into core.
+func TestComputeOverheadBreakdown_KeySelectionReparentedLLMCall(t *testing.T) {
+	base := time.Now()
+	trace := &schemas.Trace{Spans: []*schemas.Span{
+		span(base, "root", "", "/v1/chat/completions", schemas.SpanKindHTTPRequest, 0, 100),
+		span(base, "keysel", "root", "key.selection", schemas.SpanKindInternal, 1, 3),
+		// llm.call is linked UNDER key.selection but runs 3..95 (after keysel ends).
+		span(base, "llm", "keysel", "chat gpt-4o", schemas.SpanKindLLMCall, 3, 95),
+	}}
+
+	got := bucketMap(t, trace, 5, true)
+	// key.selection self-time is its own 2ms, not 2ms - 92ms.
+	if got["key.selection"] != 2000 {
+		t.Errorf("key.selection = %v us, want 2000", got["key.selection"])
+	}
+	// 5ms overhead - 2ms key.selection = 3ms core.
+	if got["core"] != 3000 {
+		t.Errorf("core = %v us, want 3000", got["core"])
+	}
+}
+
+// When socket time dominates (upstream ~= root), overhead spans are near-zero and
+// produce no buckets: the exact "~1 microsecond" symptom this feature diagnoses.
+func TestComputeOverheadBreakdown_NegligibleOverhead(t *testing.T) {
+	base := time.Now()
+	trace := &schemas.Trace{Spans: []*schemas.Span{
+		span(base, "root", "", "/v1/chat/completions", schemas.SpanKindHTTPRequest, 0, 100),
+		// llm.call covers essentially the whole root window; root self-time ~= 0.
+		span(base, "llm", "root", "chat gpt-4o", schemas.SpanKindLLMCall, 0, 100),
+	}}
+
+	if got := computeOverheadBreakdown(trace, 0, false); len(got) != 0 {
+		t.Errorf("expected no overhead buckets when overhead is negligible, got %v", got)
+	}
+}
+
+func TestComputeOverheadBreakdown_Empty(t *testing.T) {
+	if computeOverheadBreakdown(nil, 0, false) != nil {
+		t.Error("nil trace must yield nil")
+	}
+	if computeOverheadBreakdown(&schemas.Trace{}, 5, true) != nil {
+		t.Error("trace with no spans must yield nil")
+	}
+}

--- a/plugins/maxim/main.go
+++ b/plugins/maxim/main.go
@@ -4,6 +4,7 @@ package maxim
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -521,6 +522,27 @@ func (plugin *Plugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifro
 	return req, nil, nil
 }
 
+// addLatencyTags forwards Bifrost's upstream/overhead latency split onto the Maxim
+// generation and trace as tags. Maxim has no native field for the breakdown, so
+// tags are the channel, matching how model and dimensions are forwarded. A nil
+// value is left unreported so absent stays distinct from zero.
+func addLatencyTags(logger *logging.Logger, generationID, traceID string, upstreamMs, overheadMs *int64) {
+	add := func(key string, v *int64) {
+		if v == nil {
+			return
+		}
+		val := strconv.FormatInt(*v, 10)
+		if generationID != "" {
+			logger.AddTagToGeneration(generationID, key, val)
+		}
+		if traceID != "" {
+			logger.AddTagToTrace(traceID, key, val)
+		}
+	}
+	add("upstream_latency_ms", upstreamMs)
+	add("overhead_latency_ms", overheadMs)
+}
+
 // PostLLMHook is called after a request has been processed by Bifrost.
 // It completes the request trace by:
 // - Adding response data to the generation if a generation ID exists
@@ -575,6 +597,23 @@ func (plugin *Plugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.B
 		reqHeaders = schemas.FilterHeaders(allHeaders, plugin.requestHeaders)
 	}
 	hasReqHeaders := len(reqHeaders) > 0
+
+	// Bifrost's latency breakdown (time on provider sockets vs Bifrost's own cost),
+	// stamped onto ExtraFields before post-hooks run. Copied out here so the
+	// goroutine can forward them as tags without racing a reused context or result.
+	var upstreamLatencyMs, overheadLatencyMs *int64
+	if result != nil {
+		if ef := result.GetExtraFields(); ef != nil {
+			if v := ef.UpstreamLatency; v != nil {
+				u := *v
+				upstreamLatencyMs = &u
+			}
+			if v := ef.OverheadLatency; v != nil {
+				o := *v
+				overheadLatencyMs = &o
+			}
+		}
+	}
 
 	isFinalChunk := bifrost.IsFinalChunk(ctx)
 
@@ -708,6 +747,8 @@ func (plugin *Plugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.B
 		if hasTraceID && traceID != "" && modelTag != "" {
 			logger.AddTagToTrace(traceID, "model", string(modelTag))
 		}
+		// Forward Bifrost's upstream/overhead latency split, matching the logs UI.
+		addLatencyTags(logger, generationID, traceID, upstreamLatencyMs, overheadLatencyMs)
 		// add configured request headers as tags (prefixed to avoid colliding with other tags)
 		if hasReqHeaders {
 			for key, value := range reqHeaders {

--- a/plugins/otel/converter.go
+++ b/plugins/otel/converter.go
@@ -225,11 +225,6 @@ func convertAttributesToKeyValues(attrs map[string]any, disableContentLogging bo
 		if disableContentLogging && schemas.IsContentAttribute(k) {
 			continue
 		}
-		// Overhead is not exported to connectors; it is still computed and stored in
-		// the logs DB. Skip it here so it does not ride the exported span.
-		if k == schemas.AttrBifrostOverheadDurationMs {
-			continue
-		}
 		kv := anyToKeyValue(k, v)
 		if kv != nil {
 			kvs = append(kvs, kv)

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -989,9 +989,40 @@ func getFloat64Attr(attrs map[string]any, key string) float64 {
 }
 
 // getFloat64AttrOK is getFloat64Attr with presence reporting. Needed where zero
-// is a meaningful value distinct from "absent" — an upstream total of 0 (a cache
+// is a meaningful value distinct from "absent": an upstream total of 0 (a cache
 // hit, or a request rejected before any provider call) means all of the elapsed
 // time was Bifrost's, whereas a missing attribute means it was never measured.
+func getFloat64AttrOK(attrs map[string]any, key string) (float64, bool) {
+	if attrs == nil {
+		return 0, false
+	}
+	switch v := attrs[key].(type) {
+	case float64:
+		return v, true
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	}
+	return 0, false
+}
+
+// overheadMicrosFromTrace reads Bifrost's own cost (in microseconds) off the root
+// span, where the tracer stamps it as AttrBifrostOverheadDurationMs (root duration
+// minus the upstream total, in ms). Reading the stamped value rather than recomputing
+// keeps the overhead metric and the span attribute in lockstep. Returns false when the
+// request carried no measurement; absent must not be reported as zero overhead.
+func overheadMicrosFromTrace(trace *schemas.Trace) (float64, bool) {
+	if trace == nil || trace.RootSpan == nil {
+		return 0, false
+	}
+	overheadMs, ok := getFloat64AttrOK(trace.RootSpan.Attributes, schemas.AttrBifrostOverheadDurationMs)
+	if !ok {
+		return 0, false
+	}
+	return overheadMs * 1000.0, true
+}
+
 // buildSpanAttrs extracts metric dimension attrs from a single attempt span.
 func buildSpanAttrs(span *schemas.Span) []attribute.KeyValue {
 	attrs := span.Attributes
@@ -1167,6 +1198,19 @@ func (p *OtelPlugin) recordMetricsFromTrace(ctx context.Context, exporter *Metri
 		if finalSpan == nil || span.EndTime.After(finalSpan.EndTime) {
 			finalSpan = span
 		}
+	}
+
+	// Bifrost's own overhead. Derived once per trace from the root span, the only
+	// span whose duration covers the whole request (queue wait, plugin hooks and
+	// transport work no llm.call span sees). Labelled off the final attempt span so
+	// provider/model dimensions match the other per-request metrics; the root span
+	// carries only HTTP attributes.
+	if overheadMicros, ok := overheadMicrosFromTrace(trace); ok {
+		labelSpan := finalSpan
+		if labelSpan == nil {
+			labelSpan = trace.RootSpan
+		}
+		exporter.RecordOverheadLatency(ctx, overheadMicros, buildSpanAttrs(labelSpan)...)
 	}
 
 	if finalSpan == nil {

--- a/plugins/otel/metrics.go
+++ b/plugins/otel/metrics.go
@@ -55,6 +55,7 @@ type MetricsExporter struct {
 
 	// Bifrost metrics - histograms
 	upstreamLatencySeconds         *syncFloat64Histogram
+	overheadLatencyMicros          *syncFloat64Histogram
 	streamFirstTokenLatencySeconds *syncFloat64Histogram
 	streamInterTokenLatencySeconds *syncFloat64Histogram
 	requestRetries                 *syncFloat64Histogram
@@ -131,6 +132,17 @@ var (
 	upstreamLatencyBuckets = []float64{
 		.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5,
 		10, 15, 30, 45, 60, 90, 120, 180, 300, 600, 900,
+	}
+
+	// overheadLatencyBuckets: Bifrost's own processing cost, i.e. total minus time
+	// blocked on upstream sockets, in microseconds. A different scale entirely from
+	// upstream latency: healthy values run from sub-millisecond to low tens of ms,
+	// dominated by request and response marshalling. Microseconds keep the fast,
+	// sub-millisecond common case as clean integers instead of tiny fractions. The
+	// tail up to 30_000_000us catches queue saturation and pathological payloads.
+	overheadLatencyBuckets = []float64{
+		100, 250, 500, 1000, 2500, 5000, 10000, 25000, 50000, 100000,
+		250000, 500000, 1000000, 2500000, 5000000, 10000000, 30000000,
 	}
 
 	// firstTokenLatencyBuckets: TTFT. Bimodal - sub-second for fast streaming
@@ -386,6 +398,14 @@ func (m *MetricsExporter) initMetrics() {
 		boundaries: upstreamLatencyBuckets,
 	}
 
+	m.overheadLatencyMicros = &syncFloat64Histogram{
+		name:       "bifrost_overhead_latency_microseconds",
+		desc:       "Latency added by Bifrost itself, in microseconds: total request time minus time blocked on upstream providers",
+		unit:       "us",
+		meter:      m.meter,
+		boundaries: overheadLatencyBuckets,
+	}
+
 	m.streamFirstTokenLatencySeconds = &syncFloat64Histogram{
 		name:       "bifrost_stream_first_token_latency_seconds",
 		desc:       "Latency of the first token of a stream response",
@@ -518,6 +538,13 @@ func (m *MetricsExporter) RecordCost(ctx context.Context, cost float64, attrs ..
 // RecordUpstreamLatency records upstream latency metric
 func (m *MetricsExporter) RecordUpstreamLatency(ctx context.Context, latencySeconds float64, attrs ...attribute.KeyValue) {
 	m.upstreamLatencySeconds.Record(ctx, latencySeconds, metric.WithAttributes(attrs...))
+}
+
+// RecordOverheadLatency records the latency Bifrost itself added to a request, in
+// microseconds. Recorded once per trace (off the root span), not once per attempt:
+// the underlying accumulator already spans every retry and fallback.
+func (m *MetricsExporter) RecordOverheadLatency(ctx context.Context, overheadMicros float64, attrs ...attribute.KeyValue) {
+	m.overheadLatencyMicros.Record(ctx, overheadMicros, metric.WithAttributes(attrs...))
 }
 
 // RecordStreamFirstTokenLatency records first token latency metric

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -34,6 +35,11 @@ const (
 	mcpStartTimeKey      schemas.BifrostContextKey = "bf-prom-mcp-start-time"
 	mcpClientNameKey     schemas.BifrostContextKey = "bf-prom-mcp-client-name"
 	mcpToolNameKey       schemas.BifrostContextKey = "bf-prom-mcp-tool-name"
+
+	// Overhead is measured across the transport hooks rather than the LLM hooks,
+	// so the window matches the OTEL root span. See recordOverhead.
+	transportStartTimeKey schemas.BifrostContextKey = "bf-prom-transport-start-time"
+	overheadLabelsKey     schemas.BifrostContextKey = "bf-prom-overhead-labels"
 )
 
 // PushGatewayConfig holds the configuration for pushing metrics to a Prometheus Push Gateway.
@@ -160,6 +166,7 @@ type PrometheusPlugin struct {
 	HTTPResponseSizeBytes          *prometheus.HistogramVec
 	UpstreamRequestsTotal          *prometheus.CounterVec
 	UpstreamLatencySeconds         *prometheus.HistogramVec
+	OverheadLatencyMicros          *prometheus.HistogramVec
 	SuccessRequestsTotal           *prometheus.CounterVec
 	ErrorRequestsTotal             *prometheus.CounterVec
 	InputTokensTotal               *prometheus.CounterVec
@@ -213,6 +220,17 @@ var (
 	upstreamLatencyBuckets = []float64{
 		.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5,
 		10, 15, 30, 45, 60, 90, 120, 180, 300, 600, 900,
+	}
+
+	// overheadLatencyBuckets: Bifrost's own processing cost, i.e. total minus time
+	// blocked on upstream sockets, in microseconds. A different scale entirely from
+	// upstream latency: healthy values run from sub-millisecond to low tens of ms,
+	// dominated by request and response marshalling. Microseconds keep the fast,
+	// sub-millisecond common case as clean integers instead of tiny fractions. The
+	// tail up to 30_000_000us catches queue saturation and pathological payloads.
+	overheadLatencyBuckets = []float64{
+		100, 250, 500, 1000, 2500, 5000, 10000, 25000, 50000, 100000,
+		250000, 500000, 1000000, 2500000, 5000000, 10000000, 30000000,
 	}
 
 	// firstTokenLatencyBuckets: TTFT. Bimodal - sub-second for fast streaming
@@ -387,6 +405,18 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 		append(append(defaultBifrostLabels, "is_success"), filteredCustomLabels...),
 	)
 
+	// Labelled without is_success: unlike upstream latency, overhead is dominated by
+	// payload marshalling and is not expected to differ between success and failure,
+	// and a failed request often has no response to marshal at all.
+	bifrostOverheadLatencyMicros := factory.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "bifrost_overhead_latency_microseconds",
+			Help:    "Latency added by Bifrost itself, in microseconds: total request time minus time blocked on upstream providers.",
+			Buckets: overheadLatencyBuckets,
+		},
+		append(defaultBifrostLabels, filteredCustomLabels...),
+	)
+
 	bifrostSuccessRequestsTotal := factory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "bifrost_success_requests_total",
@@ -550,6 +580,7 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 		HTTPResponseSizeBytes:          httpResponseSizeBytes,
 		UpstreamRequestsTotal:          bifrostUpstreamRequestsTotal,
 		UpstreamLatencySeconds:         bifrostUpstreamLatencySeconds,
+		OverheadLatencyMicros:          bifrostOverheadLatencyMicros,
 		SuccessRequestsTotal:           bifrostSuccessRequestsTotal,
 		ErrorRequestsTotal:             bifrostErrorRequestsTotal,
 		InputTokensTotal:               bifrostInputTokensTotal,
@@ -660,14 +691,44 @@ func (*PrometheusPlugin) HTTPTransportPreAuthHook(_ *schemas.BifrostContext, _ *
 	return nil, nil
 }
 
-// HTTPTransportPreHook is not used for this plugin
+// HTTPTransportPreHook stamps the start of the transport window used to measure
+// Bifrost's overhead. See HTTPTransportPostHook.
 func (p *PrometheusPlugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	ctx.SetValue(transportStartTimeKey, time.Now())
 	return nil, nil
 }
 
-// HTTPTransportPostHook is not used for this plugin
+// HTTPTransportPostHook records Bifrost's own overhead.
+//
+// This is the widest window the plugin can see: the middleware order is
+// Tracing.pre -> TransportInterceptor.pre -> handler -> TransportInterceptor.post
+// -> Tracing.defer, so it brackets request parsing, the full core pipeline and
+// response marshalling, matching what OTEL derives from the root span. Measuring
+// across PreLLMHook/PostLLMHook instead would miss the transport work, and
+// marshalling a large response body is a real part of the cost.
+//
+// Running here also makes the observation once-per-request rather than
+// once-per-attempt, so a retried request no longer contributes several times.
 func (p *PrometheusPlugin) HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error {
+	start, ok := ctx.Value(transportStartTimeKey).(time.Time)
+	if !ok {
+		return nil
+	}
+	p.recordOverhead(ctx, time.Since(start))
 	return nil
+}
+
+// recordOverhead observes total-minus-upstream against the labels the LLM hook
+// resolved. Silent when either is missing: no accumulator means upstream was
+// never measured, and reporting the full duration as overhead would be wrong.
+func (p *PrometheusPlugin) recordOverhead(ctx *schemas.BifrostContext, total time.Duration) {
+	labels, ok := ctx.Value(overheadLabelsKey).([]string)
+	if !ok || len(labels) == 0 {
+		return
+	}
+	if overhead, ok := schemas.CalculateOverhead(ctx, total); ok {
+		p.OverheadLatencyMicros.WithLabelValues(labels...).Observe(float64(overhead) / float64(time.Microsecond))
+	}
 }
 
 // HTTPTransportStreamChunkHook passes through streaming chunks unchanged
@@ -838,6 +899,7 @@ func extractProviderCacheTokens(result *schemas.BifrostResponse) (read, write, w
 // It records:
 //   - Request latency
 //   - Total request count
+//
 // canonicalEntitySet resolves one entity dimension from context: plural arrays,
 // else scalar as a set of one, canonicalized.
 func canonicalEntitySet(ctx context.Context, idsKey, namesKey, scalarIDKey, scalarNameKey schemas.BifrostContextKey) (idsCSV, namesCSV string) {
@@ -881,6 +943,9 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 		p.logger.Warn("Warning: startTime not found in context for Prometheus PostLLMHook")
 		return result, bifrostErr, nil
 	}
+	// Capture the LLM-hook window synchronously, before the goroutine below and its
+	// cost/metric work can inflate it. Used for the SDK-path overhead metric.
+	llmHookWindow := time.Since(startTime)
 
 	virtualKeyID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceVirtualKeyID)
 	virtualKeyName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceVirtualKeyName)
@@ -948,6 +1013,13 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 
 	pricingScopes := modelcatalog.PricingLookupScopesFromContext(ctx, string(provider))
 
+	// Labels for HTTPTransportPostHook, which observes overhead. Written before
+	// the goroutine launches so the transport hook can't race it; on a retry the
+	// final attempt's labels win.
+	if isStreamFinal {
+		ctx.SetValue(overheadLabelsKey, slices.Clone(promLabelValues))
+	}
+
 	// Calculate cost and record metrics in a separate goroutine to avoid blocking the main thread
 	go func() {
 		// For streaming requests, handle per-token metrics for intermediate chunks
@@ -1005,6 +1077,12 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 		latencyLabelValues = append(latencyLabelValues, strconv.FormatBool(bifrostErr == nil))            // is_success
 		latencyLabelValues = append(latencyLabelValues, promLabelValues[len(p.defaultBifrostLabels):]...) // then custom labels
 		p.UpstreamLatencySeconds.WithLabelValues(latencyLabelValues...).Observe(duration)
+
+		// SDK caller: no transport hooks fire, so this LLM-hook window is all there
+		// is to measure overhead against.
+		if _, viaTransport := ctx.Value(transportStartTimeKey).(time.Time); !viaTransport {
+			p.recordOverhead(ctx, llmHookWindow)
+		}
 
 		// Record cost using the dedicated cost counter
 		if cost > 0 {

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -1042,7 +1042,11 @@ func prepareChatCompletionRequest(ctx *fasthttp.RequestCtx, config *lib.Config) 
 
 // chatCompletion handles POST /v1/chat/completions - Process chat completion requests
 func (h *CompletionHandler) chatCompletion(ctx *fasthttp.RequestCtx) {
+	pt, ph := startTransportSpan(ctx, "request-unmarshal")
 	req, bifrostChatReq, err := prepareChatCompletionRequest(ctx, h.config)
+	if pt != nil {
+		pt.EndSpan(ph, schemas.SpanStatusOk, "")
+	}
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
@@ -1074,7 +1078,11 @@ func (h *CompletionHandler) chatCompletion(ctx *fasthttp.RequestCtx) {
 		return
 	}
 	// Send successful response
+	mt, mh := startTransportSpan(ctx, "response-marshal")
 	SendJSON(ctx, resp)
+	if mt != nil {
+		mt.EndSpan(mh, schemas.SpanStatusOk, "")
+	}
 }
 
 // prepareResponsesRequest prepares a BifrostResponsesRequest from a ResponsesRequest

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -490,7 +490,9 @@ func TransportInterceptorMiddleware(config *lib.Config) schemas.BifrostHTTPMiddl
 			for _, plugin := range plugins {
 				pluginName := plugin.GetName()
 				pluginCtx := bifrostCtx.WithPluginScope(&pluginName)
+				st, sh := startTransportPluginSpan(ctx, pluginName, "transportprehook")
 				resp, err := plugin.HTTPTransportPreHook(pluginCtx, req)
+				endTransportPluginSpan(st, sh, err)
 				pluginCtx.ReleasePluginScope()
 				if err != nil {
 					// Short-circuit with error — drain plugin logs before returning
@@ -547,10 +549,23 @@ func TransportInterceptorMiddleware(config *lib.Config) schemas.BifrostHTTPMiddl
 					preHookLogs = logs
 				}
 
+				// Capture the tracer and trace/root-span ids while ctx is still live so the
+				// deferred post-hooks can be timed after ctx is recycled. spanParentCtx is a
+				// minimal context carrying just what StartSpanID reads (trace id + parent id).
+				var spanTracer schemas.Tracer
+				var spanParentCtx context.Context
+				if t, ok := ctx.UserValue(schemas.BifrostContextKeyTracer).(schemas.Tracer); ok && t != nil {
+					if traceID, _ := ctx.UserValue(schemas.BifrostContextKeyTraceID).(string); traceID != "" {
+						rootSpanID, _ := ctx.UserValue(schemas.BifrostContextKeySpanID).(string)
+						spanTracer = t
+						spanParentCtx = context.WithValue(context.WithValue(context.Background(), schemas.BifrostContextKeyTraceID, traceID), schemas.BifrostContextKeySpanID, rootSpanID)
+					}
+				}
+
 				completer := func() ([]schemas.PluginLogEntry, error) {
 					defer schemas.ReleaseHTTPRequest(capturedReq)
 					defer schemas.ReleaseHTTPResponse(capturedResp)
-					postHookLogs, err := runTransportPostHooksCaptured(capturedReq, capturedResp, plugins, bifrostCtx)
+					postHookLogs, err := runTransportPostHooksCaptured(capturedReq, capturedResp, plugins, bifrostCtx, spanTracer, spanParentCtx)
 					allLogs := preHookLogs
 					if len(postHookLogs) > 0 {
 						allLogs = append(allLogs, postHookLogs...)
@@ -596,7 +611,9 @@ func runTransportPostHooks(ctx *fasthttp.RequestCtx, plugins []schemas.HTTPTrans
 		plugin := plugins[i]
 		pluginName := plugin.GetName()
 		pluginCtx := bifrostCtx.WithPluginScope(&pluginName)
+		st, sh := startTransportPluginSpan(ctx, pluginName, "transportposthook")
 		err := plugin.HTTPTransportPostHook(pluginCtx, req, httpResp)
+		endTransportPluginSpan(st, sh, err)
 		pluginCtx.ReleasePluginScope()
 		if err != nil {
 			logger.Warn("error in HTTPTransportPostHook for plugin %s: %s", pluginName, err.Error())
@@ -621,7 +638,10 @@ func runTransportPostHooks(ctx *fasthttp.RequestCtx, plugins []schemas.HTTPTrans
 // a fasthttp RequestCtx, which may have been recycled by the time this runs in a
 // streaming goroutine. Returns accumulated plugin logs (instead of writing them to
 // ctx.UserValue) so the caller can forward them to the trace completer.
-func runTransportPostHooksCaptured(capturedReq *schemas.HTTPRequest, capturedResp *schemas.HTTPResponse, plugins []schemas.HTTPTransportPlugin, bifrostCtx *schemas.BifrostContext) ([]schemas.PluginLogEntry, error) {
+// spanTracer/spanParentCtx (captured before the fasthttp ctx was recycled) let each
+// post-hook be timed as a plugin.<name>.transportposthook span nested under the root;
+// both are nil when no trace is active and the hooks run untimed.
+func runTransportPostHooksCaptured(capturedReq *schemas.HTTPRequest, capturedResp *schemas.HTTPResponse, plugins []schemas.HTTPTransportPlugin, bifrostCtx *schemas.BifrostContext, spanTracer schemas.Tracer, spanParentCtx context.Context) ([]schemas.PluginLogEntry, error) {
 	// Clone into fresh pooled objects so plugins can mutate without affecting the snapshots.
 	req := schemas.AcquireHTTPRequest()
 	defer schemas.ReleaseHTTPRequest(req)
@@ -646,7 +666,12 @@ func runTransportPostHooksCaptured(capturedReq *schemas.HTTPRequest, capturedRes
 		plugin := plugins[i]
 		pluginName := plugin.GetName()
 		pluginCtx := bifrostCtx.WithPluginScope(&pluginName)
+		var sh schemas.SpanHandle
+		if spanTracer != nil {
+			_, sh = spanTracer.StartSpanID(spanParentCtx, transportPluginSpanName(pluginName, "transportposthook"), schemas.SpanKindPlugin)
+		}
 		err := plugin.HTTPTransportPostHook(pluginCtx, req, httpResp)
+		endTransportPluginSpan(spanTracer, sh, err)
 		pluginCtx.ReleasePluginScope()
 		if err != nil {
 			logger.Warn("error in HTTPTransportPostHook for plugin %s: %s", pluginName, err.Error())
@@ -1488,6 +1513,11 @@ func (m *TracingMiddleware) Middleware() schemas.BifrostHTTPMiddleware {
 				if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
 					ctx.SetUserValue(schemas.BifrostContextKeySpanID, spanID)
 				}
+				// Expose this exact tracer on the request context so transport-edge
+				// handlers can open "transport" spans (client request parse, response
+				// marshal) that nest under this root span. Using the same tracer instance
+				// that created the root span keeps the spans in the same trace store.
+				ctx.SetUserValue(schemas.BifrostContextKeyTracer, tracer)
 			}
 			// Capture request headers onto the trace when a connector has opted in.
 			// Gated so there is no overhead when no observability plugin wants headers.

--- a/transports/bifrost-http/handlers/utils.go
+++ b/transports/bifrost-http/handlers/utils.go
@@ -19,6 +19,90 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+// startTransportSpan opens a nil-safe "transport" internal span for edge
+// (de)serialization: parsing the client request body in, marshalling the response
+// out. The tracer is placed on the request context by TracingMiddleware and the
+// span nests under the root http.request span. Both returns are nil when no trace
+// is active; EndSpan is nil-safe, so callers guard only on the tracer. The name marks
+// the transport phase ("request-unmarshal" for inbound parse, "response-marshal" for
+// outbound serialization); spans sharing a name aggregate into a single bucket.
+func startTransportSpan(ctx *fasthttp.RequestCtx, name string) (schemas.Tracer, schemas.SpanHandle) {
+	t, ok := ctx.UserValue(schemas.BifrostContextKeyTracer).(schemas.Tracer)
+	if !ok || t == nil {
+		return nil, nil
+	}
+	_, h := t.StartSpanID(ctx, name, schemas.SpanKindInternal)
+	return t, h
+}
+
+// transportPluginSpanName is the span name for an HTTP transport hook. The
+// plugin.<name>.<phase> shape lets the overhead breakdown collapse it into the same
+// plugin.<name> bucket as that plugin's core LLM hooks.
+func transportPluginSpanName(pluginName, phase string) string {
+	return "plugin." + pluginName + "." + phase
+}
+
+// startTransportPluginSpan opens a nil-safe SpanKindPlugin span for an HTTP transport
+// hook, reading the tracer off the request context. Used on the synchronous paths
+// (pre-hook, inline post-hook) where the fasthttp ctx is still live. Returns a nil
+// handle when no trace is active; EndSpan is nil-safe.
+func startTransportPluginSpan(ctx *fasthttp.RequestCtx, pluginName, phase string) (schemas.Tracer, schemas.SpanHandle) {
+	t, ok := ctx.UserValue(schemas.BifrostContextKeyTracer).(schemas.Tracer)
+	if !ok || t == nil {
+		return nil, nil
+	}
+	_, h := t.StartSpanID(ctx, transportPluginSpanName(pluginName, phase), schemas.SpanKindPlugin)
+	return t, h
+}
+
+// endTransportPluginSpan closes a transport-hook span, recording the hook's error.
+func endTransportPluginSpan(t schemas.Tracer, h schemas.SpanHandle, err error) {
+	if t == nil {
+		return
+	}
+	if err != nil {
+		t.EndSpan(h, schemas.SpanStatusError, err.Error())
+	} else {
+		t.EndSpan(h, schemas.SpanStatusOk, "")
+	}
+}
+
+// TimedMiddleware wraps an inference auth/routing middleware so its own work — the
+// time it spends before handing off — is recorded as a middleware.<name> overhead
+// span instead of hiding in the "core" bucket. The span ends the instant the wrapped
+// middleware invokes next (so the whole downstream request is excluded), or when it
+// short-circuits without calling next. Named middleware.<name> so the breakdown groups
+// these into a single "Middleware" category with a per-middleware drill-down. Applied
+// at the middleware-composition site; the wrapped middleware's body is untouched.
+func TimedMiddleware(name string, mw schemas.BifrostHTTPMiddleware) schemas.BifrostHTTPMiddleware {
+	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+		return func(ctx *fasthttp.RequestCtx) {
+			t, ok := ctx.UserValue(schemas.BifrostContextKeyTracer).(schemas.Tracer)
+			if !ok || t == nil {
+				// No trace on this request: run the middleware untimed.
+				mw(next)(ctx)
+				return
+			}
+			_, h := t.StartSpanID(ctx, "middleware."+name, schemas.SpanKindInternal)
+			ended := false
+			endOnce := func() {
+				if !ended {
+					ended = true
+					t.EndSpan(h, schemas.SpanStatusOk, "")
+				}
+			}
+			// End the span the moment the middleware hands off, so downstream time is
+			// excluded; endOnce below covers the short-circuit (no-next) path.
+			timedNext := func(c *fasthttp.RequestCtx) {
+				endOnce()
+				next(c)
+			}
+			mw(timedNext)(ctx)
+			endOnce()
+		}
+	}
+}
+
 // ResolvePeriod converts a relative period string ("1h","6h","24h","7d","30d") to concrete
 // start/end time pointers computed from the current server time. Returns nil, nil for
 // unrecognised values. When used in filter parsing, period takes precedence over any explicit

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -874,11 +874,24 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 			return
 		}
 
-		// Convert the integration-specific request to Bifrost format (inference requests)
+		// Convert the integration-specific request to Bifrost format (inference requests).
+		// Timed as a "convertor" overhead phase (nests under the root span via the tracer
+		// on the request ctx); folds into core when no trace is active.
+		convTracer, _ := ctx.UserValue(schemas.BifrostContextKeyTracer).(schemas.Tracer)
+		var convHandle schemas.SpanHandle
+		if convTracer != nil {
+			_, convHandle = convTracer.StartSpanID(ctx, "convertor", schemas.SpanKindInternal)
+		}
 		bifrostReq, err := config.RequestConverter(bifrostCtx, req)
 		if err != nil {
+			if convTracer != nil {
+				convTracer.EndSpan(convHandle, schemas.SpanStatusError, err.Error())
+			}
 			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(err, "failed to convert request to Bifrost format"))
 			return
+		}
+		if convTracer != nil {
+			convTracer.EndSpan(convHandle, schemas.SpanStatusOk, "")
 		}
 		if bifrostReq == nil {
 			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid request"))

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -38,7 +38,7 @@ import {
 	RoutingEngineUsedLabels,
 	Status,
 } from "@/lib/constants/logs";
-import { BatchRequestCounts, ContentBlock, LogEntry, ResponsesMessage } from "@/lib/types/logs";
+import { BatchRequestCounts, ContentBlock, LogEntry, OverheadBucket, ResponsesMessage } from "@/lib/types/logs";
 import { useGetUserAgentMappingsQuery } from "@/lib/store";
 import { cn } from "@/lib/utils";
 import { downloadAsJson } from "@/lib/utils/browser-download";
@@ -473,6 +473,191 @@ function HeroStat({
 				{value}
 			</div>
 			{sub ? <div className="text-muted-foreground mt-0.5 truncate text-[11px]">{sub}</div> : null}
+		</div>
+	);
+}
+
+// formatMicros renders a microsecond overhead value, promoting to ms once it is
+// large enough that microseconds would just be noise.
+function formatMicros(us: number): string {
+	if (us >= 1000) return `${(us / 1000).toFixed(2)} ms`;
+	return `${us.toFixed(us < 10 ? 1 : 0)} µs`;
+}
+
+// Top-level overhead categories. The four JSON (un)marshalling phases fold into one
+// "Serialization" category; the auth middleware spans (middleware.*) fold into
+// "Middleware"; every plugin span folds into "Plugins"; the remaining named phase
+// spans (queue-wait, convertor, key.selection) and the backend "core" remainder each
+// get their own category; anything else lands in "Other". The stacked bar and legend
+// show these categories, and "View details" drills into the member spans (individual
+// (un)marshal phases, individual middlewares, individual plugins) inside grouped ones.
+type OverheadCategory = {
+	key: string;
+	label: string;
+	colorClass: string;
+	totalUs: number;
+	members: OverheadBucket[];
+};
+
+// The four serialization phases collapsed into the "Serialization" category. Their
+// per-phase labels below are used for the drill-down rows.
+const OVERHEAD_SERIALIZATION_PHASES = new Set(["request-unmarshal", "request-marshal", "response-parse", "response-marshal"]);
+
+const OVERHEAD_CATEGORY_META: Record<string, { label: string; colorClass: string }> = {
+	serialization: { label: "Serialization", colorClass: "bg-indigo-500/70" },
+	middleware: { label: "Middleware", colorClass: "bg-cyan-500/70" },
+	"middleware.apikeys": { label: "API keys", colorClass: "bg-cyan-500/70" },
+	"middleware.scim": { label: "SCIM", colorClass: "bg-cyan-500/70" },
+	"middleware.auth": { label: "Auth", colorClass: "bg-cyan-500/70" },
+	"queue-wait": { label: "Queue wait", colorClass: "bg-orange-500/70" },
+	"request-unmarshal": { label: "Request unmarshal", colorClass: "bg-sky-500/70" },
+	convertor: { label: "Convertor", colorClass: "bg-fuchsia-500/70" },
+	"attribute-population": { label: "Attribute population", colorClass: "bg-pink-500/70" },
+	"request-marshal": { label: "Request marshal", colorClass: "bg-indigo-500/70" },
+	"response-parse": { label: "Response unmarshal", colorClass: "bg-purple-500/70" },
+	"response-marshal": { label: "Response marshal", colorClass: "bg-rose-500/70" },
+	"key.selection": { label: "Key selection", colorClass: "bg-amber-500/70" },
+	core: { label: "Core", colorClass: "bg-slate-500/70" },
+	transport: { label: "Transport", colorClass: "bg-teal-500/70" },
+	plugins: { label: "Plugins", colorClass: "bg-blue-500/70" },
+	other: { label: "Other", colorClass: "bg-emerald-500/70" },
+};
+
+function overheadCategoryKey(b: OverheadBucket): string {
+	if (OVERHEAD_SERIALIZATION_PHASES.has(b.name)) {
+		return "serialization";
+	}
+	if (b.name.startsWith("middleware.")) {
+		return "middleware";
+	}
+	if (OVERHEAD_CATEGORY_META[b.name] && b.name !== "plugins" && b.name !== "other") {
+		return b.name;
+	}
+	return b.kind === "plugin" ? "plugins" : "other";
+}
+
+// overheadMemberLabel renders a drill-down member with its friendly phase label when
+// there is one (serialization phases), else the raw span name (plugins).
+function overheadMemberLabel(name: string): string {
+	return OVERHEAD_CATEGORY_META[name]?.label ?? name;
+}
+
+// buildOverheadCategories groups the raw buckets into the top-level categories,
+// ordered largest-first so the bar and legend read like the numbers.
+function buildOverheadCategories(buckets: OverheadBucket[]): OverheadCategory[] {
+	const grouped = new Map<string, OverheadBucket[]>();
+	for (const b of buckets) {
+		const key = overheadCategoryKey(b);
+		const list = grouped.get(key);
+		if (list) list.push(b);
+		else grouped.set(key, [b]);
+	}
+	const cats: OverheadCategory[] = [];
+	for (const [key, members] of grouped) {
+		members.sort((a, b) => b.duration_us - a.duration_us);
+		cats.push({
+			key,
+			label: OVERHEAD_CATEGORY_META[key]?.label ?? key,
+			colorClass: OVERHEAD_CATEGORY_META[key]?.colorClass ?? "bg-muted-foreground/50",
+			totalUs: members.reduce((acc, m) => acc + m.duration_us, 0),
+			members,
+		});
+	}
+	return cats.sort((a, b) => b.totalUs - a.totalUs);
+}
+
+// OverheadBreakdown renders Bifrost's overhead as a single horizontal stacked bar
+// split into the top-level categories, with a legend beneath. Plugin and internal
+// spans are measured directly; the "core" bucket (from the backend) accounts for the
+// rest of the overhead, so the segments sum to the full overhead number. "View
+// details" expands the categories that hold more than one span (Plugins, Other) into
+// their individual members so a specific plugin can be inspected.
+function OverheadBreakdown({ buckets, overheadMs }: { buckets: OverheadBucket[]; overheadMs?: number }) {
+	const [showDetails, setShowDetails] = useState(false);
+	if (!buckets || buckets.length === 0) return null;
+
+	const categories = buildOverheadCategories(buckets);
+	const sumUs = buckets.reduce((acc, b) => acc + b.duration_us, 0);
+	const overheadUs = overheadMs != null && !isNaN(overheadMs) ? overheadMs * 1000 : undefined;
+
+	// When measured spans already exceed the computed overhead, the backend omits a
+	// core bucket (it would be negative): a sign the upstream accumulator is
+	// over-counting. Surface it rather than let the numbers look inconsistent.
+	const overCounted = overheadUs != null && sumUs > overheadUs + 1;
+
+	const barTotal = categories.reduce((acc, c) => acc + c.totalUs, 0) || 1;
+	// Only categories that aggregate more than one span are worth drilling into.
+	const drillable = categories.filter((c) => c.members.length > 1);
+
+	return (
+		<div className="space-y-3">
+			<div className="flex items-center justify-between gap-2">
+				<BlockHeader title="Overhead Breakdown" />
+				<div className="font-mono text-xs tabular-nums">{formatMicros(overheadUs ?? sumUs)}</div>
+			</div>
+
+			<div className="flex h-3 w-full overflow-hidden rounded-sm">
+				{categories.map((c) => (
+					<div
+						key={c.key}
+						className={cn(c.colorClass, "h-full")}
+						style={{ width: `${(c.totalUs / barTotal) * 100}%` }}
+						title={`${c.label} · ${formatMicros(c.totalUs)}`}
+					/>
+				))}
+			</div>
+
+			<div className="flex flex-wrap gap-x-4 gap-y-1.5">
+				{categories.map((c) => (
+					<div key={c.key} className="flex items-center gap-1.5 font-mono text-[11px]">
+						<span className={cn("h-2.5 w-2.5 shrink-0 rounded-[2px]", c.colorClass)} />
+						<span>{c.label}</span>
+						<span className="text-muted-foreground tabular-nums">{formatMicros(c.totalUs)}</span>
+					</div>
+				))}
+			</div>
+
+			{drillable.length > 0 ? (
+				<button
+					type="button"
+					onClick={() => setShowDetails((v) => !v)}
+					className="text-muted-foreground hover:text-foreground flex items-center gap-1 font-mono text-[11px] transition"
+				>
+					View details
+					<ChevronDown className={cn("h-3 w-3 transition-transform", showDetails ? "rotate-180" : "rotate-0")} />
+				</button>
+			) : null}
+
+			{showDetails ? (
+				<div className="space-y-3 pt-1">
+					{drillable.map((c) => (
+						<div key={c.key} className="space-y-1.5">
+							<div className="text-muted-foreground flex items-center gap-1.5 text-[11px] font-medium tracking-wide uppercase">
+								<span className={cn("h-2 w-2 shrink-0 rounded-[2px]", c.colorClass)} />
+								{c.label}
+								<span className="tabular-nums">{formatMicros(c.totalUs)}</span>
+							</div>
+							<div className="space-y-1 pl-3">
+								{c.members.map((m) => (
+									<div key={m.name} className="flex items-center justify-between gap-3 font-mono text-[11px]">
+										<span className="truncate" title={m.name}>
+											{overheadMemberLabel(m.name)}
+										</span>
+										<span className="text-muted-foreground shrink-0 tabular-nums">{formatMicros(m.duration_us)}</span>
+									</div>
+								))}
+							</div>
+						</div>
+					))}
+				</div>
+			) : null}
+
+			{overCounted ? (
+				<div className="text-muted-foreground text-[11px]">
+					Measured spans ({formatMicros(sumUs)}) exceed the computed overhead ({formatMicros(overheadUs!)}); the upstream accumulator may be
+					over-counting.
+				</div>
+			) : null}
 		</div>
 	);
 }
@@ -1089,6 +1274,9 @@ export function LogDetailView({
 								value={log.overhead_latency == null || isNaN(log.overhead_latency) ? "N/A" : <div>{log.overhead_latency.toFixed(2)}ms</div>}
 							/>
 						</div>
+						{log.overhead_breakdown && log.overhead_breakdown.length > 0 ? (
+							<OverheadBreakdown buckets={log.overhead_breakdown} overheadMs={log.overhead_latency} />
+						) : null}
 					</div>
 					<DottedSeparator />
 					<div className="space-y-4">

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -561,6 +561,16 @@ export interface RedactionMapping {
 	output?: Record<string, string>;
 }
 
+// One slice of Bifrost overhead, attributed to a span (or group of spans) by
+// self-time. duration_us is microseconds. Buckets come in chronological order and
+// summing them gives an independent measure of overhead vs the overhead_latency
+// number (which is total minus the upstream socket accumulator).
+export interface OverheadBucket {
+	name: string; // e.g. "key.selection", "plugin.governance", "transport/core"
+	kind: string; // originating span kind, for grouping/coloring
+	duration_us: number;
+}
+
 export interface LogEntry {
 	id: string;
 	object: string; // text.completion, chat.completion, embedding, audio.speech, audio.transcription
@@ -636,6 +646,7 @@ export interface LogEntry {
 	latency?: number;
 	upstream_latency?: number; // provider socket time across all attempts, ms
 	overhead_latency?: number; // Bifrost overhead (total minus upstream), ms
+	overhead_breakdown?: OverheadBucket[]; // per-span self-time decomposition of overhead (microseconds)
 	token_usage?: LLMUsage;
 	cache_debug?: CacheDebug;
 	batch_debug?: BatchDebug;


### PR DESCRIPTION
## Summary

Adds per-span self-time decomposition of Bifrost overhead ("overhead breakdown") so the log detail view can attribute exactly where Bifrost's own latency is spent — serialization, queue wait, key selection, plugins, convertor, and a residual "core" bucket — rather than reporting a single opaque overhead number.

## Changes

- **New `queue-wait` span**: opened when a request is enqueued and closed when a worker dequeues it, measuring how long messages sit in the provider queue. Stored on `ChannelMessage` and closed idempotently on dequeue or on release if the send never reached a worker.

- **New `attribute-population` spans**: wrap `PopulateLLMRequestAttributes` and `PopulateLLMResponseAttributes` calls so large-prompt attribute writes are attributed separately instead of folding into the core bucket.

- **New `convertor` spans**: wrap the Bifrost↔provider request/response format conversion (`ToBifrost*Response`, `requestConverter`) at primary chat call sites across Anthropic, Bedrock, Cohere, Gemini, and OpenAI providers, and in the integration router.

- **New `request-marshal` and `response-parse` spans**: wrap JSON encode and decode on the hot path via a new `HandleProviderResponseCtx` helper (context-aware variant of `HandleProviderResponse`) and inside `CheckContextAndGetRequestBody`.

- **Transport-edge spans**: `chatCompletion` now wraps client request parsing as `request-unmarshal` and response serialization as `response-marshal`. HTTP transport plugin pre/post hooks are timed as `plugin.<name>.transportprehook/transportposthook` spans. A `TimedMiddleware` wrapper is provided to time inference middleware without modifying middleware bodies.

- **`computeOverheadBreakdown`**: new function in the logging plugin that walks the span tree, computes each span's self-time (wall duration minus overlapping child duration), groups overhead-side spans (`SpanKindPlugin`, `SpanKindInternal`) into named buckets, and derives a residual `core` bucket from the stamped overhead total. Upstream and root HTTP spans are excluded to avoid double-counting streaming socket reads.

- **`OverheadBreakdown` UI component**: renders the breakdown as a horizontal stacked bar with a legend. Categories (Serialization, Middleware, Plugins, Queue wait, Key selection, Convertor, Core, etc.) are color-coded. A "View details" toggle drills into categories with multiple member spans.

- **`overhead_breakdown` column**: new `text` column on the `logs` table (migration `logs_add_overhead_breakdown_column`) storing a JSON-serialized `[]OverheadBucket`. Serialized/deserialized alongside existing log fields; exposed as `overhead_breakdown` in the log JSON and `LogEntry` TypeScript type.

- **`spanOverlap` guard**: child duration subtracted from a parent's self-time is clamped to the temporal intersection of the two spans, so re-parented spans that run outside their logical parent's window (e.g. `llm.call` linked under `key.selection` but starting after it ends) do not drive the parent's self-time negative.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./...
go test ./plugins/logging/... -run TestComputeOverheadBreakdown

# UI
cd ui
pnpm i
pnpm build
```

Enable tracing on a Bifrost instance, send a chat completion request, and open the log detail view. The "Overhead Breakdown" stacked bar should appear beneath the overhead latency stat, with segments for at minimum `key.selection`, `convertor`, `request-marshal`, `response-parse`, and `core`. Sending a request through a provider queue (concurrent load) should produce a `queue-wait` segment. Requests routed through a plugin should produce a `plugin.<name>` segment.

## Breaking changes

- [ ] Yes
- [x] No

The new `overhead_breakdown` column is additive; the migration is transactional and rolls back cleanly. `HandleProviderResponse` is unchanged; `HandleProviderResponseCtx` is a new wrapper used only at primary call sites.

## Related issues

## Security considerations

No new auth, secrets, or PII surface. Span names and durations written to the breakdown are internal Bifrost identifiers and timing values only.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable