### PR TITLE
fix: resolve model aliases before vendor checks in compat plugin


### DIFF
--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -505,6 +505,12 @@ func IsMistralModelFamily(ctx *BifrostContext, model string) bool {
 	return ResolveFamily(ctx, model) == ModelFamilyMistral
 }
 
+// IsAzureModelRouterFamily reports whether the current attempt resolves to
+// Azure's model-router deployment. See IsElevenlabsSoundModelFamily for usage notes.
+func IsAzureModelRouterFamily(ctx *BifrostContext, model string) bool {
+	return IsAzureModelRouter(ResolveCanonicalModel(ctx, model))
+}
+
 // IsLlamaModelFamily reports whether the current attempt resolves to the
 // Llama model family. Used by Bedrock to gate tool_choice handling — AWS
 // Bedrock Converse rejects toolConfig.toolChoice.tool on Meta Llama variants.

--- a/plugins/compat/conversion.go
+++ b/plugins/compat/conversion.go
@@ -5,22 +5,22 @@ import (
 )
 
 // applyParameterConversion rewrites request fields in place for provider compatibility.
-func applyParameterConversion(req *schemas.BifrostRequest) {
+func applyParameterConversion(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) {
 	if req == nil {
 		return
 	}
 	if req.ResponsesRequest != nil {
-		flattenNamespaceTools(req.ResponsesRequest)
+		flattenNamespaceTools(ctx, req.ResponsesRequest)
 	}
 }
 
 // flattenNamespaceTools expands namespace scoped tools into a flat list of tools.
-func flattenNamespaceTools(req *schemas.BifrostResponsesRequest) {
+func flattenNamespaceTools(ctx *schemas.BifrostContext, req *schemas.BifrostResponsesRequest) {
 	if req == nil || req.Params == nil {
 		return
 	}
 	// ignore openai models or azure hosted openai models
-	if req.Provider == schemas.OpenAI || (req.Provider == schemas.Azure && !schemas.IsAnthropicModel(req.Model)) {
+	if req.Provider == schemas.OpenAI || (req.Provider == schemas.Azure && !schemas.IsAnthropicModelFamily(ctx, req.Model)) {
 		return
 	}
 	hasNamespace := false

--- a/plugins/compat/conversion_test.go
+++ b/plugins/compat/conversion_test.go
@@ -1,0 +1,43 @@
+package compat
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// TestFlattenNamespaceTools_AzureAliasedAnthropicModel guards against a
+// routing rule (or virtual model alias) rewriting the request model to a bare
+// name like "haiku" that doesn't literally contain "claude"/"anthropic.":
+// namespace tools must still be flattened for an Azure-hosted Anthropic model,
+// or the request goes out with namespace-scoped tools Anthropic can't parse.
+func TestFlattenNamespaceTools_AzureAliasedAnthropicModel(t *testing.T) {
+	req := &schemas.BifrostResponsesRequest{
+		Provider: schemas.Azure,
+		Model:    "haiku",
+		Params: &schemas.ResponsesParameters{
+			Tools: []schemas.ResponsesTool{
+				{
+					Type: schemas.ResponsesToolTypeNamespace,
+					ResponsesToolNamespace: &schemas.ResponsesToolNamespace{
+						Tools: []schemas.ResponsesTool{
+							{Type: schemas.ResponsesToolTypeFunction, Name: schemas.Ptr("get_weather")},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := newTestContext()
+	ctx.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{
+		Config: &schemas.AliasConfig{ModelID: "anthropic.claude-haiku-4-5-v1:0"},
+	})
+
+	flattenNamespaceTools(ctx, req)
+
+	tools := req.Params.Tools
+	if len(tools) != 1 || tools[0].Type != schemas.ResponsesToolTypeFunction || tools[0].Name == nil || *tools[0].Name != "get_weather" {
+		t.Errorf("tools = %+v, want flattened to a single function tool", tools)
+	}
+}

--- a/plugins/compat/dropparams.go
+++ b/plugins/compat/dropparams.go
@@ -176,7 +176,7 @@ func dropUnsupportedParams(ctx *schemas.BifrostContext, req *schemas.BifrostRequ
 				params.Reasoning = nil
 				dropped = append(dropped, "reasoning")
 			} else if params.Reasoning.Summary != nil && *params.Reasoning.Summary != "auto" &&
-				schemas.IsAzureModelRouter(req.ResponsesRequest.Model) {
+				schemas.IsAzureModelRouterFamily(ctx, req.ResponsesRequest.Model) {
 				// model-router only supports "auto" summary
 				params.Reasoning.Summary = nil
 				dropped = append(dropped, "reasoning.summary")
@@ -217,7 +217,7 @@ func dropUnsupportedParams(ctx *schemas.BifrostContext, req *schemas.BifrostRequ
 	}
 
 	if req.ResponsesRequest != nil && req.ResponsesRequest.Input != nil {
-		if req.ResponsesRequest.Provider == schemas.Bedrock && !schemas.IsAnthropicModel(req.ResponsesRequest.Model) {
+		if req.ResponsesRequest.Provider == schemas.Bedrock && !schemas.IsAnthropicModelFamily(ctx, req.ResponsesRequest.Model) {
 			droppedKeys := applyBedrockResponsesCompatibility(req.ResponsesRequest)
 			dropped = append(dropped, droppedKeys...)
 		}

--- a/plugins/compat/dropparams_test.go
+++ b/plugins/compat/dropparams_test.go
@@ -144,6 +144,63 @@ func TestDropUnsupportedParams_MaxOutputTokensSurgical(t *testing.T) {
 	}
 }
 
+// TestDropUnsupportedParams_BedrockSignaturePreservedForAliasedAnthropicModel
+// guards against a routing rule (or virtual model alias) rewriting the
+// request model to a bare name like "haiku" that doesn't literally contain
+// "claude"/"anthropic.": the Bedrock responses-compat pass must resolve the
+// canonical model before deciding the target is non-Anthropic, or it wrongly
+// strips the signature off a real Anthropic thinking block and leaves the
+// model requiring a signature it no longer has.
+func TestDropUnsupportedParams_BedrockSignaturePreservedForAliasedAnthropicModel(t *testing.T) {
+	req := newResponsesRequest(schemas.Bedrock, "haiku", nil)
+	req.ResponsesRequest.Input = []schemas.ResponsesMessage{
+		{
+			Content: &schemas.ResponsesMessageContent{
+				ContentBlocks: []schemas.ResponsesMessageContentBlock{
+					{Signature: schemas.Ptr("sig-123")},
+				},
+			},
+		},
+	}
+
+	ctx := newTestContext()
+	ctx.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{
+		Config: &schemas.AliasConfig{ModelID: "anthropic.claude-haiku-4-5-v1:0"},
+	})
+
+	dropUnsupportedParams(ctx, req, nil)
+
+	got := req.ResponsesRequest.Input[0].Content.ContentBlocks[0].Signature
+	if got == nil || *got != "sig-123" {
+		t.Errorf("signature = %v, want preserved (sig-123)", got)
+	}
+}
+
+// TestDropUnsupportedParams_AzureModelRouterSummaryAliased guards against a
+// routing rule (or virtual model alias) rewriting the request model to a bare
+// alias like "myrouter" that doesn't literally contain "model-router": the
+// reasoning.summary override must still be dropped down to Azure model-router's
+// "auto"-only support once the alias resolves to the real deployment.
+func TestDropUnsupportedParams_AzureModelRouterSummaryAliased(t *testing.T) {
+	req := newResponsesRequest(schemas.Azure, "myrouter", &schemas.ResponsesParameters{
+		Reasoning: &schemas.ResponsesParametersReasoning{Summary: schemas.Ptr("detailed")},
+	})
+
+	ctx := newTestContext()
+	ctx.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{
+		Config: &schemas.AliasConfig{ModelID: "model-router"},
+	})
+
+	dropped := dropUnsupportedParams(ctx, req, []string{"reasoning"})
+
+	if req.ResponsesRequest.Params.Reasoning.Summary != nil {
+		t.Errorf("reasoning.summary = %v, want dropped for model-router", *req.ResponsesRequest.Params.Reasoning.Summary)
+	}
+	if !slices.Contains(dropped, "reasoning.summary") {
+		t.Errorf("reasoning.summary not reported in dropped=%v, want present", dropped)
+	}
+}
+
 // TestDropUnsupportedParams_ChatMaxCompletionTokensUnchanged guards the
 // pre-existing chat-branch behaviour that the Responses fix mirrors.
 func TestDropUnsupportedParams_ChatMaxCompletionTokensUnchanged(t *testing.T) {

--- a/plugins/compat/main.go
+++ b/plugins/compat/main.go
@@ -162,7 +162,7 @@ func (p *CompatPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 	}
 
 	if (shouldConvertParamsOverride && shouldConvertParamsOverrideEnabled) || p.config.ShouldConvertParams {
-		applyParameterConversion(modifiedReq)
+		applyParameterConversion(ctx, modifiedReq)
 	}
 
 	return modifiedReq, nil, nil


### PR DESCRIPTION
## Summary

Model alias resolution was not being applied consistently in the compat plugin's parameter conversion and param-dropping logic. When a virtual model alias (e.g. `"haiku"` or `"myrouter"`) was used instead of a canonical model ID, checks like `IsAnthropicModel` and `IsAzureModelRouter` would fail because they matched against the literal model string rather than the resolved canonical model. This caused namespace-scoped tools to be skipped for Azure-hosted Anthropic models, Bedrock thinking-block signatures to be incorrectly stripped, and Azure model-router reasoning summary overrides to not be dropped.

## Changes

- `flattenNamespaceTools` and `applyParameterConversion` now accept a `*BifrostContext` and use `IsAnthropicModelFamily` (which resolves aliases) instead of the literal `IsAnthropicModel` check, ensuring namespace tools are correctly flattened for aliased Azure-hosted Anthropic models.
- `dropUnsupportedParams` now uses `IsAzureModelRouterFamily` (alias-aware) instead of `IsAzureModelRouter` for the reasoning summary check, and `IsAnthropicModelFamily` instead of `IsAnthropicModel` for the Bedrock responses compatibility gate.
- Added `IsAzureModelRouterFamily` to `core/schemas/account.go` as an alias-aware counterpart to `IsAzureModelRouter`.
- Added tests covering the aliased-model edge cases for all three affected code paths.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Plugins

## How to test

```sh
go test ./plugins/compat/...
go test ./core/schemas/...
```

The new tests in `conversion_test.go` and `dropparams_test.go` directly exercise the aliased-model scenarios:
- `TestFlattenNamespaceTools_AzureAliasedAnthropicModel` — verifies namespace tools are flattened when the Azure model resolves to an Anthropic canonical ID.
- `TestDropUnsupportedParams_BedrockSignaturePreservedForAliasedAnthropicModel` — verifies thinking-block signatures are preserved when the Bedrock model resolves to an Anthropic canonical ID.
- `TestDropUnsupportedParams_AzureModelRouterSummaryAliased` — verifies `reasoning.summary` is dropped when the Azure model resolves to `model-router`.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable