### PR TITLE
fix(responses): default streamed message content to an empty array

### DIFF
--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -3830,9 +3830,20 @@ func (resp *BifrostResponsesStreamResponse) WithDefaults() *BifrostResponsesStre
 	// Apply event-specific defaults
 	switch resp.Type {
 	case ResponsesStreamResponseTypeOutputItemAdded:
-		// Default item status to "in_progress"
-		if result.Item != nil && result.Item.Status == nil {
-			result.Item.Status = Ptr("in_progress")
+		if result.Item != nil {
+			itemCopy := *result.Item
+			result.Item = &itemCopy
+			// Default item status to "in_progress".
+			if result.Item.Status == nil {
+				result.Item.Status = Ptr("in_progress")
+			}
+			// OpenAI message items always carry a content array, even before the
+			// first content part is added. Some compatible upstreams omit it.
+			if result.Item.Type != nil && *result.Item.Type == ResponsesMessageTypeMessage && result.Item.Content == nil {
+				result.Item.Content = &ResponsesMessageContent{
+					ContentBlocks: []ResponsesMessageContentBlock{},
+				}
+			}
 		}
 
 	case ResponsesStreamResponseTypeOutputTextDelta, ResponsesStreamResponseTypeOutputTextDone:

--- a/core/schemas/responses_test.go
+++ b/core/schemas/responses_test.go
@@ -60,6 +60,37 @@ func TestBifrostResponsesResponseWithDefaultsPreservesUltrafastServiceTier(t *te
 	}
 }
 
+func TestBifrostResponsesOutputItemAddedDefaultsMessageContentToArray(t *testing.T) {
+	itemType := ResponsesMessageTypeMessage
+	source := &BifrostResponsesStreamResponse{
+		Type: ResponsesStreamResponseTypeOutputItemAdded,
+		Item: &ResponsesMessage{
+			ID:   Ptr("msg_1"),
+			Type: &itemType,
+			Role: Ptr(ResponsesInputMessageRoleAssistant),
+		},
+	}
+
+	normalized := source.WithDefaults()
+	encoded, err := Marshal(normalized)
+	if err != nil {
+		t.Fatalf("marshal normalized output_item.added: %v", err)
+	}
+
+	var wire map[string]any
+	if err := Unmarshal(encoded, &wire); err != nil {
+		t.Fatalf("decode normalized output_item.added: %v", err)
+	}
+	item := wire["item"].(map[string]any)
+	content, ok := item["content"].([]any)
+	if !ok || len(content) != 0 {
+		t.Fatalf("expected message content to normalize to an empty array, got %s", encoded)
+	}
+	if source.Item.Content != nil {
+		t.Fatal("normalizing output_item.added mutated the source message content")
+	}
+}
+
 // Cursor (and other Chat Completions clients) send function tools nested under
 // a "function" wrapper. The unmarshal must lift name/description/parameters so
 // providers that require a top-level name (e.g. Bedrock) don't reject the tool.


### PR DESCRIPTION
## Summary

Closes #6463.

Normalizes a missing `content` field on streamed message `response.output_item.added` events to an empty array. The normalization copies the item first, so the source event is unchanged.

## Test plan

- `cd core && go test ./schemas -run TestBifrostResponsesOutputItemAddedDefaultsMessageContentToArray -count=1`