### PR TITLE
refactor: extract shared MCP client form fields, validation, and payload builder into `mcpClientFormFields` and reuse across create and library install sheets

### DIFF
--- a/ui/app/workspace/mcp-registry/library/page.tsx
+++ b/ui/app/workspace/mcp-registry/library/page.tsx
@@ -222,7 +222,7 @@ export default function MCPLibraryPage() {
 								{hasCreateMCPClientAccess && (
 									<Button variant="outline" size="sm" onClick={() => setAddServerOpen(true)} data-testid="mcp-library-add-server-btn">
 										<Plus className="h-4 w-4" />
-										Add Server
+										Add to Library
 									</Button>
 								)}
 								{hasSettingsAccess && (

--- a/ui/app/workspace/mcp-registry/library/views/mcpLibraryAddServerSheet.tsx
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibraryAddServerSheet.tsx
@@ -1,19 +1,32 @@
 import { Button } from "@/components/ui/button";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { DottedSeparator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Textarea } from "@/components/ui/textarea";
+import { IS_ENTERPRISE } from "@/lib/constants/config";
 import { getErrorMessage, useCreateMCPLibraryEntryMutation } from "@/lib/store";
 import type { CreateMCPLibraryEntryRequest, MCPAuthType, MCPConnectionType } from "@/lib/types/mcp";
+import { useGetSCIMProvidersQuery } from "@enterprise/lib/store/apis/scimApi";
+import { Info } from "lucide-react";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
+import {
+	authKindOf,
+	authScopeOf,
+	type MCPAuthKind,
+	type MCPAuthScope,
+	SectionHeader,
+	StdioRuntimeNotice,
+} from "../../views/mcpClientFormFields";
 
 interface MCPLibraryAddServerFormData {
 	name: string;
 	description: string;
 	category: string;
+	publisher: string;
 	connection_type: MCPConnectionType;
 	connection_url: string;
 	command: string;
@@ -35,6 +48,7 @@ const DEFAULTS: MCPLibraryAddServerFormData = {
 	name: "",
 	description: "",
 	category: "",
+	publisher: "",
 	connection_type: "http",
 	connection_url: "",
 	command: "",
@@ -55,17 +69,23 @@ function parseList(text: string): string[] {
 		.filter(Boolean);
 }
 
+/**
+ * Publishes a library listing: a reusable description of an MCP server that
+ * members can later install. Deliberately mirrors the layout and auth
+ * vocabulary of the create-server sheet, but collects no credentials: those
+ * are supplied per install, by whoever installs the entry.
+ */
 export function MCPLibraryAddServerSheet({ open, onClose }: MCPLibraryAddServerSheetProps) {
 	const [createEntry, { isLoading }] = useCreateMCPLibraryEntryMutation();
 
-	const {
-		register,
-		handleSubmit,
-		watch,
-		setValue,
-		reset,
-		formState: { errors },
-	} = useForm<MCPLibraryAddServerFormData>({ defaultValues: DEFAULTS });
+	// Token exchange is backed by the deployment's identity-provider
+	// integration, so the option only renders when one is enabled, same gate
+	// as the create-server sheet.
+	const { data: scimProviders } = useGetSCIMProvidersQuery(undefined, { skip: !IS_ENTERPRISE });
+	const idpConfigured = !!scimProviders?.find((p) => (p as { enabled?: boolean }).enabled);
+
+	const methods = useForm<MCPLibraryAddServerFormData>({ defaultValues: DEFAULTS });
+	const { control, handleSubmit, watch, setValue, reset } = methods;
 
 	useEffect(() => {
 		if (open) reset(DEFAULTS);
@@ -74,7 +94,29 @@ export function MCPLibraryAddServerSheet({ open, onClose }: MCPLibraryAddServerS
 	const connectionType = watch("connection_type");
 	const authType = watch("auth_type");
 	const isStdio = connectionType === "stdio";
-	const needsHeaderKeys = authType === "headers" || authType === "per_user_headers";
+	const authKind = authKindOf(authType);
+	const authScope = authScopeOf(authType);
+	const needsHeaderKeys = authKind === "headers";
+
+	const applyAuthKind = (kind: MCPAuthKind) => {
+		if (kind === "none" || kind === "token_exchange") {
+			setValue("auth_type", kind);
+			return;
+		}
+		if (kind === "oauth") {
+			setValue("auth_type", authScope === "per_user" ? "per_user_oauth" : "oauth");
+			return;
+		}
+		setValue("auth_type", authScope === "per_user" ? "per_user_headers" : "headers");
+	};
+
+	const applyAuthScope = (scope: MCPAuthScope) => {
+		if (authKind === "oauth") {
+			setValue("auth_type", scope === "per_user" ? "per_user_oauth" : "oauth");
+		} else if (authKind === "headers") {
+			setValue("auth_type", scope === "per_user" ? "per_user_headers" : "headers");
+		}
+	};
 
 	const onSubmit = async (data: MCPLibraryAddServerFormData) => {
 		const tags = parseList(data.tags);
@@ -82,6 +124,7 @@ export function MCPLibraryAddServerSheet({ open, onClose }: MCPLibraryAddServerS
 			name: data.name.trim(),
 			description: data.description.trim() || undefined,
 			category: data.category.trim() || undefined,
+			publisher: data.publisher.trim() || undefined,
 			connection_type: data.connection_type,
 			auth_type: data.auth_type,
 			icon_url: data.icon_url.trim() || undefined,
@@ -105,7 +148,7 @@ export function MCPLibraryAddServerSheet({ open, onClose }: MCPLibraryAddServerS
 
 		try {
 			await createEntry(payload).unwrap();
-			toast.success("MCP server published to the library.");
+			toast.success("Server added to the library.");
 			onClose();
 		} catch (error) {
 			toast.error(getErrorMessage(error));
@@ -114,179 +157,329 @@ export function MCPLibraryAddServerSheet({ open, onClose }: MCPLibraryAddServerS
 
 	return (
 		<Sheet open={open} onOpenChange={(sheetOpen) => !sheetOpen && onClose()}>
-			<SheetContent className="flex w-full flex-col overflow-x-hidden p-0 pt-4">
+			<SheetContent className="flex w-full flex-col gap-4 overflow-x-hidden p-0 pt-4">
 				<SheetHeader className="flex flex-col items-start px-0 py-4" headerClassName="mb-0 sticky px-4 md:px-8 -top-4 bg-card z-10">
-					<SheetTitle>Add MCP Server</SheetTitle>
-					<SheetDescription>This MCP server will be available org-wide for members to discover, install, and use.</SheetDescription>
+					<SheetTitle>Publish Server to Library</SheetTitle>
+					<SheetDescription>
+						Add a reusable server listing that members can discover and install. Nothing connects to Bifrost until someone installs it.
+					</SheetDescription>
 				</SheetHeader>
 
-				<form onSubmit={handleSubmit(onSubmit)} className="flex min-h-0 flex-1 flex-col">
-					<div className="flex-1 space-y-4 px-4 py-4 md:px-8">
-						{/* Name */}
-						<div className="space-y-2">
-							<Label htmlFor="mcp-add-name">Name</Label>
-							<Input
-								id="mcp-add-name"
-								placeholder="My Internal Server"
-								data-testid="mcp-add-name-input"
-								className={errors.name ? "border-destructive" : ""}
-								{...register("name", {
-									required: "Name is required",
-									validate: (v) => v.trim().length > 0 || "Name is required",
-								})}
-							/>
-							{errors.name && <p className="text-destructive text-sm">{errors.name.message}</p>}
-						</div>
-
-						{/* Description */}
-						<div className="space-y-2">
-							<Label htmlFor="mcp-add-description">Description</Label>
-							<Textarea
-								id="mcp-add-description"
-								placeholder="What this server does..."
-								data-testid="mcp-add-description-input"
-								{...register("description")}
-							/>
-						</div>
-
-						{/* Connection details */}
-						<div className="flex gap-3">
-							<div className="w-32 shrink-0 space-y-2">
-								<Label>Connection Type</Label>
-								<Select value={connectionType} onValueChange={(v) => setValue("connection_type", v as MCPConnectionType)}>
-									<SelectTrigger className="w-full" data-testid="mcp-add-connection-type">
-										<SelectValue />
-									</SelectTrigger>
-									<SelectContent>
-										<SelectItem value="http">HTTP</SelectItem>
-										<SelectItem value="sse">SSE</SelectItem>
-										<SelectItem value="stdio">STDIO</SelectItem>
-									</SelectContent>
-								</Select>
+				<Form {...methods}>
+					<form onSubmit={handleSubmit(onSubmit)} className="flex h-full flex-col gap-6">
+						<div className="grow space-y-4 px-4 md:px-8">
+							<div className="rounded-lg border border-blue-200 bg-blue-50 p-3" data-testid="mcp-add-listing-notice">
+								<div className="flex items-start gap-2">
+									<Info className="mt-0.5 h-4 w-4 flex-shrink-0 text-blue-700" />
+									<p className="text-xs text-blue-900">
+										This listing stays in your organization&apos;s library. It is not published to the global Bifrost MCP catalog. It is also a
+										catalog entry, not a live MCP connection: credentials are never stored on the listing, each person who installs it
+										supplies their own.
+									</p>
+								</div>
 							</div>
+
+							{/* Listing details */}
+							<div className="space-y-4">
+								<SectionHeader title="Listing Details" description="How this server appears to members browsing the library." />
+								<div className="space-y-4 rounded-md border p-4">
+									<FormField
+										control={control}
+										name="name"
+										rules={{
+											required: "Name is required",
+											validate: (v) => v.trim().length > 0 || "Name is required",
+										}}
+										render={({ field }) => (
+											<FormItem>
+												<FormLabel>Name</FormLabel>
+												<FormControl>
+													<Input {...field} placeholder="My Internal Server" data-testid="mcp-add-name-input" />
+												</FormControl>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
+									<FormField
+										control={control}
+										name="description"
+										render={({ field }) => (
+											<FormItem>
+												<FormLabel>Description</FormLabel>
+												<FormControl>
+													<Textarea {...field} placeholder="What this server does..." data-testid="mcp-add-description-input" />
+												</FormControl>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
+								</div>
+							</div>
+
+							<DottedSeparator />
+
+							{/* Connection */}
+							<div className="space-y-4">
+								<SectionHeader title="Connection" description="How Bifrost will reach this server once a member installs the listing." />
+								<div className="space-y-4 rounded-md border p-4">
+									<FormField
+										control={control}
+										name="connection_type"
+										render={({ field }) => (
+											<FormItem className="w-full">
+												<FormLabel>Connection Type</FormLabel>
+												<Select
+													value={field.value}
+													onValueChange={(value: MCPConnectionType) => {
+														field.onChange(value);
+														// STDIO servers are launched locally, so none of the
+														// network auth types apply to them.
+														if (value === "stdio") setValue("auth_type", "none");
+													}}
+												>
+													<FormControl>
+														<SelectTrigger className="w-full" data-testid="mcp-add-connection-type">
+															<SelectValue />
+														</SelectTrigger>
+													</FormControl>
+													<SelectContent>
+														<SelectItem value="http">HTTP (Streamable)</SelectItem>
+														<SelectItem value="sse">Server-Sent Events (SSE)</SelectItem>
+														<SelectItem value="stdio">STDIO</SelectItem>
+													</SelectContent>
+												</Select>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
+
+									{!isStdio && (
+										<FormField
+											control={control}
+											name="connection_url"
+											rules={{
+												validate: (v) => isStdio || v.trim().length > 0 || "Connection URL is required",
+											}}
+											render={({ field }) => (
+												<FormItem>
+													<FormLabel>Connection URL</FormLabel>
+													<FormControl>
+														<Input {...field} placeholder="https://my-server.internal/mcp" data-testid="mcp-add-url-input" />
+													</FormControl>
+													<FormMessage />
+												</FormItem>
+											)}
+										/>
+									)}
+
+									{isStdio && (
+										<>
+											<StdioRuntimeNotice />
+											<FormField
+												control={control}
+												name="command"
+												rules={{
+													validate: (v) => !isStdio || v.trim().length > 0 || "Command is required for stdio",
+												}}
+												render={({ field }) => (
+													<FormItem>
+														<FormLabel>Command</FormLabel>
+														<FormControl>
+															<Input {...field} placeholder="npx" data-testid="mcp-add-command-input" />
+														</FormControl>
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
+											<FormField
+												control={control}
+												name="args"
+												render={({ field }) => (
+													<FormItem>
+														<FormLabel>Arguments (comma-separated)</FormLabel>
+														<FormControl>
+															<Input {...field} placeholder="-y, my-package" data-testid="mcp-add-args-input" />
+														</FormControl>
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
+											<FormField
+												control={control}
+												name="envs"
+												render={({ field }) => (
+													<FormItem>
+														<FormLabel>Environment Variable Names (comma-separated)</FormLabel>
+														<FormControl>
+															<Input {...field} placeholder="API_KEY, DB_URL" data-testid="mcp-add-envs-input" />
+														</FormControl>
+														<p className="text-muted-foreground text-xs">Names only; whoever installs the listing supplies the values.</p>
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
+										</>
+									)}
+								</div>
+							</div>
+
 							{!isStdio && (
-								<div className="min-w-0 flex-1 space-y-2">
-									<Label htmlFor="mcp-add-url">Connection URL</Label>
-									<Input
-										id="mcp-add-url"
-										placeholder="https://my-server.internal/mcp"
-										data-testid="mcp-add-url-input"
-										className={errors.connection_url ? "border-destructive" : ""}
-										{...register("connection_url", {
-											validate: (v) => (!isStdio ? v.trim().length > 0 || "Connection URL is required" : true),
-										})}
-									/>
-									{errors.connection_url && <p className="text-destructive text-sm">{errors.connection_url.message}</p>}
-								</div>
+								<>
+									<DottedSeparator />
+
+									{/* Authentication */}
+									<div className="space-y-4">
+										<SectionHeader
+											title="Authentication"
+											description="The scheme this server expects. It prefills the install form; no secrets are stored on the listing."
+										/>
+										<div className="space-y-4 rounded-md border p-4">
+											<FormItem className="w-full">
+												<FormLabel>Authentication Type</FormLabel>
+												<Select value={authKind} onValueChange={(value: MCPAuthKind) => applyAuthKind(value)}>
+													<FormControl>
+														<SelectTrigger className="w-full" data-testid="mcp-add-auth-type">
+															<SelectValue />
+														</SelectTrigger>
+													</FormControl>
+													<SelectContent>
+														<SelectItem value="none">None</SelectItem>
+														<SelectItem value="headers">Headers</SelectItem>
+														<SelectItem value="oauth">OAuth 2.0</SelectItem>
+														{IS_ENTERPRISE && idpConfigured && (
+															<SelectItem value="token_exchange">Token Exchange (On-Behalf-Of)</SelectItem>
+														)}
+													</SelectContent>
+												</Select>
+											</FormItem>
+
+											{authKind !== "none" && authKind !== "token_exchange" && (
+												<FormItem className="w-full">
+													<FormLabel>Auth Scope</FormLabel>
+													<Select value={authScope} onValueChange={(value: MCPAuthScope) => applyAuthScope(value)}>
+														<FormControl>
+															<SelectTrigger className="w-full" data-testid="mcp-add-auth-scope">
+																<SelectValue />
+															</SelectTrigger>
+														</FormControl>
+														<SelectContent>
+															<SelectItem value="shared">Shared</SelectItem>
+															<SelectItem value="per_user">Per-User</SelectItem>
+														</SelectContent>
+													</Select>
+												</FormItem>
+											)}
+
+											{needsHeaderKeys && (
+												<FormField
+													control={control}
+													name="required_header_keys"
+													render={({ field }) => (
+														<FormItem>
+															<FormLabel>Required Header Names (comma-separated)</FormLabel>
+															<FormControl>
+																<Input {...field} placeholder="X-Api-Key, X-Tenant-ID" data-testid="mcp-add-header-keys-input" />
+															</FormControl>
+															<p className="text-muted-foreground text-xs">Names only; whoever installs the listing supplies the values.</p>
+															<FormMessage />
+														</FormItem>
+													)}
+												/>
+											)}
+										</div>
+									</div>
+								</>
 							)}
-						</div>
 
-						{isStdio && (
-							<div className="space-y-4 rounded-sm border p-4">
-								<div className="space-y-2">
-									<Label htmlFor="mcp-add-command">Command</Label>
-									<Input
-										id="mcp-add-command"
-										placeholder="npx"
-										data-testid="mcp-add-command-input"
-										className={errors.command ? "border-destructive" : ""}
-										{...register("command", {
-											validate: (v) => (isStdio ? v.trim().length > 0 || "Command is required for stdio" : true),
-										})}
+							<DottedSeparator />
+
+							{/* Catalog metadata */}
+							<div className="space-y-4">
+								<SectionHeader title="Discovery" description="Optional metadata used to browse, filter, and attribute this listing." />
+								<div className="space-y-4 rounded-md border p-4">
+									<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+										<FormField
+											control={control}
+											name="category"
+											render={({ field }) => (
+												<FormItem>
+													<FormLabel>Category</FormLabel>
+													<FormControl>
+														<Input {...field} placeholder="e.g. Database" data-testid="mcp-add-category-input" />
+													</FormControl>
+													<FormMessage />
+												</FormItem>
+											)}
+										/>
+										<FormField
+											control={control}
+											name="publisher"
+											render={({ field }) => (
+												<FormItem>
+													<FormLabel>Publisher</FormLabel>
+													<FormControl>
+														<Input {...field} placeholder="e.g. Platform Team" data-testid="mcp-add-publisher-input" />
+													</FormControl>
+													<FormMessage />
+												</FormItem>
+											)}
+										/>
+									</div>
+									<FormField
+										control={control}
+										name="tags"
+										render={({ field }) => (
+											<FormItem>
+												<FormLabel>Tags (comma-separated)</FormLabel>
+												<FormControl>
+													<Input {...field} placeholder="internal, database" data-testid="mcp-add-tags-input" />
+												</FormControl>
+												<FormMessage />
+											</FormItem>
+										)}
 									/>
-									{errors.command && <p className="text-destructive text-sm">{errors.command.message}</p>}
+									<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+										<FormField
+											control={control}
+											name="icon_url"
+											render={({ field }) => (
+												<FormItem>
+													<FormLabel>Icon URL</FormLabel>
+													<FormControl>
+														<Input {...field} placeholder="https://..." data-testid="mcp-add-icon-input" />
+													</FormControl>
+													<FormMessage />
+												</FormItem>
+											)}
+										/>
+										<FormField
+											control={control}
+											name="docs_url"
+											render={({ field }) => (
+												<FormItem>
+													<FormLabel>Docs URL</FormLabel>
+													<FormControl>
+														<Input {...field} placeholder="https://..." data-testid="mcp-add-docs-input" />
+													</FormControl>
+													<FormMessage />
+												</FormItem>
+											)}
+										/>
+									</div>
 								</div>
-								<div className="space-y-2">
-									<Label htmlFor="mcp-add-args">Arguments</Label>
-									<Input
-										id="mcp-add-args"
-										placeholder="comma separated, e.g. -y, my-package"
-										data-testid="mcp-add-args-input"
-										{...register("args")}
-									/>
-								</div>
-								<div className="space-y-2">
-									<Label htmlFor="mcp-add-envs">Environment Variable Names</Label>
-									<Input
-										id="mcp-add-envs"
-										placeholder="comma separated, e.g. API_KEY, DB_URL"
-										data-testid="mcp-add-envs-input"
-										{...register("envs")}
-									/>
-									<p className="text-muted-foreground text-xs">Only names; users supply values at install time.</p>
-								</div>
-							</div>
-						)}
-
-						{/* Auth + category */}
-						<div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-							<div className="w-full space-y-2">
-								<Label>Authentication</Label>
-								<Select value={authType} onValueChange={(v) => setValue("auth_type", v as MCPAuthType)}>
-									<SelectTrigger data-testid="mcp-add-auth-type" className="w-full">
-										<SelectValue />
-									</SelectTrigger>
-									<SelectContent>
-										<SelectItem value="none">None</SelectItem>
-										<SelectItem value="headers">Headers</SelectItem>
-										<SelectItem value="oauth">OAuth</SelectItem>
-										<SelectItem value="per_user_headers">Per-user Headers</SelectItem>
-										<SelectItem value="per_user_oauth">Per-user OAuth</SelectItem>
-									</SelectContent>
-								</Select>
-							</div>
-							<div className="space-y-2">
-								<Label htmlFor="mcp-add-category">Category</Label>
-								<Input id="mcp-add-category" placeholder="e.g. Database" data-testid="mcp-add-category-input" {...register("category")} />
 							</div>
 						</div>
 
-						{needsHeaderKeys && (
-							<div className="space-y-2">
-								<Label htmlFor="mcp-add-header-keys">Required Header Names</Label>
-								<Input
-									id="mcp-add-header-keys"
-									placeholder="comma separated, e.g. X-Api-Key"
-									data-testid="mcp-add-header-keys-input"
-									{...register("required_header_keys")}
-								/>
-								<p className="text-muted-foreground text-xs">Only names; users supply values at install time.</p>
-							</div>
-						)}
-
-						{/* Optional metadata */}
-						<div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-							<div className="space-y-2">
-								<Label htmlFor="mcp-add-icon">Icon URL</Label>
-								<Input id="mcp-add-icon" placeholder="https://..." data-testid="mcp-add-icon-input" {...register("icon_url")} />
-							</div>
-							<div className="space-y-2">
-								<Label htmlFor="mcp-add-docs">Docs URL</Label>
-								<Input id="mcp-add-docs" placeholder="https://..." data-testid="mcp-add-docs-input" {...register("docs_url")} />
-							</div>
-						</div>
-						<div className="space-y-2">
-							<Label htmlFor="mcp-add-tags">Tags</Label>
-							<Input
-								id="mcp-add-tags"
-								placeholder="comma separated, e.g. internal, database"
-								data-testid="mcp-add-tags-input"
-								{...register("tags")}
-							/>
-						</div>
-					</div>
-
-					<div className="border-border bg-card sticky bottom-0 z-10 border-t px-4 py-4 md:px-8">
-						<div className="flex justify-end gap-2">
+						<div className="bg-card sticky bottom-0 z-10 flex justify-end gap-2 border-t px-4 py-4 md:px-8">
 							<Button type="button" variant="outline" onClick={onClose} disabled={isLoading} data-testid="mcp-add-cancel-btn">
 								Cancel
 							</Button>
-							<Button type="submit" disabled={isLoading} data-testid="mcp-add-submit-btn">
-								{isLoading ? "Publishing..." : "Publish to Library"}
+							<Button type="submit" disabled={isLoading} isLoading={isLoading} data-testid="mcp-add-submit-btn">
+								Add to Library
 							</Button>
 						</div>
-					</div>
-				</form>
+					</form>
+				</Form>
 			</SheetContent>
 		</Sheet>
 	);

--- a/ui/app/workspace/mcp-registry/library/views/mcpLibraryInstallSheet.tsx
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibraryInstallSheet.tsx
@@ -1,28 +1,28 @@
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { SecretVarInput } from "@/components/ui/secretVarInput";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
-import { HeadersTable } from "@/components/ui/headersTable";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { DottedSeparator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
-import { Switch } from "@/components/ui/switch";
-import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useToast } from "@/hooks/use-toast";
 import { getErrorMessage, useCreateMCPClientMutation } from "@/lib/store";
-import { CreateMCPClientRequest, SecretVar, MCPAuthType, MCPLibraryEntry, MCPTLSConfig } from "@/lib/types/mcp";
-import { parseArrayFromText } from "@/lib/utils/array";
+import { CreateMCPClientRequest, MCPAuthType, MCPLibraryEntry, SecretVar } from "@/lib/types/mcp";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { Globe, Info, KeyRound, Radio, ShieldCheck, Terminal } from "lucide-react";
+import { ShieldCheck } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
+import {
+	authScopeOf,
+	buildMCPClientPayload,
+	getHeadersValidationError,
+	MCPClientFormFields,
+	useMCPClientFormSatellites,
+	validateMCPClientForm,
+} from "../../views/mcpClientFormFields";
 import { MCPHeadersAuthorizer } from "../../views/mcpHeadersAuthorizer";
 import { OAuth2Authorizer } from "../../views/oauth2Authorizer";
-
-const MCP_ICON_FALLBACK = "/images/mcp.svg";
+import { authLabel, MCP_ICON_FALLBACK, transportIcon, transportLabel } from "./mcpLibraryServerCard";
 
 interface MCPLibraryInstallSheetProps {
 	server: MCPLibraryEntry;
@@ -32,24 +32,6 @@ interface MCPLibraryInstallSheetProps {
 }
 
 const emptySecretVar: SecretVar = { value: "", ref: "" };
-
-/** Strips empty TLS config so we don't send `{}` to the server. */
-function buildTLSConfigPayload(tls: MCPTLSConfig | undefined): MCPTLSConfig | undefined {
-	if (!tls) return undefined;
-	const hasSkipVerify = tls.insecure_skip_verify === true;
-	const hasCACert = tls.ca_cert_pem?.value?.trim() || tls.ca_cert_pem?.ref?.trim();
-	if (!hasSkipVerify && !hasCACert) return undefined;
-	return { insecure_skip_verify: tls.insecure_skip_verify, ca_cert_pem: hasCACert ? tls.ca_cert_pem : undefined };
-}
-
-function isValidOAuthResourceURI(value: string): boolean {
-	try {
-		const parsed = new URL(value);
-		return parsed.protocol !== "" && parsed.hash === "";
-	} catch {
-		return false;
-	}
-}
 
 /**
  * Sanitize a catalog server name into a valid MCP client name. The backend
@@ -66,58 +48,34 @@ export function sanitizeServerName(name: string): string {
 	return /^[0-9]/.test(cleaned) || cleaned === "" ? `mcp_${cleaned}` : cleaned;
 }
 
+/**
+ * Seed the create-client form from the library entry. Everything the entry
+ * declares is prefilled; everything it can't know (credentials, per-user header
+ * values) is left for the installer to supply in the shared form body.
+ */
 function buildInitialValues(server: MCPLibraryEntry): CreateMCPClientRequest {
 	const authType = (server.auth_type || "none") as MCPAuthType;
 	const isStdio = server.connection_type === "stdio";
+	// A "headers" entry declares which header names it needs; prefill them as
+	// empty rows so the installer only has to fill in values.
+	const declaredHeaders = server.required_header_keys?.length
+		? Object.fromEntries(server.required_header_keys.map((key) => [key, { ...emptySecretVar }]))
+		: { Authorization: { ...emptySecretVar } };
+
 	return {
 		name: sanitizeServerName(server.name),
 		is_code_mode_client: false,
 		is_ping_available: true,
 		connection_type: server.connection_type || "http",
-		connection_string: isStdio ? undefined : server.connection_url ? { value: server.connection_url, ref: "" } : emptySecretVar,
-		stdio_config: isStdio && server.stdio_config ? server.stdio_config : undefined,
-		auth_type: authType,
-		headers: authType === "headers" ? { Authorization: { value: "", ref: "" } } : undefined,
+		connection_string: isStdio ? undefined : { value: server.connection_url || "", ref: "" },
+		stdio_config: isStdio && server.stdio_config ? { ...server.stdio_config } : undefined,
+		// STDIO servers are launched locally, so no request auth applies and the
+		// shared form renders no auth controls for them. The catalog sync does
+		// not validate auth_type against connection_type, so an entry can still
+		// declare one; ignore it rather than seeding state nothing can edit.
+		auth_type: isStdio ? "none" : authType,
+		headers: !isStdio && authType === "headers" ? declaredHeaders : undefined,
 	};
-}
-
-function transportLabel(connectionType?: string): string {
-	switch (connectionType) {
-		case "stdio":
-			return "stdio";
-		case "sse":
-			return "SSE";
-		default:
-			return "HTTP";
-	}
-}
-
-function TransportIcon({ connectionType }: { connectionType?: string }) {
-	switch (connectionType) {
-		case "stdio":
-			return <Terminal className="size-3.5" />;
-		case "sse":
-			return <Radio className="size-3.5" />;
-		default:
-			return <Globe className="size-3.5" />;
-	}
-}
-
-function authLabel(authType?: MCPAuthType | string): string {
-	switch (authType) {
-		case "headers":
-			return "Headers";
-		case "oauth":
-			return "OAuth 2.0";
-		case "per_user_oauth":
-			return "Per-user OAuth";
-		case "per_user_headers":
-			return "User headers";
-		case "token_exchange":
-			return "Token exchange";
-		default:
-			return "No auth";
-	}
 }
 
 function authHelpText(authType?: MCPAuthType | string): string {
@@ -142,206 +100,87 @@ export function MCPLibraryInstallSheet({ server, open, onClose, onInstalled }: M
 	const { toast } = useToast();
 	const [createMCPClient] = useCreateMCPClientMutation();
 	const [isLoading, setIsLoading] = useState(false);
-	const [scopesText, setScopesText] = useState("");
-	const [resourceText, setResourceText] = useState("");
-	const [envVars, setEnvVars] = useState<Record<string, string>>({});
 	const [oauthFlow, setOauthFlow] = useState<{
 		authorizeUrl: string;
 		oauthConfigId: string;
 		mcpClientId: string;
 		isPerUserOauth?: boolean;
 	} | null>(null);
-
-	// Per-user-headers admin flow: admin declares the required key names,
-	// then on install the MCPHeadersAuthorizer dialog runs a sample-values
-	// verify and returns discovered tools.
-	const [perUserHeaderKeys, setPerUserHeaderKeys] = useState<string[]>([]);
-	const [newHeaderKeyInput, setNewHeaderKeyInput] = useState("");
 	const [headersFlow, setHeadersFlow] = useState<{ payload: CreateMCPClientRequest } | null>(null);
 
-	// UI splits the canonical `auth_type` into two dropdowns:
-	//   - authKind: none | headers | oauth
-	//   - authScope: shared | per_user (hidden when authKind = none)
-	// They recombine into the wire `auth_type` so the backend contract is
-	// unchanged.
-	const [authScope, setAuthScope] = useState<"shared" | "per_user">("shared");
-
 	const defaultValues = useMemo(() => buildInitialValues(server), [server]);
-	const form = useForm<CreateMCPClientRequest>({ defaultValues });
-	const { control, handleSubmit, reset, setValue, watch, setError, clearErrors } = form;
+	const methods = useForm<CreateMCPClientRequest>({ defaultValues });
+	const { control, handleSubmit, reset, watch, setError } = methods;
+	const satellites = useMCPClientFormSatellites();
+
 	const authType = watch("auth_type") || "none";
 	const headers = watch("headers");
+	const headersValidationError = getHeadersValidationError(authType, headers);
 
-	const authKind: "none" | "headers" | "oauth" =
-		authType === "oauth" || authType === "per_user_oauth"
-			? "oauth"
-			: authType === "headers" || authType === "per_user_headers"
-				? "headers"
-				: "none";
+	const isStdio = server.connection_type === "stdio";
+	// Only the names the entry declares are editable as values; an entry with no
+	// declared variables falls back to a free-form table.
+	const stdioEnvKeys = useMemo(
+		() => (isStdio && server.stdio_config?.envs?.length ? server.stdio_config.envs : undefined),
+		[isStdio, server.stdio_config?.envs],
+	);
 
-	const applyAuthKind = (kind: "none" | "headers" | "oauth") => {
-		clearErrors();
-		if (kind === "none") {
-			setValue("auth_type", "none");
-			setValue("headers", undefined);
-			setValue("oauth_config", undefined);
-			return;
-		}
-		if (kind === "oauth") {
-			setValue("auth_type", authScope === "per_user" ? "per_user_oauth" : "oauth");
-			setValue("headers", undefined);
-			return;
-		}
-		setValue("auth_type", authScope === "per_user" ? "per_user_headers" : "headers");
-		setValue("oauth_config", undefined);
-		setValue("headers", { Authorization: { value: "", ref: "" } });
-	};
+	const satellitesInit = useMemo(
+		() => ({
+			argsText: (server.stdio_config?.args || []).join(", "),
+			envVars: Object.fromEntries((stdioEnvKeys || []).map((name) => [name, ""])),
+			perUserHeaderKeys: server.auth_type === "per_user_headers" ? (server.required_header_keys ?? []) : [],
+			authScope: authScopeOf(server.auth_type),
+		}),
+		[server.auth_type, server.required_header_keys, server.stdio_config?.args, stdioEnvKeys],
+	);
 
-	const applyAuthScope = (scope: "shared" | "per_user") => {
-		setAuthScope(scope);
-		if (authKind === "oauth") {
-			setValue("auth_type", scope === "per_user" ? "per_user_oauth" : "oauth");
-		} else if (authKind === "headers") {
-			setValue("auth_type", scope === "per_user" ? "per_user_headers" : "headers");
-		}
-	};
-
-	// Build initial env vars map from stdio_config.envs
-	const initialEnvVars = useMemo(() => {
-		if (server.connection_type !== "stdio" || !server.stdio_config?.envs) return {};
-		const map: Record<string, string> = {};
-		for (const env of server.stdio_config.envs) {
-			map[env] = "";
-		}
-		return map;
-	}, [server]);
-
+	const { reset: resetSatellites } = satellites;
 	useEffect(() => {
 		if (!open) return;
 		reset(defaultValues);
-		setScopesText("");
-		setResourceText("");
-		setEnvVars(initialEnvVars);
+		resetSatellites(satellitesInit);
 		setOauthFlow(null);
 		setHeadersFlow(null);
-		setPerUserHeaderKeys([]);
-		setNewHeaderKeyInput("");
-		setAuthScope("shared");
 		setIsLoading(false);
-	}, [defaultValues, initialEnvVars, open, reset]);
-
-	const headersValidationError = useMemo(() => {
-		if ((authType !== "headers" && authType !== "per_user_headers") || !headers) return null;
-		for (const [key, secretVar] of Object.entries(headers)) {
-			if (!secretVar.value && !secretVar.ref) {
-				return `Header "${key}" must have a value`;
-			}
-		}
-		return null;
-	}, [authType, headers]);
+	}, [defaultValues, open, reset, resetSatellites, satellitesInit]);
 
 	const onSubmit = async (data: CreateMCPClientRequest) => {
-		let hasErrors = false;
-
-		if (!data.name.trim()) {
-			setError("name", { message: "Server name is required" });
-			hasErrors = true;
-		} else if (!/^[a-zA-Z0-9_]+$/.test(data.name)) {
-			setError("name", {
-				message: "Server name can only contain letters, numbers, and underscores",
+		// The transport inputs are locked to the library entry, so a listing
+		// published without a target would post an empty URL or command and
+		// leave the installer staring at a server error they can't act on.
+		const hasTarget = isStdio ? !!data.stdio_config?.command?.trim() : !!data.connection_string?.value?.trim();
+		if (!hasTarget) {
+			toast({
+				title: "Incomplete library entry",
+				description: "This entry has no connection target. Ask the publisher to update the listing.",
+				variant: "destructive",
 			});
-			hasErrors = true;
+			return;
 		}
 
-		if (authType === "oauth" || authType === "per_user_oauth") {
-			if (data.oauth_config?.authorize_url && !/^https?:\/\/.+$/.test(data.oauth_config.authorize_url)) {
-				setError("oauth_config.authorize_url", {
-					message: "Authorize URL must start with http:// or https://",
-				});
-				hasErrors = true;
-			}
-			if (data.oauth_config?.token_url && !/^https?:\/\/.+$/.test(data.oauth_config.token_url)) {
-				setError("oauth_config.token_url", {
-					message: "Token URL must start with http:// or https://",
-				});
-				hasErrors = true;
-			}
-			if (data.oauth_config?.registration_url && !/^https?:\/\/.+$/.test(data.oauth_config.registration_url)) {
-				setError("oauth_config.registration_url", {
-					message: "Registration URL must start with http:// or https://",
-				});
-				hasErrors = true;
-			}
-			if (resourceText.trim() && !isValidOAuthResourceURI(resourceText.trim())) {
-				toast({
-					title: "Invalid resource URI",
-					description: "OAuth resource must be an absolute URI without a fragment.",
-					variant: "destructive",
-				});
-				hasErrors = true;
-			}
+		const isValid = validateMCPClientForm({
+			data,
+			satellites,
+			form: methods,
+			// Transport and target are fixed by the library entry, so their
+			// inputs are read-only and there is nothing for the installer to
+			// get wrong here.
+			skipConnection: true,
+			onToast: (title, description) => toast({ title, description, variant: "destructive" }),
+		});
+		if (!isValid) return;
+		// The headers table renders its own inline error, but a caller can still
+		// reach here with it non-empty; a toast keeps the button from looking inert.
+		if (headersValidationError) {
+			toast({ title: "Headers incomplete", description: headersValidationError, variant: "destructive" });
+			return;
 		}
 
-		if (authType === "per_user_headers") {
-			if (perUserHeaderKeys.length === 0) {
-				toast({
-					title: "Header keys required",
-					description: "Declare at least one header name users must supply.",
-					variant: "destructive",
-				});
-				hasErrors = true;
-			}
-		}
-
-		if (headersValidationError || hasErrors) return;
-
-		const isStdio = server.connection_type === "stdio";
-		const connectionUrl = server.connection_url || "";
-		const stdioConfig =
-			isStdio && server.stdio_config
-				? {
-						command: server.stdio_config.command,
-						args: server.stdio_config.args || [],
-						envs: (server.stdio_config.envs || []).map((name) => {
-							const val = envVars[name]?.trim();
-							return val ? `${name}=${val}` : name;
-						}),
-					}
-				: undefined;
-		const payload: CreateMCPClientRequest = {
-			...data,
-			connection_type: server.connection_type || "http",
-			connection_string: isStdio ? undefined : { value: connectionUrl, ref: "" },
-			stdio_config: stdioConfig,
-			is_code_mode_client: false,
-			is_ping_available: true,
-			tls_config: !isStdio ? buildTLSConfigPayload(data.tls_config) : undefined,
-			oauth_config:
-				authType === "oauth" || authType === "per_user_oauth"
-					? {
-							client_id: data.oauth_config?.client_id ?? emptySecretVar,
-							client_secret:
-								data.oauth_config?.client_secret?.value?.trim() || data.oauth_config?.client_secret?.ref?.trim()
-									? data.oauth_config.client_secret
-									: undefined,
-							authorize_url: data.oauth_config?.authorize_url || undefined,
-							token_url: data.oauth_config?.token_url || undefined,
-							registration_url: data.oauth_config?.registration_url || undefined,
-							scopes: scopesText.trim() ? parseArrayFromText(scopesText) : undefined,
-							server_url: connectionUrl || undefined,
-							resource: resourceText.trim() || undefined,
-						}
-					: undefined,
-			headers:
-				(authType === "headers" || authType === "per_user_headers") && data.headers && Object.keys(data.headers).length > 0
-					? data.headers
-					: undefined,
-			per_user_header_keys: authType === "per_user_headers" ? perUserHeaderKeys : undefined,
-			tools_to_execute: ["*"],
-		};
+		const payload = buildMCPClientPayload(data, satellites);
 
 		// Per-user-headers: stash the payload and open the headers test dialog.
-		if (authType === "per_user_headers") {
+		if (data.auth_type === "per_user_headers") {
 			setHeadersFlow({ payload });
 			return;
 		}
@@ -356,15 +195,12 @@ export function MCPLibraryInstallSheet({ server, open, onClose, onInstalled }: M
 					authorizeUrl: response.authorize_url,
 					oauthConfigId: response.oauth_config_id,
 					mcpClientId: response.mcp_client_id,
-					isPerUserOauth: authType === "per_user_oauth",
+					isPerUserOauth: data.auth_type === "per_user_oauth",
 				});
 				return;
 			}
 
-			toast({
-				title: "Installed",
-				description: `${server.name} MCP server installed.`,
-			});
+			toast({ title: "Installed", description: `${server.name} MCP server installed.` });
 			onInstalled();
 			onClose();
 		} catch (error) {
@@ -373,481 +209,106 @@ export function MCPLibraryInstallSheet({ server, open, onClose, onInstalled }: M
 				setError("name", { message: getErrorMessage(error) });
 				return;
 			}
-			toast({
-				title: "Error",
-				description: getErrorMessage(error),
-				variant: "destructive",
-			});
+			toast({ title: "Error", description: getErrorMessage(error), variant: "destructive" });
 		}
 	};
 
 	const iconUrl = server.icon_url || MCP_ICON_FALLBACK;
-	const isStdio = server.connection_type === "stdio";
 	const isOauth = authType === "oauth" || authType === "per_user_oauth";
 	const isPerUserHeaders = authType === "per_user_headers";
-	const displayUrl =
-		server.connection_url || (server.stdio_config ? `${server.stdio_config.command} ${(server.stdio_config.args || []).join(" ")}` : "—");
 	const installButtonLabel = isOauth || isPerUserHeaders ? "Continue" : "Install";
 
 	return (
 		<Sheet open={open} onOpenChange={(sheetOpen) => !sheetOpen && !oauthFlow && !headersFlow && onClose()}>
-			<SheetContent className="flex w-full flex-col overflow-x-hidden p-0 pt-4 sm:max-w-2xl">
+			<SheetContent className="flex w-full flex-col gap-4 overflow-x-hidden p-0 pt-4">
 				<SheetHeader className="flex flex-col items-start px-0 py-4" headerClassName="mb-0 sticky px-4 md:px-8 -top-4 bg-card z-10">
-					<SheetTitle>Install MCP server</SheetTitle>
-					<SheetDescription>Confirm the catalog configuration before adding this server to Bifrost.</SheetDescription>
+					<SheetTitle>Install MCP Server</SheetTitle>
+					<SheetDescription>Connect this library server to Bifrost and supply the credentials it needs.</SheetDescription>
 				</SheetHeader>
 
-				<Form {...form}>
-					<form onSubmit={handleSubmit(onSubmit)} className="flex min-h-0 flex-1 flex-col">
-						<div className="flex-1 space-y-6 px-4 pt-5 pb-6 md:px-8">
-							<section className="border-b pb-5">
-								<div className="bg-muted/10 flex items-start gap-3 rounded-sm border p-3">
-									<div className="bg-background flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-sm border">
-										<img
-											src={iconUrl}
-											alt=""
-											className="h-full w-full object-contain p-1"
-											onError={(event) => {
-												event.currentTarget.onerror = null;
-												event.currentTarget.src = MCP_ICON_FALLBACK;
-											}}
-										/>
-									</div>
-									<div className="min-w-0 flex-1 space-y-2">
-										<div className="min-w-0">
-											<p className="truncate text-sm font-medium">{server.name}</p>
-											<p className="text-muted-foreground truncate font-mono text-xs">{displayUrl}</p>
-										</div>
-										<div className="flex min-w-0 flex-wrap items-center gap-1.5">
-											<Badge variant="outline" className="bg-background">
-												<TransportIcon connectionType={server.connection_type} />
-												{transportLabel(server.connection_type)}
-											</Badge>
-											<Badge variant="outline" className="bg-background">
-												<ShieldCheck className="size-3.5" />
-												{authLabel(server.auth_type)}
-											</Badge>
-											{server.category && (
-												<Badge variant="secondary" className="max-w-full truncate">
-													{server.category}
-												</Badge>
-											)}
-										</div>
-									</div>
-								</div>
-							</section>
-
-							<section className="space-y-4">
-								<div className="space-y-1">
-									<h3 className="text-sm font-medium">Client details</h3>
-									<p className="text-muted-foreground text-sm">Bifrost uses this name internally when routing MCP tool calls.</p>
-								</div>
-
-								<FormField
-									control={control}
-									name="name"
-									rules={{
-										required: "Server name is required",
-										minLength: {
-											value: 3,
-											message: "Server name must be at least 3 characters",
-										},
-										maxLength: {
-											value: 50,
-											message: "Server name cannot exceed 50 characters",
-										},
-										validate: {
-											format: (value) => /^[a-zA-Z0-9_]+$/.test(value) || "Server name can only contain letters, numbers, and underscores",
-											noLeadingDigit: (value) => !/^[0-9]/.test(value) || "Server name cannot start with a number",
-										},
-									}}
-									render={({ field }) => (
-										<FormItem>
-											<FormLabel>Server name</FormLabel>
-											<FormControl>
-												<Input {...field} data-testid="library-mcp-name-input" maxLength={50} />
-											</FormControl>
-											<FormMessage />
-										</FormItem>
-									)}
-								/>
-							</section>
-
-							{isStdio && server.stdio_config?.envs && server.stdio_config.envs.length > 0 && (
-								<section className="space-y-4 border-t pt-5">
-									<div className="space-y-1">
-										<div className="flex items-center gap-2">
-											<h3 className="text-sm font-medium">Launch environment</h3>
-											<TooltipProvider>
-												<Tooltip>
-													<TooltipTrigger asChild>
-														<Info className="text-muted-foreground h-4 w-4 cursor-help" />
-													</TooltipTrigger>
-													<TooltipContent className="max-w-xs">
-														<p>Leave a value blank to read it from the environment where Bifrost runs.</p>
-													</TooltipContent>
-												</Tooltip>
-											</TooltipProvider>
-										</div>
-										<p className="text-muted-foreground text-sm">Values used when Bifrost starts this stdio MCP server.</p>
-									</div>
-									<HeadersTable
-										value={envVars}
-										onChange={setEnvVars}
-										fixedKeys={server.stdio_config.envs}
-										keyPlaceholder="Variable name"
-										valuePlaceholder="Value (or host env)"
-										label=""
+				<Form {...methods}>
+					<form onSubmit={handleSubmit(onSubmit)} className="flex h-full flex-col gap-6">
+						<div className="grow space-y-4 px-4 md:px-8">
+							{/* Catalog entry being installed */}
+							<div className="bg-muted/10 flex items-start gap-3 rounded-md border p-3">
+								<div className="bg-background flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-sm border">
+									<img
+										src={iconUrl}
+										alt=""
+										className="h-full w-full object-contain p-1"
+										onError={(event) => {
+											event.currentTarget.onerror = null;
+											event.currentTarget.src = MCP_ICON_FALLBACK;
+										}}
 									/>
-								</section>
-							)}
-
-							<section className="space-y-4 border-t pt-5">
-								<div className="space-y-1">
-									<div className="flex items-center gap-2">
-										<KeyRound className="text-muted-foreground size-4" />
-										<h3 className="text-sm font-medium">Authentication</h3>
-									</div>
-									<p className="text-muted-foreground text-sm">{authHelpText(authType)}</p>
 								</div>
+								<div className="min-w-0 flex-1 space-y-2">
+									<div className="min-w-0">
+										<p className="truncate text-sm font-medium">{server.name}</p>
+										<p className="text-muted-foreground line-clamp-2 text-xs">{server.description || "No description available."}</p>
+									</div>
+									<div className="flex min-w-0 flex-wrap items-center gap-1.5">
+										<Badge variant="outline" className="bg-background">
+											{transportIcon(server.connection_type)}
+											{transportLabel(server.connection_type)}
+										</Badge>
+										<Badge variant="outline" className="bg-background">
+											<ShieldCheck className="size-3.5" />
+											{authLabel(server.auth_type)}
+										</Badge>
+										{server.category && (
+											<Badge variant="secondary" className="max-w-full truncate">
+												{server.category}
+											</Badge>
+										)}
+									</div>
+								</div>
+							</div>
 
-								{/* Authentication Type */}
-								<FormItem className="w-full">
-									<FormLabel>Authentication type</FormLabel>
-									<Select value={authKind} onValueChange={(value: "none" | "headers" | "oauth") => applyAuthKind(value)}>
+							{/* Name */}
+							<FormField
+								control={control}
+								name="name"
+								rules={{
+									required: "Server name is required",
+									minLength: { value: 3, message: "Server name must be at least 3 characters" },
+									maxLength: { value: 50, message: "Server name cannot exceed 50 characters" },
+									validate: {
+										format: (v) => /^[a-zA-Z0-9_]+$/.test(v) || "Server name can only contain letters, numbers, and underscores",
+										noLeadingDigit: (v) => !/^[0-9]/.test(v) || "Server name cannot start with a number",
+									},
+								}}
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>Name</FormLabel>
 										<FormControl>
-											<SelectTrigger className="w-full" data-testid="library-auth-type-select">
-												<SelectValue placeholder="Select authentication type" />
-											</SelectTrigger>
+											<Input {...field} data-testid="library-mcp-name-input" placeholder="Server name" maxLength={50} />
 										</FormControl>
-										<SelectContent>
-											<SelectItem value="none" data-testid="library-auth-type-none">
-												None
-											</SelectItem>
-											<SelectItem value="headers" data-testid="library-auth-type-headers">
-												Headers
-											</SelectItem>
-											<SelectItem value="oauth" data-testid="library-auth-type-oauth">
-												OAuth 2.0
-											</SelectItem>
-										</SelectContent>
-									</Select>
-								</FormItem>
-
-								{/* Auth Scope — only meaningful when there's an auth flow */}
-								{authKind !== "none" && (
-									<FormItem className="w-full">
-										<FormLabel>Auth Scope</FormLabel>
-										<Select value={authScope} onValueChange={(value: "shared" | "per_user") => applyAuthScope(value)}>
-											<FormControl>
-												<SelectTrigger className="w-full" data-testid="library-auth-scope-select">
-													<SelectValue placeholder="Select auth scope" />
-												</SelectTrigger>
-											</FormControl>
-											<SelectContent>
-												<SelectItem value="shared" data-testid="library-auth-scope-shared">
-													Shared
-												</SelectItem>
-												<SelectItem value="per_user" data-testid="library-auth-scope-per-user">
-													Per-User
-												</SelectItem>
-											</SelectContent>
-										</Select>
+										<p className="text-muted-foreground text-xs">Bifrost uses this name internally when routing MCP tool calls.</p>
+										<FormMessage />
 									</FormItem>
 								)}
+							/>
 
-								{authType === "headers" && (
-									<FormField
-										control={control}
-										name="headers"
-										render={({ field }) => (
-											<FormItem data-testid="library-mcp-headers-table">
-												<HeadersTable
-													value={field.value || {}}
-													onChange={field.onChange}
-													keyPlaceholder="Header name"
-													valuePlaceholder="Header value"
-													label="Headers"
-													useSecretVarInput
-												/>
-												{headersValidationError && <p className="text-destructive text-xs">{headersValidationError}</p>}
-												<FormMessage />
-											</FormItem>
-										)}
-									/>
-								)}
+							<DottedSeparator />
 
-								{authType === "per_user_headers" && (
-									<div className="space-y-4">
-										{/* Required header keys (admin schema). End users supply values
-										    per-user on install via the MCPHeadersAuthorizer dialog. */}
-										<div className="space-y-1">
-											<div className="space-y-0.5">
-												<div className="text-sm font-medium">Required Headers</div>
-												<p className="text-muted-foreground text-sm">
-													Comma-separated list of header names each caller must supply when they first use this server (e.g.{" "}
-													<code>X-API-Key, X-Tenant-ID</code>). Values are submitted per user - never stored on this server config.
-												</p>
-											</div>
-											<Textarea
-												id="library-per-user-header-keys"
-												data-testid="library-per-user-header-keys-textarea"
-												className="h-24"
-												placeholder="X-API-Key, X-Tenant-ID"
-												value={newHeaderKeyInput}
-												onChange={(e) => {
-													setNewHeaderKeyInput(e.target.value);
-													setPerUserHeaderKeys(parseArrayFromText(e.target.value));
-												}}
-											/>
-										</div>
-
-										{/* Optional static admin headers (e.g. a fixed tenant header) */}
-										<FormField
-											control={control}
-											name="headers"
-											render={({ field }) => (
-												<FormItem>
-													<HeadersTable
-														value={field.value || {}}
-														onChange={field.onChange}
-														keyPlaceholder="Header name"
-														valuePlaceholder="Header value"
-														label="Static Headers (optional, applied alongside user values)"
-														useSecretVarInput
-													/>
-													{headersValidationError && <p className="text-destructive text-xs">{headersValidationError}</p>}
-													<FormMessage />
-												</FormItem>
-											)}
-										/>
-									</div>
-								)}
-
-								{isOauth && (
-									<Accordion type="single" collapsible className="w-full">
-										<AccordionItem value="oauth-advanced" className="border-b-0">
-											<AccordionTrigger className="py-0" data-testid="library-oauth-advanced-trigger">
-												<span className="text-sm font-medium">OAuth Client Advanced Settings</span>
-											</AccordionTrigger>
-											<AccordionContent className="space-y-4 pt-4 pb-0">
-												<FormField
-													control={control}
-													name="oauth_config.client_id"
-													render={({ field }) => (
-														<FormItem>
-															<div className="flex items-center gap-2">
-																<FormLabel>OAuth client ID</FormLabel>
-																<TooltipProvider>
-																	<Tooltip>
-																		<TooltipTrigger asChild>
-																			<Info className="text-muted-foreground h-4 w-4 cursor-help" />
-																		</TooltipTrigger>
-																		<TooltipContent className="max-w-xs">
-																			<p>Leave empty to use Dynamic Client Registration when the provider supports it.</p>
-																		</TooltipContent>
-																	</Tooltip>
-																</TooltipProvider>
-															</div>
-															<FormControl>
-																<SecretVarInput
-																	value={field.value}
-																	onChange={field.onChange}
-																	placeholder="your-client-id"
-																	data-testid="library-oauth-client-id"
-																/>
-															</FormControl>
-															<FormMessage />
-														</FormItem>
-													)}
-												/>
-
-												<FormField
-													control={control}
-													name="oauth_config.client_secret"
-													render={({ field }) => (
-														<FormItem>
-															<FormLabel>OAuth client secret</FormLabel>
-															<FormControl>
-																<SecretVarInput
-																	value={field.value}
-																	onChange={field.onChange}
-																	placeholder="optional for PKCE"
-																	hideValueWhenEnv
-																	maskNonEnvValue
-																	data-testid="library-oauth-client-secret"
-																/>
-															</FormControl>
-															<FormMessage />
-														</FormItem>
-													)}
-												/>
-
-												<div className="grid gap-4 sm:grid-cols-2">
-													<FormField
-														control={control}
-														name="oauth_config.authorize_url"
-														render={({ field }) => (
-															<FormItem>
-																<FormLabel>Authorization URL</FormLabel>
-																<FormControl>
-																	<Input
-																		{...field}
-																		value={field.value ?? ""}
-																		onChange={(event) => {
-																			field.onChange(event);
-																			clearErrors("oauth_config.authorize_url");
-																		}}
-																		placeholder="Auto-discovered"
-																		data-testid="library-oauth-authorize-url"
-																	/>
-																</FormControl>
-																<FormMessage />
-															</FormItem>
-														)}
-													/>
-
-													<FormField
-														control={control}
-														name="oauth_config.token_url"
-														render={({ field }) => (
-															<FormItem>
-																<FormLabel>Token URL</FormLabel>
-																<FormControl>
-																	<Input
-																		{...field}
-																		value={field.value ?? ""}
-																		onChange={(event) => {
-																			field.onChange(event);
-																			clearErrors("oauth_config.token_url");
-																		}}
-																		placeholder="Auto-discovered"
-																		data-testid="library-oauth-token-url"
-																	/>
-																</FormControl>
-																<FormMessage />
-															</FormItem>
-														)}
-													/>
-												</div>
-
-												<FormField
-													control={control}
-													name="oauth_config.registration_url"
-													render={({ field }) => (
-														<FormItem>
-															<FormLabel>Registration URL</FormLabel>
-															<FormControl>
-																<Input
-																	{...field}
-																	value={field.value ?? ""}
-																	onChange={(event) => {
-																		field.onChange(event);
-																		clearErrors("oauth_config.registration_url");
-																	}}
-																	placeholder="Auto-discovered"
-																	data-testid="library-oauth-registration-url"
-																/>
-															</FormControl>
-															<FormMessage />
-														</FormItem>
-													)}
-												/>
-
-												<div className="space-y-2">
-													<Label>Scopes</Label>
-													<Input
-														value={scopesText}
-														onChange={(event) => setScopesText(event.target.value)}
-														placeholder="read, write, admin"
-														data-testid="library-oauth-scopes-input"
-													/>
-												</div>
-												<div className="space-y-2">
-													<Label>Resource</Label>
-													<Input
-														value={resourceText}
-														onChange={(event) => setResourceText(event.target.value)}
-														placeholder="https://provider.example.com/mcp or urn:example:mcp"
-														data-testid="library-oauth-resource-input"
-													/>
-												</div>
-											</AccordionContent>
-										</AccordionItem>
-									</Accordion>
-								)}
-
-								{/* TLS / Certificate — only for remote (HTTP/SSE) connections */}
-								{!isStdio && (
-									<Accordion type="single" collapsible className="w-full">
-										<AccordionItem value="tls-config" className="border-b-0">
-											<AccordionTrigger className="py-0" data-testid="library-tls-config-trigger">
-												<span className="text-sm font-medium">TLS / Certificate</span>
-											</AccordionTrigger>
-											<AccordionContent className="space-y-4 pt-4 pb-0">
-												<FormField
-													control={control}
-													name="tls_config.insecure_skip_verify"
-													render={({ field }) => (
-														<FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
-															<div className="space-y-0.5">
-																<FormLabel>Skip TLS verification</FormLabel>
-																<p className="text-muted-foreground text-sm">
-																	Disable TLS certificate verification. Use only in trusted isolated environments. Takes priority over CA
-																	certificate.
-																</p>
-															</div>
-															<FormControl>
-																<Switch
-																	checked={field.value ?? false}
-																	onCheckedChange={field.onChange}
-																	data-testid="library-mcp-tls-insecure-skip-verify"
-																/>
-															</FormControl>
-														</FormItem>
-													)}
-												/>
-												<FormField
-													control={control}
-													name="tls_config.ca_cert_pem"
-													render={({ field }) => (
-														<FormItem>
-															<FormLabel>CA Certificate (PEM) (Optional)</FormLabel>
-															<FormControl>
-																<SecretVarInput
-																	variant="textarea"
-																	placeholder={`-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE----- or env.MCP_CA_CERT_PEM`}
-																	className="font-mono text-xs"
-																	rows={6}
-																	hideValueWhenEnv
-																	redactNonEnvValue
-																	{...field}
-																	value={field.value}
-																	data-testid="library-mcp-tls-ca-cert-pem"
-																/>
-															</FormControl>
-															<p className="text-muted-foreground text-sm">
-																PEM-encoded CA certificate to trust for MCP server connections (e.g. self-signed or private CA).
-															</p>
-															<FormMessage />
-														</FormItem>
-													)}
-												/>
-											</AccordionContent>
-										</AccordionItem>
-									</Accordion>
-								)}
-							</section>
+							<MCPClientFormFields
+								form={methods}
+								satellites={satellites}
+								headersValidationError={headersValidationError}
+								lockConnection
+								stdioEnvKeys={stdioEnvKeys}
+							/>
 						</div>
 
-						<div className="border-border bg-card sticky bottom-0 z-10 border-t px-4 py-4 md:px-8">
+						<div className="bg-card sticky bottom-0 z-10 border-t px-4 py-4 md:px-8">
 							<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-								<p className="text-muted-foreground text-sm">
+								<p className="text-muted-foreground text-xs">
 									{isOauth
 										? "OAuth authorization starts after this step."
 										: isPerUserHeaders
 											? "Header verification starts after this step."
-											: "All discovered tools will be enabled after install."}
+											: `${authHelpText(authType)} All discovered tools will be enabled after install.`}
 								</p>
 								<div className="flex justify-end gap-2">
 									<Button type="button" variant="outline" onClick={onClose} disabled={isLoading} data-testid="library-install-cancel-btn">
@@ -869,7 +330,7 @@ export function MCPLibraryInstallSheet({ server, open, onClose, onInstalled }: M
 											</TooltipTrigger>
 											{!hasCreateMCPClientAccess && (
 												<TooltipContent>
-													<p>You don't have permission to perform this action</p>
+													<p>You don&apos;t have permission to perform this action</p>
 												</TooltipContent>
 											)}
 										</Tooltip>
@@ -886,20 +347,13 @@ export function MCPLibraryInstallSheet({ server, open, onClose, onInstalled }: M
 					open={!!oauthFlow}
 					onClose={() => setOauthFlow(null)}
 					onSuccess={() => {
-						toast({
-							title: "Installed",
-							description: `${server.name} MCP server connected with OAuth.`,
-						});
+						toast({ title: "Installed", description: `${server.name} MCP server connected with OAuth.` });
 						setOauthFlow(null);
 						onInstalled();
 						onClose();
 					}}
 					onError={(error) => {
-						toast({
-							title: "OAuth Error",
-							description: error,
-							variant: "destructive",
-						});
+						toast({ title: "OAuth Error", description: error, variant: "destructive" });
 					}}
 					onConflict={(error) => {
 						setOauthFlow(null);
@@ -912,19 +366,13 @@ export function MCPLibraryInstallSheet({ server, open, onClose, onInstalled }: M
 				/>
 			)}
 
-			{/* Per-user-headers create dialog. Collects sample values inline,
-			    then calls POST /api/mcp/client once — the server verifies
-			    upstream + discovers tools + persists atomically. */}
 			{headersFlow && (
 				<MCPHeadersAuthorizer
 					open={!!headersFlow}
 					onClose={() => setHeadersFlow(null)}
 					onSuccess={() => {
 						setHeadersFlow(null);
-						toast({
-							title: "Installed",
-							description: `${server.name} MCP server connected with per-user headers.`,
-						});
+						toast({ title: "Installed", description: `${server.name} MCP server connected with per-user headers.` });
 						onInstalled();
 						onClose();
 					}}
@@ -935,7 +383,7 @@ export function MCPLibraryInstallSheet({ server, open, onClose, onInstalled }: M
 						setHeadersFlow(null);
 						setError("name", { message: error });
 					}}
-					perUserHeaderKeys={perUserHeaderKeys}
+					perUserHeaderKeys={satellites.perUserHeaderKeys}
 					submitHandler={async (values) => {
 						await createMCPClient({ ...headersFlow.payload, user_headers: values }).unwrap();
 					}}

--- a/ui/app/workspace/mcp-registry/library/views/mcpLibraryServerCard.tsx
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibraryServerCard.tsx
@@ -48,6 +48,8 @@ export function authLabel(authType?: string): string {
 			return "User headers";
 		case "per_user_oauth":
 			return "User OAuth";
+		case "token_exchange":
+			return "Token exchange";
 		default:
 			return "No auth";
 	}

--- a/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
@@ -1,31 +1,24 @@
 import { Button } from "@/components/ui/button";
-import { SecretVarInput } from "@/components/ui/secretVarInput";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
-import { HeadersTable } from "@/components/ui/headersTable";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { DottedSeparator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
-import { Switch } from "@/components/ui/switch";
-import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useToast } from "@/hooks/use-toast";
 import { getErrorMessage, useCreateMCPClientMutation } from "@/lib/store";
-import { CreateMCPClientRequest, SecretVar, MCPAuthType, MCPConnectionType, MCPStdioConfig, MCPTLSConfig } from "@/lib/types/mcp";
-import { parseArrayFromText } from "@/lib/utils/array";
-import { IS_ENTERPRISE } from "@/lib/constants/config";
+import { CreateMCPClientRequest, SecretVar, MCPStdioConfig } from "@/lib/types/mcp";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { useGetSCIMProvidersQuery } from "@enterprise/lib/store/apis/scimApi";
-import { Info } from "lucide-react";
 import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
+import {
+	buildMCPClientPayload,
+	getHeadersValidationError,
+	MCPClientFormFields,
+	useMCPClientFormSatellites,
+	validateMCPClientForm,
+} from "./mcpClientFormFields";
 import { MCPHeadersAuthorizer } from "./mcpHeadersAuthorizer";
-import { OAuthAdvancedFields } from "./oauthAdvancedFields";
 import { OAuth2Authorizer } from "./oauth2Authorizer";
-import { SectionHeader } from "./sectionHeader";
-import { TLSConfigFields } from "./tlsConfigFields";
-import { TokenExchangeFields } from "./tokenExchangeFields";
 
 interface ClientFormProps {
 	open: boolean;
@@ -41,15 +34,6 @@ const emptyStdioConfig: MCPStdioConfig = {
 
 const emptySecretVar: SecretVar = { value: "", ref: "" };
 
-/** Strips empty TLS config so we don't send `{}` to the server. */
-function buildTLSConfigPayload(tls: MCPTLSConfig | undefined): MCPTLSConfig | undefined {
-	if (!tls) return undefined;
-	const hasSkipVerify = tls.insecure_skip_verify === true;
-	const hasCACert = tls.ca_cert_pem?.value || tls.ca_cert_pem?.type === "env" || tls.ca_cert_pem?.type === "vault";
-	if (!hasSkipVerify && !hasCACert) return undefined;
-	return { insecure_skip_verify: tls.insecure_skip_verify, ca_cert_pem: hasCACert ? tls.ca_cert_pem : undefined };
-}
-
 const emptyForm: CreateMCPClientRequest = {
 	name: "",
 	is_code_mode_client: false,
@@ -60,40 +44,12 @@ const emptyForm: CreateMCPClientRequest = {
 	auth_type: "none",
 };
 
-function isValidOAuthResourceURI(value: string): boolean {
-	try {
-		const parsed = new URL(value);
-		return parsed.protocol !== "" && parsed.hash === "";
-	} catch {
-		return false;
-	}
-}
-
 const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 	const hasCreateMCPClientAccess = useRbac(RbacResource.MCPGateway, RbacOperation.Create);
 	const { toast } = useToast();
 	const [createMCPClient] = useCreateMCPClientMutation();
 
-	// Token exchange is backed by the deployment's identity-provider
-	// integration, so the option only renders when one is enabled. The exact
-	// exchange-client requirement is enforced server-side at create; a missing
-	// tokenExchangeClient section surfaces as the create error.
-	const { data: scimProviders } = useGetSCIMProvidersQuery(undefined, { skip: !IS_ENTERPRISE });
-	const enabledScimProvider = scimProviders?.find((p) => (p as { enabled?: boolean }).enabled) as { name?: string } | undefined;
-	const idpConfigured = !!enabledScimProvider;
-	// Entra's on-behalf-of grant requires use_idp_credentials — see the
-	// Prerequisites warning in docs/mcp/auth/token-exchange.mdx for why a
-	// dedicated exchange app structurally can't work there.
-	const isEntraIdp = ["entra", "azure", "azuread"].includes((enabledScimProvider?.name ?? "").toLowerCase());
-
 	const [isLoading, setIsLoading] = useState(false);
-	const [argsText, setArgsText] = useState("");
-	// STDIO env vars as a name→value map. Empty value = pass the bare name so the
-	// stdio process reads it from Bifrost's host environment.
-	const [envVars, setEnvVars] = useState<Record<string, string>>({});
-	const [scopesText, setScopesText] = useState("");
-	const [tokenExchangeScopesText, setTokenExchangeScopesText] = useState("");
-	const [resourceText, setResourceText] = useState("");
 	const [oauthFlow, setOauthFlow] = useState<{
 		authorizeUrl: string;
 		oauthConfigId: string;
@@ -101,250 +57,53 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 		isPerUserOauth?: boolean;
 	} | null>(null);
 
-	// Per-user-headers admin flow: admin declares the required key names
-	// (perUserHeaderKeys), then on Create the MCPHeadersAuthorizer dialog
-	// runs a sample-values verify and returns discovered tools. The form
-	// then persists the MCP client with those tools attached — first-time
-	// end users skip re-discovery that way. Mirrors the OAuth2Authorizer
-	// flow exactly: nothing is persisted until the test succeeds.
-	const [perUserHeaderKeys, setPerUserHeaderKeys] = useState<string[]>([]);
-	const [newHeaderKeyInput, setNewHeaderKeyInput] = useState("");
+	// Per-user-headers admin flow: admin declares the required key names, then
+	// on Create the MCPHeadersAuthorizer dialog runs a sample-values verify and
+	// returns discovered tools. The form then persists the MCP client with those
+	// tools attached — first-time end users skip re-discovery that way. Mirrors
+	// the OAuth2Authorizer flow exactly: nothing is persisted until the test
+	// succeeds.
 	const [headersFlow, setHeadersFlow] = useState<{ payload: CreateMCPClientRequest } | null>(null);
 
-	// UI splits the canonical `auth_type` into two dropdowns:
-	//   - authKind: none | headers | oauth | token_exchange
-	//   - authScope: shared | per_user (hidden when authKind is none or
-	//     token_exchange — exchange is inherently per-caller, with no shared
-	//     variant to scope)
-	// They recombine into the wire `auth_type` ("oauth", "per_user_oauth",
-	// "headers", "per_user_headers", "token_exchange", "none") so the backend
-	// contract is unchanged.
-	const [authScope, setAuthScope] = useState<"shared" | "per_user">("shared");
-
 	const methods = useForm<CreateMCPClientRequest>({ defaultValues: emptyForm });
-	const { control, handleSubmit, setValue, watch, reset, setError, clearErrors } = methods;
+	const { control, handleSubmit, watch, reset, setError } = methods;
+	const satellites = useMCPClientFormSatellites();
 
 	const connectionType = watch("connection_type");
 	const authType = watch("auth_type");
 	const headers = watch("headers");
 
-	const authKind: "none" | "headers" | "oauth" | "token_exchange" =
-		authType === "oauth" || authType === "per_user_oauth"
-			? "oauth"
-			: authType === "headers" || authType === "per_user_headers"
-				? "headers"
-				: authType === "token_exchange"
-					? "token_exchange"
-					: "none";
+	const headersValidationError =
+		connectionType === "http" || connectionType === "sse" ? getHeadersValidationError(authType, headers) : null;
 
-	const applyAuthKind = (kind: "none" | "headers" | "oauth" | "token_exchange") => {
-		if (kind === "none" || kind === "token_exchange") {
-			setValue("auth_type", kind);
-			return;
-		}
-		if (kind === "oauth") {
-			setValue("auth_type", authScope === "per_user" ? "per_user_oauth" : "oauth");
-			return;
-		}
-		setValue("auth_type", authScope === "per_user" ? "per_user_headers" : "headers");
-	};
-
-	const applyAuthScope = (scope: "shared" | "per_user") => {
-		setAuthScope(scope);
-		if (authKind === "oauth") {
-			setValue("auth_type", scope === "per_user" ? "per_user_oauth" : "oauth");
-		} else if (authKind === "headers") {
-			setValue("auth_type", scope === "per_user" ? "per_user_headers" : "headers");
-		}
-	};
-
-	// Inline header validation (shown live as user edits headers).
-	// Both "headers" and "per_user_headers" auth types persist the static
-	// headers map via the submit path (see "headers" property of payload
-	// below), so the validation gate must cover both — otherwise an empty
-	// static header in the per-user flow slips past client validation and
-	// opens MCPHeadersAuthorizer with an invalid config the server has to
-	// reject.
-	let headersValidationError: string | null = null;
-	if ((connectionType === "http" || connectionType === "sse") && (authType === "headers" || authType === "per_user_headers") && headers) {
-		for (const [key, secretVar] of Object.entries(headers)) {
-			if (!secretVar.value && !secretVar.ref) {
-				headersValidationError = `Header "${key}" must have a value`;
-				break;
-			}
-		}
-	}
-
-	// Reset form state when dialog opens
+	// Reset form state when the sheet opens
+	const { reset: resetSatellites } = satellites;
 	useEffect(() => {
-		if (open) {
-			reset(emptyForm);
-			setArgsText("");
-			setEnvVars({});
-			setScopesText("");
-			setTokenExchangeScopesText("");
-			setResourceText("");
-			setOauthFlow(null);
-			setHeadersFlow(null);
-			setPerUserHeaderKeys([]);
-			setNewHeaderKeyInput("");
-			setAuthScope("shared");
-			setIsLoading(false);
-		}
-	}, [open, reset]);
+		if (!open) return;
+		reset(emptyForm);
+		resetSatellites();
+		setOauthFlow(null);
+		setHeadersFlow(null);
+		setIsLoading(false);
+	}, [open, reset, resetSatellites]);
 
 	const onSubmit = async (data: CreateMCPClientRequest) => {
-		let hasErrors = false;
-
-		if (connectionType === "http" || connectionType === "sse") {
-			const connVal = data.connection_string?.value?.trim() || "";
-			const connRef = data.connection_string?.ref?.trim() || "";
-			const isSecret = data.connection_string?.type === "env" || data.connection_string?.type === "vault";
-			if (!connVal && !connRef) {
-				setError("connection_string", { message: "Connection URL is required" });
-				hasErrors = true;
-			} else if (!isSecret && connVal && !/^https?:\/\/.+/.test(connVal)) {
-				setError("connection_string", {
-					message: "Connection URL must start with http:// or https://",
-				});
-				hasErrors = true;
-			}
-		}
-
-		if (connectionType === "stdio") {
-			const cmd = data.stdio_config?.command || "";
-			if (!cmd.trim()) {
-				setError("stdio_config.command", { message: "Command is required for STDIO connections" });
-				hasErrors = true;
-			} else if (/[<>|&;]/.test(cmd)) {
-				setError("stdio_config.command", { message: "Command cannot contain special shell characters" });
-				hasErrors = true;
-			}
-		}
-
-		if (authType === "oauth" || authType === "per_user_oauth") {
-			if (data.oauth_config?.authorize_url && !/^https?:\/\/.+$/.test(data.oauth_config.authorize_url)) {
-				setError("oauth_config.authorize_url", { message: "Authorize URL must start with http:// or https://" });
-				hasErrors = true;
-			}
-			if (data.oauth_config?.token_url && !/^https?:\/\/.+$/.test(data.oauth_config.token_url)) {
-				setError("oauth_config.token_url", { message: "Token URL must start with http:// or https://" });
-				hasErrors = true;
-			}
-			if (data.oauth_config?.registration_url && !/^https?:\/\/.+$/.test(data.oauth_config.registration_url)) {
-				setError("oauth_config.registration_url", { message: "Registration URL must start with http:// or https://" });
-				hasErrors = true;
-			}
-			if (resourceText.trim() && !isValidOAuthResourceURI(resourceText.trim())) {
-				toast({
-					title: "Invalid resource URI",
-					description: "OAuth resource must be an absolute URI without a fragment.",
-					variant: "destructive",
-				});
-				hasErrors = true;
-			}
-		}
-
-		if (authType === "token_exchange") {
-			const audience = data.token_exchange?.audience?.trim() || "";
-			if (!audience) {
-				setError("token_exchange.audience", { message: "Audience is required for token exchange" });
-				hasErrors = true;
-			}
-			if (!data.token_exchange?.use_idp_credentials) {
-				const exchangeClientId = data.token_exchange?.client_id;
-				if (!exchangeClientId?.value && !exchangeClientId?.ref) {
-					setError("token_exchange.client_id", { message: "Exchange client ID is required for token exchange" });
-					hasErrors = true;
-				}
-			}
-		}
-
-		if (authType === "per_user_headers") {
-			if (perUserHeaderKeys.length === 0) {
-				toast({
-					title: "Header keys required",
-					description: "Declare at least one header name users must supply.",
-					variant: "destructive",
-				});
-				hasErrors = true;
-			}
-		}
-
-		if (headersValidationError || hasErrors) return;
+		const isValid = validateMCPClientForm({
+			data,
+			satellites,
+			form: methods,
+			onToast: (title, description) => toast({ title, description, variant: "destructive" }),
+		});
+		if (!isValid || headersValidationError) return;
 
 		setIsLoading(true);
+		const payload = buildMCPClientPayload(data, satellites);
 
-		const payload: CreateMCPClientRequest = {
-			...data,
-			stdio_config:
-				connectionType === "stdio"
-					? {
-							command: data.stdio_config?.command || "",
-							args: parseArrayFromText(argsText),
-							// Each row becomes KEY=value, or a bare KEY when no value is given
-							// (read from Bifrost's host environment). Rows without a name are skipped.
-							envs: Object.entries(envVars)
-								.filter(([name]) => name.trim() !== "")
-								.map(([name, value]) => {
-									const v = value.trim();
-									return v ? `${name}=${v}` : name;
-								}),
-						}
-					: undefined,
-			tls_config: connectionType === "http" || connectionType === "sse" ? buildTLSConfigPayload(data.tls_config) : undefined,
-			oauth_config:
-				authType === "oauth" || authType === "per_user_oauth"
-					? {
-							client_id: data.oauth_config?.client_id ?? emptySecretVar,
-							client_secret:
-								data.oauth_config?.client_secret?.value ||
-								data.oauth_config?.client_secret?.type === "env" ||
-								data.oauth_config?.client_secret?.type === "vault"
-									? data.oauth_config.client_secret
-									: undefined,
-							authorize_url: data.oauth_config?.authorize_url || undefined,
-							token_url: data.oauth_config?.token_url || undefined,
-							registration_url: data.oauth_config?.registration_url || undefined,
-							scopes: scopesText.trim() ? parseArrayFromText(scopesText) : undefined,
-							server_url: data.connection_string?.value || undefined,
-							resource: resourceText.trim() || undefined,
-						}
-					: undefined,
-			// "headers" and "per_user_headers" both can carry static admin
-			// headers on data.headers (per-user values are submitted
-			// separately by end users). Persist when present.
-			headers:
-				(authType === "headers" || authType === "per_user_headers") && data.headers && Object.keys(data.headers).length > 0
-					? data.headers
-					: undefined,
-			per_user_header_keys: authType === "per_user_headers" ? perUserHeaderKeys : undefined,
-			token_exchange:
-				authType === "token_exchange"
-					? {
-							audience: data.token_exchange?.audience?.trim() || "",
-							use_idp_credentials: data.token_exchange?.use_idp_credentials || undefined,
-							client_id: data.token_exchange?.use_idp_credentials ? undefined : (data.token_exchange?.client_id ?? emptySecretVar),
-							client_secret: data.token_exchange?.use_idp_credentials
-								? undefined
-								: data.token_exchange?.client_secret?.value ||
-									  data.token_exchange?.client_secret?.type === "env" ||
-									  data.token_exchange?.client_secret?.type === "vault"
-									? data.token_exchange.client_secret
-									: undefined,
-							scopes: tokenExchangeScopesText.trim() ? parseArrayFromText(tokenExchangeScopesText) : undefined,
-							authorization_server_url: data.token_exchange?.authorization_server_url?.trim() || undefined,
-						}
-					: undefined,
-			tools_to_execute: ["*"],
-		};
-
-		// Per-user-headers: stash the payload and open the headers test
-		// dialog. The dialog collects sample values and POSTs once to
-		// /api/mcp/client where the server verifies, discovers tools,
-		// and persists in a single round-trip. Mirrors the per-user
-		// OAuth flow's single-call shape.
-		if (authType === "per_user_headers") {
+		// Per-user-headers: stash the payload and open the headers test dialog.
+		// The dialog collects sample values and POSTs once to /api/mcp/client
+		// where the server verifies, discovers tools, and persists in a single
+		// round-trip. Mirrors the per-user OAuth flow's single-call shape.
+		if (data.auth_type === "per_user_headers") {
 			setIsLoading(false);
 			setHeadersFlow({ payload });
 			return;
@@ -359,7 +118,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 					authorizeUrl: response.authorize_url,
 					oauthConfigId: response.oauth_config_id,
 					mcpClientId: response.mcp_client_id,
-					isPerUserOauth: authType === "per_user_oauth",
+					isPerUserOauth: data.auth_type === "per_user_oauth",
 				});
 			} else {
 				setIsLoading(false);
@@ -414,568 +173,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 
 							<DottedSeparator />
 
-							{/* Server Behavior */}
-							<div className="space-y-4">
-								<SectionHeader title="Server Behavior" description="Control how this server participates in code mode and health checks." />
-								<div className="divide-y rounded-md border">
-									<FormField
-										control={control}
-										name="is_code_mode_client"
-										render={({ field }) => (
-											<FormItem className="flex flex-row items-center justify-between gap-4 px-4 py-3">
-												<div className="flex items-center gap-2">
-													<FormLabel htmlFor="code-mode">Code Mode Server</FormLabel>
-													<TooltipProvider>
-														<Tooltip>
-															<TooltipTrigger asChild>
-																<a
-																	href="https://docs.getbifrost.ai/mcp/code-mode"
-																	target="_blank"
-																	rel="noopener noreferrer"
-																	data-testid="code-mode-link-help"
-																	className="text-muted-foreground hover:text-foreground focus-visible:ring-ring rounded focus-visible:ring-2 focus-visible:outline-none"
-																	aria-label="Learn more about Code Mode"
-																>
-																	<Info className="h-4 w-4 cursor-help" />
-																</a>
-															</TooltipTrigger>
-															<TooltipContent>
-																<p>Click to learn more about Code Mode</p>
-															</TooltipContent>
-														</Tooltip>
-													</TooltipProvider>
-												</div>
-												<FormControl>
-													<Switch
-														id="code-mode"
-														data-testid="code-mode-switch"
-														checked={field.value || false}
-														onCheckedChange={field.onChange}
-													/>
-												</FormControl>
-											</FormItem>
-										)}
-									/>
-									<FormField
-										control={control}
-										name="is_ping_available"
-										render={({ field }) => (
-											<FormItem className="flex flex-row items-center justify-between gap-4 px-4 py-3">
-												<div className="flex items-center gap-2">
-													<FormLabel htmlFor="ping-available">Ping Available for Health Check</FormLabel>
-													<TooltipProvider>
-														<Tooltip>
-															<TooltipTrigger asChild>
-																<Info className="text-muted-foreground h-4 w-4 cursor-help" />
-															</TooltipTrigger>
-															<TooltipContent className="max-w-xs">
-																<p>
-																	Enable to use lightweight ping method for health checks. Disable if your MCP server doesn't support ping -
-																	will use listTools instead.
-																</p>
-															</TooltipContent>
-														</Tooltip>
-													</TooltipProvider>
-												</div>
-												<FormControl>
-													<Switch
-														id="ping-available"
-														data-testid="mcp-is-ping-available"
-														checked={field.value === true}
-														onCheckedChange={field.onChange}
-													/>
-												</FormControl>
-											</FormItem>
-										)}
-									/>
-									{connectionType === "http" &&
-										authType !== "per_user_oauth" &&
-										authType !== "per_user_headers" &&
-										authType !== "token_exchange" && (
-											<FormField
-												control={control}
-												name="needs_session_stickiness"
-												render={({ field }) => (
-													<FormItem className="flex flex-row items-center justify-between gap-4 px-4 py-3">
-														<div className="flex items-center gap-2">
-															<FormLabel htmlFor="needs-session-stickiness">Maintain Persistent Connection</FormLabel>
-															<TooltipProvider>
-																<Tooltip>
-																	<TooltipTrigger asChild>
-																		<Info className="text-muted-foreground h-4 w-4 cursor-help" />
-																	</TooltipTrigger>
-																	<TooltipContent className="max-w-xs">
-																		<p>
-																			Enable to keep one shared connection open and reused across every caller. Disable to connect fresh on
-																			every call instead, same as per-user auth types. Only applies to HTTP connections; SSE and STDIO
-																			always keep a persistent connection.
-																		</p>
-																	</TooltipContent>
-																</Tooltip>
-															</TooltipProvider>
-														</div>
-														<FormControl>
-															<Switch
-																id="needs-session-stickiness"
-																data-testid="mcp-needs-session-stickiness"
-																checked={field.value === true}
-																onCheckedChange={field.onChange}
-															/>
-														</FormControl>
-													</FormItem>
-												)}
-											/>
-										)}
-								</div>
-							</div>
-
-							<DottedSeparator />
-
-							{/* Connection & Authentication */}
-							<div className="space-y-4">
-								<SectionHeader
-									title="Connection & Authentication"
-									description="Choose how Bifrost connects to this server and, for network transports, how requests are authenticated."
-								/>
-								<div className="space-y-4 rounded-md border p-4">
-									<FormField
-										control={control}
-										name="connection_type"
-										render={({ field }) => (
-											<FormItem className="w-full">
-												<FormLabel>Connection Type</FormLabel>
-												<Select
-													value={field.value}
-													onValueChange={(value: MCPConnectionType) => {
-														field.onChange(value);
-														if (value === "stdio") {
-															setValue("auth_type", "none");
-															setValue("headers", undefined);
-															setValue("oauth_config", undefined);
-														}
-														// needs_session_stickiness=false is rejected for
-														// non-http connection types; SSE/STDIO always keep
-														// a persistent connection regardless, so drop any
-														// explicit false picked while http was selected.
-														if (value !== "http") {
-															setValue("needs_session_stickiness", undefined);
-														}
-														clearErrors();
-													}}
-												>
-													<FormControl>
-														<SelectTrigger className="w-full" data-testid="connection-type-select">
-															<SelectValue placeholder="Select connection type" />
-														</SelectTrigger>
-													</FormControl>
-													<SelectContent>
-														<SelectItem value="http" data-testid="connection-type-http">
-															HTTP (Streamable)
-														</SelectItem>
-														<SelectItem value="sse" data-testid="connection-type-sse">
-															Server-Sent Events (SSE)
-														</SelectItem>
-														<SelectItem value="stdio" data-testid="connection-type-stdio">
-															STDIO
-														</SelectItem>
-													</SelectContent>
-												</Select>
-												<p className="text-muted-foreground text-xs">
-													Connection type and authentication settings cannot be changed later.
-												</p>
-												<FormMessage />
-											</FormItem>
-										)}
-									/>
-
-									{(connectionType === "http" || connectionType === "sse") && (
-										<>
-											{/* Connection URL */}
-											<FormField
-												control={control}
-												name="connection_string"
-												render={({ field }) => (
-													<FormItem>
-														<FormLabel>Connection URL</FormLabel>
-														<SecretVarInput
-															value={field.value}
-															onChange={(value) => {
-																field.onChange(value);
-																clearErrors("connection_string");
-															}}
-															placeholder="http://your-mcp-server:3000 or env.MCP_SERVER_URL"
-															data-testid="connection-url-input"
-														/>
-														<FormMessage />
-													</FormItem>
-												)}
-											/>
-
-											{/* Auth Type */}
-											<FormItem className="w-full">
-												<FormLabel>Authentication Type</FormLabel>
-												<Select value={authKind} onValueChange={(value: "none" | "headers" | "oauth") => applyAuthKind(value)}>
-													<FormControl>
-														<SelectTrigger className="w-full" data-testid="auth-type-select">
-															<SelectValue placeholder="Select authentication type" />
-														</SelectTrigger>
-													</FormControl>
-													<SelectContent>
-														<SelectItem value="none" data-testid="auth-type-none">
-															None
-														</SelectItem>
-														<SelectItem value="headers" data-testid="auth-type-headers">
-															Headers
-														</SelectItem>
-														<SelectItem value="oauth" data-testid="auth-type-oauth">
-															OAuth 2.0
-														</SelectItem>
-														{IS_ENTERPRISE && idpConfigured && (
-															<SelectItem value="token_exchange" data-testid="auth-type-token-exchange">
-																Token Exchange (On-Behalf-Of)
-															</SelectItem>
-														)}
-													</SelectContent>
-												</Select>
-											</FormItem>
-
-											{/* Auth Scope — only meaningful when there's an auth flow with a
-											    shared variant; token exchange is inherently per-caller */}
-											{authKind !== "none" && authKind !== "token_exchange" && (
-												<FormItem className="w-full">
-													<FormLabel>Auth Scope</FormLabel>
-													<Select value={authScope} onValueChange={(value: "shared" | "per_user") => applyAuthScope(value)}>
-														<FormControl>
-															<SelectTrigger className="w-full" data-testid="auth-scope-select">
-																<SelectValue placeholder="Select auth scope" />
-															</SelectTrigger>
-														</FormControl>
-														<SelectContent>
-															<SelectItem value="shared" data-testid="auth-scope-shared">
-																Shared
-															</SelectItem>
-															<SelectItem value="per_user" data-testid="auth-scope-per-user">
-																Per-User
-															</SelectItem>
-														</SelectContent>
-													</Select>
-												</FormItem>
-											)}
-										</>
-									)}
-								</div>
-							</div>
-
-							{(connectionType === "http" || connectionType === "sse") && (
-								<>
-									{authType === "headers" && (
-										<>
-											<DottedSeparator />
-											<div className="space-y-4">
-												<SectionHeader title="Headers" description="Static headers sent with every request to this server." />
-												<FormField
-													control={control}
-													name="headers"
-													render={({ field }) => (
-														<FormItem data-testid="mcp-headers-table">
-															<HeadersTable
-																value={field.value || {}}
-																onChange={field.onChange}
-																keyPlaceholder="Header name"
-																valuePlaceholder="Header value"
-																label=""
-																useSecretVarInput
-															/>
-															{headersValidationError && <p className="text-destructive text-xs">{headersValidationError}</p>}
-															<FormMessage />
-														</FormItem>
-													)}
-												/>
-											</div>
-										</>
-									)}
-
-									{authType === "per_user_headers" && (
-										<>
-											<DottedSeparator />
-											<div className="space-y-4">
-												{/* Required header keys (admin schema). Same Textarea +
-												    comma-separated pattern as workspace/config security
-												    Required Headers, so the two surfaces stay visually
-												    consistent. End users supply values per-user at first
-												    tool use via the inline auth landing page. */}
-												<SectionHeader
-													title="Required Headers"
-													description="Comma-separated header names each caller must supply on first use, e.g. X-API-Key, X-Tenant-ID. Values are submitted per user, not stored on this server config."
-												/>
-												<div className="rounded-md border p-4">
-													<Textarea
-														id="per-user-header-keys"
-														data-testid="per-user-header-keys-textarea"
-														className="h-24"
-														placeholder="X-API-Key, X-Tenant-ID"
-														value={newHeaderKeyInput}
-														onChange={(e) => {
-															setNewHeaderKeyInput(e.target.value);
-															setPerUserHeaderKeys(parseArrayFromText(e.target.value));
-														}}
-													/>
-												</div>
-											</div>
-
-											{/* Optional static admin headers (e.g. a fixed tenant header) */}
-											<div className="space-y-4">
-												<SectionHeader title="Static Headers" description="Optional, applied alongside the values each caller supplies." />
-												<FormField
-													control={control}
-													name="headers"
-													render={({ field }) => (
-														<FormItem>
-															<HeadersTable
-																value={field.value || {}}
-																onChange={field.onChange}
-																keyPlaceholder="Header name"
-																valuePlaceholder="Header value"
-																label=""
-																useSecretVarInput
-															/>
-															{headersValidationError && <p className="text-destructive text-xs">{headersValidationError}</p>}
-															<FormMessage />
-														</FormItem>
-													)}
-												/>
-											</div>
-
-											{/* Sample values are collected in the MCPHeadersAuthorizer
-											    dialog that opens on Create — mirrors the OAuth flow
-											    where the verification step is also a dialog, not an
-											    inline panel. */}
-										</>
-									)}
-
-									{authType === "token_exchange" && (
-										<>
-											<DottedSeparator />
-											<div className="space-y-4" data-testid="token-exchange-fields">
-												<SectionHeader
-													title="Token Exchange Configuration"
-													description="Credentials and scopes used to exchange caller identity tokens for access to this server."
-													testId="token-exchange-heading"
-												/>
-												<div className="space-y-4 rounded-md border p-4">
-													<TokenExchangeFields
-														control={control}
-														gridClassName="space-y-4"
-														audienceLabel={
-															<>
-																Audience <span className="text-destructive">*</span>
-															</>
-														}
-														audienceTooltip={
-															isEntraIdp
-																? "The resource app's Application (client) ID at your identity provider - a bare GUID, not the api://... Application ID URI shown under Expose an API. Exchanged tokens are scoped to it."
-																: "The resource identifier this server is registered as at your identity provider. Exchanged tokens are scoped to it."
-														}
-														audienceTestId="token-exchange-audience-input"
-														onAudienceTouched={() => clearErrors("token_exchange.audience")}
-														useIdPCredentialsLabel="Exchange application"
-														useIdPCredentialsDedicatedDescription="A separate identity-provider app, scoped only to this server. Recommended for most providers."
-														useIdPCredentialsIdPDescription="Reuses your SSO login application's own credentials. Required for Microsoft Entra ID."
-														useIdPCredentialsRequiredWarning={
-															isEntraIdp &&
-															"Your identity provider is Microsoft Entra ID - a dedicated application might not work, switch to Identity provider application."
-														}
-														onUseIdPCredentialsToggled={(checked) => {
-															if (checked) clearErrors(["token_exchange.client_id", "token_exchange.client_secret"]);
-														}}
-														clientIdLabel={
-															<>
-																Exchange Client ID <span className="text-destructive">*</span>
-															</>
-														}
-														clientIdTooltip="A dedicated application at your identity provider with the token exchange (or on-behalf-of) grant enabled and permission to request this audience. Not the SSO login application. Ignored when using identity provider credentials above."
-														clientIdPlaceholder="bifrost-exchange or env.EXCHANGE_CLIENT_ID"
-														clientIdTestId="token-exchange-client-id-input"
-														onClientIdTouched={() => clearErrors("token_exchange.client_id")}
-														clientIdRedactNonEnvValue={false}
-														clientSecretLabel="Exchange Client Secret (optional)"
-														clientSecretPlaceholder="env.EXCHANGE_CLIENT_SECRET"
-														clientSecretHelperText="Omit for public clients."
-														clientSecretTestId="token-exchange-client-secret-input"
-														clientSecretHideValueWhenEnv={false}
-														clientSecretMaskNonEnvValue={true}
-														clientSecretRedactNonEnvValue={false}
-														authServerUrlLabel="Authorization Server URL (optional)"
-														authServerUrlTooltip={
-															<>
-																Only needed when the audience above is registered on a different authorization server than the one your SSO
-																login uses - for example, Okta&apos;s per-resource Custom Authorization Servers. Leave blank to use your SSO
-																login&apos;s issuer, which is correct for most providers.
-															</>
-														}
-														authServerUrlTestId="token-exchange-authorization-server-url-input"
-														scopes={{
-															variant: "textarea",
-															value: tokenExchangeScopesText,
-															onChange: setTokenExchangeScopesText,
-															label: "Scopes (optional)",
-															helperText: (
-																<>
-																	Comma-separated scopes to request on exchanged tokens. Include <code>offline_access</code> (where your
-																	identity provider supports it) so the retained discovery credential can renew itself in the background.
-																	{isEntraIdp && (
-																		<>
-																			{" "}
-																			<code>offline_access</code> alone is the only scope combined with the audience&apos;s default resource
-																			access - any other scope replaces the default entirely instead of adding to it.
-																		</>
-																	)}
-																</>
-															),
-															testId: "token-exchange-scopes-textarea",
-														}}
-													/>
-												</div>
-											</div>
-										</>
-									)}
-
-									{(authType === "oauth" || authType === "per_user_oauth") && (
-										<>
-											<DottedSeparator />
-											<div className="space-y-4">
-												<SectionHeader
-													title="OAuth Configuration"
-													description="Credentials and endpoints this server uses to authenticate via OAuth."
-													testId="oauth-advanced-heading"
-												/>
-												<div className="space-y-4 rounded-md border p-4">
-													<OAuthAdvancedFields
-														control={control}
-														scopesRaw={scopesText}
-														onScopesRawChange={setScopesText}
-														scopesLabel="Scopes (optional, comma-separated)"
-														scopesTestId="mcp-oauth-scopes-input"
-														resource={{ mode: "raw", value: resourceText, onChange: setResourceText }}
-														resourceLabel="Resource"
-														resourceTestId="mcp-oauth-resource-input"
-														clientIdLabel="OAuth Client ID (optional)"
-														clientIdPlaceholder="your-client-id (auto-generated if empty)"
-														clientIdHelperText="Will be auto-generated via dynamic registration if left empty and provider supports it"
-														clientIdTooltip="Leave empty to use Dynamic Client Registration (RFC 7591). Bifrost will automatically register with the OAuth provider if supported."
-														clientIdTestId="mcp-oauth-client-id"
-														clientSecretLabel="OAuth Client Secret (optional for PKCE)"
-														clientSecretPlaceholder="your-client-secret"
-														clientSecretHelperText="Leave empty for public clients using PKCE"
-														clientSecretTestId="mcp-oauth-client-secret"
-														authorizeUrlLabel="Authorization URL (optional, auto-discovered)"
-														authorizeUrlTestId="mcp-oauth-authorize-url"
-														tokenUrlLabel="Token URL (optional, auto-discovered)"
-														tokenUrlTestId="mcp-oauth-token-url"
-														registrationUrlLabel="Registration URL (optional, auto-discovered)"
-														registrationUrlTestId="mcp-oauth-registration-url"
-														onFieldTouched={(field) => clearErrors(`oauth_config.${field}`)}
-													/>
-												</div>
-											</div>
-										</>
-									)}
-
-									<DottedSeparator />
-
-									{/* TLS / Certificate */}
-									<div className="space-y-4">
-										<SectionHeader
-											title="TLS / Certificate"
-											description="Configure certificate verification for HTTPS connections to this server."
-											testId="tls-config-heading"
-										/>
-										<div className="space-y-4 rounded-md border p-4">
-											<TLSConfigFields control={control} />
-										</div>
-									</div>
-								</>
-							)}
-
-							{connectionType === "stdio" && (
-								<>
-									<div className="rounded-lg border border-amber-200 bg-amber-50 p-3">
-										<div className="flex items-start gap-2">
-											<Info className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-700" />
-											<div className="flex-1">
-												<p className="text-xs font-medium text-amber-900">Docker Notice</p>
-												<p className="mt-0.5 text-xs text-amber-800">
-													If not using the official Bifrost Docker image, STDIO connections may not work if required commands (npx, python,
-													etc.) aren't installed. You can safely ignore this if running locally or using a custom image with the necessary
-													dependencies.
-												</p>
-											</div>
-										</div>
-									</div>
-
-									{/* STDIO Command */}
-									<FormField
-										control={control}
-										name="stdio_config.command"
-										render={({ field }) => (
-											<FormItem>
-												<FormLabel>Command</FormLabel>
-												<FormControl>
-													<Input
-														{...field}
-														value={field.value ?? ""}
-														onChange={(e) => {
-															field.onChange(e);
-															clearErrors("stdio_config.command");
-														}}
-														placeholder="node, python, /path/to/executable"
-														data-testid="stdio-command-input"
-													/>
-												</FormControl>
-												<FormMessage />
-											</FormItem>
-										)}
-									/>
-
-									{/* Args (local state) */}
-									<div className="space-y-2">
-										<Label htmlFor="stdio-args-input">Arguments (comma-separated)</Label>
-										<Input
-											id="stdio-args-input"
-											value={argsText}
-											onChange={(e) => setArgsText(e.target.value)}
-											placeholder="--port, 3000, --config, config.json"
-											data-testid="stdio-args-input"
-										/>
-									</div>
-
-									{/* Envs (local state) */}
-									<div className="space-y-2" role="group" aria-labelledby="stdio-envs-label">
-										<div className="flex items-center gap-2">
-											<Label id="stdio-envs-label">Environment Variables</Label>
-											<TooltipProvider>
-												<Tooltip>
-													<TooltipTrigger asChild>
-														<Info className="text-muted-foreground h-4 w-4 cursor-help" />
-													</TooltipTrigger>
-													<TooltipContent className="max-w-xs">
-														<p>
-															Add a value for each variable, or leave it blank to read the value from the environment where Bifrost runs.
-														</p>
-													</TooltipContent>
-												</Tooltip>
-											</TooltipProvider>
-										</div>
-										<HeadersTable
-											value={envVars}
-											onChange={setEnvVars}
-											keyPlaceholder="API_KEY"
-											valuePlaceholder="Value (or leave blank to use host env)"
-											label=""
-										/>
-									</div>
-								</>
-							)}
+							<MCPClientFormFields form={methods} satellites={satellites} headersValidationError={headersValidationError} />
 						</div>
 
 						{/* Form Footer */}
@@ -999,7 +197,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 									</TooltipTrigger>
 									{!hasCreateMCPClientAccess && (
 										<TooltipContent>
-											<p>You don't have permission to perform this action</p>
+											<p>You don&apos;t have permission to perform this action</p>
 										</TooltipContent>
 									)}
 								</Tooltip>
@@ -1060,7 +258,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 						setHeadersFlow(null);
 						setError("name", { message: error });
 					}}
-					perUserHeaderKeys={perUserHeaderKeys}
+					perUserHeaderKeys={satellites.perUserHeaderKeys}
 					submitHandler={async (values) => {
 						await createMCPClient({ ...headersFlow.payload, user_headers: values }).unwrap();
 					}}

--- a/ui/app/workspace/mcp-registry/views/mcpClientFormFields.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientFormFields.tsx
@@ -1,0 +1,1015 @@
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { HeadersTable } from "@/components/ui/headersTable";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { SecretVarInput } from "@/components/ui/secretVarInput";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { DottedSeparator } from "@/components/ui/separator";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { IS_ENTERPRISE } from "@/lib/constants/config";
+import { CreateMCPClientRequest, MCPAuthType, MCPConnectionType, MCPTLSConfig, SecretVar } from "@/lib/types/mcp";
+import { parseArrayFromText } from "@/lib/utils/array";
+import { useGetSCIMProvidersQuery } from "@enterprise/lib/store/apis/scimApi";
+import { Info } from "lucide-react";
+import { useCallback, useState } from "react";
+import type { UseFormReturn } from "react-hook-form";
+import { OAuthAdvancedFields } from "./oauthAdvancedFields";
+import { SectionHeader } from "./sectionHeader";
+import { TLSConfigFields } from "./tlsConfigFields";
+import { TokenExchangeFields } from "./tokenExchangeFields";
+
+/**
+ * Shared configuration body for creating an MCP client. Rendered identically by
+ * the catalog's "New MCP Server" sheet and the library's install sheet, so the
+ * two surfaces can never drift in layout, copy, or supported auth types. The
+ * install sheet passes `lockConnection` because its transport and target come
+ * from the library entry the form was seeded with.
+ */
+
+const emptySecretVar: SecretVar = { value: "", ref: "" };
+
+export type MCPAuthKind = "none" | "headers" | "oauth" | "token_exchange";
+export type MCPAuthScope = "shared" | "per_user";
+
+/** Resolve the wire `auth_type` back into the two dropdowns the UI splits it into. */
+export function authKindOf(authType: MCPAuthType | undefined): MCPAuthKind {
+	switch (authType) {
+		case "oauth":
+		case "per_user_oauth":
+			return "oauth";
+		case "headers":
+		case "per_user_headers":
+			return "headers";
+		case "token_exchange":
+			return "token_exchange";
+		default:
+			return "none";
+	}
+}
+
+export function authScopeOf(authType: MCPAuthType | undefined): MCPAuthScope {
+	return authType === "per_user_oauth" || authType === "per_user_headers" ? "per_user" : "shared";
+}
+
+/**
+ * Form values that live outside react-hook-form: comma-separated text inputs
+ * whose parsed form is only needed at submit time, plus the auth scope half of
+ * the split auth dropdowns.
+ */
+export interface MCPClientFormSatellites {
+	argsText: string;
+	setArgsText: (value: string) => void;
+	envVars: Record<string, string>;
+	setEnvVars: (value: Record<string, string>) => void;
+	scopesText: string;
+	setScopesText: (value: string) => void;
+	tokenExchangeScopesText: string;
+	setTokenExchangeScopesText: (value: string) => void;
+	resourceText: string;
+	setResourceText: (value: string) => void;
+	perUserHeaderKeys: string[];
+	headerKeysInput: string;
+	setHeaderKeysInput: (value: string) => void;
+	authScope: MCPAuthScope;
+	setAuthScope: (value: MCPAuthScope) => void;
+	reset: (init?: MCPClientFormSatellitesInit) => void;
+}
+
+export interface MCPClientFormSatellitesInit {
+	argsText?: string;
+	envVars?: Record<string, string>;
+	perUserHeaderKeys?: string[];
+	authScope?: MCPAuthScope;
+}
+
+export function useMCPClientFormSatellites(): MCPClientFormSatellites {
+	const [argsText, setArgsText] = useState("");
+	const [envVars, setEnvVars] = useState<Record<string, string>>({});
+	const [scopesText, setScopesText] = useState("");
+	const [tokenExchangeScopesText, setTokenExchangeScopesText] = useState("");
+	const [resourceText, setResourceText] = useState("");
+	const [headerKeysInput, setHeaderKeysInput] = useState("");
+	const [authScope, setAuthScope] = useState<MCPAuthScope>("shared");
+
+	const reset = useCallback((init?: MCPClientFormSatellitesInit) => {
+		setArgsText(init?.argsText ?? "");
+		setEnvVars(init?.envVars ?? {});
+		setScopesText("");
+		setTokenExchangeScopesText("");
+		setResourceText("");
+		setHeaderKeysInput((init?.perUserHeaderKeys ?? []).join(", "));
+		setAuthScope(init?.authScope ?? "shared");
+	}, []);
+
+	return {
+		argsText,
+		setArgsText,
+		envVars,
+		setEnvVars,
+		scopesText,
+		setScopesText,
+		tokenExchangeScopesText,
+		setTokenExchangeScopesText,
+		resourceText,
+		setResourceText,
+		// Derived rather than stored: the textarea is the single source of truth,
+		// so the parsed list can never fall out of sync with what's on screen.
+		perUserHeaderKeys: parseArrayFromText(headerKeysInput),
+		headerKeysInput,
+		setHeaderKeysInput,
+		authScope,
+		setAuthScope,
+		reset,
+	};
+}
+
+/** Strips empty TLS config so we don't send `{}` to the server. */
+export function buildTLSConfigPayload(tls: MCPTLSConfig | undefined): MCPTLSConfig | undefined {
+	if (!tls) return undefined;
+	const hasSkipVerify = tls.insecure_skip_verify === true;
+	const hasCACert = tls.ca_cert_pem?.value || tls.ca_cert_pem?.type === "env" || tls.ca_cert_pem?.type === "vault";
+	if (!hasSkipVerify && !hasCACert) return undefined;
+	return { insecure_skip_verify: tls.insecure_skip_verify, ca_cert_pem: hasCACert ? tls.ca_cert_pem : undefined };
+}
+
+export function isValidOAuthResourceURI(value: string): boolean {
+	try {
+		const parsed = new URL(value);
+		return parsed.protocol !== "" && parsed.hash === "";
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Live header validation shared by both sheets. Both "headers" and
+ * "per_user_headers" persist the static headers map, so the gate must cover
+ * both — otherwise an empty static header in the per-user flow slips past
+ * client validation and opens MCPHeadersAuthorizer with a config the server
+ * has to reject.
+ */
+export function getHeadersValidationError(
+	authType: MCPAuthType | undefined,
+	headers: Record<string, SecretVar> | undefined,
+): string | null {
+	if ((authType !== "headers" && authType !== "per_user_headers") || !headers) return null;
+	for (const [key, secretVar] of Object.entries(headers)) {
+		if (!secretVar.value && !secretVar.ref) {
+			return `Header "${key}" must have a value`;
+		}
+	}
+	return null;
+}
+
+/**
+ * Submit-time validation shared by both sheets. Writes field errors onto the
+ * form and returns false when anything failed. `skipConnection` is set by the
+ * install sheet, whose transport and target are fixed by the library entry and
+ * therefore not user-editable.
+ */
+export function validateMCPClientForm({
+	data,
+	satellites,
+	form,
+	skipConnection,
+	onToast,
+}: {
+	data: CreateMCPClientRequest;
+	satellites: MCPClientFormSatellites;
+	form: UseFormReturn<CreateMCPClientRequest>;
+	skipConnection?: boolean;
+	onToast: (title: string, description: string) => void;
+}): boolean {
+	const { setError } = form;
+	const connectionType = data.connection_type;
+	const authType = data.auth_type;
+	let hasErrors = false;
+
+	if (!skipConnection && (connectionType === "http" || connectionType === "sse")) {
+		const connVal = data.connection_string?.value?.trim() || "";
+		const connRef = data.connection_string?.ref?.trim() || "";
+		const isSecret = data.connection_string?.type === "env" || data.connection_string?.type === "vault";
+		if (!connVal && !connRef) {
+			setError("connection_string", { message: "Connection URL is required" });
+			hasErrors = true;
+		} else if (!isSecret && connVal && !/^https?:\/\/.+/.test(connVal)) {
+			setError("connection_string", { message: "Connection URL must start with http:// or https://" });
+			hasErrors = true;
+		}
+	}
+
+	if (!skipConnection && connectionType === "stdio") {
+		const cmd = data.stdio_config?.command || "";
+		if (!cmd.trim()) {
+			setError("stdio_config.command", { message: "Command is required for STDIO connections" });
+			hasErrors = true;
+		} else if (/[<>|&;]/.test(cmd)) {
+			setError("stdio_config.command", { message: "Command cannot contain special shell characters" });
+			hasErrors = true;
+		}
+	}
+
+	if (authType === "oauth" || authType === "per_user_oauth") {
+		if (data.oauth_config?.authorize_url && !/^https?:\/\/.+$/.test(data.oauth_config.authorize_url)) {
+			setError("oauth_config.authorize_url", { message: "Authorize URL must start with http:// or https://" });
+			hasErrors = true;
+		}
+		if (data.oauth_config?.token_url && !/^https?:\/\/.+$/.test(data.oauth_config.token_url)) {
+			setError("oauth_config.token_url", { message: "Token URL must start with http:// or https://" });
+			hasErrors = true;
+		}
+		if (data.oauth_config?.registration_url && !/^https?:\/\/.+$/.test(data.oauth_config.registration_url)) {
+			setError("oauth_config.registration_url", { message: "Registration URL must start with http:// or https://" });
+			hasErrors = true;
+		}
+		if (satellites.resourceText.trim() && !isValidOAuthResourceURI(satellites.resourceText.trim())) {
+			onToast("Invalid resource URI", "OAuth resource must be an absolute URI without a fragment.");
+			hasErrors = true;
+		}
+	}
+
+	if (authType === "token_exchange") {
+		if (!data.token_exchange?.audience?.trim()) {
+			setError("token_exchange.audience", { message: "Audience is required for token exchange" });
+			hasErrors = true;
+		}
+		if (!data.token_exchange?.use_idp_credentials) {
+			const exchangeClientId = data.token_exchange?.client_id;
+			if (!exchangeClientId?.value && !exchangeClientId?.ref) {
+				setError("token_exchange.client_id", { message: "Exchange client ID is required for token exchange" });
+				hasErrors = true;
+			}
+		}
+	}
+
+	if (authType === "per_user_headers" && satellites.perUserHeaderKeys.length === 0) {
+		onToast("Header keys required", "Declare at least one header name users must supply.");
+		hasErrors = true;
+	}
+
+	return !hasErrors;
+}
+
+/**
+ * Assembles the POST /api/mcp/client body from the form values plus the
+ * satellite text inputs. Shared so a field wired into one sheet can never be
+ * silently dropped by the other.
+ */
+export function buildMCPClientPayload(data: CreateMCPClientRequest, satellites: MCPClientFormSatellites): CreateMCPClientRequest {
+	const connectionType = data.connection_type;
+	const authType = data.auth_type;
+	const isStdio = connectionType === "stdio";
+
+	return {
+		...data,
+		connection_string: isStdio ? undefined : data.connection_string,
+		stdio_config: isStdio
+			? {
+					command: data.stdio_config?.command || "",
+					args: parseArrayFromText(satellites.argsText),
+					// Each row becomes KEY=value, or a bare KEY when no value is given
+					// (read from Bifrost's host environment). Rows without a name are skipped.
+					envs: Object.entries(satellites.envVars)
+						.filter(([name]) => name.trim() !== "")
+						.map(([name, value]) => {
+							const trimmed = value.trim();
+							return trimmed ? `${name}=${trimmed}` : name;
+						}),
+				}
+			: undefined,
+		tls_config: isStdio ? undefined : buildTLSConfigPayload(data.tls_config),
+		oauth_config:
+			authType === "oauth" || authType === "per_user_oauth"
+				? {
+						client_id: data.oauth_config?.client_id ?? emptySecretVar,
+						client_secret:
+							data.oauth_config?.client_secret?.value ||
+							data.oauth_config?.client_secret?.type === "env" ||
+							data.oauth_config?.client_secret?.type === "vault"
+								? data.oauth_config.client_secret
+								: undefined,
+						authorize_url: data.oauth_config?.authorize_url || undefined,
+						token_url: data.oauth_config?.token_url || undefined,
+						registration_url: data.oauth_config?.registration_url || undefined,
+						scopes: satellites.scopesText.trim() ? parseArrayFromText(satellites.scopesText) : undefined,
+						server_url: data.connection_string?.value || undefined,
+						resource: satellites.resourceText.trim() || undefined,
+					}
+				: undefined,
+		// "headers" and "per_user_headers" both can carry static admin headers on
+		// data.headers (per-user values are submitted separately by end users).
+		headers:
+			(authType === "headers" || authType === "per_user_headers") && data.headers && Object.keys(data.headers).length > 0
+				? data.headers
+				: undefined,
+		per_user_header_keys: authType === "per_user_headers" ? satellites.perUserHeaderKeys : undefined,
+		token_exchange:
+			authType === "token_exchange"
+				? {
+						audience: data.token_exchange?.audience?.trim() || "",
+						use_idp_credentials: data.token_exchange?.use_idp_credentials || undefined,
+						client_id: data.token_exchange?.use_idp_credentials ? undefined : (data.token_exchange?.client_id ?? emptySecretVar),
+						client_secret: data.token_exchange?.use_idp_credentials
+							? undefined
+							: data.token_exchange?.client_secret?.value ||
+								  data.token_exchange?.client_secret?.type === "env" ||
+								  data.token_exchange?.client_secret?.type === "vault"
+								? data.token_exchange.client_secret
+								: undefined,
+						scopes: satellites.tokenExchangeScopesText.trim() ? parseArrayFromText(satellites.tokenExchangeScopesText) : undefined,
+						authorization_server_url: data.token_exchange?.authorization_server_url?.trim() || undefined,
+					}
+				: undefined,
+		tools_to_execute: ["*"],
+	};
+}
+
+/**
+ * Warns that STDIO servers shell out to the host, which only carries the usual
+ * runtimes on the official image. Shown wherever a STDIO server is configured.
+ */
+export function StdioRuntimeNotice() {
+	return (
+		<div className="rounded-lg border border-amber-200 bg-amber-50 p-3" data-testid="stdio-docker-notice">
+			<div className="flex items-start gap-2">
+				<Info className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-700" />
+				<div className="flex-1">
+					<p className="text-xs font-medium text-amber-900">Docker Notice</p>
+					<p className="mt-0.5 text-xs text-amber-800">
+						If not using the official Bifrost Docker image, STDIO connections may not work if required commands (npx, python, etc.)
+						aren&apos;t installed. You can safely ignore this if running locally or using a custom image with the necessary dependencies.
+					</p>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+interface MCPClientFormFieldsProps {
+	form: UseFormReturn<CreateMCPClientRequest>;
+	satellites: MCPClientFormSatellites;
+	headersValidationError: string | null;
+	/**
+	 * Renders the transport, target, and STDIO launch command read-only. Set by
+	 * the install sheet, where those values come from the library entry rather
+	 * than from the person filling in the form.
+	 */
+	lockConnection?: boolean;
+	/**
+	 * STDIO variable names declared by the library entry. When set, the env
+	 * table renders exactly these rows and only their values are editable.
+	 */
+	stdioEnvKeys?: string[];
+}
+
+export function MCPClientFormFields({ form, satellites, headersValidationError, lockConnection, stdioEnvKeys }: MCPClientFormFieldsProps) {
+	const { control, setValue, watch, clearErrors } = form;
+	const connectionType = watch("connection_type");
+	const authType = watch("auth_type");
+
+	// Token exchange is backed by the deployment's identity-provider
+	// integration, so the option only renders when one is enabled. The exact
+	// exchange-client requirement is enforced server-side at create; a missing
+	// tokenExchangeClient section surfaces as the create error.
+	const { data: scimProviders } = useGetSCIMProvidersQuery(undefined, { skip: !IS_ENTERPRISE });
+	const enabledScimProvider = scimProviders?.find((p) => (p as { enabled?: boolean }).enabled) as { name?: string } | undefined;
+	const idpConfigured = !!enabledScimProvider;
+	// Entra's on-behalf-of grant requires use_idp_credentials — see the
+	// Prerequisites warning in docs/mcp/auth/token-exchange.mdx for why a
+	// dedicated exchange app structurally can't work there.
+	const isEntraIdp = ["entra", "azure", "azuread"].includes((enabledScimProvider?.name ?? "").toLowerCase());
+
+	const authKind = authKindOf(authType);
+	const { authScope, setAuthScope } = satellites;
+	// A library entry can declare token_exchange, and the catalog sync does no
+	// auth-type validation, so the form can be seeded with an auth type this
+	// deployment can't offer. The Select would then show its placeholder while
+	// still submitting token_exchange, so surface the mismatch instead.
+	const tokenExchangeUnavailable = authKind === "token_exchange" && !(IS_ENTERPRISE && idpConfigured);
+
+	/**
+	 * The stickiness switch only renders for a shared http auth type. Picking an
+	 * auth type that hides it has to drop any value chosen while it was visible,
+	 * otherwise a stale `true` stays in form state and gets submitted. The
+	 * connection-type handler below applies the same reset for non-http
+	 * transports.
+	 */
+	const clearStickinessIfHidden = (kind: MCPAuthKind, scope: MCPAuthScope) => {
+		if (kind === "token_exchange" || (kind !== "none" && scope === "per_user")) {
+			setValue("needs_session_stickiness", undefined);
+		}
+	};
+
+	const applyAuthKind = (kind: MCPAuthKind) => {
+		clearErrors();
+		clearStickinessIfHidden(kind, authScope);
+		if (kind === "none" || kind === "token_exchange") {
+			setValue("auth_type", kind);
+			return;
+		}
+		if (kind === "oauth") {
+			setValue("auth_type", authScope === "per_user" ? "per_user_oauth" : "oauth");
+			return;
+		}
+		setValue("auth_type", authScope === "per_user" ? "per_user_headers" : "headers");
+	};
+
+	const applyAuthScope = (scope: MCPAuthScope) => {
+		setAuthScope(scope);
+		clearStickinessIfHidden(authKind, scope);
+		if (authKind === "oauth") {
+			setValue("auth_type", scope === "per_user" ? "per_user_oauth" : "oauth");
+		} else if (authKind === "headers") {
+			setValue("auth_type", scope === "per_user" ? "per_user_headers" : "headers");
+		}
+	};
+
+	const isRemote = connectionType === "http" || connectionType === "sse";
+
+	return (
+		<>
+			{/* Server Behavior */}
+			<div className="space-y-4">
+				<SectionHeader title="Server Behavior" description="Control how this server participates in code mode and health checks." />
+				<div className="divide-y rounded-md border">
+					<FormField
+						control={control}
+						name="is_code_mode_client"
+						render={({ field }) => (
+							<FormItem className="flex flex-row items-center justify-between gap-4 px-4 py-3">
+								<div className="flex items-center gap-2">
+									<FormLabel htmlFor="code-mode">Code Mode Server</FormLabel>
+									<TooltipProvider>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<a
+													href="https://docs.getbifrost.ai/mcp/code-mode"
+													target="_blank"
+													rel="noopener noreferrer"
+													data-testid="code-mode-link-help"
+													className="text-muted-foreground hover:text-foreground focus-visible:ring-ring rounded focus-visible:ring-2 focus-visible:outline-none"
+													aria-label="Learn more about Code Mode"
+												>
+													<Info className="h-4 w-4 cursor-help" />
+												</a>
+											</TooltipTrigger>
+											<TooltipContent>
+												<p>Click to learn more about Code Mode</p>
+											</TooltipContent>
+										</Tooltip>
+									</TooltipProvider>
+								</div>
+								<FormControl>
+									<Switch id="code-mode" data-testid="code-mode-switch" checked={field.value || false} onCheckedChange={field.onChange} />
+								</FormControl>
+							</FormItem>
+						)}
+					/>
+					<FormField
+						control={control}
+						name="is_ping_available"
+						render={({ field }) => (
+							<FormItem className="flex flex-row items-center justify-between gap-4 px-4 py-3">
+								<div className="flex items-center gap-2">
+									<FormLabel htmlFor="ping-available">Ping Available for Health Check</FormLabel>
+									<TooltipProvider>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<Info className="text-muted-foreground h-4 w-4 cursor-help" />
+											</TooltipTrigger>
+											<TooltipContent className="max-w-xs">
+												<p>
+													Enable to use lightweight ping method for health checks. Disable if your MCP server doesn&apos;t support ping -
+													will use listTools instead.
+												</p>
+											</TooltipContent>
+										</Tooltip>
+									</TooltipProvider>
+								</div>
+								<FormControl>
+									<Switch
+										id="ping-available"
+										data-testid="mcp-is-ping-available"
+										checked={field.value === true}
+										onCheckedChange={field.onChange}
+									/>
+								</FormControl>
+							</FormItem>
+						)}
+					/>
+					{connectionType === "http" &&
+						authType !== "per_user_oauth" &&
+						authType !== "per_user_headers" &&
+						authType !== "token_exchange" && (
+							<FormField
+								control={control}
+								name="needs_session_stickiness"
+								render={({ field }) => (
+									<FormItem className="flex flex-row items-center justify-between gap-4 px-4 py-3">
+										<div className="flex items-center gap-2">
+											<FormLabel htmlFor="needs-session-stickiness">Maintain Persistent Connection</FormLabel>
+											<TooltipProvider>
+												<Tooltip>
+													<TooltipTrigger asChild>
+														<Info className="text-muted-foreground h-4 w-4 cursor-help" />
+													</TooltipTrigger>
+													<TooltipContent className="max-w-xs">
+														<p>
+															Enable to keep one shared connection open and reused across every caller. Disable to connect fresh on every
+															call instead, same as per-user auth types. Only applies to HTTP connections; SSE and STDIO always keep a
+															persistent connection.
+														</p>
+													</TooltipContent>
+												</Tooltip>
+											</TooltipProvider>
+										</div>
+										<FormControl>
+											<Switch
+												id="needs-session-stickiness"
+												data-testid="mcp-needs-session-stickiness"
+												checked={field.value === true}
+												onCheckedChange={field.onChange}
+											/>
+										</FormControl>
+									</FormItem>
+								)}
+							/>
+						)}
+				</div>
+			</div>
+
+			<DottedSeparator />
+
+			{/* Connection & Authentication */}
+			<div className="space-y-4">
+				<SectionHeader
+					title="Connection & Authentication"
+					description={
+						lockConnection
+							? "The transport and target come from the library entry. Choose how requests to it are authenticated."
+							: "Choose how Bifrost connects to this server and, for network transports, how requests are authenticated."
+					}
+				/>
+				<div className="space-y-4 rounded-md border p-4">
+					<FormField
+						control={control}
+						name="connection_type"
+						render={({ field }) => (
+							<FormItem className="w-full">
+								<FormLabel>Connection Type</FormLabel>
+								<Select
+									value={field.value}
+									disabled={lockConnection}
+									onValueChange={(value: MCPConnectionType) => {
+										field.onChange(value);
+										if (value === "stdio") {
+											setValue("auth_type", "none");
+											setValue("headers", undefined);
+											setValue("oauth_config", undefined);
+										}
+										// needs_session_stickiness=false is rejected for
+										// non-http connection types; SSE/STDIO always keep
+										// a persistent connection regardless, so drop any
+										// explicit false picked while http was selected.
+										if (value !== "http") {
+											setValue("needs_session_stickiness", undefined);
+										}
+										clearErrors();
+									}}
+								>
+									<FormControl>
+										<SelectTrigger className="w-full" data-testid="connection-type-select">
+											<SelectValue placeholder="Select connection type" />
+										</SelectTrigger>
+									</FormControl>
+									<SelectContent>
+										<SelectItem value="http" data-testid="connection-type-http">
+											HTTP (Streamable)
+										</SelectItem>
+										<SelectItem value="sse" data-testid="connection-type-sse">
+											Server-Sent Events (SSE)
+										</SelectItem>
+										<SelectItem value="stdio" data-testid="connection-type-stdio">
+											STDIO
+										</SelectItem>
+									</SelectContent>
+								</Select>
+								{!lockConnection && (
+									<p className="text-muted-foreground text-xs">Connection type and authentication settings cannot be changed later.</p>
+								)}
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+
+					{isRemote && (
+						<>
+							{/* Connection URL */}
+							<FormField
+								control={control}
+								name="connection_string"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>Connection URL</FormLabel>
+										<SecretVarInput
+											value={field.value}
+											disabled={lockConnection}
+											onChange={(value) => {
+												field.onChange(value);
+												clearErrors("connection_string");
+											}}
+											placeholder="http://your-mcp-server:3000 or env.MCP_SERVER_URL"
+											data-testid="connection-url-input"
+										/>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+
+							{/* Auth Type */}
+							<FormItem className="w-full">
+								<FormLabel>Authentication Type</FormLabel>
+								<Select value={authKind} onValueChange={(value: MCPAuthKind) => applyAuthKind(value)}>
+									<FormControl>
+										<SelectTrigger className="w-full" data-testid="auth-type-select">
+											<SelectValue placeholder="Select authentication type" />
+										</SelectTrigger>
+									</FormControl>
+									<SelectContent>
+										<SelectItem value="none" data-testid="auth-type-none">
+											None
+										</SelectItem>
+										<SelectItem value="headers" data-testid="auth-type-headers">
+											Headers
+										</SelectItem>
+										<SelectItem value="oauth" data-testid="auth-type-oauth">
+											OAuth 2.0
+										</SelectItem>
+										{/* Also rendered when it is already the selected value, so the
+										    trigger shows the real auth type rather than a placeholder. */}
+										{((IS_ENTERPRISE && idpConfigured) || tokenExchangeUnavailable) && (
+											<SelectItem value="token_exchange" data-testid="auth-type-token-exchange">
+												Token Exchange (On-Behalf-Of)
+											</SelectItem>
+										)}
+									</SelectContent>
+								</Select>
+								{tokenExchangeUnavailable && (
+									<div
+										className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800"
+										data-testid="token-exchange-unavailable-notice"
+									>
+										<Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+										<p>
+											This server expects token exchange, which needs an enabled identity provider. Configure one, or pick a different
+											authentication type to continue.
+										</p>
+									</div>
+								)}
+							</FormItem>
+
+							{/* Auth Scope — only meaningful when there's an auth flow with a
+							    shared variant; token exchange is inherently per-caller */}
+							{authKind !== "none" && authKind !== "token_exchange" && (
+								<FormItem className="w-full">
+									<FormLabel>Auth Scope</FormLabel>
+									<Select value={authScope} onValueChange={(value: MCPAuthScope) => applyAuthScope(value)}>
+										<FormControl>
+											<SelectTrigger className="w-full" data-testid="auth-scope-select">
+												<SelectValue placeholder="Select auth scope" />
+											</SelectTrigger>
+										</FormControl>
+										<SelectContent>
+											<SelectItem value="shared" data-testid="auth-scope-shared">
+												Shared
+											</SelectItem>
+											<SelectItem value="per_user" data-testid="auth-scope-per-user">
+												Per-User
+											</SelectItem>
+										</SelectContent>
+									</Select>
+								</FormItem>
+							)}
+						</>
+					)}
+				</div>
+			</div>
+
+			{isRemote && (
+				<>
+					{authType === "headers" && (
+						<>
+							<DottedSeparator />
+							<div className="space-y-4">
+								<SectionHeader title="Headers" description="Static headers sent with every request to this server." />
+								<FormField
+									control={control}
+									name="headers"
+									render={({ field }) => (
+										<FormItem data-testid="mcp-headers-table">
+											<HeadersTable
+												value={field.value || {}}
+												onChange={field.onChange}
+												keyPlaceholder="Header name"
+												valuePlaceholder="Header value"
+												label=""
+												useSecretVarInput
+											/>
+											{headersValidationError && <p className="text-destructive text-xs">{headersValidationError}</p>}
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+							</div>
+						</>
+					)}
+
+					{authType === "per_user_headers" && (
+						<>
+							<DottedSeparator />
+							<div className="space-y-4">
+								{/* Required header keys (admin schema). Same Textarea +
+								    comma-separated pattern as workspace/config security
+								    Required Headers, so the two surfaces stay visually
+								    consistent. End users supply values per-user at first
+								    tool use via the inline auth landing page. */}
+								<SectionHeader
+									title="Required Headers"
+									description="Comma-separated header names each caller must supply on first use, e.g. X-API-Key, X-Tenant-ID. Values are submitted per user, not stored on this server config."
+								/>
+								<div className="rounded-md border p-4">
+									<Textarea
+										id="per-user-header-keys"
+										data-testid="per-user-header-keys-textarea"
+										className="h-24"
+										placeholder="X-API-Key, X-Tenant-ID"
+										value={satellites.headerKeysInput}
+										onChange={(e) => satellites.setHeaderKeysInput(e.target.value)}
+									/>
+								</div>
+							</div>
+
+							{/* Optional static admin headers (e.g. a fixed tenant header) */}
+							<div className="space-y-4">
+								<SectionHeader title="Static Headers" description="Optional, applied alongside the values each caller supplies." />
+								<FormField
+									control={control}
+									name="headers"
+									render={({ field }) => (
+										<FormItem>
+											<HeadersTable
+												value={field.value || {}}
+												onChange={field.onChange}
+												keyPlaceholder="Header name"
+												valuePlaceholder="Header value"
+												label=""
+												useSecretVarInput
+											/>
+											{headersValidationError && <p className="text-destructive text-xs">{headersValidationError}</p>}
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+							</div>
+
+							{/* Sample values are collected in the MCPHeadersAuthorizer
+							    dialog that opens on submit — mirrors the OAuth flow
+							    where the verification step is also a dialog, not an
+							    inline panel. */}
+						</>
+					)}
+
+					{authType === "token_exchange" && (
+						<>
+							<DottedSeparator />
+							<div className="space-y-4" data-testid="token-exchange-fields">
+								<SectionHeader
+									title="Token Exchange Configuration"
+									description="Credentials and scopes used to exchange caller identity tokens for access to this server."
+									testId="token-exchange-heading"
+								/>
+								<div className="space-y-4 rounded-md border p-4">
+									<TokenExchangeFields
+										control={control}
+										gridClassName="space-y-4"
+										audienceLabel={
+											<>
+												Audience <span className="text-destructive">*</span>
+											</>
+										}
+										audienceTooltip={
+											isEntraIdp
+												? "The resource app's Application (client) ID at your identity provider - a bare GUID, not the api://... Application ID URI shown under Expose an API. Exchanged tokens are scoped to it."
+												: "The resource identifier this server is registered as at your identity provider. Exchanged tokens are scoped to it."
+										}
+										audienceTestId="token-exchange-audience-input"
+										onAudienceTouched={() => clearErrors("token_exchange.audience")}
+										useIdPCredentialsLabel="Exchange application"
+										useIdPCredentialsDedicatedDescription="A separate identity-provider app, scoped only to this server. Recommended for most providers."
+										useIdPCredentialsIdPDescription="Reuses your SSO login application's own credentials. Required for Microsoft Entra ID."
+										useIdPCredentialsRequiredWarning={
+											isEntraIdp &&
+											"Your identity provider is Microsoft Entra ID - a dedicated application might not work, switch to Identity provider application."
+										}
+										onUseIdPCredentialsToggled={(checked) => {
+											if (checked) clearErrors(["token_exchange.client_id", "token_exchange.client_secret"]);
+										}}
+										clientIdLabel={
+											<>
+												Exchange Client ID <span className="text-destructive">*</span>
+											</>
+										}
+										clientIdTooltip="A dedicated application at your identity provider with the token exchange (or on-behalf-of) grant enabled and permission to request this audience. Not the SSO login application. Ignored when using identity provider credentials above."
+										clientIdPlaceholder="bifrost-exchange or env.EXCHANGE_CLIENT_ID"
+										clientIdTestId="token-exchange-client-id-input"
+										onClientIdTouched={() => clearErrors("token_exchange.client_id")}
+										clientIdRedactNonEnvValue={false}
+										clientSecretLabel="Exchange Client Secret (optional)"
+										clientSecretPlaceholder="env.EXCHANGE_CLIENT_SECRET"
+										clientSecretHelperText="Omit for public clients."
+										clientSecretTestId="token-exchange-client-secret-input"
+										clientSecretHideValueWhenEnv={false}
+										clientSecretMaskNonEnvValue={true}
+										clientSecretRedactNonEnvValue={false}
+										authServerUrlLabel="Authorization Server URL (optional)"
+										authServerUrlTooltip={
+											<>
+												Only needed when the audience above is registered on a different authorization server than the one your SSO login
+												uses - for example, Okta&apos;s per-resource Custom Authorization Servers. Leave blank to use your SSO login&apos;s
+												issuer, which is correct for most providers.
+											</>
+										}
+										authServerUrlTestId="token-exchange-authorization-server-url-input"
+										scopes={{
+											variant: "textarea",
+											value: satellites.tokenExchangeScopesText,
+											onChange: satellites.setTokenExchangeScopesText,
+											label: "Scopes (optional)",
+											helperText: (
+												<>
+													Comma-separated scopes to request on exchanged tokens. Include <code>offline_access</code> (where your identity
+													provider supports it) so the retained discovery credential can renew itself in the background.
+													{isEntraIdp && (
+														<>
+															{" "}
+															<code>offline_access</code> alone is the only scope combined with the audience&apos;s default resource access
+															- any other scope replaces the default entirely instead of adding to it.
+														</>
+													)}
+												</>
+											),
+											testId: "token-exchange-scopes-textarea",
+										}}
+									/>
+								</div>
+							</div>
+						</>
+					)}
+
+					{(authType === "oauth" || authType === "per_user_oauth") && (
+						<>
+							<DottedSeparator />
+							<div className="space-y-4">
+								<SectionHeader
+									title="OAuth Configuration"
+									description="Credentials and endpoints this server uses to authenticate via OAuth."
+									testId="oauth-advanced-heading"
+								/>
+								<div className="space-y-4 rounded-md border p-4">
+									<OAuthAdvancedFields
+										control={control}
+										scopesRaw={satellites.scopesText}
+										onScopesRawChange={satellites.setScopesText}
+										scopesLabel="Scopes (optional, comma-separated)"
+										scopesTestId="mcp-oauth-scopes-input"
+										resource={{ mode: "raw", value: satellites.resourceText, onChange: satellites.setResourceText }}
+										resourceLabel="Resource"
+										resourceTestId="mcp-oauth-resource-input"
+										clientIdLabel="OAuth Client ID (optional)"
+										clientIdPlaceholder="your-client-id (auto-generated if empty)"
+										clientIdHelperText="Will be auto-generated via dynamic registration if left empty and provider supports it"
+										clientIdTooltip="Leave empty to use Dynamic Client Registration (RFC 7591). Bifrost will automatically register with the OAuth provider if supported."
+										clientIdTestId="mcp-oauth-client-id"
+										clientSecretLabel="OAuth Client Secret (optional for PKCE)"
+										clientSecretPlaceholder="your-client-secret"
+										clientSecretHelperText="Leave empty for public clients using PKCE"
+										clientSecretTestId="mcp-oauth-client-secret"
+										authorizeUrlLabel="Authorization URL (optional, auto-discovered)"
+										authorizeUrlTestId="mcp-oauth-authorize-url"
+										tokenUrlLabel="Token URL (optional, auto-discovered)"
+										tokenUrlTestId="mcp-oauth-token-url"
+										registrationUrlLabel="Registration URL (optional, auto-discovered)"
+										registrationUrlTestId="mcp-oauth-registration-url"
+										onFieldTouched={(field) => clearErrors(`oauth_config.${field}`)}
+									/>
+								</div>
+							</div>
+						</>
+					)}
+
+					<DottedSeparator />
+
+					{/* TLS / Certificate */}
+					<div className="space-y-4">
+						<SectionHeader
+							title="TLS / Certificate"
+							description="Configure certificate verification for HTTPS connections to this server."
+							testId="tls-config-heading"
+						/>
+						<div className="space-y-4 rounded-md border p-4">
+							<TLSConfigFields control={control} />
+						</div>
+					</div>
+				</>
+			)}
+
+			{connectionType === "stdio" && (
+				<>
+					<DottedSeparator />
+					<div className="space-y-4">
+						<SectionHeader
+							title="Launch Command"
+							description={
+								lockConnection
+									? "Bifrost runs this command to start the server. It comes from the library entry and can't be changed here."
+									: "Bifrost runs this command to start the server on the machine it's deployed on."
+							}
+						/>
+						<div className="space-y-4 rounded-md border p-4">
+							<StdioRuntimeNotice />
+
+							{/* STDIO Command */}
+							<FormField
+								control={control}
+								name="stdio_config.command"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>Command</FormLabel>
+										<FormControl>
+											<Input
+												{...field}
+												value={field.value ?? ""}
+												disabled={lockConnection}
+												onChange={(e) => {
+													field.onChange(e);
+													clearErrors("stdio_config.command");
+												}}
+												placeholder="node, python, /path/to/executable"
+												data-testid="stdio-command-input"
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+
+							{/* Args (local state) */}
+							<div className="space-y-2">
+								<Label htmlFor="stdio-args-input">Arguments (comma-separated)</Label>
+								<Input
+									id="stdio-args-input"
+									value={satellites.argsText}
+									disabled={lockConnection}
+									onChange={(e) => satellites.setArgsText(e.target.value)}
+									placeholder="--port, 3000, --config, config.json"
+									data-testid="stdio-args-input"
+								/>
+							</div>
+
+							{/* Envs (local state) */}
+							<div className="space-y-2" role="group" aria-labelledby="stdio-envs-label">
+								<div className="flex items-center gap-2">
+									<Label id="stdio-envs-label">Environment Variables</Label>
+									<TooltipProvider>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<Info className="text-muted-foreground h-4 w-4 cursor-help" />
+											</TooltipTrigger>
+											<TooltipContent className="max-w-xs">
+												<p>Add a value for each variable, or leave it blank to read the value from the environment where Bifrost runs.</p>
+											</TooltipContent>
+										</Tooltip>
+									</TooltipProvider>
+								</div>
+								<HeadersTable
+									value={satellites.envVars}
+									onChange={satellites.setEnvVars}
+									fixedKeys={stdioEnvKeys}
+									keyPlaceholder="API_KEY"
+									valuePlaceholder="Value (or leave blank to use host env)"
+									label=""
+								/>
+							</div>
+						</div>
+					</div>
+				</>
+			)}
+		</>
+	);
+}
+
+// Re-exported so the library sheets can build the same section scaffolding
+// without reaching past this module into the individual field fragments.
+export { SectionHeader };

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -840,20 +840,22 @@ export default function MCPClientSheet({
 																	</FormItem>
 																)}
 															/>
-															{needsSessionStickinessDirty && (
-																<div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
-																	<Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
-																	<p>
-																		Toggling this takes effect immediately on save:{" "}
-																		{needsSessionStickiness
-																			? "the shared connection will be opened now."
-																			: "the existing shared connection will be closed now."}
-																	</p>
-																</div>
-															)}
 														</>
 													)}
 											</div>
+											{/* Sits outside the bordered row group: it's a consequence of the
+											    toggle above, not another setting row. */}
+											{needsSessionStickinessDirty && (
+												<div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+													<Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+													<p>
+														Toggling this takes effect immediately on save:{" "}
+														{needsSessionStickiness
+															? "the shared connection will be opened now."
+															: "the existing shared connection will be closed now."}
+													</p>
+												</div>
+											)}
 										</div>
 
 										<DottedSeparator />
@@ -963,8 +965,6 @@ export default function MCPClientSheet({
 												/>
 											</div>
 										</div>
-
-										<DottedSeparator />
 
 										<FormField
 											control={form.control}

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -971,18 +971,31 @@ export default function MCPClientsTable({
 							) : (
 								mcpClients.map((c: MCPClient) => {
 									const canReconnect = canReconnectMCPClient(c.config);
-									const enabledToolsCount =
-										c.state == "healthy"
-											? c.config.tools_to_execute?.includes("*")
-												? c.tools?.length
-												: (c.config.tools_to_execute?.length ?? 0)
-											: 0;
-									const autoExecuteToolsCount =
-										c.state == "healthy"
-											? c.config.tools_to_auto_execute?.includes("*")
-												? c.tools?.length
-												: (c.config.tools_to_auto_execute?.length ?? 0)
-											: 0;
+									// Tool counts come from the last successful discovery, which is
+									// deliberately retained across a failed connection check, so an
+									// "unstable" (or degraded/needs_reauth) client still has a real
+									// tool list to report. Gate on the list itself rather than on
+									// "healthy" so only the states that genuinely have no discovered
+									// tools (pending_verification, error, a disabled shared client)
+									// fall back to a dash.
+									//
+									// Both lists are matched against the discovered names: nothing
+									// prunes a tool name from the config when the upstream server
+									// stops exposing it, so an unfiltered length can exceed the
+									// number of tools that actually exist. Auto-execute is further
+									// narrowed to the enabled set, mirroring canAutoExecuteTool,
+									// which requires a tool to pass tools_to_execute first.
+									const discoveredToolNames = new Set(c.tools?.map((tool) => tool.name) ?? []);
+									const enabledToolNames = c.config.tools_to_execute?.includes("*")
+										? discoveredToolNames
+										: new Set((c.config.tools_to_execute ?? []).filter((name) => discoveredToolNames.has(name)));
+									const autoExecuteToolNames = c.config.tools_to_auto_execute?.includes("*")
+										? enabledToolNames
+										: new Set((c.config.tools_to_auto_execute ?? []).filter((name) => enabledToolNames.has(name)));
+									const toolCount = discoveredToolNames.size;
+									const hasDiscoveredTools = toolCount > 0;
+									const enabledToolsCount = enabledToolNames.size;
+									const autoExecuteToolsCount = autoExecuteToolNames.size;
 									return (
 										<TableRow key={c.config.client_id} className="group hover:bg-muted/50 transition-colors">
 											<TableCell className="font-medium">
@@ -997,17 +1010,12 @@ export default function MCPClientsTable({
 											</TableCell>
 											<TableCell data-testid="mcp-client-auth-type">{getAuthTypeDisplay(c.config.auth_type)}</TableCell>
 											<TableCell data-testid="mcp-client-auth-scope">{getAuthScopeDisplay(c.config.auth_type)}</TableCell>
-											<TableCell>
-												<Badge
-													className={
-														c.state == "healthy"
-															? c.config.is_code_mode_client
-																? "bg-green-100 text-green-800"
-																: "bg-gray-100 text-gray-800"
-															: ""
-													}
-												>
-													{c.state == "healthy" ? <>{c.config.is_code_mode_client ? "Enabled" : "Disabled"}</> : "-"}
+											<TableCell data-testid="mcp-client-code-mode">
+												{/* Pure config, valid whatever the connection state is: a server
+												    that can't be reached right now is still configured for code
+												    mode or not. */}
+												<Badge className={c.config.is_code_mode_client ? "bg-green-100 text-green-800" : "bg-gray-100 text-gray-800"}>
+													{c.config.is_code_mode_client ? "Enabled" : "Disabled"}
 												</Badge>
 											</TableCell>
 											<TableCell data-testid="mcp-client-vk-access">
@@ -1017,19 +1025,19 @@ export default function MCPClientsTable({
 														? `${c.vk_configs.length} ${c.vk_configs.length === 1 ? "VK" : "VKs"}`
 														: "None"}
 											</TableCell>
-											<TableCell>
-												{c.state == "healthy" ? (
+											<TableCell data-testid="mcp-client-enabled-tools">
+												{hasDiscoveredTools ? (
 													<>
-														{enabledToolsCount}/{c.tools?.length}
+														{enabledToolsCount}/{toolCount}
 													</>
 												) : (
 													"-"
 												)}
 											</TableCell>
-											<TableCell>
-												{c.state == "healthy" ? (
+											<TableCell data-testid="mcp-client-auto-execute-tools">
+												{hasDiscoveredTools ? (
 													<>
-														{autoExecuteToolsCount}/{c.tools?.length}
+														{autoExecuteToolsCount}/{toolCount}
 													</>
 												) : (
 													"-"


### PR DESCRIPTION
## Summary

Extracts the MCP client form body into a shared `MCPClientFormFields` component so the "New MCP Server" sheet and the library install sheet render identical layouts, validation, and payload assembly. Previously the two sheets duplicated ~500 lines of form logic each, meaning any change to one had to be manually mirrored in the other. The library "publish" sheet is also overhauled to match the visual structure of the install sheet.

## Changes

- Introduced `mcpClientFormFields.tsx` exporting:
  - `MCPClientFormFields` — the shared form body (server behavior toggles, connection & auth, TLS, STDIO launch command)
  - `useMCPClientFormSatellites` — a hook that owns the out-of-band state (args text, env vars, scopes, resource URI, per-user header keys, auth scope) that lives outside react-hook-form
  - `validateMCPClientForm` — submit-time validation shared by both sheets; accepts `skipConnection` for the install sheet where transport and target are fixed by the library entry
  - `buildMCPClientPayload` — assembles the POST body from form values and satellite state
  - `getHeadersValidationError` — live header validation used by both sheets
  - `authKindOf` / `authScopeOf` — helpers that resolve the wire `auth_type` back into the two-dropdown split the UI uses
  - `StdioRuntimeNotice` — the amber Docker warning, now rendered from one place
  - `SectionHeader` re-exported so library sheets don't reach past this module

- `mcpClientForm.tsx` (the "New MCP Server" sheet) now delegates its entire form body and all validation/payload logic to the shared module, removing ~500 lines of duplicated code.

- `mcpLibraryInstallSheet.tsx` similarly delegates to `MCPClientFormFields` with `lockConnection` set, which renders the connection type, URL, and STDIO command as read-only. The install sheet seeds the form from the library entry (prefilling declared header names as empty rows, copying stdio config) and resets satellite state from the entry on open.

- `mcpLibraryAddServerSheet.tsx` (the "publish to library" sheet) is restructured to match the install sheet's visual layout: sectioned with `SectionHeader`, wrapped in `Form`, uses `FormField` throughout, adds a `publisher` field, splits auth into kind + scope dropdowns (mirroring the create-server sheet), and gates Token Exchange on the IDP being configured.

- The library "Add Server" button label changed from "Add Server" to "Add to Library"; the sheet title changed to "Publish Server to Library"; the submit button reads "Add to Library".

- `mcpClientsTable.tsx`: tool counts and the Code Mode badge no longer gate on `state === "healthy"`. Tool counts now reflect the last successful discovery (retained across transient failures), and Code Mode is pure config so it's always shown.

- `mcpClientSheet.tsx`: the session-stickiness dirty warning banner is moved outside the bordered toggle group so it reads as a consequence of the toggle rather than another setting row; a redundant `DottedSeparator` before the disabled toggle is removed.

- `mcpLibraryServerCard.tsx`: `token_exchange` added to `authLabel`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Open the MCP registry and click **Add to Library**. Verify the sheet shows the new sectioned layout with Listing Details, Connection, Authentication (with kind + scope dropdowns), and Discovery sections. Confirm the Token Exchange option only appears when an IDP is configured (Enterprise).
2. From the library, click **Install** on an HTTP entry. Verify the connection type, URL, and auth type are pre-populated from the entry and the connection fields are read-only. Confirm credentials are not pre-filled.
3. Install a STDIO library entry. Verify the command and args are read-only, and only the env var values are editable.
4. Open **New MCP Server** directly (not from the library). Verify the form is unchanged in behavior: all connection fields are editable, all auth types are available, validation fires as before.
5. In the MCP clients table, verify that a server in a non-healthy state (e.g. `unstable`) still shows its tool counts and Code Mode badge rather than dashes.

```sh
cd ui
pnpm i
pnpm build
pnpm test
```

## Screenshots/Recordings

Before/after screenshots recommended for the "Publish Server to Library" sheet and the install sheet with a locked connection.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The publish sheet explicitly documents that credentials are never stored on a library listing — each installer supplies their own. The install sheet enforces this by leaving all credential fields empty regardless of what the entry declares.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable