### PR TITLE
fix: accept snake_case JSON-schema keys on genai FunctionDeclaration

### DIFF
--- a/core/providers/gemini/functiondeclsnakecase_test.go
+++ b/core/providers/gemini/functiondeclsnakecase_test.go
@@ -103,6 +103,21 @@ func TestFunctionDeclarationSnakeCaseAliases(t *testing.T) {
 		}
 	})
 
+	t.Run("explicit camelCase null wins over snake_case value", func(t *testing.T) {
+		// An explicit null decodes to nil just like an omitted key; presence of
+		// the camelCase key must still block the snake_case fallback.
+		fd := unmarshalSingleDeclTool(t, `{
+			"functionDeclarations": [{
+				"name": "get_weather",
+				"parametersJsonSchema": null,
+				"parameters_json_schema": {"type": "object", "marker": "snake"}
+			}]
+		}`)
+		if fd.ParametersJSONSchema != nil {
+			t.Errorf("explicit camelCase null must not be overridden by snake_case, got %+v", fd.ParametersJSONSchema)
+		}
+	})
+
 	t.Run("plain parameters still binds through the shim", func(t *testing.T) {
 		fd := unmarshalSingleDeclTool(t, `{
 			"function_declarations": [{

--- a/core/providers/gemini/functiondeclsnakecase_test.go
+++ b/core/providers/gemini/functiondeclsnakecase_test.go
@@ -118,6 +118,25 @@ func TestFunctionDeclarationSnakeCaseAliases(t *testing.T) {
 		}
 	})
 
+	t.Run("explicit snake_case null clears a reused declaration", func(t *testing.T) {
+		// Decoding into a reused struct: a payload carrying an explicit
+		// parameters_json_schema null (and no camelCase key) must clear the
+		// stale value, not leave the previous schema behind.
+		var fd FunctionDeclaration
+		if err := sonic.Unmarshal([]byte(`{"name":"a","parameters_json_schema":{"type":"object"}}`), &fd); err != nil {
+			t.Fatalf("first unmarshal: %v", err)
+		}
+		if fd.ParametersJSONSchema == nil {
+			t.Fatal("precondition: first decode must set the schema")
+		}
+		if err := sonic.Unmarshal([]byte(`{"name":"b","parameters_json_schema":null}`), &fd); err != nil {
+			t.Fatalf("second unmarshal: %v", err)
+		}
+		if fd.ParametersJSONSchema != nil {
+			t.Errorf("explicit snake_case null must clear the reused declaration, got %+v", fd.ParametersJSONSchema)
+		}
+	})
+
 	t.Run("plain parameters still binds through the shim", func(t *testing.T) {
 		fd := unmarshalSingleDeclTool(t, `{
 			"function_declarations": [{

--- a/core/providers/gemini/functiondeclsnakecase_test.go
+++ b/core/providers/gemini/functiondeclsnakecase_test.go
@@ -1,0 +1,124 @@
+package gemini
+
+// Regression tests for issue #6507: the native /genai ingress silently dropped
+// tool parameters when the client (google-genai >= 2.0.0, incl. Google ADK)
+// serialized FunctionDeclaration's schema as snake_case
+// `parameters_json_schema` instead of camelCase `parametersJsonSchema`.
+// Tool.UnmarshalJSON already aliased the outer function_declarations key, but
+// FunctionDeclaration itself had no alias shim, so the nested schema fell
+// through struct-tag matching (case-insensitive, punctuation-sensitive) and the
+// tool was forwarded upstream with no parameters, silently.
+//
+// Uses sonic.Unmarshal, the same library the real ingress uses
+// (transports/bifrost-http/integrations/router.go unmarshals the raw body into
+// GeminiGenerationRequest, whose Tools field holds []Tool).
+
+import (
+	"testing"
+
+	"github.com/bytedance/sonic"
+)
+
+func unmarshalSingleDeclTool(t *testing.T, payload string) *FunctionDeclaration {
+	t.Helper()
+	var tool Tool
+	if err := sonic.Unmarshal([]byte(payload), &tool); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if len(tool.FunctionDeclarations) != 1 {
+		t.Fatalf("expected 1 function declaration, got %d", len(tool.FunctionDeclarations))
+	}
+	return tool.FunctionDeclarations[0]
+}
+
+func TestFunctionDeclarationSnakeCaseAliases(t *testing.T) {
+	t.Run("camelCase parametersJsonSchema binds", func(t *testing.T) {
+		fd := unmarshalSingleDeclTool(t, `{
+			"functionDeclarations": [{
+				"name": "get_weather",
+				"description": "Get the weather",
+				"parametersJsonSchema": {
+					"type": "object",
+					"properties": {"location": {"type": "string"}},
+					"required": ["location"]
+				}
+			}]
+		}`)
+		if fd.ParametersJSONSchema == nil {
+			t.Fatalf("camelCase parametersJsonSchema was dropped: %+v", fd)
+		}
+	})
+
+	t.Run("snake_case parameters_json_schema binds", func(t *testing.T) {
+		// The exact shape google-genai >= 2.0.0 / Google ADK emits.
+		fd := unmarshalSingleDeclTool(t, `{
+			"functionDeclarations": [{
+				"name": "get_weather",
+				"description": "Get the weather",
+				"parameters_json_schema": {
+					"type": "object",
+					"properties": {"location": {"type": "string"}},
+					"required": ["location"]
+				}
+			}]
+		}`)
+		if fd.ParametersJSONSchema == nil {
+			t.Fatalf("snake_case parameters_json_schema was dropped: tool forwarded with no parameters. fd=%+v", fd)
+		}
+		schema, ok := fd.ParametersJSONSchema.(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected schema object, got %T", fd.ParametersJSONSchema)
+		}
+		if schema["type"] != "object" {
+			t.Errorf("schema content lost: %+v", schema)
+		}
+	})
+
+	t.Run("snake_case response_json_schema binds", func(t *testing.T) {
+		fd := unmarshalSingleDeclTool(t, `{
+			"functionDeclarations": [{
+				"name": "get_weather",
+				"response_json_schema": {"type": "string"}
+			}]
+		}`)
+		if fd.ResponseJSONSchema == nil {
+			t.Fatalf("snake_case response_json_schema was dropped. fd=%+v", fd)
+		}
+	})
+
+	t.Run("camelCase wins when both spellings present", func(t *testing.T) {
+		fd := unmarshalSingleDeclTool(t, `{
+			"functionDeclarations": [{
+				"name": "get_weather",
+				"parametersJsonSchema": {"type": "object", "marker": "camel"},
+				"parameters_json_schema": {"type": "object", "marker": "snake"}
+			}]
+		}`)
+		schema, ok := fd.ParametersJSONSchema.(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected schema object, got %T", fd.ParametersJSONSchema)
+		}
+		if schema["marker"] != "camel" {
+			t.Errorf("camelCase key must take precedence, got marker=%v", schema["marker"])
+		}
+	})
+
+	t.Run("plain parameters still binds through the shim", func(t *testing.T) {
+		fd := unmarshalSingleDeclTool(t, `{
+			"function_declarations": [{
+				"name": "get_weather",
+				"parameters": {
+					"type": "OBJECT",
+					"properties": {"location": {"type": "STRING"}},
+					"required": ["location"]
+				}
+			}]
+		}`)
+		if fd.Parameters == nil {
+			t.Fatalf("plain parameters was dropped. fd=%+v", fd)
+		}
+		if len(fd.Parameters.Properties) != 1 {
+			t.Fatalf("parameters properties lost: %+v", fd.Parameters)
+		}
+	})
+}

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -438,11 +438,14 @@ func (fd *FunctionDeclaration) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Use snake_case if camelCase wasn't provided
-	if fd.ParametersJSONSchema == nil && aux.ParametersJSONSchemaSnake != nil {
+	// Use snake_case only when the camelCase key is absent. Presence, not the
+	// decoded value, decides: an explicit camelCase null decodes to nil just
+	// like an omitted key, and must not be overridden by the snake_case
+	// sibling. See hasJSONKey.
+	if !hasJSONKey(data, "parametersJsonSchema") && aux.ParametersJSONSchemaSnake != nil {
 		fd.ParametersJSONSchema = aux.ParametersJSONSchemaSnake
 	}
-	if fd.ResponseJSONSchema == nil && aux.ResponseJSONSchemaSnake != nil {
+	if !hasJSONKey(data, "responseJsonSchema") && aux.ResponseJSONSchemaSnake != nil {
 		fd.ResponseJSONSchema = aux.ResponseJSONSchemaSnake
 	}
 	return nil

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -417,6 +417,37 @@ type FunctionDeclaration struct {
 	ResponseJSONSchema any `json:"responseJsonSchema,omitempty"`
 }
 
+// UnmarshalJSON handles both camelCase and snake_case. google-genai >= 2.0.0
+// (including Google ADK) serializes the JSON-schema fields under their Python
+// names (parameters_json_schema / response_json_schema); Go field matching is
+// case-insensitive but not punctuation-insensitive, so without the aliases
+// those schemas were silently dropped and the tool was forwarded upstream with
+// no parameters. The other fields (behavior, description, name, parameters,
+// response) spell identically in both conventions.
+func (fd *FunctionDeclaration) UnmarshalJSON(data []byte) error {
+	type Alias FunctionDeclaration
+	aux := &struct {
+		*Alias
+		ParametersJSONSchemaSnake any `json:"parameters_json_schema,omitempty"`
+		ResponseJSONSchemaSnake   any `json:"response_json_schema,omitempty"`
+	}{
+		Alias: (*Alias)(fd),
+	}
+
+	if err := sonic.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	// Use snake_case if camelCase wasn't provided
+	if fd.ParametersJSONSchema == nil && aux.ParametersJSONSchemaSnake != nil {
+		fd.ParametersJSONSchema = aux.ParametersJSONSchemaSnake
+	}
+	if fd.ResponseJSONSchema == nil && aux.ResponseJSONSchemaSnake != nil {
+		fd.ResponseJSONSchema = aux.ResponseJSONSchemaSnake
+	}
+	return nil
+}
+
 // Behavior defines the function behavior. Defaults to `BLOCKING`.
 type Behavior string
 

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -439,13 +439,14 @@ func (fd *FunctionDeclaration) UnmarshalJSON(data []byte) error {
 	}
 
 	// Use snake_case only when the camelCase key is absent. Presence, not the
-	// decoded value, decides: an explicit camelCase null decodes to nil just
-	// like an omitted key, and must not be overridden by the snake_case
-	// sibling. See hasJSONKey.
-	if !hasJSONKey(data, "parametersJsonSchema") && aux.ParametersJSONSchemaSnake != nil {
+	// decoded value, decides on both sides: an explicit null decodes to nil
+	// just like an omitted key, so a camelCase null must not be overridden by
+	// the snake_case sibling, and a snake_case null must clear any stale value
+	// on a reused declaration. See hasJSONKey.
+	if !hasJSONKey(data, "parametersJsonSchema") && hasJSONKey(data, "parameters_json_schema") {
 		fd.ParametersJSONSchema = aux.ParametersJSONSchemaSnake
 	}
-	if !hasJSONKey(data, "responseJsonSchema") && aux.ResponseJSONSchemaSnake != nil {
+	if !hasJSONKey(data, "responseJsonSchema") && hasJSONKey(data, "response_json_schema") {
 		fd.ResponseJSONSchema = aux.ResponseJSONSchemaSnake
 	}
 	return nil


### PR DESCRIPTION
## Summary

Tool calling through the native `/genai` endpoint breaks for any client on google-genai >= 2.0.0, which includes Google ADK. The tool reaches the provider with no parameters at all, the model can't populate arguments, and the request still returns 200, so nothing surfaces anywhere.

The trigger: google-genai serializes `FunctionDeclaration.parameters_json_schema` under its Python field name instead of the camelCase alias. That's legal, the Gemini REST surface is protobuf-derived and accepts both spellings. But Go struct-tag matching is case-insensitive, not punctuation-insensitive, so `parameters_json_schema` doesn't bind to `parametersJsonSchema` and is silently discarded.

The file already knows about this bug class: `Tool.UnmarshalJSON` aliases the outer `function_declarations` key, and ~10 other types in `types.go` carry the same shim. It just stopped one level short, `FunctionDeclaration` itself had no `UnmarshalJSON`.

## Changes

- `core/providers/gemini/types.go`: added `FunctionDeclaration.UnmarshalJSON` following the exact same alias pattern as `Tool.UnmarshalJSON`, covering `parameters_json_schema` and `response_json_schema`. Those are the only two multi-word fields in the struct (`behavior`, `description`, `name`, `parameters`, `response` spell identically in both conventions). camelCase wins when both spellings are present, matching the "use snake_case if camelCase wasn't provided" convention of the existing shims.
- `core/providers/gemini/functiondeclsnakecase_test.go`: regression tests using `sonic.Unmarshal`, the same library the real `/genai` ingress uses. camelCase control, both snake_case fields, precedence when both spellings present, and plain `parameters` through the outer shim. The two snake_case cases fail without the fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go test -run TestFunctionDeclarationSnakeCaseAliases -v ./providers/gemini/
go test ./providers/gemini/
```

Or live: point a google-genai >= 2.0.0 client (or a Google ADK agent) at Bifrost's `/genai` route and register a tool with `parameters_json_schema`. Before this change the upstream request carries the function declaration with no schema and the model returns argument-less calls; after it, the schema goes through and arguments populate.

Note: two pre-existing failures on dev (`TestGeminiGenerationRequestUnmarshalAcceptsSchemaIntegerConstraints`, `TestGenAIToolSchemaConstraintsRoundTripAsNumbers`) are unrelated and fail on a clean checkout too.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #6507

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
