### PR TITLE
fix: realtime / ws responses adds llm.call spans

### DIFF
--- a/transports/bifrost-http/handlers/wsresponses.go
+++ b/transports/bifrost-http/handlers/wsresponses.go
@@ -332,11 +332,70 @@ func (h *WSResponsesHandler) tryNativeWSUpstream(
 		return true
 	}
 
+	// Retrieve tracer and traceID up front: they drive both chunk accumulation and
+	// the llm.call span this path is responsible for. Without an llm.call span,
+	// span-based observability connectors export the turn unattributed (issue #6265).
+	tracer, _ := ctx.Value(schemas.BifrostContextKeyTracer).(schemas.Tracer)
+	traceID, _ := ctx.Value(schemas.BifrostContextKeyTraceID).(string)
+
+	// llm.call span for this realtime turn. Started lazily once the native path is
+	// committed (first upstream event, or a terminal error), so a fallback to the
+	// HTTP bridge does not leave a dangling span alongside the one core starts.
+	var (
+		llmSpanHandle  schemas.SpanHandle
+		llmSpanStarted bool
+		llmSpanEnded   bool
+	)
+	startLLMSpan := func() {
+		if llmSpanStarted || tracer == nil || traceID == "" {
+			return
+		}
+		llmSpanStarted = true
+		otelOp := schemas.OTelOperationName(schemas.WebSocketResponsesRequest)
+		spanID, handle := tracer.StartSpanID(ctx, otelOp+" "+req.Model, schemas.SpanKindLLMCall)
+		llmSpanHandle = handle
+		if span := tracer.SpanFromHandle(handle); span != nil {
+			span.SetAttribute(schemas.AttrProviderName, schemas.OTelProviderName(req.Provider))
+			span.SetAttribute(schemas.AttrBifrostProviderName, string(req.Provider))
+			span.SetAttribute(schemas.AttrRequestModel, req.Model)
+			span.SetAttribute(schemas.AttrOperationName, otelOp)
+			span.SetAttribute(schemas.AttrLegacyRequestType, string(schemas.WebSocketResponsesRequest))
+		}
+		tracer.PopulateLLMRequestAttributes(handle, bifrostReq)
+		// Nest per-chunk post-hook spans under the llm.call span.
+		if spanID != "" {
+			ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
+		}
+	}
+	// endLLMSpan populates response attributes and ends the span. It must run
+	// before the terminal post-hook flush so the exported trace carries the span.
+	endLLMSpan := func(resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) {
+		if !llmSpanStarted || llmSpanEnded || tracer == nil {
+			return
+		}
+		llmSpanEnded = true
+		tracer.PopulateLLMResponseAttributes(ctx, llmSpanHandle, resp, bifrostErr)
+		if bifrostErr != nil {
+			if bifrostErr.Error != nil {
+				tracer.SetAttribute(llmSpanHandle, "error", bifrostErr.Error.Message)
+			}
+			if bifrostErr.StatusCode != nil {
+				tracer.SetAttribute(llmSpanHandle, "status_code", *bifrostErr.StatusCode)
+			}
+			tracer.EndSpan(llmSpanHandle, schemas.SpanStatusError, "request failed")
+			return
+		}
+		tracer.EndSpan(llmSpanHandle, schemas.SpanStatusOk, "")
+	}
+
 	finalizeTerminalPostHooks := func(bifrostErr *schemas.BifrostError) {
 		if bifrostErr == nil {
 			return
 		}
 		ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+		// Attribute the errored turn to an llm.call span, then end it before the flush.
+		startLLMSpan()
+		endLLMSpan(nil, bifrostErr)
 		if _, postErr := hooks.PostHookRunner(ctx, nil, bifrostErr); postErr != nil {
 			logger.Warn("failed to finalize WS post-hooks for %s: %v", req.Provider, postErr)
 		}
@@ -349,9 +408,6 @@ func (h *WSResponsesHandler) tryNativeWSUpstream(
 		return false
 	}
 
-	// Retrieve tracer and traceID for chunk accumulation
-	tracer, _ := ctx.Value(schemas.BifrostContextKeyTracer).(schemas.Tracer)
-	traceID, _ := ctx.Value(schemas.BifrostContextKeyTraceID).(string)
 	streamIdleTimeout := resolveWSStreamIdleTimeout(h.config, req.Provider)
 
 	// Read response events from upstream and relay to client, running post-hooks per chunk
@@ -398,17 +454,28 @@ func (h *WSResponsesHandler) tryNativeWSUpstream(
 		}
 
 		if streamResp != nil {
+			// Commit to the native path: start the llm.call span on the first event.
+			startLLMSpan()
+
 			resp := &schemas.BifrostResponse{ResponsesStreamResponse: streamResp}
 
 			if tracer != nil && traceID != "" {
 				tracer.AddStreamingChunk(traceID, resp)
 			}
 
-			_, postErr := hooks.PostHookRunner(ctx, resp, nil)
-			if postErr != nil {
-				closeUpstream()
-				writeWSBifrostError(session, postErr)
-				return true
+			// End the llm.call span before the terminal post-hook flush so the
+			// exported trace carries provider/model/usage for this turn. Failed
+			// terminal events (response.failed/error/incomplete) end the span with
+			// error status carrying the provider's error, not as a success.
+			var terminalErr *schemas.BifrostError
+			if isTerminal {
+				terminalErr = buildWSTurnSpanError(streamResp)
+				endLLMSpan(buildWSTurnSpanResponse(streamResp, req), terminalErr)
+			}
+
+			_, postErr := hooks.PostHookRunner(ctx, resp, terminalErr)
+			if postErr != nil && terminalErr == nil {
+				logger.Warn("WS post-hook returned an error for %s: %v", req.Provider, postErr)
 			}
 		}
 
@@ -527,6 +594,70 @@ func parseUpstreamWSEvent(data []byte, provider schemas.ModelProvider, model str
 	// output text, token usage, and cost data from the logs.
 	streamResp.ExtraFields.ChunkIndex = streamResp.SequenceNumber
 	return &streamResp
+}
+
+// buildWSTurnSpanResponse builds the response used to populate the llm.call span's
+// usage/model/cost attributes from a terminal upstream event. The response.completed
+// event carries the final usage on streamResp.Response. Returns nil if the terminal
+// event has no response payload, in which case the span keeps only its request attributes.
+func buildWSTurnSpanResponse(streamResp *schemas.BifrostResponsesStreamResponse, req *schemas.BifrostResponsesRequest) *schemas.BifrostResponse {
+	if streamResp == nil || streamResp.Response == nil {
+		return nil
+	}
+	resp := &schemas.BifrostResponse{ResponsesResponse: streamResp.Response}
+	// Populate ExtraFields so cost calculation and alias resolution have provider/model.
+	resp.PopulateExtraFields(schemas.WebSocketResponsesRequest, req.Provider, req.Model, req.Model)
+	return resp
+}
+
+// isFailedTerminalStreamType returns true if a terminal event signals failure
+// rather than a normal completion.
+func isFailedTerminalStreamType(t schemas.ResponsesStreamResponseType) bool {
+	switch t {
+	case schemas.ResponsesStreamResponseTypeFailed,
+		schemas.ResponsesStreamResponseTypeIncomplete,
+		schemas.ResponsesStreamResponseTypeError:
+		return true
+	}
+	return false
+}
+
+// buildWSTurnSpanError returns a BifrostError describing a failed terminal event
+// (response.failed / response.error / response.incomplete), or nil for a normal
+// completion. It lets the llm.call span end with error status carrying the
+// provider's error code and message. Error details are read from the response.error
+// object, the top-level error event, or incomplete_details.reason, in that order.
+func buildWSTurnSpanError(streamResp *schemas.BifrostResponsesStreamResponse) *schemas.BifrostError {
+	if streamResp == nil || !isFailedTerminalStreamType(streamResp.Type) {
+		return nil
+	}
+	code := "upstream_error"
+	message := "upstream websocket response failed"
+	switch {
+	case streamResp.Response != nil && streamResp.Response.Error != nil:
+		if streamResp.Response.Error.Code != "" {
+			code = streamResp.Response.Error.Code
+		}
+		if streamResp.Response.Error.Message != "" {
+			message = streamResp.Response.Error.Message
+		}
+	case streamResp.Error != nil:
+		if streamResp.Error.Code != "" {
+			code = streamResp.Error.Code
+		}
+		if streamResp.Error.Message != "" {
+			message = streamResp.Error.Message
+		}
+	case streamResp.Message != nil && *streamResp.Message != "":
+		message = *streamResp.Message
+		if streamResp.Code != nil && *streamResp.Code != "" {
+			code = *streamResp.Code
+		}
+	case streamResp.Response != nil && streamResp.Response.IncompleteDetails != nil && streamResp.Response.IncompleteDetails.Reason != "":
+		code = "incomplete"
+		message = streamResp.Response.IncompleteDetails.Reason
+	}
+	return newBifrostError(502, code, message)
 }
 
 // isTerminalStreamType returns true if the event type signals the end of a response stream.

--- a/transports/bifrost-http/handlers/wsresponses_span_test.go
+++ b/transports/bifrost-http/handlers/wsresponses_span_test.go
@@ -1,0 +1,422 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fasthttp/websocket"
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/tracing"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	bfws "github.com/maximhq/bifrost/transports/bifrost-http/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// wsSpanTestAccount is a minimal offline Account exposing OpenAI with one keyed
+// entry, so GetProviderByKey / SelectKeyForProviderRequestType resolve without
+// any network call.
+type wsSpanTestAccount struct{}
+
+func (wsSpanTestAccount) GetConfiguredProviders() ([]schemas.ModelProvider, error) {
+	return []schemas.ModelProvider{schemas.OpenAI}, nil
+}
+
+func (wsSpanTestAccount) GetKeysForProvider(_ context.Context, p schemas.ModelProvider) ([]schemas.Key, error) {
+	if p != schemas.OpenAI {
+		return nil, nil
+	}
+	return []schemas.Key{{
+		ID:     "test-key-1",
+		Value:  *schemas.NewSecretVar("sk-test"),
+		Models: schemas.WhiteList{"*"},
+		Weight: 1.0,
+	}}, nil
+}
+
+func (wsSpanTestAccount) GetConfigForProvider(p schemas.ModelProvider) (*schemas.ProviderConfig, error) {
+	if p != schemas.OpenAI {
+		return nil, fmt.Errorf("unsupported provider %s", p)
+	}
+	return &schemas.ProviderConfig{
+		NetworkConfig:            schemas.DefaultNetworkConfig,
+		ConcurrencyAndBufferSize: schemas.DefaultConcurrencyAndBufferSize,
+	}, nil
+}
+
+// wsLLMSpanCapture is an ObservabilityPlugin that records whether the flushed
+// trace contains an llm.call span and, if so, the provider/model/usage
+// attributes carried on it. Attributes are read from the export snapshot, which
+// is an isolated copy safe to iterate.
+type wsLLMSpanCapture struct {
+	once       sync.Once
+	done       chan struct{}
+	foundLLM   bool
+	provider   any
+	model      any
+	total      any
+	status     schemas.SpanStatus
+	statusCode any
+	errAttr    any
+}
+
+func (p *wsLLMSpanCapture) GetName() string { return "ws-llm-span-capture" }
+func (p *wsLLMSpanCapture) Cleanup() error  { return nil }
+func (p *wsLLMSpanCapture) Inject(_ context.Context, trace *schemas.Trace) error {
+	defer p.once.Do(func() { close(p.done) })
+	if trace == nil {
+		return nil
+	}
+	for _, span := range trace.Spans {
+		if span != nil && span.Kind == schemas.SpanKindLLMCall {
+			p.foundLLM = true
+			p.provider = span.Attributes[schemas.AttrProviderName]
+			p.model = span.Attributes[schemas.AttrRequestModel]
+			p.total = span.Attributes[schemas.AttrTotalTokens]
+			p.status = span.Status
+			p.statusCode = span.Attributes["status_code"]
+			p.errAttr = span.Attributes["error"]
+		}
+	}
+	return nil
+}
+
+func newWSTestUpgrader() websocket.Upgrader {
+	return websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+}
+
+// TestNativeWSUpstreamProducesLLMCallSpan asserts that a realtime/WebSocket
+// Responses turn taking the native WS upstream path (tryNativeWSUpstream)
+// produces an llm.call span carrying provider, model, and token usage, matching
+// what every other request type exports to span-based observability connectors.
+//
+// Regression for issue #6265: the native WS path runs post-hooks and flushes the
+// trace, but never starts a SpanKindLLMCall span, so span-derived exports record
+// the turn as an unattributed row (no provider, model, or usage).
+func TestNativeWSUpstreamProducesLLMCallSpan(t *testing.T) {
+	SetLogger(bifrost.NewDefaultLogger(schemas.LogLevelError))
+
+	// Fake OpenAI WS upstream: read the forwarded response.create event, then
+	// reply with a terminal response.completed carrying usage.
+	upstreamSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		up := newWSTestUpgrader()
+		c, err := up.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		if _, _, err := c.ReadMessage(); err != nil {
+			return
+		}
+		completed := `{"type":"response.completed","sequence_number":1,"response":{"id":"resp_test","model":"gpt-realtime","usage":{"input_tokens":11,"output_tokens":7,"total_tokens":18}}}`
+		_ = c.WriteMessage(websocket.TextMessage, []byte(completed))
+		// Hold the connection open briefly so the handler reads the terminal event
+		// before the server tears the socket down.
+		time.Sleep(300 * time.Millisecond)
+	}))
+	defer upstreamSrv.Close()
+
+	// Client-facing sink: drains whatever the handler relays back to the client.
+	clientSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		up := newWSTestUpgrader()
+		c, err := up.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		for {
+			if _, _, err := c.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer clientSrv.Close()
+
+	// Tracer wired with an observability sink that captures the flushed trace.
+	store := tracing.NewTraceStore(5*time.Minute, nil)
+	defer store.Stop()
+	tracer := tracing.NewTracer(store, nil, nil)
+	defer tracer.Stop()
+	capture := &wsLLMSpanCapture{done: make(chan struct{})}
+	tracer.SetObservabilityPlugins([]schemas.ObservabilityPlugin{capture}, nil)
+
+	client, err := bifrost.Init(context.Background(), schemas.BifrostConfig{
+		Account: wsSpanTestAccount{},
+		Logger:  bifrost.NewDefaultLogger(schemas.LogLevelError),
+		Tracer:  tracer,
+	})
+	require.NoError(t, err)
+	defer client.Shutdown()
+
+	pool := bfws.NewPool(&schemas.WSPoolConfig{})
+	defer pool.Close()
+
+	h := &WSResponsesHandler{
+		client:       client,
+		config:       &lib.Config{Providers: map[schemas.ModelProvider]configstore.ProviderConfig{schemas.OpenAI: {}}},
+		handlerStore: testWSHandlerStore{},
+		pool:         pool,
+		sessions:     bfws.NewSessionManager(10),
+	}
+
+	// Pre-pin the upstream to the session so the native path reuses it (matching
+	// provider + key) instead of dialing through the pool.
+	upstreamURL := "ws" + strings.TrimPrefix(upstreamSrv.URL, "http")
+	upConn, err := bfws.DialUpstream(upstreamURL, nil, schemas.OpenAI, "test-key-1", nil)
+	require.NoError(t, err)
+
+	clientURL := "ws" + strings.TrimPrefix(clientSrv.URL, "http")
+	clientConn, _, err := websocket.DefaultDialer.Dial(clientURL, nil)
+	require.NoError(t, err)
+
+	session := bfws.NewSession(clientConn)
+	session.SetUpstream(upConn)
+	defer session.Close()
+
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	req := &schemas.BifrostResponsesRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-realtime",
+		Input: []schemas.ResponsesMessage{{
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("hello")},
+		}},
+	}
+	rawEvent := []byte(`{"type":"response.create","model":"gpt-realtime","input":"hello"}`)
+
+	handled := h.tryNativeWSUpstream(session, ctx, req, rawEvent)
+	require.True(t, handled, "native WS path should have handled the turn")
+
+	select {
+	case <-capture.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the trace to flush")
+	}
+
+	require.True(t, capture.foundLLM,
+		"native WS responses turn produced no llm.call span; span-based connectors export it unattributed (issue #6265)")
+	assert.Equal(t, schemas.OTelProviderName(schemas.OpenAI), capture.provider, "llm.call span must carry the provider")
+	assert.Equal(t, "gpt-realtime", capture.model, "llm.call span must carry the request model")
+	assert.NotNil(t, capture.total, "llm.call span must carry token usage")
+	assert.Equal(t, schemas.SpanStatusOk, capture.status, "a completed turn must end the llm.call span with ok status")
+}
+
+// TestNativeWSUpstreamFailedResponseProducesErroredLLMCallSpan asserts that a
+// terminal response.failed event ends the llm.call span with error status and the
+// provider's error code/message, rather than as a success (issue #6265, provider
+// error path). Usage present on the failed event is still recorded.
+func TestNativeWSUpstreamFailedResponseProducesErroredLLMCallSpan(t *testing.T) {
+	SetLogger(bifrost.NewDefaultLogger(schemas.LogLevelError))
+
+	// Fake OpenAI WS upstream that replies with a terminal response.failed carrying
+	// an error object and usage.
+	upstreamSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		up := newWSTestUpgrader()
+		c, err := up.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		if _, _, err := c.ReadMessage(); err != nil {
+			return
+		}
+		failed := `{"type":"response.failed","sequence_number":1,"response":{"id":"resp_test","model":"gpt-realtime","status":"failed","error":{"code":"server_error","message":"the model failed to generate a response"},"usage":{"input_tokens":11,"output_tokens":0,"total_tokens":11}}}`
+		_ = c.WriteMessage(websocket.TextMessage, []byte(failed))
+		time.Sleep(300 * time.Millisecond)
+	}))
+	defer upstreamSrv.Close()
+
+	clientSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		up := newWSTestUpgrader()
+		c, err := up.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		for {
+			if _, _, err := c.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer clientSrv.Close()
+
+	store := tracing.NewTraceStore(5*time.Minute, nil)
+	defer store.Stop()
+	tracer := tracing.NewTracer(store, nil, nil)
+	defer tracer.Stop()
+	capture := &wsLLMSpanCapture{done: make(chan struct{})}
+	tracer.SetObservabilityPlugins([]schemas.ObservabilityPlugin{capture}, nil)
+
+	client, err := bifrost.Init(context.Background(), schemas.BifrostConfig{
+		Account: wsSpanTestAccount{},
+		Logger:  bifrost.NewDefaultLogger(schemas.LogLevelError),
+		Tracer:  tracer,
+	})
+	require.NoError(t, err)
+	defer client.Shutdown()
+
+	pool := bfws.NewPool(&schemas.WSPoolConfig{})
+	defer pool.Close()
+
+	h := &WSResponsesHandler{
+		client:       client,
+		config:       &lib.Config{Providers: map[schemas.ModelProvider]configstore.ProviderConfig{schemas.OpenAI: {}}},
+		handlerStore: testWSHandlerStore{},
+		pool:         pool,
+		sessions:     bfws.NewSessionManager(10),
+	}
+
+	upstreamURL := "ws" + strings.TrimPrefix(upstreamSrv.URL, "http")
+	upConn, err := bfws.DialUpstream(upstreamURL, nil, schemas.OpenAI, "test-key-1", nil)
+	require.NoError(t, err)
+
+	clientURL := "ws" + strings.TrimPrefix(clientSrv.URL, "http")
+	clientConn, _, err := websocket.DefaultDialer.Dial(clientURL, nil)
+	require.NoError(t, err)
+
+	session := bfws.NewSession(clientConn)
+	session.SetUpstream(upConn)
+	defer session.Close()
+
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	req := &schemas.BifrostResponsesRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-realtime",
+		Input: []schemas.ResponsesMessage{{
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("hello")},
+		}},
+	}
+	rawEvent := []byte(`{"type":"response.create","model":"gpt-realtime","input":"hello"}`)
+
+	handled := h.tryNativeWSUpstream(session, ctx, req, rawEvent)
+	require.True(t, handled, "native WS path should have handled the failed turn")
+
+	select {
+	case <-capture.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the trace to flush")
+	}
+
+	require.True(t, capture.foundLLM, "failed native WS turn must still produce an llm.call span")
+	assert.Equal(t, schemas.SpanStatusError, capture.status, "response.failed must end the llm.call span with error status")
+	assert.Equal(t, "the model failed to generate a response", capture.errAttr, "errored llm.call span must carry the provider error message")
+	assert.Equal(t, 502, capture.statusCode, "errored llm.call span must carry a status code")
+	assert.NotNil(t, capture.total, "usage present on the failed event must still be recorded")
+}
+
+// TestNativeWSUpstreamTimeoutProducesErroredLLMCallSpan asserts that when the
+// native WS upstream stalls (no reply within the idle timeout), the turn still
+// produces an llm.call span, ended with error status and the upstream status
+// code, rather than exporting as a blank row (issue #6265, error path).
+func TestNativeWSUpstreamTimeoutProducesErroredLLMCallSpan(t *testing.T) {
+	SetLogger(bifrost.NewDefaultLogger(schemas.LogLevelError))
+
+	// Fake OpenAI WS upstream that reads the forwarded event, then never replies,
+	// so the handler's read deadline fires.
+	upstreamSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		up := newWSTestUpgrader()
+		c, err := up.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		if _, _, err := c.ReadMessage(); err != nil {
+			return
+		}
+		// Stall past the 1s idle timeout without sending any event.
+		time.Sleep(2 * time.Second)
+	}))
+	defer upstreamSrv.Close()
+
+	clientSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		up := newWSTestUpgrader()
+		c, err := up.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		for {
+			if _, _, err := c.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer clientSrv.Close()
+
+	store := tracing.NewTraceStore(5*time.Minute, nil)
+	defer store.Stop()
+	tracer := tracing.NewTracer(store, nil, nil)
+	defer tracer.Stop()
+	capture := &wsLLMSpanCapture{done: make(chan struct{})}
+	tracer.SetObservabilityPlugins([]schemas.ObservabilityPlugin{capture}, nil)
+
+	client, err := bifrost.Init(context.Background(), schemas.BifrostConfig{
+		Account: wsSpanTestAccount{},
+		Logger:  bifrost.NewDefaultLogger(schemas.LogLevelError),
+		Tracer:  tracer,
+	})
+	require.NoError(t, err)
+	defer client.Shutdown()
+
+	pool := bfws.NewPool(&schemas.WSPoolConfig{})
+	defer pool.Close()
+
+	h := &WSResponsesHandler{
+		client: client,
+		// 1s idle timeout so the stalled upstream trips the read deadline quickly.
+		config: &lib.Config{Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+			schemas.OpenAI: {NetworkConfig: &schemas.NetworkConfig{StreamIdleTimeoutInSeconds: 1}},
+		}},
+		handlerStore: testWSHandlerStore{},
+		pool:         pool,
+		sessions:     bfws.NewSessionManager(10),
+	}
+
+	upstreamURL := "ws" + strings.TrimPrefix(upstreamSrv.URL, "http")
+	upConn, err := bfws.DialUpstream(upstreamURL, nil, schemas.OpenAI, "test-key-1", nil)
+	require.NoError(t, err)
+
+	clientURL := "ws" + strings.TrimPrefix(clientSrv.URL, "http")
+	clientConn, _, err := websocket.DefaultDialer.Dial(clientURL, nil)
+	require.NoError(t, err)
+
+	session := bfws.NewSession(clientConn)
+	session.SetUpstream(upConn)
+	defer session.Close()
+
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	req := &schemas.BifrostResponsesRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-realtime",
+		Input: []schemas.ResponsesMessage{{
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("hello")},
+		}},
+	}
+	rawEvent := []byte(`{"type":"response.create","model":"gpt-realtime","input":"hello"}`)
+
+	handled := h.tryNativeWSUpstream(session, ctx, req, rawEvent)
+	require.True(t, handled, "native WS path should have handled the stalled turn")
+
+	select {
+	case <-capture.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the trace to flush")
+	}
+
+	require.True(t, capture.foundLLM, "stalled native WS turn must still produce an llm.call span")
+	assert.Equal(t, schemas.OTelProviderName(schemas.OpenAI), capture.provider, "errored llm.call span must carry the provider")
+	assert.Equal(t, "gpt-realtime", capture.model, "errored llm.call span must carry the request model")
+	assert.Equal(t, schemas.SpanStatusError, capture.status, "stalled turn must end the llm.call span with error status")
+	assert.Equal(t, 504, capture.statusCode, "errored llm.call span must carry the upstream status code")
+}


### PR DESCRIPTION
## Summary

The native WebSocket Responses path (`tryNativeWSUpstream`) was running post-hooks and flushing traces without ever starting a `SpanKindLLMCall` span. This caused span-based observability connectors to export realtime/WebSocket turns as unattributed rows with no provider, model, or usage data. This PR adds a lazily-started `llm.call` span to the native WS upstream path, matching the span lifecycle already present for all other request types.

## Changes

- Added a lazily-started `llm.call` span in `tryNativeWSUpstream` that is committed on the first upstream event (avoiding a dangling span if the path falls back to the HTTP bridge) and ended before the terminal post-hook flush so the exported trace carries provider, model, and usage attributes.
- The span ends with error status for failed terminal events (`response.failed`, `response.error`, `response.incomplete`) and for upstream errors/timeouts, carrying the provider's error code and message.
- Moved tracer and traceID retrieval to before the `finalizeTerminalPostHooks` closure so both the error and success paths share the same span lifecycle.
- Added `buildWSTurnSpanResponse` to extract usage/model attributes from a terminal `response.completed` event for span population.
- Added `buildWSTurnSpanError` to construct a `BifrostError` from failed terminal events, reading error details from `response.error`, the top-level error event, or `incomplete_details.reason` in priority order.
- Added `isFailedTerminalStreamType` to distinguish failure terminal events from normal completions.
- Added `wsresponses_span_test.go` with three integration tests covering the success path, the `response.failed` provider error path, and the upstream idle timeout path, each asserting that an `llm.call` span is produced with the correct status, provider, model, and usage attributes.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Transports (HTTP)

## How to test

```sh
go test ./transports/bifrost-http/handlers/... -run TestNativeWSUpstream
```

The three new tests exercise:
1. A normal `response.completed` turn — expects an `llm.call` span with `ok` status, provider, model, and token usage.
2. A `response.failed` turn — expects an `llm.call` span with `error` status, the provider's error message, and a 502 status code.
3. A stalled upstream that trips the idle timeout — expects an `llm.call` span with `error` status and a 504 status code.

## Breaking changes

- [x] No

## Related issues

Closes #6265

## Security considerations

None. No auth, secrets, or PII are introduced. Span attributes mirror what is already recorded for non-WebSocket request types.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable