### PR TITLE
fix(responses): retry without provider-scoped reasoning item IDs

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6081,11 +6081,17 @@ func executeRequestWithRetries[T any](
 	// Index in BifrostContextKeyAttemptTrail of an attempt that hit a rate limit and is waiting
 	// to learn whether the *next* key selection actually picks a different key. -1 = no pending.
 	pendingRotationAttemptIdx := -1
-	// Attempts granted outside the configured retry budget. Only the encrypted-reasoning
-	// fail-soft below adds one: MaxRetries defaults to 0, and a request that would
-	// otherwise die on a rejected replay deserves its one stripped attempt regardless of
-	// how the retry budget is tuned.
+	// Attempts granted outside the configured retry budget. The reasoning-replay
+	// fail-softs below add them: MaxRetries defaults to 0, and a request that would
+	// otherwise die on a rejected replay deserves its repaired attempt regardless of how
+	// the retry budget is tuned.
 	extraAttempts := 0
+	// True once non-replayable reasoning item ids have been stripped from the request, so
+	// that repair fires at most once even if the upstream keeps rejecting the retry.
+	strippedReasoningItemIDs := false
+	// True iff the previous failure stripped reasoning item ids. The payload changed, so
+	// the next attempt does not need backoff.
+	lastWasReasoningItemIDStrip := false
 	// True once encrypted_content has been stripped from the request, so the fail-soft
 	// fires at most once per request and an upstream that keeps rejecting cannot loop.
 	strippedEncryptedContent := false
@@ -6257,7 +6263,7 @@ func executeRequestWithRetries[T any](
 			}
 			ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelInfo, fmt.Sprintf("Retry %d/%d for %s/%s (previous attempt failed: %s%s)", attempts, config.NetworkConfig.MaxRetries+extraAttempts, providerKey, model, routingErrorSummary(bifrostError), keyNote))
 
-			if !((lastWasPermanentKeyFailure && keyChanged) || lastWasEncryptedContentStrip) {
+			if !((lastWasPermanentKeyFailure && keyChanged) || lastWasReasoningItemIDStrip || lastWasEncryptedContentStrip) {
 				backoff := calculateBackoff(attempts-1, config)
 				logger.Debug("sleeping for %s before retry", backoff)
 				time.Sleep(backoff)
@@ -6559,6 +6565,20 @@ func executeRequestWithRetries[T any](
 			}
 			trail[len(trail)-1].FailReason = &reason
 			ctx.SetValue(schemas.BifrostContextKeyAttemptTrail, trail)
+		}
+
+		// Fail soft when the upstream cannot resolve a replayed reasoning item id but still
+		// accepts the item's stateless encrypted_content. Retry once on the same key without
+		// the server-side handle, preserving the encrypted reasoning and visible summary.
+		lastWasReasoningItemIDStrip = false
+		if !shouldRetry && !strippedReasoningItemIDs && isReasoningItemIDRejection(bifrostError) &&
+			stripResponsesReasoningItemIDs(ctx, req) {
+			strippedReasoningItemIDs = true
+			lastWasReasoningItemIDStrip = true
+			extraAttempts++
+			shouldRetry = true
+			logger.Warn("upstream rejected a replayed reasoning item id for %s/%s; retrying once without item ids: %s", providerKey, model, errMessage)
+			ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelWarn, fmt.Sprintf("Stripped non-replayable reasoning item IDs from the request to %s/%s and retrying once", providerKey, model))
 		}
 
 		// Fail soft when the upstream refuses replayed encrypted reasoning. The ciphertext

--- a/core/encryptedreasoning.go
+++ b/core/encryptedreasoning.go
@@ -149,6 +149,20 @@ func isEncryptedReasoningRejection(err *schemas.BifrostError) bool {
 	return namesEncryptedReasoningField(message) && containsAnyMarker(message, unverifiablePayloadMarkers)
 }
 
+// isReasoningItemIDRejection reports whether an upstream refused a replayed
+// Responses reasoning item because its server-side id cannot be resolved. Some
+// OpenAI-compatible providers return encrypted_content for stateless replay but
+// issue item ids that are scoped to the response that created them. Replaying
+// the whole item then fails even though the encrypted payload remains usable.
+func isReasoningItemIDRejection(err *schemas.BifrostError) bool {
+	if err == nil || err.Error == nil || err.StatusCode == nil || *err.StatusCode != 400 {
+		return false
+	}
+	message := strings.ToLower(err.Error.Message)
+	return strings.Contains(message, "referenced reasoning item") &&
+		(strings.Contains(message, "not found") || strings.Contains(message, "expired"))
+}
+
 // encryptedReasoningCarriers returns the input array and raw body of the request
 // shape that replays reasoning items, or nils when this request carries none.
 //
@@ -175,6 +189,75 @@ func encryptedReasoningCarriers(req *schemas.BifrostRequest) (input *[]schemas.R
 	default:
 		return nil, nil
 	}
+}
+
+// stripResponsesReasoningItemIDs removes only the server-side handles from
+// replayed Responses reasoning items. The visible summary and encrypted_content
+// survive so providers that support stateless replay retain the prior turn's
+// reasoning state.
+func stripResponsesReasoningItemIDs(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) bool {
+	inputRef, rawBodyRef := encryptedReasoningCarriers(req)
+	if inputRef == nil {
+		return false
+	}
+	if ctx != nil {
+		if isLargePayload, ok := ctx.Value(schemas.BifrostContextKeyLargePayloadMode).(bool); ok && isLargePayload {
+			return false
+		}
+		if useRawBody, ok := ctx.Value(schemas.BifrostContextKeyUseRawRequestBody).(bool); ok && useRawBody {
+			return stripRawResponsesReasoningItemIDs(rawBodyRef)
+		}
+	}
+
+	input := *inputRef
+	rewritten := make([]schemas.ResponsesMessage, len(input))
+	copy(rewritten, input)
+	changed := false
+	for i := range rewritten {
+		if rewritten[i].ID == nil || rewritten[i].ResponsesReasoning == nil {
+			continue
+		}
+		rewritten[i].ID = nil
+		changed = true
+	}
+	if !changed {
+		return false
+	}
+	*inputRef = rewritten
+	return true
+}
+
+func stripRawResponsesReasoningItemIDs(rawBody *[]byte) bool {
+	if rawBody == nil || len(*rawBody) == 0 {
+		return false
+	}
+	input := gjson.GetBytes(*rawBody, "input")
+	if !input.IsArray() {
+		return false
+	}
+
+	items := make([]string, 0, len(input.Array()))
+	changed := false
+	for _, item := range input.Array() {
+		rest := item.Raw
+		if gjson.Get(rest, "type").String() == string(schemas.ResponsesMessageTypeReasoning) &&
+			gjson.Get(rest, "id").Exists() {
+			if withoutID, err := sjson.Delete(rest, "id"); err == nil {
+				rest = withoutID
+				changed = true
+			}
+		}
+		items = append(items, rest)
+	}
+	if !changed {
+		return false
+	}
+	updated, err := sjson.SetRawBytes(*rawBody, "input", []byte("["+strings.Join(items, ",")+"]"))
+	if err != nil {
+		return false
+	}
+	*rawBody = updated
+	return true
 }
 
 // stripUnverifiableReasoning removes the parts of a replayed reasoning turn that only

--- a/core/encryptedreasoning_test.go
+++ b/core/encryptedreasoning_test.go
@@ -876,6 +876,55 @@ func TestIsEncryptedReasoningRejection(t *testing.T) {
 	}
 }
 
+func TestIsReasoningItemIDRejection(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		message string
+		want    bool
+	}{
+		{
+			name:    "OpenCode missing or expired reasoning item",
+			status:  400,
+			message: "Referenced reasoning item 'rs_provider:rs_turn' was not found or has expired.",
+			want:    true,
+		},
+		{
+			name:    "expired reasoning item",
+			status:  400,
+			message: "Referenced reasoning item rs_1 has expired",
+			want:    true,
+		},
+		{
+			name:    "unrelated missing resource",
+			status:  400,
+			message: "Referenced file item file_1 was not found",
+			want:    false,
+		},
+		{
+			name:    "server error with similar text",
+			status:  500,
+			message: "Referenced reasoning item rs_1 was not found",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &schemas.BifrostError{
+				StatusCode: schemas.Ptr(tt.status),
+				Error:      &schemas.ErrorField{Message: tt.message},
+			}
+			if got := isReasoningItemIDRejection(err); got != tt.want {
+				t.Fatalf("isReasoningItemIDRejection(%q) = %v, want %v", tt.message, got, tt.want)
+			}
+		})
+	}
+	if isReasoningItemIDRejection(nil) {
+		t.Fatal("nil error must not trigger a reasoning item id retry")
+	}
+}
+
 // Regression test for the production sequence a Claude Code session hit when its
 // Azure primary was saturated. Reconstructed from the request logs, which record
 // four attempts on azure/gpt-5.6-sol (all HTTP 429), a transition to
@@ -1159,6 +1208,120 @@ func TestResponsesFallbackHealsEncryptedContentRefusal(t *testing.T) {
 				t.Error("the fail-soft strip left no routing engine log entry for operators to trace")
 			}
 		})
+	}
+}
+
+// TestResponsesRetryDropsOnlyNonReplayableReasoningItemID reproduces the
+// OpenCode Go Responses failure seen on the second turn of a Prime session.
+// The upstream returns a stateless reasoning item with encrypted_content but an
+// item id that it will not resolve on the next request. Bifrost must retry once
+// without that server-side handle while preserving the encrypted reasoning and
+// visible summary that make stateless replay possible.
+func TestResponsesRetryDropsOnlyNonReplayableReasoningItemID(t *testing.T) {
+	const (
+		reasoningID      = "rs_provider:rs_turn"
+		encryptedContent = "opaque-stateless-reasoning"
+		refusalBody      = `{"error":{"type":"invalid_request_error","message":"Referenced reasoning item 'rs_provider:rs_turn' was not found or has expired."}}`
+	)
+
+	upstream := newRecordingServer(func(attempt int, w http.ResponseWriter) {
+		if attempt == 1 {
+			writeJSON(w, http.StatusBadRequest, refusalBody)
+			return
+		}
+		writeJSON(w, http.StatusOK, successBody)
+	})
+	defer upstream.Close()
+
+	account := NewMockAccount()
+	configureUpstream(account, schemas.OpenAI, "stateless-responses", upstream.URL, 0)
+	client := newStreamTestClient(t, account)
+
+	ctx := schemas.NewBifrostContext(context.Background(), time.Now().Add(30*time.Second))
+	resp, bifrostErr := client.ResponsesRequest(ctx, &schemas.BifrostResponsesRequest{
+		Provider: schemas.OpenAI,
+		// Use a reasoning-capable OpenAI model name so the converter preserves
+		// encrypted_content on the wire; the recording server stands in for the
+		// OpenCode-compatible endpoint that issued the non-replayable id.
+		Model: "gpt-5.6-sol",
+		Input: []schemas.ResponsesMessage{
+			{
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+				Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+				Content: &schemas.ResponsesMessageContent{
+					ContentStr: schemas.Ptr("continue after the tool result"),
+				},
+			},
+			{
+				ID:   schemas.Ptr(reasoningID),
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeReasoning),
+				ResponsesReasoning: &schemas.ResponsesReasoning{
+					Summary: []schemas.ResponsesReasoningSummary{
+						{Type: schemas.ResponsesReasoningContentBlockTypeSummaryText, Text: "planning the next turn"},
+					},
+					EncryptedContent: schemas.Ptr(encryptedContent),
+				},
+			},
+		},
+	})
+
+	if bifrostErr != nil {
+		t.Fatalf("expected the non-replayable reasoning id to heal, got %s", bifrostErr.Error.Message)
+	}
+	if resp == nil {
+		t.Fatal("expected a response from the healed retry")
+	}
+
+	bodies := upstream.snapshot()
+	if len(bodies) != 2 {
+		t.Fatalf("upstream attempts = %d, want 2 (refusal + id-less retry)", len(bodies))
+	}
+	if !strings.Contains(bodies[0], reasoningID) || !strings.Contains(bodies[0], encryptedContent) {
+		t.Fatalf("first attempt did not reproduce the replayed reasoning item: %s", bodies[0])
+	}
+	if strings.Contains(bodies[1], reasoningID) {
+		t.Errorf("healed retry still carries the non-replayable item id: %s", bodies[1])
+	}
+	if !strings.Contains(bodies[1], encryptedContent) {
+		t.Errorf("healed retry dropped stateless encrypted reasoning: %s", bodies[1])
+	}
+	if !strings.Contains(bodies[1], "planning the next turn") {
+		t.Errorf("healed retry dropped the reasoning summary: %s", bodies[1])
+	}
+
+	var stripLogged bool
+	for _, entry := range ctx.GetRoutingEngineLogs() {
+		if strings.Contains(entry.Message, "non-replayable reasoning item IDs") {
+			stripLogged = true
+			break
+		}
+	}
+	if !stripLogged {
+		t.Error("the id-only fail-soft left no routing engine log entry")
+	}
+}
+
+func TestStripResponsesReasoningItemIDsRewritesRawPassthrough(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+
+	req := newEncryptedReasoningRequest("opaque-stateless-reasoning")
+	req.ResponsesRequest.RawRequestBody = []byte(`{"model":"muse-spark-1.2-contributor","input":[` +
+		`{"type":"message","id":"msg_keep","role":"user","content":"continue"},` +
+		`{"type":"reasoning","id":"rs_drop","summary":[{"type":"summary_text","text":"planning"}],"encrypted_content":"opaque-stateless-reasoning","provider_field":7}` +
+		`]}`)
+
+	if !stripResponsesReasoningItemIDs(ctx, req) {
+		t.Fatal("expected the raw passthrough body to be rewritten")
+	}
+	body := string(req.ResponsesRequest.RawRequestBody)
+	if strings.Contains(body, `"rs_drop"`) {
+		t.Errorf("expected the reasoning item id to be removed, got %s", body)
+	}
+	for _, preserved := range []string{`"msg_keep"`, `"opaque-stateless-reasoning"`, `"provider_field":7`, `"planning"`} {
+		if !strings.Contains(body, preserved) {
+			t.Errorf("expected %s to survive the id-only rewrite, got %s", preserved, body)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #6465.

Some Responses-compatible providers issue reasoning IDs that are scoped to a prior response, while still returning stateless `encrypted_content`. If replaying the ID receives the narrow 400 `Referenced reasoning item ... was not found or has expired` response, retry exactly once after removing only that ID. The encrypted reasoning payload and visible summary are preserved.

The retry follows the existing encrypted-reasoning fail-soft behavior: it does not consume the configured retry budget and skips backoff because the payload changes. Both typed and raw-passthrough Responses input are handled.

## Test plan

- `cd core && go test . -run 'TestIsReasoningItemIDRejection|TestResponsesRetryDropsOnlyNonReplayableReasoningItemID|TestStripResponsesReasoningItemIDsRewritesRawPassthrough' -count=1`