### PR TITLE
fix(core): stop dead provider blocking aggregate model list

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -474,8 +474,55 @@ func (bifrost *Bifrost) ListModelsRequest(ctx *schemas.BifrostContext, req *sche
 	return resp.ListModelsResponse, nil
 }
 
+// listAllModelsProviderTimeout bounds each provider's live poll inside
+// ListAllModels. The fan-out previously ran with no deadline, so a single
+// unreachable provider held the aggregate response back until the shared
+// request timeout (DefaultRequestTimeoutInSeconds, 300s by default) expired.
+// Listing models is a metadata read and should not wait inference-scale
+// timeouts. A var rather than a const so package tests can shrink it.
+var listAllModelsProviderTimeout = 5 * time.Second
+
+// providerModelLister is the optional model-catalog capability ListAllModels
+// falls back on when a provider's live poll fails. The framework's
+// modelcatalog.ModelCatalog implements it already; the public
+// schemas.ModelInfoProvider interface is left untouched so third-party
+// catalogs keep compiling.
+type providerModelLister interface {
+	GetModelsForProvider(provider schemas.ModelProvider) []string
+	GetUnfilteredModelsForProvider(provider schemas.ModelProvider) []string
+}
+
+// lastKnownModelsFromCatalog returns catalog-backed entries for a provider
+// whose live poll failed, or nil when no catalog with per-provider listings is
+// configured or it has nothing for this provider. IDs use the same
+// "<provider>/<model>" shape the live path produces, so downstream enrichment
+// and pagination treat them identically.
+func (bifrost *Bifrost) lastKnownModelsFromCatalog(providerKey schemas.ModelProvider, unfiltered bool) []schemas.Model {
+	lister, ok := bifrost.getModelCatalog().(providerModelLister)
+	if !ok {
+		return nil
+	}
+	var names []string
+	if unfiltered {
+		names = lister.GetUnfilteredModelsForProvider(providerKey)
+	} else {
+		names = lister.GetModelsForProvider(providerKey)
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	models := make([]schemas.Model, 0, len(names))
+	for _, name := range names {
+		models = append(models, schemas.Model{ID: string(providerKey) + "/" + name})
+	}
+	return models
+}
+
 // ListAllModels lists all models from all configured providers.
 // It accumulates responses from all providers with a limit of 1000 per provider to get all results.
+// Each provider poll is bounded by listAllModelsProviderTimeout so one unreachable provider
+// cannot block the aggregate; a provider whose poll fails contributes its last-known models
+// from the model catalog (when one with per-provider listings is configured) instead.
 func (bifrost *Bifrost) ListAllModels(ctx *schemas.BifrostContext, req *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
 	if req == nil {
 		req = &schemas.BifrostListModelsRequest{}
@@ -522,7 +569,12 @@ func (bifrost *Bifrost) ListAllModels(ctx *schemas.BifrostContext, req *schemas.
 		go func(providerKey schemas.ModelProvider) {
 			defer wg.Done()
 
-			providerCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			// Bound this provider's poll so one unreachable provider cannot
+			// hold the aggregate until the shared request timeout: at the
+			// deadline tryRequest stops waiting on the worker (the in-flight
+			// HTTP call is abandoned, not cancelled) and wg.Wait() finishes.
+			providerCtx := schemas.NewBifrostContext(ctx, time.Now().Add(listAllModelsProviderTimeout))
+			defer providerCtx.Cancel()
 			providerCtx.SetValue(schemas.BifrostContextKeyRequestID, uuid.New().String())
 
 			providerModels := make([]schemas.Model, 0)
@@ -595,6 +647,20 @@ func (bifrost *Bifrost) ListAllModels(ctx *schemas.BifrostContext, req *schemas.
 
 				// Set the page token for the next request
 				providerRequest.PageToken = response.NextPageToken
+			}
+
+			// A provider whose live poll failed shouldn't vanish from the
+			// aggregate while the catalog still remembers its models: serve
+			// the last-known list (kept fresh by the transport's background
+			// refresher) instead of nothing. Expected failures (no keys, not
+			// supported, blocked) leave providerErr nil and stay silent as
+			// before, and the poll error still propagates so an
+			// all-providers-down setup without a catalog keeps erroring.
+			if providerErr != nil && len(providerModels) == 0 {
+				if cached := bifrost.lastKnownModelsFromCatalog(providerKey, req.Unfiltered); len(cached) > 0 {
+					bifrost.logger.Warn("serving %d last-known models for provider %s from the model catalog after its live poll failed", len(cached), providerKey)
+					providerModels = cached
+				}
 			}
 
 			results <- providerResult{

--- a/core/listallmodels_test.go
+++ b/core/listallmodels_test.go
@@ -1,0 +1,224 @@
+package bifrost
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// openAIStyleModelsHandler serves a minimal OpenAI-format GET /v1/models
+// response listing the given model IDs.
+func openAIStyleModelsHandler(ids ...string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		body := `{"object":"list","data":[`
+		for i, id := range ids {
+			if i > 0 {
+				body += ","
+			}
+			body += `{"id":"` + id + `","object":"model","created":1700000000,"owned_by":"test"}`
+		}
+		body += `]}`
+		_, _ = w.Write([]byte(body))
+	}
+}
+
+// wildcardKey returns a key whose allowlist admits every model, so the
+// filtered list-models path doesn't early-exit to an empty list.
+func wildcardKey(provider schemas.ModelProvider) []schemas.Key {
+	return []schemas.Key{{
+		ID:     "test-key-" + string(provider),
+		Value:  *schemas.NewSecretVar("sk-test-" + string(provider)),
+		Models: schemas.WhiteList{"*"},
+		Weight: 100,
+	}}
+}
+
+// tuneProviderForTest shrinks the provider's HTTP budget so an abandoned
+// in-flight call to a hanging test server releases its worker (and Shutdown)
+// quickly, and disables retries for deterministic single-attempt behavior.
+func tuneProviderForTest(t *testing.T, account *MockAccount, provider schemas.ModelProvider) {
+	t.Helper()
+	cfg, ok := account.configs[provider]
+	if !ok {
+		t.Fatalf("provider %s not configured on mock account", provider)
+	}
+	cfg.NetworkConfig.DefaultRequestTimeoutInSeconds = 2
+	cfg.NetworkConfig.MaxRetries = 0
+}
+
+func newListModelsTestClient(t *testing.T, account *MockAccount, catalog schemas.ModelInfoProvider) *Bifrost {
+	t.Helper()
+	client, initErr := Init(context.Background(), schemas.BifrostConfig{
+		Account:      account,
+		Logger:       NewNoOpLogger(),
+		ModelCatalog: catalog,
+	})
+	if initErr != nil {
+		t.Fatalf("Init failed: %v", initErr)
+	}
+	t.Cleanup(client.Shutdown)
+	return client
+}
+
+func modelIDs(resp *schemas.BifrostListModelsResponse) []string {
+	if resp == nil {
+		return nil
+	}
+	ids := make([]string, 0, len(resp.Data))
+	for _, m := range resp.Data {
+		ids = append(ids, m.ID)
+	}
+	return ids
+}
+
+func containsModelID(resp *schemas.BifrostListModelsResponse, id string) bool {
+	if resp == nil {
+		return false
+	}
+	for _, m := range resp.Data {
+		if m.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// A single unreachable provider must not block the aggregate list: the healthy
+// provider's models should come back well under the unreachable provider's
+// HTTP timeout (issue #6612: the fan-out previously ran with no deadline, so
+// GET /v1/models hung for the full shared request timeout on every call).
+func TestListAllModelsUnreachableProviderDoesNotBlockAggregate(t *testing.T) {
+	healthySrv := httptest.NewServer(openAIStyleModelsHandler("gpt-4o"))
+	t.Cleanup(healthySrv.Close)
+
+	hang := make(chan struct{})
+	hangingSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-hang
+	}))
+	// Release the hanging handler before closing the server so Close doesn't
+	// wait on it. Registered before the client so Shutdown (registered later,
+	// run earlier) still exercises the abandoned-call path first.
+	t.Cleanup(func() {
+		close(hang)
+		hangingSrv.Close()
+	})
+
+	account := NewMockAccount()
+	account.AddProviderWithBaseURL(schemas.OpenAI, 1, 10, healthySrv.URL)
+	account.AddProviderWithBaseURL(schemas.Groq, 1, 10, hangingSrv.URL)
+	account.SetKeysForProvider(schemas.OpenAI, wildcardKey(schemas.OpenAI))
+	account.SetKeysForProvider(schemas.Groq, wildcardKey(schemas.Groq))
+	tuneProviderForTest(t, account, schemas.OpenAI)
+	tuneProviderForTest(t, account, schemas.Groq)
+
+	// Shrink the per-provider poll deadline so the green path is fast; the
+	// red path (no deadline honored) is still bounded by the 2s HTTP budget
+	// above, which comfortably exceeds the assertion below.
+	oldTimeout := listAllModelsProviderTimeout
+	listAllModelsProviderTimeout = 400 * time.Millisecond
+	t.Cleanup(func() { listAllModelsProviderTimeout = oldTimeout })
+
+	client := newListModelsTestClient(t, account, nil)
+
+	// No caller deadline, mirroring the HTTP handler: the aggregate itself
+	// must bound the unreachable provider's poll.
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	defer ctx.Cancel()
+
+	start := time.Now()
+	resp, bfErr := client.ListAllModels(ctx, &schemas.BifrostListModelsRequest{})
+	elapsed := time.Since(start)
+
+	if bfErr != nil {
+		t.Fatalf("ListAllModels returned error: %s", bfErr.GetErrorString())
+	}
+	if elapsed >= 1500*time.Millisecond {
+		t.Fatalf("aggregate blocked for %v by the unreachable provider; want well under its 2s HTTP timeout", elapsed)
+	}
+	if !containsModelID(resp, "openai/gpt-4o") {
+		t.Fatalf("healthy provider's models missing from aggregate; got %v", modelIDs(resp))
+	}
+}
+
+// staticListerCatalog is a schemas.ModelInfoProvider that also implements the
+// optional per-provider model listing the aggregate falls back on, mimicking
+// the framework's ModelCatalog.
+type staticListerCatalog struct {
+	modelsByProvider map[schemas.ModelProvider][]string
+}
+
+func (c *staticListerCatalog) GetModelInfo(provider schemas.ModelProvider, model string) *schemas.Model {
+	return nil
+}
+
+func (c *staticListerCatalog) CalculateRequestCost(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse) float64 {
+	return 0
+}
+
+func (c *staticListerCatalog) GetModelsForProvider(provider schemas.ModelProvider) []string {
+	return c.modelsByProvider[provider]
+}
+
+func (c *staticListerCatalog) GetUnfilteredModelsForProvider(provider schemas.ModelProvider) []string {
+	return c.modelsByProvider[provider]
+}
+
+// When a provider's live poll fails and a model catalog is configured, the
+// aggregate should serve that provider's last-known models instead of
+// dropping the provider from the response.
+func TestListAllModelsServesLastKnownModelsWhenPollFails(t *testing.T) {
+	healthySrv := httptest.NewServer(openAIStyleModelsHandler("gpt-4o"))
+	t.Cleanup(healthySrv.Close)
+
+	account := NewMockAccount()
+	account.AddProviderWithBaseURL(schemas.OpenAI, 1, 10, healthySrv.URL)
+	// Nothing listens here: the poll fails fast with connection refused.
+	account.AddProviderWithBaseURL(schemas.Groq, 1, 10, "http://127.0.0.1:1")
+	account.SetKeysForProvider(schemas.OpenAI, wildcardKey(schemas.OpenAI))
+	account.SetKeysForProvider(schemas.Groq, wildcardKey(schemas.Groq))
+	tuneProviderForTest(t, account, schemas.OpenAI)
+	tuneProviderForTest(t, account, schemas.Groq)
+
+	catalog := &staticListerCatalog{modelsByProvider: map[schemas.ModelProvider][]string{
+		schemas.Groq: {"llama-3.3-70b-versatile"},
+	}}
+	client := newListModelsTestClient(t, account, catalog)
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	defer ctx.Cancel()
+
+	resp, bfErr := client.ListAllModels(ctx, &schemas.BifrostListModelsRequest{})
+	if bfErr != nil {
+		t.Fatalf("ListAllModels returned error: %s", bfErr.GetErrorString())
+	}
+	if !containsModelID(resp, "openai/gpt-4o") {
+		t.Fatalf("healthy provider's models missing from aggregate; got %v", modelIDs(resp))
+	}
+	if !containsModelID(resp, "groq/llama-3.3-70b-versatile") {
+		t.Fatalf("last-known models for the failed provider missing from aggregate; got %v", modelIDs(resp))
+	}
+}
+
+// With no catalog to fall back on, an aggregate where every poll failed must
+// keep returning the first error rather than an empty success.
+func TestListAllModelsAllPollsFailWithoutCatalogReturnsError(t *testing.T) {
+	account := NewMockAccount()
+	account.AddProviderWithBaseURL(schemas.Groq, 1, 10, "http://127.0.0.1:1")
+	account.SetKeysForProvider(schemas.Groq, wildcardKey(schemas.Groq))
+	tuneProviderForTest(t, account, schemas.Groq)
+
+	client := newListModelsTestClient(t, account, nil)
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	defer ctx.Cancel()
+
+	resp, bfErr := client.ListAllModels(ctx, &schemas.BifrostListModelsRequest{})
+	if bfErr == nil {
+		t.Fatalf("expected an error when every provider poll fails with no catalog fallback; got %v", modelIDs(resp))
+	}
+}


### PR DESCRIPTION
## Summary

A single unreachable provider blocked the aggregate `GET /v1/models` for the full shared request timeout on every request. `Bifrost.ListAllModels` fans out one live poll per configured provider and `wg.Wait()`s for all of them, but each per-provider context was created with `schemas.NoDeadline` — so the slowest (or dead) provider bounded the whole response. Since the only cap was the provider's `default_request_timeout_in_seconds` (default 300s, shared with inference traffic), a provider whose endpoint drops packets held the model list hostage for minutes, and lowering that timeout would break long inference requests (see #6612 for the full analysis and repro).

This PR decouples model listing from the inference timeout path in core, which fixes both `GET /v1/models` and the OpenAI-compatible integration routes (both call `ListAllModels`):

1. Each provider poll now runs under a short dedicated deadline (`listAllModelsProviderTimeout`, 5s). At the deadline `tryRequest` stops waiting on the worker (the in-flight HTTP call is abandoned, not cancelled — same semantics `MakeRequestWithContext` already documents), so the aggregate returns promptly.
2. A provider whose poll fails contributes its last-known models from the existing model catalog (kept fresh by the transport's background live refresher) instead of vanishing from the list, when a catalog is configured.

## Changes

- `core/bifrost.go`
  - `listAllModelsProviderTimeout` (5s, package-level `var` so package tests can shrink it) bounds each provider poll in `ListAllModels` via a per-provider context deadline (+ `defer Cancel()` to release the watcher).
  - New unexported `providerModelLister` interface (`GetModelsForProvider` / `GetUnfilteredModelsForProvider`) asserted optionally against the configured `schemas.ModelInfoProvider`. The framework's `modelcatalog.ModelCatalog` already implements it, so no framework changes and no breaking change to the public `ModelInfoProvider` interface (third-party catalogs keep compiling; without a catalog the fallback is a graceful no-op).
  - On a non-expected poll failure with zero models fetched, `lastKnownModelsFromCatalog` synthesizes `schemas.Model{ID: "<provider>/<model>"}` entries — the same ID shape the live path produces, so the HTTP layer's `enrichListModelsResponse` enriches them identically.
  - Error semantics preserved: expected failures ("no keys found", "not supported", `provider_blocked`) stay silent as before, and when every poll fails and no catalog is wired, the aggregate still returns the first error.
- `core/listallmodels_test.go` (new)
  - Red-before-green regression tests, see below.

Design notes / trade-offs:
- Reuses the existing model catalog rather than adding a new cache or config option. Freshness comes from the transport's existing background refresher (15s budget per key, seeded at boot, entries persist across failed refreshes).
- The abandoned poll's worker stays busy until the provider's own HTTP timeout expires (pre-existing "stops waiting, doesn't cancel" behavior of `MakeRequestWithContext`); previously the caller *and* worker were both blocked for that long on every aggregate request.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go test -count=1 -run 'TestListAllModels' -v .
go test -count=1 ./...
go vet ./...
```

New tests (written red-first against the unpatched code):

- `TestListAllModelsUnreachableProviderDoesNotBlockAggregate` — one healthy `httptest` provider (OpenAI-format `/v1/models`) plus one provider pointed at a hanging `httptest` server that never responds, polled with **no caller deadline** (mirroring the HTTP handler). Red: the aggregate blocked for the hanging provider's full HTTP budget (`aggregate blocked for 2.0027555s by the unreachable provider` with the budget shrunk to 2s for the test; 300s-class with defaults). Green: returns well under the budget with the healthy provider's models present.
- `TestListAllModelsServesLastKnownModelsWhenPollFails` — a connection-refused provider plus a catalog fake that remembers its models. Red: `last-known models for the failed provider missing from aggregate; got [openai/gpt-4o]`. Green: both `openai/gpt-4o` (live) and `groq/llama-3.3-70b-versatile` (catalog) present.
- `TestListAllModelsAllPollsFailWithoutCatalogReturnsError` — guards the existing all-providers-down error contract (passed before and after).

Manual validation: with a provider whose endpoint blackholes traffic configured alongside healthy providers, `curl -s localhost:8080/v1/models` now returns in ≈5s worst case (first request; healthy-only latency otherwise) instead of hanging for the shared request timeout, and includes the dead provider's last-known models when the catalog has them.

Provider-harness note: this change is exempt from a `tests/e2e/api/collections/provider-harness.json` case — the fixed behavior (aggregate latency under a hung upstream, and catalog fallback on poll failure) requires an unreachable provider, which the live harness cannot simulate; the wire shape of successful responses is unchanged. It is pinned by the Go tests above instead.

## Screenshots/Recordings

N/A (no UI changes).

## Breaking changes

- [ ] Yes
- [x] No

Public interfaces are untouched; the catalog fallback is an optional unexported interface assertion.

## Related issues

Closes #6612

## Security considerations

None. No auth, secrets, or PII paths are touched; fallback entries only surface model IDs the configured catalog already exposes to the same endpoint.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed (not needed — no config or API surface change)
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable (`go test ./...` and `go vet ./...` on `core/` pass)

