### PR TITLE
fix: connectors test fixes

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6345,73 +6345,7 @@ func executeRequestWithRetries[T any](
 		span.SetAttribute(schemas.AttrOperationName, otelOp)
 		span.SetAttribute(schemas.AttrLegacyRequestType, string(requestType))
 
-		// Add context-related attributes (selected key, virtual key, team, customer, etc.)
-		if selectedKeyID, ok := ctx.Value(schemas.BifrostContextKeySelectedKeyID).(string); ok && selectedKeyID != "" {
-			span.SetAttribute(schemas.AttrBifrostSelectedKeyID, selectedKeyID)
-		}
-		if selectedKeyName, ok := ctx.Value(schemas.BifrostContextKeySelectedKeyName).(string); ok && selectedKeyName != "" {
-			span.SetAttribute(schemas.AttrBifrostSelectedKeyName, selectedKeyName)
-		}
-		if virtualKeyID, ok := ctx.Value(schemas.BifrostContextKeyGovernanceVirtualKeyID).(string); ok && virtualKeyID != "" {
-			span.SetAttribute(schemas.AttrBifrostVirtualKeyID, virtualKeyID)
-		}
-		if virtualKeyName, ok := ctx.Value(schemas.BifrostContextKeyGovernanceVirtualKeyName).(string); ok && virtualKeyName != "" {
-			span.SetAttribute(schemas.AttrBifrostVirtualKeyName, virtualKeyName)
-		}
-		if teamID, ok := ctx.Value(schemas.BifrostContextKeyGovernanceTeamID).(string); ok && teamID != "" {
-			span.SetAttribute(schemas.AttrBifrostTeamID, teamID)
-		}
-		if teamName, ok := ctx.Value(schemas.BifrostContextKeyGovernanceTeamName).(string); ok && teamName != "" {
-			span.SetAttribute(schemas.AttrBifrostTeamName, teamName)
-		}
-		if customerID, ok := ctx.Value(schemas.BifrostContextKeyGovernanceCustomerID).(string); ok && customerID != "" {
-			span.SetAttribute(schemas.AttrBifrostCustomerID, customerID)
-		}
-		if customerName, ok := ctx.Value(schemas.BifrostContextKeyGovernanceCustomerName).(string); ok && customerName != "" {
-			span.SetAttribute(schemas.AttrBifrostCustomerName, customerName)
-		}
-		if businessUnitID, ok := ctx.Value(schemas.BifrostContextKeyGovernanceBusinessUnitID).(string); ok && businessUnitID != "" {
-			span.SetAttribute(schemas.AttrBifrostBusinessUnitID, businessUnitID)
-		}
-		if businessUnitName, ok := ctx.Value(schemas.BifrostContextKeyGovernanceBusinessUnitName).(string); ok && businessUnitName != "" {
-			span.SetAttribute(schemas.AttrBifrostBusinessUnitName, businessUnitName)
-		}
-		if projectID, ok := ctx.Value(schemas.BifrostContextKeyGovernanceProjectID).(string); ok && projectID != "" {
-			span.SetAttribute(schemas.AttrBifrostProjectID, projectID)
-		}
-		if projectName, ok := ctx.Value(schemas.BifrostContextKeyGovernanceProjectName).(string); ok && projectName != "" {
-			span.SetAttribute(schemas.AttrBifrostProjectName, projectName)
-		}
-		if teamIDs, ok := ctx.Value(schemas.BifrostContextKeyGovernanceTeamIDs).([]string); ok && len(teamIDs) > 0 {
-			span.SetAttribute(schemas.AttrBifrostTeamIDs, teamIDs)
-		}
-		if teamNames, ok := ctx.Value(schemas.BifrostContextKeyGovernanceTeamNames).([]string); ok && len(teamNames) > 0 {
-			span.SetAttribute(schemas.AttrBifrostTeamNames, teamNames)
-		}
-		if customerIDs, ok := ctx.Value(schemas.BifrostContextKeyGovernanceCustomerIDs).([]string); ok && len(customerIDs) > 0 {
-			span.SetAttribute(schemas.AttrBifrostCustomerIDs, customerIDs)
-		}
-		if customerNames, ok := ctx.Value(schemas.BifrostContextKeyGovernanceCustomerNames).([]string); ok && len(customerNames) > 0 {
-			span.SetAttribute(schemas.AttrBifrostCustomerNames, customerNames)
-		}
-		if businessUnitIDs, ok := ctx.Value(schemas.BifrostContextKeyGovernanceBusinessUnitIDs).([]string); ok && len(businessUnitIDs) > 0 {
-			span.SetAttribute(schemas.AttrBifrostBusinessUnitIDs, businessUnitIDs)
-		}
-		if businessUnitNames, ok := ctx.Value(schemas.BifrostContextKeyGovernanceBusinessUnitNames).([]string); ok && len(businessUnitNames) > 0 {
-			span.SetAttribute(schemas.AttrBifrostBusinessUnitNames, businessUnitNames)
-		}
-		if userID, ok := ctx.Value(schemas.BifrostContextKeyUserID).(string); ok && userID != "" {
-			span.SetAttribute(schemas.AttrBifrostUserID, userID)
-		}
-		if userName, ok := ctx.Value(schemas.BifrostContextKeyUserName).(string); ok && userName != "" {
-			span.SetAttribute(schemas.AttrBifrostUserName, userName)
-		}
-		if userEmail, ok := ctx.Value(schemas.BifrostContextKeyUserEmail).(string); ok && userEmail != "" {
-			span.SetAttribute(schemas.AttrBifrostUserEmail, userEmail)
-		}
-		if fallbackIndex, ok := ctx.Value(schemas.BifrostContextKeyFallbackIndex).(int); ok {
-			span.SetAttribute(schemas.AttrBifrostFallbackIndex, fallbackIndex)
-		}
+		applyContextSpanAttributes(span, ctx)
 		span.SetAttribute(schemas.AttrBifrostRetries, attempts)
 
 		// Surface caller-supplied extra headers (from x-bf-eh-* and direct-allowlist

--- a/core/spanenrichment.go
+++ b/core/spanenrichment.go
@@ -1,0 +1,92 @@
+package bifrost
+
+import (
+	"context"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// applyContextSpanAttributes writes the governance / identity enrichment
+// attributes carried on ctx onto span. It is the single live emitter of the
+// context-sourced dimensions in schemas.EnrichmentDims (virtual key, selected
+// key, routing rule, team, customer, business unit, user, fallback index), so
+// TestContextSpanAttributesCoverRegistry pins this set to that registry: a
+// dimension cannot be added to the registry (and read by the curated connectors)
+// without being emitted here, and a renamed key surfaces as a mismatch.
+//
+// span.SetAttribute is nil-safe, so a nil span (e.g. NoOpTracer) makes this a
+// no-op with no branch at the call site.
+func applyContextSpanAttributes(span *schemas.Span, ctx context.Context) {
+	if selectedKeyID, ok := ctx.Value(schemas.BifrostContextKeySelectedKeyID).(string); ok && selectedKeyID != "" {
+		span.SetAttribute(schemas.AttrBifrostSelectedKeyID, selectedKeyID)
+	}
+	if selectedKeyName, ok := ctx.Value(schemas.BifrostContextKeySelectedKeyName).(string); ok && selectedKeyName != "" {
+		span.SetAttribute(schemas.AttrBifrostSelectedKeyName, selectedKeyName)
+	}
+	if virtualKeyID, ok := ctx.Value(schemas.BifrostContextKeyGovernanceVirtualKeyID).(string); ok && virtualKeyID != "" {
+		span.SetAttribute(schemas.AttrBifrostVirtualKeyID, virtualKeyID)
+	}
+	if virtualKeyName, ok := ctx.Value(schemas.BifrostContextKeyGovernanceVirtualKeyName).(string); ok && virtualKeyName != "" {
+		span.SetAttribute(schemas.AttrBifrostVirtualKeyName, virtualKeyName)
+	}
+	if routingRuleID, ok := ctx.Value(schemas.BifrostContextKeyGovernanceRoutingRuleID).(string); ok && routingRuleID != "" {
+		span.SetAttribute(schemas.AttrBifrostRoutingRuleID, routingRuleID)
+	}
+	if routingRuleName, ok := ctx.Value(schemas.BifrostContextKeyGovernanceRoutingRuleName).(string); ok && routingRuleName != "" {
+		span.SetAttribute(schemas.AttrBifrostRoutingRuleName, routingRuleName)
+	}
+	if teamID, ok := ctx.Value(schemas.BifrostContextKeyGovernanceTeamID).(string); ok && teamID != "" {
+		span.SetAttribute(schemas.AttrBifrostTeamID, teamID)
+	}
+	if teamName, ok := ctx.Value(schemas.BifrostContextKeyGovernanceTeamName).(string); ok && teamName != "" {
+		span.SetAttribute(schemas.AttrBifrostTeamName, teamName)
+	}
+	if customerID, ok := ctx.Value(schemas.BifrostContextKeyGovernanceCustomerID).(string); ok && customerID != "" {
+		span.SetAttribute(schemas.AttrBifrostCustomerID, customerID)
+	}
+	if customerName, ok := ctx.Value(schemas.BifrostContextKeyGovernanceCustomerName).(string); ok && customerName != "" {
+		span.SetAttribute(schemas.AttrBifrostCustomerName, customerName)
+	}
+	if businessUnitID, ok := ctx.Value(schemas.BifrostContextKeyGovernanceBusinessUnitID).(string); ok && businessUnitID != "" {
+		span.SetAttribute(schemas.AttrBifrostBusinessUnitID, businessUnitID)
+	}
+	if businessUnitName, ok := ctx.Value(schemas.BifrostContextKeyGovernanceBusinessUnitName).(string); ok && businessUnitName != "" {
+		span.SetAttribute(schemas.AttrBifrostBusinessUnitName, businessUnitName)
+	}
+	if projectId, ok := ctx.Value(schemas.BifrostContextKeyGovernanceProjectID).(string); ok && projectId != "" {
+		span.SetAttribute(schemas.AttrBifrostProjectID, projectId)
+	}
+	if projectName, ok := ctx.Value(schemas.BifrostContextKeyGovernanceProjectName).(string); ok && projectName != "" {
+		span.SetAttribute(schemas.AttrBifrostProjectName, projectName)
+	}
+	if teamIDs, ok := ctx.Value(schemas.BifrostContextKeyGovernanceTeamIDs).([]string); ok && len(teamIDs) > 0 {
+		span.SetAttribute(schemas.AttrBifrostTeamIDs, teamIDs)
+	}
+	if teamNames, ok := ctx.Value(schemas.BifrostContextKeyGovernanceTeamNames).([]string); ok && len(teamNames) > 0 {
+		span.SetAttribute(schemas.AttrBifrostTeamNames, teamNames)
+	}
+	if customerIDs, ok := ctx.Value(schemas.BifrostContextKeyGovernanceCustomerIDs).([]string); ok && len(customerIDs) > 0 {
+		span.SetAttribute(schemas.AttrBifrostCustomerIDs, customerIDs)
+	}
+	if customerNames, ok := ctx.Value(schemas.BifrostContextKeyGovernanceCustomerNames).([]string); ok && len(customerNames) > 0 {
+		span.SetAttribute(schemas.AttrBifrostCustomerNames, customerNames)
+	}
+	if businessUnitIDs, ok := ctx.Value(schemas.BifrostContextKeyGovernanceBusinessUnitIDs).([]string); ok && len(businessUnitIDs) > 0 {
+		span.SetAttribute(schemas.AttrBifrostBusinessUnitIDs, businessUnitIDs)
+	}
+	if businessUnitNames, ok := ctx.Value(schemas.BifrostContextKeyGovernanceBusinessUnitNames).([]string); ok && len(businessUnitNames) > 0 {
+		span.SetAttribute(schemas.AttrBifrostBusinessUnitNames, businessUnitNames)
+	}
+	if userID, ok := ctx.Value(schemas.BifrostContextKeyUserID).(string); ok && userID != "" {
+		span.SetAttribute(schemas.AttrBifrostUserID, userID)
+	}
+	if userName, ok := ctx.Value(schemas.BifrostContextKeyUserName).(string); ok && userName != "" {
+		span.SetAttribute(schemas.AttrBifrostUserName, userName)
+	}
+	if userEmail, ok := ctx.Value(schemas.BifrostContextKeyUserEmail).(string); ok && userEmail != "" {
+		span.SetAttribute(schemas.AttrBifrostUserEmail, userEmail)
+	}
+	if fallbackIndex, ok := ctx.Value(schemas.BifrostContextKeyFallbackIndex).(int); ok {
+		span.SetAttribute(schemas.AttrBifrostFallbackIndex, fallbackIndex)
+	}
+}

--- a/core/spanenrichment_test.go
+++ b/core/spanenrichment_test.go
@@ -1,0 +1,117 @@
+package bifrost
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// contextDimSources lists every enrichment dimension that applyContextSpanAttributes
+// is responsible for emitting, paired with the context key it reads from and a
+// distinct sentinel value. This is the emit-side counterpart to the connectors'
+// read-side parity tests: it pins the live span emission to schemas.EnrichmentDims
+// so a dimension cannot be added to the registry (and read by BigQuery/Datadog/
+// Splunk) without also being emitted here.
+var contextDimSources = []struct {
+	spanAttr string
+	ctxKey   schemas.BifrostContextKey
+	value    any
+}{
+	{schemas.AttrBifrostSelectedKeyID, schemas.BifrostContextKeySelectedKeyID, "sel-key-id"},
+	{schemas.AttrBifrostSelectedKeyName, schemas.BifrostContextKeySelectedKeyName, "sel-key-name"},
+	{schemas.AttrBifrostVirtualKeyID, schemas.BifrostContextKeyGovernanceVirtualKeyID, "vk-id"},
+	{schemas.AttrBifrostVirtualKeyName, schemas.BifrostContextKeyGovernanceVirtualKeyName, "vk-name"},
+	{schemas.AttrBifrostRoutingRuleID, schemas.BifrostContextKeyGovernanceRoutingRuleID, "rr-id"},
+	{schemas.AttrBifrostRoutingRuleName, schemas.BifrostContextKeyGovernanceRoutingRuleName, "rr-name"},
+	{schemas.AttrBifrostTeamID, schemas.BifrostContextKeyGovernanceTeamID, "team-id"},
+	{schemas.AttrBifrostTeamName, schemas.BifrostContextKeyGovernanceTeamName, "team-name"},
+	{schemas.AttrBifrostCustomerID, schemas.BifrostContextKeyGovernanceCustomerID, "cust-id"},
+	{schemas.AttrBifrostCustomerName, schemas.BifrostContextKeyGovernanceCustomerName, "cust-name"},
+	{schemas.AttrBifrostBusinessUnitID, schemas.BifrostContextKeyGovernanceBusinessUnitID, "bu-id"},
+	{schemas.AttrBifrostBusinessUnitName, schemas.BifrostContextKeyGovernanceBusinessUnitName, "bu-name"},
+	{schemas.AttrBifrostTeamIDs, schemas.BifrostContextKeyGovernanceTeamIDs, []string{"team-id-1", "team-id-2"}},
+	{schemas.AttrBifrostTeamNames, schemas.BifrostContextKeyGovernanceTeamNames, []string{"team-name-1"}},
+	{schemas.AttrBifrostCustomerIDs, schemas.BifrostContextKeyGovernanceCustomerIDs, []string{"cust-id-1"}},
+	{schemas.AttrBifrostCustomerNames, schemas.BifrostContextKeyGovernanceCustomerNames, []string{"cust-name-1"}},
+	{schemas.AttrBifrostBusinessUnitIDs, schemas.BifrostContextKeyGovernanceBusinessUnitIDs, []string{"bu-id-1"}},
+	{schemas.AttrBifrostBusinessUnitNames, schemas.BifrostContextKeyGovernanceBusinessUnitNames, []string{"bu-name-1"}},
+	{schemas.AttrBifrostUserID, schemas.BifrostContextKeyUserID, "user-id"},
+	{schemas.AttrBifrostUserName, schemas.BifrostContextKeyUserName, "user-name"},
+	{schemas.AttrBifrostUserEmail, schemas.BifrostContextKeyUserEmail, "user@example.com"},
+	{schemas.AttrBifrostFallbackIndex, schemas.BifrostContextKeyFallbackIndex, 2},
+}
+
+// dimsEmittedElsewhere are registry dimensions NOT emitted by
+// applyContextSpanAttributes: request-sourced ones written at span creation, and
+// framework-field-sourced ones written in framework/tracing from ExtractedFields.
+// Listed so the completeness check can account for every registry dimension; the
+// value records where each is actually emitted.
+var dimsEmittedElsewhere = map[string]string{
+	schemas.AttrBifrostProviderName:      "request-sourced: span creation in bifrost.go",
+	schemas.AttrRequestModel:             "request-sourced: span creation in bifrost.go",
+	schemas.AttrLegacyRequestType:        "request-sourced: span creation in bifrost.go",
+	schemas.AttrBifrostAlias:             "framework ExtractedFields: framework/tracing/tracer.go",
+	schemas.AttrBifrostRoutingEngineUsed: "framework ExtractedFields: framework/tracing/tracer.go",
+}
+
+// TestContextSpanAttributesEmit drives applyContextSpanAttributes with every
+// context key populated and asserts each dimension lands on the span under its
+// canonical SpanAttr with the exact value. A dead emit (a dim dropped from the
+// helper) fails as a missing attribute; a mis-wired read (wrong context key)
+// fails as a wrong/missing value, since every sentinel is distinct.
+func TestContextSpanAttributesEmit(t *testing.T) {
+	ctx := context.Background()
+	for _, d := range contextDimSources {
+		ctx = context.WithValue(ctx, d.ctxKey, d.value)
+	}
+
+	span := &schemas.Span{}
+	applyContextSpanAttributes(span, ctx)
+
+	for _, d := range contextDimSources {
+		got, ok := span.Attributes[d.spanAttr]
+		if !ok {
+			t.Errorf("span attribute %q was not emitted (context key %q)", d.spanAttr, d.ctxKey)
+			continue
+		}
+		if !reflect.DeepEqual(got, d.value) {
+			t.Errorf("span attribute %q = %v (%T), want %v (%T)", d.spanAttr, got, got, d.value, d.value)
+		}
+	}
+}
+
+// TestEnrichmentRegistryDimsAllEmitted is the drift guard: every dimension in the
+// canonical registry must be accounted for as emitted somewhere — either by
+// applyContextSpanAttributes (contextDimSources) or in dimsEmittedElsewhere.
+// Adding a dimension to schemas.EnrichmentDims (and thus to the connector
+// projections) without wiring its emission fails here. It also catches a stale
+// classification: a context source or "elsewhere" entry for a key no longer in
+// the registry.
+func TestEnrichmentRegistryDimsAllEmitted(t *testing.T) {
+	inContext := make(map[string]bool, len(contextDimSources))
+	for _, d := range contextDimSources {
+		inContext[d.spanAttr] = true
+	}
+	registry := make(map[string]bool)
+	for _, d := range schemas.EnrichmentDims {
+		registry[d.SpanAttr] = true
+		if !inContext[d.SpanAttr] {
+			if _, ok := dimsEmittedElsewhere[d.SpanAttr]; !ok {
+				t.Errorf("enrichment dim %q (%s) is not emitted: add it to applyContextSpanAttributes + contextDimSources, or document it in dimsEmittedElsewhere", d.Name, d.SpanAttr)
+			}
+		}
+	}
+	// Reverse: no stale classification entries for keys no longer in the registry.
+	for _, d := range contextDimSources {
+		if !registry[d.spanAttr] {
+			t.Errorf("contextDimSources references %q which is no longer in EnrichmentDims", d.spanAttr)
+		}
+	}
+	for attr := range dimsEmittedElsewhere {
+		if !registry[attr] {
+			t.Errorf("dimsEmittedElsewhere references %q which is no longer in EnrichmentDims", attr)
+		}
+	}
+}

--- a/tests/e2e/api/runners/run-observability-local.mjs
+++ b/tests/e2e/api/runners/run-observability-local.mjs
@@ -15,296 +15,319 @@ const streamErrorRequestID = `otel-e2e-stream-error-${process.pid}-${Date.now()}
 const ERROR_TRIGGER = "trigger-error";
 
 const state = {
-  otelTraceRequests: [],
-  otelMetricRequests: [],
-  mockRequests: [],
+	otelTraceRequests: [],
+	otelMetricRequests: [],
+	mockRequests: [],
 };
 
 function listen(server, host = "127.0.0.1") {
-  return new Promise((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, host, () => {
-      server.off("error", reject);
-      resolve(server.address().port);
-    });
-  });
+	return new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, host, () => {
+			server.off("error", reject);
+			resolve(server.address().port);
+		});
+	});
 }
 
 function close(server) {
-  return new Promise((resolve) => server.close(() => resolve()));
+	return new Promise((resolve) => server.close(() => resolve()));
 }
 
 function readBody(req) {
-  return new Promise((resolve, reject) => {
-    const chunks = [];
-    req.on("data", (chunk) => chunks.push(chunk));
-    req.on("end", () => resolve(Buffer.concat(chunks)));
-    req.on("error", reject);
-  });
+	return new Promise((resolve, reject) => {
+		const chunks = [];
+		req.on("data", (chunk) => chunks.push(chunk));
+		req.on("end", () => resolve(Buffer.concat(chunks)));
+		req.on("error", reject);
+	});
 }
 
 function createOtelReceiver() {
-  return http.createServer(async (req, res) => {
-    const body = await readBody(req);
-    if (req.method === "POST" && req.url === "/v1/traces") {
-      state.otelTraceRequests.push({
-        headers: req.headers,
-        bytes: body.length,
-        body,
-      });
-      res.writeHead(200, { "content-type": "application/x-protobuf" });
-      res.end("");
-      return;
-    }
-    if (req.method === "POST" && req.url === "/v1/metrics") {
-      state.otelMetricRequests.push({
-        headers: req.headers,
-        bytes: body.length,
-        body,
-      });
-      res.writeHead(200, { "content-type": "application/x-protobuf" });
-      res.end("");
-      return;
-    }
-    res.writeHead(404);
-    res.end("not found");
-  });
+	return http.createServer(async (req, res) => {
+		const body = await readBody(req);
+		if (req.method === "POST" && req.url === "/v1/traces") {
+			state.otelTraceRequests.push({
+				headers: req.headers,
+				bytes: body.length,
+				body,
+			});
+			res.writeHead(200, { "content-type": "application/x-protobuf" });
+			res.end("");
+			return;
+		}
+		if (req.method === "POST" && req.url === "/v1/metrics") {
+			state.otelMetricRequests.push({
+				headers: req.headers,
+				bytes: body.length,
+				body,
+			});
+			res.writeHead(200, { "content-type": "application/x-protobuf" });
+			res.end("");
+			return;
+		}
+		res.writeHead(404);
+		res.end("not found");
+	});
 }
 
 function createOpenAIMock() {
-  return http.createServer(async (req, res) => {
-    const body = await readBody(req);
-    if (req.method === "POST" && req.url === "/v1/chat/completions") {
-      state.mockRequests.push({
-        headers: req.headers,
-        body: body.toString("utf8"),
-      });
-      // Error scenarios: the trigger marker gets a provider-style 404, streaming
-      // or not — this is the pre-first-chunk failure path.
-      if (body.toString("utf8").includes(ERROR_TRIGGER)) {
-        res.writeHead(404, { "content-type": "application/json" });
-        res.end(JSON.stringify({
-          error: {
-            message: "The model does not exist",
-            type: "invalid_request_error",
-            code: "model_not_found",
-          },
-        }));
-        return;
-      }
-      const now = Math.floor(Date.now() / 1000);
-      res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify({
-        id: `chatcmpl-${now}`,
-        object: "chat.completion",
-        created: now,
-        model: modelName,
-        choices: [
-          {
-            index: 0,
-            message: {
-              role: "assistant",
-              content: "hello world",
-            },
-            finish_reason: "stop",
-          },
-        ],
-        usage: {
-          prompt_tokens: 2,
-          completion_tokens: 2,
-          total_tokens: 4,
-        },
-      }));
-      return;
-    }
-    res.writeHead(404);
-    res.end("not found");
-  });
+	return http.createServer(async (req, res) => {
+		const body = await readBody(req);
+		if (req.method === "POST" && req.url === "/v1/chat/completions") {
+			state.mockRequests.push({
+				headers: req.headers,
+				body: body.toString("utf8"),
+			});
+			// Error scenarios: the trigger marker gets a provider-style 404, streaming
+			// or not — this is the pre-first-chunk failure path.
+			if (body.toString("utf8").includes(ERROR_TRIGGER)) {
+				res.writeHead(404, { "content-type": "application/json" });
+				res.end(
+					JSON.stringify({
+						error: {
+							message: "The model does not exist",
+							type: "invalid_request_error",
+							code: "model_not_found",
+						},
+					}),
+				);
+				return;
+			}
+			const now = Math.floor(Date.now() / 1000);
+			res.writeHead(200, { "content-type": "application/json" });
+			res.end(
+				JSON.stringify({
+					id: `chatcmpl-${now}`,
+					object: "chat.completion",
+					created: now,
+					model: modelName,
+					choices: [
+						{
+							index: 0,
+							message: {
+								role: "assistant",
+								content: "hello world",
+							},
+							finish_reason: "stop",
+						},
+					],
+					usage: {
+						// Base counts sit above the cache detail below so no normalization
+						// treats a detail as an overflow. The cache detail is the point: it
+						// drives the OTEL exporter's read of the span cache attributes end to
+						// end, so a dead read (the exporter reading a key the framework no
+						// longer emits) shows up as a missing metric instead of passing
+						// silently. cached_tokens maps to cache_read and OpenAI's
+						// cache_write_tokens alias maps to cache_creation (see
+						// ChatPromptTokensDetails.UnmarshalJSON). Distinct values so a mis-wired
+						// read surfaces as the wrong number, not just a zero.
+						prompt_tokens: 30,
+						completion_tokens: 10,
+						total_tokens: 40,
+						prompt_tokens_details: { cached_tokens: 5, cache_write_tokens: 7 },
+					},
+				}),
+			);
+			return;
+		}
+		res.writeHead(404);
+		res.end("not found");
+	});
 }
 
 async function request(method, path, body, headers = {}) {
-  const requestHeaders = adminAuthHeader ? { Authorization: adminAuthHeader, ...headers } : { ...headers };
-  if (body !== undefined && requestHeaders["content-type"] === undefined && requestHeaders["Content-Type"] === undefined) {
-    requestHeaders["content-type"] = "application/json";
-  }
-  const res = await fetch(`${baseURL}${path}`, {
-    method,
-    headers: Object.keys(requestHeaders).length === 0 ? undefined : requestHeaders,
-    body: body === undefined ? undefined : JSON.stringify(body),
-  });
-  const text = await res.text();
-  let json = null;
-  if (text) {
-    try {
-      json = JSON.parse(text);
-    } catch {
-      json = null;
-    }
-  }
-  return { ok: res.ok, status: res.status, text, json };
+	const requestHeaders = adminAuthHeader ? { Authorization: adminAuthHeader, ...headers } : { ...headers };
+	if (body !== undefined && requestHeaders["content-type"] === undefined && requestHeaders["Content-Type"] === undefined) {
+		requestHeaders["content-type"] = "application/json";
+	}
+	const res = await fetch(`${baseURL}${path}`, {
+		method,
+		headers: Object.keys(requestHeaders).length === 0 ? undefined : requestHeaders,
+		body: body === undefined ? undefined : JSON.stringify(body),
+	});
+	const text = await res.text();
+	let json = null;
+	if (text) {
+		try {
+			json = JSON.parse(text);
+		} catch {
+			json = null;
+		}
+	}
+	return { ok: res.ok, status: res.status, text, json };
 }
 
 async function mustRequest(method, path, body, headers = {}) {
-  const res = await request(method, path, body, headers);
-  if (!res.ok) {
-    throw new Error(`${method} ${path} failed with ${res.status}: ${res.text}`);
-  }
-  return res;
+	const res = await request(method, path, body, headers);
+	if (!res.ok) {
+		throw new Error(`${method} ${path} failed with ${res.status}: ${res.text}`);
+	}
+	return res;
 }
 
 async function getPlugin(name) {
-  const res = await request("GET", `/api/plugins/${encodeURIComponent(name)}`);
-  if (res.status === 404) {
-    return null;
-  }
-  if (!res.ok) {
-    throw new Error(`GET /api/plugins/${name} failed with ${res.status}: ${res.text}`);
-  }
-  return res.json?.plugin ?? res.json ?? null;
+	const res = await request("GET", `/api/plugins/${encodeURIComponent(name)}`);
+	if (res.status === 404) {
+		return null;
+	}
+	if (!res.ok) {
+		throw new Error(`GET /api/plugins/${name} failed with ${res.status}: ${res.text}`);
+	}
+	return res.json?.plugin ?? res.json ?? null;
 }
 
 function pluginUpdatePayload(plugin) {
-  return {
-    enabled: Boolean(plugin.enabled),
-    path: plugin.path ?? null,
-    config: plugin.config ?? {},
-    placement: plugin.placement ?? undefined,
-    order: plugin.order ?? undefined,
-  };
+	return {
+		enabled: Boolean(plugin.enabled),
+		path: plugin.path ?? null,
+		config: plugin.config ?? {},
+		placement: plugin.placement ?? undefined,
+		order: plugin.order ?? undefined,
+	};
 }
 
 async function enableBuiltinPlugin(name, config) {
-  await mustRequest("PUT", `/api/plugins/${encodeURIComponent(name)}`, {
-    enabled: true,
-    path: null,
-    config,
-  });
+	await mustRequest("PUT", `/api/plugins/${encodeURIComponent(name)}`, {
+		enabled: true,
+		path: null,
+		config,
+	});
 }
 
 async function addLocalProvider(mockPort) {
-  await mustRequest("POST", "/api/providers", {
-    provider: providerName,
-    custom_provider_config: {
-      base_provider_type: "openai",
-      is_key_less: true,
-      allowed_requests: {
-        chat_completion: true,
-        chat_completion_stream: true,
-      },
-    },
-    network_config: {
-      base_url: `http://127.0.0.1:${mockPort}`,
-      allow_private_network: true,
-      default_request_timeout_in_seconds: 10,
-      max_retries: 0,
-      retry_backoff_initial: 500,
-      retry_backoff_max: 5000,
-    },
-    concurrency_and_buffer_size: {
-      concurrency: 10,
-      buffer_size: 100,
-    },
-    keys: [],
-  });
+	await mustRequest("POST", "/api/providers", {
+		provider: providerName,
+		custom_provider_config: {
+			base_provider_type: "openai",
+			is_key_less: true,
+			allowed_requests: {
+				chat_completion: true,
+				chat_completion_stream: true,
+			},
+		},
+		network_config: {
+			base_url: `http://127.0.0.1:${mockPort}`,
+			allow_private_network: true,
+			default_request_timeout_in_seconds: 10,
+			max_retries: 0,
+			retry_backoff_initial: 500,
+			retry_backoff_max: 5000,
+		},
+		concurrency_and_buffer_size: {
+			concurrency: 10,
+			buffer_size: 100,
+		},
+		keys: [],
+	});
 }
 
 async function chatHelloWorld() {
-  const res = await mustRequest("POST", "/v1/chat/completions", {
-    model: requestedModel,
-    messages: [
-      { role: "user", content: "hello world" },
-    ],
-  }, {
-    "x-request-id": requestID,
-  });
-  const content = res.json?.choices?.[0]?.message?.content;
-  if (content !== "hello world") {
-    throw new Error(`unexpected chat response content: ${JSON.stringify(content)}`);
-  }
+	const res = await mustRequest(
+		"POST",
+		"/v1/chat/completions",
+		{
+			model: requestedModel,
+			messages: [{ role: "user", content: "hello world" }],
+		},
+		{
+			"x-request-id": requestID,
+		},
+	);
+	const content = res.json?.choices?.[0]?.message?.content;
+	if (content !== "hello world") {
+		throw new Error(`unexpected chat response content: ${JSON.stringify(content)}`);
+	}
 }
 
 // chatError fires a request the mock fails with a 404 error body; stream: true
 // exercises the pre-first-chunk stream failure path.
 async function chatError(id, stream) {
-  const res = await request("POST", "/v1/chat/completions", {
-    model: requestedModel,
-    messages: [{ role: "user", content: ERROR_TRIGGER }],
-    ...(stream ? { stream: true } : {}),
-  }, {
-    "x-request-id": id,
-  });
-  if (res.ok) {
-    throw new Error(`error request (stream=${stream}) unexpectedly succeeded: ${res.text}`);
-  }
-  if (res.status !== 404) {
-    throw new Error(`error request (stream=${stream}) status=${res.status}, want 404: ${res.text}`);
-  }
+	const res = await request(
+		"POST",
+		"/v1/chat/completions",
+		{
+			model: requestedModel,
+			messages: [{ role: "user", content: ERROR_TRIGGER }],
+			...(stream ? { stream: true } : {}),
+		},
+		{
+			"x-request-id": id,
+		},
+	);
+	if (res.ok) {
+		throw new Error(`error request (stream=${stream}) unexpectedly succeeded: ${res.text}`);
+	}
+	if (res.status !== 404) {
+		throw new Error(`error request (stream=${stream}) status=${res.status}, want 404: ${res.text}`);
+	}
 }
 
 async function poll(name, timeoutMs, fn) {
-  const started = Date.now();
-  let lastError;
-  while (Date.now() - started < timeoutMs) {
-    try {
-      const result = await fn();
-      if (result) {
-        return result;
-      }
-    } catch (err) {
-      lastError = err;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 500));
-  }
-  if (lastError) {
-    throw new Error(`${name} timed out: ${lastError.message}`);
-  }
-  throw new Error(`${name} timed out`);
+	const started = Date.now();
+	let lastError;
+	while (Date.now() - started < timeoutMs) {
+		try {
+			const result = await fn();
+			if (result) {
+				return result;
+			}
+		} catch (err) {
+			lastError = err;
+		}
+		await new Promise((resolve) => setTimeout(resolve, 500));
+	}
+	if (lastError) {
+		throw new Error(`${name} timed out: ${lastError.message}`);
+	}
+	throw new Error(`${name} timed out`);
 }
 
 async function assertOtelReceived() {
-  const entry = await poll("OTEL trace receiver", 20000, () => state.otelTraceRequests.find((item) => item.bytes > 0));
-  assertBufferContainsAll("OTEL trace export", entry.body, [
-    "bifrost-e2e",
-    providerName,
-    modelName,
-    requestID,
-    "gen_ai.provider.name",
-    "gen_ai.request.model",
-    "bifrost.request.id",
-    "gen_ai.usage.input_tokens",
-    "gen_ai.usage.output_tokens",
-    "gen_ai.usage.total_tokens",
-    // These metadata attributes survive content stripping and were previously unasserted:
-    // the response model, the finish-reasons attribute, and the "stop" finish reason value the
-    // mock upstream returns.
-    "gen_ai.response.model",
-    "gen_ai.response.finish_reasons",
-    "stop",
-  ]);
-  // The plugin runs with disable_content_logging: true, so the input/output message content
-  // ("hello world") must NOT reach the collector. This asserts the privacy guarantee holds
-  // end-to-end (the mock upstream's chat text is "hello world" with a space; the model name
-  // "hello-world" is hyphenated, so this cannot false-negative on the model bytes).
-  assertBufferContainsNone("OTEL trace export", entry.body, ["hello world"]);
+	const entry = await poll("OTEL trace receiver", 20000, () => state.otelTraceRequests.find((item) => item.bytes > 0));
+	assertBufferContainsAll("OTEL trace export", entry.body, [
+		"bifrost-e2e",
+		providerName,
+		modelName,
+		requestID,
+		"gen_ai.provider.name",
+		"gen_ai.request.model",
+		"bifrost.request.id",
+		"gen_ai.usage.input_tokens",
+		"gen_ai.usage.output_tokens",
+		"gen_ai.usage.total_tokens",
+		"gen_ai.usage.cache_read.input_tokens",
+		"gen_ai.usage.cache_creation.input_tokens",
+		"gen_ai.response.model",
+		"gen_ai.response.finish_reasons",
+		"stop",
+	]);
+	// The plugin runs with disable_content_logging: true, so the input/output message content
+	// ("hello world") must NOT reach the collector. This asserts the privacy guarantee holds
+	// end-to-end (the mock upstream's chat text is "hello world" with a space; the model name
+	// "hello-world" is hyphenated, so this cannot false-negative on the model bytes).
+	assertBufferContainsNone("OTEL trace export", entry.body, ["hello world"]);
 }
 
 async function assertOtelMetricsReceived() {
-  const entry = await poll("OTEL metrics receiver", 30000, () => state.otelMetricRequests.find((item) => item.bytes > 0));
-  assertBufferContainsAll("OTEL metrics export", entry.body, [
-    "bifrost-e2e",
-    "bifrost_upstream_requests_total",
-    "bifrost_success_requests_total",
-    "bifrost_input_tokens_total",
-    "bifrost_output_tokens_total",
-    "bifrost_upstream_latency_seconds",
-    "bifrost_request_retries",
-    "provider",
-    providerName,
-    "model",
-    requestedModel,
-    "method",
-    "chat_completion",
-  ]);
+	const entry = await poll("OTEL metrics receiver", 30000, () => state.otelMetricRequests.find((item) => item.bytes > 0));
+	assertBufferContainsAll("OTEL metrics export", entry.body, [
+		"bifrost-e2e",
+		"bifrost_upstream_requests_total",
+		"bifrost_success_requests_total",
+		"bifrost_input_tokens_total",
+		"bifrost_output_tokens_total",
+		"bifrost_cache_read_input_tokens_total",
+		"bifrost_cache_write_input_tokens_total",
+		"bifrost_upstream_latency_seconds",
+		"bifrost_request_retries",
+		"provider",
+		providerName,
+		"model",
+		requestedModel,
+		"method",
+		"chat_completion",
+	]);
 }
 
 // assertOtelErrorTrace checks the error span export carries the provider error
@@ -312,154 +335,174 @@ async function assertOtelMetricsReceived() {
 // regressed silently before (spans exported with no gen_ai.error.* when a
 // stream failed before its first chunk).
 async function assertOtelErrorTrace(id, label) {
-  const entry = await poll(`OTEL ${label} trace receiver`, 20000,
-    () => state.otelTraceRequests.find((item) => item.body.includes(Buffer.from(id))));
-  assertBufferContainsAll(`OTEL ${label} trace export`, entry.body, [
-    id,
-    "error.type",
-    "invalid_request_error",
-    "gen_ai.error.code",
-    "model_not_found",
-    "http.response.status_code",
-  ]);
+	const entry = await poll(`OTEL ${label} trace receiver`, 20000, () =>
+		state.otelTraceRequests.find((item) => item.body.includes(Buffer.from(id))),
+	);
+	assertBufferContainsAll(`OTEL ${label} trace export`, entry.body, [
+		id,
+		"error.type",
+		"invalid_request_error",
+		"gen_ai.error.code",
+		"model_not_found",
+		"http.response.status_code",
+	]);
 }
 
 // assertPrometheusErrorScrape checks bifrost_error_requests_total carries the
 // status_code label for both the non-stream and stream error calls.
 async function assertPrometheusErrorScrape() {
-  await poll("Prometheus error scrape", 20000, async () => {
-    const res = await request("GET", "/metrics");
-    if (!res.ok) {
-      throw new Error(`GET /metrics failed with ${res.status}: ${res.text}`);
-    }
-    const failures = [];
-    for (const method of ["chat_completion", "chat_completion_stream"]) {
-      const line = findPrometheusSample(res.text, "bifrost_error_requests_total",
-        { provider: providerName, method, status_code: "404" });
-      if (!line || parsePrometheusValue(line) < 1) {
-        failures.push(method);
-      }
-    }
-    if (failures.length > 0) {
-      throw new Error(`bifrost_error_requests_total{status_code="404"} missing for: ${failures.join(", ")}`);
-    }
-    return true;
-  });
+	await poll("Prometheus error scrape", 20000, async () => {
+		const res = await request("GET", "/metrics");
+		if (!res.ok) {
+			throw new Error(`GET /metrics failed with ${res.status}: ${res.text}`);
+		}
+		const failures = [];
+		for (const method of ["chat_completion", "chat_completion_stream"]) {
+			const line = findPrometheusSample(res.text, "bifrost_error_requests_total", { provider: providerName, method, status_code: "404" });
+			if (!line || parsePrometheusValue(line) < 1) {
+				failures.push(method);
+			}
+		}
+		if (failures.length > 0) {
+			throw new Error(`bifrost_error_requests_total{status_code="404"} missing for: ${failures.join(", ")}`);
+		}
+		return true;
+	});
 }
 
 function assertBufferContainsAll(name, body, values) {
-  for (const value of values) {
-    if (!body.includes(Buffer.from(value))) {
-      throw new Error(`${name} is missing ${JSON.stringify(value)}`);
-    }
-  }
+	for (const value of values) {
+		if (!body.includes(Buffer.from(value))) {
+			throw new Error(`${name} is missing ${JSON.stringify(value)}`);
+		}
+	}
 }
 
 function assertBufferContainsNone(name, body, values) {
-  for (const value of values) {
-    if (body.includes(Buffer.from(value))) {
-      throw new Error(`${name} unexpectedly contains ${JSON.stringify(value)} (content logging should be disabled)`);
-    }
-  }
+	for (const value of values) {
+		if (body.includes(Buffer.from(value))) {
+			throw new Error(`${name} unexpectedly contains ${JSON.stringify(value)} (content logging should be disabled)`);
+		}
+	}
 }
 
 function findPrometheusSample(metrics, metricName, labels) {
-  const prefix = `${metricName}{`;
-  return metrics
-    .split("\n")
-    .find((line) => line.startsWith(prefix) &&
-      Object.entries(labels).every(([key, value]) => line.includes(`${key}="${value}"`)));
+	const prefix = `${metricName}{`;
+	return metrics
+		.split("\n")
+		.find((line) => line.startsWith(prefix) && Object.entries(labels).every(([key, value]) => line.includes(`${key}="${value}"`)));
 }
 
 function parsePrometheusValue(line) {
-  const raw = line?.trim().split(/\s+/).at(-1);
-  const value = Number(raw);
-  if (!Number.isFinite(value)) {
-    throw new Error(`invalid Prometheus sample value in line: ${line}`);
-  }
-  return value;
+	const raw = line?.trim().split(/\s+/).at(-1);
+	const value = Number(raw);
+	if (!Number.isFinite(value)) {
+		throw new Error(`invalid Prometheus sample value in line: ${line}`);
+	}
+	return value;
 }
 
 async function assertPrometheusScrape() {
-  const metrics = await poll("Prometheus scrape", 20000, async () => {
-    const res = await request("GET", "/metrics");
-    if (!res.ok) {
-      throw new Error(`GET /metrics failed with ${res.status}: ${res.text}`);
-    }
-    const hasLLMSuccessMetric = res.text
-      .split("\n")
-      .some((line) => line.startsWith("bifrost_success_requests_total{") &&
-        line.includes(`provider="${providerName}"`) &&
-        (line.includes(`model="${modelName}"`) || line.includes(`model="${requestedModel}"`)));
-    if (hasLLMSuccessMetric) {
-      return res.text;
-    }
-    return null;
-  });
+	const metrics = await poll("Prometheus scrape", 20000, async () => {
+		const res = await request("GET", "/metrics");
+		if (!res.ok) {
+			throw new Error(`GET /metrics failed with ${res.status}: ${res.text}`);
+		}
+		const hasLLMSuccessMetric = res.text
+			.split("\n")
+			.some(
+				(line) =>
+					line.startsWith("bifrost_success_requests_total{") &&
+					line.includes(`provider="${providerName}"`) &&
+					(line.includes(`model="${modelName}"`) || line.includes(`model="${requestedModel}"`)),
+			);
+		if (hasLLMSuccessMetric) {
+			return res.text;
+		}
+		return null;
+	});
 
-  const labels = { provider: providerName, model: requestedModel, method: "chat_completion" };
-  const successLine = findPrometheusSample(metrics, "bifrost_success_requests_total", labels);
-  const upstreamLine = findPrometheusSample(metrics, "bifrost_upstream_requests_total", labels);
-  const inputLine = findPrometheusSample(metrics, "bifrost_input_tokens_total", labels);
-  const outputLine = findPrometheusSample(metrics, "bifrost_output_tokens_total", labels);
+	const labels = { provider: providerName, model: requestedModel, method: "chat_completion" };
+	const successLine = findPrometheusSample(metrics, "bifrost_success_requests_total", labels);
+	const upstreamLine = findPrometheusSample(metrics, "bifrost_upstream_requests_total", labels);
+	const inputLine = findPrometheusSample(metrics, "bifrost_input_tokens_total", labels);
+	const outputLine = findPrometheusSample(metrics, "bifrost_output_tokens_total", labels);
+	const cacheReadLine = findPrometheusSample(metrics, "bifrost_cache_read_input_tokens_total", labels);
+	const cacheWriteLine = findPrometheusSample(metrics, "bifrost_cache_write_input_tokens_total", labels);
 
-  if (!successLine || parsePrometheusValue(successLine) < 1) {
-    throw new Error("Prometheus scrape is missing bifrost_success_requests_total for the LLM call");
-  }
-  if (!upstreamLine || parsePrometheusValue(upstreamLine) < 1) {
-    throw new Error("Prometheus scrape is missing bifrost_upstream_requests_total for the LLM call");
-  }
-  if (!inputLine || parsePrometheusValue(inputLine) < 2) {
-    throw new Error("Prometheus scrape is missing input token count for the LLM call");
-  }
-  if (!outputLine || parsePrometheusValue(outputLine) < 2) {
-    throw new Error("Prometheus scrape is missing output token count for the LLM call");
-  }
+	if (!successLine || parsePrometheusValue(successLine) < 1) {
+		throw new Error("Prometheus scrape is missing bifrost_success_requests_total for the LLM call");
+	}
+	if (!upstreamLine || parsePrometheusValue(upstreamLine) < 1) {
+		throw new Error("Prometheus scrape is missing bifrost_upstream_requests_total for the LLM call");
+	}
+	if (!inputLine || parsePrometheusValue(inputLine) < 2) {
+		throw new Error("Prometheus scrape is missing input token count for the LLM call");
+	}
+	if (!outputLine || parsePrometheusValue(outputLine) < 2) {
+		throw new Error("Prometheus scrape is missing output token count for the LLM call");
+	}
+	if (!cacheReadLine || parsePrometheusValue(cacheReadLine) !== 5) {
+		throw new Error(`Prometheus cache_read_input_tokens = ${cacheReadLine ? parsePrometheusValue(cacheReadLine) : "missing"}, want 5`);
+	}
+	if (!cacheWriteLine || parsePrometheusValue(cacheWriteLine) !== 7) {
+		throw new Error(`Prometheus cache_write_input_tokens = ${cacheWriteLine ? parsePrometheusValue(cacheWriteLine) : "missing"}, want 7`);
+	}
 
-  return metrics;
+	return metrics;
 }
 
 async function assertLoggingTrace() {
-  const log = await poll("logging trace API", 30000, async () => {
-    const res = await request("GET", `/api/logs/${encodeURIComponent(requestID)}`);
-    if (res.status === 404) {
-      return null;
-    }
-    if (!res.ok) {
-      throw new Error(`GET /api/logs/${requestID} failed with ${res.status}: ${res.text}`);
-    }
-    return res.json;
-  });
+	const log = await poll("logging trace API", 30000, async () => {
+		const res = await request("GET", `/api/logs/${encodeURIComponent(requestID)}`);
+		if (res.status === 404) {
+			return null;
+		}
+		if (!res.ok) {
+			throw new Error(`GET /api/logs/${requestID} failed with ${res.status}: ${res.text}`);
+		}
+		return res.json;
+	});
 
-  if (log.id !== requestID) {
-    throw new Error(`logging trace API returned unexpected id: ${JSON.stringify(log.id)}`);
-  }
-  if (log.status !== "success") {
-    throw new Error(`logging trace API returned unexpected status: ${JSON.stringify(log.status)}`);
-  }
-  if (log.provider !== providerName) {
-    throw new Error(`logging trace API returned unexpected provider: ${JSON.stringify(log.provider)}`);
-  }
-  if (log.model !== modelName && log.model !== requestedModel) {
-    throw new Error(`logging trace API returned unexpected model: ${JSON.stringify(log.model)}`);
-  }
-  if (log.object !== "chat_completion" && log.object !== "chat.completion") {
-    throw new Error(`logging trace API returned unexpected object: ${JSON.stringify(log.object)}`);
-  }
-  if (!log.token_usage || log.token_usage.prompt_tokens !== 2 || log.token_usage.completion_tokens !== 2 || log.token_usage.total_tokens !== 4) {
-    throw new Error(`logging trace API returned incomplete token usage: ${JSON.stringify(log.token_usage)}`);
-  }
-  if (!Array.isArray(log.input_history) || log.input_history.length !== 1 || log.input_history[0]?.role !== "user" || log.input_history[0]?.content !== "hello world") {
-    throw new Error(`logging trace API returned incomplete input history: ${JSON.stringify(log.input_history)}`);
-  }
-  if (!log.output_message || log.output_message.role !== "assistant" || log.output_message.content !== "hello world") {
-    throw new Error(`logging trace API returned incomplete output message: ${JSON.stringify(log.output_message)}`);
-  }
-  if (typeof log.latency !== "number" || log.latency < 0) {
-    throw new Error(`logging trace API returned invalid latency: ${JSON.stringify(log.latency)}`);
-  }
+	if (log.id !== requestID) {
+		throw new Error(`logging trace API returned unexpected id: ${JSON.stringify(log.id)}`);
+	}
+	if (log.status !== "success") {
+		throw new Error(`logging trace API returned unexpected status: ${JSON.stringify(log.status)}`);
+	}
+	if (log.provider !== providerName) {
+		throw new Error(`logging trace API returned unexpected provider: ${JSON.stringify(log.provider)}`);
+	}
+	if (log.model !== modelName && log.model !== requestedModel) {
+		throw new Error(`logging trace API returned unexpected model: ${JSON.stringify(log.model)}`);
+	}
+	if (log.object !== "chat_completion" && log.object !== "chat.completion") {
+		throw new Error(`logging trace API returned unexpected object: ${JSON.stringify(log.object)}`);
+	}
+	if (
+		!log.token_usage ||
+		log.token_usage.prompt_tokens !== 30 ||
+		log.token_usage.completion_tokens !== 10 ||
+		log.token_usage.total_tokens !== 40
+	) {
+		throw new Error(`logging trace API returned incomplete token usage: ${JSON.stringify(log.token_usage)}`);
+	}
+	if (
+		!Array.isArray(log.input_history) ||
+		log.input_history.length !== 1 ||
+		log.input_history[0]?.role !== "user" ||
+		log.input_history[0]?.content !== "hello world"
+	) {
+		throw new Error(`logging trace API returned incomplete input history: ${JSON.stringify(log.input_history)}`);
+	}
+	if (!log.output_message || log.output_message.role !== "assistant" || log.output_message.content !== "hello world") {
+		throw new Error(`logging trace API returned incomplete output message: ${JSON.stringify(log.output_message)}`);
+	}
+	if (typeof log.latency !== "number" || log.latency < 0) {
+		throw new Error(`logging trace API returned invalid latency: ${JSON.stringify(log.latency)}`);
+	}
 
-  return log;
+	return log;
 }
 
 // assertMetricsMatchLogs reconciles the telemetry pull-scrape counters against the
@@ -471,133 +514,144 @@ async function assertLoggingTrace() {
 // threshold. assertPrometheusScrape and assertLoggingTrace check each side in isolation;
 // only this cross-check catches a drift where both sides individually look "present".
 function assertMetricsMatchLogs(metrics, log) {
-  const labels = { provider: providerName, model: requestedModel, method: "chat_completion" };
-  const inputLine = findPrometheusSample(metrics, "bifrost_input_tokens_total", labels);
-  const outputLine = findPrometheusSample(metrics, "bifrost_output_tokens_total", labels);
-  if (!inputLine || !outputLine) {
-    throw new Error("metrics/logs reconciliation: /metrics is missing token counters for the LLM call");
-  }
-  const metricInput = parsePrometheusValue(inputLine);
-  const metricOutput = parsePrometheusValue(outputLine);
+	const labels = { provider: providerName, model: requestedModel, method: "chat_completion" };
+	const inputLine = findPrometheusSample(metrics, "bifrost_input_tokens_total", labels);
+	const outputLine = findPrometheusSample(metrics, "bifrost_output_tokens_total", labels);
+	if (!inputLine || !outputLine) {
+		throw new Error("metrics/logs reconciliation: /metrics is missing token counters for the LLM call");
+	}
+	const metricInput = parsePrometheusValue(inputLine);
+	const metricOutput = parsePrometheusValue(outputLine);
 
-  const logInput = log?.token_usage?.prompt_tokens;
-  const logOutput = log?.token_usage?.completion_tokens;
+	const logInput = log?.token_usage?.prompt_tokens;
+	const logOutput = log?.token_usage?.completion_tokens;
 
-  if (metricInput !== logInput) {
-    throw new Error(`metrics/logs input-token mismatch: /metrics bifrost_input_tokens_total=${metricInput} but logs prompt_tokens=${logInput}`);
-  }
-  if (metricOutput !== logOutput) {
-    throw new Error(`metrics/logs output-token mismatch: /metrics bifrost_output_tokens_total=${metricOutput} but logs completion_tokens=${logOutput}`);
-  }
+	if (metricInput !== logInput) {
+		throw new Error(
+			`metrics/logs input-token mismatch: /metrics bifrost_input_tokens_total=${metricInput} but logs prompt_tokens=${logInput}`,
+		);
+	}
+	if (metricOutput !== logOutput) {
+		throw new Error(
+			`metrics/logs output-token mismatch: /metrics bifrost_output_tokens_total=${metricOutput} but logs completion_tokens=${logOutput}`,
+		);
+	}
 }
 
 function assertMockProviderRequest(wantCount = 1) {
-  if (state.mockRequests.length !== wantCount) {
-    throw new Error(`expected ${wantCount} mock provider request(s), got ${state.mockRequests.length}`);
-  }
-  let body;
-  try {
-    body = JSON.parse(state.mockRequests[0].body);
-  } catch (err) {
-    throw new Error(`mock provider request body is not JSON: ${err.message}`);
-  }
-  if (body.model !== requestedModel && body.model !== modelName) {
-    throw new Error(`mock provider received unexpected model: ${JSON.stringify(body.model)}`);
-  }
-  if (!Array.isArray(body.messages) || body.messages.length !== 1 || body.messages[0]?.role !== "user" || body.messages[0]?.content !== "hello world") {
-    throw new Error(`mock provider received incomplete messages: ${JSON.stringify(body.messages)}`);
-  }
+	if (state.mockRequests.length !== wantCount) {
+		throw new Error(`expected ${wantCount} mock provider request(s), got ${state.mockRequests.length}`);
+	}
+	let body;
+	try {
+		body = JSON.parse(state.mockRequests[0].body);
+	} catch (err) {
+		throw new Error(`mock provider request body is not JSON: ${err.message}`);
+	}
+	if (body.model !== requestedModel && body.model !== modelName) {
+		throw new Error(`mock provider received unexpected model: ${JSON.stringify(body.model)}`);
+	}
+	if (
+		!Array.isArray(body.messages) ||
+		body.messages.length !== 1 ||
+		body.messages[0]?.role !== "user" ||
+		body.messages[0]?.content !== "hello world"
+	) {
+		throw new Error(`mock provider received incomplete messages: ${JSON.stringify(body.messages)}`);
+	}
 }
 
 async function main() {
-  console.log("Running local observability API check...");
-  console.log(`  Bifrost: ${baseURL}`);
-  if (adminAuthHeader) {
-    console.log("  Auth:    Bearer admin credentials");
-  }
+	console.log("Running local observability API check...");
+	console.log(`  Bifrost: ${baseURL}`);
+	if (adminAuthHeader) {
+		console.log("  Auth:    Bearer admin credentials");
+	}
 
-  const originalOtel = await getPlugin("otel");
-  const originalTelemetry = await getPlugin("telemetry");
+	const originalOtel = await getPlugin("otel");
+	const originalTelemetry = await getPlugin("telemetry");
 
-  const otelReceiver = createOtelReceiver();
-  const openaiMock = createOpenAIMock();
-  const otelPort = await listen(otelReceiver);
-  const mockPort = await listen(openaiMock);
+	const otelReceiver = createOtelReceiver();
+	const openaiMock = createOpenAIMock();
+	const otelPort = await listen(otelReceiver);
+	const mockPort = await listen(openaiMock);
 
-  let cleanupError = null;
-  try {
-    console.log(`  OTEL trace receiver:   http://127.0.0.1:${otelPort}/v1/traces`);
-    console.log(`  OTEL metrics receiver: http://127.0.0.1:${otelPort}/v1/metrics`);
-    console.log(`  Mock provider:  http://127.0.0.1:${mockPort}`);
+	let cleanupError = null;
+	try {
+		console.log(`  OTEL trace receiver:   http://127.0.0.1:${otelPort}/v1/traces`);
+		console.log(`  OTEL metrics receiver: http://127.0.0.1:${otelPort}/v1/metrics`);
+		console.log(`  Mock provider:  http://127.0.0.1:${mockPort}`);
 
-    await enableBuiltinPlugin("telemetry", { metrics_enabled: true });
-    await enableBuiltinPlugin("otel", {
-      profiles: [
-        {
-          enabled: true,
-          service_name: "bifrost-e2e",
-          collector_url: `http://127.0.0.1:${otelPort}/v1/traces`,
-          trace_type: "genai_extension",
-          protocol: "http",
-          insecure: true,
-          metrics_enabled: true,
-          metrics_endpoint: `http://127.0.0.1:${otelPort}/v1/metrics`,
-          metrics_push_interval: 1,
-          disable_content_logging: true,
-        },
-      ],
-    });
+		await enableBuiltinPlugin("telemetry", { metrics_enabled: true });
+		await enableBuiltinPlugin("otel", {
+			profiles: [
+				{
+					enabled: true,
+					service_name: "bifrost-e2e",
+					collector_url: `http://127.0.0.1:${otelPort}/v1/traces`,
+					trace_type: "genai_extension",
+					protocol: "http",
+					insecure: true,
+					metrics_enabled: true,
+					metrics_endpoint: `http://127.0.0.1:${otelPort}/v1/metrics`,
+					metrics_push_interval: 1,
+					disable_content_logging: true,
+				},
+			],
+		});
 
-    await addLocalProvider(mockPort);
-    await chatHelloWorld();
+		await addLocalProvider(mockPort);
+		await chatHelloWorld();
 
-    assertMockProviderRequest();
+		assertMockProviderRequest();
 
-    await assertOtelReceived();
-    await assertOtelMetricsReceived();
-    const metrics = await assertPrometheusScrape();
-    const log = await assertLoggingTrace();
-    assertMetricsMatchLogs(metrics, log);
+		await assertOtelReceived();
+		await assertOtelMetricsReceived();
+		const metrics = await assertPrometheusScrape();
+		const log = await assertLoggingTrace();
+		assertMetricsMatchLogs(metrics, log);
 
-    // Error scenarios: non-stream provider 404, then a stream failing before
-    // its first chunk. Both must export gen_ai.error.* span attributes and a
-    // status_code-labeled error counter.
-    await chatError(errorRequestID, false);
-    await assertOtelErrorTrace(errorRequestID, "error");
-    await chatError(streamErrorRequestID, true);
-    await assertOtelErrorTrace(streamErrorRequestID, "stream-error");
-    await assertPrometheusErrorScrape();
-    assertMockProviderRequest(3);
+		// Error scenarios: non-stream provider 404, then a stream failing before
+		// its first chunk. Both must export gen_ai.error.* span attributes and a
+		// status_code-labeled error counter.
+		await chatError(errorRequestID, false);
+		await assertOtelErrorTrace(errorRequestID, "error");
+		await chatError(streamErrorRequestID, true);
+		await assertOtelErrorTrace(streamErrorRequestID, "stream-error");
+		await assertPrometheusErrorScrape();
+		assertMockProviderRequest(3);
 
-    console.log(`  OTEL trace exports received: ${state.otelTraceRequests.length}`);
-    console.log(`  OTEL metric exports received: ${state.otelMetricRequests.length}`);
-    console.log(`  Prometheus scrape includes provider="${providerName}" model="${requestedModel}"`);
-    console.log(`  Metrics/logs token usage reconciled (scrape == logs)`);
-    console.log(`  Logging trace API returned id="${requestID}"`);
-    console.log(`  Error spans carry gen_ai.error.* and error counter has status_code (non-stream and stream).`);
-    console.log("Local observability API check passed.");
-  } finally {
-    try {
-      await request("DELETE", `/api/providers/${encodeURIComponent(providerName)}`);
-      if (originalOtel) {
-        await request("PUT", "/api/plugins/otel", pluginUpdatePayload(originalOtel));
-      } else {
-        await request("DELETE", "/api/plugins/otel");
-      }
-      if (originalTelemetry) {
-        await request("PUT", "/api/plugins/telemetry", pluginUpdatePayload(originalTelemetry));
-      }
-    } catch (err) {
-      cleanupError = err;
-    }
-    await Promise.all([close(otelReceiver), close(openaiMock)]);
-    if (cleanupError) {
-      console.warn(`WARNING: observability cleanup failed: ${cleanupError.message}`);
-    }
-  }
+		console.log(`  OTEL trace exports received: ${state.otelTraceRequests.length}`);
+		console.log(`  OTEL metric exports received: ${state.otelMetricRequests.length}`);
+		console.log(`  Prometheus scrape includes provider="${providerName}" model="${requestedModel}"`);
+		console.log(`  Metrics/logs token usage reconciled (scrape == logs)`);
+		console.log(`  Logging trace API returned id="${requestID}"`);
+		console.log(`  Error spans carry gen_ai.error.* and error counter has status_code (non-stream and stream).`);
+		console.log("Local observability API check passed.");
+	} finally {
+		try {
+			await request("DELETE", `/api/providers/${encodeURIComponent(providerName)}`);
+			if (originalOtel) {
+				await request("PUT", "/api/plugins/otel", pluginUpdatePayload(originalOtel));
+			} else {
+				await request("DELETE", "/api/plugins/otel");
+			}
+			if (originalTelemetry) {
+				await request("PUT", "/api/plugins/telemetry", pluginUpdatePayload(originalTelemetry));
+			} else {
+				await request("DELETE", "/api/plugins/telemetry");
+			}
+		} catch (err) {
+			cleanupError = err;
+		}
+		await Promise.all([close(otelReceiver), close(openaiMock)]);
+		if (cleanupError) {
+			console.warn(`WARNING: observability cleanup failed: ${cleanupError.message}`);
+		}
+	}
 }
 
 main().catch((err) => {
-  console.error(`Local observability API check failed: ${err.message}`);
-  process.exit(1);
+	console.error(`Local observability API check failed: ${err.message}`);
+	process.exit(1);
 });


### PR DESCRIPTION
## Summary

Extracts the inline block of context-to-span attribute assignments from `executeRequestWithRetries` into a dedicated `applyContextSpanAttributes` helper, adds routing rule dimensions (`AttrBifrostRoutingRuleID` / `AttrBifrostRoutingRuleName`) that were previously missing, and introduces a test suite that acts as a drift guard between the live span emission and the `schemas.EnrichmentDims` registry. The e2e observability runner is also extended to assert cache token metrics end-to-end.

## Changes

- **`core/bifrost.go`**: Replaced the 60-line inline context attribute block with a single call to `applyContextSpanAttributes(span, ctx)`.
- **`core/span_enrichment.go`** (new): Contains `applyContextSpanAttributes`, which is now the single authoritative emitter of all context-sourced governance/identity span dimensions. Adds routing rule ID and name dimensions that were absent from the original inline block.
- **`core/span_enrichment_test.go`** (new): Two tests act as a registry parity guard:
  - `TestContextSpanAttributesEmit` — populates every context key with a distinct sentinel value and asserts each lands on the span under its canonical attribute name. A dropped emit or mis-wired context key fails here.
  - `TestEnrichmentRegistryDimsAllEmitted` — cross-checks every entry in `schemas.EnrichmentDims` against either `contextDimSources` or `dimsEmittedElsewhere`. Adding a dimension to the registry without wiring its emission fails this test; stale classification entries for removed dimensions also fail.
- **`tests/e2e/api/runners/run-observability-local.mjs`**: Mock upstream now returns `prompt_tokens_details` with `cached_tokens` and `cache_write_tokens`. OTEL trace and metrics assertions extended to require `gen_ai.usage.cache_read.input_tokens`, `gen_ai.usage.cache_creation.input_tokens`, `bifrost_cache_read_input_tokens_total`, and `bifrost_cache_write_input_tokens_total`, ensuring the cache token pipeline is exercised end-to-end. Indentation normalized to tabs throughout.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Unit tests covering the new helper and registry parity guard
go test ./core/... -run TestContextSpanAttributes -v
go test ./core/... -run TestEnrichmentRegistryDimsAllEmitted -v

# Full suite
go test ./...

# E2E observability (requires a running Bifrost instance)
node tests/e2e/api/runners/run-observability-local.mjs
```

The e2e runner will assert that `gen_ai.usage.cache_read.input_tokens` and `gen_ai.usage.cache_creation.input_tokens` appear in the OTEL trace export, and that `bifrost_cache_read_input_tokens_total` and `bifrost_cache_write_input_tokens_total` appear in the OTEL metrics export.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

No new secrets, auth paths, or PII handling introduced. The `applyContextSpanAttributes` refactor does not change which attributes are written to spans; it only consolidates where that write happens.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable