### PR TITLE
chore: release Bifrost Helm chart v2.1.37 with Splunk HEC plugin, OTel/logging semaphore controls, PostgreSQL node scheduling, and separate logs-store Postgres

### DIFF
--- a/docs/changelogs/helm-v2.1.37.mdx
+++ b/docs/changelogs/helm-v2.1.37.mdx
@@ -1,0 +1,15 @@
+---
+title: "v2.1.37"
+description: "Helm v2.1.37 changelog - 2026-08-26"
+---
+
+<Update label="Bifrost Helm" description="v2.1.37">
+
+## Changelog
+
+- Added `bifrost.plugins.splunk` — the Splunk HTTP Event Collector (HEC) observability connector (Enterprise): one flattened event per request to `events_index` plus the derived metric set to `metrics_index`, with TLS (`ca_cert` / `insecure_skip_verify`), a content toggle (`disable_content_logging`), request-header capture, and indexer acknowledgement (`indexer_ack`, `ack_poll_interval_ms`, `ack_timeout_ms`, `max_ack_attempts`). Renders into the `splunk` plugin config.
+- Added `bifrost.plugins.otel.config.semaphore_size` and `inject_timeout` (plugin-level, both legacy and `profiles` wrapper shapes, default `10000` / `5`) — cap on concurrent in-flight trace injects and the timeout for a single inject call, so a hung collector can't hold its concurrency slot indefinitely. Renders into `semaphore_size` / `inject_timeout`. `bifrost.plugins.logging.config` accepts the same two keys (`inject_timeout` as a duration string, e.g. `"5s"`), passed through as-is.
+- Added `postgresql.primary.nodeSelector`, `postgresql.primary.tolerations`, and `postgresql.primary.affinity` to the hosted PostgreSQL deployment, so the hosted database can be steered independently of the Bifrost pod and kept off nodes that scale in. All three default to empty, so rendering is unchanged unless set.
+- Added `storage.logsStore.postgres` to point the logs store at a separate external PostgreSQL (different host and/or database) than the config store. Only applies when the logs store resolves to postgres; `enabled: false` (default) preserves existing behavior. Fields mirror `postgresql.external` (`host`, `port`, `user`, `password`, `passwordCommand`, `database`, `sslMode`, `connMaxLifetime`, `existingSecret`, `passwordKey`); with `existingSecret` the password is injected as `BIFROST_LOGS_POSTGRES_PASSWORD`. Renders into `logs_store.config`.
+
+</Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2002,6 +2002,7 @@
             "item": "Helm",
             "icon": "box",
             "pages": [
+              "changelogs/helm-v2.1.37",
               "changelogs/helm-v2.1.36",
               "changelogs/helm-v2.1.35",
               "changelogs/helm-v2.1.34",

--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.36
+version: 2.1.37
 appVersion: "1.5.12"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,11 +4,11 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.1.36
+**Latest Version:** 2.1.37
 
 ## Changelog
 
-### Upcoming
+### 2.1.37
 
 - Added `bifrost.plugins.splunk` — the Splunk HTTP Event Collector (HEC) observability connector (Enterprise): one flattened event per request to `events_index` plus the derived metric set to `metrics_index`, with TLS (`ca_cert` / `insecure_skip_verify`), a content toggle (`disable_content_logging`), request-header capture, and indexer acknowledgement (`indexer_ack`, `ack_poll_interval_ms`, `ack_timeout_ms`, `max_ack_attempts`). Renders into the `splunk` plugin config.
 - Added `bifrost.plugins.otel.config.semaphore_size` and `inject_timeout` (plugin-level, both legacy and `profiles` wrapper shapes, default `10000` / `5`) — cap on concurrent in-flight trace injects and the timeout for a single inject call, so a hung collector can't hold its concurrency slot indefinitely. Renders into `semaphore_size` / `inject_timeout`. `bifrost.plugins.logging.config` accepts the same two keys (`inject_timeout` as a duration string, e.g. `"5s"`), passed through as-is.


### PR DESCRIPTION
### TL;DR

Releases Bifrost Helm chart v2.1.37 with Splunk HEC support, OTel/logging concurrency controls, PostgreSQL node scheduling options, and a separate logs store PostgreSQL configuration.

### What changed?

- Added `bifrost.plugins.splunk` to enable the Splunk HTTP Event Collector (HEC) observability connector (Enterprise). Supports sending one flattened event per request to `events_index` and derived metrics to `metrics_index`, with TLS options (`ca_cert` / `insecure_skip_verify`), content logging toggle (`disable_content_logging`), request-header capture, and indexer acknowledgement controls (`indexer_ack`, `ack_poll_interval_ms`, `ack_timeout_ms`, `max_ack_attempts`).
- Added `semaphore_size` and `inject_timeout` to `bifrost.plugins.otel.config` (defaulting to `10000` and `5` respectively) to cap concurrent in-flight trace injects and prevent a hung collector from holding a concurrency slot indefinitely. The same keys are also accepted under `bifrost.plugins.logging.config`, with `inject_timeout` expressed as a duration string (e.g. `"5s"`).
- Added `postgresql.primary.nodeSelector`, `postgresql.primary.tolerations`, and `postgresql.primary.affinity` to allow the hosted PostgreSQL deployment to be scheduled independently of the Bifrost pod. All three default to empty, preserving existing rendering behavior unless explicitly set.
- Added `storage.logsStore.postgres` to configure a separate external PostgreSQL instance for the logs store, distinct from the config store. Disabled by default (`enabled: false`), preserving existing behavior. Supports the same fields as `postgresql.external`, and when `existingSecret` is used, the password is injected via the `BIFROST_LOGS_POSTGRES_PASSWORD` environment variable.

### How to test?

- Deploy the chart at v2.1.37 and configure `bifrost.plugins.splunk` with a valid Splunk HEC endpoint, then verify events and metrics appear in the configured indexes.
- Set `semaphore_size` and `inject_timeout` under `bifrost.plugins.otel.config` and confirm trace injection respects the concurrency cap and timeout under load.
- Apply `postgresql.primary.nodeSelector` or `tolerations` and verify the hosted PostgreSQL pod is scheduled to the intended nodes.
- Enable `storage.logsStore.postgres` pointing to a separate PostgreSQL instance and confirm logs are written to that database while the config store remains unaffected.

### Why make this change?

These additions expand observability options with Splunk HEC support, improve resilience of trace injection under collector failures, provide finer control over PostgreSQL pod placement for scaling scenarios, and allow the logs store to be separated from the config store for independent scaling and management.