### PR TITLE
feat: add broker clustering support to Helm chart

### DIFF
--- a/docs/enterprise/clustering.mdx
+++ b/docs/enterprise/clustering.mdx
@@ -231,6 +231,29 @@ platform that can make an outbound gRPC connection.
 | Leader election | Deterministic over gossip members | Deterministic over the broker roster (same algorithm) |
 | Entity replication | Over the gRPC mesh | Over the broker relay - identical entity types |
 
+### Broker-mode synchronization performance
+
+Broker mode separates cluster traffic into dedicated lanes for general messages,
+heartbeats, governance usage, KV-store updates, circuit-breaker events,
+load-balancer logs, and diagnostics. This prevents heavy traffic in one lane from
+blocking a different kind of cluster traffic.
+
+However, all messages of the same type addressed to a node share that node's
+corresponding broker stream:
+
+```text
+Node B ─┐
+Node C ─┼──> Node A's governance stream
+Node D ─┘
+```
+
+Mesh mode instead has a separate stream between each pair of nodes. As a result,
+slow processing or heavy traffic from one peer can delay same-lane messages from
+other peers in broker mode. Broker mode may therefore synchronize more slowly
+than mesh mode under contention. Use mesh mode when the environment permits
+direct node-to-node connectivity and maximum synchronization performance is
+required.
+
 Leadership in broker mode uses the **same deterministic rule** as mesh mode:
 the lexicographically-smallest node ID in the roster is the leader. Every node
 computes this independently from the roster the broker pushes, so there is

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -617,11 +617,27 @@ false
 {{- /* Cluster Config */ -}}
 {{- if and .Values.bifrost.cluster .Values.bifrost.cluster.enabled }}
 {{- $cluster := dict "enabled" true }}
-{{- if .Values.bifrost.cluster.peers }}
-{{- $_ := set $cluster "peers" .Values.bifrost.cluster.peers }}
-{{- end }}
+{{- $clusterType := default "mesh" .Values.bifrost.cluster.type }}
+{{- $_ := set $cluster "type" $clusterType }}
 {{- if .Values.bifrost.cluster.region }}
 {{- $_ := set $cluster "region" .Values.bifrost.cluster.region }}
+{{- end }}
+{{- if eq $clusterType "broker" }}
+{{- $broker := dict }}
+{{- $_ := set $broker "address" .Values.bifrost.cluster.broker.address }}
+{{- if .Values.bifrost.cluster.broker.listenPort }}
+{{- $_ := set $broker "listen_port" .Values.bifrost.cluster.broker.listenPort }}
+{{- end }}
+{{- if hasKey .Values.bifrost.cluster.broker "tls" }}
+{{- $_ := set $broker "tls" .Values.bifrost.cluster.broker.tls }}
+{{- end }}
+{{- if .Values.bifrost.cluster.broker.authToken }}
+{{- $_ := set $broker "auth_token" .Values.bifrost.cluster.broker.authToken }}
+{{- end }}
+{{- $_ := set $cluster "broker" $broker }}
+{{- else }}
+{{- if .Values.bifrost.cluster.peers }}
+{{- $_ := set $cluster "peers" .Values.bifrost.cluster.peers }}
 {{- end }}
 {{- if .Values.bifrost.cluster.gossip }}
 {{- $gossip := dict }}
@@ -695,6 +711,7 @@ false
 {{- $_ := set $discovery "mdns_service" .Values.bifrost.cluster.discovery.mdnsService }}
 {{- end }}
 {{- $_ := set $cluster "discovery" $discovery }}
+{{- end }}
 {{- end }}
 {{- $_ := set $config "cluster_config" $cluster }}
 {{- end }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -2261,6 +2261,36 @@
               "type": "boolean",
               "description": "Whether cluster mode is enabled"
             },
+            "type": {
+              "type": "string",
+              "enum": ["mesh", "broker"],
+              "description": "Cluster transport mode"
+            },
+            "broker": {
+              "type": "object",
+              "description": "Broker transport configuration",
+              "properties": {
+                "address": {
+                  "type": "string",
+                  "description": "Broker address in host:port format"
+                },
+                "listenPort": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535,
+                  "description": "Broker listen port"
+                },
+                "tls": {
+                  "type": "boolean",
+                  "description": "Whether to use TLS for the broker connection"
+                },
+                "authToken": {
+                  "type": "string",
+                  "description": "Optional shared secret sent when connecting to the broker"
+                }
+              },
+              "additionalProperties": false
+            },
             "peers": {
               "type": "array",
               "description": "List of peer addresses",
@@ -2422,16 +2452,40 @@
               }
             }
           },
-          "if": {
-            "properties": {
-              "enabled": {
-                "const": true
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "enabled": { "const": true },
+                  "type": { "const": "broker" }
+                },
+                "required": ["enabled", "type"]
+              },
+              "then": {
+                "required": ["broker"],
+                "properties": {
+                  "broker": {
+                    "required": ["address"],
+                    "properties": {
+                      "address": { "minLength": 1 }
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "enabled": { "const": true },
+                  "type": { "const": "mesh" }
+                },
+                "required": ["enabled"]
+              },
+              "then": {
+                "required": ["gossip"]
               }
             }
-          },
-          "then": {
-            "required": ["gossip"]
-          }
+          ]
         },
         "scim": {
           "type": "object",

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -997,7 +997,15 @@ bifrost:
   # Cluster mode configuration for distributed deployments
   cluster:
     enabled: false
+    # Cluster transport: mesh or broker (defaults to mesh)
+    # type: mesh
     # region: ""               # Region identifier for cluster
+    # Broker transport settings (used when type is broker)
+    # broker:
+    #   address: "broker.example.com:50051"
+    #   listenPort: 50051
+    #   tls: false
+    #   authToken: "env.BIFROST_CLUSTER_BROKER_AUTH_TOKEN"
     peers: []
       # - "bifrost-0.bifrost-headless:7946"
       # - "bifrost-1.bifrost-headless:7946"


### PR DESCRIPTION
## Summary

Add Helm chart support for broker-based clustering alongside the existing mesh
transport. This enables deployments without direct node-to-node connectivity to
configure the broker address, listen port, and TLS settings through Helm values.

## Changes

- Added `bifrost.cluster.type` with `mesh` and `broker` options, defaulting to
  `mesh` for backward compatibility.
- Added broker address, listen port, and TLS settings to the Helm values and
  schema.
- Updated generated `cluster_config` output to emit broker settings in broker
  mode and retain peers, gossip, and discovery settings in mesh mode.
- Updated schema conditions so broker mode requires a broker address while mesh
  mode continues to require gossip configuration.
- Documented broker traffic lanes and the synchronization performance tradeoff
  caused by same-lane contention.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Render and validate both clustering modes:

```sh
# Validate the chart and values schema
helm lint helm-charts/bifrost

# Mesh mode should include type: mesh and mesh configuration without a broker block
helm template bifrost helm-charts/bifrost \
  --set bifrost.cluster.enabled=true \
  --set bifrost.cluster.type=mesh

# Broker mode should include type: broker and the configured broker settings
helm template bifrost helm-charts/bifrost \
  --set bifrost.cluster.enabled=true \
  --set bifrost.cluster.type=broker \
  --set bifrost.cluster.broker.address=broker.example.com:50051
```

Expected outcomes:

- Mesh mode renders peers, gossip, and discovery configuration without a broker
  block.
- Broker mode renders the broker address, listen port, and TLS setting without
  mesh-only configuration.
- Schema validation rejects enabled broker mode when
  `bifrost.cluster.broker.address` is missing.

New configuration values:

- `bifrost.cluster.type`: cluster transport mode (`mesh` or `broker`).
- `bifrost.cluster.broker.address`: broker address in `host:port` format.
- `bifrost.cluster.broker.listenPort`: broker listen port; defaults to `50051`.
- `bifrost.cluster.broker.tls`: enables TLS for the broker connection; defaults
  to `false`.

## Screenshots/Recordings

Not applicable; there are no UI changes.

## Breaking changes

- [ ] Yes
- [x] No

Existing deployments continue to use mesh mode by default.

## Related issues

None.

## Security considerations

Broker connections can be configured to use TLS through
`bifrost.cluster.broker.tls`. This change does not introduce new secret values
or modify authentication behavior.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
