### PR TITLE
fix(gemini): inline remote HTTP image URLs

### DIFF
--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -285,15 +285,16 @@ func (provider *GeminiProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 		return nil, err
 	}
 
-	if err := normalizeImageURLsForGeminiChat(ctx, request); err != nil {
-		return nil, geminiImageInliningError("failed to normalize image URLs for gemini", err)
+	requestForGemini, normalizeErr := geminiChatRequestWithNormalizedImageURLs(ctx, request)
+	if normalizeErr != nil {
+		return nil, geminiImageInliningError("failed to normalize image URLs for gemini", normalizeErr)
 	}
 
 	jsonData, err := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
-		request,
+		requestForGemini,
 		func() (providerUtils.RequestBodyWithExtraParams, error) {
-			return ToGeminiChatCompletionRequest(ctx, request)
+			return ToGeminiChatCompletionRequest(ctx, requestForGemini)
 		})
 	if err != nil {
 		return nil, err
@@ -349,15 +350,16 @@ func (provider *GeminiProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 		return nil, err
 	}
 
-	if err := normalizeImageURLsForGeminiChat(ctx, request); err != nil {
-		return nil, geminiImageInliningError("failed to normalize image URLs for gemini", err)
+	requestForGemini, normalizeErr := geminiChatRequestWithNormalizedImageURLs(ctx, request)
+	if normalizeErr != nil {
+		return nil, geminiImageInliningError("failed to normalize image URLs for gemini", normalizeErr)
 	}
 
 	jsonData, err := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
-		request,
+		requestForGemini,
 		func() (providerUtils.RequestBodyWithExtraParams, error) {
-			reqBody, err := ToGeminiChatCompletionRequest(ctx, request)
+			reqBody, err := ToGeminiChatCompletionRequest(ctx, requestForGemini)
 			if err != nil {
 				return nil, err
 			}
@@ -657,8 +659,9 @@ func (provider *GeminiProvider) Responses(ctx *schemas.BifrostContext, key schem
 		return nil, err
 	}
 
-	if err := normalizeImageURLsForGeminiResponses(ctx, request); err != nil {
-		return nil, geminiImageInliningError("failed to normalize image URLs for gemini", err)
+	requestForGemini, normalizeErr := geminiResponsesRequestWithNormalizedImageURLs(ctx, request)
+	if normalizeErr != nil {
+		return nil, geminiImageInliningError("failed to normalize image URLs for gemini", normalizeErr)
 	}
 
 	// Check for large payload streaming mode (enterprise-only feature)
@@ -681,9 +684,9 @@ func (provider *GeminiProvider) Responses(ctx *schemas.BifrostContext, key schem
 		var err *schemas.BifrostError
 		jsonData, err = providerUtils.CheckContextAndGetRequestBody(
 			ctx,
-			request,
+			requestForGemini,
 			func() (providerUtils.RequestBodyWithExtraParams, error) {
-				reqBody, err := ToGeminiResponsesRequest(ctx, request)
+				reqBody, err := ToGeminiResponsesRequest(ctx, requestForGemini)
 				if err != nil {
 					return nil, err
 				}
@@ -867,15 +870,16 @@ func (provider *GeminiProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 		return nil, err
 	}
 
-	if err := normalizeImageURLsForGeminiResponses(ctx, request); err != nil {
-		return nil, geminiImageInliningError("failed to normalize image URLs for gemini", err)
+	requestForGemini, normalizeErr := geminiResponsesRequestWithNormalizedImageURLs(ctx, request)
+	if normalizeErr != nil {
+		return nil, geminiImageInliningError("failed to normalize image URLs for gemini", normalizeErr)
 	}
 
 	jsonData, err := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
-		request,
+		requestForGemini,
 		func() (providerUtils.RequestBodyWithExtraParams, error) {
-			reqBody, err := ToGeminiResponsesRequest(ctx, request)
+			reqBody, err := ToGeminiResponsesRequest(ctx, requestForGemini)
 			if err != nil {
 				return nil, err
 			}
@@ -3956,16 +3960,17 @@ func (provider *GeminiProvider) CountTokens(ctx *schemas.BifrostContext, key sch
 		bifrostErr *schemas.BifrostError
 	)
 	if !isLargePayload {
-		if err := normalizeImageURLsForGeminiResponses(ctx, request); err != nil {
-			return nil, geminiImageInliningError("failed to normalize image URLs for gemini", err)
+		requestForGemini, normalizeErr := geminiResponsesRequestWithNormalizedImageURLs(ctx, request)
+		if normalizeErr != nil {
+			return nil, geminiImageInliningError("failed to normalize image URLs for gemini", normalizeErr)
 		}
 
 		// Build JSON body from Bifrost request for normal path.
 		jsonData, bifrostErr = providerUtils.CheckContextAndGetRequestBody(
 			ctx,
-			request,
+			requestForGemini,
 			func() (providerUtils.RequestBodyWithExtraParams, error) {
-				return ToGeminiResponsesRequest(ctx, request)
+				return ToGeminiResponsesRequest(ctx, requestForGemini)
 			},
 		)
 		if bifrostErr != nil {

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -285,6 +285,10 @@ func (provider *GeminiProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 		return nil, err
 	}
 
+	if err := inlineRemoteImageURLsForGeminiChat(ctx, request); err != nil {
+		return nil, geminiImageInliningError("failed to inline remote image URLs for gemini", err)
+	}
+
 	jsonData, err := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
@@ -343,6 +347,10 @@ func (provider *GeminiProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 	// Check if chat completion stream is allowed for this provider
 	if err := providerUtils.CheckOperationAllowed(schemas.Gemini, provider.customProviderConfig, schemas.ChatCompletionStreamRequest); err != nil {
 		return nil, err
+	}
+
+	if err := inlineRemoteImageURLsForGeminiChat(ctx, request); err != nil {
+		return nil, geminiImageInliningError("failed to inline remote image URLs for gemini", err)
 	}
 
 	jsonData, err := providerUtils.CheckContextAndGetRequestBody(
@@ -649,6 +657,10 @@ func (provider *GeminiProvider) Responses(ctx *schemas.BifrostContext, key schem
 		return nil, err
 	}
 
+	if err := inlineRemoteImageURLsForGeminiResponses(ctx, request); err != nil {
+		return nil, geminiImageInliningError("failed to inline remote image URLs for gemini", err)
+	}
+
 	// Check for large payload streaming mode (enterprise-only feature)
 	// In large payload mode, the request body streams directly from the client — skip body conversion
 	var bodyReader io.Reader
@@ -853,6 +865,10 @@ func (provider *GeminiProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 	// Check if responses stream is allowed for this provider
 	if err := providerUtils.CheckOperationAllowed(schemas.Gemini, provider.customProviderConfig, schemas.ResponsesStreamRequest); err != nil {
 		return nil, err
+	}
+
+	if err := inlineRemoteImageURLsForGeminiResponses(ctx, request); err != nil {
+		return nil, geminiImageInliningError("failed to inline remote image URLs for gemini", err)
 	}
 
 	jsonData, err := providerUtils.CheckContextAndGetRequestBody(
@@ -3940,6 +3956,10 @@ func (provider *GeminiProvider) CountTokens(ctx *schemas.BifrostContext, key sch
 		bifrostErr *schemas.BifrostError
 	)
 	if !isLargePayload {
+		if err := inlineRemoteImageURLsForGeminiResponses(ctx, request); err != nil {
+			return nil, geminiImageInliningError("failed to inline remote image URLs for gemini", err)
+		}
+
 		// Build JSON body from Bifrost request for normal path.
 		jsonData, bifrostErr = providerUtils.CheckContextAndGetRequestBody(
 			ctx,

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -285,8 +285,8 @@ func (provider *GeminiProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 		return nil, err
 	}
 
-	if err := inlineRemoteImageURLsForGeminiChat(ctx, request); err != nil {
-		return nil, geminiImageInliningError("failed to inline remote image URLs for gemini", err)
+	if err := normalizeImageURLsForGeminiChat(ctx, request); err != nil {
+		return nil, geminiImageInliningError("failed to normalize image URLs for gemini", err)
 	}
 
 	jsonData, err := providerUtils.CheckContextAndGetRequestBody(
@@ -349,8 +349,8 @@ func (provider *GeminiProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 		return nil, err
 	}
 
-	if err := inlineRemoteImageURLsForGeminiChat(ctx, request); err != nil {
-		return nil, geminiImageInliningError("failed to inline remote image URLs for gemini", err)
+	if err := normalizeImageURLsForGeminiChat(ctx, request); err != nil {
+		return nil, geminiImageInliningError("failed to normalize image URLs for gemini", err)
 	}
 
 	jsonData, err := providerUtils.CheckContextAndGetRequestBody(
@@ -657,8 +657,8 @@ func (provider *GeminiProvider) Responses(ctx *schemas.BifrostContext, key schem
 		return nil, err
 	}
 
-	if err := inlineRemoteImageURLsForGeminiResponses(ctx, request); err != nil {
-		return nil, geminiImageInliningError("failed to inline remote image URLs for gemini", err)
+	if err := normalizeImageURLsForGeminiResponses(ctx, request); err != nil {
+		return nil, geminiImageInliningError("failed to normalize image URLs for gemini", err)
 	}
 
 	// Check for large payload streaming mode (enterprise-only feature)
@@ -867,8 +867,8 @@ func (provider *GeminiProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 		return nil, err
 	}
 
-	if err := inlineRemoteImageURLsForGeminiResponses(ctx, request); err != nil {
-		return nil, geminiImageInliningError("failed to inline remote image URLs for gemini", err)
+	if err := normalizeImageURLsForGeminiResponses(ctx, request); err != nil {
+		return nil, geminiImageInliningError("failed to normalize image URLs for gemini", err)
 	}
 
 	jsonData, err := providerUtils.CheckContextAndGetRequestBody(
@@ -3956,8 +3956,8 @@ func (provider *GeminiProvider) CountTokens(ctx *schemas.BifrostContext, key sch
 		bifrostErr *schemas.BifrostError
 	)
 	if !isLargePayload {
-		if err := inlineRemoteImageURLsForGeminiResponses(ctx, request); err != nil {
-			return nil, geminiImageInliningError("failed to inline remote image URLs for gemini", err)
+		if err := normalizeImageURLsForGeminiResponses(ctx, request); err != nil {
+			return nil, geminiImageInliningError("failed to normalize image URLs for gemini", err)
 		}
 
 		// Build JSON body from Bifrost request for normal path.

--- a/core/providers/gemini/remote_image_urls.go
+++ b/core/providers/gemini/remote_image_urls.go
@@ -73,6 +73,67 @@ func normalizeImageURLsForGeminiResponses(ctx *schemas.BifrostContext, request *
 	return nil
 }
 
+func geminiChatRequestWithNormalizedImageURLs(ctx *schemas.BifrostContext, request *schemas.BifrostChatRequest) (*schemas.BifrostChatRequest, error) {
+	if request == nil || shouldSkipGeminiImageURLInlining(ctx) || !geminiChatRequestHasImageURLs(request) {
+		return request, nil
+	}
+
+	requestCopy := *request
+	requestCopy.Input = make([]schemas.ChatMessage, len(request.Input))
+	for i, msg := range request.Input {
+		requestCopy.Input[i] = schemas.DeepCopyChatMessage(msg)
+	}
+	if err := normalizeImageURLsForGeminiChat(ctx, &requestCopy); err != nil {
+		return nil, err
+	}
+	return &requestCopy, nil
+}
+
+func geminiResponsesRequestWithNormalizedImageURLs(ctx *schemas.BifrostContext, request *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesRequest, error) {
+	if request == nil || shouldSkipGeminiImageURLInlining(ctx) || !geminiResponsesRequestHasImageURLs(request) {
+		return request, nil
+	}
+
+	requestCopy := *request
+	requestCopy.Input = make([]schemas.ResponsesMessage, len(request.Input))
+	for i, msg := range request.Input {
+		requestCopy.Input[i] = schemas.DeepCopyResponsesMessage(msg)
+	}
+	if err := normalizeImageURLsForGeminiResponses(ctx, &requestCopy); err != nil {
+		return nil, err
+	}
+	return &requestCopy, nil
+}
+
+func geminiChatRequestHasImageURLs(request *schemas.BifrostChatRequest) bool {
+	for _, msg := range request.Input {
+		if msg.Content == nil {
+			continue
+		}
+		for _, block := range msg.Content.ContentBlocks {
+			if block.ImageURLStruct != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func geminiResponsesRequestHasImageURLs(request *schemas.BifrostResponsesRequest) bool {
+	for _, msg := range request.Input {
+		if msg.Content == nil {
+			continue
+		}
+		for _, block := range msg.Content.ContentBlocks {
+			if block.ResponsesInputMessageContentBlockImage != nil &&
+				block.ResponsesInputMessageContentBlockImage.ImageURL != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func normalizeGeminiImageURL(ctx *schemas.BifrostContext, imageURL string) (string, bool, error) {
 	sanitizedURL, err := schemas.SanitizeImageURL(imageURL)
 	if err != nil {

--- a/core/providers/gemini/remote_image_urls.go
+++ b/core/providers/gemini/remote_image_urls.go
@@ -3,6 +3,7 @@ package gemini
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
@@ -11,7 +12,14 @@ import (
 
 var fetchAndEncodeGeminiImageURL = providerUtils.FetchAndEncodeImageURL
 
-func inlineRemoteImageURLsForGeminiChat(ctx *schemas.BifrostContext, request *schemas.BifrostChatRequest) error {
+type geminiImageURLDisposition int
+
+const (
+	geminiImageURLForward geminiImageURLDisposition = iota
+	geminiImageURLFetchInline
+)
+
+func normalizeImageURLsForGeminiChat(ctx *schemas.BifrostContext, request *schemas.BifrostChatRequest) error {
 	if request == nil || shouldSkipGeminiImageURLInlining(ctx) {
 		return nil
 	}
@@ -26,19 +34,19 @@ func inlineRemoteImageURLsForGeminiChat(ctx *schemas.BifrostContext, request *sc
 			if img == nil {
 				continue
 			}
-			inlinedURL, changed, err := inlineGeminiImageURL(ctx, img.URL)
+			normalizedURL, changed, err := normalizeGeminiImageURL(ctx, img.URL)
 			if err != nil {
 				return providerUtils.InvalidRequestErrorf("messages[%d].content[%d].image_url: %s", mi, bi, err)
 			}
 			if changed {
-				img.URL = inlinedURL
+				img.URL = normalizedURL
 			}
 		}
 	}
 	return nil
 }
 
-func inlineRemoteImageURLsForGeminiResponses(ctx *schemas.BifrostContext, request *schemas.BifrostResponsesRequest) error {
+func normalizeImageURLsForGeminiResponses(ctx *schemas.BifrostContext, request *schemas.BifrostResponsesRequest) error {
 	if request == nil || shouldSkipGeminiImageURLInlining(ctx) {
 		return nil
 	}
@@ -53,25 +61,26 @@ func inlineRemoteImageURLsForGeminiResponses(ctx *schemas.BifrostContext, reques
 			if img == nil || img.ImageURL == nil {
 				continue
 			}
-			inlinedURL, changed, err := inlineGeminiImageURL(ctx, *img.ImageURL)
+			normalizedURL, changed, err := normalizeGeminiImageURL(ctx, *img.ImageURL)
 			if err != nil {
 				return providerUtils.InvalidRequestErrorf("input[%d].content[%d].image_url: %s", mi, bi, err)
 			}
 			if changed {
-				*img.ImageURL = inlinedURL
+				*img.ImageURL = normalizedURL
 			}
 		}
 	}
 	return nil
 }
 
-func inlineGeminiImageURL(ctx *schemas.BifrostContext, imageURL string) (string, bool, error) {
+func normalizeGeminiImageURL(ctx *schemas.BifrostContext, imageURL string) (string, bool, error) {
 	sanitizedURL, err := schemas.SanitizeImageURL(imageURL)
 	if err != nil {
 		return "", false, fmt.Errorf("invalid image_url %q: %s", providerUtils.RedactURLForError(imageURL), err)
 	}
 
-	if strings.HasPrefix(sanitizedURL, "data:") {
+	switch classifyGeminiImageURL(sanitizedURL) {
+	case geminiImageURLForward:
 		return sanitizedURL, sanitizedURL != imageURL, nil
 	}
 
@@ -81,6 +90,24 @@ func inlineGeminiImageURL(ctx *schemas.BifrostContext, imageURL string) (string,
 	}
 
 	return "data:" + mediaType + ";base64," + encoded, true, nil
+}
+
+func classifyGeminiImageURL(imageURL string) geminiImageURLDisposition {
+	if strings.HasPrefix(imageURL, "data:") || isGeminiFileAPIURL(imageURL) {
+		return geminiImageURLForward
+	}
+	return geminiImageURLFetchInline
+}
+
+func isGeminiFileAPIURL(imageURL string) bool {
+	parsed, err := url.Parse(imageURL)
+	if err != nil || !strings.EqualFold(parsed.Scheme, "https") {
+		return false
+	}
+	if !strings.EqualFold(parsed.Hostname(), "generativelanguage.googleapis.com") {
+		return false
+	}
+	return strings.Contains(parsed.EscapedPath(), "/files/")
 }
 
 func shouldSkipGeminiImageURLInlining(ctx *schemas.BifrostContext) bool {

--- a/core/providers/gemini/remote_image_urls.go
+++ b/core/providers/gemini/remote_image_urls.go
@@ -1,0 +1,108 @@
+package gemini
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+var fetchAndEncodeGeminiImageURL = providerUtils.FetchAndEncodeImageURL
+
+func inlineRemoteImageURLsForGeminiChat(ctx *schemas.BifrostContext, request *schemas.BifrostChatRequest) error {
+	if request == nil || shouldSkipGeminiImageURLInlining(ctx) {
+		return nil
+	}
+
+	for mi := range request.Input {
+		msg := &request.Input[mi]
+		if msg.Content == nil || msg.Content.ContentBlocks == nil {
+			continue
+		}
+		for bi := range msg.Content.ContentBlocks {
+			img := msg.Content.ContentBlocks[bi].ImageURLStruct
+			if img == nil {
+				continue
+			}
+			inlinedURL, changed, err := inlineGeminiImageURL(ctx, img.URL)
+			if err != nil {
+				return providerUtils.InvalidRequestErrorf("messages[%d].content[%d].image_url: %s", mi, bi, err)
+			}
+			if changed {
+				img.URL = inlinedURL
+			}
+		}
+	}
+	return nil
+}
+
+func inlineRemoteImageURLsForGeminiResponses(ctx *schemas.BifrostContext, request *schemas.BifrostResponsesRequest) error {
+	if request == nil || shouldSkipGeminiImageURLInlining(ctx) {
+		return nil
+	}
+
+	for mi := range request.Input {
+		msg := &request.Input[mi]
+		if msg.Content == nil || msg.Content.ContentBlocks == nil {
+			continue
+		}
+		for bi := range msg.Content.ContentBlocks {
+			img := msg.Content.ContentBlocks[bi].ResponsesInputMessageContentBlockImage
+			if img == nil || img.ImageURL == nil {
+				continue
+			}
+			inlinedURL, changed, err := inlineGeminiImageURL(ctx, *img.ImageURL)
+			if err != nil {
+				return providerUtils.InvalidRequestErrorf("input[%d].content[%d].image_url: %s", mi, bi, err)
+			}
+			if changed {
+				*img.ImageURL = inlinedURL
+			}
+		}
+	}
+	return nil
+}
+
+func inlineGeminiImageURL(ctx *schemas.BifrostContext, imageURL string) (string, bool, error) {
+	sanitizedURL, err := schemas.SanitizeImageURL(imageURL)
+	if err != nil {
+		return "", false, fmt.Errorf("invalid image_url %q: %s", providerUtils.RedactURLForError(imageURL), err)
+	}
+
+	if strings.HasPrefix(sanitizedURL, "data:") {
+		return sanitizedURL, sanitizedURL != imageURL, nil
+	}
+
+	mediaType, encoded, err := fetchAndEncodeGeminiImageURL(geminiFetchContext(ctx), sanitizedURL)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to fetch image_url %q: %w", providerUtils.RedactURLForError(sanitizedURL), err)
+	}
+
+	return "data:" + mediaType + ";base64," + encoded, true, nil
+}
+
+func shouldSkipGeminiImageURLInlining(ctx *schemas.BifrostContext) bool {
+	if ctx == nil {
+		return false
+	}
+	if useRawBody, ok := ctx.Value(schemas.BifrostContextKeyUseRawRequestBody).(bool); ok && useRawBody {
+		return true
+	}
+	return providerUtils.IsLargePayloadPassthroughEnabled(ctx)
+}
+
+func geminiFetchContext(ctx *schemas.BifrostContext) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+	return ctx
+}
+
+func geminiImageInliningError(message string, err error) *schemas.BifrostError {
+	if badRequest, ok := providerUtils.AsBifrostBadRequestError(err); ok {
+		return badRequest
+	}
+	return providerUtils.NewBifrostOperationError(message, err)
+}

--- a/core/providers/gemini/remote_image_urls_test.go
+++ b/core/providers/gemini/remote_image_urls_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestInlineRemoteImageURLsForGeminiChatConvertsHTTPToInlineData(t *testing.T) {
+func TestNormalizeImageURLsForGeminiChatConvertsHTTPToInlineData(t *testing.T) {
 	remoteURL := "https://cdn.example.com/image.jpeg?sig=secret"
 	imageBytes := []byte("\x89PNG\r\n\x1a\nfake png bytes")
 	encoded := base64.StdEncoding.EncodeToString(imageBytes)
@@ -24,7 +24,7 @@ func TestInlineRemoteImageURLsForGeminiChatConvertsHTTPToInlineData(t *testing.T
 	})
 
 	req := geminiChatImageRequest(remoteURL)
-	require.NoError(t, inlineRemoteImageURLsForGeminiChat(nil, req))
+	require.NoError(t, normalizeImageURLsForGeminiChat(nil, req))
 	assert.Equal(t, "data:image/png;base64,"+encoded, req.Input[0].Content.ContentBlocks[1].ImageURLStruct.URL)
 
 	out, err := ToGeminiChatCompletionRequest(nil, req)
@@ -37,7 +37,7 @@ func TestInlineRemoteImageURLsForGeminiChatConvertsHTTPToInlineData(t *testing.T
 	assert.Equal(t, encoded, out.Contents[0].Parts[1].InlineData.Data)
 }
 
-func TestInlineRemoteImageURLsForGeminiResponsesConvertsHTTPToInlineData(t *testing.T) {
+func TestNormalizeImageURLsForGeminiResponsesConvertsHTTPToInlineData(t *testing.T) {
 	remoteURL := "https://cdn.example.com/image.jpeg"
 	encoded := base64.StdEncoding.EncodeToString([]byte("\xff\xd8\xff\xe0fake jpeg bytes"))
 	stubGeminiImageFetch(t, func(_ context.Context, gotURL string) (string, string, error) {
@@ -46,7 +46,7 @@ func TestInlineRemoteImageURLsForGeminiResponsesConvertsHTTPToInlineData(t *test
 	})
 
 	req := geminiResponsesImageRequest(remoteURL)
-	require.NoError(t, inlineRemoteImageURLsForGeminiResponses(nil, req))
+	require.NoError(t, normalizeImageURLsForGeminiResponses(nil, req))
 	require.Equal(t, "data:image/jpeg;base64,"+encoded, *req.Input[0].Content.ContentBlocks[1].ResponsesInputMessageContentBlockImage.ImageURL)
 
 	out, err := ToGeminiResponsesRequest(nil, req)
@@ -59,7 +59,7 @@ func TestInlineRemoteImageURLsForGeminiResponsesConvertsHTTPToInlineData(t *test
 	assert.Equal(t, encoded, out.Contents[0].Parts[1].InlineData.Data)
 }
 
-func TestInlineRemoteImageURLsForGeminiLeavesDataURLInline(t *testing.T) {
+func TestNormalizeImageURLsForGeminiLeavesDataURLInline(t *testing.T) {
 	encoded := base64.StdEncoding.EncodeToString([]byte("\x89PNG\r\n\x1a\nfake png bytes"))
 	dataURL := "data:image/png;base64," + encoded
 	stubGeminiImageFetch(t, func(context.Context, string) (string, string, error) {
@@ -68,7 +68,7 @@ func TestInlineRemoteImageURLsForGeminiLeavesDataURLInline(t *testing.T) {
 	})
 
 	req := geminiChatImageRequest(dataURL)
-	require.NoError(t, inlineRemoteImageURLsForGeminiChat(nil, req))
+	require.NoError(t, normalizeImageURLsForGeminiChat(nil, req))
 	assert.Equal(t, dataURL, req.Input[0].Content.ContentBlocks[1].ImageURLStruct.URL)
 
 	out, err := ToGeminiChatCompletionRequest(nil, req)
@@ -77,7 +77,34 @@ func TestInlineRemoteImageURLsForGeminiLeavesDataURLInline(t *testing.T) {
 	assert.Equal(t, encoded, out.Contents[0].Parts[1].InlineData.Data)
 }
 
-func TestInlineRemoteImageURLsForGeminiReportsInvalidRequest(t *testing.T) {
+func TestNormalizeImageURLsForGeminiForwardsGeminiFileAPIURL(t *testing.T) {
+	fileURI := "https://generativelanguage.googleapis.com/v1beta/files/abc"
+	stubGeminiImageFetch(t, func(context.Context, string) (string, string, error) {
+		t.Fatal("Gemini Files API URLs must be forwarded as fileData.fileUri")
+		return "", "", nil
+	})
+
+	chatReq := geminiChatImageRequest(fileURI)
+	require.NoError(t, normalizeImageURLsForGeminiChat(nil, chatReq))
+	assert.Equal(t, fileURI, chatReq.Input[0].Content.ContentBlocks[1].ImageURLStruct.URL)
+
+	chatOut, err := ToGeminiChatCompletionRequest(nil, chatReq)
+	require.NoError(t, err)
+	require.NotNil(t, chatOut.Contents[0].Parts[1].FileData)
+	assert.Equal(t, fileURI, chatOut.Contents[0].Parts[1].FileData.FileURI)
+
+	responsesReq := geminiResponsesImageRequest(fileURI)
+	require.NoError(t, normalizeImageURLsForGeminiResponses(nil, responsesReq))
+	require.NotNil(t, responsesReq.Input[0].Content.ContentBlocks[1].ResponsesInputMessageContentBlockImage.ImageURL)
+	assert.Equal(t, fileURI, *responsesReq.Input[0].Content.ContentBlocks[1].ResponsesInputMessageContentBlockImage.ImageURL)
+
+	responsesOut, err := ToGeminiResponsesRequest(nil, responsesReq)
+	require.NoError(t, err)
+	require.NotNil(t, responsesOut.Contents[0].Parts[1].FileData)
+	assert.Equal(t, fileURI, responsesOut.Contents[0].Parts[1].FileData.FileURI)
+}
+
+func TestNormalizeImageURLsForGeminiReportsInvalidRequest(t *testing.T) {
 	tests := []struct {
 		name string
 		url  string
@@ -112,7 +139,7 @@ func TestInlineRemoteImageURLsForGeminiReportsInvalidRequest(t *testing.T) {
 				})
 			}
 
-			err := inlineRemoteImageURLsForGeminiChat(nil, geminiChatImageRequest(tt.url))
+			err := normalizeImageURLsForGeminiChat(nil, geminiChatImageRequest(tt.url))
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "messages[0].content[1].image_url")
 			assert.Contains(t, err.Error(), tt.want)
@@ -120,8 +147,8 @@ func TestInlineRemoteImageURLsForGeminiReportsInvalidRequest(t *testing.T) {
 	}
 }
 
-func TestInlineRemoteImageURLsForGeminiBlocksPrivateURL(t *testing.T) {
-	err := inlineRemoteImageURLsForGeminiChat(nil, geminiChatImageRequest("https://127.0.0.1/private.png?X-Amz-Signature=deadbeefcafe"))
+func TestNormalizeImageURLsForGeminiBlocksPrivateURL(t *testing.T) {
+	err := normalizeImageURLsForGeminiChat(nil, geminiChatImageRequest("https://127.0.0.1/private.png?X-Amz-Signature=deadbeefcafe"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "messages[0].content[1].image_url")
 	assert.NotContains(t, err.Error(), "deadbeefcafe")

--- a/core/providers/gemini/remote_image_urls_test.go
+++ b/core/providers/gemini/remote_image_urls_test.go
@@ -59,6 +59,40 @@ func TestNormalizeImageURLsForGeminiResponsesConvertsHTTPToInlineData(t *testing
 	assert.Equal(t, encoded, out.Contents[0].Parts[1].InlineData.Data)
 }
 
+func TestGeminiChatRequestWithNormalizedImageURLsDoesNotMutateOriginal(t *testing.T) {
+	remoteURL := "https://cdn.example.com/image.jpeg"
+	encoded := base64.StdEncoding.EncodeToString([]byte("\xff\xd8\xff\xe0fake jpeg bytes"))
+	stubGeminiImageFetch(t, func(context.Context, string) (string, string, error) {
+		return "image/jpeg", encoded, nil
+	})
+
+	req := geminiChatImageRequest(remoteURL)
+	got, err := geminiChatRequestWithNormalizedImageURLs(nil, req)
+	require.NoError(t, err)
+	require.NotSame(t, req, got)
+
+	assert.Equal(t, remoteURL, req.Input[0].Content.ContentBlocks[1].ImageURLStruct.URL)
+	assert.Equal(t, "data:image/jpeg;base64,"+encoded, got.Input[0].Content.ContentBlocks[1].ImageURLStruct.URL)
+}
+
+func TestGeminiResponsesRequestWithNormalizedImageURLsDoesNotMutateOriginal(t *testing.T) {
+	remoteURL := "https://cdn.example.com/image.jpeg"
+	encoded := base64.StdEncoding.EncodeToString([]byte("\xff\xd8\xff\xe0fake jpeg bytes"))
+	stubGeminiImageFetch(t, func(context.Context, string) (string, string, error) {
+		return "image/jpeg", encoded, nil
+	})
+
+	req := geminiResponsesImageRequest(remoteURL)
+	got, err := geminiResponsesRequestWithNormalizedImageURLs(nil, req)
+	require.NoError(t, err)
+	require.NotSame(t, req, got)
+
+	require.NotNil(t, req.Input[0].Content.ContentBlocks[1].ResponsesInputMessageContentBlockImage.ImageURL)
+	require.NotNil(t, got.Input[0].Content.ContentBlocks[1].ResponsesInputMessageContentBlockImage.ImageURL)
+	assert.Equal(t, remoteURL, *req.Input[0].Content.ContentBlocks[1].ResponsesInputMessageContentBlockImage.ImageURL)
+	assert.Equal(t, "data:image/jpeg;base64,"+encoded, *got.Input[0].Content.ContentBlocks[1].ResponsesInputMessageContentBlockImage.ImageURL)
+}
+
 func TestNormalizeImageURLsForGeminiLeavesDataURLInline(t *testing.T) {
 	encoded := base64.StdEncoding.EncodeToString([]byte("\x89PNG\r\n\x1a\nfake png bytes"))
 	dataURL := "data:image/png;base64," + encoded

--- a/core/providers/gemini/remote_image_urls_test.go
+++ b/core/providers/gemini/remote_image_urls_test.go
@@ -1,0 +1,328 @@
+package gemini
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInlineRemoteImageURLsForGeminiChatConvertsHTTPToInlineData(t *testing.T) {
+	remoteURL := "https://cdn.example.com/image.jpeg?sig=secret"
+	imageBytes := []byte("\x89PNG\r\n\x1a\nfake png bytes")
+	encoded := base64.StdEncoding.EncodeToString(imageBytes)
+	stubGeminiImageFetch(t, func(_ context.Context, gotURL string) (string, string, error) {
+		assert.Equal(t, remoteURL, gotURL)
+		return "image/png", encoded, nil
+	})
+
+	req := geminiChatImageRequest(remoteURL)
+	require.NoError(t, inlineRemoteImageURLsForGeminiChat(nil, req))
+	assert.Equal(t, "data:image/png;base64,"+encoded, req.Input[0].Content.ContentBlocks[1].ImageURLStruct.URL)
+
+	out, err := ToGeminiChatCompletionRequest(nil, req)
+	require.NoError(t, err)
+	require.Len(t, out.Contents, 1)
+	require.Len(t, out.Contents[0].Parts, 2)
+	assert.Nil(t, out.Contents[0].Parts[1].FileData)
+	require.NotNil(t, out.Contents[0].Parts[1].InlineData)
+	assert.Equal(t, "image/png", out.Contents[0].Parts[1].InlineData.MIMEType)
+	assert.Equal(t, encoded, out.Contents[0].Parts[1].InlineData.Data)
+}
+
+func TestInlineRemoteImageURLsForGeminiResponsesConvertsHTTPToInlineData(t *testing.T) {
+	remoteURL := "https://cdn.example.com/image.jpeg"
+	encoded := base64.StdEncoding.EncodeToString([]byte("\xff\xd8\xff\xe0fake jpeg bytes"))
+	stubGeminiImageFetch(t, func(_ context.Context, gotURL string) (string, string, error) {
+		assert.Equal(t, remoteURL, gotURL)
+		return "image/jpeg", encoded, nil
+	})
+
+	req := geminiResponsesImageRequest(remoteURL)
+	require.NoError(t, inlineRemoteImageURLsForGeminiResponses(nil, req))
+	require.Equal(t, "data:image/jpeg;base64,"+encoded, *req.Input[0].Content.ContentBlocks[1].ResponsesInputMessageContentBlockImage.ImageURL)
+
+	out, err := ToGeminiResponsesRequest(nil, req)
+	require.NoError(t, err)
+	require.Len(t, out.Contents, 1)
+	require.Len(t, out.Contents[0].Parts, 2)
+	assert.Nil(t, out.Contents[0].Parts[1].FileData)
+	require.NotNil(t, out.Contents[0].Parts[1].InlineData)
+	assert.Equal(t, "image/jpeg", out.Contents[0].Parts[1].InlineData.MIMEType)
+	assert.Equal(t, encoded, out.Contents[0].Parts[1].InlineData.Data)
+}
+
+func TestInlineRemoteImageURLsForGeminiLeavesDataURLInline(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString([]byte("\x89PNG\r\n\x1a\nfake png bytes"))
+	dataURL := "data:image/png;base64," + encoded
+	stubGeminiImageFetch(t, func(context.Context, string) (string, string, error) {
+		t.Fatal("data URLs must not be fetched")
+		return "", "", nil
+	})
+
+	req := geminiChatImageRequest(dataURL)
+	require.NoError(t, inlineRemoteImageURLsForGeminiChat(nil, req))
+	assert.Equal(t, dataURL, req.Input[0].Content.ContentBlocks[1].ImageURLStruct.URL)
+
+	out, err := ToGeminiChatCompletionRequest(nil, req)
+	require.NoError(t, err)
+	require.NotNil(t, out.Contents[0].Parts[1].InlineData)
+	assert.Equal(t, encoded, out.Contents[0].Parts[1].InlineData.Data)
+}
+
+func TestInlineRemoteImageURLsForGeminiReportsInvalidRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		err  error
+		want string
+	}{
+		{
+			name: "unsupported scheme",
+			url:  "gs://bucket/image.png",
+			err:  nil,
+			want: `URL scheme "gs" is not allowed`,
+		},
+		{
+			name: "non-image fetch result",
+			url:  "https://cdn.example.com/not-image",
+			err:  errors.New(`fetched resource "https://cdn.example.com/not-image" is not an image: content-type "text/html"`),
+			want: "not an image",
+		},
+		{
+			name: "too large fetch result",
+			url:  "https://cdn.example.com/huge.png",
+			err:  errors.New(`resource at "https://cdn.example.com/huge.png" exceeds 26214400-byte limit`),
+			want: "exceeds 26214400-byte limit",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.err != nil {
+				stubGeminiImageFetch(t, func(context.Context, string) (string, string, error) {
+					return "", "", tt.err
+				})
+			}
+
+			err := inlineRemoteImageURLsForGeminiChat(nil, geminiChatImageRequest(tt.url))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "messages[0].content[1].image_url")
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
+func TestInlineRemoteImageURLsForGeminiBlocksPrivateURL(t *testing.T) {
+	err := inlineRemoteImageURLsForGeminiChat(nil, geminiChatImageRequest("https://127.0.0.1/private.png?X-Amz-Signature=deadbeefcafe"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "messages[0].content[1].image_url")
+	assert.NotContains(t, err.Error(), "deadbeefcafe")
+	assert.NotContains(t, err.Error(), "X-Amz-Signature")
+}
+
+func TestGeminiProviderChatCompletionInlinesRemoteImageURL(t *testing.T) {
+	captured := make(chan string, 1)
+	provider := newGeminiCaptureProvider(t, captured, func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}],"modelVersion":"gemini-3.5-flash","usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}`))
+	})
+	encoded := base64.StdEncoding.EncodeToString([]byte("\x89PNG\r\n\x1a\nfake png bytes"))
+	stubGeminiImageFetch(t, func(context.Context, string) (string, string, error) {
+		return "image/png", encoded, nil
+	})
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	resp, bifrostErr := provider.ChatCompletion(ctx, schemas.Key{Value: *schemas.NewSecretVar("dummy-key")}, geminiChatImageRequest("https://cdn.example.com/image.png"))
+	require.Nil(t, bifrostErr)
+	require.NotNil(t, resp)
+
+	body := <-captured
+	assert.Contains(t, body, `"inlineData"`)
+	assert.Contains(t, body, `"mimeType":"image/png"`)
+	assert.NotContains(t, body, `"fileData"`)
+	assert.NotContains(t, body, "https://cdn.example.com/image.png")
+}
+
+func TestGeminiProviderChatCompletionStreamInlinesRemoteImageURL(t *testing.T) {
+	captured := make(chan string, 1)
+	provider := newGeminiCaptureProvider(t, captured, func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"ok\"}]},\"finishReason\":\"STOP\"}],\"modelVersion\":\"gemini-3.5-flash\",\"usageMetadata\":{\"promptTokenCount\":1,\"candidatesTokenCount\":1,\"totalTokenCount\":2}}\n\n"))
+	})
+	encoded := base64.StdEncoding.EncodeToString([]byte("\x89PNG\r\n\x1a\nfake png bytes"))
+	stubGeminiImageFetch(t, func(context.Context, string) (string, string, error) {
+		return "image/png", encoded, nil
+	})
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	stream, bifrostErr := provider.ChatCompletionStream(
+		ctx,
+		func(ctx *schemas.BifrostContext, result *schemas.BifrostResponse, err *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError) {
+			return result, err
+		},
+		nil,
+		schemas.Key{Value: *schemas.NewSecretVar("dummy-key")},
+		geminiChatImageRequest("https://cdn.example.com/image.png"),
+	)
+	require.Nil(t, bifrostErr)
+
+	for range stream {
+	}
+
+	body := <-captured
+	assert.Contains(t, body, `"inlineData"`)
+	assert.Contains(t, body, `"mimeType":"image/png"`)
+	assert.NotContains(t, body, `"fileData"`)
+	assert.NotContains(t, body, "https://cdn.example.com/image.png")
+}
+
+func TestGeminiProviderResponsesInlinesRemoteImageURL(t *testing.T) {
+	captured := make(chan string, 1)
+	provider := newGeminiCaptureProvider(t, captured, func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}],"modelVersion":"gemini-3.5-flash","usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}`))
+	})
+	encoded := base64.StdEncoding.EncodeToString([]byte("\xff\xd8\xff\xe0fake jpeg bytes"))
+	stubGeminiImageFetch(t, func(context.Context, string) (string, string, error) {
+		return "image/jpeg", encoded, nil
+	})
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	resp, bifrostErr := provider.Responses(ctx, schemas.Key{Value: *schemas.NewSecretVar("dummy-key")}, geminiResponsesImageRequest("https://cdn.example.com/image.jpeg"))
+	require.Nil(t, bifrostErr)
+	require.NotNil(t, resp)
+
+	body := <-captured
+	assert.Contains(t, body, `"inlineData"`)
+	assert.Contains(t, body, `"mimeType":"image/jpeg"`)
+	assert.NotContains(t, body, `"fileData"`)
+	assert.NotContains(t, body, "https://cdn.example.com/image.jpeg")
+}
+
+func TestGeminiProviderResponsesStreamInlinesRemoteImageURL(t *testing.T) {
+	captured := make(chan string, 1)
+	provider := newGeminiCaptureProvider(t, captured, func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"ok\"}]},\"finishReason\":\"STOP\"}],\"modelVersion\":\"gemini-3.5-flash\",\"usageMetadata\":{\"promptTokenCount\":1,\"candidatesTokenCount\":1,\"totalTokenCount\":2}}\n\n"))
+	})
+	encoded := base64.StdEncoding.EncodeToString([]byte("\xff\xd8\xff\xe0fake jpeg bytes"))
+	stubGeminiImageFetch(t, func(context.Context, string) (string, string, error) {
+		return "image/jpeg", encoded, nil
+	})
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	stream, bifrostErr := provider.ResponsesStream(
+		ctx,
+		func(ctx *schemas.BifrostContext, result *schemas.BifrostResponse, err *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError) {
+			return result, err
+		},
+		nil,
+		schemas.Key{Value: *schemas.NewSecretVar("dummy-key")},
+		geminiResponsesImageRequest("https://cdn.example.com/image.jpeg"),
+	)
+	require.Nil(t, bifrostErr)
+
+	for range stream {
+	}
+
+	body := <-captured
+	assert.Contains(t, body, `"inlineData"`)
+	assert.Contains(t, body, `"mimeType":"image/jpeg"`)
+	assert.NotContains(t, body, `"fileData"`)
+	assert.NotContains(t, body, "https://cdn.example.com/image.jpeg")
+}
+
+func TestGeminiProviderCountTokensInlinesRemoteImageURL(t *testing.T) {
+	captured := make(chan string, 1)
+	provider := newGeminiCaptureProvider(t, captured, func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"totalTokens":7,"promptTokensDetails":[{"modality":"TEXT","tokenCount":7}]}`))
+	})
+	encoded := base64.StdEncoding.EncodeToString([]byte("\xff\xd8\xff\xe0fake jpeg bytes"))
+	stubGeminiImageFetch(t, func(context.Context, string) (string, string, error) {
+		return "image/jpeg", encoded, nil
+	})
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	resp, bifrostErr := provider.CountTokens(ctx, schemas.Key{Value: *schemas.NewSecretVar("dummy-key")}, geminiResponsesImageRequest("https://cdn.example.com/image.jpeg"))
+	require.Nil(t, bifrostErr)
+	require.NotNil(t, resp)
+
+	body := <-captured
+	assert.Contains(t, body, `"generateContentRequest"`)
+	assert.Contains(t, body, `"inlineData"`)
+	assert.Contains(t, body, `"mimeType":"image/jpeg"`)
+	assert.NotContains(t, body, `"fileData"`)
+	assert.NotContains(t, body, "https://cdn.example.com/image.jpeg")
+}
+
+func stubGeminiImageFetch(t *testing.T, fn func(context.Context, string) (string, string, error)) {
+	t.Helper()
+	previous := fetchAndEncodeGeminiImageURL
+	fetchAndEncodeGeminiImageURL = fn
+	t.Cleanup(func() {
+		fetchAndEncodeGeminiImageURL = previous
+	})
+}
+
+func geminiChatImageRequest(imageURL string) *schemas.BifrostChatRequest {
+	return &schemas.BifrostChatRequest{
+		Model: "gemini-3.5-flash",
+		Input: []schemas.ChatMessage{{
+			Role: schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{
+				ContentBlocks: []schemas.ChatContentBlock{
+					{Type: schemas.ChatContentBlockTypeText, Text: schemas.Ptr("Describe this image.")},
+					{Type: schemas.ChatContentBlockTypeImage, ImageURLStruct: &schemas.ChatInputImage{URL: imageURL}},
+				},
+			},
+		}},
+	}
+}
+
+func geminiResponsesImageRequest(imageURL string) *schemas.BifrostResponsesRequest {
+	return &schemas.BifrostResponsesRequest{
+		Model: "gemini-3.5-flash",
+		Input: []schemas.ResponsesMessage{{
+			Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+			Content: &schemas.ResponsesMessageContent{
+				ContentBlocks: []schemas.ResponsesMessageContentBlock{
+					{Type: schemas.ResponsesInputMessageContentBlockTypeText, Text: schemas.Ptr("Describe this image.")},
+					{
+						Type: schemas.ResponsesInputMessageContentBlockTypeImage,
+						ResponsesInputMessageContentBlockImage: &schemas.ResponsesInputMessageContentBlockImage{
+							ImageURL: schemas.Ptr(imageURL),
+						},
+					},
+				},
+			},
+		}},
+	}
+}
+
+func newGeminiCaptureProvider(t *testing.T, captured chan<- string, writeResponse func(http.ResponseWriter)) *GeminiProvider {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		captured <- string(body)
+		writeResponse(w)
+	}))
+	t.Cleanup(server.Close)
+
+	return NewGeminiProvider(&schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{
+			BaseURL:             server.URL + "/v1beta",
+			AllowPrivateNetwork: true,
+		},
+	}, testNoopLogger{})
+}

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -1288,30 +1288,31 @@ type Schema struct {
 
 type flexibleSchemaInt64 int64
 
-var schemaIntegerJSON = sonic.Config{UseInt64: true}.Froze()
-
 func (i *flexibleSchemaInt64) UnmarshalJSON(data []byte) error {
-	var value any
-	if err := schemaIntegerJSON.Unmarshal(data, &value); err != nil {
-		return fmt.Errorf("invalid schema integer constraint: %w", err)
+	token := strings.TrimSpace(string(data))
+	if token == "null" {
+		return nil
 	}
 
-	switch typedValue := value.(type) {
-	case nil:
-		return nil
-	case int64:
-		*i = flexibleSchemaInt64(typedValue)
-		return nil
-	case string:
-		parsed, err := strconv.ParseInt(typedValue, 10, 64)
+	if strings.HasPrefix(token, `"`) {
+		var value string
+		if err := json.Unmarshal(data, &value); err != nil {
+			return fmt.Errorf("invalid schema integer constraint: %w", err)
+		}
+		parsed, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
-			return fmt.Errorf("invalid schema integer constraint %q: %w", typedValue, err)
+			return fmt.Errorf("invalid schema integer constraint %q: %w", value, err)
 		}
 		*i = flexibleSchemaInt64(parsed)
 		return nil
-	default:
-		return fmt.Errorf("invalid schema integer constraint %v", typedValue)
 	}
+
+	parsed, err := strconv.ParseInt(token, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid schema integer constraint %s: %w", token, err)
+	}
+	*i = flexibleSchemaInt64(parsed)
+	return nil
 }
 
 func schemaInt64Ptr(value *flexibleSchemaInt64) *int64 {

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -1288,31 +1288,30 @@ type Schema struct {
 
 type flexibleSchemaInt64 int64
 
+var schemaIntegerJSON = sonic.Config{UseInt64: true}.Froze()
+
 func (i *flexibleSchemaInt64) UnmarshalJSON(data []byte) error {
-	token := strings.TrimSpace(string(data))
-	if token == "null" {
-		return nil
+	var value any
+	if err := schemaIntegerJSON.Unmarshal(data, &value); err != nil {
+		return fmt.Errorf("invalid schema integer constraint: %w", err)
 	}
 
-	if strings.HasPrefix(token, `"`) {
-		var value string
-		if err := json.Unmarshal(data, &value); err != nil {
-			return fmt.Errorf("invalid schema integer constraint: %w", err)
-		}
-		parsed, err := strconv.ParseInt(value, 10, 64)
+	switch typedValue := value.(type) {
+	case nil:
+		return nil
+	case int64:
+		*i = flexibleSchemaInt64(typedValue)
+		return nil
+	case string:
+		parsed, err := strconv.ParseInt(typedValue, 10, 64)
 		if err != nil {
-			return fmt.Errorf("invalid schema integer constraint %q: %w", value, err)
+			return fmt.Errorf("invalid schema integer constraint %q: %w", typedValue, err)
 		}
 		*i = flexibleSchemaInt64(parsed)
 		return nil
+	default:
+		return fmt.Errorf("invalid schema integer constraint %v", typedValue)
 	}
-
-	parsed, err := strconv.ParseInt(token, 10, 64)
-	if err != nil {
-		return fmt.Errorf("invalid schema integer constraint %s: %w", token, err)
-	}
-	*i = flexibleSchemaInt64(parsed)
-	return nil
 }
 
 func schemaInt64Ptr(value *flexibleSchemaInt64) *int64 {

--- a/core/providers/utils/fetch.go
+++ b/core/providers/utils/fetch.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"net/url"
 	"strings"
@@ -13,6 +14,10 @@ import (
 
 	"github.com/maximhq/bifrost/core/network"
 )
+
+const fetchMaxBytes int64 = 25 * 1024 * 1024
+
+type httpDoer func(client *http.Client, req *http.Request) (*http.Response, error)
 
 // RedactURLForError reduces a resource URL to the part that is safe to echo back in an
 // error: scheme, host, and path. Userinfo, query, and fragment are dropped.
@@ -65,18 +70,51 @@ func sanitizeFetchError(err error, redacted string) error {
 // so DNS rebinding does not bypass it. Redirect targets are subject to the same
 // scheme + dial-time IP validation.
 func FetchAndEncodeURL(ctx context.Context, resourceURL string) (mediaType string, encoded string, err error) {
-	const maxBytes int64 = 25 * 1024 * 1024
+	return fetchAndEncodeURL(ctx, resourceURL, DoHTTPRequest)
+}
 
+func fetchAndEncodeURL(ctx context.Context, resourceURL string, do httpDoer) (mediaType string, encoded string, err error) {
+	mediaType, body, err := fetchURLBytes(ctx, resourceURL, do)
+	if err != nil {
+		return "", "", err
+	}
+
+	return mediaType, base64.StdEncoding.EncodeToString(body), nil
+}
+
+// FetchAndEncodeImageURL downloads a remote image and returns its base64 encoding plus
+// a byte-sniffed image MIME type. It has the same timeout, redirect, body-size, and
+// SSRF protections as FetchAndEncodeURL, but additionally rejects non-image responses
+// instead of letting callers label arbitrary bytes as image/jpeg by default.
+func FetchAndEncodeImageURL(ctx context.Context, imageURL string) (mediaType string, encoded string, err error) {
+	return fetchAndEncodeImageURL(ctx, imageURL, DoHTTPRequest)
+}
+
+func fetchAndEncodeImageURL(ctx context.Context, imageURL string, do httpDoer) (mediaType string, encoded string, err error) {
+	declaredType, body, err := fetchURLBytes(ctx, imageURL, do)
+	if err != nil {
+		return "", "", err
+	}
+
+	mediaType, err = sniffFetchedImageType(imageURL, declaredType, body)
+	if err != nil {
+		return "", "", err
+	}
+
+	return mediaType, base64.StdEncoding.EncodeToString(body), nil
+}
+
+func fetchURLBytes(ctx context.Context, resourceURL string, do httpDoer) (mediaType string, body []byte, err error) {
 	// Every error below names the resource by its redacted form only; see
 	// RedactURLForError for why the query and userinfo never make it into a message.
 	redacted := RedactURLForError(resourceURL)
 
 	parsed, err := url.Parse(resourceURL)
 	if err != nil {
-		return "", "", fmt.Errorf("invalid resource URL %q: %w", redacted, sanitizeFetchError(err, redacted))
+		return "", nil, fmt.Errorf("invalid resource URL %q: %w", redacted, sanitizeFetchError(err, redacted))
 	}
 	if parsed.Scheme != "http" && parsed.Scheme != "https" {
-		return "", "", fmt.Errorf("unsupported URL scheme %q (only http/https allowed)", parsed.Scheme)
+		return "", nil, fmt.Errorf("unsupported URL scheme %q (only http/https allowed)", parsed.Scheme)
 	}
 
 	transport := &http.Transport{
@@ -98,32 +136,59 @@ func FetchAndEncodeURL(ctx context.Context, resourceURL string) (mediaType strin
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, resourceURL, nil)
 	if err != nil {
-		return "", "", fmt.Errorf("invalid resource URL %q: %w", redacted, sanitizeFetchError(err, redacted))
+		return "", nil, fmt.Errorf("invalid resource URL %q: %w", redacted, sanitizeFetchError(err, redacted))
 	}
 	req.Header.Set("User-Agent", "bifrost-fetch/1")
 
-	resp, err := DoHTTPRequest(client, req)
+	resp, err := do(client, req)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to fetch from %q: %w", redacted, sanitizeFetchError(err, redacted))
+		return "", nil, fmt.Errorf("failed to fetch from %q: %w", redacted, sanitizeFetchError(err, redacted))
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", "", fmt.Errorf("fetch %q returned non-2xx status %d", redacted, resp.StatusCode)
+		return "", nil, fmt.Errorf("fetch %q returned non-2xx status %d", redacted, resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
+	body, err = io.ReadAll(io.LimitReader(resp.Body, fetchMaxBytes+1))
 	if err != nil {
-		return "", "", fmt.Errorf("failed to read body from %q: %w", redacted, sanitizeFetchError(err, redacted))
+		return "", nil, fmt.Errorf("failed to read body from %q: %w", redacted, sanitizeFetchError(err, redacted))
 	}
-	if int64(len(body)) > maxBytes {
-		return "", "", fmt.Errorf("resource at %q exceeds %d-byte limit", redacted, maxBytes)
+	if int64(len(body)) > fetchMaxBytes {
+		return "", nil, fmt.Errorf("resource at %q exceeds %d-byte limit", redacted, fetchMaxBytes)
 	}
 
-	mediaType = resp.Header.Get("Content-Type")
+	return normalizeFetchedMediaType(resp.Header.Get("Content-Type")), body, nil
+}
+
+func normalizeFetchedMediaType(mediaType string) string {
+	if parsed, _, err := mime.ParseMediaType(mediaType); err == nil {
+		return strings.ToLower(strings.TrimSpace(parsed))
+	}
 	if i := strings.Index(mediaType, ";"); i != -1 {
-		mediaType = strings.TrimSpace(mediaType[:i])
+		mediaType = mediaType[:i]
+	}
+	return strings.ToLower(strings.TrimSpace(mediaType))
+}
+
+func sniffFetchedImageType(imageURL, declaredType string, body []byte) (string, error) {
+	redacted := RedactURLForError(imageURL)
+	if len(body) == 0 {
+		return "", fmt.Errorf("fetched image %q is empty", redacted)
 	}
 
-	return mediaType, base64.StdEncoding.EncodeToString(body), nil
+	declaredType = normalizeFetchedMediaType(declaredType)
+	if declaredType != "" && declaredType != "application/octet-stream" && !strings.HasPrefix(declaredType, "image/") {
+		return "", fmt.Errorf("fetched resource %q is not an image: content-type %q", redacted, declaredType)
+	}
+
+	detectedType := normalizeFetchedMediaType(http.DetectContentType(body))
+	if !strings.HasPrefix(detectedType, "image/") {
+		if declaredType == "application/octet-stream" {
+			return "", fmt.Errorf("fetched resource %q is not an image: detected content-type %q", redacted, detectedType)
+		}
+		return "", fmt.Errorf("fetched resource %q is not an image: content-type %q detected as %q", redacted, declaredType, detectedType)
+	}
+
+	return detectedType, nil
 }

--- a/core/providers/utils/fetch_test.go
+++ b/core/providers/utils/fetch_test.go
@@ -1,7 +1,11 @@
 package utils
 
 import (
+	"bytes"
+	"encoding/base64"
 	"errors"
+	"io"
+	"net/http"
 	"net/url"
 	"strings"
 	"testing"
@@ -107,9 +111,8 @@ func TestSanitizeFetchError(t *testing.T) {
 
 // TestFetchAndEncodeURL_ErrorsAreRedacted covers the paths reachable without a dial.
 // FetchAndEncodeURL routes through network.SSRFSafeDialContext, which rejects loopback
-// unconditionally and has no test seam, so an httptest server is unreachable by design
-// (same constraint documented in core/providers/openai/chatfileurl_test.go). The scheme
-// and parse guards run before any dial, and the dial rejection itself is reachable.
+// unconditionally. The scheme and parse guards run before any dial, and the dial
+// rejection itself is reachable.
 func TestFetchAndEncodeURL_ErrorsAreRedacted(t *testing.T) {
 	secrets := []string{"X-Amz-Signature", "deadbeefcafe", "hunter2"}
 
@@ -139,5 +142,175 @@ func TestFetchAndEncodeURL_ErrorsAreRedacted(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestFetchAndEncodeImageURL_AcceptsImagesBySniffedBytes(t *testing.T) {
+	png := []byte("\x89PNG\r\n\x1a\npng image bytes")
+	jpeg := []byte("\xff\xd8\xff\xe0jpeg image bytes")
+
+	tests := []struct {
+		name        string
+		contentType string
+		body        []byte
+		wantType    string
+	}{
+		{
+			name:        "content type parameters are stripped and bytes win",
+			contentType: "image/jpeg; charset=binary",
+			body:        png,
+			wantType:    "image/png",
+		},
+		{
+			name:        "generic content type is allowed only when bytes are image",
+			contentType: "application/octet-stream",
+			body:        png,
+			wantType:    "image/png",
+		},
+		{
+			name:        "missing content type is allowed when bytes are image",
+			contentType: "",
+			body:        jpeg,
+			wantType:    "image/jpeg",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotType, gotEncoded, err := fetchAndEncodeImageURL(t.Context(), "https://cdn.example.com/photo", stubFetchResponse(tt.contentType, http.StatusOK, bytes.NewReader(tt.body)))
+			if err != nil {
+				t.Fatalf("fetchAndEncodeImageURL: %v", err)
+			}
+			if gotType != tt.wantType {
+				t.Errorf("media type = %q, want %q", gotType, tt.wantType)
+			}
+			if gotEncoded != base64.StdEncoding.EncodeToString(tt.body) {
+				t.Errorf("encoded body = %q, want fetched bytes", gotEncoded)
+			}
+		})
+	}
+}
+
+func TestFetchAndEncodeImageURL_RejectsNonImages(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		body        []byte
+		want        string
+	}{
+		{
+			name:        "declared non-image type",
+			contentType: "text/html; charset=utf-8",
+			body:        []byte("\x89PNG\r\n\x1a\npng image bytes"),
+			want:        `content-type "text/html"`,
+		},
+		{
+			name:        "image header with non-image bytes",
+			contentType: "image/png",
+			body:        []byte("<html>not an image</html>"),
+			want:        "detected as",
+		},
+		{
+			name:        "empty body",
+			contentType: "image/png",
+			body:        nil,
+			want:        "is empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := fetchAndEncodeImageURL(t.Context(), "https://cdn.example.com/photo.png", stubFetchResponse(tt.contentType, http.StatusOK, bytes.NewReader(tt.body)))
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
+func TestFetchAndEncodeImageURL_RejectsBadStatusAndTooLarge(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   io.Reader
+		want   string
+	}{
+		{
+			name:   "bad status",
+			status: http.StatusNotFound,
+			body:   bytes.NewReader([]byte("missing")),
+			want:   "non-2xx status 404",
+		},
+		{
+			name:   "too large",
+			status: http.StatusOK,
+			body:   bytes.NewReader(bytes.Repeat([]byte{0}, int(fetchMaxBytes+1))),
+			want:   "exceeds 26214400-byte limit",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			signed := "https://cdn.example.com/private.png?X-Amz-Signature=deadbeefcafe"
+			_, _, err := fetchAndEncodeImageURL(t.Context(), signed, stubFetchResponse("image/png", tt.status, tt.body))
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tt.want)
+			}
+			if strings.Contains(err.Error(), "deadbeefcafe") || strings.Contains(err.Error(), "X-Amz-Signature") {
+				t.Errorf("error leaks signed URL credentials: %s", err.Error())
+			}
+		})
+	}
+}
+
+func TestFetchAndEncodeImageURL_ErrorsAreRedacted(t *testing.T) {
+	secrets := []string{"X-Amz-Signature", "deadbeefcafe", "hunter2"}
+
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{
+			name: "unsupported scheme",
+			url:  "ftp://alice:hunter2@files.example.com/image.png?X-Amz-Signature=deadbeefcafe",
+		},
+		{
+			name: "blocked by the SSRF dialer",
+			url:  "https://alice:hunter2@127.0.0.1/image.png?X-Amz-Signature=deadbeefcafe",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := FetchAndEncodeImageURL(t.Context(), tt.url)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			for _, secret := range secrets {
+				if strings.Contains(err.Error(), secret) {
+					t.Errorf("error leaks %q: %s", secret, err.Error())
+				}
+			}
+		})
+	}
+}
+
+func stubFetchResponse(contentType string, status int, body io.Reader) httpDoer {
+	return func(_ *http.Client, _ *http.Request) (*http.Response, error) {
+		header := http.Header{}
+		if contentType != "" {
+			header.Set("Content-Type", contentType)
+		}
+		return &http.Response{
+			StatusCode: status,
+			Header:     header,
+			Body:       io.NopCloser(body),
+		}, nil
 	}
 }


### PR DESCRIPTION
## Summary

Fix direct Gemini provider handling for ordinary remote HTTP(S) `image_url` inputs. Those URLs are fetched and sent as Gemini `inlineData`, while data URLs and Gemini Files API URIs stay on the existing pass-through path.

## Changes

- Added Gemini image URL normalization for chat, Responses, streaming, and token-count request paths.
- Fetch and inline ordinary HTTP(S) images before Gemini request conversion.
- Preserve data URLs and Gemini Files API URIs as provider-native inputs.
- Build the Gemini request body from a provider-local copy so retry/fallback callers do not observe the inline rewrite.
- Added image-only fetch validation with SSRF-safe dialing, redirect checks, MIME sniffing, a per-resource size cap, and redacted URL errors.
- Added regression coverage for conversion, provider payloads, validation failures, URL redaction, native URI pass-through, and non-mutating normalization.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Expected outcome: all commands pass.

```sh
go test ./providers/gemini -run 'TestNormalizeImageURLsForGemini|TestGeminiProvider.*Inlines|TestGeminiChatRequestWithNormalizedImageURLs|TestGeminiResponsesRequestWithNormalizedImageURLs'
go test ./providers/utils -run 'TestFetchAndEncodeImageURL|TestFetchAndEncodeURL_ErrorsAreRedacted'
go test ./providers/vertex
```

No new configs or environment variables were added.

## Screenshots/Recordings

N/A. No UI changes.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A.

## Security considerations

Remote image fetching uses the existing SSRF-safe dialer and redirect validation. Error messages redact URL userinfo, query strings, and fragments so signed URL credentials are not echoed back.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines. Note: that exact file is not present in the tree, so I checked the available contributing docs for PRs, code conventions, and running tests.
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed. N/A: provider behavior is covered by tests and no config/API surface was added.
- [x] I verified builds succeed (Go and UI). Go provider tests listed above pass; UI is not affected.
- [x] I verified the CI pipeline passes locally if applicable. Applicable local Go checks listed above pass; hosted checks are tracked on this PR.