### PR TITLE
fix: refresh tools synchronously on per-call shared-credential client credential update instead of returning `ErrMCPReconnectNotApplicable`, with disabled-client guard and per-user sentinel preserved

### DIFF
--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -1628,6 +1628,12 @@ func (m *MCPManager) UpdateClient(id string, updatedConfig *schemas.MCPClientCon
 // before being committed. Non-credential metadata (name, tools, etc.) is preserved from the
 // current execution config.
 //
+// A shared-credential client running per-call (no session stickiness) has no connection to
+// replace; instead its tool list is refreshed synchronously via a one-shot discovery with the
+// now-current credential, so a credential update lands with fresh tools on both connection
+// modes alike. Per-user auth type clients return ErrMCPReconnectNotApplicable: their shared
+// tool list is driven by the retained admin credential, which is not what changes here.
+//
 // On failure the clientMap entry is left in Disconnected state but its ExecutionConfig is restored
 // to the previous value, allowing the health monitor to recover the client using the old credentials.
 //
@@ -1719,13 +1725,41 @@ func (m *MCPManager) UpdateClientCredentials(id string, newConfig *schemas.MCPCl
 			return nil
 		}
 		// Already past that first connection (a plain reauthorize of an
-		// already-Healthy client): a per-call client dials fresh on every
+		// already-verified client): a per-call client dials fresh on every
 		// call and already picks up whatever credential is current in the
-		// DB, so there is genuinely nothing left to do — that's a no-op,
-		// not a failure, hence the shared "not applicable" sentinel rather
-		// than an opaque error.
+		// DB, so there is no persistent connection to swap. The tool list
+		// still needs the treatment sticky clients get for free from their
+		// reconnect (which always re-runs discovery): nothing else revisits
+		// a per-call client until the periodic checker's next tick, minutes
+		// away on a Healthy client, so refresh tools synchronously with the
+		// now-current shared credential. A failed discovery fails the
+		// update, mirroring the sticky path (a reconnect whose tools/list
+		// fails is a failed reconnect); the periodic checker still retries
+		// on its own cadence afterwards. Skipped for a Disabled client:
+		// SetClientTools would force it back to Healthy, and re-enabling
+		// runs its own discovery anyway.
+		//
+		// Per-user auth types keep the "not applicable" sentinel: the
+		// credentials updated through here are never the retained admin
+		// discovery credential (the admin-verify paths own that flow and
+		// re-discover themselves), so the shared tool list is unaffected
+		// and there is genuinely nothing left to do.
+		isDisabled := client.State == schemas.MCPConnectionStateDisabled
 		m.mu.RUnlock()
-		return fmt.Errorf("client uses per-call connections; there is no persistent connection to update: %w", schemas.ErrMCPReconnectNotApplicable)
+		switch newConfig.AuthType {
+		case schemas.MCPAuthTypeOauth, schemas.MCPAuthTypeHeaders, schemas.MCPAuthTypeNone:
+			if isDisabled {
+				return fmt.Errorf("client uses per-call connections; there is no persistent connection to update: %w", schemas.ErrMCPReconnectNotApplicable)
+			}
+			tools, mapping, discErr := m.performAdminToolDiscovery(m.ctx, newConfig)
+			if discErr != nil {
+				return fmt.Errorf("credentials updated but tool discovery with them failed for MCP client %s: %w", newConfig.Name, discErr)
+			}
+			m.SetClientTools(id, tools, mapping)
+			return nil
+		default:
+			return fmt.Errorf("client uses per-call connections; there is no persistent connection to update: %w", schemas.ErrMCPReconnectNotApplicable)
+		}
 	}
 	if client.ExecutionConfig == nil {
 		m.mu.RUnlock()

--- a/core/mcp/clientmanager_test.go
+++ b/core/mcp/clientmanager_test.go
@@ -274,23 +274,59 @@ func TestEnableClient_GuardLostLeavesDisabledUntouched(t *testing.T) {
 	assert.Equal(t, schemas.MCPConnectionStateDisabled, state.State)
 }
 
-// TestUpdateClientCredentials_PerCallSharedOAuth_ReturnsReconnectNotApplicable
-// pins the bug reported against a shared-OAuth client (auth_type='oauth')
-// running in per-call mode: needs_session_stickiness nil/false — the default
-// for a newly created or config.json-bootstrapped client that predates this
-// field — routes RequiresPerCallConnection through the same per-call branch
-// a genuine per-user client uses. UpdateClientCredentials's guard used to
-// return a bare "per-user auth clients" error for this case even though the
-// client is genuinely shared, just with no persistent connection to
-// reconnect (the fresh OAuth token is already live for the next per-call
-// dial). Callers must be able to tell this "nothing to do" case apart from a
-// real failure via the same ErrMCPReconnectNotApplicable sentinel
-// ReconnectClient/CloseAndMarkNeedsReauth already use for the analogous case.
-func TestUpdateClientCredentials_PerCallSharedOAuth_ReturnsReconnectNotApplicable(t *testing.T) {
+// TestUpdateClientCredentials_PerCallShared_Healthy_RefreshesToolsSynchronously
+// pins the per-call half of the reauthorize symmetry: a sticky client's
+// credential update goes through connectToMCPClient, which always re-runs
+// tool discovery, while a per-call shared client used to return the
+// not-applicable sentinel and keep serving its stale tool list until the
+// periodic checker's next tick (minutes away on a Healthy client). A
+// credential update on an already-verified per-call shared client must
+// instead refresh tools synchronously with the now-current credential.
+func TestUpdateClientCredentials_PerCallShared_Healthy_RefreshesToolsSynchronously(t *testing.T) {
+	ts, _ := buildAdminDiscoveryHTTPServer(t)
+
 	// nil credStore: NewMCPManager defaults to a real credstore.CredStore,
 	// whose RequiresPerCallConnection actually ANDs auth type with
-	// NeedsSessionStickiness — unlike expiredOAuthCredStore (used elsewhere
-	// in this file), which hardcodes false regardless of either.
+	// NeedsSessionStickiness (unlike expiredOAuthCredStore, used elsewhere
+	// in this file, which hardcodes false regardless of either).
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, nil, nil, nil)
+	config := &schemas.MCPClientConfig{
+		ID:               "client-shared-percall-refresh",
+		Name:             "shared-percall-client-refresh",
+		AuthType:         schemas.MCPAuthTypeHeaders,
+		ConnectionType:   schemas.MCPConnectionTypeHTTP,
+		ConnectionString: schemas.NewSecretVar(ts.URL),
+		Headers:          map[string]schemas.SecretVar{"Authorization": *schemas.NewSecretVar("Bearer rotated-token")},
+		// NeedsSessionStickiness left nil on purpose: the default value.
+	}
+
+	m.mu.Lock()
+	m.clientMap[config.ID] = &schemas.MCPClientState{
+		Name:            config.Name,
+		ExecutionConfig: config,
+		State:           schemas.MCPConnectionStateHealthy,
+		ToolMap:         make(map[string]schemas.ChatTool),
+		ToolNameMapping: make(map[string]string),
+	}
+	m.mu.Unlock()
+
+	err := m.UpdateClientCredentials(config.ID, config)
+	require.NoError(t, err, "a per-call shared client's credential update must succeed by refreshing tools, not report not-applicable")
+
+	m.mu.RLock()
+	state := *m.clientMap[config.ID]
+	m.mu.RUnlock()
+	assert.Contains(t, state.ToolMap, "shared-percall-client-refresh-echo", "tools must be refreshed synchronously, not deferred to the periodic checker")
+}
+
+// TestUpdateClientCredentials_PerCallSharedOAuth_DiscoveryFailureFailsUpdate
+// pins the strict half of the same symmetry: a sticky reconnect whose
+// tools/list fails is a failed reconnect, so a per-call refresh whose
+// discovery fails must fail the update with a real error, not the
+// not-applicable sentinel; the periodic checker retries on its own cadence
+// afterwards. No OAuth provider is configured here, so resolving the shared
+// credential for discovery fails deterministically.
+func TestUpdateClientCredentials_PerCallSharedOAuth_DiscoveryFailureFailsUpdate(t *testing.T) {
 	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, nil, nil, nil)
 	config := &schemas.MCPClientConfig{
 		ID:             "client-shared-percall",
@@ -310,7 +346,67 @@ func TestUpdateClientCredentials_PerCallSharedOAuth_ReturnsReconnectNotApplicabl
 
 	err := m.UpdateClientCredentials(config.ID, config)
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, schemas.ErrMCPReconnectNotApplicable), "a per-call shared-oauth client must report the same not-applicable sentinel as a genuine per-user client, not an opaque failure")
+	assert.False(t, errors.Is(err, schemas.ErrMCPReconnectNotApplicable), "a failed tool refresh is a real failure, not the not-applicable no-op")
+	assert.Contains(t, err.Error(), "tool discovery")
+}
+
+// TestUpdateClientCredentials_PerCallPerUser_ReturnsReconnectNotApplicable
+// pins that per-user auth types keep the not-applicable sentinel: the
+// credentials updated through here are never the retained admin discovery
+// credential (the admin-verify paths own that flow and re-discover
+// themselves), so there is genuinely nothing to refresh.
+func TestUpdateClientCredentials_PerCallPerUser_ReturnsReconnectNotApplicable(t *testing.T) {
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, nil, nil, nil)
+	config := &schemas.MCPClientConfig{
+		ID:             "client-per-user-creds",
+		Name:           "per-user-creds-client",
+		AuthType:       schemas.MCPAuthTypePerUserOauth,
+		ConnectionType: schemas.MCPConnectionTypeHTTP,
+	}
+
+	m.mu.Lock()
+	m.clientMap[config.ID] = &schemas.MCPClientState{
+		Name:            config.Name,
+		ExecutionConfig: config,
+		State:           schemas.MCPConnectionStateHealthy,
+	}
+	m.mu.Unlock()
+
+	err := m.UpdateClientCredentials(config.ID, config)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, schemas.ErrMCPReconnectNotApplicable))
+}
+
+// TestUpdateClientCredentials_PerCallShared_Disabled_SkipsRefresh pins the
+// Disabled guard on the per-call refresh: SetClientTools forces a client
+// back to Healthy, so a disabled client must keep the sentinel (the fresh
+// credential is picked up when the client is re-enabled, which runs its own
+// discovery) rather than get resurrected by a credential update.
+func TestUpdateClientCredentials_PerCallShared_Disabled_SkipsRefresh(t *testing.T) {
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, nil, nil, nil)
+	config := &schemas.MCPClientConfig{
+		ID:             "client-shared-percall-disabled",
+		Name:           "shared-percall-client-disabled",
+		AuthType:       schemas.MCPAuthTypeOauth,
+		ConnectionType: schemas.MCPConnectionTypeHTTP,
+	}
+
+	m.mu.Lock()
+	m.clientMap[config.ID] = &schemas.MCPClientState{
+		Name:            config.Name,
+		ExecutionConfig: config,
+		State:           schemas.MCPConnectionStateDisabled,
+	}
+	m.mu.Unlock()
+
+	err := m.UpdateClientCredentials(config.ID, config)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, schemas.ErrMCPReconnectNotApplicable))
+
+	m.mu.RLock()
+	state := *m.clientMap[config.ID]
+	m.mu.RUnlock()
+	assert.Equal(t, schemas.MCPConnectionStateDisabled, state.State, "a credential update must not resurrect a disabled client")
 }
 
 // TestUpdateClientCredentials_PerCallSharedOAuth_PendingVerification_TransitionsToHealthy
@@ -361,10 +457,15 @@ func TestUpdateClientCredentials_PerCallSharedOAuth_PendingVerification_Transiti
 	assert.True(t, hasChecker, "must start a connection checker so tools actually get discovered")
 
 	// A second call, now that the client is already Healthy, is the plain
-	// reauthorize case: genuinely nothing left to do.
+	// reauthorize case: it must attempt a synchronous tool refresh with the
+	// updated credential rather than report not-applicable. No OAuth
+	// provider is configured here, so resolving the credential for that
+	// discovery fails, and the failure must surface as a real error (not
+	// the sentinel).
 	err = m.UpdateClientCredentials(config.ID, config)
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, schemas.ErrMCPReconnectNotApplicable))
+	assert.False(t, errors.Is(err, schemas.ErrMCPReconnectNotApplicable))
+	assert.Contains(t, err.Error(), "tool discovery")
 }
 
 // TestUpdateClientCredentials_PerCallSharedType_PendingVerification_DiscoversToolsSynchronously

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -2624,14 +2624,17 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		}
 	}
 
-	// Swap the verified headers onto the live connection. Only a client that
-	// was and remains sticky needs this: it holds an open transport with the
-	// old header baked in, and UpdateMCPClientCredentials is the only thing
-	// that replaces it. Every other combination is already handled —
-	// UpdateMCPClient above replaced ExecutionConfig (all a per-call client
-	// needs, since it reads the current config on every dial) and itself
-	// re-dialed on a per-call->sticky flip, so re-dialing again here would
-	// just be a second connect with the same credentials.
+	// Apply the verified headers to the live client. A sticky client holds an
+	// open transport with the old header baked in, and
+	// UpdateMCPClientCredentials is the only thing that replaces it (redial +
+	// tool rediscovery). A per-call client reads the current config on every
+	// dial, so its credential is already live, but its tool list would sit
+	// on the pre-rotation discovery until the periodic checker's next tick,
+	// so UpdateMCPClientCredentials runs a synchronous discovery refresh for
+	// it instead of a redial. The one combination skipped is a
+	// per-call->sticky flip: UpdateMCPClient above already dialed the new
+	// connection with these credentials and rediscovered tools, so running
+	// this too would just be a second connect with the same result.
 	//
 	// The same credentials already completed a full connect during the
 	// pre-flight above, so a failure here is a transient dial problem rather
@@ -2639,11 +2642,21 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 	// previous ExecutionConfig on failure, leaving the connection checker to
 	// retry. Reported as a partial success for that reason, not a hard
 	// failure: every other effect of this request already committed.
-	if headersChanged && sharedConnectErr == nil && !wasPerCallConnection && !isPerCallConnection {
+	// Tracked separately from sharedConnectErr: a client that ends up
+	// per-call has no connection to swap, so its failure here is the
+	// synchronous tool refresh, retried by the periodic tool sync rather
+	// than the connection checker's reconnect path. The response wording
+	// below differs accordingly.
+	var toolRefreshErr error
+	if headersChanged && sharedConnectErr == nil && !(wasPerCallConnection && !isPerCallConnection) {
 		if err := h.updateMCPClientCredentialsWithRetry(ctx, id, schemasConfig); err != nil &&
 			!errors.Is(err, schemas.ErrMCPReconnectNotApplicable) {
-			logger.Error(fmt.Sprintf("MCP client %s updated, but reconnecting with the new headers failed: %v", id, err))
-			sharedConnectErr = err
+			logger.Error(fmt.Sprintf("MCP client %s updated, but applying the new headers to the live client failed: %v", id, err))
+			if isPerCallConnection {
+				toolRefreshErr = err
+			} else {
+				sharedConnectErr = err
+			}
 		}
 	}
 
@@ -2882,6 +2895,13 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		SendJSON(ctx, map[string]any{
 			"status":  "partial_success",
 			"message": fmt.Sprintf("%s However, establishing the shared connection failed: %v. The connection checker will keep retrying automatically.", message, sharedConnectErr),
+		})
+		return
+	}
+	if toolRefreshErr != nil {
+		SendJSON(ctx, map[string]any{
+			"status":  "partial_success",
+			"message": fmt.Sprintf("%s However, refreshing the client's tools with the new headers failed: %v. The periodic tool sync will retry automatically.", message, toolRefreshErr),
 		})
 		return
 	}
@@ -3328,14 +3348,23 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 				return
 			}
 			if err := h.updateMCPClientCredentialsWithRetry(bifrostCtx, reauthClientConfig.ID, reauthClientConfig); err != nil && !errors.Is(err, schemas.ErrMCPReconnectNotApplicable) {
-				logger.Error(fmt.Sprintf("Failed to reconnect MCP client after reauthorization for client %s: %v", reauthClientConfig.ID, err))
-				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("OAuth credentials refreshed but reconnecting the client failed: %v", err))
+				logger.Error(fmt.Sprintf("Failed to apply refreshed OAuth credentials to the live MCP client %s: %v", reauthClientConfig.ID, err))
+				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("OAuth credentials refreshed but applying them to the live client failed: %v", err))
 				return
 			}
-			// ErrMCPReconnectNotApplicable (a per-call client — no persistent
-			// connection to reconnect) is not an error here: the fresh
-			// credential is already what the next per-call dial will use.
-			SendJSON(ctx, map[string]any{"status": "success", "message": "MCP client re-authorized and reconnected successfully"})
+			// A per-call client refreshes its tool list synchronously inside
+			// UpdateMCPClientCredentials (mirroring the rediscovery a sticky
+			// client gets from its reconnect), so success means fresh tools
+			// on both connection modes, and the message reports what actually
+			// happened for each mode. ErrMCPReconnectNotApplicable can still
+			// come back for a disabled per-call client and is not an error:
+			// the fresh credential is already what the next dial after
+			// re-enabling will use.
+			successMsg := "MCP client re-authorized and reconnected successfully"
+			if h.mcpManager.RequiresPerCallConnection(reauthClientConfig) {
+				successMsg = "MCP client re-authorized and tools refreshed successfully"
+			}
+			SendJSON(ctx, map[string]any{"status": "success", "message": successMsg})
 			return
 		}
 		mcpClientConfig, err = h.store.ConfigStore.GetMCPClientConfigByID(ctx, dbClient.ClientID)


### PR DESCRIPTION
## Summary

When a shared-credential MCP client runs in per-call mode (no session stickiness), a credential rotation previously returned `ErrMCPReconnectNotApplicable` because there is no persistent connection to replace. While the new credential was immediately live for the next dial, the tool list would remain stale until the periodic health checker's next tick — potentially minutes later. This PR fixes that gap by running a synchronous tool discovery inside `UpdateClientCredentials` for per-call shared clients, mirroring the rediscovery that sticky clients get automatically from their reconnect.

## Changes

- Per-call shared clients (auth types `oauth`, `headers`, `none`) now perform a synchronous `performAdminToolDiscovery` call inside `UpdateClientCredentials` when the client is already verified and healthy, replacing the previous `ErrMCPReconnectNotApplicable` no-op return.
- A failed discovery fails the update with a real error (not the sentinel), matching the sticky path where a reconnect whose tool list fails is itself a failed reconnect. The periodic checker still retries on its own cadence afterwards.
- Disabled per-call clients keep the sentinel: `SetClientTools` would force the client back to Healthy, and re-enabling already runs its own discovery.
- Per-user auth types (`MCPAuthTypePerUserOauth`, etc.) keep the sentinel: the credentials updated through this path are never the retained admin discovery credential.
- The `updateMCPClient` HTTP handler's condition for calling `UpdateMCPClientCredentials` was broadened from `!wasPerCallConnection && !isPerCallConnection` to `!(wasPerCallConnection && !isPerCallConnection)`, so per-call clients that remain per-call now also go through the credential update path (and get the synchronous tool refresh) rather than being skipped.
- The `completeMCPClientOAuth` handler comment was updated to reflect that `ErrMCPReconnectNotApplicable` is now only returned for disabled per-call clients, not all per-call clients.
- The original `TestUpdateClientCredentials_PerCallSharedOAuth_ReturnsReconnectNotApplicable` test was replaced with four focused tests covering: healthy per-call shared client refreshes tools synchronously, discovery failure surfaces as a real error, per-user auth type returns the sentinel, and disabled per-call client skips refresh and stays disabled.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)

## How to test

```sh
go test ./core/mcp/... -run TestUpdateClientCredentials
```

Expected: all four new `TestUpdateClientCredentials_PerCallShared*` and `TestUpdateClientCredentials_PerCallPerUser*` tests pass. The `TestUpdateClientCredentials_PerCallSharedOAuth_PendingVerification_TransitionsToHealthy` test's second-call assertion now expects a real discovery error rather than the not-applicable sentinel.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The synchronous discovery call uses the now-current shared credential, so rotated credentials are validated against the live server before the tool list is updated. A failed discovery leaves the tool list unchanged and surfaces an error to the caller, avoiding a scenario where stale tools are served with a credential that no longer works.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)