### PR TITLE
fix: pass through xhigh reasoning effort for Qwen 3.8 family (#6424)

### DIFF
--- a/core/providers/openai/chat_test.go
+++ b/core/providers/openai/chat_test.go
@@ -329,6 +329,24 @@ func TestToOpenAIChatRequest_NormalizesReasoningEffort(t *testing.T) {
 			effort:   "max",
 			expected: "max",
 		},
+		{
+			name:     "preserves xhigh for qwen-3-8-27b",
+			model:    "qwen-3-8-27b",
+			effort:   "xhigh",
+			expected: "xhigh",
+		},
+		{
+			name:     "preserves xhigh for qwen3.8-27b",
+			model:    "qwen3.8-27b",
+			effort:   "xhigh",
+			expected: "xhigh",
+		},
+		{
+			name:     "maps high to xhigh for qwen-3-8-27b",
+			model:    "qwen-3-8-27b",
+			effort:   "high",
+			expected: "xhigh",
+		},
 	}
 
 	for _, tt := range tests {

--- a/core/providers/openai/responses_marshal_test.go
+++ b/core/providers/openai/responses_marshal_test.go
@@ -184,6 +184,9 @@ func TestNormalizeOpenAIReasoningEffort(t *testing.T) {
 		{"gpt-5.5 keeps xhigh", "gpt-5.5", "xhigh", "xhigh"},
 		{"gpt-5.1 downgrades max to high", "gpt-5.1", "max", "high"},
 		{"gpt-5.1 downgrades xhigh to high", "gpt-5.1", "xhigh", "high"},
+		{"qwen-3-8-27b keeps xhigh", "qwen-3-8-27b", "xhigh", "xhigh"},
+		{"qwen3.8-27b keeps xhigh", "qwen3.8-27b", "xhigh", "xhigh"},
+		{"qwen-3-8-27b maps high to xhigh", "qwen-3-8-27b", "high", "xhigh"},
 		{"standard effort passes through", "gpt-5.1", "medium", "medium"},
 	}
 
@@ -1144,6 +1147,12 @@ func TestEffortPredicatesAgainstCatalogIDs(t *testing.T) {
 		{"deepseek-v4-pro", false, false, true},
 		{"glm-5.2", false, false, true},
 		{"gpt-4o", false, false, false},
+		// Qwen 3.8 family: effort enum is low/medium/xhigh (#6424)
+		{"qwen-3-8-27b", false, true, false},
+		{"qwen3.8-27b", false, true, false},
+		// dash-rolled qwen3-8b is an older family with no effort enum
+		{"qwen-3-8b", false, false, false},
+		{"qwen3-8b", false, false, false},
 	}
 	for _, c := range cases {
 		if got := acceptsMinimalEffort(c.model); got != c.minimal {

--- a/core/providers/openai/utils.go
+++ b/core/providers/openai/utils.go
@@ -66,7 +66,13 @@ func defaultEffortControl(model string) *schemas.EffortControl {
 	if acceptsMaxEffort(model) {
 		levels = append(levels, schemas.ReasoningEffortMax)
 	}
-	return &schemas.EffortControl{Levels: levels}
+	ctrl := &schemas.EffortControl{Levels: levels}
+	if isQwen38Model(bareModelLower(model)) {
+		// The Qwen 3.8 enum has no "high" rung (low/medium/xhigh, default
+		// xhigh); send the default instead of a label the server 400s on (#6424).
+		ctrl.Renames = map[string]string{schemas.ReasoningEffortHigh: schemas.ReasoningEffortXHigh}
+	}
+	return ctrl
 }
 
 // acceptsXHighEffort reports models that natively accept "xhigh" effort. The
@@ -86,7 +92,39 @@ func acceptsXHighEffort(model string) bool {
 		strings.Contains(modelLower, "gpt-5.3-codex") ||
 		strings.Contains(modelLower, "gpt-5.4") ||
 		strings.Contains(modelLower, "gpt-5.5") ||
-		strings.Contains(modelLower, "gpt-5.6")
+		strings.Contains(modelLower, "gpt-5.6") ||
+		isQwen38Model(modelLower)
+}
+
+// isQwen38Model reports the Qwen 3.8 family, whose chat template exposes a
+// reasoning_effort enum of low/medium/xhigh (default xhigh) and rejects
+// "high" (maximhq/bifrost#6424). Both wire spellings are matched: the
+// upstream "qwen3.8-27b" and dash-rolled renames such as "qwen-3-8-27b". The
+// version-boundary check keeps "qwen-3-8b" (dash-rolled qwen3-8b, an older
+// family with no effort enum) out of the match.
+func isQwen38Model(modelLower string) bool {
+	return hasVersionBoundary(modelLower, "qwen3.8") ||
+		hasVersionBoundary(modelLower, "qwen-3-8")
+}
+
+// hasVersionBoundary reports whether needle appears in s at end-of-string or
+// followed by "-" or "_" — i.e. the needle is a complete version, not the
+// prefix of a longer one ("qwen-3-8" in "qwen-3-8b"). Substring, not prefix:
+// bareModelLower strips only one leading segment, so vendor namespaces like
+// "qwen/qwen3.8-27b" survive to this check.
+func hasVersionBoundary(s, needle string) bool {
+	rest := s
+	for {
+		i := strings.Index(rest, needle)
+		if i < 0 {
+			return false
+		}
+		after := rest[i+len(needle):]
+		if after == "" || after[0] == '-' || after[0] == '_' {
+			return true
+		}
+		rest = rest[i+1:]
+	}
 }
 
 // acceptsMinimalEffort reports models that natively accept "minimal" effort:

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -136765,6 +136765,107 @@
           ]
         }
       ]
+    },
+    {
+      "name": "59. Qwen 3.8 reasoning_effort xhigh pass-through (#6424)",
+      "description": "The Qwen 3.8 chat-template effort enum is low/medium/xhigh (default xhigh) and rejects \"high\" with 400 \"Unexpected reasoning effort high\". The name-based effort fallback in core/providers/openai/utils.go (defaultEffortControl/acceptsXHighEffort) did not recognise the Qwen 3.8 family as xhigh-capable, so a client's legitimate xhigh was silently downgraded to \"high\" and rejected upstream (production: SGLang serving qwen-3-8-27b behind an OpenAI-compatible custom provider, #6424). The fix adds the family (both wire spellings, qwen3.8-* and dash-rolled qwen-3-8-*) to acceptsXHighEffort and renames \"high\" to \"xhigh\". Pinned here via openrouter/qwen/qwen3.8-27b: Bifrost sends reasoning_effort on the wire to OpenRouter and OpenRouter forwards provider-specific parameters to the Qwen backend, so the same shared OpenAI-dialect normalization runs end to end. 59.A pins the unary path (upstream must not reject the downgraded \"high\"); 59.B pins the streaming variant (the issue's repro shape).",
+      "item": [
+        {
+          "name": "59.A openrouter/qwen/qwen3.8-27b reasoning_effort xhigh passes through (chat) - #6424",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\": \"openrouter/qwen/qwen3.8-27b\", \"max_tokens\": 256, \"reasoning_effort\": \"xhigh\", \"messages\": [{\"role\": \"user\", \"content\": \"Reply with one word.\"}]}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// 400 is deliberately not guarded: upstream rejecting the downgraded \"high\" is the regression.",
+                  "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                  "var t = pm.response.text() || '';",
+                  "pm.test('upstream did not reject a downgraded effort', function () {",
+                  "  pm.expect(t.indexOf('reasoning effort high') === -1, 'regression: xhigh downgraded to high and rejected upstream: ' + t.slice(0, 500)).to.be.true;",
+                  "});",
+                  "pm.test('xhigh accepted end to end', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + t.slice(0, 500)).to.be.below(400);",
+                  "  var j; try { j = pm.response.json(); } catch (e) { pm.expect.fail('unparseable response: ' + t.slice(0, 500)); return; }",
+                  "  pm.expect(j.choices && j.choices.length, 'no choices: ' + t.slice(0, 500)).to.be.above(0);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "59.B openrouter/qwen/qwen3.8-27b reasoning_effort xhigh passes through (streaming) - #6424",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\": \"openrouter/qwen/qwen3.8-27b\", \"max_tokens\": 256, \"reasoning_effort\": \"xhigh\", \"stream\": true, \"messages\": [{\"role\": \"user\", \"content\": \"Reply with one word.\"}]}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// 400 is deliberately not guarded: the Qwen backend validates the effort before the stream opens.",
+                  "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                  "var t = pm.response.text() || '';",
+                  "pm.test('upstream did not reject a downgraded effort', function () {",
+                  "  pm.expect(t.indexOf('reasoning effort high') === -1, 'regression: xhigh downgraded to high and rejected upstream: ' + t.slice(0, 500)).to.be.true;",
+                  "});",
+                  "pm.test('stream opened with xhigh', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + t.slice(0, 500)).to.be.below(400);",
+                  "  pm.expect(t.indexOf('data:') !== -1, 'no SSE chunks in body: ' + t.slice(0, 500)).to.be.true;",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
The Qwen 3.8 chat-template effort enum is low/medium/xhigh (default xhigh) and rejects "high" with 400 "Unexpected reasoning effort high". The name-based effort fallback in core/providers/openai/utils.go did not recognise the Qwen 3.8 family as xhigh-capable, so a client sending reasoning_effort "xhigh" (e.g. qwen-3-8-27b on SGLang behind an OpenAI-compatible provider) had it silently downgraded to "high", which the upstream then rejects.

- acceptsXHighEffort: match the Qwen 3.8 family under both wire spellings (qwen3.8-* and dash-rolled qwen-3-8-*) with a version-boundary check so qwen-3-8b (older family, no effort enum) is not matched
- defaultEffortControl: rename "high" to "xhigh" for the family, since the enum has no "high" rung
- red/green Go tests in the openai package (chat + responses normalization paths, effort predicates)
- provider-harness regression folder 59: unary + streaming via openrouter/qwen/qwen3.8-27b

## Summary

Briefly explain the purpose of this PR and the problem it solves.

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


