### PR TITLE
chore: update core with sub-buckets

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -64,6 +64,7 @@ type ChannelMessage struct {
 	ResponseStream chan chan *schemas.BifrostStreamChunk
 	Err            chan schemas.BifrostError
 	queueSpan      schemas.SpanHandle // "queue-wait" span opened at enqueue, closed when a worker dequeues (or on release if the send never landed)
+	sentAt         time.Time          // set by the worker immediately before sending the result/error, so tryRequest can measure the worker->caller goroutine-hop latency ("worker-handoff")
 }
 
 // Bifrost manages providers and maintains specified open channels for concurrent processing.
@@ -5208,6 +5209,11 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 		requestID := uuid.New().String()
 		ctx.SetValue(schemas.BifrostContextKeyRequestID, requestID)
 	}
+	// "handle-setup" overhead phase: model-catalog publish + the pre-request hook
+	// pipeline glue. Per-plugin work nests as its own spans; this bucket is the
+	// remaining core-side setup so it stops folding into "core".
+	setupSpan := bifrost.startCoreSpan(ctx, "handle-setup")
+
 	// Expose the model catalog to plugins (ctx.GetModelInfo / ctx.CalculateCost)
 	// before any hook runs.
 	bifrost.setModelCatalogOnContext(ctx)
@@ -5218,6 +5224,7 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 	preReqPipeline := bifrost.getPluginPipeline()
 	preReqPipeline.RunPreRequestHooks(ctx, req)
 	bifrost.releasePluginPipeline(preReqPipeline)
+	bifrost.endCoreSpan(setupSpan)
 	// Re-read after PreRequestHook — provider/model/fallbacks may have changed.
 	provider, model, fallbacks = req.GetRequestFields()
 	// Empty provider/model after PreRequestHook means no plugin
@@ -5498,6 +5505,9 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 	// must be set before requestHandler() is called.
 	ctx.SetValue(schemas.BifrostContextKeyTracer, tracer)
 
+	// "pipeline-pre" overhead phase: the LLM pre-hook pipeline glue (loop + pool
+	// around the per-plugin spans that nest inside it), previously part of "core".
+	prePipeSpan := bifrost.startCoreSpan(ctx, "pipeline-pre")
 	pipeline := bifrost.getPluginPipeline()
 	defer bifrost.releasePluginPipeline(pipeline)
 
@@ -5505,6 +5515,7 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 	// overwritten around RunPostLLMHooks — plugin modifications to these 4 fields are
 	// no-ops by design; proper request metadata is preserved and tampering is discouraged.
 	preReq, shortCircuit, preCount := pipeline.RunLLMPreHooks(ctx, req)
+	bifrost.endCoreSpan(prePipeSpan)
 	if shortCircuit != nil {
 		// Handle short-circuit with response (success case)
 		if shortCircuit.Response != nil {
@@ -5627,6 +5638,18 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 	pluginCount := len(*bifrost.llmPlugins.Load())
 	select {
 	case result = <-msg.Response:
+		// Worker->caller goroutine-hop latency: measure the instant we receive so the
+		// breakdown carves this scheduling gap out of "core" into "worker-handoff".
+		if !msg.sentAt.IsZero() {
+			msg.Context.StampWorkerHandoff(time.Since(msg.sentAt))
+		}
+		// "pipeline-post" overhead phase: everything from here to return (latency stamp,
+		// post-hook pipeline glue, raw-field stripping, message release). The defer is
+		// function-scoped and this case ends by returning, so it times exactly the post
+		// block; per-plugin post-hook spans nest inside and subtract out.
+		if ph := bifrost.startCoreSpan(msg.Context, "pipeline-post"); ph.h != nil {
+			defer bifrost.endCoreSpan(ph)
+		}
 		// Accumulator is complete once the provider returns; stamp before post-hooks
 		// so logging reads it off ExtraFields.
 		populateLatencyExtraFields(msg.Context, result)
@@ -5659,6 +5682,14 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 		return resp, nil
 	case bifrostErrVal := <-msg.Err:
 		bifrostErrPtr := &bifrostErrVal
+		// Worker->caller goroutine-hop latency on the error path too.
+		if !msg.sentAt.IsZero() {
+			msg.Context.StampWorkerHandoff(time.Since(msg.sentAt))
+		}
+		// "pipeline-post" overhead phase on the error path (see the success case above).
+		if ph := bifrost.startCoreSpan(msg.Context, "pipeline-post"); ph.h != nil {
+			defer bifrost.endCoreSpan(ph)
+		}
 		resp, bifrostErrPtr = pipeline.RunPostLLMHooks(msg.Context, nil, bifrostErrPtr, pluginCount)
 		if bifrostErrPtr != nil {
 			bifrostErrPtr.PopulateExtraFields(req.RequestType, provider, model, model)
@@ -6717,6 +6748,12 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 
 		_, model, _ := req.BifrostRequest.GetRequestFields()
 
+		// "worker-setup" overhead phase: per-attempt base-provider resolution and the
+		// raw-capture flag computation (~a dozen ctx writes) the worker does between
+		// dequeue and key acquisition. No early exits in this block, so a single span
+		// pair is safe; closed just before key acquisition below.
+		workerSetupSpan := bifrost.startCoreSpan(req.Context, "worker-setup")
+
 		var result *schemas.BifrostResponse
 		var stream chan *schemas.BifrostStreamChunk
 		var bifrostError *schemas.BifrostError
@@ -6795,6 +6832,7 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 		req.Context.SetValue(schemas.BifrostContextKeyDropRawResponseFromClient, dropResp)
 		// Tells the logging plugin whether to persist raw bytes in log records.
 		req.Context.SetValue(schemas.BifrostContextKeyShouldStoreRawInLogs, effectiveStore)
+		bifrost.endCoreSpan(workerSetupSpan)
 
 		var keys []schemas.Key
 		// keyProvider is passed to executeRequestWithRetries to manage key selection and rotation.
@@ -6882,7 +6920,12 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 					// Build the key pool for this request. Selection and rotation are deferred to
 					// executeRequestWithRetries via keyProvider so that each retry attempt can use
 					// a different key (on rate-limit errors) without re-running the full filtering.
+					// "key-pool" overhead phase: building the candidate key pool (filtering,
+					// governance/alias resolution) is worker-side work that otherwise folds
+					// into "core"; the per-attempt pick is the separate "key.selection" span.
+					keyPoolSpan := bifrost.startCoreSpan(req.Context, "key-pool")
 					supportedKeys, canRotate, keyPoolErr := bifrost.selectKeyFromProviderForModelWithPool(req.Context, req.RequestType, provider.GetProviderKey(), model, baseProvider)
+					bifrost.endCoreSpan(keyPoolSpan)
 					if keyPoolErr != nil {
 						bifrost.logger.Debug("error building key pool for model %s: %v", model, keyPoolErr)
 						req.Err <- schemas.BifrostError{
@@ -7137,6 +7180,11 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 				lastAttemptFinalizer(req.Context)
 			}
 		}
+
+		// Stamp the pre-send time so tryRequest can measure the worker->caller
+		// goroutine-hop latency ("worker-handoff") on receipt, regardless of which
+		// branch (error/stream/response) does the send below.
+		req.sentAt = time.Now()
 
 		if bifrostError != nil {
 			bifrostError.PopulateExtraFields(req.RequestType, provider.GetProviderKey(), originalModelRequested, resolvedModel)
@@ -7688,7 +7736,13 @@ func (p *PluginPipeline) RunLLMPreHooks(ctx *schemas.BifrostContext, req *schema
 	for i, plugin := range p.llmPlugins {
 		pluginName := plugin.GetName()
 		p.logger.Debug("running pre-hook for plugin %s", pluginName)
-		// Start span for this plugin's PreLLMHook
+		// Start span for this plugin's PreLLMHook. Capture the parent first so we can
+		// restore it after this plugin ends: without the restore each plugin would set
+		// itself active and never revert, so the next plugin would nest under this one
+		// (a chain) instead of being a sibling. The overhead breakdown subtracts only
+		// DIRECT children, so a chained plugin's time would be counted in both its own
+		// bucket and the enclosing phase span's self-time (e.g. pipeline-pre).
+		prevSpanID := ctx.Value(schemas.BifrostContextKeySpanID)
 		spanID, handle := p.tracer.StartSpanID(ctx, pluginSpanNamesFor(pluginName).prehook, schemas.SpanKindPlugin)
 		// Mirror the new span ID into ctx for nested operations (no valueCtx alloc).
 		if spanID != "" {
@@ -7711,6 +7765,8 @@ func (p *PluginPipeline) RunLLMPreHooks(ctx *schemas.BifrostContext, req *schema
 		} else {
 			p.tracer.EndSpan(handle, schemas.SpanStatusOk, "")
 		}
+		// Restore the parent so the next plugin is a sibling, not chained under this one.
+		ctx.SetValue(schemas.BifrostContextKeySpanID, prevSpanID)
 
 		p.executedPreHooks = i + 1
 		if shortCircuit != nil {
@@ -7740,6 +7796,9 @@ func (p *PluginPipeline) RunPreRequestHooks(ctx *schemas.BifrostContext, req *sc
 	for _, plugin := range p.llmPlugins {
 		pluginName := plugin.GetName()
 		p.logger.Debug("running pre-request hook for plugin %s", pluginName)
+		// Capture the parent so it can be restored after this plugin ends, keeping the
+		// next plugin a sibling rather than chained under this one (see RunLLMPreHooks).
+		prevSpanID := ctx.Value(schemas.BifrostContextKeySpanID)
 		spanID, handle := p.tracer.StartSpanID(ctx, pluginSpanNamesFor(pluginName).prerequesthook, schemas.SpanKindPlugin)
 		if spanID != "" {
 			ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
@@ -7754,9 +7813,11 @@ func (p *PluginPipeline) RunPreRequestHooks(ctx *schemas.BifrostContext, req *sc
 			p.tracer.EndSpan(handle, schemas.SpanStatusError, err.Error())
 			p.preHookErrors = append(p.preHookErrors, err)
 			p.logger.Warn("error in PreRequestHook for plugin %s: %s", pluginName, err.Error())
-			continue
+		} else {
+			p.tracer.EndSpan(handle, schemas.SpanStatusOk, "")
 		}
-		p.tracer.EndSpan(handle, schemas.SpanStatusOk, "")
+		// Restore the parent so the next plugin is a sibling, not chained under this one.
+		ctx.SetValue(schemas.BifrostContextKeySpanID, prevSpanID)
 	}
 	ctx.UnblockRestrictedWrites()
 
@@ -7823,7 +7884,11 @@ func (p *PluginPipeline) RunPostLLMHooks(ctx *schemas.BifrostContext, resp *sche
 				p.logger.Warn("error in PostLLMHook for plugin %s: %v", pluginName, err)
 			}
 		} else {
-			// For non-streaming: create span per plugin (existing behavior)
+			// For non-streaming: create span per plugin (existing behavior). Capture the
+			// parent first and restore it below so the next plugin is a sibling rather than
+			// chained under this one (see RunLLMPreHooks) — otherwise later post-hooks would
+			// be double-counted in both their bucket and the enclosing pipeline-post span.
+			prevSpanID := ctx.Value(schemas.BifrostContextKeySpanID)
 			spanID, handle := p.tracer.StartSpanID(ctx, pluginSpanNamesFor(pluginName).posthook, schemas.SpanKindPlugin)
 			// Mirror the new span ID into ctx for nested operations (no valueCtx alloc).
 			if spanID != "" {
@@ -7841,6 +7906,8 @@ func (p *PluginPipeline) RunPostLLMHooks(ctx *schemas.BifrostContext, resp *sche
 			} else {
 				p.tracer.EndSpan(handle, schemas.SpanStatusOk, "")
 			}
+			// Restore the parent so the next plugin is a sibling, not chained under this one.
+			ctx.SetValue(schemas.BifrostContextKeySpanID, prevSpanID)
 		}
 		// If a plugin recovers from an error (sets bifrostErr to nil and sets resp), allow that
 		// If a plugin invalidates a response (sets resp to nil and sets bifrostErr), allow that
@@ -8288,6 +8355,49 @@ func (bifrost *Bifrost) releasePluginPipeline(pipeline *PluginPipeline) {
 
 // POOL & RESOURCE MANAGEMENT
 
+// coreSpan is the token returned by startCoreSpan and consumed by endCoreSpan. It
+// carries the span handle plus the context and the span ID that was active when the
+// phase opened, so endCoreSpan can restore the prior parent. The zero value is a valid
+// no-op (no trace active), so callers need no nil guard beyond checking cs.h when they
+// want a defer only on the active path.
+type coreSpan struct {
+	h    schemas.SpanHandle
+	ctx  *schemas.BifrostContext
+	prev any
+}
+
+// startCoreSpan opens an internal overhead phase span for a core-pipeline segment
+// (setup, key-pool build, pre/post processing) that sits on no other span and would
+// otherwise fold into the residual "core" bucket. It installs the new span as the
+// ACTIVE parent on ctx so any spans opened during the phase (plugin hooks, provider
+// phases) nest as its children — computeOverheadBreakdown subtracts direct children, so
+// without this the nested work would be counted in both this phase's self-time and its
+// own bucket. endCoreSpan restores the prior parent. Returns a zero coreSpan (no-op)
+// when no trace is active. name becomes the breakdown bucket.
+func (bifrost *Bifrost) startCoreSpan(ctx *schemas.BifrostContext, name string) coreSpan {
+	t := bifrost.getTracer()
+	if t == nil {
+		return coreSpan{}
+	}
+	prev := ctx.Value(schemas.BifrostContextKeySpanID)
+	id, h := t.StartSpanID(ctx, name, schemas.SpanKindInternal)
+	if h == nil {
+		return coreSpan{}
+	}
+	ctx.SetValue(schemas.BifrostContextKeySpanID, id)
+	return coreSpan{h: h, ctx: ctx, prev: prev}
+}
+
+// endCoreSpan restores the parent that was active before the phase and closes the span.
+// Nil/zero-safe.
+func (bifrost *Bifrost) endCoreSpan(cs coreSpan) {
+	if cs.h == nil {
+		return
+	}
+	cs.ctx.SetValue(schemas.BifrostContextKeySpanID, cs.prev)
+	bifrost.getTracer().EndSpan(cs.h, schemas.SpanStatusOk, "")
+}
+
 // startQueueWaitSpan opens a nil-safe "queue-wait" internal span measuring how long
 // the message sits in the provider queue before a worker dequeues it. The handle is
 // stored on the message; endQueueWaitSpan closes it on dequeue, and
@@ -8332,6 +8442,10 @@ func (bifrost *Bifrost) getChannelMessage(req schemas.BifrostRequest) *ChannelMe
 	msg.BifrostRequest = req
 	msg.Response = responseChan
 	msg.Err = errorChan
+	// Clear the previous user's send timestamp so a reused message can't report a
+	// stale worker-handoff duration on a path that never re-stamps it (e.g. the
+	// shutdown-drain error sends). The worker sets sentAt fresh before each normal send.
+	msg.sentAt = time.Time{}
 
 	// Conditionally allocate ResponseStream for streaming requests only
 	if IsStreamRequestType(req.RequestType) {

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -629,7 +629,26 @@ func signAWSRequest(
 	req *http.Request,
 	keyCfg *schemas.BedrockKeyConfig,
 	region, service string,
-) *schemas.BifrostError {
+) (signErr *schemas.BifrostError) {
+	// "request-sign" overhead phase: AWS SigV4 signing is real per-request work that
+	// otherwise hides in "core". The nested "credentials-fetch" span (below) isolates
+	// the network portion (STS AssumeRole / credential-provider Retrieve) from the CPU
+	// crypto, so a cold credential cache on an idle box reads as its own bucket instead
+	// of inflating core.
+	// Scoped so the nested "credentials-fetch" span below is a true child and its
+	// time is subtracted from request-sign's self-time exactly once (not double-counted
+	// in both buckets). restore() reinstates the prior parent before the span ends.
+	if st, sh, restore := providerUtils.StartScopedPhaseSpan(ctx, "request-sign"); st != nil {
+		defer func() {
+			restore()
+			if signErr != nil {
+				st.EndSpan(sh, schemas.SpanStatusError, "request signing failed")
+			} else {
+				st.EndSpan(sh, schemas.SpanStatusOk, "")
+			}
+		}()
+	}
+
 	var accessKey, secretKey schemas.SecretVar
 	var sessionToken, roleARN, externalID, sessionName *schemas.SecretVar
 
@@ -756,8 +775,19 @@ func signAWSRequest(
 	// Create the AWS signer
 	signer := v4.NewSigner()
 
-	// Get credentials
+	// Get credentials. Nested "credentials-fetch" span: on a cache miss this triggers a
+	// network round trip (STS AssumeRole when RoleARN is set, or the default provider
+	// chain's IMDS/env/STS lookup), which is the dominant cost on an idle box whose
+	// credential cache has expired between sparse requests.
+	credT, credH := providerUtils.StartPhaseSpan(ctx, "credentials-fetch")
 	creds, err := cfg.Credentials.Retrieve(ctx)
+	if credT != nil {
+		if err != nil {
+			credT.EndSpan(credH, schemas.SpanStatusError, "credential retrieval failed")
+		} else {
+			credT.EndSpan(credH, schemas.SpanStatusOk, "")
+		}
+	}
 	if err != nil {
 		return providerUtils.NewBifrostOperationError("failed to retrieve aws credentials", err)
 	}

--- a/core/providers/utils/largeresponse.go
+++ b/core/providers/utils/largeresponse.go
@@ -137,7 +137,20 @@ func FinalizeResponseWithLargeDetection(
 	ctx *schemas.BifrostContext,
 	resp *fasthttp.Response,
 	logger schemas.Logger,
-) ([]byte, bool, *schemas.BifrostError) {
+) (body []byte, isLarge bool, finalizeErr *schemas.BifrostError) {
+	// "response-finalize" overhead phase: reading, decompressing (gzip/br/zstd), and
+	// copying the provider response body is payload-scaled work that otherwise hides in
+	// "core". Nil-safe; folds away when no trace is active.
+	if ft, fh := startPhaseSpan(ctx, "response-finalize"); ft != nil {
+		defer func() {
+			if finalizeErr != nil {
+				ft.EndSpan(fh, schemas.SpanStatusError, "response finalize failed")
+			} else {
+				ft.EndSpan(fh, schemas.SpanStatusOk, "")
+			}
+		}()
+	}
+
 	responseThreshold, _ := ctx.Value(schemas.BifrostContextKeyLargeResponseThreshold).(int64)
 
 	// No threshold — normal buffered read (feature-off path)

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -1707,6 +1707,35 @@ func StartResponseParseSpan(ctx context.Context) (schemas.Tracer, schemas.SpanHa
 	return startPhaseSpan(ctx, "response-parse")
 }
 
+// StartPhaseSpan opens a nil-safe internal overhead phase span with an arbitrary name,
+// so provider/auth code outside this package can carve its own work out of the residual
+// "core" bucket. name becomes the breakdown bucket; keep it stable and descriptive
+// (e.g. "request-sign", "credentials-fetch", "response-finalize"). EndSpan is nil-safe.
+func StartPhaseSpan(ctx context.Context, name string) (schemas.Tracer, schemas.SpanHandle) {
+	return startPhaseSpan(ctx, name)
+}
+
+// StartScopedPhaseSpan opens a phase span like StartPhaseSpan and additionally installs
+// it as the ACTIVE parent on ctx, so phase spans opened afterward with the same ctx nest
+// as its children. The overhead breakdown subtracts direct children from a span's
+// self-time, so a nested span opened without this would be a sibling and its time would
+// be counted in BOTH buckets. The returned restore func MUST be called when the phase
+// ends (before EndSpan) to reinstate the prior parent. Nil-safe: returns a nil
+// tracer/handle and a no-op restore when no trace is active.
+func StartScopedPhaseSpan(ctx *schemas.BifrostContext, name string) (schemas.Tracer, schemas.SpanHandle, func()) {
+	t, ok := ctx.Value(schemas.BifrostContextKeyTracer).(schemas.Tracer)
+	if !ok || t == nil {
+		return nil, nil, func() {}
+	}
+	prev := ctx.Value(schemas.BifrostContextKeySpanID)
+	id, h := t.StartSpanID(ctx, name, schemas.SpanKindInternal)
+	if h == nil {
+		return nil, nil, func() {}
+	}
+	ctx.SetValue(schemas.BifrostContextKeySpanID, id)
+	return t, h, func() { ctx.SetValue(schemas.BifrostContextKeySpanID, prev) }
+}
+
 // CheckContextAndGetRequestBody checks if the raw request body should be used, and returns it if it exists.
 func CheckContextAndGetRequestBody(ctx context.Context, request RequestBodyGetter, requestConverter RequestBodyConverter) ([]byte, *schemas.BifrostError) {
 	if IsLargePayloadPassthroughEnabled(ctx) {

--- a/core/schemas/streamoverhead.go
+++ b/core/schemas/streamoverhead.go
@@ -122,6 +122,32 @@ func (bc *BifrostContext) StampStreamOverhead() {
 	}
 }
 
+// StampWorkerHandoff writes the worker->caller goroutine-hop latency onto the
+// request's root span so the overhead breakdown can carve it out of "core" into a
+// "worker-handoff" bucket. d is time.Since(the worker's pre-send timestamp),
+// measured by tryRequest the moment it receives the result/error. Best-effort:
+// no tracer / no trace / non-positive d leaves the root span unstamped, so absent
+// stays distinct from zero.
+func (bc *BifrostContext) StampWorkerHandoff(d time.Duration) {
+	if bc == nil || d <= 0 {
+		return
+	}
+	traceID, _ := bc.Value(BifrostContextKeyTraceID).(string)
+	if traceID == "" {
+		return
+	}
+	tracer, _ := bc.Value(BifrostContextKeyTracer).(Tracer)
+	if tracer == nil {
+		return
+	}
+	// nil spanID selects the root span.
+	handle := tracer.GetSpanHandleByID(traceID, nil)
+	if handle == nil {
+		return
+	}
+	tracer.SetAttribute(handle, AttrBifrostWorkerHandoffMs, float64(d)/float64(time.Millisecond))
+}
+
 // StampStreamTransport writes the transport goroutine's per-chunk split onto the
 // root span: (B) outbound convert+marshal CPU and (A) client-socket write wait.
 // These run concurrently with the provider goroutine, so they are NOT part of the

--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -937,6 +937,14 @@ const (
 	AttrBifrostStreamTransportCPUMs = "bifrost.stream.transport_cpu_ms"
 	AttrBifrostStreamClientWriteMs  = "bifrost.stream.client_write_ms"
 
+	// AttrBifrostWorkerHandoffMs is the scheduling latency between the provider
+	// worker sending the result and tryRequest receiving it (the worker->caller
+	// goroutine hop). It is real wall-time inside the overhead window that sits on
+	// no span, so it otherwise folds into "core"; the breakdown carves it into its
+	// own "worker-handoff" bucket. The reverse hop (enqueue->dequeue) is already the
+	// "queue-wait" span.
+	AttrBifrostWorkerHandoffMs = "bifrost.worker.handoff_ms"
+
 	AttrBifrostProviderName        = "bifrost.provider.name"
 	AttrBifrostRequestID           = "bifrost.request.id"
 	AttrBifrostVirtualKeyID        = "bifrost.virtual_key.id"

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -2061,7 +2061,7 @@ func (p *LoggerPlugin) Inject(_ context.Context, trace *schemas.Trace) error {
 	}
 	// Per-span self-time decomposition of overhead, attached to the same terminal
 	// row that receives the overhead number below.
-	overheadBreakdown := computeOverheadBreakdown(trace, overheadMs, ovOK)
+	overheadBreakdown := computeOverheadBreakdown(trace, overheadMs, ovOK, upstreamMs, upOK)
 
 	p.logger.Debug("Inject: enqueuing %d log entries", len(pending.entries))
 	// Upstream/overhead are request-level: put them on one row per trace, not all.
@@ -2213,7 +2213,7 @@ func overheadBucketName(s *schemas.Span) string {
 // derived from overheadMs (which already excludes upstream), not from the root
 // span's self-time, so it never picks up streaming socket reads. Buckets are
 // returned with microsecond values, measured spans first (chronological) then core.
-func computeOverheadBreakdown(trace *schemas.Trace, overheadMs float64, overheadOK bool) []logstore.OverheadBucket {
+func computeOverheadBreakdown(trace *schemas.Trace, overheadMs float64, overheadOK bool, upstreamMs float64, upstreamOK bool) []logstore.OverheadBucket {
 	if trace == nil || len(trace.Spans) == 0 {
 		return nil
 	}
@@ -2312,6 +2312,53 @@ func computeOverheadBreakdown(trace *schemas.Trace, overheadMs float64, overhead
 			} else {
 				addStreamBucketMs("stream-backpressure", bp)
 			}
+		}
+		// Worker->caller goroutine-hop latency (unary path): scheduling wall-time
+		// inside the overhead window that sits on no span. Carve it into its own
+		// bucket so it stops inflating "core". The reverse hop is the queue-wait span.
+		if ms, ok := traceAttrFloatMs(attrs, schemas.AttrBifrostWorkerHandoffMs); ok {
+			addStreamBucketMs("worker-handoff", ms)
+		}
+	}
+
+	// Provider-agnostic catch-all. Every provider call runs inside an llm.call span
+	// (SpanKindLLMCall), which is not itself a bucket but envelops the upstream network
+	// call plus ALL provider-side glue: request conversion/marshal/signing, response
+	// read/decompress/parse, header and endpoint work. Its self-time (wall minus the
+	// child phase spans) is therefore exactly upstream + whatever provider work no phase
+	// span captured. Subtracting the measured upstream leaves that uncaptured remainder,
+	// surfaced as "provider-internal" so a brand-new provider — or an unspanned step in
+	// an existing one — can never silently inflate "core"; it lands here instead, and its
+	// size tells us a provider needs finer spans. Summed across attempts: retries create
+	// one llm.call span each, and upstream latency likewise accumulates across them.
+	// Streaming is excluded implicitly: its llm.call span ends when the channel is handed
+	// off (before the stream drains), so its self-time is small and the difference falls
+	// below the threshold; stream phases are decomposed via the stream attributes above.
+	if upstreamOK {
+		var llmSelfNs int64
+		var firstLLM time.Time
+		for _, s := range trace.Spans {
+			if s == nil || s.Kind != schemas.SpanKindLLMCall {
+				continue
+			}
+			if self := spanWall(s) - childDur[s.SpanID]; self > 0 {
+				llmSelfNs += self.Nanoseconds()
+			}
+			if firstLLM.IsZero() || s.StartTime.Before(firstLLM) {
+				firstLLM = s.StartTime
+			}
+		}
+		// llmSelfNs and upstream are both provider-side wall time; the difference is the
+		// uninstrumented glue. Guard on a small floor so measurement skew (upstream
+		// stamped slightly larger than the enveloping span) never emits a noise bucket.
+		providerInternalUs := float64(llmSelfNs)/1000.0 - upstreamMs*1000.0
+		if providerInternalUs > 0.5 {
+			b := buckets["provider-internal"]
+			if b == nil {
+				b = &agg{kind: schemas.SpanKindInternal, first: firstLLM}
+				buckets["provider-internal"] = b
+			}
+			b.dur += time.Duration(providerInternalUs * float64(time.Microsecond))
 		}
 	}
 

--- a/plugins/logging/overhead_breakdown_test.go
+++ b/plugins/logging/overhead_breakdown_test.go
@@ -22,7 +22,7 @@ func span(base time.Time, id, parent, name string, kind schemas.SpanKind, startM
 func bucketMap(t *testing.T, trace *schemas.Trace, overheadMs float64, ovOK bool) map[string]float64 {
 	t.Helper()
 	out := map[string]float64{}
-	for _, b := range computeOverheadBreakdown(trace, overheadMs, ovOK) {
+	for _, b := range computeOverheadBreakdown(trace, overheadMs, ovOK, 0, false) {
 		out[b.Name] = b.DurationUs
 	}
 	return out
@@ -65,6 +65,76 @@ func TestComputeOverheadBreakdown_ChatPath(t *testing.T) {
 	}
 	if _, ok := got["/v1/chat/completions"]; ok {
 		t.Error("root http.request span must not appear as an overhead bucket")
+	}
+}
+
+// Regression: a nested phase span (e.g. "credentials-fetch" opened while "request-sign"
+// is the active parent, or a plugin hook opened while "handle-setup" is active) must be
+// counted ONCE. Because self-time subtracts only DIRECT children, the parent phase must
+// truly be the child's parent — if the two were siblings (the bug that motivated
+// startCoreSpan/StartScopedPhaseSpan installing themselves as the active parent), the
+// overlapping window would be counted in both buckets. Here credentials-fetch (15-25) is
+// a child of request-sign (10-30): request-sign self-time = 20ms - 10ms = 10ms, and the
+// two buckets sum to 20ms, not 30ms.
+func TestComputeOverheadBreakdown_NestedPhaseSpansCountedOnce(t *testing.T) {
+	base := time.Now()
+	trace := &schemas.Trace{Spans: []*schemas.Span{
+		span(base, "root", "", "/v1/chat/completions", schemas.SpanKindHTTPRequest, 0, 100),
+		span(base, "sign", "root", "request-sign", schemas.SpanKindInternal, 10, 30),
+		span(base, "creds", "sign", "credentials-fetch", schemas.SpanKindInternal, 15, 25),
+	}}
+
+	// Overhead 20ms == the two spans' combined self-time, so core is empty.
+	got := bucketMap(t, trace, 20, true)
+
+	if got["request-sign"] != 10000 {
+		t.Errorf("request-sign = %v us, want 10000 (20ms wall - 10ms nested child)", got["request-sign"])
+	}
+	if got["credentials-fetch"] != 10000 {
+		t.Errorf("credentials-fetch = %v us, want 10000", got["credentials-fetch"])
+	}
+	// The overlapping 10ms window is counted once, not in both buckets.
+	if sum := got["request-sign"] + got["credentials-fetch"]; sum != 20000 {
+		t.Errorf("request-sign + credentials-fetch = %v us, want 20000 (no double-count)", sum)
+	}
+	if _, ok := got["core"]; ok {
+		t.Errorf("core should be empty when spans account for all overhead, got %v", got["core"])
+	}
+}
+
+// Regression: a phase span (e.g. "pipeline-post") that encloses MULTIPLE plugin hook
+// spans must subtract ALL of them, not just the first. This is why the plugin loops
+// restore the active span after each plugin (making the plugins siblings/direct children
+// of the phase span) instead of chaining them. Here pipeline-post (50-90) has three
+// direct plugin children (52-60, 60-70, 70-78): its self-time is 40ms - 26ms = 14ms, and
+// the phase + three plugin buckets sum to exactly the 40ms wall (no double-count). Were
+// the plugins chained (each parented to the previous), pipeline-post would subtract only
+// the first and the later two would be counted twice.
+func TestComputeOverheadBreakdown_SiblingPluginsUnderPhaseCountedOnce(t *testing.T) {
+	base := time.Now()
+	trace := &schemas.Trace{Spans: []*schemas.Span{
+		span(base, "root", "", "/v1/chat/completions", schemas.SpanKindHTTPRequest, 0, 100),
+		span(base, "pp", "root", "pipeline-post", schemas.SpanKindInternal, 50, 90),
+		span(base, "a", "pp", "plugin.logging.posthook", schemas.SpanKindPlugin, 52, 60),
+		span(base, "b", "pp", "plugin.telemetry.posthook", schemas.SpanKindPlugin, 60, 70),
+		span(base, "c", "pp", "plugin.governance.posthook", schemas.SpanKindPlugin, 70, 78),
+	}}
+
+	got := bucketMap(t, trace, 40, true)
+
+	if got["pipeline-post"] != 14000 {
+		t.Errorf("pipeline-post = %v us, want 14000 (40ms wall - 26ms of nested plugins)", got["pipeline-post"])
+	}
+	if got["plugin.logging"] != 8000 || got["plugin.telemetry"] != 10000 || got["plugin.governance"] != 8000 {
+		t.Errorf("plugin buckets = logging %v / telemetry %v / governance %v us, want 8000/10000/8000",
+			got["plugin.logging"], got["plugin.telemetry"], got["plugin.governance"])
+	}
+	sum := got["pipeline-post"] + got["plugin.logging"] + got["plugin.telemetry"] + got["plugin.governance"]
+	if sum != 40000 {
+		t.Errorf("phase + plugins = %v us, want 40000 (== pipeline-post wall, no double-count)", sum)
+	}
+	if _, ok := got["core"]; ok {
+		t.Errorf("core should be empty, got %v", got["core"])
 	}
 }
 
@@ -183,16 +253,16 @@ func TestComputeOverheadBreakdown_NegligibleOverhead(t *testing.T) {
 		span(base, "llm", "root", "chat gpt-4o", schemas.SpanKindLLMCall, 0, 100),
 	}}
 
-	if got := computeOverheadBreakdown(trace, 0, false); len(got) != 0 {
+	if got := computeOverheadBreakdown(trace, 0, false, 0, false); len(got) != 0 {
 		t.Errorf("expected no overhead buckets when overhead is negligible, got %v", got)
 	}
 }
 
 func TestComputeOverheadBreakdown_Empty(t *testing.T) {
-	if computeOverheadBreakdown(nil, 0, false) != nil {
+	if computeOverheadBreakdown(nil, 0, false, 0, false) != nil {
 		t.Error("nil trace must yield nil")
 	}
-	if computeOverheadBreakdown(&schemas.Trace{}, 5, true) != nil {
+	if computeOverheadBreakdown(&schemas.Trace{}, 5, true, 0, false) != nil {
 		t.Error("trace with no spans must yield nil")
 	}
 }

--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -250,6 +250,18 @@ func ResolveSessionIDFromRequest(h *fasthttp.RequestHeader) string {
 //	// session stickiness, and extra headers
 
 func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, store HandlerStore) (*schemas.BifrostContext, context.CancelFunc) {
+	// "transport-context" overhead phase: building the request-scoped BifrostContext —
+	// child-context alloc, request-id resolution, and the full request-header iteration
+	// that populates dimensions/tags/mcp-header maps. It runs inside the root http.request
+	// span but on no phase span, so it would otherwise fold into the residual "core"
+	// bucket. The tracer + root span live on the fasthttp ctx (set by TracingMiddleware),
+	// so this parents to the root span. Nil-safe when no trace is active.
+	if t, ok := ctx.UserValue(schemas.BifrostContextKeyTracer).(schemas.Tracer); ok && t != nil {
+		if _, h := t.StartSpanID(ctx, "transport-context", schemas.SpanKindInternal); h != nil {
+			defer t.EndSpan(h, schemas.SpanStatusOk, "")
+		}
+	}
+
 	var matcher *HeaderMatcher
 	mcpHeaderCombinedAllowlist := schemas.WhiteList{}
 	allowPerRequestStorageOverride := false

--- a/transports/bifrost-http/lib/responseheaders.go
+++ b/transports/bifrost-http/lib/responseheaders.go
@@ -97,6 +97,14 @@ func ApplyBifrostErrorResponseHeaders(ctx *fasthttp.RequestCtx, bifrostCtx *sche
 // didn't populate `extra` — the zero value for ExtraFields produces no
 // headers.
 func ApplyBifrostResponseHeaders(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, extra schemas.BifrostResponseExtraFields) {
+	// "transport-response-headers" overhead phase: writing routed-identity and upstream
+	// headers onto the fasthttp response. Runs inside the root http.request span on the
+	// way out, on no phase span, so it would otherwise fold into "core". Nil-safe.
+	if t, ok := ctx.UserValue(schemas.BifrostContextKeyTracer).(schemas.Tracer); ok && t != nil {
+		if _, h := t.StartSpanID(ctx, "transport-response-headers", schemas.SpanKindInternal); h != nil {
+			defer t.EndSpan(h, schemas.SpanStatusOk, "")
+		}
+	}
 	for key, value := range extra.ProviderResponseHeaders {
 		ctx.Response.Header.Set(key, value)
 	}

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -507,7 +507,7 @@ const OVERHEAD_SERIALIZATION_PHASES = new Set(["request-unmarshal", "request-mar
 const OVERHEAD_CATEGORY_META: Record<string, { label: string; colorClass: string }> = {
 	serialization: { label: "Serialization", colorClass: "bg-indigo-500/70" },
 	middleware: { label: "Middleware", colorClass: "bg-cyan-500/70" },
-	"middleware.apikeys": { label: "API keys", colorClass: "bg-cyan-500/70" },
+	"middleware.apikeys": { label: "API", colorClass: "bg-cyan-500/70" },
 	"middleware.scim": { label: "SCIM", colorClass: "bg-cyan-500/70" },
 	"middleware.auth": { label: "Auth", colorClass: "bg-cyan-500/70" },
 	"queue-wait": { label: "Queue wait", colorClass: "bg-orange-500/70" },


### PR DESCRIPTION
## Summary

Adds finer-grained overhead phase spans throughout the core request pipeline and AWS Bedrock provider so that previously invisible work stops folding into the residual "core" bucket in the latency breakdown. Introduces a `worker-handoff` measurement for the goroutine-scheduling gap between the provider worker sending a result and `tryRequest` receiving it, and a `provider-internal` bucket that surfaces uninstrumented provider-side glue as a distinct breakdown entry rather than silently inflating "core".

## Changes

- Added `handle-setup`, `pipeline-pre`, `pipeline-post`, `worker-setup`, and `key-pool` spans in `bifrost.go` to carve out previously untracked core-pipeline phases.
- Added `sentAt` timestamp to `ChannelMessage` so `tryRequest` can measure the worker→caller goroutine-hop latency and stamp it as `bifrost.worker.handoff_ms` on the root span via the new `StampWorkerHandoff` method.
- Added `startCoreSpan`/`endCoreSpan` nil-safe helpers on `Bifrost` for internal overhead phase spans that require no guard at call sites.
- Exported `StartPhaseSpan` from `providers/utils` so provider and auth code outside the package can open named phase spans without duplicating the nil-safe lookup logic.
- Added `request-sign` and `credentials-fetch` spans in the AWS Bedrock SigV4 signing path to isolate crypto CPU from STS/IMDS network round trips on credential cache misses.
- Added a `response-finalize` span in `FinalizeResponseWithLargeDetection` to account for payload-scaled body read, decompress, and copy work.
- Extended `computeOverheadBreakdown` to accept upstream latency and emit a `worker-handoff` bucket from the root-span attribute and a `provider-internal` bucket derived from `llm.call` span self-time minus measured upstream, so uninstrumented provider glue is visible rather than hidden.
- Updated tests to pass the new `upstreamMs`/`upstreamOK` parameters to `computeOverheadBreakdown`.
- Renamed the `"middleware.apikeys"` UI label from `"API keys"` to `"API"` for display consistency.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Send a unary request through a traced Bifrost instance and inspect the overhead breakdown in the logging plugin output. Verify that `handle-setup`, `pipeline-pre`, `pipeline-post`, `worker-setup`, `key-pool`, `worker-handoff`, and (for AWS Bedrock) `request-sign` / `credentials-fetch` / `response-finalize` appear as distinct buckets. Confirm that `provider-internal` appears when provider-side glue is present and that `core` shrinks correspondingly. Confirm that no buckets appear when no trace is active (nil-safe paths).

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. The new spans record only timing durations; no secrets, credentials, or PII are written to span attributes.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable