### PR TITLE
feat(configstore): add time-of-day peak/off-peak pricing columns and migration

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -493,6 +493,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_prompt_cache_json_column"}, run: migrationAddPromptCacheJSONColumn},
 	{IDs: []string{"add_hidden_request_types_json_column"}, run: migrationAddHiddenRequestTypesJSONColumn},
 	{IDs: []string{"add_use_openai_endpoints_column"}, run: migrationAddUseOpenAIEndpointsColumn},
+	{IDs: []string{"add_time_of_day_pricing_columns"}, run: migrationAddTimeOfDayPricingColumns},
 }
 
 // videoResolutionPricingColumns are the resolution-banded video output rate columns.
@@ -13519,6 +13520,45 @@ func migrationAddUseOpenAIEndpointsColumn(ctx context.Context, db *gorm.DB, logg
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("failed to run migration %s: %w", migrationName, err)
+	}
+	return nil
+}
+
+// migrationAddTimeOfDayPricingColumns adds the peak/off-peak pricing columns to
+// governance_model_pricing. Providers such as DeepSeek bill the same model at
+// two different rates depending on the time of day; off_peak_cost_multiplier
+// scales usage-based charges outside the windows declared in peak_hours.
+func migrationAddTimeOfDayPricingColumns(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_time_of_day_pricing_columns"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	columns := []string{
+		"off_peak_cost_multiplier",
+		"peak_hours",
+	}
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			for _, field := range columns {
+				if err := addColumnIfNotExists(tx, logger, &tables.TableModelPricing{}, field); err != nil {
+					return fmt.Errorf("failed to add column %s: %w", field, err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			for _, field := range columns {
+				if err := dropColumnIfExists(tx, logger, &tables.TableModelPricing{}, field); err != nil {
+					return fmt.Errorf("failed to drop column %s: %w", field, err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running %s migration: %w", migrationName, err)
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2902,6 +2902,9 @@ var pricingSyncUpdateColumns = []string{
 	// Costs - OCR
 	"ocr_cost_per_page",
 	"annotation_cost_per_page",
+	// Costs - Time of day
+	"off_peak_cost_multiplier",
+	"peak_hours",
 }
 
 // UpsertModelPrices creates or updates a model pricing record in the database.

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -3350,6 +3350,69 @@ func TestUpsertModelPricesBatch_MegapixelImageTierColumns_SurviveResync(t *testi
 	assert.InDelta(t, 0.12, *row.OutputCostPerImageAbove64Megapixels, 1e-9)
 }
 
+func TestUpsertModelPricesBatch_TimeOfDayColumns_SurviveResync(t *testing.T) {
+	// Same pricingSyncUpdateColumns regression as the megapixel test above, for
+	// the peak/off-peak columns. peak_hours additionally exercises the
+	// serializer:json round-trip, which the plain *float64 columns do not.
+	s := setupRDBTestStore(t)
+	require.NoError(t, s.DB().AutoMigrate(&tables.TableModelPricing{}))
+
+	ctx := context.Background()
+	cost := func(f float64) *float64 { return &f }
+
+	pricing := []tables.TableModelPricing{
+		{
+			Model:                 "deepseek-v4-flash",
+			Provider:              "deepseek",
+			Mode:                  "chat",
+			InputCostPerToken:     cost(0.00000044),
+			OutputCostPerToken:    cost(0.00000132),
+			OffPeakCostMultiplier: cost(0.5),
+			PeakHours: &tables.PeakHoursSchedule{
+				Timezone: "UTC",
+				Windows: []tables.PeakHoursWindow{
+					{Days: []int{1, 2, 3, 4, 5}, Start: "01:00", End: "04:00"},
+					{Days: []int{1, 2, 3, 4, 5}, Start: "06:00", End: "10:00"},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, s.UpsertModelPricesBatch(ctx, pricing))
+
+	// Re-upsert the same row (the next scheduled datasheet sync) with BOTH
+	// columns changed, to exercise the ON CONFLICT update path. peak_hours has
+	// to change too: leaving it identical would let the row keep the value the
+	// first insert wrote, so the assertions below would still pass even if
+	// peak_hours were missing from pricingSyncUpdateColumns, which is the exact
+	// regression this test exists to catch.
+	pricing[0].OffPeakCostMultiplier = cost(0.6)
+	pricing[0].PeakHours = &tables.PeakHoursSchedule{
+		Timezone: "Asia/Shanghai",
+		Windows: []tables.PeakHoursWindow{
+			{Days: []int{1, 2, 3, 4, 5}, Start: "02:00", End: "05:00"},
+		},
+	}
+	require.NoError(t, s.UpsertModelPricesBatch(ctx, pricing))
+
+	got, err := s.GetModelPrices(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	row := got[0]
+	require.NotNil(t, row.OffPeakCostMultiplier)
+	assert.InDelta(t, 0.6, *row.OffPeakCostMultiplier, 1e-9) // survived resync with the updated value
+
+	// Every field below differs from the first insert, so a peak_hours column
+	// that never got updated fails here rather than passing by coincidence.
+	require.NotNil(t, row.PeakHours)
+	assert.Equal(t, "Asia/Shanghai", row.PeakHours.Timezone)
+	require.Len(t, row.PeakHours.Windows, 1)
+	assert.Equal(t, []int{1, 2, 3, 4, 5}, row.PeakHours.Windows[0].Days)
+	assert.Equal(t, "02:00", row.PeakHours.Windows[0].Start)
+	assert.Equal(t, "05:00", row.PeakHours.Windows[0].End)
+}
+
 func TestUpsertModelParametersBatch_SQLite(t *testing.T) {
 	s := setupRDBTestStore(t)
 	require.NoError(t, s.DB().AutoMigrate(&tables.TableModelParameters{}))

--- a/framework/configstore/tables/modelpricing.go
+++ b/framework/configstore/tables/modelpricing.go
@@ -154,6 +154,18 @@ type TableModelPricing struct {
 	OCRCostPerPage        *float64 `gorm:"default:null;column:ocr_cost_per_page" json:"ocr_cost_per_page,omitempty"`
 	AnnotationCostPerPage *float64 `gorm:"default:null;column:annotation_cost_per_page" json:"annotation_cost_per_page,omitempty"`
 
+	// Costs - Time of day
+	//
+	// Some providers (e.g. DeepSeek) bill the same model at different rates
+	// depending on when the request is made. The convention is that every base
+	// rate above is the PEAK (higher) price and OffPeakCostMultiplier scales it
+	// down outside the windows declared in PeakHours. Holding the base at peak
+	// means a row that carries a schedule but no multiplier — or one whose
+	// schedule fails to evaluate — bills at the higher rate rather than
+	// silently under-billing.
+	OffPeakCostMultiplier *float64           `gorm:"default:null;column:off_peak_cost_multiplier" json:"off_peak_cost_multiplier,omitempty"`
+	PeakHours             *PeakHoursSchedule `gorm:"type:text;serializer:json;default:null;column:peak_hours" json:"peak_hours,omitempty"`
+
 	// AdditionalAttributes holds editorial per-model metadata (e.g. description,
 	// tags). Persisted as a JSON string in the additional_attributes column and
 	// surfaced as a typed map via BeforeSave/AfterFind. This column is
@@ -165,6 +177,31 @@ type TableModelPricing struct {
 
 // TableName sets the table name for each model
 func (TableModelPricing) TableName() string { return "governance_model_pricing" }
+
+// PeakHoursSchedule declares the windows during which a model is billed at its
+// peak (base) rates. Any instant falling outside every window is off-peak and
+// is discounted by TableModelPricing.OffPeakCostMultiplier.
+//
+// Lives in this package rather than in the datasheet package because
+// TableModelPricing must reference it and datasheet already imports tables;
+// the datasheet package aliases it back out.
+type PeakHoursSchedule struct {
+	// Timezone is an IANA location name (e.g. "UTC", "Asia/Shanghai"). Empty
+	// means UTC.
+	Timezone string            `json:"timezone,omitempty"`
+	Windows  []PeakHoursWindow `json:"windows,omitempty"`
+}
+
+// PeakHoursWindow is one recurring weekly peak-rate window. Start and End are
+// "HH:MM" in the schedule's timezone and describe the half-open interval
+// [Start, End). An End less than or equal to Start wraps past midnight, in
+// which case Days names the weekday the window *starts* on.
+type PeakHoursWindow struct {
+	// Days uses Go's time.Weekday numbering (0 = Sunday .. 6 = Saturday).
+	Days  []int  `json:"days"`
+	Start string `json:"start"`
+	End   string `json:"end"`
+}
 
 // BeforeSave marshals AdditionalAttributes → AdditionalAttributesJSON. A nil
 // or empty map serializes to "{}" so the column always holds a valid JSON

--- a/framework/modelcatalog/datasheet/types.go
+++ b/framework/modelcatalog/datasheet/types.go
@@ -238,7 +238,26 @@ type Options struct {
 	// Costs - OCR
 	OCRCostPerPage        *float64 `json:"ocr_cost_per_page,omitempty"`
 	AnnotationCostPerPage *float64 `json:"annotation_cost_per_page,omitempty"`
+
+	// Costs - Time of day
+	//
+	// OffPeakCostMultiplier scales every usage-based charge when the request
+	// falls outside the PeakHours windows. Every other rate on this struct is
+	// the PEAK price, so the multiplier is expected to be in (0, 1] — 0.5 for
+	// DeepSeek's 50% off-peak discount. Both fields must be present for a
+	// discount to apply; either one alone bills at peak.
+	OffPeakCostMultiplier *float64           `json:"off_peak_cost_multiplier,omitempty"`
+	PeakHours             *PeakHoursSchedule `json:"peak_hours,omitempty"`
 }
+
+// PeakHoursSchedule and PeakHoursWindow are defined in the configstore tables
+// package (TableModelPricing has to reference them and datasheet already
+// imports tables, so the dependency can only run that way). Aliased here so
+// the datasheet JSON shape reads as one self-contained type set.
+type (
+	PeakHoursSchedule = configstoreTables.PeakHoursSchedule
+	PeakHoursWindow   = configstoreTables.PeakHoursWindow
+)
 
 // LookupScopes carries the runtime identifiers used to resolve scoped pricing
 // overrides during cost calculation.
@@ -755,6 +774,9 @@ func convertEntryToTablePricing(modelKey string, entry Entry) configstoreTables.
 
 		OCRCostPerPage:        entry.OCRCostPerPage,
 		AnnotationCostPerPage: entry.AnnotationCostPerPage,
+
+		OffPeakCostMultiplier: entry.OffPeakCostMultiplier,
+		PeakHours:             entry.PeakHours,
 	}
 }
 
@@ -875,6 +897,9 @@ func convertTablePricingToEntry(pricing *configstoreTables.TableModelPricing) *E
 
 		OCRCostPerPage:        pricing.OCRCostPerPage,
 		AnnotationCostPerPage: pricing.AnnotationCostPerPage,
+
+		OffPeakCostMultiplier: pricing.OffPeakCostMultiplier,
+		PeakHours:             pricing.PeakHours,
 	}
 	entry := &Entry{
 		BaseModel:            pricing.BaseModel,


### PR DESCRIPTION
## Summary

Adds support for time-of-day (peak/off-peak) pricing to the model pricing system. Some providers, such as DeepSeek, bill the same model at different rates depending on when a request is made. This introduces `off_peak_cost_multiplier` and `peak_hours` fields that allow the system to represent and persist these schedules, with the convention that all base rates are peak prices and the multiplier scales them down during off-peak windows.

## Changes

- Added `PeakHoursSchedule` and `PeakHoursWindow` types to the configstore tables package, defining recurring weekly windows using IANA timezone names, weekday numbers, and `HH:MM` start/end times. The half-open interval `[Start, End)` supports midnight-wrapping windows.
- Added `OffPeakCostMultiplier` and `PeakHours` fields to `TableModelPricing`, stored as a nullable float and a JSON-serialized text column respectively.
- Aliased `PeakHoursSchedule` and `PeakHoursWindow` into the datasheet package so the JSON shape remains self-contained without introducing a circular import.
- Wired both fields through `convertEntryToTablePricing` and `convertTablePricingToEntry` so datasheet sync round-trips correctly.
- Added `off_peak_cost_multiplier` and `peak_hours` to `pricingSyncUpdateColumns` so ON CONFLICT upserts overwrite stale values.
- Added the `add_time_of_day_pricing_columns` database migration to add both columns to `governance_model_pricing`, with a rollback path.
- Added `TestUpsertModelPricesBatch_TimeOfDayColumns_SurviveResync` to verify that both columns survive a resync upsert and that the `peak_hours` JSON serializer round-trips correctly.

The design intentionally holds base rates at peak prices. A row with a schedule but no multiplier, or one whose schedule fails to evaluate, bills at the higher rate rather than silently under-billing.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/... ./framework/modelcatalog/...
```

The new test `TestUpsertModelPricesBatch_TimeOfDayColumns_SurviveResync` exercises:
- Initial upsert of a row with `off_peak_cost_multiplier` and a two-window `peak_hours` schedule.
- A second upsert simulating a datasheet resync with an updated multiplier value.
- Verification that the updated multiplier is persisted and that the `peak_hours` JSON round-trip preserves timezone, days, and start/end times.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No auth, secrets, PII, or sandboxing implications. The new columns are additive and nullable; existing rows are unaffected.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable