### PR TITLE
feat: add proxy to enterprise plugin skip list

### DIFF
--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -65,6 +65,7 @@ var enterprisePlugins = []string{
 	"bigquery",
 	"pubsub",
 	"kafka",
+	"proxy",
 }
 
 // ServerCallbacks is a interface that defines the callbacks for the server.


### PR DESCRIPTION
## Summary

Adds `proxy` to the list of enterprise plugins recognized by the Bifrost HTTP server.

## Changes

- Added `"proxy"` to the `enterprisePlugins` slice in `transports/bifrost-http/server/server.go`, enabling the proxy plugin to be treated as an enterprise-tier plugin alongside existing ones like `bigquery`, `pubsub`, and `kafka`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/...
```

Verify that the proxy plugin is correctly gated as an enterprise plugin and behaves consistently with other enterprise plugins such as `kafka` and `pubsub`.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The proxy plugin will now be subject to enterprise-level access controls, which may restrict its availability to non-enterprise users. Ensure any existing deployments relying on the proxy plugin have the appropriate enterprise licensing in place.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable