### PR TITLE
feat: rename `AllowOnAllVirtualKeys` to `AllowByDefault` across schema, store, API, and UI, with backward-compatible wire aliases for both JSON keys and query params

### DIFF
--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -1512,7 +1512,7 @@ func (m *MCPManager) UpdateClient(id string, updatedConfig *schemas.MCPClientCon
 			NeedsSessionStickiness: updatedConfig.NeedsSessionStickiness,
 			ToolSyncInterval:       updatedConfig.ToolSyncInterval,
 			ToolExecutionTimeout:   updatedConfig.ToolExecutionTimeout,
-			AllowOnAllVirtualKeys:  updatedConfig.AllowOnAllVirtualKeys,
+			AllowByDefault:         updatedConfig.AllowByDefault,
 			Disabled:               updatedConfig.Disabled,
 			TLSConfig:              updatedConfig.TLSConfig,
 			PerUserHeaderKeys:      slices.Clone(updatedConfig.PerUserHeaderKeys),

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -504,7 +504,13 @@ type MCPClientConfig struct {
 	ToolPricing            map[string]float64 `json:"tool_pricing,omitempty"`           // Tool pricing for each tool (cost per execution)
 	Disabled               bool               `json:"disabled"`                         // Whether the client is intentionally disabled (stops connection and workers)
 	ConfigHash             string             `json:"-"`                                // Config hash for reconciliation (not serialized)
-	AllowOnAllVirtualKeys  bool               `json:"allow_on_all_virtual_keys"`        // Whether to allow the MCP client to run on all virtual keys
+	// AllowByDefault opens the client to every caller that has not been assigned it explicitly: all
+	// of its tools, with no per-caller configuration. An explicit assignment for a caller decides for
+	// that caller instead, including one that grants no tool at all.
+	//
+	// The wire name used to be allow_on_all_virtual_keys. That key is still read (UnmarshalJSON) and
+	// still written (MarshalJSON), so configuration and clients written against it keep working.
+	AllowByDefault bool `json:"allow_by_default"`
 
 	// Discovered tools for per-user OAuth clients (persisted so they survive restart)
 	DiscoveredTools           map[string]ChatTool `json:"-"` // Discovered tool schemas keyed by prefixed name
@@ -531,11 +537,16 @@ type MCPClientConfig struct {
 // UnmarshalJSON supports Go duration strings (e.g. "10m") for tool_sync_interval and
 // tool_execution_timeout. Numeric values are treated as raw nanoseconds for tool_sync_interval
 // and as seconds for tool_execution_timeout (matching tool_manager_config behaviour).
+//
+// It also reads allow_by_default under its earlier name, allow_on_all_virtual_keys; see
+// ResolveAllowByDefault for which one decides when both are present.
 func (c *MCPClientConfig) UnmarshalJSON(data []byte) error {
 	type alias MCPClientConfig
 	aux := &struct {
-		ToolSyncInterval     *json.Number     `json:"tool_sync_interval,omitempty"`
-		ToolExecutionTimeout *json.RawMessage `json:"tool_execution_timeout,omitempty"`
+		ToolSyncInterval      *json.Number     `json:"tool_sync_interval,omitempty"`
+		ToolExecutionTimeout  *json.RawMessage `json:"tool_execution_timeout,omitempty"`
+		AllowByDefault        *bool            `json:"allow_by_default,omitempty"`
+		AllowOnAllVirtualKeys *bool            `json:"allow_on_all_virtual_keys,omitempty"`
 		*alias
 	}{alias: (*alias)(c)}
 
@@ -559,6 +570,7 @@ func (c *MCPClientConfig) UnmarshalJSON(data []byte) error {
 			}
 			c.ToolExecutionTimeout = dur
 		}
+		c.AllowByDefault = ResolveAllowByDefault(aux.AllowByDefault, aux.AllowOnAllVirtualKeys)
 		return nil
 	}
 
@@ -566,8 +578,10 @@ func (c *MCPClientConfig) UnmarshalJSON(data []byte) error {
 	// ToolExecutionTimeout uses *json.RawMessage (not *string) so that integer
 	// values like 60 remain valid even when tool_sync_interval is a string.
 	auxStr := &struct {
-		ToolSyncInterval     *string          `json:"tool_sync_interval,omitempty"`
-		ToolExecutionTimeout *json.RawMessage `json:"tool_execution_timeout,omitempty"`
+		ToolSyncInterval      *string          `json:"tool_sync_interval,omitempty"`
+		ToolExecutionTimeout  *json.RawMessage `json:"tool_execution_timeout,omitempty"`
+		AllowByDefault        *bool            `json:"allow_by_default,omitempty"`
+		AllowOnAllVirtualKeys *bool            `json:"allow_on_all_virtual_keys,omitempty"`
 		*alias
 	}{alias: (*alias)(c)}
 	if err := json.Unmarshal(data, auxStr); err != nil {
@@ -587,7 +601,25 @@ func (c *MCPClientConfig) UnmarshalJSON(data []byte) error {
 		}
 		c.ToolExecutionTimeout = dur
 	}
+	c.AllowByDefault = ResolveAllowByDefault(auxStr.AllowByDefault, auxStr.AllowOnAllVirtualKeys)
 	return nil
+}
+
+// ResolveAllowByDefault settles the flag from the two keys the wire accepts for it: allow_by_default,
+// and the earlier allow_on_all_virtual_keys. The current key decides whenever it is present; the
+// earlier one is read only in its absence, so a caller that sends both is taken at its current word.
+// Neither present is the default, which is off.
+//
+// Exported because every surface that reads the flag from JSON applies the same rule: the client
+// configuration here, and the create and update requests of the HTTP API.
+func ResolveAllowByDefault(allowByDefault, allowOnAllVirtualKeys *bool) bool {
+	if allowByDefault != nil {
+		return *allowByDefault
+	}
+	if allowOnAllVirtualKeys != nil {
+		return *allowOnAllVirtualKeys
+	}
+	return false
 }
 
 // parseToolExecutionTimeoutField parses a tool_execution_timeout JSON value.
@@ -625,13 +657,17 @@ func parseToolExecutionTimeoutField(raw json.RawMessage) (time.Duration, error) 
 // MarshalJSON emits tool_execution_timeout as a duration string so it round-trips
 // correctly — default time.Duration marshaling emits nanoseconds, but UnmarshalJSON
 // treats bare integers as seconds.
+//
+// It also writes allow_by_default under its earlier name, allow_on_all_virtual_keys, with the same
+// value, so a reader that still knows only that key sees the same answer.
 func (c MCPClientConfig) MarshalJSON() ([]byte, error) {
 	type alias MCPClientConfig
 	type shadow struct {
-		ToolExecutionTimeout string `json:"tool_execution_timeout,omitempty"`
+		ToolExecutionTimeout  string `json:"tool_execution_timeout,omitempty"`
+		AllowOnAllVirtualKeys bool   `json:"allow_on_all_virtual_keys"`
 		*alias
 	}
-	s := shadow{alias: (*alias)(&c)}
+	s := shadow{alias: (*alias)(&c), AllowOnAllVirtualKeys: c.AllowByDefault}
 	if c.ToolExecutionTimeout > 0 {
 		s.ToolExecutionTimeout = c.ToolExecutionTimeout.String()
 	}

--- a/core/schemas/mcp_json_test.go
+++ b/core/schemas/mcp_json_test.go
@@ -129,7 +129,6 @@ func TestMCPClientConfigUnmarshalToolExecutionTimeoutNegativeString(t *testing.T
 	}
 }
 
-
 // TestMCPClientConfigMarshalToolSyncIntervalEmitsNanoseconds pins the wire unit of
 // tool_sync_interval. MarshalJSON overrides tool_execution_timeout into a duration
 // string but lets tool_sync_interval fall through to time.Duration's default
@@ -171,6 +170,61 @@ func TestMCPClientConfigToolSyncIntervalRoundTrips(t *testing.T) {
 		}
 		if got.ToolSyncInterval != interval {
 			t.Fatalf("round-trip changed tool_sync_interval: want %v, got %v (wire: %s)", interval, got.ToolSyncInterval, raw)
+		}
+	}
+}
+
+// TestMCPClientConfigAllowByDefaultReadsBothKeys pins the compatibility rule for the flag's two wire
+// names: allow_by_default decides when present, and allow_on_all_virtual_keys is read in its absence.
+// The last case carries a duration string so the second decode path is exercised as well.
+func TestMCPClientConfigAllowByDefaultReadsBothKeys(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{"current key only", `{"name":"demo","allow_by_default":true}`, true},
+		{"earlier key only", `{"name":"demo","allow_on_all_virtual_keys":true}`, true},
+		{"both sent, current wins when false", `{"name":"demo","allow_by_default":false,"allow_on_all_virtual_keys":true}`, false},
+		{"both sent, current wins when true", `{"name":"demo","allow_by_default":true,"allow_on_all_virtual_keys":false}`, true},
+		{"neither sent", `{"name":"demo"}`, false},
+		{"earlier key with duration string", `{"name":"demo","tool_sync_interval":"10m","allow_on_all_virtual_keys":true}`, true},
+		{"both sent with duration string", `{"name":"demo","tool_sync_interval":"10m","allow_by_default":false,"allow_on_all_virtual_keys":true}`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var cfg MCPClientConfig
+			if err := sonic.Unmarshal([]byte(tc.raw), &cfg); err != nil {
+				t.Fatalf("unexpected unmarshal error: %v", err)
+			}
+			if cfg.AllowByDefault != tc.want {
+				t.Fatalf("allow_by_default: want %v, got %v (wire: %s)", tc.want, cfg.AllowByDefault, tc.raw)
+			}
+		})
+	}
+}
+
+// TestMCPClientConfigMarshalMirrorsAllowOnAllVirtualKeys pins that the earlier wire name is still
+// written with the same value, and that what is written reads back to the same flag.
+func TestMCPClientConfigMarshalMirrorsAllowOnAllVirtualKeys(t *testing.T) {
+	for _, value := range []bool{true, false} {
+		cfg := MCPClientConfig{Name: "demo", ConnectionType: MCPConnectionTypeHTTP, AllowByDefault: value}
+		raw, err := sonic.Marshal(cfg)
+		if err != nil {
+			t.Fatalf("unexpected marshal error: %v", err)
+		}
+		for _, key := range []string{"allow_by_default", "allow_on_all_virtual_keys"} {
+			want := `"` + key + `":` + map[bool]string{true: "true", false: "false"}[value]
+			if !strings.Contains(string(raw), want) {
+				t.Fatalf("expected %s in output, got: %s", want, raw)
+			}
+		}
+		var got MCPClientConfig
+		if err := sonic.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("unexpected unmarshal error: %v", err)
+		}
+		if got.AllowByDefault != value {
+			t.Fatalf("round-trip changed allow_by_default: want %v, got %v (wire: %s)", value, got.AllowByDefault, raw)
 		}
 	}
 }

--- a/docs/deployment-guides/config-json/schema-reference.mdx
+++ b/docs/deployment-guides/config-json/schema-reference.mdx
@@ -294,7 +294,8 @@ Common fields on each `client_configs` entry:
 | `is_ping_available` | boolean | Default `true`. Whether the MCP server supports a lightweight ping for health checks; `false` falls back to a full `listTools` call instead. |
 | `tool_sync_interval` | string \| integer | Per-client tool-list sync interval as a Go duration string in whole seconds (for example `"5m"` or `"90s"`), or a legacy non-negative integer in nanoseconds that is a whole number of seconds. `"0s"`/omitted falls back to the global `mcp.tool_sync_interval`. |
 | `tool_execution_timeout` | integer | Per-client tool execution timeout in seconds. `0`/omitted falls back to the global `client.mcp_tool_execution_timeout`. |
-| `allow_on_all_virtual_keys` | boolean | When `true`, every virtual key can use this client without an explicit allowlist entry. |
+| `allow_by_default` | boolean | When `true`, any caller can use this client without an explicit assignment, with all tools allowed. An explicit assignment for a caller takes precedence for that caller, including an empty tool list. |
+| `allow_on_all_virtual_keys` | boolean | Deprecated alias of `allow_by_default`, read only when `allow_by_default` is absent. |
 | `tls_config` | object | `{ "insecure_skip_verify": bool, "ca_cert_pem": string }` — skip TLS verification (development only) and/or trust a custom CA certificate for this client's connection. `ca_cert_pem` supports `env.VAR_NAME`. |
 
 Auth-type-specific fields:

--- a/docs/features/governance/mcp-tools.mdx
+++ b/docs/features/governance/mcp-tools.mdx
@@ -15,19 +15,19 @@ Make sure you have at least one MCP client set up. Read more about it [here](../
 The filtering logic is determined by the Virtual Key's configuration:
 
 1.  **No MCP Configuration on Virtual Key (Default)**
-    - If a Virtual Key has no specific MCP configurations, **no MCP tools are available** (deny-by-default).
-    - You must explicitly add MCP client configurations to allow tools.
+    - If a Virtual Key has no specific MCP configurations, **no MCP tools are available** (deny-by-default), except from clients marked **Allow by Default** in their MCP client settings.
+    - You must explicitly add MCP client configurations to allow other tools.
 
 2.  **With MCP Configuration on Virtual Key**
     - When you configure MCP clients on a Virtual Key, its settings take full precedence.
     - Bifrost automatically generates an `x-bf-mcp-include-tools` header based on your VK configuration (unless `disable_auto_tool_inject` is enabled or the caller already sent the header). This acts as a strict allow-list for the request.
-    - If the caller already includes an `x-bf-mcp-include-tools` header, auto-injection is skipped - but the VK allow-list is enforced at inference time and still enforced again at MCP tool execution time.
+    - If the caller already includes an `x-bf-mcp-include-tools` header, auto-injection is skipped and the header is narrowed to the VK allow-list instead: entries the key does not allow are dropped, so the header can only narrow, never widen. The allow-list is enforced again at MCP tool execution time.
 
 For each MCP client associated with a Virtual Key, you can specify the allowed tools:
 - **Select specific tools**: Only the chosen tools from that client will be available.
 - **Use `*` wildcard**: All available tools from that client will be permitted.
 - **Leave tool list empty**: All tools from that client will be **blocked**.
-- **Do not configure a client**: All tools from that client will be **blocked** (if other clients are configured).
+- **Do not configure a client**: All tools from that client will be **blocked**, unless the client is marked **Allow by Default**, in which case all of its tools are permitted to every key that does not configure it.
 
 <Note>
 Inactive or [expired](./virtual-keys#key-expiry) Virtual Keys are rejected at MCP tool execution time with a `403`, regardless of their tool configuration.
@@ -92,7 +92,7 @@ curl -X PUT http://localhost:8080/api/governance/virtual-keys/{vk_id} \
 **Behavior:**
 - The virtual key can only access the `check-status` tool from `billing-client`.
 - It can access all tools from `support-client`.
-- Any other MCP client is implicitly blocked for this key.
+- Any other MCP client is implicitly blocked for this key, unless it is marked **Allow by Default**, in which case all of its tools are reachable too, since neither `billing-client` nor `support-client` configures it.
 
 </Tab>
 
@@ -144,18 +144,19 @@ A request with this Virtual Key can access all four tools: `create-invoice`, `ch
 <Tab title="VK with Partial Access">
 **Configuration:**
 - `billing-client` -> Allowed Tools: `[check-status]`
-- `support-client` -> Not configured
+- `support-client` -> Not configured, and not marked **Allow by Default**
 
 **Result:**
-A request with this Virtual Key can only access the `check-status` tool. All other tools are blocked.
+A request with this Virtual Key can only access the `check-status` tool. All other tools are blocked. If `support-client` were marked **Allow by Default** instead, both `create-ticket` and `get-faq` would also be reachable, but only while `support-client` stays unconfigured on this key: an explicit configuration for it, even one that omits `get-faq`, would take precedence and keep that tool blocked regardless of the Allow by Default setting.
 
 </Tab>
 <Tab title="VK with No Tools">
 **Configuration:**
 - `billing-client` -> Allowed Tools: `[]` (empty list)
+- `support-client` -> Not configured, and not marked **Allow by Default**
 
 **Result:**
-A request with this Virtual Key cannot access any tools. All tools from all clients are blocked.
+A request with this Virtual Key cannot access any tools. All tools from all clients are blocked. If `support-client` were marked **Allow by Default** instead, its tools would still be reachable despite `billing-client`'s empty list: Allow by Default is decided per client and does not depend on what other clients on the same key are configured with.
 </Tab>
 </Tabs>
 

--- a/docs/mcp/filtering.mdx
+++ b/docs/mcp/filtering.mdx
@@ -224,10 +224,10 @@ This consistent naming convention ensures clear separation between tools from di
 
 ## Level 3: Virtual Key Filtering (Gateway Only)
 
-Virtual Keys can have their own MCP tool access configuration, which **takes precedence** over request-level headers.
+Virtual Keys can have their own MCP tool access configuration, which is the ceiling for request-level headers: a header can narrow the key's allow-list, never widen it.
 
 <Note>
-When a Virtual Key has no MCP configurations, **no MCP tools are available** (deny-by-default). You must explicitly add MCP client configurations to allow tools. When a Virtual Key has MCP configurations, it generates the `x-bf-mcp-include-tools` header automatically, overriding any manually sent header.
+When a Virtual Key has no MCP configurations, **no MCP tools are available** (deny-by-default) except from clients marked **Allow by Default**. You must explicitly add MCP client configurations to allow other tools. When the caller sends no `x-bf-mcp-include-tools` header, Bifrost generates one from the key's configuration, unless `disable_auto_tool_inject` is enabled; when the caller sends one, every entry the key does not allow is dropped from it.
 </Note>
 
 ### Configuration
@@ -299,7 +299,7 @@ curl -X POST http://localhost:8080/api/governance/virtual-keys \
 | `tools_to_execute: ["*"]` | All tools from this client |
 | `tools_to_execute: []` | No tools from this client |
 | `tools_to_execute: ["a", "b"]` | Only specified tools |
-| Client not configured | All tools blocked from that client |
+| Client not configured | All tools blocked from that client, unless the client is marked **Allow by Default** |
 
 Learn more in [MCP Tool Filtering for Virtual Keys](../features/governance/mcp-tools).
 
@@ -310,8 +310,8 @@ Learn more in [MCP Tool Filtering for Virtual Keys](../features/governance/mcp-t
 ### How Filters Combine
 
 1. **Client config** is the baseline (must include the tool)
-2. **Request filters** further narrow down (if specified)
-3. **VK filters** override request filters (if VK has MCP configs)
+2. **VK config** is the ceiling for the request (if the VK has MCP configs, or the client is marked Allow by Default)
+3. **Request filters** narrow within that ceiling; an entry the VK does not allow is dropped
 
 ### Example Scenario
 
@@ -321,13 +321,14 @@ Learn more in [MCP Tool Filtering for Virtual Keys](../features/governance/mcp-t
 
 **Request with `prod-key`:**
 ```bash
+## filesystem-write_file is outside the key's allow-list
 curl -X POST http://localhost:8080/v1/chat/completions \
   -H "Authorization: Bearer vk_prod_key" \
-  -H "x-bf-mcp-include-tools: filesystem-write_file" \  # This is IGNORED
+  -H "x-bf-mcp-include-tools: filesystem-write_file" \
   -d '...'
 ```
 
-**Result:** Only `read_file` is available (VK config overrides request header)
+**Result:** No tools are attached. `write_file` is outside the key's allow-list, so the header prunes to nothing. Send `filesystem-read_file`, or omit the header, to get `read_file`.
 
 **Request without VK (if allowed):**
 ```bash

--- a/docs/mcp/gateway-auth.mdx
+++ b/docs/mcp/gateway-auth.mdx
@@ -201,7 +201,7 @@ The **OAuth Grants** page lists credentials Bifrost **issued to clients** for in
 
 ## Token Lifetime & Revocation
 
-- **Access tokens** are JWTs valid for `access_token_ttl` (default 600s). On every `/mcp` request Bifrost validates the JWT — signature, expiry, issuer, and audience — and confirms the bound identity (the virtual key or user) still exists and is active. The identity check reads an in-memory cache, so in the common case it adds no database round-trip (vk-mode falls back to a single store lookup only on a cache miss).
+- **Access tokens** are JWTs valid for `access_token_ttl` (default 600s). On every `/mcp` request Bifrost validates the JWT (signature, expiry, issuer, and audience) and confirms the bound identity still exists: a user-mode token is rejected with `401` when the user is gone, and a vk-mode token resolves to its key, which governance refuses with `403` when it is inactive or expired, the same way the inference endpoints refuse it. The identity check reads an in-memory cache, so in the common case it adds no database round-trip (vk-mode falls back to a single store lookup only on a cache miss).
 - **Refresh tokens** rotate on each use and have no fixed expiry. A token is invalidated by rotation, by the bound virtual key or user becoming inactive or deleted, or by an explicit revoke.
 - An explicit revoke marks the grant's refresh-token row revoked, so renewals stop immediately — but it does **not** remove the bound identity, so the identity check still passes and the already-issued access token keeps working until it expires. Lower `access_token_ttl` to shorten that window.
 - **Deleting** the bound virtual key or user is stronger than revoking a grant: it revokes the grant immediately *and* the identity check rejects the grant's already-issued access token on its next `/mcp` request, instead of letting it live out its TTL.
@@ -235,6 +235,11 @@ In `headers` mode these endpoints return `404`.
 **Symptom:** A virtual key or API key that worked before now gets a `401`.
 **Cause:** `mcp_server_auth_mode` is `oauth`, which accepts JWTs only.
 **Fix:** Use `both` to accept header credentials alongside OAuth.
+
+### Key refused with 403 on /mcp
+**Symptom:** A request with a valid virtual key gets `403` with `virtual key is inactive` or `virtual key has expired`.
+**Cause:** The key authenticated, but governance refuses it, exactly as it would on an inference request.
+**Fix:** Reactivate the key or extend its expiry; the change applies on the next `/mcp` request.
 
 ### Conflicting credentials on /mcp
 **Symptom:** `conflicting credentials: an OAuth token and a virtual key header were both provided`.

--- a/docs/mcp/gateway.mdx
+++ b/docs/mcp/gateway.mdx
@@ -118,19 +118,19 @@ Include any required Virtual Key authentication headers if governance is enabled
 
 ## Virtual Key Authentication
 
-Bifrost supports per-Virtual Key MCP servers, allowing you to expose different tools to different clients.
+Every request to `/mcp` is scoped to what its credentials allow, so different clients see different tools from the same endpoint.
 
 <Note>
 Header credentials are one of two ways clients authenticate to `/mcp`. Clients can also connect through a browser-based OAuth flow — see [Gateway Authentication](./gateway-auth) for the `mcp_server_auth_mode` setting and the OAuth connect flow.
 </Note>
 
-### Global Server (No Virtual Key)
+### Anonymous Access (No Credentials)
 
-When `enforce_auth_on_inference` is `false`, requests without a Virtual Key use the global MCP server with all available tools.
+When `enforce_auth_on_inference` is `false`, requests without credentials see all available tools.
 
-### Virtual Key-Specific Servers
+### Scoped by Virtual Key
 
-When using Virtual Keys, each VK gets its own MCP server with filtered tools based on its configuration.
+With a Virtual Key, `tools/list` returns only the tools the key allows: the clients configured on the key (see [Tool Filtering](#tool-filtering-for-mcp-clients)) plus any client marked **Allow by Default**. `tools/call` is checked against the same allow-list, and a key that is inactive or expired is refused with `403`, exactly as on the inference endpoints. An `x-bf-mcp-include-tools` header can narrow the list further for a request, never widen it.
 
 **Authenticate with Virtual Key:**
 
@@ -225,6 +225,8 @@ Configure which tools each Virtual Key can access:
   }
 }
 ```
+
+A client marked **Allow by Default** (`allow_by_default` in its configuration) is available, with all of its tools, to every key that does not configure it explicitly. A key's own configuration for that client takes precedence, including an empty tool list, which blocks it for that key.
 
 Learn more about Virtual Key tool filtering in [MCP Tool Filtering](../features/governance/mcp-tools).
 

--- a/examples/configs/v1compat/config.json
+++ b/examples/configs/v1compat/config.json
@@ -48,7 +48,7 @@
         "connection_string": "http://localhost:3001",
         "auth_type": "none",
         "tools_to_execute": ["*"],
-        "allow_on_all_virtual_keys": false
+        "allow_by_default": false
       }
     ]
   },

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1612,7 +1612,7 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 					ToolSyncInterval:          time.Duration(dbClient.ToolSyncInterval) * time.Second,
 					ToolExecutionTimeout:      time.Duration(dbClient.ToolExecutionTimeout) * time.Second,
 					ToolPricing:               dbClient.ToolPricing,
-					AllowOnAllVirtualKeys:     dbClient.AllowOnAllVirtualKeys,
+					AllowByDefault:            dbClient.AllowByDefault,
 					Disabled:                  dbClient.Disabled,
 					DiscoveredTools:           dbClient.DiscoveredTools,
 					DiscoveredToolNameMapping: dbClient.DiscoveredToolNameMapping,
@@ -1662,7 +1662,7 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 			NeedsSessionStickiness:    dbClient.NeedsSessionStickiness,
 			ToolSyncInterval:          time.Duration(dbClient.ToolSyncInterval) * time.Second,
 			ToolExecutionTimeout:      time.Duration(dbClient.ToolExecutionTimeout) * time.Second,
-			AllowOnAllVirtualKeys:     dbClient.AllowOnAllVirtualKeys,
+			AllowByDefault:            dbClient.AllowByDefault,
 			Disabled:                  dbClient.Disabled,
 			ToolPricing:               dbClient.ToolPricing,
 			DiscoveredTools:           dbClient.DiscoveredTools,
@@ -1723,9 +1723,9 @@ func (s *RDBConfigStore) GetMCPClientsPaginated(ctx context.Context, params MCPC
 			baseQuery = baseQuery.Where("client_id NOT IN ?", params.StateClientIDs)
 		}
 	}
-	// VK access filter: OR the "open to all VKs" flag with an explicit-assignment
+	// VK access filter: OR the allowed-by-default flag with an explicit-assignment
 	// subquery over the VK⇄MCP join table (matched on the numeric primary key).
-	if params.OnlyAllVirtualKeys || len(params.VirtualKeyIDs) > 0 {
+	if params.OnlyAllowedByDefault || len(params.VirtualKeyIDs) > 0 {
 		var assignedSub *gorm.DB
 		if len(params.VirtualKeyIDs) > 0 {
 			assignedSub = s.DB().WithContext(ctx).
@@ -1734,11 +1734,11 @@ func (s *RDBConfigStore) GetMCPClientsPaginated(ctx context.Context, params MCPC
 				Where("virtual_key_id IN ?", params.VirtualKeyIDs)
 		}
 		switch {
-		case params.OnlyAllVirtualKeys && assignedSub != nil:
+		case params.OnlyAllowedByDefault && assignedSub != nil:
 			baseQuery = baseQuery.Where(
 				s.DB().Where("allow_on_all_virtual_keys = ?", true).Or("id IN (?)", assignedSub),
 			)
-		case params.OnlyAllVirtualKeys:
+		case params.OnlyAllowedByDefault:
 			baseQuery = baseQuery.Where("allow_on_all_virtual_keys = ?", true)
 		default:
 			baseQuery = baseQuery.Where("id IN (?)", assignedSub)
@@ -2099,7 +2099,7 @@ func (s *RDBConfigStore) GetMCPClientConfigByID(ctx context.Context, id string) 
 		NeedsSessionStickiness:    dbClient.NeedsSessionStickiness,
 		ToolSyncInterval:          time.Duration(dbClient.ToolSyncInterval) * time.Second,
 		ToolExecutionTimeout:      time.Duration(dbClient.ToolExecutionTimeout) * time.Second,
-		AllowOnAllVirtualKeys:     dbClient.AllowOnAllVirtualKeys,
+		AllowByDefault:            dbClient.AllowByDefault,
 		Disabled:                  dbClient.Disabled,
 		ToolPricing:               dbClient.ToolPricing,
 		DiscoveredTools:           dbClient.DiscoveredTools,
@@ -2247,7 +2247,7 @@ func (s *RDBConfigStore) CreateMCPClientConfig(ctx context.Context, clientConfig
 			NeedsSessionStickiness: clientConfigCopy.NeedsSessionStickiness,
 			ToolSyncInterval:       toolSyncIntervalSec,
 			ToolExecutionTimeout:   toolExecutionTimeoutSec,
-			AllowOnAllVirtualKeys:  clientConfigCopy.AllowOnAllVirtualKeys,
+			AllowByDefault:         clientConfigCopy.AllowByDefault,
 			// DiscoveredTools has json:"-" so deepCopy loses it; use original clientConfig
 			DiscoveredTools:           clientConfig.DiscoveredTools,
 			DiscoveredToolNameMapping: clientConfig.DiscoveredToolNameMapping,
@@ -2434,7 +2434,7 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 			"tool_pricing_json":          string(toolPricingJSON),
 			"tool_sync_interval":         clientConfigCopy.ToolSyncInterval,
 			"tool_execution_timeout":     clientConfigCopy.ToolExecutionTimeout,
-			"allow_on_all_virtual_keys":  clientConfigCopy.AllowOnAllVirtualKeys,
+			"allow_on_all_virtual_keys":  clientConfigCopy.AllowByDefault,
 			"disabled":                   clientConfigCopy.Disabled,
 			"updated_at":                 time.Now(),
 		}
@@ -8166,14 +8166,14 @@ func (s *RDBConfigStore) DeleteExpiredMCPPerUserHeaderFlows(ctx context.Context)
 // ----- Per-user credential reconciliation -----
 //
 // The Reconcile* methods orphan/reactivate vk-keyed credentials whose MCP
-// grant changed (allowlist edit, AllowOnAllVirtualKeys toggle, VK delete).
+// grant changed (allowlist edit, AllowByDefault toggle, VK delete).
 // Pending flow rows whose MCP lost the grant are hard-deleted — they're
 // transient in-flight attempts that can't complete without the grant.
 //
 // "Effective allowlist" for a VK = explicit rows in
-// governance_virtual_key_mcp_configs ∪ MCPs with
-// config_mcp_clients.allow_on_all_virtual_keys = true. Mirrors the runtime
-// check in plugins/governance/main.go isMCPToolAllowedByVKWith.
+// governance_virtual_key_mcp_configs ∪ MCPs allowed by default (column
+// config_mcp_clients.allow_on_all_virtual_keys). Mirrors grantForVirtualKey in
+// plugins/governance/store.go.
 //
 // Runtime lookups filter status='active', so orphaned rows are invisible
 // until reactivation. 'needs_reauth' (OAuth) and 'needs_update' (headers)
@@ -8184,7 +8184,7 @@ func (s *RDBConfigStore) DeleteExpiredMCPPerUserHeaderFlows(ctx context.Context)
 
 // vkEffectiveMCPClientIDs returns the set of MCP client_ids the given VK
 // can access — union of explicit per-VK allowlist and MCPs marked
-// AllowOnAllVirtualKeys=true.
+// AllowByDefault=true.
 func vkEffectiveMCPClientIDs(tx *gorm.DB, vkID string) ([]string, error) {
 	var explicit []string
 	if err := tx.Table("governance_virtual_key_mcp_configs vkmc").
@@ -8198,7 +8198,7 @@ func vkEffectiveMCPClientIDs(tx *gorm.DB, vkID string) ([]string, error) {
 	if err := tx.Table("config_mcp_clients").
 		Where("allow_on_all_virtual_keys = ?", true).
 		Pluck("client_id", &implicit).Error; err != nil {
-		return nil, fmt.Errorf("read AllowOnAllVirtualKeys MCPs: %w", err)
+		return nil, fmt.Errorf("read AllowByDefault MCPs: %w", err)
 	}
 	if len(implicit) == 0 {
 		return explicit, nil
@@ -8379,7 +8379,7 @@ func (s *RDBConfigStore) ReconcileMCPHeadersAfterVKChange(ctx context.Context, v
 
 // ReconcileOauthAfterMCPChange re-evaluates every VK that holds an OAuth
 // credential for the given MCP. Called when an MCP edit mutates who can
-// access it (vk_configs diff or AllowOnAllVirtualKeys toggle).
+// access it (vk_configs diff or AllowByDefault toggle).
 func (s *RDBConfigStore) ReconcileOauthAfterMCPChange(ctx context.Context, mcpClientID string) error {
 	if mcpClientID == "" {
 		return nil

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -95,8 +95,8 @@ type MCPClientsQueryParams struct {
 	// Virtual-key access filter (OR semantics within the group). When both are
 	// set, a client matches if it is open to all VKs OR explicitly assigned to
 	// one of VirtualKeyIDs.
-	OnlyAllVirtualKeys bool     // include clients with allow_on_all_virtual_keys=true
-	VirtualKeyIDs      []string // include clients explicitly assigned to any of these VK IDs
+	OnlyAllowedByDefault bool     // include clients allowed by default (column allow_on_all_virtual_keys)
+	VirtualKeyIDs        []string // include clients explicitly assigned to any of these VK IDs
 }
 
 // MCPLibraryQueryParams holds pagination, filtering, search, and sort
@@ -811,7 +811,7 @@ type ConfigStore interface {
 	// dashboard edit, AP propagation, SCIM auto-assign). Orphans
 	// vk-keyed credentials whose MCP is no longer in the VK's effective
 	// allowlist (explicit per-VK row ∪ MCPs with
-	// AllowOnAllVirtualKeys=true) and reactivates orphaned rows when the
+	// AllowByDefault=true) and reactivates orphaned rows when the
 	// grant returns. Pending flow rows for lost grants are hard-deleted.
 	//
 	// Session-keyed rows are never touched — they carry no notion of
@@ -822,7 +822,7 @@ type ConfigStore interface {
 	ReconcileOauthAfterVKChange(ctx context.Context, vkID string) error
 	ReconcileMCPHeadersAfterVKChange(ctx context.Context, vkID string) error
 	// MCP-side variants: called when the change originates on the MCP
-	// client (vk_configs edit OR AllowOnAllVirtualKeys toggle). Each
+	// client (vk_configs edit OR AllowByDefault toggle). Each
 	// re-evaluates every VK that holds a credential for the changed MCP.
 	ReconcileOauthAfterMCPChange(ctx context.Context, mcpClientID string) error
 	ReconcileMCPHeadersAfterMCPChange(ctx context.Context, mcpClientID string) error

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -67,8 +67,10 @@ type TableMCPClient struct {
 	// integration at exchange time.
 	TokenExchangeJSON *string `gorm:"type:text" json:"-"` // JSON serialized schemas.MCPTokenExchangeConfig
 
-	AllowOnAllVirtualKeys bool `gorm:"default:false" json:"allow_on_all_virtual_keys"` // Whether to allow the MCP client to run on all virtual keys
-	Disabled              bool `gorm:"default:false" json:"disabled"`                  // Whether the client is intentionally disabled
+	// AllowByDefault opens the client to every caller not assigned it explicitly. The column keeps the
+	// name the flag was introduced under; only the wire name moved.
+	AllowByDefault bool `gorm:"column:allow_on_all_virtual_keys;default:false" json:"allow_by_default"`
+	Disabled       bool `gorm:"default:false" json:"disabled"` // Whether the client is intentionally disabled
 
 	// PendingOAuthConfigJSON stashes the inline `oauth_config` block from
 	// config.json for shared-OAuth MCP clients (auth_type='oauth') that have

--- a/plugins/governance/allowbydefault_test.go
+++ b/plugins/governance/allowbydefault_test.go
@@ -13,25 +13,25 @@ import (
 
 // mockInMemoryStore is a test double for InMemoryStore.
 type mockInMemoryStore struct {
-	allowAllClients     map[string]string // clientID → clientName, the clients open to every virtual key
-	clientNames         map[string]string // clientID → clientName, configured clients that are not
-	configuredProviders map[schemas.ModelProvider]configstore.ProviderConfig
+	allowedByDefaultClients map[string]string // clientID → clientName
+	clientNames             map[string]string // clientID → clientName, configured clients that are not allowed by default
+	configuredProviders     map[schemas.ModelProvider]configstore.ProviderConfig
 }
 
 func (m *mockInMemoryStore) GetConfiguredProviders() map[schemas.ModelProvider]configstore.ProviderConfig {
 	return m.configuredProviders
 }
 
-func (m *mockInMemoryStore) GetMCPClientsAllowingAllVirtualKeys() map[string]string {
-	return m.allowAllClients
+func (m *mockInMemoryStore) GetMCPClientsAllowedByDefault() map[string]string {
+	return m.allowedByDefaultClients
 }
 
 // GetMCPClientNames answers as the production store does: every configured client, of which the ones
-// open to every virtual key are a subset.
+// allowed by default are a subset.
 func (m *mockInMemoryStore) GetMCPClientNames() map[string]string {
-	names := make(map[string]string, len(m.clientNames)+len(m.allowAllClients))
+	names := make(map[string]string, len(m.clientNames)+len(m.allowedByDefaultClients))
 	maps.Copy(names, m.clientNames)
-	maps.Copy(names, m.allowAllClients)
+	maps.Copy(names, m.allowedByDefaultClients)
 	return names
 }
 
@@ -74,21 +74,21 @@ func buildVKNoMCPConfigs() *configstoreTables.TableVirtualKey {
 }
 
 // ============================================================================
-// per-tool checks: AllowOnAllVirtualKeys scenarios
+// per-tool checks: AllowByDefault scenarios
 // ============================================================================
 
-// VK with no MCPConfigs + AllowOnAllVirtualKeys client → tools allowed
+// VK with no MCPConfigs + AllowByDefault client → tools allowed
 func TestToolChecks_NoVKConfig_AllowAllEnabled(t *testing.T) {
 	vk := buildVKNoMCPConfigs()
 
 	assert.True(t, accessFor(vk, map[string]string{"client-1": "youtube"}).IsMCPToolAllowed("youtube-search"),
-		"specific tool should be allowed when AllowOnAllVirtualKeys is set and VK has no explicit config")
+		"specific tool should be allowed when AllowByDefault is set and VK has no explicit config")
 
 	assert.True(t, accessFor(vk, map[string]string{"client-1": "youtube"}).IsMCPToolAllowed("youtube-*"),
-		"wildcard pattern should be allowed when AllowOnAllVirtualKeys is set and VK has no explicit config")
+		"wildcard pattern should be allowed when AllowByDefault is set and VK has no explicit config")
 }
 
-// VK with explicit empty tools config for an AllowOnAllVirtualKeys client → tools blocked
+// VK with explicit empty tools config for an AllowByDefault client → tools blocked
 func TestToolChecks_ExplicitEmptyConfig_Blocks(t *testing.T) {
 	vk := buildVKWithMCPConfigs("client-1", "youtube", []string{"search"})
 
@@ -96,7 +96,7 @@ func TestToolChecks_ExplicitEmptyConfig_Blocks(t *testing.T) {
 		"explicitly listed tool should be allowed")
 
 	assert.False(t, accessFor(vk, map[string]string{"client-1": "youtube"}).IsMCPToolAllowed("youtube-upload"),
-		"non-listed tool should be blocked even when AllowOnAllVirtualKeys is set")
+		"non-listed tool should be blocked even when AllowByDefault is set")
 }
 
 // No open clients at all → nothing is granted, so every tool is blocked
@@ -105,18 +105,18 @@ func TestToolChecks_NoOpenClients_AllBlocked(t *testing.T) {
 
 	allowed := accessFor(vk, nil).IsMCPToolAllowed("youtube-search")
 	assert.False(t, allowed,
-		"nil inMemoryStore means no AllowOnAllVirtualKeys clients; tool should be blocked")
+		"nil inMemoryStore means no AllowByDefault clients; tool should be blocked")
 }
 
-// Wildcard pattern (clientName-*) with AllowOnAllVirtualKeys client and no VK config → allowed
+// Wildcard pattern (clientName-*) with AllowByDefault client and no VK config → allowed
 func TestToolChecks_WildcardPattern_AllowAll_NoVKConfig(t *testing.T) {
 	vk := buildVKNoMCPConfigs()
 
 	assert.True(t, accessFor(vk, map[string]string{"client-1": "youtube"}).IsMCPToolAllowed("youtube-*"),
-		"clientName-* wildcard should match AllowOnAllVirtualKeys fallback")
+		"clientName-* wildcard should match AllowByDefault fallback")
 }
 
-// Explicit unrestricted config (["*"]) for AllowOnAllVirtualKeys client → all tools allowed
+// Explicit unrestricted config (["*"]) for AllowByDefault client → all tools allowed
 func TestToolChecks_ExplicitUnrestrictedConfig_AllowsAll(t *testing.T) {
 	vk := buildVKWithMCPConfigs("client-1", "youtube", []string{"*"})
 
@@ -127,24 +127,24 @@ func TestToolChecks_ExplicitUnrestrictedConfig_AllowsAll(t *testing.T) {
 		"wildcard should match when explicit config is unrestricted")
 }
 
-// Tool belonging to a different client is not allowed via AllowOnAllVirtualKeys of another client
+// Tool belonging to a different client is not allowed via AllowByDefault of another client
 func TestToolChecks_DifferentClient_Blocked(t *testing.T) {
 	vk := buildVKNoMCPConfigs()
 
 	assert.False(t, accessFor(vk, map[string]string{"client-1": "youtube"}).IsMCPToolAllowed("github-list_repos"),
-		"tool from a different client should not be allowed via another client's AllowOnAllVirtualKeys")
+		"tool from a different client should not be allowed via another client's AllowByDefault")
 }
 
 // the store's view of open clients reaches the grant it builds
 func TestIsMCPToolAllowedByVK_UsesInMemoryStore(t *testing.T) {
 	store := &mockInMemoryStore{
-		allowAllClients: map[string]string{"client-1": "youtube"},
+		allowedByDefaultClients: map[string]string{"client-1": "youtube"},
 	}
 	permit := (&LocalGovernanceStore{inMemoryStore: store}).permitForVirtualKey(emptyCtx(), buildVKNoMCPConfigs())
 	access := grant.NewAccess([]schemas.Permit{permit}, nil, "", nil)
 
 	assert.True(t, access.IsMCPToolAllowed("youtube-search"),
-		"the store resolves AllowOnAllVirtualKeys clients when it builds the key's permit")
+		"the store resolves AllowByDefault clients when it builds the key's permit")
 }
 
 // A store with no view of open clients → nothing is granted, so the tool is blocked
@@ -157,18 +157,33 @@ func TestToolChecks_StoreWithoutOpenClients_Blocked(t *testing.T) {
 }
 
 // The mock has to keep the two questions apart the way the production store does: a client that is
-// configured but not open to every key is still resolvable by name.
+// configured but not allowed by default is still resolvable by name.
 func TestMockInMemoryStore_ClientNamesCoverEveryConfiguredClient(t *testing.T) {
 	store := &mockInMemoryStore{
-		allowAllClients: map[string]string{"open-id": "open"},
-		clientNames:     map[string]string{"private-id": "private"},
+		allowedByDefaultClients: map[string]string{"open-id": "open"},
+		clientNames:             map[string]string{"private-id": "private"},
 	}
 
 	names := store.GetMCPClientNames()
 	if names["open-id"] != "open" || names["private-id"] != "private" || len(names) != 2 {
 		t.Fatalf("GetMCPClientNames should name every configured client, got %v", names)
 	}
-	if allowAll := store.GetMCPClientsAllowingAllVirtualKeys(); len(allowAll) != 1 || allowAll["open-id"] != "open" {
-		t.Fatalf("GetMCPClientsAllowingAllVirtualKeys should stay the allow-all subset, got %v", allowAll)
+	if allowAll := store.GetMCPClientsAllowedByDefault(); len(allowAll) != 1 || allowAll["open-id"] != "open" {
+		t.Fatalf("GetMCPClientsAllowedByDefault should stay the allowed-by-default subset, got %v", allowAll)
 	}
+}
+
+// TestAppendMCPPermitsAllowedByDefault pins the rule every holder appends by: a client the holder
+// configured is never widened, the rest are granted every tool, in id order.
+func TestAppendMCPPermitsAllowedByDefault(t *testing.T) {
+	configured := map[string]struct{}{"client-b": {}}
+	own := []schemas.MCPPermit{{Client: "client-b", ClientName: "b", Tools: []string{}}}
+	got := AppendMCPPermitsAllowedByDefault(own, configured, map[string]string{"client-c": "c", "client-a": "a", "client-b": "b"})
+	assert.Equal(t, []schemas.MCPPermit{
+		{Client: "client-b", ClientName: "b", Tools: []string{}},
+		{Client: "client-a", ClientName: "a", Tools: []string{grant.Wildcard}},
+		{Client: "client-c", ClientName: "c", Tools: []string{grant.Wildcard}},
+	}, got)
+
+	assert.Equal(t, own, AppendMCPPermitsAllowedByDefault(own, configured, nil), "nothing allowed by default leaves the list as it was")
 }

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -40,8 +40,8 @@ type Config struct {
 
 type InMemoryStore interface {
 	GetConfiguredProviders() map[schemas.ModelProvider]configstore.ProviderConfig
-	GetMCPClientsAllowingAllVirtualKeys() map[string]string // clientID → clientName
-	GetMCPClientNames() map[string]string                   // clientID → clientName, every client
+	GetMCPClientsAllowedByDefault() map[string]string // clientID → clientName
+	GetMCPClientNames() map[string]string             // clientID → clientName, every client
 }
 
 type BaseGovernancePlugin interface {

--- a/plugins/governance/permits_test.go
+++ b/plugins/governance/permits_test.go
@@ -44,10 +44,10 @@ func vkMCPConfig(clientID, clientName string, tools ...string) configstoreTables
 	}
 }
 
-// vkPermit builds the permit a key confers, with the given clients open to every key. The builder
+// vkPermit builds the permit a key confers, with the given clients allowed by default. The builder
 // belongs to the store that owns the key data, so tests reach it through one.
 func vkPermit(vk *configstoreTables.TableVirtualKey, openClients map[string]string) *grant.Permit {
-	store := &LocalGovernanceStore{inMemoryStore: &mockInMemoryStore{allowAllClients: openClients}}
+	store := &LocalGovernanceStore{inMemoryStore: &mockInMemoryStore{allowedByDefaultClients: openClients}}
 	return store.permitForVirtualKey(emptyCtx(), vk)
 }
 
@@ -900,7 +900,7 @@ func benchStore(b *testing.B, vk *configstoreTables.TableVirtualKey) *LocalGover
 	b.Helper()
 	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{
 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
-	}, nil, &mockInMemoryStore{allowAllClients: map[string]string{"sentry-id": "sentry", "pager-id": "pager"}})
+	}, nil, &mockInMemoryStore{allowedByDefaultClients: map[string]string{"sentry-id": "sentry", "pager-id": "pager"}})
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/plugins/governance/prunemcpincludetools_test.go
+++ b/plugins/governance/prunemcpincludetools_test.go
@@ -125,24 +125,24 @@ func TestPruneMCPIncludeTools_DedupAcrossWildcardAndSpecific(t *testing.T) {
 	assert.Equal(t, []string{"sentry-find_projects", "sentry-search_issues"}, includeToolsFromCtx(t, ctx))
 }
 
-// AllowOnAllVirtualKeys client with no explicit VK config: both specific and wildcard
+// AllowByDefault client with no explicit VK config: both specific and wildcard
 // requests survive (the implicit grant is client-wide).
-func TestPruneMCPIncludeTools_AllowOnAllVirtualKeysClient(t *testing.T) {
+func TestPruneMCPIncludeTools_AllowByDefaultClient(t *testing.T) {
 	p := newPluginWithInMemoryStore(&mockInMemoryStore{
-		allowAllClients: map[string]string{"client-1": "youtube"},
+		allowedByDefaultClients: map[string]string{"client-1": "youtube"},
 	})
 	vk := buildVKNoMCPConfigs()
 	ctx := newCtxWithIncludeTools([]string{"youtube-search", "youtube-*", "github-list_repos"})
 
 	assert.True(t, p.pruneMCPIncludeToolsFromContext(ctx, accessFor(vk, map[string]string{"client-1": "youtube"})))
 	assert.Equal(t, []string{"youtube-search", "youtube-*"}, includeToolsFromCtx(t, ctx),
-		"AllowOnAllVirtualKeys grants the whole client; other clients are still pruned")
+		"AllowByDefault grants the whole client; other clients are still pruned")
 }
 
-// An explicit empty VK config (deny-all) overrides the client's AllowOnAllVirtualKeys flag.
+// An explicit empty VK config (deny-all) overrides the client's AllowByDefault flag.
 func TestPruneMCPIncludeTools_ExplicitEmptyConfigOverridesAllowAll(t *testing.T) {
 	p := newPluginWithInMemoryStore(&mockInMemoryStore{
-		allowAllClients: map[string]string{"client-1": "youtube"},
+		allowedByDefaultClients: map[string]string{"client-1": "youtube"},
 	})
 	vk := buildVKWithMCPConfigs("client-1", "youtube", []string{})
 	ctx := newCtxWithIncludeTools([]string{"youtube-search", "youtube-*"})

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -1328,10 +1328,10 @@ func (gs *LocalGovernanceStore) CheckProviderCandidateExclusion(ctx *schemas.Bif
 
 // permitForVirtualKey builds the permit a virtual key confers: one provider permit per configured
 // provider, and one MCP permit per MCP client the key may execute tools of: its own MCP configs,
-// plus the clients that are open to every virtual key.
+// plus the clients allowed by default.
 //
-// allowAllVKsClients maps client id to client name, as the in-memory store reports it. A client the
-// key configures explicitly is never widened by that map: the explicit config decides, including
+// allowedByDefaultClients maps client id to client name, as the in-memory store reports it. A client
+// the key configures explicitly is never widened by that map: the explicit config decides, including
 // when it grants no tool at all.
 //
 // The result is a snapshot for one attempt. Provider permits carry a copy of the config they came
@@ -1343,9 +1343,9 @@ func (gs *LocalGovernanceStore) permitForVirtualKey(ctx context.Context, vk *con
 		return nil
 	}
 
-	var allowAllVKsClients map[string]string
+	var allowedByDefaultClients map[string]string
 	if gs.inMemoryStore != nil {
-		allowAllVKsClients = gs.inMemoryStore.GetMCPClientsAllowingAllVirtualKeys()
+		allowedByDefaultClients = gs.inMemoryStore.GetMCPClientsAllowedByDefault()
 	}
 
 	providerPermits := make([]schemas.ProviderPermit, 0, len(vk.ProviderConfigs))
@@ -1361,7 +1361,7 @@ func (gs *LocalGovernanceStore) permitForVirtualKey(ctx context.Context, vk *con
 	}
 
 	// The key's own MCP configs come first, so they own their clients.
-	mcpPermits := make([]schemas.MCPPermit, 0, len(vk.MCPConfigs)+len(allowAllVKsClients))
+	mcpPermits := make([]schemas.MCPPermit, 0, len(vk.MCPConfigs)+len(allowedByDefaultClients))
 	configured := make(map[string]struct{}, len(vk.MCPConfigs))
 	for _, mcpConfig := range vk.MCPConfigs {
 		configured[mcpConfig.MCPClient.ClientID] = struct{}{}
@@ -1372,26 +1372,40 @@ func (gs *LocalGovernanceStore) permitForVirtualKey(ctx context.Context, vk *con
 		})
 	}
 
-	// Clients open to every virtual key grant all their tools, unless the key configured them
-	// above. Sorted so the permit, and everything derived from it, is stable regardless of map
-	// iteration order.
-	openClientIDs := make([]string, 0, len(allowAllVKsClients))
-	for clientID := range allowAllVKsClients {
+	mcpPermits = AppendMCPPermitsAllowedByDefault(mcpPermits, configured, allowedByDefaultClients)
+
+	return grant.NewPermit(grant.PermitVirtualKey, vk.ID, vk.Name, vk.IsActiveValue(), vk.IsExpiredAt(time.Now().UTC()), providerPermits, mcpPermits)
+}
+
+// AppendMCPPermitsAllowedByDefault adds a permit for every client allowed by default that the holder
+// has not configured itself: all of the client's tools, under the client's name. A client in
+// configured is left alone whatever it was configured with, since an explicit assignment decides for
+// its holder even when it grants nothing.
+//
+// One function because every kind of holder appends the same way: a holder that has built its own
+// list hands over the clients it named and gets the list back with the defaults added. Appended in
+// id order, so the permit, and everything derived from it, is stable regardless of map iteration
+// order.
+func AppendMCPPermitsAllowedByDefault(mcpPermits []schemas.MCPPermit, configured map[string]struct{}, allowedByDefault map[string]string) []schemas.MCPPermit {
+	if len(allowedByDefault) == 0 {
+		return mcpPermits
+	}
+	clientIDs := make([]string, 0, len(allowedByDefault))
+	for clientID := range allowedByDefault {
 		if _, ok := configured[clientID]; ok {
 			continue
 		}
-		openClientIDs = append(openClientIDs, clientID)
+		clientIDs = append(clientIDs, clientID)
 	}
-	sort.Strings(openClientIDs)
-	for _, clientID := range openClientIDs {
+	sort.Strings(clientIDs)
+	for _, clientID := range clientIDs {
 		mcpPermits = append(mcpPermits, schemas.MCPPermit{
 			Client:     clientID,
-			ClientName: allowAllVKsClients[clientID],
+			ClientName: allowedByDefault[clientID],
 			Tools:      []string{grant.Wildcard},
 		})
 	}
-
-	return grant.NewPermit(grant.PermitVirtualKey, vk.ID, vk.Name, vk.IsActiveValue(), vk.IsExpiredAt(time.Now().UTC()), providerPermits, mcpPermits)
+	return mcpPermits
 }
 
 // virtualKeyOf is the key row behind a permit, when the permit is a key's. Nothing else this store

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -2396,10 +2396,11 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Per-user credential reconciliation when the VK's MCP allowlist
-	// changed. Mirrors the AP-propagation path: enterprise orphans /
+	// changed. Mirrors the AP-propagation path: the store orphans /
 	// reactivates credentials keyed to this VK (vk-keyed creds) and to the
 	// VK's owner (user-keyed creds) against the new effective allowlist
-	// (explicit rows ∪ MCPs with AllowOnAllVirtualKeys=true). OSS no-ops.
+	// (explicit rows ∪ MCPs with AllowByDefault=true). A store without
+	// per-user credentials does nothing.
 	// Must run before ReloadVirtualKey: the reload also evicts this VK's
 	// cached OAuth tokens and header credentials, and an eviction that lands
 	// before these writes could be refilled from the pre-reconcile rows and

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -552,7 +552,7 @@ func (h *MCPHandler) verifyMCPClientHeaders(ctx *fasthttp.RequestCtx) {
 		ToolPricing:               clientConfig.ToolPricing,
 		ToolSyncInterval:          int(clientConfig.ToolSyncInterval / time.Second),
 		ToolExecutionTimeout:      int(clientConfig.ToolExecutionTimeout / time.Second),
-		AllowOnAllVirtualKeys:     clientConfig.AllowOnAllVirtualKeys,
+		AllowByDefault:            clientConfig.AllowByDefault,
 		PerUserHeaderKeys:         clientConfig.PerUserHeaderKeys,
 		DiscoveredTools:           clientConfig.DiscoveredTools,
 		DiscoveredToolNameMapping: clientConfig.DiscoveredToolNameMapping,
@@ -726,7 +726,7 @@ func (h *MCPHandler) verifyMCPClientExchange(ctx *fasthttp.RequestCtx) {
 		ToolPricing:               clientConfig.ToolPricing,
 		ToolSyncInterval:          int(clientConfig.ToolSyncInterval / time.Second),
 		ToolExecutionTimeout:      int(clientConfig.ToolExecutionTimeout / time.Second),
-		AllowOnAllVirtualKeys:     clientConfig.AllowOnAllVirtualKeys,
+		AllowByDefault:            clientConfig.AllowByDefault,
 		TokenExchange:             clientConfig.TokenExchange,
 		DiscoveredTools:           clientConfig.DiscoveredTools,
 		DiscoveredToolNameMapping: clientConfig.DiscoveredToolNameMapping,
@@ -844,11 +844,18 @@ func (h *MCPHandler) getMCPClients(ctx *fasthttp.RequestCtx) {
 		AuthTypes:       parseCommaSeparated(string(ctx.QueryArgs().Peek("auth_type"))),
 		VirtualKeyIDs:   parseCommaSeparated(string(ctx.QueryArgs().Peek("virtual_keys"))),
 	}
-	if b, ok, err := parseBoolQueryArg(ctx, "all_virtual_keys"); err != nil {
+	// allowed_by_default replaced all_virtual_keys. The earlier name is still read, and the current
+	// one decides when both are sent.
+	if b, ok, err := parseBoolQueryArg(ctx, "allowed_by_default"); err != nil {
+		SendError(ctx, 400, "Invalid allowed_by_default parameter: must be a boolean")
+		return
+	} else if ok {
+		params.OnlyAllowedByDefault = b
+	} else if b, ok, err := parseBoolQueryArg(ctx, "all_virtual_keys"); err != nil {
 		SendError(ctx, 400, "Invalid all_virtual_keys parameter: must be a boolean")
 		return
 	} else if ok {
-		params.OnlyAllVirtualKeys = b
+		params.OnlyAllowedByDefault = b
 	}
 	// Runtime state selection (healthy/unstable) — resolved against the
 	// live engine inside getMCPClientsPaginated since it isn't a DB column.
@@ -1297,7 +1304,7 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, params con
 			ToolSyncInterval:       time.Duration(dbClient.ToolSyncInterval) * time.Second,
 			ToolExecutionTimeout:   time.Duration(dbClient.ToolExecutionTimeout) * time.Second,
 			ToolPricing:            dbClient.ToolPricing,
-			AllowOnAllVirtualKeys:  dbClient.AllowOnAllVirtualKeys,
+			AllowByDefault:         dbClient.AllowByDefault,
 			Disabled:               dbClient.Disabled,
 			PerUserHeaderKeys:      dbClient.PerUserHeaderKeys,
 			TokenExchange:          dbClient.TokenExchange,
@@ -1437,6 +1444,23 @@ type MCPClientRequest struct {
 	UserHeaders map[string]string   `json:"user_headers,omitempty"`
 }
 
+// UnmarshalJSON reads allow_by_default under its earlier name as well, allow_on_all_virtual_keys, so a
+// caller that has not moved to the current key is still understood. The current key decides when both
+// are sent; see schemas.ResolveAllowByDefault.
+func (r *MCPClientRequest) UnmarshalJSON(data []byte) error {
+	type alias MCPClientRequest
+	aux := &struct {
+		AllowByDefault        *bool `json:"allow_by_default,omitempty"`
+		AllowOnAllVirtualKeys *bool `json:"allow_on_all_virtual_keys,omitempty"`
+		*alias
+	}{alias: (*alias)(r)}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	r.AllowByDefault = schemas.ResolveAllowByDefault(aux.AllowByDefault, aux.AllowOnAllVirtualKeys)
+	return nil
+}
+
 // MCPVKConfigRequest represents a per-VK tool access config for an MCP client
 type MCPVKConfigRequest struct {
 	VirtualKeyID   string            `json:"virtual_key_id"`
@@ -1459,7 +1483,7 @@ const errToolSyncIntervalNegative = "tool_sync_interval must be 0 (use the globa
 type MCPClientUpdateRequest struct {
 	Name                   *string                         `json:"name,omitempty"`
 	Disabled               *bool                           `json:"disabled,omitempty"`
-	AllowOnAllVirtualKeys  *bool                           `json:"allow_on_all_virtual_keys,omitempty"`
+	AllowByDefault         *bool                           `json:"allow_by_default,omitempty"`
 	IsCodeModeClient       *bool                           `json:"is_code_mode_client,omitempty"`
 	IsPingAvailable        *bool                           `json:"is_ping_available,omitempty"`
 	NeedsSessionStickiness *bool                           `json:"needs_session_stickiness,omitempty"`
@@ -1475,6 +1499,20 @@ type MCPClientUpdateRequest struct {
 	TLSConfig              *schemas.MCPTLSConfig           `json:"tls_config,omitempty"`
 	VKConfigs              *[]MCPVKConfigRequest           `json:"vk_configs,omitempty"`
 	OauthConfig            *OAuthConfigRequest             `json:"oauth_config,omitempty"`
+
+	// AllowOnAllVirtualKeys is the earlier name of allow_by_default, still accepted. AllowByDefault
+	// decides when both are sent; see schemas.ResolveAllowByDefault.
+	AllowOnAllVirtualKeys *bool `json:"allow_on_all_virtual_keys,omitempty"`
+}
+
+// resolvedAllowByDefault applies PATCH semantics to allow_by_default: the request's value when it
+// sent one under either wire name, otherwise existing. The current name decides when both are sent;
+// see schemas.ResolveAllowByDefault.
+func (req *MCPClientUpdateRequest) resolvedAllowByDefault(existing bool) bool {
+	if req.AllowByDefault == nil && req.AllowOnAllVirtualKeys == nil {
+		return existing
+	}
+	return schemas.ResolveAllowByDefault(req.AllowByDefault, req.AllowOnAllVirtualKeys)
 }
 
 // addMCPClient handles POST /api/mcp/client - Add a new MCP client
@@ -1614,7 +1652,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 			ToolPricing:            req.ToolPricing,
 			Headers:                req.Headers,
 			AllowedExtraHeaders:    req.AllowedExtraHeaders,
-			AllowOnAllVirtualKeys:  req.AllowOnAllVirtualKeys,
+			AllowByDefault:         req.AllowByDefault,
 		}
 
 		// Verify connection and discover tools using the admin's sample
@@ -1724,7 +1762,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 			ToolPricing:            req.ToolPricing,
 			Headers:                req.Headers,
 			AllowedExtraHeaders:    req.AllowedExtraHeaders,
-			AllowOnAllVirtualKeys:  req.AllowOnAllVirtualKeys,
+			AllowByDefault:         req.AllowByDefault,
 		}
 
 		// Resolve an admin credential for synchronous verification + tool
@@ -1855,7 +1893,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 			ToolPricing:            req.ToolPricing,
 			Headers:                req.Headers,
 			AllowedExtraHeaders:    req.AllowedExtraHeaders,
-			AllowOnAllVirtualKeys:  req.AllowOnAllVirtualKeys,
+			AllowByDefault:         req.AllowByDefault,
 		}
 
 		if err := h.oauthHandler.StorePendingMCPClient(flowInitiation.OauthConfigID, pendingConfig); err != nil {
@@ -1941,7 +1979,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 			Headers:                req.Headers,
 			AllowedExtraHeaders:    req.AllowedExtraHeaders,
 			ToolPricing:            req.ToolPricing,
-			AllowOnAllVirtualKeys:  req.AllowOnAllVirtualKeys,
+			AllowByDefault:         req.AllowByDefault,
 		}
 
 		// Store pending config in database (associated with oauth_config_id for multi-instance support)
@@ -1998,7 +2036,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 		ToolSyncInterval:       toolSyncInterval,
 		ToolExecutionTimeout:   resolvedToolExecutionTimeout,
 		ToolPricing:            req.ToolPricing,
-		AllowOnAllVirtualKeys:  req.AllowOnAllVirtualKeys,
+		AllowByDefault:         req.AllowByDefault,
 	}
 
 	// Creating MCP client config in config store
@@ -2074,7 +2112,7 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 	// PerUserHeaderKeys is snapshotted via append (independent backing array) rather
 	// than a bare slice-header copy, so we're safe if a future change mutates the
 	// slice contents in-place instead of reassigning the header.
-	existingAllowOnAllVirtualKeys := existingConfig.AllowOnAllVirtualKeys
+	existingAllowByDefault := existingConfig.AllowByDefault
 	existingPerUserHeaderKeys := append([]string(nil), existingConfig.PerUserHeaderKeys...)
 
 	// Resolve all mutable fields with PATCH semantics: use the provided value if
@@ -2087,10 +2125,7 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 	if req.Disabled != nil {
 		disabled = *req.Disabled
 	}
-	allowOnAllVKs := existingConfig.AllowOnAllVirtualKeys
-	if req.AllowOnAllVirtualKeys != nil {
-		allowOnAllVKs = *req.AllowOnAllVirtualKeys
-	}
+	allowByDefault := req.resolvedAllowByDefault(existingConfig.AllowByDefault)
 	isCodeMode := existingConfig.IsCodeModeClient
 	if req.IsCodeModeClient != nil {
 		isCodeMode = *req.IsCodeModeClient
@@ -2483,7 +2518,7 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		ToolExecutionTimeout:   int(resolvedToolExecutionTimeout / time.Second),
 		AuthType:               string(existingConfig.AuthType),
 		OauthConfigID:          existingConfig.OauthConfigID,
-		AllowOnAllVirtualKeys:  allowOnAllVKs,
+		AllowByDefault:         allowByDefault,
 		Disabled:               disabled,
 		PerUserHeaderKeys:      perUserHeaderKeys,
 		TokenExchange:          tokenExchange,
@@ -2540,7 +2575,7 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		ToolSyncInterval:       toolSyncInterval,
 		ToolExecutionTimeout:   resolvedToolExecutionTimeout,
 		ToolPricing:            toolPricing,
-		AllowOnAllVirtualKeys:  allowOnAllVKs,
+		AllowByDefault:         allowByDefault,
 		Disabled:               disabled,
 		PerUserHeaderKeys:      perUserHeaderKeys,
 		TokenExchange:          tokenExchange,
@@ -2827,15 +2862,15 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 	// Per-user credential reconciliation for changes that mutate who can
 	// access this MCP. Two trigger conditions:
 	//   1. vk_configs explicitly diffed (rows added/removed/updated).
-	//   2. AllowOnAllVirtualKeys flipped — the implicit fallback toggled,
-	//      every VK with a credential for this MCP needs re-evaluation.
+	//   2. allow_by_default flipped: the default grant toggled, so every
+	//      credential held for this MCP needs re-evaluation.
 	//
 	// Reconcile is enterprise-only behavior (no-op in OSS). It orphans
 	// credentials whose MCP just lost the grant and reactivates orphaned
 	// ones whose MCP regained the grant. Both surfaces (OAuth + headers)
 	// are reconciled — they share the same VK→MCP allowlist model.
 	if h.store.ConfigStore != nil {
-		shouldReconcile := req.VKConfigs != nil || allowOnAllVKs != existingAllowOnAllVirtualKeys
+		shouldReconcile := req.VKConfigs != nil || allowByDefault != existingAllowByDefault
 		if shouldReconcile {
 			if err := h.store.ConfigStore.ReconcileOauthAfterMCPChange(ctx, id); err != nil {
 				logger.Error(fmt.Sprintf("reconcile OAuth credentials after MCP %s update failed: %v", id, err))
@@ -3154,7 +3189,7 @@ func (h *MCPHandler) completePerUserOAuthAdminRepair(ctx *fasthttp.RequestCtx, b
 		ToolPricing:               clientConfig.ToolPricing,
 		ToolSyncInterval:          int(clientConfig.ToolSyncInterval / time.Second),
 		ToolExecutionTimeout:      int(clientConfig.ToolExecutionTimeout / time.Second),
-		AllowOnAllVirtualKeys:     clientConfig.AllowOnAllVirtualKeys,
+		AllowByDefault:            clientConfig.AllowByDefault,
 		PerUserHeaderKeys:         clientConfig.PerUserHeaderKeys,
 		DiscoveredTools:           clientConfig.DiscoveredTools,
 		DiscoveredToolNameMapping: clientConfig.DiscoveredToolNameMapping,
@@ -3412,7 +3447,7 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 				ToolPricing:               mcpClientConfig.ToolPricing,
 				ToolSyncInterval:          int(mcpClientConfig.ToolSyncInterval / time.Second),
 				ToolExecutionTimeout:      int(mcpClientConfig.ToolExecutionTimeout / time.Second),
-				AllowOnAllVirtualKeys:     mcpClientConfig.AllowOnAllVirtualKeys,
+				AllowByDefault:            mcpClientConfig.AllowByDefault,
 				PerUserHeaderKeys:         mcpClientConfig.PerUserHeaderKeys,
 				DiscoveredTools:           mcpClientConfig.DiscoveredTools,
 				DiscoveredToolNameMapping: mcpClientConfig.DiscoveredToolNameMapping,
@@ -3535,7 +3570,7 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 			ToolSyncInterval:          int(mcpClientConfig.ToolSyncInterval / time.Second),
 			ToolExecutionTimeout:      int(mcpClientConfig.ToolExecutionTimeout / time.Second),
 			TLSConfig:                 mcpClientConfig.TLSConfig,
-			AllowOnAllVirtualKeys:     mcpClientConfig.AllowOnAllVirtualKeys,
+			AllowByDefault:            mcpClientConfig.AllowByDefault,
 			DiscoveredTools:           mcpClientConfig.DiscoveredTools,
 			DiscoveredToolNameMapping: mcpClientConfig.DiscoveredToolNameMapping,
 			Disabled:                  mcpClientConfig.Disabled,

--- a/transports/bifrost-http/handlers/mcp_allowbydefault_test.go
+++ b/transports/bifrost-http/handlers/mcp_allowbydefault_test.go
@@ -1,0 +1,65 @@
+package handlers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMCPClientRequestReadsAllowByDefaultUnderBothKeys pins the create request's compatibility rule:
+// allow_by_default decides when present, allow_on_all_virtual_keys is read in its absence, and the
+// alias decode leaves the rest of the request intact.
+func TestMCPClientRequestReadsAllowByDefaultUnderBothKeys(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{"current key only", `{"name":"demo","allow_by_default":true}`, true},
+		{"earlier key only", `{"name":"demo","allow_on_all_virtual_keys":true}`, true},
+		{"both sent, current wins", `{"name":"demo","allow_by_default":false,"allow_on_all_virtual_keys":true}`, false},
+		{"neither sent", `{"name":"demo"}`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var req MCPClientRequest
+			require.NoError(t, json.Unmarshal([]byte(tc.raw), &req))
+			assert.Equal(t, tc.want, req.AllowByDefault)
+			assert.Equal(t, "demo", req.Name, "fields outside the alias must still decode")
+		})
+	}
+
+	t.Run("fields of the outer request still decode", func(t *testing.T) {
+		var req MCPClientRequest
+		require.NoError(t, json.Unmarshal([]byte(`{"name":"demo","client_id":"c1","allow_on_all_virtual_keys":true,"user_headers":{"x-team":"a"}}`), &req))
+		assert.True(t, req.AllowByDefault)
+		assert.Equal(t, "c1", req.ClientID)
+		assert.Equal(t, map[string]string{"x-team": "a"}, req.UserHeaders)
+	})
+}
+
+// TestMCPClientUpdateRequestResolvedAllowByDefault pins PATCH semantics for the flag under both wire
+// names: untouched when neither is sent, the current name deciding when both are.
+func TestMCPClientUpdateRequestResolvedAllowByDefault(t *testing.T) {
+	cases := []struct {
+		name     string
+		raw      string
+		existing bool
+		want     bool
+	}{
+		{"neither sent keeps existing true", `{"name":"demo"}`, true, true},
+		{"neither sent keeps existing false", `{"name":"demo"}`, false, false},
+		{"current key only", `{"allow_by_default":false}`, true, false},
+		{"earlier key only", `{"allow_on_all_virtual_keys":true}`, false, true},
+		{"both sent, current wins", `{"allow_by_default":true,"allow_on_all_virtual_keys":false}`, false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var req MCPClientUpdateRequest
+			require.NoError(t, json.Unmarshal([]byte(tc.raw), &req))
+			assert.Equal(t, tc.want, req.resolvedAllowByDefault(tc.existing))
+		})
+	}
+}

--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -543,18 +543,18 @@ func (h *MCPServerHandler) fetchToolsForVK(vk *tables.TableVirtualKey) ([]schema
 
 	executeOnlyTools := make([]string, 0)
 
-	// Build a lookup of AllowOnAllVirtualKeys clients: clientID -> clientName.
-	// Explicit VK MCPConfigs always take precedence over AllowOnAllVirtualKeys.
-	allowAllVKsClients := h.config.GetAllowOnAllVirtualKeysClients()
-	if allowAllVKsClients == nil {
-		allowAllVKsClients = make(map[string]string)
+	// Build a lookup of AllowByDefault clients: clientID -> clientName.
+	// Explicit VK MCPConfigs always take precedence over AllowByDefault.
+	allowedByDefaultClients := h.config.GetMCPClientsAllowedByDefault()
+	if allowedByDefaultClients == nil {
+		allowedByDefaultClients = make(map[string]string)
 	}
 
 	// Process explicit VK MCPConfigs first.
 	handledClients := make(map[string]bool)
 	for _, vkMcpConfig := range vk.MCPConfigs {
 		clientID := vkMcpConfig.MCPClient.ClientID
-		if _, isAllowAll := allowAllVKsClients[clientID]; isAllowAll {
+		if _, isAllowAll := allowedByDefaultClients[clientID]; isAllowAll {
 			// Explicit config exists — it takes precedence; mark handled regardless of tool list.
 			handledClients[clientID] = true
 		}
@@ -574,14 +574,14 @@ func (h *MCPServerHandler) fetchToolsForVK(vk *tables.TableVirtualKey) ([]schema
 		}
 	}
 
-	// For AllowOnAllVirtualKeys clients with no explicit VK config, allow all their tools.
-	for clientID, clientName := range allowAllVKsClients {
+	// For AllowByDefault clients with no explicit VK config, allow all their tools.
+	for clientID, clientName := range allowedByDefaultClients {
 		if !handledClients[clientID] {
 			executeOnlyTools = append(executeOnlyTools, fmt.Sprintf("%s-*", clientName))
 		}
 	}
 
-	// Always set the include-tools filter (empty = deny-all when no MCPConfigs and no AllowOnAllVirtualKeys clients)
+	// Always set the include-tools filter (empty = deny-all when no MCPConfigs and no AllowByDefault clients)
 	ctx = context.WithValue(ctx, schemas.MCPContextKeyIncludeTools, executeOnlyTools)
 	toolFilter = executeOnlyTools
 

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -2363,7 +2363,7 @@ func mcpClientConfigToTable(clientConfig *schemas.MCPClientConfig) (configstoreT
 		ToolSyncInterval:          int(clientConfig.ToolSyncInterval / time.Second),
 		ToolExecutionTimeout:      int(math.Ceil(clientConfig.ToolExecutionTimeout.Seconds())),
 		ToolPricing:               clientConfig.ToolPricing,
-		AllowOnAllVirtualKeys:     clientConfig.AllowOnAllVirtualKeys,
+		AllowByDefault:            clientConfig.AllowByDefault,
 		Disabled:                  clientConfig.Disabled,
 		DiscoveredTools:           clientConfig.DiscoveredTools,
 		DiscoveredToolNameMapping: clientConfig.DiscoveredToolNameMapping,
@@ -5437,9 +5437,9 @@ func (c *Config) GetMCPHeaderCombinedAllowlist() schemas.WhiteList {
 	return allowlist
 }
 
-// GetAllowOnAllVirtualKeysClients returns a map of clientID -> clientName for all MCP clients
-// that have AllowOnAllVirtualKeys enabled. The returned map is a copy, safe for concurrent use.
-func (c *Config) GetAllowOnAllVirtualKeysClients() map[string]string {
+// GetMCPClientsAllowedByDefault returns a map of clientID -> clientName for all MCP clients
+// that have AllowByDefault enabled. The returned map is a copy, safe for concurrent use.
+func (c *Config) GetMCPClientsAllowedByDefault() map[string]string {
 	c.muMCP.RLock()
 	defer c.muMCP.RUnlock()
 
@@ -5448,7 +5448,7 @@ func (c *Config) GetAllowOnAllVirtualKeysClients() map[string]string {
 	}
 	result := make(map[string]string)
 	for _, client := range c.MCPConfig.ClientConfigs {
-		if client != nil && client.AllowOnAllVirtualKeys {
+		if client != nil && client.AllowByDefault {
 			result[client.ID] = client.Name
 		}
 	}
@@ -6829,7 +6829,7 @@ func (c *Config) UpdateMCPClient(ctx context.Context, id string, updatedConfig *
 	c.MCPConfig.ClientConfigs[configIndex].NeedsSessionStickiness = updatedConfig.NeedsSessionStickiness
 	c.MCPConfig.ClientConfigs[configIndex].ToolSyncInterval = updatedConfig.ToolSyncInterval
 	c.MCPConfig.ClientConfigs[configIndex].ToolExecutionTimeout = updatedConfig.ToolExecutionTimeout
-	c.MCPConfig.ClientConfigs[configIndex].AllowOnAllVirtualKeys = updatedConfig.AllowOnAllVirtualKeys
+	c.MCPConfig.ClientConfigs[configIndex].AllowByDefault = updatedConfig.AllowByDefault
 	c.MCPConfig.ClientConfigs[configIndex].Disabled = updatedConfig.Disabled
 	c.MCPConfig.ClientConfigs[configIndex].PerUserHeaderKeys = updatedConfig.PerUserHeaderKeys
 	c.MCPConfig.ClientConfigs[configIndex].TokenExchange = updatedConfig.TokenExchange

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -18253,8 +18253,9 @@ var excludedSchemaFields = map[string]map[string]bool{
 		"tool_groups": true, // Enterprise governance feature; not in OSS MCPConfig
 	},
 	"mcp.client_configs": {
-		"websocket_config": true, // Schema documents all connection types
-		"http_config":      true, // Schema documents all connection types
+		"websocket_config":          true, // Schema documents all connection types
+		"http_config":               true, // Schema documents all connection types
+		"allow_on_all_virtual_keys": true, // Earlier name of allow_by_default; read by MCPClientConfig.UnmarshalJSON, kept in schema for backward-compatible config.json validation
 	},
 }
 

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -304,8 +304,8 @@ func (s *GovernanceInMemoryStore) GetConfiguredProviders() map[schemas.ModelProv
 	return s.Config.Providers
 }
 
-func (s *GovernanceInMemoryStore) GetMCPClientsAllowingAllVirtualKeys() map[string]string {
-	return s.Config.GetAllowOnAllVirtualKeysClients()
+func (s *GovernanceInMemoryStore) GetMCPClientsAllowedByDefault() map[string]string {
+	return s.Config.GetMCPClientsAllowedByDefault()
 }
 
 func (s *GovernanceInMemoryStore) GetMCPClientNames() map[string]string {

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -5323,9 +5323,15 @@
             "minimum": 0
           }
         },
+        "allow_by_default": {
+          "type": "boolean",
+          "description": "When true, this MCP server is available to every caller that has not been assigned it explicitly, with all tools allowed. An explicit assignment for a caller takes precedence over this setting for that caller.",
+          "default": false
+        },
         "allow_on_all_virtual_keys": {
           "type": "boolean",
-          "description": "When true, this MCP server is accessible to all virtual keys without requiring explicit per-key assignment. All tools are allowed by default. If a virtual key has an explicit MCP config for this server, that config takes precedence and overrides this behaviour.",
+          "deprecated": true,
+          "description": "Deprecated: use allow_by_default. Read only when allow_by_default is absent.",
           "default": false
         },
         "disabled": {

--- a/ui/app/workspace/mcp-registry/page.tsx
+++ b/ui/app/workspace/mcp-registry/page.tsx
@@ -27,7 +27,7 @@ export default function MCPServersPage() {
 			states: parseAsArrayOf(parseAsString).withDefault([]),
 			code_mode: parseAsArrayOf(parseAsString).withDefault([]),
 			status: parseAsArrayOf(parseAsString).withDefault([]),
-			only_all_vks: parseAsBoolean.withDefault(false),
+			only_allowed_by_default: parseAsBoolean.withDefault(false),
 			virtual_keys: parseAsArrayOf(parseAsString).withDefault([]),
 			offset: parseAsInteger.withDefault(0),
 		},
@@ -42,7 +42,7 @@ export default function MCPServersPage() {
 			states: urlState.states,
 			code_mode: urlState.code_mode,
 			status: urlState.status,
-			only_all_vks: urlState.only_all_vks,
+			only_allowed_by_default: urlState.only_allowed_by_default,
 			virtual_keys: urlState.virtual_keys,
 		}),
 		[
@@ -51,7 +51,7 @@ export default function MCPServersPage() {
 			urlState.states,
 			urlState.code_mode,
 			urlState.status,
-			urlState.only_all_vks,
+			urlState.only_allowed_by_default,
 			urlState.virtual_keys,
 		],
 	);
@@ -64,7 +64,7 @@ export default function MCPServersPage() {
 				states: newFilters.states,
 				code_mode: newFilters.code_mode,
 				status: newFilters.status,
-				only_all_vks: newFilters.only_all_vks,
+				only_allowed_by_default: newFilters.only_allowed_by_default,
 				virtual_keys: newFilters.virtual_keys,
 				offset: 0,
 			});
@@ -78,7 +78,7 @@ export default function MCPServersPage() {
 		filters.states.length > 0 ||
 		filters.code_mode.length > 0 ||
 		filters.status.length > 0 ||
-		filters.only_all_vks ||
+		filters.only_allowed_by_default ||
 		filters.virtual_keys.length > 0;
 
 	const {
@@ -96,7 +96,7 @@ export default function MCPServersPage() {
 			auth_type: filters.auth_types.length > 0 ? filters.auth_types.join(",") : undefined,
 			state: filters.states.length > 0 ? filters.states.join(",") : undefined,
 			virtual_keys: filters.virtual_keys.length > 0 ? filters.virtual_keys.join(",") : undefined,
-			all_virtual_keys: filters.only_all_vks || undefined,
+			allowed_by_default: filters.only_allowed_by_default || undefined,
 			code_mode: resolveBooleanFacet(filters.code_mode),
 			disabled: resolveBooleanFacet(filters.status),
 		},

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -238,7 +238,7 @@ export default function MCPClientSheet({
 			is_code_mode_client: mcpClient.config.is_code_mode_client || false,
 			is_ping_available: mcpClient.config.is_ping_available === true || mcpClient.config.is_ping_available === undefined,
 			needs_session_stickiness: mcpClient.config.needs_session_stickiness === true,
-			allow_on_all_virtual_keys: mcpClient.config.allow_on_all_virtual_keys || false,
+			allow_by_default: mcpClient.config.allow_by_default || false,
 			disabled: mcpClient.config.disabled || false,
 			headers: mcpClient.config.headers,
 			per_user_header_keys: mcpClient.config.auth_type === "per_user_headers" ? mcpClient.config.per_user_header_keys || [] : undefined,
@@ -289,7 +289,7 @@ export default function MCPClientSheet({
 			is_code_mode_client: mcpClient.config.is_code_mode_client || false,
 			is_ping_available: mcpClient.config.is_ping_available === true || mcpClient.config.is_ping_available === undefined,
 			needs_session_stickiness: mcpClient.config.needs_session_stickiness === true,
-			allow_on_all_virtual_keys: mcpClient.config.allow_on_all_virtual_keys || false,
+			allow_by_default: mcpClient.config.allow_by_default || false,
 			disabled: mcpClient.config.disabled || false,
 			headers: mcpClient.config.headers,
 			per_user_header_keys: mcpClient.config.auth_type === "per_user_headers" ? mcpClient.config.per_user_header_keys || [] : undefined,
@@ -438,7 +438,7 @@ export default function MCPClientSheet({
 					// explicit false is rejected for sse/stdio, which always keep
 					// a persistent connection regardless of this field.
 					needs_session_stickiness: mcpClient.config.connection_type === "http" ? data.needs_session_stickiness : undefined,
-					allow_on_all_virtual_keys: data.allow_on_all_virtual_keys,
+					allow_by_default: data.allow_by_default,
 					disabled: data.disabled,
 					headers: data.headers ?? {},
 					per_user_header_keys: mcpClient.config.auth_type === "per_user_headers" ? data.per_user_header_keys : undefined,
@@ -1573,15 +1573,15 @@ export default function MCPClientSheet({
 										<div className="space-y-4">
 											<SectionHeader
 												title="Access Control"
-												description="Control whether this server is reachable by all virtual keys without explicit per-key assignment."
+												description="Control whether this server is reachable without an explicit assignment."
 											/>
 											<FormField
 												control={form.control}
-												name="allow_on_all_virtual_keys"
+												name="allow_by_default"
 												render={({ field }) => (
 													<FormItem className="flex flex-row items-center justify-between gap-4 rounded-md border p-4">
 														<div className="flex items-center gap-2">
-															<FormLabel>Allow on All Virtual Keys</FormLabel>
+															<FormLabel>Allow by Default</FormLabel>
 															<TooltipProvider>
 																<Tooltip>
 																	<TooltipTrigger asChild>
@@ -1589,9 +1589,8 @@ export default function MCPClientSheet({
 																	</TooltipTrigger>
 																	<TooltipContent className="max-w-xs">
 																		<p>
-																			When enabled, this MCP server is accessible to all virtual keys without requiring explicit per-key
-																			assignment. All tools are allowed by default. If a virtual key has an explicit MCP config for this
-																			server, that config takes precedence and overrides this behaviour.
+																			When enabled, any caller can use this MCP server without an explicit assignment, with all tools
+																			allowed. An explicit assignment for a caller takes precedence over this setting for that caller.
 																		</p>
 																	</TooltipContent>
 																</Tooltip>
@@ -1613,7 +1612,7 @@ export default function MCPClientSheet({
 
 										<div className="space-y-4">
 											<SectionHeader
-												title="Virtual Key Access"
+												title="Virtual Key Assignments"
 												description="Control which virtual keys can use this server and which tools they're allowed to call."
 												action={
 													<VirtualKeySelector
@@ -1636,11 +1635,11 @@ export default function MCPClientSheet({
 												}
 											/>
 											<div className="flex flex-col gap-2">
-												{form.watch("allow_on_all_virtual_keys") && (
+												{form.watch("allow_by_default") && (
 													<p className="text-muted-foreground flex items-center gap-1 text-xs">
 														<Info className="h-3 w-3 shrink-0" />
 														Configuring access for a virtual key here overrides the{" "}
-														<span className="font-medium">Allow on All Virtual Keys</span>&nbsp;setting for that key.
+														<span className="font-medium">Allow by Default</span>&nbsp;setting for that key.
 													</p>
 												)}
 											</div>
@@ -1706,9 +1705,9 @@ export default function MCPClientSheet({
 														</TableBody>
 													</Table>
 												</div>
-											) : form.watch("allow_on_all_virtual_keys") ? (
+											) : form.watch("allow_by_default") ? (
 												<div className="text-muted-foreground rounded-sm border p-6 text-center">
-													<p className="text-sm">All virtual keys can access this MCP server unless a key has an explicit override.</p>
+													<p className="text-sm">This MCP server is allowed by default; a virtual key with an explicit assignment uses that instead.</p>
 												</div>
 											) : (
 												<div className="text-muted-foreground rounded-sm border p-6 text-center">

--- a/ui/app/workspace/mcp-registry/views/mcpClientsFilterSidebar.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsFilterSidebar.tsx
@@ -27,7 +27,7 @@ export interface MCPClientFilters {
 	states: string[]; // subset of ["healthy", "unstable"]
 	code_mode: string[]; // subset of ["true", "false"] → is_code_mode_client
 	status: string[]; // subset of ["false", "true"] → disabled column value
-	only_all_vks: boolean; // VK access toggle → allow_on_all_virtual_keys
+	only_allowed_by_default: boolean; // access toggle → allow_by_default
 	virtual_keys: string[]; // explicit VK IDs the client must be assigned to
 }
 
@@ -37,7 +37,7 @@ export const EMPTY_FILTERS: MCPClientFilters = {
 	states: [],
 	code_mode: [],
 	status: [],
-	only_all_vks: false,
+	only_allowed_by_default: false,
 	virtual_keys: [],
 };
 
@@ -122,7 +122,7 @@ export function MCPClientsFilterSidebar({ filters, onFiltersChange }: SidebarPro
 			(filters.code_mode.length === 1 ? 1 : 0) +
 			(filters.status.length === 1 ? 1 : 0) +
 			filters.virtual_keys.length +
-			(filters.only_all_vks ? 1 : 0)
+			(filters.only_allowed_by_default ? 1 : 0)
 		);
 	}, [filters]);
 
@@ -408,17 +408,17 @@ function SearchableCheckboxList({
 
 // ---------------------------------------------------------------------------
 // VKAccessFilterSection – a single checkbox list whose pinned first option is
-// "All virtual keys" (allow_on_all_virtual_keys); the rest are individual VKs
+// "Allowed by default" (allow_by_default); the rest are individual VKs
 // resolved via server-side search. They OR together server-side: a client
-// matches if it is open to all VKs OR assigned to one of the selected VKs.
+// matches if it is allowed by default OR assigned to one of the selected VKs.
 // ---------------------------------------------------------------------------
 
-// Reserved key for the pinned "All virtual keys" row — namespaced so it can
+// Reserved key for the pinned "Allowed by default" row, namespaced so it can
 // never collide with a real virtual key id.
-const ALL_VKS_KEY = "__all_virtual_keys__";
+const ALLOWED_BY_DEFAULT_KEY = "__allowed_by_default__";
 
 function VKAccessFilterSection({ filters, onFiltersChange }: SidebarProps) {
-	const hasActive = filters.only_all_vks || filters.virtual_keys.length > 0;
+	const hasActive = filters.only_allowed_by_default || filters.virtual_keys.length > 0;
 	const [opened, setOpened] = useState(hasActive);
 	const [searchQuery, setSearchQuery] = useState("");
 	const searchInputRef = useAutoFocusOnOpen(opened);
@@ -429,11 +429,12 @@ function VKAccessFilterSection({ filters, onFiltersChange }: SidebarProps) {
 	);
 	const virtualKeys = data?.virtual_keys || [];
 
-	const isSelected = (key: string) => (key === ALL_VKS_KEY ? filters.only_all_vks : filters.virtual_keys.includes(key));
+	const isSelected = (key: string) =>
+		key === ALLOWED_BY_DEFAULT_KEY ? filters.only_allowed_by_default : filters.virtual_keys.includes(key);
 
 	const toggle = (key: string) => {
-		if (key === ALL_VKS_KEY) {
-			onFiltersChange({ ...filters, only_all_vks: !filters.only_all_vks });
+		if (key === ALLOWED_BY_DEFAULT_KEY) {
+			onFiltersChange({ ...filters, only_allowed_by_default: !filters.only_allowed_by_default });
 			return;
 		}
 		const current = filters.virtual_keys;
@@ -442,11 +443,11 @@ function VKAccessFilterSection({ filters, onFiltersChange }: SidebarProps) {
 	};
 
 	return (
-		<FilterSection title="VK Access" defaultOpen={hasActive} onOpenChange={setOpened} testId="mcp-clients-filter-vk-access-toggle">
+		<FilterSection title="Access" defaultOpen={hasActive} onOpenChange={setOpened} testId="mcp-clients-filter-vk-access-toggle">
 			<SearchableCheckboxList
 				inputRef={searchInputRef}
 				placeholder="Search virtual keys"
-				pinnedItems={[{ key: ALL_VKS_KEY, label: "All virtual keys" }]}
+				pinnedItems={[{ key: ALLOWED_BY_DEFAULT_KEY, label: "Allowed by default" }]}
 				items={virtualKeys.map((vk) => ({ key: vk.id, label: vk.name }))}
 				isSelected={isSelected}
 				onToggle={toggle}

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -927,7 +927,7 @@ export default function MCPClientsTable({
 								<TableHead className="w-[150px] font-semibold">Auth Type</TableHead>
 								<TableHead className="w-[140px] font-semibold">Auth Scope</TableHead>
 								<TableHead className="w-[120px] font-semibold">Code Mode</TableHead>
-								<TableHead className="w-[120px] font-semibold">VK Access</TableHead>
+								<TableHead className="w-[150px] font-semibold">Access</TableHead>
 								<TableHead className="w-[130px] font-semibold">Enabled Tools</TableHead>
 								<TableHead className="w-[160px] font-semibold">Auto-execute Tools</TableHead>
 								<TableHead className="w-[140px] font-semibold">
@@ -1017,8 +1017,8 @@ export default function MCPClientsTable({
 												</Badge>
 											</TableCell>
 											<TableCell data-testid="mcp-client-vk-access">
-												{c.config.allow_on_all_virtual_keys
-													? "All"
+												{c.config.allow_by_default
+													? "Allowed by default"
 													: c.vk_configs?.length
 														? `${c.vk_configs.length} ${c.vk_configs.length === 1 ? "VK" : "VKs"}`
 														: "None"}

--- a/ui/app/workspace/mcp-registry/views/mcpUsageGuide/utils.ts
+++ b/ui/app/workspace/mcp-registry/views/mcpUsageGuide/utils.ts
@@ -67,7 +67,7 @@ export function encodeBase64(value: string): string {
 /** Whether an MCP client is reachable using the given virtual key. */
 export function isClientAllowedForVirtualKey(client: MCPClient, virtualKey: VirtualKey): boolean {
 	if (client.config.disabled) return false;
-	if (client.config.allow_on_all_virtual_keys) return true;
+	if (client.config.allow_by_default) return true;
 	return client.vk_configs?.some((config) => config.virtual_key_id === virtualKey.id) ?? false;
 }
 

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -1352,11 +1352,11 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 												</TooltipProvider>
 											</div>
 
-											{/* MCP servers available on all virtual keys by default, excluding explicitly overridden ones */}
+											{/* MCP servers allowed by default, excluding explicitly overridden ones */}
 											{(() => {
 												const defaultMCPClients = mcpClientsData.filter(
 													(client) =>
-														client.config.allow_on_all_virtual_keys &&
+														client.config.allow_by_default &&
 														!mcpConfigs.some((config) => config.mcp_client_name === client.config.name),
 												);
 												return defaultMCPClients.length > 0 ? (

--- a/ui/lib/store/apis/mcpApi.ts
+++ b/ui/lib/store/apis/mcpApi.ts
@@ -42,7 +42,7 @@ export const mcpApi = baseApi.injectEndpoints({
 					...(params?.virtual_keys && { virtual_keys: params.virtual_keys }),
 					...(params?.code_mode !== undefined && { code_mode: params.code_mode }),
 					...(params?.disabled !== undefined && { disabled: params.disabled }),
-					...(params?.all_virtual_keys !== undefined && { all_virtual_keys: params.all_virtual_keys }),
+					...(params?.allowed_by_default !== undefined && { allowed_by_default: params.allowed_by_default }),
 				},
 			}),
 			providesTags: ["MCPClients"],

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -140,7 +140,7 @@ export interface MCPClientConfig {
 	tool_sync_interval?: number;
 	tool_execution_timeout?: string | number; // Per-client tool execution timeout; API returns string e.g. "30s", UI sends integer seconds (0 = use global)
 	allowed_extra_headers?: string[]; // Allowlist of x-bf-eh-* headers forwarded to this MCP server. ["*"] = allow all.
-	allow_on_all_virtual_keys?: boolean; // When true, available to all VKs with all tools allowed by default; explicit VK config overrides this
+	allow_by_default?: boolean; // When true, available to every caller not assigned this server explicitly, with all tools allowed; an explicit assignment overrides this
 	disabled?: boolean; // When true, connection/workers are shut down; tools are unavailable until re-enabled
 }
 
@@ -236,7 +236,7 @@ export interface UpdateMCPClientRequest {
 	tool_sync_interval?: number; // Per-client override in minutes (0 = use global)
 	tool_execution_timeout?: number; // Per-client tool execution timeout in seconds (0 = use global)
 	allowed_extra_headers?: string[]; // Allowlist of x-bf-eh-* headers forwarded to this MCP server. ["*"] = allow all.
-	allow_on_all_virtual_keys?: boolean; // When true, available to all VKs with all tools allowed by default; explicit VK config overrides this
+	allow_by_default?: boolean; // When true, available to every caller not assigned this server explicitly, with all tools allowed; an explicit assignment overrides this
 	disabled?: boolean; // Set to true to shut down connection/workers; false to reconnect
 	tls_config?: MCPTLSConfig; // TLS configuration for HTTP/SSE connections
 	oauth_config?: OAuthConfigUpdate; // Only supported for existing oauth/per_user_oauth clients (credential rotation)
@@ -258,7 +258,7 @@ export interface GetMCPClientsParams {
 	// Boolean facets — omit for "no filter".
 	code_mode?: boolean; // filters is_code_mode_client
 	disabled?: boolean; // filters disabled status
-	all_virtual_keys?: boolean; // when true, include clients open to all virtual keys
+	allowed_by_default?: boolean; // when true, include clients allowed by default
 }
 
 // Paginated response for MCP clients list

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -1120,7 +1120,7 @@ export const mcpClientUpdateSchema = z
 		is_code_mode_client: z.boolean().optional(),
 		is_ping_available: z.boolean().optional(),
 		needs_session_stickiness: z.boolean().optional(),
-		allow_on_all_virtual_keys: z.boolean().optional(),
+		allow_by_default: z.boolean().optional(),
 		disabled: z.boolean().optional(),
 		name: z
 			.string()


### PR DESCRIPTION
## Summary

Renames the `allow_on_all_virtual_keys` flag to `allow_by_default` across the entire codebase. The old name implied the feature was exclusive to virtual keys, but the flag controls default access for any caller. The rename makes the semantics clearer. Full backward compatibility is preserved: the old wire name is still read on JSON input and still written on JSON output alongside the new name, so existing configurations and API clients continue to work without changes.

## Changes

- `AllowOnAllVirtualKeys` renamed to `AllowByDefault` on `MCPClientConfig`, `TableMCPClient`, and all related request/response types
- `MCPClientConfig.UnmarshalJSON` and `MarshalJSON` updated to read both `allow_by_default` and `allow_on_all_virtual_keys`, with the current name taking precedence when both are present; the old name is also written on marshal so older readers see the same value
- A shared `ResolveAllowByDefault` helper centralizes the two-key resolution logic and is reused by the config schema, the create request (`MCPClientRequest`), and the update request (`MCPClientUpdateRequest`)
- `MCPClientUpdateRequest` gains a `resolvedAllowByDefault` method that applies PATCH semantics: preserves the existing value when neither key is sent, and applies `ResolveAllowByDefault` when at least one is
- `MCPClientsQueryParams.OnlyAllVirtualKeys` renamed to `OnlyAllowedByDefault`; the HTTP query parameter `all_virtual_keys` is still accepted and maps to the same field, with `allowed_by_default` taking precedence when both are sent
- `AppendMCPPermitsAllowedByDefault` extracted from `permitForVirtualKey` as a standalone exported function so the same append logic can be reused by any holder type
- `GetAllowOnAllVirtualKeysClients` renamed to `GetMCPClientsAllowedByDefault` on `Config` and the `InMemoryStore` interface; `GetMCPClientsAllowedByDefault` on `GovernanceInMemoryStore` delegates to the renamed config method
- The database column name (`allow_on_all_virtual_keys`) is unchanged; only the Go struct field and wire names moved, so no migration is required
- UI field names, filter keys, URL state keys, table column labels, and tooltip copy updated to use the new name
- `config.schema.json` adds `allow_by_default` as the canonical property and marks `allow_on_all_virtual_keys` as deprecated
- The example config updated to use `allow_by_default`
- Documentation updated to reflect the new name, clarify that an explicit assignment for a caller overrides the default, and correct the description of how `x-bf-mcp-include-tools` interacts with the VK allow-list (it narrows, never widens)
- Tests added for `ResolveAllowByDefault`, `MCPClientRequest.UnmarshalJSON`, `MCPClientUpdateRequest.resolvedAllowByDefault`, `AppendMCPPermitsAllowedByDefault`, and the marshal/unmarshal round-trip for both wire names

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
go test ./core/schemas/... ./plugins/governance/... ./transports/bifrost-http/handlers/... ./transports/bifrost-http/lib/...

cd ui
pnpm i
pnpm build
```

Verify backward compatibility by sending `allow_on_all_virtual_keys: true` in a create or update request and confirming the flag is set. Verify the new name by sending `allow_by_default: true`. Verify precedence by sending both with conflicting values and confirming `allow_by_default` wins.

## Breaking changes

- [ ] Yes
- [x] No

The old wire name `allow_on_all_virtual_keys` continues to be read and written. The database column is unchanged. No migration is required.

## Security considerations

No new authentication or authorization logic introduced. The rename does not change who is granted access; it only clarifies the semantics of an existing flag.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable