### PR TITLE
fix: bedrock models routing to converse

### DIFF
--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -1243,7 +1243,7 @@ func (provider *BedrockProvider) ChatCompletion(ctx *schemas.BifrostContext, key
 		return nil, err
 	}
 
-	if isMantleModel(ctx, request.Model) {
+	if provider.routesToMantle(ctx, key, request.Model) {
 		return provider.mantleChatCompletions(ctx, key, request)
 	}
 
@@ -1434,7 +1434,7 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx *schemas.BifrostContex
 		return nil, err
 	}
 
-	if isMantleModel(ctx, request.Model) {
+	if provider.routesToMantle(ctx, key, request.Model) {
 		return provider.mantleChatCompletionsStream(ctx, postHookRunner, postHookSpanFinalizer, key, request)
 	}
 
@@ -1756,7 +1756,7 @@ func (provider *BedrockProvider) Responses(ctx *schemas.BifrostContext, key sche
 		return nil, err
 	}
 
-	if isMantleModel(ctx, request.Model) {
+	if provider.routesToMantle(ctx, key, request.Model) {
 		return provider.mantleResponses(ctx, key, request)
 	}
 
@@ -1835,7 +1835,7 @@ func (provider *BedrockProvider) ResponsesStream(ctx *schemas.BifrostContext, po
 		return nil, err
 	}
 
-	if isMantleModel(ctx, request.Model) {
+	if provider.routesToMantle(ctx, key, request.Model) {
 		return provider.mantleResponsesStream(ctx, postHookRunner, postHookSpanFinalizer, key, request)
 	}
 

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -2385,7 +2385,7 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 		inferenceConfig := &BedrockInferenceConfig{}
 
 		if bifrostReq.Params.MaxOutputTokens != nil {
-			inferenceConfig.MaxTokens = bifrostReq.Params.MaxOutputTokens
+			inferenceConfig.MaxTokens = clampMaxTokens(ctx, bifrostReq.Params.MaxOutputTokens, caps)
 		}
 		if bifrostReq.Params.Temperature != nil {
 			inferenceConfig.Temperature = bifrostReq.Params.Temperature
@@ -2466,6 +2466,15 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 					}
 
 					bedrockReq.AdditionalModelRequestFields.Set("reasoningConfig", config)
+				} else if levels, ok := converseReasoningEffortLevels(ctx, caps); ok {
+					// Converse exposes no token budget for these models, so express the
+					// budget as the effort it corresponds to.
+					defaultMaxTokens := providerUtils.GetMaxOutputTokensOrDefault(bifrostReq.Provider, bifrostReq.Model, DefaultCompletionMaxTokens)
+					if inferenceConfig.MaxTokens != nil {
+						defaultMaxTokens = *inferenceConfig.MaxTokens
+					}
+					effort := providerUtils.GetReasoningEffortFromBudgetTokens(tokenBudget, MinimumReasoningMaxTokens, defaultMaxTokens)
+					setConverseReasoningEffort(bedrockReq.AdditionalModelRequestFields, caps, levels, effort)
 				}
 			} else {
 				if bifrostReq.Params.Reasoning.Effort != nil && *bifrostReq.Params.Reasoning.Effort != "none" {
@@ -2533,22 +2542,8 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 								"budget_tokens": budgetTokens,
 							})
 						}
-					} else {
-						modelDefaultMaxTokens := providerUtils.GetMaxOutputTokensOrDefault(bifrostReq.Provider, bifrostReq.Model, DefaultCompletionMaxTokens)
-						defaultMaxTokens := modelDefaultMaxTokens
-						if inferenceConfig.MaxTokens != nil {
-							defaultMaxTokens = *inferenceConfig.MaxTokens
-						} else {
-							inferenceConfig.MaxTokens = schemas.Ptr(modelDefaultMaxTokens)
-						}
-						budgetTokens, err := providerUtils.GetBudgetTokensFromReasoningEffort(*bifrostReq.Params.Reasoning.Effort, MinimumReasoningMaxTokens, defaultMaxTokens)
-						if err != nil {
-							return nil, err
-						}
-						bedrockReq.AdditionalModelRequestFields.Set("reasoningConfig", map[string]any{
-							"type":          "enabled",
-							"budget_tokens": budgetTokens,
-						})
+					} else if levels, ok := converseReasoningEffortLevels(ctx, caps); ok {
+						setConverseReasoningEffort(bedrockReq.AdditionalModelRequestFields, caps, levels, *bifrostReq.Params.Reasoning.Effort)
 					}
 				} else {
 					if schemas.IsAnthropicModelFamily(ctx, bifrostReq.Model) {
@@ -2563,10 +2558,8 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 						bedrockReq.AdditionalModelRequestFields.Set("reasoningConfig", map[string]any{
 							"type": "disabled",
 						})
-					} else {
-						bedrockReq.AdditionalModelRequestFields.Set("reasoningConfig", map[string]any{
-							"type": "disabled",
-						})
+					} else if levels, ok := converseReasoningEffortLevels(ctx, caps); ok {
+						setConverseReasoningEffort(bedrockReq.AdditionalModelRequestFields, caps, levels, "none")
 					}
 				}
 			}

--- a/core/providers/bedrock/surface.go
+++ b/core/providers/bedrock/surface.go
@@ -1,0 +1,178 @@
+package bedrock
+
+import (
+	"regexp"
+	"strings"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// AWS serves Bedrock models from two endpoints with mutually exclusive model
+// identifiers, so picking the wrong one fails outright rather than degrading:
+// a bare id ("openai.gpt-5.6-luna") 400s on bedrock-runtime asking for an
+// inference profile, while a cross-region id ("global.openai.gpt-5.6-luna") or
+// any ARN 404s on bedrock-mantle. The identifier therefore decides the
+// endpoint; the model family never did, even though isMantleModel routes on it.
+//
+// resolveBedrockSurface layers the rules so the narrowest signal wins and the
+// broadest — today's family match — stays the fallback, which is what keeps
+// existing configurations byte-identical.
+
+// bedrockApplicationInferenceProfileResource is the ARN resource type of an
+// application inference profile. Compared exactly, never as a substring:
+// "inference-profile" is a prefix of it, so a Contains check would also match
+// the system-defined cross-region profiles and divert them wrongly.
+const bedrockApplicationInferenceProfileResource = "application-inference-profile"
+
+// bedrockCrossRegionPrefixes are the geographic and global inference-profile
+// prefixes AWS puts in front of a model id. These identifiers exist only on
+// bedrock-runtime. None collides with a vendor segment (openai, xai, anthropic,
+// …), so matching the first dotted segment is unambiguous.
+var bedrockCrossRegionPrefixes = []string{"us-gov", "us", "eu", "apac", "au", "jp", "in", "global"}
+
+// bedrockAIPResourceIDPattern matches an application inference profile resource
+// id — the bare alphanumeric token AWS generates, e.g. "3dnkdwuaalc7". Every
+// Bedrock model id is vendor-qualified or version-suffixed and so always carries
+// a separator ("openai.gpt-5.6-luna", "gemma-4-31b", "qwen.qwen3-32b-v1:0");
+// a profile id never does.
+var bedrockAIPResourceIDPattern = regexp.MustCompile(`^[a-zA-Z0-9]+$`)
+
+// isAIPResourceID reports whether model is shaped like an application inference
+// profile resource id rather than a real model id.
+//
+// This decides whether a profile ARN actually belongs to a deployment. The ARN
+// is a prefix that gets joined as {arn}/{model_id}, which only forms a valid
+// profile ARN when model_id is the profile's resource id — so a deployment
+// naming a real model proves the ARN is not its own. That matters most for the
+// key-level ARN, which applies to every model on the credential: without this,
+// a key holding one profile would drag its plain-model deployments onto
+// bedrock-runtime, where AWS rejects the concatenated identifier outright.
+func isAIPResourceID(model string) bool {
+	_, bare := parseBedrockRegionAndModel(model)
+	return bare != "" && bedrockAIPResourceIDPattern.MatchString(bare)
+}
+
+// bedrockSurfaceReason names the rule that chose a surface. Carried into the
+// debug log because a misrouted request is otherwise undiagnosable in the field:
+// every wrong answer looks like the same upstream 404.
+type bedrockSurfaceReason string
+
+const (
+	reasonApplicationProfile    bedrockSurfaceReason = "application_inference_profile"
+	reasonCrossRegionIdentifier bedrockSurfaceReason = "cross_region_identifier"
+	reasonDatasheetRuntimeOnly  bedrockSurfaceReason = "datasheet_runtime_only"
+	reasonDatasheetMantleOnly   bedrockSurfaceReason = "datasheet_mantle_only"
+	reasonModelFamilyFallback   bedrockSurfaceReason = "model_family_fallback"
+)
+
+// bedrockSurface is the endpoint one attempt targets, with the rule that chose
+// it. Only the endpoint is acted on today: which wire API to use on it is
+// already settled downstream by the request type (chat vs responses on mantle)
+// and by the existing Converse/Invoke/Messages selection on runtime.
+type bedrockSurface struct {
+	host   bedrockService
+	reason bedrockSurfaceReason
+}
+
+// isMantle reports whether the attempt targets the Bedrock Mantle endpoint.
+func (s bedrockSurface) isMantle() bool { return s.host == bedrockServiceMantle }
+
+// bedrockARNResourceType returns the resource-type segment of an AWS ARN
+// ("application-inference-profile" for
+// "arn:aws:bedrock:us-east-1:123:application-inference-profile/abc12xyz"), or ""
+// when the value is not an ARN. Both the bare prefix form Bifrost documents and
+// the full form carrying a resource id parse to the same type.
+func bedrockARNResourceType(arn string) string {
+	if !strings.HasPrefix(arn, "arn:") {
+		return ""
+	}
+	// arn:partition:service:region:account-id:resource-type[/:]resource-id
+	parts := strings.SplitN(arn, ":", 6)
+	if len(parts) < 6 {
+		return ""
+	}
+	resource := parts[5]
+	if idx := strings.IndexAny(resource, "/:"); idx >= 0 {
+		resource = resource[:idx]
+	}
+	return resource
+}
+
+// isApplicationInferenceProfileARN reports whether arn names an application
+// inference profile, as opposed to a system-defined cross-region profile.
+func isApplicationInferenceProfileARN(arn string) bool {
+	return bedrockARNResourceType(arn) == bedrockApplicationInferenceProfileResource
+}
+
+// hasBedrockCrossRegionPrefix reports whether model carries a geographic or
+// global inference-profile prefix. Any region prefix ("us-gov-west-1/…") is
+// stripped first, since that is Bifrost's own routing syntax rather than part of
+// the AWS identifier.
+func hasBedrockCrossRegionPrefix(model string) bool {
+	_, bare := parseBedrockRegionAndModel(model)
+	for _, prefix := range bedrockCrossRegionPrefixes {
+		if strings.HasPrefix(bare, prefix+".") {
+			return true
+		}
+	}
+	return false
+}
+
+// bedrockDatasheetAPIs returns the APIs the datasheet publishes for the model on
+// each endpoint. Rows are provider-scoped, so the mantle row and the runtime row
+// are separate lookups and either may be absent.
+func bedrockDatasheetAPIs(ctx *schemas.BifrostContext, model string) (runtime, mantle []schemas.BedrockAPI) {
+	canonical := schemas.ResolveCanonicalModel(ctx, model)
+	return schemas.ResolveModelCaps(schemas.Bedrock, canonical).BedrockAPIs(),
+		schemas.ResolveModelCaps(schemas.BedrockMantle, canonical).BedrockAPIs()
+}
+
+// resolveBedrockSurface picks the endpoint for one attempt.
+//
+// Mantle stays the default for the families the transition-phase divert covers;
+// a request only leaves it when the identifier says it must. The checks run
+// narrowest first, and every one of them fires only on a configuration that is
+// broken today, which is what keeps existing setups byte-identical.
+func resolveBedrockSurface(ctx *schemas.BifrostContext, key schemas.Key, model string) bedrockSurface {
+	// An application inference profile is a bedrock-runtime construct: AWS
+	// rejects it on the Responses and Chat Completions APIs on both endpoints,
+	// so Converse is the only surface that can serve it. Alias-level ARNs take
+	// precedence over the key-level default, which resolveBedrockARN already
+	// handles. The id must look like a profile resource id: a deployment naming
+	// a real model is not covered by the profile ARN, and diverting it would
+	// break a configuration that works today.
+	if isApplicationInferenceProfileARN(resolveBedrockARN(ctx, key)) && isAIPResourceID(model) {
+		return bedrockSurface{host: bedrockServiceRuntime, reason: reasonApplicationProfile}
+	}
+
+	// Cross-region ids exist only on bedrock-runtime; mantle 404s them.
+	if hasBedrockCrossRegionPrefix(model) {
+		return bedrockSurface{host: bedrockServiceRuntime, reason: reasonCrossRegionIdentifier}
+	}
+
+	// The datasheet decides only when it names exactly one endpoint. Seventeen
+	// models (Claude among them) carry rows under both providers, so "both" is
+	// not a signal and falls through rather than guessing.
+	runtimeAPIs, mantleAPIs := bedrockDatasheetAPIs(ctx, model)
+	switch {
+	case len(runtimeAPIs) > 0 && len(mantleAPIs) == 0:
+		return bedrockSurface{host: bedrockServiceRuntime, reason: reasonDatasheetRuntimeOnly}
+	case len(mantleAPIs) > 0 && len(runtimeAPIs) == 0:
+		return bedrockSurface{host: bedrockServiceMantle, reason: reasonDatasheetMantleOnly}
+	}
+
+	// Otherwise today's family match, unchanged.
+	if isMantleModel(ctx, model) {
+		return bedrockSurface{host: bedrockServiceMantle, reason: reasonModelFamilyFallback}
+	}
+	return bedrockSurface{host: bedrockServiceRuntime, reason: reasonModelFamilyFallback}
+}
+
+// routesToMantle resolves the surface and logs the deciding rule.
+func (provider *BedrockProvider) routesToMantle(ctx *schemas.BifrostContext, key schemas.Key, model string) bool {
+	surface := resolveBedrockSurface(ctx, key, model)
+	if provider.logger != nil {
+		provider.logger.Debug("bedrock: model %q routed to %s (%s)", model, surface.host, surface.reason)
+	}
+	return surface.isMantle()
+}

--- a/core/providers/bedrock/surface_test.go
+++ b/core/providers/bedrock/surface_test.go
@@ -1,0 +1,596 @@
+package bedrock
+
+import (
+	"context"
+	"testing"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+func surfaceTestCtx() *schemas.BifrostContext {
+	return schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+}
+
+// withAlias returns a context carrying a resolved alias, optionally with a
+// per-deployment inference profile ARN.
+func withAlias(aliasKey, modelID, profileARN string) *schemas.BifrostContext {
+	ctx := surfaceTestCtx()
+	cfg := &schemas.AliasConfig{ModelID: modelID}
+	if profileARN != "" {
+		cfg.BedrockAliasCfg = &schemas.BedrockAliasCfg{InferenceProfileARN: schemas.NewSecretVar(profileARN)}
+	}
+	ctx.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{Key: aliasKey, Config: cfg})
+	return ctx
+}
+
+func keyWithARN(arn string) schemas.Key {
+	if arn == "" {
+		return schemas.Key{}
+	}
+	return schemas.Key{BedrockKeyConfig: &schemas.BedrockKeyConfig{ARN: schemas.NewSecretVar(arn)}}
+}
+
+// installCaps registers a datasheet stub for the duration of the test.
+func installCaps(t *testing.T, rows map[schemas.ModelProvider]map[string][]schemas.BedrockAPI) {
+	t.Helper()
+	schemas.SetCapabilityResolver(func(provider schemas.ModelProvider, model string) *schemas.ModelCapabilities {
+		apis, ok := rows[provider][model]
+		if !ok {
+			return nil
+		}
+		return &schemas.ModelCapabilities{BedrockAPIs: apis}
+	})
+	t.Cleanup(func() { schemas.SetCapabilityResolver(nil) })
+}
+
+const (
+	appProfileARN    = "arn:aws:bedrock:us-east-1:791152688819:application-inference-profile"
+	appProfileFullID = "arn:aws:bedrock:us-east-1:791152688819:application-inference-profile/3dnkdwuaalc7"
+	sysProfileARN    = "arn:aws:bedrock:us-east-1:791152688819:inference-profile"
+)
+
+func TestBedrockARNResourceType(t *testing.T) {
+	cases := []struct {
+		arn  string
+		want string
+	}{
+		{appProfileARN, "application-inference-profile"},
+		{appProfileFullID, "application-inference-profile"},
+		{sysProfileARN, "inference-profile"},
+		{"arn:aws:bedrock:us-east-1:123:inference-profile/global.openai.gpt-5.6-luna", "inference-profile"},
+		{"arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-v2", "foundation-model"},
+		// Not ARNs.
+		{"openai.gpt-5.6-luna", ""},
+		{"3dnkdwuaalc7", ""},
+		{"", ""},
+		// Malformed: too few segments to carry a resource type.
+		{"arn:aws:bedrock:us-east-1", ""},
+	}
+	for _, tc := range cases {
+		if got := bedrockARNResourceType(tc.arn); got != tc.want {
+			t.Errorf("bedrockARNResourceType(%q) = %q, want %q", tc.arn, got, tc.want)
+		}
+	}
+}
+
+// A system-defined profile ARN must not be mistaken for an application profile:
+// "inference-profile" is a suffix of "application-inference-profile", so a
+// substring test would divert cross-region configs to the wrong endpoint.
+func TestIsApplicationInferenceProfileARN(t *testing.T) {
+	if !isApplicationInferenceProfileARN(appProfileARN) {
+		t.Error("application profile ARN should be recognised")
+	}
+	if isApplicationInferenceProfileARN(sysProfileARN) {
+		t.Error("system-defined profile ARN must NOT be treated as an application profile")
+	}
+	if isApplicationInferenceProfileARN("arn:aws:bedrock:us-east-1:123:inference-profile/us.anthropic.claude-opus-4-8") {
+		t.Error("system-defined profile ARN with resource id must NOT match")
+	}
+}
+
+func TestHasBedrockCrossRegionPrefix(t *testing.T) {
+	cases := []struct {
+		model string
+		want  bool
+	}{
+		{"us.anthropic.claude-opus-4-8", true},
+		{"eu.amazon.nova-pro-v1:0", true},
+		{"apac.anthropic.claude-3-5-sonnet-20241022-v2:0", true},
+		{"au.anthropic.claude-opus-4-6-v1", true},
+		{"jp.anthropic.claude-haiku-4-5-20251001-v1:0", true},
+		{"global.openai.gpt-5.6-luna", true},
+		{"us-gov.anthropic.claude-opus-4-8", true},
+		{"in.openai.gpt-5.6-luna", true},
+		// Region prefix is Bifrost syntax, stripped before the check.
+		{"us-west-2/global.xai.grok-4.6", true},
+		{"us-gov-west-1/openai.gpt-oss-120b", false},
+		// Vendor segments must not be mistaken for geo prefixes.
+		{"openai.gpt-5.6-luna", false},
+		{"xai.grok-4.6", false},
+		{"anthropic.claude-opus-5", false},
+		{"amazon.titan-text-express-v1", false},
+		{"3dnkdwuaalc7", false},
+	}
+	for _, tc := range cases {
+		if got := hasBedrockCrossRegionPrefix(tc.model); got != tc.want {
+			t.Errorf("hasBedrockCrossRegionPrefix(%q) = %v, want %v", tc.model, got, tc.want)
+		}
+	}
+}
+
+func TestResolveBedrockSurface(t *testing.T) {
+	cases := []struct {
+		name       string
+		ctx        *schemas.BifrostContext
+		key        schemas.Key
+		model      string
+		wantMantle bool
+		wantReason bedrockSurfaceReason
+	}{
+		{
+			// The reported bug: an alias-level application profile on a gpt model.
+			// AWS rejects application profiles on Responses/ChatCompletions on both
+			// endpoints, so Converse on bedrock-runtime is the only surface.
+			name:       "alias application profile pins runtime",
+			ctx:        withAlias("gpt-model", "3dnkdwuaalc7", appProfileARN),
+			model:      "3dnkdwuaalc7",
+			wantMantle: false,
+			wantReason: reasonApplicationProfile,
+		},
+		{
+			// A system-defined profile ARN is not an application profile and must
+			// not trigger the divert.
+			name:       "alias system profile does not pin runtime",
+			ctx:        withAlias("gpt-model", "openai.gpt-5.6-luna", sysProfileARN),
+			model:      "openai.gpt-5.6-luna",
+			wantMantle: true,
+			wantReason: reasonModelFamilyFallback,
+		},
+		{
+			name:       "key application profile pins runtime for an opaque id",
+			ctx:        withAlias("claude-alias", "abc12xyz", ""),
+			key:        keyWithARN(appProfileARN),
+			model:      "abc12xyz",
+			wantMantle: false,
+			wantReason: reasonApplicationProfile,
+		},
+		{
+			// A key-level ARN diverts exactly like an alias-level one when the
+			// deployment names a profile resource id. The alias key naming a gpt
+			// model must not pull it back to mantle.
+			name:       "key application profile diverts a gpt-named alias",
+			ctx:        withAlias("gpt-5.6-luna", "3dnkdwuaalc7", ""),
+			key:        keyWithARN(appProfileARN),
+			model:      "3dnkdwuaalc7",
+			wantMantle: false,
+			wantReason: reasonApplicationProfile,
+		},
+		{
+			// Grok on Converse: mantle has no cross-region identifiers, so this
+			// 404s there today.
+			name:       "cross-region grok id pins runtime",
+			ctx:        surfaceTestCtx(),
+			model:      "us.xai.grok-4.6",
+			wantMantle: false,
+			wantReason: reasonCrossRegionIdentifier,
+		},
+		{
+			name:       "cross-region gpt id pins runtime",
+			ctx:        surfaceTestCtx(),
+			model:      "global.openai.gpt-5.6-luna",
+			wantMantle: false,
+			wantReason: reasonCrossRegionIdentifier,
+		},
+		{
+			// The existing-user case: a bare mantle id stays on mantle.
+			name:       "bare mantle id stays on mantle",
+			ctx:        withAlias("gpt-model", "openai.gpt-5.6-luna", ""),
+			model:      "openai.gpt-5.6-luna",
+			wantMantle: true,
+			wantReason: reasonModelFamilyFallback,
+		},
+		{
+			name:       "claude stays on runtime",
+			ctx:        surfaceTestCtx(),
+			model:      "anthropic.claude-opus-5",
+			wantMantle: false,
+			wantReason: reasonModelFamilyFallback,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveBedrockSurface(tc.ctx, tc.key, tc.model)
+			if got.isMantle() != tc.wantMantle {
+				t.Errorf("isMantle = %v, want %v (reason %q)", got.isMantle(), tc.wantMantle, got.reason)
+			}
+			if got.reason != tc.wantReason {
+				t.Errorf("reason = %q, want %q", got.reason, tc.wantReason)
+			}
+		})
+	}
+}
+
+func TestResolveBedrockSurfaceDatasheet(t *testing.T) {
+	installCaps(t, map[schemas.ModelProvider]map[string][]schemas.BedrockAPI{
+		schemas.Bedrock: {
+			// Runtime-only: a Converse model the family match would not divert.
+			"amazon.nova-pro-v1:0": {schemas.BedrockAPIConverse},
+			// Ambiguous — rows on both providers, as Claude and gpt-oss really have.
+			"anthropic.claude-opus-5": {schemas.BedrockAPIConverse, schemas.BedrockAPIMessages},
+			"openai.gpt-oss-120b":     {schemas.BedrockAPIConverse},
+		},
+		schemas.BedrockMantle: {
+			"google.gemma-4-31b":      {schemas.BedrockAPIChatCompletions, schemas.BedrockAPIResponses},
+			"anthropic.claude-opus-5": {schemas.BedrockAPIResponses},
+			"openai.gpt-oss-120b":     {schemas.BedrockAPIChatCompletions},
+		},
+	})
+
+	cases := []struct {
+		name       string
+		model      string
+		wantMantle bool
+		wantReason bedrockSurfaceReason
+	}{
+		{"runtime-only row decides", "amazon.nova-pro-v1:0", false, reasonDatasheetRuntimeOnly},
+		{"mantle-only row decides", "google.gemma-4-31b", true, reasonDatasheetMantleOnly},
+		// Rows on both providers are not a signal: falling through to the family
+		// match is what keeps Claude on Converse and gpt-oss on mantle.
+		{"both rows fall through to family (claude)", "anthropic.claude-opus-5", false, reasonModelFamilyFallback},
+		{"both rows fall through to family (gpt-oss)", "openai.gpt-oss-120b", true, reasonModelFamilyFallback},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveBedrockSurface(surfaceTestCtx(), schemas.Key{}, tc.model)
+			if got.isMantle() != tc.wantMantle || got.reason != tc.wantReason {
+				t.Errorf("got (mantle=%v, reason=%q), want (mantle=%v, reason=%q)",
+					got.isMantle(), got.reason, tc.wantMantle, tc.wantReason)
+			}
+		})
+	}
+}
+
+// Unrecognised API names must be skipped, not treated as a claim: the datasheet
+// ships ahead of the binaries that read it.
+func TestResolveBedrockSurfaceIgnoresUnknownAPIs(t *testing.T) {
+	installCaps(t, map[schemas.ModelProvider]map[string][]schemas.BedrockAPI{
+		schemas.Bedrock: {"openai.gpt-5.6-luna": {schemas.BedrockAPI("batch")}},
+	})
+	got := resolveBedrockSurface(surfaceTestCtx(), schemas.Key{}, "openai.gpt-5.6-luna")
+	if !got.isMantle() || got.reason != reasonModelFamilyFallback {
+		t.Errorf("unknown API should not decide: got (mantle=%v, reason=%q)", got.isMantle(), got.reason)
+	}
+}
+
+// Back-compat lock. With no datasheet installed, every identifier that is not a
+// cross-region id or an ARN must route exactly where isMantleModel sends it
+// today. Cross-region ids are the one deliberate change: they 404 on mantle, so
+// no working configuration can depend on the old answer.
+func TestResolveBedrockSurfaceBackCompat(t *testing.T) {
+	models := []string{
+		"gpt-oss-120b", "openai.gpt-oss-20b", "gpt-oss-safeguard-120b",
+		"gpt-5.5", "openai.gpt-5.4", "openai.gpt-5.6-luna",
+		"gemma-4-31b", "google.gemma-4-e2b", "gemma-4-26b-a4b",
+		"gemma-3-12b-it", "google.gemma-3-27b-it",
+		"xai.grok-4.3", "xai.grok-4.6",
+		"claude-opus-4-8", "anthropic.claude-3-5-sonnet-20240620-v1:0",
+		"amazon.titan-text-express-v1", "amazon.nova-pro-v1:0",
+		"meta.llama3-70b-instruct-v1:0", "cohere.command-r-plus-v1:0",
+		"3dnkdwuaalc7",
+	}
+	ctx := surfaceTestCtx()
+	for _, model := range models {
+		if hasBedrockCrossRegionPrefix(model) || bedrockARNResourceType(model) != "" {
+			t.Fatalf("test list must contain no cross-region or ARN ids, got %q", model)
+		}
+		want := isMantleModel(ctx, model)
+		got := resolveBedrockSurface(ctx, schemas.Key{}, model)
+		if got.isMantle() != want {
+			t.Errorf("%q: surface routed to mantle=%v, but isMantleModel says %v (reason %q)",
+				model, got.isMantle(), want, got.reason)
+		}
+	}
+}
+
+// ---- max_output_tokens floor ----
+
+func capsFor(t *testing.T, model string, min *int) schemas.ModelCaps {
+	t.Helper()
+	if min != nil {
+		schemas.SetCapabilityResolver(func(_ schemas.ModelProvider, m string) *schemas.ModelCapabilities {
+			if m != model {
+				return nil
+			}
+			return &schemas.ModelCapabilities{MinOutputTokens: min}
+		})
+		t.Cleanup(func() { schemas.SetCapabilityResolver(nil) })
+	}
+	return schemas.ResolveModelCaps(schemas.Bedrock, model)
+}
+
+// Bedrock serves the OpenAI family and Grok from an OpenAI-compatible backend
+// that rejects max_output_tokens below 16; Claude and Nova return a single token
+// happily, so clamping them would silently inflate a legitimate request.
+func TestClampMaxTokensFamilyFallback(t *testing.T) {
+	cases := []struct {
+		model string
+		given int
+		want  int
+	}{
+		// Raised to the floor.
+		{"openai.gpt-5.6-luna", 1, 16},
+		{"global.openai.gpt-5.6-luna", 1, 16},
+		{"xai.grok-4.6", 1, 16},
+		{"us.xai.grok-4.6", 15, 16},
+		// Already at or above the floor — untouched.
+		{"openai.gpt-5.6-luna", 16, 16},
+		{"openai.gpt-5.6-luna", 4096, 4096},
+		// No floor: a 1-token request is valid and must survive.
+		{"anthropic.claude-sonnet-4-5-20250929-v1:0", 1, 1},
+		{"us.anthropic.claude-opus-4-8", 1, 1},
+		{"amazon.nova-pro-v1:0", 1, 1},
+		{"meta.llama3-70b-instruct-v1:0", 1, 1},
+	}
+	for _, tc := range cases {
+		caps := capsFor(t, tc.model, nil)
+		got := clampMaxTokens(surfaceTestCtx(), &tc.given, caps)
+		if got == nil || *got != tc.want {
+			t.Errorf("clampMaxTokens(%d, %q) = %v, want %d", tc.given, tc.model, got, tc.want)
+		}
+	}
+}
+
+// The datasheet is authoritative over the family guess, in both directions.
+func TestClampMaxTokensDatasheetOverridesFamily(t *testing.T) {
+	t.Run("raises a model the family guess would not", func(t *testing.T) {
+		floor := 32
+		caps := capsFor(t, "amazon.nova-pro-v1:0", &floor)
+		given := 1
+		if got := clampMaxTokens(surfaceTestCtx(), &given, caps); got == nil || *got != 32 {
+			t.Errorf("got %v, want 32", got)
+		}
+	})
+	t.Run("clears the floor the family guess would apply", func(t *testing.T) {
+		floor := 0
+		caps := capsFor(t, "openai.gpt-5.6-luna", &floor)
+		given := 1
+		if got := clampMaxTokens(surfaceTestCtx(), &given, caps); got == nil || *got != 1 {
+			t.Errorf("got %v, want 1 (datasheet says no floor)", got)
+		}
+	})
+}
+
+func TestClampMaxTokensNil(t *testing.T) {
+	if got := clampMaxTokens(surfaceTestCtx(), nil, capsFor(t, "openai.gpt-5.6-luna", nil)); got != nil {
+		t.Errorf("nil max tokens should stay nil, got %v", got)
+	}
+}
+
+// An application inference profile alias carries an opaque resource id as its
+// model_id, so the floor has to be recognised from the alias chain rather than
+// the wire id alone — this is the reported Claude Code configuration.
+func TestClampMaxTokensRecognisesAliasedProfile(t *testing.T) {
+	given := 1
+	t.Run("alias key names the model", func(t *testing.T) {
+		ctx := withAlias("gpt-5.6-luna", "3dnkdwuaalc7", appProfileARN)
+		caps := schemas.ResolveModelCaps(schemas.Bedrock, schemas.ResolveCanonicalModel(ctx, "3dnkdwuaalc7"))
+		if got := clampMaxTokens(ctx, &given, caps); got == nil || *got != 16 {
+			t.Errorf("got %v, want 16", got)
+		}
+	})
+	t.Run("opaque id with no alias has no floor to find", func(t *testing.T) {
+		ctx := surfaceTestCtx()
+		caps := schemas.ResolveModelCaps(schemas.Bedrock, "3dnkdwuaalc7")
+		if got := clampMaxTokens(ctx, &given, caps); got == nil || *got != 1 {
+			t.Errorf("got %v, want 1 (nothing identifies the model)", got)
+		}
+	})
+}
+
+// ---- Converse reasoning shape ----
+
+// reasoningFields converts a Responses request and returns the
+// additionalModelRequestFields the Converse body would carry.
+func reasoningFields(t *testing.T, ctx *schemas.BifrostContext, model string, reasoning *schemas.ResponsesParametersReasoning) map[string]any {
+	t.Helper()
+	req := &schemas.BifrostResponsesRequest{
+		Provider: schemas.Bedrock,
+		Model:    model,
+		Input:    []schemas.ResponsesMessage{{Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser), Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("hi")}}},
+		Params:   &schemas.ResponsesParameters{Reasoning: reasoning},
+	}
+	out, err := ToBedrockResponsesRequest(ctx, req)
+	if err != nil {
+		t.Fatalf("convert %q: %v", model, err)
+	}
+	if out.AdditionalModelRequestFields == nil {
+		return map[string]any{}
+	}
+	return out.AdditionalModelRequestFields.ToMap()
+}
+
+// gpt-5.6 accepts only additionalModelRequestFields.reasoning={effort} and
+// rejects Nova's reasoningConfig outright; Grok accepts every shape but honors
+// only this one. Everything else on Converse either rejects the field (DeepSeek
+// R1) or ignores it, so it must be omitted entirely.
+func TestConverseReasoningShape(t *testing.T) {
+	effort := func(e string) *schemas.ResponsesParametersReasoning {
+		return &schemas.ResponsesParametersReasoning{Effort: schemas.Ptr(e)}
+	}
+	cases := []struct {
+		name      string
+		model     string
+		reasoning *schemas.ResponsesParametersReasoning
+		wantKey   string // "" ⇒ nothing emitted
+		wantValue map[string]any
+	}{
+		{"openai effort high", "global.openai.gpt-5.6-luna", effort("high"), "reasoning", map[string]any{"effort": "high"}},
+		{"grok effort high", "us.xai.grok-4.6", effort("high"), "reasoning", map[string]any{"effort": "high"}},
+		// minimal is rejected by both; the ladder snaps it to the nearest rung.
+		{"openai effort minimal snaps to low", "global.openai.gpt-5.6-luna", effort("minimal"), "reasoning", map[string]any{"effort": "low"}},
+		{"grok effort minimal snaps to low", "us.xai.grok-4.6", effort("minimal"), "reasoning", map[string]any{"effort": "low"}},
+		// max is accepted by gpt but rejected by Grok, which tops out at xhigh.
+		{"openai effort max kept", "global.openai.gpt-5.6-luna", effort("max"), "reasoning", map[string]any{"effort": "max"}},
+		{"grok effort max snaps to xhigh", "us.xai.grok-4.6", effort("max"), "reasoning", map[string]any{"effort": "xhigh"}},
+		// Disable must use the honored shape — reasoningConfig is ignored by Grok,
+		// so the caller would silently keep getting (and paying for) reasoning.
+		{"openai effort none", "global.openai.gpt-5.6-luna", effort("none"), "reasoning", map[string]any{"effort": "none"}},
+		{"grok effort none", "us.xai.grok-4.6", effort("none"), "reasoning", map[string]any{"effort": "none"}},
+		// Families whose reasoning Converse cannot express get nothing at all.
+		{"deepseek gets nothing", "us.deepseek.r1-v1:0", effort("high"), "", nil},
+		{"qwen gets nothing", "qwen.qwen3-32b-v1:0", effort("high"), "", nil},
+		{"glm gets nothing", "zai.glm-5", effort("high"), "", nil},
+		{"gemma gets nothing", "google.gemma-3-12b-it", effort("high"), "", nil},
+		{"deepseek disable gets nothing", "us.deepseek.r1-v1:0", effort("none"), "", nil},
+		{"glm disable gets nothing", "zai.glm-5", effort("none"), "", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fields := reasoningFields(t, surfaceTestCtx(), tc.model, tc.reasoning)
+			if _, hasNova := fields["reasoningConfig"]; hasNova {
+				t.Errorf("must never send Nova's reasoningConfig to %q: %v", tc.model, fields)
+			}
+			if tc.wantKey == "" {
+				if len(fields) != 0 {
+					t.Errorf("expected no additionalModelRequestFields, got %v", fields)
+				}
+				return
+			}
+			got, ok := fields[tc.wantKey]
+			if !ok {
+				t.Fatalf("missing %q in %v", tc.wantKey, fields)
+			}
+			gotMap, _ := got.(map[string]any)
+			for k, want := range tc.wantValue {
+				if gotMap[k] != want {
+					t.Errorf("%s.%s = %v, want %v", tc.wantKey, k, gotMap[k], want)
+				}
+			}
+		})
+	}
+}
+
+// Anthropic and Nova keep their own shapes.
+func TestConverseReasoningLeavesAnthropicAndNovaAlone(t *testing.T) {
+	r := &schemas.ResponsesParametersReasoning{Effort: schemas.Ptr("high")}
+	if f := reasoningFields(t, surfaceTestCtx(), "us.anthropic.claude-sonnet-4-5-20250929-v1:0", r); f["thinking"] == nil {
+		t.Errorf("anthropic should still get thinking, got %v", f)
+	}
+	if f := reasoningFields(t, surfaceTestCtx(), "us.amazon.nova-pro-v1:0", r); f["reasoningConfig"] == nil {
+		t.Errorf("nova should still get reasoningConfig, got %v", f)
+	}
+}
+
+// An alias or application inference profile hides the family behind an opaque
+// wire id. IsOpenAIModelFamily walks the alias chain by itself, but IsGrokModel
+// is a bare substring match, so passing the raw request model dropped reasoning
+// for aliased Grok entirely — enabled and disabled alike.
+func TestConverseReasoningResolvesAliasedGrok(t *testing.T) {
+	aliasedGrok := func(t *testing.T) *schemas.BifrostContext {
+		t.Helper()
+		ctx := withAlias("my-grok", "3dnkdwuaalc7", appProfileARN)
+		ra := schemas.GetResolvedAlias(ctx)
+		name := "grok-4.6"
+		ra.Config.ModelName = &name
+		return ctx
+	}
+	cases := []struct {
+		name       string
+		effort     string
+		wantEffort string
+	}{
+		{"enabled", "high", "high"},
+		{"clamped to grok's ladder", "max", "xhigh"},
+		{"disabled", "none", "none"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fields := reasoningFields(t, aliasedGrok(t), "3dnkdwuaalc7",
+				&schemas.ResponsesParametersReasoning{Effort: schemas.Ptr(tc.effort)})
+			got, ok := fields["reasoning"]
+			if !ok {
+				t.Fatalf("aliased Grok must still get a reasoning field, got %v", fields)
+			}
+			if m, _ := got.(map[string]any); m["effort"] != tc.wantEffort {
+				t.Errorf("effort = %v, want %q", m["effort"], tc.wantEffort)
+			}
+		})
+	}
+}
+
+// The same alias shape must keep the OpenAI arm working (it resolves via the
+// alias chain rather than the wire id too).
+func TestConverseReasoningResolvesAliasedOpenAI(t *testing.T) {
+	ctx := withAlias("my-gpt", "3dnkdwuaalc7", appProfileARN)
+	ra := schemas.GetResolvedAlias(ctx)
+	name := "gpt-5.6-luna"
+	ra.Config.ModelName = &name
+	fields := reasoningFields(t, ctx, "3dnkdwuaalc7",
+		&schemas.ResponsesParametersReasoning{Effort: schemas.Ptr("max")})
+	got, ok := fields["reasoning"]
+	if !ok {
+		t.Fatalf("aliased gpt must get a reasoning field, got %v", fields)
+	}
+	// gpt accepts "max"; only Grok clamps it.
+	if m, _ := got.(map[string]any); m["effort"] != "max" {
+		t.Errorf("effort = %v, want max", m["effort"])
+	}
+}
+
+// A profile ARN is a prefix joined as {arn}/{model_id}, so it only applies to a
+// deployment whose model_id is the profile's resource id. A key-level ARN spans
+// every model on the credential, so a deployment naming a real model must keep
+// routing exactly as it did before the ARN existed — AWS rejects the
+// concatenated identifier ("The provided model identifier is invalid").
+func TestApplicationProfileOnlyDivertsProfileResourceIDs(t *testing.T) {
+	cases := []struct {
+		name       string
+		modelID    string
+		wantMantle bool
+		wantReason bedrockSurfaceReason
+	}{
+		{"profile resource id diverts", "3dnkdwuaalc7", false, reasonApplicationProfile},
+		{"short profile id diverts", "abc12xyz", false, reasonApplicationProfile},
+		// Real model ids on the same key are untouched by its profile ARN.
+		{"mantle model id stays on mantle", "openai.gpt-5.6-luna", true, reasonModelFamilyFallback},
+		{"gemma-4 stays on mantle", "gemma-4-31b", true, reasonModelFamilyFallback},
+		{"grok id stays on mantle", "xai.grok-4.6", true, reasonModelFamilyFallback},
+		{"claude id stays on runtime", "anthropic.claude-opus-4-8", false, reasonModelFamilyFallback},
+		{"versioned id stays put", "qwen.qwen3-32b-v1:0", false, reasonModelFamilyFallback},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, level := range []string{"key", "alias"} {
+				ctx, key := surfaceTestCtx(), schemas.Key{}
+				if level == "key" {
+					key = keyWithARN(appProfileARN)
+				} else {
+					ctx = withAlias("d", tc.modelID, appProfileARN)
+				}
+				got := resolveBedrockSurface(ctx, key, tc.modelID)
+				if got.isMantle() != tc.wantMantle || got.reason != tc.wantReason {
+					t.Errorf("%s-level: got (mantle=%v, %q), want (mantle=%v, %q)",
+						level, got.isMantle(), got.reason, tc.wantMantle, tc.wantReason)
+				}
+			}
+		})
+	}
+}
+
+func TestIsAIPResourceID(t *testing.T) {
+	for _, id := range []string{"3dnkdwuaalc7", "53zk8ewxcsfh", "abc12xyz"} {
+		if !isAIPResourceID(id) {
+			t.Errorf("%q should look like a profile resource id", id)
+		}
+	}
+	for _, id := range []string{
+		"openai.gpt-5.6-luna", "anthropic.claude-opus-4-8", "gemma-4-31b",
+		"zai.glm-5", "qwen.qwen3-32b-v1:0", "deepseek.v3.2", "us.xai.grok-4.6",
+		"moonshotai.kimi-k2-thinking", "amazon.nova-pro-v1:0", "",
+	} {
+		if isAIPResourceID(id) {
+			t.Errorf("%q is a real model id, must not look like a profile resource id", id)
+		}
+	}
+}

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tidwall/sjson"
 
 	"github.com/maximhq/bifrost/core/providers/anthropic"
+	openai "github.com/maximhq/bifrost/core/providers/openai"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	schemas "github.com/maximhq/bifrost/core/schemas"
 )
@@ -374,6 +375,7 @@ func convertChatParameters(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifr
 
 	// Convert inference config
 	if inferenceConfig := convertInferenceConfig(bifrostReq.Params, caps); inferenceConfig != nil {
+		inferenceConfig.MaxTokens = clampMaxTokens(ctx, inferenceConfig.MaxTokens, caps)
 		bedrockReq.InferenceConfig = inferenceConfig
 	}
 
@@ -514,11 +516,15 @@ func convertChatParameters(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifr
 				}
 
 				bedrockReq.AdditionalModelRequestFields.Set("reasoningConfig", config)
-			} else {
-				bedrockReq.AdditionalModelRequestFields.Set("reasoningConfig", map[string]any{
-					"type":          "enabled",
-					"budget_tokens": tokenBudget,
-				})
+			} else if levels, ok := converseReasoningEffortLevels(ctx, caps); ok {
+				// Converse exposes no token budget for these models, so express the
+				// budget as the effort it corresponds to.
+				maxTokens := providerUtils.GetMaxOutputTokensOrDefault(bifrostReq.Provider, bifrostReq.Model, DefaultCompletionMaxTokens)
+				if bedrockReq.InferenceConfig != nil && bedrockReq.InferenceConfig.MaxTokens != nil {
+					maxTokens = *bedrockReq.InferenceConfig.MaxTokens
+				}
+				effort := providerUtils.GetReasoningEffortFromBudgetTokens(tokenBudget, MinimumReasoningMaxTokens, maxTokens)
+				setConverseReasoningEffort(bedrockReq.AdditionalModelRequestFields, caps, levels, effort)
 			}
 		} else if bifrostReq.Params.Reasoning.Effort != nil && *bifrostReq.Params.Reasoning.Effort != "none" {
 			modelDefaultMaxTokens := providerUtils.GetMaxOutputTokensOrDefault(bifrostReq.Provider, bifrostReq.Model, DefaultCompletionMaxTokens)
@@ -585,6 +591,8 @@ func convertChatParameters(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifr
 						"budget_tokens": budgetTokens,
 					})
 				}
+			} else if levels, ok := converseReasoningEffortLevels(ctx, caps); ok {
+				setConverseReasoningEffort(bedrockReq.AdditionalModelRequestFields, caps, levels, *bifrostReq.Params.Reasoning.Effort)
 			}
 		} else {
 			if schemas.IsAnthropicModelFamily(ctx, bifrostReq.Model) {
@@ -597,10 +605,8 @@ func convertChatParameters(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifr
 				bedrockReq.AdditionalModelRequestFields.Set("reasoningConfig", map[string]any{
 					"type": "disabled",
 				})
-			} else {
-				bedrockReq.AdditionalModelRequestFields.Set("reasoningConfig", map[string]any{
-					"type": "disabled",
-				})
+			} else if levels, ok := converseReasoningEffortLevels(ctx, caps); ok {
+				setConverseReasoningEffort(bedrockReq.AdditionalModelRequestFields, caps, levels, "none")
 			}
 		}
 	}
@@ -1828,6 +1834,79 @@ func convertTextFormatToTool(ctx *schemas.BifrostContext, model string, textConf
 			},
 		},
 	}, nil, nil
+}
+
+// Effort ladders Converse accepts, verified against bedrock-runtime: both
+// families reject "minimal", and Grok additionally rejects "max".
+// NormalizeReasoningEffort snaps an unsupported label onto the nearest rung, so
+// "minimal" resolves to "low" and Grok's "max" to "xhigh" with no explicit renames.
+var (
+	bedrockConverseOpenAIEffortLevels = &schemas.EffortControl{
+		Levels: []string{"none", "low", "medium", "high", "xhigh", "max"},
+	}
+	bedrockConverseGrokEffortLevels = &schemas.EffortControl{
+		Levels: []string{"none", "low", "medium", "high", "xhigh"},
+	}
+)
+
+// converseReasoningEffortLevels returns the effort ladder for models that take
+// the OpenAI-shaped `reasoning: {effort}` field on Converse, and false for the
+// models that take no reasoning field at all.
+//
+// Verified against bedrock-runtime: gpt-5.6 accepts only this shape and rejects
+// Nova's reasoningConfig outright, while Grok accepts every shape but honors
+// only this one — so the reasoningConfig sent today is silently ignored there
+// and a caller asking to disable reasoning still gets it. No other Converse
+// family surfaces reasoning at all: DeepSeek R1 fails on any
+// additionalModelRequestFields, and DeepSeek V3.2, Qwen, GLM and Gemma accept
+// the field and ignore it. Their reasoning is only reachable on the
+// OpenAI-compatible mantle surface, so on Converse they get nothing.
+// Takes ModelCaps rather than the wire model: callers hold the raw request
+// value, which for an alias or an application inference profile is an opaque id
+// carrying no family. IsOpenAIModelFamily walks the alias chain on its own, but
+// IsGrokModel is a bare substring match, so a Grok alias would fall through and
+// silently lose reasoning entirely. caps.Model() is the canonical name.
+func converseReasoningEffortLevels(ctx *schemas.BifrostContext, caps schemas.ModelCaps) (*schemas.EffortControl, bool) {
+	switch {
+	case schemas.IsGrokModel(caps.Model()):
+		return bedrockConverseGrokEffortLevels, true
+	case schemas.IsOpenAIModelFamily(ctx, caps.Model()):
+		return bedrockConverseOpenAIEffortLevels, true
+	}
+	return nil, false
+}
+
+// setConverseReasoningEffort writes the OpenAI-shaped reasoning field, mapping
+// the requested effort onto a rung the model publishes.
+func setConverseReasoningEffort(fields *schemas.OrderedMap, caps schemas.ModelCaps, levels *schemas.EffortControl, effort string) {
+	fields.Set("reasoning", map[string]any{"effort": caps.NormalizeReasoningEffort(effort, levels)})
+}
+
+// clampMaxTokens raises maxTokens to the floor the model enforces on
+// max_output_tokens, leaving it alone when the model has none.
+//
+// Bedrock serves the OpenAI family and xAI Grok from an OpenAI-compatible
+// backend that rejects anything below 16, while Claude and Nova happily return a
+// single token — so this is gated rather than applied to Converse as a whole.
+// The mantle path gets the same clamp for free from the OpenAI request builder;
+// Converse builds its own body and needs its own. The datasheet's
+// min_output_tokens overrides the name-based guess.
+func clampMaxTokens(ctx *schemas.BifrostContext, maxTokens *int, caps schemas.ModelCaps) *int {
+	if maxTokens == nil {
+		return nil
+	}
+	// IsOpenAIModelFamily walks the alias chain (canonical name → wire id → alias
+	// key), so an application inference profile whose model_id is an opaque
+	// resource id is still recognised. Grok has no ModelFamily of its own, so it
+	// stays a name match on the canonical model.
+	fallback := 0
+	if schemas.IsOpenAIModelFamily(ctx, caps.Model()) || schemas.IsGrokModel(caps.Model()) {
+		fallback = openai.MinMaxCompletionTokens
+	}
+	if floor := caps.MinOutputTokens(fallback); floor > 0 && *maxTokens < floor {
+		return schemas.Ptr(floor)
+	}
+	return maxTokens
 }
 
 // convertInferenceConfig converts Bifrost parameters to Bedrock inference config

--- a/core/schemas/modelcapabilities.go
+++ b/core/schemas/modelcapabilities.go
@@ -1,5 +1,7 @@
 package schemas
 
+import "slices"
+
 // ModelCapabilities is the per-(model, provider) capability record sourced from
 // the bifrost datasheet (https://getbifrost.ai/datasheet). It is the single
 // source of truth for behaviour the runtime previously hard-coded — model limits
@@ -177,6 +179,13 @@ type ModelCapabilities struct {
 	// Default max_tokens when the caller omits it (Anthropic requires a value).
 	DefaultMaxTokens *int `json:"default_max_tokens,omitempty"`
 
+	// Floor the provider enforces on max_output_tokens. A request below it is
+	// rejected outright rather than clamped upstream, so callers raise the value
+	// to this floor. Models served by an OpenAI-compatible backend require 16 —
+	// on Bedrock that covers the OpenAI family and xAI Grok, while Claude and
+	// Nova accept 1. Absent ⇒ the caller's own fallback; zero ⇒ no floor.
+	MinOutputTokens *int `json:"min_output_tokens,omitempty"`
+
 	// Floor for reasoning budget tokens.
 	MinReasoningMaxTokens *int `json:"min_reasoning_max_tokens,omitempty"`
 
@@ -232,7 +241,62 @@ type ModelCapabilities struct {
 	// ---- Bedrock model-family flags consumed by the runtime ----
 
 	// Bedrock: Cohere Command R/R+ uses native text-completion shape, not Converse.
+	//
+	// Deprecated: never populated and never read. Subsumed by BedrockAPIs
+	// ["invoke"]; remove once the feed drops the key.
 	IsCohereCommandR *bool `json:"is_cohere_command_r,omitempty"`
+
+	// Wire APIs this model accepts on the AWS endpoint the row is scoped to.
+	// The host is NOT encoded in the value — it comes from the row's provider
+	// ("bedrock" ⇒ bedrock-runtime, "bedrock_mantle" ⇒ bedrock-mantle), so the
+	// same value means different endpoints on different rows and a model gaining
+	// a surface is a new value on the matching row, not a new vocabulary:
+	//
+	//   openai.gpt-5.6-luna        provider bedrock_mantle → ["responses"]
+	//   global.openai.gpt-5.6-luna provider bedrock        → ["converse"]
+	//
+	// Listed in preference order. Unrecognised entries are skipped rather than
+	// rejected, so the datasheet may ship an API ahead of the binary that reads
+	// it. An empty list is treated as absent.
+	//
+	// This is a claim, not a constraint: the configured model identifier wins
+	// when the two disagree, because AWS rejects a mismatched identifier
+	// outright (a bare id 400s on bedrock-runtime, a cross-region or ARN id 404s
+	// on bedrock-mantle). Callers must resolve identifier form first.
+	BedrockAPIs []BedrockAPI `json:"bedrock_apis,omitempty"`
+}
+
+// BedrockAPI names one wire API on a Bedrock endpoint. Which endpoint serves it
+// is carried by the datasheet row's provider, not by the value — see
+// ModelCapabilities.BedrockAPIs.
+type BedrockAPI string
+
+const (
+	// Served by bedrock-runtime.
+	BedrockAPIConverse BedrockAPI = "converse"
+	BedrockAPIInvoke   BedrockAPI = "invoke"
+	BedrockAPIMessages BedrockAPI = "messages"
+
+	// Served by bedrock-mantle today, and by bedrock-runtime once that surface
+	// is wired — the row's provider distinguishes them.
+	BedrockAPIChatCompletions BedrockAPI = "chat_completions"
+	BedrockAPIResponses       BedrockAPI = "responses"
+)
+
+// BedrockAPIValues lists every recognised BedrockAPI.
+var BedrockAPIValues = []BedrockAPI{
+	BedrockAPIConverse,
+	BedrockAPIInvoke,
+	BedrockAPIMessages,
+	BedrockAPIChatCompletions,
+	BedrockAPIResponses,
+}
+
+// IsValid reports whether a is an API this binary knows how to reach. Values the
+// datasheet publishes ahead of the runtime are simply not valid yet, and callers
+// skip them.
+func (a BedrockAPI) IsValid() bool {
+	return slices.Contains(BedrockAPIValues, a)
 }
 
 // ModelParameterDescriptor is one entry of the datasheet's model_parameters

--- a/core/schemas/modelcaps.go
+++ b/core/schemas/modelcaps.go
@@ -481,3 +481,39 @@ func (c ModelCaps) SupportsTextEditorTool(fallback bool) bool {
 	}
 	return fallback
 }
+
+// ---- Bedrock surface selection ----
+
+// BedrockAPIs returns the wire APIs the datasheet says this (provider, model)
+// pair accepts, in the row's preference order, dropping any value this binary
+// does not recognise. Returns nil when the row says nothing, publishes an empty
+// list, or lists only unrecognised values — callers then fall back to their own
+// detection.
+//
+// The endpoint is the one the resolved row is scoped to, so a caller spanning
+// both Bedrock surfaces resolves ModelCaps once per provider and reads each.
+func (c ModelCaps) BedrockAPIs() []BedrockAPI {
+	if c.record == nil || len(c.record.BedrockAPIs) == 0 {
+		return nil
+	}
+	apis := make([]BedrockAPI, 0, len(c.record.BedrockAPIs))
+	for _, api := range c.record.BedrockAPIs {
+		if api.IsValid() && !slices.Contains(apis, api) {
+			apis = append(apis, api)
+		}
+	}
+	if len(apis) == 0 {
+		return nil
+	}
+	return apis
+}
+
+// MinOutputTokens returns the floor the model enforces on max_output_tokens.
+// Prefers the datasheet's min_output_tokens, falling back to the caller's
+// name-based answer. Zero means no floor, so callers clamp only above zero.
+func (c ModelCaps) MinOutputTokens(fallback int) int {
+	if c.record != nil && c.record.MinOutputTokens != nil {
+		return *c.record.MinOutputTokens
+	}
+	return fallback
+}


### PR DESCRIPTION
## Summary

Fixes misrouting of Bedrock requests when an application inference profile ARN is configured at the key or alias level. Previously, `isMantleModel` routed based solely on model family name, causing requests with application inference profile ARNs (which only bedrock-runtime/Converse can serve) to be sent to bedrock-mantle and receive 404s. Additionally fixes silent reasoning misconfiguration for OpenAI and Grok models on Converse, where Nova's `reasoningConfig` shape was being sent but ignored, and adds a `max_output_tokens` floor clamp for the OpenAI-compatible backend that rejects values below 16.

## Changes

- **Surface routing (`surface.go`)**: Replaces the `isMantleModel` call at all four dispatch points (`ChatCompletion`, `ChatCompletionStream`, `Responses`, `ResponsesStream`) with `provider.routesToMantle`, which runs a layered resolution: application inference profile ARNs pin bedrock-runtime first, cross-region identifier prefixes (`us.`, `eu.`, `global.`, etc.) pin bedrock-runtime second, the datasheet's `BedrockAPIs` field decides when it names exactly one endpoint, and the existing family match remains the fallback. This keeps all existing configurations byte-identical while fixing the broken cases.

- **Converse reasoning shape (`utils.go`, `responses.go`)**: Introduces `converseReasoningEffortLevels` and `setConverseReasoningEffort` to emit the OpenAI-shaped `reasoning: {effort}` field for gpt and Grok models on Converse, replacing the Nova-shaped `reasoningConfig` that was previously sent and silently ignored. Grok's effort ladder tops out at `xhigh`; gpt's extends to `max`. Models with no Converse reasoning surface (DeepSeek, Qwen, GLM, Gemma) now emit nothing rather than a field the model ignores or rejects. The `none` effort case now also uses the correct shape so callers can actually disable reasoning on Grok.

- **`max_output_tokens` floor (`utils.go`)**: Adds `clampMaxTokens`, which raises `max_output_tokens` to 16 for models served by the OpenAI-compatible backend (OpenAI family and Grok) while leaving Claude and Nova untouched. The clamp is applied in both the chat and responses paths. The datasheet's `min_output_tokens` field overrides the name-based guess in both directions.

- **Datasheet schema (`modelcapabilities.go`, `modelcaps.go`)**: Adds `BedrockAPIs []BedrockAPI` to `ModelCapabilities` to record which wire APIs a model accepts on each endpoint, and `MinOutputTokens *int` for the per-model output token floor. Adds `ModelCaps.BedrockAPIs()` and `ModelCaps.MinOutputTokens(fallback)` accessors. Unrecognised API values are skipped so the datasheet can ship ahead of the binary.

- **Debug logging**: `routesToMantle` logs the deciding rule at debug level, making misrouted requests diagnosable without a code change.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/bedrock/... -run TestResolveBedrockSurface
go test ./core/providers/bedrock/... -run TestClampMaxTokens
go test ./core/providers/bedrock/... -run TestConverseReasoningShape
go test ./core/providers/bedrock/... -run TestConverseReasoningLeavesAnthropicAndNovaAlone
go test ./core/providers/bedrock/... -run TestBedrockARNResourceType
go test ./core/providers/bedrock/... -run TestIsApplicationInferenceProfileARN
go test ./core/providers/bedrock/... -run TestHasBedrockCrossRegionPrefix
go test ./core/providers/bedrock/... -run TestResolveBedrockSurfaceBackCompat
go test ./...
```

To validate end-to-end: configure a key with an application inference profile ARN pointing to a gpt-family model and send a chat completion request. Previously this 404'd on bedrock-mantle; it should now route to bedrock-runtime/Converse and succeed. Similarly, send a request with `reasoning: {effort: "none"}` to a Grok model and confirm reasoning is actually disabled.

## Breaking changes

- [x] No

Cross-region identifiers (`us.model`, `global.model`, etc.) are now always routed to bedrock-runtime rather than mantle. No working configuration could have depended on the previous answer because mantle 404s those identifiers.

## Related issues

Closes the misrouting bug where alias-level or key-level application inference profile ARNs on gpt-family models caused 404s on bedrock-mantle.

## Security considerations

No auth, secrets, or PII changes. The ARN is read from the existing key/alias config and used only for routing decisions; it is not logged.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable