### PR TITLE
fix: surface the terminal error frame that follows a detail-free response.failed

### DIFF
--- a/core/providers/openai/errors.go
+++ b/core/providers/openai/errors.go
@@ -82,6 +82,30 @@ func responsesStreamError(response *schemas.BifrostResponsesStreamResponse) *sch
 	return bifrostErr
 }
 
+// responsesFailedEventHasErrorDetail reports whether a response.failed event
+// carries any usable error payload of its own. Azure emits response.failed with
+// "error": null everywhere and follows it with a terminal {"type":"error"}
+// frame holding the real reason (e.g. content_policy_violation); when nothing
+// usable is present the stream loop holds the failed event and keeps reading
+// for that richer frame instead of surfacing a detail-free error (issue #6419).
+func responsesFailedEventHasErrorDetail(response *schemas.BifrostResponsesStreamResponse) bool {
+	if response.Message != nil && *response.Message != "" {
+		return true
+	}
+	if response.Code != nil && *response.Code != "" {
+		return true
+	}
+	if response.Error != nil &&
+		(response.Error.Message != "" || response.Error.Code != "" || response.Error.Type != "") {
+		return true
+	}
+	if response.Response != nil && response.Response.Error != nil &&
+		(response.Response.Error.Message != "" || response.Response.Error.Code != "") {
+		return true
+	}
+	return false
+}
+
 // ParseOpenAIError parses OpenAI error responses.
 func ParseOpenAIError(resp *fasthttp.Response) *schemas.BifrostError {
 	var errorResp schemas.BifrostError

--- a/core/providers/openai/errors.go
+++ b/core/providers/openai/errors.go
@@ -100,7 +100,7 @@ func responsesFailedEventHasErrorDetail(response *schemas.BifrostResponsesStream
 		return true
 	}
 	if response.Response != nil && response.Response.Error != nil &&
-		(response.Response.Error.Message != "" || response.Response.Error.Code != "") {
+		(response.Response.Error.Message != "" || response.Response.Error.Code != "" || response.Response.Error.Type != "") {
 		return true
 	}
 	return false

--- a/core/providers/openai/failederrorframe_test.go
+++ b/core/providers/openai/failederrorframe_test.go
@@ -86,6 +86,23 @@ data: {"type":"response.failed","sequence_number":1,"response":{"id":"resp_1","o
 	}
 }
 
+// A response.failed whose nested error carries only a type is still detail and
+// must surface immediately, not be deferred.
+func TestResponsesStreamFailedWithTypeOnlyDetailSurfacesImmediately(t *testing.T) {
+	frames := `data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_1","object":"response","created_at":1,"model":"repro-model","status":"in_progress"}}
+
+data: {"type":"response.failed","sequence_number":1,"response":{"id":"resp_1","object":"response","created_at":1,"model":"repro-model","status":"failed","error":{"type":"invalid_request_error"}}}
+
+`
+	_, got := runResponsesStream(t, frames)
+	if got == nil || got.Error == nil {
+		t.Fatal("expected a terminal error chunk, got none")
+	}
+	if got.Error.Type == nil || *got.Error.Type != "invalid_request_error" {
+		t.Fatalf("error type = %v, want the failed event's own nested type", got.Error.Type)
+	}
+}
+
 // A detail-free response.failed with nothing after it must still produce the
 // generic failed-derived error at stream end, not a silent close or a
 // truncation error.

--- a/core/providers/openai/failederrorframe_test.go
+++ b/core/providers/openai/failederrorframe_test.go
@@ -1,0 +1,105 @@
+package openai
+
+// Regression tests for issue #6419: Azure kills a content-filtered /v1/responses
+// stream with THREE frames: response.created (seq 0), response.failed (seq 1,
+// error null inside the response object), then a terminal type:"error" frame
+// (seq 2) whose nested error object carries the content_policy_violation
+// code/message while the top-level code/message/param are null. The failed
+// branch used to surface the detail-free response.failed and return, so the
+// richer error frame was never read and clients got "provider stream error
+// (response.failed)" with a nil code.
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func responsesStreamRequest() *schemas.BifrostResponsesRequest {
+	return &schemas.BifrostResponsesRequest{
+		Provider: schemas.OpenAI,
+		Model:    "repro-model",
+		Input: []schemas.ResponsesMessage{{
+			Type:    schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("hi")},
+		}},
+	}
+}
+
+func runResponsesStream(t *testing.T, frames string) (chunks []*schemas.BifrostStreamChunk, lastErr *schemas.BifrostError) {
+	t.Helper()
+	server := completeSSEServer(t, frames)
+	defer server.Close()
+
+	provider := newStreamTestProvider(server.URL)
+	stream, bifrostErr := provider.ResponsesStream(newStreamTestContext(), passthroughPostHook, nil, testKey(), responsesStreamRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+	chunks = collectChunks(t, stream)
+	for _, chunk := range chunks {
+		if chunk.BifrostError != nil {
+			lastErr = chunk.BifrostError
+		}
+	}
+	return chunks, lastErr
+}
+
+func TestResponsesStreamErrorFrameAfterDetailFreeFailed(t *testing.T) {
+	frames := `data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_1","object":"response","created_at":1,"model":"repro-model","status":"in_progress"}}
+
+data: {"type":"response.failed","sequence_number":1,"response":{"id":"resp_1","object":"response","created_at":1,"model":"repro-model","status":"failed","error":null}}
+
+data: {"type":"error","sequence_number":2,"code":null,"message":null,"param":null,"error":{"type":"invalid_request_error","code":"content_policy_violation","message":"Image processing blocked due to content policy violation.","param":"input"}}
+
+`
+	_, got := runResponsesStream(t, frames)
+	if got == nil || got.Error == nil {
+		t.Fatal("expected a terminal error chunk, got none")
+	}
+	if got.Error.Code == nil || *got.Error.Code != "content_policy_violation" {
+		t.Fatalf("error code = %#v, want content_policy_violation (message = %q)", got.Error.Code, got.Error.Message)
+	}
+	if got.Error.Message != "Image processing blocked due to content policy violation." {
+		t.Fatalf("error message = %q, want the content-policy message from the terminal error frame", got.Error.Message)
+	}
+}
+
+// A response.failed that carries its own error details (the Fireworks shape)
+// must keep surfacing immediately.
+func TestResponsesStreamFailedWithDetailSurfacesImmediately(t *testing.T) {
+	frames := `data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_1","object":"response","created_at":1,"model":"repro-model","status":"in_progress"}}
+
+data: {"type":"response.failed","sequence_number":1,"response":{"id":"resp_1","object":"response","created_at":1,"model":"repro-model","status":"failed","error":{"code":"server_error","message":"upstream exploded"}}}
+
+`
+	_, got := runResponsesStream(t, frames)
+	if got == nil || got.Error == nil {
+		t.Fatal("expected a terminal error chunk, got none")
+	}
+	if got.Error.Code == nil || *got.Error.Code != "server_error" {
+		t.Fatalf("error code = %#v, want server_error", got.Error.Code)
+	}
+	if got.Error.Message != "upstream exploded" {
+		t.Fatalf("error message = %q, want the failed event's own message", got.Error.Message)
+	}
+}
+
+// A detail-free response.failed with nothing after it must still produce the
+// generic failed-derived error at stream end, not a silent close or a
+// truncation error.
+func TestResponsesStreamDetailFreeFailedWithoutErrorFrame(t *testing.T) {
+	frames := `data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_1","object":"response","created_at":1,"model":"repro-model","status":"in_progress"}}
+
+data: {"type":"response.failed","sequence_number":1,"response":{"id":"resp_1","object":"response","created_at":1,"model":"repro-model","status":"failed","error":null}}
+
+`
+	_, got := runResponsesStream(t, frames)
+	if got == nil || got.Error == nil {
+		t.Fatal("expected a terminal error chunk, got none")
+	}
+	if got.Error.Message == "" || got.Type == nil || *got.Type != string(schemas.ResponsesStreamResponseTypeFailed) {
+		t.Fatalf("expected the failed-derived error at stream end, got type=%v message=%q", got.Type, got.Error.Message)
+	}
+}

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -1943,6 +1943,12 @@ func HandleOpenAIResponsesStreaming(
 
 		lastChunkTime := startTime
 
+		// A detail-free response.failed held back while the loop reads on for the
+		// terminal {"type":"error"} frame some providers (Azure) send right after
+		// it, carrying the real failure reason (issue #6419).
+		var pendingFailedErr *schemas.BifrostError
+		var pendingFailedRaw []byte
+
 		for {
 			// If context was cancelled/timed out, let defer handle it
 			if ctx.Err() != nil {
@@ -2026,6 +2032,17 @@ func HandleOpenAIResponsesStreaming(
 			// instead of a pre-stream 4xx. Convert to BifrostError for consistent handling.
 			if response.Type == schemas.ResponsesStreamResponseTypeFailed {
 				bifrostErr := responsesStreamError(&response)
+				// Azure sends response.failed with a null error object and follows it
+				// with a terminal {"type":"error"} frame holding the real reason (e.g.
+				// content_policy_violation). Surfacing the detail-free failed event
+				// immediately would drop that frame unread, so hold it and keep
+				// reading; the error branch above surfaces the richer frame, and the
+				// post-loop flush surfaces this one if nothing follows.
+				if !responsesFailedEventHasErrorDetail(&response) {
+					pendingFailedErr = bifrostErr
+					pendingFailedRaw = []byte(jsonData)
+					continue
+				}
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, []byte(jsonData), sendBackRawRequest, sendBackRawResponse, latency), responseChan, logger, postHookSpanFinalizer)
 				return
@@ -2047,6 +2064,14 @@ func HandleOpenAIResponsesStreaming(
 			lastChunkTime = time.Now()
 
 			providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, &response, nil, nil, nil), responseChan, postHookSpanFinalizer)
+		}
+
+		// A detail-free response.failed with no richer error frame after it: the
+		// stream is over, surface the held failed-derived error now.
+		if pendingFailedErr != nil {
+			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+			providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, providerUtils.EnrichError(ctx, pendingFailedErr, jsonBody, pendingFailedRaw, sendBackRawRequest, sendBackRawResponse, latency), responseChan, logger, postHookSpanFinalizer)
+			return
 		}
 
 		// The loop returns as soon as a terminal event (completed / incomplete /

--- a/core/providers/openai/responseslifecycle.go
+++ b/core/providers/openai/responseslifecycle.go
@@ -285,6 +285,12 @@ func (provider *OpenAIProvider) ResponsesRetrieveStream(ctx *schemas.BifrostCont
 		sseReader := providerUtils.GetSSEDataReader(ctx, reader)
 		lastChunkTime := startTime
 
+		// A detail-free response.failed held back while the loop reads on for the
+		// terminal {"type":"error"} frame some providers (Azure) send right after
+		// it, carrying the real failure reason (issue #6419).
+		var pendingFailedErr *schemas.BifrostError
+		var pendingFailedRaw []byte
+
 		for {
 			if ctx.Err() != nil {
 				return
@@ -326,6 +332,13 @@ func (provider *OpenAIProvider) ResponsesRetrieveStream(ctx *schemas.BifrostCont
 			// Some providers send response.failed on HTTP 200 streams instead of a pre-stream 4xx.
 			if response.Type == schemas.ResponsesStreamResponseTypeFailed {
 				bifrostErr := responsesStreamError(&response)
+				// Hold a detail-free failed event and keep reading for the richer
+				// terminal error frame; see the identical branch in openai.go (#6419).
+				if !responsesFailedEventHasErrorDetail(&response) {
+					pendingFailedErr = bifrostErr
+					pendingFailedRaw = []byte(jsonData)
+					continue
+				}
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, providerUtils.EnrichError(ctx, bifrostErr, nil, []byte(jsonData), sendBackRawRequest, sendBackRawResponse, latency), responseChan, provider.logger, postHookSpanFinalizer)
 				return
@@ -343,6 +356,14 @@ func (provider *OpenAIProvider) ResponsesRetrieveStream(ctx *schemas.BifrostCont
 			lastChunkTime = time.Now()
 
 			providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, &response, nil, nil, nil), responseChan, postHookSpanFinalizer)
+		}
+
+		// A detail-free response.failed with no richer error frame after it: the
+		// stream is over, surface the held failed-derived error now.
+		if pendingFailedErr != nil {
+			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+			providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, providerUtils.EnrichError(ctx, pendingFailedErr, nil, pendingFailedRaw, sendBackRawRequest, sendBackRawResponse, latency), responseChan, provider.logger, postHookSpanFinalizer)
+			return
 		}
 
 		// Falling out of the loop means the body ended without a terminal event.


### PR DESCRIPTION
## Summary

Azure kills a content-filtered `/v1/responses` stream with three frames: `response.created`, `response.failed` (with `"error": null` inside the response object), then a terminal `{"type":"error"}` frame whose nested error carries the real reason (`content_policy_violation`). Bifrost's Responses stream loops converted the `response.failed` event to an error and returned immediately, so the third frame was never read. Clients got `"provider stream error (response.failed)"` with a nil code, and the content-policy reason was lost. Non-streaming already surfaced it correctly as a 400.

I traced this to both stream loops: `HandleOpenAIResponsesStreaming` and the lifecycle variant return on the `response.failed` branch before the richer frame arrives. The error-event schema and `responsesStreamError` already handle Azure's nested-error shape fine, the frame just never got read.

## Changes

- `core/providers/openai/openai.go` + `core/providers/openai/responseslifecycle.go`: when a `response.failed` event carries no usable error detail of its own (top-level and nested code/message all empty), hold the failed-derived error and keep reading. A following `type:"error"` frame surfaces through the existing error branch with full details; stream end flushes the held error so a detail-free failed with nothing after it still errors (not a silent close, not a truncation error).
- `core/providers/openai/errors.go`: new `responsesFailedEventHasErrorDetail` helper deciding "does this failed event say anything useful".
- Failed events that do carry details (the Fireworks shape) surface immediately, exactly as before.
- Covers azure and every provider on the shared handler (bedrock mantle, fireworks, openrouter, perplexity, vllm, xai, ...).
- `core/providers/openai/failederrorframe_test.go`: regression tests for the exact three-frame Azure sequence from the issue (asserts the client receives `content_policy_violation` with the real message), the Fireworks detail-carrying shape, and the detail-free-failed-then-EOF flush. The first fails without the fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go test -run 'TestResponsesStream(ErrorFrameAfterDetailFreeFailed|FailedWithDetailSurfacesImmediately|DetailFreeFailedWithoutErrorFrame)' -v ./providers/openai/
go test ./providers/openai/ ./providers/azure/
```

Or live: stream a request that trips Azure's content filter through `/openai/v1/responses` with `stream: true`. Before this change the stream ends after `response.failed` with a generic detail-free error; after it the terminal error carries `content_policy_violation` and the upstream message.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #6419

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
