### PR TITLE
docs: add v2.0.0 availability callouts across features, providers, and API references

### DIFF
--- a/docs/api/procuring-api-keys.mdx
+++ b/docs/api/procuring-api-keys.mdx
@@ -27,6 +27,8 @@ Use an API key as the bearer token when calling these endpoints from scripts, ba
 
 Use this bearer token for management API endpoints that configure or inspect Bifrost. The following endpoint patterns use management API authentication in the OpenAPI spec.
 
+<Info>The `/api/routing/*` routes are available in **Bifrost v2.0.0 and above**. On earlier versions the routing endpoints live under `/api/governance/*`.</Info>
+
 Governance resources moved under the `/api/governance` namespace. Both generations are listed: the canonical route is the one to build against, and the rows marked *deprecated aliases* are the pre-move paths, which still answer today and are scheduled for removal in the following major release. See the [v2.0.0 migration guide](/migration-guides/v2.0.0#breaking-change-3-governance-apis-moved-to-the-api-governance-namespace) for the full mapping.
 
 | Area | Endpoint patterns |

--- a/docs/architecture/framework/model-catalog.mdx
+++ b/docs/architecture/framework/model-catalog.mdx
@@ -16,6 +16,11 @@ The Model Catalog is a foundational component of Bifrost that provides a unified
 
 ## Core Features
 
+<Info>
+  The megapixel image rates, along with `input_cost_per_query` and `cost_per_request`,
+  are available in **Bifrost v2.0.0 and above**.
+</Info>
+
 ### **1. Automatic Pricing Synchronization**
 
 The Model Catalog manages pricing data through a two-phase approach:

--- a/docs/enterprise/guardrails/prompt-guardrails.mdx
+++ b/docs/enterprise/guardrails/prompt-guardrails.mdx
@@ -6,6 +6,8 @@ icon: "shield-check"
 
 ## Overview
 
+<Info>Prompt Guardrails is available in **Bifrost v2.0.0 and above**.</Info>
+
 **Prompt Guardrails** is a Bifrost Enterprise guardrail provider that uses a configured LLM as a judge. The judge evaluates text against a natural-language policy and returns one of two decisions:
 
 - `ALLOW` lets the request or response continue.

--- a/docs/features/governance/complexity-router.mdx
+++ b/docs/features/governance/complexity-router.mdx
@@ -94,6 +94,8 @@ The **Complexity Spectrum** bar updates live as you type boundary values, so you
 </Tab>
 <Tab title="API">
 
+<Info>The `/api/routing/*` endpoints are available in **Bifrost v2.0.0 and above**. On earlier versions use the `/api/governance/*` paths.</Info>
+
 <Note>
   These endpoints moved to `/api/routing/*` when routing became its own plugin. The previous
   `/api/governance/*` paths still work and behave identically, so existing scripts keep

--- a/docs/features/observability/otel.mdx
+++ b/docs/features/observability/otel.mdx
@@ -64,6 +64,8 @@ The plugin supports multiple trace formats to match your observability platform:
 
 ### Per-signal headers
 
+<Info>`trace_headers` and `metrics_headers` are available in **Bifrost v2.0.0 and above**.</Info>
+
 `headers` are sent to both the trace and metrics endpoints. When a collector needs a header on only one signal — for example a Databricks table name required on the metrics endpoint — use `trace_headers` or `metrics_headers`. Each is overlaid on top of `headers` for its own endpoint, and on a key collision the per-signal value wins.
 
 ```json
@@ -136,6 +138,8 @@ Because all requests in a session share one trace, very long-lived sessions prod
 </Note>
 
 To send a session ID, pass the [`x-bf-session-id`](/providers/request-options) header on each request you want grouped together.
+
+<Info>Coding-harness session header fallback is available in **Bifrost v2.0.0 and above**.</Info>
 
 Requests from a coding harness need no Bifrost-specific header: when `x-bf-session-id` is absent, Bifrost adopts the harness's own session header (Claude Code, Codex CLI, and OpenCode are recognized). That populates `session.id` on every request in the run; enable `group_traces_by_session` to collapse the run into a single trace. See [Coding Harness Headers](/providers/request-options#session-stickiness-session-id) for the full list.
 

--- a/docs/features/observability/splunk.mdx
+++ b/docs/features/observability/splunk.mdx
@@ -4,6 +4,8 @@ description: "Ship Bifrost request traces to Splunk over HTTP Event Collector (H
 icon: "database"
 ---
 
+<Info>The Splunk connector is available in **Bifrost v2.0.0 and above**.</Info>
+
 <Note>
 The Splunk connector is an **Enterprise** feature. It requires a Bifrost Enterprise license.
 </Note>

--- a/docs/mcp/auth/token-exchange.mdx
+++ b/docs/mcp/auth/token-exchange.mdx
@@ -11,6 +11,8 @@ icon: "right-left"
 
 This is strictly delegated: there is no shared service-account fallback. A caller with no identity token cannot use a `token_exchange` server — see [Identity requirements](#identity-requirements).
 
+<Info>Token exchange is available in **Bifrost v2.0.0 and above**.</Info>
+
 <Note>
 Requires an **enabled SCIM identity provider** (enterprise). Token exchange runs against whichever IdP handles your SSO, using its token endpoint. See [Prerequisites](#prerequisites).
 </Note>

--- a/docs/mcp/connections.mdx
+++ b/docs/mcp/connections.mdx
@@ -9,6 +9,8 @@ This page is the canonical reference for **connection mode** (sticky vs. per-cal
 
 ---
 
+<Info>Configurable connection mode via `needs_session_stickiness`, and the `token_exchange` auth type, are available in **Bifrost v2.0.0 and above**.</Info>
+
 ## Two independent axes
 
 Every MCP client sits somewhere on two independent axes:

--- a/docs/mcp/tool-execution.mdx
+++ b/docs/mcp/tool-execution.mdx
@@ -383,6 +383,8 @@ if err != nil {
 
 ### Auth failure recovery
 
+<Info>Inline auth-failure retry is available in **Bifrost v2.0.0 and above**.</Info>
+
 When a tool call reaches the upstream MCP server but comes back with a clean auth rejection (401/403), Bifrost reacts on the spot instead of waiting for the health monitor:
 
 - **Per-user clients** (`per_user_oauth`, `per_user_headers`): Bifrost force-refreshes the caller's credential, re-acquires a connection, and retries the same call inline, exactly once. If the retry succeeds, the caller just sees a normal success.

--- a/docs/providers/custom-pricing.mdx
+++ b/docs/providers/custom-pricing.mdx
@@ -399,6 +399,8 @@ Any field you set (including `0`) is applied as an override; omitted fields are 
 | `output_cost_per_image_above_1024_and_1536_pixels_standard_quality` | Generated image at or above 1024×1536, standard quality |
 | `output_cost_per_image_above_1536_and_1024_pixels_standard_quality` | Generated image at or above 1536×1024, standard quality |
 
+<Info>The megapixel rates are available in **Bifrost v2.0.0 and above**.</Info>
+
 When several per-image rates could apply, the most specific one wins: a joint size and quality
 rate first, then a quality-only rate, then a size-only rate, then the flat `output_cost_per_image`.
 The 1024×1536 and 1536×1024 thresholds have the same pixel count, so they are matched on width
@@ -420,6 +422,8 @@ least 1536) is billed at the 1536×1024 rate, which is checked first.
 | `input_cost_per_audio_per_second_above_128k_tokens` | Audio input cost above 128k context |
 
 ### Other costs
+
+<Info>`input_cost_per_query` and `cost_per_request` are available in **Bifrost v2.0.0 and above**.</Info>
 
 | Field | Description |
 |-------|-------------|

--- a/docs/providers/provider-routing.mdx
+++ b/docs/providers/provider-routing.mdx
@@ -1592,7 +1592,7 @@ Even when routing rules determine the provider, load balancing Level 2 still opt
 Routing rules can be configured through:
 
 - **Dashboard**: Visual rule builder with CEL expression editor
-- **API**: `POST /api/routing/rules` and related endpoints
+- **API**: `POST /api/routing/rules` and related endpoints (the `/api/routing/*` namespace is available in **Bifrost v2.0.0 and above**; earlier versions use `/api/governance/routing-rules`)
 - **Scope**: Create rules at global, customer, team, or virtual key levels
 - **Priority**: Order rules within scope with numeric priority
 

--- a/docs/providers/request-options.mdx
+++ b/docs/providers/request-options.mdx
@@ -238,6 +238,8 @@ On the first request for a session ID, Bifrost selects a key and caches the bind
 
 **Coding Harness Headers:**
 
+<Info>Coding-harness session header fallback is available in **Bifrost v2.0.0 and above**.</Info>
+
 Coding harnesses already send a session identifier on every request under their own header name. When `x-bf-session-id` is absent, Bifrost adopts the first of these it finds, so pointing a harness at Bifrost gives you session stickiness and session-grouped traces with no configuration:
 
 | Header                      | Sent by                                                          |

--- a/docs/providers/routing-rules.mdx
+++ b/docs/providers/routing-rules.mdx
@@ -300,6 +300,8 @@ The dashboard includes a visual query builder for CEL expressions:
 
 <Tab title="API">
 
+<Info>The `/api/routing/*` endpoints are available in **Bifrost v2.0.0 and above**. On earlier versions use the `/api/governance/*` paths.</Info>
+
 <Note>
   These endpoints moved to `/api/routing/*` when routing became its own plugin. The previous
   `/api/governance/*` paths still work and behave identically, so existing scripts keep

--- a/docs/providers/supported-providers/openrouter.mdx
+++ b/docs/providers/supported-providers/openrouter.mdx
@@ -212,6 +212,8 @@ The embedding request/response follows the standard OpenAI format.
 
 ## Speech (TTS) & Transcription (STT)
 
+<Info>Speech and Transcription support for OpenRouter is available in **Bifrost v2.0.0 and above**.</Info>
+
 OpenRouter exposes OpenAI-compatible audio endpoints, so Bifrost routes Speech and Transcription requests the same way it does for OpenAI: `/v1/audio/speech` for text-to-speech and `/v1/audio/transcriptions` for speech-to-text.
 
 | Parameter | Mapping |

--- a/docs/providers/supported-providers/runware.mdx
+++ b/docs/providers/supported-providers/runware.mdx
@@ -12,6 +12,8 @@ Where an operation has no dedicated Bifrost endpoint, a neutral `type` parameter
 
 ### Supported Operations
 
+<Info>Upscaling, background removal, masking/segmentation, ControlNet preprocessing, and vectorize are available in **Bifrost v2.0.0 and above**.</Info>
+
 | Operation | Supported | Endpoint | Task Type |
 |-----------|-----------|----------|-----------|
 | Image Generation | ✅ | `/v1/images/generations` | `imageInference` |


### PR DESCRIPTION
## Summary

Adds version-availability callouts across the documentation to clearly indicate which features and API namespaces require Bifrost v2.0.0 or above, helping users on earlier versions understand what is and isn't available to them.

## Changes

- Added `<Info>` callouts to the following pages noting v2.0.0 availability:
  - `/api/routing/*` endpoint namespace (vs. the older `/api/governance/*` paths) in the API keys, complexity router, routing rules, and provider routing pages
  - Prompt Guardrails enterprise feature
  - Megapixel image rates, `input_cost_per_query`, and `cost_per_request` fields in custom pricing and model catalog pages
  - `trace_headers`, `metrics_headers`, and coding-harness session header fallback in the OTel observability page
  - Splunk connector
  - MCP token exchange, configurable connection mode, and inline auth-failure retry
  - OpenRouter Speech and Transcription support
  - Runware upscaling, background removal, masking/segmentation, ControlNet preprocessing, and vectorize operations
  - Coding-harness session header fallback in request options
- Expanded the `edit_type` enum in the OpenAPI spec to include `controlnet` and `preprocess` values alongside the existing `controlnet_preprocess`
- Clarified the `/api/routing/*` namespace note inline within the provider routing configuration table

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation pages listed above and confirm that `<Info>` callouts appear at the correct locations with accurate version references. Verify the OpenAPI spec renders the updated `edit_type` enum values (`controlnet`, `preprocess`) correctly in the API reference.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable