### PR TITLE
fix: harden Bedrock tool results and weighted routing

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
+- fix: harden Bedrock tool results and weighted key selection edge cases [@hbmartin](https://github.com/hbmartin)
 - fix: forward OpenCode Responses requests directly to /v1/responses [@mohammadrezwankhan](https://github.com/mohammadrezwankhan)
 - fix: preserve max_tokens for OpenCode-compatible chat endpoints [@Alex-wangyang](https://github.com/Alex-wangyang)
 - fix: stop treating HuggingFace as a provider that omits the `[DONE]` marker - it does send one, and listing it as not sending one made the shared OpenAI streaming loop `break` on the first `finish_reason`, discarding the trailing usage-only chunk (`choices: []` plus top-level `usage`) that several router inference providers emit after it. Those streams completed with zero tokens and therefore zero cost, while non-streaming calls to the same models priced correctly [@elliottrabac](https://github.com/elliottrabac)

--- a/core/keyselectors/weightedrandom.go
+++ b/core/keyselectors/weightedrandom.go
@@ -1,20 +1,28 @@
 package keyselectors
 
 import (
+	"fmt"
 	"math/rand"
 
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
 func WeightedRandom(ctx *schemas.BifrostContext, keys []schemas.Key, providerKey schemas.ModelProvider, model string) (schemas.Key, error) {
+	if len(keys) == 0 {
+		return schemas.Key{}, fmt.Errorf("no keys available for provider %s and model %s", providerKey, model)
+	}
+
 	// Use a weighted random selection based on key weights
 	totalWeight := 0
 	for _, key := range keys {
-		totalWeight += int(key.Weight * 100) // Convert float to int for better performance
+		if key.Weight > 0 {
+			totalWeight += int(key.Weight * 100) // Convert float to int for better performance
+		}
 	}
 
-	// If all keys have zero weight, fall back to uniform random selection
-	if totalWeight == 0 {
+	// If no key has a usable positive weight, fall back to uniform random selection.
+	// This also covers tiny positive weights that truncate to zero at our precision.
+	if totalWeight <= 0 {
 		return keys[rand.Intn(len(keys))], nil
 	}
 
@@ -24,6 +32,9 @@ func WeightedRandom(ctx *schemas.BifrostContext, keys []schemas.Key, providerKey
 	// Select key based on weight
 	currentWeight := 0
 	for _, key := range keys {
+		if key.Weight <= 0 {
+			continue
+		}
 		currentWeight += int(key.Weight * 100)
 		if randomValue < currentWeight {
 			return key, nil

--- a/core/keyselectors/weightedrandom.go
+++ b/core/keyselectors/weightedrandom.go
@@ -2,6 +2,7 @@ package keyselectors
 
 import (
 	"fmt"
+	"math"
 	"math/rand"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -12,35 +13,54 @@ func WeightedRandom(ctx *schemas.BifrostContext, keys []schemas.Key, providerKey
 		return schemas.Key{}, fmt.Errorf("no keys available for provider %s and model %s", providerKey, model)
 	}
 
-	// Use a weighted random selection based on key weights
-	totalWeight := 0
+	return weightedRandomAt(keys, providerKey, model, rand.Float64())
+}
+
+// weightedRandomAt selects a key using unitRandom in [0, 1). It is split from
+// WeightedRandom so the boundary behavior can be tested deterministically.
+func weightedRandomAt(keys []schemas.Key, providerKey schemas.ModelProvider, model string, unitRandom float64) (schemas.Key, error) {
+	maxWeight := 0.0
+	eligibleCount := 0
 	for _, key := range keys {
-		if key.Weight > 0 {
-			totalWeight += int(key.Weight * 100) // Convert float to int for better performance
-		}
-	}
-
-	// If no key has a usable positive weight, fall back to uniform random selection.
-	// This also covers tiny positive weights that truncate to zero at our precision.
-	if totalWeight <= 0 {
-		return keys[rand.Intn(len(keys))], nil
-	}
-
-	// Use global thread-safe random (Go 1.20+) - no allocation, no syscall
-	randomValue := rand.Intn(totalWeight)
-
-	// Select key based on weight
-	currentWeight := 0
-	for _, key := range keys {
-		if key.Weight <= 0 {
+		weight := key.Weight
+		if !isUsableWeight(weight) {
 			continue
 		}
-		currentWeight += int(key.Weight * 100)
+		eligibleCount++
+		if weight > maxWeight {
+			maxWeight = weight
+		}
+	}
+
+	if eligibleCount == 0 {
+		return schemas.Key{}, fmt.Errorf("no keys with a positive finite weight available for provider %s and model %s", providerKey, model)
+	}
+
+	// Normalize by the largest weight before summing. This keeps the cumulative
+	// range finite even when callers supply weights near math.MaxFloat64, while
+	// preserving small positive weights without fixed-precision truncation.
+	totalWeight := 0.0
+	for _, key := range keys {
+		if isUsableWeight(key.Weight) {
+			totalWeight += key.Weight / maxWeight
+		}
+	}
+
+	randomValue := unitRandom * totalWeight
+	currentWeight := 0.0
+	for _, key := range keys {
+		if !isUsableWeight(key.Weight) {
+			continue
+		}
+		currentWeight += key.Weight / maxWeight
 		if randomValue < currentWeight {
 			return key, nil
 		}
 	}
 
-	// Fallback to first key if something goes wrong
-	return keys[0], nil
+	return schemas.Key{}, fmt.Errorf("weighted key selection failed for provider %s and model %s", providerKey, model)
+}
+
+func isUsableWeight(weight float64) bool {
+	return weight > 0 && !math.IsNaN(weight) && !math.IsInf(weight, 0)
 }

--- a/core/keyselectors/weightedrandom_test.go
+++ b/core/keyselectors/weightedrandom_test.go
@@ -1,0 +1,45 @@
+package keyselectors
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestWeightedRandomRejectsEmptyKeys(t *testing.T) {
+	if _, err := WeightedRandom(nil, nil, schemas.OpenAI, "gpt-test"); err == nil {
+		t.Fatal("expected empty key set to return an error")
+	}
+}
+
+func TestWeightedRandomHandlesNonPositiveWeights(t *testing.T) {
+	keys := []schemas.Key{
+		{ID: "negative", Weight: -1},
+		{ID: "zero", Weight: 0},
+	}
+	for range 100 {
+		selected, err := WeightedRandom(nil, keys, schemas.OpenAI, "gpt-test")
+		if err != nil {
+			t.Fatalf("select key: %v", err)
+		}
+		if selected.ID != "negative" && selected.ID != "zero" {
+			t.Fatalf("selected unknown key %q", selected.ID)
+		}
+	}
+}
+
+func TestWeightedRandomIgnoresNegativeWeightsWhenPositiveExists(t *testing.T) {
+	keys := []schemas.Key{
+		{ID: "negative", Weight: -100},
+		{ID: "positive", Weight: 1},
+	}
+	for range 100 {
+		selected, err := WeightedRandom(nil, keys, schemas.OpenAI, "gpt-test")
+		if err != nil {
+			t.Fatalf("select key: %v", err)
+		}
+		if selected.ID != "positive" {
+			t.Fatalf("negative-weight key must not participate when a positive weight exists; got %q", selected.ID)
+		}
+	}
+}

--- a/core/keyselectors/weightedrandom_test.go
+++ b/core/keyselectors/weightedrandom_test.go
@@ -1,6 +1,7 @@
 package keyselectors
 
 import (
+	"math"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -12,19 +13,13 @@ func TestWeightedRandomRejectsEmptyKeys(t *testing.T) {
 	}
 }
 
-func TestWeightedRandomHandlesNonPositiveWeights(t *testing.T) {
+func TestWeightedRandomRejectsNonPositiveWeights(t *testing.T) {
 	keys := []schemas.Key{
 		{ID: "negative", Weight: -1},
 		{ID: "zero", Weight: 0},
 	}
-	for range 100 {
-		selected, err := WeightedRandom(nil, keys, schemas.OpenAI, "gpt-test")
-		if err != nil {
-			t.Fatalf("select key: %v", err)
-		}
-		if selected.ID != "negative" && selected.ID != "zero" {
-			t.Fatalf("selected unknown key %q", selected.ID)
-		}
+	if _, err := WeightedRandom(nil, keys, schemas.OpenAI, "gpt-test"); err == nil {
+		t.Fatal("expected a key set without positive weights to return an error")
 	}
 }
 
@@ -33,13 +28,68 @@ func TestWeightedRandomIgnoresNegativeWeightsWhenPositiveExists(t *testing.T) {
 		{ID: "negative", Weight: -100},
 		{ID: "positive", Weight: 1},
 	}
-	for range 100 {
-		selected, err := WeightedRandom(nil, keys, schemas.OpenAI, "gpt-test")
-		if err != nil {
-			t.Fatalf("select key: %v", err)
-		}
-		if selected.ID != "positive" {
-			t.Fatalf("negative-weight key must not participate when a positive weight exists; got %q", selected.ID)
-		}
+	selected, err := WeightedRandom(nil, keys, schemas.OpenAI, "gpt-test")
+	if err != nil {
+		t.Fatalf("select key: %v", err)
+	}
+	if selected.ID != "positive" {
+		t.Fatalf("negative-weight key must not participate when a positive weight exists; got %q", selected.ID)
+	}
+}
+
+func TestWeightedRandomIgnoresNonFiniteWeightsWhenPositiveExists(t *testing.T) {
+	keys := []schemas.Key{
+		{ID: "nan", Weight: math.NaN()},
+		{ID: "positive-infinity", Weight: math.Inf(1)},
+		{ID: "negative-infinity", Weight: math.Inf(-1)},
+		{ID: "positive", Weight: 1},
+	}
+
+	selected, err := WeightedRandom(nil, keys, schemas.OpenAI, "gpt-test")
+	if err != nil {
+		t.Fatalf("select key: %v", err)
+	}
+	if selected.ID != "positive" {
+		t.Fatalf("non-finite weights must not participate; got %q", selected.ID)
+	}
+}
+
+func TestWeightedRandomRejectsOnlyNonFiniteWeights(t *testing.T) {
+	keys := []schemas.Key{
+		{ID: "nan", Weight: math.NaN()},
+		{ID: "infinity", Weight: math.Inf(1)},
+	}
+	if _, err := WeightedRandom(nil, keys, schemas.OpenAI, "gpt-test"); err == nil {
+		t.Fatal("expected a key set without finite positive weights to return an error")
+	}
+}
+
+func TestWeightedRandomPreservesTinyPositiveWeights(t *testing.T) {
+	keys := []schemas.Key{
+		{ID: "normal", Weight: 1},
+		{ID: "tiny", Weight: 0.001},
+	}
+
+	selected, err := weightedRandomAt(keys, schemas.OpenAI, "gpt-test", math.Nextafter(1, 0))
+	if err != nil {
+		t.Fatalf("select key: %v", err)
+	}
+	if selected.ID != "tiny" {
+		t.Fatalf("tiny positive weight must remain reachable; got %q", selected.ID)
+	}
+}
+
+func TestWeightedRandomHandlesVeryLargeWeights(t *testing.T) {
+	keys := []schemas.Key{
+		{ID: "first", Weight: math.MaxFloat64},
+		{ID: "second", Weight: math.MaxFloat64},
+	}
+
+	selected, err := weightedRandomAt(keys, schemas.OpenAI, "gpt-test", 0.75)
+	if err != nil {
+		t.Fatalf("select key: %v", err)
+	}
+	if selected.ID != "second" {
+		t.Fatalf("large finite weights must not overflow selection; got %q", selected.ID)
 	}
 }

--- a/core/providers/bedrock/toolresultstatus_test.go
+++ b/core/providers/bedrock/toolresultstatus_test.go
@@ -2,6 +2,7 @@ package bedrock
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -49,5 +50,58 @@ func TestToolResultStatusFromIsError(t *testing.T) {
 	}
 	if results[1].Status == nil || *results[1].Status != "success" {
 		t.Fatalf("non-error tool call must keep status \"success\", got %v", results[1].Status)
+	}
+}
+
+func TestToolResultWithoutContentStillEmitsResult(t *testing.T) {
+	converted, err := convertToolMessages(context.Background(), []schemas.ChatMessage{
+		{
+			Role:            schemas.ChatMessageRoleTool,
+			ChatToolMessage: &schemas.ChatToolMessage{ToolCallID: schemas.Ptr("toolu_void")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("convert content-less tool message: %v", err)
+	}
+	if len(converted.Content) != 1 || converted.Content[0].ToolResult == nil {
+		t.Fatalf("content-less tool message must emit one toolResult, got %#v", converted.Content)
+	}
+	result := converted.Content[0].ToolResult
+	if result.ToolUseID != "toolu_void" {
+		t.Fatalf("expected toolu_void, got %q", result.ToolUseID)
+	}
+	if result.Content != nil {
+		t.Fatalf("expected omitted tool-result content, got %#v", result.Content)
+	}
+}
+
+func TestMalformedToolMessagesReturnErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		message schemas.ChatMessage
+		want    string
+	}{
+		{
+			name:    "missing tool message",
+			message: schemas.ChatMessage{Role: schemas.ChatMessageRoleTool},
+			want:    "missing required ChatToolMessage",
+		},
+		{
+			name: "missing tool call id",
+			message: schemas.ChatMessage{
+				Role:            schemas.ChatMessageRoleTool,
+				ChatToolMessage: &schemas.ChatToolMessage{},
+			},
+			want: "missing required ToolCallID",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := convertToolMessages(context.Background(), []schemas.ChatMessage{tc.message})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error containing %q, got %v", tc.want, err)
+			}
+		})
 	}
 }

--- a/core/providers/bedrock/toolresultstatus_test.go
+++ b/core/providers/bedrock/toolresultstatus_test.go
@@ -2,9 +2,11 @@ package bedrock
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -70,8 +72,72 @@ func TestToolResultWithoutContentStillEmitsResult(t *testing.T) {
 	if result.ToolUseID != "toolu_void" {
 		t.Fatalf("expected toolu_void, got %q", result.ToolUseID)
 	}
-	if result.Content != nil {
-		t.Fatalf("expected omitted tool-result content, got %#v", result.Content)
+	if len(result.Content) != 1 || string(result.Content[0].JSON) != `{}` {
+		t.Fatalf("expected empty JSON tool-result content, got %#v", result.Content)
+	}
+
+	wire, err := providerUtils.MarshalSorted(result)
+	if err != nil {
+		t.Fatalf("marshal tool result: %v", err)
+	}
+	if strings.Contains(string(wire), `"content":null`) || !strings.Contains(string(wire), `"content":[{"json":{}}]`) {
+		t.Fatalf("content-less tool result must carry a valid content array, got %s", wire)
+	}
+}
+
+func TestBlankToolResultContentUsesEmptyJSON(t *testing.T) {
+	for _, content := range []string{"", " \t\n "} {
+		t.Run(fmt.Sprintf("content_%q", content), func(t *testing.T) {
+			converted, err := convertToolMessages(context.Background(), []schemas.ChatMessage{
+				{
+					Role:            schemas.ChatMessageRoleTool,
+					ChatToolMessage: &schemas.ChatToolMessage{ToolCallID: schemas.Ptr("toolu_blank")},
+					Content:         &schemas.ChatMessageContent{ContentStr: &content},
+				},
+			})
+			if err != nil {
+				t.Fatalf("convert blank tool result: %v", err)
+			}
+			result := converted.Content[0].ToolResult
+			if len(result.Content) != 1 || string(result.Content[0].JSON) != `{}` {
+				t.Fatalf("expected empty JSON tool-result content, got %#v", result.Content)
+			}
+		})
+	}
+}
+
+func TestToolResultContentBlocksUseSharedConverter(t *testing.T) {
+	converted, err := convertToolMessages(context.Background(), []schemas.ChatMessage{
+		{
+			Role:            schemas.ChatMessageRoleTool,
+			ChatToolMessage: &schemas.ChatToolMessage{ToolCallID: schemas.Ptr("toolu_blocks")},
+			Content: &schemas.ChatMessageContent{ContentBlocks: []schemas.ChatContentBlock{
+				{
+					Type: schemas.ChatContentBlockTypeFile,
+					File: &schemas.ChatInputFile{
+						Filename: schemas.Ptr("result.pdf"),
+						FileType: schemas.Ptr("application/pdf"),
+						FileData: schemas.Ptr("cGRm"),
+					},
+				},
+				{CachePoint: &schemas.CachePoint{}},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("convert tool-result blocks: %v", err)
+	}
+
+	content := converted.Content[0].ToolResult.Content
+	if len(content) != 2 || content[0].Document == nil || content[1].CachePoint == nil {
+		t.Fatalf("expected document and standalone cache point to survive, got %#v", content)
+	}
+}
+
+func TestNilSystemMessageContentReturnsError(t *testing.T) {
+	_, _, err := convertMessages(context.Background(), []schemas.ChatMessage{{Role: schemas.ChatMessageRoleSystem}})
+	if err == nil || !strings.Contains(err.Error(), "system message missing required content") {
+		t.Fatalf("expected missing system content error, got %v", err)
 	}
 }
 
@@ -91,6 +157,14 @@ func TestMalformedToolMessagesReturnErrors(t *testing.T) {
 			message: schemas.ChatMessage{
 				Role:            schemas.ChatMessageRoleTool,
 				ChatToolMessage: &schemas.ChatToolMessage{},
+			},
+			want: "missing required ToolCallID",
+		},
+		{
+			name: "empty tool call id",
+			message: schemas.ChatMessage{
+				Role:            schemas.ChatMessageRoleTool,
+				ChatToolMessage: &schemas.ChatToolMessage{ToolCallID: schemas.Ptr("  ")},
 			},
 			want: "missing required ToolCallID",
 		},

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -1152,8 +1152,15 @@ func convertToolMessages(ctx context.Context, msgs []schemas.ChatMessage) (Bedro
 	var contentBlocks []BedrockContentBlock
 
 	for _, msg := range msgs {
+		if msg.ChatToolMessage == nil {
+			return BedrockMessage{}, fmt.Errorf("tool message missing required ChatToolMessage")
+		}
+		if msg.ChatToolMessage.ToolCallID == nil {
+			return BedrockMessage{}, fmt.Errorf("tool message missing required ToolCallID")
+		}
+
 		var toolResultContent []BedrockContentBlock
-		if msg.Content.ContentStr != nil {
+		if msg.Content != nil && msg.Content.ContentStr != nil {
 			// Bedrock expects JSON to be a parsed object, not a string
 			// Validate and compact JSON without parsing into Go types (preserves key ordering)
 			var buf bytes.Buffer
@@ -1190,7 +1197,7 @@ func convertToolMessages(ctx context.Context, msgs []schemas.ChatMessage) (Bedro
 					})
 				}
 			}
-		} else if msg.Content.ContentBlocks != nil {
+		} else if msg.Content != nil && msg.Content.ContentBlocks != nil {
 			for _, block := range msg.Content.ContentBlocks {
 				switch block.Type {
 				case schemas.ChatContentBlockTypeText:
@@ -1223,14 +1230,6 @@ func convertToolMessages(ctx context.Context, msgs []schemas.ChatMessage) (Bedro
 					}
 				}
 			}
-		}
-
-		if msg.ChatToolMessage == nil {
-			return BedrockMessage{}, fmt.Errorf("tool message missing required ChatToolMessage")
-		}
-
-		if msg.ChatToolMessage.ToolCallID == nil {
-			return BedrockMessage{}, fmt.Errorf("tool message missing required ToolCallID")
 		}
 
 		// Create tool result content block for this tool message

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -982,9 +982,12 @@ func newBedrockCachePoint(ttl *string) *BedrockCachePoint {
 // convertSystemMessages converts a Bifrost system message to Bedrock format
 func convertSystemMessages(msg schemas.ChatMessage) ([]BedrockSystemMessage, error) {
 	systemMsgs := []BedrockSystemMessage{}
+	if msg.Content == nil {
+		return nil, fmt.Errorf("system message missing required content")
+	}
 
 	// Convert content
-	if msg.Content.ContentStr != nil {
+	if msg.Content.ContentStr != nil && strings.TrimSpace(*msg.Content.ContentStr) != "" {
 		systemMsgs = append(systemMsgs, BedrockSystemMessage{
 			Text: msg.Content.ContentStr,
 		})
@@ -996,7 +999,7 @@ func convertSystemMessages(msg schemas.ChatMessage) ([]BedrockSystemMessage, err
 				blockType = schemas.ChatContentBlockTypeText
 			}
 
-			if blockType == schemas.ChatContentBlockTypeText && block.Text != nil {
+			if blockType == schemas.ChatContentBlockTypeText && block.Text != nil && strings.TrimSpace(*block.Text) != "" {
 				systemMsgs = append(systemMsgs, BedrockSystemMessage{
 					Text: block.Text,
 				})
@@ -1012,6 +1015,9 @@ func convertSystemMessages(msg schemas.ChatMessage) ([]BedrockSystemMessage, err
 				})
 			}
 		}
+	}
+	if len(systemMsgs) == 0 {
+		return nil, fmt.Errorf("system message content must not be blank")
 	}
 
 	return systemMsgs, nil
@@ -1155,12 +1161,12 @@ func convertToolMessages(ctx context.Context, msgs []schemas.ChatMessage) (Bedro
 		if msg.ChatToolMessage == nil {
 			return BedrockMessage{}, fmt.Errorf("tool message missing required ChatToolMessage")
 		}
-		if msg.ChatToolMessage.ToolCallID == nil {
+		if msg.ChatToolMessage.ToolCallID == nil || strings.TrimSpace(*msg.ChatToolMessage.ToolCallID) == "" {
 			return BedrockMessage{}, fmt.Errorf("tool message missing required ToolCallID")
 		}
 
 		var toolResultContent []BedrockContentBlock
-		if msg.Content != nil && msg.Content.ContentStr != nil {
+		if msg.Content != nil && msg.Content.ContentStr != nil && strings.TrimSpace(*msg.Content.ContentStr) != "" {
 			// Bedrock expects JSON to be a parsed object, not a string
 			// Validate and compact JSON without parsing into Go types (preserves key ordering)
 			var buf bytes.Buffer
@@ -1199,37 +1205,20 @@ func convertToolMessages(ctx context.Context, msgs []schemas.ChatMessage) (Bedro
 			}
 		} else if msg.Content != nil && msg.Content.ContentBlocks != nil {
 			for _, block := range msg.Content.ContentBlocks {
-				switch block.Type {
-				case schemas.ChatContentBlockTypeText:
-					if block.Text != nil {
-						toolResultContent = append(toolResultContent, BedrockContentBlock{
-							Text: block.Text,
-						})
-						// Cache point must be in a separate block
-						if block.CacheControl != nil {
-							toolResultContent = append(toolResultContent, BedrockContentBlock{
-								CachePoint: newBedrockCachePoint(block.CacheControl.TTL),
-							})
-						}
-					}
-				case schemas.ChatContentBlockTypeImage:
-					if block.ImageURLStruct != nil {
-						imageSource, err := convertImageToBedrockSource(ctx, block.ImageURLStruct.URL)
-						if err != nil {
-							return BedrockMessage{}, fmt.Errorf("failed to convert image in tool result: %w", err)
-						}
-						toolResultContent = append(toolResultContent, BedrockContentBlock{
-							Image: imageSource,
-						})
-						// Cache point must be in a separate block
-						if block.CacheControl != nil {
-							toolResultContent = append(toolResultContent, BedrockContentBlock{
-								CachePoint: newBedrockCachePoint(block.CacheControl.TTL),
-							})
-						}
-					}
+				converted, err := convertContentBlock(ctx, block)
+				if err != nil {
+					return BedrockMessage{}, fmt.Errorf("failed to convert content block in tool result: %w", err)
 				}
+				toolResultContent = append(toolResultContent, converted...)
 			}
+		}
+		if len(toolResultContent) == 0 {
+			// Converse requires toolResult.content to be an array. Preserve a
+			// content-less tool result as an empty JSON object instead of emitting
+			// content:null or an invalid blank text block.
+			toolResultContent = append(toolResultContent, BedrockContentBlock{
+				JSON: json.RawMessage(`{}`),
+			})
 		}
 
 		// Create tool result content block for this tool message
@@ -1256,7 +1245,7 @@ func convertToolMessages(ctx context.Context, msgs []schemas.ChatMessage) (Bedro
 // The ctx is propagated to URL fetches inside individual content blocks.
 func convertContent(ctx context.Context, content schemas.ChatMessageContent) ([]BedrockContentBlock, error) {
 	var contentBlocks []BedrockContentBlock
-	if content.ContentStr != nil && *content.ContentStr != "" {
+	if content.ContentStr != nil && strings.TrimSpace(*content.ContentStr) != "" {
 		// Simple text content (skip empty strings as Bedrock rejects blank text)
 		contentBlocks = append(contentBlocks, BedrockContentBlock{
 			Text: content.ContentStr,
@@ -1291,7 +1280,7 @@ func convertContentBlock(ctx context.Context, block schemas.ChatContentBlock) ([
 		// Ideally we should not play with the payload - we should let the provider handle it.
 		// But for now, we are doing this to avoid the API error.
 		// Once the world onboards on Bifrost - we should remove these shitty patterns.
-		if block.Text == nil || *block.Text == "" {
+		if block.Text == nil || strings.TrimSpace(*block.Text) == "" {
 			// Skip nil or empty text as Bedrock rejects blank text content blocks
 			return []BedrockContentBlock{}, nil
 		}

--- a/plugins/governance/changelog.md
+++ b/plugins/governance/changelog.md
@@ -1,3 +1,4 @@
+- fix: ignore unusable provider weights during load balancing [@hbmartin](https://github.com/hbmartin)
 - fix: skip list models call for budgets and rate-limits (#6051)
 - feat: honor the auth-skip context path in the governance resolver
 - chore: upgraded core to v1.7.11 and framework to v1.5.9

--- a/plugins/governance/loadbalance_test.go
+++ b/plugins/governance/loadbalance_test.go
@@ -2,6 +2,7 @@ package governance
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -93,4 +94,54 @@ func TestLoadBalanceProvider_UnknownPrefixIsTreatedAsModelNamespace(t *testing.T
 	got, err := loadBalance(t, p, ctx, "meta-llama/llama-3.1-8b-instant")
 	require.NoError(t, err)
 	assert.Equal(t, "groq/meta-llama/llama-3.1-8b-instant", got)
+}
+
+func TestSelectWeightedProviderConfigIgnoresUnusableWeights(t *testing.T) {
+	configs := []configstoreTables.TableVirtualKeyProviderConfig{
+		{Provider: "zero", Weight: schemas.Ptr(0.0)},
+		{Provider: "negative", Weight: schemas.Ptr(-1.0)},
+		{Provider: "nan", Weight: schemas.Ptr(math.NaN())},
+		{Provider: "infinity", Weight: schemas.Ptr(math.Inf(1))},
+		{Provider: "positive", Weight: schemas.Ptr(1.0)},
+	}
+
+	selected, eligible, ok := selectWeightedProviderConfigAt(configs, 0.5)
+	require.True(t, ok)
+	assert.Equal(t, "positive", selected.Provider)
+	require.Len(t, eligible, 1)
+	assert.Equal(t, "positive", eligible[0].Provider)
+}
+
+func TestSelectWeightedProviderConfigRejectsOnlyUnusableWeights(t *testing.T) {
+	configs := []configstoreTables.TableVirtualKeyProviderConfig{
+		{Provider: "unset"},
+		{Provider: "zero", Weight: schemas.Ptr(0.0)},
+		{Provider: "nan", Weight: schemas.Ptr(math.NaN())},
+	}
+
+	_, eligible, ok := selectWeightedProviderConfigAt(configs, 0.5)
+	assert.False(t, ok)
+	assert.Empty(t, eligible)
+}
+
+func TestSelectWeightedProviderConfigPreservesTinyWeights(t *testing.T) {
+	configs := []configstoreTables.TableVirtualKeyProviderConfig{
+		{Provider: "normal", Weight: schemas.Ptr(1.0)},
+		{Provider: "tiny", Weight: schemas.Ptr(0.001)},
+	}
+
+	selected, _, ok := selectWeightedProviderConfigAt(configs, math.Nextafter(1, 0))
+	require.True(t, ok)
+	assert.Equal(t, "tiny", selected.Provider)
+}
+
+func TestSelectWeightedProviderConfigHandlesVeryLargeWeights(t *testing.T) {
+	configs := []configstoreTables.TableVirtualKeyProviderConfig{
+		{Provider: "first", Weight: schemas.Ptr(math.MaxFloat64)},
+		{Provider: "second", Weight: schemas.Ptr(math.MaxFloat64)},
+	}
+
+	selected, _, ok := selectWeightedProviderConfigAt(configs, 0.75)
+	require.True(t, ok)
+	assert.Equal(t, "second", selected.Provider)
 }

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -459,42 +459,15 @@ func (p *GovernancePlugin) LoadBalanceProvider(ctx *schemas.BifrostContext, req 
 		return nil
 	}
 
-	weightedConfigs := make([]configstoreTables.TableVirtualKeyProviderConfig, 0, len(allowedProviderConfigs))
-	for _, config := range allowedProviderConfigs {
-		if config.Weight != nil {
-			weightedConfigs = append(weightedConfigs, config)
-		}
-	}
-
-	if len(weightedConfigs) == 0 {
-		// All allowed configs survived the model-allowance / budget / rate-limit filters,
-		// but none of them have a Weight set — there's nothing to feed weighted selection.
-		// Emit an explicit log so the routing trail explains why governance stops here
-		// instead of trailing off after "Allowed providers after filtering: [...]".
-		ctx.AppendRoutingEngineLog(schemas.RoutingEngineGovernance, schemas.LogLevelInfo, fmt.Sprintf("No weighted configs for model %s — none of the allowed VK provider configs have a weight assigned; skipping load balancing", modelStr))
+	selectedConfig, weightedConfigs, ok := selectWeightedProviderConfigAt(allowedProviderConfigs, rand.Float64())
+	if !ok {
+		// Nil opts out of weighted routing; non-positive and non-finite values are
+		// unusable. Keep the existing behavior of leaving the incoming provider
+		// untouched when nothing can participate in load balancing.
+		ctx.AppendRoutingEngineLog(schemas.RoutingEngineGovernance, schemas.LogLevelInfo, fmt.Sprintf("No usable weighted configs for model %s; skipping load balancing", modelStr))
 		return nil
 	}
-
-	var selectedProvider schemas.ModelProvider
-	totalWeight := 0.0
-	for _, config := range weightedConfigs {
-		totalWeight += getWeight(config.Weight)
-	}
-	// Generate random number between 0 and totalWeight
-	randomValue := rand.Float64() * totalWeight
-	// Select provider based on weighted random selection
-	currentWeight := 0.0
-	for _, config := range weightedConfigs {
-		currentWeight += getWeight(config.Weight)
-		if randomValue <= currentWeight {
-			selectedProvider = schemas.ModelProvider(config.Provider)
-			break
-		}
-	}
-	// Fallback: if no provider was selected (shouldn't happen but guard against FP issues)
-	if selectedProvider == "" {
-		selectedProvider = schemas.ModelProvider(weightedConfigs[0].Provider)
-	}
+	selectedProvider := schemas.ModelProvider(selectedConfig.Provider)
 
 	p.logger.Debug("[governance] Selected provider: %s", selectedProvider)
 	ctx.AppendRoutingEngineLog(schemas.RoutingEngineGovernance, schemas.LogLevelInfo, fmt.Sprintf("Selected provider %s for model %s (from %d eligible: %v)", selectedProvider, modelStr, len(allowedProviderConfigs), allowedProviders))

--- a/plugins/governance/utils.go
+++ b/plugins/governance/utils.go
@@ -4,6 +4,7 @@ package governance
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 
 	bifrost "github.com/maximhq/bifrost/core"
@@ -124,6 +125,48 @@ func getWeight(w *float64) float64 {
 		return 1.0
 	}
 	return *w
+}
+
+// selectWeightedProviderConfigAt selects among provider configs whose weights
+// are finite and strictly positive. Normalizing by the largest weight prevents
+// overflow when malformed persisted data contains extremely large values.
+func selectWeightedProviderConfigAt(configs []configstoreTables.TableVirtualKeyProviderConfig, unitRandom float64) (configstoreTables.TableVirtualKeyProviderConfig, []configstoreTables.TableVirtualKeyProviderConfig, bool) {
+	eligibleConfigs := make([]configstoreTables.TableVirtualKeyProviderConfig, 0, len(configs))
+	maxWeight := 0.0
+	for _, config := range configs {
+		if config.Weight == nil {
+			continue
+		}
+		weight := *config.Weight
+		if weight <= 0 || math.IsNaN(weight) || math.IsInf(weight, 0) {
+			continue
+		}
+		eligibleConfigs = append(eligibleConfigs, config)
+		if weight > maxWeight {
+			maxWeight = weight
+		}
+	}
+	if len(eligibleConfigs) == 0 {
+		return configstoreTables.TableVirtualKeyProviderConfig{}, nil, false
+	}
+
+	totalWeight := 0.0
+	for _, config := range eligibleConfigs {
+		totalWeight += *config.Weight / maxWeight
+	}
+
+	randomValue := unitRandom * totalWeight
+	currentWeight := 0.0
+	for _, config := range eligibleConfigs {
+		currentWeight += *config.Weight / maxWeight
+		if randomValue < currentWeight {
+			return config, eligibleConfigs, true
+		}
+	}
+
+	// unitRandom comes from rand.Float64 and is always below 1. Return the final
+	// eligible config defensively if floating-point rounding reaches the boundary.
+	return eligibleConfigs[len(eligibleConfigs)-1], eligibleConfigs, true
 }
 
 // stampGovernanceCtxFromVK copies team/customer identifiers from the VK onto ctx so


### PR DESCRIPTION
## Summary

Hardens two request-routing edge cases that could select disabled credentials or produce invalid Bedrock Converse payloads. This supersedes the closed predecessor PR #6528 and is rebased onto the current upstream `dev` branch.

## Changes

- select keys only from finite, strictly positive weights
- normalize by the largest weight to avoid integer truncation and overflow while keeping small positive weights reachable
- return a selection error when no usable key remains instead of re-enabling zero or negative weights
- apply the same finite-positive selection rules to governance provider routing and fallback construction
- encode content-less or blank Bedrock tool results as a valid `content: [{"json": {}}]` array
- reject missing or blank tool-call IDs and return errors for nil or blank system content
- reuse the shared Bedrock content converter so document and standalone cache-point blocks are preserved
- add core and governance changelog entries

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go test ./keyselectors ./providers/bedrock -count=1

cd ../plugins/governance
go test ./... -count=1
```

Expected outcome: all listed packages pass. Both commands pass locally.

No new configuration or environment variables are introduced.

## Screenshots/Recordings

Not applicable; no UI changes.

## Breaking changes

- [x] Yes
- [ ] No

An all-zero or otherwise unusable key pool now returns a key-selection error instead of selecting uniformly from disabled keys. Configure at least one finite, positive key weight for an enabled pool.

## Related issues

Supersedes #6528, which was closed while the original changes were merged into the contributor fork.

## Security considerations

No authentication, secret-handling, PII, or sandbox behavior changes. Invalid persisted or SDK-supplied numeric weights are now excluded defensively.

## Checklist

- [x] I read the current contributing and PR guidelines
- [x] I added/updated tests where appropriate
- [x] I updated package changelogs; no additional user documentation is needed
- [x] I verified the affected Go packages build and their tests pass; UI is unaffected
- [ ] I verified the full CI pipeline locally; repository CI should run on this PR
