### PR TITLE
fix: deterministic tool schema extraction from plain maps

### DIFF
--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -1433,15 +1433,15 @@ func TestStructuredOutputConversion(t *testing.T) {
 				assert.NotNil(t, result.GenerationConfig.ResponseJSONSchema, "responseJsonSchema should be set")
 
 				// Validate the schema structure
-				schemaMap, ok := result.GenerationConfig.ResponseJSONSchema.(map[string]interface{})
+				schemaMap, ok := asPlainMap(t, result.GenerationConfig.ResponseJSONSchema)
 				require.True(t, ok, "ResponseJSONSchema should be a map")
 
 				// Check properties
-				properties, ok := schemaMap["properties"].(map[string]interface{})
+				properties, ok := asPlainMap(t, schemaMap["properties"])
 				require.True(t, ok, "properties should be a map")
 
 				// Validate user_id property - should be converted to anyOf
-				userID, ok := properties["user_id"].(map[string]interface{})
+				userID, ok := asPlainMap(t, properties["user_id"])
 				require.True(t, ok, "user_id should exist in properties")
 
 				// user_id should have anyOf instead of type array
@@ -1462,7 +1462,7 @@ func TestStructuredOutputConversion(t *testing.T) {
 				assert.Equal(t, "integer", integerBranch["type"])
 
 				// Validate status property - should remain unchanged
-				status, ok := properties["status"].(map[string]interface{})
+				status, ok := asPlainMap(t, properties["status"])
 				require.True(t, ok, "status should exist in properties")
 				assert.Equal(t, "string", status["type"])
 				enum := status["enum"].([]interface{})

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -674,20 +674,27 @@ func SafeExtractStringMap(value interface{}) (map[string]string, bool) {
 	}
 }
 
+// SafeExtractOrderedMap safely extracts an *OrderedMap from an interface{} with type checking.
+// Inputs that already carry a meaningful key order (OrderedMap values and raw JSON documents)
+// are returned with that order preserved. Plain Go maps have no defined iteration order, so
+// they are converted with SortedCopyPreservingProperties to guarantee deterministic,
+// byte-stable serialization at every nesting level (issue #6591: unsorted nested maps broke
+// provider prompt caching); user-defined names under "properties" keep their key order when
+// one exists.
 func SafeExtractOrderedMap(value interface{}) (*OrderedMap, bool) {
 	if value == nil {
 		return nil, false
 	}
 	switch v := value.(type) {
 	case map[string]interface{}:
-		mapped := OrderedMapFromMap(v)
+		mapped := OrderedMapFromMap(v).SortedCopyPreservingProperties()
 		if mapped != nil {
 			return mapped, true
 		}
 		return nil, false
 	case *map[string]interface{}:
 		if v != nil {
-			mapped := OrderedMapFromMap(*v)
+			mapped := OrderedMapFromMap(*v).SortedCopyPreservingProperties()
 			if mapped != nil {
 				return mapped, true
 			}

--- a/core/schemas/utils_test.go
+++ b/core/schemas/utils_test.go
@@ -1,6 +1,8 @@
 package schemas
 
 import (
+	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -133,4 +135,151 @@ func TestSanitizeImageURLAcceptsDataURLWithParameters(t *testing.T) {
 	_, err = SanitizeImageURL("data:;base64,iVBORw0KGgo=")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid data URL format")
+}
+
+// buildToolPropertiesFixture returns a tools-payload "properties" fragment as a
+// plain Go map — the shape SafeExtractOrderedMap receives when tool schemas
+// arrive through map-typed fields (e.g. the Responses conversion path for
+// Anthropic-protocol providers, issue #6591). Each property schema carries
+// several keys so that undefined map iteration order is observable in
+// serialized output.
+func buildToolPropertiesFixture() map[string]interface{} {
+	props := map[string]interface{}{}
+	for _, name := range []string{"location", "unit", "days", "verbose", "limit"} {
+		props[name] = map[string]interface{}{
+			"type":        "string",
+			"description": "property " + name,
+			"title":       name,
+			"minLength":   float64(1),
+		}
+	}
+	// One object-typed property with nested properties to exercise recursion.
+	props["filters"] = map[string]interface{}{
+		"type":        "object",
+		"description": "structured filters",
+		"properties": map[string]interface{}{
+			"start": map[string]interface{}{"type": "string", "format": "date", "description": "start date"},
+			"end":   map[string]interface{}{"type": "string", "format": "date", "description": "end date"},
+		},
+	}
+	return props
+}
+
+// assertNoPlainMaps walks the extracted value and fails if any nested object is
+// still a plain map (whose iteration order is undefined) rather than an
+// *OrderedMap carrying a stable key order. Plain maps leak Go's randomized
+// iteration order into any consumer that re-marshals a plucked sub-schema with
+// the hot-path encoder, which breaks provider prompt caching (issue #6591).
+func assertNoPlainMaps(t *testing.T, path string, v interface{}) {
+	t.Helper()
+	switch val := v.(type) {
+	case map[string]interface{}:
+		t.Fatalf("%s: nested value is %T; plain maps serialize in random key order — want *OrderedMap", path, v)
+	case *OrderedMap:
+		for _, k := range val.Keys() {
+			child, _ := val.Get(k)
+			assertNoPlainMaps(t, path+"."+k, child)
+		}
+	case OrderedMap:
+		for _, k := range val.Keys() {
+			child, _ := val.Get(k)
+			assertNoPlainMaps(t, path+"."+k, child)
+		}
+	case []interface{}:
+		for i, item := range val {
+			assertNoPlainMaps(t, fmt.Sprintf("%s[%d]", path, i), item)
+		}
+	}
+}
+
+// Regression test for #6591: tool schemas extracted from plain Go maps must
+// come out as fully ordered trees so their serialization is byte-stable.
+func TestSafeExtractOrderedMapToolSchemaDeterminism(t *testing.T) {
+	const iterations = 50
+
+	cases := []struct {
+		name    string
+		extract func() (*OrderedMap, bool)
+	}{
+		{"map", func() (*OrderedMap, bool) { return SafeExtractOrderedMap(buildToolPropertiesFixture()) }},
+		{"pointer-to-map", func() (*OrderedMap, bool) {
+			m := buildToolPropertiesFixture()
+			return SafeExtractOrderedMap(&m)
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var firstFull, firstPlucked []byte
+			for i := 0; i < iterations; i++ {
+				om, ok := tc.extract()
+				require.True(t, ok, "SafeExtractOrderedMap returned ok=false")
+
+				// Every nested object must be order-carrying.
+				assertNoPlainMaps(t, "properties", om)
+
+				// The whole extracted fragment must serialize byte-identically.
+				full, err := Marshal(om)
+				require.NoError(t, err)
+
+				// Downstream converters pluck sub-schemas out and re-marshal
+				// them individually with the hot-path encoder (sonic does not
+				// sort plain map keys).
+				plucked, err := Marshal(mustGet(t, om, "location"))
+				require.NoError(t, err)
+
+				if i == 0 {
+					firstFull, firstPlucked = full, plucked
+					continue
+				}
+				if !bytes.Equal(firstFull, full) {
+					t.Fatalf("iteration %d: full serialization diverged:\n first: %s\n later: %s", i, firstFull, full)
+				}
+				if !bytes.Equal(firstPlucked, plucked) {
+					t.Fatalf("iteration %d: plucked sub-schema serialization diverged:\n first: %s\n later: %s", i, firstPlucked, plucked)
+				}
+			}
+		})
+	}
+}
+
+func mustGet(t *testing.T, om *OrderedMap, key string) interface{} {
+	t.Helper()
+	v, ok := om.Get(key)
+	require.True(t, ok, "key %q missing from extracted map", key)
+	return v
+}
+
+// TestToolFunctionParametersFromMapSourceByteStable pins the tools payload
+// round-trip from #6591: schemas extracted from plain maps, embedded in
+// ToolFunctionParameters (the wire type for both Chat function tools and the
+// Anthropic input_schema), must marshal byte-identically across repeated
+// conversions of the same source.
+func TestToolFunctionParametersFromMapSourceByteStable(t *testing.T) {
+	const iterations = 50
+	var first []byte
+	for i := 0; i < iterations; i++ {
+		props, ok := SafeExtractOrderedMap(buildToolPropertiesFixture())
+		require.True(t, ok)
+		items, ok := SafeExtractOrderedMap(map[string]interface{}{
+			"type": "integer", "minimum": float64(0), "description": "forecast day"})
+		require.True(t, ok)
+
+		params := &ToolFunctionParameters{
+			Type:       "object",
+			Properties: props,
+			Items:      items,
+			Required:   []string{"location"},
+		}
+		b, err := Marshal(params)
+		require.NoError(t, err)
+
+		if i == 0 {
+			first = b
+			continue
+		}
+		if !bytes.Equal(first, b) {
+			t.Fatalf("iteration %d: tools payload serialization diverged:\n first: %s\n later: %s", i, first, b)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Requests carrying a non-trivial `tools` array could serialize non-deterministically, breaking upstream prefix-based prompt caching (#6591, regression of #3362). `SafeExtractOrderedMap` (`core/schemas/utils.go`) converted plain-map inputs with a bare `OrderedMapFromMap`, which orders the top-level keys but leaves every nested object as a plain Go `map[string]interface{}`. Any consumer that re-marshals those nested values through the hot-path encoder (sonic does not sort plain map keys — the exact hazard AGENTS.md calls out for prompt-cache byte stability), or that reads key order out of the extracted tree, observes Go's undefined map iteration order: byte layout differs call to call and the provider-side cache prefix diverges at the tools block.

The equivalent conversions in `core/schemas/chatcompletions.go` (`ToolFunctionParameters.Normalized()`) are already guarded — plain-map schema fragments there go through `OrderedMapFromMap(m).SortedCopyPreservingProperties()` ("convert and sort since we can't preserve an order that doesn't exist"). This PR applies the same guard at the two unguarded call sites in `SafeExtractOrderedMap`, so map-sourced schema fragments come out as fully ordered trees at every nesting level: structural keys in JSON-Schema priority order, other keys sorted, and nested `*OrderedMap` values under `properties` keeping their meaningful order where one exists.

## Changes

- `core/schemas/utils.go`: guard both plain-map branches of `SafeExtractOrderedMap` (`map[string]interface{}` and `*map[string]interface{}`) with `.SortedCopyPreservingProperties()`, matching the guarded pattern in `chatcompletions.go`; document the ordering contract on the function. The `*OrderedMap` / `OrderedMap` / `json.RawMessage` branches are untouched — order that came from a JSON document is preserved exactly as before.
- `core/schemas/utils_test.go`: regression tests (red before green):
  - `TestSafeExtractOrderedMapToolSchemaDeterminism` — extracts a 6-property tool `properties` fragment (with a nested object property) from a plain map and from a `*map`, 50 iterations each, asserting (a) no plain maps survive at any nesting level and (b) both the full fragment and a plucked sub-schema marshal byte-identically. **Failed before the fix** with `properties.days: nested value is map[string]interface {}; plain maps serialize in random key order — want *OrderedMap`; passes after.
  - `TestToolFunctionParametersFromMapSourceByteStable` — pins the tools payload contract end to end: schemas extracted from plain maps, embedded in `ToolFunctionParameters` (the wire type for Chat function tools and the Anthropic `input_schema`), marshal byte-identically across 50 repeated conversions.
- `core/providers/gemini/gemini_test.go`: `ParseChatResponseFormat` extracts `response_format` through `SafeExtractOrderedMap`, so map-sourced schemas now reach Gemini normalization as ordered trees (previously the nested `json_schema.schema` survived as a plain map and was re-marshaled with unsorted keys — the same nondeterminism class this PR fixes). The conversion code already handles `*OrderedMap` end to end (`normalizeSchemaValueForGemini`, `buildOpenAIResponseFormat`); the `JSONSchemaWithUnionTypes_ConvertedToAnyOf` subtest, which pinned the old top-level dynamic type with bare `.(map[string]interface{})` assertions, now validates through the suite's existing `asPlainMap` helper — exactly like its sibling subtest `JSONSchemaWithNullableType_KeptAsArray`.
- Deliberately not changed: the provider-local bare `OrderedMapFromMap` calls in `core/providers/gemini/utils.go` (`convertSchemaToMap`) and `core/providers/bedrock/utils.go` (`toOrderedMap`). Both are compensated at marshal time (`OrderedMap.appendJSON` routes plain nested values through `MarshalSorted`) and sit on provider-specific paths outside this issue's scope.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
GOWORK=off go test ./schemas/ -run 'TestSafeExtractOrderedMapToolSchemaDeterminism|TestToolFunctionParametersFromMapSourceByteStable' -count=1 -v
GOWORK=off go build ./... && GOWORK=off go test ./schemas/... -count=1
GOWORK=off go test ./providers/gemini/ -count=1
```

Before the fix, the determinism test fails on both input shapes:

```
--- FAIL: TestSafeExtractOrderedMapToolSchemaDeterminism (0.00s)
    --- FAIL: TestSafeExtractOrderedMapToolSchemaDeterminism/map (0.00s)
    --- FAIL: TestSafeExtractOrderedMapToolSchemaDeterminism/pointer-to-map (0.00s)
        utils_test.go:219: properties.days: nested value is map[string]interface {}; plain maps serialize in random key order — want *OrderedMap
```

After the fix, all tests pass, `go build ./...` is clean, and the full `./schemas/...` package passes.

## Screenshots/Recordings

N/A (no UI changes).

## Breaking changes

None. Plain-map inputs had no defined order to begin with (Go map iteration order is undefined), so emitting them fully sorted only replaces randomness with determinism; callers cannot have depended on the previous order. JSON-document-sourced inputs (`json.RawMessage`, `*OrderedMap`) keep their original key order exactly as before.

Provider-harness note (stating the exemption explicitly per AGENTS.md): this change adds or removes no wire field and changes no reachable behavior other than making the byte order of map-sourced tool-schema fragments deterministic. The regression is "N identical requests serialize to different bytes", which a single request/response harness fixture cannot express; the byte-stability contract is pinned by the unit tests above.

## Related issues

Fixes #6591

## Security considerations

None.
