### PR TITLE
fix: check all five budget owner columns in validateBudgetLinkOwnership

### DIFF
--- a/transports/bifrost-http/lib/budgetownership_test.go
+++ b/transports/bifrost-http/lib/budgetownership_test.go
@@ -1,0 +1,126 @@
+package lib
+
+// Regression tests for issue #6623: validateBudgetLinkOwnership checked only
+// three of the five budget owner columns TableBudget.BeforeSave enforces, so a
+// budget already owned by a customer (customer_id) or through a model config's
+// BudgetIDs list (the budget's own model_config_id column, written by
+// linkModelConfigBudgets) could be linked to a second governance entity at
+// config load. The DB layer considers that state invalid; budget accounting
+// for both owners then shared one budget row.
+
+import (
+	"testing"
+
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+)
+
+func TestValidateBudgetLinkOwnershipCoversAllOwnerColumns(t *testing.T) {
+	initTestLogger()
+	db := setupTestDB(t)
+	if err := db.AutoMigrate(
+		&configstoreTables.TableBudget{},
+		&configstoreTables.TableModelConfig{},
+		&configstoreTables.TableProvider{},
+	); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	sp := func(s string) *string { return &s }
+
+	t.Run("customer-owned budget is rejected", func(t *testing.T) {
+		if err := db.Create(&configstoreTables.TableBudget{
+			ID:            "budget-cust",
+			MaxLimit:      100,
+			ResetDuration: "1d",
+			CustomerID:    sp("customer-1"),
+		}).Error; err != nil {
+			t.Fatalf("create: %v", err)
+		}
+		if err := validateBudgetLinkOwnership(db, sp("budget-cust"), "provider", "openai"); err == nil {
+			t.Error("customer-owned budget must be rejected as already owned")
+		}
+	})
+
+	t.Run("budget owned via its own model_config_id is rejected", func(t *testing.T) {
+		// The linkage linkModelConfigBudgets writes for BudgetIDs lists: the
+		// budget's own model_config_id column, with no TableModelConfig.budget_id
+		// row pointing back, so the follow-up query alone cannot catch it.
+		if err := db.Create(&configstoreTables.TableBudget{
+			ID:            "budget-mc",
+			MaxLimit:      100,
+			ResetDuration: "1d",
+			ModelConfigID: sp("mc-1"),
+		}).Error; err != nil {
+			t.Fatalf("create: %v", err)
+		}
+		if err := validateBudgetLinkOwnership(db, sp("budget-mc"), "provider", "openai"); err == nil {
+			t.Error("budget owned through model_config_id must be rejected as already owned")
+		}
+	})
+
+	t.Run("model config re-validating its own BudgetIDs link passes", func(t *testing.T) {
+		// Config reload re-validates existing links; a model config's own
+		// linkage must not self-conflict (mirrors the id <> ? exclusion on the
+		// follow-up query).
+		if err := db.Create(&configstoreTables.TableBudget{
+			ID:            "budget-mc-self",
+			MaxLimit:      100,
+			ResetDuration: "1d",
+			ModelConfigID: sp("mc-self"),
+		}).Error; err != nil {
+			t.Fatalf("create: %v", err)
+		}
+		if err := validateBudgetLinkOwnership(db, sp("budget-mc-self"), "model config", "mc-self"); err != nil {
+			t.Errorf("self re-validation must pass, got: %v", err)
+		}
+		if err := validateBudgetLinkOwnership(db, sp("budget-mc-self"), "model config", "mc-other"); err == nil {
+			t.Error("another model config linking the same budget must be rejected")
+		}
+	})
+
+	t.Run("team-owned budget still rejected", func(t *testing.T) {
+		if err := db.Create(&configstoreTables.TableBudget{
+			ID:            "budget-team",
+			MaxLimit:      100,
+			ResetDuration: "1d",
+			TeamID:        sp("team-1"),
+		}).Error; err != nil {
+			t.Fatalf("create: %v", err)
+		}
+		if err := validateBudgetLinkOwnership(db, sp("budget-team"), "provider", "openai"); err == nil {
+			t.Error("team-owned budget must be rejected")
+		}
+	})
+
+	t.Run("unowned budget still links", func(t *testing.T) {
+		if err := db.Create(&configstoreTables.TableBudget{
+			ID:            "budget-free",
+			MaxLimit:      100,
+			ResetDuration: "1d",
+		}).Error; err != nil {
+			t.Fatalf("create: %v", err)
+		}
+		if err := validateBudgetLinkOwnership(db, sp("budget-free"), "provider", "openai"); err != nil {
+			t.Errorf("unowned budget must be linkable, got: %v", err)
+		}
+	})
+
+	t.Run("reverse model-config direction still caught", func(t *testing.T) {
+		if err := db.Create(&configstoreTables.TableModelConfig{
+			ID:        "mc-2",
+			ModelName: "gpt-4o",
+			BudgetID:  sp("budget-mc2"),
+		}).Error; err != nil {
+			t.Fatalf("create model config: %v", err)
+		}
+		if err := db.Create(&configstoreTables.TableBudget{
+			ID:            "budget-mc2",
+			MaxLimit:      100,
+			ResetDuration: "1d",
+		}).Error; err != nil {
+			t.Fatalf("create budget: %v", err)
+		}
+		if err := validateBudgetLinkOwnership(db, sp("budget-mc2"), "provider", "openai"); err == nil {
+			t.Error("budget referenced by a model config's budget_id must be rejected")
+		}
+	})
+}

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -4112,15 +4112,26 @@ func validateBudgetLinkOwnership(tx *gorm.DB, budgetID *string, ownerType, owner
 		return nil
 	}
 
+	// All five owner columns TableBudget.BeforeSave counts must be checked here,
+	// or a budget already owned through the missing column double-links at
+	// config load and the two layers disagree about the invariant (#6623).
 	var budget configstoreTables.TableBudget
-	if err := tx.Select("id", "team_id", "virtual_key_id", "provider_config_id").Where("id = ?", id).First(&budget).Error; err != nil {
+	if err := tx.Select("id", "team_id", "virtual_key_id", "provider_config_id", "model_config_id", "customer_id").Where("id = ?", id).First(&budget).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return fmt.Errorf("budget_id %q referenced by %s %q does not exist", id, ownerType, ownerID)
 		}
 		return fmt.Errorf("failed to validate budget ownership for %s %q: %w", ownerType, ownerID, err)
 	}
 
-	if budget.TeamID != nil || budget.VirtualKeyID != nil || budget.ProviderConfigID != nil {
+	// A budget's own model_config_id marks a BudgetIDs-list linkage
+	// (linkModelConfigBudgets); on config reload the same model config
+	// re-validates its own entries, so its own linkage must not self-conflict,
+	// mirroring the `id <> ?` exclusion on the follow-up query below.
+	modelConfigOwnedElsewhere := budget.ModelConfigID != nil &&
+		!(ownerType == "model config" && *budget.ModelConfigID == ownerID)
+
+	if budget.TeamID != nil || budget.VirtualKeyID != nil || budget.ProviderConfigID != nil ||
+		budget.CustomerID != nil || modelConfigOwnedElsewhere {
 		return fmt.Errorf("budget_id %q is already owned by another governance entity and cannot be linked to %s %q", id, ownerType, ownerID)
 	}
 


### PR DESCRIPTION
## Summary

The config-load budget validator and the DB layer disagree about the same invariant. `TableBudget.BeforeSave` enforces at-most-one-owner across five columns (team, virtual key, provider config, model config, customer); `validateBudgetLinkOwnership` selected and tested only three. A budget already owned by a customer, or owned through a model config's `BudgetIDs` list, passed validation and got linked to a second governance entity, so both owners shared one budget row, which is exactly what the invariant exists to prevent. It surfaces as budgets not enforcing, far from the cause.

The `model_config_id` direction is the subtle one: `linkModelConfigBudgets` writes the budget's own `model_config_id` column and leaves `TableModelConfig.budget_id` untouched (`BudgetIDs` is `gorm:"-"`, never persisted), so the validator's existing follow-up query against `TableModelConfig.budget_id` cannot see it. That matches the report in the issue comments of hitting this via `model_config_id`.

## Changes

- `transports/bifrost-http/lib/config.go`: `validateBudgetLinkOwnership` now selects and tests all five owner columns. One carve-out: a model config re-validating its own `BudgetIDs` linkage on config reload is exempt from the `model_config_id` check, mirroring the `id <> ?` exclusion the follow-up query already applies, so reloads don't self-conflict.
- `transports/bifrost-http/lib/budgetownership_test.go`: regression tests on the in-memory sqlite harness: customer-owned rejected, model-config-owned (own column, no reverse row) rejected, self re-validation passes while another model config is rejected, plus controls (team-owned still rejected, unowned still links, reverse `TableModelConfig.budget_id` direction still caught). Three subtests fail without the fix.

No DB-layer change: `BeforeSave` was already correct, the validator just has to enforce the same rule.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd transports
go test -run TestValidateBudgetLinkOwnershipCoversAllOwnerColumns -v ./bifrost-http/lib/
go test ./bifrost-http/lib/
```

Or live: create a customer with a budget in config.json, then link the same `budget_id` to a provider and reload. Before this change the config loads and both entities draw down one budget row; after it, config validation rejects the link with "already owned by another governance entity".

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

A config.json that was silently double-linking a budget now fails validation with an explicit error. That config was already invalid per the DB invariant.

## Related issues

Closes #6623

## Security considerations

None. Tightens a governance/money-safety invariant.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
