### PR TITLE
feat: honor UseRawRequestBody flag on native inference routes

### DIFF
--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -965,6 +965,22 @@ func prepareTextCompletionRequest(ctx *fasthttp.RequestCtx, config *lib.Config) 
 }
 
 // textCompletion handles POST /v1/completions - Process text completion requests
+// rawBodyForPlugins returns the request body when a transport plugin asked
+// for the raw payload to be carried on the bifrost request via
+// BifrostContextKeyUseRawRequestBody, mirroring the integrations router
+// (see GenericRouter's raw body attach). It returns nil otherwise, so
+// assigning the result to a request's RawRequestBody is a no-op for
+// requests no plugin marked.
+func rawBodyForPlugins(bifrostCtx *schemas.BifrostContext, ctx *fasthttp.RequestCtx) []byte {
+	if bifrostCtx == nil {
+		return nil
+	}
+	if carry, ok := bifrostCtx.Value(schemas.BifrostContextKeyUseRawRequestBody).(bool); ok && carry {
+		return ctx.PostBody()
+	}
+	return nil
+}
+
 func (h *CompletionHandler) textCompletion(ctx *fasthttp.RequestCtx) {
 	req, bifrostTextReq, err := prepareTextCompletionRequest(ctx, h.config)
 	if err != nil {
@@ -976,6 +992,7 @@ func (h *CompletionHandler) textCompletion(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
 		return
 	}
+	bifrostTextReq.RawRequestBody = rawBodyForPlugins(bifrostCtx, ctx)
 	if req.Stream != nil && *req.Stream {
 		h.handleStreamingTextCompletion(ctx, bifrostTextReq, bifrostCtx, cancel)
 		return
@@ -1059,6 +1076,7 @@ func (h *CompletionHandler) chatCompletion(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
 		return
 	}
+	bifrostChatReq.RawRequestBody = rawBodyForPlugins(bifrostCtx, ctx)
 	if effectiveStream(req.Stream) {
 		h.handleStreamingChatCompletion(ctx, bifrostChatReq, bifrostCtx, cancel)
 		return
@@ -1133,6 +1151,7 @@ func (h *CompletionHandler) responses(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
+	bifrostResponsesReq.RawRequestBody = rawBodyForPlugins(bifrostCtx, ctx)
 	if effectiveStream(req.Stream) {
 		h.handleStreamingResponses(ctx, bifrostResponsesReq, bifrostCtx, cancel)
 		return
@@ -1194,6 +1213,7 @@ func (h *CompletionHandler) embeddings(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
+	bifrostEmbeddingReq.RawRequestBody = rawBodyForPlugins(bifrostCtx, ctx)
 	resp, bifrostErr := h.client.EmbeddingRequest(bifrostCtx, bifrostEmbeddingReq)
 	if bifrostErr != nil {
 		forwardProviderHeadersFromContext(ctx, bifrostCtx)


### PR DESCRIPTION
## Summary

Transport plugins that set `BifrostContextKeyUseRawRequestBody` were not having the raw request body attached to bifrost requests in the HTTP transport, unlike the integrations router which already handled this. This PR brings the HTTP transport into parity by attaching the raw body for all four endpoint types when a plugin has requested it.

## Changes

- Introduced `rawBodyForPlugins`, a helper that checks whether a plugin flagged the request via `BifrostContextKeyUseRawRequestBody` and, if so, returns the raw POST body from the fasthttp context. Returns `nil` otherwise, making the assignment a no-op for unmarked requests.
- Applied `rawBodyForPlugins` to set `RawRequestBody` on bifrost requests for text completions, chat completions, responses, and embeddings endpoints, matching the behaviour already present in the integrations (`GenericRouter`) path.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Register a transport plugin that sets `BifrostContextKeyUseRawRequestBody = true` on the bifrost context, then send requests to `/v1/completions`, `/v1/chat/completions`, `/v1/responses`, and `/v1/embeddings`. Verify that `RawRequestBody` on the bifrost request is populated with the original payload body inside the plugin's handler.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The raw body is only forwarded when a plugin explicitly opts in via `BifrostContextKeyUseRawRequestBody`. No raw body data is exposed by default.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable