### PR TITLE
chore(ui): remove `max-w-7xl` from model catalog and reorder imports in `themeToggle`

### DIFF
--- a/ui/app/workspace/model-catalog/views/modelCatalogView.tsx
+++ b/ui/app/workspace/model-catalog/views/modelCatalogView.tsx
@@ -23,7 +23,7 @@ export default function ModelCatalogView() {
 	}
 
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))] min-h-0 w-full max-w-7xl flex-col overflow-hidden p-4">
+		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))] min-h-0 w-full flex-col overflow-hidden p-4">
 			<Tabs value={tab} onValueChange={(value) => setTab(value as ModelCatalogTab)} className="flex min-h-0 grow flex-col gap-4">
 				<TabsList className="shrink-0">
 					<TabsTrigger value="overview" data-testid="model-catalog-tab-overview">

--- a/ui/components/themeToggle.tsx
+++ b/ui/components/themeToggle.tsx
@@ -1,8 +1,7 @@
-import { Check, Laptop, Moon, Sun } from "lucide-react";
-import { useTheme } from "next-themes";
-import { TOPBAR_MENU_SIDE_OFFSET } from "@/components/topbar.utils";
 import { Button } from "@/components/ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
+import { Check, Laptop, Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
 
 const THEMES = [
 	{ value: "light", label: "Light", icon: Sun },


### PR DESCRIPTION
## Summary

Removes the `max-w-7xl` width constraint from the Model Catalog view so it can expand to fill the full available width, and cleans up import ordering in the theme toggle component.

## Changes

- Removed `max-w-7xl` from the Model Catalog view container, allowing the layout to use the full width instead of being capped at a fixed maximum
- Reordered imports in `themeToggle.tsx` to follow project conventions (local imports before third-party)

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Navigate to the Model Catalog view and verify that the content expands to fill the full width of the viewport without being constrained to a fixed maximum width.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before/after screenshots of the Model Catalog view at wide viewport widths would confirm the layout change.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable