### PR TITLE
feat: project `needs_reauth` onto shared-OAuth clients when their token row is invalidated via batch `GetSharedOauthTokensByConfigIDs` lookup

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -6644,6 +6644,35 @@ func (s *RDBConfigStore) DeleteSharedOauthTokensByConfigID(ctx context.Context, 
 	return nil
 }
 
+// GetSharedOauthTokensByConfigIDs is GetSharedOauthTokenByConfigID's batch
+// counterpart: resolves the auth_mode='shared' token row for each of the
+// given oauth config IDs in one query, keyed by OauthConfigID. Applies the
+// same active-first, most-recently-updated ordering, so a stale duplicate
+// row can't shadow the live one. Not filtered by status; configs with no
+// shared row are absent from the map.
+func (s *RDBConfigStore) GetSharedOauthTokensByConfigIDs(ctx context.Context, oauthConfigIDs []string) (map[string]*tables.TableMCPOauthToken, error) {
+	if len(oauthConfigIDs) == 0 {
+		return map[string]*tables.TableMCPOauthToken{}, nil
+	}
+	var tokens []tables.TableMCPOauthToken
+	if err := s.DB().WithContext(ctx).
+		Where("oauth_config_id IN ? AND auth_mode = ?", oauthConfigIDs, "shared").
+		Order("CASE WHEN status = 'active' THEN 0 ELSE 1 END, updated_at DESC, id DESC").
+		Find(&tokens).Error; err != nil {
+		return nil, fmt.Errorf("failed to batch-get shared oauth tokens: %w", err)
+	}
+	// The ordering above puts the preferred row for each config first, so the
+	// first write per key wins and later duplicates are dropped.
+	result := make(map[string]*tables.TableMCPOauthToken, len(tokens))
+	for i := range tokens {
+		if _, seen := result[tokens[i].OauthConfigID]; seen {
+			continue
+		}
+		result[tokens[i].OauthConfigID] = &tokens[i]
+	}
+	return result, nil
+}
+
 // GetAdminOauthTokenByMCPClientID resolves the single retained admin-mode
 // token row for an MCP client — the bootstrap-verification credential kept
 // alive for a per-user client's periodic tool-discovery refresh (see

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -539,6 +539,12 @@ type ConfigStore interface {
 	// of the given MCP client IDs in one query, keyed by MCPClientID. Not
 	// filtered by status; clients with no admin row are absent from the map.
 	GetAdminOauthTokensByMCPClientIDs(ctx context.Context, mcpClientIDs []string) (map[string]*tables.TableMCPOauthToken, error)
+	// GetSharedOauthTokensByConfigIDs is GetSharedOauthTokenByConfigID's batch
+	// counterpart: resolves the shared-mode token row for each of the given
+	// oauth config IDs in one query, keyed by OauthConfigID. Same
+	// active-first ordering, so a stale duplicate can't shadow the live row.
+	// Not filtered by status; configs with no shared row are absent.
+	GetSharedOauthTokensByConfigIDs(ctx context.Context, oauthConfigIDs []string) (map[string]*tables.TableMCPOauthToken, error)
 	// PromoteSharedOauthTokenToAdmin transactionally installs the config's
 	// fresh shared-mode token as the retained admin-mode discovery credential
 	// for mcpClientID: if an admin row already exists its credential fields

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -1053,26 +1053,45 @@ func (h *MCPHandler) forceSyncMCPLibrary(ctx *fasthttp.RequestCtx) {
 // getMCPClientsPaginated handles the paginated path for GET /api/mcp/clients.
 // states carries the raw connection-state selection (connected/disconnected);
 // it is resolved against the live engine here because state is not a DB column.
-// projectPerUserAdminCredentialState overlays a response-only needs_reauth
-// state onto a per-user client's runtime state when the retained admin
-// credential used for periodic tool-list discovery needs repair. The runtime
-// manager is never touched: per-user clients keep serving (end-user
-// credentials and tool calls keep working); this projection only tells the
-// registry UI that an admin should repair the discovery credential.
-// adminTokenStatus is the admin OAuth token row's status ("" when no row
-// exists), adminCredStatus the admin header credential row's status ("" when
-// no row exists). A missing row leaves the state alone: clients verified
-// before credential retention existed have no admin row and are healthy.
+// projectMCPCredentialState overlays a response-only needs_reauth state onto
+// a client's runtime state when the credential the registry depends on has
+// been invalidated. The runtime manager is never touched: this projection
+// only tells the registry UI that an admin has to re-authorize.
+//
+// Two shapes, one rule. For a per-user client it is the retained admin
+// credential used for periodic tool-list discovery: the client keeps serving
+// (end-user credentials and tool calls are unaffected) and only discovery is
+// broken. For a shared-OAuth client it is the one credential every caller
+// uses, so a dead one means the client is not usable at all.
+//
+// The shared case needs this projection rather than relying on the runtime
+// state alone. Rotating oauth_config cascades every bound token row to
+// needs_reauth, including the shared one, but the matching in-memory flip
+// (CloseAndMarkNeedsReauth) only lands for a client holding a persistent
+// connection. A shared client running per-call — the default for anything
+// created with needs_session_stickiness unset — has no connection to close,
+// so it returns ErrMCPReconnectNotApplicable and the runtime state stays
+// Healthy on credentials that no longer work. The in-memory flip is also
+// lost on restart, since nothing persists runtime state for shared clients.
+// The token row is the durable record in both cases, so read it here.
+//
+// statuses are "" when no row exists, which leaves the state alone: clients
+// verified before credential retention existed have no admin row and are
+// healthy.
 //
 // Applies over both Healthy and Unstable runtime states: needs_reauth is a
-// more actionable signal than Unstable (a dead admin credential never
-// self-heals — Unstable might, on the next successful check), so it must
-// win rather than being masked by a pre-existing Unstable reading. It does
-// NOT apply over Disabled/PendingVerification/anything else: those already
-// carry a more specific, authoritative meaning of their own (an explicit
-// admin action, or a one-time bootstrap that was never completed at all)
-// that a stale discovery credential shouldn't override.
-func projectPerUserAdminCredentialState(authType schemas.MCPAuthType, runtimeState schemas.MCPConnectionState, adminTokenStatus, adminCredStatus string) schemas.MCPConnectionState {
+// more actionable signal than Unstable (a dead credential never self-heals —
+// Unstable might, on the next successful check), so it must win rather than
+// being masked by a pre-existing Unstable reading. It does NOT apply over
+// Disabled/PendingVerification/anything else: those already carry a more
+// specific, authoritative meaning of their own (an explicit admin action, or
+// a one-time bootstrap that was never completed at all) that a stale
+// credential shouldn't override.
+func projectMCPCredentialState(
+	authType schemas.MCPAuthType,
+	runtimeState schemas.MCPConnectionState,
+	adminTokenStatus, adminCredStatus, sharedTokenStatus string,
+) schemas.MCPConnectionState {
 	if runtimeState != schemas.MCPConnectionStateHealthy && runtimeState != schemas.MCPConnectionStateUnstable {
 		return runtimeState
 	}
@@ -1083,6 +1102,10 @@ func projectPerUserAdminCredentialState(authType schemas.MCPAuthType, runtimeSta
 		}
 	case schemas.MCPAuthTypePerUserHeaders:
 		if adminCredStatus == "needs_update" {
+			return schemas.MCPConnectionStateNeedsReauth
+		}
+	case schemas.MCPAuthTypeOauth:
+		if sharedTokenStatus == "needs_reauth" {
 			return schemas.MCPConnectionStateNeedsReauth
 		}
 	}
@@ -1194,15 +1217,27 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, params con
 	// every registry list.
 	adminTokenStatusByClientID := make(map[string]string)
 	adminCredStatusByClientID := make(map[string]string)
+	sharedTokenStatusByClientID := make(map[string]string)
 	if h.store.ConfigStore != nil {
 		adminTokenClientIDs := make([]string, 0)
 		perUserHeaderClientIDs := make([]string, 0)
+		// Shared-OAuth rows are keyed by oauth_config_id, not client id, so
+		// keep the reverse mapping to fold the result back onto clients.
+		sharedOauthConfigIDs := make([]string, 0)
+		clientIDsByOauthConfigID := make(map[string][]string)
 		for _, c := range dbClients {
 			switch schemas.MCPAuthType(c.AuthType) {
 			case schemas.MCPAuthTypePerUserOauth, schemas.MCPAuthTypeTokenExchange:
 				adminTokenClientIDs = append(adminTokenClientIDs, c.ClientID)
 			case schemas.MCPAuthTypePerUserHeaders:
 				perUserHeaderClientIDs = append(perUserHeaderClientIDs, c.ClientID)
+			case schemas.MCPAuthTypeOauth:
+				if c.OauthConfigID != nil && *c.OauthConfigID != "" {
+					if _, seen := clientIDsByOauthConfigID[*c.OauthConfigID]; !seen {
+						sharedOauthConfigIDs = append(sharedOauthConfigIDs, *c.OauthConfigID)
+					}
+					clientIDsByOauthConfigID[*c.OauthConfigID] = append(clientIDsByOauthConfigID[*c.OauthConfigID], c.ClientID)
+				}
 			}
 		}
 		if len(adminTokenClientIDs) > 0 {
@@ -1221,6 +1256,17 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, params con
 				}
 			} else {
 				logger.Debug("failed to batch-get admin header credentials for MCP registry state projection: %v", err)
+			}
+		}
+		if len(sharedOauthConfigIDs) > 0 {
+			if sharedTokens, err := h.store.ConfigStore.GetSharedOauthTokensByConfigIDs(ctx, sharedOauthConfigIDs); err == nil {
+				for oauthConfigID, token := range sharedTokens {
+					for _, clientID := range clientIDsByOauthConfigID[oauthConfigID] {
+						sharedTokenStatusByClientID[clientID] = token.Status
+					}
+				}
+			} else {
+				logger.Debug("failed to batch-get shared oauth tokens for MCP registry state projection: %v", err)
 			}
 		}
 	}
@@ -1288,11 +1334,12 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, params con
 			sort.Slice(sortedTools, func(i, j int) bool {
 				return sortedTools[i].Name < sortedTools[j].Name
 			})
-			resolvedState := projectPerUserAdminCredentialState(
+			resolvedState := projectMCPCredentialState(
 				clientConfig.AuthType,
 				connectedClient.State,
 				adminTokenStatusByClientID[dbClient.ClientID],
 				adminCredStatusByClientID[dbClient.ClientID],
+				sharedTokenStatusByClientID[dbClient.ClientID],
 			)
 			resp := MCPClientResponse{
 				Config:    redactedConfig,

--- a/transports/bifrost-http/handlers/mcp_peruser_state_projection_test.go
+++ b/transports/bifrost-http/handlers/mcp_peruser_state_projection_test.go
@@ -6,27 +6,28 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-// TestProjectPerUserAdminCredentialState table-tests the response-only
-// needs_reauth projection the registry list applies to per-user clients when
-// the retained admin discovery credential needs repair. The projection must
-// only ever flip a connected per-user client to needs_reauth: any other
-// runtime state passes through untouched (a disconnected or pending client
-// has bigger problems than a stale discovery credential), shared-connection
-// auth types are never projected (their needs_reauth comes from the runtime
-// manager itself), and a missing admin row ("" status) leaves the state
-// alone because clients verified before credential retention existed have
-// no admin row and are healthy.
-func TestProjectPerUserAdminCredentialState(t *testing.T) {
+// TestProjectMCPCredentialState table-tests the response-only needs_reauth
+// projection the registry list applies when the credential a client depends
+// on has been invalidated: the retained admin discovery credential for a
+// per-user client, or the single issued token for a shared-OAuth one. The
+// projection must only ever flip a connected client to needs_reauth: any
+// other runtime state passes through untouched (a disconnected or pending
+// client has bigger problems than a stale credential), each auth type reads
+// only its own credential's status, and a missing row ("" status) leaves the
+// state alone because clients verified before credential retention existed
+// have no admin row and are healthy.
+func TestProjectMCPCredentialState(t *testing.T) {
 	connected := schemas.MCPConnectionStateHealthy
 	needsReauth := schemas.MCPConnectionStateNeedsReauth
 
 	tests := []struct {
-		name             string
-		authType         schemas.MCPAuthType
-		runtimeState     schemas.MCPConnectionState
-		adminTokenStatus string
-		adminCredStatus  string
-		want             schemas.MCPConnectionState
+		name              string
+		authType          schemas.MCPAuthType
+		runtimeState      schemas.MCPConnectionState
+		adminTokenStatus  string
+		adminCredStatus   string
+		sharedTokenStatus string
+		want              schemas.MCPConnectionState
 	}{
 		{
 			name:     "per_user_oauth connected with dead admin token projects needs_reauth",
@@ -99,23 +100,67 @@ func TestProjectPerUserAdminCredentialState(t *testing.T) {
 			adminTokenStatus: "active", want: schemas.MCPConnectionStateUnstable,
 		},
 		{
-			name:     "shared oauth clients are never projected",
+			// The regression this projection exists for on the shared side:
+			// rotating oauth_config marks the shared token row needs_reauth,
+			// but a per-call shared client has no connection for
+			// CloseAndMarkNeedsReauth to flip, so the runtime state stays
+			// healthy on credentials that no longer work.
+			name:     "shared oauth connected with rotated token projects needs_reauth",
+			authType: schemas.MCPAuthTypeOauth, runtimeState: connected,
+			sharedTokenStatus: "needs_reauth", want: needsReauth,
+		},
+		{
+			name:     "shared oauth connected with active token stays connected",
+			authType: schemas.MCPAuthTypeOauth, runtimeState: connected,
+			sharedTokenStatus: "active", want: connected,
+		},
+		{
+			name:     "shared oauth connected with no token row stays connected",
+			authType: schemas.MCPAuthTypeOauth, runtimeState: connected,
+			sharedTokenStatus: "", want: connected,
+		},
+		{
+			name:     "shared oauth unstable with rotated token projects needs_reauth",
+			authType: schemas.MCPAuthTypeOauth, runtimeState: schemas.MCPConnectionStateUnstable,
+			sharedTokenStatus: "needs_reauth", want: needsReauth,
+		},
+		{
+			name:     "shared oauth ignores the per-user admin credential statuses",
 			authType: schemas.MCPAuthTypeOauth, runtimeState: connected,
 			adminTokenStatus: "needs_reauth", adminCredStatus: "needs_update", want: connected,
 		},
 		{
+			name:     "per_user_oauth ignores the shared token status",
+			authType: schemas.MCPAuthTypePerUserOauth, runtimeState: connected,
+			sharedTokenStatus: "needs_reauth", want: connected,
+		},
+		{
+			// Shared headers carry no issued credential: the header map is the
+			// credential, so editing it is a config change with nothing to
+			// re-authorize. A wrong value surfaces as unstable via the health
+			// check instead.
+			name:     "shared headers are never projected",
+			authType: schemas.MCPAuthTypeHeaders, runtimeState: connected,
+			sharedTokenStatus: "needs_reauth", want: connected,
+		},
+		{
+			name:     "disabled shared oauth passes through even with a rotated token",
+			authType: schemas.MCPAuthTypeOauth, runtimeState: schemas.MCPConnectionStateDisabled,
+			sharedTokenStatus: "needs_reauth", want: schemas.MCPConnectionStateDisabled,
+		},
+		{
 			name:     "non-auth clients are never projected",
 			authType: schemas.MCPAuthTypeNone, runtimeState: connected,
-			adminTokenStatus: "needs_reauth", adminCredStatus: "needs_update", want: connected,
+			adminTokenStatus: "needs_reauth", adminCredStatus: "needs_update", sharedTokenStatus: "needs_reauth", want: connected,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := projectPerUserAdminCredentialState(tt.authType, tt.runtimeState, tt.adminTokenStatus, tt.adminCredStatus)
+			got := projectMCPCredentialState(tt.authType, tt.runtimeState, tt.adminTokenStatus, tt.adminCredStatus, tt.sharedTokenStatus)
 			if got != tt.want {
-				t.Errorf("projectPerUserAdminCredentialState(%q, %q, %q, %q) = %q, want %q",
-					tt.authType, tt.runtimeState, tt.adminTokenStatus, tt.adminCredStatus, got, tt.want)
+				t.Errorf("projectMCPCredentialState(%q, %q, %q, %q, %q) = %q, want %q",
+					tt.authType, tt.runtimeState, tt.adminTokenStatus, tt.adminCredStatus, tt.sharedTokenStatus, got, tt.want)
 			}
 		})
 	}

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1485,6 +1485,10 @@ func (m *MockConfigStore) GetAdminOauthTokensByMCPClientIDs(ctx context.Context,
 	return map[string]*tables.TableMCPOauthToken{}, nil
 }
 
+func (m *MockConfigStore) GetSharedOauthTokensByConfigIDs(ctx context.Context, oauthConfigIDs []string) (map[string]*tables.TableMCPOauthToken, error) {
+	return map[string]*tables.TableMCPOauthToken{}, nil
+}
+
 func (m *MockConfigStore) PromoteSharedOauthTokenToAdmin(ctx context.Context, oauthConfigID, mcpClientID string) error {
 	return nil
 }


### PR DESCRIPTION
## Summary

When an OAuth config is rotated, every bound shared-mode token row is cascaded to `needs_reauth`. For shared-OAuth clients that run per-call (no persistent connection), `CloseAndMarkNeedsReauth` returns `ErrMCPReconnectNotApplicable` and the in-memory runtime state stays `Healthy` — even though the credential no longer works. This state is also lost on restart since nothing persists runtime state for shared clients. The registry UI therefore shows the client as healthy when it isn't. This PR fixes that by reading the durable shared token row and projecting `needs_reauth` onto the response state, the same way the per-user admin credential projection already works.

## Changes

- Added `GetSharedOauthTokensByConfigIDs` batch query to `RDBConfigStore` and the `ConfigStore` interface, keyed by `OauthConfigID` with the same active-first, most-recently-updated ordering used by the single-row variant so stale duplicate rows can't shadow the live one.
- Renamed `projectPerUserAdminCredentialState` to `projectMCPCredentialState` and added a `sharedTokenStatus` parameter. The `MCPAuthTypeOauth` case now projects `needs_reauth` when the shared token row carries that status.
- In `getMCPClientsPaginated`, shared-OAuth clients are collected by `oauth_config_id`, batch-fetched in one query, and the result is fanned back out to individual client IDs before the state projection runs.
- Updated tests to cover the new shared-OAuth projection cases: rotated token projects `needs_reauth`, active or missing token leaves state alone, disabled client passes through, and each auth type ignores the other's credential statuses.
- Added the stub implementation of `GetSharedOauthTokensByConfigIDs` to `MockConfigStore` in the config test file.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)

## How to test

```sh
go test ./framework/configstore/... ./transports/bifrost-http/...
```

1. Create a shared-OAuth MCP client (leave `needs_session_stickiness` unset so it runs per-call).
2. Verify the registry shows the client as healthy.
3. Rotate the OAuth config. The shared token row should be cascaded to `needs_reauth`.
4. Fetch `GET /api/mcp/clients` — the client should now appear with state `needs_reauth` even though no connection was closed and the service was not restarted.
5. Re-authorize. The token row returns to `active` and the state returns to healthy.

## Breaking changes

- [x] No

## Security considerations

The batch query is scoped to `auth_mode = 'shared'` and filtered to the exact set of `oauth_config_id` values belonging to the clients already authorized for the requesting context. No new credential material is exposed; only the `status` field of the token row is used for the projection.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)