### PR TITLE
feat: add all converter's internal processing to individual span buckets

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -5222,7 +5222,7 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 	}
 	// "handle-setup" overhead phase: model-catalog publish + the pre-request hook
 	// pipeline glue. Per-plugin work nests as its own spans; this bucket is the
-	// remaining core-side setup so it stops folding into "core".
+	// remaining core-side setup.
 	setupSpan := bifrost.startCoreSpan(ctx, "handle-setup")
 
 	// Expose the model catalog to plugins (ctx.GetModelInfo / ctx.CalculateCost)
@@ -5236,16 +5236,21 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 	preReqPipeline.RunPreRequestHooks(ctx, req)
 	bifrost.releasePluginPipeline(preReqPipeline)
 	bifrost.endCoreSpan(setupSpan)
+	// "miscellaneous" phase: pre-dispatch glue (field re-read + validation) on no other
+	// span. Closed before tryRequest so pipeline-pre stays a separate bucket.
+	preDispatchSpan := bifrost.startCoreSpan(ctx, "miscellaneous")
 	// Re-read after PreRequestHook — provider/model/fallbacks may have changed.
 	provider, model, fallbacks = req.GetRequestFields()
 	// Empty provider/model after PreRequestHook means no plugin
 	// could pick a provider for this model — the caller's input is unresolvable.
-	if err := validateRequestAfterPreRequestHooks(req); err != nil {
+	validateErr := validateRequestAfterPreRequestHooks(req)
+	bifrost.endCoreSpan(preDispatchSpan)
+	if validateErr != nil {
 		// Returning before tryRequest skips the downstream log drain, so flush
 		// any PreRequestHook-emitted plugin logs here.
 		flushPluginLogs(ctx)
-		err.PopulateExtraFields(req.RequestType, provider, model, model)
-		return nil, err
+		validateErr.PopulateExtraFields(req.RequestType, provider, model, model)
+		return nil, validateErr
 	}
 
 	bifrost.logger.Debug("primary provider %s with model %s and %d fallbacks", provider, model, len(fallbacks))
@@ -5373,16 +5378,21 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 	preReqPipeline := bifrost.getPluginPipeline()
 	preReqPipeline.RunPreRequestHooks(ctx, req)
 	bifrost.releasePluginPipeline(preReqPipeline)
+	// "miscellaneous" phase: pre-dispatch glue (field re-read + validation) on no other
+	// span. Mirrors handleRequest so streaming classifies this cost too.
+	preDispatchSpan := bifrost.startCoreSpan(ctx, "miscellaneous")
 	// Re-read after PreRequestHook — provider/model/fallbacks may have changed.
 	provider, model, fallbacks = req.GetRequestFields()
 	// Empty provider after PreRequestHook means no plugin
 	// could pick a provider for this model — the caller's input is unresolvable.
-	if err := validateRequestAfterPreRequestHooks(req); err != nil {
+	validateErr := validateRequestAfterPreRequestHooks(req)
+	bifrost.endCoreSpan(preDispatchSpan)
+	if validateErr != nil {
 		// Returning before tryStreamRequest skips the downstream log drain, so
 		// flush any PreRequestHook-emitted plugin logs here.
 		flushPluginLogs(ctx)
-		err.PopulateExtraFields(req.RequestType, provider, model, model)
-		return nil, err
+		validateErr.PopulateExtraFields(req.RequestType, provider, model, model)
+		return nil, validateErr
 	}
 
 	bifrost.logger.Debug("primary provider %s with model %s and %d fallbacks", provider, model, len(fallbacks))
@@ -5498,9 +5508,12 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 		return nil, bifrostErr
 	}
 
-	// Add MCP tools to request if MCP is configured and requested
+	// Add MCP tools to request if MCP is configured and requested.
+	// Timed as "miscellaneous": the tool-definition merge sits on no other span.
 	if bifrost.MCPManager != nil {
+		mcpSpan := bifrost.startCoreSpan(ctx, "miscellaneous")
 		req = bifrost.MCPManager.AddToolsToRequest(ctx, req)
+		bifrost.endCoreSpan(mcpSpan)
 	}
 
 	tracer := bifrost.getTracer()
@@ -5517,7 +5530,7 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 	ctx.SetValue(schemas.BifrostContextKeyTracer, tracer)
 
 	// "pipeline-pre" overhead phase: the LLM pre-hook pipeline glue (loop + pool
-	// around the per-plugin spans that nest inside it), previously part of "core".
+	// around the per-plugin spans that nest inside it), previously part of the residual.
 	prePipeSpan := bifrost.startCoreSpan(ctx, "pipeline-pre")
 	pipeline := bifrost.getPluginPipeline()
 	defer bifrost.releasePluginPipeline(pipeline)
@@ -5568,10 +5581,13 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 		return nil, bifrostErr
 	}
 
+	// "miscellaneous" phase: field re-read + channel-message setup before enqueue.
+	preEnqueueSpan := bifrost.startCoreSpan(ctx, "miscellaneous")
 	provider, model, _ = preReq.GetRequestFields()
 
 	msg := bifrost.getChannelMessage(*preReq)
 	msg.Context = ctx
+	bifrost.endCoreSpan(preEnqueueSpan)
 
 	// Open the queue-wait span; the worker closes it when it dequeues the message.
 	startQueueWaitSpan(ctx, tracer, msg)
@@ -5650,7 +5666,7 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 	select {
 	case result = <-msg.Response:
 		// Worker->caller goroutine-hop latency: measure the instant we receive so the
-		// breakdown carves this scheduling gap out of "core" into "worker-handoff".
+		// breakdown carves this scheduling gap out of the residual into "worker-handoff".
 		if !msg.sentAt.IsZero() {
 			msg.Context.StampWorkerHandoff(time.Since(msg.sentAt))
 		}
@@ -5761,9 +5777,12 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 		return nil, bifrostErr
 	}
 
-	// Add MCP tools to request if MCP is configured and requested
+	// Add MCP tools to request if MCP is configured and requested.
+	// Timed as "miscellaneous": the tool-definition merge sits on no other span.
 	if req.RequestType != schemas.SpeechStreamRequest && req.RequestType != schemas.TranscriptionStreamRequest && bifrost.MCPManager != nil {
+		mcpSpan := bifrost.startCoreSpan(ctx, "miscellaneous")
 		req = bifrost.MCPManager.AddToolsToRequest(ctx, req)
+		bifrost.endCoreSpan(mcpSpan)
 	}
 
 	tracer := bifrost.getTracer()
@@ -5800,10 +5819,14 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 		}
 	}()
 
+	// "pipeline-pre" overhead phase: the LLM pre-hook pipeline glue (loop + pool
+	// around the per-plugin spans that nest inside it), mirroring tryRequest.
+	prePipeSpan := bifrost.startCoreSpan(ctx, "pipeline-pre")
 	// RequestType, Provider, OriginalModelRequested, and ResolvedModelUsed are always
 	// overwritten around RunPostLLMHooks — plugin modifications to these 4 fields are
 	// no-ops by design; proper request metadata is preserved and tampering is discouraged.
 	preReq, shortCircuit, preCount := pipeline.RunLLMPreHooks(ctx, req)
+	bifrost.endCoreSpan(prePipeSpan)
 	if shortCircuit != nil {
 		// Handle short-circuit with response (success case)
 		if shortCircuit.Response != nil {
@@ -5933,10 +5956,13 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 		return nil, bifrostErr
 	}
 
+	// "miscellaneous" phase: field re-read + channel-message setup before enqueue.
+	preEnqueueSpan := bifrost.startCoreSpan(ctx, "miscellaneous")
 	provider, model, _ = preReq.GetRequestFields()
 
 	msg := bifrost.getChannelMessage(*preReq)
 	msg.Context = ctx
+	bifrost.endCoreSpan(preEnqueueSpan)
 
 	// Open the queue-wait span; the worker closes it when it dequeues the message.
 	startQueueWaitSpan(ctx, tracer, msg)
@@ -6435,7 +6461,7 @@ func executeRequestWithRetries[T any](
 
 		// Populate LLM request attributes (messages, parameters, etc.). Timed as an
 		// "attribute-population" span: writing a large prompt's messages onto the span
-		// is real, payload-scaled work that otherwise hides in the core bucket.
+		// is real, payload-scaled work.
 		if req != nil {
 			_, attrHandle := tracer.StartSpanID(ctx, "attribute-population", schemas.SpanKindInternal)
 			tracer.PopulateLLMRequestAttributes(handle, req)
@@ -6834,13 +6860,12 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 			}
 		}
 
-		_, model, _ := req.BifrostRequest.GetRequestFields()
-
-		// "worker-setup" overhead phase: per-attempt base-provider resolution and the
-		// raw-capture flag computation (~a dozen ctx writes) the worker does between
-		// dequeue and key acquisition. No early exits in this block, so a single span
-		// pair is safe; closed just before key acquisition below.
+		// "worker-setup" overhead phase: the dequeue field re-read, per-attempt
+		// base-provider resolution, and raw-capture flag computation (~a dozen ctx writes)
+		// the worker does between dequeue and key acquisition. No early exits in this
+		// block, so a single span pair is safe; closed just before key acquisition below.
 		workerSetupSpan := bifrost.startCoreSpan(req.Context, "worker-setup")
+		_, model, _ := req.BifrostRequest.GetRequestFields()
 
 		var result *schemas.BifrostResponse
 		var stream chan *schemas.BifrostStreamChunk
@@ -6945,8 +6970,8 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 					// executeRequestWithRetries via keyProvider so that each retry attempt can use
 					// a different key (on rate-limit errors) without re-running the full filtering.
 					// "key-pool" overhead phase: building the candidate key pool (filtering,
-					// governance/alias resolution) is worker-side work that otherwise folds
-					// into "core"; the per-attempt pick is the separate "key.selection" span.
+					// governance/alias resolution) is worker-side work; the per-attempt pick
+					// is the separate "key.selection" span.
 					keyPoolSpan := bifrost.startCoreSpan(req.Context, "key-pool")
 					supportedKeys, canRotate, keyPoolErr := bifrost.selectKeyFromProviderForModelWithPool(req.Context, req.RequestType, provider.GetProviderKey(), model, baseProvider)
 					bifrost.endCoreSpan(keyPoolSpan)
@@ -7211,14 +7236,14 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 			}
 		}
 
-		// Stamp the pre-send time so tryRequest can measure the worker->caller
-		// goroutine-hop latency ("worker-handoff") on receipt, regardless of which
-		// branch (error/stream/response) does the send below.
-		req.sentAt = time.Now()
-
 		if bifrostError != nil {
+			// Time the field population as "miscellaneous", then stamp sentAt just before
+			// the send so "worker-handoff" measures only the goroutine hop, not this work.
+			miscSpan := bifrost.startCoreSpan(req.Context, "miscellaneous")
 			bifrostError.PopulateExtraFields(req.RequestType, provider.GetProviderKey(), originalModelRequested, resolvedModel)
 			bifrostError.PopulateRoutingInfo(attemptRoutingInfo)
+			bifrost.endCoreSpan(miscSpan)
+			req.sentAt = time.Now()
 
 			// Send error with context awareness to prevent deadlock
 			deliveryTimer.Reset(5 * time.Second)
@@ -7238,10 +7263,15 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 			}
 			deliveryTimer.Stop()
 		} else {
+			// Time the field population as "miscellaneous", then stamp sentAt just before
+			// the send so "worker-handoff" measures only the goroutine hop, not this work.
+			miscSpan := bifrost.startCoreSpan(req.Context, "miscellaneous")
 			if result != nil {
 				result.PopulateExtraFields(req.RequestType, provider.GetProviderKey(), originalModelRequested, resolvedModel)
 				result.PopulateRoutingInfo(attemptRoutingInfo)
 			}
+			bifrost.endCoreSpan(miscSpan)
+			req.sentAt = time.Now()
 			if IsStreamRequestType(req.RequestType) {
 				// Send stream with context awareness to prevent deadlock
 				deliveryTimer.Reset(5 * time.Second)
@@ -8397,8 +8427,8 @@ type coreSpan struct {
 }
 
 // startCoreSpan opens an internal overhead phase span for a core-pipeline segment
-// (setup, key-pool build, pre/post processing) that sits on no other span and would
-// otherwise fold into the residual "core" bucket. It installs the new span as the
+// (setup, key-pool build, pre/post processing) that sits on no other span. It
+// installs the new span as the
 // ACTIVE parent on ctx so any spans opened during the phase (plugin hooks, provider
 // phases) nest as its children — computeOverheadBreakdown subtracts direct children, so
 // without this the nested work would be counted in both this phase's self-time and its
@@ -8432,7 +8462,7 @@ func (bifrost *Bifrost) endCoreSpan(cs coreSpan) {
 // the message sits in the provider queue before a worker dequeues it. The handle is
 // stored on the message; endQueueWaitSpan closes it on dequeue, and
 // releaseChannelMessage closes it if the send never reached a worker. When no trace
-// is active StartSpanID returns a nil handle, so the phase simply folds into core.
+// is active StartSpanID returns a nil handle, so the phase simply folds into the residual.
 func startQueueWaitSpan(ctx *schemas.BifrostContext, tracer schemas.Tracer, msg *ChannelMessage) {
 	if tracer == nil {
 		return

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -144,7 +144,13 @@ func setAnthropicRequestBody(ctx *schemas.BifrostContext, req *fasthttp.Request,
 	// was already activated at transport layer.
 	usedLargePayloadBody := providerUtils.ApplyLargePayloadRequestBodyWithModelNormalization(ctx, req, schemas.Anthropic)
 	if !usedLargePayloadBody {
+		// Time the payload copy as "request-marshal" so it lands in the marshal bucket
+		// instead of the provider-internal residual.
+		mt, mh := providerUtils.StartPhaseSpan(ctx, "request-marshal")
 		req.SetBody(body)
+		if mt != nil {
+			mt.EndSpan(mh, schemas.SpanStatusOk, "")
+		}
 	}
 	return usedLargePayloadBody
 }
@@ -285,8 +291,14 @@ func completeRequest(
 		return nil, latency, nil, bifrostErr
 	}
 
-	// Extract provider response headers before status check so error responses also forward them
+	// Extract provider response headers before status check so error responses also forward them.
+	// Time the header copy as "response-finalize" so it lands in that bucket instead of the
+	// provider-internal residual.
+	ft, fh := providerUtils.StartPhaseSpan(ctx, "response-finalize")
 	providerResponseHeaders := providerUtils.ExtractProviderResponseHeaders(resp)
+	if ft != nil {
+		ft.EndSpan(fh, schemas.SpanStatusOk, "")
+	}
 
 	// Handle error response — materialize stream body for error parsing
 	if resp.StatusCode() != fasthttp.StatusOK {
@@ -440,12 +452,16 @@ func (provider *AnthropicProvider) TextCompletion(ctx *schemas.BifrostContext, k
 	response := acquireAnthropicTextResponse()
 	defer releaseAnthropicTextResponse(response)
 
-	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, response, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, responseBody, response, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 	if bifrostErr != nil {
 		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 	}
 
+	convTracer, convHandle := providerUtils.StartResponseConvertorSpan(ctx)
 	bifrostResponse := response.ToBifrostTextCompletionResponse()
+	if convTracer != nil {
+		convTracer.EndSpan(convHandle, schemas.SpanStatusOk, "")
+	}
 
 	// Set ExtraFields
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
@@ -1342,13 +1358,17 @@ func HandleAnthropicResponsesRequest(
 	response := AcquireAnthropicMessageResponse()
 	defer ReleaseAnthropicMessageResponse(response)
 
-	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, response, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, config.ShouldSendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, config.ShouldSendBackRawResponse))
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, responseBody, response, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, config.ShouldSendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, config.ShouldSendBackRawResponse))
 	if bifrostErr != nil {
 		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, config.ShouldSendBackRawRequest, config.ShouldSendBackRawResponse, latency)
 	}
 
 	// Create final response
+	convTracer, convHandle := providerUtils.StartResponseConvertorSpan(ctx)
 	bifrostResponse := response.ToBifrostResponsesResponse(ctx)
+	if convTracer != nil {
+		convTracer.EndSpan(convHandle, schemas.SpanStatusOk, "")
+	}
 
 	// Set ExtraFields
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()

--- a/core/providers/anthropic/requestbuilder.go
+++ b/core/providers/anthropic/requestbuilder.go
@@ -301,8 +301,12 @@ func BuildAnthropicResponsesRequestBody(ctx *schemas.BifrostContext, request *sc
 			}
 		}
 
+		ct, ch := providerUtils.StartPhaseSpan(ctx, "convertor")
 		reqBody, convErr := ToAnthropicResponsesRequest(ctx, request)
 		if convErr != nil {
+			if ct != nil {
+				ct.EndSpan(ch, schemas.SpanStatusError, convErr.Error())
+			}
 			if errors.Is(convErr, ErrReasoningMaxTokensTooLow) {
 				return nil, providerUtils.EnrichError(
 					ctx,
@@ -316,7 +320,13 @@ func BuildAnthropicResponsesRequestBody(ctx *schemas.BifrostContext, request *sc
 			return nil, newErr(schemas.ErrRequestBodyConversion, convErr, jsonBody)
 		}
 		if reqBody == nil {
+			if ct != nil {
+				ct.EndSpan(ch, schemas.SpanStatusError, "request body is not provided")
+			}
 			return nil, newErr("request body is not provided", nil, jsonBody)
+		}
+		if ct != nil {
+			ct.EndSpan(ch, schemas.SpanStatusOk, "")
 		}
 
 		if cfg.Model != "" {
@@ -343,7 +353,15 @@ func BuildAnthropicResponsesRequestBody(ctx *schemas.BifrostContext, request *sc
 
 		AddMissingBetaHeadersToContext(ctx, reqBody, cfg.Provider)
 
+		mt, mh := providerUtils.StartPhaseSpan(ctx, "request-marshal")
 		jsonBody, err = providerUtils.MarshalProviderRequest(reqBody)
+		if mt != nil {
+			if err != nil {
+				mt.EndSpan(mh, schemas.SpanStatusError, err.Error())
+			} else {
+				mt.EndSpan(mh, schemas.SpanStatusOk, "")
+			}
+		}
 		if err != nil {
 			return nil, newErr(schemas.ErrProviderRequestMarshal, fmt.Errorf("failed to marshal request body: %w", err), jsonBody)
 		}
@@ -562,8 +580,12 @@ func BuildAnthropicChatRequestBody(ctx *schemas.BifrostContext, request *schemas
 			}
 		}
 	} else {
+		ct, ch := providerUtils.StartPhaseSpan(ctx, "convertor")
 		reqBody, convErr := ToAnthropicChatRequest(ctx, request)
 		if convErr != nil {
+			if ct != nil {
+				ct.EndSpan(ch, schemas.SpanStatusError, convErr.Error())
+			}
 			if errors.Is(convErr, ErrReasoningMaxTokensTooLow) {
 				return nil, providerUtils.EnrichError(
 					ctx,
@@ -577,7 +599,13 @@ func BuildAnthropicChatRequestBody(ctx *schemas.BifrostContext, request *schemas
 			return nil, newErr(schemas.ErrRequestBodyConversion, convErr, jsonBody)
 		}
 		if reqBody == nil {
+			if ct != nil {
+				ct.EndSpan(ch, schemas.SpanStatusError, "request body is not provided")
+			}
 			return nil, newErr("request body is not provided", nil, jsonBody)
+		}
+		if ct != nil {
+			ct.EndSpan(ch, schemas.SpanStatusOk, "")
 		}
 
 		if cfg.Model != "" {
@@ -603,7 +631,15 @@ func BuildAnthropicChatRequestBody(ctx *schemas.BifrostContext, request *schemas
 
 		AddMissingBetaHeadersToContext(ctx, reqBody, cfg.Provider)
 
+		mt, mh := providerUtils.StartPhaseSpan(ctx, "request-marshal")
 		jsonBody, err = providerUtils.MarshalProviderRequest(reqBody)
+		if mt != nil {
+			if err != nil {
+				mt.EndSpan(mh, schemas.SpanStatusError, err.Error())
+			} else {
+				mt.EndSpan(mh, schemas.SpanStatusOk, "")
+			}
+		}
 		if err != nil {
 			return nil, newErr(schemas.ErrProviderRequestMarshal, fmt.Errorf("failed to marshal request body: %w", err), jsonBody)
 		}

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -918,10 +918,16 @@ func (provider *AzureProvider) SpeechStream(ctx *schemas.BifrostContext, postHoo
 						continue
 					}
 
-					// Azure sends JSON-wrapped responses for speech streaming
-					// Parse the JSON to extract the response type and audio data
+					// Azure sends JSON-wrapped responses for speech streaming.
+					// Parse the JSON to extract the response type and audio data.
+					// Timed as the "response-parse" stream phase (per-event JSON decode);
+					// the unmarshal maps straight into the Bifrost type, so there is no
+					// distinct convert step to time here.
 					var response schemas.BifrostSpeechStreamResponse
-					if err := sonic.Unmarshal(audioData, &response); err != nil {
+					parseStart := time.Now()
+					err := sonic.Unmarshal(audioData, &response)
+					schemas.AddStreamParse(ctx, time.Since(parseStart))
+					if err != nil {
 						// If JSON parsing fails, check if this might be an error response
 						// Quick check for error field (allocation-free using sonic.Get)
 						if errorNode, _ := sonic.Get(audioData, "error"); errorNode.Exists() {

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -366,7 +366,15 @@ func (provider *BedrockProvider) executeBedrockRequest(req *http.Request) ([]byt
 	defer resp.Body.Close()
 
 	// Read response body
+	ft, fh := providerUtils.StartPhaseSpan(req.Context(), "response-finalize")
 	body, err := io.ReadAll(resp.Body)
+	if ft != nil {
+		if err != nil {
+			ft.EndSpan(fh, schemas.SpanStatusError, err.Error())
+		} else {
+			ft.EndSpan(fh, schemas.SpanStatusOk, "")
+		}
+	}
 	if err != nil {
 		return nil, latency, providerResponseHeaders, providerUtils.SetErrorLatency(&schemas.BifrostError{
 			IsBifrostError: true,
@@ -630,11 +638,10 @@ func signAWSRequest(
 	keyCfg *schemas.BedrockKeyConfig,
 	region, service string,
 ) (signErr *schemas.BifrostError) {
-	// "request-sign" overhead phase: AWS SigV4 signing is real per-request work that
-	// otherwise hides in "core". The nested "credentials-fetch" span (below) isolates
-	// the network portion (STS AssumeRole / credential-provider Retrieve) from the CPU
-	// crypto, so a cold credential cache on an idle box reads as its own bucket instead
-	// of inflating core.
+	// "request-sign" overhead phase: AWS SigV4 signing is real per-request work. The
+	// nested "credentials-fetch" span (below) isolates the network portion (STS
+	// AssumeRole / credential-provider Retrieve) from the CPU crypto, so a cold
+	// credential cache on an idle box reads as its own bucket.
 	// Scoped so the nested "credentials-fetch" span below is a true child and its
 	// time is subtracted from request-sign's self-time exactly once (not double-counted
 	// in both buckets). restore() reinstates the prior parent before the span ends.
@@ -1059,17 +1066,43 @@ func (provider *BedrockProvider) TextCompletion(ctx *schemas.BifrostContext, key
 	switch {
 	case schemas.IsAnthropicModelFamily(ctx, request.Model):
 		var response BedrockAnthropicTextResponse
-		if err := sonic.Unmarshal(body, &response); err != nil {
-			return nil, providerUtils.NewBifrostOperationError("error parsing anthropic response", err)
+		parseTracer, parseHandle := providerUtils.StartResponseParseSpan(ctx)
+		umErr := sonic.Unmarshal(body, &response)
+		if parseTracer != nil {
+			if umErr != nil {
+				parseTracer.EndSpan(parseHandle, schemas.SpanStatusError, umErr.Error())
+			} else {
+				parseTracer.EndSpan(parseHandle, schemas.SpanStatusOk, "")
+			}
 		}
+		if umErr != nil {
+			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("error parsing anthropic response", umErr), jsonData, body, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
+		}
+		convTracer, convHandle := providerUtils.StartResponseConvertorSpan(ctx)
 		bifrostResponse = response.ToBifrostTextCompletionResponse()
+		if convTracer != nil {
+			convTracer.EndSpan(convHandle, schemas.SpanStatusOk, "")
+		}
 
 	case schemas.IsMistralModelFamily(ctx, request.Model):
 		var response BedrockMistralTextResponse
-		if err := sonic.Unmarshal(body, &response); err != nil {
-			return nil, providerUtils.NewBifrostOperationError("error parsing mistral response", err)
+		parseTracer, parseHandle := providerUtils.StartResponseParseSpan(ctx)
+		umErr := sonic.Unmarshal(body, &response)
+		if parseTracer != nil {
+			if umErr != nil {
+				parseTracer.EndSpan(parseHandle, schemas.SpanStatusError, umErr.Error())
+			} else {
+				parseTracer.EndSpan(parseHandle, schemas.SpanStatusOk, "")
+			}
 		}
+		if umErr != nil {
+			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("error parsing mistral response", umErr), jsonData, body, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
+		}
+		convTracer, convHandle := providerUtils.StartResponseConvertorSpan(ctx)
 		bifrostResponse = response.ToBifrostTextCompletionResponse()
+		if convTracer != nil {
+			convTracer.EndSpan(convHandle, schemas.SpanStatusOk, "")
+		}
 
 	default:
 		return nil, providerUtils.NewConfigurationError(fmt.Sprintf("unsupported model type for text completion: %s", request.Model))
@@ -1799,9 +1832,16 @@ func (provider *BedrockProvider) Responses(ctx *schemas.BifrostContext, key sche
 	}
 
 	// Convert using the new response converter
+	convTracer, convHandle := providerUtils.StartResponseConvertorSpan(ctx)
 	bifrostResponse, err := bedrockResponse.ToBifrostResponsesResponse(ctx)
 	if err != nil {
+		if convTracer != nil {
+			convTracer.EndSpan(convHandle, schemas.SpanStatusError, err.Error())
+		}
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("failed to convert bedrock response", err), jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
+	}
+	if convTracer != nil {
+		convTracer.EndSpan(convHandle, schemas.SpanStatusOk, "")
 	}
 
 	bifrostResponse.Model = request.Model
@@ -2171,18 +2211,48 @@ func (provider *BedrockProvider) Embedding(ctx *schemas.BifrostContext, key sche
 	switch modelType {
 	case "titan":
 		var titanResp BedrockTitanEmbeddingResponse
-		if err := sonic.Unmarshal(rawResponse, &titanResp); err != nil {
-			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("error parsing Titan embedding response", err), jsonData, rawResponse, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
+		titanParseTracer, titanParseHandle := providerUtils.StartResponseParseSpan(ctx)
+		umErr := sonic.Unmarshal(rawResponse, &titanResp)
+		if titanParseTracer != nil {
+			if umErr != nil {
+				titanParseTracer.EndSpan(titanParseHandle, schemas.SpanStatusError, umErr.Error())
+			} else {
+				titanParseTracer.EndSpan(titanParseHandle, schemas.SpanStatusOk, "")
+			}
 		}
+		if umErr != nil {
+			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("error parsing Titan embedding response", umErr), jsonData, rawResponse, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
+		}
+		titanConvTracer, titanConvHandle := providerUtils.StartResponseConvertorSpan(ctx)
 		bifrostResponse = titanResp.ToBifrostEmbeddingResponse()
+		if titanConvTracer != nil {
+			titanConvTracer.EndSpan(titanConvHandle, schemas.SpanStatusOk, "")
+		}
 		bifrostResponse.Model = request.Model
 
 	case "cohere":
 		var cohereResp BedrockCohereEmbeddingResponse
-		if err := sonic.Unmarshal(rawResponse, &cohereResp); err != nil {
-			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("error parsing Cohere embedding response", err), jsonData, rawResponse, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
+		cohereParseTracer, cohereParseHandle := providerUtils.StartResponseParseSpan(ctx)
+		umErr := sonic.Unmarshal(rawResponse, &cohereResp)
+		if cohereParseTracer != nil {
+			if umErr != nil {
+				cohereParseTracer.EndSpan(cohereParseHandle, schemas.SpanStatusError, umErr.Error())
+			} else {
+				cohereParseTracer.EndSpan(cohereParseHandle, schemas.SpanStatusOk, "")
+			}
 		}
+		if umErr != nil {
+			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("error parsing Cohere embedding response", umErr), jsonData, rawResponse, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
+		}
+		cohereConvTracer, cohereConvHandle := providerUtils.StartResponseConvertorSpan(ctx)
 		converted, convErr := cohereResp.ToBifrostEmbeddingResponse()
+		if cohereConvTracer != nil {
+			if convErr != nil {
+				cohereConvTracer.EndSpan(cohereConvHandle, schemas.SpanStatusError, convErr.Error())
+			} else {
+				cohereConvTracer.EndSpan(cohereConvHandle, schemas.SpanStatusOk, "")
+			}
+		}
 		if convErr != nil {
 			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("error parsing Cohere embedding response", convErr), jsonData, rawResponse, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 		}
@@ -2361,15 +2431,28 @@ func (provider *BedrockProvider) ImageGeneration(ctx *schemas.BifrostContext, ke
 	// Parse response based on model type
 	var bifrostResponse *schemas.BifrostImageGenerationResponse
 	var imageResp BedrockImageGenerationResponse
-	if err := sonic.Unmarshal(rawResponse, &imageResp); err != nil {
-		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("error parsing image generation response", err), jsonData, rawResponse, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
+	parseTracer, parseHandle := providerUtils.StartResponseParseSpan(ctx)
+	umErr := sonic.Unmarshal(rawResponse, &imageResp)
+	if parseTracer != nil {
+		if umErr != nil {
+			parseTracer.EndSpan(parseHandle, schemas.SpanStatusError, umErr.Error())
+		} else {
+			parseTracer.EndSpan(parseHandle, schemas.SpanStatusOk, "")
+		}
+	}
+	if umErr != nil {
+		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("error parsing image generation response", umErr), jsonData, rawResponse, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 	}
 
 	if imageResp.Error != "" {
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(imageResp.Error, nil), jsonData, rawResponse, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 	}
 
+	convTracer, convHandle := providerUtils.StartResponseConvertorSpan(ctx)
 	bifrostResponse = ToBifrostImageGenerationResponse(&imageResp)
+	if convTracer != nil {
+		convTracer.EndSpan(convHandle, schemas.SpanStatusOk, "")
+	}
 	bifrostResponse.Model = request.Model
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
 	bifrostResponse.ExtraFields.ProviderResponseHeaders = providerResponseHeaders
@@ -2435,8 +2518,17 @@ func (provider *BedrockProvider) ImageEdit(ctx *schemas.BifrostContext, key sche
 
 	// Parse response (reuse BedrockImageGenerationResponse)
 	var imageResp BedrockImageGenerationResponse
-	if err := sonic.Unmarshal(rawResponse, &imageResp); err != nil {
-		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("error parsing image edit response", err), jsonData, rawResponse, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
+	parseTracer, parseHandle := providerUtils.StartResponseParseSpan(ctx)
+	umErr := sonic.Unmarshal(rawResponse, &imageResp)
+	if parseTracer != nil {
+		if umErr != nil {
+			parseTracer.EndSpan(parseHandle, schemas.SpanStatusError, umErr.Error())
+		} else {
+			parseTracer.EndSpan(parseHandle, schemas.SpanStatusOk, "")
+		}
+	}
+	if umErr != nil {
+		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("error parsing image edit response", umErr), jsonData, rawResponse, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 	}
 
 	if imageResp.Error != "" {
@@ -2444,7 +2536,11 @@ func (provider *BedrockProvider) ImageEdit(ctx *schemas.BifrostContext, key sche
 	}
 
 	// Convert response and set metadata
+	convTracer, convHandle := providerUtils.StartResponseConvertorSpan(ctx)
 	bifrostResponse := ToBifrostImageGenerationResponse(&imageResp)
+	if convTracer != nil {
+		convTracer.EndSpan(convHandle, schemas.SpanStatusOk, "")
+	}
 	bifrostResponse.Model = request.Model
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
 	bifrostResponse.ExtraFields.ProviderResponseHeaders = providerResponseHeaders
@@ -2502,8 +2598,17 @@ func (provider *BedrockProvider) ImageVariation(ctx *schemas.BifrostContext, key
 
 	// Parse response (reuse BedrockImageGenerationResponse and ToBifrostImageGenerationResponse)
 	var imageResp BedrockImageGenerationResponse
-	if err := sonic.Unmarshal(rawResponse, &imageResp); err != nil {
-		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("error parsing image variation response", err), jsonData, rawResponse, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
+	parseTracer, parseHandle := providerUtils.StartResponseParseSpan(ctx)
+	umErr := sonic.Unmarshal(rawResponse, &imageResp)
+	if parseTracer != nil {
+		if umErr != nil {
+			parseTracer.EndSpan(parseHandle, schemas.SpanStatusError, umErr.Error())
+		} else {
+			parseTracer.EndSpan(parseHandle, schemas.SpanStatusOk, "")
+		}
+	}
+	if umErr != nil {
+		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("error parsing image variation response", umErr), jsonData, rawResponse, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 	}
 
 	if imageResp.Error != "" {
@@ -2511,7 +2616,11 @@ func (provider *BedrockProvider) ImageVariation(ctx *schemas.BifrostContext, key
 	}
 
 	// Convert response and set metadata
+	convTracer, convHandle := providerUtils.StartResponseConvertorSpan(ctx)
 	bifrostResponse := ToBifrostImageGenerationResponse(&imageResp)
+	if convTracer != nil {
+		convTracer.EndSpan(convHandle, schemas.SpanStatusOk, "")
+	}
 	bifrostResponse.Model = request.Model
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
 	bifrostResponse.ExtraFields.ProviderResponseHeaders = providerResponseHeaders

--- a/core/providers/cohere/cohere.go
+++ b/core/providers/cohere/cohere.go
@@ -677,12 +677,16 @@ func (provider *CohereProvider) Responses(ctx *schemas.BifrostContext, key schem
 	response := acquireCohereResponse()
 	defer releaseCohereResponse(response)
 
-	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, response, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, responseBody, response, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 	if bifrostErr != nil {
 		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 	}
 
+	convTracer, convHandle := providerUtils.StartResponseConvertorSpan(ctx)
 	bifrostResponse := response.ToBifrostResponsesResponse()
+	if convTracer != nil {
+		convTracer.EndSpan(convHandle, schemas.SpanStatusOk, "")
+	}
 
 	bifrostResponse.Model = request.Model
 
@@ -968,12 +972,16 @@ func (provider *CohereProvider) Embedding(ctx *schemas.BifrostContext, key schem
 	response := acquireCohereEmbeddingResponse()
 	defer releaseCohereEmbeddingResponse(response)
 
-	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, response, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, responseBody, response, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 	if bifrostErr != nil {
 		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 	}
 
+	convTracer, convHandle := providerUtils.StartResponseConvertorSpan(ctx)
 	bifrostResponse := response.ToBifrostEmbeddingResponse()
+	if convTracer != nil {
+		convTracer.EndSpan(convHandle, schemas.SpanStatusOk, "")
+	}
 
 	// Set ExtraFields
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()

--- a/core/providers/elevenlabs/elevenlabs.go
+++ b/core/providers/elevenlabs/elevenlabs.go
@@ -255,7 +255,15 @@ func (provider *ElevenlabsProvider) Speech(ctx *schemas.BifrostContext, key sche
 	}
 
 	// Get the response body
+	ft, fh := providerUtils.StartPhaseSpan(ctx, "response-finalize")
 	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if ft != nil {
+		if err != nil {
+			ft.EndSpan(fh, schemas.SpanStatusError, err.Error())
+		} else {
+			ft.EndSpan(fh, schemas.SpanStatusOk, "")
+		}
+	}
 	if err != nil {
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err), jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 	}
@@ -274,8 +282,17 @@ func (provider *ElevenlabsProvider) Speech(ctx *schemas.BifrostContext, key sche
 
 	if withTimestampsRequest {
 		var timestampResponse ElevenlabsSpeechWithTimestampsResponse
-		if err := sonic.Unmarshal(body, &timestampResponse); err != nil {
-			return nil, providerUtils.NewBifrostOperationError("failed to parse with-timestamps response", err)
+		pt, ph := providerUtils.StartResponseParseSpan(ctx)
+		umErr := sonic.Unmarshal(body, &timestampResponse)
+		if pt != nil {
+			if umErr != nil {
+				pt.EndSpan(ph, schemas.SpanStatusError, "response parse failed")
+			} else {
+				pt.EndSpan(ph, schemas.SpanStatusOk, "")
+			}
+		}
+		if umErr != nil {
+			return nil, providerUtils.NewBifrostOperationError("failed to parse with-timestamps response", umErr)
 		}
 
 		bifrostResponse.AudioBase64 = &timestampResponse.AudioBase64
@@ -497,7 +514,16 @@ func (provider *ElevenlabsProvider) Transcription(ctx *schemas.BifrostContext, k
 		return nil, err
 	}
 
+	// Time the request conversion as the convertor phase.
+	ct, ch := providerUtils.StartPhaseSpan(ctx, "convertor")
 	reqBody := ToElevenlabsTranscriptionRequest(request)
+	if ct != nil {
+		if reqBody == nil {
+			ct.EndSpan(ch, schemas.SpanStatusError, "transcription request is not provided")
+		} else {
+			ct.EndSpan(ch, schemas.SpanStatusOk, "")
+		}
+	}
 	if reqBody == nil {
 		return nil, providerUtils.NewBifrostOperationError("transcription request is not provided", nil)
 	}
@@ -514,7 +540,17 @@ func (provider *ElevenlabsProvider) Transcription(ctx *schemas.BifrostContext, k
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
 
-	if bifrostErr := writeTranscriptionMultipart(writer, reqBody); bifrostErr != nil {
+	// Time the multipart build as the request-marshal phase.
+	mt, mh := providerUtils.StartPhaseSpan(ctx, "request-marshal")
+	bifrostErr := writeTranscriptionMultipart(writer, reqBody)
+	if mt != nil {
+		if bifrostErr != nil {
+			mt.EndSpan(mh, schemas.SpanStatusError, bifrostErr.Error.Message)
+		} else {
+			mt.EndSpan(mh, schemas.SpanStatusOk, "")
+		}
+	}
+	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
 
@@ -554,7 +590,15 @@ func (provider *ElevenlabsProvider) Transcription(ctx *schemas.BifrostContext, k
 		return nil, providerUtils.SetErrorLatency(parseElevenlabsError(resp), latency)
 	}
 
+	ft, fh := providerUtils.StartPhaseSpan(ctx, "response-finalize")
 	responseBody, err := providerUtils.CheckAndDecodeBody(resp)
+	if ft != nil {
+		if err != nil {
+			ft.EndSpan(fh, schemas.SpanStatusError, err.Error())
+		} else {
+			ft.EndSpan(fh, schemas.SpanStatusOk, "")
+		}
+	}
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err)
 	}
@@ -570,7 +614,15 @@ func (provider *ElevenlabsProvider) Transcription(ctx *schemas.BifrostContext, k
 		}
 	}
 
+	pt, ph := providerUtils.StartResponseParseSpan(ctx)
 	chunks, err := parseTranscriptionResponse(responseBody)
+	if pt != nil {
+		if err != nil {
+			pt.EndSpan(ph, schemas.SpanStatusError, "response parse failed")
+		} else {
+			pt.EndSpan(ph, schemas.SpanStatusOk, "")
+		}
+	}
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError(err.Error(), nil)
 	}

--- a/core/providers/elevenlabs/soundgeneration.go
+++ b/core/providers/elevenlabs/soundgeneration.go
@@ -117,7 +117,15 @@ func (provider *ElevenlabsProvider) soundGeneration(ctx *schemas.BifrostContext,
 		return nil, providerUtils.EnrichError(ctx, parseElevenlabsError(resp), jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
+	ft, fh := providerUtils.StartPhaseSpan(ctx, "response-finalize")
 	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if ft != nil {
+		if err != nil {
+			ft.EndSpan(fh, schemas.SpanStatusError, err.Error())
+		} else {
+			ft.EndSpan(fh, schemas.SpanStatusOk, "")
+		}
+	}
 	if err != nil {
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err), jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -167,8 +167,17 @@ func (provider *GeminiProvider) completeRequest(ctx *schemas.BifrostContext, mod
 
 	// Parse Gemini's response
 	var geminiResponse GenerateContentResponse
-	if err := sonic.Unmarshal(body, &geminiResponse); err != nil {
-		return nil, nil, latency, providerResponseHeaders, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err)
+	pt, ph := providerUtils.StartResponseParseSpan(ctx)
+	umErr := sonic.Unmarshal(body, &geminiResponse)
+	if pt != nil {
+		if umErr != nil {
+			pt.EndSpan(ph, schemas.SpanStatusError, "response parse failed")
+		} else {
+			pt.EndSpan(ph, schemas.SpanStatusOk, "")
+		}
+	}
+	if umErr != nil {
+		return nil, nil, latency, providerResponseHeaders, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, umErr)
 	}
 
 	var rawResponse interface{}
@@ -812,10 +821,23 @@ func (provider *GeminiProvider) responsesWithLargeResponseDetection(
 
 	// Normal parse-and-convert path
 	var geminiResponse GenerateContentResponse
-	if unmarshalErr := sonic.Unmarshal(responseBody, &geminiResponse); unmarshalErr != nil {
+	pt, ph := providerUtils.StartResponseParseSpan(ctx)
+	unmarshalErr := sonic.Unmarshal(responseBody, &geminiResponse)
+	if pt != nil {
+		if unmarshalErr != nil {
+			pt.EndSpan(ph, schemas.SpanStatusError, "response parse failed")
+		} else {
+			pt.EndSpan(ph, schemas.SpanStatusOk, "")
+		}
+	}
+	if unmarshalErr != nil {
 		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, unmarshalErr)
 	}
+	ct, ch := providerUtils.StartResponseConvertorSpan(ctx)
 	bifrostResponse := geminiResponse.ToResponsesBifrostResponsesResponse()
+	if ct != nil {
+		ct.EndSpan(ch, schemas.SpanStatusOk, "")
+	}
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
 	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
 		providerUtils.ParseAndSetRawRequest(&bifrostResponse.ExtraFields, jsonData)
@@ -1302,7 +1324,15 @@ func (provider *GeminiProvider) Embedding(ctx *schemas.BifrostContext, key schem
 	}
 
 	// Convert to Bifrost format
+	ct, ch := providerUtils.StartResponseConvertorSpan(ctx)
 	bifrostResponse := ToBifrostEmbeddingResponse(&geminiResponse, request.Model)
+	if ct != nil {
+		if bifrostResponse == nil {
+			ct.EndSpan(ch, schemas.SpanStatusError, "failed to convert Gemini embedding response to Bifrost format")
+		} else {
+			ct.EndSpan(ch, schemas.SpanStatusOk, "")
+		}
+	}
 	if bifrostResponse == nil {
 		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal,
 			fmt.Errorf("failed to convert Gemini embedding response to Bifrost format"))
@@ -1538,8 +1568,10 @@ func (provider *GeminiProvider) SpeechStream(ctx *schemas.BifrostContext, postHo
 
 			jsonData := data
 
-			// Process chunk using shared function
+			// Time the per-event decode as the response-parse stream phase.
+			parseStart := time.Now()
 			geminiResponse, err := processGeminiStreamChunk(jsonData)
+			schemas.AddStreamParse(ctx, time.Since(parseStart))
 			if err != nil {
 				if strings.Contains(err.Error(), "gemini api error") {
 					// Handle API error
@@ -1826,8 +1858,10 @@ func (provider *GeminiProvider) TranscriptionStream(ctx *schemas.BifrostContext,
 
 			jsonData := data
 
-			// Process chunk using shared function.
+			// Time the per-event decode as the response-parse stream phase.
+			parseStart := time.Now()
 			geminiResponse, err := processGeminiStreamChunk(jsonData)
+			schemas.AddStreamParse(ctx, time.Since(parseStart))
 			if err != nil {
 				if strings.Contains(err.Error(), "gemini api error") {
 					bifrostErr := toGeminiStreamBifrostError(err)
@@ -2048,7 +2082,7 @@ func (provider *GeminiProvider) handleImagenImageGeneration(ctx *schemas.Bifrost
 	}
 
 	imagenResponse := GeminiImagenResponse{}
-	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(body, &imagenResponse, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, body, &imagenResponse, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -2137,7 +2171,7 @@ func (provider *GeminiProvider) ImageEdit(ctx *schemas.BifrostContext, key schem
 		}
 
 		imagenResponse := GeminiImagenResponse{}
-		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(body, &imagenResponse, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, body, &imagenResponse, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 		if bifrostErr != nil {
 			return nil, bifrostErr
 		}

--- a/core/providers/huggingface/huggingface.go
+++ b/core/providers/huggingface/huggingface.go
@@ -260,7 +260,16 @@ func (provider *HuggingFaceProvider) completeRequest(ctx *schemas.BifrostContext
 		return nil, latency, providerResponseHeaders, providerUtils.SetErrorLatency(parseHuggingFaceImageError(resp), latency)
 	}
 
+	// Time the body read/decompress as the response-finalize phase.
+	ft, fh := providerUtils.StartPhaseSpan(ctx, "response-finalize")
 	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if ft != nil {
+		if err != nil {
+			ft.EndSpan(fh, schemas.SpanStatusError, err.Error())
+		} else {
+			ft.EndSpan(fh, schemas.SpanStatusOk, "")
+		}
+	}
 	if err != nil {
 		return nil, latency, providerResponseHeaders, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err)
 	}
@@ -501,7 +510,7 @@ func (provider *HuggingFaceProvider) ChatCompletion(ctx *schemas.BifrostContext,
 
 	var rawResponse interface{}
 	var rawRequest interface{}
-	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, bifrostResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, responseBody, bifrostResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 	if bifrostErr != nil {
 		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 	}
@@ -673,8 +682,17 @@ func (provider *HuggingFaceProvider) Embedding(ctx *schemas.BifrostContext, key 
 		}
 	}
 
-	// Unmarshal directly to BifrostEmbeddingResponse with custom logic
+	// Unmarshal directly to BifrostEmbeddingResponse with custom logic.
+	// Time the decode as the response-parse phase.
+	pt, ph := providerUtils.StartResponseParseSpan(ctx)
 	bifrostResponse, convErr := UnmarshalHuggingFaceEmbeddingResponse(responseBody, request.Model)
+	if pt != nil {
+		if convErr != nil {
+			pt.EndSpan(ph, schemas.SpanStatusError, "response parse failed")
+		} else {
+			pt.EndSpan(ph, schemas.SpanStatusOk, "")
+		}
+	}
 	if convErr != nil {
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, convErr), jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 	}
@@ -1183,14 +1201,20 @@ func (provider *HuggingFaceProvider) ImageGenerationStream(ctx *schemas.BifrostC
 				}
 			}
 
-			// Parse fal-ai response
+			// Parse fal-ai response. Timed as the "response-parse" stream phase (per-event JSON decode).
 			var response HuggingFaceFalAIImageStreamResponse
-			if err := sonic.UnmarshalString(jsonData, &response); err != nil {
-				provider.logger.Warn(fmt.Sprintf("Failed to parse fal-ai stream response: %v", err))
+			parseStart := time.Now()
+			umErr := sonic.UnmarshalString(jsonData, &response)
+			schemas.AddStreamParse(ctx, time.Since(parseStart))
+			if umErr != nil {
+				provider.logger.Warn(fmt.Sprintf("Failed to parse fal-ai stream response: %v", umErr))
 				continue
 			}
-			// Extract images from response (handles both Data.Images and top-level Images)
+			// Extract images from response (handles both Data.Images and top-level Images).
+			// Timed as the "convertor" stream phase (per-event mapping / chunk build).
+			convStart := time.Now()
 			images := extractImagesFromStreamResponse(&response)
+			schemas.AddStreamConvert(ctx, time.Since(convStart))
 			// Process each image in the response
 			for i, img := range images {
 				// Create a fresh chunk for each image to avoid data race
@@ -1567,14 +1591,20 @@ func (provider *HuggingFaceProvider) ImageEditStream(ctx *schemas.BifrostContext
 				}
 			}
 
-			// Parse fal-ai response
+			// Parse fal-ai response. Timed as the "response-parse" stream phase (per-event JSON decode).
 			var response HuggingFaceFalAIImageStreamResponse
-			if err := sonic.UnmarshalString(jsonData, &response); err != nil {
-				provider.logger.Warn(fmt.Sprintf("Failed to parse fal-ai stream response: %v", err))
+			parseStart := time.Now()
+			umErr := sonic.UnmarshalString(jsonData, &response)
+			schemas.AddStreamParse(ctx, time.Since(parseStart))
+			if umErr != nil {
+				provider.logger.Warn(fmt.Sprintf("Failed to parse fal-ai stream response: %v", umErr))
 				continue
 			}
-			// Extract images from response (handles both Data.Images and top-level Images)
+			// Extract images from response (handles both Data.Images and top-level Images).
+			// Timed as the "convertor" stream phase (per-event mapping / chunk build).
+			convStart := time.Now()
 			images := extractImagesFromStreamResponse(&response)
+			schemas.AddStreamConvert(ctx, time.Since(convStart))
 			// Process each image in the response
 			for i, img := range images {
 				// Create a fresh chunk for each image to avoid data race

--- a/core/providers/mistral/mistral.go
+++ b/core/providers/mistral/mistral.go
@@ -339,7 +339,16 @@ func (provider *MistralProvider) Transcription(ctx *schemas.BifrostContext, key 
 
 	// Parse Mistral's transcription response
 	var mistralResponse MistralTranscriptionResponse
-	if err := sonic.Unmarshal(copiedResponseBody, &mistralResponse); err != nil {
+	pt, ph := providerUtils.StartResponseParseSpan(ctx)
+	umErr := sonic.Unmarshal(copiedResponseBody, &mistralResponse)
+	if pt != nil {
+		if umErr != nil {
+			pt.EndSpan(ph, schemas.SpanStatusError, umErr.Error())
+		} else {
+			pt.EndSpan(ph, schemas.SpanStatusOk, "")
+		}
+	}
+	if umErr != nil {
 		if providerUtils.IsHTMLResponse(resp, copiedResponseBody) {
 			return nil, &schemas.BifrostError{
 				IsBifrostError: false,
@@ -349,11 +358,19 @@ func (provider *MistralProvider) Transcription(ctx *schemas.BifrostContext, key 
 				},
 			}
 		}
-		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err)
+		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, umErr)
 	}
 
 	// Convert to Bifrost format
+	ct, ch := providerUtils.StartResponseConvertorSpan(ctx)
 	response := mistralResponse.ToBifrostTranscriptionResponse()
+	if ct != nil {
+		if response == nil {
+			ct.EndSpan(ch, schemas.SpanStatusError, "failed to convert transcription response")
+		} else {
+			ct.EndSpan(ch, schemas.SpanStatusOk, "")
+		}
+	}
 	if response == nil {
 		return nil, providerUtils.NewBifrostOperationError("failed to convert transcription response", nil)
 	}
@@ -576,10 +593,13 @@ func (provider *MistralProvider) processTranscriptionStreamEvent(
 		}
 	}
 
-	// Parse the event data
+	// Parse the event data. Timed as the "response-parse" stream phase (per-event JSON decode).
 	var eventData MistralTranscriptionStreamData
-	if err := sonic.UnmarshalString(jsonData, &eventData); err != nil {
-		provider.logger.Warn("Failed to parse stream event data: %v", err)
+	parseStart := time.Now()
+	umErr := sonic.UnmarshalString(jsonData, &eventData)
+	schemas.AddStreamParse(ctx, time.Since(parseStart))
+	if umErr != nil {
+		provider.logger.Warn("Failed to parse stream event data: %v", umErr)
 		return
 	}
 
@@ -589,8 +609,10 @@ func (provider *MistralProvider) processTranscriptionStreamEvent(
 		Data:  &eventData,
 	}
 
-	// Convert to Bifrost format
+	// Convert to Bifrost format. Timed as the "convertor" stream phase (per-event mapping).
+	convStart := time.Now()
 	response := streamEvent.ToBifrostTranscriptionStreamResponse()
+	schemas.AddStreamConvert(ctx, time.Since(convStart))
 	if response == nil {
 		return
 	}

--- a/core/providers/nebius/nebius.go
+++ b/core/providers/nebius/nebius.go
@@ -326,7 +326,16 @@ func (provider *NebiusProvider) ImageGeneration(ctx *schemas.BifrostContext, key
 		return nil, providerUtils.EnrichError(ctx, parseNebiusImageError(resp), jsonData, nil, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse), latency)
 	}
 
+	// Time the body read/decompress as the response-finalize phase.
+	ft, fh := providerUtils.StartPhaseSpan(ctx, "response-finalize")
 	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if ft != nil {
+		if err != nil {
+			ft.EndSpan(fh, schemas.SpanStatusError, err.Error())
+		} else {
+			ft.EndSpan(fh, schemas.SpanStatusOk, "")
+		}
+	}
 	if err != nil {
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err), jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 	}
@@ -336,7 +345,8 @@ func (provider *NebiusProvider) ImageGeneration(ctx *schemas.BifrostContext, key
 	sendBackRawRequest, sendBackRawResponse := providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
 
 	// Use enhanced response handler with pre-allocated response
-	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(
+		ctx,
 		body,
 		response,
 		jsonData,

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -331,7 +331,7 @@ func HandleOpenAITextCompletionRequest(
 		return nil, bifrostErr
 	}
 
-	req.SetBody(jsonData)
+	timedSetBody(ctx, req, jsonData)
 
 	// Make request
 	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, activeClient, req, resp)
@@ -340,7 +340,7 @@ func HandleOpenAITextCompletionRequest(
 		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, sendBackRawRequest, sendBackRawResponse, latency)
 	}
 	// Extract provider response headers early so they're available on error paths too
-	providerResponseHeaders := providerUtils.ExtractProviderResponseHeaders(resp)
+	providerResponseHeaders := timedExtractResponseHeaders(ctx, resp)
 	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
 
 	// Handle error response
@@ -370,9 +370,18 @@ func HandleOpenAITextCompletionRequest(
 	var rawRequest, rawResponse interface{}
 
 	if customResponseHandler != nil {
+		// Time the custom handler's decode as the response-parse phase.
+		pt, ph := providerUtils.StartResponseParseSpan(ctx)
 		rawRequest, rawResponse, bifrostErr = customResponseHandler(body, response, jsonData, sendBackRawRequest, sendBackRawResponse)
+		if pt != nil {
+			if bifrostErr != nil {
+				pt.EndSpan(ph, schemas.SpanStatusError, "response parse failed")
+			} else {
+				pt.EndSpan(ph, schemas.SpanStatusOk, "")
+			}
+		}
 	} else {
-		rawRequest, rawResponse, bifrostErr = providerUtils.HandleProviderResponse(body, response, jsonData, sendBackRawRequest, sendBackRawResponse)
+		rawRequest, rawResponse, bifrostErr = providerUtils.HandleProviderResponseCtx(ctx, body, response, jsonData, sendBackRawRequest, sendBackRawResponse)
 	}
 
 	if bifrostErr != nil {
@@ -650,8 +659,7 @@ func HandleOpenAITextCompletionStreaming(
 				}
 
 				// Parse into bifrost response. Timed as the "response-parse" stream phase
-				// (per-event JSON decode) so it lands in Serialization like unary/Anthropic,
-				// instead of folding into core/provider-internal.
+				// (per-event JSON decode).
 				parseStart := time.Now()
 				umErr := sonic.UnmarshalString(jsonData, &response)
 				schemas.AddStreamParse(ctx, time.Since(parseStart))
@@ -808,6 +816,29 @@ func (provider *OpenAIProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 	)
 }
 
+// timedSetBody copies the serialized request body onto the fasthttp request inside a
+// "request-marshal" span, so the payload copy is attributed to the marshal bucket
+// instead of the provider-internal residual.
+func timedSetBody(ctx *schemas.BifrostContext, req *fasthttp.Request, body []byte) {
+	mt, mh := providerUtils.StartPhaseSpan(ctx, "request-marshal")
+	req.SetBody(body)
+	if mt != nil {
+		mt.EndSpan(mh, schemas.SpanStatusOk, "")
+	}
+}
+
+// timedExtractResponseHeaders reads the upstream response headers inside a
+// "response-finalize" span, so the header copy is attributed to that bucket instead of
+// the provider-internal residual.
+func timedExtractResponseHeaders(ctx *schemas.BifrostContext, resp *fasthttp.Response) map[string]string {
+	ft, fh := providerUtils.StartPhaseSpan(ctx, "response-finalize")
+	headers := providerUtils.ExtractProviderResponseHeaders(resp)
+	if ft != nil {
+		ft.EndSpan(fh, schemas.SpanStatusOk, "")
+	}
+	return headers
+}
+
 // HandleOpenAIChatCompletionRequest handles a chat completion request to OpenAI's API.
 func HandleOpenAIChatCompletionRequest(
 	ctx *schemas.BifrostContext,
@@ -894,7 +925,7 @@ func HandleOpenAIChatCompletionRequest(
 		}
 	}
 
-	req.SetBody(jsonData)
+	timedSetBody(ctx, req, jsonData)
 
 	// Make request
 	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, activeClient, req, resp)
@@ -903,7 +934,7 @@ func HandleOpenAIChatCompletionRequest(
 		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, sendBackRawRequest, sendBackRawResponse, latency)
 	}
 	// Extract provider response headers early so they're available on error paths too
-	providerResponseHeaders := providerUtils.ExtractProviderResponseHeaders(resp)
+	providerResponseHeaders := timedExtractResponseHeaders(ctx, resp)
 	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
 
 	// Handle error response
@@ -934,7 +965,16 @@ func HandleOpenAIChatCompletionRequest(
 	var rawRequest, rawResponse interface{}
 
 	if customResponseHandler != nil {
+		// The custom handler decodes the body itself; time it as the "response-parse" phase.
+		pt, ph := providerUtils.StartResponseParseSpan(ctx)
 		rawRequest, rawResponse, bifrostErr = customResponseHandler(body, response, jsonData, sendBackRawRequest, sendBackRawResponse)
+		if pt != nil {
+			if bifrostErr != nil {
+				pt.EndSpan(ph, schemas.SpanStatusError, "response parse failed")
+			} else {
+				pt.EndSpan(ph, schemas.SpanStatusOk, "")
+			}
+		}
 	} else {
 		rawRequest, rawResponse, bifrostErr = providerUtils.HandleProviderResponseCtx(ctx, body, response, jsonData, sendBackRawRequest, sendBackRawResponse)
 	}
@@ -1661,7 +1701,7 @@ func HandleOpenAIResponsesRequest(
 		}
 	}
 
-	req.SetBody(jsonData)
+	timedSetBody(ctx, req, jsonData)
 
 	// Make request
 	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, activeClient, req, resp)
@@ -1670,7 +1710,7 @@ func HandleOpenAIResponsesRequest(
 		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, sendBackRawRequest, sendBackRawResponse, latency)
 	}
 	// Extract provider response headers early so they're available on error paths too
-	providerResponseHeaders := providerUtils.ExtractProviderResponseHeaders(resp)
+	providerResponseHeaders := timedExtractResponseHeaders(ctx, resp)
 	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
 
 	// Handle error response
@@ -1700,9 +1740,18 @@ func HandleOpenAIResponsesRequest(
 	var rawRequest, rawResponse interface{}
 
 	if customResponseHandler != nil {
+		// Time the custom handler's decode as the response-parse phase.
+		pt, ph := providerUtils.StartResponseParseSpan(ctx)
 		rawRequest, rawResponse, bifrostErr = customResponseHandler(body, response, jsonData, sendBackRawRequest, sendBackRawResponse)
+		if pt != nil {
+			if bifrostErr != nil {
+				pt.EndSpan(ph, schemas.SpanStatusError, "response parse failed")
+			} else {
+				pt.EndSpan(ph, schemas.SpanStatusOk, "")
+			}
+		}
 	} else {
-		rawRequest, rawResponse, bifrostErr = providerUtils.HandleProviderResponse(body, response, jsonData, sendBackRawRequest, sendBackRawResponse)
+		rawRequest, rawResponse, bifrostErr = providerUtils.HandleProviderResponseCtx(ctx, body, response, jsonData, sendBackRawRequest, sendBackRawResponse)
 	}
 
 	if bifrostErr != nil {
@@ -2157,7 +2206,7 @@ func HandleOpenAIEmbeddingRequest(
 		return nil, bifrostErr
 	}
 
-	req.SetBody(jsonData)
+	timedSetBody(ctx, req, jsonData)
 
 	// Make request
 	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, activeClient, req, resp)
@@ -2166,7 +2215,7 @@ func HandleOpenAIEmbeddingRequest(
 		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, sendBackRawRequest, sendBackRawResponse, latency)
 	}
 	// Extract provider response headers early so they're available on error paths too
-	providerResponseHeaders := providerUtils.ExtractProviderResponseHeaders(resp)
+	providerResponseHeaders := timedExtractResponseHeaders(ctx, resp)
 	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
 
 	// Handle error response
@@ -2194,9 +2243,18 @@ func HandleOpenAIEmbeddingRequest(
 	var rawRequest, rawResponse interface{}
 
 	if customResponseHandler != nil {
+		// Time the custom handler's decode as the response-parse phase.
+		pt, ph := providerUtils.StartResponseParseSpan(ctx)
 		rawRequest, rawResponse, bifrostErr = customResponseHandler(body, response, jsonData, sendBackRawRequest, sendBackRawResponse)
+		if pt != nil {
+			if bifrostErr != nil {
+				pt.EndSpan(ph, schemas.SpanStatusError, "response parse failed")
+			} else {
+				pt.EndSpan(ph, schemas.SpanStatusOk, "")
+			}
+		}
 	} else {
-		rawRequest, rawResponse, bifrostErr = providerUtils.HandleProviderResponse(body, response, jsonData, sendBackRawRequest, sendBackRawResponse)
+		rawRequest, rawResponse, bifrostErr = providerUtils.HandleProviderResponseCtx(ctx, body, response, jsonData, sendBackRawRequest, sendBackRawResponse)
 	}
 
 	if bifrostErr != nil {
@@ -2317,7 +2375,7 @@ func HandleOpenAISpeechRequest(
 		return nil, bifrostErr
 	}
 
-	req.SetBody(jsonData)
+	timedSetBody(ctx, req, jsonData)
 
 	// Make request
 	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, activeClient, req, resp)
@@ -2326,7 +2384,7 @@ func HandleOpenAISpeechRequest(
 		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, sendBackRawRequest, sendBackRawResponse, latency)
 	}
 	// Extract provider response headers early so they're available on error paths too
-	providerResponseHeaders := providerUtils.ExtractProviderResponseHeaders(resp)
+	providerResponseHeaders := timedExtractResponseHeaders(ctx, resp)
 	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
 
 	// Handle error response
@@ -2593,15 +2651,22 @@ func HandleOpenAISpeechStreamRequest(
 				}
 			}
 
-			// Parse into bifrost response
+			// Parse into bifrost response. Timed as the "response-parse" stream phase.
 			var response schemas.BifrostSpeechStreamResponse
-			if err := sonic.UnmarshalString(jsonData, &response); err != nil {
-				logger.Warn("Failed to parse stream response: %v", err)
+			parseStart := time.Now()
+			umErr := sonic.UnmarshalString(jsonData, &response)
+			schemas.AddStreamParse(ctx, time.Since(parseStart))
+			if umErr != nil {
+				logger.Warn("Failed to parse stream response: %v", umErr)
 				continue
 			}
 
 			if postResponseConverter != nil {
-				if converted := postResponseConverter(&response); converted != nil {
+				// Per-event mapping -> "convertor" (Convertor) stream phase.
+				convStart := time.Now()
+				converted := postResponseConverter(&response)
+				schemas.AddStreamConvert(ctx, time.Since(convStart))
+				if converted != nil {
 					response = *converted
 				} else {
 					logger.Warn("postResponseConverter returned nil; leaving chunk unmodified")
@@ -2755,20 +2820,37 @@ func HandleOpenAITranscriptionRequest(
 	}
 
 	// Use centralized converter
+	// Time the request conversion as the convertor phase.
+	ct, ch := providerUtils.StartPhaseSpan(ctx, "convertor")
 	reqBody := ToOpenAITranscriptionRequest(request)
+	if ct != nil {
+		if reqBody == nil {
+			ct.EndSpan(ch, schemas.SpanStatusError, "transcription input is not provided")
+		} else {
+			ct.EndSpan(ch, schemas.SpanStatusOk, "")
+		}
+	}
 	if reqBody == nil {
 		return nil, providerUtils.NewBifrostOperationError("transcription input is not provided", nil)
 	}
 
 	// Create multipart form
+	// Time the multipart encode as the request-marshal phase.
+	mt, mh := providerUtils.StartPhaseSpan(ctx, "request-marshal")
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
 	if err := ParseTranscriptionFormDataBodyFromRequest(writer, reqBody, providerName); err != nil {
+		if mt != nil {
+			mt.EndSpan(mh, schemas.SpanStatusError, "multipart encode failed")
+		}
 		return nil, err
+	}
+	if mt != nil {
+		mt.EndSpan(mh, schemas.SpanStatusOk, "")
 	}
 
 	req.Header.SetContentType(writer.FormDataContentType()) // This sets multipart/form-data with boundary
-	req.SetBody(body.Bytes())
+	timedSetBody(ctx, req, body.Bytes())
 
 	// Make request
 	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, activeClient, req, resp)
@@ -2777,7 +2859,7 @@ func HandleOpenAITranscriptionRequest(
 		return nil, providerUtils.SetErrorLatency(bifrostErr, latency)
 	}
 	// Extract provider response headers early so they're available on error paths too
-	providerResponseHeaders := providerUtils.ExtractProviderResponseHeaders(resp)
+	providerResponseHeaders := timedExtractResponseHeaders(ctx, resp)
 	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
 
 	// Handle error response
@@ -2821,7 +2903,17 @@ func HandleOpenAITranscriptionRequest(
 		}
 	} else if request.Params != nil && schemas.IsDiarizedTranscriptionFormat(request.Params.ResponseFormat) {
 		var diarized openAIDiarizedTranscriptionResponse
-		if err := sonic.Unmarshal(copiedResponseBody, &diarized); err != nil {
+		// Time the decode as the response-parse phase.
+		pt, ph := providerUtils.StartResponseParseSpan(ctx)
+		umErr := sonic.Unmarshal(copiedResponseBody, &diarized)
+		if pt != nil {
+			if umErr != nil {
+				pt.EndSpan(ph, schemas.SpanStatusError, "response parse failed")
+			} else {
+				pt.EndSpan(ph, schemas.SpanStatusOk, "")
+			}
+		}
+		if umErr != nil {
 			if providerUtils.IsHTMLResponse(resp, copiedResponseBody) {
 				return nil, providerUtils.SetErrorLatency(&schemas.BifrostError{
 					IsBifrostError: false,
@@ -2831,7 +2923,7 @@ func HandleOpenAITranscriptionRequest(
 					},
 				}, latency)
 			}
-			return nil, providerUtils.SetErrorLatency(providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err), latency)
+			return nil, providerUtils.SetErrorLatency(providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, umErr), latency)
 		}
 
 		// Duration/Task are decoded as pointers so an upstream response that
@@ -2853,7 +2945,17 @@ func HandleOpenAITranscriptionRequest(
 	} else if customResponseHandler != nil {
 		_, rawResponse, bifrostErr = customResponseHandler(copiedResponseBody, response, nil, false, sendBackRawResponse)
 	} else {
-		if err := sonic.Unmarshal(copiedResponseBody, response); err != nil {
+		// Time the decode as the response-parse phase.
+		pt, ph := providerUtils.StartResponseParseSpan(ctx)
+		umErr := sonic.Unmarshal(copiedResponseBody, response)
+		if pt != nil {
+			if umErr != nil {
+				pt.EndSpan(ph, schemas.SpanStatusError, "response parse failed")
+			} else {
+				pt.EndSpan(ph, schemas.SpanStatusOk, "")
+			}
+		}
+		if umErr != nil {
 			// Check if it's an HTML response
 			if providerUtils.IsHTMLResponse(resp, copiedResponseBody) {
 				return nil, providerUtils.SetErrorLatency(&schemas.BifrostError{
@@ -2864,7 +2966,7 @@ func HandleOpenAITranscriptionRequest(
 					},
 				}, latency)
 			}
-			return nil, providerUtils.SetErrorLatency(providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err), latency)
+			return nil, providerUtils.SetErrorLatency(providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, umErr), latency)
 		}
 
 		// TODO: add HandleProviderResponse here
@@ -2941,7 +3043,16 @@ func HandleOpenAITranscriptionStreamRequest(
 ) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
 	providerUtils.SetStreamIdleTimeoutIfEmpty(ctx, streamIdleTimeoutInSeconds)
 	// Use centralized converter
+	// Time the request conversion as the convertor phase.
+	ct, ch := providerUtils.StartPhaseSpan(ctx, "convertor")
 	reqBody := ToOpenAITranscriptionRequest(request)
+	if ct != nil {
+		if reqBody == nil {
+			ct.EndSpan(ch, schemas.SpanStatusError, "transcription input is not provided")
+		} else {
+			ct.EndSpan(ch, schemas.SpanStatusOk, "")
+		}
+	}
 	if reqBody == nil {
 		return nil, providerUtils.NewBifrostOperationError("transcription input is not provided", nil)
 	}
@@ -2951,11 +3062,19 @@ func HandleOpenAITranscriptionStreamRequest(
 	}
 
 	// Create multipart form
+	// Time the multipart encode as the request-marshal phase.
+	mt, mh := providerUtils.StartPhaseSpan(ctx, "request-marshal")
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
 
 	if bifrostErr := ParseTranscriptionFormDataBodyFromRequest(writer, reqBody, providerName); bifrostErr != nil {
+		if mt != nil {
+			mt.EndSpan(mh, schemas.SpanStatusError, "multipart encode failed")
+		}
 		return nil, bifrostErr
+	}
+	if mt != nil {
+		mt.EndSpan(mh, schemas.SpanStatusOk, "")
 	}
 
 	// Prepare OpenAI headers
@@ -3094,7 +3213,10 @@ func HandleOpenAITranscriptionStreamRequest(
 			response := &schemas.BifrostTranscriptionStreamResponse{}
 			var bifrostErr *schemas.BifrostError
 			if customResponseHandler != nil {
+				// Custom handler decodes the raw event itself -> time as "response-parse" stream phase.
+				parseStart := time.Now()
 				_, _, bifrostErr = customResponseHandler([]byte(jsonData), response, nil, false, false)
+				schemas.AddStreamParse(ctx, time.Since(parseStart))
 				if bifrostErr != nil {
 					if sendBackRawResponse {
 						bifrostErr.ExtraFields.RawResponse = jsonData
@@ -3118,15 +3240,23 @@ func HandleOpenAITranscriptionStreamRequest(
 					}
 				}
 
-				if err := sonic.UnmarshalString(jsonData, response); err != nil {
-					logger.Warn("Failed to parse stream response: %v", err)
+				// Parse into bifrost response. Timed as the "response-parse" stream phase.
+				parseStart := time.Now()
+				umErr := sonic.UnmarshalString(jsonData, response)
+				schemas.AddStreamParse(ctx, time.Since(parseStart))
+				if umErr != nil {
+					logger.Warn("Failed to parse stream response: %v", umErr)
 					continue
 
 				}
 			}
 
 			if postResponseConverter != nil {
-				if converted := postResponseConverter(response); converted != nil {
+				// Per-event mapping -> "convertor" (Convertor) stream phase.
+				convStart := time.Now()
+				converted := postResponseConverter(response)
+				schemas.AddStreamConvert(ctx, time.Since(convStart))
+				if converted != nil {
 					response = converted
 				} else {
 					logger.Warn("postResponseConverter returned nil; leaving chunk unmodified")
@@ -3270,7 +3400,7 @@ func HandleOpenAIImageGenerationRequest(
 		return nil, bifrostErr
 	}
 
-	req.SetBody(jsonData)
+	timedSetBody(ctx, req, jsonData)
 
 	// Make request
 	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, activeClient, req, resp)
@@ -3279,7 +3409,7 @@ func HandleOpenAIImageGenerationRequest(
 		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, sendBackRawRequest, sendBackRawResponse, latency)
 	}
 	// Extract provider response headers early so they're available on error paths too
-	providerResponseHeaders := providerUtils.ExtractProviderResponseHeaders(resp)
+	providerResponseHeaders := timedExtractResponseHeaders(ctx, resp)
 	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
 
 	// Handle error response
@@ -3303,7 +3433,7 @@ func HandleOpenAIImageGenerationRequest(
 	response := &schemas.BifrostImageGenerationResponse{}
 
 	// Use enhanced response handler with pre-allocated response
-	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(body, response, jsonData, sendBackRawRequest, sendBackRawResponse)
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, body, response, jsonData, sendBackRawRequest, sendBackRawResponse)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -3564,10 +3694,14 @@ func HandleOpenAIImageGenerationStreaming(
 				}
 			}
 
-			// Parse minimally to extract usage and check for errors
+			// Parse minimally to extract usage and check for errors.
+			// Timed as the "response-parse" stream phase (per-event JSON decode).
 			var response OpenAIImageStreamResponse
-			if err := sonic.UnmarshalString(jsonData, &response); err != nil {
-				logger.Warn("Failed to parse stream response: %v", err)
+			parseStart := time.Now()
+			umErr := sonic.UnmarshalString(jsonData, &response)
+			schemas.AddStreamParse(ctx, time.Since(parseStart))
+			if umErr != nil {
+				logger.Warn("Failed to parse stream response: %v", umErr)
 				continue
 			}
 
@@ -3656,7 +3790,9 @@ func HandleOpenAIImageGenerationStreaming(
 				imageChunkIndices[imageIndex]++
 			}
 			chunkIndex := imageChunkIndices[imageIndex]
-			// Build chunk with all OpenAI fields
+			// Build chunk with all OpenAI fields.
+			// Per-event mapping -> "convertor" (Convertor) stream phase.
+			convStart := time.Now()
 			chunk := &schemas.BifrostImageGenerationStreamResponse{
 				Type:         response.Type,
 				Index:        imageIndex, // Which image (0-N)
@@ -3671,7 +3807,6 @@ func HandleOpenAIImageGenerationStreaming(
 					Latency:    time.Since(lastChunkTime).Milliseconds(),
 				},
 			}
-
 			if postResponseConverter != nil {
 				if converted := postResponseConverter(chunk); converted != nil {
 					chunk = converted
@@ -3679,6 +3814,7 @@ func HandleOpenAIImageGenerationStreaming(
 					logger.Warn("postResponseConverter returned nil; leaving chunk unmodified")
 				}
 			}
+			schemas.AddStreamConvert(ctx, time.Since(convStart))
 
 			// Only set PartialImageIndex for partial images, not for completed events
 			if !isCompleted {
@@ -4871,7 +5007,16 @@ func HandleOpenAIImageEditRequest(
 		}, nil
 	}
 
+	// Time the request conversion as the convertor phase.
+	ct, ch := providerUtils.StartPhaseSpan(ctx, "convertor")
 	openaiReq := ToOpenAIImageEditRequest(request)
+	if ct != nil {
+		if openaiReq == nil {
+			ct.EndSpan(ch, schemas.SpanStatusError, "failed to convert request to OpenAI format")
+		} else {
+			ct.EndSpan(ch, schemas.SpanStatusOk, "")
+		}
+	}
 	if openaiReq == nil {
 		return nil, providerUtils.NewBifrostOperationError("failed to convert request to OpenAI format", nil)
 	}
@@ -4899,15 +5044,23 @@ func HandleOpenAIImageEditRequest(
 	req.Header.Set("Content-Type", "multipart/form-data")
 
 	// Create multipart form
+	// Time the multipart encode as the request-marshal phase.
+	mt, mh := providerUtils.StartPhaseSpan(ctx, "request-marshal")
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
 	if err := parseImageEditFormDataBodyFromRequest(writer, openaiReq, providerName); err != nil {
+		if mt != nil {
+			mt.EndSpan(mh, schemas.SpanStatusError, "multipart encode failed")
+		}
 		return nil, err
+	}
+	if mt != nil {
+		mt.EndSpan(mh, schemas.SpanStatusOk, "")
 	}
 
 	req.Header.SetContentType(writer.FormDataContentType())
 	bodyData := body.Bytes()
-	req.SetBody(bodyData)
+	timedSetBody(ctx, req, bodyData)
 
 	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, activeClient, req, resp)
 	defer wait()
@@ -4915,7 +5068,7 @@ func HandleOpenAIImageEditRequest(
 		return nil, providerUtils.EnrichError(ctx, bifrostErr, nil, nil, sendBackRawRequest, sendBackRawResponse, latency)
 	}
 	// Extract provider response headers early so they're available on error paths too
-	providerResponseHeaders := providerUtils.ExtractProviderResponseHeaders(resp)
+	providerResponseHeaders := timedExtractResponseHeaders(ctx, resp)
 	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
 
 	if resp.StatusCode() != fasthttp.StatusOK {
@@ -4935,7 +5088,7 @@ func HandleOpenAIImageEditRequest(
 	}
 
 	response := &schemas.BifrostImageGenerationResponse{}
-	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(bodyBytes, response, nil, false, sendBackRawResponse)
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, bodyBytes, response, nil, false, sendBackRawResponse)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -5000,7 +5153,16 @@ func HandleOpenAIImageEditStreamRequest(
 	postHookSpanFinalizer func(context.Context),
 ) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
 	providerUtils.SetStreamIdleTimeoutIfEmpty(ctx, streamIdleTimeoutInSeconds)
+	// Time the request conversion as the convertor phase.
+	ct, ch := providerUtils.StartPhaseSpan(ctx, "convertor")
 	reqBody := ToOpenAIImageEditRequest(request)
+	if ct != nil {
+		if reqBody == nil {
+			ct.EndSpan(ch, schemas.SpanStatusError, "image edit input is not provided")
+		} else {
+			ct.EndSpan(ch, schemas.SpanStatusOk, "")
+		}
+	}
 	if reqBody == nil {
 		return nil, providerUtils.NewBifrostOperationError("image edit input is not provided", nil)
 	}
@@ -5010,11 +5172,19 @@ func HandleOpenAIImageEditStreamRequest(
 		reqBody = postRequestConverter(reqBody)
 	}
 	// Create multipart form
+	// Time the multipart encode as the request-marshal phase.
+	mt, mh := providerUtils.StartPhaseSpan(ctx, "request-marshal")
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
 
 	if bifrostErr := parseImageEditFormDataBodyFromRequest(writer, reqBody, providerName); bifrostErr != nil {
+		if mt != nil {
+			mt.EndSpan(mh, schemas.SpanStatusError, "multipart encode failed")
+		}
 		return nil, bifrostErr
+	}
+	if mt != nil {
+		mt.EndSpan(mh, schemas.SpanStatusOk, "")
 	}
 
 	// Prepare OpenAI headers
@@ -5170,10 +5340,14 @@ func HandleOpenAIImageEditStreamRequest(
 				}
 			}
 
-			// Parse minimally to extract usage and check for errors
+			// Parse minimally to extract usage and check for errors.
+			// Timed as the "response-parse" stream phase (per-event JSON decode).
 			var response OpenAIImageStreamResponse
-			if err := sonic.UnmarshalString(jsonData, &response); err != nil {
-				logger.Warn("Failed to parse stream response: %v", err)
+			parseStart := time.Now()
+			umErr := sonic.UnmarshalString(jsonData, &response)
+			schemas.AddStreamParse(ctx, time.Since(parseStart))
+			if umErr != nil {
+				logger.Warn("Failed to parse stream response: %v", umErr)
 				continue
 			}
 
@@ -5262,7 +5436,9 @@ func HandleOpenAIImageEditStreamRequest(
 				imageChunkIndices[imageIndex]++
 			}
 			chunkIndex := imageChunkIndices[imageIndex]
-			// Build chunk with all OpenAI fields
+			// Build chunk with all OpenAI fields.
+			// Per-event mapping -> "convertor" (Convertor) stream phase.
+			convStart := time.Now()
 			chunk := &schemas.BifrostImageGenerationStreamResponse{
 				Type:         response.Type,
 				Index:        imageIndex, // Which image (0-N)
@@ -5277,7 +5453,6 @@ func HandleOpenAIImageEditStreamRequest(
 					Latency:    time.Since(lastChunkTime).Milliseconds(),
 				},
 			}
-
 			if postResponseConverter != nil {
 				if converted := postResponseConverter(chunk); converted != nil {
 					chunk = converted
@@ -5285,6 +5460,7 @@ func HandleOpenAIImageEditStreamRequest(
 					logger.Warn("postResponseConverter returned nil; leaving chunk unmodified")
 				}
 			}
+			schemas.AddStreamConvert(ctx, time.Since(convStart))
 
 			// Only set PartialImageIndex for partial images, not for completed events
 			if !isCompleted {
@@ -5399,7 +5575,16 @@ func HandleOpenAIImageVariationRequest(
 		}, nil
 	}
 
+	// Time the request conversion as the convertor phase.
+	ct, ch := providerUtils.StartPhaseSpan(ctx, "convertor")
 	openaiReq := ToOpenAIImageVariationRequest(request)
+	if ct != nil {
+		if openaiReq == nil {
+			ct.EndSpan(ch, schemas.SpanStatusError, "failed to convert request to OpenAI format")
+		} else {
+			ct.EndSpan(ch, schemas.SpanStatusOk, "")
+		}
+	}
 	if openaiReq == nil {
 		return nil, providerUtils.NewBifrostOperationError("failed to convert request to OpenAI format", nil)
 	}
@@ -5426,15 +5611,23 @@ func HandleOpenAIImageVariationRequest(
 	}
 
 	// Create multipart form
+	// Time the multipart encode as the request-marshal phase.
+	mt, mh := providerUtils.StartPhaseSpan(ctx, "request-marshal")
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
 	if err := parseImageVariationFormDataBodyFromRequest(writer, openaiReq, providerName); err != nil {
+		if mt != nil {
+			mt.EndSpan(mh, schemas.SpanStatusError, "multipart encode failed")
+		}
 		return nil, err
+	}
+	if mt != nil {
+		mt.EndSpan(mh, schemas.SpanStatusOk, "")
 	}
 
 	req.Header.SetContentType(writer.FormDataContentType())
 	bodyData := body.Bytes()
-	req.SetBody(bodyData)
+	timedSetBody(ctx, req, bodyData)
 
 	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, activeClient, req, resp)
 	defer wait()
@@ -5442,7 +5635,7 @@ func HandleOpenAIImageVariationRequest(
 		return nil, providerUtils.EnrichError(ctx, bifrostErr, nil, nil, sendBackRawRequest, sendBackRawResponse, latency)
 	}
 	// Extract provider response headers early so they're available on error paths too
-	providerResponseHeaders := providerUtils.ExtractProviderResponseHeaders(resp)
+	providerResponseHeaders := timedExtractResponseHeaders(ctx, resp)
 	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
 
 	if resp.StatusCode() != fasthttp.StatusOK {
@@ -5462,7 +5655,7 @@ func HandleOpenAIImageVariationRequest(
 	}
 
 	response := &schemas.BifrostImageGenerationResponse{}
-	_, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(bodyBytes, response, nil, false, sendBackRawResponse)
+	_, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, bodyBytes, response, nil, false, sendBackRawResponse)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}

--- a/core/providers/openai/responseslifecycle.go
+++ b/core/providers/openai/responseslifecycle.go
@@ -158,7 +158,7 @@ func (provider *OpenAIProvider) ResponsesRetrieve(ctx *schemas.BifrostContext, k
 	response := &schemas.BifrostResponsesResponse{}
 	sendBackRawRequest := providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest)
 	sendBackRawResponse := providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
-	_, rawResponse, err := providerUtils.HandleProviderResponse(bodyBytes, response, nil, sendBackRawRequest, sendBackRawResponse)
+	_, rawResponse, err := providerUtils.HandleProviderResponseCtx(ctx, bodyBytes, response, nil, sendBackRawRequest, sendBackRawResponse)
 	if err != nil {
 		return nil, providerUtils.EnrichError(ctx, err, nil, bodyBytes, sendBackRawRequest, sendBackRawResponse)
 	}
@@ -307,7 +307,11 @@ func (provider *OpenAIProvider) ResponsesRetrieveStream(ctx *schemas.BifrostCont
 			jsonData := string(data)
 
 			var response schemas.BifrostResponsesStreamResponse
-			if err := sonic.UnmarshalString(jsonData, &response); err != nil {
+			// Time the retrieve-stream decode as the response-parse phase.
+			parseStart := time.Now()
+			err := sonic.UnmarshalString(jsonData, &response)
+			schemas.AddStreamParse(ctx, time.Since(parseStart))
+			if err != nil {
 				provider.logger.Warn("Failed to parse stream response: %v", err)
 				continue
 			}

--- a/core/providers/perplexity/perplexity.go
+++ b/core/providers/perplexity/perplexity.go
@@ -108,7 +108,16 @@ func (provider *PerplexityProvider) completeRequest(ctx *schemas.BifrostContext,
 		return nil, latency, providerResponseHeaders, providerUtils.SetErrorLatency(openai.ParseOpenAIError(resp), latency)
 	}
 
+	// Time the body read/decompress as the response-finalize phase.
+	ft, fh := providerUtils.StartPhaseSpan(ctx, "response-finalize")
 	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if ft != nil {
+		if err != nil {
+			ft.EndSpan(fh, schemas.SpanStatusError, err.Error())
+		} else {
+			ft.EndSpan(fh, schemas.SpanStatusOk, "")
+		}
+	}
 	if err != nil {
 		return nil, latency, providerResponseHeaders, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err)
 	}
@@ -167,12 +176,16 @@ func (provider *PerplexityProvider) ChatCompletion(ctx *schemas.BifrostContext, 
 	}
 
 	var response PerplexityChatResponse
-	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, &response, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, responseBody, &response, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 	if bifrostErr != nil {
 		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 	}
 
+	ct, ch := providerUtils.StartResponseConvertorSpan(ctx)
 	bifrostResponse := response.ToBifrostChatResponse(request.Model)
+	if ct != nil {
+		ct.EndSpan(ch, schemas.SpanStatusOk, "")
+	}
 
 	// Set ExtraFields
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()

--- a/core/providers/replicate/replicate.go
+++ b/core/providers/replicate/replicate.go
@@ -167,13 +167,20 @@ func createPrediction(
 	}
 
 	// Parse response
+	ft, fh := providerUtils.StartPhaseSpan(ctx, "response-finalize")
 	body, decodeErr := providerUtils.CheckAndDecodeBody(resp)
 	if decodeErr != nil {
+		if ft != nil {
+			ft.EndSpan(fh, schemas.SpanStatusError, decodeErr.Error())
+		}
 		return nil, nil, latency, providerResponseHeaders, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, decodeErr)
+	}
+	if ft != nil {
+		ft.EndSpan(fh, schemas.SpanStatusOk, "")
 	}
 
 	var prediction ReplicatePredictionResponse
-	_, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(body, &prediction, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, sendBackRawResponse))
+	_, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, body, &prediction, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, sendBackRawResponse))
 	if bifrostErr != nil {
 		return nil, nil, latency, providerResponseHeaders, bifrostErr
 	}
@@ -222,13 +229,20 @@ func getPrediction(
 	}
 
 	// Parse response
+	ft, fh := providerUtils.StartPhaseSpan(ctx, "response-finalize")
 	body, err := providerUtils.CheckAndDecodeBody(resp)
 	if err != nil {
+		if ft != nil {
+			ft.EndSpan(fh, schemas.SpanStatusError, err.Error())
+		}
 		return nil, nil, providerResponseHeaders, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err)
+	}
+	if ft != nil {
+		ft.EndSpan(fh, schemas.SpanStatusOk, "")
 	}
 
 	prediction := &ReplicatePredictionResponse{}
-	_, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(body, prediction, nil, false, sendBackRawResponse)
+	_, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, body, prediction, nil, false, sendBackRawResponse)
 	if bifrostErr != nil {
 		return nil, nil, providerResponseHeaders, bifrostErr
 	}
@@ -2710,14 +2724,21 @@ func (provider *ReplicateProvider) VideoRetrieve(ctx *schemas.BifrostContext, ke
 	providerResponseHeaders := providerUtils.ExtractProviderResponseHeaders(resp)
 	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
 
+	ft, fh := providerUtils.StartPhaseSpan(ctx, "response-finalize")
 	body, err := providerUtils.CheckAndDecodeBody(resp)
 	if err != nil {
+		if ft != nil {
+			ft.EndSpan(fh, schemas.SpanStatusError, err.Error())
+		}
 		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err)
+	}
+	if ft != nil {
+		ft.EndSpan(fh, schemas.SpanStatusOk, "")
 	}
 
 	sendBackRawResponse := providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
 	var prediction ReplicatePredictionResponse
-	_, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(body, &prediction, nil, false, sendBackRawResponse)
+	_, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, body, &prediction, nil, false, sendBackRawResponse)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}

--- a/core/providers/runware/runware.go
+++ b/core/providers/runware/runware.go
@@ -309,7 +309,15 @@ func (provider *RunwareProvider) handleImageInference(ctx *schemas.BifrostContex
 	}
 
 	// Decode response body
+	ft, fh := providerUtils.StartPhaseSpan(ctx, "response-finalize")
 	respBody, err := providerUtils.CheckAndDecodeBody(resp)
+	if ft != nil {
+		if err != nil {
+			ft.EndSpan(fh, schemas.SpanStatusError, err.Error())
+		} else {
+			ft.EndSpan(fh, schemas.SpanStatusOk, "")
+		}
+	}
 	if err != nil {
 		rawErrBody := append([]byte(nil), resp.Body()...)
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err), body, rawErrBody, sendBackRawRequest, sendBackRawResponse, latency)
@@ -317,7 +325,7 @@ func (provider *RunwareProvider) handleImageInference(ctx *schemas.BifrostContex
 
 	// Parse response envelope
 	var runwareResp RunwareResponse
-	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(respBody, &runwareResp, body, sendBackRawRequest, sendBackRawResponse)
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, respBody, &runwareResp, body, sendBackRawRequest, sendBackRawResponse)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -396,7 +404,15 @@ func (provider *RunwareProvider) sendTaskArray(ctx *schemas.BifrostContext, key 
 	if resp.StatusCode() != fasthttp.StatusOK {
 		return reqBody, nil, lat, providerUtils.SetErrorLatency(parseRunwareError(resp), lat)
 	}
+	ft, fh := providerUtils.StartPhaseSpan(ctx, "response-finalize")
 	decoded, err := providerUtils.CheckAndDecodeBody(resp)
+	if ft != nil {
+		if err != nil {
+			ft.EndSpan(fh, schemas.SpanStatusError, err.Error())
+		} else {
+			ft.EndSpan(fh, schemas.SpanStatusOk, "")
+		}
+	}
 	if err != nil {
 		return reqBody, nil, lat, providerUtils.SetErrorLatency(providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err), lat)
 	}
@@ -427,7 +443,7 @@ func (provider *RunwareProvider) VideoGeneration(ctx *schemas.BifrostContext, ke
 	}
 
 	var videoResp RunwareResponse
-	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(respBody, &videoResp, reqBody, sendBackRawRequest, sendBackRawResponse)
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, respBody, &videoResp, reqBody, sendBackRawRequest, sendBackRawResponse)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -458,7 +474,16 @@ func (provider *RunwareProvider) VideoRetrieve(ctx *schemas.BifrostContext, key 
 	sendBackRawRequest := providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest)
 	sendBackRawResponse := providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
 
+	// Time the request marshal as the request-marshal phase.
+	mt, mh := providerUtils.StartPhaseSpan(ctx, "request-marshal")
 	jsonData, err := providerUtils.MarshalSorted(RunwareGetResponseRequest{TaskType: taskTypeGetResponse, TaskUUID: taskID})
+	if mt != nil {
+		if err != nil {
+			mt.EndSpan(mh, schemas.SpanStatusError, err.Error())
+		} else {
+			mt.EndSpan(mh, schemas.SpanStatusOk, "")
+		}
+	}
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
 	}
@@ -469,7 +494,7 @@ func (provider *RunwareProvider) VideoRetrieve(ctx *schemas.BifrostContext, key 
 	}
 
 	var videoResp RunwareResponse
-	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(respBody, &videoResp, reqBody, sendBackRawRequest, sendBackRawResponse)
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, respBody, &videoResp, reqBody, sendBackRawRequest, sendBackRawResponse)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -584,7 +609,7 @@ func (provider *RunwareProvider) VideoEdit(ctx *schemas.BifrostContext, key sche
 	}
 
 	var videoResp RunwareResponse
-	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(respBody, &videoResp, reqBody, sendBackRawRequest, sendBackRawResponse)
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, respBody, &videoResp, reqBody, sendBackRawRequest, sendBackRawResponse)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}

--- a/core/providers/runway/runway.go
+++ b/core/providers/runway/runway.go
@@ -190,7 +190,15 @@ func (provider *RunwayProvider) HandleRunwayImageTask(ctx *schemas.BifrostContex
 	}
 
 	// Decode response body
+	ft, fh := providerUtils.StartPhaseSpan(ctx, "response-finalize")
 	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if ft != nil {
+		if err != nil {
+			ft.EndSpan(fh, schemas.SpanStatusError, err.Error())
+		} else {
+			ft.EndSpan(fh, schemas.SpanStatusOk, "")
+		}
+	}
 	if err != nil {
 		rawErrBody := append([]byte(nil), resp.Body()...)
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err), jsonData, rawErrBody, sendBackRawRequest, sendBackRawResponse, latency)
@@ -198,7 +206,7 @@ func (provider *RunwayProvider) HandleRunwayImageTask(ctx *schemas.BifrostContex
 
 	// Parse task creation response
 	var taskResp RunwayTaskCreationResponse
-	rawRequest, _, bifrostErr := providerUtils.HandleProviderResponse(body, &taskResp, jsonData, sendBackRawRequest, sendBackRawResponse)
+	rawRequest, _, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, body, &taskResp, jsonData, sendBackRawRequest, sendBackRawResponse)
 	if bifrostErr != nil {
 		return nil, providerUtils.SetErrorLatency(bifrostErr, latency)
 	}
@@ -286,13 +294,21 @@ func (provider *RunwayProvider) retrieveRunwayTask(ctx *schemas.BifrostContext, 
 		return nil, nil, providerUtils.SetErrorLatency(parseRunwayError(resp), latency)
 	}
 
+	ft, fh := providerUtils.StartPhaseSpan(ctx, "response-finalize")
 	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if ft != nil {
+		if err != nil {
+			ft.EndSpan(fh, schemas.SpanStatusError, err.Error())
+		} else {
+			ft.EndSpan(fh, schemas.SpanStatusOk, "")
+		}
+	}
 	if err != nil {
 		return nil, nil, providerUtils.SetErrorLatency(providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err), latency)
 	}
 
 	var taskDetails RunwayTaskDetailsResponse
-	_, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(body, &taskDetails, nil, false, sendBackRawResponse)
+	_, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, body, &taskDetails, nil, false, sendBackRawResponse)
 	if bifrostErr != nil {
 		return nil, nil, providerUtils.SetErrorLatency(bifrostErr, latency)
 	}
@@ -386,7 +402,15 @@ func (provider *RunwayProvider) VideoGeneration(ctx *schemas.BifrostContext, key
 	}
 
 	// Decode response body
+	ft, fh := providerUtils.StartPhaseSpan(ctx, "response-finalize")
 	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if ft != nil {
+		if err != nil {
+			ft.EndSpan(fh, schemas.SpanStatusError, err.Error())
+		} else {
+			ft.EndSpan(fh, schemas.SpanStatusOk, "")
+		}
+	}
 	if err != nil {
 		rawErrBody := append([]byte(nil), resp.Body()...)
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err), jsonData, rawErrBody, sendBackRawRequest, sendBackRawResponse, latency)
@@ -394,7 +418,7 @@ func (provider *RunwayProvider) VideoGeneration(ctx *schemas.BifrostContext, key
 
 	// Parse response
 	var taskResp RunwayTaskCreationResponse
-	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(body, &taskResp, jsonData, sendBackRawRequest, sendBackRawResponse)
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, body, &taskResp, jsonData, sendBackRawRequest, sendBackRawResponse)
 	if bifrostErr != nil {
 		return nil, providerUtils.SetErrorLatency(bifrostErr, latency)
 	}
@@ -457,7 +481,15 @@ func (provider *RunwayProvider) VideoRetrieve(ctx *schemas.BifrostContext, key s
 	}
 
 	// Decode response body
+	ft, fh := providerUtils.StartPhaseSpan(ctx, "response-finalize")
 	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if ft != nil {
+		if err != nil {
+			ft.EndSpan(fh, schemas.SpanStatusError, err.Error())
+		} else {
+			ft.EndSpan(fh, schemas.SpanStatusOk, "")
+		}
+	}
 	if err != nil {
 		rawErrBody := append([]byte(nil), resp.Body()...)
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err), nil, rawErrBody, sendBackRawRequest, sendBackRawResponse, latency)
@@ -465,7 +497,7 @@ func (provider *RunwayProvider) VideoRetrieve(ctx *schemas.BifrostContext, key s
 
 	// Parse response
 	var taskDetails RunwayTaskDetailsResponse
-	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(body, &taskDetails, nil, sendBackRawRequest, sendBackRawResponse)
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, body, &taskDetails, nil, sendBackRawRequest, sendBackRawResponse)
 	if bifrostErr != nil {
 		return nil, providerUtils.SetErrorLatency(bifrostErr, latency)
 	}

--- a/core/providers/sarvam/sarvam.go
+++ b/core/providers/sarvam/sarvam.go
@@ -225,14 +225,31 @@ func (provider *SarvamProvider) Speech(ctx *schemas.BifrostContext, key schemas.
 		return nil, providerUtils.EnrichError(ctx, parseSarvamError(resp), jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 	}
 
+	ft, fh := providerUtils.StartPhaseSpan(ctx, "response-finalize")
 	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if ft != nil {
+		if err != nil {
+			ft.EndSpan(fh, schemas.SpanStatusError, err.Error())
+		} else {
+			ft.EndSpan(fh, schemas.SpanStatusOk, "")
+		}
+	}
 	if err != nil {
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err), jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 	}
 
 	var sarvamResp SarvamSpeechResponse
-	if err := sonic.Unmarshal(body, &sarvamResp); err != nil {
-		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("failed to parse Sarvam text-to-speech response", err), jsonData, body, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
+	pt, ph := providerUtils.StartResponseParseSpan(ctx)
+	umErr := sonic.Unmarshal(body, &sarvamResp)
+	if pt != nil {
+		if umErr != nil {
+			pt.EndSpan(ph, schemas.SpanStatusError, "response parse failed")
+		} else {
+			pt.EndSpan(ph, schemas.SpanStatusOk, "")
+		}
+	}
+	if umErr != nil {
+		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("failed to parse Sarvam text-to-speech response", umErr), jsonData, body, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 	}
 	if len(sarvamResp.Audios) == 0 || sarvamResp.Audios[0] == "" {
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("Sarvam text-to-speech response contained no audio", nil), jsonData, body, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
@@ -415,14 +432,33 @@ func (provider *SarvamProvider) SpeechStream(ctx *schemas.BifrostContext, postHo
 
 // Transcription performs a speech-to-text request to Sarvam's API using multipart/form-data.
 func (provider *SarvamProvider) Transcription(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
+	// Time the request conversion as the convertor phase.
+	ct, ch := providerUtils.StartPhaseSpan(ctx, "convertor")
 	reqBody := ToSarvamTranscriptionRequest(request)
+	if ct != nil {
+		if reqBody == nil || len(reqBody.File) == 0 {
+			ct.EndSpan(ch, schemas.SpanStatusError, "transcription file is required")
+		} else {
+			ct.EndSpan(ch, schemas.SpanStatusOk, "")
+		}
+	}
 	if reqBody == nil || len(reqBody.File) == 0 {
 		return nil, providerUtils.NewBifrostOperationError("transcription file is required", nil)
 	}
 
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
-	if bifrostErr := writeSarvamTranscriptionMultipart(writer, reqBody); bifrostErr != nil {
+	// Time the multipart build as the request-marshal phase.
+	mt, mh := providerUtils.StartPhaseSpan(ctx, "request-marshal")
+	bifrostErr := writeSarvamTranscriptionMultipart(writer, reqBody)
+	if mt != nil {
+		if bifrostErr != nil {
+			mt.EndSpan(mh, schemas.SpanStatusError, bifrostErr.Error.Message)
+		} else {
+			mt.EndSpan(mh, schemas.SpanStatusOk, "")
+		}
+	}
+	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
 	contentType := writer.FormDataContentType()
@@ -457,14 +493,31 @@ func (provider *SarvamProvider) Transcription(ctx *schemas.BifrostContext, key s
 		return nil, providerUtils.EnrichError(ctx, parseSarvamError(resp), nil, resp.Body(), provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 	}
 
+	ft, fh := providerUtils.StartPhaseSpan(ctx, "response-finalize")
 	responseBody, err := providerUtils.CheckAndDecodeBody(resp)
+	if ft != nil {
+		if err != nil {
+			ft.EndSpan(fh, schemas.SpanStatusError, err.Error())
+		} else {
+			ft.EndSpan(fh, schemas.SpanStatusOk, "")
+		}
+	}
 	if err != nil {
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err), nil, resp.Body(), provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 	}
 
 	var sarvamResp SarvamTranscriptionResponse
-	if err := sonic.Unmarshal(responseBody, &sarvamResp); err != nil {
-		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("failed to parse Sarvam speech-to-text response", err), nil, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
+	pt, ph := providerUtils.StartResponseParseSpan(ctx)
+	umErr := sonic.Unmarshal(responseBody, &sarvamResp)
+	if pt != nil {
+		if umErr != nil {
+			pt.EndSpan(ph, schemas.SpanStatusError, "response parse failed")
+		} else {
+			pt.EndSpan(ph, schemas.SpanStatusOk, "")
+		}
+	}
+	if umErr != nil {
+		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("failed to parse Sarvam speech-to-text response", umErr), nil, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 	}
 
 	response := ToBifrostTranscriptionResponse(&sarvamResp)

--- a/core/providers/utils/largeresponse.go
+++ b/core/providers/utils/largeresponse.go
@@ -139,8 +139,8 @@ func FinalizeResponseWithLargeDetection(
 	logger schemas.Logger,
 ) (body []byte, isLarge bool, finalizeErr *schemas.BifrostError) {
 	// "response-finalize" overhead phase: reading, decompressing (gzip/br/zstd), and
-	// copying the provider response body is payload-scaled work that otherwise hides in
-	// "core". Nil-safe; folds away when no trace is active.
+	// copying the provider response body is payload-scaled work. Nil-safe; folds away
+	// when no trace is active.
 	if ft, fh := startPhaseSpan(ctx, "response-finalize"); ft != nil {
 		defer func() {
 			if finalizeErr != nil {

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -1693,9 +1693,9 @@ func startPhaseSpan(ctx context.Context, name string) (schemas.Tracer, schemas.S
 // StartResponseConvertorSpan opens a nil-safe "convertor" span for the provider->Bifrost
 // response mapping (ToBifrost*Response). It shares the "convertor" bucket with the
 // request-side conversion so total conversion time is attributed together, instead of
-// the response half folding into core. Symmetric to the request path: response-parse
-// times the JSON decode, this times the struct->unified mapping. Wrapped at the primary
-// chat call sites; secondary response paths fold into core. EndSpan is nil-safe.
+// the response half folding into provider-internal. Symmetric to the request path:
+// response-parse times the JSON decode, this times the struct->unified mapping. Wrapped
+// at the primary response call sites; secondary paths fold into provider-internal. EndSpan is nil-safe.
 func StartResponseConvertorSpan(ctx context.Context) (schemas.Tracer, schemas.SpanHandle) {
 	return startPhaseSpan(ctx, "convertor")
 }
@@ -1708,8 +1708,8 @@ func StartResponseParseSpan(ctx context.Context) (schemas.Tracer, schemas.SpanHa
 }
 
 // StartPhaseSpan opens a nil-safe internal overhead phase span with an arbitrary name,
-// so provider/auth code outside this package can carve its own work out of the residual
-// "core" bucket. name becomes the breakdown bucket; keep it stable and descriptive
+// so provider/auth code outside this package can carve its own work out of the overhead
+// residual. name becomes the breakdown bucket; keep it stable and descriptive
 // (e.g. "request-sign", "credentials-fetch", "response-finalize"). EndSpan is nil-safe.
 func StartPhaseSpan(ctx context.Context, name string) (schemas.Tracer, schemas.SpanHandle) {
 	return startPhaseSpan(ctx, name)
@@ -1995,7 +1995,7 @@ func EnrichError(
 // Used at the primary completion call sites (chat / responses / text) where parse
 // time is on the latency hot path; the ctx-less HandleProviderResponse remains for
 // the many secondary sites (files, batches, containers) whose parse time is not
-// worth a span and simply folds into the "core" bucket.
+// worth a span and simply folds into provider-internal.
 func HandleProviderResponseCtx[T any](ctx context.Context, responseBody []byte, response *T, requestBody []byte, sendBackRawRequest bool, sendBackRawResponse bool) (rawRequest interface{}, rawResponse interface{}, bifrostErr *schemas.BifrostError) {
 	if t, h := startPhaseSpan(ctx, "response-parse"); t != nil {
 		// Inspect the named bifrostErr so a failed parse ends the span as an error

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -711,10 +711,14 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 		return nil, bifrostErr
 	}
 	if schemas.IsGeminiModelFamily(ctx, request.Model) || schemas.IsAllDigitsASCII(request.Model) || schemas.IsGemmaModelFamily(ctx, request.Model) {
+		gt, gh := providerUtils.StartPhaseSpan(ctx, "request-marshal")
 		if rawBody, ok := ctx.Value(schemas.BifrostContextKeyUseRawRequestBody).(bool); ok && rawBody {
 			jsonBody = gemini.NormalizeRawGenerateContentRequestForCompatibility(jsonBody)
 		}
 		jsonBody = stripVertexGeminiUnsupportedFieldsRaw(jsonBody)
+		if gt != nil {
+			gt.EndSpan(gh, schemas.SpanStatusOk, "")
+		}
 	}
 
 	projectID := resolveVertexProjectID(ctx, key)
@@ -729,9 +733,13 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 
 	// Remap unsupported tool versions for Vertex (handles raw passthrough bodies)
 	if schemas.IsAnthropicModelFamily(ctx, request.Model) && jsonBody != nil {
+		mt, mh := providerUtils.StartPhaseSpan(ctx, "request-marshal")
 		capModel := schemas.ResolveCanonicalModel(ctx, request.Model)
 		remappedBody, remapErr := anthropic.RemapRawToolVersionsForProvider(jsonBody, schemas.Vertex, capModel)
 		if remapErr != nil {
+			if mt != nil {
+				mt.EndSpan(mh, schemas.SpanStatusError, remapErr.Error())
+			}
 			return nil, providerUtils.NewBifrostOperationError(remapErr.Error(), nil)
 		}
 		jsonBody = remappedBody
@@ -740,7 +748,13 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 		var stripErr error
 		jsonBody, stripErr = anthropic.StripUnsupportedFieldsFromRawBody(jsonBody, schemas.Vertex, capModel)
 		if stripErr != nil {
+			if mt != nil {
+				mt.EndSpan(mh, schemas.SpanStatusError, stripErr.Error())
+			}
 			return nil, providerUtils.NewBifrostOperationError(stripErr.Error(), nil)
+		}
+		if mt != nil {
+			mt.EndSpan(mh, schemas.SpanStatusOk, "")
 		}
 	}
 
@@ -861,7 +875,7 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 		anthropicResponse := anthropic.AcquireAnthropicMessageResponse()
 		defer anthropic.ReleaseAnthropicMessageResponse(anthropicResponse)
 
-		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, anthropicResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, responseBody, anthropicResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 		if bifrostErr != nil {
 			return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 		}
@@ -888,7 +902,7 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 	} else if schemas.IsGeminiModelFamily(ctx, request.Model) || schemas.IsAllDigitsASCII(request.Model) || schemas.IsGemmaModelFamily(ctx, request.Model) {
 		geminiResponse := gemini.GenerateContentResponse{}
 
-		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, &geminiResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, responseBody, &geminiResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 		if bifrostErr != nil {
 			return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 		}
@@ -910,7 +924,7 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 		response := &schemas.BifrostChatResponse{}
 
 		// Use enhanced response handler with pre-allocated response
-		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, response, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, responseBody, response, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 		if bifrostErr != nil {
 			return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 		}
@@ -972,10 +986,14 @@ func (provider *VertexProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 
 		// Remap unsupported tool versions for Vertex streaming (handles raw passthrough bodies)
 		if jsonData != nil {
+			mt, mh := providerUtils.StartPhaseSpan(ctx, "request-marshal")
 			capModel := schemas.ResolveCanonicalModel(ctx, request.Model)
 			var remapErr error
 			jsonData, remapErr = anthropic.RemapRawToolVersionsForProvider(jsonData, schemas.Vertex, capModel)
 			if remapErr != nil {
+				if mt != nil {
+					mt.EndSpan(mh, schemas.SpanStatusError, remapErr.Error())
+				}
 				return nil, providerUtils.NewBifrostOperationError(remapErr.Error(), nil)
 			}
 
@@ -983,7 +1001,13 @@ func (provider *VertexProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 			var stripErr error
 			jsonData, stripErr = anthropic.StripUnsupportedFieldsFromRawBody(jsonData, schemas.Vertex, capModel)
 			if stripErr != nil {
+				if mt != nil {
+					mt.EndSpan(mh, schemas.SpanStatusError, stripErr.Error())
+				}
 				return nil, providerUtils.NewBifrostOperationError(stripErr.Error(), nil)
+			}
+			if mt != nil {
+				mt.EndSpan(mh, schemas.SpanStatusOk, "")
 			}
 		}
 
@@ -1288,7 +1312,7 @@ func (provider *VertexProvider) Responses(ctx *schemas.BifrostContext, key schem
 		anthropicResponse := anthropic.AcquireAnthropicMessageResponse()
 		defer anthropic.ReleaseAnthropicMessageResponse(anthropicResponse)
 
-		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, anthropicResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, responseBody, anthropicResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 		if bifrostErr != nil {
 			return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 		}
@@ -1332,10 +1356,14 @@ func (provider *VertexProvider) Responses(ctx *schemas.BifrostContext, key schem
 		if bifrostErr != nil {
 			return nil, bifrostErr
 		}
+		gt, gh := providerUtils.StartPhaseSpan(ctx, "request-marshal")
 		if rawBody, ok := ctx.Value(schemas.BifrostContextKeyUseRawRequestBody).(bool); ok && rawBody {
 			jsonBody = gemini.NormalizeRawGenerateContentRequestForCompatibility(jsonBody)
 		}
 		jsonBody = stripVertexGeminiUnsupportedFieldsRaw(jsonBody)
+		if gt != nil {
+			gt.EndSpan(gh, schemas.SpanStatusOk, "")
+		}
 
 		projectID := resolveVertexProjectID(ctx, key)
 		if projectID == "" {
@@ -1442,7 +1470,7 @@ func (provider *VertexProvider) Responses(ctx *schemas.BifrostContext, key schem
 
 		geminiResponse := &gemini.GenerateContentResponse{}
 
-		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, geminiResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, responseBody, geminiResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 		if bifrostErr != nil {
 			return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 		}
@@ -1799,12 +1827,25 @@ func (provider *VertexProvider) Embedding(ctx *schemas.BifrostContext, key schem
 
 	// Parse Vertex's native embedding response using typed response
 	var vertexResponse VertexEmbeddingResponse
-	if err := sonic.Unmarshal(responseBody, &vertexResponse); err != nil {
-		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err), jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	pt, ph := providerUtils.StartResponseParseSpan(ctx)
+	umErr := sonic.Unmarshal(responseBody, &vertexResponse)
+	if pt != nil {
+		if umErr != nil {
+			pt.EndSpan(ph, schemas.SpanStatusError, "response parse failed")
+		} else {
+			pt.EndSpan(ph, schemas.SpanStatusOk, "")
+		}
+	}
+	if umErr != nil {
+		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, umErr), jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
 	// Use centralized Vertex converter
+	ct, ch := providerUtils.StartResponseConvertorSpan(ctx)
 	bifrostResponse := vertexResponse.ToBifrostEmbeddingResponse()
+	if ct != nil {
+		ct.EndSpan(ch, schemas.SpanStatusOk, "")
+	}
 
 	// Set ExtraFields
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
@@ -2147,7 +2188,7 @@ func (provider *VertexProvider) ImageGeneration(ctx *schemas.BifrostContext, key
 	if schemas.IsGeminiModelFamily(ctx, request.Model) || schemas.IsAllDigitsASCII(request.Model) {
 		geminiResponse := gemini.GenerateContentResponse{}
 
-		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, &geminiResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, responseBody, &geminiResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 		if bifrostErr != nil {
 			return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 		}
@@ -2173,7 +2214,7 @@ func (provider *VertexProvider) ImageGeneration(ctx *schemas.BifrostContext, key
 		// Handle Imagen responses
 		imagenResponse := gemini.GeminiImagenResponse{}
 
-		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, &imagenResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, responseBody, &imagenResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 		if bifrostErr != nil {
 			return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 		}
@@ -2355,7 +2396,7 @@ func (provider *VertexProvider) ImageEdit(ctx *schemas.BifrostContext, key schem
 	if schemas.IsGeminiModelFamily(ctx, request.Model) || schemas.IsAllDigitsASCII(request.Model) {
 		geminiResponse := gemini.GenerateContentResponse{}
 
-		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, &geminiResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, responseBody, &geminiResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 		if bifrostErr != nil {
 			return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 		}
@@ -2381,7 +2422,7 @@ func (provider *VertexProvider) ImageEdit(ctx *schemas.BifrostContext, key schem
 		// Handle Imagen responses
 		imagenResponse := gemini.GeminiImagenResponse{}
 
-		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, &imagenResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponseCtx(ctx, responseBody, &imagenResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 		if bifrostErr != nil {
 			return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 		}

--- a/core/providers/vllm/vllm.go
+++ b/core/providers/vllm/vllm.go
@@ -725,14 +725,20 @@ func (provider *VLLMProvider) TranscriptionStream(ctx *schemas.BifrostContext, p
 				var response schemas.BifrostTranscriptionStreamResponse
 				var bifrostErr *schemas.BifrostError
 
+				// Decode timed as the "response-parse" stream phase (per-event JSON decode).
+				parseStart := time.Now()
 				_, _, bifrostErr = HandleVLLMResponse(dataBytes, &response, nil, false, false)
+				schemas.AddStreamParse(ctx, time.Since(parseStart))
 				if bifrostErr != nil {
 					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 					providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, providerUtils.EnrichError(ctx, bifrostErr, body.Bytes(), dataBytes, false, providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse), latency), responseChan, logger, postHookSpanFinalizer)
 					return
 				}
 
+				// Convert timed as the "convertor" stream phase (per-event mapping).
+				convStart := time.Now()
 				customChunk, ok := parseVLLMTranscriptionStreamChunk(dataBytes)
+				schemas.AddStreamConvert(ctx, time.Since(convStart))
 				if !ok || customChunk == nil {
 					logger.Warn("customChunkParser returned no chunk")
 					continue

--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -940,9 +940,8 @@ const (
 	// AttrBifrostWorkerHandoffMs is the scheduling latency between the provider
 	// worker sending the result and tryRequest receiving it (the worker->caller
 	// goroutine hop). It is real wall-time inside the overhead window that sits on
-	// no span, so it otherwise folds into "core"; the breakdown carves it into its
-	// own "worker-handoff" bucket. The reverse hop (enqueue->dequeue) is already the
-	// "queue-wait" span.
+	// no span; the breakdown carves it into its own "worker-handoff" bucket. The
+	// reverse hop (enqueue->dequeue) is already the "queue-wait" span.
 	AttrBifrostWorkerHandoffMs = "bifrost.worker.handoff_ms"
 
 	AttrBifrostProviderName        = "bifrost.provider.name"

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -2233,11 +2233,13 @@ func overheadBucketName(s *schemas.Span) string {
 // bucket; provider/upstream spans still subtract from their parent's self-time.
 //
 // The remaining overhead (the stamped total, minus the measured plugin/internal
-// self-time) is attributed to a final "core" bucket: transport parsing, routing, and
-// request/response marshalling that Bifrost does outside any plugin span. It is
-// derived from overheadMs (which already excludes upstream), not from the root
-// span's self-time, so it never picks up streaming socket reads. Buckets are
-// returned with microsecond values, measured spans first (chronological) then core.
+// self-time) is attributed to a residual "scheduling" bucket: the goroutine-scheduling
+// latency between phases plus any glue no phase span has captured yet. Now that
+// request/response conversion, marshal, and parse each have their own phase span, this
+// residual is small. It is derived from overheadMs (which already excludes upstream),
+// not from the root span's self-time, so it never picks up streaming socket reads.
+// Buckets are returned with microsecond values, measured spans first (chronological)
+// then the scheduling residual.
 // computeOverheadBreakdown returns the per-phase buckets, the measured Bifrost-CPU
 // total in ms (the sum of those buckets), and whether this was a streaming request.
 // For streams the caller uses measuredMs as the overhead (see Inject): total-upstream
@@ -2339,13 +2341,11 @@ func computeOverheadBreakdown(trace *schemas.Trace, overheadMs float64, overhead
 			if total := cpuMs + writeMs; total > 0 {
 				addStreamBucketMs("stream-client-write", bp*writeMs/total)
 				addStreamBucketMs("convertor.stream-out", bp*cpuMs/total)
-			} else {
-				addStreamBucketMs("stream-backpressure", bp)
 			}
 		}
 		// Worker->caller goroutine-hop latency (unary path): scheduling wall-time
 		// inside the overhead window that sits on no span. Carve it into its own
-		// bucket so it stops inflating "core". The reverse hop is the queue-wait span.
+		// "worker-handoff" bucket. The reverse hop is the queue-wait span.
 		if ms, ok := traceAttrFloatMs(attrs, schemas.AttrBifrostWorkerHandoffMs); ok {
 			addStreamBucketMs("worker-handoff", ms)
 		}
@@ -2353,13 +2353,13 @@ func computeOverheadBreakdown(trace *schemas.Trace, overheadMs float64, overhead
 
 	// Provider-agnostic catch-all. Every provider call runs inside an llm.call span
 	// (SpanKindLLMCall), which is not itself a bucket but envelops the upstream network
-	// call plus ALL provider-side glue: request conversion/marshal/signing, response
-	// read/decompress/parse, header and endpoint work. Its self-time (wall minus the
-	// child phase spans) is therefore exactly upstream + whatever provider work no phase
-	// span captured. Subtracting the measured upstream leaves that uncaptured remainder,
-	// surfaced as "provider-internal" so a brand-new provider — or an unspanned step in
-	// an existing one — can never silently inflate "core"; it lands here instead, and its
-	// size tells us a provider needs finer spans. Summed across attempts: retries create
+	// call plus ALL provider-side glue. The hot pieces (request conversion/marshal/signing,
+	// response read/decompress/parse) now have their own phase spans; its self-time (wall
+	// minus the child phase spans) is therefore upstream plus whatever provider work no
+	// phase span captured. Subtracting the measured upstream leaves that uncaptured
+	// remainder, surfaced as "provider-internal" so a brand-new provider (or an unspanned
+	// step in an existing one) lands here, and its size tells us a provider needs finer
+	// spans. Summed across attempts: retries create
 	// one llm.call span each, and upstream latency likewise accumulates across them.
 	//
 	// STREAMING IS EXCLUDED. For a streamed response the llm.call span is DEFERRED — it
@@ -2426,19 +2426,13 @@ func computeOverheadBreakdown(trace *schemas.Trace, overheadMs float64, overhead
 	// Unary requests: whatever overhead is left over after every instrumented phase is
 	// the residual between phases — goroutine-scheduling latency (the request hops across
 	// the HTTP, core-pipeline and provider-worker goroutines) plus any not-yet-spanned
-	// transport edge. Now that the code phases are instrumented, this is small and
-	// dominated by scheduling, so it is surfaced as "scheduling" rather than an opaque
-	// "core". Skip when measured spans already exceed the total (upstream over-counting):
-	// a negative value is a diagnostic signal, not a bucket, surfaced in the UI footer.
+	// transport edge.
 	//
 	// STREAMING IS EXCLUDED. For a stream, total-upstream is NOT Bifrost overhead: it
 	// includes the off-CPU relay/scheduler wait the request goroutine spends parked
 	// between provider chunks (confirmed ~2% CPU under load). All actual Bifrost CPU is
 	// already measured in the buckets above (parse/convert accumulators, aggregated
-	// per-chunk plugin timing, transport marshal/write). Emitting a residual bucket there
-	// would resurrect the misleading "scheduling = 95% of overhead" figure. Instead the
-	// caller takes measuredMs as the stream's overhead and folds the off-CPU remainder
-	// into upstream, so latency = upstream + overhead still holds.
+	// per-chunk plugin timing, transport marshal/write).
 	if overheadOK && !isStreaming {
 		schedulingUs := overheadMs*1000.0 - float64(measuredNs)/1000.0
 		if schedulingUs > 0.5 {

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -562,6 +562,7 @@ const OVERHEAD_LABELS: Record<string, string> = {
 	"worker-handoff": "Worker handoff",
 	"queue-wait": "Queue wait",
 	"attribute-population": "Attribute population",
+	miscellaneous: "Miscellaneous",
 	// Networking (client<->gateway<->provider handling)
 	"provider-internal": "Provider I/O",
 	"transport-context": "Request context building",
@@ -589,6 +590,7 @@ const OVERHEAD_BUCKET_CATEGORY: Record<string, string> = {
 	"worker-handoff": "processing",
 	"queue-wait": "processing",
 	"attribute-population": "processing",
+	miscellaneous: "processing",
 	"provider-internal": "networking",
 	"transport-context": "networking",
 	"transport-response-headers": "networking",


### PR DESCRIPTION
## Summary

This PR significantly expands the tracing overhead breakdown by adding `miscellaneous` phase spans to cover previously untracked core-pipeline glue work, and by propagating `HandleProviderResponseCtx` (the context-aware, span-emitting variant) across all remaining provider call sites that were still using the context-free `HandleProviderResponse`. The result is that the residual "scheduling" bucket in the overhead breakdown now reflects only true goroutine-scheduling latency rather than absorbing unspanned work like request validation, MCP tool injection, field re-reads, channel-message setup, and response field population.

## Changes

- **`miscellaneous` phase spans added** at several previously untracked core-pipeline points:
  - Pre-dispatch validation (`validateRequestAfterPreRequestHooks`) in `handleRequest`
  - MCP tool injection (`AddToolsToRequest`) in `tryRequest`
  - Pre-enqueue field re-read and channel-message setup in both `tryRequest` and `tryStreamRequest`
  - Worker-side error and success field population (`PopulateExtraFields` / `PopulateRoutingInfo`) in `requestWorker`, with `sentAt` stamped after the span closes so `worker-handoff` measures only the goroutine hop
  - `miscellaneous` label added to the UI overhead label/category maps

- **`HandleProviderResponse` → `HandleProviderResponseCtx` migration** across all remaining provider call sites (Anthropic, Azure, Bedrock, Cohere, Gemini, HuggingFace, Nebius, OpenAI, Perplexity, Replicate, Runware, Runway, Vertex, vLLM, and the OpenAI responses lifecycle), so every primary response parse path now emits a `response-parse` span.

- **`response-parse` and `convertor` spans added** at provider sites that previously had neither: Bedrock (text completion, embedding, image generation/edit/variation), Gemini (embedding, responses), Mistral (transcription), Sarvam (speech, transcription), Vertex (embedding), ElevenLabs (speech, transcription), Perplexity (chat), and others.

- **`convertor` and `request-marshal` spans added** for request-side conversion paths: Anthropic request builders, ElevenLabs transcription, OpenAI transcription/image-edit/image-variation/image-generation, Sarvam transcription, Runware video retrieve, Vertex Gemini/Anthropic body normalization.

- **`response-finalize` spans added** at body-read sites not already covered by `FinalizeResponseWithLargeDetection`: Bedrock, ElevenLabs, HuggingFace, Nebius, Perplexity, Replicate, Runware, Runway, Sarvam.

- **Stream phase timing** (`AddStreamParse` / `AddStreamConvert`) added to previously untracked streaming paths: Azure speech, Gemini speech/transcription, HuggingFace image generation/edit, Mistral transcription stream, OpenAI speech/transcription/image-generation/image-edit streams, OpenAI responses retrieve stream, vLLM transcription stream.

- **`stream-backpressure` bucket removed** from the breakdown when both CPU and write time are zero (avoids a zero-value bucket).

- **Comment and doc-string cleanup**: references to the old opaque `"core"` bucket updated to say `"residual"` or `"provider-internal"` throughout `bifrost.go`, `utils.go`, `largeresponse.go`, `trace.go`, and `main.go` (logging plugin).

- **`worker-setup` span** now opens after `GetRequestFields` rather than before, so the field re-read is inside the span rather than in the untracked gap before it.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

Enable tracing on any request type (chat, embedding, transcription, image generation, streaming) and inspect the overhead breakdown in the log detail view. Verify:
- The `miscellaneous` bucket appears and is non-zero for requests that hit the pre-dispatch validation and channel-message setup paths.
- The `scheduling` residual is smaller than before.
- `provider-internal` reflects only genuinely unspanned provider work.
- `worker-handoff` measures only the goroutine hop, not field population time.
- The UI correctly labels `miscellaneous` as "Miscellaneous" under the "processing" category.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. Changes are limited to tracing instrumentation and span lifecycle management; no auth, secrets, or PII handling is affected.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable