### PR TITLE
core test fixes

### DIFF
--- a/core/encryptedreasoning_test.go
+++ b/core/encryptedreasoning_test.go
@@ -378,7 +378,12 @@ func TestExecuteRequestWithRetries_OrdinaryRetryPaysBackoff(t *testing.T) {
 	if callCount != 2 {
 		t.Fatalf("expected 2 attempts, got %d", callCount)
 	}
-	if elapsed < 250*time.Millisecond {
+	// calculateBackoff jitters by [0.8, 1.2), so the shortest legal sleep for the
+	// configured 300ms is 240ms. The floor must sit below that: this is a negative
+	// control proving backoff was paid at all (vs the fail-soft test's ~0ms), so it
+	// only needs to separate "slept" from "did not sleep", and a floor at or above
+	// 240ms fails a correctly-paid backoff on roughly one run in eight.
+	if elapsed < 200*time.Millisecond {
 		t.Fatalf("an ordinary retryable failure must still back off (configured %s), took %s",
 			config.NetworkConfig.RetryBackoffInitial, elapsed)
 	}


### PR DESCRIPTION
## Summary

Fixes a flaky test in `TestExecuteRequestWithRetries_OrdinaryRetryPaysBackoff` where the backoff elapsed-time floor was set too high, causing intermittent failures due to jitter applied by `calculateBackoff`.

## Changes

- Lowered the minimum elapsed-time assertion from `250ms` to `200ms` to account for the `[0.8, 1.2)` jitter range applied to the configured `300ms` backoff. The shortest legally jittered sleep is `240ms`, meaning a floor of `250ms` would incorrectly fail a valid backoff on roughly one run in eight. The new floor of `200ms` reliably distinguishes "backoff was paid" from "no sleep occurred" without false negatives.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)

## How to test

```sh
go test ./core/... -run TestExecuteRequestWithRetries_OrdinaryRetryPaysBackoff -count=20
```

Expected outcome: all 20 runs pass without any `"must still back off"` failures.

## Breaking changes

- [x] No

## Security considerations

None. This is a test-only timing threshold adjustment with no impact on production behavior.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable