### PR TITLE
fix: replace `maps.Copy` merge with wholesale replacement in `SetClientTools` and `UpdateClientCredentials` to prevent removed tools from persisting in memory

### DIFF
--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -1059,7 +1059,17 @@ func (m *MCPManager) SetClientTools(clientID string, tools map[string]schemas.Ch
 		m.mu.Unlock()
 		return
 	}
-	maps.Copy(client.ToolMap, tools)
+	// Replace the tool set wholesale, mirroring connectToMCPClient's swap and
+	// the checker's writeBackTools: every caller passes a complete discovery
+	// result, and merging into the existing map would keep tools the upstream
+	// has since removed alive in memory (and on the hosted /mcp surface) while
+	// the DB, persisted from the passed-in set via the tools-change callback,
+	// has already dropped them.
+	if tools == nil {
+		tools = make(map[string]schemas.ChatTool)
+	}
+	precomputeToolSerialization(tools)
+	client.ToolMap = tools
 	client.ToolNameMapping = toolNameMapping
 	client.State = schemas.MCPConnectionStateHealthy
 	m.logger.Debug("%s Set %d tools on client '%s'", MCPLogPrefix, len(tools), client.Name)
@@ -1687,7 +1697,17 @@ func (m *MCPManager) UpdateClientCredentials(id string, newConfig *schemas.MCPCl
 			if cs, exists := m.clientMap[id]; exists && cs.State == schemas.MCPConnectionStatePendingVerification {
 				cs.ExecutionConfig = newConfig
 				if len(newConfig.DiscoveredTools) > 0 {
-					maps.Copy(cs.ToolMap, newConfig.DiscoveredTools)
+					// Replace, not merge, mirroring AddClient's own restore:
+					// the persisted DiscoveredTools are the complete set, and
+					// a pending_verification entry holds no tools of its own
+					// worth keeping anyway. Copied into a fresh map so the
+					// entry never aliases the config's own map.
+					restored := make(map[string]schemas.ChatTool, len(newConfig.DiscoveredTools))
+					for toolName, tool := range newConfig.DiscoveredTools {
+						_ = tool.EnsureSerialized() // cache serialized JSON at the source (see precomputeToolSerialization)
+						restored[toolName] = tool
+					}
+					cs.ToolMap = restored
 					cs.ToolNameMapping = newConfig.DiscoveredToolNameMapping
 				}
 				cs.State = schemas.MCPConnectionStateHealthy

--- a/core/mcp/clientmanager_test.go
+++ b/core/mcp/clientmanager_test.go
@@ -319,6 +319,42 @@ func TestUpdateClientCredentials_PerCallShared_Healthy_RefreshesToolsSynchronous
 	assert.Contains(t, state.ToolMap, "shared-percall-client-refresh-echo", "tools must be refreshed synchronously, not deferred to the periodic checker")
 }
 
+// TestSetClientTools_ReplacesStaleTools pins SetClientTools' replace
+// semantics: every caller passes a complete discovery result, so a tool the
+// upstream removed between discoveries must disappear from the in-memory
+// ToolMap. The old merge behavior kept such tools alive in memory (and on
+// the hosted MCP surface, which serves from ToolMap) while the DB, persisted
+// from the passed-in set via the tools-change callback, had already dropped
+// them.
+func TestSetClientTools_ReplacesStaleTools(t *testing.T) {
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, nil, nil, nil)
+	config := &schemas.MCPClientConfig{ID: "client-replace-tools", Name: "replace-tools-client"}
+
+	m.mu.Lock()
+	m.clientMap[config.ID] = &schemas.MCPClientState{
+		Name:            config.Name,
+		ExecutionConfig: config,
+		State:           schemas.MCPConnectionStateHealthy,
+		ToolMap: map[string]schemas.ChatTool{
+			"replace-tools-client-removed": {},
+		},
+		ToolNameMapping: map[string]string{"replace-tools-client-removed": "removed"},
+	}
+	m.mu.Unlock()
+
+	m.SetClientTools(config.ID,
+		map[string]schemas.ChatTool{"replace-tools-client-kept": {}},
+		map[string]string{"replace-tools-client-kept": "kept"},
+	)
+
+	m.mu.RLock()
+	state := *m.clientMap[config.ID]
+	m.mu.RUnlock()
+	assert.Contains(t, state.ToolMap, "replace-tools-client-kept")
+	assert.NotContains(t, state.ToolMap, "replace-tools-client-removed", "a tool absent from the fresh discovery result must not survive in memory")
+	assert.Equal(t, map[string]string{"replace-tools-client-kept": "kept"}, state.ToolNameMapping)
+}
+
 // TestUpdateClientCredentials_PerCallSharedOAuth_DiscoveryFailureFailsUpdate
 // pins the strict half of the same symmetry: a sticky reconnect whose
 // tools/list fails is a failed reconnect, so a per-call refresh whose


### PR DESCRIPTION
## Summary

When an MCP client's upstream removes a tool between discovery cycles, the old `maps.Copy` merge behavior kept that tool alive in the in-memory `ToolMap` even after the database had already dropped it (persisted from the passed-in complete discovery result via the tools-change callback). This caused stale tools to remain visible on the hosted `/mcp` surface indefinitely. This PR fixes both `SetClientTools` and `UpdateClientCredentials` to replace the tool map wholesale rather than merging into it.

## Changes

- `SetClientTools` now assigns the incoming tool map directly instead of merging it into the existing one, ensuring tools absent from the latest discovery result are evicted from memory. A nil-safe guard and `precomputeToolSerialization` call are included to match the behavior of `connectToMCPClient`.
- `UpdateClientCredentials` similarly replaces the tool map for `pending_verification` entries by copying discovered tools into a fresh map (avoiding aliasing the config's own map) and calling `EnsureSerialized` on each tool to warm the serialization cache.
- A new test, `TestSetClientTools_ReplacesStaleTools`, pins the replace semantics: a tool present in the existing `ToolMap` but absent from the fresh discovery result must not survive in memory after `SetClientTools` is called.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/mcp/... -run TestSetClientTools_ReplacesStaleTools
go test ./core/mcp/...
```

The new test verifies that after calling `SetClientTools` with a set that omits a previously registered tool, that tool is no longer present in the client's `ToolMap`. All existing MCP manager tests should continue to pass.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. This change only affects in-memory tool map state management and does not touch authentication, secrets, or PII.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable