### PR TITLE
feat(ui): use `useIsAuthEnabledQuery` as primary signal for dashboard auth checklist step

### DIFF
--- a/ui/hooks/useOnboardingChecklist.ts
+++ b/ui/hooks/useOnboardingChecklist.ts
@@ -1,5 +1,5 @@
 import { IS_ENTERPRISE } from "@/lib/constants/config";
-import { useGetCoreConfigQuery } from "@/lib/store";
+import { useGetCoreConfigQuery, useIsAuthEnabledQuery } from "@/lib/store";
 import { useGetModelConfigsQuery, useGetVirtualKeysQuery } from "@/lib/store/apis/governanceApi";
 import { useGetAllKeysQuery } from "@/lib/store/apis/providersApi";
 import { useGetSCIMProvidersQuery } from "@enterprise/lib/store/apis/scimApi";
@@ -52,10 +52,17 @@ export function useOnboardingChecklist({ skip = false }: { skip?: boolean } = {}
 	const { data: scimProviders } = useGetSCIMProvidersQuery(undefined, {
 		skip: shouldSkipChecklistQueries || !IS_ENTERPRISE,
 	});
+	// Authoritative answer to "is the dashboard actually protected?". Whitelisted
+	// (never 401s) and answered by whichever middleware is installed: the OSS
+	// handler reports auth_config.is_enabled, while the enterprise SCIM
+	// middleware intercepts this exact path and reports auth_type "sso" for OIDC
+	// cookie sessions and identity-aware-proxy tokens alike.
+	const { data: dashboardAuthState } = useIsAuthEnabledQuery(undefined, { skip: shouldSkipChecklistQueries });
 
 	const checklistReady =
 		bifrostConfig !== undefined &&
 		allKeys !== undefined &&
+		dashboardAuthState !== undefined &&
 		(!IS_ENTERPRISE || (vksResponse !== undefined && modelConfigsResponse !== undefined && scimProviders !== undefined));
 
 	const skippedIds = useMemo<string[]>(() => {
@@ -71,6 +78,12 @@ export function useOnboardingChecklist({ skip = false }: { skip?: boolean } = {}
 	// are never set on these deployments and would strand this step forever.
 	// Mirrors the server's own gate: SCIMConfig != nil && SCIMConfig.Enabled.
 	const ssoGatesDashboard = IS_ENTERPRISE && (scimProviders?.some((provider) => provider.enabled) ?? false);
+	// Primary signal: the server says dashboard auth is on, whatever the scheme
+	// (password, OIDC/SSO, IAP). Enabling password auth server-side is rejected
+	// unless both credentials resolve to a non-empty value, so is_auth_enabled
+	// already implies the local-credential check below — that check stays only
+	// as a fallback for when this probe hasn't resolved yet.
+	const dashboardAuthEnabled = dashboardAuthState?.is_auth_enabled === true;
 
 	const steps: OnboardingStep[] = useMemo(() => {
 		// Order: 1) Security, 2) Provider Setup, 3) Everything Else.
@@ -90,6 +103,7 @@ export function useOnboardingChecklist({ skip = false }: { skip?: boolean } = {}
 				route: "/workspace/config/security",
 				section: "Security",
 				complete:
+					dashboardAuthEnabled ||
 					ssoGatesDashboard ||
 					(!!authConfig?.is_enabled && authValueSet(authConfig?.admin_username) && authValueSet(authConfig?.admin_password)),
 			},
@@ -134,7 +148,7 @@ export function useOnboardingChecklist({ skip = false }: { skip?: boolean } = {}
 				]
 			: [];
 		return [...common, ...enterprise];
-	}, [allKeys, clientConfig, authConfig, ssoGatesDashboard, scimProviders, modelConfigsResponse, vksResponse]);
+	}, [allKeys, clientConfig, authConfig, dashboardAuthEnabled, ssoGatesDashboard, scimProviders, modelConfigsResponse, vksResponse]);
 
 	return { bifrostConfig, steps, skippedIds, checklistReady, isDismissedForAll };
 }


### PR DESCRIPTION
## Summary

The onboarding checklist's "Security" step was not reliably detecting all forms of dashboard authentication (OIDC/SSO, identity-aware proxy, password). This PR introduces a dedicated server-side probe (`useIsAuthEnabledQuery`) as the authoritative signal for whether dashboard auth is active, replacing the previous approach of inferring auth state solely from local credential values.

## Changes

- Added `useIsAuthEnabledQuery` to the onboarding checklist hook. This endpoint is whitelisted (never returns 401) and is answered by whichever middleware is installed — OSS reports `auth_config.is_enabled`, while the enterprise middleware reports auth type for OIDC cookie sessions and IAP tokens alike.
- Introduced `dashboardAuthEnabled` derived from the query result, which is used as the primary completion signal for the Security onboarding step. The existing local-credential check is retained as a fallback for when the probe hasn't resolved yet.
- Added `dashboardAuthState` to the `checklistReady` guard so the checklist does not render until the auth probe has returned.
- Updated the `useMemo` dependency array to include `dashboardAuthEnabled`.

## Type of change

- [x] Bug fix

## Affected areas

- [x] UI (React)

## How to test

1. Deploy with password auth enabled — the Security step should show as complete.
2. Deploy with OIDC/SSO configured — the Security step should show as complete without requiring local credentials to be set.
3. Deploy with no auth configured — the Security step should remain incomplete.
4. Verify the checklist does not flash an incorrect "complete" state before the auth probe resolves.

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Breaking changes

- [x] No

## Security considerations

The `/auth/enabled` (or equivalent) endpoint used by `useIsAuthEnabledQuery` is intentionally whitelisted and never returns a 401, so it does not expose any protected data. It only reports whether authentication is active, which is safe to surface to the client.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable