### PR TITLE
fix: use bifrost as user-agent name, show pricing for manual batch calls when resolved by sweeper

### DIFF
--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -364,6 +364,7 @@ const (
 	BifrostContextKeyTargetUserID                        BifrostContextKey = "target_user_id"
 	BifrostContextKeyIsAzureUserAgent                    BifrostContextKey = "bifrost-is-azure-user-agent" // bool (set by bifrost - DO NOT SET THIS MANUALLY)) - whether the request is an Azure user agent (only used in gateway)
 	BifrostContextKeyUserRoleID                          BifrostContextKey = "bifrost-user-role-id"
+	BifrostContextKeyRuntimeVersion                      BifrostContextKey = "bifrost-runtime-version" // string (this build's version; set at server bootstrap - DO NOT SET THIS MANUALLY)
 	BifrostContextKeyVideoOutputRequested                BifrostContextKey = "bifrost-video-output-requested"
 	BifrostContextKeyValidateKeys                        BifrostContextKey = "bifrost-validate-keys"                      // bool (triggers additional key validation during provider add/update)
 	BifrostContextKeyProviderResponseHeaders             BifrostContextKey = "bifrost-provider-response-headers"          // map[string]string (set by provider handlers for response header forwarding)

--- a/framework/batchaccounting/accounting.go
+++ b/framework/batchaccounting/accounting.go
@@ -284,7 +284,7 @@ func AccountBatchResults(ctx context.Context, stateStore BatchJobStore, logStore
 		// row's stored usage). Skipping the write would lose the usage for good — the
 		// raw provider results are not persisted anywhere else.
 		if computed != nil && summary.Usage.TotalTokens > 0 && job.AggregateLogWrittenAt == nil {
-			entry := buildAggregateLog(req, summary, now)
+			entry := buildAggregateLog(req, summary, now, userAgentFromContext(ctx))
 			// Unknown, not zero — a zero cost would read as "this batch was free".
 			entry.Cost = nil
 			if computed.UnpricedModel != "" {
@@ -323,7 +323,7 @@ func AccountBatchResults(ctx context.Context, stateStore BatchJobStore, logStore
 	summary.FailedCount = computed.FailedCount
 	summary.Complete = computed.Complete
 
-	entry := buildAggregateLog(req, summary, now)
+	entry := buildAggregateLog(req, summary, now, userAgentFromContext(ctx))
 	if !summary.Complete {
 		// Some usage priced and some did not. summary.Cost is therefore only the known
 		// part of the bill, and persisting it as the row's cost would be a lie with
@@ -490,6 +490,14 @@ func stringSliceFromParsedOrJSON(parsed []string, raw *string) []string {
 		return nil
 	}
 	return values
+}
+
+// userAgentFromContext builds the user agent for bifrost workers.
+func userAgentFromContext(ctx context.Context) string {
+	if version, ok := ctx.Value(schemas.BifrostContextKeyRuntimeVersion).(string); ok && version != "" {
+		return "bifrost/" + version
+	}
+	return "bifrost"
 }
 
 // accountingLogNamespace is the UUIDv5 namespace for aggregate cost log ids.
@@ -898,7 +906,7 @@ func firstNonZero(values ...int) int {
 	return 0
 }
 
-func buildAggregateLog(req Request, summary *Summary, now time.Time) *logstore.Log {
+func buildAggregateLog(req Request, summary *Summary, now time.Time, userAgent string) *logstore.Log {
 	model := req.FallbackModel
 	if len(summary.ModelBreakdowns) == 1 {
 		for key := range summary.ModelBreakdowns {
@@ -945,6 +953,7 @@ func buildAggregateLog(req Request, summary *Summary, now time.Time) *logstore.L
 		TotalTokens:      summary.Usage.TotalTokens,
 		CreatedAt:        now,
 		BatchDebugParsed: batchDebug,
+		UserAgent:        &userAgent,
 	}
 	// Attribution must not depend on who happens to settle the batch first. The
 	// sweeper reaches here with only the job; a /results call reaches here with the

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -1257,6 +1257,7 @@ func (s *RDBLogStore) listSelectColumns() string {
 		"latency", "upstream_latency", "overhead_latency", "token_usage", "cost", "status", "stream",
 		fmt.Sprintf("substr(content_summary, 1, %d) AS content_summary", maxContentSummaryBytes),
 		"metadata", "cache_debug",
+		"batch_debug",
 		"is_large_payload_request", "is_large_payload_response",
 		"prompt_tokens", "completion_tokens", "total_tokens",
 		"cached_read_tokens",

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -2378,6 +2378,7 @@ func startSkillsOrphanCleanupWorker(ctx context.Context, config *lib.Config, sho
 //   - GET /metrics: For Prometheus metrics
 func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	var err error
+	ctx = context.WithValue(ctx, schemas.BifrostContextKeyRuntimeVersion, s.Version)
 	s.Ctx, s.cancel = schemas.NewBifrostContextWithCancel(ctx)
 	handlers.SetVersion(s.Version)
 	configDir := GetDefaultConfigDir(s.AppDir)

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -388,6 +388,9 @@ const batchRequestStates = (counts: BatchRequestCounts): [string, number][] => {
 // Helper to detect passthrough operations
 const isPassthroughOperation = (object: string) => object === "passthrough" || object === "passthrough_stream";
 
+// Helper to detect batch operations (they carry no messages or tool declarations)
+const isBatchOperation = (object: string) => object.startsWith("batch_");
+
 // Helper to detect container operations (for hiding irrelevant fields like Model/Tokens)
 const isContainerOperation = (object: string) => {
 	const containerTypes = [
@@ -898,16 +901,17 @@ export function LogDetailView({
 	const showTabs = !isContainer;
 	const isPassthrough = isPassthroughOperation(log.object);
 	const isRealtimeTurn = log.object === "realtime.turn";
+	const isBatch = isBatchOperation(log.object);
 	const batchDebug = log.batch_debug;
 	const batchRawRequest = useMemo(() => {
-		if (!batchDebug || !log.raw_request) return null;
+		if (!isBatch || !log.raw_request) return null;
 		try {
 			const parsed = JSON.parse(log.raw_request);
 			return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
 		} catch {
 			return null;
 		}
-	}, [batchDebug, log.raw_request]);
+	}, [isBatch, log.raw_request]);
 	const batchInlineRequests = useMemo(() => {
 		const requests = batchRawRequest?.requests;
 		if (Array.isArray(requests)) {
@@ -953,14 +957,20 @@ export function LogDetailView({
 				? ((batchRawRequest?.batch as any).inputConfig.fileName as string)
 				: null;
 	const batchRawResponse = useMemo(() => {
-		if (!batchDebug || !log.raw_response) return null;
+		if (!isBatch || !log.raw_response) return null;
 		try {
 			const parsed = JSON.parse(log.raw_response);
 			return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
 		} catch {
 			return null;
 		}
-	}, [batchDebug, log.raw_response]);
+	}, [isBatch, log.raw_response]);
+	// batch_debug is only recorded for create/retrieve, so fall back to the raw
+	// provider payload to describe the batch a cancel addressed.
+	const batchId = batchDebug?.batch_id ?? (typeof batchRawResponse?.id === "string" ? (batchRawResponse.id as string) : null);
+	const batchStatus = batchDebug?.status ?? (typeof batchRawResponse?.status === "string" ? (batchRawResponse.status as string) : null);
+	const showBatchDetailsTab = showTabs && isBatch && log.object !== "batch_list";
+
 	const batchResultItems = useMemo(() => {
 		const raw = batchRawResponse;
 		const results: any[] = Array.isArray(raw) ? raw : Array.isArray(raw?.results) ? (raw!.results as any[]) : [];
@@ -1988,23 +1998,6 @@ export function LogDetailView({
 												)}
 											</div>
 										)}
-										{batchDebug.status && (
-											<LogEntryDetailsView
-												className="w-full"
-												label="Status"
-												value={
-													<Badge
-														variant="outline"
-														className={cn(
-															"rounded-sm px-2 py-0.5 font-medium uppercase",
-															batchStatusBadgeStyles[batchDebug.status] ?? batchStatusBadgeDefault,
-														)}
-													>
-														{batchDebug.status.replace(/_/g, " ")}
-													</Badge>
-												}
-											/>
-										)}
 									</div>
 								</>
 							)}
@@ -2201,9 +2194,9 @@ export function LogDetailView({
 						)}
 				</div>
 			</details>
-			<Tabs key={log.id} defaultValue={batchDebug ? "details" : showTabs ? "messages" : "plugins"} className="gap-2">
+			<Tabs key={log.id} defaultValue={showBatchDetailsTab ? "details" : showTabs && !isBatch ? "messages" : showTabs ? "routing" : "plugins"} className="gap-2">
 				<TabsList className="bg-muted/60 h-10 w-fit">
-					{showTabs && batchDebug && (
+					{showBatchDetailsTab && (
 						<TabsTrigger value="details" className="px-3">
 							Details
 							{batchInlineRequests.length + batchResultItems.length ? (
@@ -2213,7 +2206,7 @@ export function LogDetailView({
 							) : null}
 						</TabsTrigger>
 					)}
-					{showTabs && !batchDebug && (
+					{showTabs && !isBatch && (
 						<TabsTrigger value="messages" className="px-3">
 							Messages
 							{log.input_history?.length ? (
@@ -2224,7 +2217,7 @@ export function LogDetailView({
 						</TabsTrigger>
 					)}
 
-					{showTabs && !isPassthrough && !log.list_models_output && !batchDebug && (
+					{showTabs && !isPassthrough && !log.list_models_output && !isBatch && (
 						<TabsTrigger value="tools" className="px-3">
 							Tools
 							{declaredTools.length ? (
@@ -2259,17 +2252,17 @@ export function LogDetailView({
 					)}
 				</TabsList>
 
-				{batchDebug && (
+				{showBatchDetailsTab && (
 					<TabsContent value="details" className="space-y-4">
-						{(batchDebug.batch_id || (batchInlineRequests.length === 0 && batchInputFileId)) && (
+						{(batchId || batchStatus || (batchInlineRequests.length === 0 && batchInputFileId)) && (
 							<div className="bg-card rounded-sm border p-5 space-y-4">
-								{batchDebug.batch_id && (
+								{batchId && (
 									<LogEntryDetailsView
 										label="Batch ID"
 										value={
 											<span className="flex items-center gap-1">
-												<code className="font-mono text-xs">{batchDebug.batch_id}</code>
-												<CopyInlineButton text={batchDebug.batch_id} testId="logdetails-details-copy-batch-id-button" />
+												<code className="font-mono text-xs">{batchId}</code>
+												<CopyInlineButton text={batchId} testId="logdetails-details-copy-batch-id-button" />
 											</span>
 										}
 									/>
@@ -2282,6 +2275,19 @@ export function LogDetailView({
 												<code className="font-mono text-xs">{batchInputFileId}</code>
 												<CopyInlineButton text={batchInputFileId} testId="logdetails-copy-input-file-id-button" />
 											</span>
+										}
+									/>
+								)}
+								{batchStatus && (
+									<LogEntryDetailsView
+										label="Status"
+										value={
+											<Badge
+												variant="outline"
+												className={cn("rounded-sm px-2 py-0.5 font-medium uppercase", batchStatusBadgeStyles[batchStatus] ?? batchStatusBadgeDefault)}
+											>
+												{batchStatus.replace(/_/g, " ")}
+											</Badge>
 										}
 									/>
 								)}

--- a/ui/app/workspace/logs/views/columns.tsx
+++ b/ui/app/workspace/logs/views/columns.tsx
@@ -2,6 +2,7 @@ import { formatCost, formatLatency } from "@/app/workspace/dashboard/utils/chart
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import {
 	getProviderLabel,
@@ -14,7 +15,7 @@ import {
 	Status,
 	StatusBarColors,
 } from "@/lib/constants/logs";
-import { ChatMessageContent, DisplayLogEntry, LogEntry, ResponsesMessageContentBlock } from "@/lib/types/logs";
+import { ChatMessageContent, DisplayLogEntry, LLMUsage, LogEntry, ResponsesMessageContentBlock } from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
 import { formatCompactNumber } from "@/lib/utils/numbers";
 import { ColumnDef } from "@tanstack/react-table";
@@ -28,6 +29,28 @@ export interface LogsTableMeta {
 	expandedChainIds: Set<string>;
 	loadingChainIds: Set<string>;
 	onToggleChain: (log: LogEntry) => void;
+}
+
+function batchAccountingDisplay(log: LogEntry): { model: string; usage: LLMUsage } | null {
+	const breakdowns = log.batch_debug?.accounting?.model_breakdowns;
+	if (!breakdowns) {
+		return null;
+	}
+	const entries = Object.values(breakdowns);
+	if (entries.length === 0) {
+		return null;
+	}
+	const model = entries.length === 1 ? entries[0].model : "mixed";
+	const usage: LLMUsage = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
+	for (const entry of entries) {
+		usage.prompt_tokens = (usage.prompt_tokens ?? 0) + (entry.usage?.prompt_tokens ?? 0);
+		usage.completion_tokens = (usage.completion_tokens ?? 0) + (entry.usage?.completion_tokens ?? 0);
+		usage.total_tokens = (usage.total_tokens ?? 0) + (entry.usage?.total_tokens ?? 0);
+	}
+	if ((usage.total_tokens ?? 0) === 0) {
+		return null;
+	}
+	return { model, usage };
 }
 
 function LogActionsMenu({ log, onDelete }: { log: LogEntry; onDelete: (log: LogEntry) => void }) {
@@ -369,7 +392,7 @@ export const createColumns = (
 			size: 190,
 			cell: ({ row }) => {
 				const provider = row.original.provider as ProviderName | undefined;
-				const model = row.original.model;
+				const model = row.original.model || batchAccountingDisplay(row.original)?.model;
 				return (
 					<div className="flex min-w-0 items-center gap-2">
 						{provider ? <RenderProviderIcon provider={provider as ProviderIconType} size="xs" /> : null}
@@ -434,7 +457,7 @@ export const createColumns = (
 			),
 			size: 190,
 			cell: ({ row }) => {
-				const tokenUsage = row.original.token_usage;
+				const tokenUsage = row.original.token_usage ?? batchAccountingDisplay(row.original)?.usage;
 				if (!tokenUsage) {
 					return <div className="pl-4 font-mono text-xs">N/A</div>;
 				}
@@ -477,6 +500,17 @@ export const createColumns = (
 			size: 120,
 			cell: ({ row }) => {
 				if (row.original.cost == null) {
+					const batchCost = row.original.batch_debug?.accounting?.cost;
+					if (batchCost != null) {
+						return (
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<div className="text-muted-foreground pl-4 font-mono text-sm tabular-nums">{formatCost(batchCost)}</div>
+								</TooltipTrigger>
+								<TooltipContent>Settled cost of this batch, billed once.</TooltipContent>
+							</Tooltip>
+						);
+					}
 					return <div className="pl-4 font-mono text-[12px]">N/A</div>;
 				}
 				return <div className="pl-4 font-mono text-sm tabular-nums">{formatCost(row.original.cost)}</div>;


### PR DESCRIPTION
## Summary

Surfaces batch accounting data (model, token usage, and cost) in the logs table UI, and ensures `batch_debug` is included in list queries so that data is available for display. Batch log entries that lack a top-level model, token usage, or cost now fall back to values derived from the batch debug accounting breakdowns. Additionally, the server version is propagated into the context at bootstrap so that batch accounting settlement logs carry a `UserAgent` field.

## Changes

- Added `BifrostContextKeyRuntimeVersion` context key and set it at server bootstrap so the runtime version is available throughout the request lifecycle.
- Added `userAgentFromContext` helper that reads the runtime version from context and builds a `"bifrost/<version>"` user agent string, falling back to `"bifrost"`.
- Passed the resolved user agent into `buildAggregateLog` and set it as `UserAgent` on the resulting log entry during batch accounting settlement.
- Added `batch_debug` to the `listSelectColumns` query so batch debug data is returned when listing log entries.
- Added a `batchAccountingDisplay` helper that aggregates model and token usage across `batch_debug.accounting.model_breakdowns`, returning `"mixed"` when multiple models are present.
- Model and token usage columns now fall back to `batchAccountingDisplay` when the top-level fields are absent.
- The cost column now renders the settled batch cost (from `batch_debug.accounting.cost`) with a tooltip explaining it is billed once, rather than showing `N/A`.
- Replaced `batchDebug`-gated UI logic with an `isBatch` flag derived from the log object type, so batch cancel and list operations are handled correctly even when `batch_debug` is absent.
- Batch ID and status in the detail view now fall back to the raw provider response payload when `batch_debug` is not present.
- Moved the status badge from the summary header section into the Details tab alongside the batch ID, so it is consistently sourced from either `batch_debug` or the raw response.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Submit a batch request and wait for it to settle.
2. Open the logs table and locate the batch log entry.
3. Verify the model column shows the correct model name (or `"mixed"` for multi-model batches).
4. Verify the token usage column shows aggregated prompt, completion, and total tokens.
5. Verify the cost column shows the settled batch cost with a tooltip reading "Settled cost of this batch, billed once." instead of `N/A`.
6. Open a batch cancel or batch list log entry and verify the Details tab and batch ID/status fields render correctly without `batch_debug`.

```sh
# Core/Transports
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before: Model, token usage, and cost columns showed `N/A` for settled batch log entries. Batch cancel and list log entries did not render a Details tab or batch status.

After: All three columns display values derived from `batch_debug` accounting data, with a tooltip on the cost cell. Batch cancel and list entries correctly show or hide the Details tab based on object type.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No new auth, secrets, PII, or sandboxing concerns introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable