### PR TITLE
updated sheet design

### DIFF
--- a/ui/components/ui/sheet.tsx
+++ b/ui/components/ui/sheet.tsx
@@ -111,14 +111,14 @@ function SheetContent({
 					className={cn(
 						"bg-card data-[state=open]:animate-in data-[state=closed]:animate-out custom-scrollbar fixed z-50 flex flex-col shadow-lg transition-all ease-in-out overscroll-none data-[state=closed]:duration-100 data-[state=open]:duration-100",
 						side === "right" &&
-							"data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right top-2 right-0 bottom-2 h-auto w-full rounded-l-lg border-l sm:w-3/4",
+							"data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right top-2 right-2 bottom-2  h-auto w-full rounded-sm border-l sm:w-3/4",
 						side === "right" && (!expandable || !expanded) && "sm:max-w-2xl",
 						side === "right" && expandable && expanded && "sm:max-w-5xl",
 						side === "left" &&
-							"data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left top-2 bottom-2 left-0 h-auto w-full rounded-r-lg border-r sm:w-3/4 sm:max-w-sm",
-						side === "top" && "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
+							"data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left top-2 bottom-2 left-2 h-auto w-full rounded-sm border-r sm:w-3/4 sm:max-w-sm",
+						side === "top" && "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-2 h-auto border-b",
 						side === "bottom" &&
-							"data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
+							"data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-2 h-auto border-t",
 						className,
 					)}
 					{...props}
@@ -142,7 +142,7 @@ function SheetHeader({
 	return (
 		<div
 			data-slot="sheet-header"
-			className={cn("flex items-center gap-1 w-full pr-2", sheetContext?.expandable ? "p-0" : "mb-6", headerClassName)}
+			className={cn("flex items-center gap-1 w-full pr-0", sheetContext?.expandable ? "p-0" : "mb-6", headerClassName)}
 			{...props}
 		>
 			{sheetContext?.expandable && sheetContext?.side === "right" && (


### PR DESCRIPTION
## Summary

Adjusts the Sheet component's positioning and border radius styling to add consistent spacing from the viewport edges and update corner rounding across all slide directions.

## Changes

- Added `right-2`, `left-2`, `top-2`, and `bottom-2` offsets to right, left, top, and bottom sheet variants so panels float slightly away from the screen edges instead of being flush against them
- Changed `rounded-l-lg` and `rounded-r-lg` to `rounded-sm` on the right and left sheet variants for a subtler corner radius
- Removed `pr-2` from the sheet header, replacing it with `pr-0` to eliminate unintended right padding

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

Open any sheet panel (right, left, top, bottom) and verify:
- The panel has a small gap between itself and the viewport edge on all sides
- Corner rounding appears subtle (`rounded-sm`) on left and right panels
- No extra right padding appears in the sheet header

## Screenshots/Recordings

Before/after screenshots showing the gap between the sheet and the viewport edge would be helpful.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable