### PR TITLE
core changelog

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,2 @@
+- fix: strip the encrypted reasoning signature when the upstream reports the field as unsupported (e.g. Bedrock Converse replaying a Claude signature onto a non-Anthropic model after a mid-conversation model switch), extending the existing unverifiable-signature fail-soft
+- fix: clear Anthropic raw-body passthrough based on the resolved provider and model pair, so non-Claude models on multi-family providers (Vertex, Azure, Bedrock Mantle) convert the request instead of passing the Anthropic payload through


### PR DESCRIPTION
## Summary

Fixes two related issues affecting multi-family providers (Bedrock, Vertex, Azure) where model switches or non-Anthropic model selections caused incorrect request handling due to stale or misapplied Anthropic-specific state.

## Changes

- Strip the encrypted reasoning signature when the upstream reports the field as unsupported — for example, when Bedrock Converse replays a Claude signature onto a non-Anthropic model after a mid-conversation model switch. This extends the existing fail-soft behavior for unverifiable signatures.
- Clear the Anthropic raw-body passthrough flag based on the resolved provider and model pair, ensuring non-Claude models on multi-family providers (Vertex, Azure, Bedrock Mantle) properly convert the request rather than forwarding the raw Anthropic payload.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

- Switch models mid-conversation on Bedrock Converse from a Claude model to a non-Anthropic model and verify the encrypted reasoning signature is stripped without error.
- Send a request to a non-Claude model on Vertex, Azure, or Bedrock Mantle and verify the request is converted rather than passed through as a raw Anthropic payload.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The reasoning signature stripping is a fail-soft extension — signatures that cannot be verified or are reported as unsupported by the upstream are discarded rather than causing a hard failure, which maintains the existing security posture without introducing new attack surface.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable