### PR TITLE
feat: update log details views UI to show input / output cost split

### DIFF
--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -261,26 +261,30 @@ type Log struct {
 	// Denormalized cost split for per-category quota aggregation. input + output +
 	// additional reconcile to the cost column. Additional holds internal sidecar
 	// costs with no input/output token category (guardrail, MCP).
-	InputCost               float64  `gorm:"default:0" json:"-"`
-	OutputCost              float64  `gorm:"default:0" json:"-"`
-	AdditionalCost          float64  `gorm:"default:0" json:"-"`
-	Cost                    *float64 `gorm:"index" json:"cost,omitempty"`                                                                // Cost in dollars (total cost of the request - includes cache lookup cost)
-	Status                  string   `gorm:"type:varchar(50);index;index:idx_logs_ts_provider_status,priority:3;not null" json:"status"` // "processing", "success", or "error"
-	StopReason              *string  `gorm:"type:varchar(50);index:idx_logs_stop_reason" json:"stop_reason,omitempty"`                   // Why the model stopped: "stop", "length", "content_filter", "tool_calls", etc.
-	ErrorDetails            string   `gorm:"type:text" json:"-"`                                                                         // JSON serialized *schemas.BifrostError
-	Stream                  bool     `gorm:"default:false" json:"stream"`                                                                // true if this was a streaming response
-	ContentSummary          string   `gorm:"type:text" json:"content_summary,omitempty"`                                                 // Last user message preview; UI log-list display fallback when payload fields are offloaded to object storage
-	RawRequest              string   `gorm:"type:text" json:"raw_request"`                                                               // Populated when `send-back-raw-request` is on
-	RawResponse             string   `gorm:"type:text" json:"raw_response"`                                                              // Populated when `send-back-raw-response` is on
-	PassthroughRequestBody  string   `gorm:"type:text" json:"passthrough_request_body,omitempty"`                                        // Raw body for passthrough requests (UTF-8)
-	PassthroughResponseBody string   `gorm:"type:text" json:"passthrough_response_body,omitempty"`                                       // Raw body for passthrough responses (UTF-8)
-	RoutingEngineLogs       string   `gorm:"type:text" json:"routing_engine_logs,omitempty"`                                             // Formatted routing engine decision logs
-	PluginLogs              string   `gorm:"type:text" json:"plugin_logs,omitempty"`                                                     // JSON serialized plugin log entries grouped by plugin name
-	Metadata                *string  `gorm:"type:text" json:"-"`                                                                         // JSON serialized map[string]interface{}
-	IsLargePayloadRequest   bool     `gorm:"default:false" json:"is_large_payload_request"`
-	IsLargePayloadResponse  bool     `gorm:"default:false" json:"is_large_payload_response"`
-	HasObject               bool     `gorm:"default:false" json:"-"`              // True when payload is stored in object storage
-	ContentHidden           bool     `gorm:"default:false" json:"content_hidden"` // True when content logging was disabled for the request, so the payload must never be served back through the API/UI (whether it was retained in object storage or dropped entirely)
+	InputCost      float64  `gorm:"default:0" json:"-"`
+	OutputCost     float64  `gorm:"default:0" json:"-"`
+	AdditionalCost float64  `gorm:"default:0" json:"-"`
+	Cost           *float64 `gorm:"index" json:"cost,omitempty"` // Cost in dollars (total cost of the request - includes cache lookup cost)
+	// Virtual: one cost breakdown the UI reads across every row type. Assembled in
+	// DeserializeFields from token_usage.cost when present (full detail), else from
+	// the denormalized columns. Never stored.
+	CostBreakdown           *schemas.BifrostCost `gorm:"-" json:"cost_breakdown,omitempty"`
+	Status                  string               `gorm:"type:varchar(50);index;index:idx_logs_ts_provider_status,priority:3;not null" json:"status"` // "processing", "success", or "error"
+	StopReason              *string              `gorm:"type:varchar(50);index:idx_logs_stop_reason" json:"stop_reason,omitempty"`                   // Why the model stopped: "stop", "length", "content_filter", "tool_calls", etc.
+	ErrorDetails            string               `gorm:"type:text" json:"-"`                                                                         // JSON serialized *schemas.BifrostError
+	Stream                  bool                 `gorm:"default:false" json:"stream"`                                                                // true if this was a streaming response
+	ContentSummary          string               `gorm:"type:text" json:"content_summary,omitempty"`                                                 // Last user message preview; UI log-list display fallback when payload fields are offloaded to object storage
+	RawRequest              string               `gorm:"type:text" json:"raw_request"`                                                               // Populated when `send-back-raw-request` is on
+	RawResponse             string               `gorm:"type:text" json:"raw_response"`                                                              // Populated when `send-back-raw-response` is on
+	PassthroughRequestBody  string               `gorm:"type:text" json:"passthrough_request_body,omitempty"`                                        // Raw body for passthrough requests (UTF-8)
+	PassthroughResponseBody string               `gorm:"type:text" json:"passthrough_response_body,omitempty"`                                       // Raw body for passthrough responses (UTF-8)
+	RoutingEngineLogs       string               `gorm:"type:text" json:"routing_engine_logs,omitempty"`                                             // Formatted routing engine decision logs
+	PluginLogs              string               `gorm:"type:text" json:"plugin_logs,omitempty"`                                                     // JSON serialized plugin log entries grouped by plugin name
+	Metadata                *string              `gorm:"type:text" json:"-"`                                                                         // JSON serialized map[string]interface{}
+	IsLargePayloadRequest   bool                 `gorm:"default:false" json:"is_large_payload_request"`
+	IsLargePayloadResponse  bool                 `gorm:"default:false" json:"is_large_payload_response"`
+	HasObject               bool                 `gorm:"default:false" json:"-"`              // True when payload is stored in object storage
+	ContentHidden           bool                 `gorm:"default:false" json:"content_hidden"` // True when content logging was disabled for the request, so the payload must never be served back through the API/UI (whether it was retained in object storage or dropped entirely)
 
 	// Aggregates over this log's child rows (rows whose parent_request_id equals
 	// this log's ID, i.e. fallback attempts). Populated only on roots_only list
@@ -1167,7 +1171,79 @@ func (l *Log) DeserializeFields() error {
 		l.usageRebuiltFromColumns = true
 	}
 
+	l.assembleCostBreakdown()
+
 	return nil
+}
+
+// assembleCostBreakdown builds the cost_breakdown the UI reads. The top-level
+// input/output/additional/total split comes from the denormalized columns: they
+// are the authoritative source (a reprice via BulkUpdateCost updates the columns
+// and the cost column but NOT the token_usage blob, so token_usage.cost goes
+// stale on recompute) and they survive OCR, offloaded, content-hidden, and
+// rebuilt-stub rows where token_usage.cost is gone. The finer per-category detail
+// objects live only in token_usage.cost, so graft them in, but only per category
+// where the payload still reconciles with the columns, so stale detail from an
+// old reprice never contradicts the fresh split. Presence tracks the scalar Cost
+// field, so cost and cost_breakdown appear together.
+func (l *Log) assembleCostBreakdown() {
+	hasColumns := l.Cost != nil || l.InputCost != 0 || l.OutputCost != 0 || l.AdditionalCost != 0
+	if !hasColumns {
+		// No columns (e.g. a projection that selected token_usage but not the cost
+		// columns): fall back to whatever the payload carries.
+		if l.TokenUsageParsed != nil && l.TokenUsageParsed.Cost != nil {
+			l.CostBreakdown = l.TokenUsageParsed.Cost
+		}
+		return
+	}
+
+	total := l.InputCost + l.OutputCost + l.AdditionalCost
+	if l.Cost != nil {
+		total = *l.Cost
+	}
+	inputCost := l.InputCost
+	// Legacy rows written before the split columns existed carry only the total.
+	// Attribute it to input so the breakdown reconciles, mirroring SerializeFields
+	// and CostUpdateFromBreakdown's handling of opaque provider totals.
+	if l.InputCost == 0 && l.OutputCost == 0 && l.AdditionalCost == 0 && total > 0 {
+		inputCost = total
+	}
+	cb := &schemas.BifrostCost{
+		InputCost:      inputCost,
+		OutputCost:     l.OutputCost,
+		AdditionalCost: l.AdditionalCost,
+		TotalCost:      total,
+	}
+	if l.TokenUsageParsed != nil && l.TokenUsageParsed.Cost != nil {
+		d := l.TokenUsageParsed.Cost
+		if costsReconcile(d.InputCost, l.InputCost) {
+			cb.InputCostDetails = d.InputCostDetails
+		}
+		if costsReconcile(d.OutputCost, l.OutputCost) {
+			cb.OutputCostDetails = d.OutputCostDetails
+		}
+		if costsReconcile(d.AdditionalCost, l.AdditionalCost) {
+			cb.AdditionalCostDetails = d.AdditionalCostDetails
+		}
+	}
+	l.CostBreakdown = cb
+}
+
+// costsReconcile reports whether two cost figures match within float noise, used
+// to gate grafting token_usage detail onto the authoritative column split.
+func costsReconcile(a, b float64) bool {
+	diff := a - b
+	if diff < 0 {
+		diff = -diff
+	}
+	scale := a
+	if b > scale {
+		scale = b
+	}
+	if scale < 0 {
+		scale = -scale
+	}
+	return diff <= 1e-9*(1+scale)
 }
 
 // MCPToolLog represents a log entry for MCP tool executions

--- a/framework/logstore/tables_test.go
+++ b/framework/logstore/tables_test.go
@@ -132,3 +132,116 @@ func TestDeserializeFieldsSkipsTokenUsageReconstructionWhenAllZero(t *testing.T)
 	require.NoError(t, log.DeserializeFields())
 	assert.Nil(t, log.TokenUsageParsed)
 }
+
+// TestDeserializeFieldsCostBreakdownGraftsDetailFromPayload covers a normal
+// hydrated row: the top-level split comes from the columns and the finer detail
+// objects are grafted from token_usage.cost, which reconciles with them.
+func TestDeserializeFieldsCostBreakdownGraftsDetailFromPayload(t *testing.T) {
+	total := 0.0099
+	log := &Log{
+		Cost:           &total,
+		InputCost:      0.0021,
+		OutputCost:     0.0075,
+		AdditionalCost: 0.0003,
+		TokenUsage: `{"prompt_tokens":1000,"completion_tokens":500,"total_tokens":1500,` +
+			`"cost":{"input_cost":0.0021,"input_cost_details":{"cached_read_cost":0.00045},` +
+			`"output_cost":0.0075,"additional_cost":0.0003,` +
+			`"additional_cost_details":{"guardrail_cost":0.0003},"total_cost":0.0099}}`,
+	}
+	require.NoError(t, log.DeserializeFields())
+	require.NotNil(t, log.CostBreakdown)
+	assert.InDelta(t, 0.0021, log.CostBreakdown.InputCost, 1e-12)
+	assert.InDelta(t, 0.0075, log.CostBreakdown.OutputCost, 1e-12)
+	assert.InDelta(t, 0.0003, log.CostBreakdown.AdditionalCost, 1e-12)
+	assert.InDelta(t, 0.0099, log.CostBreakdown.TotalCost, 1e-12)
+	require.NotNil(t, log.CostBreakdown.InputCostDetails)
+	assert.InDelta(t, 0.00045, log.CostBreakdown.InputCostDetails.CachedReadCost, 1e-12)
+	require.NotNil(t, log.CostBreakdown.AdditionalCostDetails)
+	assert.InDelta(t, 0.0003, log.CostBreakdown.AdditionalCostDetails.GuardrailCost, 1e-12)
+}
+
+// TestDeserializeFieldsCostBreakdownPrefersColumnsOnReprice covers a repriced row:
+// BulkUpdateCost refreshes the columns and the cost column but leaves the
+// token_usage blob stale. The top-level split must track the fresh columns, and
+// stale detail must NOT be grafted since it no longer reconciles.
+func TestDeserializeFieldsCostBreakdownPrefersColumnsOnReprice(t *testing.T) {
+	total := 0.02 // repriced upward
+	log := &Log{
+		Cost:           &total,
+		InputCost:      0.005,
+		OutputCost:     0.015,
+		AdditionalCost: 0,
+		// Stale payload from before the reprice.
+		TokenUsage: `{"prompt_tokens":1000,"completion_tokens":500,"total_tokens":1500,` +
+			`"cost":{"input_cost":0.0021,"input_cost_details":{"cached_read_cost":0.00045},` +
+			`"output_cost":0.0075,"total_cost":0.0099}}`,
+	}
+	require.NoError(t, log.DeserializeFields())
+	require.NotNil(t, log.CostBreakdown)
+	assert.InDelta(t, 0.005, log.CostBreakdown.InputCost, 1e-12)
+	assert.InDelta(t, 0.015, log.CostBreakdown.OutputCost, 1e-12)
+	assert.InDelta(t, total, log.CostBreakdown.TotalCost, 1e-12)
+	// Stale detail is dropped because it no longer matches the column split.
+	assert.Nil(t, log.CostBreakdown.InputCostDetails)
+	assert.Nil(t, log.CostBreakdown.OutputCostDetails)
+}
+
+// TestDeserializeFieldsCostBreakdownOpaqueTotal covers opaque-total providers
+// (xAI, Runware): the whole total is attributed to input in the columns, and no
+// detail is grafted since the payload's zero input does not reconcile.
+func TestDeserializeFieldsCostBreakdownOpaqueTotal(t *testing.T) {
+	total := 0.0042
+	log := &Log{
+		Cost:      &total,
+		InputCost: 0.0042, // SerializeFields attributes the opaque total to input
+	}
+	require.NoError(t, log.DeserializeFields())
+	require.NotNil(t, log.CostBreakdown)
+	assert.InDelta(t, total, log.CostBreakdown.InputCost, 1e-12)
+	assert.Zero(t, log.CostBreakdown.OutputCost)
+	assert.InDelta(t, total, log.CostBreakdown.TotalCost, 1e-12)
+	assert.Nil(t, log.CostBreakdown.InputCostDetails)
+}
+
+// TestDeserializeFieldsCostBreakdownLegacyTotalOnly covers rows written before the
+// split columns existed: only the cost column is set, so the total is attributed
+// to input and the breakdown still reconciles.
+func TestDeserializeFieldsCostBreakdownLegacyTotalOnly(t *testing.T) {
+	total := 0.0123
+	log := &Log{Cost: &total}
+	require.NoError(t, log.DeserializeFields())
+	require.NotNil(t, log.CostBreakdown)
+	assert.InDelta(t, total, log.CostBreakdown.InputCost, 1e-12)
+	assert.Zero(t, log.CostBreakdown.OutputCost)
+	assert.Zero(t, log.CostBreakdown.AdditionalCost)
+	assert.InDelta(t, total, log.CostBreakdown.TotalCost, 1e-12)
+}
+
+// TestDeserializeFieldsCostBreakdownFromColumns covers rows where token_usage.cost
+// is gone (OCR, offloaded, content-hidden, rebuilt-stub, list rows): cost_breakdown
+// is derived from the denormalized columns, carrying the top-level split but no
+// per-category detail.
+func TestDeserializeFieldsCostBreakdownFromColumns(t *testing.T) {
+	total := 0.0099
+	log := &Log{
+		Cost:           &total,
+		InputCost:      0.0021,
+		OutputCost:     0.0075,
+		AdditionalCost: 0.0003,
+	}
+	require.NoError(t, log.DeserializeFields())
+	require.NotNil(t, log.CostBreakdown)
+	assert.InDelta(t, 0.0021, log.CostBreakdown.InputCost, 1e-12)
+	assert.InDelta(t, 0.0075, log.CostBreakdown.OutputCost, 1e-12)
+	assert.InDelta(t, 0.0003, log.CostBreakdown.AdditionalCost, 1e-12)
+	assert.InDelta(t, total, log.CostBreakdown.TotalCost, 1e-12)
+	assert.Nil(t, log.CostBreakdown.InputCostDetails)
+}
+
+// TestDeserializeFieldsCostBreakdownNilWhenNoCost: a row with no cost gets no
+// cost_breakdown, so the field tracks the scalar cost field.
+func TestDeserializeFieldsCostBreakdownNilWhenNoCost(t *testing.T) {
+	log := &Log{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15}
+	require.NoError(t, log.DeserializeFields())
+	assert.Nil(t, log.CostBreakdown)
+}

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -63,6 +63,10 @@ import SpeechView from "../views/speechView";
 import TranscriptionView from "../views/transcriptionView";
 import VideoView from "../views/videoView";
 
+// Full-precision cost for the detail view; per-request costs are often < $0.01,
+// where formatCost's 2-4 dp rounding would hide the value.
+const formatCostPrecise = (value?: number): string => `$${parseFloat((value ?? 0).toFixed(6))}`;
+
 const formatRealtimeTransport = (value: unknown): string => {
 	const transport = String(value ?? "").trim();
 	switch (transport.toLowerCase()) {
@@ -1921,11 +1925,56 @@ export function LogDetailView({
 									<LogEntryDetailsView className="w-full" label="Input Tokens" value={log.token_usage?.prompt_tokens || "-"} />
 									<LogEntryDetailsView className="w-full" label="Output Tokens" value={log.token_usage?.completion_tokens || "-"} />
 									<LogEntryDetailsView className="w-full" label="Total Tokens" value={log.token_usage?.total_tokens || "-"} />
-									<LogEntryDetailsView
-										className="w-full"
-										label="Cost"
-										value={log.cost != null ? `$${parseFloat(log.cost.toFixed(6))}` : "-"}
-									/>
+									{(log.cost_breakdown?.input_cost ?? 0) > 0 && (
+										<LogEntryDetailsView
+											className="w-full"
+											label="Input Cost"
+											value={formatCostPrecise(log.cost_breakdown?.input_cost)}
+										/>
+									)}
+									{(log.cost_breakdown?.output_cost ?? 0) > 0 && (
+										<LogEntryDetailsView
+											className="w-full"
+											label="Output Cost"
+											value={formatCostPrecise(log.cost_breakdown?.output_cost)}
+										/>
+									)}
+									{(log.cost_breakdown?.total_cost ?? log.cost ?? 0) > 0 && (
+										<LogEntryDetailsView
+											className="w-full"
+											label="Total Cost"
+											value={formatCostPrecise(log.cost_breakdown?.total_cost ?? log.cost)}
+										/>
+									)}
+									{/* Additional cost (guardrail / semantic cache / MCP) on its own row below. */}
+									{(log.cost_breakdown?.additional_cost ?? 0) > 0 && (
+										<LogEntryDetailsView
+											className="w-full md:col-start-1"
+											label="Additional Cost"
+											value={formatCostPrecise(log.cost_breakdown?.additional_cost)}
+										/>
+									)}
+									{(log.cost_breakdown?.additional_cost_details?.guardrail_cost ?? 0) > 0 && (
+										<LogEntryDetailsView
+											className="w-full"
+											label="Guardrail Cost"
+											value={formatCostPrecise(log.cost_breakdown?.additional_cost_details?.guardrail_cost)}
+										/>
+									)}
+									{(log.cost_breakdown?.additional_cost_details?.semantic_cache_cost ?? 0) > 0 && (
+										<LogEntryDetailsView
+											className="w-full"
+											label="Semantic Cache Cost"
+											value={formatCostPrecise(log.cost_breakdown?.additional_cost_details?.semantic_cache_cost)}
+										/>
+									)}
+									{(log.cost_breakdown?.additional_cost_details?.mcp_cost ?? 0) > 0 && (
+										<LogEntryDetailsView
+											className="w-full"
+											label="MCP Cost"
+											value={formatCostPrecise(log.cost_breakdown?.additional_cost_details?.mcp_cost)}
+										/>
+									)}
 									{isRealtimeTurn && (
 										<>
 											<LogEntryDetailsView

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -433,6 +433,44 @@ export interface LLMUsage {
 	completion_tokens_details?: CompletionTokensDetails;
 }
 
+// Cost breakdown types mirror schemas.BifrostCost: input + output + additional
+// reconcile to total. The sub-detail objects are present only when the usage
+// payload was retained (absent for OCR, offloaded, content-hidden, and list rows,
+// which still carry the top-level input/output/additional/total split).
+export interface InputCostDetails {
+	text_cost?: number;
+	audio_cost?: number;
+	image_cost?: number;
+	cached_read_cost?: number;
+	cached_write_cost?: number;
+	request_cost?: number; // flat per-request / OCR per-page / container per-session
+}
+
+export interface OutputCostDetails {
+	text_cost?: number;
+	audio_cost?: number;
+	image_cost?: number;
+	reasoning_cost?: number;
+	citation_cost?: number;
+	search_queries_cost?: number;
+}
+
+export interface AdditionalCostDetails {
+	guardrail_cost?: number; // guardrail judge-call cost
+	mcp_cost?: number; // MCP tool-execution cost
+	semantic_cache_cost?: number; // semantic-cache embedding-lookup cost
+}
+
+export interface CostBreakdown {
+	input_cost?: number;
+	input_cost_details?: InputCostDetails;
+	output_cost?: number;
+	output_cost_details?: OutputCostDetails;
+	additional_cost?: number;
+	additional_cost_details?: AdditionalCostDetails;
+	total_cost?: number;
+}
+
 export interface CacheDebug {
 	cache_hit: boolean;
 	cache_id?: string;
@@ -652,6 +690,7 @@ export interface LogEntry {
 	batch_debug?: BatchDebug;
 	guardrail_debug?: GuardrailDebug;
 	cost?: number; // Cost in dollars (total cost of the request - includes cache lookup cost and also guardrail judge calls)
+	cost_breakdown?: CostBreakdown; // Per-category split (input/output/additional); present whenever cost is
 	// Served billing tier, denormalized onto the log row so cost recomputation can reprice
 	// at the rates the request was actually served at. OpenAI: "priority" / "flex" / "ultrafast" / "default".
 	service_tier?: string;


### PR DESCRIPTION
## Summary

The log detail view previously showed only a single scalar `cost` field. This PR introduces a `cost_breakdown` field on log entries that exposes the input/output/additional cost split to the UI, with per-category detail (cached read, reasoning, guardrail, MCP, semantic cache, etc.) grafted in from the `token_usage` payload when it reconciles with the authoritative denormalized columns.

## Changes

- Added a virtual `CostBreakdown *schemas.BifrostCost` field to the `Log` struct (tagged `gorm:"-"` so it is never stored). It is assembled during `DeserializeFields` by `assembleCostBreakdown`.
- `assembleCostBreakdown` uses the denormalized `InputCost`/`OutputCost`/`AdditionalCost`/`Cost` columns as the authoritative top-level split. This ensures repriced rows (where `BulkUpdateCost` refreshes the columns but leaves the `token_usage` blob stale) always reflect the current pricing. Finer per-category detail objects from `token_usage.cost` are grafted in only when they reconcile with the column values within float noise, preventing stale detail from contradicting a fresh reprice.
- Legacy rows that carry only the total `Cost` column (written before the split columns existed) have the total attributed to `InputCost` in the breakdown, matching the existing `SerializeFields` and `CostUpdateFromBreakdown` convention for opaque provider totals.
- Added `costsReconcile` helper for float-tolerant comparison used to gate detail grafting.
- Added `CostBreakdown`, `InputCostDetails`, `OutputCostDetails`, and `AdditionalCostDetails` TypeScript interfaces to `logs.ts`, mirroring `schemas.BifrostCost`.
- Replaced the single "Cost" row in the log detail view with individual rows for Input Cost, Output Cost, Total Cost, Additional Cost, Guardrail Cost, Semantic Cache Cost, and MCP Cost. Each row is conditionally rendered and only appears when its value is non-zero.
- Extracted `formatCostPrecise` in the detail view to render costs to 6 decimal places, since per-request costs are frequently below `$0.01` where 2–4 dp rounding would hide the value.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/logstore/...

# UI
cd ui
pnpm i || npm i
pnpm build || npm run build
```

Open a log detail sheet for a request that has cost data. Verify:
- Input Cost, Output Cost, and Total Cost rows appear with 6 dp precision.
- Additional Cost, Guardrail Cost, Semantic Cache Cost, and MCP Cost rows appear only when non-zero.
- After a reprice via `BulkUpdateCost`, the displayed split reflects the updated columns, not the stale `token_usage` blob.
- Rows with no cost data show no cost breakdown rows.

## Screenshots/Recordings

Before: a single "Cost" row showing the total.

After: individual Input Cost / Output Cost / Total Cost rows, with Additional Cost, Guardrail Cost, Semantic Cache Cost, and MCP Cost rows appearing when applicable.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

`cost_breakdown` is assembled from already-stored cost columns and the existing `token_usage` blob. No new data is persisted and no new fields are exposed beyond what the scalar `cost` field already conveyed.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable