### PR TITLE
docs: langchain rerank and base url updates

### DIFF
--- a/docs/integrations/langchain-sdk.mdx
+++ b/docs/integrations/langchain-sdk.mdx
@@ -605,6 +605,72 @@ doc_embeddings = embeddings.embed_documents([
 
 ---
 
+## Reranking
+
+| Class | Package | Dialect | Model string |
+| --- | --- | --- | --- |
+| `CohereRerank` | `langchain-cohere` | `/langchain/v2/rerank` | `cohere/rerank-v3.5` |
+| `BedrockRerank` | `langchain-aws` | Bedrock Agent Runtime `Rerank` | `bedrock/cohere.rerank-v3-5:0` |
+
+### CohereRerank
+
+```python
+from langchain_cohere import CohereRerank
+from langchain_core.documents import Document
+
+cohere_compressor = CohereRerank(
+    base_url="http://localhost:8080/langchain",
+    cohere_api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
+    model="cohere/rerank-v3.5",
+    top_n=2,
+)
+
+documents = [
+    Document(page_content="Paris is the capital and largest city of France."),
+    Document(page_content="Berlin is the capital of Germany."),
+    Document(page_content="The Eiffel Tower is a landmark in Paris."),
+]
+
+compressed = cohere_compressor.compress_documents(documents, "What is the capital of France?")
+for document in compressed:
+    print(document.metadata["relevance_score"], document.page_content)
+```
+
+### BedrockRerank
+
+Pass a pre-built boto3 client. `BedrockRerank` aliases `endpoint_url` to `base_url` and its own client builder never picks it up, so it would otherwise call AWS directly.
+
+```python
+import boto3
+from langchain_aws import BedrockRerank
+
+client = boto3.client(
+    "bedrock-agent-runtime",
+    region_name="us-west-2",
+    endpoint_url="http://localhost:8080/langchain",
+    aws_access_key_id="dummy-access-key",
+    aws_secret_access_key="dummy-secret-key",
+)
+
+def add_bifrost_headers(request, **kwargs):
+    """boto3 has no API key field, so the virtual key travels as a header"""
+    request.headers.add_header("x-bf-vk", "<YOUR-BIFROST-VIRTUAL-KEY>")  # Replace with your actual Bifrost virtual key.
+
+client.meta.events.register_first("before-sign.bedrock-agent-runtime.*", add_bifrost_headers)
+
+bedrock_compressor = BedrockRerank(
+    client=client,
+    model_arn="bedrock/cohere.rerank-v3-5:0",
+    region_name="us-west-2",
+    top_n=2,
+)
+
+# Reuses the documents list from the CohereRerank example above.
+compressed = bedrock_compressor.compress_documents(documents, "What is the capital of France?")
+```
+
+---
+
 ## Supported Features
 
 The Langchain integration supports all features that are available in both the Langchain SDK and Bifrost core functionality. Your existing Langchain chains and workflows work seamlessly with Bifrost's enterprise features. 😄

--- a/docs/providers/supported-providers/wafer.mdx
+++ b/docs/providers/supported-providers/wafer.mdx
@@ -97,13 +97,13 @@ case schemas.Wafer:
 
 Wafer supports OpenAI-compatible chat completion parameters. For the full parameter reference and message conversion behavior, see [OpenAI Chat Completions](/providers/supported-providers/openai#1-chat-completions).
 
-Available chat models include `glm-5.2` and `kimi-k2.6`.
+Bifrost serves every model Wafer exposes, for example `GLM-5.2`, `Kimi-K3`, and `DeepSeek-V4-Flash-0731-Fast`. Call [List Models](#4-list-models) for the current catalog.
 
 ```bash
 curl -X POST http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "wafer/glm-5.2",
+    "model": "wafer/GLM-5.2",
     "messages": [{"role": "user", "content": "Hello!"}]
   }'
 ```

--- a/docs/quickstart/gateway/provider-configuration.mdx
+++ b/docs/quickstart/gateway/provider-configuration.mdx
@@ -347,7 +347,7 @@ Override the default API endpoint for a provider. This is useful for connecting 
 </Frame>
 
 1. Navigate to **"Model Providers"** → **"Configurations"** → **"OpenAI"** → **"Provider level configuration"** → **"Network config"**
-2. Set **Base URL**: `http://localhost:8000/v1`
+2. Set **Base URL**: `http://localhost:8000`
 3. Save configuration
 
 </Tab>
@@ -368,7 +368,7 @@ curl --location 'http://localhost:8080/api/providers' \
         }
     ],
     "network_config": {
-        "base_url": "http://localhost:8000/v1"
+        "base_url": "http://localhost:8000"
     }
 }'
 ```
@@ -390,7 +390,7 @@ curl --location 'http://localhost:8080/api/providers' \
         }
       ],
       "network_config": {
-        "base_url": "http://localhost:8000/v1"
+        "base_url": "http://localhost:8000"
       }
     }
   }


### PR DESCRIPTION
## Summary

Adds reranking documentation to the LangChain SDK integration page, covering both `CohereRerank` and `BedrockRerank` compressors. Also fixes an incorrect base URL in the provider configuration docs that included a trailing `/v1` path segment.

## Changes

- Added a new **Reranking** section to `docs/integrations/langchain-sdk.mdx` with:
  - A reference table mapping reranker classes to their packages, dialects, and model strings
  - A `CohereRerank` example using `langchain-cohere` routed through Bifrost via `base_url` and a virtual key
  - A `BedrockRerank` example using a pre-built `boto3` client with a custom event hook to inject the Bifrost virtual key as an `x-bf-vk` header, with an explanation of why the pre-built client is required
- Corrected the example base URL in `provider-configuration.mdx` from `http://localhost:8000/v1` to `http://localhost:8000` in both the UI walkthrough and the two curl examples

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Verify the documentation renders correctly and that the code examples work end-to-end:

```sh
# CohereRerank
pip install langchain-cohere
python -c "
from langchain_cohere import CohereRerank
from langchain_core.documents import Document
compressor = CohereRerank(base_url='http://localhost:8080/langchain', cohere_api_key='<VK>', model='cohere/rerank-v3.5', top_n=2)
docs = [Document(page_content='Paris is the capital of France.'), Document(page_content='Berlin is the capital of Germany.')]
print(compressor.compress_documents(docs, 'What is the capital of France?'))
"

# BedrockRerank
pip install langchain-aws boto3
# Configure boto3 client with endpoint_url=http://localhost:8080/langchain and run compress_documents
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The `BedrockRerank` example passes the Bifrost virtual key as a custom HTTP header (`x-bf-vk`) via a `boto3` event hook, since the AWS client has no native API key field. Ensure virtual keys are kept out of source control and treated as secrets.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable