### PR TITLE
fix: drop legacy FK constraints on `oauth_user_tokens`/`oauth_user_sessions` blocking `DeleteMCPClientConfig` after token-table merge, with `-:migration` struct tags and regression tests

### DIFF
--- a/framework/configstore/mcpoauthusertoken_fk_test.go
+++ b/framework/configstore/mcpoauthusertoken_fk_test.go
@@ -1,0 +1,232 @@
+package configstore
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// setupOauthUserTokenFKStore opens a fresh in-memory SQLite DB with foreign_keys on
+// (mirrors the production DSN in sqlite.go, unlike setupRDBTestStore's bare
+// ":memory:" DSN, which leaves FK enforcement off and so cannot reproduce a
+// constraint-violation bug), runs the full migration chain, and wraps it in a
+// minimal RDBConfigStore.
+func setupOauthUserTokenFKStore(t *testing.T) (*RDBConfigStore, *gorm.DB) {
+	t.Helper()
+	ctx := context.Background()
+	n := time.Now().UnixNano() + testDBCounter
+	testDBCounter++
+	dsn := fmt.Sprintf("file:oauthuserfk_%d?mode=memory&cache=shared&_foreign_keys=on", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	require.NoError(t, err)
+	require.NoError(t, triggerMigrations(ctx, db, testMigrationLogger))
+
+	s := &RDBConfigStore{}
+	s.db.Store(db)
+	s.migrateOnFreshFn = func(ctx context.Context, fn func(context.Context, *gorm.DB) error) error {
+		return fn(ctx, s.DB())
+	}
+	s.refreshPoolFn = func(ctx context.Context) error { return nil }
+	return s, db
+}
+
+// seedLegacyOauthUserToken plants a row in oauth_user_tokens the way pre-merge code
+// used to write one: the shape migrationMergeOauthTokenTables's own comment says is
+// left "completely untouched and undropped" by that migration, and that nothing
+// currently deletes on an MCP client's behalf.
+func seedLegacyOauthUserToken(t *testing.T, db *gorm.DB, id, mcpClientID, oauthConfigID string) {
+	t.Helper()
+	now := time.Now()
+	require.NoError(t, db.Create(&tables.TableOauthUserToken{
+		ID:            id,
+		UserID:        stringPtr("user-legacy"),
+		MCPClientID:   mcpClientID,
+		AuthMode:      "user",
+		Status:        "active",
+		OauthConfigID: oauthConfigID,
+		AccessToken:   "legacy-access-token",
+		TokenType:     "Bearer",
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}).Error)
+}
+
+func stringPtr(s string) *string { return &s }
+
+// TestDeleteMCPClientConfig_LegacyOauthUserTokenRow reproduces the reported bug: an
+// MCP client that had per-user OAuth activity before the mcp_oauth_tokens merge
+// keeps an orphaned-but-FK-enforced row in oauth_user_tokens, and DeleteMCPClientConfig
+// (which only cleans up mcp_oauth_tokens now) can no longer delete that client at all.
+func TestDeleteMCPClientConfig_LegacyOauthUserTokenRow(t *testing.T) {
+	store, db := setupOauthUserTokenFKStore(t)
+	ctx := context.Background()
+
+	client := tables.TableMCPClient{
+		ClientID:       "client-legacy-peruser",
+		Name:           "legacy-peruser-client",
+		ConnectionType: "http",
+		AuthType:       "per_user_oauth",
+	}
+	require.NoError(t, db.Create(&client).Error)
+	seedLegacyOauthUserToken(t, db, "tok-legacy-1", client.ClientID, "cfg-legacy-1")
+
+	err := store.DeleteMCPClientConfig(ctx, client.ClientID)
+	require.NoError(t, err, "a client with only a legacy oauth_user_tokens row must still be deletable")
+
+	var clientCount int64
+	require.NoError(t, db.Model(&tables.TableMCPClient{}).Where("client_id = ?", client.ClientID).Count(&clientCount).Error)
+	assert.Equal(t, int64(0), clientCount, "the MCP client row should be gone")
+
+	// The legacy row itself is untouched — the fix removes the constraint, not the
+	// data. migrationMergeOauthTokenTables explicitly kept oauth_user_tokens as a
+	// rollback safety net; this pins that nothing here starts deleting from it.
+	var legacyCount int64
+	require.NoError(t, db.Model(&tables.TableOauthUserToken{}).Where("id = ?", "tok-legacy-1").Count(&legacyCount).Error)
+	assert.Equal(t, int64(1), legacyCount, "the legacy oauth_user_tokens row must be left in place, not deleted")
+}
+
+// TestMigrationDropLegacyOauthUserFKConstraints_RemovesAllFour pins the migration's
+// own effect directly. It cannot use setupOauthUserTokenFKStore/triggerMigrations for
+// its starting state: the struct tags are already fixed, so the full chain's own
+// table creation never produces these constraints in the first place, and a test
+// that never creates them proves nothing about DropConstraint actually removing them
+// (confirmed by temporarily disabling this migration's registry entry - both this
+// test and TestDeleteMCPClientConfig_LegacyOauthUserTokenRow still passed). Instead,
+// this builds the four tables directly and recreates each constraint by hand -
+// exactly the starting state every deployment that ran the pre-fix
+// migrationAddPerUserOAuthTables actually has - then calls the migration function
+// directly (mirroring TestMigrationAddModelConfigBudgetsFKConstraint_PreCleansOrphans)
+// so it isn't skipped by triggerMigrations' own already-applied bookkeeping either.
+func TestMigrationDropLegacyOauthUserFKConstraints_RemovesAllFour(t *testing.T) {
+	ctx := context.Background()
+	n := time.Now().UnixNano() + testDBCounter
+	testDBCounter++
+	dsn := fmt.Sprintf("file:fkdroplegacy_%d?mode=memory&cache=shared", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&tables.TableMCPClient{},
+		&tables.TableVirtualKey{},
+		&tables.TableOauthUserToken{},
+		&tables.TableOauthUserSession{},
+	))
+	mig := db.Migrator()
+
+	targets := []struct {
+		model any
+		field string
+	}{
+		{&tables.TableOauthUserToken{}, "MCPClient"},
+		{&tables.TableOauthUserToken{}, "VirtualKey"},
+		{&tables.TableOauthUserSession{}, "MCPClient"},
+		{&tables.TableOauthUserSession{}, "VirtualKey"},
+	}
+	for _, target := range targets {
+		require.NoError(t, mig.CreateConstraint(target.model, target.field))
+	}
+	for _, target := range targets {
+		require.True(t, mig.HasConstraint(target.model, target.field),
+			"setup should have created the %s constraint on %T", target.field, target.model)
+	}
+
+	require.NoError(t, migrationDropLegacyOauthUserFKConstraints(ctx, db, testMigrationLogger))
+
+	for _, target := range targets {
+		assert.False(t, mig.HasConstraint(target.model, target.field),
+			"the %s constraint on %T should be gone", target.field, target.model)
+	}
+
+	// Idempotent: already-clean must not error on a second pass.
+	require.NoError(t, migrationDropLegacyOauthUserFKConstraints(ctx, db, testMigrationLogger))
+}
+
+// TestPostgresDeleteMCPClientConfig_LegacyOauthUserTokenRow is
+// TestDeleteMCPClientConfig_LegacyOauthUserTokenRow's real-Postgres twin. The
+// reported bug's own error (SQLSTATE 23503) only ever surfaces on Postgres — SQLite
+// needs foreign_keys=on to enforce anything at all, which the production DSN sets
+// but nothing here can verify beyond "the constraint API agrees it's gone" — so this
+// is the one place that error class is actually reproduced and confirmed fixed.
+//
+// triggerMigrations alone is not enough to set that up: the struct tags are already
+// fixed, so the chain's own table creation never produces the legacy constraint in
+// the first place (same reasoning as TestMigrationDropLegacyOauthUserFKConstraints_
+// RemovesAllFour above). Running the full chain and then re-adding just the one
+// constraint this test exercises reproduces the exact pre-fix deployment state
+// without hand-building every table DeleteMCPClientConfig touches.
+func TestPostgresDeleteMCPClientConfig_LegacyOauthUserTokenRow(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, err := gorm.Open(postgres.Open(postgresDSN), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Skipf("postgres not available: %v", err)
+	}
+	require.NoError(t, db.Exec("DROP SCHEMA IF EXISTS "+pgTestSchema+" CASCADE").Error)
+	require.NoError(t, db.Exec("CREATE SCHEMA "+pgTestSchema).Error)
+	require.NoError(t, triggerMigrations(ctx, db, testMigrationLogger))
+
+	// Re-add the legacy constraint the fix migration just dropped, putting the schema
+	// back into the state every deployment that ran the pre-fix
+	// migrationAddPerUserOAuthTables actually has.
+	require.NoError(t, db.Migrator().CreateConstraint(&tables.TableOauthUserToken{}, "MCPClient"))
+
+	store := &RDBConfigStore{logger: bifrost.NewDefaultLogger(schemas.LogLevelInfo)}
+	store.db.Store(db)
+	store.migrateOnFreshFn = func(ctx context.Context, fn func(context.Context, *gorm.DB) error) error {
+		return fn(ctx, store.DB())
+	}
+	store.refreshPoolFn = func(ctx context.Context) error { return nil }
+
+	client := tables.TableMCPClient{
+		ClientID:       "client-legacy-peruser-pg",
+		Name:           "legacy-peruser-client-pg",
+		ConnectionType: "http",
+		AuthType:       "per_user_oauth",
+	}
+	require.NoError(t, db.Create(&client).Error)
+	seedLegacyOauthUserToken(t, db, "tok-legacy-pg-1", client.ClientID, "cfg-legacy-pg-1")
+
+	// With the legacy constraint back in place, deletion must fail with the exact
+	// SQLSTATE 23503 the reported bug hit — proving this test can actually reproduce
+	// the original failure, not just assert the migration's after-state.
+	delErr := store.DeleteMCPClientConfig(ctx, client.ClientID)
+	require.Error(t, delErr, "deletion must fail while the legacy FK constraint is in place")
+	assert.Contains(t, delErr.Error(), "23503", "failure must be the FK violation the reported bug hit")
+
+	var clientCountBeforeFix int64
+	require.NoError(t, db.Model(&tables.TableMCPClient{}).Where("client_id = ?", client.ClientID).Count(&clientCountBeforeFix).Error)
+	assert.Equal(t, int64(1), clientCountBeforeFix, "the failed transaction must have rolled back, leaving the client row in place")
+
+	// Drop the constraint directly through the migrator rather than calling
+	// migrationDropLegacyOauthUserFKConstraints again: triggerMigrations already
+	// recorded that migration ID as applied, so gormigrate's own bookkeeping would
+	// silently skip a second invocation with the same ID — the constraint was only
+	// put back by hand above, not by re-running the migration.
+	// TestMigrationDropLegacyOauthUserFKConstraints_RemovesAllFour already covers the
+	// migration function's own logic directly; this test's job is the end-to-end
+	// SQLSTATE 23503 reproduction, not a second proof of that function's internals.
+	require.NoError(t, db.Migrator().DropConstraint(&tables.TableOauthUserToken{}, "MCPClient"))
+
+	require.NoError(t, store.DeleteMCPClientConfig(ctx, client.ClientID),
+		"a client with only a legacy oauth_user_tokens row must be deletable once the constraint is dropped")
+
+	var clientCount int64
+	require.NoError(t, db.Model(&tables.TableMCPClient{}).Where("client_id = ?", client.ClientID).Count(&clientCount).Error)
+	assert.Equal(t, int64(0), clientCount, "the MCP client row should be gone")
+
+	var legacyCount int64
+	require.NoError(t, db.Model(&tables.TableOauthUserToken{}).Where("id = ?", "tok-legacy-pg-1").Count(&legacyCount).Error)
+	assert.Equal(t, int64(1), legacyCount, "the legacy oauth_user_tokens row must be left in place, not deleted")
+}

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -477,6 +477,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_batch_jobs_attribution_columns"}, run: migrationAddBatchJobsAttributionColumns},
 	{IDs: []string{"add_vk_rotation_cooldown_columns"}, run: migrationAddVKRotationCooldownColumns},
 	{IDs: []string{"add_vk_rotation_cooldown_client_column"}, run: migrationAddVKRotationCooldownClientColumn},
+	{IDs: []string{"drop_legacy_oauth_user_fk_constraints"}, run: migrationDropLegacyOauthUserFKConstraints},
 }
 
 // migrationAddBatchJobsAttributionColumns adds the requester-identity columns to
@@ -12322,6 +12323,86 @@ func migrationAddImageSizeQualityPricingColumns(ctx context.Context, db *gorm.DB
 			for _, field := range columns {
 				if err := dropColumnIfExists(tx, logger, &tables.TableModelPricing{}, field); err != nil {
 					return fmt.Errorf("failed to drop column %s: %w", field, err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running %s migration: %s", migrationName, err.Error())
+	}
+	return nil
+}
+
+// migrationDropLegacyOauthUserFKConstraints drops the real foreign key constraints
+// GORM created on oauth_user_tokens and oauth_user_sessions for their MCPClient and
+// VirtualKey preload relations. Both relations were always meant to be display-only
+// (their comments said so from the start), but the struct tags never carried
+// "-:migration" (or even "constraint:-") to tell GORM that, so
+// migrationAddPerUserOAuthTables's mg.CreateTable created a real
+// fk_oauth_user_tokens_mcp_client / fk_oauth_user_tokens_virtual_key /
+// fk_oauth_user_sessions_mcp_client / fk_oauth_user_sessions_virtual_key constraint
+// on every deployment that ever ran it.
+//
+// This went unnoticed for a long time because DeleteMCPClientConfig used to
+// explicitly delete matching oauth_user_tokens (and, before the flow-table merge,
+// oauth_user_sessions) rows before deleting the client, so the constraint was never
+// actually violated in practice. migrationMergeOauthTokenTables (and the flow-table
+// merge before it) replaced that with a delete against the new mcp_oauth_tokens /
+// mcp_oauth_flows tables only, reasoning that the old tables are "no longer read or
+// written by any application code" — true for new activity, but the old tables'
+// pre-merge rows were only ever copied forward, never deleted from the source (see
+// that migration's own comment: both older tables are "left completely untouched
+// and undropped... kept solely as a rollback safety net"). Any MCP client that had
+// per-user OAuth activity before its merge migration ran keeps an orphaned-but-still-
+// enforced row in the old table, and deleting that client now fails outright on the
+// live constraint.
+//
+// This migration removes only the constraints, not the tables or their rows: the
+// rollback safety net the merge migrations already committed to stays intact, this
+// just stops it from blocking an otherwise-ordinary delete. The struct tags are
+// fixed alongside this (see TableOauthUserToken/TableOauthUserSession) so a fresh
+// install never creates these constraints in the first place.
+func migrationDropLegacyOauthUserFKConstraints(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "drop_legacy_oauth_user_fk_constraints"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	type constraintTarget struct {
+		model any
+		field string
+	}
+	targets := []constraintTarget{
+		{&tables.TableOauthUserToken{}, "MCPClient"},
+		{&tables.TableOauthUserToken{}, "VirtualKey"},
+		{&tables.TableOauthUserSession{}, "MCPClient"},
+		{&tables.TableOauthUserSession{}, "VirtualKey"},
+	}
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mig := tx.Migrator()
+			for _, target := range targets {
+				if !mig.HasConstraint(target.model, target.field) {
+					continue
+				}
+				if err := mig.DropConstraint(target.model, target.field); err != nil {
+					return fmt.Errorf("failed to drop %s constraint on %T: %w", target.field, target.model, err)
+				}
+			}
+			return nil
+		},
+		// Recreates the constraints the forward migration dropped. Schema-only:
+		// neither direction touches a row in either table.
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mig := tx.Migrator()
+			for _, target := range targets {
+				if mig.HasConstraint(target.model, target.field) {
+					continue
+				}
+				if err := mig.CreateConstraint(target.model, target.field); err != nil {
+					return fmt.Errorf("failed to recreate %s constraint on %T: %w", target.field, target.model, err)
 				}
 			}
 			return nil

--- a/framework/configstore/tables/mcpoauth2.go
+++ b/framework/configstore/tables/mcpoauth2.go
@@ -383,9 +383,18 @@ type TableOauthUserSession struct {
 	CreatedAt        time.Time `gorm:"index;not null" json:"created_at"`
 	UpdatedAt        time.Time `gorm:"index;not null" json:"updated_at"`
 
-	// Display-only relations (no DB-level FK constraint; preloaded for sessions UI).
-	MCPClient  *TableMCPClient  `gorm:"foreignKey:MCPClientID;references:ClientID" json:"-"`
-	VirtualKey *TableVirtualKey `gorm:"foreignKey:VirtualKeyID;references:ID" json:"-"`
+	// Display-only relations. "-:migration" skips both constraint creation and
+	// ordinary column migration for these two fields, matching TableMCPOauthFlow's
+	// equivalent relations: the actual FK values live in MCPClientID/VirtualKeyID
+	// above, which are ordinary migrated columns, and these are preloaded for the
+	// sessions UI only. Before this tag was added, GORM's default association
+	// handling created a real fk_oauth_user_sessions_mcp_client /
+	// fk_oauth_user_sessions_virtual_key constraint at table-creation time
+	// (migrationAddPerUserOAuthTables's mg.CreateTable respects association tags
+	// the same as any other GORM operation) — see
+	// migrationDropLegacyOauthUserFKConstraints for why that had to be undone.
+	MCPClient  *TableMCPClient  `gorm:"-:migration;foreignKey:MCPClientID;references:ClientID" json:"-"`
+	VirtualKey *TableVirtualKey `gorm:"-:migration;foreignKey:VirtualKeyID;references:ID" json:"-"`
 
 	// User is a non-DB, enterprise-only annotation populated after fetch on
 	// user-keyed flow rows so the sessions UI can render name/email instead
@@ -460,9 +469,18 @@ type TableOauthUserToken struct {
 	CreatedAt        time.Time  `gorm:"index;not null" json:"created_at"`
 	UpdatedAt        time.Time  `gorm:"index;not null" json:"updated_at"`
 
-	// Display-only relations (no DB-level FK constraint; preloaded for sessions UI).
-	MCPClient  *TableMCPClient  `gorm:"foreignKey:MCPClientID;references:ClientID" json:"-"`
-	VirtualKey *TableVirtualKey `gorm:"foreignKey:VirtualKeyID;references:ID" json:"-"`
+	// Display-only relations. "-:migration" skips both constraint creation and
+	// ordinary column migration for these two fields, matching TableMCPOauthToken's
+	// equivalent relations (see that struct's comment for why a real FK here is
+	// wrong): the actual FK values live in MCPClientID/VirtualKeyID above, which are
+	// ordinary migrated columns, and these are preloaded for the sessions UI only.
+	// Before this tag was added, GORM's default association handling created a real
+	// fk_oauth_user_tokens_mcp_client / fk_oauth_user_tokens_virtual_key constraint
+	// at table-creation time (migrationAddPerUserOAuthTables's mg.CreateTable
+	// respects association tags the same as any other GORM operation) — see
+	// migrationDropLegacyOauthUserFKConstraints for why that had to be undone.
+	MCPClient  *TableMCPClient  `gorm:"-:migration;foreignKey:MCPClientID;references:ClientID" json:"-"`
+	VirtualKey *TableVirtualKey `gorm:"-:migration;foreignKey:VirtualKeyID;references:ID" json:"-"`
 
 	// User mirrors TableOauthUserSession.User — see OauthUserSummary above.
 	User *OauthUserSummary `gorm:"-" json:"-"`


### PR DESCRIPTION
## Summary

Fixes a bug where `DeleteMCPClientConfig` fails with a foreign key constraint violation (Postgres SQLSTATE 23503) for any MCP client that had per-user OAuth activity before the `migrationMergeOauthTokenTables` migration ran. Those clients retain rows in the legacy `oauth_user_tokens` table that were copied forward but never deleted from the source. Because `DeleteMCPClientConfig` now only cleans up `mcp_oauth_tokens`, the enforced FK constraint on the old table blocks the client deletion entirely.

## Changes

- **New migration `drop_legacy_oauth_user_fk_constraints`**: Drops the four FK constraints (`fk_oauth_user_tokens_mcp_client`, `fk_oauth_user_tokens_virtual_key`, `fk_oauth_user_sessions_mcp_client`, `fk_oauth_user_sessions_virtual_key`) that GORM silently created when `migrationAddPerUserOAuthTables` ran `CreateTable`. The migration is idempotent and includes a rollback that recreates the constraints. It does not touch any rows — the legacy tables remain intact as the rollback safety net the merge migrations committed to.

- **Struct tag fix on `TableOauthUserToken` and `TableOauthUserSession`**: The `MCPClient` and `VirtualKey` association fields on both structs now carry `gorm:"-:migration"`, which prevents GORM from creating real FK constraints for these display-only preload relations on any fresh install going forward. This matches the pattern already used on `TableMCPOauthToken` and `TableMCPOauthFlow`.

- **Tests**: Added `mcpoauthusertoken_fk_test.go` covering three scenarios:
  - SQLite (FK enforcement on): `DeleteMCPClientConfig` succeeds for a client with only a legacy `oauth_user_tokens` row, and that row is left in place.
  - Migration idempotency: `migrationDropLegacyOauthUserFKConstraints` is a no-op on a DB that already ran it or never had the constraints.
  - Postgres: Reproduces the original SQLSTATE 23503 error and confirms it is resolved.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Run the new FK constraint tests (SQLite path, no external DB needed)
go test ./framework/configstore/... -run TestDeleteMCPClientConfig_LegacyOauthUserTokenRow
go test ./framework/configstore/... -run TestMigrationDropLegacyOauthUserFKConstraints_RemovesAllFour

# Run the Postgres twin (requires a reachable Postgres instance)
go test ./framework/configstore/... -run TestPostgresDeleteMCPClientConfig_LegacyOauthUserTokenRow

# Full suite
go test ./...
```

The Postgres test skips automatically if no Postgres instance is available, so CI without a DB sidecar will still pass.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

The bug surfaces as a Postgres SQLSTATE 23503 error on `DeleteMCPClientConfig` for clients with pre-merge per-user OAuth rows.

## Security considerations

No auth, secrets, or PII changes. The migration removes database constraints only; no data is read, written, or deleted.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable