### PR TITLE
fix: clear BifrostContextKeyURLPath and BifrostContextKeyDirectKey

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6707,6 +6707,7 @@ func clearAnthropicPassthroughForNonNativeProvider(ctx *schemas.BifrostContext, 
 	ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, false)
 	ctx.SetValue(schemas.BifrostContextKeySendBackRawResponse, false)
 	ctx.SetValue(schemas.BifrostContextKeyPassthroughOverridesPresent, false)
+	ctx.ClearValue(schemas.BifrostContextKeyURLPath)
 }
 
 // requestWorker handles incoming requests from the queue for a specific provider.

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -2970,6 +2970,7 @@ func TestClearAnthropicPassthroughForNonNativeProvider(t *testing.T) {
 			}
 
 			ctx.SetValue(schemas.BifrostContextKeySkipKeySelection, true)
+			ctx.SetValue(schemas.BifrostContextKeyURLPath, "/v1/messages")
 
 			clearAnthropicPassthroughForNonNativeProvider(ctx, tt.baseProvider)
 
@@ -2981,6 +2982,16 @@ func TestClearAnthropicPassthroughForNonNativeProvider(t *testing.T) {
 				}
 			}
 
+			// The caller's captured path goes with the raw body: a converted request must land on
+			// the provider's own endpoint, not Anthropic's /v1/messages.
+			callerPath, hasCallerPath := ctx.Value(schemas.BifrostContextKeyURLPath).(string)
+			if tt.wantCleared && hasCallerPath {
+				t.Errorf("URLPath = %q, want it cleared for a non-native provider", callerPath)
+			}
+			if !tt.wantCleared && callerPath != "/v1/messages" {
+				t.Errorf("URLPath = %q, want %q preserved", callerPath, "/v1/messages")
+			}
+
 			// SkipKeySelection must survive: it also drives IsClaudeCodeMaxMode, which suppresses
 			// x-api-key on the Anthropic provider. Clearing it here would make an Anthropic
 			// fallback after a non-native attempt send the account key alongside the caller's
@@ -2990,6 +3001,44 @@ func TestClearAnthropicPassthroughForNonNativeProvider(t *testing.T) {
 				t.Error("SkipKeySelection was cleared; it must be gated at the read site, not mutated per attempt")
 			}
 		})
+	}
+}
+
+// TestClearCtxForFallback_DropsCallerSuppliedKey verifies that a raw key supplied via
+// x-bf-direct-key does not ride a fallback onto a different provider. Key selection resolves the
+// direct key before it ever reaches the provider's own pool, so an uncleared value would send the
+// caller's credential for provider A to provider B.
+func TestClearCtxForFallback_DropsCallerSuppliedKey(t *testing.T) {
+	account := NewMockAccount()
+	account.SetKeysForProvider(schemas.Anthropic, []schemas.Key{
+		{ID: "anthropic-configured", Name: "anthropic-configured", Value: schemas.SecretVar{Val: "sk-ant-real"}, Models: []string{"*"}, Weight: 1.0},
+	})
+	bifrost := &Bifrost{account: account, logger: NewDefaultLogger(schemas.LogLevelError)}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyDirectKey, schemas.Key{
+		ID: "header-provided", Name: "header-provided",
+		Value: schemas.SecretVar{Val: "sk-caller-supplied"}, Weight: 1.0,
+	})
+
+	// A routing rule's key pin is scoped to the provider whose pool it was resolved against.
+	ctx.SetValue(schemas.BifrostContextKeyRoutingPinnedAPIKeyID, "primary-provider-key")
+
+	clearCtxForFallback(ctx)
+
+	if _, ok := ctx.Value(schemas.BifrostContextKeyDirectKey).(schemas.Key); ok {
+		t.Fatal("DirectKey survived clearCtxForFallback")
+	}
+	if pin, ok := ctx.Value(schemas.BifrostContextKeyRoutingPinnedAPIKeyID).(string); ok {
+		t.Fatalf("RoutingPinnedAPIKeyID survived clearCtxForFallback: %q", pin)
+	}
+
+	keys, _, err := bifrost.selectKeyFromProviderForModelWithPool(ctx, schemas.ChatCompletionRequest, schemas.Anthropic, "claude-opus-4-5", schemas.Anthropic)
+	if err != nil {
+		t.Fatalf("selectKeyFromProviderForModelWithPool: %v", err)
+	}
+	if len(keys) != 1 || keys[0].ID != "anthropic-configured" {
+		t.Fatalf("got %v, want the fallback provider's own key", keys)
 	}
 }
 

--- a/core/utils.go
+++ b/core/utils.go
@@ -354,6 +354,8 @@ func newBifrostMessageChan(message *schemas.BifrostResponse) chan *schemas.Bifro
 func clearCtxForFallback(ctx *schemas.BifrostContext) {
 	ctx.ClearValue(schemas.BifrostContextKeyAPIKeyID)
 	ctx.ClearValue(schemas.BifrostContextKeyAPIKeyName)
+	ctx.ClearValue(schemas.BifrostContextKeyDirectKey)
+	ctx.ClearValue(schemas.BifrostContextKeyRoutingPinnedAPIKeyID)
 	ctx.ClearValue(schemas.BifrostContextKeyGovernanceIncludeOnlyKeys)
 	ctx.ClearValue(schemas.BifrostContextKeyChangeRequestType)
 	ctx.ClearValue(schemas.BifrostContextKeyAttemptTrail)


### PR DESCRIPTION
## Summary

Two context values were leaking across provider boundaries during fallback and passthrough-clearing flows. A caller-supplied direct key (`x-bf-direct-key`) was surviving `clearCtxForFallback`, meaning the credential intended for provider A could be forwarded to provider B. Separately, the caller's Anthropic URL path (`/v1/messages`) was surviving `clearAnthropicPassthroughForNonNativeProvider`, meaning a converted request could attempt to land on Anthropic's endpoint instead of the fallback provider's own endpoint.

## Changes

- `clearCtxForFallback` now clears `BifrostContextKeyDirectKey` so a caller-supplied key cannot ride a fallback onto a different provider
- `clearCtxForFallback` now clears `BifrostContextKeyRoutingPinnedAPIKeyID` so a key pin scoped to the primary provider's pool is not carried into the fallback attempt
- `clearAnthropicPassthroughForNonNativeProvider` now clears `BifrostContextKeyURLPath` so the Anthropic-specific path is not carried over when the request is converted for a non-native provider
- Tests added to verify `DirectKey` and `RoutingPinnedAPIKeyID` are dropped before fallback key selection resolves to the configured provider pool, and that `URLPath` is cleared for non-native providers but preserved for native Anthropic passthrough

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/... -run TestClearAnthropicPassthroughForNonNativeProvider
go test ./core/... -run TestClearCtxForFallback_DropsCallerSuppliedKey
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The `DirectKey` fix is security-relevant: without it, a credential supplied by the caller via `x-bf-direct-key` for one provider could be forwarded in a request to a different provider during fallback. This change ensures the caller's key is scoped strictly to the intended provider and that fallback attempts always resolve keys from the fallback provider's own configured pool.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable