### PR TITLE
fix: accept json bodies in image edit request

### DIFF
--- a/core/providers/runware/images.go
+++ b/core/providers/runware/images.go
@@ -176,6 +176,17 @@ func ToRunwareImageEditRequest(bifrostReq *schemas.BifrostImageEditRequest) (*Ru
 		}
 
 		request.ExtraParams = params.ExtraParams
+
+		// Same promotion the tool tasks do: providerSettings carries the vendor-specific knobs
+		// these models take, and multipart delivers it as a JSON string rather than an object.
+		if v, ok := runwareSettings(request.ExtraParams["settings"]); ok {
+			delete(request.ExtraParams, "settings")
+			request.Settings = v
+		}
+		if v, ok := runwareSettings(request.ExtraParams["providerSettings"]); ok {
+			delete(request.ExtraParams, "providerSettings")
+			request.ProviderSettings = v
+		}
 	}
 
 	return request, nil

--- a/core/providers/runware/images_test.go
+++ b/core/providers/runware/images_test.go
@@ -131,6 +131,43 @@ func TestToRunwareImageEditRequest_RemoveBackgroundSettings(t *testing.T) {
 	}
 }
 
+// The imageInference branch promotes the same two nested objects the tool tasks do. It matters for
+// multipart callers, who can only deliver them as a JSON string: providerSettings is how the
+// vendor-specific knobs reach these models, and a string there is not the object Runware expects.
+func TestToRunwareImageEditRequest_ImageInferenceSettings(t *testing.T) {
+	req := upscaleEditRequest(map[string]interface{}{
+		"settings":         `{"returnOnlyMask":true}`,
+		"providerSettings": `{"google":{"personGeneration":"allow_adult"}}`,
+		"unrelated":        "keep-me",
+	})
+	req.Model = "google:4@1"
+	req.Params.Type = nil
+	req.Input.Prompt = "make the teapot blue"
+
+	out, err := ToRunwareImageEditRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.TaskType != taskTypeImageInference {
+		t.Fatalf("taskType = %q, want %q", out.TaskType, taskTypeImageInference)
+	}
+	if out.Settings["returnOnlyMask"] != true {
+		t.Fatalf("settings = %+v, want returnOnlyMask=true", out.Settings)
+	}
+	if out.ProviderSettings["google"] == nil {
+		t.Fatalf("providerSettings = %+v, want a google entry", out.ProviderSettings)
+	}
+	if _, ok := out.ExtraParams["settings"]; ok {
+		t.Fatalf("settings must be consumed, not re-sent verbatim: %+v", out.ExtraParams)
+	}
+	if _, ok := out.ExtraParams["providerSettings"]; ok {
+		t.Fatalf("providerSettings must be consumed, not re-sent verbatim: %+v", out.ExtraParams)
+	}
+	if out.ExtraParams["unrelated"] != "keep-me" {
+		t.Fatalf("unrecognised extra params must pass through, got %+v", out.ExtraParams)
+	}
+}
+
 // A settings object supplied by a JSON caller is used as-is, without a string round-trip.
 func TestToRunwareImageEditRequest_UpscaleSettingsObject(t *testing.T) {
 	out, err := ToRunwareImageEditRequest(upscaleEditRequest(map[string]interface{}{

--- a/core/schemas/images.go
+++ b/core/schemas/images.go
@@ -1,5 +1,10 @@
 package schemas
 
+import (
+	"bytes"
+	"fmt"
+)
+
 type ImageEventType string
 
 const (
@@ -339,6 +344,32 @@ type ImageEditInput struct {
 type ImageInput struct {
 	Image []byte `json:"image"`
 	URL   string `json:"url,omitempty"` // alternative to Image; providers that require bytes reject it
+}
+
+// UnmarshalJSON accepts either the object form or a bare string, so images: ["https://..."] reads
+// the way input_images does on /v1/images/generations. A string lands in URL, the same field the
+// multipart image_url path fills. Marshalling always emits the object form.
+func (i *ImageInput) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		i.Image = nil
+		i.URL = ""
+		return nil
+	}
+
+	var s string
+	if err := Unmarshal(data, &s); err == nil {
+		i.Image = nil
+		i.URL = s
+		return nil
+	}
+	type imageInput ImageInput
+	var obj imageInput
+	if err := Unmarshal(data, &obj); err != nil {
+		return fmt.Errorf("image input is neither a string nor an object")
+	}
+	*i = ImageInput(obj)
+	return nil
 }
 
 type ImageEditParameters struct {

--- a/core/schemas/images_test.go
+++ b/core/schemas/images_test.go
@@ -1,0 +1,87 @@
+package schemas
+
+import "testing"
+
+// An image source arrives either as the object form or as a bare string, so images: ["https://..."]
+// reads the way input_images does on /v1/images/generations.
+func TestImageInputUnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		name    string
+		body    string
+		wantURL string
+		wantImg string
+		wantErr bool
+	}{
+		{name: "bare string url", body: `"https://example.com/teapot.jpg"`, wantURL: "https://example.com/teapot.jpg"},
+		{name: "bare string data uri", body: `"data:image/png;base64,aGVsbG8="`, wantURL: "data:image/png;base64,aGVsbG8="},
+		{name: "object url", body: `{"url":"https://example.com/teapot.jpg"}`, wantURL: "https://example.com/teapot.jpg"},
+		{name: "object base64 bytes", body: `{"image":"aGVsbG8="}`, wantImg: "hello"},
+		{name: "null clears both arms", body: `null`},
+		{name: "number is neither form", body: `42`, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got ImageInput
+			err := Unmarshal([]byte(tc.body), &got)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.URL != tc.wantURL {
+				t.Fatalf("url = %q, want %q", got.URL, tc.wantURL)
+			}
+			if string(got.Image) != tc.wantImg {
+				t.Fatalf("image = %q, want %q", got.Image, tc.wantImg)
+			}
+		})
+	}
+}
+
+// The two forms mix freely inside one images array, and decoding into a reused value must not
+// leave the other arm populated.
+func TestImageEditInputUnmarshalMixedImageForms(t *testing.T) {
+	var input ImageEditInput
+	if err := Unmarshal([]byte(
+		`{"prompt":"blue","images":["https://example.com/a.jpg",{"image":"aGVsbG8="},{"url":"https://example.com/b.jpg"}]}`,
+	), &input); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(input.Images) != 3 {
+		t.Fatalf("images = %+v, want 3 entries", input.Images)
+	}
+	if input.Images[0].URL != "https://example.com/a.jpg" || input.Images[0].Image != nil {
+		t.Fatalf("string form = %+v", input.Images[0])
+	}
+	if string(input.Images[1].Image) != "hello" || input.Images[1].URL != "" {
+		t.Fatalf("bytes form = %+v", input.Images[1])
+	}
+	if input.Images[2].URL != "https://example.com/b.jpg" {
+		t.Fatalf("object url form = %+v", input.Images[2])
+	}
+
+	// A second decode into the same value replaces both arms rather than merging them.
+	reused := &input.Images[1]
+	if err := Unmarshal([]byte(`"https://example.com/c.jpg"`), reused); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if reused.URL != "https://example.com/c.jpg" || reused.Image != nil {
+		t.Fatalf("reused decode = %+v, want only the url arm set", reused)
+	}
+}
+
+// Marshalling stays on the object form; the string form is an input convenience only, so logged
+// and replayed requests keep one shape.
+func TestImageInputMarshalsObjectForm(t *testing.T) {
+	out, err := Marshal(ImageInput{URL: "https://example.com/teapot.jpg"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(out) != `{"image":null,"url":"https://example.com/teapot.jpg"}` {
+		t.Fatalf("marshalled = %s", out)
+	}
+}

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -2767,16 +2767,213 @@
       "post": {
         "operationId": "imageEdit",
         "summary": "Edit an image",
-        "description": "Edits an image using a text prompt and optional mask. Request must be sent as multipart/form-data\nwith at least `model`, `prompt` (unless `type` is `background_removal`), and `image` (or `image[]`).\n",
+        "description": "Edits an image using a text prompt and optional mask. Accepts either `application/json` (sources\nas URLs or base64 under `images`) or `multipart/form-data` (to upload the image as `image` or\n`image[]`). Requires at least `model`, one image, and `prompt` - the latter except for the\noperation types driven purely by the input image, e.g. `background_removal`. Only the JSON body\npreserves the types of provider-native extra params; multipart carries every value as a string.\n",
         "tags": [
           "Images"
         ],
         "requestBody": {
           "required": true,
           "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "description": "JSON encoding of an image edit. Sources are supplied as an `images` array, the same nested form\n/v1/videos/edits uses for its source video. Unrecognised top-level fields are forwarded to the\nprovider as extra params with their JSON types intact, which is what a model's nested tuning\nobject needs (e.g. Runware's `settings` and `providerSettings`). To upload the image as a file,\npost `multipart/form-data` instead - see `ImageEditMultipartRequest`.\n",
+                "required": [
+                  "model",
+                  "images"
+                ],
+                "properties": {
+                  "model": {
+                    "type": "string",
+                    "description": "Model identifier in format `provider/model`"
+                  },
+                  "images": {
+                    "type": "array",
+                    "items": {
+                      "description": "One source image, either as a bare string - the form `input_images` takes on\n/v1/images/generations - or as an object naming which arm it fills. Providers that cannot accept\na given form reject it.\n",
+                      "oneOf": [
+                        {
+                          "type": "string",
+                          "description": "Public URL, data URI, base64 payload, or provider-side asset ID. Equivalent to the object\nform's `url`.\n"
+                        },
+                        {
+                          "type": "object",
+                          "description": "Exactly one of the two properties is expected.",
+                          "properties": {
+                            "url": {
+                              "type": "string",
+                              "description": "Public URL, data URI, or provider-side asset ID, for providers whose upstream fetches\nthe asset itself (e.g. Runware). Avoids round-tripping the asset through the gateway as\nbase64.\n"
+                            },
+                            "image": {
+                              "type": "string",
+                              "format": "byte",
+                              "description": "Base64-encoded image bytes"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "description": "Source images. Entries carrying neither a URL nor bytes are dropped; a request left with no\nusable image is rejected. Providers treat the first image as the primary one (Runware's seed\nimage, Bedrock's style-transfer base), so the order is part of the contract. Only the\nreference-image models accept more than one; elsewhere images after the first are dropped.\n"
+                  },
+                  "prompt": {
+                    "type": "string",
+                    "description": "Text prompt describing the edit. Required except for the operation types that are driven\npurely by the input image: `background_removal`, `erase_object`, `upscale`, `upscale_fast`,\n`mask`, `segmentation`, `vectorize` and `controlnet_preprocess`.\n"
+                  },
+                  "mask": {
+                    "type": "string",
+                    "format": "byte",
+                    "description": "Optional base64-encoded mask image for inpainting (transparent areas indicate regions to\nedit). Dropped for models that declare no mask input.\n"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "inpainting",
+                      "outpainting",
+                      "background_removal",
+                      "remove_background",
+                      "remove_bg",
+                      "erase_object",
+                      "recolor",
+                      "search_replace",
+                      "control_sketch",
+                      "control_structure",
+                      "style_guide",
+                      "style_transfer",
+                      "upscale",
+                      "upscale_fast",
+                      "upscale_creative",
+                      "upscale_conservative",
+                      "mask",
+                      "segmentation",
+                      "vectorize",
+                      "controlnet_preprocess",
+                      "controlnet",
+                      "preprocess"
+                    ],
+                    "description": "Type of edit operation. Support varies by provider; unsupported values are dropped and the\nrequest runs as a standard edit.\n"
+                  },
+                  "upscale_factor": {
+                    "type": "integer",
+                    "description": "Multiply each dimension by this factor. `type: \"upscale\"` only; mutually exclusive with\n`target_megapixels`.\n"
+                  },
+                  "target_megapixels": {
+                    "type": "integer",
+                    "description": "Target output size in megapixels. `type: \"upscale\"` only; mutually exclusive with\n`upscale_factor`.\n"
+                  },
+                  "n": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 10,
+                    "description": "Number of images to generate"
+                  },
+                  "size": {
+                    "type": "string",
+                    "enum": [
+                      "256x256",
+                      "512x512",
+                      "1024x1024",
+                      "1536x1024",
+                      "1024x1536",
+                      "auto"
+                    ],
+                    "description": "Size of the output image"
+                  },
+                  "response_format": {
+                    "type": "string",
+                    "enum": [
+                      "url",
+                      "b64_json",
+                      "data_uri"
+                    ],
+                    "default": "url",
+                    "description": "Format of the response. `data_uri` is supported by providers that return an inline\ndata URI (e.g. Runware).\n"
+                  },
+                  "stream": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When true, stream the response via Server-Sent Events"
+                  },
+                  "background": {
+                    "type": "string",
+                    "enum": [
+                      "transparent",
+                      "opaque",
+                      "auto"
+                    ],
+                    "description": "Background type for the image"
+                  },
+                  "input_fidelity": {
+                    "type": "string",
+                    "enum": [
+                      "low",
+                      "high"
+                    ],
+                    "description": "How closely to follow the original image"
+                  },
+                  "partial_images": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 3,
+                    "description": "Number of partial images to generate when streaming"
+                  },
+                  "quality": {
+                    "type": "string",
+                    "enum": [
+                      "auto",
+                      "high",
+                      "medium",
+                      "low",
+                      "standard"
+                    ],
+                    "description": "Quality of the output image"
+                  },
+                  "output_format": {
+                    "type": "string",
+                    "enum": [
+                      "png",
+                      "webp",
+                      "jpeg",
+                      "tiff",
+                      "svg"
+                    ],
+                    "description": "Output image format. `svg` applies to vectorize operations"
+                  },
+                  "num_inference_steps": {
+                    "type": "integer",
+                    "description": "Number of inference steps"
+                  },
+                  "seed": {
+                    "type": "integer",
+                    "description": "Seed for reproducible editing"
+                  },
+                  "output_compression": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 100,
+                    "description": "Compression level (0-100%)"
+                  },
+                  "negative_prompt": {
+                    "type": "string",
+                    "description": "What to avoid in the edit"
+                  },
+                  "user": {
+                    "type": "string",
+                    "description": "User identifier for tracking"
+                  },
+                  "fallbacks": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Fallback"
+                    },
+                    "description": "Fallback models to try if primary model fails"
+                  }
+                }
+              }
+            },
             "multipart/form-data": {
               "schema": {
                 "type": "object",
+                "description": "Multipart encoding of an image edit, and the only encoding that can upload the image as a file.\nThis is what the official OpenAI SDKs send unconditionally. Every value crosses the wire as a\nstring, so provider-native extra params arrive as strings; post `application/json` instead when\na provider expects them as numbers, booleans or nested objects - see `ImageEditRequest`.\n",
                 "required": [
                   "model"
                 ],
@@ -2825,7 +3022,9 @@
                       "mask",
                       "segmentation",
                       "vectorize",
-                      "controlnet_preprocess"
+                      "controlnet_preprocess",
+                      "controlnet",
+                      "preprocess"
                     ],
                     "description": "Type of edit operation. Support varies by provider; unsupported values are dropped and the\nrequest runs as a standard edit.\n"
                   },
@@ -10223,9 +10422,206 @@
         "requestBody": {
           "required": true,
           "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "description": "JSON encoding of an image edit. Sources are supplied as an `images` array, the same nested form\n/v1/videos/edits uses for its source video. Unrecognised top-level fields are forwarded to the\nprovider as extra params with their JSON types intact, which is what a model's nested tuning\nobject needs (e.g. Runware's `settings` and `providerSettings`). To upload the image as a file,\npost `multipart/form-data` instead - see `ImageEditMultipartRequest`.\n",
+                "required": [
+                  "model",
+                  "images"
+                ],
+                "properties": {
+                  "model": {
+                    "type": "string",
+                    "description": "Model identifier in format `provider/model`"
+                  },
+                  "images": {
+                    "type": "array",
+                    "items": {
+                      "description": "One source image, either as a bare string - the form `input_images` takes on\n/v1/images/generations - or as an object naming which arm it fills. Providers that cannot accept\na given form reject it.\n",
+                      "oneOf": [
+                        {
+                          "type": "string",
+                          "description": "Public URL, data URI, base64 payload, or provider-side asset ID. Equivalent to the object\nform's `url`.\n"
+                        },
+                        {
+                          "type": "object",
+                          "description": "Exactly one of the two properties is expected.",
+                          "properties": {
+                            "url": {
+                              "type": "string",
+                              "description": "Public URL, data URI, or provider-side asset ID, for providers whose upstream fetches\nthe asset itself (e.g. Runware). Avoids round-tripping the asset through the gateway as\nbase64.\n"
+                            },
+                            "image": {
+                              "type": "string",
+                              "format": "byte",
+                              "description": "Base64-encoded image bytes"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "description": "Source images. Entries carrying neither a URL nor bytes are dropped; a request left with no\nusable image is rejected. Providers treat the first image as the primary one (Runware's seed\nimage, Bedrock's style-transfer base), so the order is part of the contract. Only the\nreference-image models accept more than one; elsewhere images after the first are dropped.\n"
+                  },
+                  "prompt": {
+                    "type": "string",
+                    "description": "Text prompt describing the edit. Required except for the operation types that are driven\npurely by the input image: `background_removal`, `erase_object`, `upscale`, `upscale_fast`,\n`mask`, `segmentation`, `vectorize` and `controlnet_preprocess`.\n"
+                  },
+                  "mask": {
+                    "type": "string",
+                    "format": "byte",
+                    "description": "Optional base64-encoded mask image for inpainting (transparent areas indicate regions to\nedit). Dropped for models that declare no mask input.\n"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "inpainting",
+                      "outpainting",
+                      "background_removal",
+                      "remove_background",
+                      "remove_bg",
+                      "erase_object",
+                      "recolor",
+                      "search_replace",
+                      "control_sketch",
+                      "control_structure",
+                      "style_guide",
+                      "style_transfer",
+                      "upscale",
+                      "upscale_fast",
+                      "upscale_creative",
+                      "upscale_conservative",
+                      "mask",
+                      "segmentation",
+                      "vectorize",
+                      "controlnet_preprocess",
+                      "controlnet",
+                      "preprocess"
+                    ],
+                    "description": "Type of edit operation. Support varies by provider; unsupported values are dropped and the\nrequest runs as a standard edit.\n"
+                  },
+                  "upscale_factor": {
+                    "type": "integer",
+                    "description": "Multiply each dimension by this factor. `type: \"upscale\"` only; mutually exclusive with\n`target_megapixels`.\n"
+                  },
+                  "target_megapixels": {
+                    "type": "integer",
+                    "description": "Target output size in megapixels. `type: \"upscale\"` only; mutually exclusive with\n`upscale_factor`.\n"
+                  },
+                  "n": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 10,
+                    "description": "Number of images to generate"
+                  },
+                  "size": {
+                    "type": "string",
+                    "enum": [
+                      "256x256",
+                      "512x512",
+                      "1024x1024",
+                      "1536x1024",
+                      "1024x1536",
+                      "auto"
+                    ],
+                    "description": "Size of the output image"
+                  },
+                  "response_format": {
+                    "type": "string",
+                    "enum": [
+                      "url",
+                      "b64_json",
+                      "data_uri"
+                    ],
+                    "default": "url",
+                    "description": "Format of the response. `data_uri` is supported by providers that return an inline\ndata URI (e.g. Runware).\n"
+                  },
+                  "stream": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When true, stream the response via Server-Sent Events"
+                  },
+                  "background": {
+                    "type": "string",
+                    "enum": [
+                      "transparent",
+                      "opaque",
+                      "auto"
+                    ],
+                    "description": "Background type for the image"
+                  },
+                  "input_fidelity": {
+                    "type": "string",
+                    "enum": [
+                      "low",
+                      "high"
+                    ],
+                    "description": "How closely to follow the original image"
+                  },
+                  "partial_images": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 3,
+                    "description": "Number of partial images to generate when streaming"
+                  },
+                  "quality": {
+                    "type": "string",
+                    "enum": [
+                      "auto",
+                      "high",
+                      "medium",
+                      "low",
+                      "standard"
+                    ],
+                    "description": "Quality of the output image"
+                  },
+                  "output_format": {
+                    "type": "string",
+                    "enum": [
+                      "png",
+                      "webp",
+                      "jpeg",
+                      "tiff",
+                      "svg"
+                    ],
+                    "description": "Output image format. `svg` applies to vectorize operations"
+                  },
+                  "num_inference_steps": {
+                    "type": "integer",
+                    "description": "Number of inference steps"
+                  },
+                  "seed": {
+                    "type": "integer",
+                    "description": "Seed for reproducible editing"
+                  },
+                  "output_compression": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 100,
+                    "description": "Compression level (0-100%)"
+                  },
+                  "negative_prompt": {
+                    "type": "string",
+                    "description": "What to avoid in the edit"
+                  },
+                  "user": {
+                    "type": "string",
+                    "description": "User identifier for tracking"
+                  },
+                  "fallbacks": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Fallback"
+                    },
+                    "description": "Fallback models to try if primary model fails"
+                  }
+                }
+              }
+            },
             "multipart/form-data": {
               "schema": {
                 "type": "object",
+                "description": "Multipart encoding of an image edit, and the only encoding that can upload the image as a file.\nThis is what the official OpenAI SDKs send unconditionally. Every value crosses the wire as a\nstring, so provider-native extra params arrive as strings; post `application/json` instead when\na provider expects them as numbers, booleans or nested objects - see `ImageEditRequest`.\n",
                 "required": [
                   "model"
                 ],
@@ -10274,7 +10670,9 @@
                       "mask",
                       "segmentation",
                       "vectorize",
-                      "controlnet_preprocess"
+                      "controlnet_preprocess",
+                      "controlnet",
+                      "preprocess"
                     ],
                     "description": "Type of edit operation. Support varies by provider; unsupported values are dropped and the\nrequest runs as a standard edit.\n"
                   },

--- a/docs/openapi/paths/inference/async.yaml
+++ b/docs/openapi/paths/inference/async.yaml
@@ -269,9 +269,12 @@ async-image-edit:
     requestBody:
       required: true
       content:
-        multipart/form-data:
+        application/json:
           schema:
             $ref: '../../schemas/inference/images.yaml#/ImageEditRequest'
+        multipart/form-data:
+          schema:
+            $ref: '../../schemas/inference/images.yaml#/ImageEditMultipartRequest'
     responses:
       '202':
         description: Job accepted for processing

--- a/docs/openapi/paths/inference/images.yaml
+++ b/docs/openapi/paths/inference/images.yaml
@@ -44,16 +44,22 @@ image-edit:
     operationId: imageEdit
     summary: Edit an image
     description: |
-      Edits an image using a text prompt and optional mask. Request must be sent as multipart/form-data
-      with at least `model`, `prompt` (unless `type` is `background_removal`), and `image` (or `image[]`).
+      Edits an image using a text prompt and optional mask. Accepts either `application/json` (sources
+      as URLs or base64 under `images`) or `multipart/form-data` (to upload the image as `image` or
+      `image[]`). Requires at least `model`, one image, and `prompt` - the latter except for the
+      operation types driven purely by the input image, e.g. `background_removal`. Only the JSON body
+      preserves the types of provider-native extra params; multipart carries every value as a string.
     tags:
     - Images
     requestBody:
       required: true
       content:
-        multipart/form-data:
+        application/json:
           schema:
             $ref: '../../schemas/inference/images.yaml#/ImageEditRequest'
+        multipart/form-data:
+          schema:
+            $ref: '../../schemas/inference/images.yaml#/ImageEditMultipartRequest'
     responses:
       '200':
         description: |

--- a/docs/openapi/schemas/inference/images.yaml
+++ b/docs/openapi/schemas/inference/images.yaml
@@ -329,10 +329,201 @@ ImageGenerationStreamResponse:
     extra_fields:
       $ref: './common.yaml#/BifrostResponseExtraFields'
 
-# Image Edit Schemas (multipart/form-data)
+# Image Edit Schemas (application/json and multipart/form-data)
+
+ImageInput:
+  description: |
+    One source image, either as a bare string - the form `input_images` takes on
+    /v1/images/generations - or as an object naming which arm it fills. Providers that cannot accept
+    a given form reject it.
+  oneOf:
+    - type: string
+      description: |
+        Public URL, data URI, base64 payload, or provider-side asset ID. Equivalent to the object
+        form's `url`.
+    - type: object
+      description: Exactly one of the two properties is expected.
+      properties:
+        url:
+          type: string
+          description: |
+            Public URL, data URI, or provider-side asset ID, for providers whose upstream fetches
+            the asset itself (e.g. Runware). Avoids round-tripping the asset through the gateway as
+            base64.
+        image:
+          type: string
+          format: byte
+          description: Base64-encoded image bytes
 
 ImageEditRequest:
   type: object
+  description: |
+    JSON encoding of an image edit. Sources are supplied as an `images` array, the same nested form
+    /v1/videos/edits uses for its source video. Unrecognised top-level fields are forwarded to the
+    provider as extra params with their JSON types intact, which is what a model's nested tuning
+    object needs (e.g. Runware's `settings` and `providerSettings`). To upload the image as a file,
+    post `multipart/form-data` instead - see `ImageEditMultipartRequest`.
+  required:
+    - model
+    - images
+  properties:
+    model:
+      type: string
+      description: Model identifier in format `provider/model`
+    images:
+      type: array
+      items:
+        $ref: '#/ImageInput'
+      description: |
+        Source images. Entries carrying neither a URL nor bytes are dropped; a request left with no
+        usable image is rejected. Providers treat the first image as the primary one (Runware's seed
+        image, Bedrock's style-transfer base), so the order is part of the contract. Only the
+        reference-image models accept more than one; elsewhere images after the first are dropped.
+    prompt:
+      type: string
+      description: |
+        Text prompt describing the edit. Required except for the operation types that are driven
+        purely by the input image: `background_removal`, `erase_object`, `upscale`, `upscale_fast`,
+        `mask`, `segmentation`, `vectorize` and `controlnet_preprocess`.
+    mask:
+      type: string
+      format: byte
+      description: |
+        Optional base64-encoded mask image for inpainting (transparent areas indicate regions to
+        edit). Dropped for models that declare no mask input.
+    type:
+      type: string
+      enum:
+        - "inpainting"
+        - "outpainting"
+        - "background_removal"
+        - "remove_background"
+        - "remove_bg"
+        - "erase_object"
+        - "recolor"
+        - "search_replace"
+        - "control_sketch"
+        - "control_structure"
+        - "style_guide"
+        - "style_transfer"
+        - "upscale"
+        - "upscale_fast"
+        - "upscale_creative"
+        - "upscale_conservative"
+        - "mask"
+        - "segmentation"
+        - "vectorize"
+        - "controlnet_preprocess"
+        - "controlnet"
+        - "preprocess"
+      description: |
+        Type of edit operation. Support varies by provider; unsupported values are dropped and the
+        request runs as a standard edit.
+    upscale_factor:
+      type: integer
+      description: |
+        Multiply each dimension by this factor. `type: "upscale"` only; mutually exclusive with
+        `target_megapixels`.
+    target_megapixels:
+      type: integer
+      description: |
+        Target output size in megapixels. `type: "upscale"` only; mutually exclusive with
+        `upscale_factor`.
+    n:
+      type: integer
+      minimum: 1
+      maximum: 10
+      description: Number of images to generate
+    size:
+      type: string
+      enum:
+        - "256x256"
+        - "512x512"
+        - "1024x1024"
+        - "1536x1024"
+        - "1024x1536"
+        - "auto"
+      description: Size of the output image
+    response_format:
+      type: string
+      enum:
+        - "url"
+        - "b64_json"
+        - "data_uri"
+      default: "url"
+      description: |
+        Format of the response. `data_uri` is supported by providers that return an inline
+        data URI (e.g. Runware).
+    stream:
+      type: boolean
+      default: false
+      description: When true, stream the response via Server-Sent Events
+    background:
+      type: string
+      enum:
+        - "transparent"
+        - "opaque"
+        - "auto"
+      description: Background type for the image
+    input_fidelity:
+      type: string
+      enum:
+        - "low"
+        - "high"
+      description: How closely to follow the original image
+    partial_images:
+      type: integer
+      minimum: 0
+      maximum: 3
+      description: Number of partial images to generate when streaming
+    quality:
+      type: string
+      enum:
+        - "auto"
+        - "high"
+        - "medium"
+        - "low"
+        - "standard"
+      description: Quality of the output image
+    output_format:
+      type: string
+      enum:
+        - "png"
+        - "webp"
+        - "jpeg"
+        - "tiff"
+        - "svg"
+      description: Output image format. `svg` applies to vectorize operations
+    num_inference_steps:
+      type: integer
+      description: Number of inference steps
+    seed:
+      type: integer
+      description: Seed for reproducible editing
+    output_compression:
+      type: integer
+      minimum: 0
+      maximum: 100
+      description: Compression level (0-100%)
+    negative_prompt:
+      type: string
+      description: What to avoid in the edit
+    user:
+      type: string
+      description: User identifier for tracking
+    fallbacks:
+      type: array
+      items:
+        $ref: './common.yaml#/Fallback'
+      description: Fallback models to try if primary model fails
+
+ImageEditMultipartRequest:
+  type: object
+  description: |
+    Multipart encoding of an image edit, and the only encoding that can upload the image as a file.
+    This is what the official OpenAI SDKs send unconditionally. Every value crosses the wire as a
+    string, so provider-native extra params arrive as strings; post `application/json` instead when
+    a provider expects them as numbers, booleans or nested objects - see `ImageEditRequest`.
   required:
     - model
   properties:

--- a/docs/providers/supported-providers/runware.mdx
+++ b/docs/providers/supported-providers/runware.mdx
@@ -118,19 +118,20 @@ curl -X POST http://localhost:8080/v1/images/generations \
 
 ## Edit (`POST /v1/images/edits`)
 
-This endpoint is **multipart/form-data only** - a JSON body is rejected. Alongside file uploads it accepts `image_url` / `image_url[]` form fields, which pass a URL straight to Runware instead of round-tripping the asset through the gateway as base64.
+This endpoint accepts **JSON** and **multipart/form-data**. Use multipart to upload the image as a file; use JSON to reference it by URL, which passes straight to Runware instead of round-tripping the asset through the gateway as base64.
 
 | Parameter | Runware field | Notes |
 |-----------|---------------|-------|
-| `image[]` / `image` | input image | File upload (bytes → data URI) |
-| `image_url[]` / `image_url` | input image | Runware asset UUID or public URL |
+| `images` | input image | JSON only; a URL string, a Runware asset UUID, or `{ "image": "<base64>" }` |
+| `image[]` / `image` | input image | Multipart only; file upload (bytes → data URI) |
+| `image_url[]` / `image_url` | input image | Multipart only; Runware asset UUID or public URL |
 | `mask` | mask image | Inpainting mask (bytes → data URI) |
 | `prompt` | `positivePrompt` | Edit instruction; not required for the operation types below |
 | `type` | `taskType` | Selects the operation - see the table below |
 | `negative_prompt`, `size`, `num_inference_steps`, `seed`, `n`, `response_format`, `output_format`, `output_compression` | same as [Image Generation](#1-image-generation) | |
 | `upscale_factor`, `target_megapixels` | `upscaleFactor`, `targetMegapixels` | `type: "upscale"` only; mutually exclusive |
 
-**Extra Params**: provider-native fields (`strength`, `maskMargin`, `outpaint`, `settings`, ...) are forwarded as-is - no header required.
+**Extra Params**: provider-native fields (`strength`, `maskMargin`, `outpaint`, `settings`, `providerSettings`, ...) are forwarded as-is - no header required. Multipart carries every value as a string, so send JSON when a model's parameters are numbers, booleans or nested objects.
 
 ### Operation types
 
@@ -175,12 +176,21 @@ curl -X POST http://localhost:8080/v1/images/edits \
 </Tab>
 <Tab title="Upscale">
 
+Per-model tuning that has no Bifrost equivalent goes in `settings`, which reaches Runware with its JSON types intact.
+
 ```bash
 curl -X POST http://localhost:8080/v1/images/edits \
-  --form 'model="runware/topazlabs:wonder@3.5"' \
-  --form 'image_url="https://example.com/teapot.jpg"' \
-  --form 'type="upscale"' \
-  --form 'upscale_factor="2"'
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "runware/topazlabs:wonder@3.5",
+    "images": ["https://example.com/teapot.jpg"],
+    "type": "upscale",
+    "upscale_factor": 4,
+    "settings": {
+      "enhancementStrength": "high",
+      "grain": { "size": 1.5 }
+    }
+  }'
 ```
 
 </Tab>
@@ -188,7 +198,7 @@ curl -X POST http://localhost:8080/v1/images/edits \
 
 ```bash
 curl -X POST http://localhost:8080/v1/images/edits \
-  --form 'model="runware/runware:110@1"' \
+  --form 'model="runware/ideogram:remove-background@0"' \
   --form 'image_url="https://example.com/teapot.jpg"' \
   --form 'type="background_removal"'
 ```

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -132788,7 +132788,7 @@
         },
         {
           "name": "54.3 Image edits (/v1/images/edits) - task types via the neutral `type` selector",
-          "description": "First /v1/images/edits coverage in the harness for any provider. Runware routes five distinct taskTypes off Bifrost's neutral `type` parameter - imageInference (no type), upscale, removeBackground, imageMasking and vectorize - each with its own envelope and its own output family. Masking returns maskImage* rather than image*, so reading only image* would surface an empty response; that row asserts the asset and the detections array both survive.\n\nModel choices are load-bearing. runware:101@1 is a plain image-to-image model, while runware:102@1 is FLUX Fill, which the provider rejects without a mask ('Model is of type Inpainting'), so the two are separate rows. The upscalers run at 4x, not 2x: the 360x360 fixture at 2x is 0.52 MP, and prunaai floors that to a target of 0 and rejects it.\n\nCovers the two upscalers a customer was blocked on: topazlabs Wonder 3.5 and prunaai P-Image.",
+          "description": "First /v1/images/edits coverage in the harness for any provider. Runware routes five distinct taskTypes off Bifrost's neutral `type` parameter - imageInference (no type), upscale, removeBackground, imageMasking and vectorize - each with its own envelope and its own output family. Masking returns maskImage* rather than image*, so reading only image* would surface an empty response; that row asserts the asset and the detections array both survive.\n\nModel choices are load-bearing. runware:101@1 is a plain image-to-image model, while runware:102@1 is FLUX Fill, which the provider rejects without a mask ('Model is of type Inpainting'), so the two are separate rows. The upscalers run at 4x, not 2x: the 360x360 fixture at 2x is 0.52 MP, and prunaai floors that to a target of 0 and rejects it.\n\nCovers the two upscalers a customer was blocked on: topazlabs Wonder 3.5 and prunaai P-Image.\n\nThe route takes both encodings. Multipart is the only one that can upload the image as a file, and it carries every value as a string; JSON references the image under `images` (a bare URL string or `{url}` / `{image}`) and is the only encoding that preserves the types of provider-native extra params. The JSON rows assert on raw_request because both regressions they pin are invisible in the response body: a nested `settings` object arriving stringified, and `images` leaking back out as an extra param on top of the `inputs` envelope the converter already built.",
           "item": [
             {
               "name": "runware/runware:101@1 image edit image-to-image (seed image, no mask)",
@@ -133504,6 +133504,199 @@
                       "  var j = pm.response.json();",
                       "  pm.expect(j.id, 'no job id: ' + pm.response.text()).to.be.a('string').that.is.not.empty;",
                       "  pm.collectionVariables.set('runwareAsyncEditJobId', j.id);",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "runware/topazlabs:wonder@3.5 upscale via JSON body (images[] + typed settings)",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"runware/topazlabs:wonder@3.5\",\n  \"images\": [\n    \"https://storage.googleapis.com/generativeai-downloads/images/scones.jpg\"\n  ],\n  \"type\": \"upscale\",\n  \"upscale_factor\": 4,\n  \"settings\": {\n    \"enhancementStrength\": \"high\",\n    \"grain\": {\n      \"size\": 1.5\n    }\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/images/edits",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "images",
+                    "edits"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('a JSON body is accepted on /v1/images/edits', function () {",
+                      "  pm.expect(pm.response.text(), 'JSON body parsed as multipart').to.not.include('multipart');",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var rr = ((pm.response.json() || {}).extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var task = (rr && rr.length) ? rr[0] : null;",
+                      "pm.test('raw_request captured', function () {",
+                      "  pm.expect(task, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!task) { return; }",
+                      "pm.test('a bare string in images[] reaches the nested inputs envelope', function () {",
+                      "  pm.expect(task.inputs && task.inputs.image, 'inputs: ' + JSON.stringify(task.inputs)).to.be.a('string').that.is.not.empty;",
+                      "});",
+                      "pm.test('images is a known field, not re-sent verbatim as an extra param', function () {",
+                      "  // Runware rejects the duplicate with \"Unsupported use of 'images' parameter\".",
+                      "  pm.expect(task, 'images leaked to the wire: ' + JSON.stringify(task)).to.not.have.property('images');",
+                      "});",
+                      "pm.test('nested settings keep their JSON types (multipart would stringify them)', function () {",
+                      "  var s = task.settings || {};",
+                      "  pm.expect(s.enhancementStrength, 'settings: ' + JSON.stringify(s)).to.equal('high');",
+                      "  pm.expect(s.grain, 'grain stringified: ' + JSON.stringify(s)).to.be.an('object');",
+                      "  pm.expect(s.grain.size, 'grain.size: ' + JSON.stringify(s)).to.be.a('number');",
+                      "});",
+                      "pm.test('typed upscale_factor maps to a numeric upscaleFactor', function () {",
+                      "  pm.expect(task.upscaleFactor, 'task: ' + JSON.stringify(task)).to.equal(4);",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "runware/ideogram:remove-background@0 background removal via JSON images[{url}] (object form)",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"runware/ideogram:remove-background@0\",\n  \"images\": [\n    {\n      \"url\": \"https://storage.googleapis.com/generativeai-downloads/images/scones.jpg\"\n    }\n  ],\n  \"type\": \"background_removal\",\n  \"output_format\": \"png\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/images/edits",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "images",
+                    "edits"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('the object form of images[] is accepted', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var rr = ((pm.response.json() || {}).extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var task = (rr && rr.length) ? rr[0] : null;",
+                      "pm.test('raw_request captured', function () {",
+                      "  pm.expect(task, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!task) { return; }",
+                      "pm.test('images[{url}] reaches inputs.image and never the wire as-is', function () {",
+                      "  pm.expect(task.inputs && task.inputs.image, 'inputs: ' + JSON.stringify(task.inputs)).to.be.a('string').that.is.not.empty;",
+                      "  pm.expect(task, 'images leaked to the wire: ' + JSON.stringify(task)).to.not.have.property('images');",
+                      "});",
+                      "pm.test('typed output_format still maps to outputFormat on the JSON path', function () {",
+                      "  pm.expect(task.outputFormat, 'task: ' + JSON.stringify(task)).to.equal('PNG');",
+                      "});"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "runware/runware:101@1 async image edit submit (JSON via /v1/async/images/edits)",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"runware/runware:101@1\",\n  \"images\": [\n    \"https://storage.googleapis.com/generativeai-downloads/images/scones.jpg\"\n  ],\n  \"prompt\": \"make the background a deep blue\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/async/images/edits",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "async",
+                    "images",
+                    "edits"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('the async route shares prepareImageEditRequest, so it takes JSON too', function () {",
+                      "  pm.expect(pm.response.text(), 'JSON body parsed as multipart').to.not.include('multipart');",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.equal(202);",
+                      "});",
+                      "pm.test('returns an async job id', function () {",
+                      "  // Deliberately does not set runwareAsyncEditJobId - the multipart submit row owns that chain.",
+                      "  var j = pm.response.json();",
+                      "  pm.expect(j.id, 'no job id: ' + pm.response.text()).to.be.a('string').that.is.not.empty;",
                       "});"
                     ]
                   }

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -283,6 +283,7 @@ var imageEditParamsKnownFields = map[string]bool{
 	"image[]":             true,
 	"image_url":           true,
 	"image_url[]":         true,
+	"images":              true, // JSON body form of the above
 	"mask":                true,
 	"type":                true,
 	"background":          true,
@@ -2354,27 +2355,13 @@ func (h *CompletionHandler) handleStreamingImageGeneration(ctx *fasthttp.Request
 	h.handleStreamingResponse(ctx, bifrostCtx, schemas.ImageGenerationStreamRequest, getStream, cancel)
 }
 
-// prepareImageEditRequest prepares a BifrostImageEditRequest from a multipart form
-func prepareImageEditRequest(ctx *fasthttp.RequestCtx, config *lib.Config) (*ImageEditHTTPRequest, *schemas.BifrostImageEditRequest, error) {
-	var req ImageEditHTTPRequest
-	form, err := ctx.MultipartForm()
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse multipart form: %v", err)
+// parseImageEditMultipartForm fills req from an OpenAI-style multipart image edit form. Uploaded
+// files and the image_url convenience fields both feed Images; scalars are converted here because
+// multipart carries every value as a string.
+func parseImageEditMultipartForm(form *multipart.Form, req *ImageEditHTTPRequest) error {
+	if modelValues := form.Value["model"]; len(modelValues) > 0 {
+		req.Model = modelValues[0]
 	}
-	modelValues := form.Value["model"]
-	if len(modelValues) == 0 || modelValues[0] == "" {
-		return nil, nil, fmt.Errorf("model is required")
-	}
-	req.Model = modelValues[0]
-	provider, modelName, err := resolveModelAndProvider(ctx, config, req.Model)
-	if err != nil {
-		return nil, nil, err
-	}
-	var editType string
-	if typeValues := form.Value["type"]; len(typeValues) > 0 && typeValues[0] != "" {
-		editType = typeValues[0]
-	}
-	promptValues := form.Value["prompt"]
 	var imageFiles []*multipart.FileHeader
 	if imageFilesArray := form.File["image[]"]; len(imageFilesArray) > 0 {
 		imageFiles = imageFilesArray
@@ -2387,9 +2374,6 @@ func prepareImageEditRequest(ctx *fasthttp.RequestCtx, config *lib.Config) (*Ima
 	if len(imageURLs) == 0 {
 		imageURLs = form.Value["image_url"]
 	}
-	if len(imageFiles) == 0 && len(imageURLs) == 0 {
-		return nil, nil, fmt.Errorf("at least one image or image_url is required")
-	}
 	// Uploads keep their leading position so a request that sends no URL is ordered exactly as
 	// before: providers treat the first image as the primary one (Runware's seed image, Bedrock's
 	// style-transfer base), so the order is part of the contract.
@@ -2397,12 +2381,12 @@ func prepareImageEditRequest(ctx *fasthttp.RequestCtx, config *lib.Config) (*Ima
 	for _, fh := range imageFiles {
 		f, err := fh.Open()
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to open uploaded file: %v", err)
+			return fmt.Errorf("failed to open uploaded file: %v", err)
 		}
 		fileData, err := io.ReadAll(f)
 		f.Close()
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to read uploaded file: %v", err)
+			return fmt.Errorf("failed to read uploaded file: %v", err)
 		}
 		images = append(images, schemas.ImageInput{Image: fileData})
 	}
@@ -2412,7 +2396,7 @@ func prepareImageEditRequest(ctx *fasthttp.RequestCtx, config *lib.Config) (*Ima
 		}
 	}
 	prompt := ""
-	if len(promptValues) > 0 && promptValues[0] != "" {
+	if promptValues := form.Value["prompt"]; len(promptValues) > 0 && promptValues[0] != "" {
 		prompt = promptValues[0]
 	}
 	req.ImageEditInput = &schemas.ImageEditInput{
@@ -2420,10 +2404,13 @@ func prepareImageEditRequest(ctx *fasthttp.RequestCtx, config *lib.Config) (*Ima
 		Prompt: prompt,
 	}
 	req.ImageEditParameters = &schemas.ImageEditParameters{}
+	if typeValues := form.Value["type"]; len(typeValues) > 0 && typeValues[0] != "" {
+		req.ImageEditParameters.Type = &typeValues[0]
+	}
 	if nValues := form.Value["n"]; len(nValues) > 0 && nValues[0] != "" {
 		n, err := strconv.Atoi(nValues[0])
 		if err != nil {
-			return nil, nil, fmt.Errorf("invalid n value: %v", err)
+			return fmt.Errorf("invalid n value: %v", err)
 		}
 		req.ImageEditParameters.N = &n
 	}
@@ -2436,7 +2423,7 @@ func prepareImageEditRequest(ctx *fasthttp.RequestCtx, config *lib.Config) (*Ima
 	if partialImagesValues := form.Value["partial_images"]; len(partialImagesValues) > 0 && partialImagesValues[0] != "" {
 		partialImages, err := strconv.Atoi(partialImagesValues[0])
 		if err != nil {
-			return nil, nil, fmt.Errorf("invalid partial_images value: %v", err)
+			return fmt.Errorf("invalid partial_images value: %v", err)
 		}
 		req.ImageEditParameters.PartialImages = &partialImages
 	}
@@ -2452,35 +2439,35 @@ func prepareImageEditRequest(ctx *fasthttp.RequestCtx, config *lib.Config) (*Ima
 	if numInferenceStepsValues := form.Value["num_inference_steps"]; len(numInferenceStepsValues) > 0 && numInferenceStepsValues[0] != "" {
 		numInferenceSteps, err := strconv.Atoi(numInferenceStepsValues[0])
 		if err != nil {
-			return nil, nil, fmt.Errorf("invalid num_inference_steps value: %v", err)
+			return fmt.Errorf("invalid num_inference_steps value: %v", err)
 		}
 		req.ImageEditParameters.NumInferenceSteps = &numInferenceSteps
 	}
 	if upscaleFactorValues := form.Value["upscale_factor"]; len(upscaleFactorValues) > 0 && upscaleFactorValues[0] != "" {
 		upscaleFactor, err := strconv.Atoi(upscaleFactorValues[0])
 		if err != nil {
-			return nil, nil, fmt.Errorf("invalid upscale_factor value: %v", err)
+			return fmt.Errorf("invalid upscale_factor value: %v", err)
 		}
 		req.ImageEditParameters.UpscaleFactor = &upscaleFactor
 	}
 	if targetMegapixelsValues := form.Value["target_megapixels"]; len(targetMegapixelsValues) > 0 && targetMegapixelsValues[0] != "" {
 		targetMegapixels, err := strconv.Atoi(targetMegapixelsValues[0])
 		if err != nil {
-			return nil, nil, fmt.Errorf("invalid target_megapixels value: %v", err)
+			return fmt.Errorf("invalid target_megapixels value: %v", err)
 		}
 		req.ImageEditParameters.TargetMegapixels = &targetMegapixels
 	}
 	if seedValues := form.Value["seed"]; len(seedValues) > 0 && seedValues[0] != "" {
 		seed, err := strconv.Atoi(seedValues[0])
 		if err != nil {
-			return nil, nil, fmt.Errorf("invalid seed value: %v", err)
+			return fmt.Errorf("invalid seed value: %v", err)
 		}
 		req.ImageEditParameters.Seed = &seed
 	}
 	if outputCompressionValues := form.Value["output_compression"]; len(outputCompressionValues) > 0 && outputCompressionValues[0] != "" {
 		outputCompression, err := strconv.Atoi(outputCompressionValues[0])
 		if err != nil {
-			return nil, nil, fmt.Errorf("invalid output_compression value: %v", err)
+			return fmt.Errorf("invalid output_compression value: %v", err)
 		}
 		req.ImageEditParameters.OutputCompression = &outputCompression
 	}
@@ -2493,29 +2480,18 @@ func prepareImageEditRequest(ctx *fasthttp.RequestCtx, config *lib.Config) (*Ima
 	if userValues := form.Value["user"]; len(userValues) > 0 && userValues[0] != "" {
 		req.ImageEditParameters.User = &userValues[0]
 	}
-	if editType != "" {
-		req.ImageEditParameters.Type = &editType
-	}
 	if maskFiles := form.File["mask"]; len(maskFiles) > 0 {
 		maskFile := maskFiles[0]
 		f, err := maskFile.Open()
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to open mask file: %v", err)
+			return fmt.Errorf("failed to open mask file: %v", err)
 		}
 		maskData, err := io.ReadAll(f)
 		f.Close()
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to read mask file: %v", err)
+			return fmt.Errorf("failed to read mask file: %v", err)
 		}
 		req.ImageEditParameters.Mask = maskData
-	}
-	if req.ImageEditParameters.ExtraParams == nil {
-		req.ImageEditParameters.ExtraParams = make(map[string]interface{})
-	}
-	for key, value := range form.Value {
-		if len(value) > 0 && value[0] != "" && !imageEditParamsKnownFields[key] {
-			req.ImageEditParameters.ExtraParams[key] = value[0]
-		}
 	}
 	if fallbackValues := form.Value["fallbacks"]; len(fallbackValues) > 0 {
 		req.Fallbacks = fallbackValues
@@ -2524,6 +2500,70 @@ func prepareImageEditRequest(ctx *fasthttp.RequestCtx, config *lib.Config) (*Ima
 		stream := streamValues[0] == "true"
 		req.Stream = &stream
 	}
+	return nil
+}
+
+// prepareImageEditRequest builds a BifrostImageEditRequest from either a multipart form (uploaded
+// image bytes, matching OpenAI's /v1/images/edits) or a JSON body (images referenced by URL or
+// base64 under "images"). JSON is the only form that carries typed provider-native extra params:
+// multipart values are always strings, so a nested object or a number reaches the provider with
+// its type intact only through the JSON body.
+func prepareImageEditRequest(ctx *fasthttp.RequestCtx, config *lib.Config) (*ImageEditHTTPRequest, *schemas.BifrostImageEditRequest, error) {
+	var req ImageEditHTTPRequest
+	var extraParams map[string]any
+
+	if isMultipartRequest(ctx) {
+		form, err := ctx.MultipartForm()
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to parse multipart form: %v", err)
+		}
+		if err := parseImageEditMultipartForm(form, &req); err != nil {
+			return nil, nil, err
+		}
+		extraParams = make(map[string]any)
+		for key, value := range form.Value {
+			if len(value) > 0 && value[0] != "" && !imageEditParamsKnownFields[key] {
+				extraParams[key] = value[0]
+			}
+		}
+	} else {
+		if err := sonic.Unmarshal(ctx.PostBody(), &req); err != nil {
+			return nil, nil, fmt.Errorf("Invalid request payload")
+		}
+		ep, epErr := extractExtraParams(ctx.PostBody(), imageEditParamsKnownFields)
+		if epErr != nil {
+			logger.Warn("Failed to extract extra params: %v", epErr)
+		} else {
+			extraParams = ep
+		}
+	}
+
+	if req.Model == "" {
+		return nil, nil, fmt.Errorf("model is required")
+	}
+	provider, modelName, err := resolveModelAndProvider(ctx, config, req.Model)
+	if err != nil {
+		return nil, nil, err
+	}
+	if req.ImageEditInput != nil {
+		// An entry carrying neither bytes nor a URL is meaningless to every provider, and JSON has
+		// several ways to produce one (null, {}, {"url":""}). Drop them the way the multipart path
+		// already drops empty image_url values, so the count below is the count that can be sent.
+		kept := req.ImageEditInput.Images[:0]
+		for _, img := range req.ImageEditInput.Images {
+			if len(img.Image) > 0 || strings.TrimSpace(img.URL) != "" {
+				kept = append(kept, img)
+			}
+		}
+		req.ImageEditInput.Images = kept
+	}
+	if req.ImageEditInput == nil || len(req.ImageEditInput.Images) == 0 {
+		return nil, nil, fmt.Errorf("at least one image or image_url is required")
+	}
+	if req.ImageEditParameters == nil {
+		req.ImageEditParameters = &schemas.ImageEditParameters{}
+	}
+	req.ImageEditParameters.ExtraParams = extraParams
 	fallbacks, err := parseFallbacks(req.Fallbacks)
 	if err != nil {
 		return nil, nil, err

--- a/transports/bifrost-http/handlers/inference_imageedit_test.go
+++ b/transports/bifrost-http/handlers/inference_imageedit_test.go
@@ -1,0 +1,276 @@
+package handlers
+
+import (
+	"bytes"
+	"mime/multipart"
+	"testing"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+func jsonImageEditCtx(body string) *fasthttp.RequestCtx {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("POST")
+	ctx.Request.SetRequestURI("/v1/images/edits")
+	ctx.Request.Header.SetContentType("application/json")
+	ctx.Request.SetBody([]byte(body))
+	return ctx
+}
+
+func multipartImageEditCtx(t *testing.T, fields map[string]string, files map[string][]byte) *fasthttp.RequestCtx {
+	t.Helper()
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	for k, v := range fields {
+		if err := writer.WriteField(k, v); err != nil {
+			t.Fatalf("write field %s: %v", k, err)
+		}
+	}
+	for name, content := range files {
+		part, err := writer.CreateFormFile(name, name+".png")
+		if err != nil {
+			t.Fatalf("create file part %s: %v", name, err)
+		}
+		if _, err := part.Write(content); err != nil {
+			t.Fatalf("write file part %s: %v", name, err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("POST")
+	ctx.Request.SetRequestURI("/v1/images/edits")
+	ctx.Request.Header.SetContentType(writer.FormDataContentType())
+	ctx.Request.SetBody(body.Bytes())
+	return ctx
+}
+
+// The JSON shape: images carry their source under "images", the same nested form /v1/videos/edits
+// uses for its source video.
+func TestPrepareImageEditRequest_JSON(t *testing.T) {
+	_, req, err := prepareImageEditRequest(jsonImageEditCtx(
+		`{"model":"runware/topazlabs:wonder@3.5","images":[{"url":"https://example.com/teapot.jpg"}],"prompt":"sharpen","type":"upscale","upscale_factor":4}`), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.Provider != schemas.Runware || req.Model != "topazlabs:wonder@3.5" {
+		t.Fatalf("provider/model = %q/%q", req.Provider, req.Model)
+	}
+	if len(req.Input.Images) != 1 || req.Input.Images[0].URL != "https://example.com/teapot.jpg" {
+		t.Fatalf("images not carried: %+v", req.Input.Images)
+	}
+	if req.Input.Prompt != "sharpen" {
+		t.Fatalf("prompt = %q", req.Input.Prompt)
+	}
+	if req.Params == nil || req.Params.Type == nil || *req.Params.Type != "upscale" {
+		t.Fatalf("type not carried: %+v", req.Params)
+	}
+	if req.Params.UpscaleFactor == nil || *req.Params.UpscaleFactor != 4 {
+		t.Fatalf("upscale_factor = %v, want 4", req.Params.UpscaleFactor)
+	}
+}
+
+// The reason JSON exists on this route: multipart stringifies every value, so a model's nested
+// tuning object (Topaz Wonder's settings.enhancementStrength / settings.grain) can only reach the
+// provider with its real JSON types through a JSON body.
+func TestPrepareImageEditRequest_JSONTypedExtraParams(t *testing.T) {
+	_, req, err := prepareImageEditRequest(jsonImageEditCtx(
+		`{"model":"runware/topazlabs:wonder@3.5","images":[{"url":"https://example.com/teapot.jpg"}],"type":"upscale",`+
+			`"settings":{"upscaleFactor":4,"enhancementStrength":"high","grain":{"amount":2}},"outputQuality":90,"includeCost":true}`), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	settings, ok := req.Params.ExtraParams["settings"].(map[string]any)
+	if !ok {
+		t.Fatalf("settings = %#v, want a nested object", req.Params.ExtraParams["settings"])
+	}
+	if _, ok := settings["upscaleFactor"].(string); ok {
+		t.Fatalf("settings.upscaleFactor arrived as a string: %#v", settings["upscaleFactor"])
+	}
+	if grain, ok := settings["grain"].(map[string]any); !ok || grain["amount"] == nil {
+		t.Fatalf("settings.grain = %#v, want a nested object", settings["grain"])
+	}
+	if _, ok := req.Params.ExtraParams["outputQuality"].(string); ok {
+		t.Fatalf("outputQuality arrived as a string: %#v", req.Params.ExtraParams["outputQuality"])
+	}
+	if req.Params.ExtraParams["includeCost"] != true {
+		t.Fatalf("includeCost = %#v, want the boolean true", req.Params.ExtraParams["includeCost"])
+	}
+}
+
+// Every field the JSON body consumes must be a known field, or passthrough re-sends it verbatim on
+// top of the envelope the provider converter already built - Runware rejects the duplicate.
+func TestPrepareImageEditRequest_JSONInputFieldsAreNotExtraParams(t *testing.T) {
+	_, req, err := prepareImageEditRequest(jsonImageEditCtx(
+		`{"model":"runware/topazlabs:wonder@3.5","images":["https://example.com/teapot.jpg"],"prompt":"sharpen","type":"upscale","upscale_factor":4,"settings":{"grain":true}}`), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, key := range []string{"model", "images", "prompt", "type", "upscale_factor", "fallbacks", "stream"} {
+		if _, leaked := req.Params.ExtraParams[key]; leaked {
+			t.Fatalf("%q leaked into extra params: %+v", key, req.Params.ExtraParams)
+		}
+	}
+	if req.Params.ExtraParams["settings"] == nil {
+		t.Fatalf("settings should still reach extra params: %+v", req.Params.ExtraParams)
+	}
+}
+
+// A bare string is accepted alongside the object form, so the array reads the way input_images does
+// on /v1/images/generations.
+func TestPrepareImageEditRequest_JSONBareStringImages(t *testing.T) {
+	_, req, err := prepareImageEditRequest(jsonImageEditCtx(
+		`{"model":"runware/google:4@1","images":["https://example.com/a.jpg",{"url":"https://example.com/b.jpg"}],"prompt":"make it blue"}`), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(req.Input.Images) != 2 {
+		t.Fatalf("images = %+v, want 2 entries", req.Input.Images)
+	}
+	if req.Input.Images[0].URL != "https://example.com/a.jpg" {
+		t.Fatalf("string form not carried: %+v", req.Input.Images[0])
+	}
+	if req.Input.Images[1].URL != "https://example.com/b.jpg" {
+		t.Fatalf("object form not carried: %+v", req.Input.Images[1])
+	}
+}
+
+// Base64 bytes ride in the same "images" array, so a JSON caller never has to switch to multipart
+// just to send an image it holds in memory.
+func TestPrepareImageEditRequest_JSONBase64Image(t *testing.T) {
+	_, req, err := prepareImageEditRequest(jsonImageEditCtx(
+		`{"model":"runware/runware:110@1","images":[{"image":"aGVsbG8="}],"type":"background_removal"}`), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(req.Input.Images) != 1 || string(req.Input.Images[0].Image) != "hello" {
+		t.Fatalf("image bytes not decoded: %+v", req.Input.Images)
+	}
+}
+
+// The multipart contract is unchanged: image_url still stands in for an upload, scalars are still
+// converted, and unrecognised values still pass through as the strings multipart delivers.
+func TestPrepareImageEditRequest_MultipartUnchanged(t *testing.T) {
+	_, req, err := prepareImageEditRequest(multipartImageEditCtx(t, map[string]string{
+		"model":          "runware/topazlabs:wonder@3.5",
+		"image_url":      "https://example.com/teapot.jpg",
+		"type":           "upscale",
+		"upscale_factor": "4",
+		"settings":       `{"enhancementStrength":"high"}`,
+	}, nil), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.Provider != schemas.Runware || req.Model != "topazlabs:wonder@3.5" {
+		t.Fatalf("provider/model = %q/%q", req.Provider, req.Model)
+	}
+	if len(req.Input.Images) != 1 || req.Input.Images[0].URL != "https://example.com/teapot.jpg" {
+		t.Fatalf("image_url not carried: %+v", req.Input.Images)
+	}
+	if req.Params.UpscaleFactor == nil || *req.Params.UpscaleFactor != 4 {
+		t.Fatalf("upscale_factor = %v, want 4", req.Params.UpscaleFactor)
+	}
+	if req.Params.ExtraParams["settings"] != `{"enhancementStrength":"high"}` {
+		t.Fatalf("settings = %#v, want the raw form string", req.Params.ExtraParams["settings"])
+	}
+}
+
+// Uploads keep their leading position ahead of any image_url, and the mask still arrives as bytes.
+func TestPrepareImageEditRequest_MultipartUpload(t *testing.T) {
+	_, req, err := prepareImageEditRequest(multipartImageEditCtx(t,
+		map[string]string{
+			"model":     "runware/runware:102@1",
+			"prompt":    "a bunch of yellow sunflowers",
+			"image_url": "https://example.com/teapot.jpg",
+		},
+		map[string][]byte{"image": []byte("png-bytes"), "mask": []byte("mask-bytes")}), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(req.Input.Images) != 2 {
+		t.Fatalf("images = %+v, want the upload plus the url", req.Input.Images)
+	}
+	if string(req.Input.Images[0].Image) != "png-bytes" {
+		t.Fatalf("uploaded image must lead: %+v", req.Input.Images)
+	}
+	if req.Input.Images[1].URL != "https://example.com/teapot.jpg" {
+		t.Fatalf("image_url must follow the upload: %+v", req.Input.Images)
+	}
+	if string(req.Params.Mask) != "mask-bytes" {
+		t.Fatalf("mask = %q", req.Params.Mask)
+	}
+}
+
+// Model and at least one image are required on both bodies, and a malformed JSON body is rejected
+// rather than silently treated as an empty request.
+func TestPrepareImageEditRequest_Validation(t *testing.T) {
+	if _, _, err := prepareImageEditRequest(jsonImageEditCtx(
+		`{"images":[{"url":"https://example.com/teapot.jpg"}]}`), nil); err == nil {
+		t.Fatal("expected an error when model is missing from a JSON body")
+	}
+	if _, _, err := prepareImageEditRequest(jsonImageEditCtx(
+		`{"model":"runware/runware:110@1"}`), nil); err == nil {
+		t.Fatal("expected an error when a JSON body carries no images")
+	}
+	if _, _, err := prepareImageEditRequest(jsonImageEditCtx(`{"model":`), nil); err == nil {
+		t.Fatal("expected an error for a malformed JSON body")
+	}
+	if _, _, err := prepareImageEditRequest(multipartImageEditCtx(t,
+		map[string]string{"image_url": "https://example.com/teapot.jpg"}, nil), nil); err == nil {
+		t.Fatal("expected an error when model is missing from a multipart form")
+	}
+	if _, _, err := prepareImageEditRequest(multipartImageEditCtx(t,
+		map[string]string{"model": "runware/runware:110@1"}, nil), nil); err == nil {
+		t.Fatal("expected an error when a multipart form carries no image")
+	}
+}
+
+// JSON has several ways to spell an image entry that carries nothing. None of them may reach a
+// provider, where they would become an empty input key and a confusing upstream 4xx.
+func TestPrepareImageEditRequest_EmptyImageEntriesAreDropped(t *testing.T) {
+	for _, entries := range []string{`[null]`, `[{}]`, `[{"image":null}]`, `[{"url":"  "}]`} {
+		if _, _, err := prepareImageEditRequest(jsonImageEditCtx(
+			`{"model":"runware/runware:110@1","images":`+entries+`}`), nil); err == nil {
+			t.Fatalf("images: %s was accepted, want the same error as an empty array", entries)
+		}
+	}
+
+	// A junk entry alongside a real one is dropped rather than failing the whole request.
+	_, req, err := prepareImageEditRequest(jsonImageEditCtx(
+		`{"model":"runware/runware:110@1","images":[null,{"url":"https://example.com/a.jpg"},{}],"type":"background_removal"}`), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(req.Input.Images) != 1 || req.Input.Images[0].URL != "https://example.com/a.jpg" {
+		t.Fatalf("images = %+v, want only the populated entry", req.Input.Images)
+	}
+}
+
+// Streaming is selected the same way on both bodies, so the handler's stream branch is reachable
+// from JSON callers too.
+func TestPrepareImageEditRequest_Stream(t *testing.T) {
+	req, _, err := prepareImageEditRequest(jsonImageEditCtx(
+		`{"model":"openai/gpt-image-1","images":[{"url":"https://example.com/teapot.jpg"}],"prompt":"blue","stream":true}`), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.Stream == nil || !*req.Stream {
+		t.Fatalf("stream = %v, want true from the JSON body", req.Stream)
+	}
+
+	req, _, err = prepareImageEditRequest(multipartImageEditCtx(t, map[string]string{
+		"model":     "openai/gpt-image-1",
+		"image_url": "https://example.com/teapot.jpg",
+		"prompt":    "blue",
+		"stream":    "true",
+	}, nil), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.Stream == nil || !*req.Stream {
+		t.Fatalf("stream = %v, want true from the multipart form", req.Stream)
+	}
+}


### PR DESCRIPTION
## Summary

`POST /v1/images/edits` previously only accepted `multipart/form-data`. This PR adds a JSON body path to the same endpoint so callers can reference images by URL or base64 without switching to multipart, and so provider-native extra params (nested objects, numbers, booleans) reach the provider with their real JSON types instead of being stringified by the multipart encoding.

## Changes

- **JSON body support on `/v1/images/edits`**: The handler now detects the content type and routes to either the existing multipart parser or a new JSON decode path. Both paths share the same validation (model required, at least one image required) and the same `BifrostImageEditRequest` output shape.

- **`ImageInput.UnmarshalJSON`**: `ImageInput` now accepts either a bare string or the object form `{ "url": "...", "image": "<base64>" }`, so `"images": ["https://..."]` reads the same way `input_images` does on `/v1/images/generations`. Marshalling always emits the object form to keep logged and replayed requests in one shape.

- **Typed extra params via JSON**: Multipart carries every value as a string, so a nested tuning object (e.g. Topaz Wonder's `settings.grain`) or a numeric/boolean field can only reach the provider with its real type through the JSON body. The JSON path uses `extractExtraParams` to separate known envelope fields from provider-native passthrough, preventing duplicates in the request the provider converter builds.

- **`parseImageEditMultipartForm` refactor**: The multipart parsing logic was extracted into its own function that returns an error, making it independently testable and keeping `prepareImageEditRequest` focused on dispatch and shared validation.

- **`images` added to `imageEditParamsKnownFields`**: Prevents the JSON `images` field from leaking into extra params.

- **Runware docs updated**: The edit endpoint docs now describe both JSON and multipart, document the `images` field, clarify that multipart stringifies all values, and update the upscale example to use the JSON body with a typed `settings` object.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./core/schemas/... ./transports/bifrost-http/handlers/...
```

**JSON body — URL reference:**
```sh
curl -X POST http://localhost:8080/v1/images/edits \
  -H "Content-Type: application/json" \
  -d '{
    "model": "runware/topazlabs:wonder@3.5",
    "images": ["https://example.com/teapot.jpg"],
    "type": "upscale",
    "upscale_factor": 4,
    "settings": { "enhancementStrength": "high", "grain": { "size": 1.5 } }
  }'
```

**JSON body — base64 bytes:**
```sh
curl -X POST http://localhost:8080/v1/images/edits \
  -H "Content-Type: application/json" \
  -d '{
    "model": "runware/runware:110@1",
    "images": [{ "image": "<base64-encoded-bytes>" }],
    "type": "background_removal"
  }'
```

**Multipart (unchanged behaviour):**
```sh
curl -X POST http://localhost:8080/v1/images/edits \
  --form 'model="runware/ideogram:remove-background@0"' \
  --form 'image_url="https://example.com/teapot.jpg"' \
  --form 'type="background_removal"'
```

## Breaking changes

- [ ] Yes
- [x] No

The multipart contract is unchanged. JSON is an additive path.

## Related issues

## Security considerations

Base64-encoded image bytes decoded from the JSON body are handled the same way as multipart file uploads — no additional attack surface is introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable