### PR TITLE
fix: model caps check for effort

### DIFF
--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -199,32 +199,6 @@ func isValidAudioBase64Payload(data string) bool {
 	return err == nil && len(decoded) > 0
 }
 
-// supportsThinkingConfig returns true if the model supports ThinkingConfig.
-// Only specific Gemini models support thinking:
-// - gemini-*-thinking models (e.g., gemini-2.0-flash-thinking)
-// - gemini-2.5-* models
-// - gemini-3.* and higher models
-func supportsThinkingConfig(model string) bool {
-	modelLower := strings.ToLower(model)
-
-	// Check for explicit "thinking" in model name
-	if strings.Contains(modelLower, "thinking") {
-		return true
-	}
-
-	// Check for gemini-2.5-* models
-	if strings.Contains(modelLower, "gemini-2.5") {
-		return true
-	}
-
-	// Check for Gemini 3.0+ models
-	return isGemini3Plus(model)
-}
-
-func canDisableThinkingWithBudget(model string) bool {
-	return !strings.Contains(strings.ToLower(model), "gemini-2.5-pro")
-}
-
 // geminiThinkingLevels is the thinkingLevel ladder ordered from least to most
 // thinking. Source: https://ai.google.dev/api/generate-content#ThinkingLevel
 var geminiThinkingLevels = []string{"minimal", "low", "medium", "high"}
@@ -329,7 +303,7 @@ func setThinkingBudgetZeroIfSupported(config *GenerationConfig, caps schemas.Mod
 	// functions, which surfaced as tools being advertised but never called.
 	// Docs: https://ai.google.dev/gemini-api/docs/thinking#thinking-levels
 	//       https://ai.google.dev/gemini-api/docs/function-calling#thinking
-	if isGemini3Plus(model) {
+	if caps.SupportsReasoningEffort(isGemini3Plus(model)) {
 		if config.ThinkingConfig == nil {
 			config.ThinkingConfig = &GenerationConfigThinkingConfig{}
 		}


### PR DESCRIPTION
## Summary

Removes the hardcoded `supportsThinkingConfig` and `canDisableThinkingWithBudget` helper functions in favor of delegating thinking support detection to the model capabilities (`caps.SupportsReasoningEffort`). This ensures thinking budget configuration is driven by a centralized capability check rather than scattered string-matching logic.

## Changes

- Removed `supportsThinkingConfig` and `canDisableThinkingWithBudget` functions, which relied on string matching against model names to determine thinking support.
- Updated `setThinkingBudgetZeroIfSupported` to use `caps.SupportsReasoningEffort(isGemini3Plus(model))` instead of calling `isGemini3Plus(model)` directly, so the capability schema governs whether the thinking budget can be set to zero.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/gemini/...
```

Verify that models with and without reasoning effort support correctly apply (or skip) the zero thinking budget configuration, particularly for Gemini 2.5 Pro and Gemini 3+ models.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable