### PR TITLE
fix: default core params as supported for sparse datasheet rows missing model_parameters array

### DIFF
--- a/framework/modelcatalog/datasheet/capabilities_test.go
+++ b/framework/modelcatalog/datasheet/capabilities_test.go
@@ -315,3 +315,48 @@ func TestExtractSupportedParams_NoneReasoningEffort(t *testing.T) {
 		t.Errorf("expected supported params to omit \"supports_none_reasoning_effort\" when unset, got %v", got)
 	}
 }
+
+// TestExtractSupportedParams_SparseRowDefaultsCoreParams guards against a
+// datasheet row that sets a few supports_* flags (e.g. from a pricing-only
+// sync) but carries no model_parameters array at all — the only place
+// temperature/top_p/stop/max_tokens/etc. are normally sourced from. Without
+// this default, such a row would make compat's dropUnsupportedParams strip
+// those core params from every request to that model.
+func TestExtractSupportedParams_SparseRowDefaultsCoreParams(t *testing.T) {
+	sparse := &schemas.ModelCapabilities{
+		SupportsFunctionCalling: capabilityBoolPtr(true),
+		SupportsToolChoice:      capabilityBoolPtr(true),
+	}
+	got := extractSupportedParams(sparse)
+	for _, want := range []string{"temperature", "top_p", "stop", "max_tokens", "frequency_penalty", "presence_penalty", "seed", "logprobs", "top_logprobs", "n", "logit_bias", "metadata"} {
+		if !slices.Contains(got, want) {
+			t.Errorf("expected sparse row (no model_parameters) to default-include %q, got %v", want, got)
+		}
+	}
+
+	// A row with an explicit model_parameters array is well-formed — its
+	// omissions are a real restriction (e.g. reasoning-only models), so the
+	// default must not kick in.
+	explicit := &schemas.ModelCapabilities{
+		ModelParameters: []schemas.ModelParameterDescriptor{{ID: "tools"}},
+	}
+	got = extractSupportedParams(explicit)
+	if slices.Contains(got, "temperature") {
+		t.Errorf("expected explicit model_parameters row to omit \"temperature\" when not listed, got %v", got)
+	}
+
+	// An explicit supports_sampling_params=false must suppress the default
+	// even on a sparse row (adaptive-only models that reject sampling params).
+	rejectsSampling := &schemas.ModelCapabilities{
+		SupportsSamplingParams: capabilityBoolPtr(false),
+	}
+	got = extractSupportedParams(rejectsSampling)
+	for _, unexpected := range []string{"temperature", "top_p"} {
+		if slices.Contains(got, unexpected) {
+			t.Errorf("expected supports_sampling_params=false to omit %q, got %v", unexpected, got)
+		}
+	}
+	if !slices.Contains(got, "stop") {
+		t.Errorf("expected supports_sampling_params=false to still default-include \"stop\", got %v", got)
+	}
+}

--- a/framework/modelcatalog/datasheet/types.go
+++ b/framework/modelcatalog/datasheet/types.go
@@ -499,6 +499,16 @@ func normalizeModeToOutputType(mode string) string {
 	}
 }
 
+// sparseRowDefaultParams are the OpenAI-compatible request parameters that
+// extractSupportedParams can only ever learn about from model_parameters[].id
+// — none of them has a dedicated supports_* flag. When a row's model_parameters
+// array is empty, these default to supported instead of silently falling out of
+// the allowlist; see the completeness guard below.
+var sparseRowDefaultParams = []string{
+	"temperature", "top_p", "stop", "max_tokens", "max_completion_tokens", "max_output_tokens",
+	"frequency_penalty", "presence_penalty", "seed", "logprobs", "top_logprobs", "n", "logit_bias", "metadata",
+}
+
 // extractSupportedParams builds a list of supported OpenAI-compatible parameter
 // names from model_parameters[].id values and supports_* boolean flags.
 func extractSupportedParams(parsed *schemas.ModelCapabilities) []string {
@@ -526,6 +536,20 @@ func extractSupportedParams(parsed *schemas.ModelCapabilities) []string {
 			// skip — not top-level request parameters
 		default:
 			addParam(mp.ID)
+		}
+	}
+
+	if len(parsed.ModelParameters) == 0 {
+		// An empty array means the row never described its request-parameter
+		// surface (a sync gap), not that only the flag-driven params below are
+		// supported. Trust the standard sampling and limit params by default —
+		// except temperature/top_p when the row explicitly rejects them.
+		samplingParamsSupported := parsed.SupportsSamplingParams == nil || *parsed.SupportsSamplingParams
+		for _, name := range sparseRowDefaultParams {
+			if !samplingParamsSupported && (name == "temperature" || name == "top_p") {
+				continue
+			}
+			addParam(name)
 		}
 	}
 


### PR DESCRIPTION
## Summary

When a model catalog datasheet row has no `model_parameters` array (e.g. rows synced from pricing data only), `extractSupportedParams` previously returned an allowlist that omitted core OpenAI-compatible parameters like `temperature`, `top_p`, `stop`, and `max_tokens`. This caused `dropUnsupportedParams` in the compat layer to silently strip those parameters from every request sent to such models.

## Changes

- Added a `sparseRowDefaultParams` list of core OpenAI-compatible request parameters that have no dedicated `supports_*` flag and can only be discovered via `model_parameters[].id`.
- When `model_parameters` is empty, `extractSupportedParams` now defaults these parameters to supported rather than omitting them from the allowlist.
- `temperature` and `top_p` are still suppressed when the row explicitly sets `supports_sampling_params=false`, preserving the restriction for adaptive-only models.
- Rows with an explicit (non-empty) `model_parameters` array are unaffected — their omissions are treated as intentional restrictions (e.g. reasoning-only models).
- Added `TestExtractSupportedParams_SparseRowDefaultsCoreParams` covering the sparse-row default, the explicit-array case, and the `supports_sampling_params=false` suppression.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)

## How to test

```sh
go test ./framework/modelcatalog/datasheet/...
```

The new test `TestExtractSupportedParams_SparseRowDefaultsCoreParams` validates:
1. A sparse row (no `model_parameters`) includes `temperature`, `top_p`, `stop`, `max_tokens`, and other core params by default.
2. A row with an explicit `model_parameters` array does not have the default applied — `temperature` is absent if not listed.
3. A row with `supports_sampling_params=false` suppresses `temperature` and `top_p` even on a sparse row, while still including `stop`.

## Breaking changes

- [x] No

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable