### PR TITLE
fix: skip key selection on anthropic provider

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -8771,7 +8771,7 @@ func (bifrost *Bifrost) getKeysForBatchAndFileOps(ctx *schemas.BifrostContext, p
 // via the keyProvider closure built by the caller.
 //
 // canRotate=false is returned for cases where the caller must always use the same key:
-//   - SkipKeySelection (provider allows keyless requests; empty slice returned)
+//   - SkipKeySelection (Claude Code OAuth passthrough to Anthropic; empty slice returned)
 //   - Explicit BifrostContextKeyAPIKeyID / APIKeyName (user pinned a specific key)
 //   - Session stickiness (key persisted in KV store for the session lifetime)
 //   - Single-key pool (only one eligible key — rotation is a no-op, KV write skipped)
@@ -8786,8 +8786,8 @@ func (bifrost *Bifrost) selectKeyFromProviderForModelWithPool(ctx *schemas.Bifro
 		}
 	}
 
-	// SkipKeySelection: provider allows keyless requests — return empty pool, no rotation.
-	if skipKeySelection, ok := ctx.Value(schemas.BifrostContextKeySkipKeySelection).(bool); ok && skipKeySelection && isKeySkippingAllowed(providerKey) {
+	// SkipKeySelection: the caller's OAuth token is the credential — return empty pool, no rotation.
+	if skipKeySelection, ok := ctx.Value(schemas.BifrostContextKeySkipKeySelection).(bool); ok && skipKeySelection && isKeySkippingAllowed(baseProviderType) {
 		return []schemas.Key{}, false, nil
 	}
 

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -2969,6 +2969,8 @@ func TestClearAnthropicPassthroughForNonNativeProvider(t *testing.T) {
 				ctx.SetValue(k, true)
 			}
 
+			ctx.SetValue(schemas.BifrostContextKeySkipKeySelection, true)
+
 			clearAnthropicPassthroughForNonNativeProvider(ctx, tt.baseProvider)
 
 			for _, k := range flagKeys {
@@ -2977,6 +2979,69 @@ func TestClearAnthropicPassthroughForNonNativeProvider(t *testing.T) {
 				if got != want {
 					t.Errorf("flag %v = %v, want %v", k, got, want)
 				}
+			}
+
+			// SkipKeySelection must survive: it also drives IsClaudeCodeMaxMode, which suppresses
+			// x-api-key on the Anthropic provider. Clearing it here would make an Anthropic
+			// fallback after a non-native attempt send the account key alongside the caller's
+			// OAuth token. The flag is gated at the key-selection read site instead —
+			// see isKeySkippingAllowed.
+			if skip, _ := ctx.Value(schemas.BifrostContextKeySkipKeySelection).(bool); !skip {
+				t.Error("SkipKeySelection was cleared; it must be gated at the read site, not mutated per attempt")
+			}
+		})
+	}
+}
+
+// TestSelectKeyFromProviderForModelWithPool_SkipKeySelectionGatedOnBaseProvider verifies that the
+// Claude Code OAuth key-selection skip applies only when the attempt resolved to Anthropic. A
+// governance routing rule can rewrite provider/model after the transport set the flag, and every
+// non-Anthropic provider authenticates with its own configured key — so it must still get one.
+func TestSelectKeyFromProviderForModelWithPool_SkipKeySelectionGatedOnBaseProvider(t *testing.T) {
+	account := NewMockAccount()
+	account.SetKeysForProvider(schemas.Anthropic, []schemas.Key{
+		{ID: "anthropic-key", Name: "anthropic-key", Value: schemas.SecretVar{Val: "sk-ant"}, Models: []string{"*"}, Weight: 1.0},
+	})
+	account.SetKeysForProvider(schemas.Fireworks, []schemas.Key{
+		{ID: "fireworks-key", Name: "fireworks-key", Value: schemas.SecretVar{Val: "fw-key"}, Models: []string{"*"}, Weight: 1.0, UseAnthropicEndpoints: schemas.Ptr(true)},
+	})
+	bifrost := &Bifrost{account: account, logger: NewDefaultLogger(schemas.LogLevelError)}
+
+	tests := []struct {
+		name      string
+		provider  schemas.ModelProvider
+		model     string
+		wantKeyID string // "" means the pool must be empty (key selection skipped)
+	}{
+		{"anthropic keeps the skip", schemas.Anthropic, "claude-opus-4-5", ""},
+		{"fireworks selects its own key", schemas.Fireworks, "accounts/fireworks/models/kimi-k2p7-code", "fireworks-key"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			ctx.SetValue(schemas.BifrostContextKeySkipKeySelection, true)
+
+			keys, canRotate, err := bifrost.selectKeyFromProviderForModelWithPool(ctx, schemas.ResponsesRequest, tt.provider, tt.model, tt.provider)
+			if err != nil {
+				t.Fatalf("selectKeyFromProviderForModelWithPool: %v", err)
+			}
+			if canRotate {
+				t.Error("canRotate = true, want false")
+			}
+			if tt.wantKeyID == "" {
+				if len(keys) != 0 {
+					t.Fatalf("got %d keys, want an empty pool (key selection skipped)", len(keys))
+				}
+				return
+			}
+			if len(keys) != 1 || keys[0].ID != tt.wantKeyID {
+				t.Fatalf("got %v, want a single key %q", keys, tt.wantKeyID)
+			}
+			// The regression: without a key, UseAnthropicEndpoints is unreadable and the request
+			// is built with the OpenAI schema, which Fireworks rejects for missing max_tokens.
+			if keys[0].UseAnthropicEndpoints == nil || !*keys[0].UseAnthropicEndpoints {
+				t.Error("selected key lost UseAnthropicEndpoints")
 			}
 		})
 	}

--- a/core/utils.go
+++ b/core/utils.go
@@ -136,8 +136,11 @@ func CanProviderKeyValueBeEmpty(providerKey schemas.ModelProvider) bool {
 	return providerKey == schemas.Vertex || providerKey == schemas.Bedrock || providerKey == schemas.BedrockMantle || providerKey == schemas.VLLM || providerKey == schemas.Azure || providerKey == schemas.Ollama || providerKey == schemas.SGL
 }
 
-func isKeySkippingAllowed(providerKey schemas.ModelProvider) bool {
-	return providerKey != schemas.Azure && providerKey != schemas.Bedrock && providerKey != schemas.BedrockMantle && providerKey != schemas.Vertex
+// isKeySkippingAllowed gates SkipKeySelection on the provider this attempt resolved to. The flag
+// is set only for Claude Code OAuth passthrough, where the caller's token is the upstream
+// credential — and only the Anthropic provider forwards it.
+func isKeySkippingAllowed(baseProvider schemas.ModelProvider) bool {
+	return baseProvider == schemas.Anthropic
 }
 
 // calculateBackoff implements exponential backoff with jitter for retry attempts.


### PR DESCRIPTION
## Summary

`SkipKeySelection` was previously allowed for any provider that wasn't Azure, Bedrock, BedrockMantle, or Vertex. This meant that if a governance routing rule rewrote the provider/model after the Claude Code OAuth transport set the flag, a non-Anthropic provider (e.g. Fireworks) would skip key selection entirely — leaving it without a configured key and causing request construction to fall back to the OpenAI schema, which breaks providers like Fireworks that require `max_tokens`.

The fix tightens `isKeySkippingAllowed` to an allowlist of exactly one provider (`Anthropic`), since `SkipKeySelection` exists solely for Claude Code OAuth passthrough where the caller's token is the upstream credential and only the Anthropic provider forwards it.

## Changes

- `isKeySkippingAllowed` now returns `true` only for `schemas.Anthropic`, replacing the previous denylist approach. This ensures non-Anthropic providers always receive a configured key from the pool.
- The `selectKeyFromProviderForModelWithPool` call site now passes `baseProviderType` instead of `providerKey` to `isKeySkippingAllowed`, so the gate is evaluated against the resolved base provider.
- `SkipKeySelection` is intentionally **not** cleared in `clearAnthropicPassthroughForNonNativeProvider` — it also drives `IsClaudeCodeMaxMode`, which suppresses `x-api-key` on the Anthropic provider. Clearing it during a non-native attempt would cause an Anthropic fallback to send the account key alongside the caller's OAuth token. The flag is gated at the read site instead.
- A new test `TestSelectKeyFromProviderForModelWithPool_SkipKeySelectionGatedOnBaseProvider` verifies that Anthropic skips key selection while Fireworks (with `UseAnthropicEndpoints`) still selects its own key.
- `TestClearAnthropicPassthroughForNonNativeProvider` is updated to assert that `SkipKeySelection` survives the clear operation and documents why.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
go test ./core/... -run TestSelectKeyFromProviderForModelWithPool_SkipKeySelectionGatedOnBaseProvider
go test ./core/... -run TestClearAnthropicPassthroughForNonNativeProvider
go test ./...
```

The new test covers the regression directly: with `SkipKeySelection` set and a Fireworks provider, the selected key must be present and must have `UseAnthropicEndpoints = true`. Without this fix, the key pool would be empty and that assertion would fail.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

`SkipKeySelection` bypasses key injection entirely, relying on the caller's OAuth token as the upstream credential. Tightening the allowlist to Anthropic-only reduces the surface where a misconfigured or rewritten routing rule could cause a request to be sent without any credential, or with the wrong credential type for the target provider.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable