### PR TITLE
fix: update overrides fields

### DIFF
--- a/ui/app/workspace/custom-pricing/overrides/pricingFields.test.ts
+++ b/ui/app/workspace/custom-pricing/overrides/pricingFields.test.ts
@@ -29,6 +29,10 @@ describe("pricingFieldUnit", () => {
 	it("keeps the token unit across context-tier and service-tier suffixes", () => {
 		for (const key of [
 			"input_cost_per_token_above_128k_tokens",
+			"input_cost_per_token_ultrafast",
+			"output_cost_per_token_ultrafast",
+			"cache_read_input_token_cost_ultrafast",
+			"cache_creation_input_token_cost_ultrafast",
 			"cache_read_input_token_cost_above_200k_tokens",
 			"cache_read_input_token_cost_above_200k_tokens_priority",
 			"cache_creation_input_token_cost_above_1hr_fast",
@@ -80,7 +84,7 @@ describe("pricingFieldUnit", () => {
 			expect(byUnit[unit], `${field.key} resolved to unexpected unit ${unit}`).toBeDefined();
 			byUnit[unit].push(field.key);
 		}
-		expect(PRICING_FIELDS).toHaveLength(83);
+		expect(PRICING_FIELDS).toHaveLength(87);
 		expect(byUnit.multiplier).toEqual(["inference_geo_us_multiplier"]);
 		expect(byUnit.character).toEqual(["input_cost_per_character"]);
 		// Sanity: the split is real, not everything collapsing into one bucket.

--- a/ui/app/workspace/custom-pricing/overrides/pricingFields.ts
+++ b/ui/app/workspace/custom-pricing/overrides/pricingFields.ts
@@ -80,6 +80,18 @@ export const PRICING_FIELDS = [
 		requestTypeGroups: ["chat"],
 	},
 	{
+		key: "input_cost_per_token_ultrafast",
+		label: "Input / token (ultrafast)",
+		group: "chat",
+		requestTypeGroups: ["chat"],
+	},
+	{
+		key: "output_cost_per_token_ultrafast",
+		label: "Output / token (ultrafast)",
+		group: "chat",
+		requestTypeGroups: ["chat"],
+	},
+	{
 		key: "input_cost_per_token_flex",
 		label: "Input / token (flex)",
 		group: "chat",
@@ -218,6 +230,12 @@ export const PRICING_FIELDS = [
 		requestTypeGroups: ["chat"],
 	},
 	{
+		key: "cache_read_input_token_cost_ultrafast",
+		label: "Cache read / token (ultrafast)",
+		group: "chat",
+		requestTypeGroups: ["chat"],
+	},
+	{
 		key: "cache_read_input_token_cost_flex",
 		label: "Cache read / token (flex)",
 		group: "chat",
@@ -268,6 +286,12 @@ export const PRICING_FIELDS = [
 	{
 		key: "cache_creation_input_token_cost_priority",
 		label: "Cache creation / token (priority)",
+		group: "chat",
+		requestTypeGroups: ["chat"],
+	},
+	{
+		key: "cache_creation_input_token_cost_ultrafast",
+		label: "Cache creation / token (ultrafast)",
 		group: "chat",
 		requestTypeGroups: ["chat"],
 	},

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -486,6 +486,8 @@ export interface PricingOverridePatch {
 	output_cost_per_token_batches?: number;
 	input_cost_per_token_priority?: number;
 	output_cost_per_token_priority?: number;
+	input_cost_per_token_ultrafast?: number;
+	output_cost_per_token_ultrafast?: number;
 	input_cost_per_token_flex?: number;
 	output_cost_per_token_flex?: number;
 	input_cost_per_character?: number;
@@ -519,6 +521,7 @@ export interface PricingOverridePatch {
 	cache_creation_input_token_cost_above_1hr_above_200k_tokens?: number;
 	cache_creation_input_audio_token_cost?: number;
 	cache_read_input_token_cost_priority?: number;
+	cache_read_input_token_cost_ultrafast?: number;
 	cache_read_input_token_cost_flex?: number;
 	cache_read_input_image_token_cost?: number;
 	cache_read_input_token_cost_above_272k_tokens?: number;
@@ -528,6 +531,7 @@ export interface PricingOverridePatch {
 	cache_creation_input_token_cost_flex?: number;
 	cache_creation_input_token_cost_flex_above_272k_tokens?: number;
 	cache_creation_input_token_cost_priority?: number;
+	cache_creation_input_token_cost_ultrafast?: number;
 	cache_creation_input_token_cost_fast?: number;
 	cache_creation_input_token_cost_above_1hr_fast?: number;
 	cache_read_input_token_cost_fast?: number;


### PR DESCRIPTION
## Summary

Adds support for `ultrafast` tier pricing fields in the custom pricing overrides system, enabling per-token cost configuration for input, output, cache read, and cache creation at the ultrafast service tier.

## Changes

- Added four new pricing fields to `PRICING_FIELDS`: `input_cost_per_token_ultrafast`, `output_cost_per_token_ultrafast`, `cache_read_input_token_cost_ultrafast`, and `cache_creation_input_token_cost_ultrafast`
- Added the corresponding optional fields to the `PricingOverridePatch` interface in `governance.ts`
- Updated tests to cover the new ultrafast keys in the token unit resolution logic and bumped the expected `PRICING_FIELDS` length from 83 to 87

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Verify that the custom pricing override form renders the four new ultrafast fields and that the unit resolution tests pass with the updated field count.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. These are pricing configuration fields with no auth, secrets, or PII concerns.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable