### PR TITLE
refactor: replace per-VK MCP server map with a single atomic server, moving tool-access scoping from server selection to governance admission via `MCPGatewayAdmitter`, and unify `/mcp` auth into `authenticate`/`admit` with status-mapped refusals

### DIFF
--- a/plugins/governance/prerequesthookmcp_test.go
+++ b/plugins/governance/prerequesthookmcp_test.go
@@ -473,3 +473,87 @@ func TestPreMCPHookGatesTheToolOnAccess(t *testing.T) {
 		assert.Equal(t, string(DecisionAccessNotFound), *shortCircuit.Error.Type)
 	})
 }
+
+// ============================================================================
+// The four inputs together: a client allowed by default, an explicit VK config for another,
+// and both caller headers.
+// ============================================================================
+
+// newPluginForMCPStampingWithDefaults is newPluginForMCPStamping with the given clients allowed
+// by default, keyed by client id.
+func newPluginForMCPStampingWithDefaults(t *testing.T, vk *configstoreTables.TableVirtualKey, allowedByDefault map[string]string) *GovernancePlugin {
+	t.Helper()
+	logger := NewMockLogger()
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+	}, nil, &mockInMemoryStore{allowedByDefaultClients: allowedByDefault})
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{
+		IsVkMandatory:         boolPtr(false),
+		DisableAutoToolInject: boolPtr(false),
+	}, logger, store, nil, nil, nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, plugin.Cleanup()) })
+	return plugin
+}
+
+// A client allowed by default joins the stamped grant after the key's own configs, as a whole-client
+// wildcard. An include-clients header does not change what is stamped: the grant is the tool-level
+// ceiling, and the client-level narrowing is applied downstream where the header intersects it.
+func TestPreRequestHookMCP_AllowedByDefault_JoinsTheGrantAfterExplicitConfigs(t *testing.T) {
+	vk := buildVKForMCPStamping([]string{"read_file"})
+	defaults := map[string]string{"client-2": "youtube"}
+
+	t.Run("no filters", func(t *testing.T) {
+		p := newPluginForMCPStampingWithDefaults(t, vk, defaults)
+		assert.Equal(t, []string{"sentry-read_file", "youtube-*"}, stampedIncludeTools(t, p, newPreRequestCtx(nil, nil), newChatRequest()))
+	})
+
+	t.Run("include-clients only", func(t *testing.T) {
+		p := newPluginForMCPStampingWithDefaults(t, vk, defaults)
+		assert.Equal(t, []string{"sentry-read_file", "youtube-*"}, stampedIncludeTools(t, p, newPreRequestCtx(nil, []string{"youtube"}), newChatRequest()))
+	})
+}
+
+// A caller include-tools list is narrowed to the grant across both kinds of client at once: a
+// specific tool of the default-allowed client survives, a wildcard for it survives as a wildcard, a
+// wildcard for the explicitly configured client is replaced by that config's tools, and an entry
+// the key does not grant is dropped. An include-clients header alongside changes none of this.
+func TestPreRequestHookMCP_AllowedByDefault_IncludeToolsNarrowsAcrossBothKinds(t *testing.T) {
+	vk := buildVKForMCPStamping([]string{"read_file"})
+	defaults := map[string]string{"client-2": "youtube"}
+	requested := []string{"youtube-search", "youtube-*", "sentry-*", "sentry-write_file", "github-*"}
+	want := []string{"youtube-search", "youtube-*", "sentry-read_file"}
+
+	t.Run("include-tools only", func(t *testing.T) {
+		p := newPluginForMCPStampingWithDefaults(t, vk, defaults)
+		assert.Equal(t, want, stampedIncludeTools(t, p, newPreRequestCtx(requested, nil), newChatRequest()))
+	})
+
+	t.Run("both headers", func(t *testing.T) {
+		p := newPluginForMCPStampingWithDefaults(t, vk, defaults)
+		assert.Equal(t, want, stampedIncludeTools(t, p, newPreRequestCtx(requested, []string{"youtube"}), newChatRequest()))
+	})
+}
+
+// An explicit deny-all config for a client allowed by default is the key's decision and is never
+// reopened by the default, whether the grant is stamped whole or a caller asks for the client.
+func TestPreRequestHookMCP_ExplicitEmptyConfigBeatsAllowedByDefault(t *testing.T) {
+	vk := buildVKForMCPStamping(nil)
+	vk.MCPConfigs = []configstoreTables.TableVirtualKeyMCPConfig{{
+		MCPClient:      configstoreTables.TableMCPClient{ClientID: "client-2", Name: "youtube"},
+		ToolsToExecute: []string{},
+	}}
+	defaults := map[string]string{"client-2": "youtube"}
+
+	t.Run("no filters stamps deny-all", func(t *testing.T) {
+		p := newPluginForMCPStampingWithDefaults(t, vk, defaults)
+		assert.Equal(t, []string{}, stampedIncludeTools(t, p, newPreRequestCtx(nil, nil), newChatRequest()))
+	})
+
+	t.Run("a caller wildcard for the client prunes to deny-all", func(t *testing.T) {
+		p := newPluginForMCPStampingWithDefaults(t, vk, defaults)
+		assert.Equal(t, []string{}, stampedIncludeTools(t, p, newPreRequestCtx([]string{"youtube-*"}, []string{"youtube"}), newChatRequest()))
+	})
+}

--- a/tests/e2e/api/collections/bifrost-v1-mcp-auth.postman_collection.json
+++ b/tests/e2e/api/collections/bifrost-v1-mcp-auth.postman_collection.json
@@ -317,8 +317,8 @@
                   "// it at the shared key-lookup chokepoint, oauth-strict rejects the header",
                   "// credential outright.",
                   "var code = pm.response.code;",
-                  "pm.test('inactive virtual key is rejected (401)', function () {",
-                  "  pm.expect(code, pm.response.text()).to.equal(401);",
+                  "pm.test('inactive virtual key is rejected (403)', function () {",
+                  "  pm.expect(code, pm.response.text()).to.equal(403);",
                   "});"
                 ]
               }

--- a/transports/bifrost-http/handlers/mcpoauth2consent.go
+++ b/transports/bifrost-http/handlers/mcpoauth2consent.go
@@ -35,12 +35,6 @@ type OAuth2IdentityResolver interface {
 	// ResolveVKUserUpgrade checks whether a VK is bound to a specific user.
 	// Returns the userID if bound, empty string if unbound.
 	ResolveVKUserUpgrade(ctx context.Context, vkID string) (userID string, err error)
-	// ResolveUserVirtualKey returns the ID of a virtual key that represents the
-	// user's effective MCP grant, or an empty string when the user has none.
-	// Callers use it to scope the /mcp tool listing for user-mode tokens, which
-	// carry no virtual key of their own. When a user maps to several equivalent
-	// virtual keys, any one of them may be returned.
-	ResolveUserVirtualKey(ctx context.Context, userID string) (vkID string, err error)
 	// IsUserActive reports whether the given user identity still exists and is
 	// usable. Returns (false, nil) when the user is gone or deactivated; an
 	// error is reserved for transient lookup failures that should be retried.

--- a/transports/bifrost-http/handlers/mcpoauth2consent_test.go
+++ b/transports/bifrost-http/handlers/mcpoauth2consent_test.go
@@ -21,8 +21,6 @@ type fakeResolver struct {
 	resolveErr        error
 	vkBoundUserID     string
 	vkBindErr         error
-	userVKID          string
-	userVKErr         error
 	userInactive      bool // when true, IsUserActive reports the user as gone
 	userActiveErr     error
 }
@@ -33,9 +31,6 @@ func (f *fakeResolver) ResolveUserIdentity(_ *fasthttp.RequestCtx) (string, stri
 }
 func (f *fakeResolver) ResolveVKUserUpgrade(_ context.Context, _ string) (string, error) {
 	return f.vkBoundUserID, f.vkBindErr
-}
-func (f *fakeResolver) ResolveUserVirtualKey(_ context.Context, _ string) (string, error) {
-	return f.userVKID, f.userVKErr
 }
 func (f *fakeResolver) IsUserActive(_ context.Context, _ string) (bool, error) {
 	return !f.userInactive, f.userActiveErr

--- a/transports/bifrost-http/handlers/mcpoauth2issuance.go
+++ b/transports/bifrost-http/handlers/mcpoauth2issuance.go
@@ -436,7 +436,7 @@ func (h *OAuth2IssuanceHandler) handleTokenRefresh(ctx *fasthttp.RequestCtx) {
 
 	// VK identity cutoff (refresh side): when virtual-key identity has been
 	// disabled, vk-mode grants must not refresh. Live /mcp requests are already
-	// rejected at request time (see getMCPServerForRequest); denying refresh here
+	// rejected at request time (see MCPServerHandler.authenticate); denying refresh here
 	// closes the second path so a disabled grant can neither be used nor renewed.
 	// Gated on user identity being available, identical to the consent flow's
 	// availableModes — so this can never fire where vk is still the offered path.

--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -28,11 +27,27 @@ import (
 // gratuitous wake-ups on idle clients.
 const sseHeartbeatInterval = 15 * time.Second
 
+// mcpServerName is what the server calls itself in the initialize handshake. One server serves
+// every caller, so it carries no caller's name.
+const mcpServerName = "bifrost"
+
 // MCPToolExecutor interface defines the method needed for executing MCP tools
 type MCPToolManager interface {
 	GetAvailableMCPTools(ctx context.Context) []schemas.ChatTool
 	ExecuteChatMCPTool(ctx context.Context, toolCall *schemas.ChatAssistantMessageToolCall) (*schemas.ChatMessage, *schemas.BifrostError)
 	ExecuteResponsesMCPTool(ctx context.Context, toolCall *schemas.ResponsesToolMessage) (*schemas.ResponsesMessage, *schemas.BifrostError)
+}
+
+// MCPGatewayAdmitter decides whether a /mcp request may be served, and what it may reach. It runs
+// the request through the same governance funnel every tool execution passes, so a caller is told at
+// initialize and tools/list exactly what tools/call would tell them, by the same rules.
+type MCPGatewayAdmitter interface {
+	// AdmitMCPGatewayRequest evaluates the request as an MCP tool execution with no tool named yet,
+	// resolving and recording its access on ctx. It returns that access, and the refusal governance
+	// gave when it gave one. Nil access with no refusal means nothing restricts the request (the
+	// deployment has nothing to resolve access with, or the request presented nothing), and it is
+	// served unrestricted, as every other path serves it.
+	AdmitMCPGatewayRequest(ctx *schemas.BifrostContext) (schemas.Access, *schemas.BifrostError)
 }
 
 // VirtualKeyCache resolves a virtual key by its row ID from an in-memory cache,
@@ -46,26 +61,31 @@ type VirtualKeyCache interface {
 // MCPServerHandler manages HTTP requests for MCP server operations
 // It implements the MCP protocol over HTTP streaming (SSE) for MCP clients
 type MCPServerHandler struct {
-	toolManager     MCPToolManager
-	globalMCPServer *server.MCPServer
-	vkMCPServers    map[string]*server.MCPServer // Map of vk value -> mcp server
-	config          *lib.Config
-	// identityResolver scopes a user-mode /mcp request to the user's own tools by
-	// resolving a representative virtual key. Optional: when nil, user-mode
-	// requests fall back to the global server.
+	toolManager MCPToolManager
+	// admitter answers what the request may reach. Optional: without one nothing resolves access,
+	// and every request is served unrestricted.
+	admitter MCPGatewayAdmitter
+	config   *lib.Config
+	// identityResolver answers the identity questions that are the transport's rather than
+	// governance's: whether a user-mode caller still exists, and whether user mode is offered at
+	// all. Optional.
 	identityResolver OAuth2IdentityResolver
 	// vkCache serves by-ID virtual key lookups on the JWT auth path from the
 	// governance in-memory store, avoiding a per-request DB read. Optional: a nil
 	// cache or a miss falls back to the config store. See getVirtualKeyByID.
 	vkCache VirtualKeyCache
-	mu      sync.RWMutex
+	// mcpServer is the one server every caller is served from. What each caller sees of it is
+	// decided per request, from the tool list stamped on the request context, so nothing about
+	// it is per caller. Replaced whole when the tool registry changes; a request already holding
+	// the previous one finishes against it.
+	mcpServer atomic.Pointer[server.MCPServer]
 }
 
 // getVirtualKeyByID resolves a virtual key by its row ID for the JWT auth path,
 // preferring the governance in-memory cache and falling back to the config store
 // on a miss (e.g. a key created since the cache last refreshed) or when no cache
-// is wired. The active-state check is left to the caller, matching both sources
-// (neither filters inactive keys by ID).
+// is wired. Whether the key may be used is not decided here: governance refuses a
+// key that is inactive or expired, from the grant it resolves for it.
 func (h *MCPServerHandler) getVirtualKeyByID(ctx context.Context, vkID string) (*tables.TableVirtualKey, error) {
 	if h.vkCache != nil {
 		if vk, ok := h.vkCache.GetVirtualKeyByID(ctx, vkID); ok && vk != nil {
@@ -73,17 +93,17 @@ func (h *MCPServerHandler) getVirtualKeyByID(ctx context.Context, vkID string) (
 		}
 	}
 	if h.config.ConfigStore == nil {
-		return nil, fmt.Errorf("virtual key not found or inactive")
+		return nil, fmt.Errorf("virtual key not found")
 	}
 	vk, err := h.config.ConfigStore.GetVirtualKey(ctx, vkID)
 	if err != nil || vk == nil {
-		return nil, fmt.Errorf("virtual key not found or inactive")
+		return nil, fmt.Errorf("virtual key not found")
 	}
 	return vk, nil
 }
 
 // NewMCPServerHandler creates a new MCP server handler instance
-func NewMCPServerHandler(ctx context.Context, config *lib.Config, toolManager MCPToolManager, identityResolver OAuth2IdentityResolver, vkCache VirtualKeyCache) (*MCPServerHandler, error) {
+func NewMCPServerHandler(ctx context.Context, config *lib.Config, toolManager MCPToolManager, admitter MCPGatewayAdmitter, identityResolver OAuth2IdentityResolver, vkCache VirtualKeyCache) (*MCPServerHandler, error) {
 	if config == nil {
 		return nil, fmt.Errorf("config is required")
 	}
@@ -91,29 +111,15 @@ func NewMCPServerHandler(ctx context.Context, config *lib.Config, toolManager MC
 		return nil, fmt.Errorf("tool manager is required")
 	}
 
-	// Create MCP server instance using mcp-go
-	globalMCPServer := server.NewMCPServer(
-		"global",
-		version,
-		server.WithToolCapabilities(true),
-	)
-
 	handler := &MCPServerHandler{
 		toolManager:      toolManager,
-		globalMCPServer:  globalMCPServer,
+		admitter:         admitter,
 		config:           config,
-		vkMCPServers:     make(map[string]*server.MCPServer),
 		identityResolver: identityResolver,
 		vkCache:          vkCache,
 	}
 
-	// Register per-request tool filter so x-bf-mcp-include-clients and x-bf-mcp-include-tools are respected on tools/list
-	server.WithToolFilter(handler.makeIncludeClientsFilter())(handler.globalMCPServer)
-
-	// Register per-request tool filter so x-bf-mcp-include-clients and x-bf-mcp-include-tools are respected on tools/list
-	server.WithToolFilter(handler.makeIncludeClientsFilter())(handler.globalMCPServer)
-
-	if err := handler.SyncAllMCPServers(ctx); err != nil {
+	if err := handler.SyncMCPServer(ctx); err != nil {
 		return nil, fmt.Errorf("failed to sync all MCP servers: %w", err)
 	}
 
@@ -139,26 +145,19 @@ func (h *MCPServerHandler) RegisterRoutes(r *router.Router, middlewares ...schem
 }
 
 func (h *MCPServerHandler) handleMCPServer(ctx *fasthttp.RequestCtx) {
-	authResult, err := h.getMCPServerForRequest(ctx)
-	if err != nil {
-		SendError(ctx, fasthttp.StatusUnauthorized, err.Error())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.config)
+	defer cancel()
+	bifrostCtx.SetValue(schemas.BifrostContextKeyIsMCPGateway, true)
+
+	if refusal := h.admit(ctx, bifrostCtx); refusal != nil {
+		SendError(ctx, refusal.status, refusal.message)
 		return
 	}
-
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.config)
-	bifrostCtx.SetValue(schemas.BifrostContextKeyIsMCPGateway, true)
-	defer cancel()
-
-	// Inject JWT identity into BifrostContext so downstream resolvers
-	// (per-user OAuth, governance, tool-group filtering) see the same context
-	// keys as header-based auth paths.
-	if authResult.jwtClaims != nil {
-		if injErr := injectJWTContext(bifrostCtx, authResult.jwtClaims, authResult.jwtVK); injErr != nil {
-			SendError(ctx, fasthttp.StatusUnauthorized, injErr.Error())
-			return
-		}
+	mcpServer := h.server()
+	if mcpServer == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "MCP server is not ready")
+		return
 	}
-	mcpServer := authResult.mcpServer
 
 	// Use mcp-go server to handle the request
 	// HandleMessage processes JSON-RPC messages and returns appropriate responses
@@ -184,11 +183,15 @@ func (h *MCPServerHandler) handleMCPServer(ctx *fasthttp.RequestCtx) {
 
 // handleMCPServerSSE handles GET requests for MCP Server-Sent Events streaming
 func (h *MCPServerHandler) handleMCPServerSSE(ctx *fasthttp.RequestCtx) {
-	authResult, err := h.getMCPServerForRequest(ctx)
-	if err != nil {
-		SendError(ctx, fasthttp.StatusUnauthorized, err.Error())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.config)
+	bifrostCtx.SetValue(schemas.BifrostContextKeyIsMCPGateway, true)
+
+	if refusal := h.admit(ctx, bifrostCtx); refusal != nil {
+		cancel()
+		SendError(ctx, refusal.status, refusal.message)
 		return
 	}
+
 	// Signal to transport-plugin and tracing middlewares that this is a streaming
 	// response. Without this, fasthttpResponseToHTTPResponse calls ctx.Response.Body()
 	// during post-hook processing, which materializes the SSE body stream and
@@ -212,18 +215,6 @@ func (h *MCPServerHandler) handleMCPServerSSE(ctx *fasthttp.RequestCtx) {
 	ctx.Response.Header.Set("Cache-Control", "no-cache")
 	ctx.Response.Header.Set("Connection", "keep-alive")
 	ctx.Response.Header.Set("X-Accel-Buffering", "no")
-
-	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.config)
-	bifrostCtx.SetValue(schemas.BifrostContextKeyIsMCPGateway, true)
-
-	if authResult.jwtClaims != nil {
-		if injErr := injectJWTContext(bifrostCtx, authResult.jwtClaims, authResult.jwtVK); injErr != nil {
-			cancel()
-			SendError(ctx, fasthttp.StatusUnauthorized, injErr.Error())
-			return
-		}
-	}
 
 	// Use SSEStreamReader to bypass fasthttp's internal pipe batching
 	reader := lib.NewSSEStreamReader()
@@ -329,58 +320,32 @@ func (h *MCPServerHandler) handleMCPServerSSE(ctx *fasthttp.RequestCtx) {
 	}()
 }
 
-// Sync methods for MCP servers
-
-func (h *MCPServerHandler) SyncAllMCPServers(ctx context.Context) error {
-	h.mu.Lock()
-	defer h.mu.Unlock()
+// SyncMCPServer rebuilds the server from the tools currently available and swaps it in. Called
+// whenever the set of MCP clients or their tools changes. Every caller is served from this one
+// server; what each of them sees is decided per request.
+func (h *MCPServerHandler) SyncMCPServer(ctx context.Context) error {
 	availableTools := h.toolManager.GetAvailableMCPTools(ctx)
-	h.syncServer(h.globalMCPServer, availableTools, nil)
-	logger.Debug("Synced global MCP server with %d tools", len(availableTools))
-
-	// Per-VK MCP servers are created lazily on first request (see
-	// getMCPServerForRequest / ensureVKMCPServer) rather than eagerly here.
-	// Building one server per virtual key previously scaled O(number of keys)
-	// and stalled startup with large key counts (100k+). Resetting the map
-	// invalidates any cached servers so they are rebuilt with the latest tool
-	// configuration on next use.
-	h.vkMCPServers = make(map[string]*server.MCPServer)
+	h.mcpServer.Store(h.buildServer(availableTools))
+	logger.Debug("Synced MCP server with %d tools", len(availableTools))
 	return nil
 }
 
-func (h *MCPServerHandler) SyncVKMCPServer(vk *tables.TableVirtualKey) *server.MCPServer {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	vkServer, ok := h.vkMCPServers[vk.Value.GetValue()]
-	if !ok {
-		// Add new server
-		vkServer = server.NewMCPServer(
-			vk.Name,
-			version,
-			server.WithToolCapabilities(true),
-		)
-		server.WithToolFilter(h.makeIncludeClientsFilter())(vkServer)
-		h.vkMCPServers[vk.Value.GetValue()] = vkServer
-	}
-	availableTools, toolFilter := h.fetchToolsForVK(vk)
-	h.syncServer(vkServer, availableTools, toolFilter)
-	h.vkMCPServers[vk.Value.GetValue()] = vkServer
-	logger.Debug("Synced MCP server for virtual key '%s' with %d tools", vk.Name, len(availableTools))
-	return vkServer
+// server returns the server requests are currently served from, or nil before the first sync.
+func (h *MCPServerHandler) server() *server.MCPServer {
+	return h.mcpServer.Load()
 }
 
-func (h *MCPServerHandler) DeleteVKMCPServer(vkValue string) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	delete(h.vkMCPServers, vkValue)
-}
-
-func (h *MCPServerHandler) syncServer(server *server.MCPServer, availableTools []schemas.ChatTool, toolFilter []string) {
-	// Clear existing tools
-	toolMap := server.ListTools()
-	for toolName, _ := range toolMap {
-		server.DeleteTools(toolName)
-	}
+// buildServer registers every available tool on a fresh server. A tool's handler reads nothing
+// about the caller: what a request may see and call rides on its context, and both the tool filter
+// and the executor read it from there.
+func (h *MCPServerHandler) buildServer(availableTools []schemas.ChatTool) *server.MCPServer {
+	mcpServer := server.NewMCPServer(
+		mcpServerName,
+		version,
+		server.WithToolCapabilities(true),
+	)
+	// Per-request tool filter so tools/list answers with what this request may see.
+	server.WithToolFilter(h.makeIncludeClientsFilter())(mcpServer)
 
 	// Register tools from all connected clients
 	for _, tool := range availableTools {
@@ -393,11 +358,7 @@ func (h *MCPServerHandler) syncServer(server *server.MCPServer, availableTools [
 		toolName := tool.Function.Name
 
 		handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			logger.Info("[mcp-server] tool handler start tool=%q arg_count=%d", toolName, len(request.GetArguments()))
-			// Inject tool filter into execution context if present
-			if toolFilter != nil {
-				ctx = context.WithValue(ctx, schemas.MCPContextKeyIncludeTools, toolFilter)
-			}
+			logger.Debug("[mcp-server] tool handler start tool=%q arg_count=%d", toolName, len(request.GetArguments()))
 			// Convert to Bifrost tool call format
 			toolCallType := "function"
 			toolCallID := fmt.Sprintf("mcp-%s", toolName)
@@ -417,7 +378,7 @@ func (h *MCPServerHandler) syncServer(server *server.MCPServer, availableTools [
 			// Execute the tool via tool executor
 			toolMessage, err := h.toolManager.ExecuteChatMCPTool(ctx, &toolCall)
 			if err != nil {
-				logger.Info("[mcp-server] tool handler error tool=%q error=%s", toolName, bifrost.GetErrorMessage(err))
+				logger.Debug("[mcp-server] tool handler error tool=%q error=%s", toolName, bifrost.GetErrorMessage(err))
 				if authReq := err.ExtraFields.MCPAuthRequired; authReq != nil {
 					// Two surfaces share this error: per-user OAuth uses
 					// AuthorizeURL (the upstream provider's authorize page);
@@ -441,7 +402,7 @@ func (h *MCPServerHandler) syncServer(server *server.MCPServer, availableTools [
 				}
 				return mcp.NewToolResultError(fmt.Sprintf("Tool execution failed: %v", bifrost.GetErrorMessage(err))), nil
 			}
-			logger.Info("[mcp-server] tool handler success tool=%q", toolName)
+			logger.Debug("[mcp-server] tool handler success tool=%q", toolName)
 
 			// Extract content from tool message
 			var resultText string
@@ -484,113 +445,20 @@ func (h *MCPServerHandler) syncServer(server *server.MCPServer, availableTools [
 		}
 
 		// Register tool with the server
-		server.AddTool(mcp.Tool{
+		mcpServer.AddTool(mcp.Tool{
 			Name:        toolName,
 			Description: description,
 			InputSchema: inputSchema,
 			Annotations: toolAnnotation,
 		}, handler)
 	}
+	return mcpServer
 }
 
-func convertToolFunctionParametersToMCPInputSchema(params *schemas.ToolFunctionParameters) mcp.ToolInputSchema {
-	if params == nil {
-		return mcp.ToolInputSchema{
-			Type:       "object",
-			Properties: make(map[string]any),
-		}
-	}
-
-	inputSchema := mcp.ToolInputSchema{
-		Type:     params.Type,
-		Required: params.Required,
-	}
-
-	if params.Properties != nil {
-		props := make(map[string]any, params.Properties.Len())
-		params.Properties.Range(func(key string, value interface{}) bool {
-			props[key] = value
-			return true
-		})
-		inputSchema.Properties = props
-	}
-
-	if params.Defs != nil {
-		defs := make(map[string]any, params.Defs.Len())
-		params.Defs.Range(func(key string, value interface{}) bool {
-			defs[key] = value
-			return true
-		})
-		inputSchema.Defs = defs
-	} else if params.Definitions != nil {
-		defs := make(map[string]any, params.Definitions.Len())
-		params.Definitions.Range(func(key string, value interface{}) bool {
-			defs[key] = value
-			return true
-		})
-		inputSchema.Defs = defs
-	}
-
-	return inputSchema
-}
-
-// fetchToolsForVK fetches the tools for a given virtual key value.
-// vkValue is the virtual key value for the server, if empty, all tools will be fetched for global mcp server.
-// Returns the list of available tools and the tool filter to be applied during execution.
-func (h *MCPServerHandler) fetchToolsForVK(vk *tables.TableVirtualKey) ([]schemas.ChatTool, []string) {
-	ctx := context.Background()
-	var toolFilter []string
-
-	executeOnlyTools := make([]string, 0)
-
-	// Build a lookup of AllowByDefault clients: clientID -> clientName.
-	// Explicit VK MCPConfigs always take precedence over AllowByDefault.
-	allowedByDefaultClients := h.config.GetMCPClientsAllowedByDefault()
-	if allowedByDefaultClients == nil {
-		allowedByDefaultClients = make(map[string]string)
-	}
-
-	// Process explicit VK MCPConfigs first.
-	handledClients := make(map[string]bool)
-	for _, vkMcpConfig := range vk.MCPConfigs {
-		clientID := vkMcpConfig.MCPClient.ClientID
-		if _, isAllowAll := allowedByDefaultClients[clientID]; isAllowAll {
-			// Explicit config exists — it takes precedence; mark handled regardless of tool list.
-			handledClients[clientID] = true
-		}
-		if vkMcpConfig.ToolsToExecute.IsEmpty() {
-			continue
-		}
-		if vkMcpConfig.ToolsToExecute.IsUnrestricted() {
-			executeOnlyTools = append(executeOnlyTools, fmt.Sprintf("%s-*", vkMcpConfig.MCPClient.Name))
-			continue
-		}
-		for _, tool := range vkMcpConfig.ToolsToExecute {
-			if tool != "" {
-				// Add the tool - client config filtering will be handled by mcp.go
-				// Note: Use '-' separator for individual tools (wildcard uses '-*' after client name, e.g., "client-*")
-				executeOnlyTools = append(executeOnlyTools, fmt.Sprintf("%s-%s", vkMcpConfig.MCPClient.Name, tool))
-			}
-		}
-	}
-
-	// For AllowByDefault clients with no explicit VK config, allow all their tools.
-	for clientID, clientName := range allowedByDefaultClients {
-		if !handledClients[clientID] {
-			executeOnlyTools = append(executeOnlyTools, fmt.Sprintf("%s-*", clientName))
-		}
-	}
-
-	// Always set the include-tools filter (empty = deny-all when no MCPConfigs and no AllowByDefault clients)
-	ctx = context.WithValue(ctx, schemas.MCPContextKeyIncludeTools, executeOnlyTools)
-	toolFilter = executeOnlyTools
-
-	return h.toolManager.GetAvailableMCPTools(ctx), toolFilter
-}
-
-// makeIncludeClientsFilter returns a ToolFilterFunc that dynamically filters the tools/list
-// response based on the x-bf-mcp-include-clients and x-bf-mcp-include-tools request headers.
-// When neither header is present the filter is a no-op, preserving existing behaviour.
+// makeIncludeClientsFilter returns a ToolFilterFunc that narrows tools/list to what the request's
+// context permits: the include lists the caller sent (x-bf-mcp-include-clients,
+// x-bf-mcp-include-tools) and the tool list the request was admitted with, which admit stamps on the
+// same key. When the context carries neither the filter is a no-op.
 func (h *MCPServerHandler) makeIncludeClientsFilter() server.ToolFilterFunc {
 	return func(ctx context.Context, tools []mcp.Tool) []mcp.Tool {
 		if ctx.Value(schemas.MCPContextKeyIncludeClients) == nil && ctx.Value(schemas.MCPContextKeyIncludeTools) == nil {
@@ -613,66 +481,98 @@ func (h *MCPServerHandler) makeIncludeClientsFilter() server.ToolFilterFunc {
 	}
 }
 
-// Utility methods
+// Admission
 
-// mcpAuthResult carries the outcome of /mcp request authentication.
-type mcpAuthResult struct {
-	mcpServer *server.MCPServer
-	jwtClaims *jwtMCPClaims           // non-nil when authenticated via JWT
-	jwtVK     *tables.TableVirtualKey // non-nil when jwt bf_mode=vk
+// mcpRefusal is what a /mcp request is refused with: the status to answer and the message to say.
+type mcpRefusal struct {
+	status  int
+	message string
 }
 
-// getMCPServerForRequest authenticates the /mcp request and returns the
-// appropriate scoped MCP server alongside any JWT claims that must be injected
-// into the BifrostContext after it is created.
+// admit settles who is asking and what they may reach, in that order, before a single JSON-RPC
+// message is handled. Authentication is the transport's: which credential the request presents,
+// whether the configured mode accepts it, whether it verifies. What the credential grants is
+// governance's, asked through the admitter so initialize and tools/list are refused by exactly the
+// rules tools/call is refused by. What survives is stamped on bifrostCtx as the tool list this
+// request may see and call.
+func (h *MCPServerHandler) admit(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext) *mcpRefusal {
+	if err := h.authenticate(ctx, bifrostCtx); err != nil {
+		return &mcpRefusal{status: fasthttp.StatusUnauthorized, message: err.Error()}
+	}
+
+	access, refused := h.admitAccess(bifrostCtx)
+	if refused != nil {
+		status := fasthttp.StatusForbidden
+		if refused.StatusCode != nil {
+			status = *refused.StatusCode
+		}
+		// A refusal for want of a usable credential is answered the way every other credential
+		// failure is, with the pointer to where one can be obtained.
+		if status == fasthttp.StatusUnauthorized && h.discoveryEnabled() {
+			ctx.Response.Header.Set("WWW-Authenticate", wwwAuthenticateValue(ctx, h.config))
+		}
+		return &mcpRefusal{status: status, message: bifrost.GetErrorMessage(refused)}
+	}
+
+	stampToolAccess(bifrostCtx, access)
+	return nil
+}
+
+// admitAccess asks governance what the request may reach. Without an admitter there is nothing to
+// ask, and the answer is what a request nobody governs has always had: no restriction.
+func (h *MCPServerHandler) admitAccess(bifrostCtx *schemas.BifrostContext) (schemas.Access, *schemas.BifrostError) {
+	if h.admitter == nil {
+		return nil, nil
+	}
+	return h.admitter.AdmitMCPGatewayRequest(bifrostCtx)
+}
+
+// stampToolAccess records the tools this request may see and call, as the include list the tool
+// filter and the executor both read. A request with no access is one nothing restricts, and is left
+// unstamped: it enumerates nothing, and an empty list would read as no tool at all. A list the caller
+// supplied is narrowed to the access rather than replaced, so a caller can ask for less but never
+// for more.
+func stampToolAccess(bifrostCtx *schemas.BifrostContext, access schemas.Access) {
+	if access == nil {
+		return
+	}
+	tools := access.MCPToolIncludeList()
+	if requested := bifrostCtx.Value(schemas.MCPContextKeyIncludeTools); requested != nil {
+		requestedList, _ := requested.([]string)
+		tools = access.NarrowMCPToolIncludeList(requestedList)
+	}
+	bifrostCtx.SetValue(schemas.MCPContextKeyIncludeTools, tools)
+}
+
+// authSettings reads the two settings admission depends on under the config lock.
+func (h *MCPServerHandler) authSettings() (enforceAuth bool, authMode tables.MCPServerAuthMode) {
+	h.config.Mu.RLock()
+	defer h.config.Mu.RUnlock()
+	return h.config.ClientConfig.EnforceAuthOnInference, h.config.ClientConfig.MCPServerAuthMode
+}
+
+// discoveryEnabled reports whether Bifrost-issued OAuth tokens are accepted on /mcp, which is also
+// when a refusal points the caller at the authorization server.
+func (h *MCPServerHandler) discoveryEnabled() bool {
+	_, authMode := h.authSettings()
+	return authMode == tables.MCPServerAuthModeBoth || authMode == tables.MCPServerAuthModeOAuth
+}
+
+// authenticate settles who is asking. It verifies whatever credential the request presents under
+// the configured auth mode, refuses what the mode does not accept, and stamps the identity on
+// bifrostCtx for governance to resolve. It decides nothing about what the caller may reach, and
+// nothing about whether a credential is still usable: a key that is inactive or expired is refused
+// by governance, from the grant it resolves for it, so both paths refuse it the same way.
 //
 // Authentication priority:
 //  1. JWT Bearer token (when MCPServerAuthMode is both or oauth)
-//  2. VK / header credentials (when MCPServerAuthMode is headers or both)
+//  2. Header credentials, or an identity an upstream auth layer stamped (headers or both)
 //  3. Anonymous access (when EnforceAuthOnInference is false)
 //
 // When MCPServerAuthMode is oauth (strict), header credentials are rejected.
-func (h *MCPServerHandler) getMCPServerForRequest(ctx *fasthttp.RequestCtx) (*mcpAuthResult, error) {
-	h.config.Mu.RLock()
-	enforceAuth := h.config.ClientConfig.EnforceAuthOnInference
-	authMode := h.config.ClientConfig.MCPServerAuthMode
-	h.config.Mu.RUnlock()
-
+func (h *MCPServerHandler) authenticate(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext) error {
+	enforceAuth, authMode := h.authSettings()
 	discoveryEnabled := authMode == tables.MCPServerAuthModeBoth || authMode == tables.MCPServerAuthModeOAuth
-
-	// --- Pre-authenticated user path ---
-	// An upstream auth layer that authenticated the caller as a user stamps the
-	// user id onto the request context. In headers/both modes, scope the request
-	// to that user's virtual key — the same representative-VK scoping a user-mode
-	// token gets — so a user authenticated by a bearer token is treated like a
-	// virtual key. oauth-strict accepts only Bifrost-issued tokens and is excluded.
-	if h.identityResolver != nil &&
-		(authMode == tables.MCPServerAuthModeHeaders || authMode == tables.MCPServerAuthModeBoth) {
-		if userID, _ := ctx.UserValue(schemas.BifrostContextKeyUserID).(string); userID != "" {
-			// Dual-credential conflict (IDP token + VK) is handled upstream in the SCIM
-			// InferenceMiddleware before identity is stamped, respecting the operator's
-			// dual_credential_conflict_behavior config. No check needed here.
-			vkID, err := h.identityResolver.ResolveUserVirtualKey(ctx, userID)
-			if err != nil {
-				return nil, err
-			}
-			if vkID == "" {
-				return nil, fmt.Errorf("no MCP access grant for the authenticated user")
-			}
-			vk, err := h.getVirtualKeyByID(ctx, vkID)
-			if err != nil {
-				return nil, err
-			}
-			if !vk.IsActiveValue() {
-				return nil, fmt.Errorf("virtual key is inactive")
-			}
-			vkServer, err := h.ensureVKMCPServerByValue(ctx, vk.Value.GetValue())
-			if err != nil {
-				return nil, err
-			}
-			return &mcpAuthResult{mcpServer: vkServer}, nil
-		}
-	}
 
 	// --- JWT path ---
 	if rawJWT := extractBearerJWT(ctx); rawJWT != "" && discoveryEnabled {
@@ -683,7 +583,7 @@ func (h *MCPServerHandler) getMCPServerForRequest(ctx *fasthttp.RequestCtx) (*mc
 		// would otherwise leak onto the context and be attributed to the request.
 		if headerVK := getVKFromRequest(ctx); headerVK != "" {
 			ctx.Response.Header.Set("WWW-Authenticate", wwwAuthenticateValue(ctx, h.config))
-			return nil, fmt.Errorf("conflicting credentials: an OAuth token and a virtual key header were both provided; send only the OAuth token")
+			return fmt.Errorf("conflicting credentials: an OAuth token and a virtual key header were both provided; send only the OAuth token")
 		}
 
 		// Load the signing key (cached for the process lifetime). A failure here is
@@ -694,48 +594,55 @@ func (h *MCPServerHandler) getMCPServerForRequest(ctx *fasthttp.RequestCtx) (*mc
 		if err != nil {
 			logger.Error("mcp: failed to load oauth2 signing key for jwt verification: %v", err)
 			ctx.Response.Header.Set("WWW-Authenticate", wwwAuthenticateValue(ctx, h.config))
-			return nil, fmt.Errorf("signing key unavailable")
+			return fmt.Errorf("signing key unavailable")
 		}
 		claims, err := verifyMCPJWT(ctx, rawJWT, h.config, signingKey)
 		if err != nil {
-			if discoveryEnabled {
-				ctx.Response.Header.Set("WWW-Authenticate", wwwAuthenticateValue(ctx, h.config))
-			}
+			ctx.Response.Header.Set("WWW-Authenticate", wwwAuthenticateValue(ctx, h.config))
 			// Forward verifyMCPJWT's error verbatim: it already labels a genuine
 			// token failure ("invalid token: ...") precisely, while its config
 			// faults ("signing key unavailable", ...) must not be mislabeled as
 			// the client's token being bad.
-			return nil, err
+			return err
 		}
 
-		// For user-mode JWTs, if a dashboard session is present on the request
-		// (BifrostContextKeyUserID, set by the auth middleware) it must match
-		// bf_sub — a mismatch means the session and the token disagree on
-		// identity. Its absence is not fatal: the JWT itself proves identity, and
-		// initiating a new upstream per-user flow is verified later at the
-		// session-bearing UI step (flowStart → canAccessUserFlow).
-		if schemas.MCPAuthMode(claims.BfMode) == schemas.MCPAuthModeUser {
+		switch schemas.MCPAuthMode(claims.BfMode) {
+		case schemas.MCPAuthModeUser:
+			// If a dashboard session is present on the request (BifrostContextKeyUserID,
+			// set by the auth middleware) it must match bf_sub: a mismatch means the
+			// session and the token disagree on identity. Its absence is not fatal: the
+			// JWT itself proves identity, and initiating a new upstream per-user flow is
+			// verified later at the session-bearing UI step (flowStart → canAccessUserFlow).
 			sessionUserID, _ := ctx.UserValue(schemas.BifrostContextKeyUserID).(string)
 			if sessionUserID != "" && sessionUserID != claims.Subject {
 				ctx.Response.Header.Set("WWW-Authenticate", wwwAuthenticateValue(ctx, h.config))
-				return nil, fmt.Errorf("session user does not match the authenticated token")
+				return fmt.Errorf("session user does not match the authenticated token")
 			}
-		}
+			// Reject deleted or deactivated users at request time rather than letting an
+			// already-issued access token keep working until it expires. Whether the user
+			// still exists is an identity question; what they may reach is governance's.
+			if h.identityResolver != nil {
+				if active, err := h.identityResolver.IsUserActive(ctx, claims.Subject); err != nil {
+					return fmt.Errorf("failed to verify user: %w", err)
+				} else if !active {
+					return fmt.Errorf("user is no longer active")
+				}
+			}
+			return injectJWTContext(bifrostCtx, claims, nil)
 
-		// Session-mode tokens carry no verified identity. When the operator
-		// requires authentication (EnforceAuthOnInference=true), session-mode
-		// JWT requests are rejected — the session itself is not deleted, but
-		// this endpoint becomes inaccessible until the client re-authenticates
-		// with a VK or user-mode token.
-		if schemas.MCPAuthMode(claims.BfMode) == schemas.MCPAuthModeSession && enforceAuth {
-			ctx.Response.Header.Set("WWW-Authenticate", wwwAuthenticateValue(ctx, h.config))
-			return nil, fmt.Errorf("authentication required; session-mode tokens are not accepted when authentication is enforced - re-authenticate with a virtual key or user identity")
-		}
+		case schemas.MCPAuthModeSession:
+			// Session-mode tokens carry no verified identity. When the operator
+			// requires authentication (EnforceAuthOnInference=true), session-mode
+			// JWT requests are rejected: the session itself is not deleted, but
+			// this endpoint becomes inaccessible until the client re-authenticates
+			// with a VK or user-mode token.
+			if enforceAuth {
+				ctx.Response.Header.Set("WWW-Authenticate", wwwAuthenticateValue(ctx, h.config))
+				return fmt.Errorf("authentication required; session-mode tokens are not accepted when authentication is enforced - re-authenticate with a virtual key or user identity")
+			}
+			return injectJWTContext(bifrostCtx, claims, nil)
 
-		res := &mcpAuthResult{jwtClaims: claims}
-
-		// For vk mode, look up the VK by ID to get the scoped server and value.
-		if schemas.MCPAuthMode(claims.BfMode) == schemas.MCPAuthModeVK {
+		case schemas.MCPAuthModeVK:
 			// Live virtual-key identity cutoff: when virtual-key identity has been
 			// disabled, reject vk-mode tokens at request time rather than waiting
 			// for the access token to expire and its refresh to be denied. The
@@ -747,142 +654,43 @@ func (h *MCPServerHandler) getMCPServerForRequest(ctx *fasthttp.RequestCtx) (*mc
 			if oauth2ServerCfg(h.config).DisableVKIdentity &&
 				h.identityResolver != nil && h.identityResolver.IsUserModeAvailable() {
 				ctx.Response.Header.Set("WWW-Authenticate", wwwAuthenticateValue(ctx, h.config))
-				return nil, fmt.Errorf("virtual-key identity is no longer accepted; re-authenticate")
+				return fmt.Errorf("virtual-key identity is no longer accepted; re-authenticate")
 			}
+			// The token names the key by row ID; governance resolves keys by value, so the
+			// row is read to stamp the value. Nothing else about the key is decided here.
 			vk, err := h.getVirtualKeyByID(ctx, claims.Subject)
 			if err != nil {
-				return nil, err
+				return err
 			}
-			if !vk.IsActiveValue() {
-				return nil, fmt.Errorf("virtual key is inactive")
-			}
-			res.jwtVK = vk
-			vkServer, serverErr := h.ensureVKMCPServerByValue(ctx, vk.Value.GetValue())
-			if serverErr != nil {
-				return nil, serverErr
-			}
-			res.mcpServer = vkServer
-		} else if scopedServer, scopedErr := h.userScopedServer(ctx, claims); scopedErr != nil {
-			return nil, scopedErr
-		} else if scopedServer != nil {
-			res.mcpServer = scopedServer
-		} else {
-			res.mcpServer = h.globalMCPServer
+			return injectJWTContext(bifrostCtx, claims, vk)
+
+		default:
+			return injectJWTContext(bifrostCtx, claims, nil)
 		}
-		return res, nil
 	}
 
 	// --- oauth strict mode: reject non-JWT requests ---
 	if authMode == tables.MCPServerAuthModeOAuth {
 		ctx.Response.Header.Set("WWW-Authenticate", wwwAuthenticateValue(ctx, h.config))
-		return nil, fmt.Errorf("this server requires OAuth JWT authentication; header credentials are not accepted in oauth mode")
+		return fmt.Errorf("this server requires OAuth JWT authentication; header credentials are not accepted in oauth mode")
 	}
 
-	// --- VK / header credential path ---
-	vk := getVKFromRequest(ctx)
-
-	// EnforceAuth=false: anonymous access to the global (un-scoped) MCP server
-	// is allowed in dev mode. EnforceAuth=true: VK header is mandatory.
-	if !enforceAuth && vk == "" {
-		// Anonymous access allowed in dev mode.
-		return &mcpAuthResult{mcpServer: h.globalMCPServer}, nil
+	// --- Header credentials, or an identity an upstream auth layer already authenticated ---
+	// Converting the request already stamped a virtual key found in its headers, and copied the
+	// user an upstream auth layer stamped. Governance resolves both; all that is decided here is
+	// whether the request presented anything, when it must.
+	//
+	// EnforceAuth=false: anonymous access to the MCP server is allowed in dev mode.
+	if !enforceAuth {
+		return nil
 	}
-
-	if vk == "" {
-		if discoveryEnabled {
-			ctx.Response.Header.Set("WWW-Authenticate", wwwAuthenticateValue(ctx, h.config))
-		}
-		return nil, fmt.Errorf("virtual key required to access mcp server; set one of x-bf-vk, Authorization: Bearer <vk>, x-api-key, or x-goog-api-key in your MCP client config")
+	if getVKFromRequest(ctx) != "" || bifrost.GetStringFromContext(bifrostCtx, schemas.BifrostContextKeyUserID) != "" {
+		return nil
 	}
-
-	vkServer, err := h.ensureVKMCPServerByValue(ctx, vk)
-	if err != nil {
-		return nil, err
+	if discoveryEnabled {
+		ctx.Response.Header.Set("WWW-Authenticate", wwwAuthenticateValue(ctx, h.config))
 	}
-	return &mcpAuthResult{mcpServer: vkServer}, nil
-}
-
-// userScopedServer returns a per-VK MCP server scoped to a user-mode token's
-// own tools, or nil (with nil error) when no scoping applies — no resolver, a
-// non-user-mode token, or a user with no virtual key — so the caller falls back
-// to the global server.
-//
-// User-mode tokens carry a user identity but no virtual key of their own. The
-// resolver maps the user to a representative virtual key (any one of the user's
-// equivalent keys), letting this reuse the per-VK scoped server instead of
-// serving the global (unscoped) one. Session-mode tokens have no identity to
-// scope by and return nil here.
-func (h *MCPServerHandler) userScopedServer(ctx *fasthttp.RequestCtx, claims *jwtMCPClaims) (*server.MCPServer, error) {
-	if h.identityResolver == nil || h.config.ConfigStore == nil {
-		return nil, nil
-	}
-	if schemas.MCPAuthMode(claims.BfMode) != schemas.MCPAuthModeUser {
-		return nil, nil
-	}
-	// Reject deleted or deactivated users at request time, mirroring the vk-mode
-	// IsActiveValue() cutoff, rather than letting an already-issued access token
-	// keep working until it expires. Placed before the no-virtual-key early
-	// return below so a removed user cannot fall through to the global server.
-	if active, err := h.identityResolver.IsUserActive(ctx, claims.Subject); err != nil {
-		return nil, fmt.Errorf("failed to verify user: %w", err)
-	} else if !active {
-		return nil, fmt.Errorf("user is no longer active")
-	}
-	vkID, err := h.identityResolver.ResolveUserVirtualKey(ctx, claims.Subject)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve virtual key for user: %w", err)
-	}
-	if vkID == "" {
-		return nil, nil
-	}
-	// Mirror the vk-mode branch: resolve the representative VK by ID to get its
-	// value and active state, then reuse the shared per-VK server cache.
-	vk, err := h.getVirtualKeyByID(ctx, vkID)
-	if err != nil {
-		return nil, err
-	}
-	if !vk.IsActiveValue() {
-		return nil, fmt.Errorf("virtual key is inactive")
-	}
-	return h.ensureVKMCPServerByValue(ctx, vk.Value.GetValue())
-}
-
-// ensureVKMCPServerByValue returns the per-VK server from cache or creates it.
-func (h *MCPServerHandler) ensureVKMCPServerByValue(ctx context.Context, vkValue string) (*server.MCPServer, error) {
-	h.mu.RLock()
-	s, ok := h.vkMCPServers[vkValue]
-	h.mu.RUnlock()
-	// Fast path: a per-VK server already exists in the cache.
-	if ok {
-		return s, nil
-	}
-	// Slow path: build the per-VK server lazily on first use.
-	return h.ensureVKMCPServer(ctx, vkValue)
-}
-
-// ensureVKMCPServer lazily builds and caches the MCP server for a virtual key on
-// first use, looking the key up by value via the config store. Per-VK servers
-// are no longer created eagerly at startup, so the first MCP request for a given
-// key materializes it here. Returns "virtual key not found" if the value does
-// not resolve to a known virtual key (or no config store is configured).
-func (h *MCPServerHandler) ensureVKMCPServer(ctx context.Context, vkValue string) (*server.MCPServer, error) {
-	if h.config.ConfigStore == nil {
-		return nil, fmt.Errorf("virtual key not found")
-	}
-	vk, err := h.config.ConfigStore.GetVirtualKeyByValue(ctx, vkValue)
-	if err != nil || vk == nil {
-		return nil, fmt.Errorf("virtual key not found")
-	}
-	// GetVirtualKeyByValue does not filter inactive keys, so fail closed here:
-	// a deactivated key must not yield (or cache) a usable MCP server. This is
-	// the single chokepoint for both the header path and the JWT vk path.
-	if !vk.IsActiveValue() {
-		return nil, fmt.Errorf("virtual key is inactive")
-	}
-	// SyncVKMCPServer creates (or refreshes) and caches the server under the
-	// handler write lock, returning the live server so a concurrent
-	// SyncAllMCPServers cannot wipe the map out from under us before we read it.
-	return h.SyncVKMCPServer(vk), nil
+	return fmt.Errorf("virtual key required to access mcp server; set one of x-bf-vk, Authorization: Bearer <vk>, x-api-key, or x-goog-api-key in your MCP client config")
 }
 
 // getVKFromRequest extracts a virtual key from the request headers, checking
@@ -924,4 +732,45 @@ func getVKFromRequest(ctx *fasthttp.RequestCtx) string {
 	}
 
 	return ""
+}
+
+func convertToolFunctionParametersToMCPInputSchema(params *schemas.ToolFunctionParameters) mcp.ToolInputSchema {
+	if params == nil {
+		return mcp.ToolInputSchema{
+			Type:       "object",
+			Properties: make(map[string]any),
+		}
+	}
+
+	inputSchema := mcp.ToolInputSchema{
+		Type:     params.Type,
+		Required: params.Required,
+	}
+
+	if params.Properties != nil {
+		props := make(map[string]any, params.Properties.Len())
+		params.Properties.Range(func(key string, value interface{}) bool {
+			props[key] = value
+			return true
+		})
+		inputSchema.Properties = props
+	}
+
+	if params.Defs != nil {
+		defs := make(map[string]any, params.Defs.Len())
+		params.Defs.Range(func(key string, value interface{}) bool {
+			defs[key] = value
+			return true
+		})
+		inputSchema.Defs = defs
+	} else if params.Definitions != nil {
+		defs := make(map[string]any, params.Definitions.Len())
+		params.Definitions.Range(func(key string, value interface{}) bool {
+			defs[key] = value
+			return true
+		})
+		inputSchema.Defs = defs
+	}
+
+	return inputSchema
 }

--- a/transports/bifrost-http/handlers/mcpserver_auth_test.go
+++ b/transports/bifrost-http/handlers/mcpserver_auth_test.go
@@ -1,28 +1,58 @@
 package handlers
 
 import (
+	"context"
 	"testing"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/maximhq/bifrost/core/schemas"
 	configtables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/grant"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
 )
 
-// newTestMCPHandler builds an MCPServerHandler around the given config without
-// going through NewMCPServerHandler (which needs a live tool manager). Per-VK
-// servers are looked up from vkMCPServers; tests pre-seed it to keep the VK
-// path from building a real server.
+// newTestMCPHandler builds an MCPServerHandler around the given config without going through
+// NewMCPServerHandler (which needs a live tool manager). No admitter is wired, so admission
+// resolves nothing; tests of the admission step install a fakeAdmitter.
 func newTestMCPHandler(cfg *lib.Config) *MCPServerHandler {
-	return &MCPServerHandler{
-		globalMCPServer: server.NewMCPServer("test", "v0", server.WithToolCapabilities(true)),
-		vkMCPServers:    map[string]*server.MCPServer{},
-		config:          cfg,
-	}
+	h := &MCPServerHandler{config: cfg}
+	h.mcpServer.Store(server.NewMCPServer("test", "v0", server.WithToolCapabilities(true)))
+	return h
+}
+
+// fakeAdmitter stands in for governance: it hands back a fixed access or a fixed refusal, and
+// remembers the context it was asked about.
+type fakeAdmitter struct {
+	access  schemas.Access
+	refusal *schemas.BifrostError
+	seen    *schemas.BifrostContext
+}
+
+func (f *fakeAdmitter) AdmitMCPGatewayRequest(ctx *schemas.BifrostContext) (schemas.Access, *schemas.BifrostError) {
+	f.seen = ctx
+	return f.access, f.refusal
+}
+
+// newRequestCtx returns the pair a request is handled with: the fasthttp request, and a
+// BifrostContext standing in for what ConvertToBifrostContext would have produced from it.
+func newRequestCtx() (*fasthttp.RequestCtx, *schemas.BifrostContext) {
+	return &fasthttp.RequestCtx{}, schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+}
+
+func stringFromCtx(ctx *schemas.BifrostContext, key schemas.BifrostContextKey) string {
+	value, _ := ctx.Value(key).(string)
+	return value
+}
+
+// restrictedAccess is the access of a caller granted the listed tools of one client.
+func restrictedAccess(client string, tools ...string) schemas.Access {
+	permit := grant.NewPermit(grant.PermitVirtualKey, "vk-1", "Caller Key", true, false, nil,
+		[]schemas.MCPPermit{{Client: client + "-id", ClientName: client, Tools: tools}})
+	return grant.NewAccess([]schemas.Permit{permit}, nil, "", nil)
 }
 
 // TestGetVKFromRequest verifies the VK value is extracted from each supported
@@ -91,503 +121,391 @@ func TestGetVKFromRequest(t *testing.T) {
 	}
 }
 
-// TestGetMCPServerForRequest_JWTPath covers the JWT branch of /mcp auth across
-// modes and identity kinds: the security contract for OAuth-authenticated calls.
-func TestGetMCPServerForRequest_JWTPath(t *testing.T) {
+// TestAuthenticate_JWTPath covers the JWT branch of /mcp authentication across modes and identity
+// kinds: what is verified, what is refused, and what identity is stamped for governance to resolve.
+func TestAuthenticate_JWTPath(t *testing.T) {
 	SetLogger(&mockLogger{})
 	key, priv := newTestSigningKey(t)
 
-	t.Run("oauth mode: valid vk JWT with active key is accepted", func(t *testing.T) {
+	vkToken := func(sub string) string {
+		return mintTestToken(t, priv, key.KID, func(c jwt.MapClaims) {
+			c["bf_mode"] = string(schemas.MCPAuthModeVK)
+			c["sub"] = sub
+		})
+	}
+	userToken := func(sub string) string {
+		return mintTestToken(t, priv, key.KID, func(c jwt.MapClaims) {
+			c["bf_mode"] = string(schemas.MCPAuthModeUser)
+			c["sub"] = sub
+		})
+	}
+	sessionToken := func(sub string) string {
+		return mintTestToken(t, priv, key.KID, func(c jwt.MapClaims) {
+			c["bf_mode"] = string(schemas.MCPAuthModeSession)
+			c["sub"] = sub
+		})
+	}
+
+	t.Run("oauth mode: vk JWT stamps the key's value for governance to resolve", func(t *testing.T) {
 		activeVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: *schemas.NewSecretVar("sk-bf-active"), IsActive: new(true)}
-		store := &mockOAuth2Store{
-			signingKey: key,
-			vksByID:    map[string]*configtables.TableVirtualKey{"vk-row-1": activeVK},
-		}
-		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeOAuth, false)
-		h := newTestMCPHandler(cfg)
-		// Pre-seed the per-VK server so the accepted path does not build one.
-		h.vkMCPServers[activeVK.Value.GetValue()] = server.NewMCPServer("vk", "v0")
+		store := &mockOAuth2Store{signingKey: key, vksByID: map[string]*configtables.TableVirtualKey{"vk-row-1": activeVK}}
+		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeOAuth, false))
 
-		raw := mintTestToken(t, priv, key.KID, func(c jwt.MapClaims) {
-			c["bf_mode"] = string(schemas.MCPAuthModeVK)
-			c["sub"] = "vk-row-1"
-		})
-		ctx := &fasthttp.RequestCtx{}
-		ctx.Request.Header.Set("Authorization", "Bearer "+raw)
+		ctx, bifrostCtx := newRequestCtx()
+		ctx.Request.Header.Set("Authorization", "Bearer "+vkToken("vk-row-1"))
 
-		res, err := h.getMCPServerForRequest(ctx)
-		require.NoError(t, err)
-		require.NotNil(t, res)
-		require.NotNil(t, res.jwtClaims)
-		require.NotNil(t, res.jwtVK)
-		assert.Equal(t, "vk-row-1", res.jwtVK.ID)
-		assert.NotNil(t, res.mcpServer)
+		require.NoError(t, h.authenticate(ctx, bifrostCtx))
+		assert.Equal(t, "sk-bf-active", stringFromCtx(bifrostCtx, schemas.BifrostContextKeyVirtualKey))
+		assert.Empty(t, stringFromCtx(bifrostCtx, schemas.BifrostContextKeyUserID))
 	})
 
-	t.Run("vk JWT with inactive key is rejected", func(t *testing.T) {
+	// Whether a key may still be used is governance's answer, read off the grant it resolves, so the
+	// same key is refused the same way on every path. Authentication only stamps it.
+	t.Run("vk JWT with an inactive key is stamped rather than refused here", func(t *testing.T) {
 		inactiveVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: *schemas.NewSecretVar("sk-bf-x"), IsActive: new(false)}
-		store := &mockOAuth2Store{
-			signingKey: key,
-			vksByID:    map[string]*configtables.TableVirtualKey{"vk-row-1": inactiveVK},
-		}
-		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, false)
-		h := newTestMCPHandler(cfg)
+		store := &mockOAuth2Store{signingKey: key, vksByID: map[string]*configtables.TableVirtualKey{"vk-row-1": inactiveVK}}
+		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, false))
 
-		raw := mintTestToken(t, priv, key.KID, func(c jwt.MapClaims) {
-			c["bf_mode"] = string(schemas.MCPAuthModeVK)
-			c["sub"] = "vk-row-1"
-		})
-		ctx := &fasthttp.RequestCtx{}
-		ctx.Request.Header.Set("Authorization", "Bearer "+raw)
+		ctx, bifrostCtx := newRequestCtx()
+		ctx.Request.Header.Set("Authorization", "Bearer "+vkToken("vk-row-1"))
 
-		_, err := h.getMCPServerForRequest(ctx)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "inactive")
+		require.NoError(t, h.authenticate(ctx, bifrostCtx))
+		assert.Equal(t, "sk-bf-x", stringFromCtx(bifrostCtx, schemas.BifrostContextKeyVirtualKey))
 	})
 
-	t.Run("vk JWT for unknown key is rejected", func(t *testing.T) {
+	t.Run("vk JWT for an unknown key is rejected", func(t *testing.T) {
 		store := &mockOAuth2Store{signingKey: key, vksByID: map[string]*configtables.TableVirtualKey{}}
+		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, false))
+
+		ctx, bifrostCtx := newRequestCtx()
+		ctx.Request.Header.Set("Authorization", "Bearer "+vkToken("missing-vk"))
+
+		require.Error(t, h.authenticate(ctx, bifrostCtx))
+		assert.Empty(t, stringFromCtx(bifrostCtx, schemas.BifrostContextKeyVirtualKey))
+	})
+
+	t.Run("vk JWT is rejected once virtual-key identity is disabled and user mode is offered", func(t *testing.T) {
+		activeVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: *schemas.NewSecretVar("sk-bf-active"), IsActive: new(true)}
+		store := &mockOAuth2Store{signingKey: key, vksByID: map[string]*configtables.TableVirtualKey{"vk-row-1": activeVK}}
 		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, false)
+		cfg.ClientConfig.OAuth2ServerConfig.DisableVKIdentity = true
 		h := newTestMCPHandler(cfg)
+		h.identityResolver = &fakeResolver{userModeAvailable: true}
 
-		raw := mintTestToken(t, priv, key.KID, func(c jwt.MapClaims) {
-			c["bf_mode"] = string(schemas.MCPAuthModeVK)
-			c["sub"] = "missing-vk"
-		})
-		ctx := &fasthttp.RequestCtx{}
-		ctx.Request.Header.Set("Authorization", "Bearer "+raw)
+		ctx, bifrostCtx := newRequestCtx()
+		ctx.Request.Header.Set("Authorization", "Bearer "+vkToken("vk-row-1"))
 
-		_, err := h.getMCPServerForRequest(ctx)
+		err := h.authenticate(ctx, bifrostCtx)
 		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no longer accepted")
+		assert.NotEmpty(t, ctx.Response.Header.Peek("WWW-Authenticate"))
 	})
 
-	t.Run("user JWT without a session is allowed", func(t *testing.T) {
+	t.Run("user JWT without a session stamps the user", func(t *testing.T) {
 		store := &mockOAuth2Store{signingKey: key}
-		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, false)
-		h := newTestMCPHandler(cfg)
+		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, false))
 
-		raw := mintTestToken(t, priv, key.KID, func(c jwt.MapClaims) {
-			c["bf_mode"] = string(schemas.MCPAuthModeUser)
-			c["sub"] = "user-1"
-		})
-		ctx := &fasthttp.RequestCtx{}
-		ctx.Request.Header.Set("Authorization", "Bearer "+raw)
+		ctx, bifrostCtx := newRequestCtx()
+		ctx.Request.Header.Set("Authorization", "Bearer "+userToken("user-1"))
 
-		res, err := h.getMCPServerForRequest(ctx)
-		require.NoError(t, err)
-		require.NotNil(t, res)
-		// No resolver wired → falls back to the global server.
-		assert.Equal(t, h.globalMCPServer, res.mcpServer)
-	})
-
-	t.Run("user JWT is scoped to the user's representative virtual key", func(t *testing.T) {
-		activeVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: *schemas.NewSecretVar("sk-bf-user-rep"), IsActive: new(true)}
-		store := &mockOAuth2Store{
-			signingKey: key,
-			vksByID:    map[string]*configtables.TableVirtualKey{"vk-row-1": activeVK},
-		}
-		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, false)
-		h := newTestMCPHandler(cfg)
-		// Resolver maps the user to a representative VK; pre-seed its server so the
-		// scoped path does not build a real one.
-		h.identityResolver = &fakeResolver{userVKID: "vk-row-1"}
-		vkServer := server.NewMCPServer("vk", "v0")
-		h.vkMCPServers[activeVK.Value.GetValue()] = vkServer
-
-		raw := mintTestToken(t, priv, key.KID, func(c jwt.MapClaims) {
-			c["bf_mode"] = string(schemas.MCPAuthModeUser)
-			c["sub"] = "user-1"
-		})
-		ctx := &fasthttp.RequestCtx{}
-		ctx.Request.Header.Set("Authorization", "Bearer "+raw)
-
-		res, err := h.getMCPServerForRequest(ctx)
-		require.NoError(t, err)
-		require.NotNil(t, res)
-		// Served the user's scoped VK server, NOT the global (unscoped) server.
-		assert.Equal(t, vkServer, res.mcpServer)
-		assert.NotEqual(t, h.globalMCPServer, res.mcpServer)
-		// User mode keeps the user identity — no VK identity is attributed.
-		assert.Nil(t, res.jwtVK)
+		require.NoError(t, h.authenticate(ctx, bifrostCtx))
+		assert.Equal(t, "user-1", stringFromCtx(bifrostCtx, schemas.BifrostContextKeyUserID))
+		assert.Empty(t, stringFromCtx(bifrostCtx, schemas.BifrostContextKeyVirtualKey), "user mode attributes no virtual key")
 	})
 
 	t.Run("user JWT is rejected when the user is no longer active", func(t *testing.T) {
-		activeVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: *schemas.NewSecretVar("sk-bf-user-rep"), IsActive: new(true)}
-		store := &mockOAuth2Store{
-			signingKey: key,
-			vksByID:    map[string]*configtables.TableVirtualKey{"vk-row-1": activeVK},
-		}
-		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, false)
-		h := newTestMCPHandler(cfg)
-		// The resolver still maps the user to a VK, but reports the user as gone.
-		// The request must be rejected at request time rather than falling through
-		// to the global (unscoped) server until the access token expires.
-		h.identityResolver = &fakeResolver{userVKID: "vk-row-1", userInactive: true}
-
-		raw := mintTestToken(t, priv, key.KID, func(c jwt.MapClaims) {
-			c["bf_mode"] = string(schemas.MCPAuthModeUser)
-			c["sub"] = "user-1"
-		})
-		ctx := &fasthttp.RequestCtx{}
-		ctx.Request.Header.Set("Authorization", "Bearer "+raw)
-
-		_, err := h.getMCPServerForRequest(ctx)
-		require.Error(t, err)
-	})
-
-	t.Run("user JWT falls back to the global server when the user has no virtual key", func(t *testing.T) {
 		store := &mockOAuth2Store{signingKey: key}
-		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, false)
-		h := newTestMCPHandler(cfg)
-		h.identityResolver = &fakeResolver{userVKID: ""} // user has no AP-managed VK
+		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, false))
+		h.identityResolver = &fakeResolver{userInactive: true}
 
-		raw := mintTestToken(t, priv, key.KID, func(c jwt.MapClaims) {
-			c["bf_mode"] = string(schemas.MCPAuthModeUser)
-			c["sub"] = "user-1"
-		})
-		ctx := &fasthttp.RequestCtx{}
-		ctx.Request.Header.Set("Authorization", "Bearer "+raw)
+		ctx, bifrostCtx := newRequestCtx()
+		ctx.Request.Header.Set("Authorization", "Bearer "+userToken("user-1"))
 
-		res, err := h.getMCPServerForRequest(ctx)
-		require.NoError(t, err)
-		assert.Equal(t, h.globalMCPServer, res.mcpServer)
+		require.Error(t, h.authenticate(ctx, bifrostCtx))
+		assert.Empty(t, stringFromCtx(bifrostCtx, schemas.BifrostContextKeyUserID))
 	})
 
 	t.Run("user JWT with a matching session is accepted", func(t *testing.T) {
 		store := &mockOAuth2Store{signingKey: key}
-		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, false)
-		h := newTestMCPHandler(cfg)
+		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, false))
 
-		raw := mintTestToken(t, priv, key.KID, func(c jwt.MapClaims) {
-			c["bf_mode"] = string(schemas.MCPAuthModeUser)
-			c["sub"] = "user-1"
-		})
-		ctx := &fasthttp.RequestCtx{}
-		ctx.Request.Header.Set("Authorization", "Bearer "+raw)
+		ctx, bifrostCtx := newRequestCtx()
+		ctx.Request.Header.Set("Authorization", "Bearer "+userToken("user-1"))
 		ctx.SetUserValue(schemas.BifrostContextKeyUserID, "user-1")
 
-		_, err := h.getMCPServerForRequest(ctx)
-		require.NoError(t, err)
+		require.NoError(t, h.authenticate(ctx, bifrostCtx))
 	})
 
 	t.Run("user JWT with a mismatched session is rejected", func(t *testing.T) {
 		store := &mockOAuth2Store{signingKey: key}
-		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, false)
-		h := newTestMCPHandler(cfg)
+		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, false))
 
-		raw := mintTestToken(t, priv, key.KID, func(c jwt.MapClaims) {
-			c["bf_mode"] = string(schemas.MCPAuthModeUser)
-			c["sub"] = "user-1"
-		})
-		ctx := &fasthttp.RequestCtx{}
-		ctx.Request.Header.Set("Authorization", "Bearer "+raw)
+		ctx, bifrostCtx := newRequestCtx()
+		ctx.Request.Header.Set("Authorization", "Bearer "+userToken("user-1"))
 		ctx.SetUserValue(schemas.BifrostContextKeyUserID, "someone-else")
 
-		_, err := h.getMCPServerForRequest(ctx)
-		require.Error(t, err)
+		require.Error(t, h.authenticate(ctx, bifrostCtx))
 	})
 
 	t.Run("session JWT is rejected when auth is enforced", func(t *testing.T) {
 		store := &mockOAuth2Store{signingKey: key}
-		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, true)
-		h := newTestMCPHandler(cfg)
+		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, true))
 
-		raw := mintTestToken(t, priv, key.KID, func(c jwt.MapClaims) {
-			c["bf_mode"] = string(schemas.MCPAuthModeSession)
-			c["sub"] = "session-abc"
-		})
-		ctx := &fasthttp.RequestCtx{}
-		ctx.Request.Header.Set("Authorization", "Bearer "+raw)
+		ctx, bifrostCtx := newRequestCtx()
+		ctx.Request.Header.Set("Authorization", "Bearer "+sessionToken("session-abc"))
 
-		_, err := h.getMCPServerForRequest(ctx)
-		require.Error(t, err)
+		require.Error(t, h.authenticate(ctx, bifrostCtx))
+		assert.Empty(t, stringFromCtx(bifrostCtx, schemas.BifrostContextKeyMCPSessionID))
 	})
 
-	t.Run("session JWT is accepted when auth is not enforced", func(t *testing.T) {
+	t.Run("session JWT stamps the session when auth is not enforced", func(t *testing.T) {
 		store := &mockOAuth2Store{signingKey: key}
-		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, false)
-		h := newTestMCPHandler(cfg)
+		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, false))
 
-		raw := mintTestToken(t, priv, key.KID, func(c jwt.MapClaims) {
-			c["bf_mode"] = string(schemas.MCPAuthModeSession)
-			c["sub"] = "session-abc"
-		})
-		ctx := &fasthttp.RequestCtx{}
-		ctx.Request.Header.Set("Authorization", "Bearer "+raw)
+		ctx, bifrostCtx := newRequestCtx()
+		ctx.Request.Header.Set("Authorization", "Bearer "+sessionToken("session-abc"))
 
-		res, err := h.getMCPServerForRequest(ctx)
-		require.NoError(t, err)
-		assert.Equal(t, h.globalMCPServer, res.mcpServer)
+		require.NoError(t, h.authenticate(ctx, bifrostCtx))
+		assert.Equal(t, "session-abc", stringFromCtx(bifrostCtx, schemas.BifrostContextKeyMCPSessionID))
 	})
 
 	t.Run("both mode: session token with a header VK is rejected", func(t *testing.T) {
 		store := &mockOAuth2Store{signingKey: key}
-		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, false)
-		h := newTestMCPHandler(cfg)
+		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, false))
 
-		raw := mintTestToken(t, priv, key.KID, func(c jwt.MapClaims) {
-			c["bf_mode"] = string(schemas.MCPAuthModeSession)
-			c["sub"] = "session-abc"
-		})
-		ctx := &fasthttp.RequestCtx{}
-		ctx.Request.Header.Set("Authorization", "Bearer "+raw)
+		ctx, bifrostCtx := newRequestCtx()
+		ctx.Request.Header.Set("Authorization", "Bearer "+sessionToken("session-abc"))
 		ctx.Request.Header.Set(string(schemas.BifrostContextKeyVirtualKey), "sk-bf-header")
 
-		_, err := h.getMCPServerForRequest(ctx)
+		err := h.authenticate(ctx, bifrostCtx)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "conflicting credentials")
 	})
 
 	t.Run("both mode: vk token with a header VK is rejected", func(t *testing.T) {
 		store := &mockOAuth2Store{signingKey: key}
-		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, false)
-		h := newTestMCPHandler(cfg)
+		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, false))
 
-		raw := mintTestToken(t, priv, key.KID, func(c jwt.MapClaims) {
-			c["bf_mode"] = string(schemas.MCPAuthModeVK)
-			c["sub"] = "vk-row-1"
-		})
-		ctx := &fasthttp.RequestCtx{}
-		ctx.Request.Header.Set("Authorization", "Bearer "+raw)
+		ctx, bifrostCtx := newRequestCtx()
+		ctx.Request.Header.Set("Authorization", "Bearer "+vkToken("vk-row-1"))
 		ctx.Request.Header.Set(string(schemas.BifrostContextKeyVirtualKey), "sk-bf-header")
 
-		_, err := h.getMCPServerForRequest(ctx)
+		err := h.authenticate(ctx, bifrostCtx)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "conflicting credentials")
 	})
 }
 
-// TestGetMCPServerForRequest_PreAuthenticatedUserPath covers the path where an
-// upstream auth layer has already authenticated the caller as a user and stamped
-// the user id onto the request context (BifrostContextKeyUserID). In headers/both
-// modes the request is scoped to the user's representative virtual key, just like
-// a user-mode token; oauth-strict ignores it (Bifrost-issued tokens only).
-func TestGetMCPServerForRequest_PreAuthenticatedUserPath(t *testing.T) {
+// TestAuthenticate_HeaderAndAnonPath covers header credentials, identities an upstream auth layer
+// stamped, anonymous access, and oauth-strict rejection.
+func TestAuthenticate_HeaderAndAnonPath(t *testing.T) {
 	SetLogger(&mockLogger{})
 	key, _ := newTestSigningKey(t)
 
-	activeVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: *schemas.NewSecretVar("sk-bf-user-rep"), IsActive: new(true)}
-	newStore := func() *mockOAuth2Store {
-		return &mockOAuth2Store{
-			signingKey: key,
-			vksByID:    map[string]*configtables.TableVirtualKey{"vk-row-1": activeVK},
-		}
-	}
-
-	for _, mode := range []configtables.MCPServerAuthMode{
-		configtables.MCPServerAuthModeHeaders,
-		configtables.MCPServerAuthModeBoth,
-	} {
-		t.Run(string(mode)+" mode: stamped user id is scoped to the user's virtual key", func(t *testing.T) {
-			cfg := newTestOAuth2Config(newStore(), mode, true)
-			h := newTestMCPHandler(cfg)
-			h.identityResolver = &fakeResolver{userVKID: "vk-row-1"}
-			vkServer := server.NewMCPServer("vk", "v0")
-			h.vkMCPServers[activeVK.Value.GetValue()] = vkServer
-
-			ctx := &fasthttp.RequestCtx{}
-			ctx.SetUserValue(schemas.BifrostContextKeyUserID, "user-1")
-
-			res, err := h.getMCPServerForRequest(ctx)
-			require.NoError(t, err)
-			require.NotNil(t, res)
-			// Served the user's scoped VK server, NOT the global (unscoped) one.
-			assert.Equal(t, vkServer, res.mcpServer)
-			assert.NotEqual(t, h.globalMCPServer, res.mcpServer)
-			// Identity stays the user; no VK identity or JWT claims are attributed.
-			assert.Nil(t, res.jwtVK)
-			assert.Nil(t, res.jwtClaims)
-		})
-	}
-
-	t.Run("user with no virtual key is rejected (strict VK parity)", func(t *testing.T) {
-		cfg := newTestOAuth2Config(newStore(), configtables.MCPServerAuthModeBoth, true)
-		h := newTestMCPHandler(cfg)
-		h.identityResolver = &fakeResolver{userVKID: ""} // no AP-managed VK
-
-		ctx := &fasthttp.RequestCtx{}
-		ctx.SetUserValue(schemas.BifrostContextKeyUserID, "user-1")
-
-		_, err := h.getMCPServerForRequest(ctx)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "no MCP access grant")
-	})
-
-	// A stamped user id wins over any virtual key sent in the request headers: the
-	// request is scoped to the user's representative VK and the header VK is never
-	// honoured. Rejecting the pair as conflicting is deliberately NOT this
-	// function's job — that decision belongs upstream, in the SCIM inference
-	// middleware, which applies the operator's dual_credential_conflict_behavior
-	// before any identity is stamped (see getMCPServerForRequest). What matters
-	// here is that a header VK cannot escalate or redirect an already-authenticated
-	// user to a different key.
-	t.Run("stamped user id takes precedence over a header VK", func(t *testing.T) {
-		cfg := newTestOAuth2Config(newStore(), configtables.MCPServerAuthModeBoth, true)
-		h := newTestMCPHandler(cfg)
-		h.identityResolver = &fakeResolver{userVKID: "vk-row-1"}
-		userVKServer := server.NewMCPServer("vk", "v0")
-		h.vkMCPServers[activeVK.Value.GetValue()] = userVKServer
-		headerVKServer := server.NewMCPServer("header-vk", "v0")
-		h.vkMCPServers["sk-bf-header"] = headerVKServer
-
-		ctx := &fasthttp.RequestCtx{}
-		ctx.SetUserValue(schemas.BifrostContextKeyUserID, "user-1")
-		ctx.Request.Header.Set(string(schemas.BifrostContextKeyVirtualKey), "sk-bf-header")
-
-		res, err := h.getMCPServerForRequest(ctx)
-		require.NoError(t, err)
-		require.NotNil(t, res)
-		assert.Equal(t, userVKServer, res.mcpServer)
-		assert.NotEqual(t, headerVKServer, res.mcpServer)
-		assert.Nil(t, res.jwtVK)
-		assert.Nil(t, res.jwtClaims)
-	})
-
-	t.Run("inactive representative virtual key is rejected", func(t *testing.T) {
-		inactiveVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: *schemas.NewSecretVar("sk-bf-x"), IsActive: new(false)}
-		store := &mockOAuth2Store{
-			signingKey: key,
-			vksByID:    map[string]*configtables.TableVirtualKey{"vk-row-1": inactiveVK},
-		}
-		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, true)
-		h := newTestMCPHandler(cfg)
-		h.identityResolver = &fakeResolver{userVKID: "vk-row-1"}
-
-		ctx := &fasthttp.RequestCtx{}
-		ctx.SetUserValue(schemas.BifrostContextKeyUserID, "user-1")
-
-		_, err := h.getMCPServerForRequest(ctx)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "inactive")
-	})
-
-	t.Run("oauth-strict mode ignores the stamped user id", func(t *testing.T) {
-		cfg := newTestOAuth2Config(newStore(), configtables.MCPServerAuthModeOAuth, true)
-		h := newTestMCPHandler(cfg)
-		h.identityResolver = &fakeResolver{userVKID: "vk-row-1"}
-
-		ctx := &fasthttp.RequestCtx{}
-		ctx.SetUserValue(schemas.BifrostContextKeyUserID, "user-1")
-
-		// No bearer JWT, and header credentials are rejected in oauth-strict: the
-		// user-id check does not run, so this falls through to the strict rejection.
-		_, err := h.getMCPServerForRequest(ctx)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "OAuth JWT")
-	})
-
-	t.Run("no resolver: stamped user id is ignored", func(t *testing.T) {
-		cfg := newTestOAuth2Config(newStore(), configtables.MCPServerAuthModeHeaders, false)
-		h := newTestMCPHandler(cfg)
-		// identityResolver is nil (pure OSS, no IdP); enforce=false → anonymous.
-
-		ctx := &fasthttp.RequestCtx{}
-		ctx.SetUserValue(schemas.BifrostContextKeyUserID, "user-1")
-
-		res, err := h.getMCPServerForRequest(ctx)
-		require.NoError(t, err)
-		assert.Equal(t, h.globalMCPServer, res.mcpServer)
-	})
-}
-
-// TestGetMCPServerForRequest_HeaderAndAnonPath covers the legacy header-VK path,
-// anonymous access, and oauth-strict header rejection.
-func TestGetMCPServerForRequest_HeaderAndAnonPath(t *testing.T) {
-	SetLogger(&mockLogger{})
-	key, _ := newTestSigningKey(t)
-
-	t.Run("headers mode: active header VK connects", func(t *testing.T) {
-		activeVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: *schemas.NewSecretVar("sk-bf-active"), IsActive: new(true)}
-		store := &mockOAuth2Store{
-			signingKey: key,
-			vksByValue: map[string]*configtables.TableVirtualKey{"sk-bf-active": activeVK},
-		}
-		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeHeaders, true)
-		h := newTestMCPHandler(cfg)
-		h.vkMCPServers[activeVK.Value.GetValue()] = server.NewMCPServer("vk", "v0")
-
-		ctx := &fasthttp.RequestCtx{}
-		ctx.Request.Header.Set(string(schemas.BifrostContextKeyVirtualKey), "sk-bf-active")
-
-		res, err := h.getMCPServerForRequest(ctx)
-		require.NoError(t, err)
-		assert.Nil(t, res.jwtClaims)
-		assert.NotNil(t, res.mcpServer)
-	})
-
-	t.Run("inactive header VK is rejected at the shared chokepoint", func(t *testing.T) {
-		inactiveVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: *schemas.NewSecretVar("sk-bf-x"), IsActive: new(false)}
-		store := &mockOAuth2Store{
-			signingKey: key,
-			vksByValue: map[string]*configtables.TableVirtualKey{"sk-bf-x": inactiveVK},
-		}
-		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeHeaders, true)
-		h := newTestMCPHandler(cfg) // not pre-seeded: must traverse ensureVKMCPServer
-
-		ctx := &fasthttp.RequestCtx{}
-		ctx.Request.Header.Set(string(schemas.BifrostContextKeyVirtualKey), "sk-bf-x")
-
-		_, err := h.getMCPServerForRequest(ctx)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "inactive")
-	})
-
-	t.Run("anonymous access yields the global server when auth is not enforced", func(t *testing.T) {
+	// The key is not looked up here: governance resolves it from the value the request converter
+	// stamped, and refuses one that does not exist, is inactive or has expired.
+	t.Run("headers mode: a header VK is accepted without being looked up", func(t *testing.T) {
 		store := &mockOAuth2Store{signingKey: key}
-		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeHeaders, false)
-		h := newTestMCPHandler(cfg)
+		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeHeaders, true))
 
-		ctx := &fasthttp.RequestCtx{}
-		res, err := h.getMCPServerForRequest(ctx)
-		require.NoError(t, err)
-		assert.Equal(t, h.globalMCPServer, res.mcpServer)
+		ctx, bifrostCtx := newRequestCtx()
+		ctx.Request.Header.Set(string(schemas.BifrostContextKeyVirtualKey), "sk-bf-anything")
+
+		require.NoError(t, h.authenticate(ctx, bifrostCtx))
+	})
+
+	t.Run("anonymous access is accepted when auth is not enforced", func(t *testing.T) {
+		store := &mockOAuth2Store{signingKey: key}
+		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeHeaders, false))
+
+		ctx, bifrostCtx := newRequestCtx()
+		require.NoError(t, h.authenticate(ctx, bifrostCtx))
 	})
 
 	t.Run("no credentials rejected when auth is enforced", func(t *testing.T) {
 		store := &mockOAuth2Store{signingKey: key}
-		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeHeaders, true)
-		h := newTestMCPHandler(cfg)
+		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeHeaders, true))
 
-		ctx := &fasthttp.RequestCtx{}
-		_, err := h.getMCPServerForRequest(ctx)
+		ctx, bifrostCtx := newRequestCtx()
+		require.Error(t, h.authenticate(ctx, bifrostCtx))
+	})
+
+	for _, mode := range []configtables.MCPServerAuthMode{configtables.MCPServerAuthModeHeaders, configtables.MCPServerAuthModeBoth} {
+		t.Run(string(mode)+" mode: an identity stamped upstream satisfies enforced auth", func(t *testing.T) {
+			store := &mockOAuth2Store{signingKey: key}
+			h := newTestMCPHandler(newTestOAuth2Config(store, mode, true))
+
+			ctx, bifrostCtx := newRequestCtx()
+			bifrostCtx.SetValue(schemas.BifrostContextKeyUserID, "user-1")
+
+			require.NoError(t, h.authenticate(ctx, bifrostCtx))
+			assert.Equal(t, "user-1", stringFromCtx(bifrostCtx, schemas.BifrostContextKeyUserID))
+		})
+	}
+
+	t.Run("oauth strict mode ignores an identity stamped upstream", func(t *testing.T) {
+		store := &mockOAuth2Store{signingKey: key}
+		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeOAuth, true))
+
+		ctx, bifrostCtx := newRequestCtx()
+		bifrostCtx.SetValue(schemas.BifrostContextKeyUserID, "user-1")
+
+		err := h.authenticate(ctx, bifrostCtx)
 		require.Error(t, err)
+		assert.Contains(t, err.Error(), "OAuth JWT")
 	})
 
 	t.Run("oauth strict mode rejects a header VK with WWW-Authenticate", func(t *testing.T) {
 		store := &mockOAuth2Store{signingKey: key}
-		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeOAuth, false)
-		h := newTestMCPHandler(cfg)
+		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeOAuth, false))
 
-		ctx := &fasthttp.RequestCtx{}
+		ctx, bifrostCtx := newRequestCtx()
 		ctx.Request.Header.Set(string(schemas.BifrostContextKeyVirtualKey), "sk-bf-active")
 
-		_, err := h.getMCPServerForRequest(ctx)
-		require.Error(t, err)
+		require.Error(t, h.authenticate(ctx, bifrostCtx))
 		assert.NotEmpty(t, ctx.Response.Header.Peek("WWW-Authenticate"))
 	})
 
 	t.Run("oauth strict mode with no credentials sets WWW-Authenticate", func(t *testing.T) {
 		store := &mockOAuth2Store{signingKey: key}
-		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeOAuth, false)
-		h := newTestMCPHandler(cfg)
+		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeOAuth, false))
 
-		ctx := &fasthttp.RequestCtx{}
-		_, err := h.getMCPServerForRequest(ctx)
-		require.Error(t, err)
+		ctx, bifrostCtx := newRequestCtx()
+		require.Error(t, h.authenticate(ctx, bifrostCtx))
 		assert.NotEmpty(t, ctx.Response.Header.Peek("WWW-Authenticate"))
 	})
 
 	t.Run("headers mode: a JWT bearer is not treated as a credential", func(t *testing.T) {
 		store := &mockOAuth2Store{signingKey: key}
-		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeHeaders, true)
-		h := newTestMCPHandler(cfg)
+		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeHeaders, true))
 
 		// A JWT-looking bearer in headers mode: discovery is off, so the JWT path
-		// is skipped and the token is not a VK — with auth enforced this rejects.
-		ctx := &fasthttp.RequestCtx{}
+		// is skipped and the token is not a VK; with auth enforced this rejects.
+		ctx, bifrostCtx := newRequestCtx()
 		ctx.Request.Header.Set("Authorization", "Bearer eyJhbGciOiJSUzI1NiJ9.payload.sig")
 
-		_, err := h.getMCPServerForRequest(ctx)
-		require.Error(t, err)
+		require.Error(t, h.authenticate(ctx, bifrostCtx))
+	})
+}
+
+// TestAdmit covers the step after authentication: governance's answer is either a refusal, mapped to
+// the status it carries, or an access whose tool list is stamped for the tool filter and the executor.
+func TestAdmit(t *testing.T) {
+	SetLogger(&mockLogger{})
+	key, _ := newTestSigningKey(t)
+	newHandler := func(mode configtables.MCPServerAuthMode, admitter MCPGatewayAdmitter) *MCPServerHandler {
+		h := newTestMCPHandler(newTestOAuth2Config(&mockOAuth2Store{signingKey: key}, mode, false))
+		h.admitter = admitter
+		return h
+	}
+	includeTools := func(ctx *schemas.BifrostContext) any { return ctx.Value(schemas.MCPContextKeyIncludeTools) }
+
+	t.Run("a refusal is answered with the status it carries", func(t *testing.T) {
+		for _, tc := range []struct {
+			status  int
+			message string
+		}{
+			{fasthttp.StatusForbidden, "virtual key is inactive"},
+			{fasthttp.StatusPaymentRequired, "Budget exceeded"},
+			{fasthttp.StatusTooManyRequests, "Rate limit exceeded"},
+		} {
+			h := newHandler(configtables.MCPServerAuthModeHeaders, &fakeAdmitter{refusal: &schemas.BifrostError{
+				StatusCode: new(tc.status), Error: &schemas.ErrorField{Message: tc.message},
+			}})
+			ctx, bifrostCtx := newRequestCtx()
+			refusal := h.admit(ctx, bifrostCtx)
+			require.NotNil(t, refusal)
+			assert.Equal(t, tc.status, refusal.status)
+			assert.Contains(t, refusal.message, tc.message)
+			assert.Nil(t, includeTools(bifrostCtx), "a refused request has no tool list")
+		}
+	})
+
+	t.Run("a 401 refusal points at the authorization server when discovery is enabled", func(t *testing.T) {
+		refusal := &schemas.BifrostError{StatusCode: new(fasthttp.StatusUnauthorized), Error: &schemas.ErrorField{Message: "access not found"}}
+
+		h := newHandler(configtables.MCPServerAuthModeBoth, &fakeAdmitter{refusal: refusal})
+		ctx, bifrostCtx := newRequestCtx()
+		require.Equal(t, fasthttp.StatusUnauthorized, h.admit(ctx, bifrostCtx).status)
+		assert.NotEmpty(t, ctx.Response.Header.Peek("WWW-Authenticate"))
+
+		h = newHandler(configtables.MCPServerAuthModeHeaders, &fakeAdmitter{refusal: refusal})
+		ctx, bifrostCtx = newRequestCtx()
+		require.Equal(t, fasthttp.StatusUnauthorized, h.admit(ctx, bifrostCtx).status)
+		assert.Empty(t, ctx.Response.Header.Peek("WWW-Authenticate"))
+	})
+
+	t.Run("a refusal without a status is forbidden", func(t *testing.T) {
+		h := newHandler(configtables.MCPServerAuthModeHeaders, &fakeAdmitter{refusal: &schemas.BifrostError{Error: &schemas.ErrorField{Message: "no"}}})
+		ctx, bifrostCtx := newRequestCtx()
+		assert.Equal(t, fasthttp.StatusForbidden, h.admit(ctx, bifrostCtx).status)
+	})
+
+	t.Run("restricted access stamps the tools it grants", func(t *testing.T) {
+		h := newHandler(configtables.MCPServerAuthModeHeaders, &fakeAdmitter{access: restrictedAccess("sentry", "find_projects", "search_issues")})
+		ctx, bifrostCtx := newRequestCtx()
+		require.Nil(t, h.admit(ctx, bifrostCtx))
+		assert.Equal(t, []string{"sentry-find_projects", "sentry-search_issues"}, includeTools(bifrostCtx))
+	})
+
+	t.Run("access granting no tool stamps an empty list, which permits none", func(t *testing.T) {
+		h := newHandler(configtables.MCPServerAuthModeHeaders, &fakeAdmitter{access: restrictedAccess("sentry")})
+		ctx, bifrostCtx := newRequestCtx()
+		require.Nil(t, h.admit(ctx, bifrostCtx))
+		assert.Equal(t, []string{}, includeTools(bifrostCtx))
+	})
+
+	t.Run("a caller's list narrows within the access and cannot widen it", func(t *testing.T) {
+		h := newHandler(configtables.MCPServerAuthModeHeaders, &fakeAdmitter{access: restrictedAccess("sentry", "find_projects", "search_issues")})
+		ctx, bifrostCtx := newRequestCtx()
+		bifrostCtx.SetValue(schemas.MCPContextKeyIncludeTools, []string{"sentry-find_projects", "sentry-delete_project", "github-*"})
+		require.Nil(t, h.admit(ctx, bifrostCtx))
+		assert.Equal(t, []string{"sentry-find_projects"}, includeTools(bifrostCtx))
+	})
+
+	t.Run("no access leaves the caller's list alone and stamps nothing of its own", func(t *testing.T) {
+		// Nothing restricts a request that carries no access: it presented nothing, or the deployment
+		// has nothing to resolve access with.
+		h := newHandler(configtables.MCPServerAuthModeHeaders, &fakeAdmitter{})
+		ctx, bifrostCtx := newRequestCtx()
+		bifrostCtx.SetValue(schemas.MCPContextKeyIncludeTools, []string{"sentry-*"})
+		require.Nil(t, h.admit(ctx, bifrostCtx))
+		assert.Equal(t, []string{"sentry-*"}, includeTools(bifrostCtx))
+
+		ctx, bifrostCtx = newRequestCtx()
+		require.Nil(t, h.admit(ctx, bifrostCtx))
+		assert.Nil(t, includeTools(bifrostCtx), "an empty list would read as no tool at all")
+	})
+
+	t.Run("nothing resolved stamps nothing", func(t *testing.T) {
+		h := newHandler(configtables.MCPServerAuthModeHeaders, &fakeAdmitter{})
+		ctx, bifrostCtx := newRequestCtx()
+		require.Nil(t, h.admit(ctx, bifrostCtx))
+		assert.Nil(t, includeTools(bifrostCtx))
+
+		h = newHandler(configtables.MCPServerAuthModeHeaders, nil)
+		ctx, bifrostCtx = newRequestCtx()
+		require.Nil(t, h.admit(ctx, bifrostCtx))
+		assert.Nil(t, includeTools(bifrostCtx))
+	})
+
+	t.Run("governance is asked about the request's own context, after authentication", func(t *testing.T) {
+		admitter := &fakeAdmitter{access: restrictedAccess("sentry", "find_projects")}
+		h := newHandler(configtables.MCPServerAuthModeHeaders, admitter)
+		ctx, bifrostCtx := newRequestCtx()
+		ctx.Request.Header.Set(string(schemas.BifrostContextKeyVirtualKey), "sk-bf-active")
+		require.Nil(t, h.admit(ctx, bifrostCtx))
+		assert.Same(t, bifrostCtx, admitter.seen)
+	})
+
+	t.Run("a request that fails authentication is refused before governance is asked", func(t *testing.T) {
+		admitter := &fakeAdmitter{access: restrictedAccess("sentry", "find_projects")}
+		h := newTestMCPHandler(newTestOAuth2Config(&mockOAuth2Store{signingKey: key}, configtables.MCPServerAuthModeHeaders, true))
+		h.admitter = admitter
+		ctx, bifrostCtx := newRequestCtx()
+		refusal := h.admit(ctx, bifrostCtx)
+		require.NotNil(t, refusal)
+		assert.Equal(t, fasthttp.StatusUnauthorized, refusal.status)
+		assert.Nil(t, admitter.seen)
 	})
 }

--- a/transports/bifrost-http/server/mcp_tools_persist_test.go
+++ b/transports/bifrost-http/server/mcp_tools_persist_test.go
@@ -83,7 +83,7 @@ func TestPersistMCPClientTools_StoreErrorLogsAndDoesNotPanic(t *testing.T) {
 // TestSyncMCPServersAfterToolsChange_NilHandler_NoOp confirms the nil-guard
 // convention this package uses elsewhere — MCPServerHandler not yet wired
 // (e.g. in a partially-constructed test server) must not panic. The
-// underlying SyncAllMCPServers call itself is exercised the same way the
+// underlying SyncMCPServer call itself is exercised the same way the
 // pre-existing SetClientTools wrapper's identical call already is: only via
 // full integration, since MCPServerHandler has no fake-able seam from this
 // package.

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -317,7 +317,7 @@ func (s *BifrostHTTPServer) AddMCPClient(ctx context.Context, clientConfig *sche
 	if err := s.Config.AddMCPClient(ctx, clientConfig); err != nil {
 		return err
 	}
-	if err := s.MCPServerHandler.SyncAllMCPServers(ctx); err != nil {
+	if err := s.MCPServerHandler.SyncMCPServer(ctx); err != nil {
 		logger.Warn("failed to sync MCP servers after adding client: %v", err)
 	}
 	return nil
@@ -344,7 +344,7 @@ func (s *BifrostHTTPServer) ReconnectMCPClient(ctx context.Context, id string) e
 	if err := s.Client.AddMCPClient(ctx, clientConfig); err != nil {
 		return err
 	}
-	if err := s.MCPServerHandler.SyncAllMCPServers(ctx); err != nil {
+	if err := s.MCPServerHandler.SyncMCPServer(ctx); err != nil {
 		logger.Warn("failed to sync MCP servers after adding client: %v", err)
 	}
 	return nil
@@ -355,7 +355,7 @@ func (s *BifrostHTTPServer) UpdateMCPClient(ctx context.Context, id string, upda
 	if err := s.Config.UpdateMCPClient(ctx, id, updatedConfig); err != nil {
 		return err
 	}
-	if err := s.MCPServerHandler.SyncAllMCPServers(ctx); err != nil {
+	if err := s.MCPServerHandler.SyncMCPServer(ctx); err != nil {
 		logger.Warn("failed to sync MCP servers after editing client: %v", err)
 	}
 	return nil
@@ -389,7 +389,7 @@ func (s *BifrostHTTPServer) SyncMCPServersAfterToolsChange(ctx context.Context, 
 	if s.MCPServerHandler == nil {
 		return
 	}
-	if err := s.MCPServerHandler.SyncAllMCPServers(ctx); err != nil {
+	if err := s.MCPServerHandler.SyncMCPServer(ctx); err != nil {
 		logger.Warn(fmt.Sprintf("Failed to sync MCP servers after tools change for client %s: %v", clientID, err))
 	}
 }
@@ -398,7 +398,7 @@ func (s *BifrostHTTPServer) UpdateMCPClientCredentials(ctx context.Context, id s
 	if err := s.Config.UpdateMCPClientCredentials(ctx, id, newConfig); err != nil {
 		return err
 	}
-	if err := s.MCPServerHandler.SyncAllMCPServers(ctx); err != nil {
+	if err := s.MCPServerHandler.SyncMCPServer(ctx); err != nil {
 		logger.Warn("failed to sync MCP servers after updating client connection: %v", err)
 	}
 	return nil
@@ -409,7 +409,7 @@ func (s *BifrostHTTPServer) RemoveMCPClient(ctx context.Context, id string) erro
 	if err := s.Config.RemoveMCPClient(ctx, id); err != nil {
 		return err
 	}
-	if err := s.MCPServerHandler.SyncAllMCPServers(ctx); err != nil {
+	if err := s.MCPServerHandler.SyncMCPServer(ctx); err != nil {
 		logger.Warn("failed to sync MCP servers after removing client: %v", err)
 	}
 	s.Config.OAuthProvider.EvictUserTokensByMCPClient(id)
@@ -429,7 +429,7 @@ func (s *BifrostHTTPServer) DisableMCPClient(ctx context.Context, id string) err
 	if err := s.Config.DisableMCPClient(ctx, id); err != nil {
 		return err
 	}
-	if err := s.MCPServerHandler.SyncAllMCPServers(ctx); err != nil {
+	if err := s.MCPServerHandler.SyncMCPServer(ctx); err != nil {
 		logger.Warn("failed to sync MCP servers after disabling client: %v", err)
 	}
 	return nil
@@ -440,7 +440,7 @@ func (s *BifrostHTTPServer) EnableMCPClient(ctx context.Context, id string) erro
 	if err := s.Config.EnableMCPClient(ctx, id); err != nil {
 		return err
 	}
-	if err := s.MCPServerHandler.SyncAllMCPServers(ctx); err != nil {
+	if err := s.MCPServerHandler.SyncMCPServer(ctx); err != nil {
 		logger.Warn("failed to sync MCP servers after enabling client: %v", err)
 	}
 	return nil
@@ -462,7 +462,7 @@ func (s *BifrostHTTPServer) VerifyPerUserOAuthConnection(ctx context.Context, co
 // then re-syncs the MCP server so the new tools are immediately visible via /mcp.
 func (s *BifrostHTTPServer) SetClientTools(clientID string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string) {
 	s.Client.SetClientTools(clientID, tools, toolNameMapping)
-	if err := s.MCPServerHandler.SyncAllMCPServers(context.Background()); err != nil {
+	if err := s.MCPServerHandler.SyncMCPServer(context.Background()); err != nil {
 		logger.Warn("failed to sync MCP servers after setting client tools: %v", err)
 	}
 }
@@ -570,9 +570,6 @@ func (s *BifrostHTTPServer) ReloadVirtualKey(ctx context.Context, id string) (*t
 		return virtualKey, fmt.Errorf("failed to reload VK-scoped model configs for VK %s: %w", id, err)
 	}
 	store := governancePlugin.GetGovernanceStore()
-	if existingVK, found := store.GetVirtualKeyByID(ctx, virtualKey.ID); found && existingVK != nil && existingVK.Value.IsSet() && existingVK.Value.GetValue() != virtualKey.Value.GetValue() {
-		s.MCPServerHandler.DeleteVKMCPServer(existingVK.Value.GetValue())
-	}
 	store.UpdateVirtualKeyInMemory(ctx, virtualKey, nil, nil, nil)
 	// Snapshot in-memory VK-scoped config IDs before the upserts so we can evict
 	// the ones that no longer exist in the DB (e.g. a standalone VK adopted into
@@ -589,7 +586,6 @@ func (s *BifrostHTTPServer) ReloadVirtualKey(ctx context.Context, id string) (*t
 	for mcID := range staleIDs {
 		store.DeleteModelConfigInMemory(ctx, mcID)
 	}
-	s.MCPServerHandler.SyncVKMCPServer(virtualKey)
 	s.Config.OAuthProvider.EvictUserTokensByVirtualKey(id)
 	s.Config.MCPHeadersProvider.EvictCredentialsByVirtualKey(id)
 	return virtualKey, nil
@@ -678,7 +674,6 @@ func (s *BifrostHTTPServer) RemoveVirtualKey(ctx context.Context, id string) err
 		return nil
 	}
 	governancePlugin.GetGovernanceStore().DeleteVirtualKeyInMemory(ctx, id)
-	s.MCPServerHandler.DeleteVKMCPServer(preloadedVk.Value.GetValue())
 	s.Config.OAuthProvider.EvictUserTokensByVirtualKey(id)
 	s.Config.MCPHeadersProvider.EvictCredentialsByVirtualKey(id)
 	return nil
@@ -1367,6 +1362,25 @@ func (s *BifrostHTTPServer) ResolveAccess(ctx *schemas.BifrostContext) (schemas.
 		return nil, nil
 	}
 	return governancePlugin.ResolveAccess(ctx)
+}
+
+// AdmitMCPGatewayRequest runs a /mcp request through the governance funnel before any tool is listed
+// or called, as an MCP tool execution with no tool named yet. Evaluating is what resolves and records
+// the request's access, so what tools/list shows and what tools/call permits come from one answer.
+//
+// Without governance there is nothing to evaluate against and nothing to restrict, which is why a
+// missing plugin answers with no access rather than with access permitting nothing.
+func (s *BifrostHTTPServer) AdmitMCPGatewayRequest(ctx *schemas.BifrostContext) (schemas.Access, *schemas.BifrostError) {
+	governancePlugin, err := s.getGovernancePlugin()
+	if err != nil {
+		return nil, nil
+	}
+	if _, refused := governancePlugin.Evaluate(ctx, &governance.EvaluationRequest{RequestType: schemas.MCPToolExecutionRequest}); refused != nil {
+		return nil, refused
+	}
+	// Evaluating refuses a request that carries no grant, so one that was admitted carries the
+	// access it was admitted with.
+	return ctx.Grant().Access(), nil
 }
 
 // backgroundCtx returns the server-lifetime context background workers should
@@ -2081,7 +2095,7 @@ func (s *BifrostHTTPServer) RegisterInferenceRoutes(ctx context.Context, middlew
 			vkCache = c
 		}
 	}
-	mcpServerHandler, err := handlers.NewMCPServerHandler(ctx, s.Config, s, s.OAuth2IdentityResolver, vkCache)
+	mcpServerHandler, err := handlers.NewMCPServerHandler(ctx, s.Config, s, s, s.OAuth2IdentityResolver, vkCache)
 	if err != nil {
 		return fmt.Errorf("failed to initialize mcp server handler: %v", err)
 	}

--- a/transports/bifrost-http/server/server_test.go
+++ b/transports/bifrost-http/server/server_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"reflect"
 	"runtime"
 	"slices"
 	"sync"
@@ -83,71 +82,41 @@ func (reloadVirtualKeyToolManager) ExecuteResponsesMCPTool(context.Context, *sch
 	return nil, nil
 }
 
-// hasVKMCPServer reports whether the handler still caches a server for a secret.
-func hasVKMCPServer(handler *handlers.MCPServerHandler, value string) bool {
-	servers := reflect.ValueOf(handler).Elem().FieldByName("vkMCPServers")
-	return servers.MapIndex(reflect.ValueOf(value)).IsValid()
-}
-
-// TestReloadVirtualKeyDeletesOnlyRotatedOldMCPServer pins the old-secret cleanup
-// semantics and verifies the direct ID lookup avoids GetGovernanceData.
-func TestReloadVirtualKeyDeletesOnlyRotatedOldMCPServer(t *testing.T) {
+// TestReloadVirtualKeyAvoidsGovernanceSnapshot pins that reloading one key reads and replaces it
+// directly rather than through a full governance snapshot, which is what keeps a key edit cheap on
+// a deployment holding many keys.
+func TestReloadVirtualKeyAvoidsGovernanceSnapshot(t *testing.T) {
 	handlers.SetLogger(noopTestLogger{})
-	tests := []struct {
-		name          string
-		oldValue      string
-		newValue      string
-		seedOldVK     bool
-		wantOldServer bool
-	}{
-		{name: "rotated set secret deletes old server", oldValue: "sk-bf-old", newValue: "sk-bf-new", seedOldVK: true, wantOldServer: false},
-		{name: "unchanged secret keeps old server", oldValue: "sk-bf-same", newValue: "sk-bf-same", seedOldVK: true, wantOldServer: true},
-		{name: "unset old secret keeps old server", oldValue: "", newValue: "sk-bf-new", seedOldVK: true, wantOldServer: true},
-		{name: "missing old virtual key keeps old server", oldValue: "sk-bf-old", newValue: "sk-bf-new", seedOldVK: false, wantOldServer: true},
+	ctx := context.Background()
+	baseStore, err := governance.NewLocalGovernanceStore(ctx, governance.NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil, nil)
+	if err != nil {
+		t.Fatalf("create governance store: %v", err)
 	}
+	baseStore.CreateVirtualKeyInMemory(ctx, &configstoreTables.TableVirtualKey{ID: "vk-id", Name: "old", Value: *schemas.NewSecretVar("sk-bf-old")})
+	store := &reloadVirtualKeyGovernanceStore{GovernanceStore: baseStore}
+	plugin := &reloadVirtualKeyPlugin{store: store}
+	persistedVK := &configstoreTables.TableVirtualKey{ID: "vk-id", Name: "new", Value: *schemas.NewSecretVar("sk-bf-new")}
+	config := &lib.Config{
+		ConfigStore:  &reloadVirtualKeyConfigStore{vk: persistedVK},
+		ClientConfig: &configstore.ClientConfig{},
+	}
+	plugins := []schemas.BasePlugin{plugin}
+	config.BasePlugins.Store(&plugins)
+	mcpHandler, err := handlers.NewMCPServerHandler(ctx, config, reloadVirtualKeyToolManager{}, nil, nil, store)
+	if err != nil {
+		t.Fatalf("create MCP handler: %v", err)
+	}
+	server := &BifrostHTTPServer{Ctx: schemas.NewBifrostContext(ctx, schemas.NoDeadline), Config: config, MCPServerHandler: mcpHandler}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
-			baseStore, err := governance.NewLocalGovernanceStore(ctx, governance.NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil, nil)
-			if err != nil {
-				t.Fatalf("create governance store: %v", err)
-			}
-			oldVK := &configstoreTables.TableVirtualKey{ID: "vk-id", Name: "old", Value: *schemas.NewSecretVar(tt.oldValue)}
-			if tt.seedOldVK {
-				baseStore.CreateVirtualKeyInMemory(ctx, oldVK)
-			}
-			store := &reloadVirtualKeyGovernanceStore{GovernanceStore: baseStore}
-			plugin := &reloadVirtualKeyPlugin{store: store}
-			persistedVK := &configstoreTables.TableVirtualKey{ID: "vk-id", Name: "new", Value: *schemas.NewSecretVar(tt.newValue)}
-			config := &lib.Config{
-				ConfigStore:  &reloadVirtualKeyConfigStore{vk: persistedVK},
-				ClientConfig: &configstore.ClientConfig{},
-			}
-			plugins := []schemas.BasePlugin{plugin}
-			config.BasePlugins.Store(&plugins)
-			mcpHandler, err := handlers.NewMCPServerHandler(ctx, config, reloadVirtualKeyToolManager{}, nil, store)
-			if err != nil {
-				t.Fatalf("create MCP handler: %v", err)
-			}
-			mcpHandler.SyncVKMCPServer(oldVK)
-			server := &BifrostHTTPServer{Ctx: schemas.NewBifrostContext(ctx, schemas.NoDeadline), Config: config, MCPServerHandler: mcpHandler}
-
-			if _, err := server.ReloadVirtualKey(ctx, persistedVK.ID); err != nil {
-				t.Fatalf("ReloadVirtualKey returned unexpected error: %v", err)
-			}
-			if store.governanceDataCalls != 0 {
-				t.Fatalf("GetGovernanceData called %d times, want 0", store.governanceDataCalls)
-			}
-
-			oldServerExists := hasVKMCPServer(mcpHandler, tt.oldValue)
-			if tt.wantOldServer && !oldServerExists {
-				t.Fatal("old MCP server was deleted")
-			}
-			if !tt.wantOldServer && oldServerExists {
-				t.Fatal("old MCP server still exists after secret rotation")
-			}
-		})
+	if _, err := server.ReloadVirtualKey(ctx, persistedVK.ID); err != nil {
+		t.Fatalf("ReloadVirtualKey returned unexpected error: %v", err)
+	}
+	if store.governanceDataCalls != 0 {
+		t.Fatalf("GetGovernanceData called %d times, want 0", store.governanceDataCalls)
+	}
+	reloaded, ok := baseStore.GetVirtualKeyByID(ctx, "vk-id")
+	if !ok || reloaded.Value.GetValue() != "sk-bf-new" {
+		t.Fatalf("store does not answer with the reloaded key: %+v", reloaded)
 	}
 }
 


### PR DESCRIPTION
## Summary

Replaces the per-virtual-key MCP server model with a single shared server whose per-request tool visibility is decided by governance at admission time. Previously, each virtual key got its own `MCPServer` instance (built lazily and cached in a map), and authentication resolved which server to hand the request. Now there is one server for all callers; what each caller may see and call is stamped on the request context by a new `MCPGatewayAdmitter` interface, which runs the request through the same governance funnel that `tools/call` uses, so `initialize`, `tools/list`, and `tools/call` all answer by the same rules.

The inactive-key check is removed from the transport layer. Whether a key may be used is now governance's answer, read from the grant it resolves, so an inactive or expired key is refused the same way on every path rather than being caught at a separate chokepoint in the MCP handler.

## Changes

- **Single MCP server**: `vkMCPServers` map, `SyncAllMCPServers`, `SyncVKMCPServer`, `DeleteVKMCPServer`, and `ensureVKMCPServer` are removed. `SyncMCPServer` replaces them, building one server from all available tools and swapping it in atomically via `atomic.Pointer`.
- **`MCPGatewayAdmitter` interface**: Introduced so the transport can ask governance what a request may reach without importing governance directly. `BifrostHTTPServer.AdmitMCPGatewayRequest` implements it by running an `MCPToolExecutionRequest` evaluation with no tool named.
- **`admit` / `authenticate` split**: `getMCPServerForRequest` is replaced by `admit`, which calls `authenticate` (identity only: verifies the credential and stamps it) and then `admitAccess` (governance only: resolves the grant and stamps the tool list). The two concerns no longer share a code path.
- **Tool access stamping**: `stampToolAccess` records the tools a request may see as the include list both the tool filter and the executor read. A caller-supplied list is narrowed to the access rather than replaced, so a caller can ask for less but never more.
- **`ResolveUserVirtualKey` removed**: User-mode tokens no longer resolve a representative virtual key to pick a scoped server. The user identity is stamped and governance resolves what the user may reach, the same as every other credential.
- **Active-state check moved to governance**: `IsActiveValue()` checks are removed from `authenticate`. An inactive key is stamped and then refused by governance when it resolves the grant, matching the behavior of every other refusal path. The e2e test expectation for an inactive key is updated from 401 to 403 accordingly.
- **`ReloadVirtualKey` simplified**: The old-secret deletion and `SyncVKMCPServer` call are removed; reloading a key updates the in-memory store and the single shared server is unaffected.
- **Governance tests**: Three new test cases cover allowed-by-default clients joining the stamped grant after explicit configs, include-tools narrowing across both client kinds, and an explicit deny-all config beating an allowed-by-default entry.
- **Auth tests rewritten**: `TestGetMCPServerForRequest_*` tests are replaced by `TestAuthenticate_JWTPath`, `TestAuthenticate_HeaderAndAnonPath`, and `TestAdmit`, which assert on what is stamped rather than which server is returned.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/... ./transports/bifrost-http/handlers/... ./transports/bifrost-http/server/...
```

The e2e Postman collection for `bifrost-v1-mcp-auth` covers the inactive-key 403 change. Run it against a deployment with an inactive virtual key and confirm the response is 403 rather than 401.

## Breaking changes

- [x] Yes
- [ ] No

`NewMCPServerHandler` gains an `admitter MCPGatewayAdmitter` parameter between `toolManager` and `identityResolver`. Callers must be updated. `ResolveUserVirtualKey` is removed from the `OAuth2IdentityResolver` interface; any implementation of that interface must drop the method. `SyncAllMCPServers`, `SyncVKMCPServer`, and `DeleteVKMCPServer` are removed from `MCPServerHandler`; call sites must switch to `SyncMCPServer`.

## Security considerations

The inactive-key check moving from the transport into governance means a key that is deactivated between the cache refresh and the request is refused by the grant governance resolves rather than by a stale `IsActiveValue()` read. The refusal is the same; the authority for it is now consistent with every other path. The `admit` function ensures governance is never asked about a request that failed authentication, preserving the authentication-before-authorization ordering.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable