### PR TITLE
feat(providers): add Databricks provider with Model Serving and Unity AI Gateway support, PAT and OAuth M2M auth, and Gemini stream-options fixup

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -27,6 +27,7 @@ import (
 	"github.com/maximhq/bifrost/core/providers/bedrockmantle"
 	"github.com/maximhq/bifrost/core/providers/cerebras"
 	"github.com/maximhq/bifrost/core/providers/cohere"
+	"github.com/maximhq/bifrost/core/providers/databricks"
 	"github.com/maximhq/bifrost/core/providers/deepseek"
 	"github.com/maximhq/bifrost/core/providers/elevenlabs"
 	"github.com/maximhq/bifrost/core/providers/fireworks"
@@ -4540,6 +4541,8 @@ func (bifrost *Bifrost) createBaseProvider(providerKey schemas.ModelProvider, co
 		return fireworks.NewFireworksProvider(config, bifrost.logger)
 	case schemas.Sarvam:
 		return sarvam.NewSarvamProvider(config, bifrost.logger)
+	case schemas.Databricks:
+		return databricks.NewDatabricksProvider(config, bifrost.logger)
 	default:
 		return nil, fmt.Errorf("unsupported provider: %s", targetProviderKey)
 	}

--- a/core/internal/llmtests/account.go
+++ b/core/internal/llmtests/account.go
@@ -194,6 +194,7 @@ func (account *ComprehensiveTestAccount) GetConfiguredProviders() ([]schemas.Mod
 		schemas.Fireworks,
 		schemas.Sarvam,
 		schemas.Wafer,
+		schemas.Databricks,
 		ProviderOpenAICustom,
 	}, nil
 }
@@ -492,6 +493,17 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 				Models:         []string{"*"},
 				Weight:         1.0,
 				UseForBatchAPI: bifrost.Ptr(true),
+			},
+		}, nil
+	case schemas.Databricks:
+		return []schemas.Key{
+			{
+				Value:  *schemas.NewSecretVar("env.DATABRICKS_TOKEN"),
+				Models: []string{"*"},
+				Weight: 1.0,
+				DatabricksKeyConfig: &schemas.DatabricksKeyConfig{
+					WorkspaceURL: *schemas.NewSecretVar("env.DATABRICKS_WORKSPACE_URL"),
+				},
 			},
 		}, nil
 	case schemas.Gemini:
@@ -873,6 +885,19 @@ func (account *ComprehensiveTestAccount) GetConfigForProvider(providerKey schema
 			},
 		}, nil
 	case schemas.Wafer:
+		return &schemas.ProviderConfig{
+			NetworkConfig: schemas.NetworkConfig{
+				DefaultRequestTimeoutInSeconds: 120,
+				MaxRetries:                     10,
+				RetryBackoffInitial:            5 * time.Second,
+				RetryBackoffMax:                3 * time.Minute,
+			},
+			ConcurrencyAndBufferSize: schemas.ConcurrencyAndBufferSize{
+				Concurrency: Concurrency,
+				BufferSize:  10,
+			},
+		}, nil
+	case schemas.Databricks:
 		return &schemas.ProviderConfig{
 			NetworkConfig: schemas.NetworkConfig{
 				DefaultRequestTimeoutInSeconds: 120,

--- a/core/internal/llmtests/validation_presets.go
+++ b/core/internal/llmtests/validation_presets.go
@@ -490,6 +490,11 @@ func ModifyExpectationsForProvider(expectations ResponseExpectations, provider s
 		expectations.ShouldHaveUsageStats = true
 		expectations.ShouldHaveLatency = true
 
+	case schemas.Databricks:
+		// Both Databricks surfaces return the OpenAI-shaped usage object.
+		expectations.ShouldHaveUsageStats = true
+		expectations.ShouldHaveLatency = true
+
 	case schemas.OpenRouter:
 		// OpenRouter proxies to multiple providers; returns OpenAI-compatible fields
 		expectations.ShouldHaveUsageStats = true

--- a/core/providers/databricks/cachedcontents.go
+++ b/core/providers/databricks/cachedcontents.go
@@ -1,0 +1,34 @@
+package databricks
+
+import (
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// CachedContentCreate is unsupported on DatabricksProvider. Only Gemini and Vertex AI
+// implement the cached-content lifecycle (Google AI Studio + Vertex AI named
+// caches). Other providers either lack named cache management entirely or
+// handle caching implicitly via per-message cache_control markers.
+func (provider *DatabricksProvider) CachedContentCreate(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostCachedContentCreateRequest) (*schemas.BifrostCachedContentCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CachedContentCreateRequest, provider.GetProviderKey())
+}
+
+// CachedContentList is unsupported on DatabricksProvider (see CachedContentCreate).
+func (provider *DatabricksProvider) CachedContentList(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostCachedContentListRequest) (*schemas.BifrostCachedContentListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CachedContentListRequest, provider.GetProviderKey())
+}
+
+// CachedContentRetrieve is unsupported on DatabricksProvider (see CachedContentCreate).
+func (provider *DatabricksProvider) CachedContentRetrieve(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostCachedContentRetrieveRequest) (*schemas.BifrostCachedContentRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CachedContentRetrieveRequest, provider.GetProviderKey())
+}
+
+// CachedContentUpdate is unsupported on DatabricksProvider (see CachedContentCreate).
+func (provider *DatabricksProvider) CachedContentUpdate(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostCachedContentUpdateRequest) (*schemas.BifrostCachedContentUpdateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CachedContentUpdateRequest, provider.GetProviderKey())
+}
+
+// CachedContentDelete is unsupported on DatabricksProvider (see CachedContentCreate).
+func (provider *DatabricksProvider) CachedContentDelete(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostCachedContentDeleteRequest) (*schemas.BifrostCachedContentDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CachedContentDeleteRequest, provider.GetProviderKey())
+}

--- a/core/providers/databricks/databricks.go
+++ b/core/providers/databricks/databricks.go
@@ -1,0 +1,336 @@
+// Package databricks implements the Databricks provider. It covers the two Databricks
+// inference surfaces that serve foundation models, both of which speak the OpenAI wire
+// format under a workspace host:
+//
+//   - Model Serving / Foundation Model APIs, at /serving-endpoints. The model name is a
+//     serving endpoint name (e.g. "databricks-claude-sonnet-4-5"), covering pay-per-token
+//     endpoints and provisioned-throughput endpoints alike. This surface also serves the
+//     OpenAI Responses API at /serving-endpoints/responses.
+//   - Unity AI Gateway model APIs (model services), at /ai-gateway/mlflow/v1. The model name
+//     is a Unity Catalog name (e.g. "system.ai.claude-sonnet-4-5", or a user-created
+//     "<catalog>.<schema>.<service>").
+//
+// Because both surfaces are OpenAI-compatible, every request is delegated to the shared
+// openai.HandleOpenAI* helpers; this package only resolves the workspace host, selects the
+// base path, and produces the Authorization header.
+//
+// Authentication is either a Databricks personal access token (set as the key value) or
+// OAuth machine-to-machine using a service principal (set client_id/client_secret and leave
+// the key value empty). M2M tokens are minted and refreshed by a cached oauth2.TokenSource.
+package databricks
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+const (
+	// modelServingBasePath is the OpenAI-compatible base path for Model Serving / Foundation
+	// Model API endpoints. Databricks documents it as an OpenAI client base_url.
+	modelServingBasePath = "/serving-endpoints"
+	// aiGatewayBasePath is the OpenAI-compatible base path for Unity AI Gateway model APIs.
+	aiGatewayBasePath = "/ai-gateway/mlflow/v1"
+
+	// oauthTokenPath is the workspace-level OAuth token endpoint for M2M service principals.
+	oauthTokenPath = "/oidc/v1/token"
+	// oauthScope is the scope Databricks requires for M2M client-credentials grants.
+	oauthScope = "all-apis"
+
+	// gatewayRequestTagsHeader carries JSON string-to-string labels that Databricks records
+	// against the request for usage tracking and cost attribution.
+	gatewayRequestTagsHeader = "Databricks-Ai-Gateway-Request-Tags"
+
+	// modelServingListPath lists Model Serving endpoints.
+	modelServingListPath = "/api/2.0/serving-endpoints"
+	// aiGatewayListPath lists Unity Catalog model services.
+	aiGatewayListPath = "/api/2.1/unity-catalog/model-services"
+)
+
+// DatabricksProvider implements the Provider interface for Databricks.
+type DatabricksProvider struct {
+	logger              schemas.Logger        // Logger for provider operations
+	client              *fasthttp.Client      // HTTP client for unary API requests (ReadTimeout bounds overall response)
+	streamingClient     *fasthttp.Client      // HTTP client for streaming API requests (no ReadTimeout; idle governed by NewIdleTimeoutReader)
+	networkConfig       schemas.NetworkConfig // Network configuration including extra headers
+	sendBackRawRequest  bool                  // Whether to include raw request in BifrostResponse
+	sendBackRawResponse bool                  // Whether to include raw response in BifrostResponse
+}
+
+// NewDatabricksProvider creates a new Databricks provider instance.
+// There is no default BaseURL: every request targets a workspace host resolved from the key's
+// DatabricksKeyConfig, falling back to a provider-level BaseURL when one is configured.
+func NewDatabricksProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*DatabricksProvider, error) {
+	config.CheckAndSetDefaults()
+
+	requestTimeout := time.Second * time.Duration(config.NetworkConfig.DefaultRequestTimeoutInSeconds)
+	client := &fasthttp.Client{
+		ReadTimeout:         requestTimeout,
+		WriteTimeout:        requestTimeout,
+		MaxConnsPerHost:     config.NetworkConfig.MaxConnsPerHost,
+		MaxIdleConnDuration: time.Second * time.Duration(config.NetworkConfig.KeepAliveTimeoutInSeconds),
+		MaxConnWaitTimeout:  requestTimeout,
+		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
+		ConnPoolStrategy:    fasthttp.FIFO,
+	}
+	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
+	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
+	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
+	streamingClient := providerUtils.BuildStreamingClient(client)
+
+	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+
+	return &DatabricksProvider{
+		logger:              logger,
+		client:              client,
+		streamingClient:     streamingClient,
+		networkConfig:       config.NetworkConfig,
+		sendBackRawRequest:  config.SendBackRawRequest,
+		sendBackRawResponse: config.SendBackRawResponse,
+	}, nil
+}
+
+// GetProviderKey returns the provider identifier for Databricks.
+func (provider *DatabricksProvider) GetProviderKey() schemas.ModelProvider {
+	return schemas.Databricks
+}
+
+// resolveWorkspaceHost returns the bare Databricks workspace host for a key, tolerating a
+// value pasted with a scheme or a trailing path. It falls back to the provider-level BaseURL
+// so a single-workspace deployment can configure the host once instead of per key.
+func (provider *DatabricksProvider) resolveWorkspaceHost(key schemas.Key) (string, *schemas.BifrostError) {
+	if key.DatabricksKeyConfig != nil {
+		if host := schemas.NormalizeEndpointHost(&key.DatabricksKeyConfig.WorkspaceURL); host != "" {
+			return host, nil
+		}
+	}
+	if provider.networkConfig.BaseURL != "" {
+		if host := normalizeHost(provider.networkConfig.BaseURL); host != "" {
+			return host, nil
+		}
+	}
+	return "", providerUtils.NewConfigurationError("databricks workspace url is not set: configure databricks_key_config.workspace_url on the key, or a provider base_url")
+}
+
+// normalizeHost strips a scheme and any trailing path from a raw workspace URL string.
+func normalizeHost(raw string) string {
+	host := strings.TrimSpace(raw)
+	host = strings.TrimPrefix(host, "https://")
+	host = strings.TrimPrefix(host, "http://")
+	if i := strings.IndexByte(host, '/'); i >= 0 {
+		host = host[:i]
+	}
+	return host
+}
+
+// resolveAPIFormat decides which Databricks surface a request targets. An explicit
+// api_format on the key wins; otherwise the model name decides. A dotted name is a Unity
+// Catalog model service (system.ai.*, or <catalog>.<schema>.<service>) and goes to the Unity
+// AI Gateway; anything else is a Model Serving endpoint name.
+//
+// Model aliases need no special handling here: alias resolution rewrites the model to its
+// upstream model_id before the provider sees it, so auto-detection reads the wire name.
+func resolveAPIFormat(key schemas.Key, model string) schemas.DatabricksAPIFormat {
+	if key.DatabricksKeyConfig != nil {
+		switch key.DatabricksKeyConfig.APIFormat {
+		case schemas.DatabricksAPIFormatModelServing, schemas.DatabricksAPIFormatAIGateway:
+			return key.DatabricksKeyConfig.APIFormat
+		}
+	}
+	if strings.Contains(model, ".") {
+		return schemas.DatabricksAPIFormatAIGateway
+	}
+	return schemas.DatabricksAPIFormatModelServing
+}
+
+// basePathFor returns the OpenAI-compatible base path under the workspace host for a surface.
+func basePathFor(format schemas.DatabricksAPIFormat) string {
+	if format == schemas.DatabricksAPIFormatAIGateway {
+		return aiGatewayBasePath
+	}
+	return modelServingBasePath
+}
+
+// buildURL composes the full upstream URL for a request. suffix is an OpenAI path such as
+// "/chat/completions". A BifrostContextKeyURLPath override replaces the suffix, which lets a
+// caller reach a route this provider does not model (an absolute override replaces the whole URL).
+func (provider *DatabricksProvider) buildURL(ctx *schemas.BifrostContext, key schemas.Key, model, suffix string) (string, *schemas.BifrostError) {
+	path := providerUtils.GetPathFromContext(ctx, suffix)
+	if u, err := url.Parse(path); err == nil && u.IsAbs() && u.Host != "" {
+		return path, nil
+	}
+	host, bErr := provider.resolveWorkspaceHost(key)
+	if bErr != nil {
+		return "", bErr
+	}
+	return "https://" + host + basePathFor(resolveAPIFormat(key, model)) + path, nil
+}
+
+// workspaceAPIURL composes a URL for a Databricks control-plane REST API (not an inference
+// surface), which lives directly under the workspace host rather than a base path.
+func (provider *DatabricksProvider) workspaceAPIURL(key schemas.Key, path string) (string, *schemas.BifrostError) {
+	host, bErr := provider.resolveWorkspaceHost(key)
+	if bErr != nil {
+		return "", bErr
+	}
+	return "https://" + host + path, nil
+}
+
+// tokenSourcePool caches oauth2.TokenSource instances keyed by a hash of the workspace host
+// and service principal credentials. The clientcredentials TokenSource refreshes on expiry
+// and serialises concurrent refreshes internally, so caching the source is all that is needed
+// to avoid a token mint per request.
+var tokenSourcePool sync.Map
+
+// tokenSourceCacheKey hashes the credential tuple so no secret is used as a map key in a form
+// that could be logged.
+func tokenSourceCacheKey(host, clientID, clientSecret string) string {
+	sum := sha256.Sum256([]byte(host + "|" + clientID + "|" + clientSecret))
+	return hex.EncodeToString(sum[:])
+}
+
+// getTokenSource returns a cached OAuth M2M token source for the given workspace and service
+// principal, creating one on first use.
+func getTokenSource(host, clientID, clientSecret string) oauth2.TokenSource {
+	cacheKey := tokenSourceCacheKey(host, clientID, clientSecret)
+	if cached, ok := tokenSourcePool.Load(cacheKey); ok {
+		return cached.(oauth2.TokenSource)
+	}
+	conf := &clientcredentials.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		TokenURL:     "https://" + host + oauthTokenPath,
+		Scopes:       []string{oauthScope},
+		// Databricks expects the service principal credentials as HTTP Basic auth.
+		AuthStyle: oauth2.AuthStyleInHeader,
+	}
+	// oauth2.ReuseTokenSource caches the token until shortly before expiry and refreshes
+	// under a mutex, so a burst of concurrent requests mints exactly one token.
+	ts := oauth2.ReuseTokenSource(nil, conf.TokenSource(oauthContext()))
+	actual, _ := tokenSourcePool.LoadOrStore(cacheKey, ts)
+	return actual.(oauth2.TokenSource)
+}
+
+// oauthHTTPClient overrides the HTTP client the token exchange uses. It is nil in production,
+// where the oauth2 package uses http.DefaultClient; tests set it to reach a stub token endpoint.
+var oauthHTTPClient *http.Client
+
+// oauthContext returns the context the client-credentials token exchange runs under.
+func oauthContext() context.Context {
+	if oauthHTTPClient != nil {
+		return context.WithValue(context.Background(), oauth2.HTTPClient, oauthHTTPClient)
+	}
+	return context.Background()
+}
+
+// removeTokenSource evicts a cached token source so the next request re-mints. Called when
+// credentials are rejected, mirroring the eviction the Vertex provider performs on 401/403.
+func removeTokenSource(host, clientID, clientSecret string) {
+	tokenSourcePool.Delete(tokenSourceCacheKey(host, clientID, clientSecret))
+}
+
+// authHeader builds the Authorization header for a request: a personal access token when the
+// key carries a value, otherwise an OAuth M2M bearer token minted from the service principal.
+//
+// Unlike SigV4-style providers this needs no BodySigner, because the credential does not
+// depend on the request body and can be resolved before the body is built.
+func (provider *DatabricksProvider) authHeader(key schemas.Key) (map[string]string, *schemas.BifrostError) {
+	if token := key.Value.GetValue(); token != "" {
+		return map[string]string{"Authorization": "Bearer " + token}, nil
+	}
+
+	cfg := key.DatabricksKeyConfig
+	if cfg == nil || cfg.ClientID == nil || cfg.ClientSecret == nil {
+		return nil, providerUtils.NewConfigurationError("databricks key has no credentials: set the key value to a personal access token, or set databricks_key_config.client_id and client_secret for OAuth M2M")
+	}
+	clientID, clientSecret := cfg.ClientID.GetValue(), cfg.ClientSecret.GetValue()
+	if clientID == "" || clientSecret == "" {
+		return nil, providerUtils.NewConfigurationError("databricks oauth m2m requires both databricks_key_config.client_id and databricks_key_config.client_secret")
+	}
+	host, bErr := provider.resolveWorkspaceHost(key)
+	if bErr != nil {
+		return nil, bErr
+	}
+
+	token, err := getTokenSource(host, clientID, clientSecret).Token()
+	if err != nil {
+		// The credentials may have been rotated or revoked; drop the cached source so the
+		// next attempt re-mints rather than replaying a source pinned to a failing refresh.
+		removeTokenSource(host, clientID, clientSecret)
+		// err can embed the token endpoint response; never surface or log the secret itself.
+		return nil, providerUtils.NewBifrostOperationError("failed to acquire databricks oauth token", err)
+	}
+	return map[string]string{"Authorization": "Bearer " + token.AccessToken}, nil
+}
+
+// applyGatewayTags forwards Bifrost governance labels to Databricks as request tags, so
+// Databricks-side usage tracking can attribute spend to the same virtual key, team and
+// customer that Bifrost bills against. Opt-in per key.
+//
+// Only display names are forwarded, never user identifiers. The context extra-headers value
+// is a whole map, so it is read, merged and written back rather than overwritten — otherwise
+// this would clobber headers the caller supplied via x-bf-eh-*.
+func (provider *DatabricksProvider) applyGatewayTags(ctx *schemas.BifrostContext, key schemas.Key) {
+	if key.DatabricksKeyConfig == nil || !key.DatabricksKeyConfig.ForwardGatewayTags || ctx == nil {
+		return
+	}
+
+	tags := map[string]string{}
+	for label, ctxKey := range map[string]schemas.BifrostContextKey{
+		"virtual_key": schemas.BifrostContextKeyGovernanceVirtualKeyName,
+		"team":        schemas.BifrostContextKeyGovernanceTeamName,
+		"customer":    schemas.BifrostContextKeyGovernanceCustomerName,
+	} {
+		if v, ok := ctx.Value(ctxKey).(string); ok && v != "" {
+			tags[label] = v
+		}
+	}
+	if len(tags) == 0 {
+		return
+	}
+	encoded, err := providerUtils.MarshalSorted(tags)
+	if err != nil {
+		provider.logger.Warn("[databricks] failed to encode ai gateway request tags: %v", err)
+		return
+	}
+
+	extraHeaders := map[string][]string{}
+	if existing, ok := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string); ok && existing != nil {
+		extraHeaders = existing
+	}
+	// A caller-supplied tag header wins: it is more specific than the governance defaults.
+	if _, exists := extraHeaders[gatewayRequestTagsHeader]; !exists {
+		extraHeaders[gatewayRequestTagsHeader] = []string{string(encoded)}
+		ctx.SetValue(schemas.BifrostContextKeyExtraHeaders, extraHeaders)
+	}
+}
+
+// prepareRequest resolves the upstream URL and auth header for an inference request, and
+// applies the per-request context flags every Databricks call needs.
+func (provider *DatabricksProvider) prepareRequest(ctx *schemas.BifrostContext, key schemas.Key, model, suffix string) (string, map[string]string, *schemas.BifrostError) {
+	url, bErr := provider.buildURL(ctx, key, model, suffix)
+	if bErr != nil {
+		return "", nil, bErr
+	}
+	auth, bErr := provider.authHeader(key)
+	if bErr != nil {
+		return "", nil, bErr
+	}
+	// Databricks accepts fields Bifrost does not model canonically — service_tier for
+	// priority pay-per-token, reasoning_effort, and other model-specific extensions. Enable
+	// extra-param passthrough so they survive to the wire instead of being dropped.
+	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+	provider.applyGatewayTags(ctx, key)
+	return url, auth, nil
+}

--- a/core/providers/databricks/databricks.go
+++ b/core/providers/databricks/databricks.go
@@ -29,6 +29,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/maximhq/bifrost/core/providers/openai"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	schemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/valyala/fasthttp"
@@ -274,16 +275,22 @@ func (provider *DatabricksProvider) authHeader(key schemas.Key) (map[string]stri
 	return map[string]string{"Authorization": "Bearer " + token.AccessToken}, nil
 }
 
-// applyGatewayTags forwards Bifrost governance labels to Databricks as request tags, so
-// Databricks-side usage tracking can attribute spend to the same virtual key, team and
-// customer that Bifrost bills against. Opt-in per key.
-//
-// Only display names are forwarded, never user identifiers. The context extra-headers value
-// is a whole map, so it is read, merged and written back rather than overwritten — otherwise
-// this would clobber headers the caller supplied via x-bf-eh-*.
-func (provider *DatabricksProvider) applyGatewayTags(ctx *schemas.BifrostContext, key schemas.Key) {
+// gatewayTagsHeader returns the Databricks-Ai-Gateway-Request-Tags value for this request when
+// the key forwards governance labels, or "" when there is nothing to send. The header is
+// returned rather than stored on the context: the context's extra-headers map is owned by the
+// caller and shared with every other reader (a fallback provider, concurrent goroutines), so it
+// must never be mutated here. A caller-supplied tag header wins: it is more specific than the
+// governance defaults, so nothing is returned when the context already carries one.
+func (provider *DatabricksProvider) gatewayTagsHeader(ctx *schemas.BifrostContext, key schemas.Key) string {
 	if key.DatabricksKeyConfig == nil || !key.DatabricksKeyConfig.ForwardGatewayTags || ctx == nil {
-		return
+		return ""
+	}
+	if existing, ok := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string); ok {
+		for name := range existing {
+			if strings.EqualFold(name, gatewayRequestTagsHeader) {
+				return ""
+			}
+		}
 	}
 
 	tags := map[string]string{}
@@ -297,23 +304,14 @@ func (provider *DatabricksProvider) applyGatewayTags(ctx *schemas.BifrostContext
 		}
 	}
 	if len(tags) == 0 {
-		return
+		return ""
 	}
 	encoded, err := providerUtils.MarshalSorted(tags)
 	if err != nil {
 		provider.logger.Warn("[databricks] failed to encode ai gateway request tags: %v", err)
-		return
+		return ""
 	}
-
-	extraHeaders := map[string][]string{}
-	if existing, ok := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string); ok && existing != nil {
-		extraHeaders = existing
-	}
-	// A caller-supplied tag header wins: it is more specific than the governance defaults.
-	if _, exists := extraHeaders[gatewayRequestTagsHeader]; !exists {
-		extraHeaders[gatewayRequestTagsHeader] = []string{string(encoded)}
-		ctx.SetValue(schemas.BifrostContextKeyExtraHeaders, extraHeaders)
-	}
+	return string(encoded)
 }
 
 // prepareRequest resolves the upstream URL and auth header for an inference request, and
@@ -331,6 +329,30 @@ func (provider *DatabricksProvider) prepareRequest(ctx *schemas.BifrostContext, 
 	// priority pay-per-token, reasoning_effort, and other model-specific extensions. Enable
 	// extra-param passthrough so they survive to the wire instead of being dropped.
 	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
-	provider.applyGatewayTags(ctx, key)
+	if tags := provider.gatewayTagsHeader(ctx, key); tags != "" {
+		auth[gatewayRequestTagsHeader] = tags
+	}
 	return url, auth, nil
+}
+
+// chatStreamOptionsFixup drops stream_options for endpoints whose upstream model rejects it.
+//
+// Bifrost sets stream_options.include_usage on every OpenAI-shaped stream so the final chunk
+// carries token counts for cost attribution. Databricks forwards request fields it does not
+// itself consume straight to the serving model, and the Gemini-backed endpoints map those onto
+// Gemini's generation_config, which rejects unknown names — the request fails with
+// INVALID_ARGUMENT before a single chunk is produced. Those endpoints report usage on the final
+// chunk regardless, so dropping the field costs nothing.
+//
+// Returns nil for every other endpoint, leaving the shared handler's default in place.
+func chatStreamOptionsFixup(model string) func(*openai.OpenAIChatRequest) *openai.OpenAIChatRequest {
+	if !strings.Contains(strings.ToLower(model), "gemini") {
+		return nil
+	}
+	return func(reqBody *openai.OpenAIChatRequest) *openai.OpenAIChatRequest {
+		if reqBody != nil {
+			reqBody.StreamOptions = nil
+		}
+		return reqBody
+	}
 }

--- a/core/providers/databricks/databricks_test.go
+++ b/core/providers/databricks/databricks_test.go
@@ -1,0 +1,750 @@
+package databricks_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/internal/llmtests"
+	"github.com/maximhq/bifrost/core/providers/databricks"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestDatabricks(t *testing.T) {
+	t.Parallel()
+	if strings.TrimSpace(os.Getenv("DATABRICKS_TOKEN")) == "" || strings.TrimSpace(os.Getenv("DATABRICKS_WORKSPACE_URL")) == "" {
+		t.Skip("Skipping Databricks tests because DATABRICKS_TOKEN or DATABRICKS_WORKSPACE_URL is not set")
+	}
+
+	client, ctx, cancel, err := llmtests.SetupTest()
+	if err != nil {
+		t.Fatalf("Error initializing test setup: %v", err)
+	}
+	defer cancel()
+	defer client.Shutdown()
+
+	// Model Serving endpoint names. Availability varies by workspace region, so override
+	// with a model the target workspace actually serves when these are unavailable.
+	testConfig := llmtests.ComprehensiveTestConfig{
+		Provider:  schemas.Databricks,
+		ChatModel: "databricks-claude-sonnet-4-5",
+		Fallbacks: []schemas.Fallback{
+			{Provider: schemas.Databricks, Model: "databricks-claude-sonnet-4-5"},
+			{Provider: schemas.Databricks, Model: "databricks-gpt-oss-120b"},
+		},
+		EmbeddingModel: "databricks-gte-large-en",
+		ReasoningModel: "databricks-claude-sonnet-4-5",
+		VisionModel:    "databricks-claude-sonnet-4-5",
+		Scenarios: llmtests.TestScenarios{
+			SimpleChat:            true,
+			CompletionStream:      true,
+			MultiTurnConversation: true,
+			ToolCalls:             true,
+			ToolCallsStreaming:    true,
+			MultipleToolCalls:     true,
+			End2EndToolCalling:    true,
+			AutomaticFunctionCall: true,
+			ImageURL:              true,
+			ImageBase64:           true,
+			CompleteEnd2End:       true,
+			Embedding:             true,
+			ListModels:            true,
+			Reasoning:             true,
+			// Text completions are not exposed by either Databricks surface.
+			TextCompletion:       false,
+			TextCompletionStream: false,
+		},
+	}
+
+	t.Run("DatabricksTests", func(t *testing.T) {
+		llmtests.RunAllComprehensiveTests(t, client, ctx, testConfig)
+	})
+}
+
+// newStubProvider returns a Databricks provider pointed at a TLS test server, along with a
+// key whose workspace URL is that server's host. Databricks is always https, so the stub has
+// to be a TLS server with verification disabled.
+func newStubProvider(t *testing.T, handler http.HandlerFunc) (*databricks.DatabricksProvider, *httptest.Server) {
+	t.Helper()
+
+	server := httptest.NewTLSServer(handler)
+	t.Cleanup(server.Close)
+
+	provider, err := databricks.NewDatabricksProvider(&schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{
+			DefaultRequestTimeoutInSeconds: 10,
+			InsecureSkipVerify:             true,
+			AllowPrivateNetwork:            true,
+		},
+	}, bifrost.NewDefaultLogger(schemas.LogLevelError))
+	if err != nil {
+		t.Fatalf("NewDatabricksProvider: %v", err)
+	}
+	return provider, server
+}
+
+func serverHost(t *testing.T, server *httptest.Server) string {
+	t.Helper()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
+	}
+	return u.Host
+}
+
+const stubChatResponse = `{
+	"id": "chatcmpl-1",
+	"object": "chat.completion",
+	"created": 1700000000,
+	"model": "m",
+	"choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+	"usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+}`
+
+// TestDatabricksSurfaceRouting pins the base path each surface is addressed on, and the rule
+// that picks between them. A dotted model name is a Unity Catalog model service and must go
+// to the AI Gateway; a bare name is a Model Serving endpoint. Getting this wrong sends every
+// request to a 404 on the wrong surface.
+func TestDatabricksSurfaceRouting(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		model     string
+		apiFormat schemas.DatabricksAPIFormat
+		wantPath  string
+	}{
+		{"auto routes a serving endpoint name to model serving", "databricks-claude-sonnet-4-5", "", "/serving-endpoints/chat/completions"},
+		{"auto routes a system.ai name to the ai gateway", "system.ai.claude-sonnet-4-5", "", "/ai-gateway/mlflow/v1/chat/completions"},
+		{"auto routes a unity catalog fqn to the ai gateway", "main.default.my-service", "", "/ai-gateway/mlflow/v1/chat/completions"},
+		{"explicit model_serving overrides a dotted name", "system.ai.claude-sonnet-4-5", schemas.DatabricksAPIFormatModelServing, "/serving-endpoints/chat/completions"},
+		{"explicit ai_gateway overrides a bare name", "databricks-claude-sonnet-4-5", schemas.DatabricksAPIFormatAIGateway, "/ai-gateway/mlflow/v1/chat/completions"},
+		{"explicit auto falls back to the name rule", "databricks-gpt-oss-120b", schemas.DatabricksAPIFormatAuto, "/serving-endpoints/chat/completions"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var mu sync.Mutex
+			var gotPath string
+
+			provider, server := newStubProvider(t, func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				gotPath = r.URL.Path
+				mu.Unlock()
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(stubChatResponse))
+			})
+
+			key := schemas.Key{
+				Models: []string{"*"},
+				Value:  *schemas.NewSecretVar("dapi-test"),
+				DatabricksKeyConfig: &schemas.DatabricksKeyConfig{
+					WorkspaceURL: *schemas.NewSecretVar(serverHost(t, server)),
+					APIFormat:    tt.apiFormat,
+				},
+			}
+
+			ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			if _, bErr := provider.ChatCompletion(ctx, key, &schemas.BifrostChatRequest{
+				Provider: schemas.Databricks,
+				Model:    tt.model,
+				Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hi")}}},
+			}); bErr != nil {
+				t.Fatalf("ChatCompletion returned an error: %v", bErr)
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			if gotPath != tt.wantPath {
+				t.Errorf("path: got %q, want %q", gotPath, tt.wantPath)
+			}
+		})
+	}
+}
+
+// TestDatabricksWorkspaceURLAcceptsScheme covers a workspace URL pasted straight out of the
+// Databricks console, which carries a scheme and often a trailing slash.
+func TestDatabricksWorkspaceURLAcceptsScheme(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var gotPath string
+
+	provider, server := newStubProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotPath = r.URL.Path
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(stubChatResponse))
+	})
+
+	key := schemas.Key{
+		Models: []string{"*"},
+		Value:  *schemas.NewSecretVar("dapi-test"),
+		DatabricksKeyConfig: &schemas.DatabricksKeyConfig{
+			WorkspaceURL: *schemas.NewSecretVar("https://" + serverHost(t, server) + "/"),
+		},
+	}
+
+	ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if _, bErr := provider.ChatCompletion(ctx, key, &schemas.BifrostChatRequest{
+		Provider: schemas.Databricks,
+		Model:    "databricks-gpt-oss-120b",
+		Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hi")}}},
+	}); bErr != nil {
+		t.Fatalf("ChatCompletion returned an error: %v", bErr)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if gotPath != "/serving-endpoints/chat/completions" {
+		t.Errorf("path: got %q, want %q (a pasted scheme and trailing slash must be stripped)", gotPath, "/serving-endpoints/chat/completions")
+	}
+}
+
+// TestDatabricksPATAuth pins that a key value is sent as a bearer token.
+func TestDatabricksPATAuth(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var gotAuth string
+
+	provider, server := newStubProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotAuth = r.Header.Get("Authorization")
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(stubChatResponse))
+	})
+
+	key := schemas.Key{
+		Models: []string{"*"},
+		Value:  *schemas.NewSecretVar("dapi-secret-token"),
+		DatabricksKeyConfig: &schemas.DatabricksKeyConfig{
+			WorkspaceURL: *schemas.NewSecretVar(serverHost(t, server)),
+		},
+	}
+
+	ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if _, bErr := provider.ChatCompletion(ctx, key, &schemas.BifrostChatRequest{
+		Provider: schemas.Databricks,
+		Model:    "databricks-gpt-oss-120b",
+		Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hi")}}},
+	}); bErr != nil {
+		t.Fatalf("ChatCompletion returned an error: %v", bErr)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if gotAuth != "Bearer dapi-secret-token" {
+		t.Errorf("Authorization: got %q, want %q", gotAuth, "Bearer dapi-secret-token")
+	}
+}
+
+// TestDatabricksChatStripsUnsupportedFields reproduces the Unity AI Gateway
+// rejection seen with Claude Code requests. Databricks' OpenAI-compatible Chat
+// Completions surface rejects these extensions, while unrelated provider-specific
+// extra params still need to pass through.
+func TestDatabricksChatStripsUnsupportedFields(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var gotBody map[string]any
+
+	provider, server := newStubProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		mu.Lock()
+		gotBody = body
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(stubChatResponse))
+	})
+
+	key := schemas.Key{
+		Models: []string{"*"},
+		Value:  *schemas.NewSecretVar("dapi-test"),
+		DatabricksKeyConfig: &schemas.DatabricksKeyConfig{
+			WorkspaceURL: *schemas.NewSecretVar(serverHost(t, server)),
+		},
+	}
+	contextManagement := json.RawMessage(`{"edits":[{"type":"clear_thinking_20251015","keep":"all"}]}`)
+	request := &schemas.BifrostChatRequest{
+		Provider: schemas.Databricks,
+		Model:    "system.ai.claude-opus-5",
+		Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hey")}}},
+		Params: &schemas.ChatParameters{
+			ContextManagement: contextManagement,
+			Reasoning:         &schemas.ChatReasoning{Effort: schemas.Ptr("medium")},
+			ExtraParams: map[string]any{
+				"context_management":    contextManagement,
+				"reasoning_effort":      "medium",
+				"databricks_test_param": "kept",
+			},
+		},
+	}
+
+	ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, bErr := provider.ChatCompletion(ctx, key, request); bErr != nil {
+		t.Fatalf("ChatCompletion returned an error: %v", bErr)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if _, exists := gotBody["context_management"]; exists {
+		t.Errorf("context_management reached Databricks: %#v", gotBody["context_management"])
+	}
+	if _, exists := gotBody["reasoning_effort"]; exists {
+		t.Errorf("reasoning_effort reached Databricks: %#v", gotBody["reasoning_effort"])
+	}
+	if gotBody["databricks_test_param"] != "kept" {
+		t.Errorf("unrelated extra param: got %#v, want %q", gotBody["databricks_test_param"], "kept")
+	}
+	if len(request.Params.ContextManagement) == 0 || request.Params.Reasoning == nil || request.Params.Reasoning.Effort == nil ||
+		request.Params.ExtraParams["context_management"] == nil || request.Params.ExtraParams["reasoning_effort"] == nil {
+		t.Error("sanitizing the wire request mutated the original request")
+	}
+}
+
+// TestDatabricksChatStreamStripsUnsupportedFields covers the streaming handler
+// used by Claude Code. It must apply the same field filtering as the unary path.
+func TestDatabricksChatStreamStripsUnsupportedFields(t *testing.T) {
+	t.Parallel()
+
+	bodyCh := make(chan map[string]any, 1)
+	provider, server := newStubProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		bodyCh <- body
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	})
+
+	key := schemas.Key{
+		Models: []string{"*"},
+		Value:  *schemas.NewSecretVar("dapi-test"),
+		DatabricksKeyConfig: &schemas.DatabricksKeyConfig{
+			WorkspaceURL: *schemas.NewSecretVar(serverHost(t, server)),
+		},
+	}
+	contextManagement := json.RawMessage(`{"edits":[{"type":"clear_thinking_20251015","keep":"all"}]}`)
+	request := &schemas.BifrostChatRequest{
+		Provider: schemas.Databricks,
+		Model:    "system.ai.claude-opus-5",
+		Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hey")}}},
+		Params: &schemas.ChatParameters{
+			ContextManagement: contextManagement,
+			Reasoning:         &schemas.ChatReasoning{Effort: schemas.Ptr("medium")},
+			ExtraParams: map[string]any{
+				"context_management":    contextManagement,
+				"reasoning_effort":      "medium",
+				"databricks_test_param": "kept",
+			},
+		},
+	}
+
+	ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	postHookRunner := func(_ *schemas.BifrostContext, result *schemas.BifrostResponse, bErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError) {
+		return result, bErr
+	}
+	stream, bErr := provider.ChatCompletionStream(ctx, postHookRunner, nil, key, request)
+	if bErr != nil {
+		t.Fatalf("ChatCompletionStream returned an error: %v", bErr)
+	}
+	for range stream {
+	}
+
+	select {
+	case gotBody := <-bodyCh:
+		if _, exists := gotBody["context_management"]; exists {
+			t.Errorf("context_management reached Databricks: %#v", gotBody["context_management"])
+		}
+		if _, exists := gotBody["reasoning_effort"]; exists {
+			t.Errorf("reasoning_effort reached Databricks: %#v", gotBody["reasoning_effort"])
+		}
+		if gotBody["databricks_test_param"] != "kept" {
+			t.Errorf("unrelated extra param: got %#v, want %q", gotBody["databricks_test_param"], "kept")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("mock server did not receive the streaming request")
+	}
+
+	if len(request.Params.ContextManagement) == 0 || request.Params.Reasoning == nil || request.Params.Reasoning.Effort == nil ||
+		request.Params.ExtraParams["context_management"] == nil || request.Params.ExtraParams["reasoning_effort"] == nil {
+		t.Error("sanitizing the wire request mutated the original request")
+	}
+}
+
+// TestDatabricksGatewayRequestTags covers forwarding Bifrost governance labels to Databricks
+// for usage attribution. The header is opt-in, carries display names only, and must not
+// displace a header the caller supplied.
+func TestDatabricksGatewayRequestTags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		forward   bool
+		preset    string
+		wantTags  map[string]string
+		wantEmpty bool
+	}{
+		{name: "disabled by default", forward: false, wantEmpty: true},
+		{
+			name:     "forwards governance labels when enabled",
+			forward:  true,
+			wantTags: map[string]string{"virtual_key": "vk-prod", "team": "platform", "customer": "acme"},
+		},
+		{
+			name:    "a caller supplied header wins",
+			forward: true,
+			preset:  `{"project":"caller"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var mu sync.Mutex
+			var gotTags string
+
+			provider, server := newStubProvider(t, func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				gotTags = r.Header.Get("Databricks-Ai-Gateway-Request-Tags")
+				mu.Unlock()
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(stubChatResponse))
+			})
+
+			key := schemas.Key{
+				Models: []string{"*"},
+				Value:  *schemas.NewSecretVar("dapi-test"),
+				DatabricksKeyConfig: &schemas.DatabricksKeyConfig{
+					WorkspaceURL:       *schemas.NewSecretVar(serverHost(t, server)),
+					ForwardGatewayTags: tt.forward,
+				},
+			}
+
+			ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			ctx.SetValue(schemas.BifrostContextKeyGovernanceVirtualKeyName, "vk-prod")
+			ctx.SetValue(schemas.BifrostContextKeyGovernanceTeamName, "platform")
+			ctx.SetValue(schemas.BifrostContextKeyGovernanceCustomerName, "acme")
+			if tt.preset != "" {
+				ctx.SetValue(schemas.BifrostContextKeyExtraHeaders, map[string][]string{
+					"Databricks-Ai-Gateway-Request-Tags": {tt.preset},
+				})
+			}
+
+			if _, bErr := provider.ChatCompletion(ctx, key, &schemas.BifrostChatRequest{
+				Provider: schemas.Databricks,
+				Model:    "system.ai.claude-sonnet-4-5",
+				Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hi")}}},
+			}); bErr != nil {
+				t.Fatalf("ChatCompletion returned an error: %v", bErr)
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+
+			if tt.wantEmpty {
+				if gotTags != "" {
+					t.Errorf("request tags: got %q, want no header when forwarding is disabled", gotTags)
+				}
+				return
+			}
+			if tt.preset != "" {
+				if gotTags != tt.preset {
+					t.Errorf("request tags: got %q, want the caller supplied %q", gotTags, tt.preset)
+				}
+				return
+			}
+
+			var got map[string]string
+			if err := json.Unmarshal([]byte(gotTags), &got); err != nil {
+				t.Fatalf("request tags %q is not valid JSON: %v", gotTags, err)
+			}
+			for k, want := range tt.wantTags {
+				if got[k] != want {
+					t.Errorf("request tag %q: got %q, want %q", k, got[k], want)
+				}
+			}
+		})
+	}
+}
+
+// TestDatabricksListModelsDoesNotCallWorkspaceAPIs verifies that both configured API formats
+// use the datasheet-only model catalog and never call a Databricks inventory endpoint.
+func TestDatabricksListModelsDoesNotCallWorkspaceAPIs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		apiFormat schemas.DatabricksAPIFormat
+		wantPath  string
+		body      string
+		wantIDs   []string
+	}{
+		{
+			name:      "model serving endpoints",
+			apiFormat: schemas.DatabricksAPIFormatModelServing,
+			wantPath:  "/api/2.0/serving-endpoints",
+			body: `{"endpoints":[
+				{"name":"databricks-claude-sonnet-4-5","task":"llm/v1/chat","state":{"ready":"READY"}},
+				{"name":"databricks-gte-large-en","task":"llm/v1/embeddings"},
+				{"name":"half-built","state":{"ready":"NOT_READY"}}
+			]}`,
+			wantIDs: []string{"databricks/databricks-claude-sonnet-4-5", "databricks/databricks-gte-large-en"},
+		},
+		{
+			name:      "unity catalog model services",
+			apiFormat: schemas.DatabricksAPIFormatAIGateway,
+			wantPath:  "/api/2.1/unity-catalog/model-services",
+			body: `{"model_services":[
+				{"full_name":"model-services/system.ai.claude-sonnet-4-5","name":"claude-sonnet-4-5"},
+				{"catalog_name":"main","schema_name":"default","name":"my-service"}
+			]}`,
+			wantIDs: []string{"databricks/system.ai.claude-sonnet-4-5", "databricks/main.default.my-service"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var mu sync.Mutex
+			var gotPath string
+
+			provider, server := newStubProvider(t, func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				gotPath = r.URL.Path
+				mu.Unlock()
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.body))
+			})
+
+			keys := []schemas.Key{{
+				Models: []string{"*"},
+				Value:  *schemas.NewSecretVar("dapi-test"),
+				DatabricksKeyConfig: &schemas.DatabricksKeyConfig{
+					WorkspaceURL: *schemas.NewSecretVar(serverHost(t, server)),
+					APIFormat:    tt.apiFormat,
+				},
+			}}
+
+			ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			response, bErr := provider.ListModels(ctx, keys, &schemas.BifrostListModelsRequest{Provider: schemas.Databricks})
+			if bErr != nil {
+				t.Fatalf("ListModels returned an error: %v", bErr)
+			}
+
+			mu.Lock()
+			if gotPath != "" {
+				t.Errorf("unexpected Databricks model inventory request to %q", gotPath)
+			}
+			mu.Unlock()
+
+			if len(response.Data) != 0 {
+				t.Fatalf("ListModels returned live models instead of deferring to the datasheet: %#v", response.Data)
+			}
+		})
+	}
+}
+
+// TestDatabricksUnfilteredListModelsDoesNotCallWorkspaceAPIs covers the unfiltered path used
+// by GET /api/models and ensures it also leaves model selection entirely to the datasheet.
+func TestDatabricksUnfilteredListModelsDoesNotCallWorkspaceAPIs(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	gotPaths := make(map[string]int)
+	provider, server := newStubProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotPaths[r.URL.Path]++
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/2.0/serving-endpoints":
+			_, _ = w.Write([]byte(`{"endpoints":[{"name":"databricks-gpt-oss-120b","state":{"ready":"READY"}}]}`))
+		case "/api/2.1/unity-catalog/model-services":
+			_, _ = w.Write([]byte(`{"model_services":[{"full_name":"model-services/main.default.my-service"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	keys := []schemas.Key{{
+		Models: []string{"*"},
+		Value:  *schemas.NewSecretVar("dapi-test"),
+		DatabricksKeyConfig: &schemas.DatabricksKeyConfig{
+			WorkspaceURL: *schemas.NewSecretVar(serverHost(t, server)),
+			APIFormat:    schemas.DatabricksAPIFormatModelServing,
+		},
+	}}
+	ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	response, bErr := provider.ListModels(ctx, keys, &schemas.BifrostListModelsRequest{
+		Provider:   schemas.Databricks,
+		Unfiltered: true,
+	})
+	if bErr != nil {
+		t.Fatalf("ListModels returned an error: %v", bErr)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(gotPaths) != 0 {
+		t.Errorf("unexpected Databricks model inventory requests: %v", gotPaths)
+	}
+	if len(response.Data) != 0 {
+		t.Fatalf("ListModels returned live models instead of deferring to the datasheet: %#v", response.Data)
+	}
+}
+
+// TestDatabricksUnfilteredListModelsIgnoresWorkspaceResponses ensures even a reachable
+// inventory endpoint cannot leak live resource names into the datasheet-only catalog.
+func TestDatabricksUnfilteredListModelsIgnoresWorkspaceResponses(t *testing.T) {
+	t.Parallel()
+
+	provider, server := newStubProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/2.0/serving-endpoints" {
+			_, _ = w.Write([]byte(`{"endpoints":[{"name":"databricks-gpt-oss-120b"}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error_code":"PERMISSION_DENIED","message":"AI Gateway unavailable"}`))
+	})
+
+	keys := []schemas.Key{{
+		Models: []string{"*"},
+		Value:  *schemas.NewSecretVar("dapi-test"),
+		DatabricksKeyConfig: &schemas.DatabricksKeyConfig{
+			WorkspaceURL: *schemas.NewSecretVar(serverHost(t, server)),
+		},
+	}}
+	ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	response, bErr := provider.ListModels(ctx, keys, &schemas.BifrostListModelsRequest{
+		Provider:   schemas.Databricks,
+		Unfiltered: true,
+	})
+	if bErr != nil {
+		t.Fatalf("ListModels returned an error despite one successful surface: %v", bErr)
+	}
+	if len(response.Data) != 0 {
+		t.Fatalf("ListModels returned live models instead of deferring to the datasheet: %#v", response.Data)
+	}
+}
+
+// TestDatabricksListModelsIgnoresWorkspaceErrors verifies that an unavailable inventory API
+// cannot mark an otherwise usable Databricks key as failed.
+func TestDatabricksListModelsIgnoresWorkspaceErrors(t *testing.T) {
+	t.Parallel()
+
+	provider, server := newStubProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("Databricks model inventory API was called")
+	})
+
+	keys := []schemas.Key{{
+		Models: []string{"*"},
+		Value:  *schemas.NewSecretVar("dapi-test"),
+		DatabricksKeyConfig: &schemas.DatabricksKeyConfig{
+			WorkspaceURL: *schemas.NewSecretVar(serverHost(t, server)),
+		},
+	}}
+
+	ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	response, bErr := provider.ListModels(ctx, keys, &schemas.BifrostListModelsRequest{Provider: schemas.Databricks})
+	if bErr != nil {
+		t.Fatalf("ListModels returned an error: %v", bErr)
+	}
+	if len(response.Data) != 0 {
+		t.Fatalf("ListModels returned live models instead of deferring to the datasheet: %#v", response.Data)
+	}
+}
+
+// TestDatabricksMissingCredentials covers the two misconfigurations the provider must reject
+// locally rather than sending an unauthenticated request upstream.
+func TestDatabricksMissingCredentials(t *testing.T) {
+	t.Parallel()
+
+	provider, server := newStubProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("upstream was called; the request should have been rejected locally")
+	})
+	host := serverHost(t, server)
+
+	tests := []struct {
+		name string
+		key  schemas.Key
+	}{
+		{
+			name: "no workspace url",
+			key: schemas.Key{
+				Models: []string{"*"},
+				Value:  *schemas.NewSecretVar("dapi-test"),
+			},
+		},
+		{
+			name: "no token and no service principal",
+			key: schemas.Key{
+				Models:              []string{"*"},
+				DatabricksKeyConfig: &schemas.DatabricksKeyConfig{WorkspaceURL: *schemas.NewSecretVar(host)},
+			},
+		},
+		{
+			name: "half configured service principal",
+			key: schemas.Key{
+				Models: []string{"*"},
+				DatabricksKeyConfig: &schemas.DatabricksKeyConfig{
+					WorkspaceURL: *schemas.NewSecretVar(host),
+					ClientID:     schemas.NewSecretVar("sp-client-id"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			if _, bErr := provider.ChatCompletion(ctx, tt.key, &schemas.BifrostChatRequest{
+				Provider: schemas.Databricks,
+				Model:    "databricks-gpt-oss-120b",
+				Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hi")}}},
+			}); bErr == nil {
+				t.Fatal("ChatCompletion: got nil error, want a configuration error")
+			}
+		})
+	}
+}

--- a/core/providers/databricks/databricks_test.go
+++ b/core/providers/databricks/databricks_test.go
@@ -748,3 +748,65 @@ func TestDatabricksMissingCredentials(t *testing.T) {
 		})
 	}
 }
+
+// TestDatabricksGatewayTagsDoNotMutateCallerHeaders pins that forwarding governance tags
+// never writes into the caller-owned extra-headers map on the context. That map is shared
+// with every other reader of the context (a fallback provider, concurrent goroutines), so
+// the tag header must travel with the Databricks request alone.
+func TestDatabricksGatewayTagsDoNotMutateCallerHeaders(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var gotTags, gotCaller string
+
+	provider, server := newStubProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotTags = r.Header.Get("Databricks-Ai-Gateway-Request-Tags")
+		gotCaller = r.Header.Get("X-Caller")
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(stubChatResponse))
+	})
+
+	key := schemas.Key{
+		Models: []string{"*"},
+		Value:  *schemas.NewSecretVar("dapi-test"),
+		DatabricksKeyConfig: &schemas.DatabricksKeyConfig{
+			WorkspaceURL:       *schemas.NewSecretVar(serverHost(t, server)),
+			ForwardGatewayTags: true,
+		},
+	}
+
+	callerHeaders := map[string][]string{"X-Caller": {"1"}}
+
+	ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceTeamName, "platform")
+	ctx.SetValue(schemas.BifrostContextKeyExtraHeaders, callerHeaders)
+
+	if _, bErr := provider.ChatCompletion(ctx, key, &schemas.BifrostChatRequest{
+		Provider: schemas.Databricks,
+		Model:    "system.ai.claude-sonnet-4-5",
+		Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hi")}}},
+	}); bErr != nil {
+		t.Fatalf("ChatCompletion returned an error: %v", bErr)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if gotTags == "" {
+		t.Fatal("request tags header was not sent")
+	}
+	if gotCaller != "1" {
+		t.Errorf("caller header: got %q, want %q", gotCaller, "1")
+	}
+	if _, leaked := callerHeaders["Databricks-Ai-Gateway-Request-Tags"]; leaked {
+		t.Error("the caller-owned extra headers map was mutated with the tag header")
+	}
+	if len(callerHeaders) != 1 {
+		t.Errorf("caller-owned extra headers map has %d entries, want 1", len(callerHeaders))
+	}
+	if ctxHeaders, _ := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string); len(ctxHeaders) != 1 {
+		t.Errorf("context extra headers has %d entries after the request, want the caller's 1", len(ctxHeaders))
+	}
+}

--- a/core/providers/databricks/errors.go
+++ b/core/providers/databricks/errors.go
@@ -1,0 +1,57 @@
+package databricks
+
+import (
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+// DatabricksError is the error envelope the Databricks workspace REST APIs return. The
+// inference surfaces return the OpenAI-shaped {"error": {...}} instead, so both shapes are
+// declared here and whichever is populated wins.
+type DatabricksError struct {
+	// Workspace REST API shape (serving-endpoints, unity-catalog).
+	ErrorCode string `json:"error_code,omitempty"`
+	Message   string `json:"message,omitempty"`
+	Details   any    `json:"details,omitempty"`
+
+	// OpenAI-compatible inference shape.
+	Error *struct {
+		Message string  `json:"message"`
+		Type    *string `json:"type,omitempty"`
+		Code    *string `json:"code,omitempty"`
+	} `json:"error,omitempty"`
+}
+
+// parseDatabricksError normalises a Databricks HTTP error response, preserving the Databricks
+// error code so an authorization failure stays an authorization failure rather than being
+// flattened into a generic "model not found".
+func parseDatabricksError(resp *fasthttp.Response) *schemas.BifrostError {
+	var dbErr DatabricksError
+	bifrostErr := providerUtils.HandleProviderAPIError(resp, &dbErr)
+
+	if bifrostErr.Error == nil {
+		bifrostErr.Error = &schemas.ErrorField{}
+	}
+
+	if dbErr.Error != nil {
+		if dbErr.Error.Message != "" {
+			bifrostErr.Error.Message = dbErr.Error.Message
+		}
+		if dbErr.Error.Type != nil {
+			bifrostErr.Error.Type = dbErr.Error.Type
+		}
+		if dbErr.Error.Code != nil {
+			bifrostErr.Error.Code = dbErr.Error.Code
+		}
+		return bifrostErr
+	}
+
+	if dbErr.Message != "" {
+		bifrostErr.Error.Message = dbErr.Message
+	}
+	if dbErr.ErrorCode != "" {
+		bifrostErr.Error.Code = schemas.Ptr(dbErr.ErrorCode)
+	}
+	return bifrostErr
+}

--- a/core/providers/databricks/inference.go
+++ b/core/providers/databricks/inference.go
@@ -94,7 +94,7 @@ func (provider *DatabricksProvider) ChatCompletionStream(ctx *schemas.BifrostCon
 		nil,
 		nil,
 		nil,
-		nil,
+		chatStreamOptionsFixup(request.Model),
 		nil,
 		nil,
 		provider.logger,

--- a/core/providers/databricks/inference.go
+++ b/core/providers/databricks/inference.go
@@ -1,0 +1,191 @@
+// Inference operations served by both Databricks surfaces. Every method delegates to the
+// shared OpenAI handlers; this file only supplies the resolved URL and Authorization header.
+package databricks
+
+import (
+	"context"
+	"maps"
+
+	"github.com/maximhq/bifrost/core/providers/openai"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// stripUnsupportedChatFields removes request extensions that Databricks'
+// OpenAI-compatible Chat Completions surfaces reject. Work on a
+// copy because the original request may be reused by fallbacks and post-hooks.
+func stripUnsupportedChatFields(request *schemas.BifrostChatRequest) *schemas.BifrostChatRequest {
+	if request == nil || request.Params == nil {
+		return request
+	}
+	_, hasExtraContextManagement := request.Params.ExtraParams["context_management"]
+	_, hasExtraReasoningEffort := request.Params.ExtraParams["reasoning_effort"]
+	hasReasoningEffort := request.Params.Reasoning != nil &&
+		(request.Params.Reasoning.Effort != nil || request.Params.Reasoning.MaxTokens != nil)
+	if len(request.Params.ContextManagement) == 0 && !hasExtraContextManagement &&
+		!hasReasoningEffort && !hasExtraReasoningEffort {
+		return request
+	}
+
+	requestCopy := *request
+	paramsCopy := *request.Params
+	paramsCopy.ContextManagement = nil
+	if paramsCopy.Reasoning != nil {
+		reasoningCopy := *paramsCopy.Reasoning
+		reasoningCopy.Effort = nil
+		// The shared OpenAI converter derives reasoning_effort from MaxTokens
+		// when Effort is absent, so clear both inputs to guarantee omission.
+		reasoningCopy.MaxTokens = nil
+		paramsCopy.Reasoning = &reasoningCopy
+	}
+	if paramsCopy.ExtraParams != nil {
+		paramsCopy.ExtraParams = maps.Clone(paramsCopy.ExtraParams)
+		delete(paramsCopy.ExtraParams, "context_management")
+		delete(paramsCopy.ExtraParams, "reasoning_effort")
+	}
+	requestCopy.Params = &paramsCopy
+	return &requestCopy
+}
+
+// ChatCompletion performs a chat completion request against the resolved Databricks surface.
+func (provider *DatabricksProvider) ChatCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostChatRequest) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+	request = stripUnsupportedChatFields(request)
+	url, auth, bErr := provider.prepareRequest(ctx, key, request.Model, "/chat/completions")
+	if bErr != nil {
+		return nil, bErr
+	}
+	return openai.HandleOpenAIChatCompletionRequest(
+		ctx,
+		provider.client,
+		url,
+		request,
+		auth,
+		provider.networkConfig.ExtraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		provider.GetProviderKey(),
+		nil,
+		nil,
+		nil,
+		provider.logger,
+	)
+}
+
+// ChatCompletionStream performs a streaming chat completion request against the resolved
+// Databricks surface. Both surfaces emit OpenAI-shaped Server-Sent Events.
+func (provider *DatabricksProvider) ChatCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	request = stripUnsupportedChatFields(request)
+	url, auth, bErr := provider.prepareRequest(ctx, key, request.Model, "/chat/completions")
+	if bErr != nil {
+		return nil, bErr
+	}
+	return openai.HandleOpenAIChatCompletionStreaming(
+		ctx,
+		provider.streamingClient,
+		url,
+		request,
+		auth,
+		provider.networkConfig.ExtraHeaders,
+		provider.networkConfig.StreamIdleTimeoutInSeconds,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		provider.GetProviderKey(),
+		postHookRunner,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		provider.logger,
+		postHookSpanFinalizer,
+	)
+}
+
+// Embedding performs an embedding request against the resolved Databricks surface.
+func (provider *DatabricksProvider) Embedding(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+	url, auth, bErr := provider.prepareRequest(ctx, key, request.Model, "/embeddings")
+	if bErr != nil {
+		return nil, bErr
+	}
+	return openai.HandleOpenAIEmbeddingRequest(
+		ctx,
+		provider.client,
+		url,
+		request,
+		auth,
+		provider.networkConfig.ExtraHeaders,
+		provider.GetProviderKey(),
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		nil,
+		provider.logger,
+	)
+}
+
+// Responses performs a responses request. Model Serving exposes the OpenAI Responses API
+// natively at /serving-endpoints/responses. The Unity AI Gateway MLflow surface is chat-only,
+// so there the request is emulated through chat completions.
+func (provider *DatabricksProvider) Responses(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
+	if resolveAPIFormat(key, request.Model) == schemas.DatabricksAPIFormatAIGateway {
+		chatResponse, bErr := provider.ChatCompletion(ctx, key, request.ToChatRequest())
+		if bErr != nil {
+			return nil, bErr
+		}
+		return chatResponse.ToBifrostResponsesResponse(), nil
+	}
+
+	url, auth, bErr := provider.prepareRequest(ctx, key, request.Model, "/responses")
+	if bErr != nil {
+		return nil, bErr
+	}
+	return openai.HandleOpenAIResponsesRequest(
+		ctx,
+		provider.client,
+		url,
+		request,
+		auth,
+		provider.networkConfig.ExtraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		provider.GetProviderKey(),
+		nil,
+		nil,
+		nil,
+		provider.logger,
+	)
+}
+
+// ResponsesStream performs a streaming responses request. See Responses for how the two
+// surfaces differ.
+func (provider *DatabricksProvider) ResponsesStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostResponsesRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	if resolveAPIFormat(key, request.Model) == schemas.DatabricksAPIFormatAIGateway {
+		ctx.SetValue(schemas.BifrostContextKeyIsResponsesToChatCompletionFallback, true)
+		return provider.ChatCompletionStream(ctx, postHookRunner, postHookSpanFinalizer, key, request.ToChatRequest())
+	}
+
+	url, auth, bErr := provider.prepareRequest(ctx, key, request.Model, "/responses")
+	if bErr != nil {
+		return nil, bErr
+	}
+	return openai.HandleOpenAIResponsesStreaming(
+		ctx,
+		provider.streamingClient,
+		url,
+		request,
+		auth,
+		provider.networkConfig.ExtraHeaders,
+		provider.networkConfig.StreamIdleTimeoutInSeconds,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		provider.GetProviderKey(),
+		postHookRunner,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		provider.logger,
+		postHookSpanFinalizer,
+	)
+}

--- a/core/providers/databricks/models.go
+++ b/core/providers/databricks/models.go
@@ -1,0 +1,22 @@
+package databricks
+
+import (
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// listModelsByKey intentionally returns no live models. Databricks exposes model inventory
+// through workspace APIs whose resource names do not consistently match inference model IDs.
+// Until that mapping is reliable, the framework model catalog uses its datasheet
+// (governance_model_pricing) as the sole source of Databricks models.
+func (provider *DatabricksProvider) listModelsByKey(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
+	return &schemas.BifrostListModelsResponse{Data: []schemas.Model{}}, nil
+}
+
+// ListModels returns an empty successful live result for every configured key. The shared
+// multi-key helper preserves normal key-status handling while ensuring no Databricks list-models
+// HTTP request is made. The HTTP transport subsequently serves Databricks models exclusively
+// from the datasheet-backed model catalog.
+func (provider *DatabricksProvider) ListModels(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
+	return providerUtils.HandleMultipleListModelsRequests(ctx, keys, request, provider.listModelsByKey)
+}

--- a/core/providers/databricks/oauth_internal_test.go
+++ b/core/providers/databricks/oauth_internal_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"sync"
+
+	"github.com/maximhq/bifrost/core/providers/openai"
 	"testing"
 	"time"
 
@@ -128,5 +130,41 @@ func TestOAuthM2M(t *testing.T) {
 	}
 	if tokenMints != 1 {
 		t.Errorf("token mints: got %d, want 1 (the token source must cache across requests)", tokenMints)
+	}
+}
+
+// TestChatStreamOptionsFixup covers the Gemini-backed endpoints that reject the
+// stream_options Bifrost sets on every stream. Every other endpoint must keep the
+// shared handler's default so usage still lands on the final chunk.
+func TestChatStreamOptionsFixup(t *testing.T) {
+	for _, tc := range []struct {
+		model   string
+		dropped bool
+	}{
+		{"databricks-gemini-3-1-pro", true},
+		{"databricks-Gemini-2-5-flash", true},
+		{"system.ai.gemini-2-5-pro", true},
+		{"databricks-claude-sonnet-4-5", false},
+		{"databricks-gpt-5", false},
+		{"system.ai.claude-sonnet-4-5", false},
+	} {
+		fixup := chatStreamOptionsFixup(tc.model)
+		if !tc.dropped {
+			if fixup != nil {
+				t.Errorf("%s: expected no fixup, got one", tc.model)
+			}
+			continue
+		}
+		if fixup == nil {
+			t.Fatalf("%s: expected a fixup, got nil", tc.model)
+		}
+		reqBody := &openai.OpenAIChatRequest{}
+		reqBody.StreamOptions = &schemas.ChatStreamOptions{IncludeUsage: schemas.Ptr(true)}
+		if got := fixup(reqBody); got.StreamOptions != nil {
+			t.Errorf("%s: stream_options survived the fixup", tc.model)
+		}
+		if fixup(nil) != nil {
+			t.Errorf("%s: fixup must tolerate a nil body", tc.model)
+		}
 	}
 }

--- a/core/providers/databricks/oauth_internal_test.go
+++ b/core/providers/databricks/oauth_internal_test.go
@@ -1,0 +1,132 @@
+package databricks
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// testLogger is a minimal logger for tests that implements schemas.Logger. The provider
+// package cannot import the root core package (which imports it), so a local one is used.
+type testLogger struct{}
+
+func (testLogger) Debug(string, ...any)                   {}
+func (testLogger) Info(string, ...any)                    {}
+func (testLogger) Warn(string, ...any)                    {}
+func (testLogger) Error(string, ...any)                   {}
+func (testLogger) Fatal(string, ...any)                   {}
+func (testLogger) SetLevel(schemas.LogLevel)              {}
+func (testLogger) SetOutputType(schemas.LoggerOutputType) {}
+func (testLogger) LogHTTPRequest(schemas.LogLevel, string) schemas.LogEventBuilder {
+	return schemas.NoopLogEvent
+}
+
+// TestOAuthM2M covers the service principal path end to end: the token is minted from the
+// workspace OIDC endpoint with a client_credentials grant and HTTP Basic auth, then used as
+// the bearer token; and a second request reuses the cached token rather than minting again.
+// A regression here would mint a token per request against a rate-limited endpoint.
+//
+// This lives in the package's own test binary so it can point the token exchange at a stub
+// without exposing a test hook on the public API.
+func TestOAuthM2M(t *testing.T) {
+	var mu sync.Mutex
+	var tokenMints int
+	var gotGrantType, gotScope, gotBasicUser, gotBasicPass, gotAuth string
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == oauthTokenPath {
+			body, _ := io.ReadAll(r.Body)
+			form, _ := url.ParseQuery(string(body))
+			user, pass, _ := r.BasicAuth()
+
+			mu.Lock()
+			tokenMints++
+			gotGrantType = form.Get("grant_type")
+			gotScope = form.Get("scope")
+			gotBasicUser, gotBasicPass = user, pass
+			mu.Unlock()
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"minted-token","token_type":"Bearer","expires_in":3600}`))
+			return
+		}
+
+		mu.Lock()
+		gotAuth = r.Header.Get("Authorization")
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-1","object":"chat.completion","created":1700000000,"model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer server.Close()
+
+	// The oauth2 client-credentials flow uses its own HTTP client, which must be told to
+	// trust the test server's certificate.
+	oauthHTTPClient = &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
+	defer func() { oauthHTTPClient = nil }()
+
+	provider, err := NewDatabricksProvider(&schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{
+			DefaultRequestTimeoutInSeconds: 10,
+			InsecureSkipVerify:             true,
+			AllowPrivateNetwork:            true,
+		},
+	}, testLogger{})
+	if err != nil {
+		t.Fatalf("NewDatabricksProvider: %v", err)
+	}
+
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
+	}
+
+	key := schemas.Key{
+		Models: []string{"*"},
+		DatabricksKeyConfig: &schemas.DatabricksKeyConfig{
+			WorkspaceURL: *schemas.NewSecretVar(u.Host),
+			ClientID:     schemas.NewSecretVar("sp-client-id"),
+			ClientSecret: schemas.NewSecretVar("sp-client-secret"),
+		},
+	}
+	request := &schemas.BifrostChatRequest{
+		Provider: schemas.Databricks,
+		Model:    "databricks-gpt-oss-120b",
+		Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hi")}}},
+	}
+
+	for i := range 2 {
+		ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 10*time.Second)
+		if _, bErr := provider.ChatCompletion(ctx, key, request); bErr != nil {
+			cancel()
+			t.Fatalf("ChatCompletion (attempt %d) returned an error: %v", i+1, bErr)
+		}
+		cancel()
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if gotGrantType != "client_credentials" {
+		t.Errorf("grant_type: got %q, want %q", gotGrantType, "client_credentials")
+	}
+	if gotScope != oauthScope {
+		t.Errorf("scope: got %q, want %q", gotScope, oauthScope)
+	}
+	if gotBasicUser != "sp-client-id" || gotBasicPass != "sp-client-secret" {
+		t.Errorf("basic auth: got %q/%q, want the service principal credentials", gotBasicUser, gotBasicPass)
+	}
+	if gotAuth != "Bearer minted-token" {
+		t.Errorf("Authorization: got %q, want %q", gotAuth, "Bearer minted-token")
+	}
+	if tokenMints != 1 {
+		t.Errorf("token mints: got %d, want 1 (the token source must cache across requests)", tokenMints)
+	}
+}

--- a/core/providers/databricks/unsupported.go
+++ b/core/providers/databricks/unsupported.go
@@ -1,0 +1,189 @@
+// Operations the Databricks inference surfaces do not serve. Databricks Model Serving hosts
+// arbitrary MLflow models behind /serving-endpoints/{name}/invocations, but that route takes a
+// per-model schema rather than a canonical Bifrost request, so it is not modelled here.
+package databricks
+
+import (
+	"context"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+func (provider *DatabricksProvider) TextCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (*schemas.BifrostTextCompletionResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.TextCompletionRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) TextCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostTextCompletionRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.TextCompletionStreamRequest, provider.GetProviderKey())
+}
+
+// Speech is not supported by the Databricks provider.
+func (provider *DatabricksProvider) Speech(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.SpeechRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) Rerank(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostRerankRequest) (*schemas.BifrostRerankResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.RerankRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) OCR(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostOCRRequest) (*schemas.BifrostOCRResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.OCRRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) SpeechStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostSpeechRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.SpeechStreamRequest, provider.GetProviderKey())
+}
+
+// Transcription is not supported by the Databricks provider.
+func (provider *DatabricksProvider) Transcription(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.TranscriptionRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) TranscriptionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostTranscriptionRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.TranscriptionStreamRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) ImageGeneration(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostImageGenerationRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ImageGenerationRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) ImageGenerationStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostImageGenerationRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ImageGenerationStreamRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) ImageEdit(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostImageEditRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ImageEditRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) ImageEditStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostImageEditRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ImageEditStreamRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) ImageVariation(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostImageVariationRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ImageVariationRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) VideoGeneration(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostVideoGenerationRequest) (*schemas.BifrostVideoGenerationResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.VideoGenerationRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) VideoRetrieve(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostVideoRetrieveRequest) (*schemas.BifrostVideoGenerationResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.VideoRetrieveRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) VideoDownload(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostVideoDownloadRequest) (*schemas.BifrostVideoDownloadResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.VideoDownloadRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) VideoDelete(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostVideoDeleteRequest) (*schemas.BifrostVideoDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.VideoDeleteRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) VideoList(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostVideoListRequest) (*schemas.BifrostVideoListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.VideoListRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) VideoEdit(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostVideoEditRequest) (*schemas.BifrostVideoEditResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.VideoEditRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) VideoRemix(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostVideoRemixRequest) (*schemas.BifrostVideoGenerationResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.VideoRemixRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) BatchCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostBatchCreateRequest) (*schemas.BifrostBatchCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchCreateRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) BatchList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchListRequest) (*schemas.BifrostBatchListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchListRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) BatchRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchRetrieveRequest) (*schemas.BifrostBatchRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchRetrieveRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) BatchCancel(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchCancelRequest) (*schemas.BifrostBatchCancelResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchCancelRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) BatchDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchDeleteRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) BatchResults(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchResultsRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) FileUpload(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostFileUploadRequest) (*schemas.BifrostFileUploadResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileUploadRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) FileList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostFileListRequest) (*schemas.BifrostFileListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileListRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) FileRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostFileRetrieveRequest) (*schemas.BifrostFileRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileRetrieveRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) FileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostFileDeleteRequest) (*schemas.BifrostFileDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileDeleteRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) FileContent(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostFileContentRequest) (*schemas.BifrostFileContentResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileContentRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) CountTokens(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) Compaction(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostCompactionRequest) (*schemas.BifrostCompactionResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CompactionRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) ContainerCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerCreateRequest) (*schemas.BifrostContainerCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerCreateRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) ContainerList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerListRequest) (*schemas.BifrostContainerListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerListRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) ContainerRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerRetrieveRequest) (*schemas.BifrostContainerRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerRetrieveRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) ContainerDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerDeleteRequest) (*schemas.BifrostContainerDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerDeleteRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) ContainerFileCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerFileCreateRequest) (*schemas.BifrostContainerFileCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileCreateRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) ContainerFileList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileListRequest) (*schemas.BifrostContainerFileListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileListRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) ContainerFileRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileRetrieveRequest) (*schemas.BifrostContainerFileRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileRetrieveRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) ContainerFileContent(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileContentRequest) (*schemas.BifrostContainerFileContentResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileContentRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileDeleteRequest) (*schemas.BifrostContainerFileDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) Passthrough(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughRequest, provider.GetProviderKey())
+}
+
+func (provider *DatabricksProvider) PassthroughStream(_ *schemas.BifrostContext, _ schemas.PostHookRunner, _ func(context.Context), _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughStreamRequest, provider.GetProviderKey())
+}

--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -139,6 +139,7 @@ type Key struct {
 	ReplicateKeyConfig     *ReplicateKeyConfig     `json:"replicate_key_config,omitempty"`      // Replicate-specific key configuration
 	OllamaKeyConfig        *OllamaKeyConfig        `json:"ollama_key_config,omitempty"`         // Ollama-specific key configuration
 	SGLKeyConfig           *SGLKeyConfig           `json:"sgl_key_config,omitempty"`            // SGLang-specific key configuration
+	DatabricksKeyConfig    *DatabricksKeyConfig    `json:"databricks_key_config,omitempty"`     // Databricks-specific key configuration
 	Enabled                *bool                   `json:"enabled,omitempty"`                   // Whether the key is active (default:true)
 	UseForBatchAPI         *bool                   `json:"use_for_batch_api,omitempty"`         // Whether this key can be used for batch API operations (default:false for new keys, migrated keys default to true)
 	UseAnthropicEndpoints  *bool                   `json:"use_anthropic_endpoints,omitempty"`   // Whether to use anthropic endpoints for this key
@@ -821,6 +822,38 @@ type OllamaKeyConfig struct {
 // enabling per-key routing and round-robin load balancing across multiple SGLang instances.
 type SGLKeyConfig struct {
 	URL SecretVar `json:"url"` // SGLang server base URL (required, supports env. prefix)
+}
+
+// DatabricksAPIFormat selects which Databricks inference surface a key targets. Both surfaces
+// speak the OpenAI wire format, so this only selects the base path under the workspace host.
+type DatabricksAPIFormat string
+
+const (
+	// DatabricksAPIFormatAuto picks the surface from the model name: a dotted name
+	// (system.ai.*, or a <catalog>.<schema>.<service> Unity Catalog model service) goes to the
+	// Unity AI Gateway; anything else is treated as a Model Serving endpoint name.
+	DatabricksAPIFormatAuto DatabricksAPIFormat = "auto"
+	// DatabricksAPIFormatModelServing targets /serving-endpoints — the Foundation Model APIs,
+	// covering pay-per-token endpoints (databricks-*) and provisioned-throughput endpoints.
+	DatabricksAPIFormatModelServing DatabricksAPIFormat = "model_serving"
+	// DatabricksAPIFormatAIGateway targets /ai-gateway/mlflow/v1 — the Unity AI Gateway model
+	// APIs (model services), governed through Unity Catalog.
+	DatabricksAPIFormatAIGateway DatabricksAPIFormat = "ai_gateway"
+)
+
+// DatabricksKeyConfig represents the Databricks-specific key configuration.
+// It allows each key to target a different Databricks workspace and inference surface, and
+// carries the OAuth machine-to-machine service principal credentials when a personal access
+// token is not used.
+//
+// NOTE: To use OAuth M2M authentication, leave Value in the Key struct empty and set both
+// ClientID and ClientSecret. To use a personal access token, set Value instead.
+type DatabricksKeyConfig struct {
+	WorkspaceURL       SecretVar           `json:"workspace_url"`                  // Databricks workspace URL (required, supports env. prefix); a scheme and trailing path are tolerated
+	APIFormat          DatabricksAPIFormat `json:"api_format,omitempty"`           // Which inference surface to target (default: auto)
+	ClientID           *SecretVar          `json:"client_id,omitempty"`            // OAuth M2M service principal client ID
+	ClientSecret       *SecretVar          `json:"client_secret,omitempty"`        // OAuth M2M service principal client secret
+	ForwardGatewayTags bool                `json:"forward_gateway_tags,omitempty"` // Whether to forward Bifrost governance labels as Databricks-Ai-Gateway-Request-Tags
 }
 
 // Account defines the interface for managing provider accounts and their configurations.

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -74,6 +74,7 @@ const (
 	Sarvam        ModelProvider = "sarvam"
 	Wafer         ModelProvider = "wafer"
 	GithubCopilot ModelProvider = "github-copilot"
+	Databricks    ModelProvider = "databricks"
 )
 
 // SupportedBaseProviders is the list of base providers allowed for custom providers.
@@ -120,6 +121,7 @@ var StandardProviders = []ModelProvider{
 	Sarvam,
 	Wafer,
 	GithubCopilot,
+	Databricks,
 }
 
 // RequestType represents the type of request being made to a provider.

--- a/core/utils.go
+++ b/core/utils.go
@@ -93,6 +93,7 @@ var dynamicallyConfigurableProviders = []schemas.ModelProvider{
 	schemas.BedrockMantle,
 	schemas.Cerebras,
 	schemas.Cohere,
+	schemas.Databricks,
 	schemas.DeepSeek,
 	schemas.Elevenlabs,
 	schemas.Gemini,
@@ -133,7 +134,7 @@ func providerRequiresKey(customConfig *schemas.CustomProviderConfig) bool {
 // Some providers like Vertex and Bedrock have their credentials in additional key configs.
 // Ollama and SGL are keyless (API Key is optional) but use per-key server URLs.
 func CanProviderKeyValueBeEmpty(providerKey schemas.ModelProvider) bool {
-	return providerKey == schemas.Vertex || providerKey == schemas.Bedrock || providerKey == schemas.BedrockMantle || providerKey == schemas.VLLM || providerKey == schemas.Azure || providerKey == schemas.Ollama || providerKey == schemas.SGL
+	return providerKey == schemas.Vertex || providerKey == schemas.Bedrock || providerKey == schemas.BedrockMantle || providerKey == schemas.VLLM || providerKey == schemas.Azure || providerKey == schemas.Ollama || providerKey == schemas.SGL || providerKey == schemas.Databricks
 }
 
 // isKeySkippingAllowed gates SkipKeySelection on the provider this attempt resolved to. The flag
@@ -221,6 +222,18 @@ func validateKey(providerKey schemas.ModelProvider, key *schemas.Key) error {
 		// short-lived setups.
 		if key.Value.GetValue() == "" {
 			return fmt.Errorf("value is required and must be a GitHub Copilot API token")
+		}
+	case schemas.Databricks:
+		// The workspace URL is not required here: an SDK caller may set it once as the
+		// provider base_url instead of per key. The provider raises a configuration error at
+		// request time when neither is set. What is checked here is that the OAuth M2M
+		// service principal is whole, since a half-configured pair can never authenticate.
+		if key.DatabricksKeyConfig != nil {
+			hasClientID := key.DatabricksKeyConfig.ClientID != nil && key.DatabricksKeyConfig.ClientID.GetValue() != ""
+			hasClientSecret := key.DatabricksKeyConfig.ClientSecret != nil && key.DatabricksKeyConfig.ClientSecret.GetValue() != ""
+			if hasClientID != hasClientSecret {
+				return fmt.Errorf("databricks_key_config.client_id and databricks_key_config.client_secret must be set together")
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

Adds Databricks as a first-class provider, covering both Databricks inference surfaces: Model Serving / Foundation Model APIs (`/serving-endpoints`) and Unity AI Gateway model APIs (`/ai-gateway/mlflow/v1`). Both surfaces speak the OpenAI wire format, so all inference is delegated to the shared OpenAI handlers with Databricks-specific URL resolution, authentication, and request sanitization layered on top.

## Changes

- **New `databricks` provider package** implementing `ChatCompletion`, `ChatCompletionStream`, `Embedding`, `Responses`, `ResponsesStream`, and `ListModels`. All other operations return an unsupported-operation error.
- **Surface routing**: model names containing a dot (e.g. `system.ai.claude-sonnet-4-5`, `main.default.my-service`) are automatically routed to the Unity AI Gateway; bare names (e.g. `databricks-claude-sonnet-4-5`) go to Model Serving. An explicit `api_format` on the key overrides auto-detection.
- **Authentication**: supports Databricks personal access tokens (key `Value`) and OAuth M2M service principal credentials (`client_id` / `client_secret` in `DatabricksKeyConfig`). M2M tokens are minted via a `client_credentials` grant against the workspace OIDC endpoint and cached in a `sync.Map`-backed pool to avoid per-request token mints. Cached sources are evicted on credential rejection.
- **`DatabricksKeyConfig`** added to `Key`, carrying `workspace_url`, `api_format`, `client_id`, `client_secret`, and `forward_gateway_tags`. The key value is allowed to be empty (OAuth M2M path), consistent with Vertex/Bedrock.
- **Request sanitization**: `context_management` and `reasoning_effort` fields are stripped from the wire request before sending to Databricks, since Databricks forwards unknown fields to the backing model and Gemini-backed endpoints reject them. The original request object is never mutated so fallbacks and post-hooks see the unmodified input.
- **Gemini stream options fixup**: `stream_options.include_usage` is dropped for Gemini-backed endpoints, which reject it via the Gemini `generation_config` mapping. Non-Gemini endpoints are unaffected.
- **Gateway request tags**: when `forward_gateway_tags` is enabled on a key, Bifrost governance labels (`virtual_key`, `team`, `customer`) are forwarded as the `Databricks-Ai-Gateway-Request-Tags` header. The tag header is attached to the per-request auth map rather than the caller-owned context headers map, so the context is never mutated.
- **`ListModels`** returns an empty live result for every key. Databricks workspace inventory APIs do not produce model IDs that reliably match inference endpoint names, so the datasheet-backed model catalog is the sole source of Databricks models.
- **Validation**: `validateKey` checks that OAuth M2M credentials are either both set or both absent; a half-configured service principal is rejected at registration time.
- **Comprehensive tests** covering surface routing, workspace URL normalization, PAT auth, OAuth M2M token caching, request field stripping (unary and streaming), gateway tag forwarding, context mutation safety, and misconfiguration rejection.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/databricks/...
go test ./core/...
```

For live integration tests, set the following environment variables and run:

```sh
export DATABRICKS_TOKEN=<personal-access-token>
export DATABRICKS_WORKSPACE_URL=<workspace-host>   # e.g. adb-1234567890.azuredatabricks.net
go test ./core/internal/llmtests/... -run TestDatabricks -v
```

**New environment variables:**

| Variable | Description |
|---|---|
| `DATABRICKS_TOKEN` | Databricks personal access token for integration tests |
| `DATABRICKS_WORKSPACE_URL` | Databricks workspace host for integration tests |

For OAuth M2M, configure `DatabricksKeyConfig.ClientID` and `DatabricksKeyConfig.ClientSecret` on the key (leave `Value` empty).

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

- OAuth M2M client secrets are stored as `SecretVar` and resolved at request time; they are never used as map keys or logged. The token source cache key is a SHA-256 hash of the credential tuple.
- The `oauthHTTPClient` override used in internal tests is a package-level variable gated to the internal test binary and is `nil` in production.
- Gateway request tags carry only display-name governance labels (`virtual_key`, `team`, `customer`); no secrets or PII are forwarded.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable