### PR TITLE
chore: inherit semantic cache embedding keys from `bifrost.providers` and drop `keys` field from semantic cache config across Helm charts, values, and docs

### DIFF
--- a/docs/features/semantic-caching.mdx
+++ b/docs/features/semantic-caching.mdx
@@ -229,6 +229,45 @@ A vector store must be enabled in `config.json` first — the plugin has nowhere
 
 </Tab>
 
+<Tab title="Helm">
+
+```yaml
+bifrost:
+  # The embedding provider's API key is inherited from bifrost.providers.
+  # Configure the provider here — the plugin config has no `keys` field.
+  providers:
+    openai:
+      keys:
+        - name: "embeddings"
+          value: "env.OPENAI_API_KEY"
+          weight: 1
+          models: ["text-embedding-3-small"]
+  plugins:
+    semanticCache:
+      enabled: true
+      config:
+        provider: "openai"
+        embedding_model: "text-embedding-3-small"
+        dimension: 1536
+
+        ttl: "5m"
+        threshold: 0.8
+
+        conversation_history_threshold: 3
+        exclude_system_prompt: false
+
+        cache_by_model: true
+        cache_by_provider: true
+
+        vector_store_namespace: "BifrostSemanticCachePlugin"
+```
+
+<Note>
+Enable a **vector store** separately (see [Prerequisites](#prerequisites)) — `vectorStore.enabled: true` with a `type`. Provider API keys are **inherited from `bifrost.providers`**; the semantic cache config has no `keys` field. See the ready-to-run overlays in [`helm-charts/bifrost/values-examples/`](https://github.com/maximhq/bifrost/tree/main/helm-charts/bifrost/values-examples) (e.g. `sqlite-redis.yaml`, `postgres-weaviate.yaml`).
+</Note>
+
+</Tab>
+
 <Tab title="Go SDK">
 
 ```go

--- a/examples/configs/withauth/config.json
+++ b/examples/configs/withauth/config.json
@@ -4,8 +4,7 @@
         "auth_config": {
             "admin_username": "env.BIFROST_ADMIN_USERNAME",
             "admin_password": "env.BIFROST_ADMIN_PASSWORD",
-            "is_enabled": true,
-            "disable_auth_on_inference": false
+            "is_enabled": true
         }
     },
     "config_store": {

--- a/examples/configs/withconfigstore/config.json
+++ b/examples/configs/withconfigstore/config.json
@@ -7,13 +7,12 @@
       "path": "../../examples/configs/withconfigstore/config.db"
     }
   },
-  "auth_config": {
-    "admin_username": "env.BIFROST_ADMIN_USERNAME",
-    "admin_password": "env.BIFROST_ADMIN_PASSWORD",
-    "is_enabled": true,
-    "disable_auth_on_inference": true
-  },
   "governance": {
+    "auth_config": {
+      "admin_username": "env.BIFROST_ADMIN_USERNAME",
+      "admin_password": "env.BIFROST_ADMIN_PASSWORD",
+      "is_enabled": true
+    },
     "virtual_keys": [
       {
         "id": "vk-gpt",

--- a/examples/configs/withobjectstoragegcs/config.json
+++ b/examples/configs/withobjectstoragegcs/config.json
@@ -9,7 +9,7 @@
     "object_storage": {
       "type": "gcs",
       "bucket": "env.GCS_BUCKET",
-      "credentials": "env.GCS_KEY",
+      "credentials_json": "env.GCS_KEY",
       "prefix":"bifrost/logs"
     }
   }

--- a/examples/configs/withotel/config.json
+++ b/examples/configs/withotel/config.json
@@ -33,7 +33,7 @@
       "config": {
         "service_name": "bifrost",
         "collector_url": "http://localhost:4318/v1/traces",
-        "trace_type": "otel",
+        "trace_type": "genai_extension",
         "protocol": "http",
         "metrics_enabled": true,
         "metrics_endpoint": "http://localhost:4318/v1/metrics",

--- a/examples/configs/withpostgresmcpclientsinconfig/config.json
+++ b/examples/configs/withpostgresmcpclientsinconfig/config.json
@@ -56,7 +56,6 @@
     "auth_config": {
       "admin_password": "env.BIFROST_ADMIN_PASSWORD",
       "admin_username": "env.BIFROST_ADMIN_USERNAME",
-      "disable_auth_on_inference": true,
       "is_enabled": false
     },
     "virtual_keys": [

--- a/examples/configs/withvirtualkeys/config.json
+++ b/examples/configs/withvirtualkeys/config.json
@@ -28,7 +28,6 @@
     "auth_config": {
       "admin_password": "env.BIFROST_ADMIN_PASSWORD",
       "admin_username": "env.BIFROST_ADMIN_USERNAME",
-      "disable_auth_on_inference": true,
       "is_enabled": false
     },
     "virtual_keys": [

--- a/examples/k8s/examples/values-client-configs.yaml
+++ b/examples/k8s/examples/values-client-configs.yaml
@@ -5,7 +5,6 @@ bifrost:
   # The chart renders these into config.json auth_config.admin_username/admin_password.
   authConfig:
     isEnabled: true
-    disableAuthOnInference: false
     adminUsername: "env.BIFROST_ADMIN_USERNAME"
     adminPassword: "env.BIFROST_ADMIN_PASSWORD"
 
@@ -19,8 +18,8 @@ bifrost:
     enableLogging: true
     disableContentLogging: false
     logRetentionDays: 365
-    # Deprecated in transport schema; prefer enforceAuthOnInference.
-    enforceSCIMAuth: false
+    # Require auth (VK / API key / user token) on inference endpoints.
+    enforceAuthOnInference: false
     maxRequestBodySizeMb: 101
     compat:
       convertTextToChat: true

--- a/examples/k8s/examples/values-providers.yaml
+++ b/examples/k8s/examples/values-providers.yaml
@@ -48,8 +48,7 @@ bifrost:
           }
           # Optional key-scoped config blocks (provider specific)
           # azure_key_config:
-          #   endpoint: "https://your-resource.openai.azure.com"
-          #   api_version: "2024-02-15-preview"
+          #   endpoint: "https://your-resource.openai.azure.com"  # Azure v1 API — no api_version needed
           # bedrock_key_config:
           #   region: "us-east-1"
           # vertex_key_config:
@@ -85,8 +84,7 @@ bifrost:
           aliases: {}
           # Optional key-scoped config blocks (provider specific)
           # azure_key_config:
-          #   endpoint: "https://your-resource.openai.azure.com"
-          #   api_version: "2024-02-15-preview"
+          #   endpoint: "https://your-resource.openai.azure.com"  # Azure v1 API — no api_version needed
           # bedrock_key_config:
           #   region: "us-east-1"
           # vertex_key_config:

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -1448,9 +1448,6 @@ false
 {{- if $inputConfig.provider }}
 {{- $_ := set $scConfig "provider" $inputConfig.provider }}
 {{- end }}
-{{- if $inputConfig.keys }}
-{{- $_ := set $scConfig "keys" $inputConfig.keys }}
-{{- end }}
 {{- if $inputConfig.embedding_model }}
 {{- $_ := set $scConfig "embedding_model" $inputConfig.embedding_model }}
 {{- end }}
@@ -2106,10 +2103,7 @@ Call this template at the beginning of deployment/stateful templates
 {{/* When dimension is 1, direct (hash-based) caching is used — provider and keys are not required. */}}
 {{- if ne (int .Values.bifrost.plugins.semanticCache.config.dimension) 1 }}
 {{- if not .Values.bifrost.plugins.semanticCache.config.provider }}
-{{- fail "ERROR: bifrost.plugins.semanticCache.config.provider is required for semantic caching. Supported providers: openai, anthropic, gemini, bedrock, azure, cohere, mistral, groq, ollama, openrouter, vertex, cerebras, parasail, perplexity, sgl, huggingface. For direct (hash-based) caching, set dimension: 1." }}
-{{- end }}
-{{- if not .Values.bifrost.plugins.semanticCache.config.keys }}
-{{- fail "ERROR: bifrost.plugins.semanticCache.config.keys is required for semantic caching. Provide at least one API key for the embedding provider. For direct (hash-based) caching, set dimension: 1." }}
+{{- fail "ERROR: bifrost.plugins.semanticCache.config.provider is required for semantic caching. Supported providers: openai, anthropic, gemini, bedrock, azure, cohere, mistral, groq, ollama, openrouter, vertex, cerebras, parasail, perplexity, sgl, huggingface. The provider's API keys are inherited from bifrost.providers, so configure that provider there. For direct (hash-based) caching, set dimension: 1." }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm-charts/bifrost/values-examples/postgres-qdrant.yaml
+++ b/helm-charts/bifrost/values-examples/postgres-qdrant.yaml
@@ -58,24 +58,27 @@ vectorStore:
 bifrost:
   client:
     enableLogging: true
-  providers: {}
-    # Add your provider keys here
+  # The embedding provider for the semantic cache below. Its API key is injected
+  # from the Kubernetes secret (semanticCache.secretRef) as SEMANTIC_CACHE_API_KEY.
+  providers:
+    openai:
+      keys:
+        - name: "embeddings"
+          value: "env.SEMANTIC_CACHE_API_KEY"
+          weight: 1
+          models: ["text-embedding-3-small"]
 
   # Enable semantic cache plugin to use Qdrant vector store
   plugins:
     semanticCache:
       enabled: true
-      # OPTION 1 (Recommended): Reference to external Kubernetes Secret for OpenAI API key
-      # Create the secret with: kubectl create secret generic bifrost-semantic-cache --from-literal=openai-key=sk-YOUR_OPENAI_KEY
+      # OpenAI key for the embedding provider, injected as SEMANTIC_CACHE_API_KEY (used by providers.openai above).
+      # Create it: kubectl create secret generic bifrost-semantic-cache --from-literal=openai-key=sk-YOUR_OPENAI_KEY
       secretRef:
         name: "bifrost-semantic-cache"
         key: "openai-key"
-      # OPTION 2 (Not recommended): Or uncomment to provide keys directly (not secure)
-      # Remove secretRef above and uncomment the keys below:
       config:
         provider: "openai"
-        # keys:
-        #   - "REPLACE_WITH_OPENAI_API_KEY"  # Not recommended: use secretRef instead
         embedding_model: "text-embedding-3-small"
         dimension: 1536
         threshold: 0.8

--- a/helm-charts/bifrost/values-examples/postgres-redis.yaml
+++ b/helm-charts/bifrost/values-examples/postgres-redis.yaml
@@ -53,8 +53,15 @@ vectorStore:
 bifrost:
   client:
     enableLogging: true
-  providers: {}
-    # Add your provider keys here
+  # The embedding provider for the semantic cache below. Its API key is injected
+  # from the Kubernetes secret (semanticCache.secretRef) as SEMANTIC_CACHE_API_KEY.
+  providers:
+    openai:
+      keys:
+        - name: "embeddings"
+          value: "env.SEMANTIC_CACHE_API_KEY"
+          weight: 1
+          models: ["text-embedding-3-small"]
   
   # Enable semantic cache plugin to use Redis vector store
   plugins:
@@ -67,7 +74,6 @@ bifrost:
         key: "openai-key"
       config:
         provider: "openai"
-        # keys are injected from the secret via environment variable
         embedding_model: "text-embedding-3-small"
         dimension: 1536
         threshold: 0.8

--- a/helm-charts/bifrost/values-examples/postgres-weaviate.yaml
+++ b/helm-charts/bifrost/values-examples/postgres-weaviate.yaml
@@ -50,8 +50,15 @@ vectorStore:
 bifrost:
   client:
     enableLogging: true
-  providers: {}
-    # Add your provider keys here
+  # The embedding provider for the semantic cache below. Its API key is injected
+  # from the Kubernetes secret (semanticCache.secretRef) as SEMANTIC_CACHE_API_KEY.
+  providers:
+    openai:
+      keys:
+        - name: "embeddings"
+          value: "env.SEMANTIC_CACHE_API_KEY"
+          weight: 1
+          models: ["text-embedding-3-small"]
   
   # Enable semantic cache plugin to use vector store
   plugins:
@@ -64,7 +71,6 @@ bifrost:
         key: "openai-key"
       config:
         provider: "openai"
-        # keys are injected from the secret via environment variable
         embedding_model: "text-embedding-3-small"
         dimension: 1536
         threshold: 0.8

--- a/helm-charts/bifrost/values-examples/production-ha.yaml
+++ b/helm-charts/bifrost/values-examples/production-ha.yaml
@@ -101,8 +101,15 @@ bifrost:
     enableLogging: true
     maxRequestBodySizeMb: 100
   
-  providers: {}
-    # Add your production provider keys here
+  # The embedding provider for the semantic cache below. Its API key is injected
+  # from the Kubernetes secret (semanticCache.secretRef) as SEMANTIC_CACHE_API_KEY.
+  providers:
+    openai:
+      keys:
+        - name: "embeddings"
+          value: "env.SEMANTIC_CACHE_API_KEY"
+          weight: 1
+          models: ["text-embedding-3-small"]
   
   plugins:
     telemetry:
@@ -122,7 +129,6 @@ bifrost:
         key: "openai-key"
       config:
         provider: "openai"
-        # keys are injected from the secret via environment variable
         embedding_model: "text-embedding-3-small"
         dimension: 1536
         threshold: 0.85

--- a/helm-charts/bifrost/values-examples/providers-and-virtual-keys.yaml
+++ b/helm-charts/bifrost/values-examples/providers-and-virtual-keys.yaml
@@ -91,7 +91,8 @@ bifrost:
     allowedOrigins:
       - "*"
     enableLogging: true
-    enforceGovernanceHeader: false
+    # Require auth (VK / API key / user token) on inference endpoints. Set true to enforce the virtual keys defined below
+    enforceAuthOnInference: false
     maxRequestBodySizeMb: 100
 
   # ==========================================================================
@@ -314,14 +315,14 @@ bifrost:
           value: "env.AZURE_API_KEY"
           weight: 1
           models: ["gpt-4o", "gpt-4o-mini", "text-embedding-3-small"]
+          # aliases map a model name to its Azure deployment name (replaces the
+          # removed azure_key_config.deployments field). Omit when they match.
+          aliases:
+            gpt-4o: "gpt-4o-prod"
+            gpt-4o-mini: "gpt-4o-mini-prod"
+            text-embedding-3-small: "embeddings-prod"
           azure_key_config:
-            endpoint: "env.AZURE_ENDPOINT" # e.g. https://my-resource.openai.azure.com
-            api_version: "2024-10-21"
-            deployments:
-              # Logical model name -> Azure deployment name
-              gpt-4o: "gpt-4o-prod"
-              gpt-4o-mini: "gpt-4o-mini-prod"
-              text-embedding-3-small: "embeddings-prod"
+            endpoint: "env.AZURE_ENDPOINT" # e.g. https://my-resource.openai.azure.com. Uses the Azure v1 API — no api_version.
         - name: "azure-managed-identity"
           # Pure identity inheritance: empty `value` triggers DefaultAzureCredential.
           # Works out-of-the-box on AKS with workload identity, Azure VMs with
@@ -329,11 +330,10 @@ bifrost:
           value: ""
           weight: 1
           models: ["gpt-4o"]
+          aliases:
+            gpt-4o: "gpt-4o-prod"
           azure_key_config:
             endpoint: "env.AZURE_ENDPOINT"
-            api_version: "2024-10-21"
-            deployments:
-              gpt-4o: "gpt-4o-prod"
 
     # Google Vertex AI — two auth modes:
     #   1. vertex-sa-key:       explicit service-account key JSON via env var.

--- a/helm-charts/bifrost/values-examples/sqlite-qdrant.yaml
+++ b/helm-charts/bifrost/values-examples/sqlite-qdrant.yaml
@@ -37,8 +37,15 @@ vectorStore:
 bifrost:
   client:
     enableLogging: true
-  providers: {}
-    # Add your provider keys here
+  # The embedding provider for the semantic cache below. Its API key is injected
+  # from the Kubernetes secret (semanticCache.secretRef) as SEMANTIC_CACHE_API_KEY.
+  providers:
+    openai:
+      keys:
+        - name: "embeddings"
+          value: "env.SEMANTIC_CACHE_API_KEY"
+          weight: 1
+          models: ["text-embedding-3-small"]
 
   # Enable semantic cache plugin to use vector store
   plugins:
@@ -51,7 +58,6 @@ bifrost:
         key: "openai-key"
       config:
         provider: "openai"
-        # keys are injected from the secret via environment variable
         embedding_model: "text-embedding-3-small"
         dimension: 1536
         threshold: 0.8

--- a/helm-charts/bifrost/values-examples/sqlite-redis.yaml
+++ b/helm-charts/bifrost/values-examples/sqlite-redis.yaml
@@ -51,24 +51,27 @@ vectorStore:
 bifrost:
   client:
     enableLogging: true
-  providers: {}
-    # Add your provider keys here
+  # The embedding provider for the semantic cache below. Its API key is injected
+  # from the Kubernetes secret (semanticCache.secretRef) as SEMANTIC_CACHE_API_KEY.
+  providers:
+    openai:
+      keys:
+        - name: "embeddings"
+          value: "env.SEMANTIC_CACHE_API_KEY"
+          weight: 1
+          models: ["text-embedding-3-small"]
   
   # Enable semantic cache plugin to use Redis vector store
   plugins:
     semanticCache:
       enabled: true
-      # OPTION 1 (Recommended): Reference to external Kubernetes Secret for OpenAI API key
-      # Create the secret with: kubectl create secret generic bifrost-semantic-cache --from-literal=openai-key=sk-YOUR_OPENAI_KEY
+      # OpenAI key for the embedding provider, injected as SEMANTIC_CACHE_API_KEY (used by providers.openai above).
+      # Create it: kubectl create secret generic bifrost-semantic-cache --from-literal=openai-key=sk-YOUR_OPENAI_KEY
       secretRef:
         name: "bifrost-semantic-cache"
         key: "openai-key"
-      # OPTION 2 (Not recommended): Or uncomment to provide keys directly (not secure)
-      # Remove secretRef above and uncomment the keys below:
       config:
         provider: "openai"
-        # keys:
-        #   - "REPLACE_WITH_OPENAI_API_KEY"  # Not recommended: use secretRef instead
         embedding_model: "text-embedding-3-small"
         dimension: 1536
         threshold: 0.8

--- a/helm-charts/bifrost/values-examples/sqlite-weaviate.yaml
+++ b/helm-charts/bifrost/values-examples/sqlite-weaviate.yaml
@@ -38,8 +38,15 @@ vectorStore:
 bifrost:
   client:
     enableLogging: true
-  providers: {}
-    # Add your provider keys here
+  # The embedding provider for the semantic cache below. Its API key is injected
+  # from the Kubernetes secret (semanticCache.secretRef) as SEMANTIC_CACHE_API_KEY.
+  providers:
+    openai:
+      keys:
+        - name: "embeddings"
+          value: "env.SEMANTIC_CACHE_API_KEY"
+          weight: 1
+          models: ["text-embedding-3-small"]
   
   # Enable semantic cache plugin to use vector store
   plugins:
@@ -52,7 +59,6 @@ bifrost:
         key: "openai-key"
       config:
         provider: "openai"
-        # keys are injected from the secret via environment variable
         embedding_model: "text-embedding-3-small"
         dimension: 1536
         threshold: 0.8

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -960,13 +960,6 @@
                         "huggingface"
                       ]
                     },
-                    "keys": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      },
-                      "description": "API keys for embedding provider (required for semantic caching, not needed for direct caching with dimension: 1)"
-                    },
                     "embedding_model": {
                       "type": "string"
                     },

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -604,10 +604,10 @@ bifrost:
       enabled: false
       version: 1
       config:
-        # Semantic caching mode (dimension > 1): requires provider, keys, and embedding_model
-        # Direct caching mode (dimension: 1): hash-based exact matching, no embedding provider needed
+        # Semantic mode (dimension > 1): set provider + embedding_model. The provider's API keys
+        #   are inherited from bifrost.providers, so configure that provider there (not here).
+        # Direct mode (dimension: 1): hash-based exact matching, no embedding provider needed.
         provider: "openai"
-        keys: []
         embedding_model: "text-embedding-3-small"
         dimension: 1536
         threshold: 0.8


### PR DESCRIPTION
## Summary

The semantic cache plugin's embedding provider API keys are now inherited from `bifrost.providers` instead of being configured directly inside the plugin's `config` block. This removes the redundant `keys` field from the semantic cache config and aligns key management with the rest of the Bifrost provider configuration pattern.

## Changes

- Removed the `keys` field from `semanticCache.config` in the Helm chart schema, values, helpers, and all example overlays. The embedding provider's API key must now be configured under `bifrost.providers` and is inherited automatically by the plugin.
- Updated the validation error message in `_helpers.tpl` to reflect that keys are no longer configured in the plugin block.
- Added concrete `bifrost.providers.openai` blocks to all semantic cache example overlays (`sqlite-redis`, `sqlite-qdrant`, `sqlite-weaviate`, `postgres-redis`, `postgres-qdrant`, `postgres-weaviate`, `production-ha`) showing how to wire the Kubernetes secret into the provider via `env.SEMANTIC_CACHE_API_KEY`.
- Added a Helm tab to the semantic caching documentation with a full working example and a note explaining the key inheritance model.
- Removed the deprecated `disable_auth_on_inference` field from several example configs and moved `auth_config` into the `governance` block where it belongs in `withconfigstore/config.json`.
- Renamed `credentials` to `credentials_json` in the GCS object storage example config.
- Changed the default `trace_type` in the OTel example config from `otel` to `genai_extension`.
- Replaced the deprecated `enforceGovernanceHeader` / `enforceSCIMAuth` fields with `enforceAuthOnInference` in the client config examples.
- Removed `azure_key_config.api_version` and `azure_key_config.deployments` from Azure provider examples, replacing deployments with the `aliases` field and noting that the Azure v1 API requires no `api_version`.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

1. Deploy any of the updated example overlays (e.g. `sqlite-redis.yaml`) and confirm the semantic cache initialises correctly using the provider key defined under `bifrost.providers`.
2. Confirm that omitting `bifrost.plugins.semanticCache.config.provider` (with `dimension != 1`) still produces the updated validation error message.
3. Confirm that passing a `keys` field inside `semanticCache.config` no longer has any effect and does not cause a schema validation error.

```sh
helm template bifrost ./helm-charts/bifrost -f helm-charts/bifrost/values-examples/sqlite-redis.yaml | grep -A5 semanticCache
```

## Breaking changes

- [x] Yes
- [ ] No

The `keys` field inside `bifrost.plugins.semanticCache.config` is removed. Any existing values files that set `semanticCache.config.keys` must be migrated: move the API key to `bifrost.providers.<provider>.keys` and reference it via an environment variable (e.g. `env.SEMANTIC_CACHE_API_KEY`). The `secretRef` mechanism for injecting the key into the environment remains unchanged.

## Security considerations

Embedding provider API keys are no longer accepted as a plain list inside the plugin config block, reducing the surface area for accidentally committing keys in values files. Keys must flow through `bifrost.providers`, which already supports `env.*` references and Kubernetes secret injection via `secretRef`.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable