### PR TITLE
feat: add fallback UI for vk creation page for AP-managed VKs

### DIFF
--- a/ui/app/_fallbacks/enterprise/lib/store/apis/accessProfileApi.ts
+++ b/ui/app/_fallbacks/enterprise/lib/store/apis/accessProfileApi.ts
@@ -1,4 +1,4 @@
-import { GetUserAccessProfilesResponse } from "@enterprise/lib/types/accessProfile";
+import { GetUserAccessProfilesResponse, VKCreationPolicyResponse } from "@enterprise/lib/types/accessProfile";
 
 // OSS build has no access-profile backend — return undefined data so consumers
 // (e.g. useVirtualKeyUsage) fall back to VK-owned budget/rate-limit values.
@@ -7,6 +7,23 @@ export const useGetUserAccessProfilesQuery = (
 	_opts?: { skip?: boolean; pollingInterval?: number },
 ): {
 	data: GetUserAccessProfilesResponse | undefined;
+	isLoading: boolean;
+	isError: boolean;
+	error: null;
+} => ({
+	data: undefined,
+	isLoading: false,
+	isError: false,
+	error: null,
+});
+
+// OSS build has no access-profile backend — returns undefined so the create form
+// never locks (governed stays falsy).
+export const useGetMyVKCreationPolicyQuery = (
+	_arg?: void,
+	_opts?: { skip?: boolean; refetchOnMountOrArgChange?: boolean },
+): {
+	data: VKCreationPolicyResponse | undefined;
 	isLoading: boolean;
 	isError: boolean;
 	error: null;

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -61,6 +61,7 @@ import {
 } from "@/lib/utils/governance";
 import ManagedVirtualKeyActions from "@enterprise/components/access-profiles/managedVirtualKeyActions";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { useGetMyVKCreationPolicyQuery } from "@enterprise/lib/store/apis/accessProfileApi";
 import { useAttachVirtualKeyUsersMutation, useDetachVirtualKeyUserMutation } from "@enterprise/lib/store/apis/virtualKeyUsersApi";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigate } from "@tanstack/react-router";
@@ -302,7 +303,14 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 	// Detect AP-managed status via the managing profile's virtual_key_ids, not just by the presence
 	// of assignees — directly-attached users don't imply an access-profile relation.
 	const { assignedUsers, isManagedByProfile: isManagedByProfileHook, managingProfile } = useVirtualKeyUsage(virtualKey);
-	const isManagedByProfile = isEditing && isManagedByProfileHook;
+	// On create, check whether the user's access profile will govern the new VK. If so,
+	// lock the governance fields up front — the server applies the profile regardless.
+	const { data: vkCreationPolicy } = useGetMyVKCreationPolicyQuery(undefined, {
+		skip: isEditing,
+		refetchOnMountOrArgChange: true,
+	});
+	const willBeGovernedOnCreate = !isEditing && !!vkCreationPolicy?.governed;
+	const isManagedByProfile = (isEditing && isManagedByProfileHook) || willBeGovernedOnCreate;
 	// User assignment is enterprise-only: OSS registers no picker, so the option stays hidden.
 	const UserPicker = getUserPicker();
 	// A VK can have at most one user (enforced by a unique index server-side).
@@ -1073,11 +1081,27 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 									<Alert variant="info">
 										<Lock className="h-4 w-4" />
 										<AlertDescription>
-											This virtual key is managed by an access profile. Only the name and description can be modified; providers, budgets,
-											rate limits, and MCP access are controlled by the profile.
+											{isEditing ? (
+												<>
+													This virtual key is managed by an access profile. Only the name and description can be modified; providers,
+													budgets, rate limits, and MCP access are controlled by the profile.
+												</>
+											) : (
+												<>
+													This virtual key will be managed by your access profile
+													{vkCreationPolicy?.profile_name ? (
+														<>
+															{" "}
+															<span className="font-medium">{vkCreationPolicy.profile_name}</span>
+														</>
+													) : null}
+													. Set a name and description; providers, budgets, rate limits, and MCP access are applied from the profile on
+													creation.
+												</>
+											)}
 										</AlertDescription>
 									</Alert>
-									<ManagedVirtualKeyActions managingProfile={managingProfile} />
+									{isEditing && <ManagedVirtualKeyActions managingProfile={managingProfile} />}
 								</>
 							)}
 


### PR DESCRIPTION
## Summary

When a user's access profile is configured to govern newly created virtual keys, the creation form previously had no awareness of this — the server would silently apply the profile's constraints after submission. This PR surfaces that governance state up front by fetching the user's VK creation policy before the form is submitted, locking the governed fields and displaying an informative banner so users understand what the profile will control.

## Changes

- Added `useGetMyVKCreationPolicyQuery` to the OSS fallback API, returning `undefined` so the create form never locks in non-enterprise builds.
- On the virtual key create form, `useGetMyVKCreationPolicyQuery` is called (skipped when editing) to determine if the new key will be governed by an access profile.
- `isManagedByProfile` now also evaluates `willBeGovernedOnCreate`, causing governance fields to lock during creation when applicable.
- The managed-key alert banner now renders context-aware messaging: on edit it shows the existing copy, and on create it explains that the profile will be applied at creation time, optionally displaying the profile name.
- `ManagedVirtualKeyActions` is only rendered when editing, since there is no managing profile object available during creation.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Configure an access profile that governs virtual key creation for a user.
2. Navigate to the virtual key creation form as that user.
3. Verify the governance fields (providers, budgets, rate limits, MCP access) are locked.
4. Verify the banner displays the correct profile name and creation-time messaging.
5. As a user without a governing access profile, verify the create form is fully editable and no banner appears.
6. Open an existing managed virtual key and verify the edit banner and `ManagedVirtualKeyActions` still render correctly.

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

Before: No banner or field locking on the create form, even when an access profile would govern the new key.

After: Governance fields are locked and a banner reads: _"This virtual key will be managed by your access profile **[Profile Name]**. Set a name and description; providers, budgets, rate limits, and MCP access are applied from the profile on creation."_

## Breaking changes

- [x] No

## Related issues

## Security considerations

No new auth surfaces introduced. The creation policy is fetched for the currently authenticated user only, consistent with existing access profile query patterns.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable