### PR TITLE
fix: use `ShutdownWithContext` for bounded HTTP shutdown and pin Vite dev server to `127.0.0.1` to avoid IPv4/IPv6 race

### DIFF
--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -2838,8 +2838,16 @@ func (s *BifrostHTTPServer) Start() error {
 		// Create shutdown context with timeout
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		// Perform graceful shutdown
-		if err := s.Server.Shutdown(); err != nil {
+		// Perform graceful shutdown. ShutdownWithContext, not the bare Shutdown() (which
+		// delegates to ShutdownWithContext(context.Background()) internally): the plain
+		// call waits for every open connection to go idle with no deadline of its own, so
+		// one connection that never closes on its own - a stuck SSE stream, a long-poll,
+		// a client that simply never sends its FIN - blocks this line forever. Nothing
+		// after it (client shutdown, storage cleanup, the 30s cleanup-timeout logging
+		// below) ever runs, and the process never exits: it sits holding its DB
+		// connections and the cluster gossip port indefinitely, so a hung shutdown here
+		// also breaks whatever replacement process is supposed to take its place.
+		if err := s.Server.ShutdownWithContext(shutdownCtx); err != nil {
 			logger.Error("error during graceful shutdown: %v", err)
 		} else {
 			logger.Info("server gracefully shutdown")

--- a/ui/vite.config.mts
+++ b/ui/vite.config.mts
@@ -51,6 +51,15 @@ export default defineConfig({
 		"process.env.BIFROST_PORT": JSON.stringify(process.env.BIFROST_PORT ?? ""),
 	},
 	server: {
+		// Pinned rather than left to resolve "localhost": Node's listen() with a bare
+		// hostname binds whichever address it resolves first, not both, and "localhost"
+		// resolves to both ::1 and 127.0.0.1 here - which one wins is not guaranteed
+		// stable across restarts. Bifrost's dev-mode UI proxy (ui.go's uiDevClient)
+		// dials this by the literal string "localhost:3000" too, so a run that bound
+		// IPv6-only left every proxied request (including the OAuth popup's hard
+		// navigation back to /workspace/mcp-registry/oauth-callback) hitting connection
+		// refused. Pinning both sides to the same explicit address removes the race.
+		host: "127.0.0.1",
 		port: 3000,
 		proxy: {
 			"/api": {


### PR DESCRIPTION
## Summary

Two independent fixes for reliability issues: a hung server shutdown caused by connections that never close on their own, and a flaky Vite dev server binding that caused OAuth callbacks and proxied requests to hit connection refused.

## Changes

- **Graceful shutdown now uses `ShutdownWithContext`** instead of the bare `Shutdown()` call. The plain `Shutdown()` delegates to `ShutdownWithContext(context.Background())` internally, meaning it waits indefinitely for every open connection to go idle. A single stuck connection — an SSE stream, a long-poll, or a client that never sends its FIN — would block the shutdown path forever, preventing DB connection cleanup, cluster gossip port release, and process exit. This also blocked any replacement process from starting. Passing the already-created 30-second timeout context enforces a deadline.

- **Vite dev server is now pinned to `127.0.0.1`** instead of resolving `localhost`. Node's `listen()` with a bare hostname binds whichever address it resolves first — either `::1` or `127.0.0.1` — and that result is not stable across restarts. Since `ui.go`'s `uiDevClient` dials `localhost:3000` literally, a run that bound IPv6-only caused every proxied request (including the OAuth popup's hard navigation back to `/workspace/mcp-registry/oauth-callback`) to hit connection refused. Pinning both sides to the same explicit address removes the race.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Verify server shutdown completes within the timeout even with a live SSE or long-poll connection open
go test ./transports/bifrost-http/server/...

# Verify the Vite dev server binds on 127.0.0.1 and proxied requests succeed
cd ui
pnpm i || npm i
pnpm build || npm run build
# Start dev server and confirm it listens on 127.0.0.1:3000, then exercise the OAuth callback flow
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No new auth, secrets, or PII surface introduced. Pinning the dev server to `127.0.0.1` reduces exposure compared to a potential `::1` bind that might behave differently under certain network configurations.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable