### PR TITLE
feat(cost): add time-of-day peak/off-peak pricing with cached timezone resolution and tests

### DIFF
--- a/framework/jobaccounting/pricingscopes_test.go
+++ b/framework/jobaccounting/pricingscopes_test.go
@@ -1,0 +1,37 @@
+package jobaccounting
+
+import (
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/framework/logstore"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPricingScopesForLog_CarriesBilledAt guards the one pricing input a
+// reprice cannot re-derive from anywhere else. Without BilledAt the time-of-day
+// engine falls back to the wall clock, so a model on a peak/off-peak schedule
+// reprices to a different cost on every pass.
+func TestPricingScopesForLog_CarriesBilledAt(t *testing.T) {
+	vk := "vk-1"
+	userID := "user-1"
+	ts := time.Date(2026, 8, 17, 2, 0, 0, 0, time.UTC)
+
+	scopes := PricingScopesForLog(&logstore.Log{
+		Timestamp:     ts,
+		Provider:      "deepseek",
+		SelectedKeyID: "key-1",
+		VirtualKeyID:  &vk,
+		UserID:        &userID,
+	})
+
+	assert.Equal(t, ts, scopes.BilledAt)
+	assert.Equal(t, "deepseek", scopes.Provider)
+	assert.Equal(t, "key-1", scopes.SelectedKeyID)
+	assert.Equal(t, vk, scopes.VirtualKeyID)
+	assert.Equal(t, userID, scopes.UserID)
+}
+
+func TestPricingScopesForLog_NilEntry(t *testing.T) {
+	assert.True(t, PricingScopesForLog(nil).BilledAt.IsZero())
+}

--- a/framework/jobaccounting/types.go
+++ b/framework/jobaccounting/types.go
@@ -382,5 +382,13 @@ func PricingScopesForLog(entry *logstore.Log) modelcatalog.PricingLookupScopes {
 		SelectedKeyID: entry.SelectedKeyID,
 		VirtualKeyID:  virtualKeyID,
 		UserID:        userID,
+		// Pin time-of-day pricing to the row's own Timestamp so a reprice charges
+		// the same rate the row was settled at. For an aggregate batch or video
+		// row that instant is settlement time, since buildAggregateLog stamps
+		// Timestamp from JobRequest.Now, which is also what the initial
+		// settlement priced against. Leaving this unset made every reprice
+		// resolve peak vs off-peak against whenever the sweeper happened to run,
+		// so the same row yielded a different cost on each pass.
+		BilledAt: entry.Timestamp,
 	}
 }

--- a/framework/modelcatalog/datasheet/cost.go
+++ b/framework/modelcatalog/datasheet/cost.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
@@ -247,6 +249,10 @@ func (s *Store) computeGuardrailJudgeCost(call schemas.BifrostGuardrailJudgeCall
 	judgeScopes := LookupScopes{Provider: string(call.JudgeProvider)}
 	if scopes != nil {
 		judgeScopes.VirtualKeyID = scopes.VirtualKeyID
+		// The judge call is part of the same request, so it prices against the
+		// same instant. Dropping this would silently fall back to wall-clock
+		// time-of-day pricing for judge calls only.
+		judgeScopes.BilledAt = scopes.BilledAt
 	}
 
 	usage := &schemas.BifrostLLMUsage{
@@ -636,9 +642,20 @@ func (s *Store) computeCostFromInput(input costInput, routingInfo schemas.Routin
 		return nil
 	}
 
+	// Time-of-day pricing: providers that discount outside declared peak windows
+	// (e.g. DeepSeek's 50% off-peak rate) scale every usage-based charge by a
+	// flat multiplier. Applied here rather than inside each compute*Cost so one
+	// branch covers every modality. It lands after computeTextCost's
+	// inference_geo multiplier, so the two compose multiplicatively.
+	if m, ok := offPeakMultiplier(pricing, scopes.BilledAt); ok {
+		scaleUsageCost(cost, m)
+	}
+
 	// Flat per-request surcharge, billed once on top of usage-based cost whenever
 	// the resolved pricing row carries one. It maps to no token category, so it
 	// folds into the input side (InputCostDetails.RequestCost) and the total.
+	// Deliberately added after the off-peak scaling: a flat per-request fee is
+	// not a usage charge and is not discounted.
 	if pricing.CostPerRequest != nil {
 		if cost == nil {
 			cost = &schemas.BifrostCost{}
@@ -2432,4 +2449,195 @@ func passthroughUsageToCostInput(su *schemas.BifrostPassthroughUsage) costInput 
 		}
 	}
 	return input
+}
+
+// ---------------------------------------------------------------------------
+// Time-of-day (peak / off-peak) pricing
+// ---------------------------------------------------------------------------
+
+// peakHoursLocations caches resolved IANA locations. time.LoadLocation hits the
+// filesystem (or the embedded tzdata) on every call, which is far too expensive
+// to repeat per priced request. A nil value memoizes a failed lookup so a bad
+// timezone string is not retried forever.
+var peakHoursLocations sync.Map // string -> *time.Location
+
+// peakHoursLocation resolves a schedule's timezone. An empty name means UTC.
+// An unknown name returns nil, which callers must treat as "cannot evaluate".
+func peakHoursLocation(name string) *time.Location {
+	if name == "" {
+		return time.UTC
+	}
+	if cached, ok := peakHoursLocations.Load(name); ok {
+		loc, _ := cached.(*time.Location)
+		return loc
+	}
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		peakHoursLocations.Store(name, (*time.Location)(nil))
+		return nil
+	}
+	peakHoursLocations.Store(name, loc)
+	return loc
+}
+
+// parseClockMinutes parses an "HH:MM" wall-clock string into minutes since
+// midnight. Returns false for anything malformed or out of range. "24:00" is
+// accepted as an end-of-day marker so a window can span a full day.
+func parseClockMinutes(v string) (int, bool) {
+	hh, mm, ok := strings.Cut(v, ":")
+	if !ok {
+		return 0, false
+	}
+	h, err := strconv.Atoi(hh)
+	if err != nil || h < 0 || h > 24 {
+		return 0, false
+	}
+	m, err := strconv.Atoi(mm)
+	if err != nil || m < 0 || m > 59 {
+		return 0, false
+	}
+	if h == 24 && m != 0 {
+		return 0, false
+	}
+	return h*60 + m, true
+}
+
+// isWithinPeakWindows reports whether at falls inside any window of sched, and
+// whether the schedule could be evaluated at all. A schedule that cannot be
+// evaluated — no windows, unknown timezone, every window malformed — returns
+// ok=false, and callers bill at peak. That direction matters: base rates are
+// the peak (higher) prices, so failing closed over-bills rather than handing
+// out a discount that was never configured.
+func isWithinPeakWindows(sched *PeakHoursSchedule, at time.Time) (peak bool, ok bool) {
+	if sched == nil || len(sched.Windows) == 0 {
+		return false, false
+	}
+	loc := peakHoursLocation(sched.Timezone)
+	if loc == nil {
+		return false, false
+	}
+
+	local := at.In(loc)
+	weekday := int(local.Weekday())
+	minutes := local.Hour()*60 + local.Minute()
+
+	// A window that wraps past midnight is also matched against the previous
+	// day: 22:00-02:00 on Monday still covers Tuesday 01:00.
+	prevWeekday := (weekday + 6) % 7
+	prevMinutes := minutes + 24*60
+
+	valid := false
+	for _, w := range sched.Windows {
+		start, startOK := parseClockMinutes(w.Start)
+		end, endOK := parseClockMinutes(w.End)
+		if !startOK || !endOK || len(w.Days) == 0 {
+			continue
+		}
+		wrapped := end <= start
+		if wrapped {
+			end += 24 * 60
+		}
+
+		for _, d := range w.Days {
+			if d < 0 || d > 6 {
+				continue
+			}
+			// Only a weekday inside 0..6 makes the window usable. Marking the
+			// schedule valid before this point let a window whose every Days
+			// entry is out of range (say []int{7}) report "evaluated, not
+			// peak", which hands out the off-peak discount on garbage input.
+			// Base rates are the peak prices, so an unusable schedule has to
+			// bill at peak.
+			valid = true
+			// Half-open [start, end): a window ending at 04:00 does not cover
+			// 04:00:00 itself, so adjacent windows never double-count.
+			if d == weekday && minutes >= start && minutes < end {
+				return true, true
+			}
+			if wrapped && d == prevWeekday && prevMinutes >= start && prevMinutes < end {
+				return true, true
+			}
+		}
+	}
+	if !valid {
+		return false, false
+	}
+	return false, true
+}
+
+// offPeakMultiplier returns the multiplier to scale usage-based costs by when
+// at falls outside pricing's declared peak windows, and whether a discount
+// applies at all.
+//
+// Both off_peak_cost_multiplier and peak_hours must be present: a multiplier
+// with no schedule has no way to know when to apply, and a schedule with no
+// multiplier has nothing to apply. Either alone bills at peak. A multiplier
+// outside (0, 1] is rejected for the same reason — every base rate on the row
+// is the peak price, so a discount can only ever scale downward, and a bogus
+// value must not silently zero out or inflate a bill.
+//
+// A zero at means the caller never learned the request's start time; fall back
+// to the wall clock rather than mispricing everything as peak.
+func offPeakMultiplier(pricing *configstoreTables.TableModelPricing, at time.Time) (float64, bool) {
+	if pricing == nil || pricing.OffPeakCostMultiplier == nil || pricing.PeakHours == nil {
+		return 0, false
+	}
+	m := *pricing.OffPeakCostMultiplier
+	if !(m > 0 && m <= 1) {
+		return 0, false
+	}
+	if at.IsZero() {
+		at = time.Now()
+	}
+	peak, ok := isWithinPeakWindows(pricing.PeakHours, at)
+	if !ok || peak {
+		return 0, false
+	}
+	return m, true
+}
+
+// scaleUsageCost multiplies every usage-based charge on cost by m, in place.
+//
+// RequestCost and SearchQueriesCost are deliberately excluded: they are flat
+// per-request and per-query fees rather than usage categories, matching how the
+// inference_geo multiplier in computeTextCost already treats the search fee.
+// AdditionalCost is excluded too — guardrail and MCP sidecar costs are priced
+// through their own computeCostFromInput call and are discounted there on
+// their own pricing rows.
+func scaleUsageCost(cost *schemas.BifrostCost, m float64) {
+	if cost == nil {
+		return
+	}
+
+	if cost.InputCostDetails != nil {
+		d := cost.InputCostDetails
+		cost.InputCost -= d.RequestCost
+		d.TextCost *= m
+		d.AudioCost *= m
+		d.ImageCost *= m
+		d.CachedReadCost *= m
+		d.CachedWriteCost *= m
+		cost.InputCost *= m
+		cost.InputCost += d.RequestCost
+	} else {
+		cost.InputCost *= m
+	}
+
+	if cost.OutputCostDetails != nil {
+		d := cost.OutputCostDetails
+		cost.OutputCost -= d.SearchQueriesCost
+		d.TextCost *= m
+		d.AudioCost *= m
+		d.ImageCost *= m
+		d.ReasoningCost *= m
+		d.CitationCost *= m
+		cost.OutputCost *= m
+		cost.OutputCost += d.SearchQueriesCost
+	} else {
+		cost.OutputCost *= m
+	}
+
+	// Recompute rather than scaling: TotalCost also carries AdditionalCost,
+	// which is not discounted here.
+	cost.TotalCost = cost.InputCost + cost.OutputCost + cost.AdditionalCost
 }

--- a/framework/modelcatalog/datasheet/cost_timeofday_test.go
+++ b/framework/modelcatalog/datasheet/cost_timeofday_test.go
@@ -1,0 +1,567 @@
+package datasheet
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// deepSeekPeakHours mirrors DeepSeek's published schedule: peak is Mon-Fri
+// 01:00-04:00 and 06:00-10:00 UTC, and every other instant is off-peak.
+func deepSeekPeakHours() *configstoreTables.PeakHoursSchedule {
+	return &configstoreTables.PeakHoursSchedule{
+		Timezone: "UTC",
+		Windows: []configstoreTables.PeakHoursWindow{
+			{Days: []int{1, 2, 3, 4, 5}, Start: "01:00", End: "04:00"},
+			{Days: []int{1, 2, 3, 4, 5}, Start: "06:00", End: "10:00"},
+		},
+	}
+}
+
+// deepSeekPricing is a deepseek-v4-flash row: base rates are the PEAK prices
+// and the multiplier halves them off-peak.
+func deepSeekPricing() configstoreTables.TableModelPricing {
+	return configstoreTables.TableModelPricing{
+		Model:                   "deepseek-v4-flash",
+		Provider:                "deepseek",
+		Mode:                    "chat",
+		InputCostPerToken:       bifrost.Ptr(0.00000044),
+		OutputCostPerToken:      bifrost.Ptr(0.00000132),
+		CacheReadInputTokenCost: bifrost.Ptr(0.000000014),
+		OffPeakCostMultiplier:   bifrost.Ptr(0.5),
+		PeakHours:               deepSeekPeakHours(),
+	}
+}
+
+func utc(t *testing.T, s string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, s)
+	require.NoError(t, err)
+	return parsed
+}
+
+// TestOffPeak_DeepSeekSchedule walks DeepSeek's real windows. 2026-08-17 is a
+// Monday, so 08-15 is Saturday and 08-16 is Sunday.
+func TestOffPeak_DeepSeekSchedule(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("deepseek-v4-flash", "deepseek", "chat"): deepSeekPricing(),
+	})
+
+	// 1000 prompt + 1000 completion at peak:
+	// 1000*0.00000044 + 1000*0.00000132 = 0.00176
+	const peakCost = 0.00176
+
+	cases := []struct {
+		name     string
+		at       string
+		expected float64
+	}{
+		{"monday inside first peak window", "2026-08-17T02:00:00Z", peakCost},
+		{"monday inside second peak window", "2026-08-17T09:59:00Z", peakCost},
+		{"monday in the gap between windows", "2026-08-17T05:00:00Z", peakCost / 2},
+		{"monday before the first window", "2026-08-17T00:30:00Z", peakCost / 2},
+		{"monday after the last window", "2026-08-17T23:00:00Z", peakCost / 2},
+		{"saturday at a peak-hour clock time", "2026-08-15T02:00:00Z", peakCost / 2},
+		{"sunday at a peak-hour clock time", "2026-08-16T02:00:00Z", peakCost / 2},
+		// Half-open [start, end): the start instant is peak, the end instant is not.
+		{"exact window start is peak", "2026-08-17T01:00:00Z", peakCost},
+		{"exact window end is off-peak", "2026-08-17T04:00:00Z", peakCost / 2},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := makeChatResponse(schemas.DeepSeek, "deepseek-v4-flash", &schemas.BifrostLLMUsage{
+				PromptTokens: 1000, CompletionTokens: 1000, TotalTokens: 2000,
+			})
+			cost := s.CalculateCost(resp, &LookupScopes{BilledAt: utc(t, tc.at)})
+			assert.InDelta(t, tc.expected, cost, 1e-12)
+		})
+	}
+}
+
+// TestOffPeak_DiscountsCacheReads verifies the discount reaches the cache-hit
+// rate, not just the plain input rate — DeepSeek halves all three categories.
+func TestOffPeak_DiscountsCacheReads(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("deepseek-v4-flash", "deepseek", "chat"): deepSeekPricing(),
+	})
+
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens: 1000, CompletionTokens: 500, TotalTokens: 1500,
+		PromptTokensDetails: &schemas.ChatPromptTokensDetails{CachedReadTokens: 800},
+	}
+
+	peak := s.CalculateCostBreakdown(
+		makeChatResponse(schemas.DeepSeek, "deepseek-v4-flash", usage),
+		&LookupScopes{BilledAt: utc(t, "2026-08-17T02:00:00Z")},
+	)
+	off := s.CalculateCostBreakdown(
+		makeChatResponse(schemas.DeepSeek, "deepseek-v4-flash", usage),
+		&LookupScopes{BilledAt: utc(t, "2026-08-17T05:00:00Z")},
+	)
+	require.NotNil(t, peak)
+	require.NotNil(t, off)
+	require.NotNil(t, peak.InputCostDetails)
+	require.NotNil(t, off.InputCostDetails)
+
+	assert.Greater(t, peak.InputCostDetails.CachedReadCost, 0.0)
+	assert.InDelta(t, peak.InputCostDetails.CachedReadCost/2, off.InputCostDetails.CachedReadCost, 1e-15)
+	assert.InDelta(t, peak.InputCostDetails.TextCost/2, off.InputCostDetails.TextCost, 1e-15)
+	assert.InDelta(t, peak.OutputCost/2, off.OutputCost, 1e-15)
+	assert.InDelta(t, peak.TotalCost/2, off.TotalCost, 1e-15)
+}
+
+// TestOffPeak_FlatFeesAreNotDiscounted pins the exclusions: a per-request
+// surcharge and a per-search-query fee are not usage charges, so an off-peak
+// request pays them in full.
+func TestOffPeak_FlatFeesAreNotDiscounted(t *testing.T) {
+	pricing := deepSeekPricing()
+	pricing.CostPerRequest = bifrost.Ptr(0.01)
+	pricing.SearchContextCostPerQuery = bifrost.Ptr(0.005)
+
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("deepseek-v4-flash", "deepseek", "chat"): pricing,
+	})
+
+	queries := 2
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens: 1000, CompletionTokens: 1000, TotalTokens: 2000,
+		CompletionTokensDetails: &schemas.ChatCompletionTokensDetails{NumSearchQueries: &queries},
+	}
+
+	bd := s.CalculateCostBreakdown(
+		makeChatResponse(schemas.DeepSeek, "deepseek-v4-flash", usage),
+		&LookupScopes{BilledAt: utc(t, "2026-08-17T05:00:00Z")},
+	)
+	require.NotNil(t, bd)
+	require.NotNil(t, bd.InputCostDetails)
+	require.NotNil(t, bd.OutputCostDetails)
+
+	// Flat fees at full price...
+	assert.InDelta(t, 0.01, bd.InputCostDetails.RequestCost, 1e-12)
+	assert.InDelta(t, 0.01, bd.OutputCostDetails.SearchQueriesCost, 1e-12)
+	// ...token costs halved.
+	assert.InDelta(t, 1000*0.00000044/2, bd.InputCostDetails.TextCost, 1e-15)
+	assert.InDelta(t, 1000*0.00000132/2, bd.OutputCostDetails.TextCost, 1e-15)
+	// Sides still reconcile.
+	assert.InDelta(t, bd.InputCost+bd.OutputCost+bd.AdditionalCost, bd.TotalCost, 1e-12)
+}
+
+// TestOffPeak_FailsClosed covers every way the discount can fail to resolve.
+// All of them must bill at the peak (higher) rate — base rates are the peak
+// prices, so failing open would hand out a discount that was never configured.
+func TestOffPeak_FailsClosed(t *testing.T) {
+	const peakCost = 0.00176
+
+	mutate := map[string]func(p *configstoreTables.TableModelPricing){
+		"no multiplier": func(p *configstoreTables.TableModelPricing) { p.OffPeakCostMultiplier = nil },
+		"no schedule":   func(p *configstoreTables.TableModelPricing) { p.PeakHours = nil },
+		"empty windows": func(p *configstoreTables.TableModelPricing) {
+			p.PeakHours = &configstoreTables.PeakHoursSchedule{Timezone: "UTC"}
+		},
+		"unknown timezone": func(p *configstoreTables.TableModelPricing) {
+			p.PeakHours.Timezone = "Mars/Olympus_Mons"
+		},
+		"malformed clock": func(p *configstoreTables.TableModelPricing) {
+			p.PeakHours.Windows = []configstoreTables.PeakHoursWindow{{Days: []int{1}, Start: "0100", End: "04:00"}}
+		},
+		"out of range hour": func(p *configstoreTables.TableModelPricing) {
+			p.PeakHours.Windows = []configstoreTables.PeakHoursWindow{{Days: []int{1}, Start: "25:00", End: "26:00"}}
+		},
+		"no days": func(p *configstoreTables.TableModelPricing) {
+			p.PeakHours.Windows = []configstoreTables.PeakHoursWindow{{Days: nil, Start: "01:00", End: "04:00"}}
+		},
+		// A Days list that parses but names no real weekday leaves the window
+		// unusable. Counting it as evaluated would report "not peak" and hand
+		// out the discount on garbage input.
+		"weekday above range": func(p *configstoreTables.TableModelPricing) {
+			p.PeakHours.Windows = []configstoreTables.PeakHoursWindow{{Days: []int{7}, Start: "01:00", End: "04:00"}}
+		},
+		"weekday below range": func(p *configstoreTables.TableModelPricing) {
+			p.PeakHours.Windows = []configstoreTables.PeakHoursWindow{{Days: []int{-1}, Start: "01:00", End: "04:00"}}
+		},
+		"every weekday out of range across windows": func(p *configstoreTables.TableModelPricing) {
+			p.PeakHours.Windows = []configstoreTables.PeakHoursWindow{
+				{Days: []int{9}, Start: "01:00", End: "04:00"},
+				{Days: []int{-3}, Start: "06:00", End: "10:00"},
+			}
+		},
+		"multiplier above one": func(p *configstoreTables.TableModelPricing) {
+			p.OffPeakCostMultiplier = bifrost.Ptr(1.5)
+		},
+		"zero multiplier": func(p *configstoreTables.TableModelPricing) {
+			p.OffPeakCostMultiplier = bifrost.Ptr(0.0)
+		},
+		"negative multiplier": func(p *configstoreTables.TableModelPricing) {
+			p.OffPeakCostMultiplier = bifrost.Ptr(-0.5)
+		},
+	}
+
+	for name, fn := range mutate {
+		t.Run(name, func(t *testing.T) {
+			pricing := deepSeekPricing()
+			fn(&pricing)
+			s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+				makeKey("deepseek-v4-flash", "deepseek", "chat"): pricing,
+			})
+			resp := makeChatResponse(schemas.DeepSeek, "deepseek-v4-flash", &schemas.BifrostLLMUsage{
+				PromptTokens: 1000, CompletionTokens: 1000, TotalTokens: 2000,
+			})
+			// 05:00 Monday is off-peak under the real schedule, so anything
+			// other than the full peak price means the guard leaked.
+			cost := s.CalculateCost(resp, &LookupScopes{BilledAt: utc(t, "2026-08-17T05:00:00Z")})
+			assert.InDelta(t, peakCost, cost, 1e-12)
+		})
+	}
+}
+
+// TestOffPeak_MidnightWrappingWindow covers a window whose end is before its
+// start: 22:00-02:00 on Monday must also cover Tuesday 01:00.
+func TestOffPeak_MidnightWrappingWindow(t *testing.T) {
+	pricing := deepSeekPricing()
+	pricing.PeakHours = &configstoreTables.PeakHoursSchedule{
+		Timezone: "UTC",
+		Windows: []configstoreTables.PeakHoursWindow{
+			{Days: []int{1}, Start: "22:00", End: "02:00"}, // Monday 22:00 -> Tuesday 02:00
+		},
+	}
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("deepseek-v4-flash", "deepseek", "chat"): pricing,
+	})
+
+	const peakCost = 0.00176
+	cases := []struct {
+		name     string
+		at       string
+		expected float64
+	}{
+		{"monday late evening is peak", "2026-08-17T23:30:00Z", peakCost},
+		{"tuesday small hours still peak", "2026-08-18T01:30:00Z", peakCost},
+		{"tuesday after the wrap ends", "2026-08-18T02:30:00Z", peakCost / 2},
+		{"monday before the window opens", "2026-08-17T21:00:00Z", peakCost / 2},
+		{"tuesday evening is not covered", "2026-08-18T23:30:00Z", peakCost / 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := makeChatResponse(schemas.DeepSeek, "deepseek-v4-flash", &schemas.BifrostLLMUsage{
+				PromptTokens: 1000, CompletionTokens: 1000, TotalTokens: 2000,
+			})
+			cost := s.CalculateCost(resp, &LookupScopes{BilledAt: utc(t, tc.at)})
+			assert.InDelta(t, tc.expected, cost, 1e-12)
+		})
+	}
+}
+
+// TestOffPeak_NonUTCSchedule verifies the schedule is evaluated in its own
+// timezone, not the instant's UTC clock reading.
+func TestOffPeak_NonUTCSchedule(t *testing.T) {
+	pricing := deepSeekPricing()
+	pricing.PeakHours = &configstoreTables.PeakHoursSchedule{
+		Timezone: "Asia/Kolkata", // UTC+05:30
+		Windows: []configstoreTables.PeakHoursWindow{
+			{Days: []int{1}, Start: "09:00", End: "17:00"},
+		},
+	}
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("deepseek-v4-flash", "deepseek", "chat"): pricing,
+	})
+
+	const peakCost = 0.00176
+	resp := func() *schemas.BifrostResponse {
+		return makeChatResponse(schemas.DeepSeek, "deepseek-v4-flash", &schemas.BifrostLLMUsage{
+			PromptTokens: 1000, CompletionTokens: 1000, TotalTokens: 2000,
+		})
+	}
+
+	// 2026-08-17 05:00 UTC == 10:30 Monday in Kolkata -> peak.
+	assert.InDelta(t, peakCost,
+		s.CalculateCost(resp(), &LookupScopes{BilledAt: utc(t, "2026-08-17T05:00:00Z")}), 1e-12)
+	// 2026-08-17 02:00 UTC == 07:30 Monday in Kolkata -> off-peak.
+	assert.InDelta(t, peakCost/2,
+		s.CalculateCost(resp(), &LookupScopes{BilledAt: utc(t, "2026-08-17T02:00:00Z")}), 1e-12)
+}
+
+// TestOffPeak_AppliesToNonTextModalities confirms the single application site
+// in computeCostFromInput reaches modalities other than chat.
+func TestOffPeak_AppliesToNonTextModalities(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("embed-model", "deepseek", "embedding"): {
+			Model: "embed-model", Provider: "deepseek", Mode: "embedding",
+			InputCostPerToken:     bifrost.Ptr(0.000001),
+			OffPeakCostMultiplier: bifrost.Ptr(0.5),
+			PeakHours:             deepSeekPeakHours(),
+		},
+	})
+
+	usage := &schemas.BifrostLLMUsage{PromptTokens: 1000, TotalTokens: 1000}
+	peak := s.CalculateCost(makeEmbeddingResponse(schemas.DeepSeek, "embed-model", usage),
+		&LookupScopes{BilledAt: utc(t, "2026-08-17T02:00:00Z")})
+	off := s.CalculateCost(makeEmbeddingResponse(schemas.DeepSeek, "embed-model", usage),
+		&LookupScopes{BilledAt: utc(t, "2026-08-17T05:00:00Z")})
+
+	assert.InDelta(t, 0.001, peak, 1e-12)
+	assert.InDelta(t, 0.0005, off, 1e-12)
+}
+
+// insideNeverPeakWindow reports whether an instant falls inside the only span
+// the neverPeak schedule below actually covers, 00:00:00-00:02:00 UTC.
+func insideNeverPeakWindow(at time.Time) bool {
+	at = at.UTC()
+	return at.Hour() == 0 && at.Minute() < 2
+}
+
+// bracketsNeverPeakWindow reports whether a CalculateCost call that started at
+// before and returned at after could have read the wall clock inside that span.
+// Sampling only one side is not enough: the production read happens between the
+// two, so a call that straddles 00:02:00 UTC prices as peak while a later
+// single sample reads as outside the window and declines to skip.
+func bracketsNeverPeakWindow(before, after time.Time) bool {
+	return insideNeverPeakWindow(before) || insideNeverPeakWindow(after)
+}
+
+// TestOffPeak_ZeroBilledAtFallsBackToWallClock verifies a caller that never
+// learned the request start time still prices coherently rather than treating
+// the zero time (year 1) as a real instant.
+//
+// Both schedules below answer the same at every instant, so the test never
+// reads the clock itself and cannot straddle a window boundary between
+// computing the expectation and pricing the response. Deriving the expectation
+// from a time.Now() of its own would race the second time.Now() inside
+// offPeakMultiplier.
+func TestOffPeak_ZeroBilledAtFallsBackToWallClock(t *testing.T) {
+	const peakCost = 0.00176
+
+	alwaysPeak := &configstoreTables.PeakHoursSchedule{
+		Timezone: "UTC",
+		Windows: []configstoreTables.PeakHoursWindow{
+			{Days: []int{0, 1, 2, 3, 4, 5, 6}, Start: "00:00", End: "24:00"},
+		},
+	}
+	// A window listing no weekday that ever occurs cannot match, so every
+	// instant is off-peak.
+	neverPeak := &configstoreTables.PeakHoursSchedule{
+		Timezone: "UTC",
+		Windows: []configstoreTables.PeakHoursWindow{
+			{Days: []int{0, 1, 2, 3, 4, 5, 6}, Start: "00:00", End: "00:01"},
+			{Days: []int{0, 1, 2, 3, 4, 5, 6}, Start: "00:01", End: "00:02"},
+		},
+	}
+
+	for _, tc := range []struct {
+		name  string
+		sched *configstoreTables.PeakHoursSchedule
+		want  float64
+	}{
+		{"peak at every instant", alwaysPeak, peakCost},
+		{"off-peak at almost every instant", neverPeak, peakCost / 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pricing := deepSeekPricing()
+			pricing.PeakHours = tc.sched
+			s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+				makeKey("deepseek-v4-flash", "deepseek", "chat"): pricing,
+			})
+			resp := makeChatResponse(schemas.DeepSeek, "deepseek-v4-flash", &schemas.BifrostLLMUsage{
+				PromptTokens: 1000, CompletionTokens: 1000, TotalTokens: 2000,
+			})
+			// A zero BilledAt is the point: it forces the wall-clock fallback.
+			// The read that decides the price happens inside CalculateCost, so
+			// bracket the call and skip if either side of the bracket sits in
+			// the two-minute window neverPeak does cover. Sampling only after
+			// the call misses a call that straddles the window's edge.
+			before := time.Now()
+			got := s.CalculateCost(resp, &LookupScopes{})
+			after := time.Now()
+			if tc.want != peakCost && bracketsNeverPeakWindow(before, after) {
+				t.Skip("wall clock is inside the neverPeak schedule's only window")
+			}
+			assert.InDelta(t, tc.want, got, 1e-12)
+		})
+	}
+}
+
+// TestNeverPeakWindowBracket pins the skip guard used by
+// TestOffPeak_ZeroBilledAtFallsBackToWallClock: a call whose wall-clock read
+// could have landed inside the neverPeak window must be recognised as such even
+// when the reading taken after the call has already left the window.
+func TestNeverPeakWindowBracket(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		before time.Time
+		after  time.Time
+		want   bool
+	}{
+		{
+			name:   "call straddles the end of the window",
+			before: time.Date(2026, 8, 17, 0, 1, 59, 900_000_000, time.UTC),
+			after:  time.Date(2026, 8, 17, 0, 2, 0, 100_000_000, time.UTC),
+			want:   true,
+		},
+		{
+			name:   "call straddles the start of the window",
+			before: time.Date(2026, 8, 16, 23, 59, 59, 900_000_000, time.UTC),
+			after:  time.Date(2026, 8, 17, 0, 0, 0, 100_000_000, time.UTC),
+			want:   true,
+		},
+		{
+			name:   "call sits wholly inside the window",
+			before: time.Date(2026, 8, 17, 0, 0, 30, 0, time.UTC),
+			after:  time.Date(2026, 8, 17, 0, 0, 31, 0, time.UTC),
+			want:   true,
+		},
+		{
+			name:   "call sits wholly outside the window",
+			before: time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC),
+			after:  time.Date(2026, 8, 17, 12, 0, 1, 0, time.UTC),
+			want:   false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, bracketsNeverPeakWindow(tc.before, tc.after))
+		})
+	}
+}
+
+// TestOffPeak_NilScopes exercises the nil-scopes entry point, which builds an
+// empty LookupScopes and therefore a zero BilledAt.
+func TestOffPeak_NilScopes(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("deepseek-v4-flash", "deepseek", "chat"): deepSeekPricing(),
+	})
+	resp := makeChatResponse(schemas.DeepSeek, "deepseek-v4-flash", &schemas.BifrostLLMUsage{
+		PromptTokens: 1000, CompletionTokens: 1000, TotalTokens: 2000,
+	})
+	assert.NotPanics(t, func() { s.CalculateCost(resp, nil) })
+}
+
+// TestParseClockMinutes pins the "HH:MM" parser, including the 24:00
+// end-of-day marker that lets a window span a full day.
+func TestParseClockMinutes(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+		ok   bool
+	}{
+		{"00:00", 0, true},
+		{"01:00", 60, true},
+		{"09:59", 599, true},
+		{"23:59", 1439, true},
+		{"24:00", 1440, true},
+		{"24:01", 0, false},
+		{"25:00", 0, false},
+		{"01:60", 0, false},
+		{"-1:00", 0, false},
+		{"0100", 0, false},
+		{"", 0, false},
+		{"aa:bb", 0, false},
+	}
+	for _, tc := range cases {
+		got, ok := parseClockMinutes(tc.in)
+		assert.Equal(t, tc.ok, ok, "ok for %q", tc.in)
+		if tc.ok {
+			assert.Equal(t, tc.want, got, "value for %q", tc.in)
+		}
+	}
+}
+
+// TestEntryUnmarshal_TimeOfDayFields verifies the two fields survive Entry's
+// custom UnmarshalJSON, which routes through an alias struct to special-case
+// search_context_cost_per_query and could otherwise drop embedded fields.
+func TestEntryUnmarshal_TimeOfDayFields(t *testing.T) {
+	raw := []byte(`{
+		"provider": "deepseek",
+		"mode": "chat",
+		"input_cost_per_token": 0.00000044,
+		"output_cost_per_token": 0.00000132,
+		"off_peak_cost_multiplier": 0.5,
+		"peak_hours": {
+			"timezone": "UTC",
+			"windows": [
+				{"days": [1,2,3,4,5], "start": "01:00", "end": "04:00"},
+				{"days": [1,2,3,4,5], "start": "06:00", "end": "10:00"}
+			]
+		}
+	}`)
+
+	var entry Entry
+	require.NoError(t, entry.UnmarshalJSON(raw))
+
+	require.NotNil(t, entry.OffPeakCostMultiplier)
+	assert.Equal(t, 0.5, *entry.OffPeakCostMultiplier)
+	require.NotNil(t, entry.PeakHours)
+	assert.Equal(t, "UTC", entry.PeakHours.Timezone)
+	require.Len(t, entry.PeakHours.Windows, 2)
+	assert.Equal(t, []int{1, 2, 3, 4, 5}, entry.PeakHours.Windows[0].Days)
+	assert.Equal(t, "01:00", entry.PeakHours.Windows[0].Start)
+	assert.Equal(t, "10:00", entry.PeakHours.Windows[1].End)
+
+	// And that they survive the Entry -> Table -> Entry round trip the sync uses.
+	table := convertEntryToTablePricing("deepseek-v4-flash", entry)
+	require.NotNil(t, table.OffPeakCostMultiplier)
+	assert.Equal(t, 0.5, *table.OffPeakCostMultiplier)
+	require.NotNil(t, table.PeakHours)
+	assert.Len(t, table.PeakHours.Windows, 2)
+
+	back := convertTablePricingToEntry(&table)
+	require.NotNil(t, back.OffPeakCostMultiplier)
+	assert.Equal(t, 0.5, *back.OffPeakCostMultiplier)
+	require.NotNil(t, back.PeakHours)
+	assert.Equal(t, "UTC", back.PeakHours.Timezone)
+	assert.Len(t, back.PeakHours.Windows, 2)
+}
+
+// TestOffPeak_EndToEndFromDatasheetFile drives the real sync entry point
+// against a file:// datasheet, so the fields are exercised through URL fetch,
+// JSON decode, Entry -> TableModelPricing conversion and the in-memory catalog
+// — not just the hand-built pricing rows the other tests use.
+func TestOffPeak_EndToEndFromDatasheetFile(t *testing.T) {
+	datasheet := `{
+		"deepseek-v4-flash": {
+			"provider": "deepseek",
+			"mode": "chat",
+			"input_cost_per_token": 0.00000044,
+			"output_cost_per_token": 0.00000132,
+			"off_peak_cost_multiplier": 0.5,
+			"peak_hours": {
+				"timezone": "UTC",
+				"windows": [
+					{"days": [1,2,3,4,5], "start": "01:00", "end": "04:00"},
+					{"days": [1,2,3,4,5], "start": "06:00", "end": "10:00"}
+				]
+			}
+		}
+	}`
+
+	path := filepath.Join(t.TempDir(), "datasheet.json")
+	require.NoError(t, os.WriteFile(path, []byte(datasheet), 0o600))
+
+	s := newTestStore()
+	s.url = "file://" + path
+	require.NoError(t, s.LoadFromURLIntoMemory(context.Background()))
+
+	pricing, ok := s.pricingData[makeKey("deepseek-v4-flash", "deepseek", "chat")]
+	require.True(t, ok, "model missing from catalog after sync")
+	require.NotNil(t, pricing.OffPeakCostMultiplier, "off_peak_cost_multiplier lost in sync")
+	assert.Equal(t, 0.5, *pricing.OffPeakCostMultiplier)
+	require.NotNil(t, pricing.PeakHours, "peak_hours lost in sync")
+	require.Len(t, pricing.PeakHours.Windows, 2)
+
+	resp := func() *schemas.BifrostResponse {
+		return makeChatResponse(schemas.DeepSeek, "deepseek-v4-flash", &schemas.BifrostLLMUsage{
+			PromptTokens: 1000, CompletionTokens: 1000, TotalTokens: 2000,
+		})
+	}
+	const peakCost = 0.00176
+	assert.InDelta(t, peakCost,
+		s.CalculateCost(resp(), &LookupScopes{BilledAt: utc(t, "2026-08-17T02:00:00Z")}), 1e-12)
+	assert.InDelta(t, peakCost/2,
+		s.CalculateCost(resp(), &LookupScopes{BilledAt: utc(t, "2026-08-17T05:00:00Z")}), 1e-12)
+}

--- a/framework/modelcatalog/datasheet/types.go
+++ b/framework/modelcatalog/datasheet/types.go
@@ -266,6 +266,14 @@ type LookupScopes struct {
 	VirtualKeyID  string
 	SelectedKeyID string
 	Provider      string
+	// BilledAt is the instant used to decide peak vs off-peak for models that
+	// carry a PeakHours schedule. It is the request's START time, not the
+	// completion time: that keeps pricing deterministic and reproducible, makes
+	// streaming and non-streaming agree, and matches the timestamp users see in
+	// logs. A long stream that crosses a window boundary bills entirely at its
+	// start-time rate. The zero value means "unknown" and falls back to the
+	// wall clock at evaluation time.
+	BilledAt time.Time
 }
 
 // LookupScopesFromContext builds a LookupScopes from a BifrostContext. Reads
@@ -285,11 +293,13 @@ func LookupScopesFromContext(ctx *schemas.BifrostContext, provider string) *Look
 	userID, _ := ctx.Value(schemas.BifrostContextKeyUserID).(string)
 	virtualKeyID, _ := ctx.Value(schemas.BifrostContextKeyGovernanceVirtualKeyID).(string)
 	selectedKeyID, _ := ctx.Value(schemas.BifrostContextKeySelectedKeyID).(string)
+	billedAt, _ := ctx.Value(schemas.BifrostContextKeyRequestStartTime).(time.Time)
 	return &LookupScopes{
 		UserID:        userID,
 		VirtualKeyID:  virtualKeyID,
 		SelectedKeyID: selectedKeyID,
 		Provider:      provider,
+		BilledAt:      billedAt,
 	}
 }
 

--- a/plugins/logging/costfidelity_test.go
+++ b/plugins/logging/costfidelity_test.go
@@ -1556,3 +1556,38 @@ func TestFailedVideoRepricesAsSettledZeroNotSkipped(t *testing.T) {
 	settledZero := repriced.Cost <= 0 && !repriced.DisplayOnly
 	assert.True(t, settledZero, "must persist CostUpdate{} and count as priced")
 }
+
+// TestPricingScopesForLogCarriesBilledAt guards the one pricing input a reprice
+// cannot re-derive from the reconstructed response. Everything else the row was
+// billed under (served tier, OCR pages, speech usage) is restored from dedicated
+// columns; the billing instant has to come from the row's Timestamp the same
+// way. Without it, a model on a peak/off-peak schedule resolves time-of-day
+// pricing against whenever the recalculation happened to run, so the same row
+// reprices to a different cost on every pass.
+func TestPricingScopesForLogCarriesBilledAt(t *testing.T) {
+	vk := "vk-1"
+	userID := "user-1"
+	ts := time.Date(2026, 8, 17, 2, 0, 0, 0, time.UTC)
+
+	scopes := pricingScopesForLog(&logstore.Log{
+		Timestamp:     ts,
+		Provider:      string(schemas.DeepSeek),
+		SelectedKeyID: "key-1",
+		VirtualKeyID:  &vk,
+		UserID:        &userID,
+	})
+
+	if !scopes.BilledAt.Equal(ts) {
+		t.Fatalf("BilledAt = %v, want %v", scopes.BilledAt, ts)
+	}
+	if scopes.Provider != string(schemas.DeepSeek) || scopes.SelectedKeyID != "key-1" ||
+		scopes.VirtualKeyID != vk || scopes.UserID != userID {
+		t.Fatalf("unexpected scopes: %+v", scopes)
+	}
+}
+
+func TestPricingScopesForLogNilEntry(t *testing.T) {
+	if got := pricingScopesForLog(nil); !got.BilledAt.IsZero() {
+		t.Fatalf("BilledAt = %v, want zero", got.BilledAt)
+	}
+}

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -2309,5 +2309,11 @@ func pricingScopesForLog(logEntry *logstore.Log) modelcatalog.PricingLookupScope
 		SelectedKeyID: logEntry.SelectedKeyID,
 		VirtualKeyID:  virtualKeyID,
 		UserID:        userID,
+		// Price against when the request ran, not when the reprice runs. The row's
+		// Timestamp is stamped in PreLLMHook, so it is the same instant the live
+		// path reads off the context. Without it a model on a peak/off-peak
+		// schedule reprices against the wall clock and the same row yields a
+		// different cost on every run.
+		BilledAt: logEntry.Timestamp,
 	}
 }


### PR DESCRIPTION
## Summary

Adds time-of-day (peak/off-peak) pricing support to the cost calculation engine. Providers like DeepSeek publish discounted rates during off-peak hours (e.g. 50% off outside declared peak windows). This PR evaluates a `PeakHoursSchedule` against the request's start time and scales all usage-based charges by a configured `OffPeakCostMultiplier` when the request falls outside peak windows.

## Changes

- Added `offPeakMultiplier`, `isWithinPeakWindows`, `scaleUsageCost`, `parseClockMinutes`, and `peakHoursLocation` helpers to implement time-of-day pricing evaluation.
- The multiplier is applied in `computeCostFromInput` after all usage-based costs are computed, so a single application site covers every modality (chat, embedding, etc.).
- Flat per-request fees (`CostPerRequest`) and per-search-query fees (`SearchQueriesCost`) are explicitly excluded from the discount — only usage-based charges are scaled.
- `AdditionalCost` (guardrail and MCP sidecar costs) is also excluded; those are discounted independently through their own `computeCostFromInput` calls on their own pricing rows.
- `LookupScopes` gains a `BilledAt` field representing the request's start time. Using the start time keeps pricing deterministic across streaming and non-streaming responses and matches what users see in logs. A long stream crossing a window boundary bills entirely at its start-time rate.
- `LookupScopesFromContext` populates `BilledAt` from `BifrostContextKeyRequestStartTime`. A zero value falls back to wall-clock time at evaluation rather than mispricing as peak.
- Judge calls in `computeGuardrailJudgeCost` now inherit `BilledAt` from the parent request's scopes so they price against the same instant.
- Timezone lookups are memoized in a `sync.Map` to avoid repeated filesystem hits per priced request. Failed lookups are also memoized so a bad timezone string is not retried.
- The discount fails closed: any misconfiguration (missing schedule, missing multiplier, unknown timezone, malformed window, multiplier outside `(0, 1]`) bills at the peak (higher) rate rather than silently applying a discount.
- Midnight-wrapping windows (e.g. 22:00–02:00) are handled by checking the previous day's window against an adjusted minute offset.
- Added `cost_timeofday_test.go` covering: DeepSeek's real schedule, cache-read discounting, flat-fee exclusions, all failure-closed cases, midnight-wrapping windows, non-UTC schedules, non-text modalities, zero `BilledAt` fallback, nil scopes, `parseClockMinutes` edge cases, JSON unmarshal round-trip, and an end-to-end test loading a real datasheet file through the sync pipeline.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/modelcatalog/datasheet/... -run TestOffPeak -v
go test ./framework/modelcatalog/datasheet/... -run TestParseClockMinutes -v
go test ./framework/modelcatalog/datasheet/... -run TestEntryUnmarshal_TimeOfDayFields -v
go test ./...
```

To exercise the discount manually, configure a model pricing row with `off_peak_cost_multiplier` and a `peak_hours` schedule, then issue requests at times inside and outside the declared windows and compare the returned cost breakdowns.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. The discount logic operates entirely on pricing metadata and timestamps; no user-supplied data influences the multiplier path beyond the request start time already present in context.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable