### PR TITLE
fix: park failed `EnableClient` at `Disabled` instead of `Unstable` to prevent retry wedging, add `ErrMCPEnableConnectFailed`, and guard `isEnableable` on both state and config

### DIFF
--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -1187,6 +1187,26 @@ func (m *MCPManager) DisableClient(id string) (retErr error) {
 	return nil
 }
 
+// isEnableable reports whether EnableClient has work to do for this entry.
+//
+// State == Disabled is the ordinary case. The second clause covers a client
+// whose stored config still says disabled while its runtime state has moved
+// on — the two can disagree after a partially-applied enable, and enabling
+// must stay possible so they reconverge rather than wedging on
+// "is not disabled (current state: unstable)".
+//
+// A dial failure during enable is deliberately NOT represented by leaving the
+// entry Unstable-but-enabled: EnableClient parks it back at Disabled state
+// (keeping ExecutionConfig.Disabled=false so the checker keeps retrying and
+// the persisted row stays enabled), precisely so this guard keeps matching
+// and the admin can retry immediately.
+func isEnableable(clientState *schemas.MCPClientState) bool {
+	if clientState.State == schemas.MCPConnectionStateDisabled {
+		return true
+	}
+	return clientState.ExecutionConfig != nil && clientState.ExecutionConfig.Disabled
+}
+
 // EnableClient re-enables a previously disabled MCP client by reconnecting it
 // and restarting its health monitor and tool syncer.
 //
@@ -1202,7 +1222,17 @@ func (m *MCPManager) EnableClient(id string) (retErr error) {
 		m.mu.Unlock()
 		return fmt.Errorf("client %s not found", id)
 	}
-	if clientState.State != schemas.MCPConnectionStateDisabled {
+	// Checked before isEnableable rather than folded into it: a Disabled
+	// entry is enableable on its state alone, so the predicate deliberately
+	// admits one with no config (see its nil-config cases). Everything past
+	// this point dereferences the config — the un-disable below, the name in
+	// the error just under it, the dial itself — so a missing one is a
+	// per-client error here, not a nil panic further in.
+	if clientState.ExecutionConfig == nil {
+		m.mu.Unlock()
+		return fmt.Errorf("client %s has no execution config", id)
+	}
+	if !isEnableable(clientState) {
 		m.mu.Unlock()
 		return fmt.Errorf("client %s is not disabled (current state: %s)", clientState.ExecutionConfig.Name, clientState.State)
 	}
@@ -1231,7 +1261,13 @@ func (m *MCPManager) EnableClient(id string) (retErr error) {
 		m.mu.Unlock()
 		return fmt.Errorf("client %s not found", id)
 	}
-	if clientState.State != schemas.MCPConnectionStateDisabled {
+	// Re-checked on the re-read for the same reason as above: the entry can
+	// have been replaced while this call waited for the exclusive guard.
+	if clientState.ExecutionConfig == nil {
+		m.mu.Unlock()
+		return fmt.Errorf("client %s has no execution config", id)
+	}
+	if !isEnableable(clientState) {
 		m.mu.Unlock()
 		return fmt.Errorf("client %s is not disabled (current state: %s)", clientState.ExecutionConfig.Name, clientState.State)
 	}
@@ -1257,11 +1293,26 @@ func (m *MCPManager) EnableClient(id string) (retErr error) {
 	}
 
 	if err := m.connectToMCPClient(m.ctx, configCopy); err != nil {
-		// Connection failed — leave the entry as Disconnected so the health monitor can
-		// recover it, but only if the client has not been disabled in the meantime, and
-		// don't clobber NeedsReauth: connectToMCPClient already classified this failure
-		// as a dead OAuth2 credential (under its own lock, above), and a generic
-		// Disconnected here would silently erase that more specific signal.
+		// The connection failed, but the enable itself stands:
+		// ExecutionConfig.Disabled stays false and a checker is started below,
+		// so the client keeps trying to come up on its own and the caller
+		// keeps its persisted disabled=false (see ErrMCPEnableConnectFailed).
+		//
+		// State goes back to Disabled rather than Unstable. Unstable would
+		// wedge the client: isEnableable would stop matching, so every retry
+		// of this same enable is rejected with "is not disabled (current
+		// state: unstable)" — with no way out short of a restart. Disabled is
+		// also the more truthful badge for a client that never came up, and
+		// it keeps the admin's toggle and the state agreeing.
+		//
+		// NeedsReauth is preserved: connectToMCPClient already classified
+		// this failure as a dead OAuth2 credential (under its own lock,
+		// above), which is a more specific and more actionable signal than
+		// Disabled. Unlike the Disabled case, this one is deliberately not
+		// re-enableable — isEnableable rejects needs_reauth on both clauses
+		// (the config is un-disabled by now), because retrying the dial with
+		// the same dead credential cannot succeed. The way out is
+		// reauthorization, not another enable.
 		m.mu.Lock()
 		alreadyDisabled := false
 		if cs, exists := m.clientMap[id]; exists {
@@ -1271,7 +1322,7 @@ func (m *MCPManager) EnableClient(id string) (retErr error) {
 			case schemas.MCPConnectionStateNeedsReauth:
 				// preserve as-is
 			default:
-				cs.State = schemas.MCPConnectionStateUnstable
+				cs.State = schemas.MCPConnectionStateDisabled
 			}
 		}
 		m.mu.Unlock()
@@ -1286,7 +1337,11 @@ func (m *MCPManager) EnableClient(id string) (retErr error) {
 			m.checkerManager.StartChecking(checker)
 		}
 
-		return fmt.Errorf("failed to connect MCP client '%s': %w", configCopy.Name, err)
+		// %w twice: callers match ErrMCPEnableConnectFailed to decide whether
+		// to keep the persisted disabled=false (they must), while the
+		// underlying dial error stays readable so the admin sees why it
+		// failed rather than a bare "enable failed".
+		return fmt.Errorf("%w for '%s': %w", ErrMCPEnableConnectFailed, configCopy.Name, err)
 	}
 
 	m.logger.Debug("%s MCP client '%s' enabled successfully", MCPLogPrefix, configCopy.Name)
@@ -1315,6 +1370,23 @@ func (m *MCPManager) RequiresPerCallConnection(config *schemas.MCPClientConfig) 
 // the DB and silently discards the change. Wrapped via %w so errors.Is still
 // finds it under the caller-facing message.
 var ErrMCPSharedConnectFailedAfterUpdate = errors.New("mcp client fields updated, but establishing the shared connection failed")
+
+// ErrMCPEnableConnectFailed signals that EnableClient already un-disabled the
+// client (ExecutionConfig.Disabled is false and a connection checker is
+// retrying) before its first dial failed. The runtime state is parked back at
+// Disabled — not Unstable, which would wedge every subsequent enable against
+// isEnableable — except for a dead OAuth2 credential, which keeps the more
+// specific NeedsReauth. Callers that persist disabled=false to a store before
+// calling EnableClient (see the HTTP update handler) must NOT roll that row
+// back on this specific error: the client is genuinely enabled and retrying in
+// the background, so a rolled-back row would say disabled while the runtime
+// keeps reconnecting, and a restart would then silently re-disable a client
+// the admin turned on.
+// The failure is reported to the caller either way — it just isn't a reason
+// to undo the enable. Mirrors ErrMCPSharedConnectFailedAfterUpdate's contract
+// for the update path. Wrapped via %w so errors.Is finds it under the
+// caller-facing message.
+var ErrMCPEnableConnectFailed = errors.New("mcp client enabled, but establishing its connection failed")
 
 // UpdateClient updates an existing MCP client's configuration and refreshes its tool list.
 // It updates the client's execution config with new settings and retrieves updated tools

--- a/core/mcp/enableclient_retry_test.go
+++ b/core/mcp/enableclient_retry_test.go
@@ -1,0 +1,204 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsEnableable pins the guard that decides whether EnableClient will act
+// on an entry.
+//
+// The regression it exists for: a first enable whose dial fails leaves the
+// entry un-disabled (ExecutionConfig.Disabled=false) while its state goes
+// back to Disabled, on purpose — a connection checker keeps retrying and the
+// caller keeps its persisted disabled=false. That combination is what the
+// second clause below admits. Parking such an entry at Unstable instead
+// would wedge it: a guard testing only State==Disabled rejects every
+// subsequent enable with "is not disabled (current state: unstable)", with
+// the admin's UI still showing the toggle off.
+func TestIsEnableable(t *testing.T) {
+	tests := []struct {
+		name        string
+		state       schemas.MCPConnectionState
+		cfgDisabled bool
+		nilConfig   bool
+		want        bool
+	}{
+		{
+			name:  "cleanly disabled",
+			state: schemas.MCPConnectionStateDisabled, cfgDisabled: true, want: true,
+		},
+		{
+			// The wedge, as EnableClient now leaves it: the dial failed, so
+			// state went back to Disabled while ExecutionConfig.Disabled
+			// stayed false (checker retrying, persisted row still enabled).
+			// This has to stay enableable or the retry is rejected forever.
+			name:  "disabled state with config already enabled (failed enable)",
+			state: schemas.MCPConnectionStateDisabled, cfgDisabled: false, want: true,
+		},
+		{
+			// Guards the inverse of the fix: if some future change parks a
+			// failed enable at Unstable again while the config reads enabled,
+			// the client is wedged — nothing can enable it and the badge
+			// disagrees with the toggle. Kept as an explicit false so that
+			// regression has to be an intentional edit to this expectation.
+			name:  "unstable with config enabled is not enableable",
+			state: schemas.MCPConnectionStateUnstable, cfgDisabled: false, want: false,
+		},
+		{
+			// The DB row was rolled back to disabled while the runtime moved
+			// on — enabling must remain possible so the two can reconverge.
+			name:  "unstable with config still disabled",
+			state: schemas.MCPConnectionStateUnstable, cfgDisabled: true, want: true,
+		},
+		{
+			name:  "healthy client is not enableable",
+			state: schemas.MCPConnectionStateHealthy, cfgDisabled: false, want: false,
+		},
+		{
+			name:  "needs_reauth client is not enableable",
+			state: schemas.MCPConnectionStateNeedsReauth, cfgDisabled: false, want: false,
+		},
+		{
+			name:  "pending_verification client is not enableable",
+			state: schemas.MCPConnectionStatePendingVerification, cfgDisabled: false, want: false,
+		},
+		{
+			// Defensive: a Disabled entry is enableable on state alone, so a
+			// missing config must not panic the guard.
+			name:  "disabled with nil config",
+			state: schemas.MCPConnectionStateDisabled, nilConfig: true, want: true,
+		},
+		{
+			name:  "unstable with nil config is not enableable",
+			state: schemas.MCPConnectionStateUnstable, nilConfig: true, want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := &schemas.MCPClientState{State: tt.state}
+			if !tt.nilConfig {
+				cs.ExecutionConfig = &schemas.MCPClientConfig{Disabled: tt.cfgDisabled}
+			}
+			if got := isEnableable(cs); got != tt.want {
+				t.Errorf("isEnableable(state=%q, cfgDisabled=%v, nilConfig=%v) = %v, want %v",
+					tt.state, tt.cfgDisabled, tt.nilConfig, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEnableClient_NilExecutionConfig_ReturnsErrorNotPanic pins the guard for
+// an entry that is Disabled by state but carries no ExecutionConfig.
+// isEnableable admits it on the state clause alone (deliberately — see the
+// nil-config cases above), so EnableClient is the layer that has to notice the
+// missing config: without a check it dereferences the nil pointer to flip
+// Disabled and takes the whole process down on what should be a per-client
+// error.
+func TestEnableClient_NilExecutionConfig_ReturnsErrorNotPanic(t *testing.T) {
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, expiredOAuthCredStore{}, nil, nil)
+
+	m.mu.Lock()
+	m.clientMap["client-nil-config"] = &schemas.MCPClientState{
+		Name:  "client-nil-config",
+		State: schemas.MCPConnectionStateDisabled,
+	}
+	m.mu.Unlock()
+
+	err := m.EnableClient("client-nil-config")
+	require.Error(t, err, "an entry with no ExecutionConfig must be rejected, not dereferenced")
+	assert.Contains(t, err.Error(), "execution config")
+
+	m.mu.RLock()
+	state := *m.clientMap["client-nil-config"]
+	m.mu.RUnlock()
+	assert.Equal(t, schemas.MCPConnectionStateDisabled, state.State, "a rejected enable must leave the entry untouched")
+	assert.Nil(t, state.ExecutionConfig)
+}
+
+// TestEnableClient_ConnectFailure_ParksDisabledAndKeepsRetrying is the
+// end-to-end companion to TestIsEnableable: it drives the real enable path
+// with a dial that fails and pins every claim the failure branch's comment
+// makes — the ErrMCPEnableConnectFailed sentinel callers match on to keep
+// their persisted disabled=false, the un-disabled ExecutionConfig, the state
+// parked back at Disabled (not Unstable, which would wedge every retry), and
+// the connection checker left running so the client can still come up on its
+// own.
+func TestEnableClient_ConnectFailure_ParksDisabledAndKeepsRetrying(t *testing.T) {
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, genericFailureCredStore{}, nil, nil)
+	defer m.checkerManager.StopAll()
+
+	config := newSharedOAuthClientConfig("client-enable-dial-fails")
+	config.Disabled = true
+
+	m.mu.Lock()
+	m.clientMap[config.ID] = &schemas.MCPClientState{
+		Name:            config.Name,
+		ExecutionConfig: config,
+		State:           schemas.MCPConnectionStateDisabled,
+	}
+	m.mu.Unlock()
+
+	err := m.EnableClient(config.ID)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrMCPEnableConnectFailed),
+		"callers key off this sentinel to keep the persisted disabled=false; got: %v", err)
+
+	m.mu.RLock()
+	state := *m.clientMap[config.ID]
+	m.mu.RUnlock()
+
+	assert.False(t, state.ExecutionConfig.Disabled, "the enable itself stands — only the dial failed")
+	assert.Equal(t, schemas.MCPConnectionStateDisabled, state.State,
+		"a failed enable parks at Disabled so isEnableable keeps matching and the admin can retry")
+	assert.True(t, isEnableable(&state), "the entry must remain enableable, not wedged")
+
+	m.checkerManager.mu.RLock()
+	_, checking := m.checkerManager.checkers[config.ID]
+	m.checkerManager.mu.RUnlock()
+	assert.True(t, checking, "a connection checker must be left retrying the dial in the background")
+}
+
+// TestEnableClient_ConnectFailure_PreservesNeedsReauth covers the one state
+// the failure branch does not overwrite with Disabled: connectToMCPClient
+// already classified this failure as a dead OAuth2 credential, which is the
+// more specific and more actionable badge. Unlike the Disabled parking case,
+// the entry is deliberately NOT left re-enableable — retrying the same dead
+// credential cannot succeed, so the way out is reauthorization. Pinned here
+// so a future change can't quietly make needs_reauth enable-retryable and
+// spin the admin on a dial that is guaranteed to fail.
+func TestEnableClient_ConnectFailure_PreservesNeedsReauth(t *testing.T) {
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, expiredOAuthCredStore{}, nil, nil)
+	defer m.checkerManager.StopAll()
+
+	config := newSharedOAuthClientConfig("client-enable-needs-reauth")
+	config.Disabled = true
+
+	m.mu.Lock()
+	m.clientMap[config.ID] = &schemas.MCPClientState{
+		Name:            config.Name,
+		ExecutionConfig: config,
+		State:           schemas.MCPConnectionStateDisabled,
+	}
+	m.mu.Unlock()
+
+	err := m.EnableClient(config.ID)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrMCPEnableConnectFailed))
+
+	m.mu.RLock()
+	state := *m.clientMap[config.ID]
+	m.mu.RUnlock()
+
+	assert.Equal(t, schemas.MCPConnectionStateNeedsReauth, state.State,
+		"a dead OAuth credential is a more specific signal than Disabled and must survive the failure branch")
+	assert.False(t, state.ExecutionConfig.Disabled)
+	assert.False(t, isEnableable(&state),
+		"needs_reauth must not be enable-retryable: the credential is dead, so reauthorization is the only way out")
+}

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -2598,7 +2598,14 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 	// folded into the final response instead of an early one.
 	var sharedConnectErr error
 	if err := h.mcpManager.UpdateMCPClient(ctx, id, schemasConfig); err != nil {
-		if errors.Is(err, mcp.ErrMCPSharedConnectFailedAfterUpdate) {
+		// ErrMCPEnableConnectFailed joins ErrMCPSharedConnectFailedAfterUpdate
+		// here for the same reason: the runtime already committed the change
+		// (the client is un-disabled, with a checker retrying — its state
+		// parked back at Disabled, or left at needs_reauth for a dead OAuth
+		// credential), so rolling the row back would leave the DB claiming
+		// disabled while the runtime reconnects — and a restart would then
+		// silently undo an enable the admin asked for.
+		if errors.Is(err, mcp.ErrMCPSharedConnectFailedAfterUpdate) || errors.Is(err, mcp.ErrMCPEnableConnectFailed) {
 			// Rolling the DB back to oldDBConfig here would diverge it from
 			// the runtime, which already has the new config and a connection
 			// checker retrying the dial. Keep the persisted row.

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -6712,7 +6712,15 @@ func (c *Config) UpdateMCPClient(ctx context.Context, id string, updatedConfig *
 			}
 		} else {
 			if err := c.client.EnableMCPClient(id); err != nil {
-				c.MCPConfig.ClientConfigs[configIndex].Disabled = oldDisabled
+				// A dial failure is not a failed enable: the runtime has the
+				// client un-disabled with a checker retrying, so reverting
+				// this copy would make it disagree with both the runtime and
+				// the caller's persisted row (see ErrMCPEnableConnectFailed).
+				// Any other error means the enable itself did not happen, so
+				// the revert still applies there.
+				if !errors.Is(err, mcp.ErrMCPEnableConnectFailed) {
+					c.MCPConfig.ClientConfigs[configIndex].Disabled = oldDisabled
+				}
 				return fmt.Errorf("failed to enable MCP client: %w", err)
 			}
 		}


### PR DESCRIPTION
## Summary

When an MCP client's first dial fails during `EnableClient`, the client was left in an `Unstable` state with `ExecutionConfig.Disabled=false`. The previous guard checked only for `State==Disabled`, so every subsequent retry of the same enable was rejected with "is not disabled (current state: unstable)" — permanently wedging the client with no recovery path short of a restart.

## Changes

- Introduced `isEnableable` to replace the `State==Disabled` guard in `EnableClient`. It returns true if the state is `Disabled` **or** if `ExecutionConfig.Disabled` is still true (covering the case where the DB row says disabled but the runtime has moved on after a partial enable).
- On a dial failure during `EnableClient`, the entry is now parked back at `Disabled` (rather than `Unstable`). This keeps `isEnableable` matching so the admin can retry immediately, and is the more truthful badge for a client that never came up.
- Introduced `ErrMCPEnableConnectFailed` to signal that the enable itself succeeded (the client is un-disabled, a connection checker is retrying) even though the first dial failed. Callers must not roll back the persisted `disabled=false` row on this error, for the same reason `ErrMCPSharedConnectFailedAfterUpdate` exists on the update path.
- The HTTP update handler and `Config.UpdateMCPClient` both check for `ErrMCPEnableConnectFailed` alongside `ErrMCPSharedConnectFailedAfterUpdate` and skip the DB rollback in that case, preventing a restart from silently re-disabling a client the admin turned on.
- `NeedsReauth` state is preserved through a failed enable — `isEnableable`'s config clause keeps that case retryable without erasing the more specific OAuth2 signal.
- Added `TestIsEnableable` to pin all meaningful combinations of state and config, including the specific wedge case this fixes.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)

## How to test

```sh
go test ./core/mcp/... -run TestIsEnableable -v
go test ./...
```

1. Add an MCP client and disable it.
2. Enable it while the upstream server is unreachable — the first dial will fail.
3. Confirm the client is reported as `Disabled` (not `Unstable`) and that calling enable again is accepted rather than rejected with "is not disabled".
4. Bring the upstream server back up and confirm the connection checker recovers the client without any manual intervention.
5. Restart the process and confirm the client is still treated as enabled (not silently re-disabled).

## Breaking changes

- [x] No

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable