### PR TITLE
fix: carry logprobs through the Gemini-native Responses route

### DIFF
--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -329,6 +329,9 @@ func (response *GenerateContentResponse) ToResponsesBifrostResponsesResponse() *
 		if candidate.AvgLogprobs != 0 {
 			extraFields["avgLogprobs"] = candidate.AvgLogprobs
 		}
+		if candidate.LogprobsResult != nil {
+			extraFields["logprobsResult"] = candidate.LogprobsResult
+		}
 		// Server-side tool parts have no lossless home in Bifrost's OpenAI-shaped schema
 		// (the web_search_call item keeps the queries, but not the raw tool response or the
 		// thoughtSignature Gemini requires back on replay). Carry them verbatim so the
@@ -688,6 +691,9 @@ func ToGeminiResponsesResponse(bifrostResp *schemas.BifrostResponsesResponse) *G
 			if target.AvgLogprobs == 0 {
 				target.AvgLogprobs = terminal.AvgLogprobs
 			}
+			if target.LogprobsResult == nil {
+				target.LogprobsResult = terminal.LogprobsResult
+			}
 		} else {
 			candidates = append(candidates, terminal)
 		}
@@ -825,14 +831,18 @@ func buildGeminiTerminalCandidate(
 		candidate.GroundingMetadata = buildGroundingMetadataFromWebSearch(lastWebSearchCall, webSearchAnnotations, lastRenderedContent)
 	}
 
-	// Restore safetyRatings/avgLogprobs preserved by ToResponsesBifrostResponsesResponse
-	// (they have no field in Bifrost's OpenAI-shaped Responses schema).
+	// Restore safetyRatings/avgLogprobs/logprobsResult preserved by
+	// ToResponsesBifrostResponsesResponse (they have no field in Bifrost's
+	// OpenAI-shaped Responses schema).
 	if bifrostResp.ProviderExtraFields != nil {
 		if ratings := extractGeminiSafetyRatings(bifrostResp.ProviderExtraFields["safetyRatings"]); ratings != nil {
 			candidate.SafetyRatings = ratings
 		}
 		if avgLogprobs, ok := extractGeminiAvgLogprobs(bifrostResp.ProviderExtraFields["avgLogprobs"]); ok {
 			candidate.AvgLogprobs = avgLogprobs
+		}
+		if logprobs := extractGeminiLogprobsResult(bifrostResp.ProviderExtraFields["logprobsResult"]); logprobs != nil {
+			candidate.LogprobsResult = logprobs
 		}
 	}
 
@@ -858,6 +868,27 @@ func extractGeminiSafetyRatings(v interface{}) []*SafetyRating {
 		return nil
 	}
 	return ratings
+}
+
+// extractGeminiLogprobsResult recovers a *LogprobsResult from
+// ProviderExtraFields["logprobsResult"]. Handles both the in-memory pointer
+// (normal non-streaming path) and a JSON-decoded map form.
+func extractGeminiLogprobsResult(v interface{}) *LogprobsResult {
+	if v == nil {
+		return nil
+	}
+	if result, ok := v.(*LogprobsResult); ok {
+		return result
+	}
+	b, err := sonic.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	var result LogprobsResult
+	if err := sonic.Unmarshal(b, &result); err != nil {
+		return nil
+	}
+	return &result
 }
 
 // extractGeminiAvgLogprobs recovers a float64 from ProviderExtraFields["avgLogprobs"].
@@ -1170,6 +1201,9 @@ func ToGeminiResponsesStreamResponse(bifrostResp *schemas.BifrostResponsesStream
 				if avgLogprobs, ok := extractGeminiAvgLogprobs(bifrostResp.Response.ProviderExtraFields["avgLogprobs"]); ok {
 					candidate.AvgLogprobs = avgLogprobs
 				}
+				if logprobs := extractGeminiLogprobsResult(bifrostResp.Response.ProviderExtraFields["logprobsResult"]); logprobs != nil {
+					candidate.LogprobsResult = logprobs
+				}
 				if responseID, ok := bifrostResp.Response.ProviderExtraFields["responseId"].(string); ok && responseID != "" {
 					streamResp.ResponseID = responseID
 				}
@@ -1240,8 +1274,9 @@ type GeminiResponsesStreamState struct {
 	// Candidate metadata that only arrives on the terminal chunk (alongside finishReason).
 	// Preserved here so closeGeminiOpenItems can stash them onto the response.completed
 	// event's ProviderExtraFields for the reverse (Bifrost -> Gemini) conversion to restore.
-	SafetyRatings []*SafetyRating
-	AvgLogprobs   float64
+	SafetyRatings  []*SafetyRating
+	AvgLogprobs    float64
+	LogprobsResult *LogprobsResult
 
 	// Content tracking
 	HasStartedText     bool            // Whether we've started text content
@@ -1333,6 +1368,7 @@ func (state *GeminiResponsesStreamState) flush() {
 	state.ResponseID = nil
 	state.SafetyRatings = nil
 	state.AvgLogprobs = 0
+	state.LogprobsResult = nil
 	state.CreatedAt = int(time.Now().Unix())
 	state.HasEmittedCreated = false
 	state.HasEmittedCompleted = false
@@ -1432,12 +1468,16 @@ func (response *GenerateContentResponse) ToBifrostResponsesStream(sequenceNumber
 			}
 		}
 
-		// safetyRatings/avgLogprobs only arrive on the terminal chunk, alongside finishReason.
+		// safetyRatings/avgLogprobs/logprobsResult only arrive on the terminal chunk,
+		// alongside finishReason.
 		if len(candidate.SafetyRatings) > 0 {
 			state.SafetyRatings = candidate.SafetyRatings
 		}
 		if candidate.AvgLogprobs != 0 {
 			state.AvgLogprobs = candidate.AvgLogprobs
+		}
+		if candidate.LogprobsResult != nil {
+			state.LogprobsResult = candidate.LogprobsResult
 		}
 
 		// Check for finish reason (indicates end of generation)
@@ -2389,6 +2429,9 @@ func closeGeminiOpenItems(state *GeminiResponsesStreamState, groundingMetadata *
 	}
 	if state.AvgLogprobs != 0 {
 		extraFields["avgLogprobs"] = state.AvgLogprobs
+	}
+	if state.LogprobsResult != nil {
+		extraFields["logprobsResult"] = state.LogprobsResult
 	}
 	if len(extraFields) > 0 {
 		completedResp.ProviderExtraFields = extraFields
@@ -3829,6 +3872,19 @@ func (r *GeminiGenerationRequest) convertParamsToGenerationConfigResponses(param
 		}
 	}
 
+	// Mapping top_logprobs to generation config, mirroring the chat route
+	// (convertParamsToGenerationConfig): Gemini caps logprobs at 20.
+	if params.TopLogProbs != nil {
+		topLogProbs := *params.TopLogProbs
+		if topLogProbs > 20 {
+			topLogProbs = 20
+		}
+		if topLogProbs > 0 {
+			config.ResponseLogprobs = true
+			config.Logprobs = schemas.Ptr(int32(topLogProbs))
+		}
+	}
+
 	if params.ExtraParams != nil {
 		if topK, ok := params.ExtraParams["top_k"]; ok {
 			delete(params.ExtraParams, "top_k")
@@ -3858,6 +3914,15 @@ func (r *GeminiGenerationRequest) convertParamsToGenerationConfigResponses(param
 			delete(params.ExtraParams, "media_resolution")
 			if val, success := schemas.SafeExtractString(mediaResolution); success {
 				config.MediaResolution = val
+			}
+		}
+		// The Gemini-native ingress carries responseLogprobs as an extra param
+		// (convertGenerationConfigToResponsesParameters); without this mapping a
+		// passthrough request never asks Gemini for logprobs.
+		if responseLogprobs, ok := params.ExtraParams["response_logprobs"]; ok {
+			delete(params.ExtraParams, "response_logprobs")
+			if val, success := schemas.SafeExtractBool(responseLogprobs); success && val {
+				config.ResponseLogprobs = true
 			}
 		}
 

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -145,12 +145,23 @@ func ToGeminiResponsesRequestWithImageURLSchemes(ctx *schemas.BifrostContext, bi
 
 	// Convert parameters to generation config
 	if bifrostReq.Params != nil {
+		// Work on a shallow copy of ExtraParams: convertParamsToGenerationConfigResponses
+		// consumes entries (top_k, response_logprobs, ...) with delete, and handing it the
+		// caller's map would make a retry/fallback that reconverts the same request lose
+		// them. The pruned copy is what geminiReq carries onto the wire.
+		params := *bifrostReq.Params
+		if bifrostReq.Params.ExtraParams != nil {
+			params.ExtraParams = make(map[string]interface{}, len(bifrostReq.Params.ExtraParams))
+			for key, value := range bifrostReq.Params.ExtraParams {
+				params.ExtraParams[key] = value
+			}
+		}
 		var err error
-		geminiReq.GenerationConfig, err = geminiReq.convertParamsToGenerationConfigResponses(bifrostReq.Params, bifrostReq.Provider, capModel)
+		geminiReq.GenerationConfig, err = geminiReq.convertParamsToGenerationConfigResponses(&params, bifrostReq.Provider, capModel)
 		if err != nil {
 			return nil, err
 		}
-		geminiReq.ExtraParams = bifrostReq.Params.ExtraParams
+		geminiReq.ExtraParams = params.ExtraParams
 		includeServerSideToolInvocations := bifrostReq.Params.IncludeServerSideToolInvocations != nil && *bifrostReq.Params.IncludeServerSideToolInvocations
 		// Handle tool-related parameters
 		if len(bifrostReq.Params.Tools) > 0 {

--- a/core/providers/gemini/responseslogprobs_test.go
+++ b/core/providers/gemini/responseslogprobs_test.go
@@ -1,0 +1,185 @@
+package gemini
+
+// Regression tests for issue #6231: the Gemini-native (Responses) route dropped
+// logprobs on both sides. Request side: top_logprobs and the response_logprobs
+// extra param were never mapped into GenerationConfig by
+// convertParamsToGenerationConfigResponses (the chat route already mapped them).
+// Response side: candidate logprobsResult was never preserved through the
+// Gemini -> Bifrost -> Gemini conversions, non-streaming or streaming.
+
+import (
+	"testing"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// top_logprobs and the response_logprobs extra param (the exact shape
+// convertGenerationConfigToResponsesParameters produces on the Gemini-native
+// ingress path) must be mapped back into GenerationConfig by
+// ToGeminiResponsesRequest -> convertParamsToGenerationConfigResponses.
+func TestResponsesLogprobsRequestSide(t *testing.T) {
+	req := &schemas.BifrostResponsesRequest{
+		Provider: schemas.Gemini,
+		Model:    "gemini-2.5-flash",
+		Input: []schemas.ResponsesMessage{
+			{
+				Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+				Content: &schemas.ResponsesMessageContent{
+					ContentStr: schemas.Ptr("hello"),
+				},
+			},
+		},
+		Params: &schemas.ResponsesParameters{
+			TopLogProbs: schemas.Ptr(5),
+			ExtraParams: map[string]interface{}{
+				"response_logprobs": true,
+			},
+		},
+	}
+
+	geminiReq, err := ToGeminiResponsesRequest(nil, req)
+	require.NoError(t, err)
+	require.NotNil(t, geminiReq)
+
+	assert.True(t, geminiReq.GenerationConfig.ResponseLogprobs,
+		"response_logprobs extra param must map to generationConfig.responseLogprobs")
+	require.NotNil(t, geminiReq.GenerationConfig.Logprobs,
+		"top_logprobs must map to generationConfig.logprobs")
+	assert.Equal(t, int32(5), *geminiReq.GenerationConfig.Logprobs)
+}
+
+// Gemini caps logprobs at 20; the Responses mapping must apply the same cap as
+// the chat route.
+func TestResponsesLogprobsRequestSideCap(t *testing.T) {
+	req := &schemas.BifrostResponsesRequest{
+		Provider: schemas.Gemini,
+		Model:    "gemini-2.5-flash",
+		Input: []schemas.ResponsesMessage{
+			{
+				Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+				Content: &schemas.ResponsesMessageContent{
+					ContentStr: schemas.Ptr("hello"),
+				},
+			},
+		},
+		Params: &schemas.ResponsesParameters{
+			TopLogProbs: schemas.Ptr(50),
+		},
+	}
+
+	geminiReq, err := ToGeminiResponsesRequest(nil, req)
+	require.NoError(t, err)
+	require.NotNil(t, geminiReq.GenerationConfig.Logprobs)
+	assert.Equal(t, int32(20), *geminiReq.GenerationConfig.Logprobs)
+	assert.True(t, geminiReq.GenerationConfig.ResponseLogprobs)
+}
+
+// candidates[0].logprobsResult must survive Gemini -> Bifrost Responses ->
+// Gemini on the GenAI generateContent path.
+func TestResponsesLogprobsResultRoundTrip(t *testing.T) {
+	logprobs := &LogprobsResult{
+		ChosenCandidates: []*LogprobsResultCandidate{
+			{Token: "Hello", TokenID: 42, LogProbability: -0.05},
+		},
+		TopCandidates: []*LogprobsResultTopCandidates{
+			{
+				Candidates: []*LogprobsResultCandidate{
+					{Token: "Hello", TokenID: 42, LogProbability: -0.05},
+					{Token: "Hi", TokenID: 43, LogProbability: -3.1},
+				},
+			},
+		},
+	}
+
+	geminiResp := &GenerateContentResponse{
+		ResponseID:   "resp-6231",
+		ModelVersion: "gemini-2.5-flash",
+		Candidates: []*Candidate{
+			{
+				Index:          0,
+				FinishReason:   FinishReasonStop,
+				AvgLogprobs:    -0.05,
+				LogprobsResult: logprobs,
+				Content: &Content{
+					Role:  "model",
+					Parts: []*Part{{Text: "Hello"}},
+				},
+			},
+		},
+	}
+
+	bifrostResp := geminiResp.ToResponsesBifrostResponsesResponse()
+	require.NotNil(t, bifrostResp)
+
+	out := ToGeminiResponsesResponse(bifrostResp)
+	require.NotNil(t, out)
+	require.Len(t, out.Candidates, 1)
+
+	assert.Equal(t, -0.05, out.Candidates[0].AvgLogprobs)
+	require.NotNil(t, out.Candidates[0].LogprobsResult,
+		"logprobsResult must survive the Gemini -> Bifrost -> Gemini round trip")
+	require.Len(t, out.Candidates[0].LogprobsResult.ChosenCandidates, 1)
+	assert.Equal(t, "Hello", out.Candidates[0].LogprobsResult.ChosenCandidates[0].Token)
+	require.Len(t, out.Candidates[0].LogprobsResult.TopCandidates, 1)
+	assert.Len(t, out.Candidates[0].LogprobsResult.TopCandidates[0].Candidates, 2)
+}
+
+// Streaming flavor: a terminal streaming chunk carrying logprobsResult must have
+// it preserved on the response.completed event's ProviderExtraFields (the
+// mechanism used for safetyRatings/avgLogprobs), and the Gemini-native stream
+// egress must restore it onto the terminal candidate.
+func TestResponsesLogprobsResultStreaming(t *testing.T) {
+	state := &GeminiResponsesStreamState{}
+	state.flush()
+
+	chunk := &GenerateContentResponse{
+		ResponseID:   "resp-6231-stream",
+		ModelVersion: "gemini-2.5-flash",
+		Candidates: []*Candidate{
+			{
+				Index:        0,
+				FinishReason: FinishReasonStop,
+				AvgLogprobs:  -0.05,
+				LogprobsResult: &LogprobsResult{
+					ChosenCandidates: []*LogprobsResultCandidate{
+						{Token: "Hello", TokenID: 42, LogProbability: -0.05},
+					},
+				},
+				Content: &Content{
+					Role:  "model",
+					Parts: []*Part{{Text: "Hello"}},
+				},
+			},
+		},
+	}
+
+	events, bErr := chunk.ToBifrostResponsesStream(0, state)
+	require.Nil(t, bErr)
+
+	var completed *schemas.BifrostResponsesStreamResponse
+	for _, ev := range events {
+		if ev.Type == schemas.ResponsesStreamResponseTypeCompleted {
+			completed = ev
+		}
+	}
+	require.NotNil(t, completed, "expected a response.completed event")
+	require.NotNil(t, completed.Response)
+	require.NotNil(t, completed.Response.ProviderExtraFields)
+
+	assert.Equal(t, -0.05, completed.Response.ProviderExtraFields["avgLogprobs"])
+	require.NotNil(t, completed.Response.ProviderExtraFields["logprobsResult"],
+		"logprobsResult must be preserved for the streaming egress path")
+
+	// Egress: the completed event converted back to a Gemini stream chunk must
+	// carry logprobsResult on its terminal candidate.
+	egressState := &BifrostToGeminiStreamState{}
+	geminiChunk := ToGeminiResponsesStreamResponse(completed, egressState)
+	require.NotNil(t, geminiChunk)
+	require.NotEmpty(t, geminiChunk.Candidates)
+	require.NotNil(t, geminiChunk.Candidates[0].LogprobsResult,
+		"logprobsResult must be restored on the Gemini-native stream egress")
+	require.Len(t, geminiChunk.Candidates[0].LogprobsResult.ChosenCandidates, 1)
+	assert.Equal(t, "Hello", geminiChunk.Candidates[0].LogprobsResult.ChosenCandidates[0].Token)
+}

--- a/core/providers/gemini/responseslogprobs_test.go
+++ b/core/providers/gemini/responseslogprobs_test.go
@@ -48,6 +48,18 @@ func TestResponsesLogprobsRequestSide(t *testing.T) {
 	require.NotNil(t, geminiReq.GenerationConfig.Logprobs,
 		"top_logprobs must map to generationConfig.logprobs")
 	assert.Equal(t, int32(5), *geminiReq.GenerationConfig.Logprobs)
+
+	// The conversion consumes extra params from a copy, not the caller's map: a
+	// retry/fallback reconverting the same request must still see them.
+	assert.Contains(t, req.Params.ExtraParams, "response_logprobs",
+		"conversion must not mutate the caller's ExtraParams")
+	assert.NotContains(t, geminiReq.ExtraParams, "response_logprobs",
+		"consumed extra param must not ride the wire map")
+
+	retryReq, err := ToGeminiResponsesRequest(nil, req)
+	require.NoError(t, err)
+	assert.True(t, retryReq.GenerationConfig.ResponseLogprobs,
+		"a reconversion of the same request must still enable responseLogprobs")
 }
 
 // Gemini caps logprobs at 20; the Responses mapping must apply the same cap as


### PR DESCRIPTION
## Summary

The Gemini-native (Responses) route loses logprobs in both directions, while the chat route handles them fine.

Request side: `convertParamsToGenerationConfigResponses` never mapped `top_logprobs` or the `response_logprobs` extra param into `GenerationConfig`, so Gemini was never even asked for logprobs. The chat route already does this in `convertParamsToGenerationConfig`.

Response side: even when Gemini returns `logprobsResult` on a candidate, the Gemini→Bifrost Responses conversion dropped it. Only `avgLogprobs` rode `ProviderExtraFields`, so the reverse conversion back to Gemini-native had nothing to restore. Both non-streaming and streaming.

Net effect: a google-genai SDK client pointed at Bifrost's `/genai` route with `response_logprobs: true, logprobs: 3` gets `candidates[0].logprobs_result = None`, while the same request direct to Gemini returns it populated.

## Changes

- `core/providers/gemini/responses.go` (request): `convertParamsToGenerationConfigResponses` now maps `params.TopLogProbs` (with the same 20-cap as the chat route) and the `response_logprobs` extra param (the exact shape the Gemini-native ingress produces in `convertGenerationConfigToResponsesParameters`) into `GenerationConfig`, consuming the extra param like the surrounding `top_k`/`frequency_penalty` handling does.
- `core/providers/gemini/responses.go` (non-streaming response): `ToResponsesBifrostResponsesResponse` preserves `candidate.LogprobsResult` in `ProviderExtraFields` alongside `safetyRatings`/`avgLogprobs`; `buildGeminiTerminalCandidate` restores it via a new `extractGeminiLogprobsResult` extractor tolerant of both the in-memory pointer and a JSON-decoded map (mirrors `extractGeminiSafetyRatings`).
- `core/providers/gemini/responses.go` (streaming): `GeminiResponsesStreamState` gains a `LogprobsResult` field, reset in `flush()`, captured from the terminal chunk, stashed on the `response.completed` event's `ProviderExtraFields`, and restored on the Gemini-native stream egress. Terminal-candidate merge in `ToGeminiResponsesResponse` carries it too.
- `core/providers/gemini/responseslogprobs_test.go`: regression tests for the request mapping (incl. the 20-cap), the non-streaming round trip, and the streaming preserve+restore path. All four fail without the fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go test -run TestResponsesLogprobs -v ./providers/gemini/
go test ./providers/gemini/ ./providers/vertex/
```

Or live: run the repro script from #6231 (google-genai SDK pointed at `/genai`, `response_logprobs=True, logprobs=3` on `gemini-2.5-flash`). Before this change `candidates[0].logprobs_result` is `None`; after it, populated, matching a direct Gemini call. Same for `generate_content_stream`.

Note: two pre-existing failures on dev (`TestGeminiGenerationRequestUnmarshalAcceptsSchemaIntegerConstraints`, `TestGenAIToolSchemaConstraintsRoundTripAsNumbers`) are unrelated to this change and fail on a clean checkout too.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #6231

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
