### PR TITLE
fix: unify `getAuthScopeDisplay` with `authScopeOf` from form fields, using `MCPAuthType` instead of `string`

### DIFF
--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -31,7 +31,7 @@ import {
 	useVerifyMCPClientExchangeMutation,
 	useVerifyMCPClientHeadersMutation,
 } from "@/lib/store";
-import { MCPClient } from "@/lib/types/mcp";
+import { MCPAuthType, MCPClient } from "@/lib/types/mcp";
 import { titleCaseFromSnakeCase } from "@/lib/utils/strings";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Link } from "@tanstack/react-router";
@@ -53,6 +53,7 @@ import {
 import { ReactNode, useEffect, useMemo, useState } from "react";
 import { IconWrap, InfoBox } from "./authorizerUi";
 import MCPClientSheet from "./mcpClientSheet";
+import { authScopeOf } from "./mcpClientFormFields";
 import { canReconnectMCPClient } from "./mcpClientsTable.utils";
 import { MCPHeadersAuthorizer } from "./mcpHeadersAuthorizer";
 import { MCPServersEmptyState } from "./mcpServersEmptyState";
@@ -502,18 +503,15 @@ export default function MCPClientsTable({
 		}
 	};
 
-	const getAuthScopeDisplay = (type: string | undefined) => {
-		switch (type) {
-			case "per_user_oauth":
-			case "per_user_headers":
-			case "token_exchange":
-				return "Per-User";
-			case "oauth":
-			case "headers":
-				return "Shared";
-			default:
-				return "-";
+	// token_exchange carries the caller's own token on every call, so it is
+	// per-user even though the form does not expose a scope dropdown for it.
+	// Everything else, including "none", resolves through authScopeOf so the
+	// table agrees with the form.
+	const getAuthScopeDisplay = (type: MCPAuthType | undefined) => {
+		if (type === "token_exchange") {
+			return "Per-User";
 		}
+		return authScopeOf(type) === "per_user" ? "Per-User" : "Shared";
 	};
 
 	const handleRowClick = (mcpClient: MCPClient) => {


### PR DESCRIPTION
## Summary

The "Auth Scope" column in the MCP clients table was using a local, duplicated switch statement to determine whether an auth type is per-user or shared. This could drift out of sync with the logic in the form itself. This PR consolidates the logic by reusing `authScopeOf` from `mcpClientFormFields`, ensuring the table and the form always agree on how auth types are classified.

## Changes

- Replaced the inline `getAuthScopeDisplay` switch statement with a call to the shared `authScopeOf` utility from `mcpClientFormFields`.
- `token_exchange` is handled as a special case before delegating to `authScopeOf`, since it is inherently per-user (it carries the caller's own token on every call) but the form does not expose a scope dropdown for it.
- Imported `MCPAuthType` to give `getAuthScopeDisplay` a properly typed parameter instead of a plain `string`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Navigate to the MCP Registry clients table and verify that the "Auth Scope" column displays the correct value ("Per-User" or "Shared") for each auth type, including `token_exchange`, `per_user_oauth`, `per_user_headers`, `oauth`, `headers`, and `none`. Confirm the displayed value matches what the MCP client form shows for the same client.

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications. This is a display-layer change that consolidates how auth scope labels are derived.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable