### PR TITLE
feat(providers): add Databricks as a supported provider with pricing catalog support and migration CLI exclusion

### DIFF
--- a/docs/deployment-guides/config-json/schema-reference.mdx
+++ b/docs/deployment-guides/config-json/schema-reference.mdx
@@ -114,7 +114,7 @@ Full documentation: [Client Configuration](/deployment-guides/config-json/client
 
 Keyed by provider name. Each entry contains a `keys` array and optional `network_config`, `concurrency_and_buffer_size`, `proxy_config`.
 
-Supported provider keys: `anthropic`, `azure`, `bedrock`, `bedrock_mantle`, `cerebras`, `cohere`, `deepseek`, `gemini`, `groq`, `mistral`, `ollama`, `opencode-go`, `opencode-zen`, `openai`, `parasail`, `perplexity`, `sgl`, `vertex`, `openrouter`, `elevenlabs`, `huggingface`, `nebius`, `xai`, `replicate`, `vllm`, `runway`, `runware`, `fireworks`, `sarvam`, `wafer`.
+Supported provider keys: `anthropic`, `azure`, `bedrock`, `bedrock_mantle`, `cerebras`, `cohere`, `deepseek`, `gemini`, `groq`, `mistral`, `ollama`, `opencode-go`, `opencode-zen`, `openai`, `parasail`, `perplexity`, `sgl`, `vertex`, `openrouter`, `elevenlabs`, `huggingface`, `nebius`, `xai`, `replicate`, `vllm`, `runway`, `runware`, `fireworks`, `sarvam`, `wafer`, `databricks`.
 
 Full documentation: [Provider Setup](/deployment-guides/config-json/providers).
 

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -87150,7 +87150,8 @@
           "runware",
           "fireworks",
           "sarvam",
-          "wafer"
+          "wafer",
+          "databricks"
         ]
       },
       "Fallback": {

--- a/docs/openapi/schemas/inference/common.yaml
+++ b/docs/openapi/schemas/inference/common.yaml
@@ -34,6 +34,7 @@ ModelProvider:
     - fireworks
     - sarvam
     - wafer
+    - databricks
 
 Fallback:
   type: object

--- a/framework/modelcatalog/pool_test.go
+++ b/framework/modelcatalog/pool_test.go
@@ -52,6 +52,35 @@ func TestUpsertLiveFromResponse_PopulatesFromResponse(t *testing.T) {
 	}
 }
 
+// TestGetUnfilteredModelsForProvider_UsesDatabricksPricing verifies the management catalog
+// still returns Databricks models when the provider intentionally publishes no live models.
+func TestGetUnfilteredModelsForProvider_UsesDatabricksPricing(t *testing.T) {
+	pricingPath := filepath.Join(t.TempDir(), "pricing.json")
+	pricingJSON := []byte(`{
+		"databricks/databricks-pricing-model": {
+			"provider":"databricks",
+			"mode":"chat",
+			"base_model":"pricing-model"
+		}
+	}`)
+	if err := os.WriteFile(pricingPath, pricingJSON, 0o600); err != nil {
+		t.Fatalf("write pricing testdata: %v", err)
+	}
+
+	ds := datasheet.New(nil, nil, datasheet.Config{URL: "file://" + pricingPath})
+	if err := ds.LoadFromURLIntoMemory(t.Context()); err != nil {
+		t.Fatalf("load pricing testdata: %v", err)
+	}
+	mc := NewTestCatalogWithDatasheet(ds)
+	mc.UpsertLive(schemas.Databricks, "key-1", true, []string{})
+
+	got := mc.GetUnfilteredModelsForProvider(schemas.Databricks)
+	want := []string{"databricks-pricing-model"}
+	if !slices.Equal(got, want) {
+		t.Errorf("GetUnfilteredModelsForProvider(Databricks) = %v, want %v", got, want)
+	}
+}
+
 func TestGetModelsForProvider_IncludesDeprecatedDatasheetModelsWhenLiveExists(t *testing.T) {
 	pricingPath := filepath.Join(t.TempDir(), "pricing.json")
 	pricingJSON := []byte(`{

--- a/scripts/bifrost-migration-cli/model.go
+++ b/scripts/bifrost-migration-cli/model.go
@@ -115,7 +115,10 @@ var specialCredProviders = map[string]bool{
 
 // standardProviders is the set of Bifrost standard provider names (from schemas.StandardProviders).
 // A LiteLLM provider absent from this is either added as a custom provider or is skipped and reported.
-
+//
+// Databricks is deliberately excluded: its keys need a per-key workspace URL that a LiteLLM
+// model entry does not carry, so migrating it here would emit a key the gateway rejects at
+// validation. Falling through to the custom-provider path produces a working config instead.
 var standardProviders = map[string]bool{
 	"anthropic":      true,
 	"azure":          true,


### PR DESCRIPTION
## Summary

Adds Databricks as a supported provider in the gateway. Databricks is intentionally excluded from the migration CLI's standard provider list because its keys require a per-key workspace URL that LiteLLM model entries do not carry — falling through to the custom-provider path produces a valid config instead.

## Changes

- Added `databricks` to the `ModelProvider` enum in the OpenAPI schema and updated the generated `openapi.json` accordingly.
- Added `databricks` to the supported provider keys list in the config JSON schema reference docs.
- Added a test (`TestGetUnfilteredModelsForProvider_UsesDatabricksPricing`) verifying that the management catalog correctly returns Databricks models from the pricing datasheet even when the provider publishes no live models.
- Explicitly excluded `databricks` from `standardProviders` in the migration CLI with a comment explaining why: its workspace URL requirement means the standard migration path would emit a key the gateway rejects at validation.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./framework/modelcatalog/...
go test ./scripts/bifrost-migration-cli/...
go test ./...
```

Configure a Databricks provider entry in `config.json` using the `databricks` provider key and verify the gateway accepts and routes requests correctly.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Databricks keys include a per-key workspace URL. The migration CLI deliberately skips automatic migration of Databricks entries to avoid emitting incomplete or invalid key configurations. Users migrating from LiteLLM should configure Databricks keys manually.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable