### PR TITLE
fix: logs in batches ui, resolve VK-scoped wildcard budgets when request has no model


### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -2294,6 +2294,10 @@ func (provider *AnthropicProvider) BatchResults(ctx *schemas.BifrostContext, key
 			},
 		}
 
+		if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+			batchResultsResp.ExtraFields.RawResponse = results
+		}
+
 		if len(parseResult.Errors) > 0 {
 			batchResultsResp.ExtraFields.ParseErrors = parseResult.Errors
 		}

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -2565,6 +2565,10 @@ func (provider *AzureProvider) BatchResults(ctx *schemas.BifrostContext, keys []
 		},
 	}
 
+	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+		batchResultsResp.ExtraFields.RawResponse = results
+	}
+
 	if len(parseResult.Errors) > 0 {
 		batchResultsResp.ExtraFields.ParseErrors = parseResult.Errors
 	}

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -3205,8 +3205,8 @@ func (provider *BedrockProvider) BatchCreate(ctx *schemas.BifrostContext, key sc
 		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
 	}
 
-	sendBackRawRequest := provider.sendBackRawRequest
-	sendBackRawResponse := provider.sendBackRawResponse
+	sendBackRawRequest := providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest)
+	sendBackRawResponse := providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
 
 	region := DefaultBedrockRegion
 	if key.BedrockKeyConfig.Region != nil && key.BedrockKeyConfig.Region.GetValue() != "" {
@@ -3254,8 +3254,9 @@ func (provider *BedrockProvider) BatchCreate(ctx *schemas.BifrostContext, key sc
 	}
 
 	var bedrockResp BedrockBatchJobResponse
-	if err := sonic.Unmarshal(body, &bedrockResp); err != nil {
-		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err), jsonData, body, sendBackRawRequest, sendBackRawResponse)
+	rawRequest, rawResponse, bifrostErr2 := providerUtils.HandleProviderResponse(body, &bedrockResp, jsonData, sendBackRawRequest, sendBackRawResponse)
+	if bifrostErr2 != nil {
+		return nil, providerUtils.EnrichError(ctx, bifrostErr2, jsonData, body, sendBackRawRequest, sendBackRawResponse)
 	}
 
 	// AWS CreateModelInvocationJob only returns jobArn, not status or other details.
@@ -3272,7 +3273,9 @@ func (provider *BedrockProvider) BatchCreate(ctx *schemas.BifrostContext, key sc
 			InputFileID: inputFileID,
 			Status:      schemas.BatchStatusValidating,
 			ExtraFields: schemas.BifrostResponseExtraFields{
-				Latency: latency.Milliseconds(),
+				Latency:     latency.Milliseconds(),
+				RawRequest:  rawRequest,
+				RawResponse: rawResponse,
 			},
 		}, nil
 	}
@@ -3285,7 +3288,9 @@ func (provider *BedrockProvider) BatchCreate(ctx *schemas.BifrostContext, key sc
 		Status:      retrieveResp.Status,
 		CreatedAt:   retrieveResp.CreatedAt,
 		ExtraFields: schemas.BifrostResponseExtraFields{
-			Latency: latency.Milliseconds(),
+			Latency:     latency.Milliseconds(),
+			RawRequest:  rawRequest,
+			RawResponse: rawResponse,
 		},
 	}
 
@@ -3562,8 +3567,9 @@ func (provider *BedrockProvider) BatchRetrieve(ctx *schemas.BifrostContext, keys
 		}
 
 		var bedrockResp BedrockBatchJobResponse
-		if err := sonic.Unmarshal(body, &bedrockResp); err != nil {
-			lastErr = providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err)
+		_, rawResponse, bifrostErr2 := providerUtils.HandleProviderResponse(body, &bedrockResp, nil, false, providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+		if bifrostErr2 != nil {
+			lastErr = bifrostErr2
 			continue
 		}
 
@@ -3582,7 +3588,8 @@ func (provider *BedrockProvider) BatchRetrieve(ctx *schemas.BifrostContext, keys
 			Status:   ToBifrostBatchStatus(bedrockResp.Status),
 			Metadata: metadata,
 			ExtraFields: schemas.BifrostResponseExtraFields{
-				Latency: latency.Milliseconds(),
+				Latency:     latency.Milliseconds(),
+				RawResponse: rawResponse,
 			},
 		}
 
@@ -3815,6 +3822,9 @@ func (provider *BedrockProvider) BatchResults(ctx *schemas.BifrostContext, keys 
 				Latency: fileContentResp.ExtraFields.Latency,
 			},
 		}
+		if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+			batchResultsResp.ExtraFields.RawResponse = results
+		}
 		if len(parseErrors) > 0 {
 			batchResultsResp.ExtraFields.ParseErrors = parseErrors
 		}
@@ -3850,6 +3860,9 @@ func (provider *BedrockProvider) BatchResults(ctx *schemas.BifrostContext, keys 
 		},
 	}
 
+	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+		batchResultsResp.ExtraFields.RawResponse = allResults
+	}
 	if len(allParseErrors) > 0 {
 		batchResultsResp.ExtraFields.ParseErrors = allParseErrors
 	}

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -2592,9 +2592,10 @@ func (provider *GeminiProvider) BatchCreate(ctx *schemas.BifrostContext, key sch
 
 	// Parse the batch job response
 	var geminiResp GeminiBatchJobResponse
-	if err := sonic.Unmarshal(body, &geminiResp); err != nil {
-		provider.logger.Error("gemini batch create unmarshal error: " + err.Error())
-		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err), jsonData, body, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
+	rawRequest, rawResponse, bifrostErr2 := providerUtils.HandleProviderResponse(body, &geminiResp, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+	if bifrostErr2 != nil {
+		provider.logger.Error("gemini batch create unmarshal error: " + bifrostErr2.Error.Message)
+		return nil, providerUtils.SetErrorLatency(bifrostErr2, latency)
 	}
 	// Check for metadata
 	if geminiResp.Metadata == nil {
@@ -2646,7 +2647,9 @@ func (provider *GeminiProvider) BatchCreate(ctx *schemas.BifrostContext, key sch
 			Failed:    failedCount,
 		},
 		ExtraFields: schemas.BifrostResponseExtraFields{
-			Latency: latency.Milliseconds(),
+			Latency:     latency.Milliseconds(),
+			RawRequest:  rawRequest,
+			RawResponse: rawResponse,
 		},
 	}
 
@@ -2871,8 +2874,9 @@ func (provider *GeminiProvider) batchRetrieveByKey(ctx *schemas.BifrostContext, 
 	}
 
 	var geminiResp GeminiBatchJobResponse
-	if err := sonic.Unmarshal(body, &geminiResp); err != nil {
-		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err)
+	_, rawResponse, bifrostErr2 := providerUtils.HandleProviderResponse(body, &geminiResp, nil, false, providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+	if bifrostErr2 != nil {
+		return nil, bifrostErr2
 	}
 
 	var completedCount, failedCount int
@@ -2901,7 +2905,8 @@ func (provider *GeminiProvider) batchRetrieveByKey(ctx *schemas.BifrostContext, 
 			Failed:    failedCount,
 		},
 		ExtraFields: schemas.BifrostResponseExtraFields{
-			Latency: latency.Milliseconds(),
+			Latency:     latency.Milliseconds(),
+			RawResponse: rawResponse,
 		},
 	}
 
@@ -3337,6 +3342,9 @@ func (provider *GeminiProvider) batchResultsByKey(ctx *schemas.BifrostContext, k
 		},
 	}
 
+	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+		batchResultsResp.ExtraFields.RawResponse = results
+	}
 	if len(parseErrors) > 0 {
 		batchResultsResp.ExtraFields.ParseErrors = parseErrors
 	}

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -6509,6 +6509,10 @@ func (provider *OpenAIProvider) BatchResults(ctx *schemas.BifrostContext, keys [
 			},
 		}
 
+		if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+			batchResultsResp.ExtraFields.RawResponse = results
+		}
+
 		if len(parseResult.Errors) > 0 {
 			batchResultsResp.ExtraFields.ParseErrors = parseResult.Errors
 		}

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -3432,14 +3432,18 @@ func (provider *VertexProvider) batchResultsByKey(ctx *schemas.BifrostContext, k
 		}
 	}
 
-	return &schemas.BifrostBatchResultsResponse{
+	batchResultsResp := &schemas.BifrostBatchResultsResponse{
 		BatchID:  request.BatchID,
 		Endpoint: schemas.BatchEndpointChatCompletions,
 		Results:  results,
 		ExtraFields: schemas.BifrostResponseExtraFields{
 			Latency: time.Since(startTime).Milliseconds(),
 		},
-	}, nil
+	}
+	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+		batchResultsResp.ExtraFields.RawResponse = results
+	}
+	return batchResultsResp, nil
 }
 
 func vertexNormalizeBatchUsage(body map[string]any) map[string]any {

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -16,8 +16,10 @@ import (
 	"gorm.io/gorm"
 )
 
-type EntityWiseBudgets map[string][]*configstoreTables.TableBudget
-type EntityWiseRateLimits map[string][]*configstoreTables.TableRateLimit
+type (
+	EntityWiseBudgets    map[string][]*configstoreTables.TableBudget
+	EntityWiseRateLimits map[string][]*configstoreTables.TableRateLimit
+)
 
 // LocalGovernanceStore provides in-memory cache for governance data with fast, non-blocking access
 type LocalGovernanceStore struct {
@@ -3412,14 +3414,12 @@ func (gs *LocalGovernanceStore) CollectApplicableGovernanceIDs(ctx context.Conte
 	}
 
 	// --- Model-level (global scope), all four tiers incl. provider/all-models wildcards ---
-	if model != "" {
-		for _, mc := range gs.collectModelConfigsFor(ctx, configstoreTables.ModelConfigScopeGlobal, "", model, providerStr) {
-			addModelConfigIDs(mc)
-		}
+	for _, mc := range gs.collectModelConfigsFor(ctx, configstoreTables.ModelConfigScopeGlobal, "", model, providerStr) {
+		addModelConfigIDs(mc)
 	}
 
 	// --- User-scoped model configs (user / AP path) ---
-	if userID != "" && model != "" {
+	if userID != "" {
 		for _, mc := range gs.collectModelConfigsFor(ctx, configstoreTables.ModelConfigScopeUser, userID, model, providerStr) {
 			addModelConfigIDs(mc)
 		}
@@ -3429,11 +3429,9 @@ func (gs *LocalGovernanceStore) CollectApplicableGovernanceIDs(ctx context.Conte
 	if virtualKey != "" {
 		if vk, exists := gs.GetVirtualKey(ctx, virtualKey); exists && vk != nil {
 			// VK-scoped model configs (provider-level + all-models wildcards).
-			if model != "" {
-				for _, scope := range nonGlobalModelConfigScopeChain(vk) {
-					for _, mc := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, providerStr) {
-						addModelConfigIDs(mc)
-					}
+			for _, scope := range nonGlobalModelConfigScopeChain(vk) {
+				for _, mc := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, providerStr) {
+					addModelConfigIDs(mc)
 				}
 			}
 			for _, id := range gs.collectBudgetIDsFromMemory(ctx, vk, provider) {

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -1038,6 +1038,35 @@ func TestGetBudgetAndRateLimitStatus_VKScopedModelConfig_NoMatchOtherProvider(t 
 	assert.Equal(t, 0.0, status.BudgetPercentUsed, "openai VK-scoped budget must not appear for anthropic requests")
 }
 
+// TestCollectApplicableGovernanceIDs_VKWildcardBudget_NoModel is a regression test for a
+// batch accounting bug: a VK created with an unscoped "Budget configuration" (via the
+// Create Virtual Key UI) stores the budget as a VK-scoped, all-providers, all-models
+// wildcard model config (scope=virtual_key, model="*", provider=nil). Batch-create
+// requests may not carry a top-level model, so CollectApplicableGovernanceIDs used to
+// gate the entire VK-scoped model-config lookup on model != "" and silently miss this
+// budget — the batch settled but the VK budget was never bumped.
+func TestCollectApplicableGovernanceIDs_VKWildcardBudget_NoModel(t *testing.T) {
+	logger := NewMockLogger()
+	vkID := "vk-batches"
+	vkValue := "vk-batches-value"
+
+	budget := buildBudgetWithUsage("vk-wildcard-budget", 100.0, 0.0, "1M")
+	mc := buildVKScopedModelConfig("mc-vk-wildcard", configstoreTables.ModelConfigAllModels, nil, vkID, budget, nil)
+	vk := buildVirtualKey(vkID, vkValue, "batches", true)
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*mc},
+		Budgets:      []configstoreTables.TableBudget{*budget},
+	}, nil)
+	require.NoError(t, err)
+
+	store.virtualKeys.Store(vkValue, vk)
+
+	budgetIDs, _ := store.CollectApplicableGovernanceIDs(context.Background(), vkValue, "", schemas.ModelProvider("anthropic"), "")
+
+	assert.Contains(t, budgetIDs, budget.ID, "VK-scoped wildcard budget must be found even when the request carries no model (e.g. batch-create)")
+}
+
 // TestGetBudgetAndRateLimitStatus_GlobalModelConfig tests that a global model+provider
 // config budget is visible to GetBudgetAndRateLimitStatus.
 func TestGetBudgetAndRateLimitStatus_GlobalModelConfig(t *testing.T) {

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -1,4 +1,5 @@
 import { formatCost, formatLatency } from "@/app/workspace/dashboard/utils/chartUtils";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -885,6 +886,117 @@ export function LogDetailView({
 	const isPassthrough = isPassthroughOperation(log.object);
 	const isRealtimeTurn = log.object === "realtime.turn";
 	const batchDebug = log.batch_debug;
+	const batchRawRequest = useMemo(() => {
+		if (!batchDebug || !log.raw_request) return null;
+		try {
+			const parsed = JSON.parse(log.raw_request);
+			return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+		} catch {
+			return null;
+		}
+	}, [batchDebug, log.raw_request]);
+	const batchInlineRequests = useMemo(() => {
+		const requests = batchRawRequest?.requests;
+		if (Array.isArray(requests)) {
+			return requests
+				.map((r: any, index: number) => ({
+					customId: typeof r?.custom_id === "string" && r.custom_id ? r.custom_id : `request-${index + 1}`,
+					model: typeof r?.params?.model === "string" ? r.params.model : typeof r?.body?.model === "string" ? r.body.model : null,
+					messages: Array.isArray(r?.params?.messages) ? r.params.messages : Array.isArray(r?.body?.messages) ? r.body.messages : [],
+				}))
+				.filter((r) => r.messages.length > 0);
+		}
+		const geminiRequests = batchRawRequest?.batch as any;
+		const geminiItems = geminiRequests?.inputConfig?.requests?.requests;
+		if (Array.isArray(geminiItems)) {
+			return geminiItems
+				.map((item: any, index: number) => {
+					const contents = item?.request?.contents;
+					const messages = Array.isArray(contents)
+						? contents.map((c: any) => ({
+								role: c?.role === "model" ? "assistant" : c?.role || "user",
+								content: Array.isArray(c?.parts)
+									? c.parts
+											.filter((p: any) => p && typeof p.text === "string")
+											.map((p: any) => p.text)
+											.join("")
+									: "",
+							}))
+						: [];
+					return {
+						customId: typeof item?.metadata?.key === "string" && item.metadata.key ? item.metadata.key : `request-${index + 1}`,
+						model: null as string | null,
+						messages,
+					};
+				})
+				.filter((r) => r.messages.length > 0);
+		}
+		return [];
+	}, [batchRawRequest]);
+	const batchInputFileId =
+		typeof batchRawRequest?.input_file_id === "string"
+			? (batchRawRequest.input_file_id as string)
+			: typeof (batchRawRequest?.batch as any)?.inputConfig?.fileName === "string"
+				? ((batchRawRequest?.batch as any).inputConfig.fileName as string)
+				: null;
+	const batchRawResponse = useMemo(() => {
+		if (!batchDebug || !log.raw_response) return null;
+		try {
+			const parsed = JSON.parse(log.raw_response);
+			return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+		} catch {
+			return null;
+		}
+	}, [batchDebug, log.raw_response]);
+	const batchResultItems = useMemo(() => {
+		const raw = batchRawResponse;
+		const results: any[] = Array.isArray(raw) ? raw : Array.isArray(raw?.results) ? (raw!.results as any[]) : [];
+		return results
+			.map((item: any, index: number) => {
+				const customId = typeof item?.custom_id === "string" && item.custom_id ? item.custom_id : `result-${index + 1}`;
+				const body = item?.response?.body;
+				const model =
+					typeof item?.result?.message?.model === "string"
+						? item.result.message.model
+						: typeof body?.model === "string"
+							? body.model
+							: null;
+				let message: any = null;
+				let rawFallback: string | null = null;
+				const candidate = Array.isArray(body?.candidates) ? body.candidates[0] : null;
+				if (item?.result?.message) {
+					message = item.result.message;
+				} else if (body?.choices?.[0]?.message) {
+					message = body.choices[0].message;
+				} else if (body?.content !== undefined) {
+					message = body;
+				} else if (candidate) {
+					const parts = candidate?.content?.parts;
+					const text = Array.isArray(parts)
+						? parts
+								.filter((p: any) => p && typeof p.text === "string")
+								.map((p: any) => p.text)
+								.join("")
+						: "";
+					const role = candidate?.content?.role === "model" ? "assistant" : candidate?.content?.role || "assistant";
+					message = { role, content: text };
+				} else if (typeof body?.text === "string") {
+					message = { role: "assistant", content: body.text };
+				} else if (body && Object.keys(body).length > 0) {
+					rawFallback = JSON.stringify(body, null, 2);
+				} else if (item?.result && Object.keys(item.result).length > 0) {
+					rawFallback = JSON.stringify(item.result, null, 2);
+				}
+				const errorMessage: string | null =
+					item?.error?.message ||
+					(item?.result?.type && item.result.type !== "succeeded" ? `Batch item ${item.result.type}` : null) ||
+					(typeof item?.response?.status_code === "number" && item.response.status_code >= 400
+						? `Provider returned HTTP ${item.response.status_code}`
+						: null);
+				return { customId, model, message, rawFallback, errorMessage };
+			})
+			.filter((r) => r.message || r.rawFallback || r.errorMessage);
+	}, [batchRawResponse]);
 	const passthroughParams = isPassthrough
 		? (log.params as {
 				method?: string;
@@ -1100,17 +1212,6 @@ export function LogDetailView({
 									className="rounded-sm border-amber-300 bg-amber-50 px-2 py-0.5 font-medium text-amber-700 dark:border-amber-600 dark:bg-amber-950 dark:text-amber-300"
 								>
 									{log.metadata.realtime_voice}
-								</Badge>
-							)}
-							{batchDebug?.status && (
-								<Badge
-									variant="outline"
-									className={cn(
-										"rounded-sm px-2 py-0.5 font-medium uppercase",
-										batchStatusBadgeStyles[batchDebug.status] ?? batchStatusBadgeDefault,
-									)}
-								>
-									{batchDebug.status.replace(/_/g, " ")}
 								</Badge>
 							)}
 						</div>
@@ -1874,6 +1975,23 @@ export function LogDetailView({
 												)}
 											</div>
 										)}
+										{batchDebug.status && (
+											<LogEntryDetailsView
+												className="w-full"
+												label="Status"
+												value={
+													<Badge
+														variant="outline"
+														className={cn(
+															"rounded-sm px-2 py-0.5 font-medium uppercase",
+															batchStatusBadgeStyles[batchDebug.status] ?? batchStatusBadgeDefault,
+														)}
+													>
+														{batchDebug.status.replace(/_/g, " ")}
+													</Badge>
+												}
+											/>
+										)}
 									</div>
 								</>
 							)}
@@ -2070,9 +2188,19 @@ export function LogDetailView({
 						)}
 				</div>
 			</details>
-			<Tabs key={log.id} defaultValue={showTabs ? "messages" : "plugins"} className="gap-2">
+			<Tabs key={log.id} defaultValue={batchDebug ? "details" : showTabs ? "messages" : "plugins"} className="gap-2">
 				<TabsList className="bg-muted/60 h-10 w-fit">
-					{showTabs && (
+					{showTabs && batchDebug && (
+						<TabsTrigger value="details" className="px-3">
+							Details
+							{batchInlineRequests.length + batchResultItems.length ? (
+								<span className="bg-background text-muted-foreground ml-1.5 rounded-sm border px-2 py-0.5 text-[10px] tabular-nums">
+									{batchInlineRequests.length + batchResultItems.length}
+								</span>
+							) : null}
+						</TabsTrigger>
+					)}
+					{showTabs && !batchDebug && (
 						<TabsTrigger value="messages" className="px-3">
 							Messages
 							{log.input_history?.length ? (
@@ -2083,7 +2211,7 @@ export function LogDetailView({
 						</TabsTrigger>
 					)}
 
-					{showTabs && !isPassthrough && !log.list_models_output && (
+					{showTabs && !isPassthrough && !log.list_models_output && !batchDebug && (
 						<TabsTrigger value="tools" className="px-3">
 							Tools
 							{declaredTools.length ? (
@@ -2117,6 +2245,139 @@ export function LogDetailView({
 						</TabsTrigger>
 					)}
 				</TabsList>
+
+				{batchDebug && (
+					<TabsContent value="details" className="space-y-4">
+						{(batchDebug.batch_id || (batchInlineRequests.length === 0 && batchInputFileId)) && (
+							<div className="bg-card rounded-sm border p-5 space-y-4">
+								{batchDebug.batch_id && (
+									<LogEntryDetailsView
+										label="Batch ID"
+										value={
+											<span className="flex items-center gap-1">
+												<code className="font-mono text-xs">{batchDebug.batch_id}</code>
+												<CopyInlineButton text={batchDebug.batch_id} testId="logdetails-details-copy-batch-id-button" />
+											</span>
+										}
+									/>
+								)}
+								{batchInlineRequests.length === 0 && batchInputFileId && (
+									<LogEntryDetailsView
+										label="Input File ID"
+										value={
+											<span className="flex items-center gap-1">
+												<code className="font-mono text-xs">{batchInputFileId}</code>
+												<CopyInlineButton text={batchInputFileId} testId="logdetails-copy-input-file-id-button" />
+											</span>
+										}
+									/>
+								)}
+							</div>
+						)}
+						<div className="bg-card rounded-sm border">
+							{batchInlineRequests.length > 0 ? (
+								<div className="px-5 pt-5 pb-2">
+									<div className="text-muted-foreground mb-1 text-[10.5px] font-semibold tracking-wider uppercase">
+										Batch Requests ({batchInlineRequests.length})
+									</div>
+									<Accordion type="multiple" className="w-full">
+										{batchInlineRequests.map((request, index) => (
+											<AccordionItem key={`${request.customId}-${index}`} value={`${request.customId}-${index}`}>
+												<AccordionTrigger className="text-[13px]">
+													<span className="flex items-center gap-2">
+														<code className="font-mono text-xs">{request.customId}</code>
+														{request.model && (
+															<Badge variant="secondary" className="rounded-sm px-1.5 py-0 text-[10.5px] font-normal">
+																{request.model}
+															</Badge>
+														)}
+														<span className="text-muted-foreground text-[11px]">
+															{request.messages.length} message{request.messages.length === 1 ? "" : "s"}
+														</span>
+													</span>
+												</AccordionTrigger>
+												<AccordionContent className="space-y-3 pb-2">
+													{request.messages.map((message: any, msgIndex: number) => {
+														const role = ((message?.role as string) || "user") as MessageRole;
+														const text = extractMessageText(message);
+														return (
+															<MessageRow key={msgIndex} role={role} last={msgIndex === request.messages.length - 1}>
+																{text ? (
+																	<CollapsibleCode text={text} preview={3} mono={false} />
+																) : (
+																	<span className="text-muted-foreground text-xs">Empty message</span>
+																)}
+															</MessageRow>
+														);
+													})}
+												</AccordionContent>
+											</AccordionItem>
+										))}
+									</Accordion>
+								</div>
+							) : batchResultItems.length > 0 ? (
+								<div className="px-5 pt-5 pb-2">
+									<div className="text-muted-foreground mb-1 text-[10.5px] font-semibold tracking-wider uppercase">
+										Batch Results ({batchResultItems.length})
+									</div>
+									<Accordion type="multiple" className="w-full">
+										{batchResultItems.map((result, index) => (
+											<AccordionItem key={`${result.customId}-${index}`} value={`${result.customId}-${index}`}>
+												<AccordionTrigger className="text-[13px]">
+													<span className="flex items-center gap-2">
+														<code className="font-mono text-xs">{result.customId}</code>
+														{result.model && (
+															<Badge variant="secondary" className="rounded-sm px-1.5 py-0 text-[10.5px] font-normal">
+																{result.model}
+															</Badge>
+														)}
+														{result.errorMessage && (
+															<span className="text-[11px] text-red-600 dark:text-red-400">Failed</span>
+														)}
+													</span>
+												</AccordionTrigger>
+												<AccordionContent className="space-y-3 pb-2">
+													{result.errorMessage ? (
+														<div className="rounded-sm border border-red-200 bg-red-50/70 p-3 text-[12.5px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-400">
+															{result.errorMessage}
+														</div>
+													) : result.message ? (
+														(() => {
+															const role = ((result.message?.role as string) || "assistant") as MessageRole;
+															const text = extractMessageText(result.message);
+															return (
+																<MessageRow role={role} last>
+																	{text ? (
+																		<CollapsibleCode text={text} preview={3} mono={false} />
+																	) : (
+																		<span className="text-muted-foreground text-xs">Empty message</span>
+																	)}
+																</MessageRow>
+															);
+														})()
+													) : result.rawFallback ? (
+														<div>
+															<div className="text-muted-foreground mb-1 text-[10.5px]">
+																Unrecognized result shape — showing the raw response body
+															</div>
+															<CollapsibleCode text={result.rawFallback} preview={5} lang="json" />
+														</div>
+													) : (
+														<span className="text-muted-foreground text-xs">Empty result</span>
+													)}
+												</AccordionContent>
+											</AccordionItem>
+										))}
+									</Accordion>
+								</div>
+							) : (
+								<div className="text-muted-foreground p-5 text-center text-sm">
+									No batch request or result details were captured for this row.
+								</div>
+							)}
+						</div>
+					</TabsContent>
+				)}
 
 				<TabsContent value="messages" className="space-y-4">
 					{log.content_hidden && (

--- a/ui/lib/constants/logs.ts
+++ b/ui/lib/constants/logs.ts
@@ -100,6 +100,12 @@ export const RequestTypes = [
 	"batch_cancel",
 	"batch_delete",
 	"batch_results",
+	// File operations
+	"file_upload",
+	"file_list",
+	"file_retrieve",
+	"file_delete",
+	"file_content",
 	// Container operations
 	"container_create",
 	"container_list",


### PR DESCRIPTION
## Summary

Fixes a batch accounting bug where VK-scoped wildcard budgets were silently skipped when a request carried no model (e.g. batch-create requests). A virtual key created with an unscoped "Budget configuration" stores the budget as a VK-scoped, all-providers, all-models wildcard model config (`model="*"`, `provider=nil`). Because `CollectApplicableGovernanceIDs` gated all VK-scoped model config lookups on `model != ""`, batch requests without a top-level model would settle successfully but never decrement the VK budget if model is missing.

## Changes

- Removed the `model != ""` guards from the global-scope, user-scoped, and VK-scoped model config collection paths in `CollectApplicableGovernanceIDs`, allowing wildcard model configs (`model="*"`) to be matched even when no model is present on the request.
- Added a regression test (`TestCollectApplicableGovernanceIDs_VKWildcardBudget_NoModel`) that reproduces the batch accounting bug and confirms the VK-scoped wildcard budget is now collected when `model` is empty.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/... -run TestCollectApplicableGovernanceIDs_VKWildcardBudget_NoModel -v
```

Expected: the test passes and the VK-scoped wildcard budget ID is present in the returned budget IDs even when the request carries an empty model string.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. This is a budget enforcement correctness fix — the change makes governance controls more restrictive, not less.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable