### PR TITLE
fix(opencode): use legacy max_tokens for Chat Completions requests

### DIFF
--- a/core/providers/openai/chat.go
+++ b/core/providers/openai/chat.go
@@ -102,6 +102,15 @@ func ToOpenAIChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifros
 		openaiReq.filterOpenAISpecificParameters(caps)
 		openaiReq.applyMistralCompatibility()
 		return openaiReq
+	case schemas.OpencodeGo, schemas.OpencodeZen:
+		openaiReq.filterOpenAISpecificParameters(caps)
+		// OpenCode's chat-completions endpoints still use the legacy max_tokens
+		// field and ignore max_completion_tokens.
+		if openaiReq.MaxCompletionTokens != nil {
+			openaiReq.MaxTokens = openaiReq.MaxCompletionTokens
+			openaiReq.MaxCompletionTokens = nil
+		}
+		return openaiReq
 	case schemas.Vertex:
 		openaiReq.filterOpenAISpecificParameters(caps)
 

--- a/core/providers/openai/chat_test.go
+++ b/core/providers/openai/chat_test.go
@@ -1574,6 +1574,48 @@ func TestOpenAIInbound_MaxCompletionTokensTakesPriorityOverMaxTokens(t *testing.
 	}
 }
 
+func TestToOpenAIChatRequest_OpencodeUsesLegacyMaxTokensOnWire(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider schemas.ModelProvider
+	}{
+		{name: "Go", provider: schemas.OpencodeGo},
+		{name: "Zen", provider: schemas.OpencodeZen},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bifrostReq := &schemas.BifrostChatRequest{
+				Provider: tt.provider,
+				Model:    "glm-5.3",
+				Input: []schemas.ChatMessage{{
+					Role: schemas.ChatMessageRoleUser,
+					Content: &schemas.ChatMessageContent{
+						ContentStr: schemas.Ptr("hello"),
+					},
+				}},
+				Params: &schemas.ChatParameters{
+					MaxCompletionTokens: schemas.Ptr(512),
+				},
+			}
+
+			converted := ToOpenAIChatRequest(schemas.NewBifrostContext(nil, schemas.NoDeadline), bifrostReq)
+			require.NotNil(t, converted)
+
+			wireJSON, err := json.Marshal(converted)
+			require.NoError(t, err)
+
+			var wire map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(wireJSON, &wire))
+			require.Contains(t, wire, "max_tokens")
+			var maxTokens int
+			require.NoError(t, json.Unmarshal(wire["max_tokens"], &maxTokens))
+			require.Equal(t, 512, maxTokens)
+			require.NotContains(t, wire, "max_completion_tokens")
+		})
+	}
+}
+
 // When a conversation switches from Gemini to OpenAI, Gemini's thoughtSignature is
 // embedded in the tool call_id as "<baseID>_ts_<sig>" and can exceed OpenAI's 64-char
 // limit. The chat converter must strip it to the base ID on the wire while leaving the


### PR DESCRIPTION
## Summary

Closes #6464.

For OpenCode Go and OpenCode Zen Chat Completions requests, maps `max_completion_tokens` to the legacy `max_tokens` field expected by those upstream endpoints. Other providers retain their existing parameter handling.

## Test plan

- `cd core && go test ./providers/openai -run TestToOpenAIChatRequest_OpencodeUsesLegacyMaxTokensOnWire -count=1`