### PR TITLE
topbar fixes

### DIFF
--- a/ui/app/workspace/edge-control/config/page.tsx
+++ b/ui/app/workspace/edge-control/config/page.tsx
@@ -2,7 +2,7 @@ import ConfigView from "@enterprise/components/edge-control/configView";
 
 export default function EdgeConfigPage() {
 	return (
-		<div data-testid="edge-config-page" className="mx-auto flex w-full max-w-3xl">
+		<div data-testid="edge-config-page" className="no-padding-parent mx-auto flex w-full max-w-7xl p-4">
 			<ConfigView />
 		</div>
 	);

--- a/ui/components/topbar.tsx
+++ b/ui/components/topbar.tsx
@@ -34,29 +34,29 @@ const externalLinks: {
 	icon: React.ComponentType<Record<string, unknown>>;
 	strokeWidth?: number;
 }[] = [
-		{
-			title: "Discord Server",
-			url: "https://discord.gg/exN5KAydbU",
-			icon: DiscordLogoIcon,
-		},
-		{
-			title: "GitHub Repository",
-			url: "https://github.com/maximhq/bifrost",
-			icon: GithubLogoIcon,
-		},
-		{
-			title: "Report a bug",
-			url: "https://github.com/maximhq/bifrost/issues/new?title=[Bug Report]&labels=bug&type=bug&projects=maximhq/1",
-			icon: BugIcon,
-			strokeWidth: 1.5,
-		},
-		{
-			title: "Full Documentation",
-			url: "https://docs.getbifrost.ai",
-			icon: BooksIcon,
-			strokeWidth: 1,
-		},
-	];
+	{
+		title: "Discord Server",
+		url: "https://discord.gg/exN5KAydbU",
+		icon: DiscordLogoIcon,
+	},
+	{
+		title: "GitHub Repository",
+		url: "https://github.com/maximhq/bifrost",
+		icon: GithubLogoIcon,
+	},
+	{
+		title: "Report a bug",
+		url: "https://github.com/maximhq/bifrost/issues/new?title=[Bug Report]&labels=bug&type=bug&projects=maximhq/1",
+		icon: BugIcon,
+		strokeWidth: 1.5,
+	},
+	{
+		title: "Full Documentation",
+		url: "https://docs.getbifrost.ai",
+		icon: BooksIcon,
+		strokeWidth: 1,
+	},
+];
 
 /**
  * Resolves the topbar title. A page can name itself via useSetTopbarTitle();


### PR DESCRIPTION
## Summary

Expands the Edge Control config page layout to use a wider max-width and adds padding, giving the config view more horizontal space to display content.

## Changes

- Updated the Edge Control config page container from `max-w-3xl` to `max-w-7xl` and added `p-4` padding along with the `no-padding-parent` class to properly control spacing within the wider layout.
- Fixed indentation of the `externalLinks` array entries in the topbar to align with the surrounding code style.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Navigate to the Edge Control config page and verify the layout renders correctly at the wider width with appropriate padding.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before/after screenshots of the Edge Control config page showing the expanded layout width are recommended.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable