### PR TITLE
feat: add `AliasConfig` object shape, `BedrockMantleKeyConfig`, per-alias provider overrides, and deprecate key-level `api_version` for Azure

### DIFF
--- a/docs/deployment-guides/helm/providers.mdx
+++ b/docs/deployment-guides/helm/providers.mdx
@@ -178,7 +178,7 @@ bifrost:
 
 ### Azure OpenAI
 
-Azure requires `azure_key_config` on every key with `endpoint` and `api_version`. Use top-level `aliases` to map logical model names to Azure deployment names.
+Azure requires `azure_key_config` on every key with `endpoint`. Bifrost uses the Azure OpenAI v1 API, so no key-level `api_version` is needed; set `api_version` on an individual alias when one deployment needs a specific version. Use top-level `aliases` to map logical model names to Azure deployment names. An alias value can also be an object carrying a canonical `model_name`, a `model_family`, and per-alias overrides such as `api_version` or `endpoint`; see [Aliasing Models](/providers/aliasing-models) for the full schema.
 
 Two auth modes are supported:
 
@@ -210,7 +210,6 @@ bifrost:
           models: ["gpt-4o", "gpt-4o-mini", "text-embedding-3-small"]
           azure_key_config:
             endpoint: "env.AZURE_ENDPOINT"
-            api_version: "2024-10-21"
           aliases:
             gpt-4o: "gpt-4o-prod"
             gpt-4o-mini: "gpt-4o-mini-prod"
@@ -281,7 +280,6 @@ bifrost:
           models: ["gpt-4o"]
           azure_key_config:
             endpoint: "env.AZURE_ENDPOINT"
-            api_version: "2024-10-21"
           aliases:
             gpt-4o: "gpt-4o-prod"
 
@@ -313,7 +311,6 @@ bifrost:
           weight: 1
           azure_key_config:
             endpoint: "env.AZURE_ENDPOINT_EAST"
-            api_version: "2024-10-21"
           aliases:
             gpt-4o: "gpt-4o-eastus"
         - name: "westus"
@@ -321,7 +318,6 @@ bifrost:
           weight: 1
           azure_key_config:
             endpoint: "env.AZURE_ENDPOINT_WEST"
-            api_version: "2024-10-21"
           aliases:
             gpt-4o: "gpt-4o-westus"
 ```

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -2825,7 +2825,9 @@
                       "mask",
                       "segmentation",
                       "vectorize",
-                      "controlnet_preprocess"
+                      "controlnet_preprocess",
+                      "controlnet",
+                      "preprocess"
                     ],
                     "description": "Type of edit operation. Support varies by provider; unsupported values are dropped and the\nrequest runs as a standard edit.\n"
                   },
@@ -10274,7 +10276,9 @@
                       "mask",
                       "segmentation",
                       "vectorize",
-                      "controlnet_preprocess"
+                      "controlnet_preprocess",
+                      "controlnet",
+                      "preprocess"
                     ],
                     "description": "Type of edit operation. Support varies by provider; unsupported values are dropped and the\nrequest runs as a standard edit.\n"
                   },
@@ -93716,10 +93720,189 @@
               "minLength": 1
             },
             "additionalProperties": {
-              "type": "string",
-              "minLength": 1
+              "oneOf": [
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Legacy shape. A bare provider-specific identifier, equivalent to an AliasConfig with only model_id set."
+                },
+                {
+                  "type": "object",
+                  "description": "Rich configuration for a single key-level alias. Carries the wire model identifier plus\noptional canonical name, model family, and provider-specific overrides. Shared fields\n(region, project_id, use_anthropic_endpoints) are accepted on any provider's key but are\nonly read by the providers named in their descriptions. The provider-specific overrides\nare validated against the owning key's provider and rejected on a mismatch.\n",
+                  "properties": {
+                    "model_id": {
+                      "type": "string",
+                      "minLength": 1,
+                      "description": "Provider-specific identifier sent on the wire (deployment name, inference profile ID, fine-tuned model ID, etc.)"
+                    },
+                    "model_name": {
+                      "type": "string",
+                      "description": "Canonical model name used for pricing, logging, and family inference. Set this when model_id is opaque."
+                    },
+                    "model_family": {
+                      "type": "string",
+                      "enum": [
+                        "anthropic",
+                        "openai",
+                        "mistral",
+                        "cohere",
+                        "gemini",
+                        "gemma",
+                        "llama",
+                        "imagen",
+                        "veo",
+                        "nova",
+                        "titan"
+                      ],
+                      "description": "Underlying model family used for provider routing decisions. When unset, the family is inferred from model_name, model_id, and the alias name."
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Free-form note surfaced in the UI. Not used for routing."
+                    },
+                    "region": {
+                      "type": "object",
+                      "description": "Per-alias region override. Read by Bedrock, Bedrock Mantle, and Vertex; falls back to the key-level region.",
+                      "properties": {
+                        "value": {
+                          "type": "string",
+                          "description": "Resolved value (redacted in GET responses for secret fields)"
+                        },
+                        "ref": {
+                          "type": "string",
+                          "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "plain_text",
+                            "env",
+                            "vault"
+                          ],
+                          "description": "Source type of the value"
+                        }
+                      }
+                    },
+                    "project_id": {
+                      "type": "object",
+                      "description": "Per-alias project override. Vertex reads it as the GCP project; Bedrock and Bedrock Mantle send it as the AWS project on the OpenAI-Project / anthropic-workspace-id header.",
+                      "properties": {
+                        "value": {
+                          "type": "string",
+                          "description": "Resolved value (redacted in GET responses for secret fields)"
+                        },
+                        "ref": {
+                          "type": "string",
+                          "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "plain_text",
+                            "env",
+                            "vault"
+                          ],
+                          "description": "Source type of the value"
+                        }
+                      }
+                    },
+                    "use_anthropic_endpoints": {
+                      "type": "boolean",
+                      "description": "For DeepSeek, Fireworks, vLLM, and SGLang keys, routes this alias's chat completions and responses requests through the Anthropic-compatible /v1/messages endpoint. Overrides the key-level setting for this alias only."
+                    },
+                    "api_version": {
+                      "type": "string",
+                      "description": "Azure only. Overrides the api-version query parameter."
+                    },
+                    "anthropic_version": {
+                      "type": "string",
+                      "description": "Azure only. Overrides the anthropic-version header for Claude-on-Azure deployments."
+                    },
+                    "endpoint": {
+                      "type": "object",
+                      "description": "Azure only. Overrides the key-level Azure endpoint for this alias.",
+                      "properties": {
+                        "value": {
+                          "type": "string",
+                          "description": "Resolved value (redacted in GET responses for secret fields)"
+                        },
+                        "ref": {
+                          "type": "string",
+                          "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "plain_text",
+                            "env",
+                            "vault"
+                          ],
+                          "description": "Source type of the value"
+                        }
+                      }
+                    },
+                    "project_number": {
+                      "type": "object",
+                      "description": "Vertex only. Per-alias GCP project number, required for fine-tuned models.",
+                      "properties": {
+                        "value": {
+                          "type": "string",
+                          "description": "Resolved value (redacted in GET responses for secret fields)"
+                        },
+                        "ref": {
+                          "type": "string",
+                          "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "plain_text",
+                            "env",
+                            "vault"
+                          ],
+                          "description": "Source type of the value"
+                        }
+                      }
+                    },
+                    "force_single_region": {
+                      "type": "boolean",
+                      "description": "Vertex only. Calls the alias region as-is and skips promoting multi-region-only models to a multi-region endpoint."
+                    },
+                    "inference_profile_arn": {
+                      "type": "object",
+                      "description": "Bedrock only. Cross-region inference profile ARN invoked instead of the model ID.",
+                      "properties": {
+                        "value": {
+                          "type": "string",
+                          "description": "Resolved value (redacted in GET responses for secret fields)"
+                        },
+                        "ref": {
+                          "type": "string",
+                          "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "plain_text",
+                            "env",
+                            "vault"
+                          ],
+                          "description": "Source type of the value"
+                        }
+                      }
+                    },
+                    "use_deployments_endpoint": {
+                      "type": "boolean",
+                      "description": "Replicate only. Routes the alias through the deployments endpoint instead of the models endpoint."
+                    }
+                  },
+                  "required": [
+                    "model_id"
+                  ]
+                }
+              ]
             },
-            "description": "Model alias mappings - maps a user-facing model name to a provider-specific identifier (deployment name, inference profile ID, fine-tuned model ID, etc.)"
+            "description": "Model alias mappings. Each entry maps a user-facing model name to either a bare\nprovider-specific identifier (deployment name, inference profile ID, fine-tuned model\nID) or an AliasConfig object carrying that identifier plus optional canonical name,\nmodel family, and provider-specific overrides. Both shapes are accepted on input; a\nresponse emits the bare string when only model_id is set.\n"
           },
           "azure_key_config": {
             "type": "object",
@@ -93750,7 +93933,7 @@
               },
               "api_version": {
                 "type": "object",
-                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
+                "description": "Deprecated and ignored. Bifrost uses the Azure OpenAI v1 API, which needs no api-version parameter. Set api_version on an individual alias to override it for that deployment.",
                 "properties": {
                   "value": {
                     "type": "string",
@@ -93769,7 +93952,8 @@
                     ],
                     "description": "Source type of the value"
                   }
-                }
+                },
+                "deprecated": true
               },
               "client_id": {
                 "type": "object",
@@ -94090,6 +94274,317 @@
               }
             }
           },
+          "bedrock_mantle_key_config": {
+            "type": "object",
+            "description": "Bedrock Mantle-specific key configuration",
+            "properties": {
+              "access_key": {
+                "type": "object",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
+                  },
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
+                  }
+                }
+              },
+              "secret_key": {
+                "type": "object",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
+                  },
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
+                  }
+                }
+              },
+              "session_token": {
+                "type": "object",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
+                  },
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
+                  }
+                }
+              },
+              "region": {
+                "type": "object",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
+                  },
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
+                  }
+                }
+              },
+              "role_arn": {
+                "type": "object",
+                "description": "IAM role ARN for STS AssumeRole",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
+                  },
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
+                  }
+                }
+              },
+              "external_id": {
+                "type": "object",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
+                  },
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
+                  }
+                }
+              },
+              "session_name": {
+                "type": "object",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
+                  },
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
+                  }
+                }
+              },
+              "project_id": {
+                "type": "object",
+                "description": "Scopes inference and model listing to a Bedrock project, sent as the OpenAI-Project or anthropic-workspace-id header. Defaults to the account's default project when empty.",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
+                  },
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
+                  }
+                }
+              },
+              "endpoints": {
+                "type": "object",
+                "description": "Routes each AWS endpoint service through an interface VPC endpoint",
+                "properties": {
+                  "runtime": {
+                    "type": "object",
+                    "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
+                    "properties": {
+                      "value": {
+                        "type": "string",
+                        "description": "Resolved value (redacted in GET responses for secret fields)"
+                      },
+                      "ref": {
+                        "type": "string",
+                        "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
+                      },
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "plain_text",
+                          "env",
+                          "vault"
+                        ],
+                        "description": "Source type of the value"
+                      }
+                    }
+                  },
+                  "control_plane": {
+                    "type": "object",
+                    "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
+                    "properties": {
+                      "value": {
+                        "type": "string",
+                        "description": "Resolved value (redacted in GET responses for secret fields)"
+                      },
+                      "ref": {
+                        "type": "string",
+                        "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
+                      },
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "plain_text",
+                          "env",
+                          "vault"
+                        ],
+                        "description": "Source type of the value"
+                      }
+                    }
+                  },
+                  "mantle": {
+                    "type": "object",
+                    "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
+                    "properties": {
+                      "value": {
+                        "type": "string",
+                        "description": "Resolved value (redacted in GET responses for secret fields)"
+                      },
+                      "ref": {
+                        "type": "string",
+                        "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
+                      },
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "plain_text",
+                          "env",
+                          "vault"
+                        ],
+                        "description": "Source type of the value"
+                      }
+                    }
+                  },
+                  "agent_runtime": {
+                    "type": "object",
+                    "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
+                    "properties": {
+                      "value": {
+                        "type": "string",
+                        "description": "Resolved value (redacted in GET responses for secret fields)"
+                      },
+                      "ref": {
+                        "type": "string",
+                        "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
+                      },
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "plain_text",
+                          "env",
+                          "vault"
+                        ],
+                        "description": "Source type of the value"
+                      }
+                    }
+                  },
+                  "s3": {
+                    "type": "object",
+                    "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
+                    "properties": {
+                      "value": {
+                        "type": "string",
+                        "description": "Resolved value (redacted in GET responses for secret fields)"
+                      },
+                      "ref": {
+                        "type": "string",
+                        "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
+                      },
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "plain_text",
+                          "env",
+                          "vault"
+                        ],
+                        "description": "Source type of the value"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "vllm_key_config": {
             "type": "object",
             "description": "VLLM-specific key configuration",
@@ -94206,6 +94701,10 @@
           "use_for_batch_api": {
             "type": "boolean",
             "description": "Whether this key can be used for batch API operations"
+          },
+          "use_anthropic_endpoints": {
+            "type": "boolean",
+            "description": "For DeepSeek, Fireworks, vLLM, and SGLang keys, routes chat completions and responses requests through the provider's Anthropic-compatible endpoints. Can be overridden per alias."
           },
           "config_hash": {
             "type": "string",

--- a/docs/openapi/schemas/management/providers.yaml
+++ b/docs/openapi/schemas/management/providers.yaml
@@ -77,6 +77,8 @@ AzureKeyConfig:
       $ref: '../../schemas/management/common.yaml#/EnvVar'
     api_version:
       $ref: '../../schemas/management/common.yaml#/EnvVar'
+      deprecated: true
+      description: Deprecated and ignored. Bifrost uses the Azure OpenAI v1 API, which needs no api-version parameter. Set api_version on an individual alias to override it for that deployment.
     client_id:
       $ref: '../../schemas/management/common.yaml#/EnvVar'
     client_secret:
@@ -179,6 +181,99 @@ VLLMKeyConfig:
       type: string
       description: Exact model name served on this vLLM instance
 
+AliasConfig:
+  type: object
+  description: |
+    Rich configuration for a single key-level alias. Carries the wire model identifier plus
+    optional canonical name, model family, and provider-specific overrides. Shared fields
+    (region, project_id, use_anthropic_endpoints) are accepted on any provider's key but are
+    only read by the providers named in their descriptions. The provider-specific overrides
+    are validated against the owning key's provider and rejected on a mismatch.
+  properties:
+    model_id:
+      type: string
+      minLength: 1
+      description: Provider-specific identifier sent on the wire (deployment name, inference profile ID, fine-tuned model ID, etc.)
+    model_name:
+      type: string
+      description: Canonical model name used for pricing, logging, and family inference. Set this when model_id is opaque.
+    model_family:
+      type: string
+      enum: [anthropic, openai, mistral, cohere, gemini, gemma, llama, imagen, veo, nova, titan]
+      description: Underlying model family used for provider routing decisions. When unset, the family is inferred from model_name, model_id, and the alias name.
+    description:
+      type: string
+      description: Free-form note surfaced in the UI. Not used for routing.
+    region:
+      $ref: '../../schemas/management/common.yaml#/EnvVar'
+      description: Per-alias region override. Read by Bedrock, Bedrock Mantle, and Vertex; falls back to the key-level region.
+    project_id:
+      $ref: '../../schemas/management/common.yaml#/EnvVar'
+      description: Per-alias project override. Vertex reads it as the GCP project; Bedrock and Bedrock Mantle send it as the AWS project on the OpenAI-Project / anthropic-workspace-id header.
+    use_anthropic_endpoints:
+      type: boolean
+      description: For DeepSeek, Fireworks, vLLM, and SGLang keys, routes this alias's chat completions and responses requests through the Anthropic-compatible /v1/messages endpoint. Overrides the key-level setting for this alias only.
+    api_version:
+      type: string
+      description: Azure only. Overrides the api-version query parameter.
+    anthropic_version:
+      type: string
+      description: Azure only. Overrides the anthropic-version header for Claude-on-Azure deployments.
+    endpoint:
+      $ref: '../../schemas/management/common.yaml#/EnvVar'
+      description: Azure only. Overrides the key-level Azure endpoint for this alias.
+    project_number:
+      $ref: '../../schemas/management/common.yaml#/EnvVar'
+      description: Vertex only. Per-alias GCP project number, required for fine-tuned models.
+    force_single_region:
+      type: boolean
+      description: Vertex only. Calls the alias region as-is and skips promoting multi-region-only models to a multi-region endpoint.
+    inference_profile_arn:
+      $ref: '../../schemas/management/common.yaml#/EnvVar'
+      description: Bedrock only. Cross-region inference profile ARN invoked instead of the model ID.
+    use_deployments_endpoint:
+      type: boolean
+      description: Replicate only. Routes the alias through the deployments endpoint instead of the models endpoint.
+  required:
+    - model_id
+
+BedrockMantleKeyConfig:
+  type: object
+  description: Bedrock Mantle-specific key configuration
+  properties:
+    access_key:
+      $ref: '../../schemas/management/common.yaml#/EnvVar'
+    secret_key:
+      $ref: '../../schemas/management/common.yaml#/EnvVar'
+    session_token:
+      $ref: '../../schemas/management/common.yaml#/EnvVar'
+    region:
+      $ref: '../../schemas/management/common.yaml#/EnvVar'
+    role_arn:
+      $ref: '../../schemas/management/common.yaml#/EnvVar'
+      description: IAM role ARN for STS AssumeRole
+    external_id:
+      $ref: '../../schemas/management/common.yaml#/EnvVar'
+    session_name:
+      $ref: '../../schemas/management/common.yaml#/EnvVar'
+    project_id:
+      $ref: '../../schemas/management/common.yaml#/EnvVar'
+      description: Scopes inference and model listing to a Bedrock project, sent as the OpenAI-Project or anthropic-workspace-id header. Defaults to the account's default project when empty.
+    endpoints:
+      type: object
+      description: Routes each AWS endpoint service through an interface VPC endpoint
+      properties:
+        runtime:
+          $ref: '../../schemas/management/common.yaml#/EnvVar'
+        control_plane:
+          $ref: '../../schemas/management/common.yaml#/EnvVar'
+        mantle:
+          $ref: '../../schemas/management/common.yaml#/EnvVar'
+        agent_runtime:
+          $ref: '../../schemas/management/common.yaml#/EnvVar'
+        s3:
+          $ref: '../../schemas/management/common.yaml#/EnvVar'
+
 Key:
   type: object
   description: API key configuration
@@ -210,15 +305,25 @@ Key:
       propertyNames:
         minLength: 1
       additionalProperties:
-        type: string
-        minLength: 1
-      description: Model alias mappings - maps a user-facing model name to a provider-specific identifier (deployment name, inference profile ID, fine-tuned model ID, etc.)
+        oneOf:
+          - type: string
+            minLength: 1
+            description: Legacy shape. A bare provider-specific identifier, equivalent to an AliasConfig with only model_id set.
+          - $ref: '#/AliasConfig'
+      description: |
+        Model alias mappings. Each entry maps a user-facing model name to either a bare
+        provider-specific identifier (deployment name, inference profile ID, fine-tuned model
+        ID) or an AliasConfig object carrying that identifier plus optional canonical name,
+        model family, and provider-specific overrides. Both shapes are accepted on input; a
+        response emits the bare string when only model_id is set.
     azure_key_config:
       $ref: '#/AzureKeyConfig'
     vertex_key_config:
       $ref: '#/VertexKeyConfig'
     bedrock_key_config:
       $ref: '#/BedrockKeyConfig'
+    bedrock_mantle_key_config:
+      $ref: '#/BedrockMantleKeyConfig'
     vllm_key_config:
       $ref: '#/VllmKeyConfig'
     ollama_key_config:
@@ -233,6 +338,9 @@ Key:
     use_for_batch_api:
       type: boolean
       description: Whether this key can be used for batch API operations
+    use_anthropic_endpoints:
+      type: boolean
+      description: For DeepSeek, Fireworks, vLLM, and SGLang keys, routes chat completions and responses requests through the provider's Anthropic-compatible endpoints. Can be overridden per alias.
     config_hash:
       type: string
       description: Hash of config.json version, used for change detection

--- a/docs/providers/aliasing-models.mdx
+++ b/docs/providers/aliasing-models.mdx
@@ -60,6 +60,8 @@ Add an `aliases` object to any key in `config.json`:
 }
 ```
 
+In the Web UI, aliases are the rows of the **Deployments** table on the key form: navigate to **Models** > **Model Providers**, open a provider, add or edit a key, and use the **Deployments** section. Each row takes a **Deployment name** (the name your application sends) and a **Model ID** (the wire identifier). Expand a row to set the canonical model name, model family, description, and any provider-specific overrides described below.
+
 You can also add aliases via the provider keys API:
 
 ```bash
@@ -93,25 +95,41 @@ Each alias maps the name your application sends to either a plain target string 
 }
 ```
 
+**Shared fields.** Available on an alias for any provider. `region`, `project_id`, and `use_anthropic_endpoints` are read only by the providers listed in their description and are ignored elsewhere.
+
 | Field | Type | Description |
 |-------|------|-------------|
-| `model_id` | string | **Required.** The wire identifier forwarded to the provider — deployment name, inference profile ARN, fine-tune ID, anything. |
+| `model_id` | string | **Required.** The wire identifier forwarded to the provider: deployment name, inference profile ARN, fine-tune ID, anything. |
 | `model_name` | string | Canonical model name used by pricing and logs. Set this when `model_id` is opaque (e.g. an Azure deployment ID) so cost attribution still hits the catalog. |
 | `model_family` | enum | Forces the family used for provider routing decisions (request shape, response parsing, etc.). One of: `anthropic`, `openai`, `mistral`, `cohere`, `gemini`, `gemma`, `llama`, `imagen`, `veo`, `nova`, `titan`. When unset, the family is auto-detected by substring matching against `model_name`, `model_id`, and the alias name. |
 | `description` | string | Free-form note. Surfaced in the UI; not used for routing. |
-| `region` | string / EnvVar | Per-alias region override (Bedrock + Vertex). Falls back to the key-level region when unset. |
+| `region` | string / EnvVar | Per-alias region override, read by **Bedrock**, **Bedrock Mantle**, and **Vertex**. Falls back to the key-level region when unset. |
+| `project_id` | string / EnvVar | Per-alias project override. **Vertex** reads it as the GCP project; **Bedrock** and **Bedrock Mantle** send it as the AWS project on the `OpenAI-Project` / `anthropic-workspace-id` header. Falls back to the key-level project when unset. |
+| `use_anthropic_endpoints` | boolean | Routes this alias's chat completions and responses requests through the provider's Anthropic-compatible `/v1/messages` endpoint instead of its OpenAI-compatible one. Read by **DeepSeek**, **Fireworks**, **vLLM**, and **SGLang**; overrides the key-level `use_anthropic_endpoints` for this alias only. Text completions and embeddings are unaffected. |
 
-**Provider-specific overrides** (only set on aliases whose owning key matches the provider; validation rejects mismatches):
+**Provider-specific overrides.** These four groups are validated against the owning key's provider, so an Azure override on a Bedrock key is rejected at config load. (The shared fields above are not provider-gated.)
 
-| Provider | Field | Description |
-|----------|-------|-------------|
-| Azure | `api_version` | Overrides the `api-version` query parameter |
-| Azure | `anthropic_version` | Overrides the `anthropic-version` header for Claude-on-Azure deployments |
-| Azure | `endpoint` | Overrides the key-level Azure endpoint — useful when one credential spans deployments on multiple Azure resources |
-| Vertex | `project_id` | Per-alias GCP project ID |
-| Vertex | `project_number` | Per-alias GCP project number (required for fine-tuned models) |
-| Bedrock | `inference_profile_arn` | Cross-region inference profile ARN invoked instead of the model ID |
-| Replicate | `use_deployments_endpoint` | Routes the alias through Replicate's deployments endpoint |
+| Provider | Field | Type | Description |
+|----------|-------|------|-------------|
+| Azure | `api_version` | string | Overrides the `api-version` query parameter |
+| Azure | `anthropic_version` | string | Overrides the `anthropic-version` header for Claude-on-Azure deployments |
+| Azure | `endpoint` | string / EnvVar | Overrides the key-level Azure endpoint, useful when one credential spans deployments on multiple Azure resources |
+| Vertex | `project_number` | string / EnvVar | Per-alias GCP project number (required for fine-tuned models) |
+| Vertex | `force_single_region` | boolean | Calls the alias `region` as-is and skips promoting multi-region-only models to a multi-region endpoint. Use for provisioned throughput. |
+| Bedrock | `inference_profile_arn` | string / EnvVar | Cross-region inference profile ARN invoked instead of the model ID |
+| Replicate | `use_deployments_endpoint` | boolean | Routes the alias through Replicate's deployments endpoint instead of the models endpoint |
+
+### Which fields apply per provider
+
+| Provider | Alias fields beyond `model_id` / `model_name` / `model_family` / `description` |
+|----------|------------------------------------------------------------------------------|
+| Azure | `api_version`, `anthropic_version`, `endpoint` |
+| Vertex | `region`, `project_id`, `project_number`, `force_single_region` |
+| Bedrock | `region`, `project_id`, `inference_profile_arn` |
+| Bedrock Mantle | `region`, `project_id` |
+| Replicate | `use_deployments_endpoint` |
+| DeepSeek, Fireworks, vLLM, SGLang | `use_anthropic_endpoints` |
+| Every other provider | None. The shared fields are accepted but unused. |
 
 ### Validation rules
 

--- a/docs/providers/supported-providers/bedrock-mantle.mdx
+++ b/docs/providers/supported-providers/bedrock-mantle.mdx
@@ -149,6 +149,53 @@ Alternatively, authenticate with a Bedrock Mantle API key sent as a Bearer token
 ```
 </CodeGroup>
 
+### 4. Model Aliases
+
+Mantle model IDs are long and version-less, so a key's `aliases` map is the usual way to expose short, stable names to callers. An alias value can be a bare model ID or an object carrying per-alias overrides:
+
+<CodeGroup>
+```json config.json
+{
+  "providers": {
+    "bedrock_mantle": {
+      "keys": [
+        {
+          "name": "mantle-static",
+          "models": ["*"],
+          "weight": 1.0,
+          "bedrock_mantle_key_config": {
+            "region": "us-east-1",
+            "project_id": "env.BEDROCK_PROJECT_ID"
+          },
+          "aliases": {
+            "claude-opus": "anthropic.claude-opus-4-8",
+            "claude-opus-west": {
+              "model_id": "anthropic.claude-opus-4-8",
+              "model_name": "claude-opus-4-8",
+              "region": "us-west-2",
+              "project_id": "env.BEDROCK_WEST_PROJECT_ID"
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+</CodeGroup>
+
+| Field                      | Required | Description                                                                                                          |
+| -------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `aliases.*.model_id`       | Yes      | The Mantle model ID sent on the wire                                                                                 |
+| `aliases.*.model_name`     | No       | Canonical model name used for pricing and logs. Set this when the alias `model_id` is opaque                         |
+| `aliases.*.model_family`   | No       | Forces the family used for request shaping and response parsing instead of inferring it from the model ID            |
+| `aliases.*.region`         | No       | Per-alias AWS region; overrides `bedrock_mantle_key_config.region` for that alias only                                |
+| `aliases.*.project_id`     | No       | Per-alias Bedrock project, sent as the `OpenAI-Project` header on the OpenAI-compatible surface and `anthropic-workspace-id` on the native-Anthropic surface; overrides `bedrock_mantle_key_config.project_id` |
+
+The per-alias `region` is applied to the endpoint host, so one key can serve the same model from several regions under different names. Region precedence is: a `region/` prefix in the requested model ID, then the alias `region`, then `bedrock_mantle_key_config.region`. Note that alias names, not the underlying model IDs, are what `models` and `blacklisted_models` match against.
+
+In the Web UI these are the expanded fields of a row in the **Deployments** table, under **Bedrock Mantle overrides**. See [Aliasing Models](/providers/aliasing-models) for the full alias schema.
+
 ---
 
 ## Usage

--- a/docs/providers/supported-providers/bedrock.mdx
+++ b/docs/providers/supported-providers/bedrock.mdx
@@ -457,14 +457,36 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
 | `role_arn`      | No       | -                 | IAM role ARN for STS AssumeRole                                                                                       |
 | `external_id`   | No       | -                 | External ID for AssumeRole (when required by trust policy)                                                            |
 | `session_name`  | No       | `bifrost-session` | Session name for AssumeRole CloudTrail logs                                                                           |
+| `project_id`    | No       | -                 | Bedrock project scoping the Mantle sub-surface (`gpt-*` / Gemma routing) via the `OpenAI-Project` header; no effect on the Converse paths |
 
 **Key-level fields:**
 
 | Field                             | Required | Description                                                                                                                                  |
 | --------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `aliases`                         | No       | Map model names to inference profile IDs or Bedrock model IDs (v1.5.0-prerelease2+)                                                          |
+| `aliases.*.model_name`            | No       | Canonical model name used for pricing and logs. Set this whenever the alias `model_id` is an opaque profile resource ID, so cost attribution still resolves |
+| `aliases.*.model_family`          | No       | Forces the family used for request shaping and response parsing instead of inferring it from the model ID                                     |
+| `aliases.*.region`                | No       | Per-alias AWS region; overrides `bedrock_key_config.region` for that alias only. A `region/` prefix in the requested model ID still wins over both |
+| `aliases.*.project_id`            | No       | Per-alias Bedrock project; overrides `bedrock_key_config.project_id` for that alias only                                                     |
 | `aliases.*.inference_profile_arn` | No       | Per-deployment ARN prefix; overrides `bedrock_key_config.arn` (see [Inference Profiles](#inference-profiles--arn-configuration))              |
 | `models`                          | Yes      | Models this key can serve; use `["*"]` to allow all                                                                                          |
+
+The per-alias overrides let a single key span regions or projects. Here one key serves Sonnet from both `us-east-1` (the key default) and `us-west-2`, with `model_name` keeping both rows priced against the same catalog entry:
+
+```json
+{
+  "aliases": {
+    "claude-sonnet-4-5": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "claude-sonnet-4-5-west": {
+      "model_id": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+      "model_name": "claude-sonnet-4-5",
+      "region": "us-west-2"
+    }
+  }
+}
+```
+
+In the Web UI these are the expanded fields of a row in the **Deployments** table, under **Bedrock overrides**. See [Aliasing Models](/providers/aliasing-models) for the full alias schema.
 
 ---
 

--- a/docs/providers/supported-providers/deepseek.mdx
+++ b/docs/providers/supported-providers/deepseek.mdx
@@ -136,14 +136,20 @@ The `use_anthropic_endpoints` boolean is part of the same key payload used by [P
 }
 ```
 
-To override this per-alias (for example, on a virtual key's model config), set `use_anthropic_endpoints` alongside the alias's `model_id`:
+To override this for one alias, set `use_anthropic_endpoints` alongside that alias's `model_id` in the key's `aliases` map:
 
 ```json
 {
-  "model_id": "deepseek-v4-flash",
-  "use_anthropic_endpoints": false
+  "aliases": {
+    "fast-model": {
+      "model_id": "deepseek-v4-flash",
+      "use_anthropic_endpoints": false
+    }
+  }
 }
 ```
+
+See [Aliasing Models](/providers/aliasing-models) for the full alias schema.
 
 | Field | Type | Required | Description |
 |-------|------|----------|--------------|

--- a/docs/providers/supported-providers/fireworks.mdx
+++ b/docs/providers/supported-providers/fireworks.mdx
@@ -94,6 +94,66 @@ case schemas.Fireworks:
 
 ---
 
+## Anthropic-Compatible Endpoints (optional)
+
+Fireworks serves an Anthropic-compatible Messages endpoint (`/v1/messages`) alongside its default OpenAI-compatible APIs. Setting `use_anthropic_endpoints` routes **Chat Completions** and the **Responses API** through that endpoint instead, streaming included. Text Completions and Embeddings are unaffected and always use the OpenAI-compatible paths. Both modes authenticate with the same `Authorization: Bearer <key>` header.
+
+The setting can be configured per key, and overridden per alias:
+
+- **Key-level** - sets the default endpoint mode for every request made with that key.
+- **Alias-level** - overrides the key-level default for a single alias, so one key can serve some aliases through the OpenAI-compatible endpoints and others through the Anthropic-compatible one.
+
+If neither is set, requests use the OpenAI-compatible endpoints.
+
+<Tabs>
+<Tab title="Web UI">
+
+On the key form, toggle **Use Anthropic Endpoints** (off by default). To override it for a single alias, expand that alias's row in the **Deployments** table and set **Use Anthropic endpoints** under **Fireworks overrides** to On or Off. Leaving it on **Use key setting** inherits the key-level toggle.
+
+</Tab>
+<Tab title="config.json">
+
+```json
+{
+  "providers": {
+    "fireworks": {
+      "keys": [
+        {
+          "name": "fireworks-key-1",
+          "value": "env.FIREWORKS_API_KEY",
+          "models": ["*"],
+          "weight": 1.0,
+          "use_anthropic_endpoints": true
+        }
+      ]
+    }
+  }
+}
+```
+
+To override it for one alias, set `use_anthropic_endpoints` alongside the alias's `model_id`:
+
+```json
+{
+  "aliases": {
+    "fast-model": {
+      "model_id": "accounts/fireworks/models/deepseek-v3p2",
+      "use_anthropic_endpoints": false
+    }
+  }
+}
+```
+
+</Tab>
+<Tab title="API">
+The `use_anthropic_endpoints` boolean is part of the key payload used by [Provider Keys Management](https://docs.getbifrost.ai/api-reference/providers/create-a-key-for-a-provider), and can also be set on any entry of that key's `aliases` map.
+</Tab>
+</Tabs>
+
+See [Aliasing Models](/providers/aliasing-models) for the full alias schema.
+
+---
+
 # 1. Chat Completions
 
 Fireworks chat completions use the standard OpenAI-compatible wire format.

--- a/docs/providers/supported-providers/sgl.mdx
+++ b/docs/providers/supported-providers/sgl.mdx
@@ -100,6 +100,68 @@ case schemas.SGL:
 
 ---
 
+## Anthropic-Compatible Endpoints (optional)
+
+SGLang can serve an Anthropic-compatible Messages endpoint (`/v1/messages`) alongside its OpenAI-compatible API. Setting `use_anthropic_endpoints` routes **Chat Completions** and the **Responses API** through that endpoint on the same server URL, streaming included. Text Completions are unaffected and always use the OpenAI-compatible path. Requests carry the same `Authorization: Bearer <key>` header plus an `anthropic-version: 2023-06-01` header. Make sure the SGLang server you point at actually exposes `/v1/messages` before turning this on.
+
+The setting can be configured per key, and overridden per alias:
+
+- **Key-level** - sets the default endpoint mode for every request made with that key.
+- **Alias-level** - overrides the key-level default for a single alias, so one key can serve some aliases through the OpenAI-compatible endpoints and others through the Anthropic-compatible one.
+
+If neither is set, requests use the OpenAI-compatible endpoints.
+
+<Tabs>
+<Tab title="Web UI">
+
+On the key form, toggle **Use Anthropic Endpoints** (off by default). To override it for a single alias, expand that alias's row in the **Deployments** table and set **Use Anthropic endpoints** under **SGLang overrides** to On or Off. Leaving it on **Use key setting** inherits the key-level toggle.
+
+</Tab>
+<Tab title="config.json">
+
+```json
+{
+  "providers": {
+    "sgl": {
+      "keys": [
+        {
+          "name": "sgl-key-1",
+          "models": ["*"],
+          "weight": 1.0,
+          "use_anthropic_endpoints": true,
+          "sgl_key_config": {
+            "url": "env.SGL_URL"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+To override it for one alias, set `use_anthropic_endpoints` alongside the alias's `model_id`:
+
+```json
+{
+  "aliases": {
+    "fast-model": {
+      "model_id": "meta-llama/Llama-3.2-1B-Instruct",
+      "use_anthropic_endpoints": false
+    }
+  }
+}
+```
+
+</Tab>
+<Tab title="API">
+The `use_anthropic_endpoints` boolean is part of the key payload used by [Provider Keys Management](https://docs.getbifrost.ai/api-reference/providers/create-a-key-for-a-provider), and can also be set on any entry of that key's `aliases` map.
+</Tab>
+</Tabs>
+
+See [Aliasing Models](/providers/aliasing-models) for the full alias schema.
+
+---
+
 # 1. Chat Completions
 
 ## Request Parameters

--- a/docs/providers/supported-providers/vertex.mdx
+++ b/docs/providers/supported-providers/vertex.mdx
@@ -447,6 +447,36 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
 | `aliases` | No       | Map model names to fine-tuned model IDs or endpoint identifiers (v1.5.0-prerelease2+)     |
 | `models`  | Yes      | Models this key can serve; use `["*"]` to allow all                                       |
 
+**Per-alias overrides.** Every `vertex_key_config` field above except `auth_credentials` can also be set on an individual alias, overriding the key default for that alias only:
+
+| Field                             | Required | Description                                                                                     |
+| --------------------------------- | -------- | ----------------------------------------------------------------------------------------------- |
+| `aliases.*.model_name`            | No       | Canonical model name used for pricing and logs. Set this when the alias `model_id` is an opaque endpoint or tuned-model ID |
+| `aliases.*.model_family`          | No       | Forces the family used for request shaping and response parsing instead of inferring it from the model ID |
+| `aliases.*.project_id`            | No       | Per-alias GCP project; overrides `vertex_key_config.project_id`                                 |
+| `aliases.*.project_number`        | No       | Per-alias GCP project number; overrides `vertex_key_config.project_number` (required for fine-tuned models) |
+| `aliases.*.region`                | No       | Per-alias GCP region; overrides `vertex_key_config.region`                                      |
+| `aliases.*.force_single_region`   | No       | Per-alias multi-region behavior; overrides `vertex_key_config.force_single_region`              |
+
+This lets one key serve a fine-tuned model from a different project than the foundation models on the same key:
+
+```json
+{
+  "aliases": {
+    "gemini-2.5-flash": "gemini-2.5-flash",
+    "my-tuned-model": {
+      "model_id": "1234567890123456789",
+      "model_name": "gemini-2.5-flash",
+      "project_id": "env.VERTEX_TUNING_PROJECT",
+      "project_number": "env.VERTEX_TUNING_PROJECT_NUMBER",
+      "region": "us-central1"
+    }
+  }
+}
+```
+
+In the Web UI these are the expanded fields of a row in the **Deployments** table, under **Vertex overrides**. See [Aliasing Models](/providers/aliasing-models) for the full alias schema.
+
 ---
 
 ## GKE Workload Identity Federation

--- a/docs/providers/supported-providers/vllm.mdx
+++ b/docs/providers/supported-providers/vllm.mdx
@@ -116,6 +116,69 @@ case schemas.VLLM:
 
 ---
 
+## Anthropic-Compatible Endpoints (optional)
+
+vLLM can serve an Anthropic-compatible Messages endpoint (`/v1/messages`) alongside its OpenAI-compatible API. Setting `use_anthropic_endpoints` routes **Chat Completions** and the **Responses API** through that endpoint on the same server URL, streaming included. Text Completions and Embeddings are unaffected. Both modes authenticate with the same `Authorization: Bearer <key>` header. Make sure the vLLM server you point at actually exposes `/v1/messages` before turning this on.
+
+The setting can be configured per key, and overridden per alias:
+
+- **Key-level** - sets the default endpoint mode for every request made with that key.
+- **Alias-level** - overrides the key-level default for a single alias, so one key can serve some aliases through the OpenAI-compatible endpoints and others through the Anthropic-compatible one.
+
+If neither is set, requests use the OpenAI-compatible endpoints.
+
+<Tabs>
+<Tab title="Web UI">
+
+On the key form, toggle **Use Anthropic Endpoints** (off by default). To override it for a single alias, expand that alias's row in the **Deployments** table and set **Use Anthropic endpoints** under **vLLM overrides** to On or Off. Leaving it on **Use key setting** inherits the key-level toggle.
+
+</Tab>
+<Tab title="config.json">
+
+```json
+{
+  "providers": {
+    "vllm": {
+      "keys": [
+        {
+          "name": "vllm-key-1",
+          "models": ["*"],
+          "weight": 1.0,
+          "use_anthropic_endpoints": true,
+          "vllm_key_config": {
+            "url": "env.VLLM_URL",
+            "model_name": "meta-llama/Llama-3.2-1B-Instruct"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+To override it for one alias, set `use_anthropic_endpoints` alongside the alias's `model_id`:
+
+```json
+{
+  "aliases": {
+    "fast-model": {
+      "model_id": "meta-llama/Llama-3.2-1B-Instruct",
+      "use_anthropic_endpoints": false
+    }
+  }
+}
+```
+
+</Tab>
+<Tab title="API">
+The `use_anthropic_endpoints` boolean is part of the key payload used by [Provider Keys Management](https://docs.getbifrost.ai/api-reference/providers/create-a-key-for-a-provider), and can also be set on any entry of that key's `aliases` map.
+</Tab>
+</Tabs>
+
+See [Aliasing Models](/providers/aliasing-models) for the full alias schema.
+
+---
+
 # 1. Chat Completions
 
 vLLM supports standard OpenAI chat completion parameters. For full parameter reference, see [OpenAI Chat Completions](/providers/supported-providers/openai#1-chat-completions). Message types, tools, and streaming follow the same behavior.

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -5521,16 +5521,9 @@
               },
               "description": "Azure scopes for authentication"
             },
-            "deployments": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              },
-              "description": "Model to deployment mappings"
-            },
             "api_version": {
               "type": "string",
-              "description": "Azure API version"
+              "description": "Deprecated: Bifrost now uses the Azure OpenAI v1 API which does not require an api-version parameter. Set api_version on an individual alias to override it for that deployment."
             }
           },
           "required": ["endpoint"],
@@ -5564,13 +5557,6 @@
               "type": "boolean",
               "description": "When true, always call the configured region and skip automatic promotion of multi-region-only models to a multi-region endpoint. Enable for provisioned throughput.",
               "default": false
-            },
-            "deployments": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              },
-              "description": "Model to deployment mappings"
             }
           },
           "required": ["project_id", "region"],
@@ -5618,13 +5604,6 @@
             "project_id": {
               "type": "string",
               "description": "Bedrock project ID scoping inference and model listing. Sent as the OpenAI-Project header on the OpenAI-compatible surface and the anthropic-workspace-id header on the native-Anthropic (Claude) surface. When empty, AWS routes to the account's default project (can use env. prefix)"
-            },
-            "deployments": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              },
-              "description": "Model to deployment mappings"
             },
             "batch_s3_config": {
               "type": "object",
@@ -5781,7 +5760,7 @@
                   },
                   "model_family": {
                     "type": "string",
-                    "enum": ["anthropic", "openai", "mistral", "cohere", "gemini", "nova", "titan"],
+                    "enum": ["anthropic", "openai", "mistral", "cohere", "gemini", "gemma", "llama", "imagen", "veo", "nova", "titan"],
                     "description": "Underlying model family. Used by provider routing without substring-sniffing the wire model ID."
                   },
                   "description": {
@@ -5821,7 +5800,7 @@
                   },
                   "use_anthropic_endpoints": {
                     "type": "boolean",
-                    "description": "Routes chat completions and responses requests through Anthropic-compatible endpoints."
+                    "description": "For deepseek, fireworks, vllm, and sgl keys: route this alias's chat completions and responses requests through Anthropic-compatible endpoints. Overrides the key-level use_anthropic_endpoints setting."
                   }
                 },
                 "required": ["model_id"],
@@ -6585,16 +6564,9 @@
                     },
                     "description": "Azure scopes for authentication"
                   },
-                  "deployments": {
-                    "type": "object",
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "description": "Model to deployment mappings"
-                  },
                   "api_version": {
                     "type": "string",
-                    "description": "Azure API version"
+                    "description": "Deprecated: Bifrost now uses the Azure OpenAI v1 API which does not require an api-version parameter. Set api_version on an individual alias to override it for that deployment."
                   }
                 },
                 "dependentRequired": {
@@ -6627,13 +6599,6 @@
                     "type": "boolean",
                     "description": "When true, always call the configured region and skip automatic promotion of multi-region-only models to a multi-region endpoint. Enable for provisioned throughput.",
                     "default": false
-                  },
-                  "deployments": {
-                    "type": "object",
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "description": "Model to deployment mappings"
                   }
                 },
                 "additionalProperties": false
@@ -6676,13 +6641,6 @@
                   "batch_role_arn": {
                     "type": "string",
                     "description": "Service role ARN passed to Bedrock batch jobs for S3 access; takes priority over any role_arn sent in the request (can use env. prefix)"
-                  },
-                  "deployments": {
-                    "type": "object",
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "description": "Model to deployment mappings"
                   },
                   "batch_s3_config": {
                     "type": "object",

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -4165,6 +4165,10 @@
                       "mistral",
                       "cohere",
                       "gemini",
+                      "gemma",
+                      "llama",
+                      "imagen",
+                      "veo",
                       "nova",
                       "titan"
                     ],
@@ -4211,7 +4215,7 @@
                   },
                   "use_anthropic_endpoints": {
                     "type": "boolean",
-                    "description": "Routes chat completions and responses requests through Anthropic-compatible endpoints."
+                    "description": "For deepseek, fireworks, vllm, and sgl keys: route this alias's chat completions and responses requests through Anthropic-compatible endpoints. Overrides the key-level use_anthropic_endpoints setting."
                   }
                 },
                 "required": ["model_id"],
@@ -4277,13 +4281,6 @@
                 "project_id": {
                   "type": "string",
                   "description": "Bedrock project ID scoping the Mantle sub-surface (OpenAI-compatible gpt-*/Gemma routing) via the OpenAI-Project header. When empty, AWS routes to the account's default project. No effect on the Converse/bedrock-runtime paths (can use env. prefix)."
-                },
-                "deployments": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "description": "Model to deployment mappings"
                 },
                 "batch_s3_config": {
                   "type": "object",
@@ -4598,7 +4595,7 @@
                 },
                 "api_version": {
                   "type": "string",
-                  "description": "Deprecated: Bifrost now uses the Azure OpenAI v1 API which does not require an api-version parameter."
+                  "description": "Deprecated: Bifrost now uses the Azure OpenAI v1 API which does not require an api-version parameter. Set api_version on an individual alias to override it for that deployment."
                 }
               },
               "required": ["endpoint"],

--- a/transports/schema_test/config_schema_test.go
+++ b/transports/schema_test/config_schema_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -550,12 +551,19 @@ func TestSchemaKeyAliases(t *testing.T) {
 		}
 	})
 
-	t.Run("vertex_key_config does not include deployments field", func(t *testing.T) {
-		_, found := navigateJSON(schema, "$defs", "vertex_key", "allOf", 1, "properties", "vertex_key_config", "properties", "deployments")
-		if found {
-			t.Error("$defs/vertex_key still has 'deployments' in vertex_key_config — deployments were moved to top-level key aliases")
-		}
-	})
+	// No key config carries a "deployments" map any more: the Go structs dropped the field
+	// and config loading has no legacy fallback, so a "deployments" entry in config.json is
+	// silently discarded. Keeping it in the schema would validate a config whose model
+	// mappings never take effect.
+	for _, def := range []string{"azure_key", "vertex_key", "bedrock_key", "replicate_key"} {
+		configKey := strings.TrimSuffix(def, "_key") + "_key_config"
+		t.Run(configKey+" does not include deployments field", func(t *testing.T) {
+			_, found := navigateJSON(schema, "$defs", def, "allOf", 1, "properties", configKey, "properties", "deployments")
+			if found {
+				t.Errorf("$defs/%s still has 'deployments' in %s: deployments were replaced by top-level key aliases", def, configKey)
+			}
+		})
+	}
 
 	t.Run("key with aliases validates successfully", func(t *testing.T) {
 		compiled := compileSchema(t)


### PR DESCRIPTION
## Summary

This PR expands the alias schema to support rich per-alias configuration objects (in addition to the existing bare string form), deprecates the key-level `api_version` field on Azure in favor of per-alias overrides, adds `BedrockMantleKeyConfig` to the OpenAPI spec, and documents `use_anthropic_endpoints` support for Fireworks, vLLM, and SGLang. It also removes the legacy `deployments` map from all provider key configs in both the Helm and transport JSON schemas.

## Changes

- **Alias schema (`AliasConfig`)**: Alias values now accept either a bare string (legacy) or a structured object with `model_id`, `model_name`, `model_family`, `description`, and provider-specific overrides (`api_version`, `anthropic_version`, `endpoint` for Azure; `project_number`, `force_single_region` for Vertex; `inference_profile_arn` for Bedrock; `use_deployments_endpoint` for Replicate). Shared fields `region`, `project_id`, and `use_anthropic_endpoints` are accepted on any provider but only read by the providers that support them.
- **Azure `api_version` deprecation**: `azure_key_config.api_version` is now marked deprecated and ignored. Bifrost uses the Azure OpenAI v1 API, which requires no global `api-version` parameter. The field can still be set on individual aliases to override it per deployment. All Helm deployment guide examples have had the key-level `api_version` removed.
- **`BedrockMantleKeyConfig`**: Added to the OpenAPI spec and provider YAML schema, covering `access_key`, `secret_key`, `session_token`, `region`, `role_arn`, `external_id`, `session_name`, `project_id`, and a VPC `endpoints` block (`runtime`, `control_plane`, `mantle`, `agent_runtime`, `s3`).
- **`use_anthropic_endpoints`**: Added as a top-level key field and as a per-alias override. Documented for Fireworks, vLLM, SGLang, and DeepSeek, explaining key-level vs. alias-level precedence and which request types are affected.
- **`deployments` field removal**: The `deployments` map has been removed from `azure_key_config`, `vertex_key_config`, `bedrock_key_config`, and `replicate_key_config` in both `values.schema.json` and `config.schema.json`. Model mappings belong in the top-level `aliases` field. Schema tests updated to cover all four provider key configs.
- **`model_family` enum expansion**: Added `gemma`, `llama`, `imagen`, and `veo` to the `model_family` enum in both the Helm values schema and the transport config schema.
- **Image edit operation types**: Added `controlnet` and `preprocess` as valid `edit_type` enum values in the OpenAPI spec.
- **Documentation**: Updated the aliasing models reference page with a per-provider field matrix, clarified shared vs. provider-specific fields, and added Web UI guidance. Added per-alias override tables and examples to the Bedrock, Bedrock Mantle, and Vertex provider pages.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./...
```

Validate that:
- A key with a bare string alias still loads and routes correctly.
- A key with an `AliasConfig` object alias routes using `model_id` and applies per-alias overrides (e.g., `region`, `api_version`, `use_anthropic_endpoints`).
- An Azure key with `api_version` set at the key level logs a deprecation warning and ignores the value; setting it on an alias applies it only to that alias's requests.
- A Bedrock or Vertex key with per-alias `region` or `project_id` overrides routes to the correct regional endpoint.
- `use_anthropic_endpoints: true` on a Fireworks, vLLM, SGLang, or DeepSeek key sends chat completions to `/v1/messages`; setting it to `false` on a single alias reverts that alias to the OpenAI-compatible path.
- Config validation rejects provider-specific alias overrides on a mismatched provider (e.g., `api_version` on a Bedrock key).
- The `deployments` field in any provider key config is silently discarded and does not populate model mappings.

## Breaking changes

- [x] Yes
- [ ] No

`azure_key_config.api_version` is now ignored. Operators who relied on it to set the API version globally must either remove it (Bifrost's v1 API path requires no version parameter) or move it to individual aliases using `api_version` in an `AliasConfig` object. The `deployments` field on `azure_key_config`, `vertex_key_config`, `bedrock_key_config`, and `replicate_key_config` is no longer recognized; any model mappings stored there must be migrated to the top-level `aliases` map on the key.

## Related issues

## Security considerations

No new secrets or auth flows are introduced. Per-alias `endpoint`, `region`, and `project_id` fields support the existing `env.VAR_NAME` and `vault.path` reference syntax, so secrets are not stored in plain text.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable