### PR TITLE
fix: update new attribute names in OTEl

### DIFF
--- a/tests/e2e/api/runners/run-observability-local.mjs
+++ b/tests/e2e/api/runners/run-observability-local.mjs
@@ -270,7 +270,7 @@ async function assertOtelReceived() {
     requestID,
     "gen_ai.provider.name",
     "gen_ai.request.model",
-    "gen_ai.request_id",
+    "bifrost.request.id",
     "gen_ai.usage.input_tokens",
     "gen_ai.usage.output_tokens",
     "gen_ai.usage.total_tokens",
@@ -316,7 +316,7 @@ async function assertOtelErrorTrace(id, label) {
     () => state.otelTraceRequests.find((item) => item.body.includes(Buffer.from(id))));
   assertBufferContainsAll(`OTEL ${label} trace export`, entry.body, [
     id,
-    "gen_ai.error.type",
+    "error.type",
     "invalid_request_error",
     "gen_ai.error.code",
     "model_not_found",


### PR DESCRIPTION
## Summary

Updates OpenTelemetry attribute names in the observability E2E tests to align with the correct attribute key conventions used in the system.

## Changes

- Renamed the `gen_ai.request_id` span attribute to `bifrost.request.id` to reflect the correct namespace for Bifrost-specific attributes
- Renamed the `gen_ai.error.type` span attribute to `error.type` to align with the standard OpenTelemetry semantic conventions for error attributes

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the observability E2E tests locally and verify that the OTEL span assertions pass with the updated attribute names.

```sh
node tests/e2e/api/runners/run-observability-local.mjs
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable