### PR TITLE
fix(core): prevent duplicate tool call completion when upstream emits multiple finish chunks

### DIFF
--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -3323,6 +3323,15 @@ func toAnthropicResponsesStreamEvents(ctx *schemas.BifrostContext, bifrostResp *
 			*bifrostResp.Item.ResponsesToolMessage.Name == "WebSearch" &&
 			bifrostResp.Item.ResponsesToolMessage.Arguments != nil {
 
+			// Guard against duplicate synthetic delta generation:
+			// only generate synthetic deltas if this WebSearch item is currently tracked.
+			if bifrostResp.Item.ID != nil {
+				streamState := getOrCreateAnthropicToResponsesStreamState(ctx)
+				if !streamState.webSearchItemIDs[*bifrostResp.Item.ID] {
+					return nil
+				}
+			}
+
 			argumentsJSON := sanitizeWebSearchArguments(*bifrostResp.Item.ResponsesToolMessage.Arguments)
 			bifrostResp.Item.ResponsesToolMessage.Arguments = &argumentsJSON
 

--- a/core/providers/anthropic/websearch_test.go
+++ b/core/providers/anthropic/websearch_test.go
@@ -305,3 +305,43 @@ func TestServerSearchTools_VersionRecognition(t *testing.T) {
 		})
 	}
 }
+
+func TestWebSearch_OutputItemDone_Idempotent_DuplicateDoneReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	const itemID = "toolu_ws_idempotent_test"
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	// Pre-seed per-request state as if output_item.added already fired
+	state := getOrCreateAnthropicToResponsesStreamState(ctx)
+	state.webSearchItemIDs = map[string]bool{itemID: true}
+
+	query := `{"query":"test query"}`
+	bifrostResp := &schemas.BifrostResponsesStreamResponse{
+		Type:        schemas.ResponsesStreamResponseTypeOutputItemDone,
+		OutputIndex: schemas.Ptr(1),
+		Item: &schemas.ResponsesMessage{
+			ID:   schemas.Ptr(itemID),
+			Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+			ResponsesToolMessage: &schemas.ResponsesToolMessage{
+				CallID:    schemas.Ptr(itemID),
+				Name:      schemas.Ptr("WebSearch"),
+				Arguments: &query,
+			},
+		},
+	}
+
+	// First call should generate deltas and stop event
+	firstEvents := ToAnthropicResponsesStreamResponse(ctx, bifrostResp)
+	if len(firstEvents) == 0 {
+		t.Fatal("expected events on first output_item.done")
+	}
+
+	// Second call with same item ID should return nil (idempotent, no duplicate synthetic deltas)
+	secondEvents := ToAnthropicResponsesStreamResponse(ctx, bifrostResp)
+	if len(secondEvents) != 0 {
+		t.Fatalf("expected 0 events on duplicate output_item.done, got %d", len(secondEvents))
+	}
+}

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -1544,6 +1544,7 @@ type ChatToResponsesStreamState struct {
 	ReasoningBuffer       strings.Builder   // Accumulated reasoning deltas for reasoning output_item.done
 	CurrentOutputIndex    int               // Current output index counter
 	ToolCallOutputIndices map[string]int    // Maps tool call ID to output index
+	ToolCallsClosed       map[string]bool   // Maps tool call ID to whether its output_item.done has been emitted
 	SequenceNumber        int               // Monotonic sequence number across all chunks
 }
 
@@ -1558,6 +1559,7 @@ var chatToResponsesStreamStatePool = sync.Pool{
 			CreatedAt:             int(time.Now().Unix()),
 			CurrentOutputIndex:    0,
 			ToolCallOutputIndices: make(map[string]int),
+			ToolCallsClosed:       make(map[string]bool),
 			SequenceNumber:        0,
 			HasEmittedCreated:     false,
 			HasEmittedInProgress:  false,
@@ -1599,6 +1601,11 @@ func AcquireChatToResponsesStreamState() *ChatToResponsesStreamState {
 	} else {
 		clear(state.ToolCallOutputIndices)
 	}
+	if state.ToolCallsClosed == nil {
+		state.ToolCallsClosed = make(map[string]bool)
+	} else {
+		clear(state.ToolCallsClosed)
+	}
 	// Reset other fields
 	state.CurrentOutputIndex = 0
 	state.MessageID = nil
@@ -1637,6 +1644,9 @@ func ReleaseChatToResponsesStreamState(state *ChatToResponsesStreamState) {
 		}
 		if state.ToolCallOutputIndices != nil {
 			clear(state.ToolCallOutputIndices)
+		}
+		if state.ToolCallsClosed != nil {
+			clear(state.ToolCallsClosed)
 		}
 		// Reset other fields
 		state.CurrentOutputIndex = 0
@@ -2171,7 +2181,7 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 
 		// Close any open tool call items and emit function_call_arguments.done
 		for toolCallID, args := range state.ToolArgumentBuffers {
-			if args != "" {
+			if args != "" && !state.ToolCallsClosed[toolCallID] {
 				outputIndex := state.ToolCallOutputIndices[toolCallID]
 				itemID := state.ItemIDs[toolCallID]
 				contentIndex := 1 // Tool calls use content_index:1
@@ -2221,6 +2231,7 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 					ExtraFields:    cr.ExtraFields,
 				})
 				state.SequenceNumber++
+				state.ToolCallsClosed[toolCallID] = true
 			}
 		}
 

--- a/core/schemas/mux_test.go
+++ b/core/schemas/mux_test.go
@@ -1449,7 +1449,6 @@ func TestToBifrostResponsesStreamResponse_ReasoningOpensThinkingBlock(t *testing
 	}
 }
 
-
 // responseFormatAsMap reads a converted chat response_format regardless of its
 // representation. The Responses to Chat conversion emits raw JSON (the same
 // representation the chat wire decode produces), so tests read it through the
@@ -1470,4 +1469,106 @@ func nestedMap(t *testing.T, parent map[string]interface{}, key string) map[stri
 		t.Fatalf("expected %q to be an object, got %T", key, parent[key])
 	}
 	return om.ToMap()
+}
+
+func TestToBifrostResponsesStreamResponse_DuplicateFinishReasonDoesNotDuplicateToolDone(t *testing.T) {
+	state := AcquireChatToResponsesStreamState()
+	defer ReleaseChatToResponsesStreamState(state)
+
+	role := string(ChatMessageRoleAssistant)
+	toolCallsFinish := string(BifrostFinishReasonToolCalls)
+	funcName := "WebSearch"
+	toolCallID := "call_websearch_123"
+
+	var all []*BifrostResponsesStreamResponse
+
+	// Role chunk
+	all = append(all, (&BifrostChatResponse{
+		ID:    "chatcmpl-test",
+		Model: "test-model",
+		Choices: []BifrostResponseChoice{
+			{
+				ChatStreamResponseChoice: &ChatStreamResponseChoice{
+					Delta: &ChatStreamResponseChoiceDelta{
+						Role: &role,
+					},
+				},
+			},
+		},
+	}).ToBifrostResponsesStreamResponse(state)...)
+
+	// Tool call chunk with arguments
+	all = append(all, (&BifrostChatResponse{
+		ID:    "chatcmpl-test",
+		Model: "test-model",
+		Choices: []BifrostResponseChoice{
+			{
+				ChatStreamResponseChoice: &ChatStreamResponseChoice{
+					Delta: &ChatStreamResponseChoiceDelta{
+						ToolCalls: []ChatAssistantMessageToolCall{
+							{
+								Index:    0,
+								ID:       &toolCallID,
+								Function: ChatAssistantMessageToolCallFunction{Name: &funcName, Arguments: `{"query":"test"}`},
+							},
+						},
+					},
+				},
+			},
+		},
+	}).ToBifrostResponsesStreamResponse(state)...)
+
+	// First finish chunk with tool_calls finish reason
+	all = append(all, (&BifrostChatResponse{
+		ID:    "chatcmpl-test",
+		Model: "test-model",
+		Choices: []BifrostResponseChoice{
+			{
+				FinishReason: &toolCallsFinish,
+				ChatStreamResponseChoice: &ChatStreamResponseChoice{
+					Delta: &ChatStreamResponseChoiceDelta{},
+				},
+			},
+		},
+	}).ToBifrostResponsesStreamResponse(state)...)
+
+	// Second finish chunk with usage and repeating finish reason (common in OpenAI compatible proxies)
+	all = append(all, (&BifrostChatResponse{
+		ID:    "chatcmpl-test",
+		Model: "test-model",
+		Choices: []BifrostResponseChoice{
+			{
+				FinishReason: &toolCallsFinish,
+				ChatStreamResponseChoice: &ChatStreamResponseChoice{
+					Delta: &ChatStreamResponseChoiceDelta{},
+				},
+			},
+		},
+		Usage: &BifrostLLMUsage{
+			PromptTokens:     10,
+			CompletionTokens: 20,
+			TotalTokens:      30,
+		},
+	}).ToBifrostResponsesStreamResponse(state)...)
+
+	// Count output_item.done and function_call_arguments.done
+	outputItemDoneCount := 0
+	funcArgsDoneCount := 0
+	for _, evt := range all {
+		if evt != nil {
+			if evt.Type == ResponsesStreamResponseTypeOutputItemDone && evt.Item != nil && evt.Item.ResponsesToolMessage != nil {
+				outputItemDoneCount++
+			}
+			if evt.Type == ResponsesStreamResponseTypeFunctionCallArgumentsDone {
+				funcArgsDoneCount++
+			}
+		}
+	}
+
+	if outputItemDoneCount != 1 {
+		t.Fatalf("expected output_item.done to be emitted exactly 1 time, got %d", outputItemDoneCount)
+	}
+	if funcArgsDoneCount != 1 {
+		t.Fatalf("expected function_call_arguments.done to be emitted exactly 1 time, got %d", funcArgsDoneCount)
+	}
 }


### PR DESCRIPTION
## Summary

When routing `/anthropic/v1/messages` to OpenAI-compatible providers, some providers (e.g. CommandCode, Azure, vLLM, MiniMax, or third-party proxies) emit multiple finish chunks at the end of a stream — for instance, one chunk with `finish_reason: "tool_calls"`, followed by a subsequent chunk carrying `usage` with repeating `finish_reason: "tool_calls"`.

In `ToBifrostResponsesStreamResponse` (`core/schemas/mux.go`), each chunk with a non-nil `finish_reason` iterates over `state.ToolArgumentBuffers` to emit `OutputItemDone` and `FunctionCallArgumentsDone`. Because `ToolArgumentBuffers` was neither closed nor cleared, receiving multiple terminal chunks caused `OutputItemDone` to be re-emitted.

For tools like `WebSearch` (which delay streaming raw argument deltas and instead synthesize `input_json_delta` during `OutputItemDone` per #2706), this resulted in `WebSearch` arguments being synthesized and emitted twice in the client-facing Anthropic stream (e.g. `{"query":"..."}{"query":"..."}`). Strict agentic clients like Claude Code then fail with `Invalid tool parameters: Expected object, received string / JSON.parse error`.

## Changes

1. **`core/schemas/mux.go`**:
   - Added `ToolCallsClosed map[string]bool` to `ChatToResponsesStreamState` to track closed tool calls.
   - Initialized and reset `ToolCallsClosed` in `AcquireChatToResponsesStreamState` and `ReleaseChatToResponsesStreamState`.
   - Guaranteed that `OutputItemDone` and `FunctionCallArgumentsDone` are emitted at most once per tool call ID (`if args != "" && !state.ToolCallsClosed[toolCallID]`).

2. **`core/providers/anthropic/responses.go`**:
   - Added an idempotency guard in the Anthropic streaming converter (`ResponsesStreamResponseTypeOutputItemDone`) for `WebSearch`: verifies `streamState.webSearchItemIDs[*bifrostResp.Item.ID]` before synthesizing deltas so duplicate events cannot re-emit synthetic deltas.

3. **Regression Tests**:
   - Added `TestToBifrostResponsesStreamResponse_DuplicateFinishReasonDoesNotDuplicateToolDone` in `core/schemas/mux_test.go` simulating multiple finish chunks.
   - Added `TestWebSearch_OutputItemDone_Idempotent_DuplicateDoneReturnsNil` in `core/providers/anthropic/websearch_test.go`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Run new regression test in core/schemas
go test ./core/schemas -run TestToBifrostResponsesStreamResponse_DuplicateFinishReasonDoesNotDuplicateToolDone -v

# Run new WebSearch idempotency test in core/providers/anthropic
go test ./core/providers/anthropic -run TestWebSearch -v
```

## Screenshots/Recordings

N/A - Streaming API protocol fix.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Related: #5128, #3441, #2706, #5878

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable