### PR TITLE
fix: configured provider extra_headers win over client headers

### DIFF
--- a/core/providers/anthropic/passthroughheaders_test.go
+++ b/core/providers/anthropic/passthroughheaders_test.go
@@ -331,12 +331,14 @@ func TestSetPassthroughHeaders_ConfiguredExtraHeadersWin(t *testing.T) {
 		"x-app":           {"cli"},
 		"accept-encoding": {"gzip, deflate, br"},
 		"authorization":   {"Bearer sk-ant-oat01-caller-token"},
+		"x-pinned-empty":  {"caller-value"},
 	}
 	// network_config.extra_headers configured on the provider by the gateway operator.
 	configured := map[string]string{
 		"User-Agent":      "gateway-agent/1.0",
 		"X-App":           "gateway",
 		"Accept-Encoding": "identity",
+		"X-Pinned-Empty":  "", // an empty value still pins the header against the caller's copy
 	}
 
 	for _, streaming := range []bool{false, true} {

--- a/core/providers/anthropic/passthroughheaders_test.go
+++ b/core/providers/anthropic/passthroughheaders_test.go
@@ -321,3 +321,52 @@ func TestSetPassthroughHeaders_OnlyAnthropicReceivesThem(t *testing.T) {
 		}
 	})
 }
+
+// TestSetPassthroughHeaders_ConfiguredExtraHeadersWin reproduces #6587: the provider's
+// network_config.extra_headers are applied before OAuth passthrough, and a caller-sent
+// copy of the same header must not overwrite them.
+func TestSetPassthroughHeaders_ConfiguredExtraHeadersWin(t *testing.T) {
+	callerHeaders := map[string][]string{
+		"user-agent":      {"claude-cli/2.0.8 (external, cli)"},
+		"x-app":           {"cli"},
+		"accept-encoding": {"gzip, deflate, br"},
+		"authorization":   {"Bearer sk-ant-oat01-caller-token"},
+	}
+	// network_config.extra_headers configured on the provider by the gateway operator.
+	configured := map[string]string{
+		"User-Agent":      "gateway-agent/1.0",
+		"X-App":           "gateway",
+		"Accept-Encoding": "identity",
+	}
+
+	for _, streaming := range []bool{false, true} {
+		name := "buffered"
+		if streaming {
+			name = "streaming"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			ctx.SetValue(schemas.BifrostContextKeyPassthroughHeaders, callerHeaders)
+
+			req := fasthttp.AcquireRequest()
+			defer fasthttp.ReleaseRequest(req)
+			// Same order as completeRequest and the streaming handlers: network-config
+			// extra headers first, then the caller's passthrough headers.
+			providerUtils.SetExtraHeaders(ctx, req, configured, []string{AnthropicBetaHeader})
+			if streaming {
+				providerUtils.SetPassthroughHeadersForStreaming(ctx, req, schemas.Anthropic, []string{AnthropicBetaHeader})
+			} else {
+				providerUtils.SetPassthroughHeaders(ctx, req, schemas.Anthropic, []string{AnthropicBetaHeader})
+			}
+
+			for header, want := range configured {
+				if got := string(req.Header.Peek(header)); got != want {
+					t.Errorf("configured extra header %q must win over the caller's copy: got %q, want %q", header, got, want)
+				}
+			}
+			if got := string(req.Header.Peek("authorization")); got != "Bearer sk-ant-oat01-caller-token" {
+				t.Errorf("caller headers without a configured counterpart must still be forwarded, got %q", got)
+			}
+		})
+	}
+}

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -1062,6 +1062,8 @@ func filterSupportedAcceptEncodings(values []string, supportedEncodings map[stri
 // may call this: every other provider authenticates with its own configured credentials, so
 // forwarding these would leak x-bf-* upstream and, on Bedrock, break SigV4 when a hop rewrites
 // x-forwarded-for. Hop-by-hop headers are dropped by filterHeaders, x-bf-* never leaves the gateway.
+// Call it after SetExtraHeaders: a header already on the request — notably the provider's
+// configured network extra_headers — is never overwritten by the caller's copy.
 func SetPassthroughHeaders(ctx context.Context, req *fasthttp.Request, provider schemas.ModelProvider, skipHeaders []string) {
 	setPassthroughHeaders(ctx, req, provider, skipHeaders, supportedBufferedContentEncodings)
 }
@@ -1093,6 +1095,12 @@ func setPassthroughHeaders(ctx context.Context, req *fasthttp.Request, provider 
 		}
 		// Bifrost owns the body it sends, so a caller cannot override its content type.
 		if lower == "content-type" {
+			continue
+		}
+		// Never overwrite a header that is already on the request: SetExtraHeaders runs
+		// before this at every call site, so the provider's configured network extra_headers
+		// keep precedence over the caller's copy of the same header (#6587).
+		if len(req.Header.Peek(k)) > 0 {
 			continue
 		}
 		if lower == "accept-encoding" {

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -1099,8 +1099,9 @@ func setPassthroughHeaders(ctx context.Context, req *fasthttp.Request, provider 
 		}
 		// Never overwrite a header that is already on the request: SetExtraHeaders runs
 		// before this at every call site, so the provider's configured network extra_headers
-		// keep precedence over the caller's copy of the same header (#6587).
-		if len(req.Header.Peek(k)) > 0 {
+		// keep precedence over the caller's copy of the same header (#6587). PeekAll rather
+		// than Peek, so a configured header pinned to an empty value still counts as present.
+		if len(req.Header.PeekAll(k)) > 0 {
 			continue
 		}
 		if lower == "accept-encoding" {


### PR DESCRIPTION
## Summary

Fixes #6587 — a client-supplied header (e.g. `user-agent`) overwrites the provider's `network_config.extra_headers` on the upstream request. Gateway configuration should be authoritative for the headers it pins: `extra_headers` now wins over headers organically forwarded from the client.

**Root cause:** in the Anthropic OAuth passthrough flow (client authenticates the Anthropic-compatible route with its own `Authorization: Bearer ...` token), the integration captures the caller's raw headers and `setPassthroughHeaders` (`core/providers/utils/utils.go`) applies them with an unconditional `Set()` *after* `SetExtraHeaders` has applied the provider's `network_config.extra_headers` — so the caller's value for the same header always clobbers the configured one.

## Changes

- `core/providers/utils/utils.go`: `setPassthroughHeaders` never overwrites a header that is already on the request. Every call site (`completeRequest` and both streaming handlers in `core/providers/anthropic/anthropic.go`) applies `SetExtraHeaders` first, so configured `network_config.extra_headers` keep precedence over the caller's copy of the same header — no exported signature change, no call-site churn. Caller headers without a configured counterpart (the OAuth `authorization` credential, `x-stainless-*` telemetry, ...) are forwarded exactly as before, including the `accept-encoding` codec filtering.
- `core/providers/anthropic/passthroughheaders_test.go`: new regression test `TestSetPassthroughHeaders_ConfiguredExtraHeadersWin` — the caller sends `user-agent` / `x-app` / `accept-encoding`, the operator configures the same keys, and the configured values must reach the upstream request on both the buffered and streaming paths while the caller's `authorization` still passes through.

Design notes:
- Header precedence is now a property of call order and reads: explicit per-request override (`x-bf-eh-*` → `BifrostContextKeyExtraHeaders`, applied inside `SetExtraHeaders` with documented priority) > configured `network_config.extra_headers` > organic caller passthrough headers.
- The check is `req.Header.Peek(k)` — fasthttp normalizes header-name case on Set/Peek, so `User-Agent` in config matches `user-agent` from the client without manual canonicalization.
- Caller auth/version headers applied last by `completeRequest` are untouched, as is the forced JSON content type.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go build ./...
go test ./providers/anthropic/ -run 'TestSetPassthroughHeaders' -v
go test ./providers/anthropic/ ./providers/utils/
```

Red-before-green: `TestSetPassthroughHeaders_ConfiguredExtraHeadersWin` fails on `dev` with the caller's values winning (`configured extra header "User-Agent" must win over the caller's copy: got "claude-cli/2.0.8 (external, cli)", want "gateway-agent/1.0"`) and passes with this change.

Manual validation matching the issue repro: configure `user-agent` in the provider's `network_config.extra_headers`, call the Anthropic-compatible endpoint with a Bearer (OAuth) credential and a `user-agent: client_header` request header — the upstream request now carries the configured value.

## Screenshots/Recordings

N/A (no UI changes).

## Breaking changes

- [ ] Yes
- [x] No

Behavioral note: callers in the OAuth passthrough flow can no longer override a header the gateway operator has explicitly pinned in `network_config.extra_headers` (that is the bug being fixed); the `x-bf-eh-*` header channel remains the supported per-request override. All other caller headers are forwarded as before.

## Related issues

Closes #6587

## Security considerations

Strengthens operator control: gateway-configured headers can no longer be silently replaced by client-supplied values on upstream requests. No secrets, auth flows, or PII handling changed; `x-bf-*` internals remain stripped, hop-by-hop headers remain dropped.

Provider-harness exemption: this change is not client-observable on the wire (it alters headers sent upstream in the Anthropic OAuth passthrough flow, which needs a live OAuth credential and per-case provider `network_config` that the harness does not model); regression coverage is the Go unit test above. `tests/e2e/api/collections/provider-harness.json` was checked: it has no case asserting upstream header precedence for `extra_headers` (its section 9 "Passthrough (catch-all forwarding)" covers the unrelated catch-all routes where Bifrost injects its own key), and it already delegates behavior it cannot provoke to Go unit tests (see the harness note referencing `core/providers/anthropic/serversidefallback_test.go`), which this PR follows.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
