### PR TITLE
fix: OTEL UI fix

### DIFF
--- a/ui/app/workspace/observability/fragments/otelFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/otelFormFragment.tsx
@@ -605,11 +605,12 @@ function OtelProfileSection({ form, control, index, hasOtelAccess, canRemove, op
 											</FormItem>
 										)}
 									/>
+									<div className="flex flex-col gap-4 sm:flex-row sm:items-start">
 									<FormField
 										control={control}
 										name={`${base}.trace_type`}
 										render={({ field }) => (
-											<FormItem className="w-full max-w-xs">
+											<FormItem className="w-full sm:flex-1">
 												<FormLabel>Format</FormLabel>
 												<Select onValueChange={field.onChange} value={field.value ?? traceTypeOptions[0].value} disabled={!hasOtelAccess}>
 													<FormControl>
@@ -638,7 +639,7 @@ function OtelProfileSection({ form, control, index, hasOtelAccess, canRemove, op
 										control={control}
 										name={`${base}.export_timeout`}
 										render={({ field }) => (
-											<FormItem className="w-full max-w-xs">
+											<FormItem className="w-full sm:flex-1">
 												<FormLabel>Export Timeout (seconds)</FormLabel>
 												<FormControl>
 													<Input
@@ -659,6 +660,7 @@ function OtelProfileSection({ form, control, index, hasOtelAccess, canRemove, op
 											</FormItem>
 										)}
 									/>
+									</div>
 									<FormField
 										control={control}
 										name={`${base}.request_headers`}


### PR DESCRIPTION
## Summary

The "Format" and "Export Timeout" fields in the OTel profile form section are now displayed side-by-side on wider screens, improving the layout density and visual consistency of the observability configuration form.

## Changes

- Wrapped the `trace_type` (Format) and `export_timeout` (Export Timeout) form fields in a flex container that stacks vertically on small screens and switches to a horizontal row on `sm` and larger breakpoints.
- Replaced fixed `max-w-xs` width constraints on both fields with `sm:flex-1` so they share available space equally when displayed in a row.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

Navigate to the observability settings page and open an OTel profile. Verify that the "Format" and "Export Timeout" fields appear side-by-side on wider viewports and stack vertically on narrow/mobile viewports.

## Screenshots/Recordings

Before/after screenshots of the OTel profile form on both mobile and desktop viewports recommended.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable