### PR TITLE
patched missing file embedding

### DIFF
--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -2994,7 +2994,7 @@ func TestToolResultJSONParsingResponsesAPI(t *testing.T) {
 				},
 			}
 
-			messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, false)
+			messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), anthropicModel, input, false)
 			require.NoError(t, err)
 			require.Len(t, messages, 1)
 
@@ -5395,7 +5395,7 @@ func TestDocumentFormatResponsesPathRoundTrip(t *testing.T) {
 			require.NotEmpty(t, bifrostMessages, "expected at least one Bifrost message")
 
 			// Outbound: Bifrost responses messages -> Bedrock
-			roundTripped, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(ctx, bifrostMessages, false)
+			roundTripped, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(ctx, anthropicModel, bifrostMessages, false)
 			require.NoError(t, err)
 			require.NotEmpty(t, roundTripped, "expected at least one Bedrock message after round-trip")
 
@@ -5593,7 +5593,7 @@ func TestToolResultImageContentResponsesAPI(t *testing.T) {
 			},
 		}
 
-		messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, false)
+		messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), anthropicModel, input, false)
 		require.NoError(t, err)
 		require.Len(t, messages, 1)
 
@@ -5637,7 +5637,7 @@ func TestToolResultImageContentResponsesAPI(t *testing.T) {
 			},
 		}
 
-		messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, false)
+		messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), anthropicModel, input, false)
 		require.NoError(t, err)
 		require.Len(t, messages, 1)
 
@@ -5670,7 +5670,7 @@ func TestToolResultImageContentResponsesAPI(t *testing.T) {
 			},
 		}
 
-		messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, false)
+		messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), anthropicModel, input, false)
 		require.NoError(t, err)
 		require.Len(t, messages, 1)
 
@@ -6724,7 +6724,7 @@ func TestMidConversationSystemReminderStaysInline(t *testing.T) {
 		userReminderTextMsg("second user turn"),
 	}
 
-	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), anthropicModel, input, true)
 	require.NoError(t, err)
 
 	// Only the leading system prompt should be hoisted into the system block.
@@ -6761,7 +6761,7 @@ func TestMidConversationSystemReminderHoistedForNonAnthropic(t *testing.T) {
 		userReminderTextMsg("second user turn"),
 	}
 
-	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, false)
+	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), anthropicModel, input, false)
 	require.NoError(t, err)
 
 	// Both system messages are hoisted (historical behavior), not just the leading one.
@@ -6789,7 +6789,7 @@ func TestMultipleLeadingSystemMessagesAllHoisted(t *testing.T) {
 		systemReminderTextMsg("Injected reminder."),
 	}
 
-	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), anthropicModel, input, true)
 	require.NoError(t, err)
 
 	require.Len(t, systemMessages, 2, "both leading system messages belong in the system block")
@@ -6825,7 +6825,7 @@ func TestSystemReminderAfterToolResultPreservesPairing(t *testing.T) {
 		systemReminderTextMsg("The task tools haven't been used recently."), // reminder right after tool result
 	}
 
-	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), anthropicModel, input, true)
 	require.NoError(t, err)
 	require.Len(t, systemMessages, 1)
 
@@ -6893,7 +6893,7 @@ func TestMidConversationDeveloperReminderStaysInline(t *testing.T) {
 		userReminderTextMsg("second user turn"),
 	}
 
-	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), anthropicModel, input, true)
 	require.NoError(t, err)
 
 	// Only the leading system prompt is hoisted; the developer reminder is NOT.
@@ -6931,7 +6931,7 @@ func TestMidConversationReminderContentStrInlined(t *testing.T) {
 		},
 	}
 
-	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), anthropicModel, input, true)
 	require.NoError(t, err)
 	require.Len(t, systemMessages, 1, "only the leading prompt is hoisted")
 
@@ -6960,7 +6960,7 @@ func TestMidConversationReminderEmptyContentDropped(t *testing.T) {
 		},
 	}
 
-	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), anthropicModel, input, true)
 	require.NoError(t, err)
 	require.Len(t, systemMessages, 1)
 
@@ -6998,7 +6998,7 @@ func TestSystemReminderBetweenToolCallAndResult(t *testing.T) {
 		},
 	}
 
-	messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), anthropicModel, input, true)
 	require.NoError(t, err)
 
 	// Locate the assistant message carrying the tool_use.
@@ -7054,7 +7054,7 @@ func TestSystemReminderCarriesCachePoint(t *testing.T) {
 		reminder,
 	}
 
-	messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), anthropicModel, input, true)
 	require.NoError(t, err)
 
 	// The marker must follow the wrapped reminder text: per Converse semantics a cachePoint
@@ -7085,7 +7085,7 @@ func TestSystemReminderWithoutCacheControlAddsNoCachePoint(t *testing.T) {
 		systemReminderTextMsg("Reminder with no breakpoint."),
 	}
 
-	messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), anthropicModel, input, true)
 	require.NoError(t, err)
 
 	for _, m := range messages {
@@ -7126,7 +7126,7 @@ func TestToolCacheControlBecomesCachePointWithTTL(t *testing.T) {
 	}
 
 	assertTTLPreserved := func(t *testing.T, input []schemas.ResponsesMessage) {
-		messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+		messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), anthropicModel, input, true)
 		require.NoError(t, err)
 
 		var afterToolUse, afterToolResult bool
@@ -7177,7 +7177,7 @@ func TestLoneSystemMessageReturnsUserMessage(t *testing.T) {
 	for role, msg := range roles {
 		for _, inline := range []bool{true, false} {
 			input := []schemas.ResponsesMessage{msg}
-			messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, inline)
+			messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), anthropicModel, input, inline)
 			require.NoError(t, err)
 			assert.Empty(t, systemMessages, "lone %s message must not populate the system block (inline=%v)", role, inline)
 			require.Len(t, messages, 1, "lone %s message must yield exactly one message (inline=%v)", role, inline)
@@ -7196,7 +7196,7 @@ func TestNoLeadingSystemBlockReminderInlined(t *testing.T) {
 		userReminderTextMsg("continue"),
 	}
 
-	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), anthropicModel, input, true)
 	require.NoError(t, err)
 
 	assert.Empty(t, systemMessages, "no leading system block means nothing should be hoisted")
@@ -7330,6 +7330,10 @@ func TestReasoningConfigNoDoubleEmissionOnEgress(t *testing.T) {
 // DocumentSource is documented as bytes | content | s3Location | text, so the object
 // reference is a first-class source - inlining it would burn a round trip and put the
 // payload under the 25 MiB inline cap for nothing.
+//
+// Nova, because forwarding the reference is only correct for a model whose Converse
+// backend resolves it: see schemas.BedrockModelSupportsS3Location, and
+// TestS3LocationRefusedForModelsThatCannotReadIt for the other side of that gate.
 func TestBedrockDocumentS3URIUsesS3Location(t *testing.T) {
 	t.Parallel()
 
@@ -7339,7 +7343,7 @@ func TestBedrockDocumentS3URIUsesS3Location(t *testing.T) {
 	fileType := "application/pdf"
 
 	got, err := bedrock.ToBedrockChatCompletionRequest(ctx, &schemas.BifrostChatRequest{
-		Model: "anthropic.claude-sonnet-4-5-v1:0",
+		Model: novaModel,
 		Input: []schemas.ChatMessage{
 			{
 				Role: schemas.ChatMessageRoleUser,
@@ -7405,7 +7409,7 @@ func TestBedrockDocumentS3URIResolvesFormatFromObjectExtension(t *testing.T) {
 			fileURL := tc.uri
 
 			got, err := bedrock.ToBedrockChatCompletionRequest(ctx, &schemas.BifrostChatRequest{
-				Model: "anthropic.claude-sonnet-4-5-v1:0",
+				Model: novaModel,
 				Input: []schemas.ChatMessage{
 					{
 						Role: schemas.ChatMessageRoleUser,
@@ -7449,7 +7453,7 @@ func TestBedrockDocumentS3URIResolvesFormatFromObjectExtension(t *testing.T) {
 		fileURL := "s3://my-bucket/reports/q4.pdf"
 
 		got, err := bedrock.ToBedrockResponsesRequest(ctx, &schemas.BifrostResponsesRequest{
-			Model: "anthropic.claude-sonnet-4-5-v1:0",
+			Model: novaModel,
 			Input: []schemas.ResponsesMessage{
 				{
 					Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
@@ -7491,7 +7495,7 @@ func TestBedrockDocumentS3URIResolvesFormatFromObjectExtension(t *testing.T) {
 		fileURL := "s3://my-bucket/reports/q4"
 
 		_, err := bedrock.ToBedrockChatCompletionRequest(ctx, &schemas.BifrostChatRequest{
-			Model: "anthropic.claude-sonnet-4-5-v1:0",
+			Model: novaModel,
 			Input: []schemas.ChatMessage{
 				{
 					Role: schemas.ChatMessageRoleUser,
@@ -7513,7 +7517,8 @@ func TestBedrockDocumentS3URIResolvesFormatFromObjectExtension(t *testing.T) {
 
 // TestBedrockImageS3URIUsesS3Location is the ImageSource twin. Note the format has to be
 // derived from the object's extension: nothing is fetched, so there is no Content-Type,
-// and Converse requires a format on every image block.
+// and Converse requires a format on every image block. Nova for the same reason as its
+// document twin above.
 func TestBedrockImageS3URIUsesS3Location(t *testing.T) {
 	t.Parallel()
 
@@ -7521,7 +7526,7 @@ func TestBedrockImageS3URIUsesS3Location(t *testing.T) {
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
 	got, err := bedrock.ToBedrockChatCompletionRequest(ctx, &schemas.BifrostChatRequest{
-		Model: "anthropic.claude-sonnet-4-5-v1:0",
+		Model: novaModel,
 		Input: []schemas.ChatMessage{
 			{
 				Role: schemas.ChatMessageRoleUser,
@@ -7558,7 +7563,7 @@ func TestBedrockImageS3URIWithoutExtensionErrors(t *testing.T) {
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
 	_, err := bedrock.ToBedrockChatCompletionRequest(ctx, &schemas.BifrostChatRequest{
-		Model: "anthropic.claude-sonnet-4-5-v1:0",
+		Model: novaModel,
 		Input: []schemas.ChatMessage{
 			{
 				Role: schemas.ChatMessageRoleUser,

--- a/core/providers/bedrock/chat.go
+++ b/core/providers/bedrock/chat.go
@@ -39,7 +39,7 @@ func ToBedrockChatCompletionRequest(ctx *schemas.BifrostContext, bifrostReq *sch
 	}
 
 	// Convert messages and system messages
-	messages, systemMessages, err := convertMessages(ctx, input)
+	messages, systemMessages, err := convertMessages(ctx, capModel, input)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert messages: %w", err)
 	}

--- a/core/providers/bedrock/files.go
+++ b/core/providers/bedrock/files.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/bytedance/sonic"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -62,6 +63,24 @@ func bedrockS3LocationFromURL(rawURL string) (*BedrockS3Location, bool) {
 		return nil, false
 	}
 	return &BedrockS3Location{URI: rawURL}, true
+}
+
+// bedrockS3LocationUnsupportedError refuses an s3:// reference bound for a model whose
+// Converse backend cannot read it. See schemas.BedrockModelSupportsS3Location for why the
+// alternative is not "let Bedrock reject it": Bedrock does not reject it, it drops the
+// source member and lets the model fail on the resulting empty source, several layers
+// away from anything the caller wrote.
+//
+// inlineHint names the working alternative for this content kind, because the two differ:
+// a document travels as base64 file_data, an image as a data: URL. Presigning is offered as
+// the other way out for the same reason Vertex's classifyURLSource offers it: Bifrost cannot
+// fetch the object on the caller's behalf here, since AWS credentials live on
+// BedrockKeyConfig and never reach a request converter.
+func bedrockS3LocationUnsupportedError(model, kind, rawURL, inlineHint string) error {
+	return providerUtils.InvalidRequestErrorf(
+		"model %q does not support s3:// references on Bedrock Converse (%s %s): the s3Location source is dropped for this model and the request then fails inside the model itself. Send the %s %s, or presign the object to an https:// URL",
+		model, kind, rawURL, kind, inlineHint,
+	)
 }
 
 // S3ListObjectsResponse represents S3 ListObjectsV2 response.

--- a/core/providers/bedrock/midconvcachepoint_test.go
+++ b/core/providers/bedrock/midconvcachepoint_test.go
@@ -108,7 +108,7 @@ func TestMidConversationSystemReminderPreservesCachePoint(t *testing.T) {
 		userReminderTextMsg("what next?"),
 	}
 
-	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), anthropicModel, input, true)
 	require.NoError(t, err)
 
 	inSystem, inMessages := countCachePoints(messages, systemMessages)
@@ -146,7 +146,7 @@ func TestMidConversationDeveloperReminderPreservesCachePoint(t *testing.T) {
 		userReminderTextMsg("what next?"),
 	}
 
-	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), anthropicModel, input, true)
 	require.NoError(t, err)
 
 	inSystem, inMessages := countCachePoints(messages, systemMessages)
@@ -166,7 +166,7 @@ func TestMidConversationSystemReminderContentStrAddsNoCachePoint(t *testing.T) {
 		userReminderTextMsg("what next?"),
 	}
 
-	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), anthropicModel, input, true)
 	require.NoError(t, err)
 
 	inSystem, inMessages := countCachePoints(messages, systemMessages)
@@ -191,7 +191,7 @@ func TestMidConversationSystemRemindersRespectCheckpointBudget(t *testing.T) {
 		userReminderTextMsg("what next?"),
 	}
 
-	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), anthropicModel, input, true)
 	require.NoError(t, err)
 
 	inSystem, inMessages := countCachePoints(messages, systemMessages)
@@ -211,7 +211,7 @@ func TestLeadingSystemRunCachePointsUnaffected(t *testing.T) {
 		cachedRoleMsg(schemas.ResponsesInputMessageRoleUser, "Reminder: stay concise."),
 	}
 
-	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), anthropicModel, input, true)
 	require.NoError(t, err)
 
 	inSystem, inMessages := countCachePoints(messages, systemMessages)
@@ -247,7 +247,7 @@ func claudeCodeShape(reminderRole schemas.ResponsesMessageRoleType) []schemas.Re
 // cachePoints must reach Bedrock: 2 hoisted into system, 1 on the inlined reminder.
 func TestInlinedSystemReminder_KeepsCachePoint(t *testing.T) {
 	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(
-		context.Background(), claudeCodeShape(schemas.ResponsesInputMessageRoleSystem), true)
+		context.Background(), anthropicModel, claudeCodeShape(schemas.ResponsesInputMessageRoleSystem), true)
 	require.NoError(t, err)
 
 	inSystem, inMessages := countCachePoints(messages, systemMessages)
@@ -260,7 +260,7 @@ func TestInlinedSystemReminder_KeepsCachePoint(t *testing.T) {
 // so it must come after the text it closes over, never before and never first.
 func TestInlinedSystemReminder_CachePointFollowsText(t *testing.T) {
 	messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(
-		context.Background(), claudeCodeShape(schemas.ResponsesInputMessageRoleSystem), true)
+		context.Background(), anthropicModel, claudeCodeShape(schemas.ResponsesInputMessageRoleSystem), true)
 	require.NoError(t, err)
 
 	for _, msg := range messages {
@@ -278,7 +278,7 @@ func TestInlinedSystemReminder_CachePointFollowsText(t *testing.T) {
 // it already worked and must keep working identically.
 func TestInlinedSystemReminder_UserRoleTailUnchanged(t *testing.T) {
 	messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(
-		context.Background(), claudeCodeShape(schemas.ResponsesInputMessageRoleUser), true)
+		context.Background(), anthropicModel, claudeCodeShape(schemas.ResponsesInputMessageRoleUser), true)
 	require.NoError(t, err)
 
 	inSystem, inMessages := countCachePoints(messages, systemMessages)
@@ -303,7 +303,7 @@ func TestInlinedSystemReminder_MultipleBreakpointsEmitOne(t *testing.T) {
 		},
 	}
 
-	messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), anthropicModel, input, true)
 	require.NoError(t, err)
 
 	_, inMessages := countCachePoints(messages, nil)
@@ -329,7 +329,7 @@ func TestInlinedSystemReminder_PreservesOneHourTTL(t *testing.T) {
 		reminder,
 	}
 
-	messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), input, true)
+	messages, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(context.Background(), anthropicModel, input, true)
 	require.NoError(t, err)
 
 	var checked bool
@@ -389,7 +389,7 @@ func TestMidconvAnthropicWireShapeReachesBedrockWithAllBreakpoints(t *testing.T)
 		require.NotNil(t, bifrostReq)
 
 		messages, systemMessages, err := bedrock.ConvertBifrostMessagesToBedrockMessages(
-			context.Background(), bifrostReq.Input, true)
+			context.Background(), anthropicModel, bifrostReq.Input, true)
 		require.NoError(t, err)
 		return messages, systemMessages
 	}

--- a/core/providers/bedrock/reasoning_replay_test.go
+++ b/core/providers/bedrock/reasoning_replay_test.go
@@ -297,7 +297,7 @@ func TestStreamingReasoningReplaySerialisesForBedrock(t *testing.T) {
 		)
 	}
 
-	messages, _, err := ConvertBifrostMessagesToBedrockMessages(context.Background(), input, false)
+	messages, _, err := ConvertBifrostMessagesToBedrockMessages(context.Background(), "anthropic.claude-sonnet-4-5-20250929-v1:0", input, false)
 	require.NoError(t, err)
 
 	raw, err := sonic.Marshal(messages)

--- a/core/providers/bedrock/reasoningreplayaudit_test.go
+++ b/core/providers/bedrock/reasoningreplayaudit_test.go
@@ -14,7 +14,7 @@ import (
 // and returns the reasoning blocks it produced.
 func bedrockReasoningBlocksForChatMessage(t *testing.T, msg schemas.ChatMessage) []BedrockContentBlock {
 	t.Helper()
-	converted, err := convertMessage(context.Background(), msg)
+	converted, err := convertMessage(context.Background(), "anthropic.claude-sonnet-4-5-20250929-v1:0", msg)
 	require.NoError(t, err)
 	var blocks []BedrockContentBlock
 	for _, block := range converted.Content {

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -2279,7 +2279,7 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 
 		// Inline mid-conversation system reminders for Anthropic models (keeps Bedrock's
 		// prefix-based prompt cache stable); hoist-everything for other families.
-		messages, systemMessages, err := ConvertBifrostMessagesToBedrockMessages(ctx, input, schemas.IsAnthropicModelFamily(ctx, bifrostReq.Model))
+		messages, systemMessages, err := ConvertBifrostMessagesToBedrockMessages(ctx, capModel, input, schemas.IsAnthropicModelFamily(ctx, bifrostReq.Model))
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert Responses messages: %w", err)
 		}
@@ -2852,7 +2852,7 @@ func ToBedrockConverseResponse(bifrostResp *schemas.BifrostResponsesResponse) (*
 		// Response-side conversion does not perform outbound fetches in practice (model output
 		// blocks already carry inline data), so context.Background() is acceptable here.
 		// Response output never contains mid-conversation system reminders, so disable inlining.
-		bedrockMessages, _, err := ConvertBifrostMessagesToBedrockMessages(context.Background(), bifrostResp.Output, false)
+		bedrockMessages, _, err := ConvertBifrostMessagesToBedrockMessages(context.Background(), bifrostResp.Model, bifrostResp.Output, false)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert bifrost output messages: %w", err)
 		}
@@ -3300,12 +3300,12 @@ func (m *ToolCallStateManager) HasPendingResults() bool {
 // messages is hoisted into the top-level `system` block and later (mid-conversation) ones are
 // inlined in place; when false, every system/developer message is hoisted (historical behavior).
 // Callers compute it from the provider+model — see the call site in ToBedrockResponsesRequest.
-func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessages []schemas.ResponsesMessage, inlineSystemReminders bool) ([]BedrockMessage, []BedrockSystemMessage, error) {
+func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, model string, bifrostMessages []schemas.ResponsesMessage, inlineSystemReminders bool) ([]BedrockMessage, []BedrockSystemMessage, error) {
 	// If only a single system message is present, convert it user message (since openai allows it)
 	if len(bifrostMessages) == 1 && bifrostMessages[0].Role != nil && (*bifrostMessages[0].Role == schemas.ResponsesInputMessageRoleSystem || *bifrostMessages[0].Role == schemas.ResponsesInputMessageRoleDeveloper) {
 		msg := bifrostMessages[0]
 		msg.Role = schemas.Ptr(schemas.ResponsesInputMessageRoleUser)
-		bedrockMsg, err := convertBifrostMessageToBedrockMessage(ctx, &msg)
+		bedrockMsg, err := convertBifrostMessageToBedrockMessage(ctx, model, &msg)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -3517,14 +3517,24 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 							} else if block.Type == schemas.ResponsesInputMessageContentBlockTypeImage &&
 								block.ResponsesInputMessageContentBlockImage != nil &&
 								block.ResponsesInputMessageContentBlockImage.ImageURL != nil {
-								imageSource, err := convertImageToBedrockSource(ctx, *block.ResponsesInputMessageContentBlockImage.ImageURL)
-								if err != nil {
-									// Bedrock only supports base64 data URIs for images. If conversion
-									// fails (e.g. remote URL), the image is dropped from the tool result
-									// which silently degrades the model's ability to see tool output.
-									_ = fmt.Errorf("bedrock: converting tool result image: %w", err)
-								} else {
+								imageSource, err := convertImageToBedrockSource(ctx, model, *block.ResponsesInputMessageContentBlockImage.ImageURL)
+								switch {
+								case err == nil:
 									resultContent = append(resultContent, BedrockContentBlock{Image: imageSource})
+								case providerUtils.IsInvalidRequestError(err):
+									// An s3:// reference this model cannot read is caller input that can
+									// never succeed as written, so it is refused rather than dropped.
+									// ImageSource is a union of bytes and s3Location
+									// (docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ImageSource.html),
+									// so dropping the block sends a tool result carrying no image member
+									// at all and reports 200 for a request Bifrost already knows is wrong.
+									// The three other convertImageToBedrockSource call sites return here;
+									// this one is the outlier only because it predates the model gate.
+									return nil, nil, fmt.Errorf("failed to convert image in responses tool result: %w", err)
+								default:
+									// A remote http(s) image that could not be fetched is transient and
+									// outside the caller's control, so the tool result still goes out
+									// without it. This is the only case the original drop was written for.
 								}
 							}
 						}
@@ -3694,7 +3704,7 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 				}
 			} else {
 				// Convert user/assistant text message
-				bedrockMsg, err := convertBifrostMessageToBedrockMessage(ctx, &msg)
+				bedrockMsg, err := convertBifrostMessageToBedrockMessage(ctx, model, &msg)
 				if err != nil {
 					return nil, nil, err
 				}
@@ -4037,7 +4047,7 @@ func convertBifrostSystemReminderToBedrockUserMessage(msg *schemas.ResponsesMess
 // The ctx is propagated to URL fetches inside content blocks. A conversion failure
 // (e.g. an image or document URL that can't be fetched) is returned rather than
 // swallowed - dropping the message would send Bedrock a request missing the turn.
-func convertBifrostMessageToBedrockMessage(ctx context.Context, msg *schemas.ResponsesMessage) (*BedrockMessage, error) {
+func convertBifrostMessageToBedrockMessage(ctx context.Context, model string, msg *schemas.ResponsesMessage) (*BedrockMessage, error) {
 	// Ensure Content is present
 	if msg.Content == nil {
 		return nil, nil
@@ -4048,7 +4058,7 @@ func convertBifrostMessageToBedrockMessage(ctx context.Context, msg *schemas.Res
 	}
 
 	// Convert content
-	contentBlocks, err := convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(ctx, *msg.Content)
+	contentBlocks, err := convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(ctx, model, *msg.Content)
 	if err != nil {
 		return nil, err
 	}
@@ -4723,7 +4733,7 @@ func convertBifrostReasoningToBedrockReasoning(msg *schemas.ResponsesMessage) []
 
 // convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks converts Bifrost content to Bedrock content blocks.
 // The ctx is propagated to URL fetches inside image blocks.
-func convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(ctx context.Context, content schemas.ResponsesMessageContent) ([]BedrockContentBlock, error) {
+func convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(ctx context.Context, model string, content schemas.ResponsesMessageContent) ([]BedrockContentBlock, error) {
 	var blocks []BedrockContentBlock
 
 	if content.ContentStr != nil {
@@ -4742,7 +4752,7 @@ func convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(ctx conte
 				bedrockBlock.Text = block.Text
 			case schemas.ResponsesInputMessageContentBlockTypeImage:
 				if block.ResponsesInputMessageContentBlockImage != nil && block.ResponsesInputMessageContentBlockImage.ImageURL != nil {
-					imageSource, err := convertImageToBedrockSource(ctx, *block.ResponsesInputMessageContentBlockImage.ImageURL)
+					imageSource, err := convertImageToBedrockSource(ctx, model, *block.ResponsesInputMessageContentBlockImage.ImageURL)
 					if err != nil {
 						return nil, fmt.Errorf("failed to convert image in responses content block: %w", err)
 					}
@@ -4812,6 +4822,11 @@ func convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(ctx conte
 					// resolved above, since nothing is fetched here.
 					if file.FileURL != nil {
 						if s3Loc, ok := bedrockS3LocationFromURL(*file.FileURL); ok {
+							// Same gate as the chat path, ahead of format resolution for the
+							// same reason: see schemas.BedrockModelSupportsS3Location.
+							if !schemas.BedrockModelSupportsS3Location(model) {
+								return nil, bedrockS3LocationUnsupportedError(model, "document", *file.FileURL, "as base64 file_data")
+							}
 							// Last resort: the object key's own extension, which the
 							// refusal below already instructs the caller to supply. See
 							// bedrockDocumentFormatFromPath; the chat path does the same.
@@ -4822,7 +4837,7 @@ func convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(ctx conte
 								}
 							}
 							if format == "" {
-								return nil, fmt.Errorf("cannot determine document format for %q: set file_type or give the object a file extension", *file.FileURL)
+								return nil, providerUtils.InvalidRequestErrorf("cannot determine document format for %q: set file_type or give the object a file extension", *file.FileURL)
 							}
 							doc.Source.S3Location = s3Loc
 							bedrockBlock.Document = doc
@@ -4832,7 +4847,7 @@ func convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(ctx conte
 							// particular reference is malformed (a bucket with no object
 							// key), and the http(s) fetch path's "unsupported URL scheme"
 							// error would say the opposite.
-							return nil, fmt.Errorf("invalid s3:// document reference %q: expected s3://bucket/key", *file.FileURL)
+							return nil, providerUtils.InvalidRequestErrorf("invalid s3:// document reference %q: expected s3://bucket/key", *file.FileURL)
 						}
 					}
 					if format != "" {

--- a/core/providers/bedrock/s3documentref_test.go
+++ b/core/providers/bedrock/s3documentref_test.go
@@ -97,7 +97,9 @@ func TestBedrockImageS3URIFormatVocabulary(t *testing.T) {
 		t.Helper()
 		return &schemas.BifrostChatRequest{
 			Provider: schemas.Bedrock,
-			Model:    "anthropic.claude-sonnet-4-5-20250929-v1:0",
+			// Nova: the s3Location path this exercises is only reached for a model whose
+			// Converse backend resolves the reference. See BedrockModelSupportsS3Location.
+			Model: novaModel,
 			Input: []schemas.ChatMessage{
 				{
 					Role: schemas.ChatMessageRoleUser,

--- a/core/providers/bedrock/s3locationmodelgate_test.go
+++ b/core/providers/bedrock/s3locationmodelgate_test.go
@@ -1,0 +1,438 @@
+package bedrock_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/providers/bedrock"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// s3Location is a documented member of the Converse source unions, but the API reference
+// is explicit that support is per-model: "To see which models support S3 uploads, see
+// Supported models and features for Converse."
+// https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_DocumentSource.html
+//
+// Anthropic models are not among them. Converse validates the union, then translates the
+// request into the model's native Messages format, where no S3 source type exists -- the
+// member is dropped and the model receives an empty source. The failure surfaces one layer
+// down, in Anthropic's vocabulary rather than Converse's:
+//
+//	ValidationException: The model returned the following errors:
+//	messages.0.content.0.document.source.type: Field required
+//
+// which names a field Converse does not even have. Forwarding s3Location to a model that
+// cannot read it is therefore never a working request, so refuse it here where the error
+// can say what to do instead.
+const (
+	novaModel      = "amazon.nova-lite-v1:0"
+	anthropicModel = "anthropic.claude-haiku-4-5-20251001-v1:0"
+)
+
+func chatRequestWithS3Document(model, uri string) *schemas.BifrostChatRequest {
+	return &schemas.BifrostChatRequest{
+		Provider: schemas.Bedrock,
+		Model:    model,
+		Input: []schemas.ChatMessage{
+			{
+				Role: schemas.ChatMessageRoleUser,
+				Content: &schemas.ChatMessageContent{
+					ContentBlocks: []schemas.ChatContentBlock{
+						{
+							Type: schemas.ChatContentBlockTypeFile,
+							File: &schemas.ChatInputFile{
+								FileURL:  schemas.Ptr(uri),
+								FileType: schemas.Ptr("application/pdf"),
+							},
+						},
+						{
+							Type: schemas.ChatContentBlockTypeText,
+							Text: schemas.Ptr("Summarize this document."),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func chatRequestWithS3Image(model, uri string) *schemas.BifrostChatRequest {
+	return &schemas.BifrostChatRequest{
+		Provider: schemas.Bedrock,
+		Model:    model,
+		Input: []schemas.ChatMessage{
+			{
+				Role: schemas.ChatMessageRoleUser,
+				Content: &schemas.ChatMessageContent{
+					ContentBlocks: []schemas.ChatContentBlock{
+						{
+							Type:           schemas.ChatContentBlockTypeImage,
+							ImageURLStruct: &schemas.ChatInputImage{URL: uri},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestS3LocationRefusedForModelsThatCannotReadIt pins the refusal for both content kinds
+// on both request surfaces. The assertion is on the actionable half of the message, not
+// merely on the model name: an error that echoes the model without saying what to send
+// instead leaves the caller exactly as stuck as the raw Bedrock 400 did.
+func TestS3LocationRefusedForModelsThatCannotReadIt(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ChatDocument", func(t *testing.T) {
+		t.Parallel()
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+		_, err := bedrock.ToBedrockChatCompletionRequest(ctx, chatRequestWithS3Document(anthropicModel, "s3://bucket/doc.pdf"))
+
+		require.Error(t, err, "an s3:// document must not be forwarded to a model that cannot read it")
+		assert.Contains(t, err.Error(), "does not support s3:// references")
+		assert.Contains(t, err.Error(), "file_data", "the error must name the working alternative")
+	})
+
+	t.Run("ChatImage", func(t *testing.T) {
+		t.Parallel()
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+		_, err := bedrock.ToBedrockChatCompletionRequest(ctx, chatRequestWithS3Image(anthropicModel, "s3://bucket/shot.png"))
+
+		require.Error(t, err, "an s3:// image must not be forwarded to a model that cannot read it")
+		assert.Contains(t, err.Error(), "does not support s3:// references")
+	})
+
+	t.Run("ResponsesDocument", func(t *testing.T) {
+		t.Parallel()
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+		_, err := bedrock.ToBedrockResponsesRequest(ctx, &schemas.BifrostResponsesRequest{
+			Provider: schemas.Bedrock,
+			Model:    anthropicModel,
+			Input: []schemas.ResponsesMessage{
+				{
+					Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+					Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+					Content: &schemas.ResponsesMessageContent{
+						ContentBlocks: []schemas.ResponsesMessageContentBlock{
+							{
+								Type: schemas.ResponsesInputMessageContentBlockTypeFile,
+								ResponsesInputMessageContentBlockFile: &schemas.ResponsesInputMessageContentBlockFile{
+									FileURL:  schemas.Ptr("s3://bucket/doc.pdf"),
+									FileType: schemas.Ptr("application/pdf"),
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		require.Error(t, err, "the Responses surface must refuse it too, not just Chat")
+		assert.Contains(t, err.Error(), "does not support s3:// references")
+	})
+}
+
+// TestS3LocationStillForwardedForSupportingModels is the other half of the gate. Nova is
+// the family AWS's own Converse examples use s3Location with, and the whole point of the
+// member is that Converse resolves the object itself: no download round trip in Bifrost
+// and no squeezing the payload under the inline byte cap. A gate that refused everything
+// would "fix" the 400 by deleting a working feature.
+func TestS3LocationStillForwardedForSupportingModels(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ChatDocument", func(t *testing.T) {
+		t.Parallel()
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		const uri = "s3://bucket/doc.pdf"
+
+		got, err := bedrock.ToBedrockChatCompletionRequest(ctx, chatRequestWithS3Document(novaModel, uri))
+		require.NoError(t, err)
+		require.Len(t, got.Messages, 1)
+
+		var doc *bedrock.BedrockDocumentSource
+		for _, block := range got.Messages[0].Content {
+			if block.Document != nil {
+				doc = block.Document
+				break
+			}
+		}
+		require.NotNil(t, doc, "expected a document block")
+		require.NotNil(t, doc.Source.S3Location, "Nova reads s3Location, so the reference must still travel")
+		assert.Equal(t, uri, doc.Source.S3Location.URI)
+		assert.Nil(t, doc.Source.Bytes, "nothing is downloaded on the s3Location path")
+	})
+
+	t.Run("ChatImage", func(t *testing.T) {
+		t.Parallel()
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		const uri = "s3://bucket/shot.png"
+
+		got, err := bedrock.ToBedrockChatCompletionRequest(ctx, chatRequestWithS3Image(novaModel, uri))
+		require.NoError(t, err)
+		require.Len(t, got.Messages, 1)
+
+		var img *bedrock.BedrockImageSource
+		for _, block := range got.Messages[0].Content {
+			if block.Image != nil {
+				img = block.Image
+				break
+			}
+		}
+		require.NotNil(t, img, "expected an image block")
+		require.NotNil(t, img.Source.S3Location, "Nova reads s3Location, so the reference must still travel")
+		assert.Equal(t, uri, img.Source.S3Location.URI)
+	})
+}
+
+// The malformed-reference refusal must keep firing ahead of the model gate. Both errors
+// are correct for an unsupported model given "s3://bucket-only", but only one of them is
+// actionable: telling the caller to switch to file_data hides the fact that the URI they
+// wrote has no object key and would not have worked on Nova either.
+func TestMalformedS3ReferenceIsReportedBeforeTheModelGate(t *testing.T) {
+	t.Parallel()
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	_, err := bedrock.ToBedrockChatCompletionRequest(ctx, chatRequestWithS3Document(anthropicModel, "s3://bucket-only"))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected s3://bucket/key",
+		"a malformed URI is the caller's more immediate problem than the model's capability")
+}
+
+// TestS3LocationRefusalIsA400 pins the status, not just the text. Converter errors default
+// to ErrRequestBodyConversion, which the HTTP layer answers with 500 - correct for a bug in
+// our conversion, wrong here: the caller sent a reference this model can never read, and no
+// retry fixes it. It also matters operationally, because 5xx is what infrastructure alerting
+// and the e2e harness both treat as "Bifrost is broken" rather than "the request was".
+func TestS3LocationRefusalIsA400(t *testing.T) {
+	t.Parallel()
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	_, err := bedrock.ToBedrockChatCompletionRequest(ctx, chatRequestWithS3Document(anthropicModel, "s3://bucket/doc.pdf"))
+	require.Error(t, err)
+
+	// Through the same wrapping the real request path applies: ToBedrockChatCompletionRequest
+	// has already prefixed "failed to convert messages:" by the time this is reached, so a
+	// promotion that only worked on the unwrapped error would pass a narrower test and fail
+	// in production.
+	bifrostErr, ok := providerUtils.AsBifrostBadRequestError(err)
+	require.True(t, ok, "the refusal must survive %%w wrapping and promote to a bad request")
+	require.NotNil(t, bifrostErr.StatusCode)
+	assert.Equal(t, 400, *bifrostErr.StatusCode)
+	require.NotNil(t, bifrostErr.Error)
+	assert.Contains(t, bifrostErr.Error.Message, "does not support s3:// references")
+	assert.NotContains(t, bifrostErr.Error.Message, "failed to convert messages",
+		"the caller gets their own mistake, not our call stack")
+}
+
+// responsesRequestWithToolResultImage builds the one Responses shape that reaches the
+// tool-result image branch: a function_call registering the call, followed by the
+// function_call_output that carries the image back. The two must share a call_id, since
+// the converter routes results through the call it registered.
+func responsesRequestWithToolResultImage(model, imageURL string) *schemas.BifrostResponsesRequest {
+	return &schemas.BifrostResponsesRequest{
+		Provider: schemas.Bedrock,
+		Model:    model,
+		Input: []schemas.ResponsesMessage{
+			{
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					CallID:    schemas.Ptr("call_screenshot_1"),
+					Name:      schemas.Ptr("take_screenshot"),
+					Arguments: schemas.Ptr("{}"),
+				},
+			},
+			{
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCallOutput),
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					CallID: schemas.Ptr("call_screenshot_1"),
+					Output: &schemas.ResponsesToolMessageOutputStruct{
+						ResponsesFunctionToolCallOutputBlocks: []schemas.ResponsesMessageContentBlock{
+							{
+								Type: schemas.ResponsesInputMessageContentBlockTypeImage,
+								ResponsesInputMessageContentBlockImage: &schemas.ResponsesInputMessageContentBlockImage{
+									ImageURL: schemas.Ptr(imageURL),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestS3ToolResultImageRefusalIsNotSwallowed covers the one call site that used to drop
+// what convertImageToBedrockSource returned. The drop was written when the only possible
+// failure was an unreachable remote image; the model gate then added a second, entirely
+// different failure to the same call, and dropping that one turns a request Bifrost knows
+// is wrong into a 200 carrying a toolResult with no image member at all. ImageSource is a
+// union of bytes and s3Location, so there is no third thing an empty source could mean:
+// https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ImageSource.html
+func TestS3ToolResultImageRefusalIsNotSwallowed(t *testing.T) {
+	t.Parallel()
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	_, err := bedrock.ToBedrockResponsesRequest(ctx, responsesRequestWithToolResultImage(anthropicModel, "s3://bucket/shot.png"))
+
+	require.Error(t, err, "an s3:// image in a tool result must be refused, not silently dropped")
+	assert.Contains(t, err.Error(), "does not support s3:// references")
+
+	// Same promotion the other gate sites get. A refusal that reached the caller as a 500
+	// would tell them to retry something that can never succeed.
+	bifrostErr, ok := providerUtils.AsBifrostBadRequestError(err)
+	require.True(t, ok, "the refusal must survive %w wrapping and promote to a bad request")
+	require.NotNil(t, bifrostErr.StatusCode)
+	assert.Equal(t, 400, *bifrostErr.StatusCode)
+}
+
+// The other half: refusing every failure at this site would delete the tolerance the drop
+// existed for. A remote image Bifrost cannot resolve is not the caller's mistake and not
+// something a retry of the same request fixes on their end, so the tool result still goes
+// out without it rather than failing the whole conversation.
+func TestUnresolvableToolResultImageIsStillDropped(t *testing.T) {
+	t.Parallel()
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	// A data: URL with no comma fails inside SanitizeImageURL, which returns a plain
+	// error rather than an InvalidRequestErrorf. That is the discriminator under test,
+	// and it needs no network to reach.
+	got, err := bedrock.ToBedrockResponsesRequest(ctx, responsesRequestWithToolResultImage(anthropicModel, "data:image/png;base64"))
+
+	require.NoError(t, err, "an image Bifrost cannot resolve must not fail the request")
+	require.NotNil(t, got)
+
+	var toolResult *bedrock.BedrockToolResult
+	for _, msg := range got.Messages {
+		for _, block := range msg.Content {
+			if block.ToolResult != nil {
+				toolResult = block.ToolResult
+			}
+		}
+	}
+	require.NotNil(t, toolResult, "the tool result itself must still reach Converse")
+	for _, block := range toolResult.Content {
+		assert.Nil(t, block.Image, "the unresolvable image is the only thing dropped")
+	}
+}
+
+// TestS3ToolResultImageStillForwardedForNova pins that the refusal is gated on the model,
+// not on the tool-result surface. Nova reads s3Location, so the reference must travel
+// untouched here exactly as it does in a plain user message.
+func TestS3ToolResultImageStillForwardedForNova(t *testing.T) {
+	t.Parallel()
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	const uri = "s3://bucket/shot.png"
+
+	got, err := bedrock.ToBedrockResponsesRequest(ctx, responsesRequestWithToolResultImage(novaModel, uri))
+	require.NoError(t, err)
+
+	var img *bedrock.BedrockImageSource
+	for _, msg := range got.Messages {
+		for _, block := range msg.Content {
+			if block.ToolResult == nil {
+				continue
+			}
+			for _, inner := range block.ToolResult.Content {
+				if inner.Image != nil {
+					img = inner.Image
+				}
+			}
+		}
+	}
+	require.NotNil(t, img, "expected the tool result to carry an image block")
+	require.NotNil(t, img.Source.S3Location, "Nova reads s3Location, so the reference must still travel")
+	assert.Equal(t, uri, img.Source.S3Location.URI)
+	assert.Nil(t, img.Source.Bytes, "nothing is downloaded on the s3Location path")
+}
+
+// responsesRequestWithContentImage is the plain user-message counterpart to
+// responsesRequestWithToolResultImage, so the two Responses surfaces can be asserted
+// against the same reference without either one standing in for the other.
+func responsesRequestWithContentImage(model, imageURL string) *schemas.BifrostResponsesRequest {
+	return &schemas.BifrostResponsesRequest{
+		Provider: schemas.Bedrock,
+		Model:    model,
+		Input: []schemas.ResponsesMessage{
+			{
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+				Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+				Content: &schemas.ResponsesMessageContent{
+					ContentBlocks: []schemas.ResponsesMessageContentBlock{
+						{
+							Type: schemas.ResponsesInputMessageContentBlockTypeImage,
+							ResponsesInputMessageContentBlockImage: &schemas.ResponsesInputMessageContentBlockImage{
+								ImageURL: schemas.Ptr(imageURL),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestMalformedS3ImageReferenceIsReportedLikeTheDocumentPath closes the gap between the
+// two content kinds. A document with no object key is refused by name
+// (TestMalformedS3ReferenceIsReportedBeforeTheModelGate); an image with no object key used
+// to fall through to SanitizeImageURL instead, which answers with
+//
+//	URL scheme "s3" is not allowed; expected one of: http, https
+//
+// as a 500. Both halves are wrong for the same request. The status is wrong because no
+// retry fixes a mistyped URI, and the message is wrong because s3:// is exactly what Nova
+// wants: a caller who believes it would delete the working reference and start inlining
+// bytes. The two kinds reach the same s3Location union member, so they must agree here.
+func TestMalformedS3ImageReferenceIsReportedLikeTheDocumentPath(t *testing.T) {
+	t.Parallel()
+
+	// novaModel deliberately, not anthropicModel: on a model that cannot read s3Location
+	// the capability gate would fire first and mask which error is under test.
+	const malformed = "s3://bucket-only"
+
+	assertMalformed := func(t *testing.T, err error) {
+		t.Helper()
+		require.Error(t, err, "a keyless s3:// image reference names no object and can never resolve")
+		assert.Contains(t, err.Error(), "expected s3://bucket/key",
+			"the caller needs the missing object key named, the same way the document path names it")
+		assert.NotContains(t, err.Error(), "is not allowed",
+			"s3:// is allowed on this model, so blaming the scheme sends the caller away from the approach that works")
+
+		bifrostErr, ok := providerUtils.AsBifrostBadRequestError(err)
+		require.True(t, ok, "a mistyped URI is caller input, not a Bifrost fault")
+		require.NotNil(t, bifrostErr.StatusCode)
+		assert.Equal(t, 400, *bifrostErr.StatusCode)
+	}
+
+	t.Run("Chat", func(t *testing.T) {
+		t.Parallel()
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+		_, err := bedrock.ToBedrockChatCompletionRequest(ctx, chatRequestWithS3Image(novaModel, malformed))
+		assertMalformed(t, err)
+	})
+
+	t.Run("ResponsesContent", func(t *testing.T) {
+		t.Parallel()
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+		_, err := bedrock.ToBedrockResponsesRequest(ctx, responsesRequestWithContentImage(novaModel, malformed))
+		assertMalformed(t, err)
+	})
+
+	t.Run("ResponsesToolResult", func(t *testing.T) {
+		t.Parallel()
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+		// Reachable only because the tool-result branch stopped discarding what
+		// convertImageToBedrockSource returns. It used to drop this and answer 200.
+		_, err := bedrock.ToBedrockResponsesRequest(ctx, responsesRequestWithToolResultImage(novaModel, malformed))
+		assertMalformed(t, err)
+	})
+}

--- a/core/providers/bedrock/toolresultstatus_test.go
+++ b/core/providers/bedrock/toolresultstatus_test.go
@@ -26,7 +26,7 @@ func TestToolResultStatusFromIsError(t *testing.T) {
 		},
 	}
 
-	converted, err := convertToolMessages(context.Background(), msgs)
+	converted, err := convertToolMessages(context.Background(), "anthropic.claude-sonnet-4-5-20250929-v1:0", msgs)
 	if err != nil {
 		t.Fatalf("convert tool messages: %v", err)
 	}

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -893,7 +893,10 @@ func ensureChatToolConfigForConversation(ctx context.Context, bifrostReq *schema
 // convertMessages converts Bifrost messages to Bedrock format
 // Returns regular messages and system messages separately.
 // The ctx is propagated to URL fetches inside individual messages.
-func convertMessages(ctx context.Context, bifrostMessages []schemas.ChatMessage) ([]BedrockMessage, []BedrockSystemMessage, error) {
+//
+// model is the canonical model id, carried down to the content-block converters because
+// two source unions are model-dependent: see schemas.BedrockModelSupportsS3Location.
+func convertMessages(ctx context.Context, model string, bifrostMessages []schemas.ChatMessage) ([]BedrockMessage, []BedrockSystemMessage, error) {
 	var messages []BedrockMessage
 	var systemMessages []BedrockSystemMessage
 
@@ -901,7 +904,7 @@ func convertMessages(ctx context.Context, bifrostMessages []schemas.ChatMessage)
 	if len(bifrostMessages) == 1 && (bifrostMessages[0].Role == schemas.ChatMessageRoleSystem || bifrostMessages[0].Role == schemas.ChatMessageRoleDeveloper) {
 		msg := bifrostMessages[0]
 		msg.Role = schemas.ChatMessageRoleUser
-		bedrockMsg, err := convertMessage(ctx, msg)
+		bedrockMsg, err := convertMessage(ctx, model, msg)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to convert message: %w", err)
 		}
@@ -923,7 +926,7 @@ func convertMessages(ctx context.Context, bifrostMessages []schemas.ChatMessage)
 
 		case schemas.ChatMessageRoleUser, schemas.ChatMessageRoleAssistant:
 			// Convert regular message
-			bedrockMsg, err := convertMessage(ctx, msg)
+			bedrockMsg, err := convertMessage(ctx, model, msg)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to convert message: %w", err)
 			}
@@ -941,7 +944,7 @@ func convertMessages(ctx context.Context, bifrostMessages []schemas.ChatMessage)
 			}
 
 			// Convert all collected tool messages into a single Bedrock message
-			bedrockMsg, err := convertToolMessages(ctx, toolMessages)
+			bedrockMsg, err := convertToolMessages(ctx, model, toolMessages)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to convert tool messages: %w", err)
 			}
@@ -1051,7 +1054,7 @@ func leadingBedrockReasoningBlockCount(blocks []BedrockContentBlock) int {
 
 // convertMessage converts a Bifrost message to Bedrock format.
 // The ctx is propagated to URL fetches inside content blocks.
-func convertMessage(ctx context.Context, msg schemas.ChatMessage) (BedrockMessage, error) {
+func convertMessage(ctx context.Context, model string, msg schemas.ChatMessage) (BedrockMessage, error) {
 	bedrockMsg := BedrockMessage{
 		Role: BedrockMessageRole(msg.Role),
 	}
@@ -1092,7 +1095,7 @@ func convertMessage(ctx context.Context, msg schemas.ChatMessage) (BedrockMessag
 
 	// Convert text/image content
 	if msg.Content != nil {
-		textBlocks, err := convertContent(ctx, *msg.Content)
+		textBlocks, err := convertContent(ctx, model, *msg.Content)
 		if err != nil {
 			return BedrockMessage{}, fmt.Errorf("failed to convert content: %w", err)
 		}
@@ -1140,7 +1143,7 @@ func convertMessage(ctx context.Context, msg schemas.ChatMessage) (BedrockMessag
 
 // convertToolMessages converts multiple consecutive Bifrost tool messages to a single Bedrock message.
 // The ctx is propagated to URL fetches inside tool result image blocks.
-func convertToolMessages(ctx context.Context, msgs []schemas.ChatMessage) (BedrockMessage, error) {
+func convertToolMessages(ctx context.Context, model string, msgs []schemas.ChatMessage) (BedrockMessage, error) {
 	if len(msgs) == 0 {
 		return BedrockMessage{}, fmt.Errorf("no tool messages provided")
 	}
@@ -1207,7 +1210,7 @@ func convertToolMessages(ctx context.Context, msgs []schemas.ChatMessage) (Bedro
 					}
 				case schemas.ChatContentBlockTypeImage:
 					if block.ImageURLStruct != nil {
-						imageSource, err := convertImageToBedrockSource(ctx, block.ImageURLStruct.URL)
+						imageSource, err := convertImageToBedrockSource(ctx, model, block.ImageURLStruct.URL)
 						if err != nil {
 							return BedrockMessage{}, fmt.Errorf("failed to convert image in tool result: %w", err)
 						}
@@ -1254,8 +1257,9 @@ func convertToolMessages(ctx context.Context, msgs []schemas.ChatMessage) (Bedro
 }
 
 // convertContent converts Bifrost message content to Bedrock content blocks.
-// The ctx is propagated to URL fetches inside individual content blocks.
-func convertContent(ctx context.Context, content schemas.ChatMessageContent) ([]BedrockContentBlock, error) {
+// The ctx is propagated to URL fetches inside individual content blocks; model reaches the
+// per-block converter for the model-dependent s3Location source union.
+func convertContent(ctx context.Context, model string, content schemas.ChatMessageContent) ([]BedrockContentBlock, error) {
 	var contentBlocks []BedrockContentBlock
 	if content.ContentStr != nil && *content.ContentStr != "" {
 		// Simple text content (skip empty strings as Bedrock rejects blank text)
@@ -1265,7 +1269,7 @@ func convertContent(ctx context.Context, content schemas.ChatMessageContent) ([]
 	} else if content.ContentBlocks != nil {
 		// Multi-modal content
 		for _, block := range content.ContentBlocks {
-			bedrockBlocks, err := convertContentBlock(ctx, block)
+			bedrockBlocks, err := convertContentBlock(ctx, model, block)
 			if err != nil {
 				return nil, fmt.Errorf("failed to convert content block: %w", err)
 			}
@@ -1277,8 +1281,9 @@ func convertContent(ctx context.Context, content schemas.ChatMessageContent) ([]
 }
 
 // convertContentBlock converts a Bifrost content block to Bedrock format.
-// The ctx is propagated to URL fetches for image and document blocks.
-func convertContentBlock(ctx context.Context, block schemas.ChatContentBlock) ([]BedrockContentBlock, error) {
+// The ctx is propagated to URL fetches for image and document blocks; model gates the
+// s3Location source union, which only some Converse backends resolve.
+func convertContentBlock(ctx context.Context, model string, block schemas.ChatContentBlock) ([]BedrockContentBlock, error) {
 	// Handle Bedrock native format where type may be empty but text is set directly
 	// This occurs when requests are sent in Bedrock's native format (e.g., from Claude Code)
 	// In Bedrock format: {"text": "hello"} vs OpenAI format: {"type": "text", "text": "hello"}
@@ -1314,7 +1319,7 @@ func convertContentBlock(ctx context.Context, block schemas.ChatContentBlock) ([
 			return nil, fmt.Errorf("image_url block missing image_url field")
 		}
 
-		imageSource, err := convertImageToBedrockSource(ctx, block.ImageURLStruct.URL)
+		imageSource, err := convertImageToBedrockSource(ctx, model, block.ImageURLStruct.URL)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert image: %w", err)
 		}
@@ -1379,6 +1384,12 @@ func convertContentBlock(ctx context.Context, block schemas.ChatContentBlock) ([
 		// refine it from.
 		if block.File.FileURL != nil {
 			if s3Loc, ok := bedrockS3LocationFromURL(*block.File.FileURL); ok {
+				// Ahead of format resolution: a model that cannot read the reference at all
+				// has no use for its format, and "cannot determine document format" would
+				// send the caller off renaming their object for no gain.
+				if !schemas.BedrockModelSupportsS3Location(model) {
+					return nil, bedrockS3LocationUnsupportedError(model, "document", *block.File.FileURL, "as base64 file_data")
+				}
 				// Last resort: the object key's own extension. Nothing is downloaded for
 				// an s3:// reference, so there is no Content-Type to read and no bytes to
 				// sniff -- the key is the only signal left, and the refusal below already
@@ -1391,7 +1402,7 @@ func convertContentBlock(ctx context.Context, block schemas.ChatContentBlock) ([
 					}
 				}
 				if format == "" {
-					return nil, fmt.Errorf("cannot determine document format for %q: set file_type or give the object a file extension", *block.File.FileURL)
+					return nil, providerUtils.InvalidRequestErrorf("cannot determine document format for %q: set file_type or give the object a file extension", *block.File.FileURL)
 				}
 				documentSource.Source.S3Location = s3Loc
 				return []BedrockContentBlock{
@@ -1404,7 +1415,7 @@ func convertContentBlock(ctx context.Context, block schemas.ChatContentBlock) ([
 				// rejects a bucket with no object key. Falling through would hand it to
 				// the http(s) fetch path, whose "unsupported URL scheme" refusal is
 				// actively misleading -- s3:// is supported, this one is just malformed.
-				return nil, fmt.Errorf("invalid s3:// document reference %q: expected s3://bucket/key", *block.File.FileURL)
+				return nil, providerUtils.InvalidRequestErrorf("invalid s3:// document reference %q: expected s3://bucket/key", *block.File.FileURL)
 			}
 		}
 		if format != "" {
@@ -1529,7 +1540,7 @@ func bedrockImageFormatFromPath(rawURL string) (string, error) {
 	case "jpg", "jpeg":
 		return "jpeg", nil
 	default:
-		return "", fmt.Errorf("cannot determine image format for %q: bedrock requires png, jpeg, gif or webp, and an s3:// reference carries no content type", rawURL)
+		return "", providerUtils.InvalidRequestErrorf("cannot determine image format for %q: bedrock requires png, jpeg, gif or webp, and an s3:// reference carries no content type", rawURL)
 	}
 }
 
@@ -1539,10 +1550,13 @@ func bedrockImageFormatFromPath(rawURL string) (string, error) {
 // the exception -- Converse resolves those itself via the s3Location union member. The
 // ctx is propagated to the fetch so request cancellation/deadlines abort in-flight
 // downloads.
-func convertImageToBedrockSource(ctx context.Context, imageURL string) (*BedrockImageSource, error) {
+func convertImageToBedrockSource(ctx context.Context, model, imageURL string) (*BedrockImageSource, error) {
 	// Checked before sanitizing: SanitizeImageURL runs the default http/https allowlist
 	// and would reject s3:// outright.
 	if s3Loc, ok := bedrockS3LocationFromURL(imageURL); ok {
+		if !schemas.BedrockModelSupportsS3Location(model) {
+			return nil, bedrockS3LocationUnsupportedError(model, "image", imageURL, "as a data: URL")
+		}
 		format, err := bedrockImageFormatFromPath(imageURL)
 		if err != nil {
 			return nil, err
@@ -1551,6 +1565,12 @@ func convertImageToBedrockSource(ctx context.Context, imageURL string) (*Bedrock
 			Format: format,
 			Source: BedrockImageSourceData{S3Location: s3Loc},
 		}, nil
+	} else if strings.HasPrefix(imageURL, "s3://") {
+		// Same guard the document path carries, for the same reason: bedrockS3LocationFromURL
+		// rejects a bucket with no object key, and falling through hands the reference to the
+		// http(s) fetch path, whose "scheme s3 is not allowed" refusal is both a 500 and untrue
+		// on a model that reads s3Location. The caller mistyped a URI; tell them that.
+		return nil, providerUtils.InvalidRequestErrorf("invalid s3:// image reference %q: expected s3://bucket/key", imageURL)
 	}
 
 	sanitizedURL, err := schemas.SanitizeImageURL(imageURL)

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -1754,6 +1754,11 @@ func CheckContextAndGetRequestBody(ctx context.Context, request RequestBodyGette
 			if ct != nil {
 				ct.EndSpan(chdl, schemas.SpanStatusError, err.Error())
 			}
+			// Caller-fault refusals carry their own 400; everything else is a conversion
+			// bug on our side and keeps the 500 default.
+			if badRequest, ok := AsBifrostBadRequestError(err); ok {
+				return nil, badRequest
+			}
 			return nil, NewBifrostOperationError(schemas.ErrRequestBodyConversion, err)
 		}
 		if ct != nil {
@@ -2449,6 +2454,45 @@ func NewBifrostBadRequestError(message string) *schemas.BifrostError {
 			Type:    &errorType,
 		},
 	}
+}
+
+// invalidRequestError marks a converter failure as caller input rather than an internal
+// Bifrost fault. Converters return a plain error (see the note on ResolveChatFileURLs for
+// why), and CheckContextAndGetRequestBody wraps whatever comes back as
+// ErrRequestBodyConversion, which the HTTP layer defaults to 500. That default is right for
+// a genuine conversion bug and wrong for a request that can never succeed as written: the
+// caller cannot fix a 5xx by retrying, and 5xx is what infrastructure alerting pages on.
+type invalidRequestError struct{ msg string }
+
+func (e *invalidRequestError) Error() string { return e.msg }
+
+// InvalidRequestErrorf builds the error a request converter returns when the caller's own
+// input is the problem. CheckContextAndGetRequestBody promotes it to a 400; anything the
+// converter wraps it in with %w still promotes, so intermediate context lines are free.
+func InvalidRequestErrorf(format string, args ...any) error {
+	return &invalidRequestError{msg: fmt.Sprintf(format, args...)}
+}
+
+// AsBifrostBadRequestError converts a converter error into a 400 when it (or anything it
+// wraps) was built by InvalidRequestErrorf. The BifrostError carries the converter's own
+// message rather than the wrapped chain, because the outer "failed to convert messages:"
+// prefixes describe Bifrost's call stack, not the caller's mistake.
+func AsBifrostBadRequestError(err error) (*schemas.BifrostError, bool) {
+	var invalid *invalidRequestError
+	if errors.As(err, &invalid) {
+		return NewBifrostBadRequestError(invalid.msg), true
+	}
+	return nil, false
+}
+
+// IsInvalidRequestError reports whether err, or anything it wraps, was built by
+// InvalidRequestErrorf. It answers the same question as AsBifrostBadRequestError without
+// building a BifrostError, for converters that are still deep in the conversion path and
+// want to keep returning a plain error up their own call chain. Use it to tell a caller
+// mistake apart from a transient fault at a site that otherwise tolerates failure.
+func IsInvalidRequestError(err error) bool {
+	var invalid *invalidRequestError
+	return errors.As(err, &invalid)
 }
 
 // NewBifrostUpstreamConnectionError creates a standardized error for upstream

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -1748,6 +1748,33 @@ func BedrockModelSupportsExtendedCacheTTL(model string) bool {
 	return IsAnthropicModel(model)
 }
 
+// BedrockModelSupportsS3Location reports whether the model's Converse backend actually
+// resolves the s3Location member of an image/document/video source union.
+//
+// s3Location is part of the Converse schema for every model, but the API reference is
+// explicit that reading it is not: "To see which models support S3 uploads, see Supported
+// models and features for Converse."
+// https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_DocumentSource.html
+//
+// The gate has to exist because an unsupported model does not produce an s3Location error.
+// Converse validates the union, translates the request into the model's native format, and
+// drops the member when that format has no S3 source type. Anthropic's does not, so the
+// model receives an empty source and answers in its own vocabulary:
+//
+//	messages.0.content.0.document.source.type: Field required
+//
+// naming a field Converse has never had. Nothing upstream of the model ever touches S3, so
+// the object's existence and the caller's permissions are irrelevant to that failure.
+//
+// Allowlist rather than a denylist: AWS folded the per-model matrix into its model cards
+// and no longer publishes an S3 column, so "supported" is only knowable where it has been
+// observed. Nova is the family AWS's own Converse S3 examples use. Add families here as
+// they are confirmed - a model missing from this list is refused with an actionable error
+// rather than silently mangled, which is the safer way to be wrong.
+func BedrockModelSupportsS3Location(model string) bool {
+	return IsNovaModel(model)
+}
+
 // IsMistralModel checks if the model is a Mistral or Codestral model.
 func IsMistralModel(model string) bool {
 	return strings.Contains(model, "mistral") || strings.Contains(model, "codestral")

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -130278,7 +130278,7 @@
           ]
         },
         {
-          "name": "[EXPECT-4XX] 52.E1 s3:// document -> bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0 (forwarded as s3Location)",
+          "name": "[EXPECT-4XX] 52.E1 s3:// document -> bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0 (refused: model cannot read s3Location)",
           "request": {
             "method": "POST",
             "header": [
@@ -130310,10 +130310,18 @@
                 "type": "text/javascript",
                 "exec": [
                   "var txt = pm.response.text() || '';",
-                  "pm.test('s3:// document is forwarded to Converse, not rejected by bifrost', function () {",
-                  "  pm.expect(txt, 'bifrost rejected the scheme instead of forwarding it as s3Location: ' +",
-                  "    txt.slice(0, 300))",
-                  "    .to.not.match(/unsupported URL scheme|only http\\/https allowed/i);",
+                  "// Converse validates the s3Location union, then translates to the model's native format,",
+                  "// where Anthropic has no S3 source type - the member is dropped and the model answers",
+                  "// 'document.source.type: Field required', naming a field Converse does not have. That is",
+                  "// never a working request, so Bifrost refuses it here with the way out.",
+                  "pm.test('s3:// document to an Anthropic model is refused by bifrost, with the fix named', function () {",
+                  "  pm.expect(pm.response.code, 'expected 400 from bifrost, got ' + pm.response.code + ': ' + txt.slice(0, 300)).to.eql(400);",
+                  "  pm.expect(txt, 'the refusal must name the model limitation: ' + txt.slice(0, 300))",
+                  "    .to.match(/does not support s3:\\/\\/ references/i);",
+                  "  pm.expect(txt, 'a refusal that does not say what to send instead leaves the caller as stuck as the raw 400 did: ' + txt.slice(0, 300))",
+                  "    .to.match(/file_data|presign/i);",
+                  "  pm.expect(txt, 'the block must never reach the model, so its source.type complaint must be gone: ' + txt.slice(0, 300))",
+                  "    .to.not.match(/source\\.type/i);",
                   "});"
                 ]
               }
@@ -130321,7 +130329,7 @@
           ]
         },
         {
-          "name": "[EXPECT-4XX] 52.E2 s3:// image -> bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0 (forwarded as s3Location)",
+          "name": "[EXPECT-4XX] 52.E2 s3:// image -> bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0 (refused: model cannot read s3Location)",
           "request": {
             "method": "POST",
             "header": [
@@ -130353,13 +130361,143 @@
                 "type": "text/javascript",
                 "exec": [
                   "var txt = pm.response.text() || '';",
-                  "pm.test('s3:// image is forwarded to Converse, not rejected by bifrost', function () {",
-                  "  pm.expect(txt, 'bifrost rejected the scheme instead of forwarding it as s3Location: ' +",
-                  "    txt.slice(0, 300))",
-                  "    .to.not.match(/unsupported URL scheme|only http\\/https allowed/i);",
-                  "  pm.expect(txt, 'the .png extension should have resolved the Converse image format: ' +",
-                  "    txt.slice(0, 300))",
+                  "pm.test('s3:// image to an Anthropic model is refused by bifrost, with the fix named', function () {",
+                  "  pm.expect(pm.response.code, 'expected 400 from bifrost, got ' + pm.response.code + ': ' + txt.slice(0, 300)).to.eql(400);",
+                  "  pm.expect(txt, 'the refusal must name the model limitation: ' + txt.slice(0, 300))",
+                  "    .to.match(/does not support s3:\\/\\/ references/i);",
+                  "  pm.expect(txt, 'the image hint differs from the document one and must reach the caller: ' + txt.slice(0, 300))",
+                  "    .to.match(/data: URL|presign/i);",
+                  "  pm.expect(txt, 'the model gate runs ahead of format resolution, so this is not a format complaint: ' + txt.slice(0, 300))",
                   "    .to.not.match(/cannot determine image format/i);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[EXPECT-4XX] 52.E3 s3:// document -> bedrock/us.amazon.nova-lite-v1:0 (forwarded as s3Location, bucket rejects)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-send-back-raw-request",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"bedrock/us.amazon.nova-lite-v1:0\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"file\",\n          \"file\": {\n            \"file_url\": \"s3://bifrost-harness-no-such-bucket/doc.pdf\",\n            \"file_type\": \"application/pdf\"\n          }\n        },\n        {\n          \"type\": \"text\",\n          \"text\": \"Summarize this document in one sentence.\"\n        }\n      ]\n    }\n  ],\n  \"max_tokens\": 64\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var txt = pm.response.text() || '';",
+                  "var body = {};",
+                  "try { body = pm.response.json() || {}; } catch (e) { body = {}; }",
+                  "var rr = (body.extra_fields || {}).raw_request;",
+                  "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                  "var wire = JSON.stringify(rr || null);",
+                  "// The bucket does not exist, so the upstream call fails either way. What this row pins is",
+                  "// the OUTBOUND payload, which is deterministic: asserting on the error text would only",
+                  "// prove what AWS happens to say this week. 52.E1 is the same request to a model that",
+                  "// cannot read s3Location, and must be refused by Bifrost instead of reaching Converse.",
+                  "pm.test('s3:// document reaches Converse as s3Location for a model that reads it', function () {",
+                  "  pm.expect(rr, 'raw_request missing or unparseable - x-bf-send-back-raw-request not honored: ' + txt.slice(0, 300)).to.be.an('object');",
+                  "  var doc = null;",
+                  "  (rr.messages || []).forEach(function (m) { (m.content || []).forEach(function (b) { if (b && b.document) { doc = b.document; } }); });",
+                  "  pm.expect(doc, 'no document block on the wire: ' + wire.slice(0, 400)).to.be.an('object');",
+                  "  var src = doc.source || {};",
+                  "  var srcTxt = JSON.stringify(src).slice(0, 400);",
+                  "  // DocumentSource is a union and s3Location is an S3Location object whose uri member is",
+                  "  // required, so a bare string there is refused by Converse while still satisfying a",
+                  "  // substring search for the key and for the URI independently.",
+                  "  pm.expect(src.s3Location, 'the document source must be a nested s3Location object: ' + srcTxt).to.be.an('object');",
+                  "  pm.expect(src.s3Location.uri, 'the object URI must survive verbatim on the required uri member: ' + srcTxt)",
+                  "    .to.eql('s3://bifrost-harness-no-such-bucket/doc.pdf');",
+                  "  pm.expect(src.bytes === undefined || src.bytes === null, 'nothing is downloaded on the s3Location path, so no base64 bytes member: ' + srcTxt).to.be.true;",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[EXPECT-4XX] 52.E4 s3:// image -> bedrock/us.amazon.nova-lite-v1:0 (forwarded as s3Location, bucket rejects)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-send-back-raw-request",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"bedrock/us.amazon.nova-lite-v1:0\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"image_url\",\n          \"image_url\": {\n            \"url\": \"s3://bifrost-harness-no-such-bucket/shot.png\"\n          }\n        },\n        {\n          \"type\": \"text\",\n          \"text\": \"Describe this in one short sentence.\"\n        }\n      ]\n    }\n  ],\n  \"max_tokens\": 64\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var txt = pm.response.text() || '';",
+                  "var body = {};",
+                  "try { body = pm.response.json() || {}; } catch (e) { body = {}; }",
+                  "var rr = (body.extra_fields || {}).raw_request;",
+                  "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                  "var wire = JSON.stringify(rr || null);",
+                  "pm.test('s3:// image reaches Converse as s3Location for a model that reads it', function () {",
+                  "  pm.expect(rr, 'raw_request missing or unparseable - x-bf-send-back-raw-request not honored: ' + txt.slice(0, 300)).to.be.an('object');",
+                  "  var img = null;",
+                  "  (rr.messages || []).forEach(function (m) { (m.content || []).forEach(function (b) { if (b && b.image) { img = b.image; } }); });",
+                  "  pm.expect(img, 'no image block on the wire: ' + wire.slice(0, 400)).to.be.an('object');",
+                  "  var src = img.source || {};",
+                  "  var srcTxt = JSON.stringify(src).slice(0, 400);",
+                  "  // ImageSource is a union and s3Location is an S3Location object whose uri member is",
+                  "  // required, so a bare string there is refused by Converse while still satisfying a",
+                  "  // substring search for the key and for the URI independently.",
+                  "  pm.expect(src.s3Location, 'the image source must be a nested s3Location object: ' + srcTxt).to.be.an('object');",
+                  "  pm.expect(src.s3Location.uri, 'the object URI must survive verbatim on the required uri member: ' + srcTxt)",
+                  "    .to.eql('s3://bifrost-harness-no-such-bucket/shot.png');",
+                  "  pm.expect(src.bytes === undefined || src.bytes === null, 'nothing is downloaded on the s3Location path, so no base64 bytes member: ' + srcTxt).to.be.true;",
+                  "  pm.expect(img.format, 'the .png key is the only format signal on this path, and Converse requires one: ' + wire.slice(0, 400)).to.eql('png');",
                   "});"
                 ]
               }


### PR DESCRIPTION
## Summary

Bedrock's Converse API exposes an `s3Location` source union member for image and document blocks, but only some model families actually resolve it. Anthropic models have no S3 source type in their native Messages format, so Converse validates the union, drops the member during translation, and the model returns `document.source.type: Field required` — a field Converse does not have. This PR adds a model-capability gate that refuses `s3://` references for models that cannot read them, returning a 400 with an actionable error message naming the working alternative, rather than letting the request reach the model and fail with a cryptic internal error.

## Changes

- Added `BedrockModelSupportsS3Location` to `core/schemas/utils.go` — an allowlist (currently Nova only) that gates `s3Location` forwarding. Allowlist rather than denylist because AWS no longer publishes a per-model S3 column; a model missing from the list is refused with an actionable error rather than silently mangled.
- Added `bedrockS3LocationUnsupportedError` in `files.go` to produce a consistent refusal message that names the model, the content kind, the URI, and the working alternative (`file_data` for documents, `data:` URL for images).
- Added `InvalidRequestErrorf` and `AsBifrostBadRequestError` in `core/providers/utils/utils.go` so converter errors caused by caller input promote to HTTP 400 rather than the default 500. `CheckContextAndGetRequestBody` now checks for this sentinel before wrapping in `ErrRequestBodyConversion`.
- Threaded `model string` through the entire chat and responses message conversion call chain (`convertMessages`, `convertMessage`, `convertContent`, `convertContentBlock`, `convertToolMessages`, `convertImageToBedrockSource`, `ConvertBifrostMessagesToBedrockMessages`, `convertBifrostMessageToBedrockMessage`, `convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks`) so the gate is reachable at every content-block conversion site.
- The model gate runs ahead of format resolution: a model that cannot read the reference has no use for its format, and surfacing "cannot determine document format" would send the caller off renaming their S3 object for no gain.
- Malformed `s3://` references (bucket with no object key) are still reported before the model gate, because that is the caller's more immediate problem and would not work on Nova either.
- Existing tests that used an Anthropic model for S3 path coverage are switched to `novaModel` (`amazon.nova-lite-v1:0`), since the s3Location path is only reachable for a model whose Converse backend resolves it.
- Added `s3locationmodelgate_test.go` with tests covering: refusal for Anthropic on both Chat and Responses surfaces, forwarding still works for Nova, malformed URI is reported before the model gate, and the refusal error survives `%w` wrapping and surfaces as a 400 (not 500).
- Updated e2e harness cases 52.E1 and 52.E2 to assert the new Bifrost-level 400 refusal for Anthropic, and added 52.E3 and 52.E4 to assert that Nova still forwards `s3Location` to Converse verbatim.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/bedrock/... -run TestS3Location
go test ./core/providers/bedrock/... -run TestMalformedS3
go test ./core/providers/bedrock/... -run TestBedrockDocumentS3URI
go test ./core/providers/bedrock/... -run TestBedrockImageS3URI
go test ./core/providers/utils/...
```

For the e2e harness, run the provider-harness collection against a live Bifrost instance with Bedrock credentials. Cases 52.E1 and 52.E2 must return 400 with `does not support s3:// references` in the body. Cases 52.E3 and 52.E4 must show `s3Location` in the raw outbound request and a 4xx from AWS (bucket does not exist), not from Bifrost.

## Breaking changes

- [x] Yes
- [ ] No

Callers sending `s3://` document or image references to Anthropic models on Bedrock will now receive a 400 from Bifrost instead of a cryptic model-level error. The request was never working; only the error surface changes. No change for Nova or other models confirmed to support `s3Location`.

## Security considerations

None. The gate operates on the model identifier and URL scheme only; no credentials or object contents are accessed.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable