### PR TITLE
docs: add ClickHouse as a supported logs store backend across storage docs, Helm guide, and contributing guide

### DIFF
--- a/docs/contributing/adding-a-logstore.mdx
+++ b/docs/contributing/adding-a-logstore.mdx
@@ -6,7 +6,7 @@ icon: "database"
 
 The Log store in Bifrost is designed to be extensible, allowing support for different database backends. This guide outlines the philosophy, architecture, and steps to add support for a new database.
 
-This guide will help you add a new custom backend for the log store. Currently, Bifrost supports PostgreSQL and SQLite.
+This guide will help you add a new custom backend for the log store. Currently, Bifrost supports PostgreSQL, SQLite, and ClickHouse.
 
 ## Setup
 
@@ -22,7 +22,7 @@ The system is built around a few key components:
 
 ## Log store structure
 
-The log store is used to persist all request/response logs from your Bifrost proxy. This can be a lightweight SQLite database or a production-grade Postgres database. Bifrost exposes a single interface (`LogStore`) for all logging operations.
+The log store is used to persist all request/response logs from your Bifrost proxy. This can be a lightweight SQLite database, a production-grade Postgres database, or a ClickHouse cluster for high-volume analytics. Bifrost exposes a single interface (`LogStore`) for all logging operations.
 
 Any custom backend for log store should implement the `LogStore` interface. The interface is defined in [logstore/store.go](https://github.com/maximhq/bifrost/blob/main/framework/logstore/store.go).
 

--- a/docs/deployment-guides/config-json.mdx
+++ b/docs/deployment-guides/config-json.mdx
@@ -393,7 +393,7 @@ Ready-to-use reference configurations from the [examples/configs](https://github
     OpenAI, Anthropic, Azure, Bedrock, Vertex, Groq, self-hosted
   </Card>
   <Card title="Storage" icon="database" href="/deployment-guides/config-json/storage">
-    config_store, logs_store, vector_store - SQLite, PostgreSQL, object storage
+    config_store, logs_store, vector_store - SQLite, PostgreSQL, ClickHouse, object storage
   </Card>
   <Card title="Plugins" icon="puzzle-piece" href="/deployment-guides/config-json/plugins">
     Semantic cache, OTel, Maxim, Datadog, custom plugins

--- a/docs/deployment-guides/config-json/schema-reference.mdx
+++ b/docs/deployment-guides/config-json/schema-reference.mdx
@@ -28,7 +28,7 @@ This page is a concise reference for every top-level key in `config.json`. Click
 | `access_profiles` | array | Access profile templates for enterprise RBAC/governance controls *(enterprise only)* | [Enterprise Governance](/enterprise/advanced-governance) |
 | `cluster_config` | object | Cluster mode settings: gossip, peers, and auto-discovery backends *(enterprise only)* | [Cluster](/deployment-guides/config-json/cluster) |
 | `config_store` | object | Configuration database backend - SQLite, PostgreSQL, or disabled (file-only mode) | [Storage](/deployment-guides/config-json/storage#config_store) |
-| `logs_store` | object | Request/response log database - SQLite, PostgreSQL + optional S3/GCS offload | [Storage](/deployment-guides/config-json/storage#logs_store) |
+| `logs_store` | object | Request/response log database - SQLite, PostgreSQL, ClickHouse + optional S3/GCS offload | [Storage](/deployment-guides/config-json/storage#logs_store) |
 | `vector_store` | object | Vector database for semantic cache - Weaviate, Redis, Qdrant, Pinecone, Valkey | [Storage](/deployment-guides/config-json/storage#vector_store) |
 | `plugins` | array | Opt-in plugins: `semantic_cache`, `otel`, `maxim`, `datadog`, custom | [Plugins](/deployment-guides/config-json/plugins) |
 | `framework` | object | Model pricing catalog URL and sync interval | [Framework](#framework) |
@@ -209,7 +209,7 @@ Storage backends. Each has `enabled` (boolean), `type` (string), and `config` (o
 | Store | Types |
 |-------|-------|
 | `config_store` | `"sqlite"`, `"postgres"` |
-| `logs_store` | `"sqlite"`, `"postgres"` (+ optional `object_storage` for LLM and MCP logs) |
+| `logs_store` | `"sqlite"`, `"postgres"`, `"clickhouse"` (+ optional `object_storage` for LLM and MCP logs) |
 | `vector_store` | `"weaviate"`, `"redis"`, `"qdrant"`, `"pinecone"` (`"redis"` also covers Valkey-compatible endpoints) |
 
 Full documentation: [Storage](/deployment-guides/config-json/storage).

--- a/docs/deployment-guides/config-json/storage.mdx
+++ b/docs/deployment-guides/config-json/storage.mdx
@@ -9,7 +9,7 @@ Bifrost persists two types of data - **config** (providers, virtual keys, govern
 | Store | Purpose | Backends |
 |-------|---------|---------|
 | `config_store` | Provider configs, virtual keys, governance rules | SQLite, PostgreSQL |
-| `logs_store` | Request/response logs shown in UI | SQLite, PostgreSQL + optional S3/GCS offload |
+| `logs_store` | Request/response logs shown in UI | SQLite, PostgreSQL, ClickHouse + optional S3/GCS offload |
 | `vector_store` | Semantic response caching | Weaviate, Redis, Valkey, Qdrant, Pinecone |
 
 <Note>
@@ -23,10 +23,6 @@ If you use PostgreSQL for any store, the target database must be **UTF8 encoded*
 <Note>
 When `config_store` is omitted, Bifrost creates a default SQLite config store in the app directory. Set `config_store.enabled` to `false` only when you want file-only configuration with no config-backed Web UI/API edits. See [Source of Truth & Reconciliation](/deployment-guides/config-json/source-of-truth).
 </Note>
-
-<Tabs>
-
-<Tab title="SQLite">
 
 ### SQLite (Default)
 
@@ -47,10 +43,6 @@ Simplest setup - no external database required. Bifrost stores configuration in 
 | Field | Description |
 |-------|-------------|
 | `config.path` | Path to the SQLite file (relative to app-dir, or absolute) |
-
-</Tab>
-
-<Tab title="PostgreSQL">
 
 ### PostgreSQL
 
@@ -123,10 +115,6 @@ Use `password_command` for short-lived database credentials such as AWS RDS IAM 
 }
 ```
 
-</Tab>
-
-<Tab title="Disabled">
-
 ### Disabled (file-only mode)
 
 Use this when you want Bifrost to read all configuration from `config.json` only - no configuration database and no config-backed Web UI/API edits.
@@ -141,17 +129,9 @@ Use this when you want Bifrost to read all configuration from `config.json` only
 
 This is the recommended setup for [multinode OSS deployments](/deployment-guides/how-to/multinode) where a shared `config.json` is the single source of truth.
 
-</Tab>
-
-</Tabs>
-
 ---
 
 ## logs_store
-
-<Tabs>
-
-<Tab title="SQLite">
 
 ### SQLite
 
@@ -166,10 +146,6 @@ This is the recommended setup for [multinode OSS deployments](/deployment-guides
   }
 }
 ```
-
-</Tab>
-
-<Tab title="PostgreSQL">
 
 ### PostgreSQL
 
@@ -222,9 +198,89 @@ For high log volumes, increase `max_open_conns`:
 }
 ```
 
-</Tab>
+### ClickHouse
 
-<Tab title="Disabled">
+A column-oriented backend built for high-volume log ingestion and fast analytical queries. Best suited for large-scale deployments where log throughput and dashboard query performance on big time ranges matter more than operational simplicity.
+
+<Note>
+ClickHouse is a **`logs_store`-only** backend. The `config_store` supports only `sqlite` and `postgres` — pair a ClickHouse logs store with a SQLite or PostgreSQL config store (see [Mixed Backend Examples](#mixed-backend-examples)).
+</Note>
+
+```json
+{
+  "logs_store": {
+    "enabled": true,
+    "type": "clickhouse",
+    "retention_days": 30,
+    "config": {
+      "host": "env.CLICKHOUSE_HOST",
+      "port": "9000",
+      "database": "bifrost",
+      "username": "env.CLICKHOUSE_USER",
+      "password": "env.CLICKHOUSE_PASSWORD"
+    }
+  }
+}
+```
+
+`host` is the only required field; the rest have sensible defaults.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `host` | - | **Required.** ClickHouse host (supports `env.` prefix) |
+| `port` | protocol-based | Port as a string. Defaults by protocol: native `9000` (`9440` with TLS), http `8123` (`8443` with TLS) |
+| `database` | `default` | Database name (supports `env.` prefix) |
+| `username` | - | ClickHouse user (supports `env.` prefix) |
+| `password` | - | ClickHouse password (supports `env.` prefix) |
+| `protocol` | `native` | Wire protocol: `"native"` or `"http"` |
+| `secure` | `false` | Enable TLS |
+| `dial_timeout` | `10000` | Connection dial timeout in **milliseconds** |
+| `cluster` | - | Optional cluster name. When set, DDL runs `ON CLUSTER` with replicated table engines for a clustered ClickHouse deployment |
+
+**TLS + HTTP protocol** against a managed ClickHouse (e.g. ClickHouse Cloud):
+
+```json
+{
+  "logs_store": {
+    "enabled": true,
+    "type": "clickhouse",
+    "retention_days": 30,
+    "config": {
+      "host": "env.CLICKHOUSE_HOST",
+      "port": "8443",
+      "database": "bifrost",
+      "username": "env.CLICKHOUSE_USER",
+      "password": "env.CLICKHOUSE_PASSWORD",
+      "protocol": "http",
+      "secure": true
+    }
+  }
+}
+```
+
+**Clustered ClickHouse** — set `cluster` so tables are created with replicated engines across the cluster:
+
+```json
+{
+  "logs_store": {
+    "enabled": true,
+    "type": "clickhouse",
+    "config": {
+      "host": "env.CLICKHOUSE_HOST",
+      "database": "bifrost",
+      "username": "env.CLICKHOUSE_USER",
+      "password": "env.CLICKHOUSE_PASSWORD",
+      "cluster": "my_cluster"
+    }
+  }
+}
+```
+
+<Note>
+With ClickHouse, `retention_days` is enforced by a native table **TTL** rather than a background delete job. Setting it to `0` (or omitting it) leaves the TTL unset, so ClickHouse itself never expires rows. Background cleanup is controlled separately by `client_config.log_retention_days`, so set that to your desired horizon as well. `matview_refresh_interval` and `matview_refresh_timeout` do not apply — they are PostgreSQL-only settings for materialized views.
+</Note>
+
+### Disabled
 
 ```json
 {
@@ -233,10 +289,6 @@ For high log volumes, increase `max_open_conns`:
   }
 }
 ```
-
-</Tab>
-
-</Tabs>
 
 ### Log Retention
 
@@ -305,10 +357,9 @@ Set `matview_refresh_interval` (Go duration string) to slow down refreshes when 
 
 Offload LLM request/response logs and MCP tool logs from the database to S3 or GCS. The database retains lightweight index records and fetches full payloads on demand. For MCP logs, the full tool log is stored in object storage and the database keeps dashboard/table fields plus a 200-character input preview.
 
-<Tabs>
-<Tab title="AWS S3">
+#### AWS S3
 
-#### Required IAM Permissions
+**Required IAM permissions**
 
 The IAM user or role needs the following permissions on your bucket:
 
@@ -384,6 +435,7 @@ The IAM user or role needs the following permissions on your bucket:
 | `endpoint` | Custom endpoint for MinIO / Cloudflare R2 |
 | `force_path_style` | Use path-style URLs (required for MinIO, default: `false`) |
 
+
 <Accordion title="Using KMS to encrypt your bucket?">
 
 1. Attach this IAM policy to whichever AWS principal Bifrost authenticates as: the IAM user behind `access_key_id`/`secret_access_key`, or the IAM role behind `role_arn`:
@@ -410,8 +462,9 @@ Default encryption applies KMS without requiring encryption headers from the upl
 
 </Accordion>
 
-</Tab>
-<Tab title="Google Cloud Storage">
+
+#### Google Cloud Storage
+
 
 ```json
 {
@@ -438,8 +491,7 @@ Omit `credentials_json` to use Application Default Credentials (Workload Identit
 | `project_id` | GCP project ID (supports `env.` prefix) |
 | `credentials_json` | Service account JSON or path - omit for ADC |
 
-</Tab>
-<Tab title="MinIO (Self-Hosted)">
+#### MinIO (Self-Hosted)
 
 ```json
 {
@@ -457,18 +509,13 @@ Omit `credentials_json` to use Application Default Credentials (Workload Identit
 }
 ```
 
-</Tab>
-</Tabs>
-
 ---
 
 ## vector_store
 
 A vector store is required for [semantic caching](/features/semantic-caching). Choose from Weaviate, Redis/Valkey, Qdrant, or Pinecone.
 
-<Tabs>
-
-<Tab title="Weaviate">
+### Weaviate
 
 ```json
 {
@@ -496,9 +543,7 @@ A vector store is required for [semantic caching](/features/semantic-caching). C
 | `grpc_config.host` | No | gRPC host for faster vector operations |
 | `grpc_config.secured` | No | Use TLS for gRPC connection |
 
-</Tab>
-
-<Tab title="Redis / Valkey">
+### Redis / Valkey
 
 ```json
 {
@@ -541,9 +586,7 @@ A vector store is required for [semantic caching](/features/semantic-caching). C
 | `cluster_mode` | `false` | Enable cluster mode (required for MemoryDB; `db` must be `0`) |
 | `pool_size` | - | Maximum socket connections |
 
-</Tab>
-
-<Tab title="Qdrant">
+### Qdrant
 
 ```json
 {
@@ -567,9 +610,7 @@ A vector store is required for [semantic caching](/features/semantic-caching). C
 | `api_key` | - | API key (supports `env.` prefix) |
 | `use_tls` | `false` | Enable TLS |
 
-</Tab>
-
-<Tab title="Pinecone">
+### Pinecone
 
 Pinecone is external-only.
 
@@ -591,15 +632,61 @@ Pinecone is external-only.
 | `api_key` | Pinecone API key (supports `env.` prefix) |
 | `index_host` | Index host from Pinecone console (e.g. `your-index.svc.us-east1-gcp.pinecone.io`) |
 
-</Tab>
-
-</Tabs>
-
 ---
 
-## Mixed Backend Example
+## Mixed Backend Examples
 
-Run the config store on PostgreSQL (for UI) while keeping logs on SQLite (simpler, cheaper for append-heavy workloads):
+Each store is configured independently, so you can run the config store and logs store on **different backends — or even different database instances**. This is useful when config and logs have different scaling, cost, or retention profiles.
+
+<Note>
+In `config.json` each store carries its own `config` block, so the two stores can point at entirely separate hosts. The Helm chart shares one PostgreSQL connection across both stores by default; set `storage.logsStore.postgres.enabled: true` to point the logs store at a separate PostgreSQL instance. See [Separate PostgreSQL for Logs](/deployment-guides/helm/storage#separate-postgresql-for-logs).
+</Note>
+
+### Config on PostgreSQL #1, Logs on PostgreSQL #2
+
+Keep configuration on a small, highly-available Postgres while sending high-volume logs to a separate Postgres instance sized for write throughput — so log traffic never competes with config reads:
+
+```json
+{
+  "$schema": "https://www.getbifrost.ai/schema",
+  "encryption_key": "env.BIFROST_ENCRYPTION_KEY",
+
+  "config_store": {
+    "enabled": true,
+    "type": "postgres",
+    "config": {
+      "host": "env.PG_CONFIG_HOST",
+      "port": "5432",
+      "user": "env.PG_CONFIG_USER",
+      "password": "env.PG_CONFIG_PASSWORD",
+      "db_name": "bifrost_config",
+      "ssl_mode": "require",
+      "max_idle_conns": 5,
+      "max_open_conns": 50
+    }
+  },
+
+  "logs_store": {
+    "enabled": true,
+    "type": "postgres",
+    "config": {
+      "host": "env.PG_LOGS_HOST",
+      "port": "5432",
+      "user": "env.PG_LOGS_USER",
+      "password": "env.PG_LOGS_PASSWORD",
+      "db_name": "bifrost_logs",
+      "ssl_mode": "require",
+      "max_idle_conns": 10,
+      "max_open_conns": 200
+    },
+    "retention_days": 90
+  }
+}
+```
+
+### Config on PostgreSQL, Logs on ClickHouse
+
+Run configuration on PostgreSQL (transactional, backs the Web UI) while sending logs to ClickHouse for high-volume ingestion and fast analytics. ClickHouse is a logs-store-only backend, so this pairing is the recommended shape for analytics-heavy deployments:
 
 ```json
 {
@@ -621,10 +708,15 @@ Run the config store on PostgreSQL (for UI) while keeping logs on SQLite (simple
 
   "logs_store": {
     "enabled": true,
-    "type": "sqlite",
+    "type": "clickhouse",
     "config": {
-      "path": "./logs.db"
-    }
+      "host": "env.CLICKHOUSE_HOST",
+      "port": "9000",
+      "database": "bifrost",
+      "username": "env.CLICKHOUSE_USER",
+      "password": "env.CLICKHOUSE_PASSWORD"
+    },
+    "retention_days": 30
   }
 }
 ```

--- a/docs/deployment-guides/helm.mdx
+++ b/docs/deployment-guides/helm.mdx
@@ -605,7 +605,7 @@ curl http://localhost:8080/health
     OpenAI, Anthropic, Azure, Bedrock, Vertex, Groq, self-hosted
   </Card>
   <Card title="Storage" icon="database" href="/deployment-guides/helm/storage">
-    SQLite, PostgreSQL, object storage for logs, vector stores
+    SQLite, PostgreSQL, ClickHouse logs, object storage for logs, vector stores
   </Card>
   <Card title="Plugins" icon="puzzle-piece" href="/deployment-guides/helm/plugins">
     Telemetry, logging, semantic cache, OTel, Datadog, governance

--- a/docs/deployment-guides/helm/storage.mdx
+++ b/docs/deployment-guides/helm/storage.mdx
@@ -9,8 +9,12 @@ Bifrost persists two types of data - **config** (providers, virtual keys, govern
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `storage.mode` | Default backend for both stores (`sqlite` or `postgres`) | `sqlite` |
-| `storage.configStore.type` | Override backend for the config store | `""` (inherits `storage.mode`) |
-| `storage.logsStore.type` | Override backend for the logs store | `""` (inherits `storage.mode`) |
+| `storage.configStore.type` | Override backend for the config store (`sqlite` or `postgres`) | `""` (inherits `storage.mode`) |
+| `storage.logsStore.type` | Override backend for the logs store (`sqlite`, `postgres`, or `clickhouse`) | `""` (inherits `storage.mode`) |
+
+<Note>
+**ClickHouse is a logs-store-only backend.** The config store supports only `sqlite` and `postgres`. To use ClickHouse for logs, set `storage.logsStore.type: clickhouse` and keep the config store on SQLite or PostgreSQL — see [ClickHouse Logs Store](#clickhouse-logs-store) below.
+</Note>
 
 <Note>
 When any store uses SQLite the chart deploys a **StatefulSet** with a PVC. With PostgreSQL only (no SQLite) it deploys a **Deployment**. Mixing backends (e.g. config=postgres, logs=sqlite) still requires a StatefulSet.
@@ -18,11 +22,7 @@ When any store uses SQLite the chart deploys a **StatefulSet** with a PVC. With 
 
 ---
 
-<Tabs>
-
-<Tab title="SQLite">
-
-### SQLite (Default)
+## SQLite (Default)
 
 Simplest setup - no external database required. Bifrost runs as a StatefulSet with a persistent volume for the SQLite files.
 
@@ -66,7 +66,7 @@ storage:
 Upgrading from SQLite to PostgreSQL requires a data migration - the two stores are not compatible. Plan accordingly before switching `storage.mode` on a running deployment.
 </Warning>
 
-#### StatefulSet Migration (chart v2.0.0+)
+### StatefulSet Migration (chart v2.0.0+)
 
 Prior to v2.0.0, SQLite used a Deployment + manual PVC. v2.0.0 moved SQLite to a StatefulSet. If upgrading from an older chart:
 
@@ -84,11 +84,9 @@ helm upgrade bifrost bifrost/bifrost \
   --set image.tag=v1.4.11
 ```
 
-</Tab>
+---
 
-<Tab title="Embedded PostgreSQL">
-
-### Embedded PostgreSQL
+## Embedded PostgreSQL
 
 The chart can deploy a PostgreSQL instance alongside Bifrost. Good for simple production setups where you don't have an existing database.
 
@@ -167,11 +165,9 @@ postgresql:
 kubectl exec -it deployment/bifrost -- nc -zv bifrost-postgresql 5432
 ```
 
-</Tab>
+---
 
-<Tab title="External PostgreSQL">
-
-### External PostgreSQL
+## External PostgreSQL
 
 Point Bifrost at an existing PostgreSQL instance - RDS, Cloud SQL, Azure Database, or self-managed.
 
@@ -259,11 +255,114 @@ kubectl run pg-test --image=postgres:16-alpine --rm -it --restart=Never -- \
   -c "SELECT version();"
 ```
 
-</Tab>
+---
 
-<Tab title="Mixed (Config=Postgres, Logs=SQLite)">
+## Separate PostgreSQL for Logs
 
-### Mixed Backend
+By default the chart points both stores at the same PostgreSQL connection. Set `storage.logsStore.postgres.enabled: true` to give the logs store its own external PostgreSQL instance while the config store keeps using the top-level `postgresql` connection.
+
+Use this when config and logs have different scaling or cost profiles: a small highly-available database for configuration, and a separate instance sized for log write throughput so log traffic never competes with config reads.
+
+<Note>
+This applies only when the logs store resolves to `postgres`. When `storage.logsStore.postgres.enabled` is `false` (the default), every logs-store connection setting falls back to the shared `postgresql` connection and behavior is unchanged. The whole `postgres` block is absent from the shipped `values.yaml`, so when you enable it, set each field you need explicitly. There are no per-field defaults apart from `passwordKey`.
+</Note>
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `storage.logsStore.postgres.enabled` | Point the logs store at a separate PostgreSQL instance | `false` |
+| `storage.logsStore.postgres.host` | Hostname or IP of the logs database. Required when `enabled` is `true`. | unset |
+| `storage.logsStore.postgres.port` | Port. Integer, or an `env.VAR_NAME` string. | unset |
+| `storage.logsStore.postgres.user` | Username | unset |
+| `storage.logsStore.postgres.database` | Database name | unset |
+| `storage.logsStore.postgres.sslMode` | `disable`, `allow`, `prefer`, `require`, `verify-ca`, `verify-full` | unset |
+| `storage.logsStore.postgres.password` | Plaintext password. Prefer `existingSecret`. | unset |
+| `storage.logsStore.postgres.existingSecret` | Secret holding the password. Takes precedence over `password`, and is mounted as `BIFROST_LOGS_POSTGRES_PASSWORD`. | unset |
+| `storage.logsStore.postgres.passwordKey` | Key within the secret | `"password"` |
+| `storage.logsStore.postgres.passwordCommand` | Command executed by Bifrost to produce the password on stdout, for dynamic credentials such as RDS IAM auth | unset |
+| `storage.logsStore.postgres.connMaxLifetime` | Maximum lifetime for physical connections, such as `"10m"` | unset |
+
+```bash
+kubectl create secret generic postgres-credentials \
+  --from-literal=password='your-config-db-password'
+
+kubectl create secret generic logs-postgres-credentials \
+  --from-literal=password='your-logs-db-password'
+```
+
+```yaml
+# split-postgres-values.yaml
+image:
+  tag: "v1.4.11"
+
+storage:
+  mode: postgres
+  logsStore:
+    type: postgres
+    maxIdleConns: 10
+    maxOpenConns: 200
+    postgres:
+      enabled: true
+      host: "logs-db.example.com"
+      port: 5432
+      user: bifrost
+      database: bifrost_logs
+      sslMode: require
+      existingSecret: "logs-postgres-credentials"
+      passwordKey: "password"
+
+# config store keeps using this connection
+postgresql:
+  enabled: false
+  external:
+    enabled: true
+    host: "config-db.example.com"
+    port: 5432
+    user: bifrost
+    database: bifrost_config
+    sslMode: require
+    existingSecret: "postgres-credentials"
+    passwordKey: "password"
+
+bifrost:
+  encryptionKey: "your-32-byte-encryption-key-here"
+```
+
+```bash
+helm install bifrost bifrost/bifrost -f split-postgres-values.yaml
+```
+
+For dynamic credentials on the logs database, use `passwordCommand` instead of `existingSecret`:
+
+```yaml
+storage:
+  logsStore:
+    postgres:
+      enabled: true
+      host: "logs-db.example.com"
+      port: 5432
+      user: bifrost
+      database: bifrost_logs
+      sslMode: require
+      passwordCommand:
+        command: aws
+        args:
+          - rds
+          - generate-db-auth-token
+          - --hostname
+          - logs-db.example.com
+          - --port
+          - "5432"
+          - --region
+          - us-east-1
+          - --username
+          - bifrost
+        timeout: 10s
+      connMaxLifetime: 10m
+```
+
+---
+
+## Mixed Backend (Config = Postgres, Logs = SQLite)
 
 Run the config store on PostgreSQL (fast lookups, shared across replicas) while keeping logs on SQLite (simpler, cheaper for append-heavy workloads).
 
@@ -322,9 +421,89 @@ storage:
     maxOpenConns: 100
 ```
 
-</Tab>
+---
 
-</Tabs>
+## ClickHouse Logs Store
+
+ClickHouse is a column-oriented backend for the **logs store**, built for high-volume log ingestion and fast analytical queries at scale. Set `storage.logsStore.type: clickhouse` and provide a `storage.logsStore.clickhouse` block. The config store stays on SQLite or PostgreSQL.
+
+<Note>
+ClickHouse applies to the logs store only. `storage.configStore.type` must remain `sqlite` or `postgres`. The chart does **not** deploy ClickHouse for you — point Bifrost at an existing ClickHouse instance (self-managed or ClickHouse Cloud).
+</Note>
+
+```bash
+kubectl create secret generic postgres-credentials \
+  --from-literal=password='your-postgres-password'
+
+kubectl create secret generic clickhouse-credentials \
+  --from-literal=password='your-clickhouse-password'
+```
+
+```yaml
+# clickhouse-logs-values.yaml
+image:
+  tag: "v1.4.11"
+
+storage:
+  mode: postgres            # config store backend
+  configStore:
+    type: postgres          # config store: sqlite or postgres only
+  logsStore:
+    type: clickhouse
+    clickhouse:
+      host: "clickhouse.default.svc.cluster.local"  # required
+      port: "9000"          # native 9000 (9440 TLS); http 8123 (8443 TLS)
+      database: "bifrost"
+      username: "default"
+      password: "env.CLICKHOUSE_PASSWORD"
+      protocol: "native"    # native or http
+      secure: false         # enable TLS
+      dialTimeout: 10000    # dial timeout in milliseconds
+      cluster: ""           # optional; runs DDL ON CLUSTER with replicated engines
+
+postgresql:
+  external:
+    enabled: true
+    host: "your-postgres-host.example.com"
+    port: 5432
+    user: bifrost
+    database: bifrost
+    sslMode: require
+    existingSecret: "postgres-credentials"
+    passwordKey: "password"
+
+# inject the ClickHouse password as an env var referenced by password: "env.CLICKHOUSE_PASSWORD" above
+env:
+  - name: CLICKHOUSE_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: clickhouse-credentials
+        key: password
+
+bifrost:
+  encryptionKey: "your-32-byte-encryption-key-here"
+```
+
+```bash
+helm install bifrost bifrost/bifrost -f clickhouse-logs-values.yaml
+```
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `storage.logsStore.type` | Set to `clickhouse` | `""` |
+| `storage.logsStore.clickhouse.host` | ClickHouse host (**required**) | - |
+| `storage.logsStore.clickhouse.port` | Port as a string. Defaults by protocol: native `9000` (`9440` TLS), http `8123` (`8443` TLS) | protocol-based |
+| `storage.logsStore.clickhouse.database` | Database name | `default` |
+| `storage.logsStore.clickhouse.username` | ClickHouse user | - |
+| `storage.logsStore.clickhouse.password` | ClickHouse password (supports `env.` prefix) | - |
+| `storage.logsStore.clickhouse.protocol` | Wire protocol: `native` or `http` | `native` |
+| `storage.logsStore.clickhouse.secure` | Enable TLS | `false` |
+| `storage.logsStore.clickhouse.dialTimeout` | Connection dial timeout in milliseconds | `10000` |
+| `storage.logsStore.clickhouse.cluster` | Optional cluster name; runs DDL `ON CLUSTER` with replicated engines | `""` |
+
+<Note>
+With ClickHouse, the table **TTL** comes from `logs_store.retention_days`, which the chart does not expose yet. Set it in `config.json` directly if you need ClickHouse to expire rows on its own. Background log cleanup is controlled separately by `bifrost.client.logRetentionDays`. The PostgreSQL-only `matviewRefreshInterval` and `matviewRefreshTimeout` settings have no effect on ClickHouse.
+</Note>
 
 ---
 
@@ -332,10 +511,9 @@ storage:
 
 Offload large request/response payloads from the database to S3 or GCS. The DB retains only lightweight index records; payloads are fetched on demand.
 
-<Tabs>
-<Tab title="AWS S3">
+### AWS S3
 
-#### Required IAM Permissions
+**Required IAM permissions**
 
 The IAM user or role needs the following permissions on your bucket:
 
@@ -419,8 +597,7 @@ storage:
       roleArn: "arn:aws:iam::123456789012:role/BifrostS3Role"
 ```
 
-</Tab>
-<Tab title="Google Cloud Storage">
+### Google Cloud Storage
 
 ```bash
 kubectl create secret generic gcs-credentials \
@@ -449,8 +626,7 @@ bifrost:
       envVar: "GCS_CREDENTIALS_JSON"
 ```
 
-</Tab>
-<Tab title="MinIO (Self-Hosted)">
+### MinIO (Self-Hosted)
 
 ```yaml
 storage:
@@ -469,8 +645,7 @@ storage:
       forcePathStyle: true        # required for MinIO
 ```
 
-</Tab>
-</Tabs>
+Apply any of the object storage options above with:
 
 ```bash
 helm upgrade bifrost bifrost/bifrost \
@@ -484,8 +659,7 @@ helm upgrade bifrost bifrost/bifrost \
 
 A vector store is required for [semantic caching](/deployment-guides/helm/plugins). Choose from Weaviate, Redis, or Qdrant (embedded or external), or Pinecone (external only).
 
-<Tabs>
-<Tab title="Weaviate">
+### Weaviate
 
 ```yaml
 vectorStore:
@@ -525,8 +699,7 @@ vectorStore:
       apiKeyKey: "api-key"
 ```
 
-</Tab>
-<Tab title="Redis / Valkey">
+### Redis / Valkey
 
 ```yaml
 vectorStore:
@@ -565,8 +738,7 @@ vectorStore:
       passwordKey: "password"
 ```
 
-</Tab>
-<Tab title="Qdrant">
+### Qdrant
 
 ```yaml
 vectorStore:
@@ -600,8 +772,7 @@ vectorStore:
       apiKeyKey: "api-key"
 ```
 
-</Tab>
-<Tab title="Pinecone">
+### Pinecone
 
 Pinecone is external-only.
 
@@ -622,8 +793,7 @@ vectorStore:
       apiKeyKey: "api-key"
 ```
 
-</Tab>
-</Tabs>
+Apply any of the vector store options above with:
 
 ```bash
 helm install bifrost bifrost/bifrost \

--- a/docs/deployment-guides/runtime-contract.mdx
+++ b/docs/deployment-guides/runtime-contract.mdx
@@ -28,7 +28,7 @@ Keep the supplied entrypoint unless your own wrapper prepares `/app/data`, forwa
 
 ## Choose storage
 
-OSS Bifrost can store application configuration and request logs in SQLite or PostgreSQL. Bifrost Enterprise requires PostgreSQL 16 or later for both stores and does not support SQLite.
+OSS Bifrost can store application configuration in SQLite or PostgreSQL, and request logs in SQLite, PostgreSQL, or ClickHouse. Bifrost Enterprise requires PostgreSQL 16 or later for the config store and does not support SQLite; the logs store may use PostgreSQL 16+ or ClickHouse.
 
 <Note>
 Persistent `/app/data` storage is used only when the configuration store or log store uses SQLite. When both stores use PostgreSQL, Bifrost does not create or use the SQLite databases and the Helm chart does not create the Bifrost data PVC. The container still needs access to its application directory and `config.json` during startup.
@@ -44,7 +44,7 @@ Keep one Bifrost process attached to each SQLite database. A shared SQLite file 
 
 **Bifrost requires PostgreSQL 16 or later.** Startup fails when the configured PostgreSQL server is older than version 16. Use PostgreSQL when Bifrost runs on ephemeral compute, when you prefer an external database, or for every Enterprise deployment.
 
-Configure both `config_store` and `logs_store` as PostgreSQL to remove SQLite from the deployment. Enterprise deployments must use PostgreSQL for both stores. With Helm, `storage.mode: postgres` makes both enabled stores inherit PostgreSQL unless a per-store `type` override selects another backend.
+Configure both `config_store` and `logs_store` as PostgreSQL to remove SQLite from the deployment. Enterprise deployments must use PostgreSQL for the config store; the logs store may use PostgreSQL or ClickHouse. With Helm, `storage.mode: postgres` makes both enabled stores inherit PostgreSQL unless a per-store `type` override selects another backend.
 
 The database may be hosted anywhere that Bifrost can reach. Common choices include an existing PostgreSQL server, Amazon RDS or Aurora PostgreSQL, Google Cloud SQL, Azure Database for PostgreSQL, and provider-hosted PostgreSQL services.
 

--- a/docs/enterprise/log-exports.mdx
+++ b/docs/enterprise/log-exports.mdx
@@ -4,7 +4,7 @@ description: "Offload Bifrost request and response payloads to S3 or GCS object 
 icon: "download"
 ---
 
-Bifrost's log store can be paired with an **object storage** backend (S3 or GCS) so that large request/response payloads are streamed to durable object storage while the logs database (SQLite or Postgres) keeps only searchable metadata, indexes, and pointers. This keeps the database small and fast, makes payloads cheap to retain for long periods, and lets you query archived traffic from your own data lake.
+Bifrost's log store can be paired with an **object storage** backend (S3 or GCS) so that large request/response payloads are streamed to durable object storage while the logs database (SQLite, Postgres, or ClickHouse) keeps only searchable metadata, indexes, and pointers. This keeps the database small and fast, makes payloads cheap to retain for long periods, and lets you query archived traffic from your own data lake.
 
 ## How it works
 
@@ -13,8 +13,8 @@ Bifrost's log store can be paired with an **object storage** backend (S3 or GCS)
 ```
 logs_store
 ├── enabled
-├── type            (sqlite | postgres)
-├── config          (SQLite path or Postgres connection)
+├── type            (sqlite | postgres | clickhouse)
+├── config          (SQLite path, or Postgres / ClickHouse connection)
 ├── object_storage              ← S3 or GCS payload offload (optional)
 └── object_storage_exclude_fields
 ```


### PR DESCRIPTION
## Summary

Adds ClickHouse as a supported `logs_store` backend across all documentation. ClickHouse is a column-oriented database suited for high-volume log ingestion and fast analytical queries, and is now a first-class option alongside SQLite and PostgreSQL for the logs store.

## Changes

- Updated all references listing supported `logs_store` backends to include ClickHouse (contributing guide, config reference, schema reference, storage guides, runtime contract, log exports, and Helm docs).
- Added full ClickHouse configuration documentation to `config-json/storage.mdx`, covering native and HTTP protocols, TLS, clustered deployments, field reference table, and behavior notes (TTL-based retention, no `matview_refresh_interval` support).
- Added a dedicated **ClickHouse Logs Store** section to `helm/storage.mdx` with a complete `values.yaml` example, secret creation steps, and a parameter reference table.
- Expanded the **Mixed Backend Examples** section in `config-json/storage.mdx` to cover three scenarios: Config on PostgreSQL + Logs on PostgreSQL , and Config on PostgreSQL + Logs on ClickHouse (replacing the previous single SQLite example).
- Updated the runtime contract to clarify that Enterprise supports ClickHouse for the logs store alongside PostgreSQL.
- Removed `<Tabs>`/`<Tab>` wrappers throughout `config-json/storage.mdx` and `helm/storage.mdx`, replacing them with flat headings for improved readability and navigation.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation pages for:

- `docs/deployment-guides/config-json/storage.mdx` — verify the ClickHouse section renders correctly with all code blocks, tables, and notes.
- `docs/deployment-guides/helm/storage.mdx` — verify the ClickHouse Logs Store section and updated mixed backend section render correctly.
- `docs/contributing/adding-a-logstore.mdx` — verify ClickHouse is listed as a supported backend.
- Confirm no broken tab components remain (all `<Tabs>`/`<Tab>` wrappers have been removed).

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. Documentation-only change. ClickHouse credentials in examples use `env.` prefixes consistent with existing patterns for secret handling.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable