### PR TITLE
feat(schema): add Databricks provider support with workspace URL, OAuth M2M, and AI Gateway routing config

### DIFF
--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -961,7 +961,8 @@
                         "parasail",
                         "perplexity",
                         "sgl",
-                        "huggingface"
+                        "huggingface",
+                        "databricks"
                       ]
                     },
                     "embedding_model": {

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -406,6 +406,9 @@
         "azure": {
           "$ref": "#/$defs/provider_with_azure_config"
         },
+        "databricks": {
+          "$ref": "#/$defs/provider_with_databricks_config"
+        },
         "vertex": {
           "$ref": "#/$defs/provider_with_vertex_config"
         },
@@ -2576,7 +2579,8 @@
                         "perplexity",
                         "replicate",
                         "sgl",
-                        "huggingface"
+                        "huggingface",
+                        "databricks"
                       ]
                     },
                     "embedding_model": {
@@ -4631,6 +4635,51 @@
         }
       ]
     },
+    "databricks_key": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_key"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "databricks_key_config": {
+              "type": "object",
+              "properties": {
+                "workspace_url": {
+                  "type": "string",
+                  "description": "Databricks workspace URL, e.g. https://dbc-1234abcd-5678.cloud.databricks.com (can use env. prefix). A scheme and trailing path are tolerated."
+                },
+                "api_format": {
+                  "type": "string",
+                  "enum": ["auto", "model_serving", "ai_gateway"],
+                  "description": "Which Databricks inference surface to target. 'model_serving' uses /serving-endpoints (Foundation Model APIs, provisioned throughput). 'ai_gateway' uses /ai-gateway/mlflow/v1 (Unity AI Gateway model services). 'auto' (default) picks by model name: a dotted name such as system.ai.claude-sonnet-4-5 goes to the AI Gateway, anything else to Model Serving."
+                },
+                "client_id": {
+                  "type": "string",
+                  "description": "OAuth M2M service principal client ID (can use env. prefix). Set together with client_secret, and leave the key value empty, to authenticate without a personal access token."
+                },
+                "client_secret": {
+                  "type": "string",
+                  "description": "OAuth M2M service principal client secret (can use env. prefix)"
+                },
+                "forward_gateway_tags": {
+                  "type": "boolean",
+                  "description": "Forward Bifrost governance labels (virtual key, team, customer names) to Databricks as the Databricks-Ai-Gateway-Request-Tags header for usage attribution (default: false)"
+                }
+              },
+              "required": ["workspace_url"],
+              "dependentRequired": {
+                "client_id": ["client_secret"],
+                "client_secret": ["client_id"]
+              },
+              "additionalProperties": false
+            }
+          },
+          "required": ["databricks_key_config"]
+        }
+      ]
+    },
     "vertex_key": {
       "allOf": [
         {
@@ -4838,6 +4887,45 @@
           "type": "array",
           "items": {
             "$ref": "#/$defs/replicate_key"
+          },
+          "minItems": 1,
+          "description": "API keys for this provider"
+        },
+        "network_config": {
+          "$ref": "#/$defs/network_config"
+        },
+        "concurrency_and_buffer_size": {
+          "$ref": "#/$defs/concurrency_and_buffer_size"
+        },
+        "proxy_config": {
+          "$ref": "#/$defs/proxy_config"
+        },
+        "send_back_raw_request": {
+          "type": "boolean",
+          "description": "Include raw request in BifrostResponse (default: false)"
+        },
+        "send_back_raw_response": {
+          "type": "boolean",
+          "description": "Include raw response in BifrostResponse (default: false)"
+        },
+        "store_raw_request_response": {
+          "type": "boolean",
+          "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
+        },
+        "custom_provider_config": {
+          "$ref": "#/$defs/custom_provider_config"
+        }
+      },
+      "required": ["keys"],
+      "additionalProperties": false
+    },
+    "provider_with_databricks_config": {
+      "type": "object",
+      "properties": {
+        "keys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/databricks_key"
           },
           "minItems": 1,
           "description": "API keys for this provider"


### PR DESCRIPTION
## Summary

Adds Databricks as a supported provider in Bifrost, enabling routing to Databricks Model Serving and AI Gateway inference surfaces.

## Changes

- Added `"databricks"` as a valid provider enum value in both `helm-charts/bifrost/values.schema.json` and `transports/config.schema.json`
- Introduced a `databricks_key` schema definition with a `databricks_key_config` object supporting:
  - `workspace_url` (required): the Databricks workspace URL
  - `api_format`: selects between `model_serving`, `ai_gateway`, or `auto` (default), where `auto` routes dotted model names (e.g. `system.ai.claude-sonnet-4-5`) to the AI Gateway and everything else to Model Serving
  - `client_id` / `client_secret`: OAuth M2M service principal credentials as an alternative to personal access tokens; both must be provided together (enforced via `dependentRequired`)
  - `forward_gateway_tags`: optionally forwards Bifrost governance labels (virtual key, team, customer names) to Databricks as `Databricks-Ai-Gateway-Request-Tags` for usage attribution
- Added a `provider_with_databricks_config` provider block definition wiring the Databricks key schema into the standard provider config structure
- Registered `databricks` as a top-level provider key in the transport config schema

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Configure a Databricks provider block in your transport config:

```yaml
databricks:
  keys:
    - key: "dapi..."
      databricks_key_config:
        workspace_url: "https://dbc-1234abcd-5678.cloud.databricks.com"
        api_format: "auto"
```

Or using OAuth M2M (no personal access token):

```yaml
databricks:
  keys:
    - key: ""
      databricks_key_config:
        workspace_url: "https://dbc-1234abcd-5678.cloud.databricks.com"
        client_id: "env.DATABRICKS_CLIENT_ID"
        client_secret: "env.DATABRICKS_CLIENT_SECRET"
        api_format: "model_serving"
```

Validate the schema is accepted:

```sh
go test ./...
```

**New config fields:**

| Field | Description |
|---|---|
| `workspace_url` | Databricks workspace base URL (required) |
| `api_format` | `auto` \| `model_serving` \| `ai_gateway` |
| `client_id` | OAuth M2M client ID (pair with `client_secret`) |
| `client_secret` | OAuth M2M client secret (pair with `client_id`) |
| `forward_gateway_tags` | Forward governance labels as `Databricks-Ai-Gateway-Request-Tags` |

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

- OAuth M2M credentials (`client_id`, `client_secret`) support the `env.` prefix to avoid hardcoding secrets in config files.
- `client_id` and `client_secret` are mutually required via `dependentRequired`, preventing partial credential configuration.
- `forward_gateway_tags` may propagate internal metadata (virtual key names, team/customer identifiers) to Databricks; operators should enable this only when usage attribution is desired and the data sharing is acceptable.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable