### PR TITLE
fix: routing-rule reads honor the row-visibility queryscope

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -5214,7 +5214,11 @@ func (s *RDBConfigStore) UpdateRateLimitUsage(ctx context.Context, id string, to
 // loadRoutingRulesOrdered loads routing rules with Targets preloaded, using consistent ordering:
 // rules by priority ASC, created_at DESC, id ASC; targets by weight DESC for deterministic ordering.
 func (s *RDBConfigStore) loadRoutingRulesOrdered(ctx context.Context, dest *[]tables.TableRoutingRule, scopes ...func(*gorm.DB) *gorm.DB) error {
-	q := s.DB().WithContext(ctx).
+	// ScopedDB, not DB: routing-rule reads must honor any row-visibility
+	// QueryScope stashed on ctx (the enterprise DAC wrapper attaches one for
+	// request-driven reads). Background callers (engine bootstrap, cache
+	// reloads on context.Background) carry no scope and stay unfiltered.
+	q := s.ScopedDB(ctx).
 		Preload("Targets", func(db *gorm.DB) *gorm.DB {
 			return db.Order("weight DESC").
 				Order("COALESCE(provider, '') ASC").

--- a/framework/configstore/scopeddb_test.go
+++ b/framework/configstore/scopeddb_test.go
@@ -99,3 +99,41 @@ func TestScopedDB_ScopeReturningDB_IsRespected(t *testing.T) {
 	require.NotNil(t, got)
 	require.NoError(t, got.Exec("SELECT 1").Error)
 }
+
+// TestRoutingRuleReads_HonorQueryScope is the regression for the routing-rule
+// read family silently ignoring the row-visibility QueryScope on ctx:
+// loadRoutingRulesOrdered built its query from DB() instead of ScopedDB(), so
+// GetRoutingRules / GetRoutingRule / GetRoutingRulesByScope returned every rule
+// to callers whose scope should have narrowed them (the paginated variant
+// already honored the scope). A ctx without a scope keeps full visibility.
+func TestRoutingRuleReads_HonorQueryScope(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, store.CreateRoutingRule(ctx, routingRuleFixture("rule-visible", 0, "openai")))
+	require.NoError(t, store.CreateRoutingRule(ctx, routingRuleFixture("rule-hidden", 1, "openai")))
+
+	scoped := queryscope.WithQueryScope(ctx, func(db *gorm.DB) *gorm.DB {
+		return db.Where("id <> ?", "rule-hidden")
+	})
+
+	rules, err := store.GetRoutingRules(scoped)
+	require.NoError(t, err)
+	require.Len(t, rules, 1, "GetRoutingRules must honor the ctx scope")
+	assert.Equal(t, "rule-visible", rules[0].ID)
+
+	_, err = store.GetRoutingRule(scoped, "rule-hidden")
+	assert.ErrorIs(t, err, ErrNotFound, "GetRoutingRule must hide scoped-out rules")
+
+	visible, err := store.GetRoutingRule(scoped, "rule-visible")
+	require.NoError(t, err)
+	assert.Equal(t, "rule-visible", visible.ID)
+
+	byScope, err := store.GetRoutingRulesByScope(scoped, "global", "")
+	require.NoError(t, err)
+	require.Len(t, byScope, 1, "GetRoutingRulesByScope must honor the ctx scope")
+	assert.Equal(t, "rule-visible", byScope[0].ID)
+
+	unscoped, err := store.GetRoutingRules(ctx)
+	require.NoError(t, err)
+	assert.Len(t, unscoped, 2, "a ctx without a scope keeps full visibility")
+}


### PR DESCRIPTION
## Summary

`GetRoutingRules`, `GetRoutingRule`, and `GetRoutingRulesByScope` were silently ignoring the row-visibility `QueryScope` attached to the context by the enterprise DAC wrapper. This happened because `loadRoutingRulesOrdered` built its query from `DB()` instead of `ScopedDB()`, causing all three methods to return every routing rule regardless of what the caller's scope should have restricted. The paginated variant already used `ScopedDB()` correctly — this fixes the non-paginated family to match.

## Changes

- `loadRoutingRulesOrdered` now calls `ScopedDB(ctx)` instead of `DB()`, so any `QueryScope` stashed on the context is applied to routing-rule reads. Background callers (engine bootstrap, cache reloads on `context.Background`) carry no scope and remain unfiltered.
- Added regression test `TestRoutingRuleReads_HonorQueryScope` that seeds two rules, attaches a scope that excludes one, and asserts all three affected read methods respect the scope while an unscoped context retains full visibility.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/... -run TestRoutingRuleReads_HonorQueryScope -v
```

Expected: the scoped context returns only `rule-visible` across all three read methods, and the unscoped context returns both rules.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This fix ensures that row-level visibility enforced by the enterprise DAC layer is correctly applied to routing-rule reads. Without it, callers operating under a restricted scope could observe routing rules they should not have access to.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable