### PR TITLE
feat(ui): add `off_peak_cost_multiplier` and `peak_hours` support to pricing overrides

### DIFF
--- a/ui/app/workspace/custom-pricing/overrides/pricingFields.test.ts
+++ b/ui/app/workspace/custom-pricing/overrides/pricingFields.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { PRICING_FIELDS, pricingFieldUnit } from "./pricingFields";
+import { PRICING_FIELDS, pricingFieldError, pricingFieldUnit } from "./pricingFields";
 
 describe("pricingFieldUnit", () => {
 	// Character-priced fields carry a "/ character" label, so rendering them
@@ -84,11 +84,41 @@ describe("pricingFieldUnit", () => {
 			expect(byUnit[unit], `${field.key} resolved to unexpected unit ${unit}`).toBeDefined();
 			byUnit[unit].push(field.key);
 		}
-		expect(PRICING_FIELDS).toHaveLength(106);
-		expect(byUnit.multiplier).toEqual(["inference_geo_us_multiplier"]);
+		expect(PRICING_FIELDS).toHaveLength(107);
+		expect(byUnit.multiplier).toEqual(["inference_geo_us_multiplier", "off_peak_cost_multiplier"]);
 		expect(byUnit.character).toEqual(["input_cost_per_character"]);
 		// Sanity: the split is real, not everything collapsing into one bucket.
 		expect(byUnit.token.length).toBeGreaterThan(20);
 		expect(byUnit.currency.length).toBeGreaterThan(20);
+	});
+});
+
+describe("pricingFieldError", () => {
+	it("treats an empty value as no override rather than an error", () => {
+		expect(pricingFieldError("input_cost_per_token", "")).toBeUndefined();
+		expect(pricingFieldError("input_cost_per_token", "   ")).toBeUndefined();
+		expect(pricingFieldError("input_cost_per_token", undefined)).toBeUndefined();
+	});
+
+	it("rejects non-numeric input", () => {
+		expect(pricingFieldError("input_cost_per_token", "abc")).toBe("Must be a number");
+		expect(pricingFieldError("input_cost_per_token", "Infinity")).toBe("Must be a number");
+	});
+
+	it("keeps the default non-negative rule for ordinary cost fields", () => {
+		expect(pricingFieldError("input_cost_per_token", "0")).toBeUndefined();
+		expect(pricingFieldError("input_cost_per_token", "0.000001")).toBeUndefined();
+		expect(pricingFieldError("input_cost_per_token", "-1")).toBe("Must be >= 0");
+	});
+
+	// Every base rate is the peak price, so the off-peak multiplier can only
+	// scale downward: 0 would make off-peak free, >1 would exceed peak. The Go
+	// engine rejects both and bills at peak, so the form must not accept them.
+	it("bounds the off-peak multiplier to (0, 1]", () => {
+		expect(pricingFieldError("off_peak_cost_multiplier", "0.5")).toBeUndefined();
+		expect(pricingFieldError("off_peak_cost_multiplier", "1")).toBeUndefined();
+		expect(pricingFieldError("off_peak_cost_multiplier", "0")).toBe("Must be greater than 0 and at most 1");
+		expect(pricingFieldError("off_peak_cost_multiplier", "-0.5")).toBe("Must be greater than 0 and at most 1");
+		expect(pricingFieldError("off_peak_cost_multiplier", "1.5")).toBe("Must be greater than 0 and at most 1");
 	});
 });

--- a/ui/app/workspace/custom-pricing/overrides/pricingFields.ts
+++ b/ui/app/workspace/custom-pricing/overrides/pricingFields.ts
@@ -346,6 +346,12 @@ export const PRICING_FIELDS = [
 		group: "chat",
 		requestTypeGroups: ["chat", "embedding", "rerank", "audio", "image", "video", "ocr"],
 	},
+	{
+		key: "off_peak_cost_multiplier",
+		label: "Off-peak multiplier",
+		group: "chat",
+		requestTypeGroups: ["chat", "embedding", "rerank", "audio", "image", "video", "ocr"],
+	},
 	// Audio fields
 	{
 		key: "input_cost_per_character",
@@ -718,6 +724,39 @@ export const fieldLabelByKey = Object.fromEntries(PRICING_FIELDS.map((field) => 
 >;
 export const patchKeys = PRICING_FIELDS.map((field) => field.key) as PricingFieldKey[];
 
+/**
+ * Per-field numeric bounds for fields that are not plain "any non-negative
+ * cost". Fields absent from this map keep the default `>= 0` rule.
+ */
+export const FIELD_BOUNDS: Partial<Record<PricingFieldKey, { min?: number; max?: number; message: string }>> = {
+	// Every base rate is the peak price, so the off-peak multiplier can only
+	// ever scale downward. A value of 0 would make off-peak requests free and a
+	// value above 1 would make them cost more than peak; the pricing engine
+	// rejects both and bills at peak, so reject them here too rather than
+	// silently accepting a setting that will never take effect.
+	off_peak_cost_multiplier: { min: 0, max: 1, message: "Must be greater than 0 and at most 1" },
+};
+
+/**
+ * Validates one raw form value for a pricing field. Returns an error message,
+ * or undefined when the value is acceptable. An empty value is not an error —
+ * it means "do not override this field".
+ */
+export function pricingFieldError(key: PricingFieldKey, raw: string | undefined): string | undefined {
+	if (raw == null || raw.trim() === "") return undefined;
+	const parsed = Number(raw);
+	if (!Number.isFinite(parsed)) return "Must be a number";
+
+	const bounds = FIELD_BOUNDS[key];
+	if (bounds) {
+		if (bounds.min != null && parsed <= bounds.min) return bounds.message;
+		if (bounds.max != null && parsed > bounds.max) return bounds.message;
+		return undefined;
+	}
+	if (parsed < 0) return "Must be >= 0";
+	return undefined;
+}
+
 export type FieldErrors = Partial<Record<PricingFieldKey | "name" | "scope" | "pattern" | "patch", string>>;
 
 // ---------------------------------------------------------------------------
@@ -740,6 +779,13 @@ export interface FormState {
 	pattern: string;
 	requestTypes: RequestType[];
 	pricingValues: Partial<Record<PricingFieldKey, string>>;
+	/**
+	 * Patch fields this form does not render — currently `peak_hours`, which is
+	 * a schedule object rather than a number and is set via the API or the
+	 * datasheet. Carried through verbatim so opening and saving an override in
+	 * the UI never silently drops what the form cannot display.
+	 */
+	preservedPatch: Record<string, unknown>;
 }
 
 export const defaultFormState: FormState = {
@@ -753,25 +799,51 @@ export const defaultFormState: FormState = {
 	pattern: "",
 	requestTypes: [],
 	pricingValues: {},
+	preservedPatch: {},
 };
+
+/**
+ * Patch keys the form cannot render as a number but still round-trips. Today
+ * only the `peak_hours` schedule object. Anything outside this list that is
+ * also outside `patchKeys` is a typo, and the JSON editor rejects it rather
+ * than saving a key the pricing engine will ignore forever.
+ */
+export const PRESERVED_PATCH_KEYS: readonly string[] = ["peak_hours"];
+
+/**
+ * `__proto__` and friends are never valid pricing field names, and assigning
+ * them onto a plain object walks into `Object.prototype`'s accessor instead of
+ * creating an own property: the value is silently dropped and the object's
+ * prototype is mutated. JSON.parse does create `__proto__` as an own property,
+ * so a patch fetched from the API can carry one. Refuse to carry these keys at
+ * every point where an arbitrary patch key is copied.
+ */
+export function isUnsafePatchKey(key: string): boolean {
+	return key === "__proto__" || key === "constructor" || key === "prototype";
+}
 
 export function buildPatchFromForm(form: FormState): { patch: PricingOverridePatch; errors: FieldErrors } {
 	const errors: FieldErrors = {};
 	const patch: PricingOverridePatch = {};
 
+	// Only keys the form cannot render ride through. A key the form does render
+	// can still reach preservedPatch when the stored value was not a number, and
+	// copying it here would resurrect that stale value even after the user
+	// cleared the field. The rendered form stays authoritative for its own keys.
+	for (const [key, value] of Object.entries(form.preservedPatch ?? {})) {
+		if (isUnsafePatchKey(key) || patchKeys.includes(key as PricingFieldKey)) continue;
+		(patch as Record<string, unknown>)[key] = value;
+	}
+
 	for (const key of patchKeys) {
 		const raw = form.pricingValues[key];
 		if (raw == null || raw.trim() === "") continue;
-		const parsed = Number(raw);
-		if (!Number.isFinite(parsed)) {
-			errors[key] = "Must be a number";
+		const err = pricingFieldError(key, raw);
+		if (err) {
+			errors[key] = err;
 			continue;
 		}
-		if (parsed < 0) {
-			errors[key] = "Must be >= 0";
-			continue;
-		}
-		(patch as Record<string, number>)[key] = parsed;
+		(patch as Record<string, number>)[key] = Number(raw);
 	}
 
 	return { patch, errors };

--- a/ui/app/workspace/custom-pricing/overrides/pricingOverridePatch.test.ts
+++ b/ui/app/workspace/custom-pricing/overrides/pricingOverridePatch.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPatchFromForm, defaultFormState, isUnsafePatchKey, type FormState } from "./pricingFields";
+
+function formWith(overrides: Partial<FormState>): FormState {
+	return { ...defaultFormState, ...overrides };
+}
+
+describe("buildPatchFromForm", () => {
+	it("emits only the fields that were filled in", () => {
+		const { patch, errors } = buildPatchFromForm(
+			formWith({ pricingValues: { input_cost_per_token: "0.000001", output_cost_per_token: "" } }),
+		);
+		expect(errors).toEqual({});
+		expect(patch).toEqual({ input_cost_per_token: 0.000001 });
+	});
+
+	it("reports per-field validation errors and omits the bad field", () => {
+		const { patch, errors } = buildPatchFromForm(
+			formWith({ pricingValues: { off_peak_cost_multiplier: "1.5", input_cost_per_token: "0.000001" } }),
+		);
+		expect(errors.off_peak_cost_multiplier).toBe("Must be greater than 0 and at most 1");
+		expect(patch).toEqual({ input_cost_per_token: 0.000001 });
+	});
+
+	// Regression: the form renders numeric fields only, so a schedule object set
+	// through the API used to be dropped the moment someone opened and saved the
+	// override in the UI.
+	it("carries through patch fields the form cannot render", () => {
+		const peakHours = {
+			timezone: "UTC",
+			windows: [{ days: [1, 2, 3, 4, 5], start: "01:00", end: "04:00" }],
+		};
+		const { patch, errors } = buildPatchFromForm(
+			formWith({
+				pricingValues: { off_peak_cost_multiplier: "0.5" },
+				preservedPatch: { peak_hours: peakHours },
+			}),
+		);
+		expect(errors).toEqual({});
+		expect(patch).toEqual({ off_peak_cost_multiplier: 0.5, peak_hours: peakHours });
+	});
+
+	it("lets a rendered field win over a stale preserved value of the same name", () => {
+		const { patch } = buildPatchFromForm(
+			formWith({
+				pricingValues: { input_cost_per_token: "0.000002" },
+				preservedPatch: { input_cost_per_token: 0.000009 },
+			}),
+		);
+		expect(patch.input_cost_per_token).toBe(0.000002);
+	});
+
+	// A key the form does render lands in preservedPatch whenever the stored
+	// value was not a number, so clearing that field in the form used to save
+	// the stale value straight back.
+	it("drops a preserved value for a rendered field the user cleared", () => {
+		const { patch } = buildPatchFromForm(
+			formWith({
+				pricingValues: { input_cost_per_token: "" },
+				preservedPatch: { input_cost_per_token: "0.000009" },
+			}),
+		);
+		expect(patch).not.toHaveProperty("input_cost_per_token");
+	});
+
+	it("keeps a rendered field out of the patch when it was never filled in", () => {
+		const { patch } = buildPatchFromForm(formWith({ preservedPatch: { output_cost_per_token: null } }));
+		expect(patch).toEqual({});
+	});
+
+	// Assigning "__proto__" onto a plain object hits Object.prototype's accessor
+	// instead of storing a field, so the key vanishes and the patch object's
+	// prototype is mutated. JSON.parse does produce it as an own property, so a
+	// patch fetched from the API can carry one.
+	it("refuses to copy prototype-polluting keys out of the preserved patch", () => {
+		const preservedPatch = JSON.parse('{"__proto__": {"polluted": true}, "peak_hours": {"timezone": "UTC"}}');
+		const { patch } = buildPatchFromForm(formWith({ preservedPatch }));
+
+		expect(patch).toEqual({ peak_hours: { timezone: "UTC" } });
+		expect(Object.getPrototypeOf(patch)).toBe(Object.prototype);
+		expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+	});
+});
+
+describe("isUnsafePatchKey", () => {
+	it("flags the keys that cannot be stored as own properties", () => {
+		expect(isUnsafePatchKey("__proto__")).toBe(true);
+		expect(isUnsafePatchKey("constructor")).toBe(true);
+		expect(isUnsafePatchKey("prototype")).toBe(true);
+	});
+
+	it("leaves real pricing field names alone", () => {
+		expect(isUnsafePatchKey("peak_hours")).toBe(false);
+		expect(isUnsafePatchKey("off_peak_cost_multiplier")).toBe(false);
+		expect(isUnsafePatchKey("input_cost_per_token")).toBe(false);
+	});
+});

--- a/ui/app/workspace/custom-pricing/overrides/pricingOverrideSheet.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/pricingOverrideSheet.tsx
@@ -15,12 +15,7 @@ import { getErrorMessage, useCreatePricingOverrideMutation, useGetProvidersQuery
 import { useGetAllKeysQuery } from "@/lib/store/apis/providersApi";
 import { getUserPicker } from "@/lib/registries/userPicker";
 import { ModelProvider, RequestType } from "@/lib/types/config";
-import {
-	CreatePricingOverrideRequest,
-	PricingOverride,
-	PricingOverrideMatchType,
-	PricingOverrideScopeKind,
-} from "@/lib/types/governance";
+import { CreatePricingOverrideRequest, PricingOverride, PricingOverrideMatchType, PricingOverrideScopeKind } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
 import { ChevronDown, Save, X } from "lucide-react";
 import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -46,10 +41,13 @@ import {
 	buildPatchFromForm,
 	defaultFormState,
 	fieldLabelByKey,
+	isUnsafePatchKey,
 	patchKeys,
+	PRESERVED_PATCH_KEYS,
 	PRICING_FIELDS,
 	REQUEST_TYPE_GROUPS,
 	REQUEST_TYPE_OPTIONS,
+	pricingFieldError,
 } from "./pricingFields";
 import type { FieldErrors, FormState, PricingFieldKey, ScopeRoot } from "./pricingFields";
 
@@ -75,9 +73,18 @@ function toFormState(override: PricingOverride): FormState {
 	} catch {
 		// malformed patch — leave values empty
 	}
-	for (const key of patchKeys) {
-		const val = parsedPatch[key];
-		if (typeof val === "number") values[key] = String(val);
+	// Existing overrides are read leniently: an unrecognized key the API stored
+	// is carried through rather than dropped on save. Unsafe keys are the one
+	// exception, since assigning them here would mutate the prototype instead
+	// of storing anything.
+	const preservedPatch: Record<string, unknown> = {};
+	for (const [key, val] of Object.entries(parsedPatch)) {
+		if (isUnsafePatchKey(key)) continue;
+		if (patchKeys.includes(key as PricingFieldKey) && typeof val === "number") {
+			values[key as PricingFieldKey] = String(val);
+		} else {
+			preservedPatch[key] = val;
+		}
 	}
 	const scopeKind = resolveScopeKind(override);
 
@@ -99,6 +106,7 @@ function toFormState(override: PricingOverride): FormState {
 		pattern: override.pattern,
 		requestTypes: override.request_types ?? [],
 		pricingValues: values,
+		preservedPatch,
 	};
 }
 
@@ -261,6 +269,7 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 	const matchType = watch("matchType");
 	const requestTypes = watch("requestTypes");
 	const pricingValues = watch("pricingValues");
+	const preservedPatch = watch("preservedPatch");
 
 	const shouldLockScope = useMemo(() => !editingOverride && isCompleteScopeLock(scopeLock), [editingOverride, scopeLock]);
 
@@ -364,11 +373,8 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 	const pricingFieldErrors = useMemo<FieldErrors>(() => {
 		const errs: FieldErrors = {};
 		for (const key of patchKeys) {
-			const raw = pricingValues[key];
-			if (!raw || raw.trim() === "") continue;
-			const parsed = Number(raw);
-			if (!Number.isFinite(parsed)) errs[key] = "Must be a number";
-			else if (parsed < 0) errs[key] = "Must be >= 0";
+			const err = pricingFieldError(key, pricingValues[key]);
+			if (err) errs[key] = err;
 		}
 		return errs;
 	}, [pricingValues]);
@@ -380,7 +386,7 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 			setJSONPatch(json);
 			setJSONError(undefined);
 		}
-	}, [pricingValues, getValues]);
+	}, [pricingValues, preservedPatch, getValues]);
 
 	const handleJSONChange = useCallback(
 		(value: string) => {
@@ -389,6 +395,7 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 			const trimmed = value.trim();
 			if (!trimmed) {
 				setJSONError(undefined);
+				setValue("preservedPatch", {});
 				setValue("pricingValues", {});
 				return;
 			}
@@ -399,18 +406,39 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 					return;
 				}
 				const newPricingValues: Partial<Record<PricingFieldKey, string>> = {};
+				const newPreserved: Record<string, unknown> = {};
 				for (const [key, val] of Object.entries(parsed)) {
-					if (!patchKeys.includes(key as PricingFieldKey)) {
-						setJSONError(`Unknown field: ${key}`);
+					if (isUnsafePatchKey(key)) {
+						setJSONError(`Unsupported field: ${key}`);
 						return;
 					}
-					if (typeof val !== "number" || Number.isNaN(val) || val < 0) {
-						setJSONError(`${key} must be a non-negative number`);
+					// Keys the form cannot render as a number (today only the
+					// peak_hours schedule object) ride through untouched so an
+					// override authored via the API stays editable here. Anything
+					// else unrecognized is a typo and is rejected: the pricing
+					// engine ignores unknown keys, so accepting one would save a
+					// setting that silently never takes effect.
+					if (!patchKeys.includes(key as PricingFieldKey)) {
+						if (!PRESERVED_PATCH_KEYS.includes(key)) {
+							setJSONError(`Unknown field: ${key}`);
+							return;
+						}
+						newPreserved[key] = val;
+						continue;
+					}
+					if (typeof val !== "number" || Number.isNaN(val)) {
+						setJSONError(`${key} must be a number`);
+						return;
+					}
+					const err = pricingFieldError(key as PricingFieldKey, String(val));
+					if (err) {
+						setJSONError(`${key}: ${err}`);
 						return;
 					}
 					newPricingValues[key as PricingFieldKey] = String(val);
 				}
 				setJSONError(undefined);
+				setValue("preservedPatch", newPreserved);
 				setValue("pricingValues", newPricingValues);
 			} catch {
 				setJSONError("Invalid JSON");

--- a/ui/app/workspace/model-catalog/views/attributeSheet.tsx
+++ b/ui/app/workspace/model-catalog/views/attributeSheet.tsx
@@ -15,7 +15,7 @@ import {
 	useUpsertModelCatalogEntriesMutation,
 } from "@/lib/store";
 import { KnownProvider } from "@/lib/types/config";
-import { PricingOverrideScopeKind } from "@/lib/types/governance";
+import { PeakHoursSchedule, PricingOverrideScopeKind } from "@/lib/types/governance";
 import { formatCharacterPriceFull, formatTokenPriceFull } from "@/lib/utils/numbers";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Link } from "@tanstack/react-router";
@@ -84,11 +84,45 @@ function getPricingSourceUrl(configuredUrl: string | undefined, modelName: strin
 	return url.toString();
 }
 
+const WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+// formatPeakHours renders a peak-hours schedule as a compact one-liner, e.g.
+// "Mon-Fri 01:00-04:00, 06:00-10:00 UTC".
+// The patch arrives as parsed API JSON, so the TypeScript type is a claim
+// rather than a guarantee. A non-array `windows`, or a null entry inside it,
+// would throw here and take the whole sheet's render down with it, so every
+// level is checked before it is walked.
+function formatPeakHours(value: PeakHoursSchedule): string {
+	const windows = Array.isArray(value.windows) ? value.windows : [];
+	if (windows.length === 0) return "—";
+	const tz = typeof value.timezone === "string" && value.timezone ? value.timezone : "UTC";
+	const rendered = windows
+		.map((w) => {
+			if (!w || typeof w !== "object") return null;
+			const days = (Array.isArray(w.days) ? w.days : [])
+				.filter((d) => typeof d === "number" && d >= 0 && d <= 6)
+				.map((d) => WEEKDAY_LABELS[d])
+				.join(",");
+			const start = typeof w.start === "string" ? w.start : "?";
+			const end = typeof w.end === "string" ? w.end : "?";
+			return days ? `${days} ${start}-${end}` : `${start}-${end}`;
+		})
+		.filter((w): w is string => w !== null);
+	if (rendered.length === 0) return "—";
+	return `${rendered.join("; ")} ${tz}`;
+}
+
 // formatPatchValue renders a patch value in its field's own unit: the way the
 // pricing table does for token-priced fields, as a bare multiplier for the geo
-// multiplier, and as a plain dollar amount for everything else (per-image,
-// per-second, per-page, …).
-function formatPatchValue(key: string, value: number): string {
+// and off-peak multipliers, and as a plain dollar amount for everything else
+// (per-image, per-second, per-page, …). Non-numeric patch fields — currently
+// only the peak_hours schedule object — get their own rendering; falling
+// through to the dollar branch would print "$[object Object]".
+function formatPatchValue(key: string, value: unknown): string {
+	if (key === "peak_hours" && typeof value === "object" && value !== null) {
+		return formatPeakHours(value as PeakHoursSchedule);
+	}
+	if (typeof value !== "number") return String(value);
 	switch (pricingFieldUnit(key)) {
 		case "token":
 			return formatTokenPriceFull(value);
@@ -341,7 +375,7 @@ export default function AttributeSheet({ model, overrides, onClose }: AttributeS
 														{patchEntries.map(([key, value]) => (
 															<div key={key} className="flex items-baseline justify-between gap-3 text-xs">
 																<span className="text-muted-foreground">{fieldLabelByKey[key as PricingFieldKey] || key}</span>
-																<span className="font-mono">{formatPatchValue(key, value as number)}</span>
+																<span className="font-mono">{formatPatchValue(key, value)}</span>
 															</div>
 														))}
 													</div>

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -610,6 +610,29 @@ export interface PricingOverridePatch {
 	// OCR
 	ocr_cost_per_page?: number;
 	annotation_cost_per_page?: number;
+	// Time of day
+	off_peak_cost_multiplier?: number;
+	peak_hours?: PeakHoursSchedule;
+}
+
+/**
+ * Recurring weekly windows during which a model is billed at its peak (base)
+ * rates. Any instant outside every window is off-peak and is discounted by
+ * `off_peak_cost_multiplier`.
+ */
+export interface PeakHoursSchedule {
+	/** IANA location name (e.g. "UTC", "Asia/Shanghai"). Empty means UTC. */
+	timezone?: string;
+	windows?: PeakHoursWindow[];
+}
+
+export interface PeakHoursWindow {
+	/** Weekdays, 0 = Sunday through 6 = Saturday. */
+	days: number[];
+	/** "HH:MM" in the schedule's timezone, inclusive. */
+	start: string;
+	/** "HH:MM" in the schedule's timezone, exclusive; <= start wraps midnight. */
+	end: string;
 }
 
 export interface PricingOverride {


### PR DESCRIPTION
## Summary

Adds support for off-peak pricing in the custom pricing override UI. This introduces an `off_peak_cost_multiplier` field and a `peak_hours` schedule type, allowing overrides to discount model costs during off-peak windows defined via the API or datasheet. It also fixes a regression where opening and saving an override in the UI would silently drop patch fields the form cannot render (such as the `peak_hours` schedule object).

## Changes

- Added `off_peak_cost_multiplier` to `PRICING_FIELDS` and `PricingOverridePatch`, with validation bounds enforcing the value must be in `(0, 1]` — values outside this range are rejected by the pricing engine and would silently bill at peak rate.
- Added `PeakHoursSchedule` and `PeakHoursWindow` TypeScript types to `governance.ts`.
- Introduced `pricingFieldError` and `FIELD_BOUNDS` to centralize per-field validation logic, replacing duplicated inline checks in both the form's live error display and `buildPatchFromForm`.
- Added `preservedPatch` to `FormState` to carry through patch fields the form cannot render (e.g. `peak_hours`). These fields are round-tripped verbatim so saving an override in the UI never drops API-authored schedule data.
- Updated `toFormState` and `handleJSONChange` to populate `preservedPatch` with non-numeric or unrecognized patch keys rather than rejecting them as unknown fields.
- Updated `formatPatchValue` in `attributeSheet.tsx` to handle non-numeric patch values, adding a `formatPeakHours` renderer that displays the schedule as a compact one-liner (e.g. `Mon-Fri 01:00-04:00 UTC`).
- Added `pricingOverridePatch.test.ts` covering `buildPatchFromForm` behavior including the `preservedPatch` round-trip and field precedence.
- Extended `pricingFields.test.ts` with a `pricingFieldError` describe block covering empty values, non-numeric input, the default non-negative rule, and the off-peak multiplier bounds.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

To validate the `preservedPatch` fix manually:
1. Create a pricing override via the API that includes a `peak_hours` schedule object alongside numeric cost fields.
2. Open that override in the custom pricing UI and save it without changes.
3. Confirm the `peak_hours` field is still present in the saved patch.

To validate the off-peak multiplier:
1. Add an override with `off_peak_cost_multiplier` set to a value in `(0, 1]` — the field should accept it.
2. Attempt to set it to `0`, a negative value, or a value greater than `1` — the form should display `"Must be greater than 0 and at most 1"`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. All changes are UI-side form validation and display logic with no impact on auth, secrets, or PII.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable