### PR TITLE
fix: preserve provider key name on update, keep constraint detail in already-exists errors

### DIFF
--- a/transports/bifrost-http/handlers/provider_keys.go
+++ b/transports/bifrost-http/handlers/provider_keys.go
@@ -566,6 +566,15 @@ func (h *ProviderHandler) mergeUpdatedKey(oldRawKey, updateKey schemas.Key) (sch
 	mergedKey.ConfigHash = oldRawKey.ConfigHash
 	mergedKey.Status = oldRawKey.Status
 
+	// An update that omits name must not clear it: schemas.Key.Name is a plain
+	// string, so an omitted field and an explicit "" are indistinguishable here.
+	// Treating that as "clear the name" persists an empty name, and config_keys.name
+	// carries a global unique index — the first cleared key claims "" and every
+	// later update that also omits name then fails with a confusing 409.
+	if mergedKey.Name == "" {
+		mergedKey.Name = oldRawKey.Name
+	}
+
 	return mergedKey, nil
 }
 

--- a/transports/bifrost-http/handlers/provider_keys_test.go
+++ b/transports/bifrost-http/handlers/provider_keys_test.go
@@ -112,6 +112,44 @@ func TestMergeUpdatedKey_Value(t *testing.T) {
 	})
 }
 
+// TestMergeUpdatedKey_Name locks in the invariant that a PUT update omitting
+// name must not clear the stored one. config_keys.name carries a global unique
+// index, so silently clearing it lets the first such update claim "" and wedge
+// every later name-omitting update behind a 409 (observed in a downstream
+// production deployment: a single edit that omitted name broke every
+// subsequent key edit going through this path).
+func TestMergeUpdatedKey_Name(t *testing.T) {
+	h := &ProviderHandler{}
+	merge := func(oldRaw, update schemas.Key) schemas.Key {
+		t.Helper()
+		merged, err := h.mergeUpdatedKey(oldRaw, update)
+		if err != nil {
+			t.Fatalf("mergeUpdatedKey returned error: %v", err)
+		}
+		return merged
+	}
+
+	t.Run("name omitted from update preserves stored name", func(t *testing.T) {
+		oldRaw := schemas.Key{ID: "key-1", Name: "prod-openai-key", Value: *schemas.NewSecretVar("sk-realkey1234567890abcdefghij")}
+		update := schemas.Key{ID: "key-1", Value: oldRaw.Value} // client PUT body has no "name" field
+
+		merged := merge(oldRaw, update)
+		if merged.Name != "prod-openai-key" {
+			t.Fatalf("expected stored name preserved, got %q", merged.Name)
+		}
+	})
+
+	t.Run("explicit new name is applied", func(t *testing.T) {
+		oldRaw := schemas.Key{ID: "key-1", Name: "prod-openai-key", Value: *schemas.NewSecretVar("sk-realkey1234567890abcdefghij")}
+		update := schemas.Key{ID: "key-1", Name: "renamed-key", Value: oldRaw.Value}
+
+		merged := merge(oldRaw, update)
+		if merged.Name != "renamed-key" {
+			t.Fatalf("expected new name applied, got %q", merged.Name)
+		}
+	})
+}
+
 func TestMergeUpdatedKey_ProviderConfigMaskedPreviews(t *testing.T) {
 	h := &ProviderHandler{}
 	merge := func(oldRaw, update schemas.Key) schemas.Key {

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -6256,7 +6256,10 @@ func (c *Config) AddProviderKey(ctx context.Context, provider schemas.ModelProvi
 				return ErrNotFound
 			}
 			if errors.Is(err, configstore.ErrAlreadyExists) {
-				return ErrAlreadyExists
+				// Wrap rather than discard: parseGormError's message names the
+				// constraint that actually fired (key name vs. key ID), which a bare
+				// ErrAlreadyExists would otherwise erase from the warn log below.
+				return fmt.Errorf("%w: %w", ErrAlreadyExists, err)
 			}
 			return fmt.Errorf("failed to create provider key in store: %w", err)
 		}
@@ -6328,7 +6331,10 @@ func (c *Config) UpdateProviderKey(ctx context.Context, provider schemas.ModelPr
 				return ErrNotFound
 			}
 			if errors.Is(err, configstore.ErrAlreadyExists) {
-				return ErrAlreadyExists
+				// Wrap rather than discard: parseGormError's message names the
+				// constraint that actually fired (key name vs. key ID), which a bare
+				// ErrAlreadyExists would otherwise erase from the warn log below.
+				return fmt.Errorf("%w: %w", ErrAlreadyExists, err)
 			}
 			return fmt.Errorf("failed to update provider key in store: %w", err)
 		}

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -19616,6 +19616,99 @@ func TestAddProvider_NilConfigStore_AddsToMemoryOnly(t *testing.T) {
 }
 
 // =============================================================================
+// AddProviderKey / UpdateProviderKey ErrAlreadyExists Tests
+// =============================================================================
+//
+// parseGormError (framework/configstore/rdb.go) names the constraint that
+// actually fired — e.g. the key-name unique index vs. the key-ID unique index —
+// in its wrapped error message. Config.AddProviderKey/UpdateProviderKey used to
+// discard that message and return a bare ErrAlreadyExists, so the constraint
+// detail never reached the handler's warn log. These tests pin that the
+// original message survives the collapse.
+
+// mockConfigStoreAddProviderKey is a ConfigStore mock that allows controlling CreateProviderKey behavior.
+type mockConfigStoreAddProviderKey struct {
+	MockConfigStore
+	createProviderKeyErr error
+}
+
+func (m *mockConfigStoreAddProviderKey) CreateProviderKey(ctx context.Context, provider schemas.ModelProvider, key schemas.Key, tx ...*gorm.DB) error {
+	if m.createProviderKeyErr != nil {
+		return m.createProviderKeyErr
+	}
+	return m.MockConfigStore.CreateProviderKey(ctx, provider, key, tx...)
+}
+
+func TestAddProviderKey_AlreadyExists_PreservesConstraintDetail(t *testing.T) {
+	initTestLogger()
+	// Simulates parseGormError's message for a key-ID unique-index hit, distinct
+	// from the generic "already exists" the collapse used to leave behind.
+	detailed := fmt.Errorf("a record with this id %w. Please use a different value", configstore.ErrAlreadyExists)
+	mockStore := &mockConfigStoreAddProviderKey{
+		MockConfigStore:      *NewMockConfigStore(),
+		createProviderKeyErr: detailed,
+	}
+	cfg := &Config{
+		Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+			"test-provider": {},
+		},
+		ConfigStore: mockStore,
+	}
+
+	err := cfg.AddProviderKey(context.Background(), "test-provider", schemas.Key{ID: "key-1", Value: *schemas.NewSecretVar("test-key")})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrAlreadyExists) {
+		t.Fatalf("expected ErrAlreadyExists, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "record with this id") {
+		t.Fatalf("expected original constraint detail preserved in error, got: %v", err)
+	}
+}
+
+// mockConfigStoreUpdateProviderKey is a ConfigStore mock that allows controlling UpdateProviderKey behavior.
+type mockConfigStoreUpdateProviderKey struct {
+	MockConfigStore
+	updateProviderKeyErr error
+}
+
+func (m *mockConfigStoreUpdateProviderKey) UpdateProviderKey(ctx context.Context, provider schemas.ModelProvider, keyID string, key schemas.Key, tx ...*gorm.DB) error {
+	if m.updateProviderKeyErr != nil {
+		return m.updateProviderKeyErr
+	}
+	return m.MockConfigStore.UpdateProviderKey(ctx, provider, keyID, key, tx...)
+}
+
+func TestUpdateProviderKey_AlreadyExists_PreservesConstraintDetail(t *testing.T) {
+	initTestLogger()
+	detailed := fmt.Errorf("a record with this id %w. Please use a different value", configstore.ErrAlreadyExists)
+	mockStore := &mockConfigStoreUpdateProviderKey{
+		MockConfigStore:      *NewMockConfigStore(),
+		updateProviderKeyErr: detailed,
+	}
+	cfg := &Config{
+		Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+			"test-provider": {Keys: []schemas.Key{{ID: "key-1", Value: *schemas.NewSecretVar("test-key")}}},
+		},
+		ConfigStore: mockStore,
+	}
+
+	err := cfg.UpdateProviderKey(context.Background(), "test-provider", "key-1", schemas.Key{ID: "key-1", Value: *schemas.NewSecretVar("test-key")})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrAlreadyExists) {
+		t.Fatalf("expected ErrAlreadyExists, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "record with this id") {
+		t.Fatalf("expected original constraint detail preserved in error, got: %v", err)
+	}
+}
+
+// =============================================================================
 // RemoveProvider Tests
 // =============================================================================
 


### PR DESCRIPTION
## Summary

Fixes #6416. Two related bugs found while diagnosing a production incident in a downstream deployment (EnHeim): a provider-key update that omits `"name"` silently clears the stored name, and the global unique-name index then 409s every later update that also omits `name`. While tracing that 409, the error-collapsing that made it hard to diagnose turned out to be its own small bug.

## Changes

**1. `mergeUpdatedKey` now preserves `Name` when a PUT update omits it** (`transports/bifrost-http/handlers/provider_keys.go`)

`mergeUpdatedKey` already restores every secret sub-field (`Value`, Azure/Vertex/Bedrock/... configs) plus `ConfigHash` and `Status` from the stored key when a request omits them, but never touched `Name`. Since `schemas.Key.Name` is a plain `string`, an update body that omits `"name"` unmarshals to `Name == ""` and that empty string then gets persisted — and because `config_keys.name` carries a global unique index, the first key cleared this way claims `""` and wedges every later name-omitting update behind a 409.

The fix mirrors the existing "omitted = keep existing" semantics already applied to every other field in this function: if the merged name is empty, restore it from the stored key.

**2. `AddProviderKey`/`UpdateProviderKey` no longer discard the constraint detail on an already-exists error** (`transports/bifrost-http/lib/config.go`)

`parseGormError` (`framework/configstore/rdb.go`) already identifies which of `config_keys`'s two unique constraints (name vs. key ID) actually fired, and wraps that into its returned error's message. `Config.AddProviderKey`/`Config.UpdateProviderKey` threw that away and returned a bare `ErrAlreadyExists` sentinel instead, so the handler's warn log printed only `"already exists"` — no way to tell which constraint was hit. That made this bug harder to diagnose than it needed to be.

Fixed by wrapping the original error alongside the sentinel (`fmt.Errorf("%w: %w", ErrAlreadyExists, err)` — the same double-`%w` idiom already used in `framework/logstore/asyncjob.go` and `framework/vectorstore/redis.go`), so `errors.Is(err, ErrAlreadyExists)` still holds for the handler's existing dispatch, while the constraint detail now survives into the log.

*Not changed:* the handler's user-facing 409 message ("API key names must be unique across providers...") is still hardcoded regardless of which constraint fired. That's a separate, much smaller inaccuracy — it only misfires on a `key_id` collision, which in practice is a random-UUID collision — and didn't seem worth bundling into this fix. Happy to address it too if you'd rather it went in the same PR.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go version
cd transports
go test ./bifrost-http/handlers/... ./bifrost-http/lib/...
```

Both new tests fail on `dev` HEAD without this PR's changes (confirmed locally by reverting each fix in isolation and re-running):

- `TestMergeUpdatedKey_Name/name_omitted_from_update_preserves_stored_name` — `expected stored name preserved, got ""`
- `TestAddProviderKey_AlreadyExists_PreservesConstraintDetail` / `TestUpdateProviderKey_AlreadyExists_PreservesConstraintDetail` — `expected original constraint detail preserved in error, got: already exists`

Full `bifrost-http/handlers` and `bifrost-http/lib` suites pass with the changes applied.

## Screenshots/Recordings

N/A — server-side logic only, no UI change.

## Breaking changes

- [ ] Yes
- [x] No

`errors.Is(err, ErrAlreadyExists)` still holds after fix 2, so existing callers keying off that sentinel are unaffected; only the wrapped error's message gains detail.

## Related issues

Closes #6416

## Security considerations

None. Fix 1 only affects which value is written back for a non-secret display field. Fix 2 only affects an error's message content (already a non-secret, generic "already exists" string); no additional information is exposed that the original `parseGormError` message didn't already carry before being discarded.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed — no user-facing docs describe this behavior
- [x] I verified builds succeed (Go) — `go build ./bifrost-http/handlers/... ./bifrost-http/lib/...`
- [ ] I verified the CI pipeline passes locally if applicable — ran the two affected packages' test suites directly (see "How to test"); did not run the full `make test-all` (UI/provider-harness suites are unrelated to this change)

Note: no `transports/changelog.md` entry included — that file looks maintained via your own release-notes tooling rather than hand-authored per PR (recent entries read as generated prose, not the `[type]: description [@name]` line format `docs/contributing/code-conventions.mdx` describes). Happy to add one in whatever format you'd prefer.
