### PR TITLE
fix: exclude batch echo rows from missing-cost filter, prevent recalculation billing them, and enforce model allowlist for inline batch requests

### DIFF
--- a/core/schemas/batch.go
+++ b/core/schemas/batch.go
@@ -104,6 +104,11 @@ type BatchAccountingDebug struct {
 	// be parsed at all. Their usage is unrecoverable — the raw results are not
 	// persisted — so the count is kept as the record of how much the row omits.
 	ParseErrorCount int `json:"parse_error_count,omitempty"`
+	// Echo marks a read-only copy of another row's settled price, written onto the
+	// log row of a /results call that did not settle the batch. Such a row is never
+	// billed, so its NULL cost is final rather than pending: without this marker it
+	// looks like an unpriced row to every missing-cost query and recovery pass.
+	Echo bool `json:"echo,omitempty"`
 	// Incomplete marks a total that is known to under-state the batch: some
 	// usage-bearing row failed to price, or rows were lost to parse errors. It is
 	// only ever set, never cleared by a repricing pass — usage that never reached

--- a/framework/logstore/missingcostbatchecho_test.go
+++ b/framework/logstore/missingcostbatchecho_test.go
@@ -1,0 +1,73 @@
+package logstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/require"
+)
+
+// A /results call that did not settle the batch gets a log row carrying a read-only
+// copy of the settled price and no cost of its own. That NULL cost is final — no
+// recalculation will ever fill it — so the row must stay out of "show missing cost
+// only", which it used to flood.
+func TestMissingCostOnlyExcludesBatchEchoRows(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	ctx := context.Background()
+	base := time.Date(2026, 3, 4, 5, 6, 0, 0, time.UTC)
+	settled := 1.25
+
+	newBatchRow := func(id string, ts time.Time, cost *float64, echo bool) *Log {
+		entry := &Log{
+			ID:        id,
+			Timestamp: ts,
+			Object:    string(schemas.BatchResultsRequest),
+			Provider:  "anthropic",
+			Model:     "claude-sonnet-4",
+			Status:    "success",
+			Cost:      cost,
+			BatchDebugParsed: &schemas.BifrostBatchDebug{
+				BatchID: "batch_1",
+				Accounting: &schemas.BatchAccountingDebug{
+					Echo: echo,
+					ModelBreakdowns: map[string]schemas.BatchModelBreakdown{
+						"claude-sonnet-4": {Model: "claude-sonnet-4", RequestCount: 1},
+					},
+				},
+			},
+		}
+		require.NoError(t, entry.SerializeFields())
+		return entry
+	}
+
+	unpricedChat := &Log{
+		ID:        "chat-unpriced",
+		Timestamp: base,
+		Object:    "chat.completion",
+		Provider:  "anthropic",
+		Model:     "claude-sonnet-4",
+		Status:    "success",
+	}
+	// An aggregate row that failed to price is exactly what the filter is for.
+	unpricedAggregate := newBatchRow("batch-aggregate-unpriced", base.Add(time.Minute), nil, false)
+	pricedAggregate := newBatchRow("batch-aggregate-priced", base.Add(2*time.Minute), &settled, false)
+	echoRow := newBatchRow("batch-echo", base.Add(3*time.Minute), nil, true)
+
+	for _, entry := range []*Log{unpricedChat, unpricedAggregate, pricedAggregate, echoRow} {
+		require.NoError(t, store.Create(ctx, entry))
+	}
+
+	result, err := store.SearchLogs(ctx, SearchFilters{MissingCostOnly: true}, PaginationOptions{
+		Limit: 50, SortBy: "timestamp", Order: "asc",
+	})
+	require.NoError(t, err)
+
+	got := make([]string, 0, len(result.Logs))
+	for _, l := range result.Logs {
+		got = append(got, l.ID)
+	}
+	require.ElementsMatch(t, []string{"chat-unpriced", "batch-aggregate-unpriced"}, got,
+		"only rows a recalculation can actually resolve belong in the missing-cost scope")
+}

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -424,7 +424,9 @@ func (s *RDBLogStore) applyFilters(baseQuery *gorm.DB, filters SearchFilters) *g
 	}
 	if filters.MissingCostOnly {
 		// cost is null and status is not error
-		baseQuery = baseQuery.Where("(cost IS NULL OR cost <= 0) AND status NOT IN ('error')")
+		baseQuery = baseQuery.Where(
+			"(cost IS NULL OR cost <= 0) AND status NOT IN ('error') AND COALESCE(batch_debug, '') NOT LIKE ?",
+			"%\"echo\":true%")
 	}
 	if len(filters.CacheHitTypes) > 0 {
 		// Only keep allowed values to avoid passing arbitrary input into the JSON path expression.

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -1052,6 +1052,21 @@ func (p *GovernancePlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.
 		Model:      model,
 		UserID:     userID,
 	}
+	// A batch create fans out to many completions, each naming its own model, so
+	// every model it will run is evaluated before the request itself. Every check
+	// reached from here is read-only, so the extra passes cannot double-count usage.
+	if req.RequestType == schemas.BatchCreateRequest && req.BatchCreateRequest != nil && len(req.BatchCreateRequest.Requests) > 0 {
+		for _, batchModel := range BatchCreateModels(req, model) {
+			batchEvaluationRequest := *evaluationRequest
+			batchEvaluationRequest.Model = batchModel
+			_, bifrostError := p.EvaluateGovernanceRequest(ctx, &batchEvaluationRequest, req.RequestType)
+			if bifrostError != nil {
+				return req, &schemas.LLMPluginShortCircuit{
+					Error: bifrostError,
+				}, nil
+			}
+		}
+	}
 	// Evaluate governance using common function
 	_, bifrostError := p.EvaluateGovernanceRequest(ctx, evaluationRequest, req.RequestType)
 	// Convert BifrostError to LLMPluginShortCircuit if needed
@@ -1062,6 +1077,42 @@ func (p *GovernancePlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.
 	}
 
 	return req, nil, nil
+}
+
+// BatchCreateModels returns every distinct model an inline batch create will run,
+// starting with the request's own model.
+func BatchCreateModels(req *schemas.BifrostRequest, model string) []string {
+	if req.RequestType != schemas.BatchCreateRequest || req.BatchCreateRequest == nil || len(req.BatchCreateRequest.Requests) == 0 {
+		return []string{model}
+	}
+	seen := make(map[string]struct{})
+	models := make([]string, 0, 1)
+	add := func(m string) {
+		if m == "" {
+			return
+		}
+		if _, exists := seen[m]; exists {
+			return
+		}
+		seen[m] = struct{}{}
+		models = append(models, m)
+	}
+	add(model)
+	for _, item := range req.BatchCreateRequest.Requests {
+		// Body is the OpenAI shape, Params the Anthropic one; an item carries one.
+		for _, body := range []map[string]any{item.Body, item.Params} {
+			if m, ok := body["model"].(string); ok {
+				add(m)
+				break
+			}
+		}
+	}
+	if len(models) == 0 {
+		// No item named a model: fall back to the model-less evaluation so the
+		// provider-level and virtual-key checks still run.
+		return []string{model}
+	}
+	return models
 }
 
 // PostLLMHook processes the response and updates usage tracking (business logic execution)

--- a/plugins/governance/resolver.go
+++ b/plugins/governance/resolver.go
@@ -186,7 +186,6 @@ func (r *BudgetResolver) EvaluateTeamRequest(ctx *schemas.BifrostContext, teamID
 		Decision: DecisionAllow,
 		Reason:   "Team-level checks passed",
 	}
-
 }
 
 // EvaluateUserRequest evaluates user-level rate limits and budgets (enterprise-only)
@@ -304,8 +303,7 @@ func (r *BudgetResolver) EvaluateVirtualKeyRequest(ctx *schemas.BifrostContext, 
 	// them. This is separate from skipProviderCheck: a provider the key does configure
 	// still carries a model allowlist that would deny the request one step later.
 	skipModelCheck := bifrost.GetBoolFromContext(ctx, schemas.BifrostContextKeySkipModelCheck)
-	isPassthrough := requestType == schemas.PassthroughRequest || requestType == schemas.PassthroughStreamRequest
-	checkModelIfPresent := isPassthrough || requestType == schemas.VideoEditRequest
+	checkModelIfPresent := IsModelCheckedWhenPresent(requestType)
 	if !skipModelCheck && !providerUnconfigured && (IsModelRequiredForRequest(requestType) || (checkModelIfPresent && model != "")) && !r.isModelAllowed(vk, provider, model) {
 		return &EvaluationResult{
 			Decision:   DecisionModelBlocked,

--- a/plugins/governance/resolver_test.go
+++ b/plugins/governance/resolver_test.go
@@ -689,9 +689,12 @@ func TestBudgetResolver_EvaluateRequest_PassthroughModelFiltering(t *testing.T) 
 		{"passthrough stream disallowed model is blocked", "gpt-4o-mini", schemas.PassthroughStreamRequest, DecisionModelBlocked},
 		{"passthrough stream allowed model passes", "gpt-4", schemas.PassthroughStreamRequest, DecisionAllow},
 		{"passthrough stream without model has no restriction", "", schemas.PassthroughStreamRequest, DecisionAllow},
-		// Scoping guard: batch is model-not-required and not passthrough, so its model is never
-		// filtered even when set to a disallowed value (behavior unchanged by the passthrough fix).
-		{"batch with disallowed model is not filtered", "gpt-4o-mini", schemas.BatchCreateRequest, DecisionAllow},
+		// Batch create carries no model of its own for a file-based batch, but an inline
+		// one names a model per item and governance evaluates each — so the allowlist
+		// applies whenever a model is actually present.
+		{"batch with disallowed model is blocked", "gpt-4o-mini", schemas.BatchCreateRequest, DecisionModelBlocked},
+		{"batch with allowed model passes", "gpt-4", schemas.BatchCreateRequest, DecisionAllow},
+		{"batch without model has no restriction", "", schemas.BatchCreateRequest, DecisionAllow},
 	}
 
 	for _, tt := range tests {

--- a/plugins/governance/utils.go
+++ b/plugins/governance/utils.go
@@ -63,6 +63,23 @@ func IsModelRequiredForRequest(requestType schemas.RequestType) bool {
 	return true
 }
 
+// IsModelCheckedWhenPresent reports whether a request type whose model is optional
+// should still be checked against the model allowlist when it does carry one.
+//
+// These are the types IsModelRequiredForRequest excludes because their model may
+// legitimately be absent — a file-based batch names none, passthrough forwards raw
+// routes, video edit lets the provider infer it. "Optional" must not mean
+// "unenforced": when the caller does name a model, the allowlist applies.
+func IsModelCheckedWhenPresent(requestType schemas.RequestType) bool {
+	switch requestType {
+	case schemas.PassthroughRequest, schemas.PassthroughStreamRequest,
+		schemas.VideoEditRequest, schemas.BatchCreateRequest:
+		return true
+	default:
+		return false
+	}
+}
+
 // parseVirtualKeyFromHTTPRequest parses the virtual key from HTTP request headers.
 // It checks multiple headers in order: x-bf-vk, Authorization (Bearer token), x-api-key, and x-goog-api-key.
 // Parameters:

--- a/plugins/logging/costfidelity_test.go
+++ b/plugins/logging/costfidelity_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/batchaccounting"
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
 	"github.com/stretchr/testify/assert"
@@ -998,7 +999,7 @@ func TestCalculateBatchAggregateCost_MultiModel(t *testing.T) {
 		},
 	}
 
-	cost, batchDebugJSON, err := plugin.calculateBatchAggregateCost(entry)
+	cost, batchDebugJSON, err := plugin.calculateBatchAggregateCost(entry, false)
 	require.NoError(t, err)
 	assert.NotEmpty(t, batchDebugJSON)
 
@@ -1044,7 +1045,7 @@ func TestCalculateBatchAggregateCost_PartiallyUnpriced(t *testing.T) {
 		},
 	}
 
-	cost, _, err := plugin.calculateBatchAggregateCost(entry)
+	cost, _, err := plugin.calculateBatchAggregateCost(entry, false)
 	require.NoError(t, err)
 	assertCostsEqual(t, "partially-unpriced batch total", cost, 1000*1.25e-06+200*5e-06)
 
@@ -1080,14 +1081,14 @@ func TestCalculateBatchAggregateCost_EmbeddingEndpointUsesEmbeddingRates(t *test
 		}
 	}
 
-	cost, _, err := plugin.calculateBatchAggregateCost(newEntry(string(schemas.BatchEndpointEmbeddings)))
+	cost, _, err := plugin.calculateBatchAggregateCost(newEntry(string(schemas.BatchEndpointEmbeddings)), false)
 	require.NoError(t, err)
 	// testdata input_cost_per_token_batches for text-embedding-3-small: 1e-08.
 	assertCostsEqual(t, "embeddings batch total", cost, 1000*1e-08)
 
 	// Rows written before the endpoint was persisted keep the old behavior rather
 	// than being guessed at — for an embedding-only model that still means unpriceable.
-	_, _, err = plugin.calculateBatchAggregateCost(newEntry(""))
+	_, _, err = plugin.calculateBatchAggregateCost(newEntry(""), false)
 	require.ErrorIs(t, err, errPricingInputsUnavailable)
 }
 
@@ -1114,7 +1115,7 @@ func TestCalculateBatchAggregateCost_PartialRepriceMarksIncomplete(t *testing.T)
 		},
 	}
 
-	_, batchDebugJSON, err := plugin.calculateBatchAggregateCost(entry)
+	_, batchDebugJSON, err := plugin.calculateBatchAggregateCost(entry, false)
 	require.NoError(t, err)
 	assert.True(t, entry.BatchDebugParsed.Accounting.Incomplete)
 
@@ -1148,7 +1149,7 @@ func TestCalculateBatchAggregateCost_IncompleteIsNeverCleared(t *testing.T) {
 		},
 	}
 
-	_, _, err := plugin.calculateBatchAggregateCost(entry)
+	_, _, err := plugin.calculateBatchAggregateCost(entry, false)
 	require.NoError(t, err)
 	assert.True(t, entry.BatchDebugParsed.Accounting.Incomplete,
 		"unparseable rows are gone for good; a successful reprice does not recover them")
@@ -1177,7 +1178,7 @@ func TestCalculateBatchAggregateCost_AllUnpriced(t *testing.T) {
 		},
 	}
 
-	_, _, err := plugin.calculateBatchAggregateCost(entry)
+	_, _, err := plugin.calculateBatchAggregateCost(entry, false)
 	require.ErrorIs(t, err, errPricingInputsUnavailable)
 }
 
@@ -1191,7 +1192,7 @@ func TestRecalculateCostsReprisesMixedModelBatchRow(t *testing.T) {
 	store := plugin.store
 
 	entry := &logstore.Log{
-		ID:        "batch-e2e-mixed",
+		ID:        batchaccounting.AccountingLogID(schemas.OpenAI, "batch_e2e_mixed"),
 		Timestamp: time.Now().UTC(),
 		Object:    string(schemas.BatchResultsRequest),
 		Provider:  string(schemas.OpenAI),
@@ -1214,7 +1215,7 @@ func TestRecalculateCostsReprisesMixedModelBatchRow(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, result.Updated)
 
-	logged, err := store.FindByID(context.Background(), "batch-e2e-mixed")
+	logged, err := store.FindByID(context.Background(), batchaccounting.AccountingLogID(schemas.OpenAI, "batch_e2e_mixed"))
 	require.NoError(t, err)
 	require.NotNil(t, logged.Cost)
 
@@ -1246,7 +1247,7 @@ func TestRunCostRecalcJobDoesNotZeroPricedBatchRow(t *testing.T) {
 	settledCost := wantGPT4o + wantGPT4oMini
 
 	entry := &logstore.Log{
-		ID:        "batch-job-priced",
+		ID:        batchaccounting.AccountingLogID(schemas.OpenAI, "batch_job_priced"),
 		Timestamp: time.Now().UTC(),
 		Object:    string(schemas.BatchResultsRequest),
 		Provider:  string(schemas.OpenAI),
@@ -1277,7 +1278,7 @@ func TestRunCostRecalcJobDoesNotZeroPricedBatchRow(t *testing.T) {
 	require.NoError(t, sonic.Unmarshal([]byte(finalJSON), &meta))
 	require.Equal(t, 1, meta.Updated)
 
-	logged, err := store.FindByID(ctx, "batch-job-priced")
+	logged, err := store.FindByID(ctx, batchaccounting.AccountingLogID(schemas.OpenAI, "batch_job_priced"))
 	require.NoError(t, err)
 	require.NotNil(t, logged.Cost)
 	assertCostsEqual(t, "batch row cost after background recalculation", *logged.Cost, settledCost)
@@ -1290,4 +1291,70 @@ func TestRunCostRecalcJobDoesNotZeroPricedBatchRow(t *testing.T) {
 	assertCostsEqual(t, "gpt-4o breakdown cost", *breakdowns["gpt-4o"].Cost, wantGPT4o)
 	require.NotNil(t, breakdowns["gpt-4o-mini"].Cost)
 	assertCostsEqual(t, "gpt-4o-mini breakdown cost", *breakdowns["gpt-4o-mini"].Cost, wantGPT4oMini)
+}
+
+// TestRecalculateCostsDoesNotBillBatchEchoRow is the regression test for a
+// recalculation turning one batch into N charges. A repeated /results fetch gets
+// its own log row carrying the settled breakdowns and a snapshot cost, and it is
+// indistinguishable from the settlement row by object type — so repricing wrote a
+// full copy of the batch bill onto every one of them. The echo row must keep a
+// NULL cost (it contributes to no total) while the price it displays is refreshed.
+func TestRecalculateCostsDoesNotBillBatchEchoRow(t *testing.T) {
+	plugin := newCostFidelityPlugin(t)
+	store := plugin.store
+	ctx := context.Background()
+
+	const batchID = "batch_echo"
+	aggregateID := batchaccounting.AccountingLogID(schemas.OpenAI, batchID)
+	staleCost := 42.0
+	now := time.Now().UTC()
+
+	breakdowns := func() map[string]schemas.BatchModelBreakdown {
+		return map[string]schemas.BatchModelBreakdown{"gpt-4o": batchModelBreakdown(1000, 200)}
+	}
+	wantCost := 1000*1.25e-06 + 200*5e-06
+
+	aggregate := &logstore.Log{
+		ID:        aggregateID,
+		Timestamp: now,
+		Object:    string(schemas.BatchResultsRequest),
+		Provider:  string(schemas.OpenAI),
+		Model:     "gpt-4o",
+		Status:    "success",
+		BatchDebugParsed: &schemas.BifrostBatchDebug{
+			BatchID:    batchID,
+			Accounting: &schemas.BatchAccountingDebug{ModelBreakdowns: breakdowns()},
+		},
+	}
+	echo := &logstore.Log{
+		ID:        "echo-results-fetch",
+		Timestamp: now.Add(time.Minute),
+		Object:    string(schemas.BatchResultsRequest),
+		Provider:  string(schemas.OpenAI),
+		Model:     "gpt-4o",
+		Status:    "success",
+		BatchDebugParsed: &schemas.BifrostBatchDebug{
+			BatchID:    batchID,
+			Accounting: &schemas.BatchAccountingDebug{ModelBreakdowns: breakdowns(), Cost: &staleCost},
+		},
+	}
+	require.NoError(t, store.Create(ctx, aggregate))
+	require.NoError(t, store.Create(ctx, echo))
+
+	_, err := plugin.RecalculateCosts(ctx, logstore.SearchFilters{}, 10)
+	require.NoError(t, err)
+
+	settled, err := store.FindByID(ctx, aggregateID)
+	require.NoError(t, err)
+	require.NotNil(t, settled.Cost, "the settlement row owns the bill")
+	assertCostsEqual(t, "aggregate row cost", *settled.Cost, wantCost)
+
+	fetched, err := store.FindByID(ctx, "echo-results-fetch")
+	require.NoError(t, err)
+	require.Nil(t, fetched.Cost, "an echo row must never be billed")
+	require.NotNil(t, fetched.BatchDebugParsed)
+	require.NotNil(t, fetched.BatchDebugParsed.Accounting)
+	require.NotNil(t, fetched.BatchDebugParsed.Accounting.Cost)
+	assertCostsEqual(t, "echo row displayed cost", *fetched.BatchDebugParsed.Accounting.Cost, wantCost)
+	require.NotNil(t, fetched.BatchDebugParsed.Accounting.ModelBreakdowns["gpt-4o"].Cost)
 }

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -450,6 +450,7 @@ func attachBatchResultsDisplay(entry *logstore.Log, batchResp *schemas.BifrostBa
 			accounting := &schemas.BatchAccountingDebug{
 				ModelBreakdowns: summary.ModelBreakdowns,
 				Incomplete:      !summary.Complete,
+				Echo:            true,
 			}
 			if summary.Complete {
 				cost := summary.Cost

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -1631,6 +1631,10 @@ type billingOutcome struct {
 	// model_breakdowns would stay stuck showing the pre-recalculation (unpriced)
 	// state even after cost is fixed.
 	batchDebugUpdate string
+	// batchDebugOnly marks a repriced batch echo row: batch_debug is refreshed so
+	// the displayed price is current, but the cost column is left NULL. Writing a
+	// cost there would bill the batch once per /results fetch.
+	batchDebugOnly bool
 }
 
 // recalcTally is what persisting one page of billing outcomes did.
@@ -1674,6 +1678,17 @@ func (p *LoggerPlugin) persistRecalcOutcomes(ctx context.Context, batch []logsto
 				tally.skipped++
 				p.logger.Debug("skipping cost recalculation for log %s: resolved cost is zero", logEntry.ID)
 			}
+			continue
+		}
+		if outcomes[i].batchDebugUpdate != "" && outcomes[i].batchDebugOnly {
+			// Echo row: refresh only what it displays. Its cost stays NULL, so it
+			// contributes to no total and priced stays false for the cursor.
+			if err := p.store.Update(ctx, logEntry.ID, map[string]any{
+				"batch_debug": outcomes[i].batchDebugUpdate,
+			}); err != nil {
+				return recalcTally{}, fmt.Errorf("failed to update batch display cost for log %s: %w", logEntry.ID, err)
+			}
+			tally.updated++
 			continue
 		}
 		if outcomes[i].batchDebugUpdate != "" {
@@ -1767,11 +1782,14 @@ func (p *LoggerPlugin) priceLogsInChunks(ctx context.Context, batch []logstore.L
 				outcomes[i].err = fmt.Errorf("%w: log %s", errPricingInputsUnavailable, batch[i].ID)
 				continue
 			}
-			if isBatchAggregateRow(&batch[i]) {
+			if role := batchRowRoleOf(&batch[i]); role != batchRowRoleNone {
 				// Batch aggregate rows reprice per model and carry only a scalar
 				// total (no input/output split), persisted via the batchDebugUpdate
-				// path below.
-				outcomes[i].cost, outcomes[i].batchDebugUpdate, outcomes[i].err = p.calculateBatchAggregateCost(&batch[i])
+				// path below. An echo row reprices identically, but only to refresh
+				// what it displays; the bill stays on the aggregate row alone.
+				isEcho := role == batchRowRoleEcho
+				outcomes[i].batchDebugOnly = isEcho
+				outcomes[i].cost, outcomes[i].batchDebugUpdate, outcomes[i].err = p.calculateBatchAggregateCost(&batch[i], isEcho)
 			} else {
 				outcomes[i].breakdown, outcomes[i].err = p.calculateCostBreakdownForLog(&batch[i])
 				if outcomes[i].breakdown != nil {
@@ -1806,20 +1824,51 @@ func (p *LoggerPlugin) priceLogsInChunks(ctx context.Context, batch []logstore.L
 	return outcomes, nil
 }
 
-// isBatchAggregateRow reports whether logEntry is a batch settlement row with
-// per-model usage to reprice from. AfterFind deserializes BatchDebug on every
-// load, so BatchDebugParsed is normally already populated; the direct-field
-// check here is a cheap defensive fallback, not the primary path.
-func isBatchAggregateRow(logEntry *logstore.Log) bool {
+// batchRowRole distinguishes the two kinds of row that carry batch accounting.
+type batchRowRole int
+
+const (
+	// batchRowRoleNone is any row that is not a batch accounting row.
+	batchRowRoleNone batchRowRole = iota
+	// batchRowRoleAggregate is the single settlement row that owns the batch's bill.
+	batchRowRoleAggregate
+	// batchRowRoleEcho is a /results HTTP call's own log row, which carries a
+	// read-only copy of the aggregate row's price for display.
+	batchRowRoleEcho
+)
+
+// batchRowRoleOf classifies a row that carries per-model batch usage.
+//
+// A repeated /results fetch gets its own row stamped with the settled breakdowns,
+// and its object is "batch_results" just like the settlement row's — so repricing
+// both as owners billed the batch once per fetch. Only the aggregate row's id is
+// derived from (provider, batch id), which separates them exactly.
+func batchRowRoleOf(logEntry *logstore.Log) batchRowRole {
 	if logEntry.BatchDebugParsed == nil && logEntry.BatchDebug != "" {
 		if err := logEntry.DeserializeFields(); err != nil {
-			return false
+			return batchRowRoleNone
 		}
 	}
-	return logEntry.Object == string(schemas.BatchResultsRequest) &&
-		logEntry.BatchDebugParsed != nil &&
-		logEntry.BatchDebugParsed.Accounting != nil &&
-		len(logEntry.BatchDebugParsed.Accounting.ModelBreakdowns) > 0
+	if logEntry.Object != string(schemas.BatchResultsRequest) ||
+		logEntry.BatchDebugParsed == nil ||
+		logEntry.BatchDebugParsed.Accounting == nil ||
+		len(logEntry.BatchDebugParsed.Accounting.ModelBreakdowns) == 0 {
+		return batchRowRoleNone
+	}
+	if logEntry.BatchDebugParsed.Accounting.Echo {
+		return batchRowRoleEcho
+	}
+	// Rows written before the echo marker existed are classified by id. Without a
+	// batch id there is nothing to derive the aggregate id from, so keep the
+	// pre-split behaviour of treating the row as the owner.
+	batchID := logEntry.BatchDebugParsed.BatchID
+	if batchID == "" {
+		return batchRowRoleAggregate
+	}
+	if logEntry.ID == batchaccounting.AccountingLogID(schemas.ModelProvider(logEntry.Provider), batchID) {
+		return batchRowRoleAggregate
+	}
+	return batchRowRoleEcho
 }
 
 // calculateBatchAggregateCost reprices a batch aggregate row from its per-model
@@ -1838,7 +1887,11 @@ func isBatchAggregateRow(logEntry *logstore.Log) bool {
 // batch_debug JSON to persist alongside it, since BulkUpdateCost only ever
 // writes the cost column and would otherwise leave model_breakdowns stuck
 // showing the pre-recalculation state.
-func (p *LoggerPlugin) calculateBatchAggregateCost(logEntry *logstore.Log) (float64, string, error) {
+//
+// refreshSnapshotCost updates Accounting.Cost, which is where an echo row's
+// displayed price lives; the aggregate row keeps it nil and bills via its cost
+// column.
+func (p *LoggerPlugin) calculateBatchAggregateCost(logEntry *logstore.Log, refreshSnapshotCost bool) (float64, string, error) {
 	accounting := logEntry.BatchDebugParsed.Accounting
 	scopes := pricingScopesForLog(logEntry)
 	// The row's Object is always "batch_results", which normalizes to "chat" — so
@@ -1881,6 +1934,13 @@ func (p *LoggerPlugin) calculateBatchAggregateCost(logEntry *logstore.Log) (floa
 	// those. Clearing it here would close a gap this pass cannot see.
 	if priced < len(accounting.ModelBreakdowns) {
 		accounting.Incomplete = true
+	}
+	if refreshSnapshotCost {
+		refreshed := total
+		accounting.Cost = &refreshed
+		// Stamp the marker while the row is being rewritten anyway, so a row written
+		// before it existed stops relying on the id comparison to be classified.
+		accounting.Echo = true
 	}
 
 	batchDebugJSON, err := sonic.Marshal(logEntry.BatchDebugParsed)

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -3423,9 +3423,12 @@ func (h *CompletionHandler) batchCreate(ctx *fasthttp.RequestCtx) {
 	var model *string
 	if modelName != "" {
 		model = schemas.Ptr(modelName)
-	} else if len(req.Requests) > 0 && req.Requests[0].Body != nil {
-		if m, ok := req.Requests[0].Body["model"].(string); ok && m != "" {
-			model = schemas.Ptr(m)
+	} else if len(req.Requests) > 0 {
+		for _, body := range []map[string]any{req.Requests[0].Body, req.Requests[0].Params} {
+			if m, ok := body["model"].(string); ok && m != "" {
+				model = schemas.Ptr(m)
+				break
+			}
 		}
 	}
 

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -526,23 +526,30 @@ func CreateAnthropicBatchRouteConfigs(pathPrefix string, handlerStore lib.Handle
 					isNonAnthropicProvider = true
 				}
 				var model *string
+				mixedModels := false
 				requests := make([]schemas.BatchRequestItem, len(anthropicReq.Requests))
 				for i, r := range anthropicReq.Requests {
-					if isNonAnthropicProvider {
-						requestModel, ok := r.Params["model"].(string)
-						if !ok {
+					requestModel, ok := r.Params["model"].(string)
+					if !ok || requestModel == "" {
+						// Only the non-Anthropic providers need a model to route at all.
+						if isNonAnthropicProvider {
 							return nil, errors.New("model is required")
 						}
-						if model == nil {
-							model = schemas.Ptr(requestModel)
-						} else if *model != requestModel {
+					} else if model == nil {
+						model = schemas.Ptr(requestModel)
+					} else if *model != requestModel {
+						if isNonAnthropicProvider {
 							return nil, errors.New("for non-Anthropic providers, model must be the same for all requests")
 						}
+						mixedModels = true
 					}
 					requests[i] = schemas.BatchRequestItem{
 						CustomID: r.CustomID,
 						Params:   r.Params,
 					}
+				}
+				if mixedModels {
+					model = nil
 				}
 				br := &BatchRequest{
 					Type: schemas.BatchCreateRequest,


### PR DESCRIPTION
## Summary

Batch `/results` calls that did not settle a batch were getting their own log rows treated as billable aggregate rows during cost recalculation, causing the batch to be billed once per `/results` fetch. This PR introduces an `Echo` marker on batch accounting rows to distinguish read-only display copies from the single settlement row that owns the bill, and extends governance model-allowlist enforcement to cover inline batch create requests.

## Changes

- **Echo marker on batch accounting rows**: A new `Echo bool` field on `BatchAccountingDebug` marks log rows written by `/results` calls that did not settle the batch. These rows carry a snapshot of the settled price for display but must never be billed.
- **`MissingCostOnly` filter exclusion**: The logstore query for missing-cost rows now excludes echo rows (`batch_debug NOT LIKE "%\"echo\":true%"`), since their NULL cost is final and no recalculation will ever fill it.
- **`batchRowRoleOf` replaces `isBatchAggregateRow`**: The classification function now returns one of three roles — `None`, `Aggregate`, or `Echo`. Rows without the echo marker are classified by whether their ID matches the deterministic aggregate ID derived from `(provider, batch_id)`, providing backward compatibility for rows written before the marker existed.
- **Echo rows reprice display-only**: `calculateBatchAggregateCost` accepts a `refreshSnapshotCost bool` parameter. When true, `Accounting.Cost` is updated so the displayed price stays current, but the row's `cost` column is left NULL via the new `batchDebugOnly` path in `persistRecalcOutcomes`.
- **Governance allowlist applied to inline batch create**: `PreLLMHook` now iterates every distinct model named across batch item bodies/params via `BatchCreateModels`, evaluating governance for each. `IsModelCheckedWhenPresent` is extracted into a shared utility and extended to include `BatchCreateRequest`, so the model allowlist applies whenever a model is present even if it is not required.
- **Anthropic batch route: mixed-model handling**: The Anthropic integration now tracks when items carry different models and sets the top-level model to nil rather than erroring, allowing mixed-model Anthropic batches while still rejecting mixed models for non-Anthropic providers.
- **`batchCreate` handler model extraction**: The handler now checks both `Body` and `Params` when inferring the model from the first batch item, matching the Anthropic integration's dual-shape awareness.
- **Test IDs use `AccountingLogID`**: Existing cost-fidelity tests now derive their log IDs from `batchaccounting.AccountingLogID` so the `batchRowRoleOf` classification correctly identifies them as aggregate rows.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/... ./framework/logstore/... ./plugins/governance/... ./plugins/logging/... ./transports/bifrost-http/...
```

Key scenarios to validate:
- A batch that is fetched via `/results` multiple times produces exactly one billed row; subsequent fetch rows have `NULL` cost and `echo: true` in `batch_debug`.
- `MissingCostOnly` search does not return echo rows.
- After `RecalculateCosts`, echo rows have an updated `Accounting.Cost` snapshot but their `cost` column remains `NULL`.
- A `BatchCreateRequest` with a model on the virtual key's disallowed list is rejected by governance.
- A `BatchCreateRequest` with no model passes governance without restriction.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None beyond the governance enforcement fix, which tightens model allowlist checks to cover inline batch requests that were previously bypassing them.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable