### PR TITLE
tests: harness tests fixes

### DIFF
--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -290,6 +290,11 @@
     },
     {
       "key": "bedrockOpenaiModel",
+      "value": "openai.gpt-5.6-sol",
+      "type": "string"
+    },
+    {
+      "key": "bedrockOpenaiDirectModel",
       "value": "global.openai.gpt-5.6-sol",
       "type": "string"
     },
@@ -4554,7 +4559,7 @@
                     ],
                     "body": {
                       "mode": "raw",
-                      "raw": "{\n  \"messages\": [{ \"role\": \"user\", \"content\": [{ \"text\": \"Hello from Bedrock Converse.\" }] }],\n  \"inferenceConfig\": { \"maxTokens\": 1024 }\n}"
+                      "raw": "{\n  \"messages\": [{ \"role\": \"user\", \"content\": [{ \"text\": \"Hello from Bedrock Converse.\" }] }],\n  \"inferenceConfig\": { \"maxTokens\": 4096 }\n}"
                     },
                     "url": {
                       "raw": "{{baseUrl}}/bedrock/model/gemini%2Fgemini-2.5-pro/converse",
@@ -4610,7 +4615,7 @@
                     ],
                     "body": {
                       "mode": "raw",
-                      "raw": "{\n  \"messages\": [{ \"role\": \"user\", \"content\": [{ \"text\": \"Hello from Bedrock Converse.\" }] }],\n  \"inferenceConfig\": { \"maxTokens\": 1024 }\n}"
+                      "raw": "{\n  \"messages\": [{ \"role\": \"user\", \"content\": [{ \"text\": \"Hello from Bedrock Converse.\" }] }],\n  \"inferenceConfig\": { \"maxTokens\": 4096 }\n}"
                     },
                     "url": {
                       "raw": "{{baseUrl}}/bedrock/model/vertex%2Fgemini-2.5-pro/converse",
@@ -7365,7 +7370,7 @@
                   }
                 },
                 {
-                  "name": "vertex/imagen-4.0-generate-001",
+                  "name": "vertex/gemini-2.5-flash-image",
                   "request": {
                     "method": "POST",
                     "header": [
@@ -7376,7 +7381,7 @@
                     ],
                     "body": {
                       "mode": "raw",
-                      "raw": "{\n  \"model\": \"vertex/imagen-4.0-generate-001\",\n  \"prompt\": \"A simple red apple on a white background\",\n  \"n\": 1,\n  \"size\": \"1024x1024\"\n}"
+                      "raw": "{\n  \"model\": \"vertex/gemini-2.5-flash-image\",\n  \"prompt\": \"A simple red apple on a white background\",\n  \"n\": 1,\n  \"size\": \"1024x1024\"\n}"
                     },
                     "url": {
                       "raw": "{{baseUrl}}/v1/images/generations",
@@ -7508,7 +7513,7 @@
                   }
                 },
                 {
-                  "name": "vertex/imagen-4.0-generate-001",
+                  "name": "vertex/gemini-2.5-flash-image",
                   "request": {
                     "method": "POST",
                     "header": [
@@ -7519,7 +7524,7 @@
                     ],
                     "body": {
                       "mode": "raw",
-                      "raw": "{\n  \"model\": \"vertex/imagen-4.0-generate-001\",\n  \"prompt\": \"A simple red apple on a white background\",\n  \"n\": 1,\n  \"size\": \"1024x1024\"\n}"
+                      "raw": "{\n  \"model\": \"vertex/gemini-2.5-flash-image\",\n  \"prompt\": \"A simple red apple on a white background\",\n  \"n\": 1,\n  \"size\": \"1024x1024\"\n}"
                     },
                     "url": {
                       "raw": "{{baseUrl}}/openai/v1/images/generations",
@@ -38926,7 +38931,7 @@
                       }
                     },
                     {
-                      "name": "vertex/imagen-4.0-generate-001",
+                      "name": "vertex/gemini-2.5-flash-image",
                       "request": {
                         "method": "POST",
                         "header": [
@@ -38937,7 +38942,7 @@
                         ],
                         "body": {
                           "mode": "raw",
-                          "raw": "{\n  \"model\": \"vertex/imagen-4.0-generate-001\",\n  \"prompt\": \"A simple red apple on a white background\",\n  \"n\": 1,\n  \"size\": \"1024x1024\"\n}"
+                          "raw": "{\n  \"model\": \"vertex/gemini-2.5-flash-image\",\n  \"prompt\": \"A simple red apple on a white background\",\n  \"n\": 1,\n  \"size\": \"1024x1024\"\n}"
                         },
                         "url": {
                           "raw": "{{baseUrl}}/openai/v1/images/generations",
@@ -130365,11 +130370,11 @@
     },
     {
       "name": "53. Embeddings x provider x parameter surface",
-      "description": "Embedding coverage before this folder was one request per provider, each sending a single string and asserting nothing beyond the collection-level status check - and that check is a no-op for embeddings, because the shape branch it lands in is Array.isArray(j.data) with hasContent = j.data.length >= 0, which is true for an empty list. A provider returning zero vectors passed.\n\nThis folder pins the request parameter surface end to end: what the caller sends at the gateway, what the provider-native field is called, and what observable property of the response proves the rename survived the trip. Bedrock gets the depth because it is the only provider carrying two incompatible embedding envelopes behind one name, chosen by substring match on the model id.\n\nRoute reachability worth knowing before adding rows here: /v1/embeddings parses exactly four body fields (model, input, encoding_format, dimensions) plus fallbacks. Every other key is dropped silently unless the request carries x-bf-passthrough-extra-params: true and nests the key under \"extra_params\" (transports/bifrost-http/integrations/router.go). Native Bedrock embeddings are also reachable through /bedrock/model/{id}/invoke and /langchain/model/{id}/invoke; normalized and SDK-compatible routes include /v1/embeddings, /openai/v1/embeddings, /genai/.../:embedContent and /cohere/v2/embed.\n\nSub-folder names avoid provider keywords on purpose. runners/filter-collection.mjs matches PROVIDER against ancestor folder names as well as the item body, so naming this folder after Bedrock would hand every openai/gemini/vertex/azure row to the bedrock partition.",
+      "description": "Embedding coverage before this folder was one request per provider, each sending a single string and asserting nothing beyond the collection-level status check - and that check is a no-op for embeddings, because the shape branch it lands in is Array.isArray(j.data) with hasContent = j.data.length >= 0, which is true for an empty list. A provider returning zero vectors passed.\n\nThis folder pins the request parameter surface end to end: what the caller sends at the gateway, what the provider-native field is called, and what observable property of the response proves the rename survived the trip. Bedrock gets the depth because it is the only provider carrying two incompatible embedding envelopes behind one name, chosen by substring match on the model id.\n\nRoute reachability worth knowing before adding rows here: /v1/embeddings parses exactly four body fields (model, input, encoding_format, dimensions) plus fallbacks. Every OTHER top-level key is collected as an extra param by extractExtraParams (transports/bifrost-http/handlers/inference.go) and handed to the provider converter, which maps the ones it knows (normalize, embeddingTypes, input_type, truncate, embedding_types) onto native fields; anything left over reaches the wire only when the request carries x-bf-passthrough-extra-params: true. Do NOT nest these under an \"extra_params\" object here - that unwrapping exists only on the integration/drop-in routes served by GenericRouter (transports/bifrost-http/integrations/router.go). On this native route the wrapper is just another unknown key, so the params inside it are ignored AND the wrapper itself is forwarded, which Bedrock rejects with \"extraneous key [extra_params] is not permitted\". Native Bedrock embeddings are also reachable through /bedrock/model/{id}/invoke and /langchain/model/{id}/invoke; normalized and SDK-compatible routes include /v1/embeddings, /openai/v1/embeddings, /genai/.../:embedContent and /cohere/v2/embed.\n\nSub-folder names avoid provider keywords on purpose. runners/filter-collection.mjs matches PROVIDER against ancestor folder names as well as the item body, so naming this folder after Bedrock would hand every openai/gemini/vertex/azure row to the bedrock partition.",
       "item": [
         {
           "name": "53.A Bedrock Titan envelope (amazon.titan-embed-*)",
-          "description": "Titan takes a single `inputText` string, so Bifrost joins array input with \" \\n\" before sending (core/providers/bedrock/embedding.go ToBedrockTitanEmbeddingRequest). The legacy/default response has one float vector; `embeddingTypes` returns one vector per requested representation. These rows pin the Titan-shaped request body reaching AWS and every requested representation coming back.\n\nAWS request fields (docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-embed-text.html): inputText (required), dimensions (1024 default | 512 | 256), normalize (default true), embeddingTypes (camelCase, [\"float\"] | [\"binary\"] | both). Response: embedding, inputTextTokenCount, embeddingsByType.\n\nnormalize and embeddingTypes are not first-class fields on /v1/embeddings - only model, input, encoding_format and dimensions are parsed there. They reach the provider through x-bf-passthrough-extra-params: true plus an \"extra_params\" object, which is the door those rows use.",
+          "description": "Titan takes a single `inputText` string, so Bifrost joins array input with \" \\n\" before sending (core/providers/bedrock/embedding.go ToBedrockTitanEmbeddingRequest). The legacy/default response has one float vector; `embeddingTypes` returns one vector per requested representation. These rows pin the Titan-shaped request body reaching AWS and every requested representation coming back.\n\nAWS request fields (docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-embed-text.html): inputText (required), dimensions (1024 default | 512 | 256), normalize (default true), embeddingTypes (camelCase, [\"float\"] | [\"binary\"] | both). Response: embedding, inputTextTokenCount, embeddingsByType.\n\nnormalize and embeddingTypes are not first-class fields on /v1/embeddings - only model, input, encoding_format and dimensions are parsed there. They reach the provider as plain TOP-LEVEL keys, which extractExtraParams collects and ToBedrockTitanEmbeddingRequest maps onto the Titan envelope; that is the door those rows use. Nesting them under \"extra_params\" does not work on this route (see the parent folder description).\n\nnormalize is only observable below the default width: at 1024 dimensions Titan V2 returns a vector that is already unit-length, so normalize:false is indistinguishable from normalize:true. The A4/A5 pair pins dimensions:256, where normalize:false measures L2 ~0.57 against ~1.0 for the control.",
           "item": [
             {
               "name": "53.A1 bedrock/amazon.titan-embed-text-v2:0 - baseline single input",
@@ -130544,7 +130549,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"model\": \"bedrock/amazon.titan-embed-text-v2:0\",\n  \"input\": \"Hello world\",\n  \"extra_params\": {\n    \"normalize\": true\n  }\n}"
+                  "raw": "{\n  \"model\": \"bedrock/amazon.titan-embed-text-v2:0\",\n  \"input\": \"Hello world\",\n  \"dimensions\": 256,\n  \"normalize\": true\n}"
                 },
                 "url": {
                   "raw": "{{baseUrl}}/v1/embeddings",
@@ -130598,7 +130603,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"model\": \"bedrock/amazon.titan-embed-text-v2:0\",\n  \"input\": \"Hello world\",\n  \"extra_params\": {\n    \"normalize\": false\n  }\n}"
+                  "raw": "{\n  \"model\": \"bedrock/amazon.titan-embed-text-v2:0\",\n  \"input\": \"Hello world\",\n  \"dimensions\": 256,\n  \"normalize\": false\n}"
                 },
                 "url": {
                   "raw": "{{baseUrl}}/v1/embeddings",
@@ -130823,7 +130828,10 @@
                       "pm.test('values are int8, not floats', function () {",
                       "  var v = data[0].embedding;",
                       "  for (var i = 0; i < v.length; i++) {",
-                      "    pm.expect(v[i] % 1, 'value at ' + i + ' is not an integer: ' + v[i]).to.eql(0);",
+                      "    // Number.isInteger, not `v[i] % 1`: the latter is -0 for any negative integer and",
+                      "    // chai's eql compares with SameValue, so -0 never equals +0 - this assertion used to",
+                      "    // fail on the first negative value of every int8 vector.",
+                      "    pm.expect(Number.isInteger(v[i]), 'value at ' + i + ' is not an integer: ' + v[i]).to.be.true;",
                       "    pm.expect(v[i], 'value at ' + i + ' is outside int8 range: ' + v[i]).to.be.within(-128, 127);",
                       "  }",
                       "});"
@@ -130889,7 +130897,7 @@
               ]
             },
             {
-              "name": "53.B4 bedrock/global.cohere.embed-v4:0 - /v1/embeddings + extra_params.input_type",
+              "name": "53.B4 bedrock/global.cohere.embed-v4:0 - /v1/embeddings + top-level input_type",
               "request": {
                 "method": "POST",
                 "header": [
@@ -130904,7 +130912,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"model\": \"bedrock/global.cohere.embed-v4:0\",\n  \"input\": \"Hello world\",\n  \"extra_params\": {\n    \"input_type\": \"search_query\"\n  }\n}"
+                  "raw": "{\n  \"model\": \"bedrock/global.cohere.embed-v4:0\",\n  \"input\": \"Hello world\",\n  \"input_type\": \"search_query\"\n}"
                 },
                 "url": {
                   "raw": "{{baseUrl}}/v1/embeddings",
@@ -130930,8 +130938,9 @@
                       "var j; try { j = pm.response.json(); } catch (e) {",
                       "  pm.expect.fail('response was not JSON: ' + (pm.response.text() || '').slice(0, 300)); return; }",
                       "var data = j.data || [];",
-                      "// The working counterpart to 53.B3: input_type supplied through the passthrough door.",
-                      "pm.test('returns 1 vector(s) - input_type via extra_params reaches Bedrock', function () {",
+                      "// The working counterpart to 53.B3: input_type supplied through the passthrough door -",
+                      "// a top-level key, which is what /v1/embeddings collects as an extra param.",
+                      "pm.test('returns 1 vector(s) - top-level input_type reaches Bedrock', function () {",
                       "  pm.expect(data.length, 'wrong vector count; body: ' + pm.response.text().slice(0, 300))",
                       "    .to.eql(1);",
                       "  for (var i = 0; i < data.length; i++) {",
@@ -130960,7 +130969,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"model\": \"bedrock/global.cohere.embed-v4:0\",\n  \"input\": [\n    \"alpha kestrel harbor\",\n    \"beta lantern quarry\",\n    \"gamma meridian trellis\"\n  ],\n  \"extra_params\": {\n    \"input_type\": \"search_document\"\n  }\n}"
+                  "raw": "{\n  \"model\": \"bedrock/global.cohere.embed-v4:0\",\n  \"input\": [\n    \"alpha kestrel harbor\",\n    \"beta lantern quarry\",\n    \"gamma meridian trellis\"\n  ],\n  \"input_type\": \"search_document\"\n}"
                 },
                 "url": {
                   "raw": "{{baseUrl}}/v1/embeddings",
@@ -131022,7 +131031,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"model\": \"bedrock/global.cohere.embed-v4:0\",\n  \"input\": \"Hello world\",\n  \"dimensions\": 512,\n  \"extra_params\": {\n    \"input_type\": \"search_document\"\n  }\n}"
+                  "raw": "{\n  \"model\": \"bedrock/global.cohere.embed-v4:0\",\n  \"input\": \"Hello world\",\n  \"dimensions\": 512,\n  \"input_type\": \"search_document\"\n}"
                 },
                 "url": {
                   "raw": "{{baseUrl}}/v1/embeddings",
@@ -131078,7 +131087,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"model\": \"bedrock/global.cohere.embed-v4:0\",\n  \"input\": \"Hello world\",\n  \"extra_params\": {\n    \"input_type\": \"search_document\"\n  }\n}"
+                  "raw": "{\n  \"model\": \"bedrock/global.cohere.embed-v4:0\",\n  \"input\": \"Hello world\",\n  \"input_type\": \"search_document\"\n}"
                 },
                 "url": {
                   "raw": "{{baseUrl}}/v1/embeddings",
@@ -131522,7 +131531,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"model\": \"bedrock/global.cohere.embed-v4:0\",\n  \"input\": \"Hello world\",\n  \"dimensions\": 256,\n  \"extra_params\": {\n    \"input_type\": \"search_document\"\n  }\n}"
+                  "raw": "{\n  \"model\": \"bedrock/global.cohere.embed-v4:0\",\n  \"input\": \"Hello world\",\n  \"dimensions\": 256,\n  \"input_type\": \"search_document\"\n}"
                 },
                 "url": {
                   "raw": "{{baseUrl}}/v1/embeddings",

--- a/tests/e2e/api/runners/lib/crossprovider-cache-matrix.mjs
+++ b/tests/e2e/api/runners/lib/crossprovider-cache-matrix.mjs
@@ -177,13 +177,17 @@ const salt = (cellId) => `[cache-matrix cell ${cellId} run {{pcNonce}}]\n\n${SEG
 // bedrock/openai.gpt-oss-120b-1:0 is NOT here: it 404s against this account, which is also why
 // the collection's bedrockOpenaiModel default was retargeted to the OpenAI-family-on-Bedrock id.
 //
-// That default is the INFERENCE PROFILE, global.openai.gpt-5.6-sol, not the bare model id. The
-// bare id reaches Converse but is refused before inference: "Invocation of model ID
-// openai.gpt-5.6-sol with on-demand throughput isn't supported. Retry your request with the ID or
-// ARN of an inference profile that contains this model." The profile form answers normally. The
-// cells below route through Bifrost, which resolves the profile itself, so they read either way -
-// the token-parity matrix's DIRECT leg calls bedrock-runtime converse with this value verbatim
-// and does not.
+// Which form of the id is correct depends on the ENDPOINT, not on the caller, and the two forms
+// are mutually exclusive (model-card-openai-gpt-56-sol.html, "Programmatic Access"):
+//   bedrock-runtime  in-region "Not supported"; requires us.openai.gpt-5.6-sol or
+//                    global.openai.gpt-5.6-sol (Converse is a supported API there)
+//   bedrock-mantle   Geo and Global "Not supported"; requires the bare openai.gpt-5.6-sol
+// So there is no single value both legs can share. bedrockOpenaiModel holds the bare id, used by
+// anything that goes through Bifrost - its `bedrock` provider routes all OpenAI-family models to
+// mantle, where a profile-prefixed id 404s. bedrockOpenaiDirectModel holds the global profile,
+// used only by the token-parity matrix's DIRECT leg, which calls bedrock-runtime converse.
+// (An earlier note here claimed Bifrost resolves the profile itself so the cells read either way;
+// it does not - that assumption is what made those parity rows 404.)
 // ---------------------------------------------------------------------------------------------
 const CELLS = [
   // --- Anthropic API, Claude family: latest through several generations back -----------------

--- a/tests/e2e/api/runners/lib/prompt-caching-extension.mjs
+++ b/tests/e2e/api/runners/lib/prompt-caching-extension.mjs
@@ -47,7 +47,16 @@ const CACHING_BACKENDS = [
   { key: "openai", label: "OpenAI", model: "openai/gpt-4o-mini", explicitCache: false, cacheReadGuaranteed: true },
   { key: "anthropic", label: "Anthropic", model: "anthropic/claude-haiku-4-5", explicitCache: true, cacheReadGuaranteed: true },
   { key: "gemini", label: "Gemini", model: "gemini/gemini-2.5-flash", explicitCache: false, cacheReadGuaranteed: false },
-  { key: "vertex", label: "Vertex (Claude)", model: "vertex/claude-sonnet-4-6", explicitCache: true, cacheReadGuaranteed: true },
+  // Not read-guaranteed, unlike the other two explicit-cache backends, and the difference is the
+  // deployment rather than the model. This key is configured at location=global, which routes each
+  // request to whichever region has capacity, and an Anthropic cache entry lives in the region that
+  // wrote it - so a repeat is only a hit when it happens to land on a region already holding the
+  // prefix. Measured on a guaranteed-cold prefix: round 3 missed 4 times out of 5, and raising the
+  // settle from 1.2s to 5s changed nothing (so it is not write propagation). Sending one cold prefix
+  // 12 times in a row gave MMMHHMHMHHHH - 1 hit in the first 4, 6 in the last 8, the hit rate
+  // climbing as more regions warm. Three requests cannot reliably read back a cold prefix here, so
+  // the row asserts what Bifrost actually controls (below) and reports the hit.
+  { key: "vertex", label: "Vertex (Claude)", model: "vertex/claude-sonnet-4-6", explicitCache: true, cacheReadGuaranteed: false },
   { key: "bedrock", label: "Bedrock (Claude)", model: "bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0", explicitCache: true, cacheReadGuaranteed: true },
 ];
 
@@ -91,7 +100,47 @@ const extractScript = `
 var j = pm.response.json();
 var u = j.usage || {};
 var cached = (u.prompt_tokens_details && u.prompt_tokens_details.cached_tokens) || 0;
+var written = (u.prompt_tokens_details && (u.prompt_tokens_details.cached_write_tokens || u.prompt_tokens_details.cache_write_tokens)) || 0;
 var prompt = u.prompt_tokens || 0;`.trim();
+
+// These three rounds are one stateful chain - round 1 writes the prefix, rounds 2 and 3 read it
+// back - but nothing in the harness inferred that, because the link lived only in the rounds'
+// shared prompt text. sliceByCost (lib/shard-cost.mjs) bin-packs rows individually and promises
+// only original order WITHIN a slice, and --rerun-failed selects exactly the rows that failed, so
+// either one can hand round 3 to a newman process that never ran round 1. Round 3 then meets a
+// cold prefix; its ephemeral breakpoint writes the prefix instead of reading it and reports
+// cached_tokens 0, which fails the assertion for a reason that has nothing to do with caching.
+// Worse, it is self-perpetuating: the row failed, so the next --rerun-failed pass selects it
+// alone again, and it can never go green.
+//
+// So the link is now declared the way this harness already declares request ordering - as a
+// chained collection variable (lib/chained-vars.mjs). Each round publishes one on success and the
+// next round consumes it, which buys both halves of the fix from machinery that already exists:
+// filter-collection.mjs pulls a consumer's producers into any sliced or rerun selection, and
+// augment-provider-harness.mjs guards a consumer whose producer still did not run, so a partial
+// selection reports "prerequisite did not set its chained variable" once instead of a misleading
+// cache miss.
+//
+// The variable rides the URL as a query parameter rather than the request body on purpose. This
+// is a prompt-caching test: the cached prefix and the payload around it have to stay
+// byte-identical from round to round, and a variable interpolated into the body would change the
+// bytes every run. Bifrost ignores the parameter, and the "cross-cut" route-shape matcher in
+// filter-collection.mjs already anchors on /v1/chat/completions(\\?|$), so classification is
+// unaffected.
+const chainVar = (backendKey, round) => `cacheChain_${backendKey}_r${round}`;
+
+// Published on any non-error response, because what the next round requires is simply that the
+// prefix reached the provider - not that this round's own cache assertion passed. A round that
+// 4xx'd publishes nothing, and the guard downstream then names it as the unmet prerequisite.
+const publishChain = (backendKey, round) =>
+  `if (pm.response.code < 400) { pm.collectionVariables.set(${J(chainVar(backendKey, round))}, "sent-" + prompt); }`;
+
+const urlFor = (backendKey, round) => {
+  const base = { raw: "{{baseUrl}}/v1/chat/completions", host: ["{{baseUrl}}"], path: ["v1", "chat", "completions"] };
+  if (round === 1) return base;
+  const consumed = `{{${chainVar(backendKey, round - 1)}}}`;
+  return { ...base, raw: `${base.raw}?_chain=${consumed}`, query: [{ key: "_chain", value: consumed }] };
+};
 
 export function buildPromptCachingHitVerificationItems() {
   const items = [];
@@ -128,18 +177,31 @@ if (pm.response.code < 400) {
         // counter must be a real number and can never exceed the prompt it came from - so a
         // nonsense value is still caught. The hit/miss is logged so a permanent regression to
         // 0% stays visible in the run output instead of disappearing entirely.
-        `pm.test(${J(`Prompt caching hit-verification: ${backend.key} round ${round} - cached_tokens coherent (best-effort cache, hit not guaranteed)`)}, function () {
+        //
+        // An explicit-breakpoint backend gets one more assertion than an implicit one, because
+        // more of its behaviour is Bifrost's to get right. Whether a repeat LANDS on the region
+        // holding the entry is the deployment's business, but whether cache_control survived the
+        // conversion and reached the provider at all is not: an honoured breakpoint always books
+        // the prefix as either a write or a read, so a dropped one is the case where both counters
+        // are zero. That keeps a real regression - Bifrost silently losing the breakpoint - failing
+        // the run, which a bare hit/miss report would have let through.
+        `${backend.explicitCache ? `pm.test(${J(`Prompt caching hit-verification: ${backend.key} round ${round} - cache breakpoint honoured (write or read recorded)`)}, function () {
+    pm.expect(cached + written, "cached=" + cached + " written=" + written + " (usage=" + JSON.stringify(u) + ") - neither counter moved, so cache_control never reached the provider").to.be.above(0);
+  });
+  ` : ""}pm.test(${J(`Prompt caching hit-verification: ${backend.key} round ${round} - cached_tokens coherent (best-effort cache, hit not guaranteed)`)}, function () {
     pm.expect(cached, "cached=" + cached + " (usage=" + JSON.stringify(u) + ")").to.be.a("number").that.is.at.least(0);
     pm.expect(cached, "cached=" + cached + " exceeds prompt=" + prompt + " (usage=" + JSON.stringify(u) + ")").to.be.at.most(prompt);
   });
   console.log("IMPLICIT_CACHE_OBSERVATION", JSON.stringify({ backend: ${J(backend.key)}, model: ${J(backend.model)}, round: ${round}, prompt: prompt, cached: cached, hit: cached > 0 }));`
   }
-}`.trim()
+}
+${round < 3 ? publishChain(backend.key, round) : ""}`.trim()
         : `
 ${extractScript}
 pm.test(${J(`Prompt caching hit-verification: ${backend.key} round 1 (write) succeeds`)}, function () {
   pm.expect(pm.response.code, "request failed: " + pm.response.text()).to.be.below(400);
-});`.trim();
+});
+${publishChain(backend.key, round)}`.trim();
 
       items.push({
         name: `Prompt caching hit-verification: ${backend.key}/${backend.model.split("/")[1]} round ${round}${isReadRound ? " (read)" : " (write)"}`,
@@ -153,11 +215,7 @@ pm.test(${J(`Prompt caching hit-verification: ${backend.key} round 1 (write) suc
           method: "POST",
           header: [{ key: "Content-Type", value: "application/json" }],
           body: { mode: "raw", raw: JSON.stringify(body, null, 2) },
-          url: {
-            raw: "{{baseUrl}}/v1/chat/completions",
-            host: ["{{baseUrl}}"],
-            path: ["v1", "chat", "completions"],
-          },
+          url: urlFor(backend.key, round),
         },
       });
     }

--- a/tests/e2e/api/runners/lib/token-parity-matrix.mjs
+++ b/tests/e2e/api/runners/lib/token-parity-matrix.mjs
@@ -958,6 +958,10 @@ function buildGeminiFamilyDirect(backendKey, backendLabel, modality) {
 // same builder covers both the existing Claude-on-Bedrock backend and the "one more model per
 // provider" OpenAI-family (gpt-oss)-on-Bedrock addition below - Bedrock's Converse API is
 // model-family-agnostic, so nothing else about the direct call changes.
+//
+// This leg hits bedrock-runtime, where OpenAI-family models are only reachable through a
+// cross-Region inference profile, so its modelVar is not always the same one the bifrost leg
+// uses. See the BACKENDS entry for bedrock_openai.
 function buildBedrockDirect(backendKey, backendLabel, modelVar, modality) {
   return buildLegItems({
     leg: "direct",
@@ -1176,10 +1180,18 @@ const BACKENDS = [
     bifrost: (m) => buildBedrockBifrost("bedrock", "Bedrock (Claude)", "bedrockModel", m),
   },
   // "One more model per provider": Bedrock and Vertex both host more than one model family.
+  // The two legs take DIFFERENT model ids because they reach different AWS endpoints, and each
+  // endpoint accepts only one of the two forms (model-card-openai-gpt-56-sol.html, "Programmatic
+  // Access"): bedrock-runtime lists in-region as "Not supported" and requires a cross-Region
+  // profile (us./global.), while bedrock-mantle lists Geo and Global as "Not supported" and takes
+  // the bare id. The direct leg calls bedrock-runtime converse, so it needs the profile form. The
+  // bifrost leg goes through Bifrost's `bedrock` provider, which routes every OpenAI-family model
+  // to mantle (isMantleModel in core/providers/bedrock/mantle.go), so it needs the bare form -
+  // a profile-prefixed id 404s there with "The model '...' does not exist".
   {
     key: "bedrock_openai",
     label: "Bedrock (OpenAI/gpt-oss)",
-    direct: (m) => buildBedrockDirect("bedrock_openai", "Bedrock (OpenAI/gpt-oss)", "bedrockOpenaiModel", m),
+    direct: (m) => buildBedrockDirect("bedrock_openai", "Bedrock (OpenAI/gpt-oss)", "bedrockOpenaiDirectModel", m),
     bifrost: (m) => buildBedrockBifrost("bedrock_openai", "Bedrock (OpenAI/gpt-oss)", "bedrockOpenaiModel", m),
   },
   { key: "vertex_claude", label: "Vertex AI (Claude)", direct: buildVertexClaudeDirect, bifrost: buildVertexClaudeBifrost },


### PR DESCRIPTION
## Summary

This PR fixes several correctness issues in the E2E test harness: the wrong AWS endpoint form was being used for OpenAI-family models on Bedrock (causing 404s on the direct leg of the token-parity matrix), embedding extra params were being sent inside an `extra_params` wrapper that is silently ignored on the native `/v1/embeddings` route, prompt-caching round-trip tests could fail non-deterministically when sliced or rerun in isolation, and a Vertex (Claude) caching backend was incorrectly marked as read-guaranteed despite routing through a global multi-region deployment.

## Changes

- **Bedrock OpenAI-family model id split**: Introduced a separate `bedrockOpenaiDirectModel` collection variable holding the cross-Region inference profile form (`global.openai.gpt-5.6-sol`), while `bedrockOpenaiModel` now holds the bare id (`openai.gpt-5.6-sol`). The direct leg of the token-parity matrix calls `bedrock-runtime` Converse, which requires the profile form; the Bifrost leg routes through Bedrock Mantle, which requires the bare id and 404s on a profile-prefixed id. The two variables are now used by the correct legs respectively.

- **Embedding extra params routing fix**: Removed `extra_params` wrappers from all `/v1/embeddings` test bodies for Titan and Cohere on Bedrock. The `extra_params` unwrapping only applies to integration/drop-in routes served by `GenericRouter`; on the native `/v1/embeddings` route, `extractExtraParams` collects unknown top-level keys directly. Sending them nested under `extra_params` caused the wrapper itself to be forwarded to Bedrock, which rejected it. Affected fields (`normalize`, `embeddingTypes`, `input_type`) are now sent as plain top-level keys. The `normalize` test rows also now include `dimensions: 256` so the effect of `normalize: false` is actually observable (at 1024 dimensions Titan V2 already returns a unit-length vector).

- **Prompt-caching chain variable ordering**: The three caching rounds (write → read → read) are now linked via chained collection variables. Each round publishes a variable on any non-4xx response, and the next round consumes it via a `?_chain=` query parameter on the URL. This integrates with the existing `filter-collection.mjs` and `augment-provider-harness.mjs` machinery so that sliced or rerun selections automatically pull in prerequisite rounds, and a missing prerequisite reports a clear error instead of a misleading cache miss.

- **Explicit-cache breakpoint assertion**: Read rounds for explicit-cache backends (Anthropic, Bedrock Claude) now assert that at least one of `cached_tokens` or `cache_write_tokens` is non-zero, catching the case where Bifrost silently drops a `cache_control` breakpoint before it reaches the provider.

- **Vertex (Claude) caching backend marked non-guaranteed**: The `vertex/claude-sonnet-4-6` backend is now `cacheReadGuaranteed: false`. The deployment is configured at `location=global`, which distributes requests across regions; an Anthropic cache entry lives only in the region that wrote it, so a repeat read is not guaranteed to land on the same region.

- **int8 vector assertion fix**: The assertion checking that binary embedding values are integers now uses `Number.isInteger(v[i])` instead of `v[i] % 1 === 0`. Chai's `eql` uses `SameValue` semantics, so `-0 % 1` (which is `-0`) never equalled `+0`, causing the assertion to fail on the first negative value in every int8 vector.

- **Image generation model swap**: Test cases using `vertex/imagen-4.0-generate-001` are replaced with `vertex/gemini-2.5-flash-image`.

- **Gemini Converse `maxTokens` increase**: Bedrock Converse requests targeting `gemini/gemini-2.5-pro` and `vertex/gemini-2.5-pro` now use `maxTokens: 4096` instead of `1024`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the E2E provider harness against a live environment:

```sh
# Run the full collection
cd tests/e2e/api
node runners/run-collection.mjs --provider bedrock
node runners/run-collection.mjs --provider vertex

# Validate prompt-caching chain ordering with a sliced run
node runners/run-collection.mjs --provider anthropic --folder "Prompt caching"

# Validate embedding extra-param routing
node runners/run-collection.mjs --provider bedrock --folder "53. Embeddings"
```

Expected: all token-parity matrix rows for `bedrock_openai` pass on both direct and Bifrost legs; embedding rows for Titan and Cohere pass without Bedrock rejecting an `extra_params` key; prompt-caching rounds 2 and 3 pass when run in isolation via `--rerun-failed`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable