### PR TITLE
fix: drop service_tier for Bedrock Mantle instead of forwarding a field it rejects

### DIFF
--- a/core/providers/openai/chat.go
+++ b/core/providers/openai/chat.go
@@ -148,11 +148,34 @@ func ToOpenAIChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifros
 	}
 }
 
+// providerRejectsServiceTier reports whether the provider's endpoint implements
+// service_tier at all. Bedrock Mantle does not: its OpenAI-compatible surface on
+// bedrock-mantle.{region}.api.aws rejects the field outright ("'priority' is not
+// supported for 'service_tier' on this model"). Provider bedrock reaches these
+// converters only through the deprecated in-provider Mantle routing in
+// bedrock/mantle.go — every other Bedrock path uses Converse — so it means the
+// same endpoint and the same rejection.
+func providerRejectsServiceTier(provider schemas.ModelProvider) bool {
+	switch provider {
+	case schemas.BedrockMantle, schemas.Bedrock:
+		return true
+	default:
+		return false
+	}
+}
+
 // serviceTierForModel filters a requested tier against the final target model's
 // capabilities. Omitting an unsupported tier lets the provider use its default
 // instead of returning an unsupported-tier error.
 func serviceTierForModel(caps schemas.ModelCaps, tier *schemas.BifrostServiceTier) *schemas.BifrostServiceTier {
 	if tier == nil {
+		return nil
+	}
+	// Checked before the datasheet: ServiceTierSupported falls back to "keep the
+	// tier" when the catalog has no row for the pair, and Mantle model ids
+	// (openai.gpt-5.6-terra, ...) generally have none — so the fallback would
+	// forward a field the endpoint 400s on.
+	if providerRejectsServiceTier(caps.Provider()) {
 		return nil
 	}
 	if !caps.ServiceTierSupported(*tier, true) {

--- a/core/providers/openai/servicetiercapabilities_test.go
+++ b/core/providers/openai/servicetiercapabilities_test.go
@@ -84,6 +84,14 @@ func TestOpenAIConvertersFilterUltrafastByModelCapability(t *testing.T) {
 		{name: "compatible provider without tier metadata", provider: schemas.OpenRouter, model: "other-model", wantTier: true},
 		{name: "compatible provider explicitly unsupported tier", provider: schemas.OpenRouter, model: "compatible-standard-model", wantTier: false},
 		{name: "compatible provider supported model", provider: schemas.OpenRouter, model: "compatible-fast-model", wantTier: true},
+		// Mantle's OpenAI-compatible surface rejects service_tier outright, and its
+		// verbatim model ids carry no datasheet row — so the "no metadata means keep
+		// the tier" fallback above must not apply to it.
+		{name: "bedrock mantle drops tier without metadata", provider: schemas.BedrockMantle, model: "openai.gpt-5.6-terra", wantTier: false},
+		{name: "bedrock mantle drops tier for bare name", provider: schemas.BedrockMantle, model: "gpt-5.6-terra", wantTier: false},
+		// Provider bedrock reaches these converters only via the deprecated
+		// in-provider Mantle routing, so it means the same endpoint.
+		{name: "legacy in-bedrock mantle drops tier", provider: schemas.Bedrock, model: "openai.gpt-5.4", wantTier: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Requests carrying `service_tier` to `bedrock_mantle` fail with:

```
'priority' is not supported for 'service_tier' on this model
```

Mantle's OpenAI-compatible surface does not implement `service_tier`, but Bifrost forwards it anyway, so every such request 400s.

`serviceTierForModel` already strips tiers a model doesn't support — but it asks the datasheet and **falls back to keeping the tier** when no record exists (`ServiceTierSupported`'s `fallback=true`, `core/schemas/modelcaps.go:238`). Capabilities resolve against the *verbatim Mantle id* (`openai.gpt-5.6-terra`, not `gpt-5.6-terra`), which generally has no row — so the fallback fires and the field reaches AWS.

Fail-open is the right default for a gateway that shouldn't silently drop params (see #5902, where the opposite behaviour silently downgraded billing tier). It's wrong only when the endpoint rejects the field outright, which is the case here.

## Changes

- Gate on the provider **before** consulting the datasheet, so the answer doesn't depend on catalog coverage. Mantle accepts no tier at all. This mirrors the existing Gemini handling, which nulls `ServiceTier` outright (`core/providers/openai/chat.go:99`).
- The fix lands in `serviceTierForModel`, which both `ToOpenAIChatRequest` and `ToOpenAIResponsesRequest` call — so **chat and Responses are covered by one change**.
- Provider `bedrock` is included alongside `bedrock_mantle`: it reaches these converters *only* through the deprecated in-provider Mantle routing in `bedrock/mantle.go` (verified — all four `openai.HandleOpenAI*` call sites in `core/providers/bedrock/` are in that file). Every other Bedrock path uses Converse and never touches the OpenAI converters, so the same fix covers the legacy route.

No functionality is lost: the field was producing a 400, and omitting it lets the endpoint serve at its default tier.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
cd core
go test ./providers/openai/ -run 'ServiceTier|Ultrafast' -v
go test ./providers/... ./schemas/...
```

Three cases added to `TestOpenAIConvertersFilterUltrafastByModelCapability`, which already exercises both the chat and Responses converters:

| Case | Provider | Model | Tier forwarded |
|---|---|---|---|
| drops tier without metadata | `bedrock_mantle` | `openai.gpt-5.6-terra` | no |
| drops tier for bare name | `bedrock_mantle` | `gpt-5.6-terra` | no |
| legacy in-bedrock mantle | `bedrock` | `openai.gpt-5.4` | no |

Confirmed they fail without the source change and pass with it; existing cases (OpenAI supported/unsupported, OpenRouter with and without metadata) are unaffected. `go build ./...`, `go vet`, and `gofmt` are clean, and the full `./providers/...` + `./schemas/...` suites pass.

Reproduced in production behind a governance load-balancer splitting bare `gpt-5.x` 80/20 between `bedrock_mantle` and `openai`: errors appeared on exactly the Mantle share, none on the OpenAI share.

## Breaking changes

- [x] No

Requests that previously 400'd now succeed at the endpoint's default tier. `service_tier` behaviour for every other provider is untouched.

## Related issues

Related to #5902 (closed) — the mirror-image bug, where a *missing* datasheet row caused `service_tier` to be silently dropped for the gpt-5.4 family on first-party OpenAI. Same datasheet-driven gating, failing in the opposite direction. That one was fixed with a datasheet update; this one can't be, because no set of catalog rows makes forwarding correct for an endpoint that rejects the field.

A datasheet row publishing `service_tiers: []` for Mantle ids would be a reasonable complement, but the provider gate holds regardless of catalog coverage.

## Security considerations

None. No auth, secrets, or PII involved — one request parameter is omitted for two provider values.