### PR TITLE
fix: fixes openai integrations cost usage

### DIFF
--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -2267,6 +2267,78 @@ func (u *BifrostLLMUsage) NormalizeProviderCost() {
 	u.Cost = costFromUSDTicks(u.CostInUsdTicks)
 }
 
+// DeepCopy returns a copy whose mutable pointer children are all cloned, so a
+// caller can attach cost or edit any nested field without mutating a usage shared
+// with the client-facing response. Returns nil for a nil receiver.
+func (u *BifrostLLMUsage) DeepCopy() *BifrostLLMUsage {
+	if u == nil {
+		return nil
+	}
+	c := *u
+	if u.PromptTokensDetails != nil {
+		pd := *u.PromptTokensDetails
+		if u.PromptTokensDetails.CachedWriteTokenDetails != nil {
+			cw := *u.PromptTokensDetails.CachedWriteTokenDetails
+			pd.CachedWriteTokenDetails = &cw
+		}
+		c.PromptTokensDetails = &pd
+	}
+	if u.CompletionTokensDetails != nil {
+		cd := *u.CompletionTokensDetails
+		cd.CitationTokens = copyIntPtr(u.CompletionTokensDetails.CitationTokens)
+		cd.NumSearchQueries = copyIntPtr(u.CompletionTokensDetails.NumSearchQueries)
+		cd.ImageTokens = copyIntPtr(u.CompletionTokensDetails.ImageTokens)
+		c.CompletionTokensDetails = &cd
+	}
+	if u.SearchUnits != nil {
+		su := *u.SearchUnits
+		c.SearchUnits = &su
+	}
+	if u.Cost != nil {
+		cost := *u.Cost
+		if u.Cost.InputCostDetails != nil {
+			d := *u.Cost.InputCostDetails
+			cost.InputCostDetails = &d
+		}
+		if u.Cost.OutputCostDetails != nil {
+			d := *u.Cost.OutputCostDetails
+			cost.OutputCostDetails = &d
+		}
+		if u.Cost.AdditionalCostDetails != nil {
+			d := *u.Cost.AdditionalCostDetails
+			cost.AdditionalCostDetails = &d
+		}
+		c.Cost = &cost
+	}
+	if u.CostInUsdTicks != nil {
+		t := *u.CostInUsdTicks
+		c.CostInUsdTicks = &t
+	}
+	if u.Speed != nil {
+		s := *u.Speed
+		c.Speed = &s
+	}
+	if u.InferenceGeo != nil {
+		g := *u.InferenceGeo
+		c.InferenceGeo = &g
+	}
+	if u.ServerSideFallbackModel != nil {
+		m := *u.ServerSideFallbackModel
+		c.ServerSideFallbackModel = &m
+	}
+	return &c
+}
+
+// copyIntPtr returns an independent copy of an *int (nil-safe), for deep-copying
+// the optional token-detail counters.
+func copyIntPtr(p *int) *int {
+	if p == nil {
+		return nil
+	}
+	v := *p
+	return &v
+}
+
 type SearchResult struct {
 	Title       string  `json:"title"`
 	URL         string  `json:"url"`

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -256,8 +256,7 @@ func (p *LoggerPlugin) applyErrorBillingFromBilledUsage(ctx *schemas.BifrostCont
 		return
 	}
 	if entry.TokenUsageParsed == nil {
-		usageCopy := *billed
-		entry.TokenUsageParsed = &usageCopy
+		entry.TokenUsageParsed = billed.DeepCopy()
 		entry.PromptTokens = billed.PromptTokens
 		entry.CompletionTokens = billed.CompletionTokens
 		entry.TotalTokens = billed.TotalTokens
@@ -1876,9 +1875,6 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 				entry.OutputCost = breakdown.OutputCost
 				entry.AdditionalCost = breakdown.AdditionalCost
 			}
-			// Speech / transcription / OCR usage is not aliased into
-			// TokenUsageParsed, so write the split onto the native response too.
-			attachCostToNativeUsage(result, breakdown)
 		}
 		if bifrostErr == nil &&
 			requestType == schemas.BatchResultsRequest &&

--- a/plugins/logging/nativecost_test.go
+++ b/plugins/logging/nativecost_test.go
@@ -10,45 +10,42 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestAttachCostToNativeUsage covers the speech / transcription / OCR modalities
-// whose usage object is not aliased into TokenUsageParsed, so the breakdown has
-// to be written onto the native response explicitly.
-func TestAttachCostToNativeUsage(t *testing.T) {
-	bd := &schemas.BifrostCost{InputCost: 0.002, OutputCost: 0.001, TotalCost: 0.003}
+// TestCostBreakdownDoesNotMutateClientUsage verifies the 1A invariant: attaching
+// the cost breakdown for logging never mutates the usage object shared with the
+// client-facing response. applyNonStreamingOutputToEntry hands the log entry a
+// deep copy, so the cost write lands on the copy, not result.ChatResponse.Usage.
+func TestCostBreakdownDoesNotMutateClientUsage(t *testing.T) {
+	plugin := newCostFidelityPlugin(t)
 
-	t.Run("speech", func(t *testing.T) {
-		r := &schemas.BifrostResponse{SpeechResponse: &schemas.BifrostSpeechResponse{Usage: &schemas.SpeechUsage{}}}
-		attachCostToNativeUsage(r, bd)
-		require.NotNil(t, r.SpeechResponse.Usage.Cost)
-		assert.InDelta(t, 0.003, r.SpeechResponse.Usage.Cost.TotalCost, 1e-12)
-	})
+	const promptTokens, completionTokens = 100, 50
+	clientUsage := &schemas.BifrostLLMUsage{
+		PromptTokens:     promptTokens,
+		CompletionTokens: completionTokens,
+		TotalTokens:      promptTokens + completionTokens,
+	}
+	result := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			Usage: clientUsage,
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType: schemas.ChatCompletionRequest,
+				RoutingInfo: schemas.RoutingInfo{Provider: schemas.OpenAI, Model: "gpt-4o"},
+			},
+		},
+	}
+	entry := &logstore.Log{Provider: string(schemas.OpenAI), Model: "gpt-4o"}
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
-	t.Run("transcription", func(t *testing.T) {
-		r := &schemas.BifrostResponse{TranscriptionResponse: &schemas.BifrostTranscriptionResponse{Usage: &schemas.TranscriptionUsage{}}}
-		attachCostToNativeUsage(r, bd)
-		require.NotNil(t, r.TranscriptionResponse.Usage.Cost)
-		assert.InDelta(t, 0.003, r.TranscriptionResponse.Usage.Cost.TotalCost, 1e-12)
-	})
+	plugin.applyNonStreamingOutputToEntry(entry, result, false, false)
+	plugin.attachCostBreakdown(ctx, entry, result)
 
-	t.Run("ocr", func(t *testing.T) {
-		r := &schemas.BifrostResponse{OCRResponse: &schemas.BifrostOCRResponse{UsageInfo: &schemas.OCRUsageInfo{}}}
-		attachCostToNativeUsage(r, bd)
-		require.NotNil(t, r.OCRResponse.UsageInfo.Cost)
-		assert.InDelta(t, 0.003, r.OCRResponse.UsageInfo.Cost.TotalCost, 1e-12)
-	})
+	// The log entry owns a distinct usage copy that carries the computed cost.
+	require.NotNil(t, entry.TokenUsageParsed)
+	assert.NotSame(t, clientUsage, entry.TokenUsageParsed)
+	require.NotNil(t, entry.TokenUsageParsed.Cost)
+	assert.Positive(t, entry.TokenUsageParsed.Cost.TotalCost)
 
-	t.Run("preserves provider-supplied cost", func(t *testing.T) {
-		existing := &schemas.BifrostCost{TotalCost: 9.99}
-		r := &schemas.BifrostResponse{SpeechResponse: &schemas.BifrostSpeechResponse{Usage: &schemas.SpeechUsage{Cost: existing}}}
-		attachCostToNativeUsage(r, bd)
-		assert.Same(t, existing, r.SpeechResponse.Usage.Cost)
-	})
-
-	t.Run("no usage slot is a no-op", func(t *testing.T) {
-		r := &schemas.BifrostResponse{SpeechResponse: &schemas.BifrostSpeechResponse{}}
-		attachCostToNativeUsage(r, bd)
-		assert.Nil(t, r.SpeechResponse.Usage)
-	})
+	// The client-facing usage is untouched: no cost leaked onto it.
+	assert.Nil(t, clientUsage.Cost)
 }
 
 // TestAttachCostBreakdownDenormalizesSplitWithoutUsageCarrier covers the OCR-shaped

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -415,10 +415,11 @@ func (p *LoggerPlugin) applyStreamingOutputToEntry(entry *logstore.Log, streamRe
 
 	// Token usage
 	if streamResponse.Data.TokenUsage != nil {
-		entry.TokenUsageParsed = streamResponse.Data.TokenUsage
-		entry.PromptTokens = streamResponse.Data.TokenUsage.PromptTokens
-		entry.CompletionTokens = streamResponse.Data.TokenUsage.CompletionTokens
-		entry.TotalTokens = streamResponse.Data.TokenUsage.TotalTokens
+		usage := streamResponse.Data.TokenUsage.DeepCopy()
+		entry.TokenUsageParsed = usage
+		entry.PromptTokens = usage.PromptTokens
+		entry.CompletionTokens = usage.CompletionTokens
+		entry.TotalTokens = usage.TotalTokens
 	}
 	if streamResponse.Data.ServiceTier != nil {
 		entry.ServiceTier = new(string(*streamResponse.Data.ServiceTier))
@@ -623,6 +624,7 @@ func (p *LoggerPlugin) applyNonStreamingOutputToEntry(entry *logstore.Log, resul
 		}
 	}
 	if usage != nil {
+		usage = usage.DeepCopy()
 		entry.TokenUsageParsed = usage
 		entry.PromptTokens = usage.PromptTokens
 		entry.CompletionTokens = usage.CompletionTokens
@@ -1972,10 +1974,10 @@ func normalizeLogRequestType(object string) schemas.RequestType {
 
 // attachCostBreakdown fills entry.TokenUsageParsed.Cost with the per-category
 // cost split (input / output / cache) computed from result, so log detail views
-// can surface it alongside the total, and also writes it onto the native typed
-// usage for modalities not aliased into TokenUsageParsed (speech, transcription,
-// OCR) so their client-facing responses carry cost too. A provider-supplied
-// breakdown already present on either target is preserved.
+// can surface it alongside the total. entry.TokenUsageParsed is a logging-owned
+// deep copy (see applyNonStreamingOutputToEntry / applyStreamingOutputToEntry),
+// so this write never touches the usage object shared with the client-facing
+// response. A provider-supplied breakdown already present is preserved.
 func (p *LoggerPlugin) attachCostBreakdown(ctx *schemas.BifrostContext, entry *logstore.Log, result *schemas.BifrostResponse) {
 	if p.pricingManager == nil || result == nil {
 		return
@@ -1995,31 +1997,6 @@ func (p *LoggerPlugin) attachCostBreakdown(ctx *schemas.BifrostContext, entry *l
 		entry.InputCost = breakdown.InputCost
 		entry.OutputCost = breakdown.OutputCost
 		entry.AdditionalCost = breakdown.AdditionalCost
-	}
-	attachCostToNativeUsage(result, breakdown)
-}
-
-// attachCostToNativeUsage writes the cost breakdown onto the native typed usage
-// for speech, transcription, and OCR responses. Unlike chat/embedding (whose
-// usage pointer is aliased into TokenUsageParsed and thus already carries cost),
-// these modalities build a separate usage object, so the client-facing response
-// would otherwise never see cost. No-op when the usage slot is absent or a
-// provider already supplied a breakdown.
-func attachCostToNativeUsage(result *schemas.BifrostResponse, breakdown *schemas.BifrostCost) {
-	if result == nil || breakdown == nil {
-		return
-	}
-	switch {
-	case result.SpeechResponse != nil && result.SpeechResponse.Usage != nil && result.SpeechResponse.Usage.Cost == nil:
-		result.SpeechResponse.Usage.Cost = breakdown
-	case result.SpeechStreamResponse != nil && result.SpeechStreamResponse.Usage != nil && result.SpeechStreamResponse.Usage.Cost == nil:
-		result.SpeechStreamResponse.Usage.Cost = breakdown
-	case result.TranscriptionResponse != nil && result.TranscriptionResponse.Usage != nil && result.TranscriptionResponse.Usage.Cost == nil:
-		result.TranscriptionResponse.Usage.Cost = breakdown
-	case result.TranscriptionStreamResponse != nil && result.TranscriptionStreamResponse.Usage != nil && result.TranscriptionStreamResponse.Usage.Cost == nil:
-		result.TranscriptionStreamResponse.Usage.Cost = breakdown
-	case result.OCRResponse != nil && result.OCRResponse.UsageInfo != nil && result.OCRResponse.UsageInfo.Cost == nil:
-		result.OCRResponse.UsageInfo.Cost = breakdown
 	}
 }
 

--- a/transports/bifrost-http/integrations/openai.go
+++ b/transports/bifrost-http/integrations/openai.go
@@ -280,7 +280,7 @@ func openAIResponsesWireConverter(ctx *schemas.BifrostContext, resp *schemas.Bif
 	if resp == nil {
 		return nil, nil
 	}
-	return resp.WithDefaults(), nil
+	return openAIWireCostResponse(resp.WithDefaults()), nil
 }
 
 // CreateOpenAIRouteConfigs creates route configurations for OpenAI endpoints.
@@ -431,7 +431,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 					return resp.ExtraFields.RawResponse, nil
 				}
 			}
-			return resp, nil
+			return openAIWireCostResponse(resp), nil
 		},
 		TextResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostTextCompletionResponse) (interface{}, error) {
 			if resp.ExtraFields.Provider == schemas.OpenAI {
@@ -439,7 +439,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 					return resp.ExtraFields.RawResponse, nil
 				}
 			}
-			return resp, nil
+			return openAIWireCostResponse(resp), nil
 		},
 		EmbeddingResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostEmbeddingResponse) (interface{}, error) {
 			if resp.ExtraFields.Provider == schemas.OpenAI {
@@ -474,16 +474,9 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 					return resp.ExtraFields.RawResponse, nil
 				}
 			}
-			return resp, nil
+			return openAIWireCostResponse(resp), nil
 		},
-		ResponsesResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostResponsesResponse) (interface{}, error) {
-			if resp.ExtraFields.Provider == schemas.OpenAI {
-				if resp.ExtraFields.RawResponse != nil {
-					return resp.ExtraFields.RawResponse, nil
-				}
-			}
-			return resp.WithDefaults(), nil
-		},
+		ResponsesResponseConverter: openAIResponsesWireConverter,
 		StreamConfig: &StreamConfig{
 			ChatStreamResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostChatResponse) (string, interface{}, error) {
 				if resp.ExtraFields.Provider == schemas.OpenAI {
@@ -491,7 +484,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 						return "", resp.ExtraFields.RawResponse, nil
 					}
 				}
-				return "", resp, nil
+				return "", openAIWireCostResponse(resp), nil
 			},
 			TextStreamResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostTextCompletionResponse) (string, interface{}, error) {
 				if resp.ExtraFields.Provider == schemas.OpenAI {
@@ -499,7 +492,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 						return "", resp.ExtraFields.RawResponse, nil
 					}
 				}
-				return "", resp, nil
+				return "", openAIWireCostResponse(resp), nil
 			},
 			SpeechStreamResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostSpeechStreamResponse) (string, interface{}, error) {
 				if resp.ExtraFields.Provider == schemas.OpenAI {
@@ -523,7 +516,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 						return "", resp.ExtraFields.RawResponse, nil
 					}
 				}
-				return "", resp, nil
+				return "", openAIWireCostResponse(resp), nil
 			},
 			ResponsesStreamResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostResponsesStreamResponse) (string, interface{}, error) {
 				if resp.ExtraFields.Provider == schemas.OpenAI {
@@ -535,7 +528,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 				if converted == nil {
 					return "", nil, nil
 				}
-				return string(resp.Type), converted, nil
+				return string(resp.Type), openAIWireCostResponse(converted), nil
 			},
 			ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 				return err
@@ -580,13 +573,13 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 				}
 				// Here we will combine content blocks into a single text block as required by openai SDK
 				if len(resp.Choices) == 0 {
-					return resp, nil
+					return openAIWireCostResponse(resp), nil
 				}
 				choice := resp.Choices[0]
 				allText := true
 				message := choice.ChatNonStreamResponseChoice.Message
 				if message == nil || message.Content == nil || message.Content.ContentBlocks == nil {
-					return resp, nil
+					return openAIWireCostResponse(resp), nil
 				}
 				for _, block := range message.Content.ContentBlocks {
 					if block.Type != schemas.ChatContentBlockTypeText {
@@ -595,7 +588,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 					}
 				}
 				if !allText || len(message.Content.ContentBlocks) == 0 {
-					return resp, nil
+					return openAIWireCostResponse(resp), nil
 				}
 				var contentStr *string
 				contentBlocks := message.Content.ContentBlocks
@@ -622,7 +615,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 				}
 				message.Content.ContentStr = contentStr
 				message.Content.ContentBlocks = nil
-				return resp, nil
+				return openAIWireCostResponse(resp), nil
 			},
 			ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 				return err
@@ -634,7 +627,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 							return "", resp.ExtraFields.RawResponse, nil
 						}
 					}
-					return "", resp, nil
+					return "", openAIWireCostResponse(resp), nil
 				},
 				ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 					return err
@@ -673,7 +666,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 						return resp.ExtraFields.RawResponse, nil
 					}
 				}
-				return resp, nil
+				return openAIWireCostResponse(resp), nil
 			},
 			ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 				return err
@@ -685,7 +678,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 							return "", resp.ExtraFields.RawResponse, nil
 						}
 					}
-					return "", resp, nil
+					return "", openAIWireCostResponse(resp), nil
 				},
 				ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 					return err
@@ -751,7 +744,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 					if converted == nil {
 						return "", nil, nil
 					}
-					return string(resp.Type), converted, nil
+					return string(resp.Type), openAIWireCostResponse(converted), nil
 				},
 				ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 					return err
@@ -845,7 +838,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 					if converted == nil {
 						return "", nil, nil
 					}
-					return string(resp.Type), converted, nil
+					return string(resp.Type), openAIWireCostResponse(converted), nil
 				},
 				ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 					return err
@@ -1166,7 +1159,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 						return resp.ExtraFields.RawResponse, nil
 					}
 				}
-				return resp, nil
+				return openAIWireCostResponse(resp), nil
 			},
 			ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 				return err
@@ -1178,7 +1171,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 							return string(resp.Type), resp.ExtraFields.RawResponse, nil
 						}
 					}
-					return string(resp.Type), resp, nil
+					return string(resp.Type), openAIWireCostResponse(resp), nil
 				},
 				ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 					return err
@@ -1217,7 +1210,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 						return resp.ExtraFields.RawResponse, nil
 					}
 				}
-				return resp, nil
+				return openAIWireCostResponse(resp), nil
 			},
 			ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 				return err
@@ -1229,7 +1222,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 							return string(resp.Type), resp.ExtraFields.RawResponse, nil
 						}
 					}
-					return string(resp.Type), resp, nil
+					return string(resp.Type), openAIWireCostResponse(resp), nil
 				},
 				ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 					return err
@@ -1267,7 +1260,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 						return resp.ExtraFields.RawResponse, nil
 					}
 				}
-				return resp, nil
+				return openAIWireCostResponse(resp), nil
 			},
 			ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 				return err
@@ -1279,7 +1272,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 							return string(resp.Type), resp.ExtraFields.RawResponse, nil
 						}
 					}
-					return string(resp.Type), resp, nil
+					return string(resp.Type), openAIWireCostResponse(resp), nil
 				},
 				ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 					return err
@@ -1314,7 +1307,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 				return nil, errors.New("invalid video generation request type")
 			},
 			VideoGenerationResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostVideoGenerationResponse) (interface{}, error) {
-				return resp, nil
+				return openAIWireCostResponse(resp), nil
 			},
 			ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 				return err
@@ -1354,7 +1347,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 				return nil, errors.New("invalid video retrieve request type")
 			},
 			VideoGenerationResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostVideoGenerationResponse) (interface{}, error) {
-				return resp, nil
+				return openAIWireCostResponse(resp), nil
 			},
 			ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 				return err
@@ -1456,7 +1449,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 				return nil, errors.New("invalid video remix request type")
 			},
 			VideoGenerationResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostVideoGenerationResponse) (interface{}, error) {
-				return resp, nil
+				return openAIWireCostResponse(resp), nil
 			},
 			ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 				return err
@@ -1490,7 +1483,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 				return nil, errors.New("invalid video edit request type")
 			},
 			VideoGenerationResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostVideoGenerationResponse) (interface{}, error) {
-				return resp, nil
+				return openAIWireCostResponse(resp), nil
 			},
 			ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 				return err
@@ -1532,6 +1525,134 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 	}
 
 	return routes
+}
+
+// OpenAIUsage is the OpenAI-compatible usage shape: the standard usage fields,
+// but cost is the bare total (float) rather than the nested BifrostCost object
+// which strict OpenAI SDKs reject. The embedded pointer promotes every other
+// usage field unchanged; the shallower Cost field shadows the embedded object's
+// `cost` at marshal time.
+type OpenAIUsage struct {
+	*schemas.BifrostLLMUsage
+	Cost *float64 `json:"cost,omitempty"`
+}
+
+// newOpenAIUsage wraps u so cost serializes as the bare total float. Copies the
+// total into a local, so the wrapper never aliases into the shared response.
+func newOpenAIUsage(u *schemas.BifrostLLMUsage) *OpenAIUsage {
+	if u == nil || u.Cost == nil {
+		return &OpenAIUsage{BifrostLLMUsage: u}
+	}
+	total := u.Cost.TotalCost
+	return &OpenAIUsage{BifrostLLMUsage: u, Cost: &total}
+}
+
+// openAIResponsesUsage / openAIImageUsage / openAIVideoUsage are the same
+// float-cost shadow for the modalities whose usage type differs from
+// BifrostLLMUsage. Each provider that reports cost natively (xAI Responses via
+// ticks; Runware images/videos) surfaces it here.
+type openAIResponsesUsage struct {
+	*schemas.ResponsesResponseUsage
+	Cost *float64 `json:"cost,omitempty"`
+}
+
+type openAIImageUsage struct {
+	*schemas.ImageUsage
+	Cost *float64 `json:"cost,omitempty"`
+}
+
+type openAIVideoUsage struct {
+	*schemas.VideoUsage
+	Cost *float64 `json:"cost,omitempty"`
+}
+
+func totalOf(c *schemas.BifrostCost) *float64 {
+	total := c.TotalCost
+	return &total
+}
+
+type openAIChatResponse struct {
+	*schemas.BifrostChatResponse
+	Usage *OpenAIUsage `json:"usage,omitempty"`
+}
+
+type openAITextResponse struct {
+	*schemas.BifrostTextCompletionResponse
+	Usage *OpenAIUsage `json:"usage,omitempty"`
+}
+
+type openAIResponsesResponse struct {
+	*schemas.BifrostResponsesResponse
+	Usage *openAIResponsesUsage `json:"usage,omitempty"`
+}
+
+type openAIResponsesStreamResponse struct {
+	*schemas.BifrostResponsesStreamResponse
+	Response *openAIResponsesResponse `json:"response,omitempty"`
+}
+
+type openAIImageResponse struct {
+	*schemas.BifrostImageGenerationResponse
+	Usage *openAIImageUsage `json:"usage,omitempty"`
+}
+
+type openAIImageStreamResponse struct {
+	*schemas.BifrostImageGenerationStreamResponse
+	Usage *openAIImageUsage `json:"usage,omitempty"`
+}
+
+type openAIVideoResponse struct {
+	*schemas.BifrostVideoGenerationResponse
+	Usage *openAIVideoUsage `json:"usage,omitempty"`
+}
+
+func openAIWireResponses(r *schemas.BifrostResponsesResponse) *openAIResponsesResponse {
+	return &openAIResponsesResponse{
+		BifrostResponsesResponse: r,
+		Usage:                    &openAIResponsesUsage{ResponsesResponseUsage: r.Usage, Cost: totalOf(r.Usage.Cost)},
+	}
+}
+
+// openAIWireCostResponse rewrites usage.cost to the bare total (float) for the
+// OpenAI-compatible wire. The OpenAI usage schema has no nested cost object, so a
+// BifrostCost object breaks strict SDK deserialization; a bare number is the
+// legacy shape SDKs tolerate. Only provider-supplied cost reaches here (Bifrost
+// computes cost log-only), and it stays intact in logs. The rewrite wraps rather
+// than mutates, so the shared response (which governance/telemetry may still read
+// on another goroutine) is untouched. Raw upstream payloads and cost-free
+// responses pass through unchanged.
+func openAIWireCostResponse(v interface{}) interface{} {
+	switch r := v.(type) {
+	case *schemas.BifrostChatResponse:
+		if r != nil && r.Usage != nil && r.Usage.Cost != nil {
+			return &openAIChatResponse{BifrostChatResponse: r, Usage: newOpenAIUsage(r.Usage)}
+		}
+	case *schemas.BifrostTextCompletionResponse:
+		if r != nil && r.Usage != nil && r.Usage.Cost != nil {
+			return &openAITextResponse{BifrostTextCompletionResponse: r, Usage: newOpenAIUsage(r.Usage)}
+		}
+	case *schemas.BifrostResponsesResponse:
+		if r != nil && r.Usage != nil && r.Usage.Cost != nil {
+			return openAIWireResponses(r)
+		}
+	case *schemas.BifrostResponsesStreamResponse:
+		if r != nil && r.Response != nil && r.Response.Usage != nil && r.Response.Usage.Cost != nil {
+			return &openAIResponsesStreamResponse{BifrostResponsesStreamResponse: r, Response: openAIWireResponses(r.Response)}
+		}
+	case *schemas.BifrostImageGenerationResponse:
+		if r != nil && r.Usage != nil && r.Usage.Cost != nil {
+			return &openAIImageResponse{BifrostImageGenerationResponse: r, Usage: &openAIImageUsage{ImageUsage: r.Usage, Cost: totalOf(r.Usage.Cost)}}
+		}
+	case *schemas.BifrostImageGenerationStreamResponse:
+		if r != nil && r.Usage != nil && r.Usage.Cost != nil {
+			return &openAIImageStreamResponse{BifrostImageGenerationStreamResponse: r, Usage: &openAIImageUsage{ImageUsage: r.Usage, Cost: totalOf(r.Usage.Cost)}}
+		}
+	case *schemas.BifrostVideoGenerationResponse:
+		if r != nil && r.Usage != nil && r.Usage.Cost != nil {
+			return &openAIVideoResponse{BifrostVideoGenerationResponse: r, Usage: &openAIVideoUsage{VideoUsage: r.Usage, Cost: totalOf(r.Usage.Cost)}}
+		}
+	}
+	return v
 }
 
 // CreateOpenAIListModelsRouteConfigs creates route configurations for OpenAI list models endpoint.

--- a/transports/bifrost-http/integrations/openai_cost_test.go
+++ b/transports/bifrost-http/integrations/openai_cost_test.go
@@ -1,0 +1,91 @@
+package integrations
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// TestOpenAIWireCostResponse verifies 2A: the OpenAI-compatible wire renders
+// usage.cost as the bare total (float), the legacy shape SDKs accept, instead of
+// the nested BifrostCost object. The rewrite wraps rather than mutates, so the
+// shared response is left intact.
+func TestOpenAIWireCostResponse(t *testing.T) {
+	t.Run("chat renders cost as float total without mutating the shared response", func(t *testing.T) {
+		cost := &schemas.BifrostCost{InputCost: 1, OutputCost: 2, TotalCost: 3}
+		usage := &schemas.BifrostLLMUsage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15, Cost: cost}
+		resp := &schemas.BifrostChatResponse{Usage: usage}
+
+		out := openAIWireCostResponse(resp)
+		if any(out) == any(resp) {
+			t.Fatal("expected a wire wrapper, got the shared response")
+		}
+		js, err := sonic.Marshal(out)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		s := string(js)
+		if !strings.Contains(s, `"cost":3`) {
+			t.Errorf("wire cost is not the bare total float: %s", s)
+		}
+		if strings.Contains(s, "total_cost") || strings.Contains(s, "input_cost") {
+			t.Errorf("wire still carries the nested cost object: %s", s)
+		}
+		if !strings.Contains(s, `"total_tokens":15`) {
+			t.Errorf("usage fields lost in wrapper: %s", s)
+		}
+
+		// The shared response keeps its full breakdown object.
+		if usage.Cost != cost {
+			t.Error("shared response usage.cost was mutated")
+		}
+	})
+
+	t.Run("responses renders cost as float total", func(t *testing.T) {
+		resp := &schemas.BifrostResponsesResponse{
+			Usage: &schemas.ResponsesResponseUsage{TotalTokens: 15, Cost: &schemas.BifrostCost{TotalCost: 3}},
+		}
+		js, err := sonic.Marshal(openAIWireCostResponse(resp))
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if s := string(js); !strings.Contains(s, `"cost":3`) || strings.Contains(s, "total_cost") {
+			t.Errorf("responses wire cost not flattened to float: %s", s)
+		}
+		if resp.Usage.Cost == nil {
+			t.Error("shared responses usage.cost was mutated")
+		}
+	})
+
+	t.Run("image renders cost as float total", func(t *testing.T) {
+		resp := &schemas.BifrostImageGenerationResponse{
+			Usage: &schemas.ImageUsage{Cost: &schemas.BifrostCost{TotalCost: 3}},
+		}
+		js, err := sonic.Marshal(openAIWireCostResponse(resp))
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if s := string(js); !strings.Contains(s, `"cost":3`) || strings.Contains(s, "total_cost") {
+			t.Errorf("image wire cost not flattened to float: %s", s)
+		}
+		if resp.Usage.Cost == nil {
+			t.Error("shared image usage.cost was mutated")
+		}
+	})
+
+	t.Run("chat without cost passes through the same pointer", func(t *testing.T) {
+		resp := &schemas.BifrostChatResponse{Usage: &schemas.BifrostLLMUsage{TotalTokens: 15}}
+		if out := openAIWireCostResponse(resp); any(out) != any(resp) {
+			t.Error("cost-free response should pass through unchanged")
+		}
+	})
+
+	t.Run("raw upstream payload passes through unchanged", func(t *testing.T) {
+		raw := "raw-openai-json"
+		if out := openAIWireCostResponse(raw); out != raw {
+			t.Errorf("raw passthrough altered: %v", out)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

The logging plugin was mutating the shared `BifrostLLMUsage` object (the same pointer returned to the caller in the client-facing response) when attaching computed cost breakdowns to log entries. Separately, the OpenAI-compatible wire format was serializing `usage.cost` as a nested `BifrostCost` object, which strict OpenAI SDKs reject. This PR fixes both issues: log entries now own a deep copy of usage, and the wire layer wraps responses to emit cost as a bare float total.

## Changes

- Added `BifrostLLMUsage.DeepCopy()` to clone all mutable nested pointers (token details, cost, search units) without touching the original.
- `applyNonStreamingOutputToEntry` and `applyStreamingOutputToEntry` now call `DeepCopy()` before assigning usage to the log entry, so subsequent cost writes in `attachCostBreakdown` never reach the client-facing response.
- `applyErrorBillingFromBilledUsage` uses `DeepCopy()` instead of a shallow struct copy.
- Removed `attachCostToNativeUsage` and its call in `PostLLMHook`. Cost is no longer written back onto the native speech/transcription/OCR response objects; it lives only on the log entry's owned copy.
- Introduced `openAIWireCostResponse` and a family of thin wrapper types (`openAIChatResponse`, `openAITextResponse`, `openAIResponsesResponse`, `openAIImageResponse`, `openAIVideoResponse`, etc.) that shadow the `cost` field with a bare `*float64` (the total) at marshal time, without mutating the shared response.
- Applied `openAIWireCostResponse` across all OpenAI route converters (chat, text, embedding, responses, image, video, streaming variants).
- Replaced the `TestAttachCostToNativeUsage` test with `TestCostBreakdownDoesNotMutateClientUsage`, which asserts the log entry receives a distinct usage copy carrying computed cost while the client-facing usage pointer remains untouched.
- Added `TestOpenAIWireCostResponse` covering chat, responses, image, cost-free passthrough, and raw upstream payload passthrough.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/... ./plugins/logging/... ./transports/bifrost-http/integrations/...
```

- `TestCostBreakdownDoesNotMutateClientUsage`: confirms `entry.TokenUsageParsed` is a distinct pointer from `clientUsage` and carries a non-zero cost while `clientUsage.Cost` remains nil.
- `TestOpenAIWireCostResponse`: confirms the wire output serializes `"cost":3` (bare float) with no `total_cost`/`input_cost` keys, that cost-free responses pass through as the same pointer, and that raw upstream strings are unmodified.

## Breaking changes

- [x] No

The `attachCostToNativeUsage` function is removed. Speech, transcription, and OCR client-facing responses will no longer have `cost` injected by the logging plugin. Cost for those modalities is available in log entries only.

## Related issues
Fixes #6553 

## Security considerations

None. No auth, secrets, or PII involved. The change reduces unintended shared-state mutation between the logging path and the response returned to callers.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable