### PR TITLE
fix: clear passthrough for non claude models in non native claude model providers

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6689,25 +6689,101 @@ func executeRequestWithRetries[T any](
 }
 
 // clearAnthropicPassthroughForNonNativeProvider disables Anthropic raw-body passthrough when a
-// request from the Anthropic-format integration resolves to a provider that doesn't speak the
-// Anthropic Messages API natively (e.g. Bedrock), forcing that provider to convert the request
-// itself. Gated on the final resolved provider so it fires regardless of how the provider was
-// picked (prefix, catalog, key alias, governance) and re-runs per attempt for fallbacks. No-op
-// for Anthropic/Vertex/Azure providers and for non-Anthropic integrations.
-func clearAnthropicPassthroughForNonNativeProvider(ctx *schemas.BifrostContext, baseProvider schemas.ModelProvider) {
+// request from the Anthropic-format integration resolves to a provider/model pair that doesn't
+// speak the Anthropic Messages API natively (e.g. Bedrock, or a routing rule that retargets a
+// Claude Code request to an OpenAI-family model on Bedrock Mantle), forcing that provider to
+// convert the request itself. Gated on the final resolved provider and model so it fires
+// regardless of how either was picked (prefix, catalog, key alias, governance, routing rule)
+// and re-runs per attempt for fallbacks. No-op for Anthropic and for non-Anthropic integrations.
+//
+// Vertex, Azure and Bedrock Mantle are multi-family: they serve Anthropic Messages for Claude and
+// OpenAI/Gemini surfaces for everything else, so their exemption reuses the IsAnthropicModelFamily
+// predicate their own dispatch uses. Call this only after key-level alias resolution — that
+// predicate reads the resolved alias from context.
+func clearAnthropicPassthroughForNonNativeProvider(ctx *schemas.BifrostContext, baseProvider schemas.ModelProvider, model string) {
 	if integrationType, _ := ctx.Value(schemas.BifrostContextKeyIntegrationType).(string); integrationType != "anthropic" {
 		return
 	}
-	if baseProvider == schemas.Anthropic ||
-		baseProvider == schemas.Vertex ||
+	if baseProvider == schemas.Anthropic {
+		return
+	}
+	if (baseProvider == schemas.Vertex ||
 		baseProvider == schemas.Azure ||
-		baseProvider == schemas.BedrockMantle {
+		baseProvider == schemas.BedrockMantle) &&
+		schemas.IsAnthropicModelFamily(ctx, model) {
 		return
 	}
 	ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, false)
 	ctx.SetValue(schemas.BifrostContextKeySendBackRawResponse, false)
 	ctx.SetValue(schemas.BifrostContextKeyPassthroughOverridesPresent, false)
 	ctx.ClearValue(schemas.BifrostContextKeyURLPath)
+}
+
+// applyRawCaptureSignals writes this attempt's raw-payload capture signals, merging provider
+// config with any per-request context overrides. Call it after
+// clearAnthropicPassthroughForNonNativeProvider: that helper can drop the passthrough overrides
+// this derivation reads, so deriving first would leave a converted response captured and
+// unstripped on a request that no longer passes anything through.
+func applyRawCaptureSignals(ctx *schemas.BifrostContext, config *schemas.ProviderConfig) {
+	// Effective values are computed by merging provider config with any per-request
+	// context overrides (BifrostContextKeySendBackRawRequest/Response and
+	// BifrostContextKeyStoreRawRequestResponse). A context value set to either true
+	// or false fully overrides the provider config for that flag.
+	//
+	// Each flag is independent:
+	//   send_back_raw_request  — include raw request bytes in the client response.
+	//   send_back_raw_response — include raw response bytes in the client response.
+	//   store_raw_request_response — persist raw bytes in log records (logging plugin only).
+	//
+	// Capture is enabled per-side whenever send-back OR store is requested for that side.
+	// Strip flags tell the response path to remove that side's bytes before the payload
+	// reaches the caller (used when store=true but send-back=false for that side).
+	//
+	// All internal signals are always written explicitly on every attempt so stale values
+	// from a previous provider attempt (e.g. different fallback provider config) cannot
+	// leak into the new attempt on a reused context. The user override keys
+	// (BifrostContextKeySendBackRaw*, BifrostContextKeyStoreRawRequestResponse) are
+	// never overwritten — they are read-only from bifrost.go's perspective.
+
+	// Step 1: compute effective value for each flag (provider config ← per-request override).
+	effectiveSendBackReq := config.SendBackRawRequest
+	allowRawOverride, _ := ctx.Value(schemas.BifrostContextKeyAllowPerRequestRawOverride).(bool)
+	passthroughOverridePresent, _ := ctx.Value(schemas.BifrostContextKeyPassthroughOverridesPresent).(bool)
+
+	if allowRawOverride || passthroughOverridePresent {
+		if override, ok := ctx.Value(schemas.BifrostContextKeySendBackRawRequest).(bool); ok {
+			effectiveSendBackReq = override
+		}
+	}
+	effectiveSendBackResp := config.SendBackRawResponse
+	if allowRawOverride || passthroughOverridePresent {
+		if override, ok := ctx.Value(schemas.BifrostContextKeySendBackRawResponse).(bool); ok {
+			effectiveSendBackResp = override
+		}
+	}
+	effectiveStore := config.StoreRawRequestResponse
+	allowStorageOverride, _ := ctx.Value(schemas.BifrostContextKeyAllowPerRequestStorageOverride).(bool)
+	if allowStorageOverride {
+		if override, ok := ctx.Value(schemas.BifrostContextKeyStoreRawRequestResponse).(bool); ok {
+			effectiveStore = override
+		}
+	}
+
+	// Step 2: derive per-side capture and strip flags.
+	// Capture if we need to send the data back OR store it — independent per side.
+	captureReq := effectiveSendBackReq || effectiveStore
+	captureResp := effectiveSendBackResp || effectiveStore
+	// Strip from client response if we captured for storage but not for send-back.
+	dropReq := effectiveStore && !effectiveSendBackReq
+	dropResp := effectiveStore && !effectiveSendBackResp
+
+	// Step 3: write all internal signals explicitly (never touch the user override keys).
+	ctx.SetValue(schemas.BifrostContextKeyCaptureRawRequest, captureReq)
+	ctx.SetValue(schemas.BifrostContextKeyCaptureRawResponse, captureResp)
+	ctx.SetValue(schemas.BifrostContextKeyDropRawRequestFromClient, dropReq)
+	ctx.SetValue(schemas.BifrostContextKeyDropRawResponseFromClient, dropResp)
+	// Tells the logging plugin whether to persist raw bytes in log records.
+	ctx.SetValue(schemas.BifrostContextKeyShouldStoreRawInLogs, effectiveStore)
 }
 
 // requestWorker handles incoming requests from the queue for a specific provider.
@@ -6780,70 +6856,6 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 		// Lets downstream converters resolve a custom provider key back to the built-in provider it wraps.
 		req.Context.SetValue(schemas.BifrostContextKeyBaseProviderType, baseProvider)
 
-		// Disable Anthropic raw-body passthrough when this attempt's provider isn't Anthropic-native (e.g. Bedrock).
-		clearAnthropicPassthroughForNonNativeProvider(req.Context, baseProvider)
-
-		// Determine whether this provider attempt should capture raw payloads.
-		//
-		// Effective values are computed by merging provider config with any per-request
-		// context overrides (BifrostContextKeySendBackRawRequest/Response and
-		// BifrostContextKeyStoreRawRequestResponse). A context value set to either true
-		// or false fully overrides the provider config for that flag.
-		//
-		// Each flag is independent:
-		//   send_back_raw_request  — include raw request bytes in the client response.
-		//   send_back_raw_response — include raw response bytes in the client response.
-		//   store_raw_request_response — persist raw bytes in log records (logging plugin only).
-		//
-		// Capture is enabled per-side whenever send-back OR store is requested for that side.
-		// Strip flags tell the response path to remove that side's bytes before the payload
-		// reaches the caller (used when store=true but send-back=false for that side).
-		//
-		// All internal signals are always written explicitly on every attempt so stale values
-		// from a previous provider attempt (e.g. different fallback provider config) cannot
-		// leak into the new attempt on a reused context. The user override keys
-		// (BifrostContextKeySendBackRaw*, BifrostContextKeyStoreRawRequestResponse) are
-		// never overwritten — they are read-only from bifrost.go's perspective.
-
-		// Step 1: compute effective value for each flag (provider config ← per-request override).
-		effectiveSendBackReq := config.SendBackRawRequest
-		allowRawOverride, _ := req.Context.Value(schemas.BifrostContextKeyAllowPerRequestRawOverride).(bool)
-		passthroughOverridePresent, _ := req.Context.Value(schemas.BifrostContextKeyPassthroughOverridesPresent).(bool)
-
-		if allowRawOverride || passthroughOverridePresent {
-			if override, ok := req.Context.Value(schemas.BifrostContextKeySendBackRawRequest).(bool); ok {
-				effectiveSendBackReq = override
-			}
-		}
-		effectiveSendBackResp := config.SendBackRawResponse
-		if allowRawOverride || passthroughOverridePresent {
-			if override, ok := req.Context.Value(schemas.BifrostContextKeySendBackRawResponse).(bool); ok {
-				effectiveSendBackResp = override
-			}
-		}
-		effectiveStore := config.StoreRawRequestResponse
-		allowStorageOverride, _ := req.Context.Value(schemas.BifrostContextKeyAllowPerRequestStorageOverride).(bool)
-		if allowStorageOverride {
-			if override, ok := req.Context.Value(schemas.BifrostContextKeyStoreRawRequestResponse).(bool); ok {
-				effectiveStore = override
-			}
-		}
-
-		// Step 2: derive per-side capture and strip flags.
-		// Capture if we need to send the data back OR store it — independent per side.
-		captureReq := effectiveSendBackReq || effectiveStore
-		captureResp := effectiveSendBackResp || effectiveStore
-		// Strip from client response if we captured for storage but not for send-back.
-		dropReq := effectiveStore && !effectiveSendBackReq
-		dropResp := effectiveStore && !effectiveSendBackResp
-
-		// Step 3: write all internal signals explicitly (never touch the user override keys).
-		req.Context.SetValue(schemas.BifrostContextKeyCaptureRawRequest, captureReq)
-		req.Context.SetValue(schemas.BifrostContextKeyCaptureRawResponse, captureResp)
-		req.Context.SetValue(schemas.BifrostContextKeyDropRawRequestFromClient, dropReq)
-		req.Context.SetValue(schemas.BifrostContextKeyDropRawResponseFromClient, dropResp)
-		// Tells the logging plugin whether to persist raw bytes in log records.
-		req.Context.SetValue(schemas.BifrostContextKeyShouldStoreRawInLogs, effectiveStore)
 		bifrost.endCoreSpan(workerSetupSpan)
 
 		var keys []schemas.Key
@@ -7073,6 +7085,9 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 					req.Context.SetValue(schemas.BifrostContextKeyResolvedAlias, nil)
 				}
 				req.SetModel(resolvedModel)
+				// Disable Anthropic raw-body passthrough when this attempt's provider/model isn't Anthropic-native.
+				clearAnthropicPassthroughForNonNativeProvider(req.Context, baseProvider, resolvedModel)
+				applyRawCaptureSignals(req.Context, config)
 				// Snapshot per-attempt so postHookRunner doesn't observe a later retry's
 				// alias while this attempt's provider goroutine is still emitting chunks.
 				attemptResolvedModel := resolvedModel
@@ -7172,6 +7187,9 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 					req.Context.SetValue(schemas.BifrostContextKeyResolvedAlias, nil)
 				}
 				req.SetModel(resolvedModel)
+				// Disable Anthropic raw-body passthrough when this attempt's provider/model isn't Anthropic-native.
+				clearAnthropicPassthroughForNonNativeProvider(req.Context, baseProvider, resolvedModel)
+				applyRawCaptureSignals(req.Context, config)
 				attemptRoutingInfo = schemas.BuildRoutingInfo(req.Context, provider.GetProviderKey(), originalModelRequested, k)
 				return bifrost.handleProviderRequest(provider, config, req, k, keys)
 			}, keyProvider, req.RequestType, provider.GetProviderKey(), model, &req.BifrostRequest, bifrost.logger)

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -2935,9 +2935,12 @@ func TestRunPreRequestHooks_CommitsRoutingPinnedKey(t *testing.T) {
 
 // TestClearAnthropicPassthroughForNonNativeProvider verifies that Anthropic raw-body
 // passthrough flags are cleared only when an Anthropic-integration request resolves to a
-// provider that doesn't speak the Anthropic Messages API natively (e.g. Bedrock). This
-// guards the fix for Claude-via-Bedrock tool calls breaking when the model is routed to
-// Bedrock through a key alias (so the catalog-time guard never fires).
+// provider/model pair that doesn't speak the Anthropic Messages API natively (e.g. Bedrock).
+// This guards the fix for Claude-via-Bedrock tool calls breaking when the model is routed to
+// Bedrock through a key alias (so the catalog-time guard never fires), and the fix for a
+// routing rule retargeting a Claude Code request to a non-Claude model on a multi-family
+// provider (Vertex/Azure/Bedrock Mantle), which sent the raw Anthropic body to that provider's
+// OpenAI/Gemini surface.
 func TestClearAnthropicPassthroughForNonNativeProvider(t *testing.T) {
 	flagKeys := []schemas.BifrostContextKey{
 		schemas.BifrostContextKeyUseRawRequestBody,
@@ -2949,14 +2952,31 @@ func TestClearAnthropicPassthroughForNonNativeProvider(t *testing.T) {
 		name            string
 		integrationType string
 		baseProvider    schemas.ModelProvider
+		model           string
+		alias           *schemas.ResolvedAlias
 		wantCleared     bool
 	}{
-		{"anthropic integration to bedrock clears", "anthropic", schemas.Bedrock, true},
-		{"anthropic integration to anthropic preserved", "anthropic", schemas.Anthropic, false},
-		{"anthropic integration to vertex preserved", "anthropic", schemas.Vertex, false},
-		{"anthropic integration to azure preserved", "anthropic", schemas.Azure, false},
-		{"non-anthropic integration to bedrock preserved", "openai", schemas.Bedrock, false},
-		{"no integration type to bedrock preserved", "", schemas.Bedrock, false},
+		{"anthropic integration to bedrock clears", "anthropic", schemas.Bedrock, "anthropic.claude-sonnet-4-20250514-v1:0", nil, true},
+		{"anthropic integration to anthropic preserved", "anthropic", schemas.Anthropic, "claude-sonnet-4-20250514", nil, false},
+		{"anthropic integration to vertex preserved", "anthropic", schemas.Vertex, "claude-sonnet-4@20250514", nil, false},
+		{"anthropic integration to azure preserved", "anthropic", schemas.Azure, "claude-sonnet-4-20250514", nil, false},
+		{"anthropic integration to bedrock mantle preserved", "anthropic", schemas.BedrockMantle, "claude-sonnet-4-20250514", nil, false},
+		{"anthropic integration to bedrock mantle openai model clears", "anthropic", schemas.BedrockMantle, "gpt-5-6-luna", nil, true},
+		{"anthropic integration to azure openai model clears", "anthropic", schemas.Azure, "gpt-5", nil, true},
+		{"anthropic integration to vertex gemini model clears", "anthropic", schemas.Vertex, "gemini-2.5-pro", nil, true},
+		{
+			name:            "anthropic integration to bedrock mantle claude alias preserved",
+			integrationType: "anthropic",
+			baseProvider:    schemas.BedrockMantle,
+			model:           "fast-model",
+			alias: &schemas.ResolvedAlias{
+				Key:    "fast-model",
+				Config: &schemas.AliasConfig{ModelID: "anthropic.claude-sonnet-4-20250514-v1:0"},
+			},
+			wantCleared: false,
+		},
+		{"non-anthropic integration to bedrock preserved", "openai", schemas.Bedrock, "claude-sonnet-4-20250514", nil, false},
+		{"no integration type to bedrock preserved", "", schemas.Bedrock, "claude-sonnet-4-20250514", nil, false},
 	}
 
 	for _, tt := range tests {
@@ -2965,6 +2985,9 @@ func TestClearAnthropicPassthroughForNonNativeProvider(t *testing.T) {
 			if tt.integrationType != "" {
 				ctx.SetValue(schemas.BifrostContextKeyIntegrationType, tt.integrationType)
 			}
+			if tt.alias != nil {
+				ctx.SetValue(schemas.BifrostContextKeyResolvedAlias, tt.alias)
+			}
 			for _, k := range flagKeys {
 				ctx.SetValue(k, true)
 			}
@@ -2972,7 +2995,7 @@ func TestClearAnthropicPassthroughForNonNativeProvider(t *testing.T) {
 			ctx.SetValue(schemas.BifrostContextKeySkipKeySelection, true)
 			ctx.SetValue(schemas.BifrostContextKeyURLPath, "/v1/messages")
 
-			clearAnthropicPassthroughForNonNativeProvider(ctx, tt.baseProvider)
+			clearAnthropicPassthroughForNonNativeProvider(ctx, tt.baseProvider, tt.model)
 
 			for _, k := range flagKeys {
 				got, _ := ctx.Value(k).(bool)
@@ -3251,5 +3274,44 @@ func TestExecuteRequestWithRetries_EmptyStreamReturnsClosedChannel(t *testing.T)
 	}
 	if count != 0 {
 		t.Errorf("Expected range over empty stream to yield 0 chunks, got %d", count)
+	}
+}
+
+// TestApplyRawCaptureSignals_RunsAfterPassthroughClear pins the ordering between
+// clearAnthropicPassthroughForNonNativeProvider and applyRawCaptureSignals. The derivation reads
+// the very override keys the clear drops, so deriving first leaves a converted provider response
+// captured and unstripped on a request that no longer passes anything through.
+func TestApplyRawCaptureSignals_RunsAfterPassthroughClear(t *testing.T) {
+	// Provider config asks for nothing: any capture must come from the passthrough override.
+	config := &schemas.ProviderConfig{}
+
+	tests := []struct {
+		name            string
+		model           string
+		wantCaptureResp bool
+	}{
+		{"non-native model drops the override", "gpt-5-6-luna", false},
+		{"claude model keeps the override", "claude-sonnet-4-20250514", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			ctx.SetValue(schemas.BifrostContextKeyIntegrationType, "anthropic")
+			ctx.SetValue(schemas.BifrostContextKeyPassthroughOverridesPresent, true)
+			ctx.SetValue(schemas.BifrostContextKeySendBackRawResponse, true)
+
+			clearAnthropicPassthroughForNonNativeProvider(ctx, schemas.BedrockMantle, tt.model)
+			applyRawCaptureSignals(ctx, config)
+
+			captureResp, _ := ctx.Value(schemas.BifrostContextKeyCaptureRawResponse).(bool)
+			if captureResp != tt.wantCaptureResp {
+				t.Errorf("CaptureRawResponse = %v, want %v", captureResp, tt.wantCaptureResp)
+			}
+			// Nothing is stored, so the client-strip flag stays off either way.
+			if dropResp, _ := ctx.Value(schemas.BifrostContextKeyDropRawResponseFromClient).(bool); dropResp {
+				t.Error("DropRawResponseFromClient = true, want false (store is off)")
+			}
+		})
 	}
 }

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -87,7 +87,7 @@ func createAnthropicMessagesRouteConfig(pathPrefix string, logger schemas.Logger
 			},
 			ResponsesResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostResponsesResponse) (interface{}, error) {
 				soToolName, _ := ctx.Value(schemas.BifrostContextKeyStructuredOutputToolName).(string)
-				if soToolName == "" && isClaudeModel(resp.ExtraFields.OriginalModelRequested, resp.ExtraFields.ResolvedModelUsed, string(resp.ExtraFields.Provider)) {
+				if soToolName == "" && isClaudeModel(ctx, resp.ExtraFields.OriginalModelRequested, resp.ExtraFields.ResolvedModelUsed, string(resp.ExtraFields.Provider)) {
 					if resp.ExtraFields.RawResponse != nil {
 						return resp.ExtraFields.RawResponse, nil
 					}
@@ -359,7 +359,7 @@ func checkAnthropicPassthrough(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.Bif
 
 // shouldUsePassthrough checks if the request should be sent to the passthrough endpoint.
 func shouldUsePassthrough(ctx *schemas.BifrostContext, provider schemas.ModelProvider, model string, alias string) bool {
-	return anthropic.IsClaudeCodeRequest(ctx) && isClaudeModel(model, alias, string(provider))
+	return anthropic.IsClaudeCodeRequest(ctx) && isClaudeModel(ctx, model, alias, string(provider))
 }
 
 // serverToolSynthesizesResultBlock reports whether an item's output_item.done
@@ -428,12 +428,32 @@ func mustConvertInPassthrough(resp *schemas.BifrostResponsesStreamResponse) bool
 	return false
 }
 
-func isClaudeModel(model, alias, provider string) bool {
-	return (provider == string(schemas.Anthropic) ||
-		(provider == "" && (schemas.IsAnthropicModel(model) || schemas.IsAnthropicModel(alias)))) ||
-		(provider == string(schemas.BedrockMantle) && (schemas.IsAnthropicModel(model) || schemas.IsAnthropicModel(alias))) ||
-		(provider == string(schemas.Vertex) && (schemas.IsAnthropicModel(model) || schemas.IsAnthropicModel(alias))) ||
-		(provider == string(schemas.Azure) && (schemas.IsAnthropicModel(model) || schemas.IsAnthropicModel(alias)))
+// isClaudeModel reports whether this attempt talks to a native Anthropic Messages surface, which
+// is what makes forwarding the upstream response verbatim safe. model is the caller-sent model and
+// alias the resolved wire model, empty at ingress; provider is empty only when the caller sent no
+// provider prefix.
+//
+// Bedrock Mantle, Vertex and Azure are multi-family, so they resolve the model family instead of
+// sniffing names: an alias labelled "claude-opus" may well point at an OpenAI model, and passing an
+// OpenAI Responses body back to an Anthropic client yields a malformed (HTTP 200) response.
+func isClaudeModel(ctx *schemas.BifrostContext, model, alias, provider string) bool {
+	switch provider {
+	case string(schemas.Anthropic):
+		return true
+	case string(schemas.BedrockMantle), string(schemas.Vertex), string(schemas.Azure):
+		// alias is empty at ingress, where the caller-sent model is all there is to resolve against.
+		candidate := alias
+		if candidate == "" {
+			candidate = model
+		}
+		// Name check first so this stays a strict subset of the pre-family behavior: the family
+		// resolution can only downgrade a Claude-looking name, never promote a non-Claude one.
+		return (schemas.IsAnthropicModel(model) || schemas.IsAnthropicModel(alias)) &&
+			schemas.IsAnthropicModelFamily(ctx, candidate)
+	case "":
+		return schemas.IsAnthropicModel(model) || schemas.IsAnthropicModel(alias)
+	}
+	return false
 }
 
 // extractAnthropicListModelsParams extracts query parameters for list models request

--- a/transports/bifrost-http/integrations/anthropic_test.go
+++ b/transports/bifrost-http/integrations/anthropic_test.go
@@ -253,3 +253,112 @@ func TestCheckAnthropicPassthrough_OAuthHeaderRouting(t *testing.T) {
 		}
 	}
 }
+
+// TestIsClaudeModel_MultiFamilyProvidersResolveFamily locks in that the response-side raw
+// passthrough decision resolves the model family instead of sniffing names. An alias labelled
+// "claude-opus" on Bedrock Mantle may point at an OpenAI model; forwarding that provider's
+// Responses body verbatim to an Anthropic client produced a malformed HTTP 200 ("body is JSON
+// but not a Message") in Claude Code. The alias's ModelID — not its label — decides.
+func TestIsClaudeModel_MultiFamilyProvidersResolveFamily(t *testing.T) {
+	claudeAlias := &schemas.ResolvedAlias{
+		Key:    "claude-opus",
+		Config: &schemas.AliasConfig{ModelID: "openai.gpt-5.6-sol"},
+	}
+	neutralAlias := &schemas.ResolvedAlias{
+		Key:    "fast-model",
+		Config: &schemas.AliasConfig{ModelID: "anthropic.claude-sonnet-4-20250514-v1:0"},
+	}
+	// Azure deployment names / Vertex endpoint ids: the Claude identity lives in ModelName, not ModelID.
+	deploymentAlias := &schemas.ResolvedAlias{
+		Key:    "fast-model",
+		Config: &schemas.AliasConfig{ModelID: "prod-deployment-01", ModelName: schemas.Ptr("claude-sonnet-4")},
+	}
+
+	cases := []struct {
+		name     string
+		provider schemas.ModelProvider
+		model    string // ExtraFields.OriginalModelRequested
+		alias    string // ExtraFields.ResolvedModelUsed (the wire model)
+		resolved *schemas.ResolvedAlias
+		want     bool
+	}{
+		{"mantle claude-named alias to openai model", schemas.BedrockMantle, "claude-opus", "openai.gpt-5.6-sol", claudeAlias, false},
+		{"vertex claude-named alias to openai model", schemas.Vertex, "claude-opus", "openai.gpt-5.6-sol", claudeAlias, false},
+		{"azure claude-named alias to openai model", schemas.Azure, "claude-opus", "openai.gpt-5.6-sol", claudeAlias, false},
+		{"mantle neutral alias to claude model", schemas.BedrockMantle, "fast-model", "anthropic.claude-sonnet-4-20250514-v1:0", neutralAlias, true},
+		{"mantle unaliased claude model", schemas.BedrockMantle, "claude-sonnet-4-20250514", "claude-sonnet-4-20250514", nil, true},
+		{"mantle unaliased openai model", schemas.BedrockMantle, "gpt-5-6-luna", "gpt-5-6-luna", nil, false},
+		{
+			// Neither name looks Claude, so this keeps converting exactly as it did before the family
+			// check existed — the predicate must never newly enable raw passthrough.
+			name:     "azure deployment alias naming claude only in model_name",
+			provider: schemas.Azure,
+			model:    "fast-model",
+			alias:    "prod-deployment-01",
+			resolved: deploymentAlias,
+			want:     false,
+		},
+		{"anthropic provider always native", schemas.Anthropic, "claude-sonnet-4-20250514", "claude-sonnet-4-20250514", nil, true},
+		{"bedrock is never native", schemas.Bedrock, "claude-sonnet-4-20250514", "anthropic.claude-sonnet-4-20250514-v1:0", nil, false},
+		// Ingress: no alias is resolved yet, so the caller-sent model is all there is to go on.
+		{"ingress claude model", "", "claude-sonnet-5", "", nil, true},
+		{"ingress non-claude model", "", "gpt-5", "", nil, false},
+		{"ingress mantle claude model", schemas.BedrockMantle, "claude-haiku-4-5", "", nil, true},
+		{"ingress vertex claude model", schemas.Vertex, "claude-haiku-4-5", "", nil, true},
+		{"ingress azure claude model", schemas.Azure, "claude-haiku-4-5", "", nil, true},
+		{"ingress mantle openai model", schemas.BedrockMantle, "gpt-5-6-luna", "", nil, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+			defer cancel()
+			if tc.resolved != nil {
+				ctx.SetValue(schemas.BifrostContextKeyResolvedAlias, tc.resolved)
+			}
+
+			if got := isClaudeModel(ctx, tc.model, tc.alias, string(tc.provider)); got != tc.want {
+				t.Errorf("isClaudeModel(%q, %q, %q) = %v, want %v", tc.model, tc.alias, tc.provider, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCheckAnthropicPassthrough_ProviderPrefixedClaudeModel pins the ingress half of the
+// passthrough decision for provider-prefixed Claude requests. TestCheckAnthropicPassthrough_
+// OutputConfigEscapeHatch cannot cover this: it asserts UseRawRequestBody ends up false for these
+// providers, which also holds when passthrough was never enabled at all.
+func TestCheckAnthropicPassthrough_ProviderPrefixedClaudeModel(t *testing.T) {
+	cases := []struct {
+		name      string
+		model     string
+		wantRawOn bool
+	}{
+		{"vertex claude", "vertex/claude-haiku-4-5", true},
+		{"bedrock_mantle claude", "bedrock_mantle/claude-haiku-4-5", true},
+		{"azure claude", "azure/claude-haiku-4-5", true},
+		{"bedrock_mantle openai", "bedrock_mantle/gpt-5-6-luna", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reqCtx := &fasthttp.RequestCtx{}
+			reqCtx.Request.Header.SetMethod(fasthttp.MethodPost)
+			reqCtx.Request.Header.Set("user-agent", "claude-code/1.0")
+			reqCtx.Request.Header.Set("x-api-key", "sk-ant-test")
+
+			bifrostCtx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+			defer cancel()
+
+			req := &anthropic.AnthropicMessageRequest{Model: tc.model, MaxTokens: 1024}
+			if err := checkAnthropicPassthrough(reqCtx, bifrostCtx, req); err != nil {
+				t.Fatalf("checkAnthropicPassthrough: %v", err)
+			}
+
+			useRaw, _ := bifrostCtx.Value(schemas.BifrostContextKeyUseRawRequestBody).(bool)
+			if useRaw != tc.wantRawOn {
+				t.Errorf("UseRawRequestBody = %v, want %v for %s", useRaw, tc.wantRawOn, tc.model)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

When a routing rule retargets a Claude Code (Anthropic-integration) request to a non-Claude model on a multi-family provider like Vertex, Azure, or Bedrock Mantle, the raw Anthropic request body was being forwarded to that provider's OpenAI or Gemini surface. This happened because the passthrough guard only checked the provider, not the model, so it incorrectly preserved the raw body for any request going to those providers regardless of whether the target model actually speaks the Anthropic Messages API. The same blind spot existed on the response side: `isClaudeModel` in the Anthropic integration sniffed model names rather than resolving the model family, so an alias labelled `claude-opus` pointing at an OpenAI model on Bedrock Mantle would forward the provider's Responses body verbatim back to the Anthropic client, producing a malformed HTTP 200 in Claude Code.

## Changes

- `clearAnthropicPassthroughForNonNativeProvider` now accepts the resolved model name in addition to the provider, and uses `IsAnthropicModelFamily` to determine whether multi-family providers (Vertex, Azure, Bedrock Mantle) are actually serving a Claude model before preserving the passthrough flag.
- The call site was moved to after key-level alias resolution so the resolved alias is available in context when `IsAnthropicModelFamily` reads it — required for alias-based routing (e.g. `fast-model` → `anthropic.claude-sonnet-4-...`) to be correctly identified as Anthropic-native.
- The raw capture signal derivation was extracted into `applyRawCaptureSignals` and explicitly ordered after `clearAnthropicPassthroughForNonNativeProvider`, since the derivation reads the override keys that the clear step may drop. Deriving first would leave a converted provider response captured and unstripped on a request that no longer passes anything through.
- `isClaudeModel` in the Anthropic integration was rewritten to use `IsAnthropicModelFamily` for multi-family providers (Vertex, Azure, Bedrock Mantle) instead of sniffing model name strings, so the alias's resolved `ModelID` — not its label — decides whether the response is safe to forward verbatim.
- Tests were expanded to cover: non-Claude models on Vertex/Azure/Bedrock Mantle clearing the passthrough flag, Claude models on those providers preserving it, alias-resolved Claude models on Bedrock Mantle preserving it, the ordering invariant between the clear and derive steps, and provider-prefixed Claude/non-Claude models at ingress.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

Validate that an Anthropic-integration request routed via a routing rule to a non-Claude model on Vertex, Azure, or Bedrock Mantle does not forward the raw Anthropic body, and that Claude models on those same providers continue to use the raw passthrough path. Also validate that an alias with a Claude-sounding name pointing at an OpenAI model on Bedrock Mantle does not forward the provider's response body verbatim to the Anthropic client.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable