### PR TITLE
fix(anthropic): forward tool_search server_tool_use/tool_search_tool_result on the non-streaming path

### DIFF
--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -6547,6 +6547,35 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 				if isOutputMessage {
 					bifrostMessages = append(bifrostMessages, buildBifrostCodeExecutionCall(block))
 				}
+			} else if block.Name != nil &&
+				(*block.Name == string(AnthropicToolNameToolSearchBM25) ||
+					*block.Name == string(AnthropicToolNameToolSearchRegex)) {
+				// Server-side tool_search; the paired tool_search_tool_result
+				// attaches its tool_references onto this message below.
+				bifrostMsg := schemas.ResponsesMessage{
+					Type:   schemas.Ptr(schemas.ResponsesMessageTypeToolSearchCall),
+					ID:     block.ID,
+					Status: schemas.Ptr("completed"),
+					ResponsesToolMessage: &schemas.ResponsesToolMessage{
+						Name:                    block.Name,
+						CallID:                  block.ID,
+						ResponsesToolSearchCall: &schemas.ResponsesToolSearchCall{},
+					},
+				}
+				if block.Caller != nil {
+					bifrostMsg.ResponsesToolMessage.Caller = &schemas.ResponsesToolCaller{
+						Type:   string(block.Caller.Type),
+						ToolID: block.Caller.ToolID,
+					}
+				}
+				if block.Input != nil {
+					if q := providerUtils.GetJSONField(block.Input, "query"); q.Exists() && q.Type == gjson.String {
+						bifrostMsg.ResponsesToolMessage.ResponsesToolSearchCall.Query = schemas.Ptr(q.Str)
+					}
+				}
+				if isOutputMessage {
+					bifrostMessages = append(bifrostMessages, bifrostMsg)
+				}
 			}
 
 		case AnthropicContentBlockTypeCodeExecutionToolResult,
@@ -6555,6 +6584,12 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 			// Fold the code-execution result onto the matching code_interpreter_call.
 			if block.ToolUseID != nil {
 				attachAnthropicCodeExecutionResult(bifrostMessages, *block.ToolUseID, block)
+			}
+
+		case AnthropicContentBlockTypeToolSearchToolResult:
+			// Mirrors the AdvisorToolResult / WebFetchToolResult handling below.
+			if block.ToolUseID != nil {
+				attachAnthropicToolSearchResult(bifrostMessages, *block.ToolUseID, block)
 			}
 
 		case AnthropicContentBlockTypeAdvisorToolResult:
@@ -7299,6 +7334,60 @@ func convertAnthropicWebFetchResultToBifrost(block *AnthropicContentBlock) *sche
 	return result
 }
 
+// attachAnthropicToolSearchResult folds a tool_search_tool_result block's
+// tool_references onto the tool_search_call whose id matches its tool_use_id.
+// Mirrors attachAnthropicWebFetchResult.
+func attachAnthropicToolSearchResult(messages []schemas.ResponsesMessage, toolUseID string, block AnthropicContentBlock) {
+	for i := len(messages) - 1; i >= 0; i-- {
+		msg := &messages[i]
+		if msg.Type == nil || *msg.Type != schemas.ResponsesMessageTypeToolSearchCall {
+			continue
+		}
+		if msg.ID == nil || *msg.ID != toolUseID {
+			continue
+		}
+		if msg.ResponsesToolMessage == nil {
+			msg.ResponsesToolMessage = &schemas.ResponsesToolMessage{}
+		}
+		msg.ResponsesToolMessage.CallID = &toolUseID
+		// A replayed history item may carry caller metadata only on the
+		// result block; keep it so the reverse conversion can re-emit it.
+		if msg.ResponsesToolMessage.Caller == nil && block.Caller != nil {
+			msg.ResponsesToolMessage.Caller = &schemas.ResponsesToolCaller{
+				Type:   string(block.Caller.Type),
+				ToolID: block.Caller.ToolID,
+			}
+		}
+		// The wire nests the references: content is a single
+		// tool_search_tool_search_result object carrying tool_references.
+		// The top-level field is kept as a fallback for the flattened shape
+		// streaming deltas use.
+		refBlocks := block.ToolReferences
+		if c := block.Content; c != nil {
+			inner := c.ContentObj
+			if inner == nil && len(c.ContentBlocks) > 0 {
+				inner = &c.ContentBlocks[0]
+			}
+			if inner != nil && len(inner.ToolReferences) > 0 {
+				refBlocks = inner.ToolReferences
+			}
+		}
+		var toolRefs []string
+		for _, ref := range refBlocks {
+			if ref.ToolName != nil {
+				toolRefs = append(toolRefs, *ref.ToolName)
+			} else if ref.Name != nil {
+				toolRefs = append(toolRefs, *ref.Name)
+			}
+		}
+		if msg.ResponsesToolMessage.ResponsesToolSearchCall == nil {
+			msg.ResponsesToolMessage.ResponsesToolSearchCall = &schemas.ResponsesToolSearchCall{}
+		}
+		msg.ResponsesToolMessage.ResponsesToolSearchCall.ToolReferences = toolRefs
+		break
+	}
+}
+
 func attachAnthropicWebFetchResult(messages []schemas.ResponsesMessage, toolUseID string, block AnthropicContentBlock) {
 	for i := len(messages) - 1; i >= 0; i-- {
 		msg := &messages[i]
@@ -7312,6 +7401,14 @@ func attachAnthropicWebFetchResult(messages []schemas.ResponsesMessage, toolUseI
 			msg.ResponsesToolMessage = &schemas.ResponsesToolMessage{}
 		}
 		msg.ResponsesToolMessage.CallID = &toolUseID
+		// A replayed history item may carry caller metadata only on the
+		// result block; keep it so the reverse conversion can re-emit it.
+		if msg.ResponsesToolMessage.Caller == nil && block.Caller != nil {
+			msg.ResponsesToolMessage.Caller = &schemas.ResponsesToolCaller{
+				Type:   string(block.Caller.Type),
+				ToolID: block.Caller.ToolID,
+			}
+		}
 		msg.ResponsesToolMessage.ResponsesWebFetchCall = convertAnthropicWebFetchResultToBifrost(&block)
 		break
 	}
@@ -7474,20 +7571,36 @@ func convertBifrostToolSearchCallToAnthropicBlocks(msg *schemas.ResponsesMessage
 		return nil
 	}
 
-	// 1. server_tool_use block. Preserve the search variant name (regex/bm25);
-	// the query is not retained on the neutral item, so send an empty input.
+	// 1. server_tool_use block. Preserve the search variant name (regex/bm25)
+	// and the original query, so a replayed block matches what the API sent.
 	name := string(AnthropicToolNameToolSearchRegex)
 	if msg.ResponsesToolMessage.Name != nil && *msg.ResponsesToolMessage.Name != "" {
 		name = *msg.ResponsesToolMessage.Name
 	}
+	input := json.RawMessage("{}")
+	if sc := msg.ResponsesToolMessage.ResponsesToolSearchCall; sc != nil && sc.Query != nil {
+		if b, err := providerUtils.MarshalSorted(map[string]interface{}{"query": *sc.Query}); err == nil {
+			input = b
+		}
+	}
+	var caller *AnthropicToolCaller
+	if c := msg.ResponsesToolMessage.Caller; c != nil {
+		caller = &AnthropicToolCaller{
+			Type:   AnthropicToolCallerType(c.Type),
+			ToolID: providerUtils.SanitizeAnthropicToolUseIDPtr(c.ToolID),
+		}
+	}
 	serverToolUseBlock := AnthropicContentBlock{
-		Type:  AnthropicContentBlockTypeServerToolUse,
-		ID:    toolUseID,
-		Name:  schemas.Ptr(name),
-		Input: json.RawMessage("{}"),
+		Type:   AnthropicContentBlockTypeServerToolUse,
+		ID:     toolUseID,
+		Name:   schemas.Ptr(name),
+		Input:  input,
+		Caller: caller,
 	}
 
-	// 2. tool_search_tool_result block reconstructed from the discovered tool names.
+	// 2. tool_search_tool_result block reconstructed from the discovered tool
+	// names, in the wire's nested shape: content is a single
+	// tool_search_tool_search_result object carrying the tool_references.
 	var toolReferences []AnthropicContentBlock
 	if msg.ResponsesToolMessage.ResponsesToolSearchCall != nil {
 		for _, toolName := range msg.ResponsesToolMessage.ResponsesToolSearchCall.ToolReferences {
@@ -7498,9 +7611,13 @@ func convertBifrostToolSearchCallToAnthropicBlocks(msg *schemas.ResponsesMessage
 		}
 	}
 	resultBlock := AnthropicContentBlock{
-		Type:           AnthropicContentBlockTypeToolSearchToolResult,
-		ToolUseID:      toolUseID,
-		ToolReferences: toolReferences,
+		Type:      AnthropicContentBlockTypeToolSearchToolResult,
+		ToolUseID: toolUseID,
+		Caller:    caller,
+		Content: &AnthropicContent{ContentObj: &AnthropicContentBlock{
+			Type:           AnthropicContentBlockType("tool_search_tool_search_result"),
+			ToolReferences: toolReferences,
+		}},
 	}
 
 	return []AnthropicContentBlock{serverToolUseBlock, resultBlock}

--- a/core/providers/anthropic/toolsearch_test.go
+++ b/core/providers/anthropic/toolsearch_test.go
@@ -311,9 +311,9 @@ func TestToolSearch_ReverseRebuildsAnthropicBlocks(t *testing.T) {
 	if resultBlock.ToolUseID == nil || *resultBlock.ToolUseID != tsServerToolUseID {
 		t.Fatalf("tool_search_tool_result tool_use_id = %v, want %q", resultBlock.ToolUseID, tsServerToolUseID)
 	}
-	if len(resultBlock.ToolReferences) != 1 || resultBlock.ToolReferences[0].ToolName == nil ||
-		*resultBlock.ToolReferences[0].ToolName != tsDiscoveredTool {
-		t.Fatalf("rebuilt tool_references = %+v, want one ref to %q", resultBlock.ToolReferences, tsDiscoveredTool)
+	refs := rebuiltToolRefs(resultBlock)
+	if len(refs) != 1 || refs[0].ToolName == nil || *refs[0].ToolName != tsDiscoveredTool {
+		t.Fatalf("rebuilt tool_references = %+v, want one nested ref to %q", refs, tsDiscoveredTool)
 	}
 }
 

--- a/core/providers/anthropic/toolsearchnonstreaming_test.go
+++ b/core/providers/anthropic/toolsearchnonstreaming_test.go
@@ -1,0 +1,264 @@
+package anthropic
+
+import (
+	"context"
+	"testing"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// Tool_search content-block coverage for the NON-STREAMING path: a plain
+// /v1/messages response, and replayed conversation history on a follow-up
+// request. toolsearch_test.go covers the streaming SSE path.
+
+const (
+	tsnServerToolUseID  = "srvtoolu_tsn_1"
+	tsnCallerToolID     = "toolu_caller_tsn_1"
+	tsnDiscoveredTool   = "OpenMeteoMCP-weather_forecast"
+	tsnDiscoveredCallID = "toolu_weather_tsn_1"
+)
+
+// toolSearchNonStreamingBlocks builds the three-block sequence Anthropic emits
+// for a server-side tool_search: server_tool_use(tool_search variant) ->
+// tool_search_tool_result(tool_references) -> tool_use(discovered tool).
+func toolSearchNonStreamingBlocks(toolName string) []AnthropicContentBlock {
+	return []AnthropicContentBlock{
+		{
+			Type:  AnthropicContentBlockTypeServerToolUse,
+			ID:    schemas.Ptr(tsnServerToolUseID),
+			Name:  schemas.Ptr(toolName),
+			Input: []byte(`{"query":"weather"}`),
+			Caller: &AnthropicToolCaller{
+				Type:   AnthropicToolCallerTypeCodeExecution20250825,
+				ToolID: schemas.Ptr(tsnCallerToolID),
+			},
+		},
+		{
+			// The wire nests the references under a single
+			// tool_search_tool_search_result content object (live-verified
+			// against api.anthropic.com, 2026-08-26).
+			Type:      AnthropicContentBlockTypeToolSearchToolResult,
+			ToolUseID: schemas.Ptr(tsnServerToolUseID),
+			Content: &AnthropicContent{ContentObj: &AnthropicContentBlock{
+				Type: AnthropicContentBlockType("tool_search_tool_search_result"),
+				ToolReferences: []AnthropicContentBlock{
+					{Type: AnthropicContentBlockTypeToolReference, ToolName: schemas.Ptr(tsnDiscoveredTool)},
+				},
+			}},
+		},
+		{
+			Type:  AnthropicContentBlockTypeToolUse,
+			ID:    schemas.Ptr(tsnDiscoveredCallID),
+			Name:  schemas.Ptr(tsnDiscoveredTool),
+			Input: []byte(`{"location":"Tokyo"}`),
+		},
+	}
+}
+
+// findToolSearchCall returns the tool_search_call message in msgs, if any.
+func findToolSearchCall(msgs []schemas.ResponsesMessage) *schemas.ResponsesMessage {
+	for i := range msgs {
+		if msgs[i].Type != nil && *msgs[i].Type == schemas.ResponsesMessageTypeToolSearchCall {
+			return &msgs[i]
+		}
+	}
+	return nil
+}
+
+// TestToolSearch_NonStreamingResponseForwardsToolReferences asserts a plain
+// (non-streaming) AnthropicMessageResponse containing server_tool_use(tool_search)
+// + tool_search_tool_result survives ToBifrostResponsesResponse as a
+// tool_search_call carrying the discovered tool_references, instead of being
+// silently dropped. Fails on the unpatched provider (Output has no
+// tool_search_call at all).
+func TestToolSearch_NonStreamingResponseForwardsToolReferences(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name     string
+		toolName string
+	}{
+		{"regex", string(AnthropicToolNameToolSearchRegex)},
+		{"bm25", string(AnthropicToolNameToolSearchBM25)},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+			defer cancel()
+
+			resp := &AnthropicMessageResponse{
+				ID:      "msg_tsn_test",
+				Type:    "message",
+				Role:    string(AnthropicMessageRoleAssistant),
+				Content: toolSearchNonStreamingBlocks(tc.toolName),
+				Model:   "claude-sonnet-4-6",
+				Usage:   &AnthropicUsage{InputTokens: 10, OutputTokens: 5},
+			}
+
+			bifrostResp := resp.ToBifrostResponsesResponse(ctx)
+			if bifrostResp == nil {
+				t.Fatal("ToBifrostResponsesResponse returned nil")
+			}
+
+			call := findToolSearchCall(bifrostResp.Output)
+			if call == nil {
+				t.Fatal("no tool_search_call in Output — tool_search_tool_result was dropped on the non-streaming response path")
+			}
+			if call.ID == nil || *call.ID != tsnServerToolUseID {
+				t.Fatalf("tool_search_call ID = %v, want %q", call.ID, tsnServerToolUseID)
+			}
+			if call.ResponsesToolMessage == nil || call.ResponsesToolMessage.ResponsesToolSearchCall == nil {
+				t.Fatal("tool_search_call carries no ResponsesToolSearchCall payload")
+			}
+			refs := call.ResponsesToolMessage.ResponsesToolSearchCall.ToolReferences
+			if len(refs) != 1 || refs[0] != tsnDiscoveredTool {
+				t.Fatalf("tool_references = %v, want [%q]", refs, tsnDiscoveredTool)
+			}
+			if call.ResponsesToolMessage.Name == nil || *call.ResponsesToolMessage.Name != tc.toolName {
+				t.Fatalf("tool_search_call Name = %v, want %q", call.ResponsesToolMessage.Name, tc.toolName)
+			}
+		})
+	}
+}
+
+// TestToolSearch_NonStreamingRoundTripPreservesBlocks feeds a non-streaming
+// Anthropic response through the full forward-then-reverse round trip
+// (ToBifrostResponsesResponse -> ConvertBifrostMessagesToAnthropicMessages) and
+// asserts the server_tool_use + tool_search_tool_result blocks come back with
+// the same id, tool name and tool_references the upstream response carried —
+// the exact contract Anthropic's continuation flow requires. This is the
+// non-streaming counterpart to TestToolSearch_ReverseRebuildsAnthropicBlocks,
+// which starts from a hand-built canonical message rather than a parsed
+// response and so did not catch this gap.
+func TestToolSearch_NonStreamingRoundTripPreservesBlocks(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	resp := &AnthropicMessageResponse{
+		ID:      "msg_tsn_rt",
+		Type:    "message",
+		Role:    string(AnthropicMessageRoleAssistant),
+		Content: toolSearchNonStreamingBlocks(string(AnthropicToolNameToolSearchBM25)),
+		Model:   "claude-sonnet-4-6",
+		Usage:   &AnthropicUsage{InputTokens: 10, OutputTokens: 5},
+	}
+
+	bifrostResp := resp.ToBifrostResponsesResponse(ctx)
+	if bifrostResp == nil || len(bifrostResp.Output) == 0 {
+		t.Fatal("ToBifrostResponsesResponse produced no output")
+	}
+
+	msgs, _ := ConvertBifrostMessagesToAnthropicMessages(ctx, bifrostResp.Output, true,
+		schemas.ResolveModelCaps(schemas.Anthropic, "claude-sonnet-4-6"))
+
+	var serverToolUse, resultBlock *AnthropicContentBlock
+	for mi := range msgs {
+		for bi := range msgs[mi].Content.ContentBlocks {
+			b := &msgs[mi].Content.ContentBlocks[bi]
+			switch b.Type {
+			case AnthropicContentBlockTypeServerToolUse:
+				if b.Name != nil && *b.Name == string(AnthropicToolNameToolSearchBM25) {
+					serverToolUse = b
+				}
+			case AnthropicContentBlockTypeToolSearchToolResult:
+				resultBlock = b
+			}
+		}
+	}
+
+	if serverToolUse == nil {
+		t.Fatal("round trip dropped tool_search_call — no server_tool_use(tool_search) block rebuilt")
+	}
+	if serverToolUse.ID == nil || *serverToolUse.ID != tsnServerToolUseID {
+		t.Fatalf("server_tool_use ID = %v, want %q", serverToolUse.ID, tsnServerToolUseID)
+	}
+	if serverToolUse.Caller == nil || serverToolUse.Caller.Type != AnthropicToolCallerTypeCodeExecution20250825 ||
+		serverToolUse.Caller.ToolID == nil || *serverToolUse.Caller.ToolID != tsnCallerToolID {
+		t.Fatalf("round trip dropped the caller: %+v", serverToolUse.Caller)
+	}
+
+	if string(serverToolUse.Input) != `{"query":"weather"}` {
+		t.Fatalf("round trip lost the input query: %s", serverToolUse.Input)
+	}
+	if resultBlock == nil {
+		t.Fatal("round trip dropped the tool_search_tool_result block")
+	}
+	if resultBlock.Caller == nil || resultBlock.Caller.Type != AnthropicToolCallerTypeCodeExecution20250825 {
+		t.Fatalf("round trip dropped the caller on the result block: %+v", resultBlock.Caller)
+	}
+	if resultBlock.ToolUseID == nil || *resultBlock.ToolUseID != tsnServerToolUseID {
+		t.Fatalf("tool_search_tool_result tool_use_id = %v, want %q", resultBlock.ToolUseID, tsnServerToolUseID)
+	}
+	refs := rebuiltToolRefs(resultBlock)
+	if len(refs) != 1 || refs[0].ToolName == nil || *refs[0].ToolName != tsnDiscoveredTool {
+		t.Fatalf("round-tripped tool_references = %+v, want one nested ref to %q", refs, tsnDiscoveredTool)
+	}
+}
+
+// TestToolSearch_RequestHistoryForwardsToolReferences asserts that when a
+// client replays a previous assistant turn's server_tool_use(tool_search) +
+// tool_search_tool_result blocks as conversation history on a follow-up
+// request — exactly what Anthropic's continuation contract requires — Bifrost
+// preserves them into the outbound request instead of silently dropping them
+// before forwarding to Anthropic. This is the request-side half of the
+// harness#189 defect: ToBifrostResponsesRequest funnels history through the
+// same convertAnthropicContentBlocksToResponsesMessages converter as the
+// response path.
+func TestToolSearch_RequestHistoryForwardsToolReferences(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	req := &AnthropicMessageRequest{
+		Model:     "anthropic/claude-sonnet-4-6",
+		MaxTokens: 1024,
+		Messages: []AnthropicMessage{
+			{
+				Role: AnthropicMessageRoleAssistant,
+				Content: AnthropicContent{
+					ContentBlocks: toolSearchNonStreamingBlocks(string(AnthropicToolNameToolSearchRegex)),
+				},
+			},
+			{
+				Role: AnthropicMessageRoleUser,
+				Content: AnthropicContent{
+					ContentStr: schemas.Ptr("what's next?"),
+				},
+			},
+		},
+	}
+
+	bifrostReq := req.ToBifrostResponsesRequest(ctx)
+	if bifrostReq == nil {
+		t.Fatal("ToBifrostResponsesRequest returned nil")
+	}
+
+	call := findToolSearchCall(bifrostReq.Input)
+	if call == nil {
+		t.Fatal("no tool_search_call in the parsed request history — tool_search_tool_result was dropped before forwarding to Anthropic")
+	}
+	if call.ResponsesToolMessage == nil || call.ResponsesToolMessage.ResponsesToolSearchCall == nil {
+		t.Fatal("history tool_search_call carries no ResponsesToolSearchCall payload")
+	}
+	refs := call.ResponsesToolMessage.ResponsesToolSearchCall.ToolReferences
+	if len(refs) != 1 || refs[0] != tsnDiscoveredTool {
+		t.Fatalf("history tool_references = %v, want [%q]", refs, tsnDiscoveredTool)
+	}
+}
+
+// rebuiltToolRefs extracts the tool_reference blocks from a rebuilt
+// tool_search_tool_result block's nested content object.
+func rebuiltToolRefs(b *AnthropicContentBlock) []AnthropicContentBlock {
+	if b == nil || b.Content == nil {
+		return nil
+	}
+	inner := b.Content.ContentObj
+	if inner == nil && len(b.Content.ContentBlocks) > 0 {
+		inner = &b.Content.ContentBlocks[0]
+	}
+	if inner == nil {
+		return nil
+	}
+	return inner.ToolReferences
+}

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -1933,6 +1933,7 @@ type ResponsesAdvisorCall struct {
 // the names of the deferred tools the search discovered (from the result block's
 // tool_references); the model then emits a normal tool_use to call one of them.
 type ResponsesToolSearchCall struct {
+	Query          *string  `json:"tool_search_query,omitempty"`  // the server_tool_use input query, preserved for replay
 	ToolReferences []string `json:"tool_references,omitempty"` // names of discovered (deferred) tools
 }
 


### PR DESCRIPTION
## Summary

The [tool-search server tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool) returns a `server_tool_use` block paired with a `tool_search_tool_result` block carrying the discovered `tool_references`, and the continuation contract requires both to be replayed unchanged on later requests.

`convertAnthropicContentBlocksToResponsesMessages` — shared by `ToBifrostResponsesResponse` (response parsing) and `ToBifrostResponsesRequest` (history parsing) — drops both: the `server_tool_use` case recognizes no tool-search name, and there is no case for `tool_search_tool_result` at all. Any non-streaming caller outside the Claude Code passthrough loses the pair twice — from the parsed response, and from replayed history on the follow-up. The streaming SSE path and the reverse converter already handle the pair; the request-side tool declaration was fixed separately in #5279.

## Changes

- Add the tool-search branch to the `ServerToolUse` case and a `ToolSearchToolResult` case, mirroring the existing `web_search` / `web_fetch` handling (caller and query preserved).
- Read `tool_references` from the wire's nested `tool_search_tool_search_result` content object (the flattened top-level field is kept as a fallback for streaming deltas).
- Rebuild the same nested shape in `convertBifrostToolSearchCallToAnthropicBlocks`, with the input query (new `Query` field on `ResponsesToolSearchCall`) and `caller` re-emitted so a replayed block matches what the API sent.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
cd core
go test ./providers/anthropic/ -run TestToolSearch -v
go test ./providers/anthropic/ ./schemas/...
```

Also verified against `api.anthropic.com` with a real key: a non-streaming tool-search response parsed through `ToBifrostResponsesResponse` retains the discovered references, and a follow-up request replaying the blocks rebuilt by `ConvertBifrostMessagesToAnthropicMessages` is accepted (`end_turn`).

## Breaking changes

- [x] No

## Related issues

Related: #5279 (request-side declaration; this PR covers the response/history side).

## Security considerations

None — forwards two documented Anthropic content-block types through existing canonical structures.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed (no doc surface for provider content-block coverage)
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
