### PR TITLE
feat(ui): add canary setup settings section

### DIFF
--- a/ui/app/_fallbacks/enterprise/components/canary/canarySetupView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/canary/canarySetupView.tsx
@@ -1,0 +1,22 @@
+import { Split } from "lucide-react";
+import ContactUsView from "../views/contactUsView";
+
+export default function CanarySetupView() {
+	return (
+		<div className="space-y-6">
+			{/* Content - OSS: paywall only */}
+			<div className="space-y-4">
+				<div className="flex w-full flex-col items-center justify-center py-8">
+					<ContactUsView
+						align="middle"
+						className="mx-auto w-full max-w-lg"
+						icon={<Split className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
+						title="Unlock canary deployments for safe rollouts"
+						description="Forward a configurable share of live traffic to a second Bifrost deployment to validate new versions before full rollout. This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
+						readmeLink="https://docs.getbifrost.ai/enterprise/canary-deployments"
+					/>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/ui/app/workspace/config/canary/layout.tsx
+++ b/ui/app/workspace/config/canary/layout.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import CanaryPage from "./page";
+
+export const Route = createFileRoute("/workspace/config/canary")({
+	component: CanaryPage,
+});

--- a/ui/app/workspace/config/canary/page.tsx
+++ b/ui/app/workspace/config/canary/page.tsx
@@ -1,0 +1,24 @@
+import { IS_ENTERPRISE } from "@/lib/constants/config";
+import CanarySetupView from "@enterprise/components/canary/canarySetupView";
+import { useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
+
+export default function CanaryPage() {
+	const navigate = useNavigate();
+
+	useEffect(() => {
+		if (!IS_ENTERPRISE) {
+			navigate({ to: "/workspace/config/client-settings", replace: true });
+		}
+	}, [navigate]);
+
+	if (!IS_ENTERPRISE) {
+		return null;
+	}
+
+	return (
+		<div className="mx-auto flex w-full max-w-7xl px-4 md:px-0">
+			<CanarySetupView />
+		</div>
+	);
+}

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -40,6 +40,7 @@ import {
 	ShieldCheck,
 	Shuffle,
 	Siren,
+	Split,
 	SlidersHorizontal,
 	Telescope,
 	ToolCase,
@@ -1018,6 +1019,13 @@ export default function AppSidebar() {
 									url: "/workspace/config/proxy",
 									icon: Globe,
 									description: "Proxy configuration",
+									hasAccess: hasSettingsAccess,
+								},
+								{
+									title: "Canary Setup",
+									url: "/workspace/config/canary",
+									icon: Split,
+									description: "Canary deployment traffic forwarding",
 									hasAccess: hasSettingsAccess,
 								},
 							]


### PR DESCRIPTION
## Summary

Adds a Canary Setup page to the workspace configuration section, enabling enterprise users to configure canary deployments for traffic splitting. Non-enterprise builds are redirected away from this route and shown a paywall/contact view instead.

## Changes

- Added a new `/workspace/config/canary` route and page that renders the `CanarySetupView` enterprise component
- Added an OSS fallback `CanarySetupView` that displays a paywall/contact prompt with a link to the canary deployments documentation
- Non-enterprise builds are redirected to `/workspace/config/client-settings` when attempting to access the canary route
- Added a "Canary Setup" entry to the sidebar under the config section with the `Split` icon

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

1. Navigate to `/workspace/config/canary` in a non-enterprise build — verify you are redirected to `/workspace/config/client-settings`.
2. In an enterprise build, navigate to `/workspace/config/canary` — verify the Canary Setup view renders correctly.
3. Confirm the "Canary Setup" entry appears in the sidebar under the config section for users with settings access.

## Screenshots/Recordings

_Add before/after screenshots of the sidebar and the Canary Setup page._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The canary route is gated behind both the `IS_ENTERPRISE` flag and the existing `hasSettingsAccess` permission check, ensuring only authorized enterprise users can access the configuration.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable