### PR TITLE
fix: update stream overhead with sub-buckets and UI fixes

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -5335,6 +5335,7 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 	}
 
 	ctx.ResetUpstreamLatency()
+	ctx.ResetStreamOverhead()
 	// Whole-request start for overhead on the streaming short-circuit path; the
 	// normal path derives its total from the final chunk.
 	ctx.SetValue(schemas.BifrostContextKeyRequestStartTime, time.Now())

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -1640,8 +1640,11 @@ func HandleAnthropicResponsesStream(
 				continue
 			}
 			var event AnthropicStreamEvent
-			if err := sonic.Unmarshal([]byte(eventData), &event); err != nil {
-				logger.Warn("Failed to parse message_start event: %v", err)
+			parseStart := time.Now()
+			umErr := sonic.Unmarshal([]byte(eventData), &event)
+			schemas.AddStreamParse(ctx, time.Since(parseStart))
+			if umErr != nil {
+				logger.Warn("Failed to parse message_start event: %v", umErr)
 				continue
 			}
 			if event.Message != nil && modelName == "" {
@@ -1692,7 +1695,9 @@ func HandleAnthropicResponsesStream(
 				}
 			}
 
+			convCallStart := time.Now()
 			responses, bifrostErr, isLastChunk := event.ToBifrostResponsesStream(ctx, chunkIndex, streamState)
+			schemas.AddStreamConvert(ctx, time.Since(convCallStart))
 			// Propagate message_delta emission flag to context so the output converter
 			// (ToAnthropicResponsesStreamResponse) can skip synthesizing a duplicate.
 			if streamState.HasEmittedMessageDelta {

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2733,7 +2733,11 @@ func ProcessAndSendResponse(
 	streamResponse := BuildClientStreamChunk(ctx, processedResponse, processedError)
 
 	// Complete the final-chunk span even if the client send fails, so a dropped connection can't strand it.
+	// Time the send: a block here is the transport/client failing to drain (downstream
+	// backpressure), which the overhead breakdown attributes separately from Bifrost CPU.
+	sendStart := time.Now()
 	GateSendChunk(ctx, streamResponse, responseChan)
+	schemas.AddStreamBackpressure(ctx, time.Since(sendStart))
 
 	// Check if this is the final chunk and complete deferred span with post-processed data
 	if isFinalChunk := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator); isFinalChunk != nil {
@@ -3808,6 +3812,7 @@ func completeDeferredSpan(ctx *schemas.BifrostContext, result *schemas.BifrostRe
 	// Stamp now the stream has drained; the handler returned long ago. Before the
 	// guard below so it still runs when there is no deferred span.
 	ctx.StampUpstreamLatency()
+	ctx.StampStreamOverhead()
 
 	// Get the deferred span handle from TraceStore using trace ID
 	handle := tracer.GetDeferredSpanHandle(traceID)

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -410,6 +410,7 @@ const (
 	BifrostContextKeyTempTokenResourceID                 BifrostContextKey = "bifrost-temp-token-resource-id" // string (set by auth middleware alongside the scope - the resource_id the token is bound to, e.g. an OAuth flow ID for mcp_auth)
 	BifrostContextKeyAsyncWebhookEndpoint                BifrostContextKey = "bifrost-async-webhook-endpoint" // string (webhook endpoint name to notify when an async job finishes - carried as-is from the x-bf-async-webhook header; the submit path resolves and validates it before the job is created)
 	BifrostContextKeyUpstreamLatency                     BifrostContextKey = "bifrost-upstream-latency"       // *atomic.Int64 nanoseconds (set by bifrost - DO NOT SET THIS MANUALLY) - cumulative time blocked on provider sockets across every attempt; subtract from total to get Bifrost overhead
+	BifrostContextKeyStreamOverhead                      BifrostContextKey = "bifrost-stream-overhead"        // *streamOverhead (set by bifrost - DO NOT SET THIS MANUALLY) - per-chunk stream conversion CPU and downstream backpressure, carved out of the overhead breakdown's "core" bucket
 )
 
 const (

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -37,6 +37,7 @@ var reservedKeys = map[BifrostContextKey]struct{}{
 	BifrostContextKeyStreamGated:             {},
 	BifrostContextKeyMCPHealthCheckRequest:   {},
 	BifrostContextKeyUpstreamLatency:         {},
+	BifrostContextKeyStreamOverhead:          {},
 	BifrostContextKeyRoutingInfo:             {},
 	BifrostContextKeyMCPInboundBearer:        {},
 }

--- a/core/schemas/streamoverhead.go
+++ b/core/schemas/streamoverhead.go
@@ -1,0 +1,155 @@
+package schemas
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+)
+
+// Streaming overhead attribution.
+//
+// For a streamed response, Bifrost's overhead (total wall minus the upstream
+// socket total) is dominated by work the provider goroutine does between socket
+// reads: decoding each SSE event's JSON, mapping it to the Bifrost shape, and
+// handing each chunk to the transport. None of that sits on an instrumented span,
+// so it all lands in the breakdown's "core" bucket, which for streams can be
+// hundreds of ms and says nothing about where the time went.
+//
+// This accumulator splits that time into the SAME phases a unary request already
+// reports, so a stream's breakdown reads like a unary one:
+//   - parse:   per-event JSON decode        -> folds into "response-parse" (Serialization)
+//   - convert: per-event struct->unified map -> folds into "convertor" (Convertor)
+//   - backpressure: time blocked handing chunks to the transport. This has no unary
+//     twin and is not Bifrost CPU (it is the client/transport draining slowly), so it
+//     gets its own bucket rather than joining a compute phase.
+//
+// Each category is an *atomic.Int64 (nanoseconds) on a single struct pointer
+// installed once per request; per-chunk adds are lock-free and safe from the
+// provider goroutine after the handler has returned (same reasoning as the upstream
+// accumulator: the pointer is installed once, then only dereferenced).
+type streamOverhead struct {
+	parseNs        atomic.Int64 // per-event SSE JSON decode CPU
+	convertNs      atomic.Int64 // per-event provider->Bifrost struct mapping CPU
+	backpressureNs atomic.Int64 // time blocked handing a chunk to the transport (downstream/client backpressure)
+}
+
+// ResetStreamOverhead installs a fresh accumulator on ctx. Call once at stream
+// entry, before the provider goroutine starts, alongside ResetUpstreamLatency.
+func (bc *BifrostContext) ResetStreamOverhead() {
+	if bc == nil {
+		return
+	}
+	bc.setReservedValue(BifrostContextKeyStreamOverhead, &streamOverhead{})
+}
+
+// streamOverheadFrom returns the accumulator on ctx, or nil when absent (internal
+// calls, tests, SDK callers that never reset). A nil accumulator is silently
+// ignored by the Add helpers: this is telemetry and must never break a request.
+func streamOverheadFrom(ctx context.Context) *streamOverhead {
+	if isNilContext(ctx) {
+		return nil
+	}
+	acc, _ := ctx.Value(BifrostContextKeyStreamOverhead).(*streamOverhead)
+	return acc
+}
+
+// AddStreamParse adds d to the request's per-event JSON-decode total.
+func AddStreamParse(ctx context.Context, d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	if acc := streamOverheadFrom(ctx); acc != nil {
+		acc.parseNs.Add(int64(d))
+	}
+}
+
+// AddStreamConvert adds d to the request's per-event struct-mapping total.
+func AddStreamConvert(ctx context.Context, d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	if acc := streamOverheadFrom(ctx); acc != nil {
+		acc.convertNs.Add(int64(d))
+	}
+}
+
+// AddStreamBackpressure adds d to the request's downstream-backpressure total: the
+// time the provider goroutine spends blocked handing a chunk to the transport
+// (client-side slowness), which today masquerades as Bifrost overhead.
+func AddStreamBackpressure(ctx context.Context, d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	if acc := streamOverheadFrom(ctx); acc != nil {
+		acc.backpressureNs.Add(int64(d))
+	}
+}
+
+// StampStreamOverhead writes the accumulated stream phases onto the request's root
+// span so the overhead breakdown can carve them out of "core" and fold them into
+// the matching unary phases. Mirrors StampUpstreamLatency: call at stream
+// completion, once the accumulator has stopped growing. Best-effort; a request with
+// no tracer or no accumulator is left unstamped, so absent stays distinct from zero.
+func (bc *BifrostContext) StampStreamOverhead() {
+	if bc == nil {
+		return
+	}
+	acc := streamOverheadFrom(bc)
+	if acc == nil {
+		return
+	}
+	traceID, _ := bc.Value(BifrostContextKeyTraceID).(string)
+	if traceID == "" {
+		return
+	}
+	tracer, _ := bc.Value(BifrostContextKeyTracer).(Tracer)
+	if tracer == nil {
+		return
+	}
+	// nil spanID selects the root span.
+	handle := tracer.GetSpanHandleByID(traceID, nil)
+	if handle == nil {
+		return
+	}
+	if parse := acc.parseNs.Load(); parse > 0 {
+		tracer.SetAttribute(handle, AttrBifrostStreamParseMs, float64(parse)/float64(time.Millisecond))
+	}
+	if convert := acc.convertNs.Load(); convert > 0 {
+		tracer.SetAttribute(handle, AttrBifrostStreamConvertMs, float64(convert)/float64(time.Millisecond))
+	}
+	if bp := acc.backpressureNs.Load(); bp > 0 {
+		tracer.SetAttribute(handle, AttrBifrostStreamBackpressureMs, float64(bp)/float64(time.Millisecond))
+	}
+}
+
+// StampStreamTransport writes the transport goroutine's per-chunk split onto the
+// root span: (B) outbound convert+marshal CPU and (A) client-socket write wait.
+// These run concurrently with the provider goroutine, so they are NOT part of the
+// overhead total; the breakdown uses them only as weights to split the provider-side
+// backpressure bucket into its (A) client vs (B) Bifrost composition. Called from the
+// transport goroutine after its send loop drains, before trace completion. Values are
+// passed in (accumulated locally in the transport loop) rather than via the shared
+// context, so reachability of the accumulator across goroutines is never in question.
+func (bc *BifrostContext) StampStreamTransport(transportCPU, clientWrite time.Duration) {
+	if bc == nil {
+		return
+	}
+	traceID, _ := bc.Value(BifrostContextKeyTraceID).(string)
+	if traceID == "" {
+		return
+	}
+	tracer, _ := bc.Value(BifrostContextKeyTracer).(Tracer)
+	if tracer == nil {
+		return
+	}
+	handle := tracer.GetSpanHandleByID(traceID, nil)
+	if handle == nil {
+		return
+	}
+	if transportCPU > 0 {
+		tracer.SetAttribute(handle, AttrBifrostStreamTransportCPUMs, float64(transportCPU)/float64(time.Millisecond))
+	}
+	if clientWrite > 0 {
+		tracer.SetAttribute(handle, AttrBifrostStreamClientWriteMs, float64(clientWrite)/float64(time.Millisecond))
+	}
+}

--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -918,6 +918,25 @@ const (
 	// never disagree.
 	AttrBifrostOverheadDurationMs = "bifrost.overhead.duration_ms"
 
+	// Per-chunk streaming overhead split out of the "core" bucket so a stream's
+	// breakdown reads like a unary request's. All float64 ms, stamped on the ROOT
+	// span at stream completion. parse/convert fold into the same buckets as their
+	// unary equivalents (response-parse, convertor); backpressure has no unary twin
+	// and is not Bifrost CPU (the transport/client draining slowly).
+	//   - parse:        per-event SSE JSON decode CPU
+	//   - convert:      per-event provider->Bifrost struct mapping CPU
+	//   - backpressure: time the provider goroutine blocked handing chunks to the transport
+	AttrBifrostStreamParseMs        = "bifrost.stream.parse_ms"
+	AttrBifrostStreamConvertMs      = "bifrost.stream.convert_ms"
+	AttrBifrostStreamBackpressureMs = "bifrost.stream.backpressure_ms"
+	// Transport-goroutine per-chunk split, stamped after the send loop drains.
+	// Concurrent with the provider, so NOT part of the overhead total: used only
+	// as weights to split backpressure into (A) client-write vs (B) transport CPU.
+	//   - transport_cpu: outbound Bifrost->client convert + marshal CPU
+	//   - client_write:  time blocked writing frames to the client socket
+	AttrBifrostStreamTransportCPUMs = "bifrost.stream.transport_cpu_ms"
+	AttrBifrostStreamClientWriteMs  = "bifrost.stream.client_write_ms"
+
 	AttrBifrostProviderName        = "bifrost.provider.name"
 	AttrBifrostRequestID           = "bifrost.request.id"
 	AttrBifrostVirtualKeyID        = "bifrost.virtual_key.id"

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -2266,6 +2266,55 @@ func computeOverheadBreakdown(trace *schemas.Trace, overheadMs float64, overhead
 			b.first = s.StartTime
 		}
 	}
+
+	// Streaming runs no per-chunk spans: the relay loop's JSON decode, struct->unified
+	// mapping, and downstream-backpressure stall are stamped as root-span attributes at
+	// stream end. Fold them into the same buckets as their unary equivalents (decode ->
+	// response-parse/Serialization, mapping -> convertor/Convertor) so a stream's numbers
+	// read like a unary request's. Backpressure has no unary twin and is not Bifrost CPU,
+	// so it gets its own bucket. Seeding the map here means measuredNs and core pick them
+	// up on the existing path, with no separate bookkeeping.
+	if trace.RootSpan != nil {
+		attrs := trace.RootSpan.Attributes
+		addStreamBucketMs := func(name string, ms float64) {
+			if ms <= 0 {
+				return
+			}
+			b := buckets[name]
+			if b == nil {
+				b = &agg{kind: schemas.SpanKindInternal, first: trace.RootSpan.StartTime}
+				buckets[name] = b
+			}
+			b.dur += time.Duration(ms * float64(time.Millisecond))
+		}
+		if ms, ok := traceAttrFloatMs(attrs, schemas.AttrBifrostStreamParseMs); ok {
+			addStreamBucketMs("response-parse", ms)
+		}
+		// Inbound per-chunk mapping (provider->Bifrost) is conversion work: it belongs
+		// in the Convertor category, as its own member so the stream split is visible.
+		if ms, ok := traceAttrFloatMs(attrs, schemas.AttrBifrostStreamConvertMs); ok {
+			addStreamBucketMs("convertor.stream-in", ms)
+		}
+		// Backpressure is the provider-side downstream wait that IS in the overhead
+		// total. Split it into (A) client-write vs (B) transport CPU using the transport
+		// goroutine's concurrent measurements as weights (those run in parallel and are
+		// not themselves in the total, so they weight rather than add). The (B) share is
+		// the outbound per-chunk mapping (Bifrost->client) -- also conversion work, so it
+		// joins the Convertor category as the outbound member. The (A) share is the client
+		// socket write and stays its own bucket. No transport timing (raw passthrough, or a
+		// client that disconnected) falls back to a single undifferentiated bucket.
+		if bp, ok := traceAttrFloatMs(attrs, schemas.AttrBifrostStreamBackpressureMs); ok && bp > 0 {
+			cpuMs, _ := traceAttrFloatMs(attrs, schemas.AttrBifrostStreamTransportCPUMs)
+			writeMs, _ := traceAttrFloatMs(attrs, schemas.AttrBifrostStreamClientWriteMs)
+			if total := cpuMs + writeMs; total > 0 {
+				addStreamBucketMs("stream-client-write", bp*writeMs/total)
+				addStreamBucketMs("convertor.stream-out", bp*cpuMs/total)
+			} else {
+				addStreamBucketMs("stream-backpressure", bp)
+			}
+		}
+	}
+
 	out := make([]logstore.OverheadBucket, 0, len(buckets)+1)
 	var measuredNs int64
 	for name, b := range buckets {

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -57,6 +57,7 @@ import (
 	"mime/multipart"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream"
 	"github.com/bytedance/sonic"
@@ -2796,6 +2797,12 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 
 	// Producer goroutine: processes the stream channel, formats events, sends to reader
 	go func() {
+		// Transport-side overhead split (streaming): (B) outbound convert+marshal CPU
+		// and (A) client-socket write wait. Accumulated across the send loop below and
+		// stamped on the root span before trace completion; the breakdown uses their
+		// ratio to split the provider-side backpressure into its client vs Bifrost parts.
+		var transportCPUNs, clientWriteNs int64
+
 		// Create encoder for AWS Event Stream if needed
 		var eventStreamEncoder *eventstream.Encoder
 		if config.Type == RouteConfigTypeBedrock {
@@ -2835,6 +2842,10 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 			}
 			schemas.ReleaseHTTPRequest(httpReq)
 			reader.Done()
+			// Split the provider-side backpressure into (A) client-write vs (B) transport
+			// CPU using what the send loop just measured. Before traceCompleter so the
+			// attributes are on the root span when the trace exports.
+			bifrostCtx.StampStreamTransport(time.Duration(transportCPUNs), time.Duration(clientWriteNs))
 			// Complete the trace after streaming finishes
 			// This ensures all spans (including llm.call) are properly ended before the trace is sent to OTEL
 			if traceCompleter != nil {
@@ -2982,6 +2993,7 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 				var convertedResponse interface{}
 				var err error
 
+				cpuStart := time.Now()
 				switch {
 				case chunk.BifrostTextCompletionResponse != nil:
 					eventType, convertedResponse, err = config.StreamConfig.TextStreamResponseConverter(bifrostCtx, chunk.BifrostTextCompletionResponse)
@@ -2999,6 +3011,7 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 					requestType := safeGetRequestType(chunk)
 					convertedResponse, err = nil, fmt.Errorf("no response converter found for request type: %s", requestType)
 				}
+				transportCPUNs += time.Since(cpuStart).Nanoseconds()
 
 				if convertedResponse == nil && err == nil {
 					// Skip streaming chunk if no response is available and no error is returned
@@ -3024,7 +3037,12 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 					continue
 				}
 
-				// Build and send SSE event
+				// Build and send SSE event. Time the whole build+send: for the common
+				// pre-formatted-SSE path (Anthropic) the buf build is trivial and this is
+				// essentially the reader.Send socket-write wait; integrations that marshal
+				// here fold a small marshal CPU into this figure, which is acceptable for
+				// the A/B ratio the breakdown derives from it.
+				writeStart := time.Now()
 				var buf []byte
 				var sent bool
 				if sseString, ok := convertedResponse.(string); ok {
@@ -3063,6 +3081,7 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 					}
 					return
 				}
+				clientWriteNs += time.Since(writeStart).Nanoseconds()
 			}
 		}
 

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -519,6 +519,10 @@ const OVERHEAD_CATEGORY_META: Record<string, { label: string; colorClass: string
 	"response-marshal": { label: "Response marshal", colorClass: "bg-rose-500/70" },
 	"key.selection": { label: "Key selection", colorClass: "bg-amber-500/70" },
 	core: { label: "Core", colorClass: "bg-slate-500/70" },
+	"convertor.stream-in": { label: "Stream inbound convert", colorClass: "bg-fuchsia-500/70" },
+	"convertor.stream-out": { label: "Stream outbound convert", colorClass: "bg-fuchsia-500/70" },
+	"stream-client-write": { label: "Stream client write", colorClass: "bg-red-500/70" },
+	"stream-backpressure": { label: "Stream backpressure", colorClass: "bg-red-500/70" },
 	transport: { label: "Transport", colorClass: "bg-teal-500/70" },
 	plugins: { label: "Plugins", colorClass: "bg-blue-500/70" },
 	other: { label: "Other", colorClass: "bg-emerald-500/70" },
@@ -531,6 +535,11 @@ function overheadCategoryKey(b: OverheadBucket): string {
 	if (b.name.startsWith("middleware.")) {
 		return "middleware";
 	}
+	// Streaming emits per-chunk convert phases (convertor.stream-in / .stream-out) that
+	// belong under the single Convertor category, shown as members in the drill-down.
+	if (b.name.startsWith("convertor.")) {
+		return "convertor";
+	}
 	if (OVERHEAD_CATEGORY_META[b.name] && b.name !== "plugins" && b.name !== "other") {
 		return b.name;
 	}
@@ -538,9 +547,12 @@ function overheadCategoryKey(b: OverheadBucket): string {
 }
 
 // overheadMemberLabel renders a drill-down member with its friendly phase label when
-// there is one (serialization phases), else the raw span name (plugins).
+// there is one (serialization phases), else the span name with the redundant
+// "plugin." prefix stripped (every plugin row already sits under the Plugins group).
 function overheadMemberLabel(name: string): string {
-	return OVERHEAD_CATEGORY_META[name]?.label ?? name;
+	const friendly = OVERHEAD_CATEGORY_META[name]?.label;
+	if (friendly) return friendly;
+	return name.startsWith("plugin.") ? name.slice("plugin.".length) : name;
 }
 
 // buildOverheadCategories groups the raw buckets into the top-level categories,
@@ -636,7 +648,8 @@ function OverheadBreakdown({ buckets, overheadMs }: { buckets: OverheadBucket[];
 							<div className="text-muted-foreground flex items-center gap-1.5 text-[11px] font-medium tracking-wide uppercase">
 								<span className={cn("h-2 w-2 shrink-0 rounded-[2px]", c.colorClass)} />
 								{c.label}
-								<span className="tabular-nums">{formatMicros(c.totalUs)}</span>
+								{/* normal-case: keep the unit as "µs" — uppercasing mangles the micro sign into "ΜS" (reads as ms) */}
+								<span className="tabular-nums normal-case">{formatMicros(c.totalUs)}</span>
 							</div>
 							<div className="space-y-1 pl-3">
 								{c.members.map((m) => (


### PR DESCRIPTION
## Summary

Streaming requests previously reported all per-chunk work (JSON decode, struct mapping, downstream backpressure) as undifferentiated "core" overhead, making it impossible to understand where time was spent. This PR introduces a `streamOverhead` accumulator that tracks parse, convert, and backpressure time across the streaming lifecycle and stamps them as root-span attributes at stream completion, so a stream's overhead breakdown reads like a unary request's.

## Changes

- Added `streamOverhead` struct in `core/schemas/streamoverhead.go` with three lock-free `atomic.Int64` accumulators: `parseNs`, `convertNs`, and `backpressureNs`. Installed once per request via `ResetStreamOverhead` and read at completion via `StampStreamOverhead`.
- Added `BifrostContextKeyStreamOverhead` as a reserved context key alongside the existing upstream latency key.
- Instrumented the Anthropic stream handler to time per-event JSON decode (`AddStreamParse`) and provider→Bifrost struct mapping (`AddStreamConvert`).
- Instrumented `ProcessAndSendResponse` to time the `GateSendChunk` call (`AddStreamBackpressure`), capturing downstream backpressure that previously appeared as Bifrost CPU.
- Added `StampStreamTransport` to record the transport goroutine's outbound convert+marshal CPU and client-socket write wait as root-span attributes. These run concurrently with the provider goroutine and are not part of the overhead total; they serve as weights to split the provider-side backpressure bucket into client-write vs. Bifrost-CPU shares.
- Instrumented the HTTP transport's streaming send loop to accumulate `transportCPUNs` and `clientWriteNs` per chunk, calling `StampStreamTransport` before trace completion.
- Updated `computeOverheadBreakdown` in the logging plugin to fold stream attributes into the existing bucket structure: parse → `response-parse`, inbound mapping → `convertor.stream-in`, and backpressure split into `convertor.stream-out` and `stream-client-write` (or `stream-backpressure` when no transport timing is available).
- Added UI metadata for the four new overhead buckets (`convertor.stream-in`, `convertor.stream-out`, `stream-client-write`, `stream-backpressure`) and grouped `convertor.*` names under the existing Convertor category in the drill-down view.
- Fixed the overhead category label rendering to strip the redundant `plugin.` prefix from plugin member names and added `normal-case` to the microsecond unit display to prevent the micro sign from being uppercased to "ΜS".

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Send a streaming request through Bifrost with tracing enabled and inspect the overhead breakdown in the log detail view. The breakdown should show `Stream inbound convert`, `Stream outbound convert`, and `Stream client write` (or `Stream backpressure`) buckets in addition to the standard phases, with the "Core" bucket reduced accordingly.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

All new context values use the existing reserved-key mechanism. Accumulators are installed once and only dereferenced thereafter; no new goroutine synchronization primitives beyond `atomic.Int64` are introduced. No auth, secrets, or PII are involved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable