### PR TITLE
fix(ui): make `use_deployments_endpoint` optional, improve Replicate deployment descriptions, and add form error logging

### DIFF
--- a/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
@@ -1,8 +1,8 @@
-import { SecretVarInput } from "@/components/ui/secretVarInput";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { ModelMultiselect } from "@/components/ui/modelMultiselect";
+import { SecretVarInput } from "@/components/ui/secretVarInput";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -449,9 +449,15 @@ export function ApiKeyFormFragment({ control, providerName, baseProviderType, fo
 							<FormItem data-testid="apikey-deployments-field">
 								<FormLabel>Deployments (Optional)</FormLabel>
 								<FormDescription>
-									Map a request model name to the provider&apos;s identifier (deployment name, inference profile ID, fine-tuned endpoint ID,
-									etc.). Expand a row to set the canonical model name, model family, and provider-specific overrides - these power
-									cost/pricing logs and family-based routing.
+									Map a request model name to the provider&apos;s identifier (deployment name, inference profile ID, etc.). Expand a row for
+									canonical name, model family, and provider overrides - these drive cost logs and family-based routing.
+									{isReplicate && (
+										<>
+											{" "}
+											Replicate deployments are listed only while &quot;Use Deployments Endpoint&quot; is on - otherwise type the owner/name
+											and press Enter.
+										</>
+									)}
 								</FormDescription>
 								<FormControl>
 									<div data-testid="apikey-deployments-table">
@@ -786,8 +792,11 @@ export function ApiKeyFormFragment({ control, providerName, baseProviderType, fo
 								<div className="space-y-1.5">
 									<FormLabel>Use Deployments Endpoint</FormLabel>
 									<FormDescription>
-										Route requests through the Replicate deployments endpoint instead of the models endpoint.
+										Sends <strong>every</strong> model on this key to /v1/deployments/&#123;owner&#125;/&#123;name&#125;/predictions, so
+										plain model names stop working. To switch just one model, leave this off and set &quot;Use deployments endpoint&quot; on
+										its row above.
 									</FormDescription>
+									<FormMessage />
 								</div>
 								<FormControl>
 									<Switch checked={field.value ?? false} onCheckedChange={field.onChange} />

--- a/ui/lib/schemas/providerForm.ts
+++ b/ui/lib/schemas/providerForm.ts
@@ -194,8 +194,10 @@ const BedrockMantleKeyConfigSchema = z
 		},
 	);
 
+// Optional for the same reason as replicateKeyConfigSchema in lib/types/schemas.ts:
+// the registered-but-untouched switch leaves an empty object behind.
 const ReplicateKeyConfigSchema = z.object({
-	use_deployments_endpoint: z.boolean(),
+	use_deployments_endpoint: z.boolean().optional(),
 });
 
 const KeySchema = z.object({

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -254,7 +254,7 @@ export const vllmKeyConfigSchema = z
 	});
 
 export const replicateKeyConfigSchema = z.object({
-	use_deployments_endpoint: z.boolean(),
+	use_deployments_endpoint: z.boolean().optional(),
 });
 
 // Ollama key config schema
@@ -366,8 +366,7 @@ export const modelProviderKeySchema = z
 	})
 	.refine(
 		(data) => {
-			// Providers with dedicated config that never need a top-level API key
-			if (data.vllm_key_config || data.replicate_key_config || data.ollama_key_config || data.sgl_key_config) {
+			if (data.vllm_key_config || data.ollama_key_config || data.sgl_key_config) {
 				return true;
 			}
 			// Bedrock Mantle authenticates via SigV4 (its key config) or a Bearer key — only require


### PR DESCRIPTION
## Summary

Fixes a validation bug where the Replicate provider's `use_deployments_endpoint` field caused form errors when the switch was registered but never touched, leaving an empty object that failed the required boolean check. Also improves the UI descriptions for Replicate deployments and the deployments endpoint toggle.

## Changes

- Made `use_deployments_endpoint` optional in both `replicateKeyConfigSchema` (lib/types/schemas.ts) and `ReplicateKeyConfigSchema` (providerForm.ts) to handle the case where the switch is registered but untouched, leaving an empty object behind
- Removed `replicate_key_config` from the API key refine check that bypasses top-level API key validation, since Replicate does require an API key unlike vLLM, Ollama, and SGL
- Added a `FormMessage` to the "Use Deployments Endpoint" toggle so validation errors surface visibly in the UI
- Rewrote the "Use Deployments Endpoint" description to clearly explain that enabling it routes **every** model on the key through the deployments endpoint, and that per-model overrides are available as an alternative
- Added a contextual note in the Deployments field description for Replicate explaining that deployments are only listed when "Use Deployments Endpoint" is on, and that plain `owner/name` strings can be typed and entered otherwise
- Added a temporary `console.log` of form errors for debugging (should be removed before merge)

## Type of change

- [x] Bug fix

## Affected areas

- [x] Providers/Integrations
- [x] UI (React)

## How to test

1. Navigate to the Replicate provider configuration page.
2. Add a new API key without toggling "Use Deployments Endpoint."
3. Save the form — it should no longer throw a validation error about `use_deployments_endpoint`.
4. Enable "Use Deployments Endpoint" and confirm the description accurately reflects the behavior and that any validation errors appear beneath the toggle.
5. Confirm that Replicate still requires a top-level API key to be provided.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. The change only affects form validation logic and UI copy for the Replicate provider configuration.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable