### PR TITLE
docs: add `max_turns_to_send` and `evaluation_mode` rule fields, move `sampling_rate` to rule level

### DIFF
--- a/docs/deployment-guides/config-json/guardrails.mdx
+++ b/docs/deployment-guides/config-json/guardrails.mdx
@@ -55,8 +55,7 @@ Runs entirely in-process with no external dependency. Patterns use RE2 syntax. S
               "redaction_strategy": "replace",
               "redaction_mode": "logs_only"
             }
-          ],
-          "sampling_rate": 100
+          ]
         }
       }
     ]
@@ -215,9 +214,7 @@ Supports three auth modes: `keys` (static credentials), `api_key` (Bedrock API k
           "auth_type": "keys",
           "access_key": "env.AWS_ACCESS_KEY_ID",
           "secret_key": "env.AWS_SECRET_ACCESS_KEY",
-          "session_token": "env.AWS_SESSION_TOKEN",
-
-          "sampling_rate": 100
+          "session_token": "env.AWS_SESSION_TOKEN"
         }
       }
     ]
@@ -270,8 +267,7 @@ Supports three auth modes: `api_key`, `default_credential` (managed identity / A
           "indirect_attack_shield_enabled": true,
           "copyright_enabled": false,
           "text_blocklist_enabled": false,
-          "blocklist_names": [],
-          "sampling_rate": 100
+          "blocklist_names": []
         }
       }
     ]
@@ -420,8 +416,7 @@ Calls CrowdStrike AIDR's `guard_chat_completions` endpoint for policy-driven AI 
           "violation_threshold": 0.7,
           "policy_id": "YOUR_GRAYSWAN_POLICY_ID",
           "policy_ids": [],
-          "rules": {},
-          "sampling_rate": 100
+          "rules": {}
         }
       }
     ]
@@ -525,7 +520,6 @@ Any field marked **env.\* supported** accepts a bare `"env.VAR_NAME"` string in 
 | `role_arn` | No | Yes | IAM role ARN to assume (optional, `auth_type="iam_role"`) |
 | `external_id` | No | Yes | External ID for role assumption |
 | `session_name` | No | Yes | Session name for role assumption |
-| `sampling_rate` | No | **Plain only** | `0`–`100`; percentage of requests to evaluate (default: `100`) |
 | `timeout` | No | **Plain only** | Execution timeout in seconds |
 
 ### Azure Content Safety
@@ -546,7 +540,6 @@ Any field marked **env.\* supported** accepts a bare `"env.VAR_NAME"` string in 
 | `text_blocklist_enabled` | No | **Plain only** | Enable custom blocklists (default: `false`) |
 | `scopes` | No | **Plain only** | OAuth scopes (string array) |
 | `blocklist_names` | No | **Plain only** | Blocklist names to apply (string array) |
-| `sampling_rate` | No | **Plain only** | `0`–`100`; percentage of requests to evaluate (default: `100`) |
 | `timeout` | No | **Plain only** | Execution timeout in seconds |
 
 ### Microsoft Presidio
@@ -632,7 +625,6 @@ Any field marked **env.\* supported** accepts a bare `"env.VAR_NAME"` string in 
 | `policy_id` | Yes | **Plain only** | Required Gray Swan policy ID string |
 | `policy_ids` | No | **Plain only** | Multiple policy IDs (string array) |
 | `rules` | No | **Plain only** | Inline rule map (`{ "rule_name": "description" }`) |
-| `sampling_rate` | No | **Plain only** | `0`–`100`; percentage of requests to evaluate (default: `100`) |
 | `timeout` | No | **Plain only** | Execution timeout in seconds |
 
 ### Lakera Guard
@@ -664,7 +656,6 @@ Any field marked **env.\* supported** accepts a bare `"env.VAR_NAME"` string in 
 | `patterns[].action` | No | **Plain only** | `detect_only` \| `block` \| `redact` (default: `block`) |
 | `patterns[].redaction_strategy` | No | **Plain only** | `replace` \| `mask` \| `hash` (default: `replace`) |
 | `patterns[].redaction_mode` | No | **Plain only** | `runtime` \| `logs_only` \| `runtime_reversible` (default: `runtime`) |
-| `sampling_rate` | No | **Plain only** | `0`–`100`; percentage of requests to evaluate (default: `100`) |
 
 ### Secrets
 
@@ -747,6 +738,8 @@ Target-specific variables are isolated. For example, `model` is unavailable to M
         "apply_to": "output",
         "sampling_rate": 100,
         "timeout": 15,
+        "max_turns_to_send": 8,
+        "evaluation_mode": "per_turn",
         "stream_replay_event_interval_ms": 25,
         "provider_config_ids": [3]
       },
@@ -790,6 +783,9 @@ Target-specific variables are isolated. For example, `model` is unavailable to M
 | `apply_to` | Yes | `"input"`, `"output"`, or `"both"`. For MCP rules, input is the tool arguments and output is the tool result |
 | `sampling_rate` | No | `0`–`100`; percentage of requests to evaluate (default: `100`) |
 | `timeout` | No | Rule timeout in seconds |
+| `max_turns_to_send` | No | Number of historical conversation turns to send to the guardrail provider; the latest message is always included. `0` sends all turns |
+| `evaluation_mode` | No | `bundled` (default) sends all selected turns in one guardrail call; `per_turn` evaluates each turn in isolation and uses more provider calls |
+| `stream_replay_event_interval_ms` | No | Delay in milliseconds between buffered events after block-capable streaming output guardrails allow the response. `0` sends buffered events immediately; maximum `1000` |
 | `provider_config_ids` | No | `id` values of providers to invoke when this rule matches. Multiple providers run in parallel |
 
 `max_turns_to_send`, `evaluation_mode`, and `stream_replay_event_interval_ms` configure LLM conversation and streaming behavior. They do not change MCP tool execution behavior.
@@ -861,6 +857,9 @@ Target-specific variables are isolated. For example, `model` is unavailable to M
         "apply_to": "both",
         "sampling_rate": 100,
         "timeout": 15,
+        "max_turns_to_send": 8,
+        "evaluation_mode": "per_turn",
+        "stream_replay_event_interval_ms": 25,
         "provider_config_ids": [2]
       }
     ]

--- a/docs/deployment-guides/helm/guardrails.mdx
+++ b/docs/deployment-guides/helm/guardrails.mdx
@@ -50,7 +50,6 @@ bifrost:
               action: "redact"
               redaction_strategy: "replace"
               redaction_mode: "logs_only"
-          sampling_rate: 100
 ```
 
 The Web UI's PII Detection template is also a `regex` provider configuration. See [Custom Regex](/enterprise/guardrails/custom-regex) for the full examples, and [Guardrail Redaction](/enterprise/guardrails/redaction) for redaction mode behavior.
@@ -202,7 +201,6 @@ bifrost:
           # external_id: "env.AWS_EXTERNAL_ID"    # optional
           # session_name: "env.AWS_SESSION_NAME"  # optional
 
-          sampling_rate: 100
 ```
 
 </Tab>
@@ -244,7 +242,6 @@ bifrost:
           copyright_enabled: false
           text_blocklist_enabled: false
           blocklist_names: []
-          sampling_rate: 100
 ```
 
 </Tab>
@@ -347,7 +344,6 @@ bifrost:
           policy_id: "YOUR_GRAYSWAN_POLICY_ID"    # required: single policy ID
           policy_ids: []                         # optional: multiple policy IDs
           rules: {}                              # optional: inline rule map
-          sampling_rate: 100
 ```
 
 Gray Swan requests automatically include sanitized incoming request headers in Gray Swan `metadata.headers`; no extra Helm value is required. Credential-bearing headers such as `authorization`, `x-api-key`, API-key variants, cookies, and `grayswan-api-key` are excluded, while non-sensitive context headers such as `x-request-id`, `traceparent`, `x-tenant-id`, `content-type`, and `content-length` are included when present.
@@ -423,7 +419,6 @@ Any field marked **env.\* supported** below accepts a bare `"env.VAR_NAME"` stri
 | `role_arn` | No | Yes | IAM role ARN to assume (optional, `auth_type="iam_role"`) |
 | `external_id` | No | Yes | External ID for role assumption |
 | `session_name` | No | Yes | Session name for role assumption |
-| `sampling_rate` | No | **Plain only** | `0`–`100`; percentage of requests to evaluate (default: `100`) |
 | `timeout` | No | **Plain only** | Execution timeout in seconds |
 
 ### Azure Content Safety
@@ -444,7 +439,6 @@ Any field marked **env.\* supported** below accepts a bare `"env.VAR_NAME"` stri
 | `text_blocklist_enabled` | No | **Plain only** | Enable custom blocklists (default: `false`) |
 | `scopes` | No | **Plain only** | OAuth scopes (string array) |
 | `blocklist_names` | No | **Plain only** | Blocklist names to apply (string array) |
-| `sampling_rate` | No | **Plain only** | `0`–`100`; percentage of requests to evaluate (default: `100`) |
 | `timeout` | No | **Plain only** | Execution timeout in seconds |
 
 ### Microsoft Presidio
@@ -530,7 +524,6 @@ Any field marked **env.\* supported** below accepts a bare `"env.VAR_NAME"` stri
 | `policy_id` | Yes | **Plain only** | Required Gray Swan policy ID string |
 | `policy_ids` | No | **Plain only** | Multiple policy IDs (string array) |
 | `rules` | No | **Plain only** | Inline rule map (`{ "rule_name": "description" }`) |
-| `sampling_rate` | No | **Plain only** | `0`–`100`; percentage of requests to evaluate (default: `100`) |
 | `timeout` | No | **Plain only** | Execution timeout in seconds |
 
 ### Lakera Guard
@@ -562,7 +555,6 @@ Any field marked **env.\* supported** below accepts a bare `"env.VAR_NAME"` stri
 | `patterns[].action` | No | **Plain only** | `detect_only` \| `block` \| `redact` (default: `block`) |
 | `patterns[].redaction_strategy` | No | **Plain only** | `replace` \| `mask` \| `hash` (default: `replace`) |
 | `patterns[].redaction_mode` | No | **Plain only** | `runtime` \| `logs_only` \| `runtime_reversible` (default: `runtime`) |
-| `sampling_rate` | No | **Plain only** | `0`–`100`; percentage of requests to evaluate (default: `100`) |
 
 ### Secrets
 
@@ -631,7 +623,9 @@ Rule fields:
 | `apply_to` | Yes | `"input"`, `"output"`, or `"both"`. For MCP rules, input is the tool arguments and output is the tool result |
 | `sampling_rate` | No | `0`–`100`; percentage of requests to check (default: 100) |
 | `timeout` | No | Rule timeout in seconds |
-| `stream_replay_event_interval_ms` | No | Delay between buffered events after block-capable output guardrails allow a streaming response. Defaults to `0` (immediate delivery); the dashboard uses `25` when pacing is enabled. |
+| `max_turns_to_send` | No | Number of historical conversation turns to send to the guardrail provider; the latest message is always included. `0` sends all turns |
+| `evaluation_mode` | No | `bundled` (default) sends all selected turns in one guardrail call; `per_turn` evaluates each turn in isolation and uses more provider calls |
+| `stream_replay_event_interval_ms` | No | Delay between buffered events after block-capable output guardrails allow a streaming response. Valid range is `0`–`1000` milliseconds; defaults to `0` (immediate delivery). The dashboard uses `25` when pacing is enabled. |
 | `provider_config_ids` | No | Provider `id`s to invoke when this rule matches |
 
 `max_turns_to_send`, `evaluation_mode`, and `stream_replay_event_interval_ms` configure LLM conversation and streaming behavior. They do not change MCP tool execution behavior.
@@ -660,6 +654,8 @@ bifrost:
         apply_to: "output"
         sampling_rate: 100
         timeout: 15
+        max_turns_to_send: 8
+        evaluation_mode: per_turn
         stream_replay_event_interval_ms: 25
         provider_config_ids: [3]
 
@@ -758,6 +754,9 @@ bifrost:
         apply_to: "both"
         sampling_rate: 100
         timeout: 15
+        max_turns_to_send: 8
+        evaluation_mode: per_turn
+        stream_replay_event_interval_ms: 25
         provider_config_ids: [2]
 ```
 

--- a/docs/enterprise/guardrails.mdx
+++ b/docs/enterprise/guardrails.mdx
@@ -254,6 +254,9 @@ Guardrail Rules are custom policies that define when and how content validation 
 | `apply_to` | enum | Yes | When to apply: `input`, `output`, or `both`. For MCP rules, input means tool arguments and output means the tool result |
 | `sampling_rate` | integer | No | Percentage of requests to evaluate (0-100) |
 | `timeout` | integer | No | Execution timeout in seconds (default: 60) |
+| `max_turns_to_send` | integer | No | Number of historical conversation turns sent to the guardrail provider; the latest message is always included. `0` sends all turns |
+| `evaluation_mode` | enum | No | `bundled` (default) sends selected turns in one guardrail call; `per_turn` evaluates each turn in isolation and uses more provider calls |
+| `stream_replay_event_interval_ms` | integer | No | Delay in milliseconds between buffered events after block-capable streaming output guardrails allow the response. `0` sends buffered events immediately; maximum `1000` |
 | `provider_config_ids` | array | No | IDs of profiles to use for evaluation |
 
 ### Creating Rules
@@ -396,6 +399,8 @@ curl -X DELETE http://localhost:8080/api/guardrails/rules/1
         "apply_to": "output",
         "sampling_rate": 100,
         "timeout": 3000,
+        "max_turns_to_send": 8,
+        "evaluation_mode": "per_turn",
         "provider_config_ids": [2]
       },
       {
@@ -441,6 +446,8 @@ bifrost:
         apply_to: "output"
         sampling_rate: 100
         timeout: 3000
+        max_turns_to_send: 8
+        evaluation_mode: per_turn
         stream_replay_event_interval_ms: 25
         provider_config_ids: [2]
       - id: 3

--- a/examples/k8s/enterprise/values-guardrails.yaml
+++ b/examples/k8s/enterprise/values-guardrails.yaml
@@ -57,6 +57,9 @@ bifrost:
         apply_to: "output"
         sampling_rate: 90
         timeout: 1800
+        max_turns_to_send: 8
+        evaluation_mode: "per_turn"
+        stream_replay_event_interval_ms: 25
         provider_config_ids: [2002, 2006, 2008, 2009, 2010]
       - id: 1004
         name: "both-phases-safety-net"


### PR DESCRIPTION
## Summary

This PR documents two new guardrail rule fields (`max_turns_to_send` and `evaluation_mode`) across all guardrail documentation and example configurations, and removes `sampling_rate` from provider-level configuration blocks where it does not belong (it is a rule-level field, not a provider-level field).

## Changes

- Removed `sampling_rate` from provider config examples and reference tables for AWS Bedrock Guardrails, Azure Content Safety, Gray Swan, Lakera Guard, and Microsoft Presidio — `sampling_rate` is a rule-level field and was incorrectly documented at the provider level
- Added `max_turns_to_send` and `evaluation_mode` to the guardrail rule field reference tables and example configurations across `config.json`, Helm, and enterprise guardrails docs
- Added `stream_replay_event_interval_ms` to the rule-level reference table in the `config.json` guide with a full description
- Updated the Kubernetes example values file to include `max_turns_to_send`, `evaluation_mode`, and `stream_replay_event_interval_ms` in the rule configuration

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation to confirm:
- `sampling_rate` no longer appears in provider-level config blocks or reference tables
- `max_turns_to_send`, `evaluation_mode`, and `stream_replay_event_interval_ms` appear correctly in rule-level reference tables with accurate descriptions
- Example YAML/JSON snippets are syntactically valid and consistent across `config.json` and Helm guides

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

None. This is a documentation-only change.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable