### PR TITLE
fix: forward the role-only opening delta on streamed chat completions

### DIFF
--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -1452,10 +1452,19 @@ func HandleOpenAIChatCompletionStreaming(
 					created = response.Created
 				}
 
-				// Handle regular content chunks, including reasoning
+				// Handle regular content chunks, including reasoning. Role must be part
+				// of the forward set: OpenAI-shaped upstreams send the role ONLY on the
+				// opening delta ({"role":"assistant","content":""}), and clients like
+				// @langchain/openai key their stream-assembly mode on whether the first
+				// delta carries a role — dropping it silently loses tool calls and usage
+				// on the client side (#6523). Refusal-only and annotations-only deltas
+				// carry payload too.
 				if choice.ChatStreamResponseChoice != nil &&
 					choice.ChatStreamResponseChoice.Delta != nil &&
 					((choice.ChatStreamResponseChoice.Delta.Content != nil && *choice.ChatStreamResponseChoice.Delta.Content != "") ||
+						choice.ChatStreamResponseChoice.Delta.Role != nil ||
+						choice.ChatStreamResponseChoice.Delta.Refusal != nil ||
+						len(choice.ChatStreamResponseChoice.Delta.Annotations) > 0 ||
 						choice.ChatStreamResponseChoice.Delta.Reasoning != nil ||
 						len(choice.ChatStreamResponseChoice.Delta.ReasoningDetails) > 0 ||
 						choice.ChatStreamResponseChoice.Delta.Audio != nil ||

--- a/core/providers/openai/roleonlydelta_test.go
+++ b/core/providers/openai/roleonlydelta_test.go
@@ -1,0 +1,122 @@
+package openai
+
+// Regression test for issue #6523: the upstream's opening role-only SSE delta
+// ({"delta":{"role":"assistant","content":"","refusal":null}} - the exact
+// opening-chunk shape OpenAI's API sends) must be forwarded to the client as
+// the first stream chunk. OpenAI-compatible SDKs (e.g. @langchain/openai) key
+// their stream-assembly mode off whether the FIRST delta carries "role";
+// dropping it silently breaks tool-call and usage mapping downstream: a
+// tool-calling turn that works direct-to-model returns zero tool calls through
+// the gateway with no error raised anywhere.
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// The exact sequence from the issue report: role-only opener, content delta,
+// tool_calls delta, finish, then the usage chunk and [DONE].
+func roleOnlyOpenerSSEBody() string {
+	head := `data: {"id":"chatcmpl-6523","object":"chat.completion.chunk","created":1,"model":"repro-model",`
+	return head + `"choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"finish_reason":null}]}` + "\n\n" +
+		head + `"choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}` + "\n\n" +
+		head + `"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"SF\"}"}}]},"finish_reason":null}]}` + "\n\n" +
+		head + `"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n" +
+		head + `"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}` + "\n\n" +
+		"data: [DONE]\n\n"
+}
+
+func TestChatStreamForwardsRoleOnlyOpeningDelta(t *testing.T) {
+	server := completeSSEServer(t, roleOnlyOpenerSSEBody())
+	defer server.Close()
+
+	provider := newStreamTestProvider(server.URL)
+	stream, bifrostErr := provider.ChatCompletionStream(newStreamTestContext(), passthroughPostHook, nil, testKey(), basicChatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectChunks(t, stream)
+	if len(chunks) == 0 {
+		t.Fatal("expected chunks from a well-formed stream")
+	}
+	for i, chunk := range chunks {
+		if chunk.BifrostError != nil {
+			t.Fatalf("chunk %d unexpectedly carried an error: %+v", i, chunk.BifrostError)
+		}
+	}
+
+	first := chunks[0].BifrostChatResponse
+	if first == nil || len(first.Choices) == 0 {
+		t.Fatalf("first chunk carries no chat response/choices: %+v", chunks[0])
+	}
+	firstChoice := first.Choices[0]
+	if firstChoice.ChatStreamResponseChoice == nil || firstChoice.ChatStreamResponseChoice.Delta == nil {
+		t.Fatalf("first chunk carries no delta: %+v", firstChoice)
+	}
+	firstDelta := firstChoice.ChatStreamResponseChoice.Delta
+	if firstDelta.Role == nil || *firstDelta.Role != string(schemas.ChatMessageRoleAssistant) {
+		t.Fatalf("first emitted chunk must carry delta.role == \"assistant\" (the upstream role-only opener); got role=%v content=%v tool_calls=%d",
+			firstDelta.Role, firstDelta.Content, len(firstDelta.ToolCalls))
+	}
+
+	// Deltas are forwarded verbatim: the upstream sets role only on the opener,
+	// so no later chunk may grow one, and the tool-call delta must survive.
+	sawToolCall := false
+	for i, chunk := range chunks[1:] {
+		resp := chunk.BifrostChatResponse
+		if resp == nil || len(resp.Choices) == 0 {
+			continue
+		}
+		c := resp.Choices[0]
+		if c.ChatStreamResponseChoice == nil || c.ChatStreamResponseChoice.Delta == nil {
+			continue
+		}
+		d := c.ChatStreamResponseChoice.Delta
+		if d.Role != nil {
+			t.Errorf("chunk %d must not carry a role (upstream sets it only on the opener), got %q", i+1, *d.Role)
+		}
+		if len(d.ToolCalls) > 0 {
+			sawToolCall = true
+		}
+	}
+	if !sawToolCall {
+		t.Error("tool_calls delta lost from the stream")
+	}
+}
+
+// A refusal-only delta carries payload and must be forwarded too; it fell into
+// the same skip branch as the role-only opener.
+func TestChatStreamForwardsRefusalOnlyDelta(t *testing.T) {
+	head := `data: {"id":"chatcmpl-6523r","object":"chat.completion.chunk","created":1,"model":"repro-model",`
+	body := head + `"choices":[{"index":0,"delta":{"role":"assistant","refusal":"I cannot help with that."},"finish_reason":null}]}` + "\n\n" +
+		head + `"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n" +
+		"data: [DONE]\n\n"
+
+	server := completeSSEServer(t, body)
+	defer server.Close()
+
+	provider := newStreamTestProvider(server.URL)
+	stream, bifrostErr := provider.ChatCompletionStream(newStreamTestContext(), passthroughPostHook, nil, testKey(), basicChatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectChunks(t, stream)
+	sawRefusal := false
+	for _, chunk := range chunks {
+		resp := chunk.BifrostChatResponse
+		if resp == nil || len(resp.Choices) == 0 {
+			continue
+		}
+		c := resp.Choices[0]
+		if c.ChatStreamResponseChoice != nil && c.ChatStreamResponseChoice.Delta != nil &&
+			c.ChatStreamResponseChoice.Delta.Refusal != nil {
+			sawRefusal = true
+		}
+	}
+	if !sawRefusal {
+		t.Error("refusal delta was dropped from the stream")
+	}
+}

--- a/core/providers/openai/roleonlydelta_test.go
+++ b/core/providers/openai/roleonlydelta_test.go
@@ -87,10 +87,11 @@ func TestChatStreamForwardsRoleOnlyOpeningDelta(t *testing.T) {
 }
 
 // A refusal-only delta carries payload and must be forwarded too; it fell into
-// the same skip branch as the role-only opener.
+// the same skip branch as the role-only opener. The fixture deliberately
+// carries no role, so this pins the Refusal condition on its own.
 func TestChatStreamForwardsRefusalOnlyDelta(t *testing.T) {
 	head := `data: {"id":"chatcmpl-6523r","object":"chat.completion.chunk","created":1,"model":"repro-model",`
-	body := head + `"choices":[{"index":0,"delta":{"role":"assistant","refusal":"I cannot help with that."},"finish_reason":null}]}` + "\n\n" +
+	body := head + `"choices":[{"index":0,"delta":{"refusal":"I cannot help with that."},"finish_reason":null}]}` + "\n\n" +
 		head + `"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n" +
 		"data: [DONE]\n\n"
 


### PR DESCRIPTION
## Summary

Streamed chat completions through Bifrost never deliver the opening role-only delta. OpenAI-shaped upstreams send the assistant role exactly once, on the first chunk (`{"role":"assistant","content":"","refusal":null}`), and Bifrost's forwarding guard drops that chunk because it carries no content, no reasoning, no audio, and no tool calls. `role` then never appears on any emitted chunk.

That's not cosmetic. OpenAI-compatible SDKs key their stream-assembly mode on whether the FIRST delta carries a role. `@langchain/openai` without one falls back to a generic `ChatMessageChunk` that has no tool-call mapping, so a tool-calling turn that works perfectly direct-to-model returns zero tool calls and null usage through the gateway, with no error raised anywhere.

I verified against the exact SSE sequence from the issue: five upstream events in, three chunks out, the opener gone, role nil everywhere.

## Changes

- `core/providers/openai/openai.go`: added `Delta.Role` to the forward set of the chunk guard in `HandleOpenAIChatCompletionStreaming`, along with `Delta.Refusal` and `Delta.Annotations`, which fell into the same skip branch (a refusal-only or annotations-only delta was dropped identically). Deltas are forwarded verbatim and upstreams set role only on the opener, so no later chunk grows a role; the synthesized terminal chunk carries none either. Since this handler is shared, the fix covers every OpenAI-compatible provider (azure, groq, openrouter, deepseek, vllm, fireworks, ...).
- `core/providers/openai/roleonlydelta_test.go`: regression tests on the established `httptest` SSE mock pattern. The issue's exact sequence (role-only opener → content → tool_calls → finish → usage → [DONE]) asserting the first emitted chunk carries `delta.role == "assistant"`, no later chunk carries a role, and the tool-call delta survives; plus a refusal-only delta case. Both fail without the fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go test -run 'TestChatStreamForwardsRoleOnlyOpeningDelta|TestChatStreamForwardsRefusalOnlyDelta' -v ./providers/openai/
go test ./providers/openai/ ./providers/azure/ ./providers/groq/
```

Or live: run the issue's repro, `@langchain/openai` with `streaming: true` and a bound tool through Bifrost against any OpenAI-compatible upstream. Before this change the turn returns zero tool calls; after it, tool calls and usage come through, matching a direct call.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

Clients now receive one additional (previously dropped) leading chunk carrying only the role, which is the shape real OpenAI sends.

## Related issues

Closes #6523

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
