### PR TITLE
chore: remove `deployments` field from Azure/Bedrock config schemas and validation scripts

### DIFF
--- a/.github/workflows/scripts/validate-helm-config-fields.sh
+++ b/.github/workflows/scripts/validate-helm-config-fields.sh
@@ -305,8 +305,6 @@ bifrost:
           azure_key_config:
             endpoint: "https://myresource.openai.azure.com"
             api_version: "2024-02-15-preview"
-            deployments:
-              gpt-4o: "my-deployment"
     vertex:
       keys:
         - name: "vertex-key"
@@ -363,7 +361,6 @@ assert_field_value 'providers.openai.send_back_raw_response' '.providers.openai.
 # Azure key config
 assert_field_value 'providers.azure.keys[0].azure_key_config.endpoint' '.providers.azure.keys.[0].azure_key_config.endpoint' '"https://myresource.openai.azure.com"'
 assert_field_value 'providers.azure.keys[0].azure_key_config.api_version' '.providers.azure.keys.[0].azure_key_config.api_version' '"2024-02-15-preview"'
-assert_field 'providers.azure.keys[0].azure_key_config.deployments' '.providers.azure.keys.[0].azure_key_config.deployments'
 
 # Vertex key config
 assert_field_value 'providers.vertex.keys[0].vertex_key_config.project_id' '.providers.vertex.keys.[0].vertex_key_config.project_id' '"my-project"'

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -5770,13 +5770,6 @@
               "type": "string",
               "description": "Bedrock project ID scoping inference and model listing. Sent as the OpenAI-Project header on the OpenAI-compatible surface and the anthropic-workspace-id header on the native-Anthropic (Claude) surface. When empty, AWS routes to the account's default project (can use env. prefix)"
             },
-            "deployments": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              },
-              "description": "Model to deployment mappings"
-            },
             "batch_s3_config": {
               "type": "object",
               "description": "S3 bucket configuration for Bedrock batch operations",
@@ -6813,13 +6806,6 @@
                   "batch_role_arn": {
                     "type": "string",
                     "description": "Service role ARN passed to Bedrock batch jobs for S3 access; takes priority over any role_arn sent in the request (can use env. prefix)"
-                  },
-                  "deployments": {
-                    "type": "object",
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "description": "Model to deployment mappings"
                   },
                   "batch_s3_config": {
                     "type": "object",

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -4280,13 +4280,6 @@
                   "type": "string",
                   "description": "Bedrock project ID scoping the Mantle sub-surface (OpenAI-compatible gpt-*/Gemma routing) via the OpenAI-Project header. When empty, AWS routes to the account's default project. No effect on the Converse/bedrock-runtime paths (can use env. prefix)."
                 },
-                "deployments": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "description": "Model to deployment mappings"
-                },
                 "batch_s3_config": {
                   "type": "object",
                   "description": "S3 bucket configuration for Bedrock batch operations",


### PR DESCRIPTION
## Summary

Removes the `deployments` field (model-to-deployment mappings) from the Bedrock key configuration in the config schema, Helm values schema, and the Helm config validation script.

## Changes

- Removed the `deployments` object field from `config.schema.json` under the Bedrock key config section
- Removed the corresponding `deployments` field from `helm-charts/bifrost/values.schema.json` in both Bedrock key config locations
- Removed the `deployments` example entry and its assertion from the Helm config validation script

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Validate that the Helm config field validation script passes without the `deployments` field assertion:

```sh
bash .github/workflows/scripts/validate-helm-config-fields.sh
```

## Breaking changes

- [x] Yes
- [ ] No

The `deployments` field under Bedrock key configuration is no longer a recognized schema field. Any existing configurations using `deployments` under `azure_key_config` or Bedrock key configs will need to remove that field.

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable