### PR TITLE
fix: harden tool results and weighted key selection

### DIFF
--- a/core/keyselectors/weightedrandom.go
+++ b/core/keyselectors/weightedrandom.go
@@ -1,20 +1,28 @@
 package keyselectors
 
 import (
+	"fmt"
 	"math/rand"
 
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
 func WeightedRandom(ctx *schemas.BifrostContext, keys []schemas.Key, providerKey schemas.ModelProvider, model string) (schemas.Key, error) {
+	if len(keys) == 0 {
+		return schemas.Key{}, fmt.Errorf("no keys available for provider %s and model %s", providerKey, model)
+	}
+
 	// Use a weighted random selection based on key weights
 	totalWeight := 0
 	for _, key := range keys {
-		totalWeight += int(key.Weight * 100) // Convert float to int for better performance
+		if key.Weight > 0 {
+			totalWeight += int(key.Weight * 100) // Convert float to int for better performance
+		}
 	}
 
-	// If all keys have zero weight, fall back to uniform random selection
-	if totalWeight == 0 {
+	// If no key has a usable positive weight, fall back to uniform random selection.
+	// This also covers tiny positive weights that truncate to zero at our precision.
+	if totalWeight <= 0 {
 		return keys[rand.Intn(len(keys))], nil
 	}
 
@@ -24,6 +32,9 @@ func WeightedRandom(ctx *schemas.BifrostContext, keys []schemas.Key, providerKey
 	// Select key based on weight
 	currentWeight := 0
 	for _, key := range keys {
+		if key.Weight <= 0 {
+			continue
+		}
 		currentWeight += int(key.Weight * 100)
 		if randomValue < currentWeight {
 			return key, nil

--- a/core/keyselectors/weightedrandom_test.go
+++ b/core/keyselectors/weightedrandom_test.go
@@ -1,0 +1,45 @@
+package keyselectors
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestWeightedRandomRejectsEmptyKeys(t *testing.T) {
+	if _, err := WeightedRandom(nil, nil, schemas.OpenAI, "gpt-test"); err == nil {
+		t.Fatal("expected empty key set to return an error")
+	}
+}
+
+func TestWeightedRandomHandlesNonPositiveWeights(t *testing.T) {
+	keys := []schemas.Key{
+		{ID: "negative", Weight: -1},
+		{ID: "zero", Weight: 0},
+	}
+	for range 100 {
+		selected, err := WeightedRandom(nil, keys, schemas.OpenAI, "gpt-test")
+		if err != nil {
+			t.Fatalf("select key: %v", err)
+		}
+		if selected.ID != "negative" && selected.ID != "zero" {
+			t.Fatalf("selected unknown key %q", selected.ID)
+		}
+	}
+}
+
+func TestWeightedRandomIgnoresNegativeWeightsWhenPositiveExists(t *testing.T) {
+	keys := []schemas.Key{
+		{ID: "negative", Weight: -100},
+		{ID: "positive", Weight: 1},
+	}
+	for range 100 {
+		selected, err := WeightedRandom(nil, keys, schemas.OpenAI, "gpt-test")
+		if err != nil {
+			t.Fatalf("select key: %v", err)
+		}
+		if selected.ID != "positive" {
+			t.Fatalf("negative-weight key must not participate when a positive weight exists; got %q", selected.ID)
+		}
+	}
+}

--- a/core/providers/bedrock/toolresultstatus_test.go
+++ b/core/providers/bedrock/toolresultstatus_test.go
@@ -2,6 +2,7 @@ package bedrock
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -49,5 +50,58 @@ func TestToolResultStatusFromIsError(t *testing.T) {
 	}
 	if results[1].Status == nil || *results[1].Status != "success" {
 		t.Fatalf("non-error tool call must keep status \"success\", got %v", results[1].Status)
+	}
+}
+
+func TestToolResultWithoutContentStillEmitsResult(t *testing.T) {
+	converted, err := convertToolMessages(context.Background(), []schemas.ChatMessage{
+		{
+			Role:            schemas.ChatMessageRoleTool,
+			ChatToolMessage: &schemas.ChatToolMessage{ToolCallID: schemas.Ptr("toolu_void")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("convert content-less tool message: %v", err)
+	}
+	if len(converted.Content) != 1 || converted.Content[0].ToolResult == nil {
+		t.Fatalf("content-less tool message must emit one toolResult, got %#v", converted.Content)
+	}
+	result := converted.Content[0].ToolResult
+	if result.ToolUseID != "toolu_void" {
+		t.Fatalf("expected toolu_void, got %q", result.ToolUseID)
+	}
+	if result.Content != nil {
+		t.Fatalf("expected omitted tool-result content, got %#v", result.Content)
+	}
+}
+
+func TestMalformedToolMessagesReturnErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		message schemas.ChatMessage
+		want    string
+	}{
+		{
+			name:    "missing tool message",
+			message: schemas.ChatMessage{Role: schemas.ChatMessageRoleTool},
+			want:    "missing required ChatToolMessage",
+		},
+		{
+			name: "missing tool call id",
+			message: schemas.ChatMessage{
+				Role:            schemas.ChatMessageRoleTool,
+				ChatToolMessage: &schemas.ChatToolMessage{},
+			},
+			want: "missing required ToolCallID",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := convertToolMessages(context.Background(), []schemas.ChatMessage{tc.message})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error containing %q, got %v", tc.want, err)
+			}
+		})
 	}
 }

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -1152,8 +1152,15 @@ func convertToolMessages(ctx context.Context, msgs []schemas.ChatMessage) (Bedro
 	var contentBlocks []BedrockContentBlock
 
 	for _, msg := range msgs {
+		if msg.ChatToolMessage == nil {
+			return BedrockMessage{}, fmt.Errorf("tool message missing required ChatToolMessage")
+		}
+		if msg.ChatToolMessage.ToolCallID == nil {
+			return BedrockMessage{}, fmt.Errorf("tool message missing required ToolCallID")
+		}
+
 		var toolResultContent []BedrockContentBlock
-		if msg.Content.ContentStr != nil {
+		if msg.Content != nil && msg.Content.ContentStr != nil {
 			// Bedrock expects JSON to be a parsed object, not a string
 			// Validate and compact JSON without parsing into Go types (preserves key ordering)
 			var buf bytes.Buffer
@@ -1190,7 +1197,7 @@ func convertToolMessages(ctx context.Context, msgs []schemas.ChatMessage) (Bedro
 					})
 				}
 			}
-		} else if msg.Content.ContentBlocks != nil {
+		} else if msg.Content != nil && msg.Content.ContentBlocks != nil {
 			for _, block := range msg.Content.ContentBlocks {
 				switch block.Type {
 				case schemas.ChatContentBlockTypeText:
@@ -1223,14 +1230,6 @@ func convertToolMessages(ctx context.Context, msgs []schemas.ChatMessage) (Bedro
 					}
 				}
 			}
-		}
-
-		if msg.ChatToolMessage == nil {
-			return BedrockMessage{}, fmt.Errorf("tool message missing required ChatToolMessage")
-		}
-
-		if msg.ChatToolMessage.ToolCallID == nil {
-			return BedrockMessage{}, fmt.Errorf("tool message missing required ToolCallID")
 		}
 
 		// Create tool result content block for this tool message


### PR DESCRIPTION
## Summary

- validate Bedrock tool-message metadata before reading optional content
- preserve content-less tool results instead of panicking or dropping them
- make weighted key selection safe for empty, zero, tiny, and negative weights
- add focused regression coverage for malformed tool messages and key-selection edge cases

## Testing

- `go test ./keyselectors ./providers/bedrock`
- `git diff --check`