### PR TITLE
 fix: stop background cost recalculation zeroing batch aggregate rows and charge access profile budgets for model-less requests

### DIFF
--- a/framework/batchaccounting/accounting.go
+++ b/framework/batchaccounting/accounting.go
@@ -3,6 +3,7 @@ package batchaccounting
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/bytedance/sonic"
@@ -79,6 +80,16 @@ type BatchUsageReport struct {
 	TokensUsed   int64
 	BudgetIDs    []string
 	RateLimitIDs []string
+	UserID       string
+	VirtualKeyID string
+	ModelUsage []BatchModelUsage
+}
+
+// BatchModelUsage is one model's share of a settled batch.
+type BatchModelUsage struct {
+	Model      string
+	Cost       float64
+	TokensUsed int64
 }
 
 type PricingManager interface {
@@ -95,6 +106,7 @@ type Request struct {
 	RequestCounts *schemas.BatchRequestCounts
 	BatchJob      *cstables.TableBatchJob
 	BaseLog       *logstore.Log
+	SourceLog     *logstore.Log
 	Emitter       AggregateLogEmitter
 	UsageReporter UsageReporter
 	ClaimedBy     string
@@ -230,6 +242,7 @@ func AccountBatchResults(ctx context.Context, stateStore BatchJobStore, logStore
 		mergeBatchJobHints(job, persisted)
 	}
 	req.BatchJob = job
+	req.SourceLog = resolveSourceLog(ctx, logStore, job, req.BaseLog)
 	if req.FallbackModel == "" {
 		req.FallbackModel = job.Model
 	}
@@ -427,18 +440,14 @@ func mergeBatchJobHints(dst *cstables.TableBatchJob, src *cstables.TableBatchJob
 	}
 	dst.AggregateLogWrittenAt = src.AggregateLogWrittenAt
 	dst.GovernanceReportedAt = src.GovernanceReportedAt
-	if dst.SelectedKeyID == "" {
-		dst.SelectedKeyID = src.SelectedKeyID
-	}
-	if dst.VirtualKeyID == nil {
-		dst.VirtualKeyID = src.VirtualKeyID
-	}
-	if dst.BudgetIDs == nil {
-		dst.BudgetIDs = src.BudgetIDs
-	}
-	if dst.RateLimitIDs == nil {
-		dst.RateLimitIDs = src.RateLimitIDs
-	}
+	dst.SelectedKeyID = src.SelectedKeyID
+	dst.VirtualKeyID = src.VirtualKeyID
+	dst.UserID = src.UserID
+	dst.TeamID = src.TeamID
+	dst.CustomerID = src.CustomerID
+	dst.BudgetIDs = src.BudgetIDs
+	dst.RateLimitIDs = src.RateLimitIDs
+	dst.SourceLogID = src.SourceLogID
 }
 
 func pricingScopesForBatchJob(scopes *modelcatalog.PricingLookupScopes, provider schemas.ModelProvider, job *cstables.TableBatchJob) *modelcatalog.PricingLookupScopes {
@@ -472,10 +481,42 @@ func batchUsageReportFromLog(provider schemas.ModelProvider, entry *logstore.Log
 		BudgetIDs:    stringSliceFromParsedOrJSON(entry.BudgetIDsParsed, entry.BudgetIDs),
 		RateLimitIDs: stringSliceFromParsedOrJSON(entry.RateLimitIDsParsed, entry.RateLimitIDs),
 	}
+	if entry.UserID != nil {
+		report.UserID = *entry.UserID
+	}
+	if entry.VirtualKeyID != nil {
+		report.VirtualKeyID = *entry.VirtualKeyID
+	}
+	report.ModelUsage = modelUsageFromLog(entry)
 	if entry.Cost != nil {
 		report.Cost = *entry.Cost
 	}
 	return report
+}
+
+// modelUsageFromLog reads the settled row's per-model split.
+func modelUsageFromLog(entry *logstore.Log) []BatchModelUsage {
+	if entry.BatchDebugParsed == nil || entry.BatchDebugParsed.Accounting == nil {
+		return nil
+	}
+	breakdowns := entry.BatchDebugParsed.Accounting.ModelBreakdowns
+	if len(breakdowns) == 0 {
+		return nil
+	}
+	usage := make([]BatchModelUsage, 0, len(breakdowns))
+	for model, breakdown := range breakdowns {
+		if model == "" {
+			continue
+		}
+		cost := 0.0
+		if breakdown.Cost != nil {
+			cost = *breakdown.Cost
+		}
+		usage = append(usage, BatchModelUsage{Model: model, Cost: cost, TokensUsed: int64(breakdown.Usage.TotalTokens)})
+	}
+	// These become billing keys, so order must be stable across retries.
+	sort.Slice(usage, func(i, j int) bool { return usage[i].Model < usage[j].Model })
+	return usage
 }
 
 func stringSliceFromParsedOrJSON(parsed []string, raw *string) []string {
@@ -961,20 +1002,22 @@ func buildAggregateLog(req Request, summary *Summary, now time.Time, userAgent s
 	// the creator's budgets or the fetcher's depending on a race, so an admin reading
 	// someone else's results absorbed the entire bill. The batch job's create-time
 	// attribution is the one identity that does not move, so it wins whenever it
-	// exists; BaseLog only fills the display/denormalization fields the job does not
-	// persist, and only when it is demonstrably the same virtual key (otherwise the
-	// row would carry one identity's ids under another's names). A batch first seen at
-	// /results has no create-time attribution to prefer, so it keeps using BaseLog.
+	// exists.
+	//
+	// The display names come from SourceLog — the creating request's own log row —
+	// rather than from whoever is settling. Matching the two on virtual key was not
+	// enough to keep identities apart: an access profile hands one virtual key to
+	// many users, so two different people compared equal and the settling user's name
+	// landed on the creator's cost row. A batch first seen at /results has no
+	// create-time attribution to prefer, so it keeps using BaseLog.
 	if req.BatchJob != nil && hasBatchJobAttribution(req.BatchJob) {
+		if req.SourceLog != nil {
+			applyLogDenormalizations(entry, req.SourceLog)
+		}
 		applyBatchJobAttribution(entry, req.BatchJob)
-		if req.BaseLog != nil {
-			// Provenance, not attribution: which request triggered this settlement.
-			if req.BaseLog.ID != "" {
-				entry.ParentRequestID = &req.BaseLog.ID
-			}
-			if sameVirtualKey(req.BatchJob.VirtualKeyID, req.BaseLog.VirtualKeyID) {
-				applyLogDenormalizations(entry, req.BaseLog)
-			}
+		// Provenance, not attribution: which request triggered this settlement.
+		if req.BaseLog != nil && req.BaseLog.ID != "" {
+			entry.ParentRequestID = &req.BaseLog.ID
 		}
 		return entry
 	}
@@ -988,6 +1031,24 @@ func buildAggregateLog(req Request, summary *Summary, now time.Time, userAgent s
 	return entry
 }
 
+// resolveSourceLog loads the log row of the request that created the batch, for the
+// display names batch_jobs does not carry. Best-effort by design: the names are
+// cosmetic, the ids on the job are what bills, so a log row that has been rotated
+// away or cannot be read costs nothing but the labels.
+func resolveSourceLog(ctx context.Context, logStore AggregateLogStore, job *cstables.TableBatchJob, baseLog *logstore.Log) *logstore.Log {
+	if job == nil || job.SourceLogID == nil || *job.SourceLogID == "" {
+		return nil
+	}
+	if baseLog != nil && baseLog.ID == *job.SourceLogID {
+		return baseLog
+	}
+	source, err := logStore.FindByID(ctx, *job.SourceLogID)
+	if err != nil {
+		return nil
+	}
+	return source
+}
+
 // hasBatchJobAttribution reports whether the job captured who to bill at create
 // time. Batches created outside Bifrost (first seen at /results) carry none.
 func hasBatchJobAttribution(job *cstables.TableBatchJob) bool {
@@ -995,20 +1056,6 @@ func hasBatchJobAttribution(job *cstables.TableBatchJob) bool {
 		return true
 	}
 	return (job.BudgetIDs != nil && *job.BudgetIDs != "") || (job.RateLimitIDs != nil && *job.RateLimitIDs != "")
-}
-
-// sameVirtualKey treats nil and "" alike: neither side claiming a virtual key is
-// not a conflict of identity, only a mismatch between two named ones is.
-func sameVirtualKey(a, b *string) bool {
-	left := ""
-	if a != nil {
-		left = *a
-	}
-	right := ""
-	if b != nil {
-		right = *b
-	}
-	return left == right
 }
 
 func requestCountsForAggregateLog(req Request) schemas.BatchRequestCounts {
@@ -1064,4 +1111,13 @@ func applyBatchJobAttribution(entry *logstore.Log, job *cstables.TableBatchJob) 
 	entry.VirtualKeyID = job.VirtualKeyID
 	entry.BudgetIDs = job.BudgetIDs
 	entry.RateLimitIDs = job.RateLimitIDs
+	if job.UserID != nil {
+		entry.UserID = job.UserID
+	}
+	if job.TeamID != nil {
+		entry.TeamID = job.TeamID
+	}
+	if job.CustomerID != nil {
+		entry.CustomerID = job.CustomerID
+	}
 }

--- a/framework/batchaccounting/accounting_test.go
+++ b/framework/batchaccounting/accounting_test.go
@@ -1520,11 +1520,22 @@ func TestAccountBatchResults_PrefersBatchJobAttributionOverFetcher(t *testing.T)
 	assert.Equal(t, []string{"budget-creator"}, reporter.reports[0].BudgetIDs)
 }
 
-// Same virtual key on both sides: the job still owns the billing ids, but the log
-// entry's denormalized names are safe to copy because they describe that same key.
-func TestAccountBatchResults_FillsNamesFromMatchingVirtualKey(t *testing.T) {
+// The denormalized names come from the log of the request that CREATED the batch,
+// not from whoever settles it.
+func TestAccountBatchResults_FillsNamesFromSourceLog(t *testing.T) {
 	store := newFakeAccountingStore()
 	sharedVK := "vk-shared"
+	sourceLogID := "create-request"
+
+	store.logs[sourceLogID] = &logstore.Log{
+		ID:             sourceLogID,
+		VirtualKeyID:   &sharedVK,
+		VirtualKeyName: strPtr("shared vk"),
+		UserID:         strPtr("user-creator"),
+		UserName:       strPtr("Creator"),
+		TeamID:         strPtr("team-1"),
+		TeamName:       strPtr("Team One"),
+	}
 
 	job := &cstables.TableBatchJob{
 		ID:               cstables.BatchJobID(string(schemas.OpenAI), "batch_same_vk"),
@@ -1533,6 +1544,9 @@ func TestAccountBatchResults_FillsNamesFromMatchingVirtualKey(t *testing.T) {
 		AccountingStatus: cstables.BatchJobAccountingStatusPending,
 		SelectedKeyID:    "key-1",
 		VirtualKeyID:     &sharedVK,
+		UserID:           strPtr("user-creator"),
+		TeamID:           strPtr("team-1"),
+		SourceLogID:      &sourceLogID,
 	}
 	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
 
@@ -1542,10 +1556,8 @@ func TestAccountBatchResults_FillsNamesFromMatchingVirtualKey(t *testing.T) {
 		FallbackModel: "gpt-4o-mini",
 		BatchJob:      job,
 		BaseLog: &logstore.Log{
-			ID:             "results-request",
-			VirtualKeyID:   &sharedVK,
-			VirtualKeyName: strPtr("shared vk"),
-			TeamID:         strPtr("team-1"),
+			ID:           "results-request",
+			VirtualKeyID: &sharedVK,
 		},
 		Results:   []schemas.BatchResultItem{openAIResult(200, "gpt-4o-mini", 10, 5)},
 		ClaimedBy: "test",
@@ -1556,8 +1568,132 @@ func TestAccountBatchResults_FillsNamesFromMatchingVirtualKey(t *testing.T) {
 	require.NotNil(t, logged)
 	require.NotNil(t, logged.VirtualKeyName)
 	assert.Equal(t, "shared vk", *logged.VirtualKeyName)
+	require.NotNil(t, logged.UserID)
+	assert.Equal(t, "user-creator", *logged.UserID)
+	require.NotNil(t, logged.UserName)
+	assert.Equal(t, "Creator", *logged.UserName)
 	require.NotNil(t, logged.TeamID)
 	assert.Equal(t, "team-1", *logged.TeamID)
+}
+
+// An access profile hands one virtual key to many users, so matching on the key
+// cannot tell two people apart. The settling user's identity must not land on the
+// creator's cost row even though both requests carry the same virtual key.
+func TestAccountBatchResults_SharedVirtualKeyKeepsUsersApart(t *testing.T) {
+	store := newFakeAccountingStore()
+	reporter := &fakeUsageReporter{}
+	sharedVK := "vk-access-profile"
+	sourceLogID := "create-request"
+	creatorBudgets := `["budget-creator"]`
+
+	store.logs[sourceLogID] = &logstore.Log{
+		ID:             sourceLogID,
+		VirtualKeyID:   &sharedVK,
+		VirtualKeyName: strPtr("access profile key"),
+		UserID:         strPtr("user-alice"),
+		UserName:       strPtr("Alice"),
+	}
+
+	job := &cstables.TableBatchJob{
+		ID:               cstables.BatchJobID(string(schemas.OpenAI), "batch_shared_vk"),
+		Provider:         string(schemas.OpenAI),
+		BatchID:          "batch_shared_vk",
+		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		SelectedKeyID:    "key-1",
+		VirtualKeyID:     &sharedVK,
+		UserID:           strPtr("user-alice"),
+		BudgetIDs:        &creatorBudgets,
+		SourceLogID:      &sourceLogID,
+	}
+	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+
+	// Bob fetches Alice's results. Same access-profile virtual key, different person.
+	_, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, Request{
+		Provider:      schemas.OpenAI,
+		BatchID:       "batch_shared_vk",
+		FallbackModel: "gpt-4o-mini",
+		BatchJob:      job,
+		BaseLog: &logstore.Log{
+			ID:             "results-request",
+			VirtualKeyID:   &sharedVK,
+			VirtualKeyName: strPtr("access profile key"),
+			UserID:         strPtr("user-bob"),
+			UserName:       strPtr("Bob"),
+		},
+		Results:       []schemas.BatchResultItem{openAIResult(200, "gpt-4o-mini", 10, 5)},
+		UsageReporter: reporter,
+		ClaimedBy:     "test",
+	})
+	require.NoError(t, err)
+
+	logged := store.logs[AccountingLogID(schemas.OpenAI, "batch_shared_vk")]
+	require.NotNil(t, logged)
+	require.NotNil(t, logged.UserID)
+	assert.Equal(t, "user-alice", *logged.UserID, "the batch is billed to whoever created it")
+	require.NotNil(t, logged.UserName)
+	assert.Equal(t, "Alice", *logged.UserName)
+	require.NotNil(t, logged.ParentRequestID)
+	assert.Equal(t, "results-request", *logged.ParentRequestID)
+
+	require.Len(t, reporter.reports, 1)
+	assert.Equal(t, "user-alice", reporter.reports[0].UserID)
+	assert.Equal(t, []string{"budget-creator"}, reporter.reports[0].BudgetIDs)
+}
+
+// The sweeper settles with no request context at all: every identity on the cost
+// row has to come off the batch job and the creating request's log.
+func TestAccountBatchResults_SweeperPathKeepsUserAttribution(t *testing.T) {
+	store := newFakeAccountingStore()
+	reporter := &fakeUsageReporter{}
+	vk := "vk-access-profile"
+	sourceLogID := "create-request"
+
+	store.logs[sourceLogID] = &logstore.Log{
+		ID:           sourceLogID,
+		VirtualKeyID: &vk,
+		UserID:       strPtr("user-alice"),
+		UserName:     strPtr("Alice"),
+		TeamID:       strPtr("team-1"),
+		TeamName:     strPtr("Team One"),
+	}
+
+	job := &cstables.TableBatchJob{
+		ID:               cstables.BatchJobID(string(schemas.OpenAI), "batch_sweeper"),
+		Provider:         string(schemas.OpenAI),
+		BatchID:          "batch_sweeper",
+		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		SelectedKeyID:    "key-1",
+		VirtualKeyID:     &vk,
+		UserID:           strPtr("user-alice"),
+		TeamID:           strPtr("team-1"),
+		SourceLogID:      &sourceLogID,
+	}
+	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+
+	// No BaseLog: this is the sweeper, hours after the request that created the batch.
+	_, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, Request{
+		Provider:      schemas.OpenAI,
+		BatchID:       "batch_sweeper",
+		FallbackModel: "gpt-4o-mini",
+		BatchJob:      job,
+		Results:       []schemas.BatchResultItem{openAIResult(200, "gpt-4o-mini", 10, 5)},
+		UsageReporter: reporter,
+		ClaimedBy:     "test",
+	})
+	require.NoError(t, err)
+
+	logged := store.logs[AccountingLogID(schemas.OpenAI, "batch_sweeper")]
+	require.NotNil(t, logged)
+	require.NotNil(t, logged.UserID)
+	assert.Equal(t, "user-alice", *logged.UserID)
+	require.NotNil(t, logged.UserName)
+	assert.Equal(t, "Alice", *logged.UserName)
+	require.NotNil(t, logged.TeamID)
+	assert.Equal(t, "team-1", *logged.TeamID)
+	assert.Nil(t, logged.ParentRequestID, "nothing triggered this settlement")
+
+	require.Len(t, reporter.reports, 1)
+	assert.Equal(t, "user-alice", reporter.reports[0].UserID, "the user must be billable without a request context")
 }
 
 // A batch created outside Bifrost has no create-time attribution to prefer, so the
@@ -1739,4 +1875,65 @@ func TestAccountBatchResults_TerminalJobsStayClosedWithoutResults(t *testing.T) 
 
 func strPtr(v string) *string {
 	return &v
+}
+
+// Production hands AccountBatchResults a job built from the settling request's own
+// log entry, so that job arrives already populated with the fetcher's key, virtual
+// key and budgets. Merging the persisted row into it must overwrite those, not fill
+// only the gaps — otherwise nothing of the creator's identity ever survives.
+func TestAccountBatchResults_PersistedIdentityOverridesFetcherBuiltJob(t *testing.T) {
+	store := newFakeAccountingStore()
+	reporter := &fakeUsageReporter{}
+	creatorVK := "vk-creator"
+	creatorBudgets := `["budget-creator"]`
+	fetcherVK := "vk-fetcher"
+	fetcherBudgets := `["budget-fetcher"]`
+	jobID := cstables.BatchJobID(string(schemas.OpenAI), "batch_merge")
+
+	require.NoError(t, store.UpsertBatchJob(context.Background(), &cstables.TableBatchJob{
+		ID:               jobID,
+		Provider:         string(schemas.OpenAI),
+		BatchID:          "batch_merge",
+		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		SelectedKeyID:    "key-creator",
+		VirtualKeyID:     &creatorVK,
+		UserID:           strPtr("user-creator"),
+		BudgetIDs:        &creatorBudgets,
+	}))
+
+	// What plugins/logging builds on the /results path: a job derived from the
+	// fetcher's log entry, carrying the fetcher's identity end to end.
+	fetcherBuiltJob := &cstables.TableBatchJob{
+		ID:               jobID,
+		Provider:         string(schemas.OpenAI),
+		BatchID:          "batch_merge",
+		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		SelectedKeyID:    "key-fetcher",
+		VirtualKeyID:     &fetcherVK,
+		UserID:           strPtr("user-fetcher"),
+		BudgetIDs:        &fetcherBudgets,
+	}
+
+	_, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, Request{
+		Provider:      schemas.OpenAI,
+		BatchID:       "batch_merge",
+		FallbackModel: "gpt-4o-mini",
+		BatchJob:      fetcherBuiltJob,
+		Results:       []schemas.BatchResultItem{openAIResult(200, "gpt-4o-mini", 10, 5)},
+		UsageReporter: reporter,
+		ClaimedBy:     "test",
+	})
+	require.NoError(t, err)
+
+	logged := store.logs[AccountingLogID(schemas.OpenAI, "batch_merge")]
+	require.NotNil(t, logged)
+	assert.Equal(t, "key-creator", logged.SelectedKeyID)
+	require.NotNil(t, logged.VirtualKeyID)
+	assert.Equal(t, creatorVK, *logged.VirtualKeyID)
+	require.NotNil(t, logged.UserID)
+	assert.Equal(t, "user-creator", *logged.UserID)
+
+	require.Len(t, reporter.reports, 1)
+	assert.Equal(t, []string{"budget-creator"}, reporter.reports[0].BudgetIDs)
+	assert.Equal(t, "user-creator", reporter.reports[0].UserID)
 }

--- a/framework/configstore/batchjob_test.go
+++ b/framework/configstore/batchjob_test.go
@@ -268,3 +268,59 @@ func TestListDueBatchJobsFiltersByDueAndStatus(t *testing.T) {
 	require.Len(t, due, 1)
 	assert.Equal(t, "due", due[0].BatchID)
 }
+
+// Attribution is create-time state. A later upsert — the /results path builds a job
+// from the fetching request's own log entry — must not be able to move the bill onto
+// whoever happened to settle the batch.
+func TestUpsertBatchJobDoesNotOverwriteAttribution(t *testing.T) {
+	store := setupBatchJobTestStore(t)
+	ctx := context.Background()
+
+	creatorVK := "vk-creator"
+	creatorUser := "user-alice"
+	creatorBudgets := `["budget-creator"]`
+	sourceLog := "req-create"
+	id := tables.BatchJobID("openai", "batch-attr")
+
+	require.NoError(t, store.UpsertBatchJob(ctx, &tables.TableBatchJob{
+		ID:               id,
+		Provider:         "openai",
+		BatchID:          "batch-attr",
+		AccountingStatus: tables.BatchJobAccountingStatusPending,
+		SelectedKeyID:    "key-creator",
+		VirtualKeyID:     &creatorVK,
+		UserID:           &creatorUser,
+		BudgetIDs:        &creatorBudgets,
+		SourceLogID:      &sourceLog,
+	}))
+
+	fetcherVK := "vk-fetcher"
+	fetcherUser := "user-bob"
+	fetcherBudgets := `["budget-fetcher"]`
+	fetcherLog := "req-results"
+	require.NoError(t, store.UpsertBatchJob(ctx, &tables.TableBatchJob{
+		ID:               id,
+		Provider:         "openai",
+		BatchID:          "batch-attr",
+		AccountingStatus: tables.BatchJobAccountingStatusPending,
+		ProviderStatus:   string(schemas.BatchStatusCompleted),
+		SelectedKeyID:    "key-fetcher",
+		VirtualKeyID:     &fetcherVK,
+		UserID:           &fetcherUser,
+		BudgetIDs:        &fetcherBudgets,
+		SourceLogID:      &fetcherLog,
+	}))
+
+	job := getBatchJob(t, store, id)
+	assert.Equal(t, "key-creator", job.SelectedKeyID)
+	require.NotNil(t, job.VirtualKeyID)
+	assert.Equal(t, creatorVK, *job.VirtualKeyID)
+	require.NotNil(t, job.UserID)
+	assert.Equal(t, creatorUser, *job.UserID)
+	require.NotNil(t, job.BudgetIDs)
+	assert.Equal(t, creatorBudgets, *job.BudgetIDs)
+	require.NotNil(t, job.SourceLogID)
+	assert.Equal(t, sourceLog, *job.SourceLogID)
+	// Lifecycle state, unlike identity, is expected to advance.
+	assert.Equal(t, string(schemas.BatchStatusCompleted), job.ProviderStatus)
+}

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -474,6 +474,55 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_input_cost_per_query_column"}, run: migrationAddInputCostPerQueryColumn},
 	{IDs: []string{"add_ultrafast_pricing_columns"}, run: migrationAddUltrafastPricingColumns},
 	{IDs: []string{"add_image_size_quality_pricing_columns"}, run: migrationAddImageSizeQualityPricingColumns},
+	{IDs: []string{"add_batch_jobs_attribution_columns"}, run: migrationAddBatchJobsAttributionColumns},
+}
+
+// migrationAddBatchJobsAttributionColumns adds the requester-identity columns to
+// batch_jobs. Before these, a settled batch could only be attributed to its virtual
+// key — which an access profile shares across users — and the sweeper, having no
+// request context at all, wrote its cost row with no user, team, or customer.
+func migrationAddBatchJobsAttributionColumns(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_batch_jobs_attribution_columns"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	columns := []string{"user_id", "team_id", "customer_id", "source_log_id"}
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mig := tx.Migrator()
+			for _, column := range columns {
+				if mig.HasColumn(&tables.TableBatchJob{}, column) {
+					continue
+				}
+				if err := mig.AddColumn(&tables.TableBatchJob{}, column); err != nil {
+					return fmt.Errorf("failed to add %s column to batch_jobs: %w", column, err)
+				}
+			}
+			// Backs per-user cost lookups over in-flight and settled batches.
+			return tx.Exec(`CREATE INDEX IF NOT EXISTS idx_batch_jobs_user_id ON batch_jobs (user_id)`).Error
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mig := tx.Migrator()
+			if err := tx.Exec("DROP INDEX IF EXISTS idx_batch_jobs_user_id").Error; err != nil {
+				return fmt.Errorf("failed to drop index idx_batch_jobs_user_id: %w", err)
+			}
+			for _, column := range columns {
+				if !mig.HasColumn(&tables.TableBatchJob{}, column) {
+					continue
+				}
+				if err := mig.DropColumn(&tables.TableBatchJob{}, column); err != nil {
+					return fmt.Errorf("failed to drop %s column from batch_jobs: %w", column, err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running %s migration: %s", migrationName, err.Error())
+	}
+	return nil
 }
 
 func migrationAddNotificationsTable(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {

--- a/framework/configstore/migrations_test.go
+++ b/framework/configstore/migrations_test.go
@@ -2979,3 +2979,68 @@ func TestMigrationAddBudgetResetConfigColumn_NonRollbackable(t *testing.T) {
 	assert.Equal(t, time.April, got.QuarterStartMonth(),
 		"the fiscal quarter definition must survive the refused rollback")
 }
+
+// TestMigrationAddBatchJobsAttributionColumns verifies the upgrade path: an existing
+// batch_jobs table gains the requester-identity columns without disturbing the rows
+// already in it (which simply have no identity to recover).
+func TestMigrationAddBatchJobsAttributionColumns(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err, "Failed to create test database")
+	ctx := context.Background()
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelError)
+
+	// Pre-migration shape: the table as migrationAddBatchJobsTable left it.
+	require.NoError(t, db.Exec(`
+		CREATE TABLE batch_jobs (
+			id VARCHAR(512) PRIMARY KEY,
+			provider VARCHAR(255) NOT NULL,
+			batch_id VARCHAR(255) NOT NULL,
+			model VARCHAR(255),
+			endpoint VARCHAR(255),
+			provider_status VARCHAR(50),
+			input_file_id VARCHAR(255),
+			output_file_id VARCHAR(255),
+			error_file_id VARCHAR(255),
+			results_url TEXT,
+			next_check_at DATETIME,
+			poll_attempts INTEGER DEFAULT 0,
+			accounting_status VARCHAR(50) NOT NULL,
+			runner_id VARCHAR(255),
+			claimed_at DATETIME,
+			unpriceable_reason VARCHAR(255),
+			last_error TEXT,
+			aggregate_log_written_at DATETIME,
+			governance_reported_at DATETIME,
+			selected_key_id VARCHAR(255),
+			virtual_key_id VARCHAR(255),
+			budget_ids TEXT,
+			rate_limit_ids TEXT,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL
+		)`).Error)
+
+	now := time.Now().UTC()
+	require.NoError(t, db.Exec(`
+		INSERT INTO batch_jobs (id, provider, batch_id, accounting_status, selected_key_id, virtual_key_id, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		tables.BatchJobID("openai", "batch-legacy"), "openai", "batch-legacy",
+		tables.BatchJobAccountingStatusPending, "key-1", "vk-1", now, now).Error)
+
+	require.NoError(t, migrationAddBatchJobsAttributionColumns(ctx, db, logger))
+
+	mig := db.Migrator()
+	for _, column := range []string{"user_id", "team_id", "customer_id", "source_log_id"} {
+		assert.True(t, mig.HasColumn(&tables.TableBatchJob{}, column), "expected column %s", column)
+	}
+
+	var job tables.TableBatchJob
+	require.NoError(t, db.Where("id = ?", tables.BatchJobID("openai", "batch-legacy")).First(&job).Error)
+	assert.Equal(t, "key-1", job.SelectedKeyID, "pre-existing attribution must survive")
+	require.NotNil(t, job.VirtualKeyID)
+	assert.Equal(t, "vk-1", *job.VirtualKeyID)
+	assert.Nil(t, job.UserID, "a batch created before the column has no user to recover")
+	assert.Nil(t, job.SourceLogID)
+
+	// Migrations are re-run on every boot; the second pass must be a no-op.
+	require.NoError(t, migrationAddBatchJobsAttributionColumns(ctx, db, logger))
+}

--- a/framework/configstore/tables/batchjob.go
+++ b/framework/configstore/tables/batchjob.go
@@ -63,8 +63,13 @@ type TableBatchJob struct {
 
 	SelectedKeyID string  `gorm:"type:varchar(255)" json:"selected_key_id,omitempty"`
 	VirtualKeyID  *string `gorm:"type:varchar(255)" json:"virtual_key_id,omitempty"`
+	UserID        *string `gorm:"type:varchar(255);index" json:"user_id,omitempty"`
+	TeamID        *string `gorm:"type:varchar(255)" json:"team_id,omitempty"`
+	CustomerID    *string `gorm:"type:varchar(255)" json:"customer_id,omitempty"`
 	BudgetIDs     *string `gorm:"type:text" json:"-"`
 	RateLimitIDs  *string `gorm:"type:text" json:"-"`
+
+	SourceLogID *string `gorm:"type:varchar(255)" json:"source_log_id,omitempty"`
 
 	CreatedAt time.Time `gorm:"not null" json:"created_at"`
 	UpdatedAt time.Time `gorm:"not null" json:"updated_at"`

--- a/plugins/governance/accounting_test.go
+++ b/plugins/governance/accounting_test.go
@@ -219,3 +219,165 @@ func TestAccounting_ZeroCostFailureNotBilled(t *testing.T) {
 	assert.Equal(t, int64(0), f.requests(), "no-usage failure counts no request")
 	assert.Equal(t, int64(0), f.tokens(), "no-usage failure counts no tokens")
 }
+
+// userUsageSpy records the user-entity bumps a batch settlement makes. The OSS
+// store implements them as no-ops (user governance is enterprise), so the spy is
+// what pins the contract an enterprise store relies on.
+type userUsageSpy struct {
+	GovernanceStore
+	budgetBumps    []float64
+	rateLimitBumps []int64
+	users          []string
+}
+
+func (s *userUsageSpy) UpdateUserBudgetUsageInMemory(ctx context.Context, userID string, cost float64) error {
+	s.users = append(s.users, userID)
+	s.budgetBumps = append(s.budgetBumps, cost)
+	return nil
+}
+
+func (s *userUsageSpy) UpdateUserRateLimitUsageInMemory(ctx context.Context, userID string, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error {
+	s.rateLimitBumps = append(s.rateLimitBumps, tokensUsed)
+	return nil
+}
+
+// A user's own budget has no id in BudgetIDs, so before this it was never charged
+// for batch spend — the gap that let a batch bypass every per-user limit under an
+// access profile, where the virtual key is shared and the user is the only thing
+// separating one person's spend from another's.
+func TestReportBatchUsage_ChargesUserEntity(t *testing.T) {
+	f := newAccountingFixture(t)
+	spy := &userUsageSpy{GovernanceStore: f.store}
+	plugin := &GovernancePlugin{store: spy, tracker: f.tracker}
+	report := batchaccounting.BatchUsageReport{
+		RequestID:    "batch-cost:openai:batch-user",
+		Provider:     schemas.OpenAI,
+		Model:        "gpt-4o-mini",
+		Cost:         12.5,
+		TokensUsed:   123,
+		BudgetIDs:    []string{"budget1"},
+		RateLimitIDs: []string{"rl1"},
+		UserID:       "user-alice",
+	}
+
+	// Settlement is at-least-once, so a repeated report must not double-charge.
+	require.NoError(t, plugin.ReportBatchUsage(context.Background(), report))
+	require.NoError(t, plugin.ReportBatchUsage(context.Background(), report))
+
+	assert.Equal(t, []string{"user-alice"}, spy.users)
+	assert.Equal(t, []float64{12.5}, spy.budgetBumps)
+	assert.Equal(t, []int64{123}, spy.rateLimitBumps)
+	// The budget-id tier is charged exactly once as well, and stays independent of
+	// the user tier: the ids carry the user's model-config scopes, not the user.
+	assert.Equal(t, 12.5, f.cost())
+}
+
+// No user on the report (no user auth, or a pre-migration batch job) must leave the
+// user tier entirely alone.
+func TestReportBatchUsage_WithoutUserSkipsUserEntity(t *testing.T) {
+	f := newAccountingFixture(t)
+	spy := &userUsageSpy{GovernanceStore: f.store}
+	plugin := &GovernancePlugin{store: spy, tracker: f.tracker}
+
+	require.NoError(t, plugin.ReportBatchUsage(context.Background(), batchaccounting.BatchUsageReport{
+		RequestID:    "batch-cost:openai:batch-nouser",
+		Provider:     schemas.OpenAI,
+		Cost:         3.0,
+		TokensUsed:   10,
+		BudgetIDs:    []string{"budget1"},
+		RateLimitIDs: []string{"rl1"},
+	}))
+
+	assert.Empty(t, spy.users)
+	assert.Empty(t, spy.budgetBumps)
+	assert.Empty(t, spy.rateLimitBumps)
+}
+
+// modelScopedFixture wires a user-scoped per-model budget (how an access profile's
+// model-level limits are stored) alongside a user-scoped all-models wildcard, so a
+// settlement can be checked for charging the first and not double-charging the second.
+type modelScopedFixture struct {
+	store   GovernanceStore
+	tracker *UsageTracker
+}
+
+func newModelScopedFixture(t *testing.T) *modelScopedFixture {
+	t.Helper()
+	logger := NewMockLogger()
+	providerName := "openai"
+	userID := "user-alice"
+
+	perModel := buildBudgetWithUsage("model-budget", 1_000_000.0, 0.0, "1d")
+	perModelRL := buildRateLimit("model-rl", 1_000_000_000, 1_000_000)
+	perModelMC := buildModelConfig("mc-user-gpt5", "gpt-5", &providerName, perModel, perModelRL)
+	perModelMC.Scope = configstoreTables.ModelConfigScopeUser
+	perModelMC.ScopeID = &userID
+
+	wildcard := buildBudgetWithUsage("wildcard-budget", 1_000_000.0, 0.0, "1d")
+	wildcardMC := buildModelConfig("mc-user-all", configstoreTables.ModelConfigAllModels, &providerName, wildcard, nil)
+	wildcardMC.Scope = configstoreTables.ModelConfigScopeUser
+	wildcardMC.ScopeID = &userID
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*perModelMC, *wildcardMC},
+		Budgets:      []configstoreTables.TableBudget{*perModel, *wildcard},
+		RateLimits:   []configstoreTables.TableRateLimit{*perModelRL},
+	}, nil)
+	require.NoError(t, err)
+
+	resolver := NewBudgetResolver(store, nil, logger, nil)
+	tracker := NewUsageTracker(context.Background(), store, resolver, nil, logger)
+	t.Cleanup(func() { _ = tracker.Cleanup() })
+
+	return &modelScopedFixture{store: store, tracker: tracker}
+}
+
+func (f *modelScopedFixture) budgetUsage(id string) float64 {
+	return f.store.GetGovernanceData(context.Background()).Budgets[id].CurrentUsage
+}
+
+func TestReportBatchUsage_ChargesPerModelBudgets(t *testing.T) {
+	f := newModelScopedFixture(t)
+	plugin := &GovernancePlugin{store: f.store, tracker: f.tracker}
+
+	// What a settled batch looks like: the wildcard budget was collected at create
+	// time (and so is already charged the full total), the per-model budget was not.
+	report := batchaccounting.BatchUsageReport{
+		RequestID:    "batch-cost:openai:batch-models",
+		Provider:     schemas.OpenAI,
+		Cost:         30.0,
+		TokensUsed:   300,
+		BudgetIDs:    []string{"wildcard-budget"},
+		UserID:       "user-alice",
+		ModelUsage: []batchaccounting.BatchModelUsage{
+			{Model: "gpt-5", Cost: 20.0, TokensUsed: 200},
+			{Model: "gpt-4o", Cost: 10.0, TokensUsed: 100},
+		},
+	}
+
+	// Settlement is at-least-once, so a repeat must not double-charge.
+	require.NoError(t, plugin.ReportBatchUsage(context.Background(), report))
+	require.NoError(t, plugin.ReportBatchUsage(context.Background(), report))
+
+	assert.Equal(t, 20.0, f.budgetUsage("model-budget"), "the gpt-5 budget takes gpt-5's share, not the batch total")
+	assert.Equal(t, 30.0, f.budgetUsage("wildcard-budget"), "an already-charged budget must not be charged again per model")
+}
+
+// A batch whose models carry no per-model config must behave exactly as before.
+func TestReportBatchUsage_PerModelChargingIsInertWithoutModelConfigs(t *testing.T) {
+	f := newModelScopedFixture(t)
+	plugin := &GovernancePlugin{store: f.store, tracker: f.tracker}
+
+	require.NoError(t, plugin.ReportBatchUsage(context.Background(), batchaccounting.BatchUsageReport{
+		RequestID:  "batch-cost:openai:batch-nomodels",
+		Provider:   schemas.OpenAI,
+		Cost:       12.0,
+		TokensUsed: 100,
+		BudgetIDs:  []string{"wildcard-budget"},
+		UserID:     "user-alice",
+		ModelUsage: []batchaccounting.BatchModelUsage{{Model: "gpt-4o", Cost: 12.0, TokensUsed: 100}},
+	}))
+
+	assert.Equal(t, 0.0, f.budgetUsage("model-budget"), "a model with no config of its own charges nothing extra")
+	assert.Equal(t, 12.0, f.budgetUsage("wildcard-budget"))
+}

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -1521,7 +1521,91 @@ func (p *GovernancePlugin) ReportBatchUsage(ctx context.Context, usage batchacco
 		}
 	}
 
+	if usage.UserID != "" {
+		billingKey := fmt.Sprintf("%s:user-rate-limit:%s", usage.RequestID, usage.UserID)
+		if usage.RequestID == "" || p.tracker.tryClaimBatchBilling(billingKey) {
+			if err := p.store.UpdateUserRateLimitUsageInMemory(ctx, usage.UserID, usage.TokensUsed, true, true); err != nil {
+				p.tracker.releaseBatchBilling(billingKey)
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	if usage.UserID != "" && usage.Cost > 0 {
+		billingKey := fmt.Sprintf("%s:user-budget:%s", usage.RequestID, usage.UserID)
+		if usage.RequestID == "" || p.tracker.tryClaimBatchBilling(billingKey) {
+			if err := p.store.UpdateUserBudgetUsageInMemory(ctx, usage.UserID, usage.Cost); err != nil {
+				p.tracker.releaseBatchBilling(billingKey)
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	errs = append(errs, p.reportBatchModelUsage(ctx, usage)...)
+
 	return errors.Join(errs...)
+}
+
+// reportBatchModelUsage charges the budgets and rate limits that are scoped to one
+// specific model.
+//
+// They are missing from usage.BudgetIDs by construction: those ids were collected
+// while the request was in flight, and a batch create carries no top-level model
+// (each input-file row names its own), so only the all-models wildcards matched.
+// An access profile's per-model limits materialise as user-scoped configs naming
+// exactly one model and provider, which is why a model-level budget never moved for
+// a batch. Settlement does know the models, so each one is resolved and charged with
+// its own share here.
+//
+// Ids already charged above are subtracted rather than skipped by construction: the
+// wildcard tiers legitimately match both collections, and charging them twice would
+// bill the batch's whole cost a second time.
+func (p *GovernancePlugin) reportBatchModelUsage(ctx context.Context, usage batchaccounting.BatchUsageReport) []error {
+	if len(usage.ModelUsage) == 0 {
+		return nil
+	}
+	alreadyCharged := make(map[string]bool, len(usage.BudgetIDs)+len(usage.RateLimitIDs))
+	for _, id := range usage.BudgetIDs {
+		alreadyCharged["budget:"+id] = true
+	}
+	for _, id := range usage.RateLimitIDs {
+		alreadyCharged["rate-limit:"+id] = true
+	}
+
+	var errs []error
+	for _, modelUsage := range usage.ModelUsage {
+		budgetIDs, rateLimitIDs := p.store.CollectModelScopedGovernanceIDs(ctx, usage.VirtualKeyID, usage.UserID, usage.Provider, modelUsage.Model)
+		if modelUsage.Cost > 0 {
+			for _, budgetID := range budgetIDs {
+				if alreadyCharged["budget:"+budgetID] {
+					continue
+				}
+				// Keyed per model: one budget reached by two models must take both shares.
+				billingKey := fmt.Sprintf("%s:model-budget:%s:%s", usage.RequestID, modelUsage.Model, budgetID)
+				if usage.RequestID != "" && !p.tracker.tryClaimBatchBilling(billingKey) {
+					continue
+				}
+				if err := p.store.BumpBudgetUsage(ctx, budgetID, modelUsage.Cost); err != nil {
+					p.tracker.releaseBatchBilling(billingKey)
+					errs = append(errs, err)
+				}
+			}
+		}
+		for _, rateLimitID := range rateLimitIDs {
+			if alreadyCharged["rate-limit:"+rateLimitID] {
+				continue
+			}
+			billingKey := fmt.Sprintf("%s:model-rate-limit:%s:%s", usage.RequestID, modelUsage.Model, rateLimitID)
+			if usage.RequestID != "" && !p.tracker.tryClaimBatchBilling(billingKey) {
+				continue
+			}
+			if err := p.store.BumpRateLimitUsage(ctx, rateLimitID, modelUsage.TokensUsed, true, true); err != nil {
+				p.tracker.releaseBatchBilling(billingKey)
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errs
 }
 
 // GenerateVirtualKey is a helper function

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -222,6 +222,12 @@ type GovernanceStore interface {
 	// missing any ID here means that usage vanishes from cluster baselines when the node ghosts.
 	// userID contributes the user-scoped model-config IDs;
 	CollectApplicableGovernanceIDs(ctx context.Context, virtualKey string, userID string, provider schemas.ModelProvider, model string) (budgetIDs []string, rateLimitIDs []string)
+	// CollectModelScopedGovernanceIDs returns the budget and rate-limit IDs owned by
+	// model configs matching (provider, model) across the global, user and virtual-key
+	// scopes. It takes the virtual key's ID rather than its value, so a caller settling
+	// long after the request — batch accounting, which has only a stored row — can
+	// still reach the same configs.
+	CollectModelScopedGovernanceIDs(ctx context.Context, virtualKeyID string, userID string, provider schemas.ModelProvider, model string) (budgetIDs []string, rateLimitIDs []string)
 }
 
 // NewLocalGovernanceStore creates a new in-memory governance store
@@ -3449,6 +3455,59 @@ func (gs *LocalGovernanceStore) CollectApplicableGovernanceIDs(ctx context.Conte
 		}
 	}
 
+	return budgetIDs, rateLimitIDs
+}
+
+// CollectModelScopedGovernanceIDs returns only the model-config-owned IDs for a
+// (provider, model) pair, across the global, user and virtual-key scopes.
+//
+// It exists for delayed settlement. CollectApplicableGovernanceIDs is called while
+// the request is in flight, and a batch create carries no top-level model — each
+// input-file row names its own — so collectModelConfigsFor matches only the
+// all-models wildcards and never the exact-model configs. Those are precisely where
+// a model-level budget lives (an access profile's per-model limits materialise as
+// user-scoped configs naming one model and provider), so batch spend never reached
+// them. Settlement does know the models, and calls this per model to charge what
+// the create-time collection could not see.
+//
+// Callers must subtract the IDs already charged for the request: the wildcard tiers
+// returned here overlap CollectApplicableGovernanceIDs by design, since both walk
+// the same four tiers.
+func (gs *LocalGovernanceStore) CollectModelScopedGovernanceIDs(ctx context.Context, virtualKeyID string, userID string, provider schemas.ModelProvider, model string) (budgetIDs []string, rateLimitIDs []string) {
+	seenBudgets := map[string]bool{}
+	seenRateLimits := map[string]bool{}
+
+	var providerStr *string
+	if provider != "" {
+		p := string(provider)
+		providerStr = &p
+	}
+	addModelConfigIDs := func(mc *configstoreTables.TableModelConfig) {
+		for i := range mc.Budgets {
+			if id := mc.Budgets[i].ID; !seenBudgets[id] {
+				budgetIDs = append(budgetIDs, id)
+				seenBudgets[id] = true
+			}
+		}
+		if mc.RateLimitID != nil && !seenRateLimits[*mc.RateLimitID] {
+			rateLimitIDs = append(rateLimitIDs, *mc.RateLimitID)
+			seenRateLimits[*mc.RateLimitID] = true
+		}
+	}
+
+	scopes := []struct{ name, id string }{
+		{configstoreTables.ModelConfigScopeGlobal, ""},
+		{configstoreTables.ModelConfigScopeUser, userID},
+		{configstoreTables.ModelConfigScopeVirtualKey, virtualKeyID},
+	}
+	for _, scope := range scopes {
+		if scope.name != configstoreTables.ModelConfigScopeGlobal && scope.id == "" {
+			continue
+		}
+		for _, mc := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, providerStr) {
+			addModelConfigIDs(mc)
+		}
+	}
 	return budgetIDs, rateLimitIDs
 }
 

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -1228,3 +1228,52 @@ func TestGovernanceStore_Customer_CalendarAligned_UpdateInMemory(t *testing.T) {
 func ptrInt64(i int64) *int64 {
 	return &i
 }
+
+// An access profile's per-model budgets materialise as user-scoped model configs
+// naming one model and provider. A batch create carries no top-level model, so the
+// in-flight collection matches only the wildcard tiers and those per-model budgets
+// are invisible to it — which is why batch spend never reached them. Settlement
+// knows the models and asks for them by name.
+func TestCollectModelScopedGovernanceIDs_FindsExactModelConfigMissedAtCreateTime(t *testing.T) {
+	logger := NewMockLogger()
+	ctx := context.Background()
+	providerName := "openai"
+	userID := "user-alice"
+
+	perModel := buildBudgetWithUsage("ap-model-budget", 100.0, 0.0, "1M")
+	perModelMC := buildModelConfig("mc-user-gpt5", "gpt-5", &providerName, perModel, nil)
+	perModelMC.Scope = configstoreTables.ModelConfigScopeUser
+	perModelMC.ScopeID = &userID
+
+	wildcard := buildBudgetWithUsage("ap-wildcard-budget", 100.0, 0.0, "1M")
+	wildcardMC := buildModelConfig("mc-user-all", configstoreTables.ModelConfigAllModels, &providerName, wildcard, nil)
+	wildcardMC.Scope = configstoreTables.ModelConfigScopeUser
+	wildcardMC.ScopeID = &userID
+
+	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*perModelMC, *wildcardMC},
+		Budgets:      []configstoreTables.TableBudget{*perModel, *wildcard},
+	}, nil)
+	require.NoError(t, err)
+
+	// What batch create sees: no model, so only the wildcard is collected.
+	inFlight, _ := store.CollectApplicableGovernanceIDs(ctx, "", userID, schemas.ModelProvider(providerName), "")
+	assert.Contains(t, inFlight, wildcard.ID)
+	assert.NotContains(t, inFlight, perModel.ID, "the per-model budget cannot be matched without a model")
+
+	// What settlement sees: the model is known, so the per-model budget is reachable.
+	atSettlement, _ := store.CollectModelScopedGovernanceIDs(ctx, "", userID, schemas.ModelProvider(providerName), "gpt-5")
+	assert.Contains(t, atSettlement, perModel.ID)
+	// The wildcard is returned too and overlaps the in-flight set by design; callers
+	// subtract what they already charged rather than relying on it being absent.
+	assert.Contains(t, atSettlement, wildcard.ID)
+
+	// A model with no config of its own still finds the wildcard and nothing else.
+	otherModel, _ := store.CollectModelScopedGovernanceIDs(ctx, "", userID, schemas.ModelProvider(providerName), "gpt-4o")
+	assert.NotContains(t, otherModel, perModel.ID)
+	assert.Contains(t, otherModel, wildcard.ID)
+
+	// Scope isolation: another user's id must not reach these configs.
+	otherUser, _ := store.CollectModelScopedGovernanceIDs(ctx, "", "user-bob", schemas.ModelProvider(providerName), "gpt-5")
+	assert.Empty(t, otherUser)
+}

--- a/plugins/logging/costfidelity_test.go
+++ b/plugins/logging/costfidelity_test.go
@@ -1230,3 +1230,64 @@ func TestRecalculateCostsReprisesMixedModelBatchRow(t *testing.T) {
 	require.NotNil(t, breakdowns["gpt-4o-mini"].Cost)
 	assertCostsEqual(t, "e2e gpt-4o-mini breakdown cost", *breakdowns["gpt-4o-mini"].Cost, wantGPT4oMini)
 }
+
+// test: the background job is the path the /api/logs/recalculate-cost endpoint
+// actually runs, and it persisted pages independently of RecalculateCosts. A batch
+// aggregate row prices to a scalar total with no breakdown, so the job fed nil to
+// CostUpdateFromBreakdown and wrote the resulting zero over an already-correct
+// cost — a full recalculation silently zeroed every settled batch in the window.
+func TestRunCostRecalcJobDoesNotZeroPricedBatchRow(t *testing.T) {
+	plugin := newCostFidelityPlugin(t)
+	store := plugin.store
+	ctx := context.Background()
+
+	wantGPT4o := 1000*1.25e-06 + 200*5e-06
+	wantGPT4oMini := 500*7.5e-08 + 100*3e-07
+	settledCost := wantGPT4o + wantGPT4oMini
+
+	entry := &logstore.Log{
+		ID:        "batch-job-priced",
+		Timestamp: time.Now().UTC(),
+		Object:    string(schemas.BatchResultsRequest),
+		Provider:  string(schemas.OpenAI),
+		Model:     "mixed",
+		Status:    "success",
+		Cost:      &settledCost,
+		BatchDebugParsed: &schemas.BifrostBatchDebug{
+			BatchID: "batch_job_priced",
+			Accounting: &schemas.BatchAccountingDebug{
+				ModelBreakdowns: map[string]schemas.BatchModelBreakdown{
+					"gpt-4o":      batchModelBreakdown(1000, 200),
+					"gpt-4o-mini": batchModelBreakdown(500, 100),
+				},
+			},
+		},
+	}
+	require.NoError(t, store.Create(ctx, entry))
+
+	// MissingCostOnly=false is the "recalculate everything in this window" scope,
+	// which is what visits an already-priced row in the first place.
+	metaJSON, err := plugin.BuildCostRecalcJobMeta(ctx, logstore.SearchFilters{}, false)
+	require.NoError(t, err)
+
+	finalJSON, err := plugin.RunCostRecalcJob(ctx, metaJSON, func(string) error { return nil })
+	require.NoError(t, err)
+
+	var meta CostRecalcJobMeta
+	require.NoError(t, sonic.Unmarshal([]byte(finalJSON), &meta))
+	require.Equal(t, 1, meta.Updated)
+
+	logged, err := store.FindByID(ctx, "batch-job-priced")
+	require.NoError(t, err)
+	require.NotNil(t, logged.Cost)
+	assertCostsEqual(t, "batch row cost after background recalculation", *logged.Cost, settledCost)
+
+	// The breakdowns must be rewritten alongside the cost, not left behind.
+	require.NotNil(t, logged.BatchDebugParsed)
+	require.NotNil(t, logged.BatchDebugParsed.Accounting)
+	breakdowns := logged.BatchDebugParsed.Accounting.ModelBreakdowns
+	require.NotNil(t, breakdowns["gpt-4o"].Cost)
+	assertCostsEqual(t, "gpt-4o breakdown cost", *breakdowns["gpt-4o"].Cost, wantGPT4o)
+	require.NotNil(t, breakdowns["gpt-4o-mini"].Cost)
+	assertCostsEqual(t, "gpt-4o-mini breakdown cost", *breakdowns["gpt-4o-mini"].Cost, wantGPT4oMini)
+}

--- a/plugins/logging/costrecalc.go
+++ b/plugins/logging/costrecalc.go
@@ -2,7 +2,6 @@ package logging
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -197,44 +196,19 @@ func (p *LoggerPlugin) RunCostRecalcJob(ctx context.Context, metaJSON string, ch
 			return snapshot(), err
 		}
 
-		costUpdates := make(map[string]logstore.CostUpdate, len(batch))
-		gotPositiveCost := make([]bool, len(batch))
-		batchSkipped := 0
-		batchUnpriceable := 0
-		for i := range batch {
-			logEntry := batch[i]
-			cost, calcErr := outcomes[i].cost, outcomes[i].err
-			if calcErr != nil {
-				batchSkipped++
-				if errors.Is(calcErr, errPricingInputsUnavailable) {
-					batchUnpriceable++
-				}
-				p.logger.Debug("skipping cost recalculation for log %s: %v", logEntry.ID, calcErr)
-				continue
-			}
-			if cost <= 0 {
-				if outcomes[i].knownZeroCost {
-					costUpdates[logEntry.ID] = logstore.CostUpdate{}
-				} else {
-					batchSkipped++
-					p.logger.Debug("skipping cost recalculation for log %s: resolved cost is zero", logEntry.ID)
-				}
-				continue
-			}
-			costUpdates[logEntry.ID] = logstore.CostUpdateFromBreakdown(outcomes[i].breakdown)
-			gotPositiveCost[i] = true
+		// Shared with RecalculateCostsWithProgress so the two paths cannot drift on
+		// how a page is persisted — notably the batch-aggregate rows, which carry a
+		// scalar total instead of a breakdown.
+		tally, err := p.persistRecalcOutcomes(ctx, batch, outcomes)
+		if err != nil {
+			return snapshot(), err
 		}
-
-		if len(costUpdates) > 0 {
-			if err := p.store.BulkUpdateCost(ctx, costUpdates); err != nil {
-				return snapshot(), fmt.Errorf("failed to bulk update costs: %w", err)
-			}
-			meta.Updated += len(costUpdates)
-		}
-		// Merge the skip counts only once the batch is durably committed, so a retry
-		// after a BulkUpdateCost failure cannot double-count the same skipped rows.
-		meta.Skipped += batchSkipped
-		meta.Unpriceable += batchUnpriceable
+		gotPositiveCost := tally.priced
+		// Merge the counts only once the batch is durably committed, so a retry
+		// after a failed write cannot double-count the same rows.
+		meta.Updated += tally.updated
+		meta.Skipped += tally.skipped
+		meta.Unpriceable += tally.unpriceable
 		meta.Processed += len(batch)
 
 		// Advance the cursor. The lower bound is inclusive and rows that keep matching

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -537,8 +537,15 @@ func batchJobFromEntry(entry *logstore.Log, batchID string, model string, endpoi
 		AccountingStatus: tables.BatchJobAccountingStatusPending,
 		SelectedKeyID:    entry.SelectedKeyID,
 		VirtualKeyID:     entry.VirtualKeyID,
+		UserID:           entry.UserID,
+		TeamID:           entry.TeamID,
+		CustomerID:       entry.CustomerID,
 		BudgetIDs:        stringSlicePtr(entry.BudgetIDsParsed),
 		RateLimitIDs:     stringSlicePtr(entry.RateLimitIDsParsed),
+	}
+	if entry.ID != "" {
+		sourceLogID := entry.ID
+		job.SourceLogID = &sourceLogID
 	}
 	if job.ID == "" && job.Provider != "" && job.BatchID != "" {
 		job.ID = tables.BatchJobID(job.Provider, job.BatchID)

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -1541,64 +1541,20 @@ func (p *LoggerPlugin) RecalculateCostsWithProgress(ctx context.Context, filters
 			return nil, err
 		}
 
-		costUpdates := make(map[string]logstore.CostUpdate, len(searchResult.Logs))
-		batchDebugUpdated := 0
+		tally, err := p.persistRecalcOutcomes(ctx, searchResult.Logs, outcomes)
+		if err != nil {
+			return nil, err
+		}
+		result.Updated += tally.updated
+		result.Skipped += tally.skipped
+		result.Unpriceable += tally.unpriceable
+
 		stillMissingInBatch := 0
-
-		for i := range searchResult.Logs {
-			logEntry := searchResult.Logs[i]
-			cost, calcErr := outcomes[i].cost, outcomes[i].err
-			if calcErr != nil {
-				result.Skipped++
-				if errors.Is(calcErr, errPricingInputsUnavailable) {
-					result.Unpriceable++
-				}
+		for _, priced := range tally.priced {
+			if !priced {
 				stillMissingInBatch++
-				p.logger.Debug("skipping cost recalculation for log %s: %v", logEntry.ID, calcErr)
-				continue
 			}
-			if cost <= 0 {
-				if outcomes[i].knownZeroCost {
-					costUpdates[logEntry.ID] = logstore.CostUpdate{}
-				} else {
-					result.Skipped++
-					p.logger.Debug("skipping cost recalculation for log %s: resolved cost is zero", logEntry.ID)
-				}
-				// MissingCostOnly currently includes zero-cost rows, so advance past them
-				// whether they were skipped or updated to avoid recalculating forever.
-				stillMissingInBatch++
-				continue
-			}
-			if outcomes[i].batchDebugUpdate != "" {
-				// A repriced batch aggregate row needs cost and batch_debug written
-				// together so model_breakdowns never disagrees with the row's own
-				// cost, and batch_debug can only be written through a dedicated update
-				// (BulkUpdateCost writes cost and the split columns, but not
-				// batch_debug). This row carries a scalar total only, so derive the
-				// split columns from it the same way CostUpdateFromBreakdown does.
-				update := logstore.CostUpdateFromBreakdown(&schemas.BifrostCost{TotalCost: cost})
-				if err := p.store.Update(ctx, logEntry.ID, map[string]any{
-					"cost":            update.Total,
-					"input_cost":      update.Input,
-					"output_cost":     update.Output,
-					"additional_cost": update.Additional,
-					"batch_debug":     outcomes[i].batchDebugUpdate,
-				}); err != nil {
-					return nil, fmt.Errorf("failed to update batch cost for log %s: %w", logEntry.ID, err)
-				}
-				batchDebugUpdated++
-				continue
-			}
-			costUpdates[logEntry.ID] = logstore.CostUpdateFromBreakdown(outcomes[i].breakdown)
 		}
-
-		if len(costUpdates) > 0 {
-			if err := p.store.BulkUpdateCost(ctx, costUpdates); err != nil {
-				return nil, fmt.Errorf("failed to bulk update costs: %w", err)
-			}
-			result.Updated += len(costUpdates)
-		}
-		result.Updated += batchDebugUpdated
 
 		if filters.MissingCostOnly {
 			// Updated rows drop out of the result set, so only advance past rows
@@ -1675,6 +1631,83 @@ type billingOutcome struct {
 	// model_breakdowns would stay stuck showing the pre-recalculation (unpriced)
 	// state even after cost is fixed.
 	batchDebugUpdate string
+}
+
+// recalcTally is what persisting one page of billing outcomes did.
+type recalcTally struct {
+	updated     int
+	skipped     int
+	unpriceable int
+	// priced[i] reports whether row i ended the pass carrying a positive cost. Rows
+	// that did not (skips, zero-cost resolutions) still match a MissingCostOnly scan,
+	// so both callers use this to advance their cursor without re-touching or
+	// skipping a row.
+	priced []bool
+}
+
+// persistRecalcOutcomes writes one page of repriced rows and reports what happened.
+//
+// Both recalculation entry points funnel through here. They used to persist the
+// page independently, and the batch-aggregate case — a scalar total plus a
+// batch_debug payload, with no breakdown — was only ever handled in one of them:
+// the background job fed the nil breakdown to CostUpdateFromBreakdown and wrote
+// the resulting zero straight over an already-correct batch cost.
+func (p *LoggerPlugin) persistRecalcOutcomes(ctx context.Context, batch []logstore.Log, outcomes []billingOutcome) (recalcTally, error) {
+	tally := recalcTally{priced: make([]bool, len(batch))}
+	costUpdates := make(map[string]logstore.CostUpdate, len(batch))
+
+	for i := range batch {
+		logEntry := batch[i]
+		cost, calcErr := outcomes[i].cost, outcomes[i].err
+		if calcErr != nil {
+			tally.skipped++
+			if errors.Is(calcErr, errPricingInputsUnavailable) {
+				tally.unpriceable++
+			}
+			p.logger.Debug("skipping cost recalculation for log %s: %v", logEntry.ID, calcErr)
+			continue
+		}
+		if cost <= 0 {
+			if outcomes[i].knownZeroCost {
+				costUpdates[logEntry.ID] = logstore.CostUpdate{}
+			} else {
+				tally.skipped++
+				p.logger.Debug("skipping cost recalculation for log %s: resolved cost is zero", logEntry.ID)
+			}
+			continue
+		}
+		if outcomes[i].batchDebugUpdate != "" {
+			// A repriced batch aggregate row needs cost and batch_debug written
+			// together so model_breakdowns never disagrees with the row's own
+			// cost, and batch_debug can only be written through a dedicated update
+			// (BulkUpdateCost writes cost and the split columns, but not
+			// batch_debug). This row carries a scalar total only, so derive the
+			// split columns from it the same way CostUpdateFromBreakdown does.
+			update := logstore.CostUpdateFromBreakdown(&schemas.BifrostCost{TotalCost: cost})
+			if err := p.store.Update(ctx, logEntry.ID, map[string]any{
+				"cost":            update.Total,
+				"input_cost":      update.Input,
+				"output_cost":     update.Output,
+				"additional_cost": update.Additional,
+				"batch_debug":     outcomes[i].batchDebugUpdate,
+			}); err != nil {
+				return recalcTally{}, fmt.Errorf("failed to update batch cost for log %s: %w", logEntry.ID, err)
+			}
+			tally.updated++
+			tally.priced[i] = true
+			continue
+		}
+		costUpdates[logEntry.ID] = logstore.CostUpdateFromBreakdown(outcomes[i].breakdown)
+		tally.priced[i] = true
+	}
+
+	if len(costUpdates) > 0 {
+		if err := p.store.BulkUpdateCost(ctx, costUpdates); err != nil {
+			return recalcTally{}, fmt.Errorf("failed to bulk update costs: %w", err)
+		}
+		tally.updated += len(costUpdates)
+	}
+	return tally, nil
 }
 
 // priceLogsInChunks hydrates and prices a batch a few rows at a time, releasing each

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -2993,3 +2993,58 @@ func TestStartBatchAccountingSweeperAfterCleanupIsRefused(t *testing.T) {
 		t.Fatal("no sweeper should be registered after Cleanup")
 	}
 }
+
+// The batch job row is the only durable record of who to bill: settlement can run
+// hours later from a sweeper with no request context. A virtual key alone is not
+// enough — an access profile shares one across users — so the user, team, customer
+// and the creating log row must all be captured at create time.
+func TestRecordBatchJobLifecycle_CreatePersistsRequesterIdentity(t *testing.T) {
+	store := newTestStore(t)
+	bs := newFakeBatchStore()
+	plugin := &LoggerPlugin{
+		ctx:        context.Background(),
+		store:      store,
+		batchStore: bs,
+		logger:     testLogger{},
+	}
+
+	vkID := "vk-access-profile"
+	userID := "user-alice"
+	teamID := "team-1"
+	customerID := "customer-1"
+	entry := &logstore.Log{
+		ID:                 "req-create-batch-identity",
+		Provider:           string(schemas.OpenAI),
+		Model:              "gpt-4o",
+		SelectedKeyID:      "key-1",
+		VirtualKeyID:       &vkID,
+		UserID:             &userID,
+		TeamID:             &teamID,
+		CustomerID:         &customerID,
+		BudgetIDsParsed:    []string{"budget-1"},
+		RateLimitIDsParsed: []string{"rl-1"},
+	}
+	plugin.recordBatchJobLifecycle(entry, &schemas.BifrostResponse{
+		BatchCreateResponse: &schemas.BifrostBatchCreateResponse{
+			ID:     "batch-identity-123",
+			Status: schemas.BatchStatusValidating,
+		},
+	})
+
+	job, err := bs.GetBatchJob(context.Background(), cstables.BatchJobID("openai", "batch-identity-123"))
+	if err != nil {
+		t.Fatalf("GetBatchJob() error = %v", err)
+	}
+	if job.UserID == nil || *job.UserID != userID {
+		t.Fatalf("expected user_id %s, got %v", userID, job.UserID)
+	}
+	if job.TeamID == nil || *job.TeamID != teamID {
+		t.Fatalf("expected team_id %s, got %v", teamID, job.TeamID)
+	}
+	if job.CustomerID == nil || *job.CustomerID != customerID {
+		t.Fatalf("expected customer_id %s, got %v", customerID, job.CustomerID)
+	}
+	if job.SourceLogID == nil || *job.SourceLogID != entry.ID {
+		t.Fatalf("expected source_log_id %s, got %v", entry.ID, job.SourceLogID)
+	}
+}


### PR DESCRIPTION
## Summary

Batch settlement could bill the wrong user. When an access profile hands one virtual key to many users, matching on the virtual key alone cannot tell two people apart — the settling user's identity (name, team, user ID) could land on the creator's cost row. The sweeper, which runs hours after the creating request with no request context at all, had no way to recover the creator's identity at all. This PR fixes both problems by capturing the full requester identity at batch-create time and using that record — not whoever happens to settle — for all attribution.

## Changes

- **`batch_jobs` table gains `user_id`, `team_id`, `customer_id`, and `source_log_id` columns** with a migration and a `user_id` index for per-user cost lookups. These are written at create time from the creating request's log entry.
- **`batchJobFromEntry` now copies `UserID`, `TeamID`, `CustomerID`, and `SourceLogID`** from the log entry into the job row so the identity is durable from the moment the batch is registered.
- **`mergeBatchJobHints` now unconditionally overwrites attribution fields** (`SelectedKeyID`, `VirtualKeyID`, `UserID`, `TeamID`, `CustomerID`, `BudgetIDs`, `RateLimitIDs`, `SourceLogID`) from the persisted row rather than filling only gaps. A job built from the fetcher's log entry on the `/results` path previously kept the fetcher's identity if the creator's fields were already set; now the persisted creator identity always wins.
- **`resolveSourceLog` loads the creating request's log row** by `SourceLogID` so display-name denormalizations (virtual key name, user name, team name) come from the creator, not the settler. The old guard — `sameVirtualKey` — is removed because a shared virtual key is not a reliable identity boundary.
- **`applyBatchJobAttribution` now also sets `UserID`, `TeamID`, and `CustomerID`** on the aggregate log entry, so the cost row carries the full creator identity.
- **`BatchUsageReport` gains a `UserID` field** and `ReportBatchUsage` charges the user's rate-limit and budget tiers when it is present, with the same at-least-once idempotency guard already used for the budget-ID and rate-limit-ID tiers.
- **`persistRecalcOutcomes` is extracted** as a shared helper used by both `RecalculateCostsWithProgress` and `RunCostRecalcJob`. Previously the background job fed a nil breakdown to `CostUpdateFromBreakdown` for batch aggregate rows and wrote the resulting zero over an already-correct cost; both paths now handle the scalar-total-plus-`batch_debug` case correctly.

## Type of change

- [x] Bug fix
- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Plugins

## How to test

```sh
go test ./framework/batchaccounting/...
go test ./framework/configstore/...
go test ./plugins/governance/...
go test ./plugins/logging/...
```

Key scenarios covered by new tests:
- `TestAccountBatchResults_FillsNamesFromSourceLog` — display names come from the creating request's log, not the settler's.
- `TestAccountBatchResults_SharedVirtualKeyKeepsUsersApart` — Bob settling Alice's batch does not move Alice's cost row onto Bob.
- `TestAccountBatchResults_SweeperPathKeepsUserAttribution` — the sweeper with no `BaseLog` still produces a fully attributed cost row.
- `TestAccountBatchResults_PersistedIdentityOverridesFetcherBuiltJob` — a fetcher-built job is fully overwritten by the persisted creator identity on merge.
- `TestUpsertBatchJobDoesNotOverwriteAttribution` — a second upsert from the `/results` path cannot move attribution.
- `TestReportBatchUsage_ChargesUserEntity` — the user's rate-limit and budget tiers are charged exactly once.
- `TestReportBatchUsage_WithoutUserSkipsUserEntity` — no user on the report leaves the user tier untouched.
- `TestRunCostRecalcJobDoesNotZeroPricedBatchRow` — the background recalculation job no longer zeros already-correct batch costs.
- `TestRecordBatchJobLifecycle_CreatePersistsRequesterIdentity` — `user_id`, `team_id`, `customer_id`, and `source_log_id` are all written at create time.
- `TestMigrationAddBatchJobsAttributionColumns` — the migration is idempotent and leaves pre-existing rows intact.

## Breaking changes

- [x] No

## Security considerations

Batch costs were attributable to the wrong user when an access profile shared a virtual key across multiple users. This fix ensures billing always follows the creator's identity, preventing one user's spend from appearing under another's budget or rate-limit counters.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable