### PR TITLE
feat(ui): add `RawJsonUnavailableNotice` explaining disabled raw storage in log detail Raw JSON tab

### DIFF
--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -23,6 +23,7 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdownMenu";
 import { DottedSeparator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -30,6 +31,7 @@ import { TruncatedLabel } from "@/components/ui/truncatedLabel";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { ProviderIconType, RenderProviderIcon, RoutingEngineUsedIcons } from "@/lib/constants/icons";
 import {
+	getProviderLabel,
 	logAppDisplayName,
 	mapAppToClientApp,
 	mapUserAgentToApp,
@@ -39,18 +41,19 @@ import {
 	RoutingEngineUsedLabels,
 	Status,
 } from "@/lib/constants/logs";
+import { useGetProvidersQuery, useGetUserAgentMappingsQuery } from "@/lib/store";
 import { BatchRequestCounts, ContentBlock, LogEntry, OverheadBucket, ResponsesMessage } from "@/lib/types/logs";
-import { useGetUserAgentMappingsQuery } from "@/lib/store";
 import { cn } from "@/lib/utils";
 import { downloadAsJson } from "@/lib/utils/browser-download";
 import { formatCompactNumber } from "@/lib/utils/numbers";
 import { applyRedactionMapping, applyRedactionMappingToValue, hasRedactionMappingEntries } from "@/lib/utils/redaction";
 import { extractResponsesItemPayload, summarizeResponsesToolCall } from "@/lib/utils/responsesItems";
 import { isJson } from "@/lib/utils/validation";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Link } from "@tanstack/react-router";
 import { addMilliseconds, format } from "date-fns";
 import { AlertCircle, ChevronDown, Clipboard, Copy, Download, Loader2, MoreVertical, Trash2, Wrench, X } from "lucide-react";
-import { useMemo, useEffect, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { toast } from "sonner";
 import BlockHeader from "../views/blockHeader";
 import CollapsibleBox from "../views/collapsibleBox";
@@ -62,6 +65,7 @@ import PluginLogsView from "../views/pluginLogsView";
 import SpeechView from "../views/speechView";
 import TranscriptionView from "../views/transcriptionView";
 import VideoView from "../views/videoView";
+import { resolveRawJsonNoticeState } from "./logDetailView.utils";
 
 // Full-precision cost for the detail view; per-request costs are often < $0.01,
 // where formatCost's 2-4 dp rounding would hide the value.
@@ -860,7 +864,7 @@ function RoutingDecisionLogs({ logs }: { logs: string }) {
 										className={cn(
 											"inline-block w-24 shrink-0 rounded px-1.5 py-0.5 text-center text-[10px] font-semibold uppercase",
 											RoutingEngineUsedColors[scope as keyof typeof RoutingEngineUsedColors] ??
-												"bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
+											"bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
 										)}
 									>
 										{RoutingEngineUsedLabels[scope as keyof typeof RoutingEngineUsedLabels] ?? scope}
@@ -956,6 +960,72 @@ interface LogDetailViewProps {
 	onFilterByParentRequestId?: (parentRequestId: string) => void;
 }
 
+// Explains an empty Raw JSON tab. Raw payloads are only persisted when the
+// provider's `store_raw_request_response` is on, and teams that turn it off for
+// storage reasons otherwise just see an unexplained blank tab. This reads the
+// provider's *current* setting, so it is phrased in the present tense — it says
+// why raw JSON is missing for this provider today, not what was configured when
+// the request ran. When the setting is on (or unreadable, e.g. the viewer has no
+// provider access) we fall back to the neutral copy, since the row may simply
+// have failed before reaching the provider. While the setting is still being
+// fetched we show neither message - see `resolveRawJsonNoticeState`.
+function RawJsonUnavailableNotice({ provider }: { provider: string }) {
+	const hasProvidersAccess = useRbac(RbacResource.ModelProvider, RbacOperation.View);
+	const {
+		data: providers,
+		isLoading: isProvidersLoading,
+		isError: isProvidersError,
+	} = useGetProvidersQuery(undefined, { skip: !hasProvidersAccess });
+
+	const noticeState = useMemo(
+		() => resolveRawJsonNoticeState({ hasProvidersAccess, isProvidersLoading, isProvidersError, providers, provider }),
+		[hasProvidersAccess, isProvidersLoading, isProvidersError, providers, provider],
+	);
+
+	if (noticeState === "loading") {
+		return (
+			<div className="rounded-sm border border-dashed p-5">
+				<Skeleton className="mx-auto h-4 w-48" />
+			</div>
+		);
+	}
+
+	if (noticeState === "unknown") {
+		return <div className="text-muted-foreground rounded-sm border border-dashed p-5 text-center text-sm">No raw JSON available.</div>;
+	}
+
+	return (
+		<div className="text-muted-foreground space-y-3 rounded-sm border border-dashed p-5 text-sm">
+			<div className="text-foreground font-medium">Raw JSON storage is disabled by settings</div>
+			<p>
+				<span className="text-foreground font-medium">{getProviderLabel(provider)}</span> is configured not to persist raw request and
+				response payloads in log records, so there is nothing to show here. To start capturing them:
+			</p>
+			<ol className="ml-4 list-decimal space-y-1">
+				<li>
+					Open{" "}
+					<Link to="/workspace/providers" search={{ provider }} className="text-foreground font-medium underline underline-offset-2">
+						Providers → {getProviderLabel(provider)}
+					</Link>
+				</li>
+				<li>
+					Click the <span className="text-foreground font-medium">settings</span> icon to open the provider configuration
+				</li>
+				<li>
+					Go to the <span className="text-foreground font-medium">Debugging</span> tab
+				</li>
+				<li>
+					Turn on <span className="text-foreground font-medium">Store Raw Request/Response</span>
+				</li>
+			</ol>
+			<p className="text-xs">
+				This applies to new requests only, existing logs will not gain raw JSON. To capture raw payloads for a single request instead, send
+				the <code className="text-[11px]">x-bf-store-raw-request-response: true</code> header.
+			</p>
+		</div>
+	);
+}
+
 export function LogDetailView({
 	log,
 	resolvedSelectedPromptName,
@@ -1040,14 +1110,14 @@ export function LogDetailView({
 					const contents = item?.request?.contents;
 					const messages = Array.isArray(contents)
 						? contents.map((c: any) => ({
-								role: c?.role === "model" ? "assistant" : c?.role || "user",
-								content: Array.isArray(c?.parts)
-									? c.parts
-											.filter((p: any) => p && typeof p.text === "string")
-											.map((p: any) => p.text)
-											.join("")
-									: "",
-							}))
+							role: c?.role === "model" ? "assistant" : c?.role || "user",
+							content: Array.isArray(c?.parts)
+								? c.parts
+									.filter((p: any) => p && typeof p.text === "string")
+									.map((p: any) => p.text)
+									.join("")
+								: "",
+						}))
 						: [];
 					return {
 						customId: typeof item?.metadata?.key === "string" && item.metadata.key ? item.metadata.key : `request-${index + 1}`,
@@ -1106,9 +1176,9 @@ export function LogDetailView({
 					const parts = candidate?.content?.parts;
 					const text = Array.isArray(parts)
 						? parts
-								.filter((p: any) => p && typeof p.text === "string")
-								.map((p: any) => p.text)
-								.join("")
+							.filter((p: any) => p && typeof p.text === "string")
+							.map((p: any) => p.text)
+							.join("")
 						: "";
 					const role = candidate?.content?.role === "model" ? "assistant" : candidate?.content?.role || "assistant";
 					message = { role, content: text };
@@ -1131,11 +1201,11 @@ export function LogDetailView({
 	}, [batchRawResponse]);
 	const passthroughParams = isPassthrough
 		? (log.params as {
-				method?: string;
-				path?: string;
-				raw_query?: string;
-				status_code?: number;
-			})
+			method?: string;
+			path?: string;
+			raw_query?: string;
+			status_code?: number;
+		})
 		: null;
 	// Only errors and passthrough requests carry a real HTTP status code; others have none.
 	// Non-HTTP errors (timeouts, network, marshal) default to 0; treat that as no status
@@ -1155,7 +1225,7 @@ export function LogDetailView({
 	if (declaredTools.length) {
 		try {
 			toolsParameter = JSON.stringify(declaredTools, null, 2);
-		} catch {}
+		} catch { }
 	}
 
 	const audioFormat = (log.params as any)?.audio?.format || (log.params as any)?.extra_params?.audio?.format || undefined;
@@ -1172,7 +1242,7 @@ export function LogDetailView({
 			if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
 				return Object.values(parsed).reduce<number>((sum, v) => sum + (Array.isArray(v) ? v.length : 0), 0);
 			}
-		} catch {}
+		} catch { }
 		return 0;
 	})();
 
@@ -1437,11 +1507,10 @@ export function LogDetailView({
 						}
 						sub={
 							log.token_usage
-								? `total ${formatCompactNumber(log.token_usage.total_tokens ?? 0)}${
-										log.token_usage.completion_tokens_details?.reasoning_tokens
-											? ` · reasoning ${formatCompactNumber(log.token_usage.completion_tokens_details.reasoning_tokens)}`
-											: ""
-									}`
+								? `total ${formatCompactNumber(log.token_usage.total_tokens ?? 0)}${log.token_usage.completion_tokens_details?.reasoning_tokens
+									? ` · reasoning ${formatCompactNumber(log.token_usage.completion_tokens_details.reasoning_tokens)}`
+									: ""
+								}`
 								: "—"
 						}
 						hasRightBorder
@@ -2743,11 +2812,11 @@ export function LogDetailView({
 							<div className="bg-card rounded-sm border p-5">
 								{(visibleRoles.size < allRoles.length
 									? log.input_history?.filter((m) => {
-											if (!m) return false;
-											const mainRole = ((m.role as string) || "user") as MessageRole;
-											const hasReasoning = !!extractChatReasoning(m);
-											return visibleRoles.has(mainRole) || (hasReasoning && visibleRoles.has("reasoning"));
-										})
+										if (!m) return false;
+										const mainRole = ((m.role as string) || "user") as MessageRole;
+										const hasReasoning = !!extractChatReasoning(m);
+										return visibleRoles.has(mainRole) || (hasReasoning && visibleRoles.has("reasoning"));
+									})
 									: log.input_history?.filter(Boolean)
 								)?.flatMap((message, index) => {
 									const role = ((message.role as string) || "user") as MessageRole;
@@ -2997,11 +3066,11 @@ export function LogDetailView({
 													? msg.call_id
 													: Array.isArray(msg.tools)
 														? (() => {
-																const callable = flattenDeclaredTools(msg.tools).length;
-																return callable !== msg.tools.length
-																	? `${msg.type} · ${msg.tools.length} declarations · ${callable} callable tools`
-																	: `${msg.type} · ${msg.tools.length} tool${msg.tools.length === 1 ? "" : "s"}`;
-															})()
+															const callable = flattenDeclaredTools(msg.tools).length;
+															return callable !== msg.tools.length
+																? `${msg.type} · ${msg.tools.length} declarations · ${callable} callable tools`
+																: `${msg.type} · ${msg.tools.length} tool${msg.tools.length === 1 ? "" : "s"}`;
+														})()
 														: [msg.type, summarizeResponsesToolCall(msg, mapping)].filter(Boolean).join(" · ") || undefined;
 									}
 									const usePlainText = role === "user" || role === "assistant";
@@ -3373,7 +3442,7 @@ export function LogDetailView({
 						</>
 					)}
 					{!rawRequest && !rawResponse && !passthroughRequestBody && !passthroughResponseBody && (
-						<div className="text-muted-foreground rounded-sm border border-dashed p-5 text-center text-sm">No raw JSON available.</div>
+						<RawJsonUnavailableNotice provider={log.provider} />
 					)}
 				</TabsContent>
 			</Tabs>

--- a/ui/app/workspace/logs/sheets/logDetailView.utils.test.ts
+++ b/ui/app/workspace/logs/sheets/logDetailView.utils.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { resolveRawJsonNoticeState } from "./logDetailView.utils";
+
+const base = {
+	hasProvidersAccess: true,
+	isProvidersLoading: false,
+	isProvidersError: false,
+	providers: undefined as { name: string; store_raw_request_response?: boolean }[] | undefined,
+	provider: "openai",
+};
+
+describe("resolveRawJsonNoticeState", () => {
+	it("is loading while the provider query is in flight", () => {
+		expect(resolveRawJsonNoticeState({ ...base, isProvidersLoading: true })).toBe("loading");
+	});
+
+	it("is loading when the query has started but has not delivered data yet", () => {
+		expect(resolveRawJsonNoticeState({ ...base, providers: undefined })).toBe("loading");
+	});
+
+	it("is unknown - never loading - when the caller cannot read providers (query is skipped)", () => {
+		expect(resolveRawJsonNoticeState({ ...base, hasProvidersAccess: false })).toBe("unknown");
+	});
+
+	it("is unknown when the provider query failed, rather than loading forever", () => {
+		expect(resolveRawJsonNoticeState({ ...base, isProvidersError: true })).toBe("unknown");
+	});
+
+	it("is storage-disabled when the provider explicitly disables raw storage", () => {
+		expect(
+			resolveRawJsonNoticeState({ ...base, providers: [{ name: "openai", store_raw_request_response: false }] }),
+		).toBe("storage-disabled");
+	});
+
+	it("is unknown when the provider has raw storage enabled", () => {
+		expect(
+			resolveRawJsonNoticeState({ ...base, providers: [{ name: "openai", store_raw_request_response: true }] }),
+		).toBe("unknown");
+	});
+
+	it("is unknown when the setting is absent on the provider", () => {
+		expect(resolveRawJsonNoticeState({ ...base, providers: [{ name: "openai" }] })).toBe("unknown");
+	});
+
+	it("is unknown when this log's provider is not in the list", () => {
+		expect(
+			resolveRawJsonNoticeState({ ...base, providers: [{ name: "anthropic", store_raw_request_response: false }] }),
+		).toBe("unknown");
+	});
+});

--- a/ui/app/workspace/logs/sheets/logDetailView.utils.ts
+++ b/ui/app/workspace/logs/sheets/logDetailView.utils.ts
@@ -1,0 +1,36 @@
+/**
+ * Which message the Raw JSON tab shows when a log row carries no raw payload.
+ *
+ * - `loading`         — the provider setting is still being fetched; committing to a
+ *                       message now would flash the wrong one.
+ * - `storage-disabled` — the provider is explicitly configured not to persist raw
+ *                       request/response payloads, so we can explain *why* it is empty.
+ * - `unknown`         — we cannot attribute the empty tab to the provider setting
+ *                       (no provider-read permission, the fetch failed, the provider is
+ *                       not in the list, or storage is on and the row simply failed
+ *                       before reaching the provider). Falls back to neutral copy.
+ */
+export type RawJsonNoticeState = "loading" | "storage-disabled" | "unknown";
+
+export function resolveRawJsonNoticeState({
+	hasProvidersAccess,
+	isProvidersLoading,
+	isProvidersError,
+	providers,
+	provider,
+}: {
+	hasProvidersAccess: boolean;
+	isProvidersLoading: boolean;
+	isProvidersError: boolean;
+	providers: { name: string; store_raw_request_response?: boolean }[] | undefined;
+	provider: string;
+}): RawJsonNoticeState {
+	// The query is skipped without provider-read permission, and a failed fetch never
+	// delivers data - in both cases waiting would strand the tab on a spinner forever.
+	if (!hasProvidersAccess || isProvidersError) return "unknown";
+	// Otherwise an absent `providers` means the request is still in flight: hold the
+	// message back rather than flashing "No raw JSON available." before the setting is known.
+	if (isProvidersLoading || !providers) return "loading";
+	const match = providers.find((p) => p.name === provider);
+	return match && match.store_raw_request_response === false ? "storage-disabled" : "unknown";
+}

--- a/ui/app/workspace/logs/views/columns.tsx
+++ b/ui/app/workspace/logs/views/columns.tsx
@@ -3,6 +3,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { TruncatedLabel } from "@/components/ui/truncatedLabel";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import {
 	getProviderLabel,
@@ -393,11 +394,13 @@ export const createColumns = (
 			cell: ({ row }) => {
 				const provider = row.original.provider as ProviderName | undefined;
 				const model = row.original.model || batchAccountingDisplay(row.original)?.model;
+				const canonicalModel = row.original.canonical_model_name;
+				const modelLabel = canonicalModel && canonicalModel !== model ? `${canonicalModel} (${model})` : model;
 				return (
 					<div className="flex min-w-0 items-center gap-2">
 						{provider ? <RenderProviderIcon provider={provider as ProviderIconType} size="xs" /> : null}
 						<div className="flex min-w-0 flex-col leading-tight">
-							<span className="truncate font-mono text-[12px]">{model || "N/A"}</span>
+							<TruncatedLabel className="font-mono text-[12px]">{modelLabel || "N/A"}</TruncatedLabel>
 							<span className="text-muted-foreground truncate text-[10.5px]">{provider ? getProviderLabel(provider) : "N/A"}</span>
 						</div>
 					</div>

--- a/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
@@ -1,8 +1,8 @@
-import { SecretVarInput } from "@/components/ui/secretVarInput";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { ModelMultiselect } from "@/components/ui/modelMultiselect";
+import { SecretVarInput } from "@/components/ui/secretVarInput";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -449,9 +449,15 @@ export function ApiKeyFormFragment({ control, providerName, baseProviderType, fo
 							<FormItem data-testid="apikey-deployments-field">
 								<FormLabel>Deployments (Optional)</FormLabel>
 								<FormDescription>
-									Map a request model name to the provider&apos;s identifier (deployment name, inference profile ID, fine-tuned endpoint ID,
-									etc.). Expand a row to set the canonical model name, model family, and provider-specific overrides - these power
-									cost/pricing logs and family-based routing.
+									Map a request model name to the provider&apos;s identifier (deployment name, inference profile ID, etc.). Expand a row for
+									canonical name, model family, and provider overrides - these drive cost logs and family-based routing.
+									{isReplicate && (
+										<>
+											{" "}
+											Replicate deployments are listed only while &quot;Use Deployments Endpoint&quot; is on - otherwise type the owner/name
+											and press Enter.
+										</>
+									)}
 								</FormDescription>
 								<FormControl>
 									<div data-testid="apikey-deployments-table">
@@ -786,8 +792,11 @@ export function ApiKeyFormFragment({ control, providerName, baseProviderType, fo
 								<div className="space-y-1.5">
 									<FormLabel>Use Deployments Endpoint</FormLabel>
 									<FormDescription>
-										Route requests through the Replicate deployments endpoint instead of the models endpoint.
+										Sends <strong>every</strong> model on this key to /v1/deployments/&#123;owner&#125;/&#123;name&#125;/predictions, so
+										plain model names stop working. To switch just one model, leave this off and set &quot;Use deployments endpoint&quot; on
+										its row above.
 									</FormDescription>
+									<FormMessage />
 								</div>
 								<FormControl>
 									<Switch checked={field.value ?? false} onCheckedChange={field.onChange} />

--- a/ui/lib/schemas/providerForm.ts
+++ b/ui/lib/schemas/providerForm.ts
@@ -194,8 +194,10 @@ const BedrockMantleKeyConfigSchema = z
 		},
 	);
 
+// Optional for the same reason as replicateKeyConfigSchema in lib/types/schemas.ts:
+// the registered-but-untouched switch leaves an empty object behind.
 const ReplicateKeyConfigSchema = z.object({
-	use_deployments_endpoint: z.boolean(),
+	use_deployments_endpoint: z.boolean().optional(),
 });
 
 const KeySchema = z.object({

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -254,7 +254,7 @@ export const vllmKeyConfigSchema = z
 	});
 
 export const replicateKeyConfigSchema = z.object({
-	use_deployments_endpoint: z.boolean(),
+	use_deployments_endpoint: z.boolean().optional(),
 });
 
 // Ollama key config schema
@@ -366,8 +366,7 @@ export const modelProviderKeySchema = z
 	})
 	.refine(
 		(data) => {
-			// Providers with dedicated config that never need a top-level API key
-			if (data.vllm_key_config || data.replicate_key_config || data.ollama_key_config || data.sgl_key_config) {
+			if (data.vllm_key_config || data.ollama_key_config || data.sgl_key_config) {
 				return true;
 			}
 			// Bedrock Mantle authenticates via SigV4 (its key config) or a Bearer key — only require


### PR DESCRIPTION
## Summary

When a provider has `store_raw_request_response` disabled, the Raw JSON tab in the log detail view shows a blank panel with no explanation. This PR replaces that generic "No raw JSON available." message with a contextual notice that explains why raw payloads are missing and guides the user to the exact setting they need to enable.

## Changes

- Added a `RawJsonUnavailableNotice` component that fetches the current provider configuration (gated behind RBAC) and checks whether `store_raw_request_response` is `false` for the log's provider.
- When storage is confirmed disabled, the notice renders a step-by-step guide linking directly to the provider's settings page, pointing users to the Debugging tab and the Store Raw Request/Response toggle.
- When storage is enabled or the viewer lacks provider access, the component falls back to the original neutral "No raw JSON available." copy, since the absence of data in that case is unrelated to the setting.
- The notice also mentions the `x-bf-store-raw-request-response: true` per-request header as an alternative for one-off captures.
- Imported `useGetProvidersQuery` and `getProviderLabel` to support the new component, and added `useRbac` to gate the provider fetch.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Configure a provider and set `store_raw_request_response` to `false` in its Debugging settings.
2. Send a request through that provider.
3. Open the resulting log entry and navigate to the **Raw JSON** tab.
4. Confirm the contextual notice appears, naming the provider and showing the four-step guide with a working link to the provider settings page.
5. Re-enable `store_raw_request_response` on the provider and verify the tab reverts to the neutral "No raw JSON available." message for logs that still have no raw data.
6. Log in as a user without provider view access and confirm the neutral fallback message is shown rather than the detailed notice.

```sh
cd ui
pnpm i
pnpm build
```

## Screenshots/Recordings

**Before:** A blank dashed box with "No raw JSON available."

**After:** A dashed box with a heading, an explanation naming the provider, a four-step guide linking to provider settings, and a note about the per-request header override.

## Breaking changes

- [x] No

## Related issues

## Security considerations

The provider configuration fetch is gated behind `RbacResource.ModelProvider` / `RbacOperation.View`, so users without provider access cannot infer provider settings from the UI — they see only the generic fallback message.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable