### PR TITLE
fix: replace fixed 500ms sleep with 5s polling loop in Redis vector search test to avoid flakiness under parallel test runs

### DIFF
--- a/framework/vectorstore/redis_test.go
+++ b/framework/vectorstore/redis_test.go
@@ -1515,16 +1515,28 @@ func TestRedisStore_VectorSearch(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		time.Sleep(500 * time.Millisecond)
-
+		// Poll rather than sleep a fixed interval: RediSearch makes a new document
+		// searchable slightly after the write returns, and under `go test ./...`
+		// (many packages sharing one Redis) a fixed 500ms was occasionally too short,
+		// so the search returned nothing. A query error still fails immediately,
+		// since an unescaped value produces a syntax error, not a delay.
 		for _, doc := range specialDocs {
 			queries := []Query{
 				{Field: "model", Operator: QueryOperatorEqual, Value: doc.model},
 			}
-			results, err := setup.Store.GetNearest(setup.ctx, TestNamespace, doc.embedding, queries, []string{"type", "model"}, 0.1, 10)
-			require.NoError(t, err, "search must not fail for model %q", doc.model)
-			require.Len(t, results, 1, "expected exactly the doc tagged %q", doc.model)
-			assert.Equal(t, doc.model, results[0].Properties["model"])
+			deadline := time.Now().Add(5 * time.Second)
+			for {
+				results, err := setup.Store.GetNearest(setup.ctx, TestNamespace, doc.embedding, queries, []string{"type", "model"}, 0.1, 10)
+				require.NoError(t, err, "search must not fail for model %q", doc.model)
+				if len(results) == 1 {
+					assert.Equal(t, doc.model, results[0].Properties["model"])
+					break
+				}
+				if time.Now().After(deadline) {
+					require.Failf(t, "tagged doc not searchable", "expected exactly the doc tagged %q, got %d results after 5s", doc.model, len(results))
+				}
+				time.Sleep(100 * time.Millisecond)
+			}
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Fixes a flaky Redis vector search test that occasionally failed when running under `go test ./...` because a fixed 500ms sleep was not always long enough for RediSearch to make newly written documents searchable.

## Changes

- Replaced the fixed `time.Sleep(500ms)` with a polling loop that retries the search query up to 5 seconds before failing. This accounts for the slight delay between a Redis write returning and the document becoming searchable in RediSearch, which is more pronounced when many packages share a single Redis instance during parallel test runs.
- A query error (e.g. from an unescaped special character causing a syntax error) still fails immediately, since that produces an error rather than an empty result set.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)

## How to test

```sh
go test ./framework/vectorstore/... -run TestRedisStore_VectorSearch -count=5
```

The test should pass consistently across multiple runs without intermittent failures due to indexing delays.

## Breaking changes

- [x] No

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable