### PR TITLE
feat: add `allow_all_providers` support in helm

### DIFF
--- a/core/schemas/grant.go
+++ b/core/schemas/grant.go
@@ -116,6 +116,12 @@ type Permit interface {
 	ProviderPermits() []ProviderPermit
 	// MCPPermits is every MCP client the permit allows tools of.
 	MCPPermits() []MCPPermit
+
+	// AllowsAllProviders reports whether the permit grants every provider, including ones it holds no
+	// provider permit for. It coexists with ProviderPermits: a provider the permit lists still has
+	// that permit's model, key, and weight rules applied; a provider it lists none for is allowed with
+	// all models and all keys. False is the default, deny-by-default behaviour.
+	AllowsAllProviders() bool
 }
 
 // Access is an attempt's resolved access: the permits the caller holds, the permit scoping the

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -93036,6 +93036,10 @@
           "calendar_aligned": {
             "type": "boolean"
           },
+          "allow_all_providers": {
+            "type": "boolean",
+            "description": "When true, this virtual key may use every configured provider. provider_configs still apply as optional per-provider overrides (budgets, rate limits, model allow/blacklists, key selection); a provider without a config gets all models, all keys, and no per-provider limits.\n"
+          },
           "team": {
             "$ref": "#/components/schemas/Team"
           },
@@ -93422,6 +93426,11 @@
             "type": "boolean",
             "default": false
           },
+          "allow_all_providers": {
+            "type": "boolean",
+            "default": false,
+            "description": "When true, this virtual key may use every configured provider. provider_configs remain optional per-provider overrides for budgets, rate limits, model allow/blacklists, and key selection.\n"
+          },
           "expires_at": {
             "type": "string",
             "format": "date-time",
@@ -93526,6 +93535,10 @@
           },
           "calendar_aligned": {
             "type": "boolean"
+          },
+          "allow_all_providers": {
+            "type": "boolean",
+            "description": "When true, this virtual key may use every configured provider. provider_configs remain optional per-provider overrides. Omit to leave the current setting unchanged.\n"
           },
           "reset_budget_usage": {
             "type": "boolean",

--- a/docs/openapi/schemas/management/governance.yaml
+++ b/docs/openapi/schemas/management/governance.yaml
@@ -406,6 +406,12 @@ VirtualKey:
       type: string
     calendar_aligned:
       type: boolean
+    allow_all_providers:
+      type: boolean
+      description: >
+        When true, this virtual key may use every configured provider. provider_configs still apply as
+        optional per-provider overrides (budgets, rate limits, model allow/blacklists, key selection);
+        a provider without a config gets all models, all keys, and no per-provider limits.
     team:
       $ref: '#/Team'
     customer:
@@ -441,7 +447,7 @@ CreateVirtualKeyRequest:
       type: string
     provider_configs:
       type: array
-      description: Provider configurations (empty means no providers allowed, deny-by-default)
+      description: Provider configurations. When allow_all_providers is omitted or false, an empty list allows no providers (deny-by-default); when true, providers without a config are allowed with all models and keys.
       items:
         type: object
         properties:
@@ -497,6 +503,12 @@ CreateVirtualKeyRequest:
     calendar_aligned:
       type: boolean
       default: false
+    allow_all_providers:
+      type: boolean
+      default: false
+      description: >
+        When true, this virtual key may use every configured provider. provider_configs remain optional
+        per-provider overrides for budgets, rate limits, model allow/blacklists, and key selection.
     expires_at:
       type: string
       format: date-time
@@ -569,6 +581,11 @@ UpdateVirtualKeyRequest:
       type: boolean
     calendar_aligned:
       type: boolean
+    allow_all_providers:
+      type: boolean
+      description: >
+        When true, this virtual key may use every configured provider. provider_configs remain optional
+        per-provider overrides. Omit to leave the current setting unchanged.
     reset_budget_usage:
       type: boolean
       description: >

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -1003,6 +1003,12 @@ func GenerateVirtualKeyHash(vk tables.TableVirtualKey) (string, error) {
 	} else {
 		hash.Write([]byte("isActive:false"))
 	}
+	// Hash AllowAllProviders so a config.json flip triggers re-sync
+	if vk.AllowAllProviders {
+		hash.Write([]byte("allowAllProviders:true"))
+	} else {
+		hash.Write([]byte("allowAllProviders:false"))
+	}
 	// Hash ExpiresAt only when set, so rows created before expiry existed keep their hash
 	if vk.ExpiresAt != nil {
 		hash.Write([]byte("expiresAt:" + vk.ExpiresAt.UTC().Format(time.RFC3339Nano)))

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -488,6 +488,8 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_databricks_key_config_columns"}, run: migrationAddDatabricksKeyConfigColumns},
 	{IDs: []string{"add_github_copilot_config_columns"}, run: migrationAddGithubCopilotConfigColumns},
 	{IDs: []string{"add_mcp_client_endpoint_slug"}, run: migrationAddMCPClientEndpointSlug},
+	{IDs: []string{"add_allow_all_providers_to_virtual_key"}, run: migrationAddAllowAllProvidersToVirtualKey},
+	{IDs: []string{"backfill_vk_allow_all_providers_hash"}, run: migrationBackfillVirtualKeyAllowAllProvidersHash},
 }
 
 // videoResolutionPricingColumns are the resolution-banded video output rate columns.
@@ -563,6 +565,85 @@ func migrationAddCompatAzureDeepseekColumn(ctx context.Context, db *gorm.DB, log
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running compat_azure_deepseek migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddAllowAllProvidersToVirtualKey adds the allow_all_providers column to the virtual
+// key table. Default false preserves the existing deny-by-default behaviour, so the column needs
+// no data backfill: existing VKs keep allowing only the providers in their ProviderConfigs. The
+// config_hash is refreshed separately by migrationBackfillVirtualKeyAllowAllProvidersHash, since
+// allow_all_providers now feeds GenerateVirtualKeyHash.
+func migrationAddAllowAllProvidersToVirtualKey(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_allow_all_providers_to_virtual_key"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if err := addColumnIfNotExists(tx, logger, &tables.TableVirtualKey{}, "allow_all_providers"); err != nil {
+				return err
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if err := dropColumnIfExists(tx, logger, &tables.TableVirtualKey{}, "allow_all_providers"); err != nil {
+				return err
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running add allow_all_providers to virtual key migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationBackfillVirtualKeyAllowAllProvidersHash recomputes config_hash for every virtual key
+// after allow_all_providers joined GenerateVirtualKeyHash. Existing rows carry a hash computed
+// without that field, so without this backfill config synchronization would see false drift on the
+// first boot after upgrade. It is a separate migration from the column-add so the DDL's lock is
+// never held across this SELECT + UPDATE backfill. The hash is deterministic, so this is safe to
+// re-run.
+func migrationBackfillVirtualKeyAllowAllProvidersHash(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "backfill_vk_allow_all_providers_hash"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+
+			var virtualKeys []tables.TableVirtualKey
+			if err := tx.
+				Preload("ProviderConfigs").
+				Preload("ProviderConfigs.Keys").
+				Preload("MCPConfigs").
+				Find(&virtualKeys).Error; err != nil {
+				return fmt.Errorf("failed to fetch virtual keys for hash recomputation: %w", err)
+			}
+			logger.Info("[configstore] %s: processing %d virtualKeys", migrationName, len(virtualKeys))
+			for _, vk := range virtualKeys {
+				newHash, err := GenerateVirtualKeyHash(vk)
+				if err != nil {
+					return fmt.Errorf("failed to generate hash for VK %s: %w", vk.ID, err)
+				}
+				if err := tx.Model(&tables.TableVirtualKey{}).
+					Where("id = ?", vk.ID).
+					Update("config_hash", newHash).Error; err != nil {
+					return fmt.Errorf("failed to update config_hash for VK %s: %w", vk.ID, err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running backfill_vk_allow_all_providers_hash migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/migrations_test.go
+++ b/framework/configstore/migrations_test.go
@@ -1876,6 +1876,39 @@ func TestMigrationBackfillEmptyVirtualKeyConfigs(t *testing.T) {
 	assert.NotEmpty(t, vkHash, "VK config_hash should be recomputed after backfill")
 }
 
+func TestMigrationBackfillVirtualKeyAllowAllProvidersHash(t *testing.T) {
+	_, db := setupFullMigrationDB(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	// Clear the migration tracking so the backfill runs against our seeded row.
+	db.Exec(`DELETE FROM migrations WHERE id = 'backfill_vk_allow_all_providers_hash'`)
+
+	// Existing VK with allow_all_providers=false and a stale config_hash from before the field
+	// joined GenerateVirtualKeyHash.
+	err := db.Exec(`INSERT INTO governance_virtual_keys (id, name, value, is_active, allow_all_providers, config_hash, encryption_status, created_at, updated_at)
+		VALUES ('vk-aap-hash-1', 'aap-vk', 'vk-value', true, false, 'stale_hash', 'plain_text', ?, ?)`, now, now).Error
+	require.NoError(t, err)
+
+	err = migrationBackfillVirtualKeyAllowAllProvidersHash(ctx, db, testMigrationLogger)
+	require.NoError(t, err)
+
+	var vkHash string
+	err = db.Table("governance_virtual_keys").Select("config_hash").
+		Where("id = ?", "vk-aap-hash-1").Scan(&vkHash).Error
+	require.NoError(t, err)
+	assert.NotEqual(t, "stale_hash", vkHash, "config_hash should be recomputed, not the stale value")
+
+	// The recomputed hash must match GenerateVirtualKeyHash for the row as read back.
+	var vk tables.TableVirtualKey
+	err = db.Preload("ProviderConfigs").Preload("ProviderConfigs.Keys").Preload("MCPConfigs").
+		Where("id = ?", "vk-aap-hash-1").First(&vk).Error
+	require.NoError(t, err)
+	expected, err := GenerateVirtualKeyHash(vk)
+	require.NoError(t, err)
+	assert.Equal(t, expected, vkHash, "config_hash should match GenerateVirtualKeyHash output")
+}
+
 func TestTriggerMigrationsAddsVKProviderConfigBlacklistColumnBeforeBackfill(t *testing.T) {
 	_, db := setupFullMigrationDB(t)
 	ctx := context.Background()

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -3859,7 +3859,7 @@ func (s *RDBConfigStore) UpdateVirtualKey(ctx context.Context, virtualKey *table
 			virtualKey.RotatedAt = existing.RotatedAt
 		}
 		if err := txDB.WithContext(ctx).
-			Select("name", "description", "value", "is_active", "expires_at", "team_id", "customer_id", "rate_limit_id", "calendar_aligned", "config_hash", "updated_at", "encryption_status", "value_hash", "previous_value", "previous_value_hash", "previous_value_expires_at", "rotated_at").
+			Select("name", "description", "value", "is_active", "expires_at", "team_id", "customer_id", "rate_limit_id", "calendar_aligned", "allow_all_providers", "config_hash", "updated_at", "encryption_status", "value_hash", "previous_value", "previous_value_hash", "previous_value_expires_at", "rotated_at").
 			Updates(virtualKey).Error; err != nil {
 			return s.parseGormError(err)
 		}

--- a/framework/configstore/tables/virtualkey.go
+++ b/framework/configstore/tables/virtualkey.go
@@ -257,6 +257,8 @@ type TableVirtualKey struct {
 
 	CalendarAligned bool `gorm:"default:false" json:"calendar_aligned"`
 
+	AllowAllProviders bool `gorm:"default:false" json:"allow_all_providers"`
+
 	// Relationships
 	Team      *TableTeam      `gorm:"foreignKey:TeamID" json:"team,omitempty"`
 	Customer  *TableCustomer  `gorm:"foreignKey:CustomerID" json:"customer,omitempty"`

--- a/framework/grant/access.go
+++ b/framework/grant/access.go
@@ -618,14 +618,21 @@ func (a *Access) permitAllowsModel(p schemas.Permit, provider string, model stri
 		return false
 	}
 	pps := p.ProviderPermits()
+	found := false
 	for i := range pps {
 		pp := &pps[i]
 		if pp.Provider != provider {
 			continue
 		}
+		found = true
 		if a.permitsModel(pp, model) {
 			return true
 		}
+	}
+	// A provider the permit lists keeps its own model rules even under allow-all; only a provider it
+	// lists no permit for is opened up by allow-all, and then every model of it is allowed.
+	if !found && p.AllowsAllProviders() {
+		return true
 	}
 	return false
 }

--- a/framework/grant/access_test.go
+++ b/framework/grant/access_test.go
@@ -207,6 +207,50 @@ func TestAccess_BlacklistWins(t *testing.T) {
 	assert.False(t, unionAccess.IsModelAllowed("anthropic", "claude-opus-4"))
 }
 
+// A permit that allows all providers grants even a provider it holds no provider permit for, with
+// every model and every key. A provider it does list keeps that permit's own rules, so allow-all
+// coexists with per-provider restrictions rather than overriding them.
+func TestAccess_AllowAllProviders(t *testing.T) {
+	// Lists openai with a blacklist and a key restriction; allows every other provider by the flag.
+	base := NewPermit(PermitVirtualKey, "vk1", "Caller Key", true, false,
+		[]schemas.ProviderPermit{
+			{Provider: "openai", AllowedModels: []string{"*"}, BlacklistedModels: []string{"gpt-4o"}, KeyIDs: []string{"key-a"}},
+			// Restrictive, non-wildcard allowlist: allow-all must not open models it omits.
+			{Provider: "anthropic", AllowedModels: []string{"claude-3-5-sonnet"}},
+		}, nil, WithAllowAllProviders(true))
+	access := NewAccess(held(base), nil, "", nil)
+
+	// A provider with no permit is allowed for any model, with no key restriction.
+	assert.True(t, access.IsProviderAllowed("cohere"), "allow-all grants an unlisted provider")
+	assert.True(t, access.IsModelAllowed("cohere", "command-r-plus"), "allow-all grants any model of an unlisted provider")
+	assert.True(t, access.IsModelAllowed("cohere", ""), "an empty model asks about the provider alone")
+	keyIDs, restricted := access.KeysForModel("cohere", "command-r-plus")
+	assert.False(t, restricted, "an unlisted provider under allow-all has no key restriction")
+	assert.Nil(t, keyIDs)
+
+	// A listed provider keeps its own rules: the blacklist still wins, and its key restriction stands.
+	assert.True(t, access.IsProviderAllowed("openai"))
+	assert.False(t, access.IsModelAllowed("openai", "gpt-4o"), "a listed provider's blacklist wins even under allow-all")
+	assert.True(t, access.IsModelAllowed("openai", "o3"))
+	keyIDs, restricted = access.KeysForModel("openai", "o3")
+	assert.True(t, restricted, "a listed provider keeps its key restriction under allow-all")
+	assert.Equal(t, []string{"key-a"}, keyIDs)
+
+	// A listed provider's restrictive allowlist wins: allow-all does not grant a model it omits.
+	assert.True(t, access.IsProviderAllowed("anthropic"))
+	assert.True(t, access.IsModelAllowed("anthropic", "claude-3-5-sonnet"), "a model in the allowlist is allowed")
+	assert.False(t, access.IsModelAllowed("anthropic", "claude-3-opus"), "allow-all must not grant a model outside a listed provider's allowlist")
+}
+
+// Without the flag, a provider the permit does not list is denied: allow-all is opt-in.
+func TestAccess_WithoutAllowAllProvidersUnlistedIsDenied(t *testing.T) {
+	base := permitWithProviders(PermitVirtualKey, "vk1", "Caller Key", "openai")
+	access := NewAccess(held(base), nil, "", nil)
+
+	assert.False(t, access.IsProviderAllowed("cohere"))
+	assert.False(t, access.IsModelAllowed("cohere", "command-r-plus"))
+}
+
 func TestAccess_UnknownModeFailsClosed(t *testing.T) {
 	base := permitWithProviders(PermitVirtualKey, "vk1", "Caller Key", "openai")
 	scoping := permitWithProviders("other", "o1", "Other", "openai")

--- a/framework/grant/permit.go
+++ b/framework/grant/permit.go
@@ -67,8 +67,21 @@ type Permit struct {
 	isActive   bool
 	isExpired  bool
 
-	providerPermits []schemas.ProviderPermit
-	mcpPermits      []schemas.MCPPermit
+	providerPermits   []schemas.ProviderPermit
+	mcpPermits        []schemas.MCPPermit
+	allowAllProviders bool
+}
+
+// PermitOption configures a Permit at construction. Options keep NewPermit's required arguments
+// stable while letting a source set the occasional extra, so a resolver that does not need one is
+// unaffected.
+type PermitOption func(*Permit)
+
+// WithAllowAllProviders grants every provider, including ones the permit holds no provider permit
+// for: those are allowed with all models and all keys, while a provider it does hold a permit for
+// still applies that permit's rules. See schemas.Permit.AllowsAllProviders.
+func WithAllowAllProviders(allow bool) PermitOption {
+	return func(p *Permit) { p.allowAllProviders = allow }
 }
 
 // NewPermit builds a Permit. See schemas.Permit for what each value means. The lists are deep
@@ -82,8 +95,9 @@ func NewPermit(
 	isExpired bool,
 	providerPermits []schemas.ProviderPermit,
 	mcpPermits []schemas.MCPPermit,
+	opts ...PermitOption,
 ) *Permit {
-	return &Permit{
+	p := &Permit{
 		permitType:      permitType,
 		id:              id,
 		name:            name,
@@ -92,6 +106,10 @@ func NewPermit(
 		providerPermits: cloneProviderPermits(providerPermits),
 		mcpPermits:      cloneMCPPermits(mcpPermits),
 	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
 }
 
 // cloneProviderPermits deep-copies each entry: slices.Clone on the outer slice only copies the
@@ -173,6 +191,11 @@ func (p *Permit) MCPPermits() []schemas.MCPPermit {
 	return cloneMCPPermits(p.mcpPermits)
 }
 
+// AllowsAllProviders implements schemas.Permit.
+func (p *Permit) AllowsAllProviders() bool {
+	return p != nil && p.allowAllProviders
+}
+
 // The rules below are written against schemas.Permit rather than *Permit, so the fold asks every
 // permit it holds the same questions whichever implementation answers them.
 
@@ -182,7 +205,8 @@ func isNilPermit(p schemas.Permit) bool {
 }
 
 // allowsProvider reports whether the permit permits provider at all. A permit with no provider
-// permit permits none (deny by default), and so does a permit that is not there.
+// permit permits none (deny by default), and so does a permit that is not there, unless the permit
+// allows all providers, which grants even a provider it holds no permit for.
 func allowsProvider(p schemas.Permit, provider string) bool {
 	if isNilPermit(p) {
 		return false
@@ -192,7 +216,7 @@ func allowsProvider(p schemas.Permit, provider string) bool {
 			return true
 		}
 	}
-	return false
+	return p.AllowsAllProviders()
 }
 
 // blacklistsModel reports whether any of the permit's provider permits for provider blocks model.
@@ -262,16 +286,23 @@ func allowsModelByName(p schemas.Permit, provider string, model string) bool {
 	if model != "" && blacklistsModel(p, provider, model) {
 		return false
 	}
+	found := false
 	for _, pp := range p.ProviderPermits() {
 		if pp.Provider != provider {
 			continue
 		}
+		found = true
 		if model == "" {
 			return true
 		}
 		if providerPermitAllowsModel(&pp, model) {
 			return true
 		}
+	}
+	// A provider the permit lists keeps its own model rules even under allow-all; only a provider it
+	// lists no permit for is opened up by allow-all, and then every model of it is allowed.
+	if !found && p.AllowsAllProviders() {
+		return true
 	}
 	return false
 }

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -603,6 +603,7 @@ false
 {{- if hasKey . "access_profile_id" }}{{- $_ := set $vk "access_profile_id" .access_profile_id }}{{- end }}
 {{- if .rate_limit_id }}{{- $_ := set $vk "rate_limit_id" .rate_limit_id }}{{- end }}
 {{- if hasKey . "calendar_aligned" }}{{- $_ := set $vk "calendar_aligned" .calendar_aligned }}{{- end }}
+{{- if hasKey . "allow_all_providers" }}{{- $_ := set $vk "allow_all_providers" .allow_all_providers }}{{- end }}
 {{- if .provider_configs }}{{- $_ := set $vk "provider_configs" .provider_configs }}{{- end }}
 {{- if .mcp_configs }}{{- $_ := set $vk "mcp_configs" .mcp_configs }}{{- end }}
 {{- $vks = append $vks $vk }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -1917,6 +1917,10 @@
                   "calendar_aligned": {
                     "type": "boolean"
                   },
+                  "allow_all_providers": {
+                    "type": "boolean",
+                    "description": "Grant this virtual key access to every provider, including ones added later. Coexists with provider_configs: a provider with a config row keeps its model allow/blacklist, budgets, rate limits, and key selection; providers without a config get all models, all keys, and no per-provider limits. When false (default), access is deny-by-default via provider_configs."
+                  },
                   "provider_configs": {
                     "type": "array",
                     "items": {

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -860,6 +860,7 @@ bifrost:
       #   is_active: true
       #   expires_at: "2026-12-31T23:59:59Z"  # Optional RFC3339 expiry; requests rejected once passed. Omit for no expiry
       #   calendar_aligned: false  # Snap all budget resets for this key to calendar boundaries
+      #   allow_all_providers: false  # Grant access to every provider (incl. ones added later); provider_configs still apply per-provider limits
       #   team_id: "team-1"        # Mutually exclusive with customer_id
       #   customer_id: ""          # Mutually exclusive with team_id
       #   rate_limit_id: "rate-limit-1"

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -1448,7 +1448,7 @@ func (gs *LocalGovernanceStore) permitForVirtualKey(ctx context.Context, vk *con
 	mcpPermits := MCPPermitsFromAccumulator(acc, "virtual key", vk.Name, gs.mcpClientNames(), gs.logger)
 	mcpPermits = AppendMCPPermitsAllowedByDefault(mcpPermits, acc.ConfiguredClients(), allowedByDefaultClients)
 
-	return grant.NewPermit(grant.PermitVirtualKey, vk.ID, vk.Name, vk.IsActiveValue(), vk.IsExpiredAt(time.Now().UTC()), providerPermits, mcpPermits)
+	return grant.NewPermit(grant.PermitVirtualKey, vk.ID, vk.Name, vk.IsActiveValue(), vk.IsExpiredAt(time.Now().UTC()), providerPermits, mcpPermits, grant.WithAllowAllProviders(vk.AllowAllProviders))
 }
 
 // virtualMCPByID returns a cached Virtual MCP definition, or nil if none is cached for the id.

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -2000,3 +2000,41 @@ func TestGetBudgetAndRateLimitStatusReachesEverySource(t *testing.T) {
 		assert.Equal(t, 90.0, status.BudgetPercentUsed)
 	})
 }
+
+// TestModelConfigScopesForSkipsEmptyKindExtraScopes covers a registered
+// ExtraScopedIDsResolver returning a ScopedID with an empty Kind — a
+// legitimate value for a batch-only caller (see ScopedID's doc comment), but
+// modelConfigScopesFor is the request-time path: propagating it would let a
+// refusal name an empty holder kind.
+func TestModelConfigScopesForSkipsEmptyKindExtraScopes(t *testing.T) {
+	extraScopedIDsResolversMu.Lock()
+	saved := extraScopedIDsResolvers
+	extraScopedIDsResolvers = nil
+	extraScopedIDsResolversMu.Unlock()
+	t.Cleanup(func() {
+		extraScopedIDsResolversMu.Lock()
+		extraScopedIDsResolvers = saved
+		extraScopedIDsResolversMu.Unlock()
+	})
+
+	RegisterExtraScopedIDsResolver(func(_ context.Context, _, _ string) []ScopedID {
+		return []ScopedID{
+			{Scope: "batch_only", ScopeID: "b-1"}, // Kind deliberately empty
+			{Scope: "with_kind", ScopeID: "w-1", Kind: grant.LimitHolderModelConfig},
+		}
+	})
+
+	scopes := modelConfigScopesFor(nil)
+
+	for _, s := range scopes {
+		assert.NotEqual(t, "batch_only", s.name, "an empty-Kind extra scope must not reach request-time enforcement")
+	}
+	found := false
+	for _, s := range scopes {
+		if s.name == "with_kind" {
+			found = true
+			assert.Equal(t, grant.LimitHolderModelConfig, s.kind)
+		}
+	}
+	assert.True(t, found, "an extra scope with a Kind must still pass through")
+}

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -288,13 +288,14 @@ type CreateVirtualKeyRequest struct {
 		MCPClientName  string            `json:"mcp_client_name" validate:"required"`
 		ToolsToExecute schemas.WhiteList `json:"tools_to_execute,omitempty"`
 	} `json:"mcp_configs,omitempty"` // Empty means no MCP clients allowed (deny-by-default)
-	TeamID          *string                 `json:"team_id,omitempty"`     // Mutually exclusive with CustomerID
-	CustomerID      *string                 `json:"customer_id,omitempty"` // Mutually exclusive with TeamID
-	Budgets         []CreateBudgetRequest   `json:"budgets,omitempty"`     // Multi-budget: each must have a unique reset_duration
-	RateLimit       *CreateRateLimitRequest `json:"rate_limit,omitempty"`
-	IsActive        *bool                   `json:"is_active,omitempty"`
-	CalendarAligned bool                    `json:"calendar_aligned,omitempty"` // When true, all budgets reset at clean calendar boundaries
-	ExpiresAt       *time.Time              `json:"expires_at,omitempty"`       // Optional expiry; nil means never expires
+	TeamID            *string                 `json:"team_id,omitempty"`     // Mutually exclusive with CustomerID
+	CustomerID        *string                 `json:"customer_id,omitempty"` // Mutually exclusive with TeamID
+	Budgets           []CreateBudgetRequest   `json:"budgets,omitempty"`     // Multi-budget: each must have a unique reset_duration
+	RateLimit         *CreateRateLimitRequest `json:"rate_limit,omitempty"`
+	IsActive          *bool                   `json:"is_active,omitempty"`
+	CalendarAligned   bool                    `json:"calendar_aligned,omitempty"`    // When true, all budgets reset at clean calendar boundaries
+	AllowAllProviders bool                    `json:"allow_all_providers,omitempty"` // When true, all providers are allowed; provider_configs remain optional overrides
+	ExpiresAt         *time.Time              `json:"expires_at,omitempty"`          // Optional expiry; nil means never expires
 }
 
 // vkModelBudgetRequest is one per-model budget/rate-limit group under a provider config
@@ -333,14 +334,15 @@ type UpdateVirtualKeyRequest struct {
 		MCPClientName  string            `json:"mcp_client_name" validate:"required"`
 		ToolsToExecute schemas.WhiteList `json:"tools_to_execute,omitempty"`
 	} `json:"mcp_configs,omitempty"`
-	TeamID           schemas.OptionalJSON[string] `json:"team_id,omitempty"`
-	CustomerID       schemas.OptionalJSON[string] `json:"customer_id,omitempty"`
-	Budgets          []CreateBudgetRequest        `json:"budgets,omitempty"` // Multi-budget: replaces all VK-level budgets
-	RateLimit        *UpdateRateLimitRequest      `json:"rate_limit,omitempty"`
-	IsActive         *bool                        `json:"is_active,omitempty"`
-	CalendarAligned  *bool                        `json:"calendar_aligned,omitempty"` // When true, all budgets reset at clean calendar boundaries
-	ResetBudgetUsage *bool                        `json:"reset_budget_usage,omitempty"`
-	ExpiresAt        *string                      `json:"expires_at,omitempty"` // RFC3339 timestamp sets a new expiry, "" clears it, omitted leaves it unchanged
+	TeamID            schemas.OptionalJSON[string] `json:"team_id,omitempty"`
+	CustomerID        schemas.OptionalJSON[string] `json:"customer_id,omitempty"`
+	Budgets           []CreateBudgetRequest        `json:"budgets,omitempty"` // Multi-budget: replaces all VK-level budgets
+	RateLimit         *UpdateRateLimitRequest      `json:"rate_limit,omitempty"`
+	IsActive          *bool                        `json:"is_active,omitempty"`
+	CalendarAligned   *bool                        `json:"calendar_aligned,omitempty"`    // When true, all budgets reset at clean calendar boundaries
+	AllowAllProviders *bool                        `json:"allow_all_providers,omitempty"` // When true, all providers are allowed; nil means leave unchanged
+	ResetBudgetUsage  *bool                        `json:"reset_budget_usage,omitempty"`
+	ExpiresAt         *string                      `json:"expires_at,omitempty"` // RFC3339 timestamp sets a new expiry, "" clears it, omitted leaves it unchanged
 }
 
 var errVirtualKeyDualAssociation = errors.New("VirtualKey cannot be attached to both Team and Customer")
@@ -1689,15 +1691,16 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 	var vk configstoreTables.TableVirtualKey
 	if err := h.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
 		vk = configstoreTables.TableVirtualKey{
-			ID:              uuid.NewString(),
-			Name:            req.Name,
-			Value:           *schemas.NewSecretVar(governance.GenerateVirtualKey()),
-			Description:     req.Description,
-			TeamID:          req.TeamID,
-			CustomerID:      req.CustomerID,
-			IsActive:        isActive,
-			CalendarAligned: req.CalendarAligned,
-			ExpiresAt:       req.ExpiresAt,
+			ID:                uuid.NewString(),
+			Name:              req.Name,
+			Value:             *schemas.NewSecretVar(governance.GenerateVirtualKey()),
+			Description:       req.Description,
+			TeamID:            req.TeamID,
+			CustomerID:        req.CustomerID,
+			IsActive:          isActive,
+			CalendarAligned:   req.CalendarAligned,
+			AllowAllProviders: req.AllowAllProviders,
+			ExpiresAt:         req.ExpiresAt,
 		}
 		if err := h.configStore.CreateVirtualKey(ctx, &vk, tx); err != nil {
 			return err
@@ -2090,6 +2093,9 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 		if req.CalendarAligned != nil {
 			alignmentSwitchedOn = !vk.CalendarAligned && *req.CalendarAligned
 			vk.CalendarAligned = *req.CalendarAligned
+		}
+		if req.AllowAllProviders != nil {
+			vk.AllowAllProviders = *req.AllowAllProviders
 		}
 		// VK top-level and per-provider budgets/rate-limits are stored in VK-scoped model
 		// configs (the single source of truth), written by syncVKGovernanceToModelConfigs

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -946,6 +946,11 @@
                 "description": "Snap all budget resets to calendar boundaries (day, week, month, year)",
                 "default": false
               },
+              "allow_all_providers": {
+                "type": "boolean",
+                "description": "Grant this virtual key access to every provider, including ones added later. Coexists with provider_configs: a provider that also has a config row still has that config's model allow/blacklist, budgets, rate limits, and key selection applied; providers without a config get all models, all keys, and no per-provider limits. When false (default), access is deny-by-default via provider_configs.",
+                "default": false
+              },
               "team_id": {
                 "type": "string",
                 "description": "Associated team ID (mutually exclusive with customer_id)"

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -159,6 +159,8 @@ const formSchema = z
 		name: z.string().min(1, "Virtual key name is required"),
 		description: z.string().optional(),
 		providerConfigs: z.array(providerConfigSchema).optional(),
+		// When true, all providers are allowed; providerConfigs remain optional per-provider overrides.
+		allowAllProviders: z.boolean(),
 		mcpConfigs: z.array(mcpConfigSchema).optional(),
 		entityType: z.enum(["team", "customer", "user", "none"]),
 		teamId: z.string().optional(),
@@ -473,6 +475,7 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 							: undefined,
 					})),
 				})) || [],
+			allowAllProviders: virtualKey?.allow_all_providers ?? false,
 			mcpConfigs:
 				virtualKey?.mcp_configs?.map((config) => ({
 					id: config.id,
@@ -559,6 +562,9 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 	// Get current provider configs from form
 	const providerConfigs = form.watch("providerConfigs") || [];
 
+	// Whether "Allow all providers" is on
+	const allowAllProviders = form.watch("allowAllProviders");
+
 	// Get current MCP configs from form
 	const mcpConfigs = form.watch("mcpConfigs") || [];
 
@@ -583,6 +589,28 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 			supportsCalendarAlignment(watchedRequestResetDuration || "1h"));
 	const showCalendarAlignToggle = hasAnyAlignableBudget || hasAnyAlignableRateLimit;
 
+	// Build a default provider config row (all models, all keys, no limits)
+	const makeDefaultProviderConfig = (provider: string) => ({
+		provider: provider,
+		weight: undefined as number | undefined, // undefined = excluded from weighted routing until user sets a weight
+		allowed_models: ["*"],
+		blacklisted_models: [] as string[],
+		key_ids: ["*"],
+	});
+
+	// A row is "untouched" if it still carries only the auto-added defaults (no budget/limit/restriction).
+	// Turning "Allow all providers" off keeps customized rows and drops these.
+	const isDefaultProviderConfig = (config: (typeof providerConfigs)[number]) =>
+		(config.allowed_models || []).length === 1 &&
+		config.allowed_models?.[0] === "*" &&
+		(config.blacklisted_models || []).length === 0 &&
+		(config.key_ids || []).length === 1 &&
+		config.key_ids?.[0] === "*" &&
+		(config.budgets || []).length === 0 &&
+		!config.rate_limit &&
+		(config.model_budgets || []).length === 0 &&
+		config.weight === undefined;
+
 	// Handle adding a new provider configuration
 	const handleAddProvider = (provider: string) => {
 		const existingConfig = providerConfigs.find((config) => config.provider === provider);
@@ -591,23 +619,75 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 			return;
 		}
 
-		const newConfig = {
-			provider: provider,
-			weight: undefined as number | undefined, // undefined = excluded from weighted routing until user sets a weight
-			allowed_models: ["*"],
-			blacklisted_models: [],
-			key_ids: ["*"],
-		};
-
-		form.setValue("providerConfigs", [...providerConfigs, newConfig], {
+		form.setValue("providerConfigs", [...providerConfigs, makeDefaultProviderConfig(provider)], {
 			shouldDirty: true,
 		});
 	};
 
 	// Handle removing a provider configuration
 	const handleRemoveProvider = (index: number) => {
-		const updatedConfigs = providerConfigs.filter((_, i) => i !== index);
+		// Removing a provider while "Allow all providers" is on means "all except this one":
+		// turn the flag off so the remaining rows become the explicit allowlist.
+		if (form.getValues("allowAllProviders")) {
+			form.setValue("allowAllProviders", false, { shouldDirty: true });
+		}
+		const updatedConfigs = (form.getValues("providerConfigs") || []).filter((_, i) => i !== index);
 		form.setValue("providerConfigs", updatedConfigs, { shouldDirty: true });
+	};
+
+	// Handle the "Allow all providers" toggle. When turned on, every configured provider is
+	// materialized as a row (via the effect below) so budgets/limits can be set or a provider
+	// excluded. When turned off, untouched default rows are dropped and customized ones kept.
+	const handleAllowAllProvidersChange = (checked: boolean) => {
+		form.setValue("allowAllProviders", checked, { shouldDirty: true });
+		if (!checked) {
+			const kept = (form.getValues("providerConfigs") || []).filter((config) => !isDefaultProviderConfig(config));
+			form.setValue("providerConfigs", kept, { shouldDirty: true });
+		}
+	};
+
+	// While "Allow all providers" is on, keep a row for every configured provider so they are
+	// visible and can be given budgets or excluded. Providers added later show up here too.
+	// Reads current configs via getValues (not a dep) so this converges in one pass without looping.
+	useEffect(() => {
+		if (!allowAllProviders || availableProviders.length === 0) return;
+		const current = form.getValues("providerConfigs") || [];
+		const missing = availableProviders.filter((p) => p.name && !current.some((c) => c.provider === p.name));
+		if (missing.length === 0) return;
+		const additions = missing.map((p) => makeDefaultProviderConfig(p.name));
+		form.setValue("providerConfigs", [...current, ...additions], { shouldDirty: false });
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [allowAllProviders, availableProviders]);
+
+	// Handle adding a new MCP client configuration
+	const handleAddMCPClient = (mcpClientName: string) => {
+		const existingConfig = mcpConfigs.find((config) => config.mcp_client_name === mcpClientName);
+		if (existingConfig) {
+			toast.error("This MCP client is already configured");
+			return;
+		}
+
+		const newConfig = {
+			mcp_client_name: mcpClientName,
+			tools_to_execute: ["*"],
+		};
+
+		form.setValue("mcpConfigs", [...mcpConfigs, newConfig], {
+			shouldDirty: true,
+		});
+	};
+
+	// Handle removing an MCP client configuration
+	const handleRemoveMCPClient = (index: number) => {
+		const updatedConfigs = mcpConfigs.filter((_, i) => i !== index);
+		form.setValue("mcpConfigs", updatedConfigs, { shouldDirty: true });
+	};
+
+	// Handle updating MCP client configuration
+	const handleUpdateMCPConfig = (index: number, field: keyof (typeof mcpConfigs)[0], value: any) => {
+		const updatedConfigs = [...mcpConfigs];
+		updatedConfigs[index] = { ...updatedConfigs[index], [field]: value };
+		form.setValue("mcpConfigs", updatedConfigs, { shouldDirty: true });
 	};
 
 	const [showCalendarAlignWarning, setShowCalendarAlignWarning] = useState(false);
@@ -937,6 +1017,7 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 								: undefined,
 					is_active: data.isActive,
 					calendar_aligned: data.budgetCalendarAligned,
+					allow_all_providers: data.allowAllProviders,
 					reset_budget_usage: resetBudgetUsage,
 					...expiryPayload,
 				};
@@ -1001,6 +1082,7 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 					is_active: data.isActive,
 					// VK-level setting that governs both budget and rate-limit calendar alignment.
 					calendar_aligned: data.budgetCalendarAligned,
+					allow_all_providers: data.allowAllProviders,
 					// Optional expiry: send as UTC ISO string, or omit for no expiry
 					...(data.expiresAt ? { expires_at: new Date(data.expiresAt).toISOString() } : {}),
 				};
@@ -1202,7 +1284,7 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 															<Info className="text-muted-foreground h-3 w-3" />
 														</span>
 													</TooltipTrigger>
-													<TooltipContent>
+													<TooltipContent className="max-w-sm">
 														<p>
 															Configure which providers this virtual key can use and their specific settings. Leave empty to block all
 															providers. Add providers to allow them.
@@ -1211,6 +1293,41 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 												</Tooltip>
 											</TooltipProvider>
 										</div>
+
+										{/* Allow all providers */}
+										<FormField
+											control={form.control}
+											name="allowAllProviders"
+											render={({ field }) => (
+												<FormItem>
+													<div className="flex w-full items-center justify-between gap-2 py-2 text-sm">
+														<div className="flex items-center gap-1.5">
+															<span>Allow all providers</span>
+															<TooltipProvider>
+																<Tooltip>
+																	<TooltipTrigger asChild>
+																		<span>
+																			<Info className="text-muted-foreground h-3 w-3" />
+																		</span>
+																	</TooltipTrigger>
+																	<TooltipContent className="max-w-sm">
+																		<p>
+																			Grant access to every provider, including ones added later. Set budgets or limits on specific
+																			providers below, or remove a provider to allow all except that one.
+																		</p>
+																	</TooltipContent>
+																</Tooltip>
+															</TooltipProvider>
+														</div>
+														<Switch
+															checked={field.value}
+															onCheckedChange={handleAllowAllProvidersChange}
+															data-testid="vk-allow-all-providers-toggle"
+														/>
+													</div>
+												</FormItem>
+											)}
+										/>
 
 										{/* Add Provider Dropdown */}
 										<div className="flex gap-2">

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -112,6 +112,8 @@ export interface VirtualKey {
 	previous_value_expires_at?: string | null; // When set, the pre-rotation value still authenticates until this time
 	rotated_at?: string | null; // Timestamp of the last value rotation
 	calendar_aligned?: boolean;
+	// When true, every provider is allowed; provider_configs remain optional per-provider overrides
+	allow_all_providers?: boolean;
 	created_at: string;
 	updated_at: string;
 	// Populated relationships
@@ -223,6 +225,7 @@ export interface CreateVirtualKeyRequest {
 	rate_limit?: CreateRateLimitRequest;
 	is_active?: boolean;
 	calendar_aligned?: boolean;
+	allow_all_providers?: boolean; // When true, all providers are allowed
 	expires_at?: string; // RFC3339 UTC timestamp; omit for a key that never expires
 }
 
@@ -237,6 +240,7 @@ export interface UpdateVirtualKeyRequest {
 	rate_limit?: UpdateRateLimitRequest;
 	is_active?: boolean;
 	calendar_aligned?: boolean;
+	allow_all_providers?: boolean; // When true, all providers are allowed; omit to leave unchanged
 	reset_budget_usage?: boolean;
 	expires_at?: string; // RFC3339 UTC timestamp sets a new expiry, "" clears it, omit to leave unchanged
 }


### PR DESCRIPTION
## Summary

Adds an `allow_all_providers` flag to virtual keys, enabling a key to access every configured provider without requiring explicit `provider_configs` entries for each one. This solves the problem of needing to manually enumerate every provider in a virtual key's config just to grant broad access, while still allowing per-provider limits to be applied where a config row exists.

## Changes

- Added `allow_all_providers` boolean field to the virtual key schema in `transports/config.schema.json`, defaulting to `false` (deny-by-default behavior is preserved)
- Added the same field to the Helm chart's `values.schema.json` with a matching description
- Updated `_helpers.tpl` to pass `allow_all_providers` through when rendering virtual key configs
- Added a commented-out example in `values.yaml` to document the new option

When `allow_all_providers: true`, providers that have an explicit `provider_configs` entry still respect that config's model allowlist/blacklist, budgets, rate limits, and key selection. Providers without a config entry get unrestricted access (all models, all keys, no per-provider limits).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Configure a virtual key with `allow_all_providers: true` and no `provider_configs` entries, then send requests targeting different providers and verify they are all permitted. Optionally add a `provider_configs` entry for one provider and confirm its model/budget restrictions are still enforced while other providers remain unrestricted.

```sh
go test ./...
```

**New config field:**

| Field | Type | Default | Description |
|---|---|---|---|
| `allow_all_providers` | boolean | `false` | Grant this virtual key access to every provider, including ones added later. Coexists with `provider_configs`; providers with a config row retain their configured limits. |

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

When `allow_all_providers: true`, a virtual key gains access to all current and future providers without requiring explicit configuration. Operators should ensure this flag is only granted to trusted consumers, as newly added providers will be automatically accessible to any key carrying this flag.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable