### PR TITLE
test case additions - vertex error exposure

### DIFF
--- a/core/internal/llmtests/account.go
+++ b/core/internal/llmtests/account.go
@@ -386,6 +386,18 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 				UseForBatchAPI: bifrost.Ptr(true),
 			},
 			{
+				// Gemini 3.x publisher models are only served from the global endpoint
+				// (single regions return 404 Publisher model not found). See issue #6589.
+				Value:  *schemas.NewSecretVar("env.VERTEX_API_KEY"),
+				Models: []string{"gemini-3.5-flash", "gemini-3.1-flash-lite"},
+				Weight: 1.0,
+				VertexKeyConfig: &schemas.VertexKeyConfig{
+					ProjectID:       *schemas.NewSecretVar("env.VERTEX_PROJECT_ID"),
+					Region:          *schemas.NewSecretVar("global"),
+					AuthCredentials: *schemas.NewSecretVar("env.VERTEX_CREDENTIALS"),
+				},
+			},
+			{
 				Value:  *schemas.NewSecretVar("env.VERTEX_API_KEY"),
 				Models: []string{"veo-3.1-generate-preview"},
 				Weight: 1.0,

--- a/core/providers/vertex/errors.go
+++ b/core/providers/vertex/errors.go
@@ -50,6 +50,13 @@ func parseVertexError(resp *fasthttp.Response) *schemas.BifrostError {
 	}
 
 	createError := func(message, status string) *schemas.BifrostError {
+		if violations := extractVertexFieldViolations(decodedBody); violations != "" {
+			if message == "" {
+				message = violations
+			} else {
+				message = message + " (" + violations + ")"
+			}
+		}
 		bifrostErr := providerUtils.NewProviderAPIError(message, nil, resp.StatusCode(), nil, nil)
 		if status != "" {
 			if bifrostErr.Error == nil {
@@ -101,4 +108,54 @@ func parseVertexError(resp *fasthttp.Response) *schemas.BifrostError {
 		}
 	}
 	return createError(openAIErr.Error.Message, openAIStatus)
+}
+
+// vertexErrorDetailsEnvelope decodes just the error.details payloads of a Vertex
+// error body, independent of which error shape the main parse matched.
+type vertexErrorDetailsEnvelope struct {
+	Error struct {
+		Details []struct {
+			Type            string `json:"@type"`
+			FieldViolations []struct {
+				Field       string `json:"field"`
+				Description string `json:"description"`
+			} `json:"fieldViolations"`
+		} `json:"details"`
+	} `json:"error"`
+}
+
+// extractVertexFieldViolations renders google.rpc.BadRequest fieldViolations from
+// error.details as "field: description" pairs. Vertex 400 INVALID_ARGUMENT bodies
+// name the rejected field there, and forwarding only error.message left callers
+// with a bare "Request contains an invalid argument." (issue #6589).
+func extractVertexFieldViolations(body []byte) string {
+	var envelope vertexErrorDetailsEnvelope
+	if err := sonic.Unmarshal(body, &envelope); err != nil {
+		// Vertex also returns array-shaped error bodies; use the first entry.
+		var envelopes []vertexErrorDetailsEnvelope
+		if err := sonic.Unmarshal(body, &envelopes); err != nil || len(envelopes) == 0 {
+			return ""
+		}
+		envelope = envelopes[0]
+	}
+	var parts []string
+	for _, detail := range envelope.Error.Details {
+		if !strings.HasSuffix(detail.Type, "google.rpc.BadRequest") {
+			continue
+		}
+		for _, violation := range detail.FieldViolations {
+			switch {
+			case violation.Field != "" && violation.Description != "":
+				parts = append(parts, violation.Field+": "+violation.Description)
+			case violation.Field != "":
+				parts = append(parts, violation.Field)
+			case violation.Description != "":
+				parts = append(parts, violation.Description)
+			}
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "violations: " + strings.Join(parts, ", ")
 }

--- a/core/providers/vertex/errors_test.go
+++ b/core/providers/vertex/errors_test.go
@@ -38,3 +38,23 @@ func TestParseVertexError_NoStatusNoType(t *testing.T) {
 	require.NotNil(t, bifrostErr.Error)
 	assert.Nil(t, bifrostErr.Error.Type, "no status present, so none should be fabricated")
 }
+
+// TestParseVertexError_SurfacesBadRequestFieldViolations covers issue #6589's
+// observability ask: Vertex 400s often carry google.rpc.BadRequest fieldViolations
+// in error.details naming the rejected field, but Bifrost only forwarded
+// error.message ("Request contains an invalid argument."), leaving callers blind
+// to which field the upstream rejected.
+func TestParseVertexError_SurfacesBadRequestFieldViolations(t *testing.T) {
+	var resp fasthttp.Response
+	resp.SetStatusCode(fasthttp.StatusBadRequest)
+	resp.SetBodyString(`{"error":{"code":400,"message":"Request contains an invalid argument.","status":"INVALID_ARGUMENT","details":[{"@type":"type.googleapis.com/google.rpc.BadRequest","fieldViolations":[{"field":"generation_config.response_json_schema","description":"Invalid JSON schema."}]}]}}`)
+
+	bifrostErr := parseVertexError(&resp)
+
+	require.NotNil(t, bifrostErr)
+	require.NotNil(t, bifrostErr.Error)
+	assert.Contains(t, bifrostErr.Error.Message, "generation_config.response_json_schema",
+		"the rejected field path from error.details must be surfaced")
+	assert.Contains(t, bifrostErr.Error.Message, "Invalid JSON schema.",
+		"the field violation description from error.details must be surfaced")
+}

--- a/core/providers/vertex/gemini3structuredoutput_test.go
+++ b/core/providers/vertex/gemini3structuredoutput_test.go
@@ -1,0 +1,94 @@
+package vertex_test
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/internal/llmtests"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVertexGemini3StructuredOutput reproduces issue #6589: on the Vertex provider,
+// structured-output request shapes (response_format json_object / json_schema) against
+// Gemini 3.x models return 400 INVALID_ARGUMENT, while plain-text requests to the same
+// models succeed. Gemini 3.x publisher models are only served from the global endpoint,
+// so the test account carries a dedicated Vertex key with Region "global" for them.
+func TestVertexGemini3StructuredOutput(t *testing.T) {
+	if strings.TrimSpace(os.Getenv("VERTEX_PROJECT_ID")) == "" || strings.TrimSpace(os.Getenv("VERTEX_CREDENTIALS")) == "" {
+		t.Skip("Skipping Vertex tests because VERTEX_PROJECT_ID or VERTEX_CREDENTIALS is not set")
+	}
+	client, ctx, cancel, err := llmtests.SetupTest()
+	require.NoError(t, err, "test setup must succeed")
+	defer cancel()
+	defer client.Shutdown()
+
+	sentimentSchema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"sentiment":     map[string]interface{}{"type": "string"},
+			"action_worthy": map[string]interface{}{"type": "boolean"},
+		},
+		"required":             []string{"sentiment", "action_worthy"},
+		"additionalProperties": false,
+	}
+
+	cases := []struct {
+		name           string
+		model          string
+		responseFormat interface{}
+	}{
+		{
+			name:           "JSONObjectGemini35Flash",
+			model:          "gemini-3.5-flash",
+			responseFormat: map[string]interface{}{"type": "json_object"},
+		},
+		{
+			name:  "JSONSchemaGemini35Flash",
+			model: "gemini-3.5-flash",
+			responseFormat: map[string]interface{}{
+				"type": "json_schema",
+				"json_schema": map[string]interface{}{
+					"name":   "sentiment",
+					"strict": true,
+					"schema": sentimentSchema,
+				},
+			},
+		},
+		{
+			name:           "JSONObjectGemini31FlashLite",
+			model:          "gemini-3.1-flash-lite",
+			responseFormat: map[string]interface{}{"type": "json_object"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rf := tc.responseFormat
+			reqCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			response, bifrostErr := client.ChatCompletionRequest(reqCtx, &schemas.BifrostChatRequest{
+				Provider: schemas.Vertex,
+				Model:    tc.model,
+				Input: []schemas.ChatMessage{
+					llmtests.CreateBasicChatMessage("Classify sentiment of: the app is great. Respond in JSON with keys sentiment (string) and action_worthy (boolean)."),
+				},
+				Params: &schemas.ChatParameters{
+					MaxCompletionTokens: schemas.Ptr(2000),
+					ResponseFormat:      &rf,
+				},
+			})
+			if bifrostErr != nil {
+				raw, _ := json.Marshal(bifrostErr)
+				t.Fatalf("structured output request must not error, got: %s", string(raw))
+			}
+			require.NotNil(t, response)
+			content := llmtests.GetChatContent(response)
+			require.NotEmpty(t, content, "structured output response content must not be empty")
+			var parsed map[string]interface{}
+			require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(content)), &parsed),
+				"structured output content must be valid JSON, got: %s", content)
+		})
+	}
+}

--- a/tests/cmd/e2eseed/go.mod
+++ b/tests/cmd/e2eseed/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-sqlite3 v1.14.32 // indirect
-	github.com/maximhq/bifrost/core v1.7.11 // indirect
+	github.com/maximhq/bifrost/core v1.8.3 // indirect
 	github.com/maximhq/bifrost/framework v1.3.16 // indirect
 	github.com/paulmach/orb v0.11.1 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect

--- a/tests/cmd/seed/go.mod
+++ b/tests/cmd/seed/go.mod
@@ -8,7 +8,7 @@ replace (
 )
 
 require (
-	github.com/maximhq/bifrost/core v1.7.11
+	github.com/maximhq/bifrost/core v1.8.3
 	github.com/maximhq/bifrost/framework v1.3.16
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/driver/sqlite v1.6.0

--- a/tests/cmd/seedvks/go.mod
+++ b/tests/cmd/seedvks/go.mod
@@ -9,7 +9,7 @@ replace (
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/maximhq/bifrost/core v1.7.11
+	github.com/maximhq/bifrost/core v1.8.3
 	github.com/maximhq/bifrost/framework v1.3.16
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.1


### PR DESCRIPTION
## Summary

Fixes issue #6589: Vertex 400 `INVALID_ARGUMENT` errors from structured-output requests against Gemini 3.x models were returning an opaque `"Request contains an invalid argument."` message with no indication of which field was rejected. Additionally, Gemini 3.x publisher models are only available via the `global` endpoint — single-region requests return 404 `Publisher model not found`.

## Changes

- Added `extractVertexFieldViolations` to the Vertex error parser, which reads `google.rpc.BadRequest` `fieldViolations` from `error.details` and appends them to the error message as `"violations: field: description"` pairs. Handles both object-shaped and array-shaped Vertex error bodies.
- Registered a dedicated Vertex key with `Region: global` for `gemini-3.5-flash` and `gemini-3.1-flash-lite` in the test account, since those models are only served from the global endpoint.
- Added `TestVertexGemini3StructuredOutput` to reproduce the structured-output failure path (`json_object` and `json_schema` response formats) against Gemini 3.x models on Vertex.
- Added `TestParseVertexError_SurfacesBadRequestFieldViolations` to unit-test that the rejected field path and description from `error.details` are surfaced in the parsed error message.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Unit tests for Vertex error parsing
go test ./core/providers/vertex/... -run TestParseVertexError

# Integration test for Gemini 3.x structured output (requires Vertex credentials)
export VERTEX_PROJECT_ID=<your-project>
export VERTEX_CREDENTIALS=<your-credentials>
export VERTEX_API_KEY=<your-api-key>
go test ./core/providers/vertex/... -run TestVertexGemini3StructuredOutput -v
```

**Expected outcomes:**
- `TestParseVertexError_SurfacesBadRequestFieldViolations` passes and the error message contains both `generation_config.response_json_schema` and `Invalid JSON schema.`
- `TestVertexGemini3StructuredOutput` passes without a 400 error and returns valid JSON content for all three sub-cases

**Environment variables required for integration test:**

| Variable | Description |
|---|---|
| `VERTEX_PROJECT_ID` | GCP project ID |
| `VERTEX_CREDENTIALS` | Vertex service account credentials |
| `VERTEX_API_KEY` | Vertex API key |

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #6589

## Security considerations

No new secrets or auth surfaces introduced. The `global` region value is passed through the existing `VertexKeyConfig` path.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable