### PR TITLE
fix: update table batch job to provider job

### DIFF
--- a/framework/configstore/batchjob.go
+++ b/framework/configstore/batchjob.go
@@ -13,17 +13,20 @@ import (
 	"github.com/maximhq/bifrost/framework/configstore/tables"
 )
 
-// UpsertBatchJob inserts a new batch job or merges non-zero fields into an
+// UpsertProviderJob inserts a new provider job or merges non-zero fields into an
 // existing one. The identity row (id) is never overwritten; only the mutable
 // lifecycle/hint columns are advanced. Terminal-but-not-completed provider states
 // clear next_check_at so the sweeper stops polling.
-func (s *RDBConfigStore) UpsertBatchJob(ctx context.Context, job *tables.TableBatchJob) error {
+func (s *RDBConfigStore) UpsertProviderJob(ctx context.Context, job *tables.TableProviderJob) error {
 	if job == nil || job.ID == "" {
-		return fmt.Errorf("batch job and id are required")
+		return fmt.Errorf("provider job and id are required")
 	}
 	now := time.Now().UTC()
+	if job.Kind == "" {
+		job.Kind = tables.ProviderJobKindBatch
+	}
 	if job.AccountingStatus == "" {
-		job.AccountingStatus = tables.BatchJobAccountingStatusPending
+		job.AccountingStatus = tables.ProviderJobAccountingStatusPending
 	}
 	if job.CreatedAt.IsZero() {
 		job.CreatedAt = now
@@ -72,15 +75,15 @@ func (s *RDBConfigStore) UpsertBatchJob(ctx context.Context, job *tables.TableBa
 		updates["next_check_at"] = nil
 	}
 
-	return db.Model(&tables.TableBatchJob{}).Where("id = ?", job.ID).Updates(updates).Error
+	return db.Model(&tables.TableProviderJob{}).Where("id = ?", job.ID).Updates(updates).Error
 }
 
-// GetBatchJob returns a batch job by its stable id, or ErrNotFound.
-func (s *RDBConfigStore) GetBatchJob(ctx context.Context, jobID string) (*tables.TableBatchJob, error) {
+// GetProviderJob returns a provider job by its stable id, or ErrNotFound.
+func (s *RDBConfigStore) GetProviderJob(ctx context.Context, jobID string) (*tables.TableProviderJob, error) {
 	if jobID == "" {
-		return nil, fmt.Errorf("batch job id is required")
+		return nil, fmt.Errorf("provider job id is required")
 	}
-	var job tables.TableBatchJob
+	var job tables.TableProviderJob
 	if err := s.DB().WithContext(ctx).Where("id = ?", jobID).First(&job).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
@@ -90,14 +93,23 @@ func (s *RDBConfigStore) GetBatchJob(ctx context.Context, jobID string) (*tables
 	return &job, nil
 }
 
-// ListDueBatchJobs returns non-terminal batch jobs whose next poll is due at or
-// before now, oldest-due first. An empty provider matches every provider.
-func (s *RDBConfigStore) ListDueBatchJobs(ctx context.Context, provider string, now time.Time, limit int) ([]*tables.TableBatchJob, error) {
+// ListDueProviderJobs returns non-terminal jobs of one kind whose next poll is due
+// at or before now, oldest-due first. An empty provider matches every provider.
+//
+// The kind filter is mandatory, not a convenience: each kind has its own settler
+// and its own way of talking to the provider, so a sweeper handed another kind's
+// rows would poll them with the wrong client and burn their attempt budget. An
+// empty kind means batch, matching rows written before the column existed.
+func (s *RDBConfigStore) ListDueProviderJobs(ctx context.Context, kind, provider string, now time.Time, limit int) ([]*tables.TableProviderJob, error) {
 	if limit <= 0 {
 		limit = 100
 	}
+	if kind == "" {
+		kind = tables.ProviderJobKindBatch
+	}
 	query := s.DB().WithContext(ctx).
-		Where("accounting_status NOT IN ?", []string{tables.BatchJobAccountingStatusAccounted, tables.BatchJobAccountingStatusUnpriceable}).
+		Where("kind = ?", kind).
+		Where("accounting_status NOT IN ?", []string{tables.ProviderJobAccountingStatusAccounted, tables.ProviderJobAccountingStatusUnpriceable}).
 		Where("next_check_at IS NOT NULL AND next_check_at <= ?", now).
 		Order("next_check_at ASC").
 		Limit(limit)
@@ -105,14 +117,14 @@ func (s *RDBConfigStore) ListDueBatchJobs(ctx context.Context, provider string, 
 		query = query.Where("provider = ?", provider)
 	}
 
-	var jobs []*tables.TableBatchJob
+	var jobs []*tables.TableProviderJob
 	if err := query.Find(&jobs).Error; err != nil {
 		return nil, err
 	}
 	return jobs, nil
 }
 
-// ClaimBatchJob transitions a claimable batch job to "processing" under runnerID
+// ClaimProviderJob transitions a claimable provider job to "processing" under runnerID
 // and returns true on success. A job is claimable when it is not already in a
 // terminal accounting state and is either not currently processing or its claim
 // has gone stale (claimed_at older than staleBefore).
@@ -123,30 +135,30 @@ func (s *RDBConfigStore) ListDueBatchJobs(ctx context.Context, provider string, 
 // caller that turns up holding the actual results. Refusing such a caller made the
 // state a one-way door that permanently dropped the batch's money, so settlement
 // paths with results in hand pass true. The sweeper's poll loop still skips these
-// jobs (ListDueBatchJobs excludes them); "accounted" is terminal forever.
+// jobs (ListDueProviderJobs excludes them); "accounted" is terminal forever.
 //
 // Staleness is measured on claimed_at rather than updated_at because updated_at is
-// refreshed by UpsertBatchJob, which is unfenced and runs on every sweep — using it
+// refreshed by UpsertProviderJob, which is unfenced and runs on every sweep — using it
 // would mean routine polling perpetually renews a dead runner's claim and the job
 // could never be reclaimed. claimed_at is written only here.
-func (s *RDBConfigStore) ClaimBatchJob(ctx context.Context, jobID, runnerID string, staleBefore time.Time, allowUnpriceable bool) (bool, error) {
+func (s *RDBConfigStore) ClaimProviderJob(ctx context.Context, jobID, runnerID string, staleBefore time.Time, allowUnpriceable bool) (bool, error) {
 	if jobID == "" {
-		return false, fmt.Errorf("batch job id is required")
+		return false, fmt.Errorf("provider job id is required")
 	}
 	if runnerID == "" {
 		return false, fmt.Errorf("runner id is required")
 	}
-	blocked := []string{tables.BatchJobAccountingStatusAccounted, tables.BatchJobAccountingStatusUnpriceable}
+	blocked := []string{tables.ProviderJobAccountingStatusAccounted, tables.ProviderJobAccountingStatusUnpriceable}
 	if allowUnpriceable {
-		blocked = []string{tables.BatchJobAccountingStatusAccounted}
+		blocked = []string{tables.ProviderJobAccountingStatusAccounted}
 	}
 	now := time.Now().UTC()
-	res := s.DB().WithContext(ctx).Model(&tables.TableBatchJob{}).
+	res := s.DB().WithContext(ctx).Model(&tables.TableProviderJob{}).
 		Where("id = ?", jobID).
 		Where("accounting_status NOT IN ?", blocked).
-		Where("(accounting_status <> ? OR claimed_at IS NULL OR claimed_at < ?)", tables.BatchJobAccountingStatusProcessing, staleBefore).
+		Where("(accounting_status <> ? OR claimed_at IS NULL OR claimed_at < ?)", tables.ProviderJobAccountingStatusProcessing, staleBefore).
 		Updates(map[string]any{
-			"accounting_status": tables.BatchJobAccountingStatusProcessing,
+			"accounting_status": tables.ProviderJobAccountingStatusProcessing,
 			"runner_id":         runnerID,
 			"claimed_at":        now,
 			"last_error":        nil,
@@ -158,16 +170,16 @@ func (s *RDBConfigStore) ClaimBatchJob(ctx context.Context, jobID, runnerID stri
 	return res.RowsAffected == 1, nil
 }
 
-// markBatchJobTimestamp sets a single lifecycle timestamp column on a job this
+// markProviderJobTimestamp sets a single lifecycle timestamp column on a job this
 // runner still owns and is still processing, clearing any prior error. Fenced on
 // runner_id so a former owner cannot advance a re-claimed job.
-func (s *RDBConfigStore) markBatchJobTimestamp(ctx context.Context, jobID, runnerID, column string) error {
+func (s *RDBConfigStore) markProviderJobTimestamp(ctx context.Context, jobID, runnerID, column string) error {
 	if jobID == "" {
-		return fmt.Errorf("batch job id is required")
+		return fmt.Errorf("provider job id is required")
 	}
 	now := time.Now().UTC()
-	res := s.DB().WithContext(ctx).Model(&tables.TableBatchJob{}).
-		Where("id = ? AND runner_id = ? AND accounting_status = ?", jobID, runnerID, tables.BatchJobAccountingStatusProcessing).
+	res := s.DB().WithContext(ctx).Model(&tables.TableProviderJob{}).
+		Where("id = ? AND runner_id = ? AND accounting_status = ?", jobID, runnerID, tables.ProviderJobAccountingStatusProcessing).
 		Updates(map[string]any{
 			column:       now,
 			"last_error": nil,
@@ -182,37 +194,37 @@ func (s *RDBConfigStore) markBatchJobTimestamp(ctx context.Context, jobID, runne
 	return nil
 }
 
-// MarkBatchJobAggregateLogWritten records that the durable aggregate cost log row
+// MarkProviderJobAggregateLogWritten records that the durable aggregate cost log row
 // has been created for this job (settlement idempotency marker).
-func (s *RDBConfigStore) MarkBatchJobAggregateLogWritten(ctx context.Context, jobID, runnerID string) error {
-	return s.markBatchJobTimestamp(ctx, jobID, runnerID, "aggregate_log_written_at")
+func (s *RDBConfigStore) MarkProviderJobAggregateLogWritten(ctx context.Context, jobID, runnerID string) error {
+	return s.markProviderJobTimestamp(ctx, jobID, runnerID, "aggregate_log_written_at")
 }
 
-// MarkBatchJobGovernanceReported records that batch usage has been reported to
+// MarkProviderJobGovernanceReported records that usage has been reported to
 // governance for this job (settlement idempotency marker).
-func (s *RDBConfigStore) MarkBatchJobGovernanceReported(ctx context.Context, jobID, runnerID string) error {
-	return s.markBatchJobTimestamp(ctx, jobID, runnerID, "governance_reported_at")
+func (s *RDBConfigStore) MarkProviderJobGovernanceReported(ctx context.Context, jobID, runnerID string) error {
+	return s.markProviderJobTimestamp(ctx, jobID, runnerID, "governance_reported_at")
 }
 
-// CompleteBatchJob marks a claimed job accounted and releases the runner fence.
-func (s *RDBConfigStore) CompleteBatchJob(ctx context.Context, jobID, runnerID string) error {
-	return s.finishBatchJob(ctx, jobID, runnerID, tables.BatchJobAccountingStatusAccounted, "", nil)
+// CompleteProviderJob marks a claimed job accounted and releases the runner fence.
+func (s *RDBConfigStore) CompleteProviderJob(ctx context.Context, jobID, runnerID string) error {
+	return s.finishProviderJob(ctx, jobID, runnerID, tables.ProviderJobAccountingStatusAccounted, "", nil)
 }
 
-// MarkBatchJobUnpriceable marks a claimed job terminal-unpriceable with a reason.
-func (s *RDBConfigStore) MarkBatchJobUnpriceable(ctx context.Context, jobID, runnerID, reason string, err error) error {
-	return s.finishBatchJob(ctx, jobID, runnerID, tables.BatchJobAccountingStatusUnpriceable, reason, err)
+// MarkProviderJobUnpriceable marks a claimed job terminal-unpriceable with a reason.
+func (s *RDBConfigStore) MarkProviderJobUnpriceable(ctx context.Context, jobID, runnerID, reason string, err error) error {
+	return s.finishProviderJob(ctx, jobID, runnerID, tables.ProviderJobAccountingStatusUnpriceable, reason, err)
 }
 
-// FailBatchJob releases the runner fence after an accounting failure so a later
+// FailProviderJob releases the runner fence after an accounting failure so a later
 // /results call or reconciler pass can retry the job.
-func (s *RDBConfigStore) FailBatchJob(ctx context.Context, jobID, runnerID string, err error) error {
-	return s.finishBatchJob(ctx, jobID, runnerID, tables.BatchJobAccountingStatusError, "", err)
+func (s *RDBConfigStore) FailProviderJob(ctx context.Context, jobID, runnerID string, err error) error {
+	return s.finishProviderJob(ctx, jobID, runnerID, tables.ProviderJobAccountingStatusError, "", err)
 }
 
-func (s *RDBConfigStore) finishBatchJob(ctx context.Context, jobID, runnerID, status, reason string, err error) error {
+func (s *RDBConfigStore) finishProviderJob(ctx context.Context, jobID, runnerID, status, reason string, err error) error {
 	if jobID == "" {
-		return fmt.Errorf("batch job id is required")
+		return fmt.Errorf("provider job id is required")
 	}
 	var lastError any
 	if err != nil {
@@ -226,14 +238,14 @@ func (s *RDBConfigStore) finishBatchJob(ctx context.Context, jobID, runnerID, st
 		"last_error":        lastError,
 		"updated_at":        now,
 	}
-	if status == tables.BatchJobAccountingStatusAccounted {
+	if status == tables.ProviderJobAccountingStatusAccounted {
 		updates["unpriceable_reason"] = nil
 	}
 	if reason != "" {
 		updates["unpriceable_reason"] = reason
 	}
-	res := s.DB().WithContext(ctx).Model(&tables.TableBatchJob{}).
-		Where("id = ? AND runner_id = ? AND accounting_status = ?", jobID, runnerID, tables.BatchJobAccountingStatusProcessing).
+	res := s.DB().WithContext(ctx).Model(&tables.TableProviderJob{}).
+		Where("id = ? AND runner_id = ? AND accounting_status = ?", jobID, runnerID, tables.ProviderJobAccountingStatusProcessing).
 		Updates(updates)
 	if res.Error != nil {
 		return res.Error

--- a/framework/configstore/batchjob_test.go
+++ b/framework/configstore/batchjob_test.go
@@ -15,25 +15,25 @@ import (
 // setupBatchJobTestStore extends the base test store with the batch_jobs table.
 func setupBatchJobTestStore(t *testing.T) *RDBConfigStore {
 	store := setupRDBTestStore(t)
-	require.NoError(t, store.DB().AutoMigrate(&tables.TableBatchJob{}), "migrate batch_jobs table")
+	require.NoError(t, store.DB().AutoMigrate(&tables.TableProviderJob{}), "migrate batch_jobs table")
 	return store
 }
 
-func seedBatchJob(t *testing.T, store *RDBConfigStore, provider, batchID string) *tables.TableBatchJob {
+func seedBatchJob(t *testing.T, store *RDBConfigStore, provider, batchID string) *tables.TableProviderJob {
 	t.Helper()
-	job := &tables.TableBatchJob{
-		ID:               tables.BatchJobID(provider, batchID),
+	job := &tables.TableProviderJob{
+		ID:               tables.ProviderJobID(tables.ProviderJobKindBatch, provider, batchID),
 		Provider:         provider,
-		BatchID:          batchID,
-		AccountingStatus: tables.BatchJobAccountingStatusPending,
+		JobID:            batchID,
+		AccountingStatus: tables.ProviderJobAccountingStatusPending,
 	}
-	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
 	return job
 }
 
-func getBatchJob(t *testing.T, store *RDBConfigStore, id string) *tables.TableBatchJob {
+func getBatchJob(t *testing.T, store *RDBConfigStore, id string) *tables.TableProviderJob {
 	t.Helper()
-	job, err := store.GetBatchJob(context.Background(), id)
+	job, err := store.GetProviderJob(context.Background(), id)
 	require.NoError(t, err)
 	require.NotNil(t, job)
 	return job
@@ -44,46 +44,46 @@ func getBatchJob(t *testing.T, store *RDBConfigStore, id string) *tables.TableBa
 // only on the claim timestamp, precisely so unfenced writers cannot renew it.
 func ageBatchClaim(t *testing.T, store *RDBConfigStore, id string, ts time.Time) {
 	t.Helper()
-	require.NoError(t, store.DB().Model(&tables.TableBatchJob{}).
+	require.NoError(t, store.DB().Model(&tables.TableProviderJob{}).
 		Where("id = ?", id).Update("claimed_at", ts).Error)
 }
 
-func TestClaimBatchJobRunnerFencesCompletion(t *testing.T) {
+func TestClaimProviderJobRunnerFencesCompletion(t *testing.T) {
 	store := setupBatchJobTestStore(t)
 	ctx := context.Background()
 	job := seedBatchJob(t, store, "openai", "batch_1")
 
-	claimed, err := store.ClaimBatchJob(ctx, job.ID, "runner-A", time.Now().UTC().Add(-time.Minute), false)
+	claimed, err := store.ClaimProviderJob(ctx, job.ID, "runner-A", time.Now().UTC().Add(-time.Minute), false)
 	require.NoError(t, err)
 	require.True(t, claimed)
 
 	// A different runner cannot advance or complete the claimed job.
-	assert.ErrorIs(t, store.MarkBatchJobAggregateLogWritten(ctx, job.ID, "runner-B"), ErrNotFound)
-	assert.ErrorIs(t, store.CompleteBatchJob(ctx, job.ID, "runner-B"), ErrNotFound)
+	assert.ErrorIs(t, store.MarkProviderJobAggregateLogWritten(ctx, job.ID, "runner-B"), ErrNotFound)
+	assert.ErrorIs(t, store.CompleteProviderJob(ctx, job.ID, "runner-B"), ErrNotFound)
 
 	// The owning runner can.
-	require.NoError(t, store.MarkBatchJobAggregateLogWritten(ctx, job.ID, "runner-A"))
-	require.NoError(t, store.CompleteBatchJob(ctx, job.ID, "runner-A"))
-	assert.Equal(t, tables.BatchJobAccountingStatusAccounted, getBatchJob(t, store, job.ID).AccountingStatus)
+	require.NoError(t, store.MarkProviderJobAggregateLogWritten(ctx, job.ID, "runner-A"))
+	require.NoError(t, store.CompleteProviderJob(ctx, job.ID, "runner-A"))
+	assert.Equal(t, tables.ProviderJobAccountingStatusAccounted, getBatchJob(t, store, job.ID).AccountingStatus)
 }
 
-func TestClaimBatchJobRejectsFreshProcessingButAllowsStale(t *testing.T) {
+func TestClaimProviderJobRejectsFreshProcessingButAllowsStale(t *testing.T) {
 	store := setupBatchJobTestStore(t)
 	ctx := context.Background()
 	job := seedBatchJob(t, store, "openai", "batch_2")
 
-	claimed, err := store.ClaimBatchJob(ctx, job.ID, "runner-A", time.Now().UTC().Add(-time.Minute), false)
+	claimed, err := store.ClaimProviderJob(ctx, job.ID, "runner-A", time.Now().UTC().Add(-time.Minute), false)
 	require.NoError(t, err)
 	require.True(t, claimed)
 
 	// A fresh in-flight claim blocks a second claimant.
-	claimed, err = store.ClaimBatchJob(ctx, job.ID, "runner-B", time.Now().UTC().Add(-time.Minute), false)
+	claimed, err = store.ClaimProviderJob(ctx, job.ID, "runner-B", time.Now().UTC().Add(-time.Minute), false)
 	require.NoError(t, err)
 	assert.False(t, claimed)
 
 	// Once the claim goes stale, another runner reclaims it.
 	ageBatchClaim(t, store, job.ID, time.Now().UTC().Add(-15*time.Minute))
-	claimed, err = store.ClaimBatchJob(ctx, job.ID, "runner-B", time.Now().UTC().Add(-time.Minute), false)
+	claimed, err = store.ClaimProviderJob(ctx, job.ID, "runner-B", time.Now().UTC().Add(-time.Minute), false)
 	require.NoError(t, err)
 	assert.True(t, claimed)
 	owner := getBatchJob(t, store, job.ID).RunnerID
@@ -94,12 +94,12 @@ func TestClaimBatchJobRejectsFreshProcessingButAllowsStale(t *testing.T) {
 // A dead runner's job must stay reclaimable. Unfenced writers — the sweeper's poll
 // upsert, a user-triggered /results call, and AccountBatchResults' own upsert — must
 // not be able to refresh the staleness clock and pin a job to a runner that is gone.
-func TestClaimBatchJobStalenessSurvivesUnfencedUpsert(t *testing.T) {
+func TestClaimProviderJobStalenessSurvivesUnfencedUpsert(t *testing.T) {
 	store := setupBatchJobTestStore(t)
 	ctx := context.Background()
 	job := seedBatchJob(t, store, "openai", "batch_stuck")
 
-	claimed, err := store.ClaimBatchJob(ctx, job.ID, "runner-A", time.Now().UTC().Add(-time.Minute), false)
+	claimed, err := store.ClaimProviderJob(ctx, job.ID, "runner-A", time.Now().UTC().Add(-time.Minute), false)
 	require.NoError(t, err)
 	require.True(t, claimed)
 
@@ -108,32 +108,32 @@ func TestClaimBatchJobStalenessSurvivesUnfencedUpsert(t *testing.T) {
 
 	// An unfenced upsert touches the row (this is what every sweep does before it
 	// tries to claim).
-	require.NoError(t, store.UpsertBatchJob(ctx, &tables.TableBatchJob{
+	require.NoError(t, store.UpsertProviderJob(ctx, &tables.TableProviderJob{
 		ID:             job.ID,
 		Provider:       "openai",
-		BatchID:        "batch_stuck",
+		JobID:          "batch_stuck",
 		ProviderStatus: string(schemas.BatchStatusCompleted),
 	}))
 
-	claimed, err = store.ClaimBatchJob(ctx, job.ID, "runner-B", time.Now().UTC().Add(-time.Minute), false)
+	claimed, err = store.ClaimProviderJob(ctx, job.ID, "runner-B", time.Now().UTC().Add(-time.Minute), false)
 	require.NoError(t, err)
 	assert.True(t, claimed,
 		"a dead runner's job must remain reclaimable after an unfenced upsert; "+
 			"otherwise the job is pinned to the dead runner forever")
 }
 
-func TestClaimBatchJobRejectsTerminalStates(t *testing.T) {
+func TestClaimProviderJobRejectsTerminalStates(t *testing.T) {
 	store := setupBatchJobTestStore(t)
 	ctx := context.Background()
 	job := seedBatchJob(t, store, "openai", "batch_3")
 
-	claimed, err := store.ClaimBatchJob(ctx, job.ID, "runner-A", time.Now().UTC().Add(-time.Minute), false)
+	claimed, err := store.ClaimProviderJob(ctx, job.ID, "runner-A", time.Now().UTC().Add(-time.Minute), false)
 	require.NoError(t, err)
 	require.True(t, claimed)
-	require.NoError(t, store.CompleteBatchJob(ctx, job.ID, "runner-A"))
+	require.NoError(t, store.CompleteProviderJob(ctx, job.ID, "runner-A"))
 
 	// Accounted is terminal; no runner can reclaim it.
-	claimed, err = store.ClaimBatchJob(ctx, job.ID, "runner-A", time.Now().UTC().Add(-time.Hour), false)
+	claimed, err = store.ClaimProviderJob(ctx, job.ID, "runner-A", time.Now().UTC().Add(-time.Hour), false)
 	require.NoError(t, err)
 	assert.False(t, claimed)
 }
@@ -142,71 +142,71 @@ func TestClaimBatchJobRejectsTerminalStates(t *testing.T) {
 // caller holding real results answers every reason a job reaches that state, so it
 // must be able to reclaim one — while a plain claim still refuses, and "accounted"
 // refuses either way.
-func TestClaimBatchJobAllowUnpriceableReopensStoppedJobs(t *testing.T) {
+func TestClaimProviderJobAllowUnpriceableReopensStoppedJobs(t *testing.T) {
 	store := setupBatchJobTestStore(t)
 	ctx := context.Background()
 	job := seedBatchJob(t, store, "openai", "batch_reclaim")
 
-	_, err := store.ClaimBatchJob(ctx, job.ID, "runner-A", time.Now().UTC().Add(-time.Minute), false)
+	_, err := store.ClaimProviderJob(ctx, job.ID, "runner-A", time.Now().UTC().Add(-time.Minute), false)
 	require.NoError(t, err)
-	require.NoError(t, store.MarkBatchJobUnpriceable(ctx, job.ID, "runner-A", "max_poll_attempts", nil))
+	require.NoError(t, store.MarkProviderJobUnpriceable(ctx, job.ID, "runner-A", "max_poll_attempts", nil))
 
-	claimed, err := store.ClaimBatchJob(ctx, job.ID, "runner-B", time.Now().UTC().Add(-time.Minute), false)
+	claimed, err := store.ClaimProviderJob(ctx, job.ID, "runner-B", time.Now().UTC().Add(-time.Minute), false)
 	require.NoError(t, err)
 	assert.False(t, claimed, "the poll loop must keep leaving unpriceable jobs alone")
 
-	claimed, err = store.ClaimBatchJob(ctx, job.ID, "runner-B", time.Now().UTC().Add(-time.Minute), true)
+	claimed, err = store.ClaimProviderJob(ctx, job.ID, "runner-B", time.Now().UTC().Add(-time.Minute), true)
 	require.NoError(t, err)
 	assert.True(t, claimed, "a settlement holding results must be able to re-drive it")
 
-	require.NoError(t, store.CompleteBatchJob(ctx, job.ID, "runner-B"))
+	require.NoError(t, store.CompleteProviderJob(ctx, job.ID, "runner-B"))
 	persisted := getBatchJob(t, store, job.ID)
-	assert.Equal(t, tables.BatchJobAccountingStatusAccounted, persisted.AccountingStatus)
+	assert.Equal(t, tables.ProviderJobAccountingStatusAccounted, persisted.AccountingStatus)
 	assert.Nil(t, persisted.UnpriceableReason, "settling clears the reason it could not be priced")
 
 	// Accounted stays terminal even for a caller holding results.
-	claimed, err = store.ClaimBatchJob(ctx, job.ID, "runner-C", time.Now().UTC().Add(-time.Hour), true)
+	claimed, err = store.ClaimProviderJob(ctx, job.ID, "runner-C", time.Now().UTC().Add(-time.Hour), true)
 	require.NoError(t, err)
 	assert.False(t, claimed)
 }
 
-func TestMarkBatchJobUnpriceableSetsReasonAndReleasesRunner(t *testing.T) {
+func TestMarkProviderJobUnpriceableSetsReasonAndReleasesRunner(t *testing.T) {
 	store := setupBatchJobTestStore(t)
 	ctx := context.Background()
 	job := seedBatchJob(t, store, "openai", "batch_4")
-	_, err := store.ClaimBatchJob(ctx, job.ID, "runner-A", time.Now().UTC().Add(-time.Minute), false)
+	_, err := store.ClaimProviderJob(ctx, job.ID, "runner-A", time.Now().UTC().Add(-time.Minute), false)
 	require.NoError(t, err)
 
-	require.NoError(t, store.MarkBatchJobUnpriceable(ctx, job.ID, "runner-A", "no_usage", nil))
+	require.NoError(t, store.MarkProviderJobUnpriceable(ctx, job.ID, "runner-A", "no_usage", nil))
 
 	persisted := getBatchJob(t, store, job.ID)
-	assert.Equal(t, tables.BatchJobAccountingStatusUnpriceable, persisted.AccountingStatus)
+	assert.Equal(t, tables.ProviderJobAccountingStatusUnpriceable, persisted.AccountingStatus)
 	require.NotNil(t, persisted.UnpriceableReason)
 	assert.Equal(t, "no_usage", *persisted.UnpriceableReason)
 	assert.Nil(t, persisted.RunnerID)
 	assert.Nil(t, persisted.LastError, "no error reported should leave last_error nil")
 }
 
-func TestFailBatchJobRecordsErrorAndAllowsRetry(t *testing.T) {
+func TestFailProviderJobRecordsErrorAndAllowsRetry(t *testing.T) {
 	store := setupBatchJobTestStore(t)
 	ctx := context.Background()
 	job := seedBatchJob(t, store, "openai", "batch_5")
-	_, err := store.ClaimBatchJob(ctx, job.ID, "runner-A", time.Now().UTC().Add(-time.Minute), false)
+	_, err := store.ClaimProviderJob(ctx, job.ID, "runner-A", time.Now().UTC().Add(-time.Minute), false)
 	require.NoError(t, err)
 
-	require.NoError(t, store.FailBatchJob(ctx, job.ID, "runner-A", errors.New("boom")))
+	require.NoError(t, store.FailProviderJob(ctx, job.ID, "runner-A", errors.New("boom")))
 	persisted := getBatchJob(t, store, job.ID)
 	require.NotNil(t, persisted.LastError)
 	assert.Equal(t, "boom", *persisted.LastError)
 	assert.Nil(t, persisted.RunnerID)
 
 	// Error is non-terminal: the job can be reclaimed and retried.
-	claimed, err := store.ClaimBatchJob(ctx, job.ID, "runner-B", time.Now().UTC().Add(-time.Minute), false)
+	claimed, err := store.ClaimProviderJob(ctx, job.ID, "runner-B", time.Now().UTC().Add(-time.Minute), false)
 	require.NoError(t, err)
 	assert.True(t, claimed)
 }
 
-func TestUpsertBatchJobNextCheckAtTerminalHandling(t *testing.T) {
+func TestUpsertProviderJobNextCheckAtTerminalHandling(t *testing.T) {
 	store := setupBatchJobTestStore(t)
 	ctx := context.Background()
 	next := time.Now().UTC().Add(time.Hour).UTC()
@@ -224,15 +224,15 @@ func TestUpsertBatchJobNextCheckAtTerminalHandling(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			require.NoError(t, store.UpsertBatchJob(ctx, &tables.TableBatchJob{
-				ID:               tables.BatchJobID("openai", tc.batchID),
+			require.NoError(t, store.UpsertProviderJob(ctx, &tables.TableProviderJob{
+				ID:               tables.ProviderJobID(tables.ProviderJobKindBatch, "openai", tc.batchID),
 				Provider:         "openai",
-				BatchID:          tc.batchID,
-				AccountingStatus: tables.BatchJobAccountingStatusPending,
+				JobID:            tc.batchID,
+				AccountingStatus: tables.ProviderJobAccountingStatusPending,
 				NextCheckAt:      &next,
 				ProviderStatus:   string(tc.status),
 			}))
-			persisted := getBatchJob(t, store, tables.BatchJobID("openai", tc.batchID))
+			persisted := getBatchJob(t, store, tables.ProviderJobID(tables.ProviderJobKindBatch, "openai", tc.batchID))
 			if tc.expectCleared {
 				assert.Nil(t, persisted.NextCheckAt, "terminal-but-not-completed clears next_check_at")
 			} else {
@@ -242,7 +242,7 @@ func TestUpsertBatchJobNextCheckAtTerminalHandling(t *testing.T) {
 	}
 }
 
-func TestListDueBatchJobsFiltersByDueAndStatus(t *testing.T) {
+func TestListDueProviderJobsFiltersByDueAndStatus(t *testing.T) {
 	store := setupBatchJobTestStore(t)
 	ctx := context.Background()
 	now := time.Now().UTC()
@@ -250,29 +250,29 @@ func TestListDueBatchJobsFiltersByDueAndStatus(t *testing.T) {
 	future := now.Add(time.Hour)
 
 	mkJob := func(batchID string, status string, next *time.Time) {
-		require.NoError(t, store.UpsertBatchJob(ctx, &tables.TableBatchJob{
-			ID:               tables.BatchJobID("openai", batchID),
+		require.NoError(t, store.UpsertProviderJob(ctx, &tables.TableProviderJob{
+			ID:               tables.ProviderJobID(tables.ProviderJobKindBatch, "openai", batchID),
 			Provider:         "openai",
-			BatchID:          batchID,
+			JobID:            batchID,
 			AccountingStatus: status,
 			NextCheckAt:      next,
 		}))
 	}
-	mkJob("due", tables.BatchJobAccountingStatusPending, &past)
-	mkJob("not_due", tables.BatchJobAccountingStatusPending, &future)
-	mkJob("accounted", tables.BatchJobAccountingStatusAccounted, &past)
-	mkJob("no_next", tables.BatchJobAccountingStatusPending, nil)
+	mkJob("due", tables.ProviderJobAccountingStatusPending, &past)
+	mkJob("not_due", tables.ProviderJobAccountingStatusPending, &future)
+	mkJob("accounted", tables.ProviderJobAccountingStatusAccounted, &past)
+	mkJob("no_next", tables.ProviderJobAccountingStatusPending, nil)
 
-	due, err := store.ListDueBatchJobs(ctx, "openai", now, 10)
+	due, err := store.ListDueProviderJobs(ctx, tables.ProviderJobKindBatch, "openai", now, 10)
 	require.NoError(t, err)
 	require.Len(t, due, 1)
-	assert.Equal(t, "due", due[0].BatchID)
+	assert.Equal(t, "due", due[0].JobID)
 }
 
 // Attribution is create-time state. A later upsert — the /results path builds a job
 // from the fetching request's own log entry — must not be able to move the bill onto
 // whoever happened to settle the batch.
-func TestUpsertBatchJobDoesNotOverwriteAttribution(t *testing.T) {
+func TestUpsertProviderJobDoesNotOverwriteAttribution(t *testing.T) {
 	store := setupBatchJobTestStore(t)
 	ctx := context.Background()
 
@@ -280,13 +280,13 @@ func TestUpsertBatchJobDoesNotOverwriteAttribution(t *testing.T) {
 	creatorUser := "user-alice"
 	creatorBudgets := `["budget-creator"]`
 	sourceLog := "req-create"
-	id := tables.BatchJobID("openai", "batch-attr")
+	id := tables.ProviderJobID(tables.ProviderJobKindBatch, "openai", "batch-attr")
 
-	require.NoError(t, store.UpsertBatchJob(ctx, &tables.TableBatchJob{
+	require.NoError(t, store.UpsertProviderJob(ctx, &tables.TableProviderJob{
 		ID:               id,
 		Provider:         "openai",
-		BatchID:          "batch-attr",
-		AccountingStatus: tables.BatchJobAccountingStatusPending,
+		JobID:            "batch-attr",
+		AccountingStatus: tables.ProviderJobAccountingStatusPending,
 		SelectedKeyID:    "key-creator",
 		VirtualKeyID:     &creatorVK,
 		UserID:           &creatorUser,
@@ -298,11 +298,11 @@ func TestUpsertBatchJobDoesNotOverwriteAttribution(t *testing.T) {
 	fetcherUser := "user-bob"
 	fetcherBudgets := `["budget-fetcher"]`
 	fetcherLog := "req-results"
-	require.NoError(t, store.UpsertBatchJob(ctx, &tables.TableBatchJob{
+	require.NoError(t, store.UpsertProviderJob(ctx, &tables.TableProviderJob{
 		ID:               id,
 		Provider:         "openai",
-		BatchID:          "batch-attr",
-		AccountingStatus: tables.BatchJobAccountingStatusPending,
+		JobID:            "batch-attr",
+		AccountingStatus: tables.ProviderJobAccountingStatusPending,
 		ProviderStatus:   string(schemas.BatchStatusCompleted),
 		SelectedKeyID:    "key-fetcher",
 		VirtualKeyID:     &fetcherVK,
@@ -323,4 +323,63 @@ func TestUpsertBatchJobDoesNotOverwriteAttribution(t *testing.T) {
 	assert.Equal(t, sourceLog, *job.SourceLogID)
 	// Lifecycle state, unlike identity, is expected to advance.
 	assert.Equal(t, string(schemas.BatchStatusCompleted), job.ProviderStatus)
+}
+
+// TestListDueProviderJobsFiltersByKind is the guard on the whole point of the kind
+// column: each kind has its own settler and its own provider client, so a sweeper
+// handed another kind's rows would poll them with the wrong one and burn their
+// attempt budget against a provider that has never heard of them.
+func TestListDueProviderJobsFiltersByKind(t *testing.T) {
+	store := setupBatchJobTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	past := now.Add(-time.Minute)
+
+	mkJob := func(kind, jobID string) {
+		require.NoError(t, store.UpsertProviderJob(ctx, &tables.TableProviderJob{
+			ID:               tables.ProviderJobID(kind, "openai", jobID),
+			Kind:             kind,
+			Provider:         "openai",
+			JobID:            jobID,
+			AccountingStatus: tables.ProviderJobAccountingStatusPending,
+			NextCheckAt:      &past,
+		}))
+	}
+	mkJob(tables.ProviderJobKindBatch, "batch-due")
+	mkJob(tables.ProviderJobKindVideo, "video-due")
+
+	batches, err := store.ListDueProviderJobs(ctx, tables.ProviderJobKindBatch, "", now, 10)
+	require.NoError(t, err)
+	require.Len(t, batches, 1)
+	assert.Equal(t, "batch-due", batches[0].JobID)
+
+	videos, err := store.ListDueProviderJobs(ctx, tables.ProviderJobKindVideo, "", now, 10)
+	require.NoError(t, err)
+	require.Len(t, videos, 1)
+	assert.Equal(t, "video-due", videos[0].JobID)
+
+	// An empty kind means batch, so a caller that predates the column keeps seeing
+	// exactly the rows it always saw.
+	legacy, err := store.ListDueProviderJobs(ctx, "", "", now, 10)
+	require.NoError(t, err)
+	require.Len(t, legacy, 1)
+	assert.Equal(t, "batch-due", legacy[0].JobID)
+}
+
+// TestUpsertProviderJobDefaultsKindToBatch pins the NOT NULL column's default on
+// the write path: a caller written before kinds existed still produces a valid row.
+func TestUpsertProviderJobDefaultsKindToBatch(t *testing.T) {
+	store := setupBatchJobTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.UpsertProviderJob(ctx, &tables.TableProviderJob{
+		ID:               tables.ProviderJobID(tables.ProviderJobKindBatch, "openai", "batch-nokind"),
+		Provider:         "openai",
+		JobID:            "batch-nokind",
+		AccountingStatus: tables.ProviderJobAccountingStatusPending,
+	}))
+
+	job, err := store.GetProviderJob(ctx, tables.ProviderJobID(tables.ProviderJobKindBatch, "openai", "batch-nokind"))
+	require.NoError(t, err)
+	assert.Equal(t, tables.ProviderJobKindBatch, job.Kind)
 }

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -479,6 +479,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_vk_rotation_cooldown_client_column"}, run: migrationAddVKRotationCooldownClientColumn},
 	{IDs: []string{"drop_legacy_oauth_user_fk_constraints"}, run: migrationDropLegacyOauthUserFKConstraints},
 	{IDs: []string{"add_video_resolution_pricing_columns"}, run: migrationAddVideoResolutionPricingColumns},
+	{IDs: []string{"add_provider_job_kind_columns"}, run: migrationAddProviderJobKindColumns},
 }
 
 // videoResolutionPricingColumns are the resolution-banded video output rate columns.
@@ -533,10 +534,10 @@ func migrationAddBatchJobsAttributionColumns(ctx context.Context, db *gorm.DB, l
 			tx = tx.WithContext(ctx)
 			mig := tx.Migrator()
 			for _, column := range columns {
-				if mig.HasColumn(&tables.TableBatchJob{}, column) {
+				if mig.HasColumn(&tables.TableProviderJob{}, column) {
 					continue
 				}
-				if err := mig.AddColumn(&tables.TableBatchJob{}, column); err != nil {
+				if err := mig.AddColumn(&tables.TableProviderJob{}, column); err != nil {
 					return fmt.Errorf("failed to add %s column to batch_jobs: %w", column, err)
 				}
 			}
@@ -550,10 +551,10 @@ func migrationAddBatchJobsAttributionColumns(ctx context.Context, db *gorm.DB, l
 				return fmt.Errorf("failed to drop index idx_batch_jobs_user_id: %w", err)
 			}
 			for _, column := range columns {
-				if !mig.HasColumn(&tables.TableBatchJob{}, column) {
+				if !mig.HasColumn(&tables.TableProviderJob{}, column) {
 					continue
 				}
-				if err := mig.DropColumn(&tables.TableBatchJob{}, column); err != nil {
+				if err := mig.DropColumn(&tables.TableProviderJob{}, column); err != nil {
 					return fmt.Errorf("failed to drop %s column from batch_jobs: %w", column, err)
 				}
 			}
@@ -12181,7 +12182,7 @@ func migrationAddBatchJobsTable(ctx context.Context, db *gorm.DB, logger schemas
 			default:
 				// Fall back to GORM for any other dialect so the migration does not
 				// hard-fail on an unsupported backend.
-				return tx.Migrator().AutoMigrate(&tables.TableBatchJob{})
+				return tx.Migrator().AutoMigrate(&tables.TableProviderJob{})
 			}
 
 			if err := tx.Exec(createTable).Error; err != nil {
@@ -12201,7 +12202,7 @@ func migrationAddBatchJobsTable(ctx context.Context, db *gorm.DB, logger schemas
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			return tx.Migrator().DropTable(&tables.TableBatchJob{})
+			return tx.Migrator().DropTable(&tables.TableProviderJob{})
 		},
 	}})
 	if err := m.Migrate(); err != nil {
@@ -12448,6 +12449,136 @@ func migrationDropLegacyOauthUserFKConstraints(ctx context.Context, db *gorm.DB,
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running %s migration: %s", migrationName, err.Error())
+	}
+	return nil
+}
+
+// migrationAddProviderJobKindColumns generalises batch_jobs from a batch-only
+// table to one holding every provider-side job kind.
+//
+// Additive by construction: kind carries a constant default, so it is
+// metadata-only on postgres 11+ and O(1) on sqlite — existing rows *become*
+// kind='batch' without an UPDATE touching a single one of them, which is exactly
+// what they always were. params is nullable with no default.
+//
+// The identity index widens from (provider, batch_id) to (provider, kind,
+// batch_id). The replacement is strictly weaker than the index it replaces, so it
+// can never fail to build on existing data, and it is created before the old one
+// is dropped so uniqueness is never briefly unenforced.
+func migrationAddProviderJobKindColumns(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_provider_job_kind_columns"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mig := tx.Migrator()
+
+			// Raw DDL rather than AddColumn so the NOT NULL DEFAULT is explicit: the
+			// default is what backfills every pre-existing row, and it must not depend
+			// on how GORM chooses to render a struct tag.
+			if !mig.HasColumn(&tables.TableProviderJob{}, "kind") {
+				if err := tx.Exec(`ALTER TABLE batch_jobs ADD COLUMN kind VARCHAR(50) NOT NULL DEFAULT 'batch'`).Error; err != nil {
+					return fmt.Errorf("failed to add kind column to batch_jobs: %w", err)
+				}
+			}
+			if !mig.HasColumn(&tables.TableProviderJob{}, "params") {
+				if err := tx.Exec(`ALTER TABLE batch_jobs ADD COLUMN params TEXT`).Error; err != nil {
+					return fmt.Errorf("failed to add params column to batch_jobs: %w", err)
+				}
+			}
+
+			if err := tx.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_batch_jobs_identity_v2 ON batch_jobs (provider, kind, batch_id)`).Error; err != nil {
+				return fmt.Errorf("failed to create idx_batch_jobs_identity_v2: %w", err)
+			}
+			if err := tx.Exec(`DROP INDEX IF EXISTS idx_batch_jobs_identity`).Error; err != nil {
+				return fmt.Errorf("failed to drop idx_batch_jobs_identity: %w", err)
+			}
+
+			// The sweeper scans by kind first now that each kind has its own settler.
+			if err := tx.Exec(`CREATE INDEX IF NOT EXISTS idx_batch_jobs_sweeper_v2 ON batch_jobs (kind, provider, accounting_status, next_check_at)`).Error; err != nil {
+				return fmt.Errorf("failed to create idx_batch_jobs_sweeper_v2: %w", err)
+			}
+			if err := tx.Exec(`DROP INDEX IF EXISTS idx_batch_jobs_sweeper`).Error; err != nil {
+				return fmt.Errorf("failed to drop idx_batch_jobs_sweeper: %w", err)
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return rollbackProviderJobKindColumns(ctx, tx)
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running %s migration: %s", migrationName, err.Error())
+	}
+	return nil
+}
+
+// rollbackProviderJobKindColumns reverses migrationAddProviderJobKindColumns.
+//
+// Order matters, and it is the reverse of the intuitive one: the columns go first,
+// the narrow indexes are recreated last. Dropping a column takes its dependent
+// indexes with it — postgres cascades, and sqlite rebuilds the whole table from the
+// model — so anything restored beforehand is destroyed on the way past.
+func rollbackProviderJobKindColumns(ctx context.Context, db *gorm.DB) error {
+	tx := db.WithContext(ctx)
+	mig := tx.Migrator()
+
+	// Refuse before touching anything if a non-batch job exists. The narrow index
+	// this rollback restores is UNIQUE on (provider, batch_id), and a video job is
+	// free to carry the same provider-side id as a batch — so rebuilding it would
+	// fail on real data. Failing here rather than there matters: the column drop
+	// comes first, so a rollback that got as far as the index would already have
+	// erased the only thing distinguishing those rows, leaving the sweeper to
+	// settle a video as a batch.
+	if mig.HasColumn(&tables.TableProviderJob{}, "kind") {
+		var foreign int64
+		if err := tx.Table("batch_jobs").Where("kind <> ?", tables.ProviderJobKindBatch).Count(&foreign).Error; err != nil {
+			return fmt.Errorf("failed to check for non-batch provider jobs: %w", err)
+		}
+		if foreign > 0 {
+			return fmt.Errorf("add_provider_job_kind_columns is non-rollbackable while %d non-batch job(s) exist in batch_jobs: dropping kind would merge them into the batch namespace, where they collide on (provider, batch_id) and would be settled as batches; delete those rows first if the rollback is genuinely intended", foreign)
+		}
+	}
+
+	if mig.HasColumn(&tables.TableProviderJob{}, "params") {
+		var captured int64
+		if err := tx.Table("batch_jobs").Where("params IS NOT NULL AND params <> ''").Count(&captured).Error; err != nil {
+			return fmt.Errorf("failed to check for captured provider job params: %w", err)
+		}
+		if captured > 0 {
+			return fmt.Errorf("add_provider_job_kind_columns is non-rollbackable while %d job(s) in batch_jobs carry captured params: dropping params discards the pricing basis recorded at submission, which no provider response can reconstruct, and those jobs would settle unpriced; clear the column first if the rollback is genuinely intended", captured)
+		}
+	}
+
+	if err := tx.Exec(`DROP INDEX IF EXISTS idx_batch_jobs_identity_v2`).Error; err != nil {
+		return fmt.Errorf("failed to drop idx_batch_jobs_identity_v2: %w", err)
+	}
+	if err := tx.Exec(`DROP INDEX IF EXISTS idx_batch_jobs_sweeper_v2`).Error; err != nil {
+		return fmt.Errorf("failed to drop idx_batch_jobs_sweeper_v2: %w", err)
+	}
+
+	// Raw DDL rather than Migrator.DropColumn. On sqlite the GORM helper rebuilds
+	// the table from the *model*, and after an ALTER TABLE ADD COLUMN the physical
+	// column order no longer matches the model's field order — the rebuild then
+	// copies values into the wrong columns and dies on a NOT NULL violation. Both
+	// dialects support DROP COLUMN natively (sqlite since 3.35), so drop in place.
+	// DROP COLUMN IF EXISTS is postgres-only syntax, hence the HasColumn guard.
+	for _, column := range []string{"kind", "params"} {
+		if !mig.HasColumn(&tables.TableProviderJob{}, column) {
+			continue
+		}
+		if err := tx.Exec(`ALTER TABLE batch_jobs DROP COLUMN ` + column).Error; err != nil {
+			return fmt.Errorf("failed to drop %s column from batch_jobs: %w", column, err)
+		}
+	}
+
+	if err := tx.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_batch_jobs_identity ON batch_jobs (provider, batch_id)`).Error; err != nil {
+		return fmt.Errorf("failed to restore idx_batch_jobs_identity: %w", err)
+	}
+	if err := tx.Exec(`CREATE INDEX IF NOT EXISTS idx_batch_jobs_sweeper ON batch_jobs (provider, accounting_status, next_check_at)`).Error; err != nil {
+		return fmt.Errorf("failed to restore idx_batch_jobs_sweeper: %w", err)
 	}
 	return nil
 }

--- a/framework/configstore/migrations_test.go
+++ b/framework/configstore/migrations_test.go
@@ -3079,18 +3079,18 @@ func TestMigrationAddBatchJobsAttributionColumns(t *testing.T) {
 	require.NoError(t, db.Exec(`
 		INSERT INTO batch_jobs (id, provider, batch_id, accounting_status, selected_key_id, virtual_key_id, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		tables.BatchJobID("openai", "batch-legacy"), "openai", "batch-legacy",
-		tables.BatchJobAccountingStatusPending, "key-1", "vk-1", now, now).Error)
+		tables.ProviderJobID(tables.ProviderJobKindBatch, "openai", "batch-legacy"), "openai", "batch-legacy",
+		tables.ProviderJobAccountingStatusPending, "key-1", "vk-1", now, now).Error)
 
 	require.NoError(t, migrationAddBatchJobsAttributionColumns(ctx, db, logger))
 
 	mig := db.Migrator()
 	for _, column := range []string{"user_id", "team_id", "customer_id", "source_log_id"} {
-		assert.True(t, mig.HasColumn(&tables.TableBatchJob{}, column), "expected column %s", column)
+		assert.True(t, mig.HasColumn(&tables.TableProviderJob{}, column), "expected column %s", column)
 	}
 
-	var job tables.TableBatchJob
-	require.NoError(t, db.Where("id = ?", tables.BatchJobID("openai", "batch-legacy")).First(&job).Error)
+	var job tables.TableProviderJob
+	require.NoError(t, db.Where("id = ?", tables.ProviderJobID(tables.ProviderJobKindBatch, "openai", "batch-legacy")).First(&job).Error)
 	assert.Equal(t, "key-1", job.SelectedKeyID, "pre-existing attribution must survive")
 	require.NotNil(t, job.VirtualKeyID)
 	assert.Equal(t, "vk-1", *job.VirtualKeyID)
@@ -3126,4 +3126,304 @@ func TestMigrationAddVideoResolutionPricingColumns(t *testing.T) {
 
 	// Rolling deploys re-run migrations; a second pass must be a no-op.
 	require.NoError(t, migrationAddVideoResolutionPricingColumns(ctx, db, testMigrationLogger))
+}
+
+// providerJobPreMigrationDDL is batch_jobs as the attribution migration left it:
+// no kind, no params, and the narrow identity index this change replaces.
+func providerJobPreMigrationDDL(dialect string) []string {
+	if dialect == "postgres" {
+		return []string{`
+			CREATE TABLE batch_jobs (
+				id VARCHAR(512) PRIMARY KEY,
+				provider VARCHAR(255) NOT NULL,
+				batch_id VARCHAR(255) NOT NULL,
+				model VARCHAR(255),
+				endpoint VARCHAR(255),
+				provider_status VARCHAR(50),
+				input_file_id VARCHAR(255),
+				output_file_id VARCHAR(255),
+				error_file_id VARCHAR(255),
+				results_url TEXT,
+				next_check_at TIMESTAMPTZ,
+				poll_attempts INTEGER NOT NULL DEFAULT 0,
+				accounting_status VARCHAR(50) NOT NULL,
+				runner_id VARCHAR(255),
+				claimed_at TIMESTAMPTZ,
+				unpriceable_reason VARCHAR(255),
+				last_error TEXT,
+				aggregate_log_written_at TIMESTAMPTZ,
+				governance_reported_at TIMESTAMPTZ,
+				selected_key_id VARCHAR(255),
+				virtual_key_id VARCHAR(255),
+				user_id VARCHAR(255),
+				team_id VARCHAR(255),
+				customer_id VARCHAR(255),
+				budget_ids TEXT,
+				rate_limit_ids TEXT,
+				source_log_id VARCHAR(255),
+				created_at TIMESTAMPTZ NOT NULL,
+				updated_at TIMESTAMPTZ NOT NULL
+			)`,
+			`CREATE UNIQUE INDEX idx_batch_jobs_identity ON batch_jobs (provider, batch_id)`,
+			`CREATE INDEX idx_batch_jobs_sweeper ON batch_jobs (provider, accounting_status, next_check_at)`,
+		}
+	}
+	return []string{`
+		CREATE TABLE batch_jobs (
+			id VARCHAR(512) PRIMARY KEY,
+			provider VARCHAR(255) NOT NULL,
+			batch_id VARCHAR(255) NOT NULL,
+			model VARCHAR(255),
+			endpoint VARCHAR(255),
+			provider_status VARCHAR(50),
+			input_file_id VARCHAR(255),
+			output_file_id VARCHAR(255),
+			error_file_id VARCHAR(255),
+			results_url TEXT,
+			next_check_at DATETIME,
+			poll_attempts INTEGER DEFAULT 0,
+			accounting_status VARCHAR(50) NOT NULL,
+			runner_id VARCHAR(255),
+			claimed_at DATETIME,
+			unpriceable_reason VARCHAR(255),
+			last_error TEXT,
+			aggregate_log_written_at DATETIME,
+			governance_reported_at DATETIME,
+			selected_key_id VARCHAR(255),
+			virtual_key_id VARCHAR(255),
+			user_id VARCHAR(255),
+			team_id VARCHAR(255),
+			customer_id VARCHAR(255),
+			budget_ids TEXT,
+			rate_limit_ids TEXT,
+			source_log_id VARCHAR(255),
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL
+		)`,
+		`CREATE UNIQUE INDEX idx_batch_jobs_identity ON batch_jobs (provider, batch_id)`,
+		`CREATE INDEX idx_batch_jobs_sweeper ON batch_jobs (provider, accounting_status, next_check_at)`,
+	}
+}
+
+// forEachProviderJobMigrationDB returns a pre-migration batch_jobs on every backend
+// available. Postgres matters here specifically: the properties this migration
+// leans on — a NOT NULL DEFAULT add being metadata-only, DROP INDEX cascading off a
+// dropped column — are postgres semantics that sqlite does not exercise.
+func forEachProviderJobMigrationDB(t *testing.T) []namedDB {
+	t.Helper()
+	dbs := []namedDB{}
+
+	sqliteDB, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	require.NoError(t, err, "Failed to create test database")
+	for _, stmt := range providerJobPreMigrationDDL("sqlite") {
+		require.NoError(t, sqliteDB.Exec(stmt).Error)
+	}
+	dbs = append(dbs, namedDB{"sqlite", sqliteDB})
+
+	pgDB, err := gorm.Open(postgres.Open(postgresDSN), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		return dbs
+	}
+	sqlDB, err := pgDB.DB()
+	if err != nil || sqlDB.Ping() != nil {
+		return dbs
+	}
+	if pgDB.Exec("CREATE SCHEMA IF NOT EXISTS "+pgTestSchema).Error != nil {
+		return dbs
+	}
+	pgDB.Exec("DROP TABLE IF EXISTS batch_jobs CASCADE")
+	pgDB.Exec(`CREATE TABLE IF NOT EXISTS migrations (id VARCHAR(255) PRIMARY KEY)`)
+	pgDB.Exec("DELETE FROM migrations")
+	for _, stmt := range providerJobPreMigrationDDL("postgres") {
+		if err := pgDB.Exec(stmt).Error; err != nil {
+			return dbs
+		}
+	}
+	t.Cleanup(func() {
+		pgDB.Exec("DELETE FROM migrations")
+		pgDB.Exec("DROP TABLE IF EXISTS batch_jobs CASCADE")
+	})
+	return append(dbs, namedDB{"postgres", pgDB})
+}
+
+// TestMigrationAddProviderJobKindColumns verifies the upgrade path that matters
+// most in this change: an existing batch_jobs table, holding both in-flight and
+// already-settled rows, gains kind/params and the widened identity index without
+// a single existing row being altered, re-keyed, or losing its place in the
+// sweeper's queue.
+func TestMigrationAddProviderJobKindColumns(t *testing.T) {
+	ctx := context.Background()
+	logr := bifrost.NewDefaultLogger(schemas.LogLevelError)
+
+	for _, backend := range forEachProviderJobMigrationDB(t) {
+		t.Run(backend.name, func(t *testing.T) {
+			db := backend.db
+			now := time.Now().UTC().Truncate(time.Second)
+			due := now.Add(-time.Minute)
+
+			// One job still being polled and one already settled: the migration must not
+			// disturb either, and the in-flight one must stay visible to the sweeper.
+			require.NoError(t, db.Exec(`
+				INSERT INTO batch_jobs (id, provider, batch_id, model, accounting_status, next_check_at, poll_attempts, selected_key_id, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				tables.ProviderJobID(tables.ProviderJobKindBatch, "openai", "batch-inflight"), "openai", "batch-inflight",
+				"gpt-4o-mini", tables.ProviderJobAccountingStatusPending, due, 3, "key-1", now, now).Error)
+			require.NoError(t, db.Exec(`
+				INSERT INTO batch_jobs (id, provider, batch_id, model, accounting_status, poll_attempts, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+				tables.ProviderJobID(tables.ProviderJobKindBatch, "anthropic", "batch-settled"), "anthropic", "batch-settled",
+				"claude-sonnet-5", tables.ProviderJobAccountingStatusAccounted, 0, now, now).Error)
+
+			require.NoError(t, migrationAddProviderJobKindColumns(ctx, db, logr))
+
+			mig := db.Migrator()
+			assert.True(t, mig.HasColumn(&tables.TableProviderJob{}, "kind"))
+			assert.True(t, mig.HasColumn(&tables.TableProviderJob{}, "params"))
+
+			// Every pre-existing row *becomes* a batch row, with no UPDATE having touched
+			// it: the column default is what backfills them.
+			var inflight tables.TableProviderJob
+			require.NoError(t, db.Where("batch_id = ?", "batch-inflight").First(&inflight).Error)
+			assert.Equal(t, tables.ProviderJobKindBatch, inflight.Kind)
+			assert.Nil(t, inflight.Params, "a batch created before the column has no params to recover")
+			assert.Equal(t, tables.ProviderJobID(tables.ProviderJobKindBatch, "openai", "batch-inflight"), inflight.ID,
+				"the primary key must survive verbatim, or the sweeper settles the job a second time under a new id")
+			assert.Equal(t, "gpt-4o-mini", inflight.Model)
+			assert.Equal(t, 3, inflight.PollAttempts, "poll progress must not reset")
+			assert.Equal(t, "key-1", inflight.SelectedKeyID)
+			require.NotNil(t, inflight.NextCheckAt)
+			assert.WithinDuration(t, due, inflight.NextCheckAt.UTC(), time.Second, "the job must stay due at the same moment")
+
+			var settled tables.TableProviderJob
+			require.NoError(t, db.Where("batch_id = ?", "batch-settled").First(&settled).Error)
+			assert.Equal(t, tables.ProviderJobKindBatch, settled.Kind)
+			assert.Equal(t, tables.ProviderJobAccountingStatusAccounted, settled.AccountingStatus,
+				"a settled batch must stay settled; re-opening it would bill it twice")
+
+			// The identity index widened, and the narrow one it replaces is gone.
+			assert.True(t, mig.HasIndex(&tables.TableProviderJob{}, "idx_batch_jobs_identity_v2"))
+			assert.False(t, mig.HasIndex(&tables.TableProviderJob{}, "idx_batch_jobs_identity"))
+			assert.True(t, mig.HasIndex(&tables.TableProviderJob{}, "idx_batch_jobs_sweeper_v2"))
+			assert.False(t, mig.HasIndex(&tables.TableProviderJob{}, "idx_batch_jobs_sweeper"))
+
+			// The widened index is what lets a video job reuse a provider's batch id.
+			require.NoError(t, db.Exec(`
+				INSERT INTO batch_jobs (id, provider, batch_id, kind, accounting_status, poll_attempts, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+				tables.ProviderJobID(tables.ProviderJobKindVideo, "openai", "batch-inflight"), "openai", "batch-inflight",
+				tables.ProviderJobKindVideo, tables.ProviderJobAccountingStatusPending, 0, now, now).Error)
+
+			// ...but two rows of the same kind still cannot share one provider job id.
+			err := db.Exec(`
+				INSERT INTO batch_jobs (id, provider, batch_id, kind, accounting_status, poll_attempts, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+				"batch-job:openai:duplicate", "openai", "batch-inflight",
+				tables.ProviderJobKindBatch, tables.ProviderJobAccountingStatusPending, 0, now, now).Error
+			require.Error(t, err, "the widened index must still enforce one row per (provider, kind, batch_id)")
+
+			// Re-run the DDL itself, not just the migrator: clearing the recorded id is
+			// what forces the HasColumn/IF NOT EXISTS guards to actually execute against
+			// an already-migrated table. Without this the migrator short-circuits and the
+			// guards are never exercised at all.
+			require.NoError(t, db.Exec("DELETE FROM migrations WHERE id = ?", "add_provider_job_kind_columns").Error)
+			require.NoError(t, migrationAddProviderJobKindColumns(ctx, db, logr),
+				"the migration's own SQL must be idempotent, not merely skipped by the migrator")
+			assert.True(t, mig.HasColumn(&tables.TableProviderJob{}, "kind"))
+			assert.True(t, mig.HasIndex(&tables.TableProviderJob{}, "idx_batch_jobs_identity_v2"))
+		})
+	}
+}
+
+// params is the pricing basis captured at submission and is reconstructible from
+// nothing else, so a rollback must refuse while any job still carries it — checked
+// on the column's own contents, not on kind. Only video writes params today, so the
+// kind guard happens to cover it; that is a fact about the current writers, not
+// about the column.
+func TestMigrationAddProviderJobKindColumns_RollbackRefusesWhileParamsExist(t *testing.T) {
+	ctx := context.Background()
+	logr := bifrost.NewDefaultLogger(schemas.LogLevelError)
+
+	for _, backend := range forEachProviderJobMigrationDB(t) {
+		t.Run(backend.name, func(t *testing.T) {
+			db := backend.db
+			now := time.Now().UTC().Truncate(time.Second)
+			require.NoError(t, migrationAddProviderJobKindColumns(ctx, db, logr))
+
+			// A batch-kind row carrying params: the kind guard passes it through.
+			require.NoError(t, db.Exec(`
+				INSERT INTO batch_jobs (id, provider, batch_id, kind, params, accounting_status, poll_attempts, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				tables.ProviderJobID(tables.ProviderJobKindBatch, "openai", "job-with-params"), "openai", "job-with-params",
+				tables.ProviderJobKindBatch, `{"seconds":8,"size":"1920x1080"}`,
+				tables.ProviderJobAccountingStatusPending, 0, now, now).Error)
+
+			err := rollbackProviderJobKindColumns(ctx, db)
+			require.Error(t, err, "rollback must refuse while captured params exist")
+			assert.Contains(t, err.Error(), "non-rollbackable")
+			assert.Contains(t, err.Error(), "params")
+			assert.True(t, db.Migrator().HasColumn(&tables.TableProviderJob{}, "params"),
+				"a refused rollback must leave the column intact")
+
+			// Cleared, it rolls back cleanly — the common case right after deploying,
+			// before any job has captured anything.
+			require.NoError(t, db.Exec("UPDATE batch_jobs SET params = NULL").Error)
+			require.NoError(t, rollbackProviderJobKindColumns(ctx, db))
+			assert.False(t, db.Migrator().HasColumn(&tables.TableProviderJob{}, "params"))
+		})
+	}
+}
+
+// TestMigrationAddProviderJobKindColumns_Rollback verifies the down path drops the
+// columns and restores the narrow indexes — and, more importantly, that it refuses
+// outright once the table holds a kind the narrow index cannot represent.
+func TestMigrationAddProviderJobKindColumns_Rollback(t *testing.T) {
+	ctx := context.Background()
+	logr := bifrost.NewDefaultLogger(schemas.LogLevelError)
+
+	for _, backend := range forEachProviderJobMigrationDB(t) {
+		t.Run(backend.name, func(t *testing.T) {
+			db := backend.db
+			mig := db.Migrator()
+			now := time.Now().UTC().Truncate(time.Second)
+
+			require.NoError(t, db.Exec(`
+				INSERT INTO batch_jobs (id, provider, batch_id, accounting_status, poll_attempts, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				tables.ProviderJobID(tables.ProviderJobKindBatch, "openai", "shared-id"), "openai", "shared-id",
+				tables.ProviderJobAccountingStatusAccounted, 0, now, now).Error)
+			require.NoError(t, migrationAddProviderJobKindColumns(ctx, db, logr))
+
+			// A video job may legitimately carry the same provider-side id as a batch.
+			require.NoError(t, db.Exec(`
+				INSERT INTO batch_jobs (id, provider, batch_id, kind, accounting_status, poll_attempts, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+				tables.ProviderJobID(tables.ProviderJobKindVideo, "openai", "shared-id"), "openai", "shared-id",
+				tables.ProviderJobKindVideo, tables.ProviderJobAccountingStatusPending, 0, now, now).Error)
+
+			// Restoring a UNIQUE (provider, batch_id) over that data is impossible, and
+			// the column drop happens first — so a rollback that discovered the problem
+			// at the index would already have erased the only thing telling the two rows
+			// apart. It has to refuse before touching anything.
+			err := rollbackProviderJobKindColumns(ctx, db)
+			require.Error(t, err, "rollback must refuse while a non-batch job exists")
+			assert.Contains(t, err.Error(), "non-rollbackable")
+			assert.True(t, mig.HasColumn(&tables.TableProviderJob{}, "kind"),
+				"a refused rollback must leave the schema exactly as it was")
+			assert.True(t, mig.HasIndex(&tables.TableProviderJob{}, "idx_batch_jobs_identity_v2"))
+
+			// With the video rows gone the narrow index is representable again.
+			require.NoError(t, db.Exec("DELETE FROM batch_jobs WHERE kind <> ?", tables.ProviderJobKindBatch).Error)
+			require.NoError(t, rollbackProviderJobKindColumns(ctx, db))
+
+			assert.False(t, mig.HasColumn(&tables.TableProviderJob{}, "kind"))
+			assert.False(t, mig.HasColumn(&tables.TableProviderJob{}, "params"))
+			assert.True(t, mig.HasIndex(&tables.TableProviderJob{}, "idx_batch_jobs_identity"),
+				"the narrow identity index must come back, or nothing enforces batch uniqueness")
+			assert.True(t, mig.HasIndex(&tables.TableProviderJob{}, "idx_batch_jobs_sweeper"))
+
+			var count int64
+			require.NoError(t, db.Table("batch_jobs").Where("batch_id = ?", "shared-id").Count(&count).Error)
+			assert.Equal(t, int64(1), count, "rolling back the schema must not drop the batch rows")
+		})
+	}
 }

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -893,15 +893,15 @@ type ConfigStore interface {
 	MarkStaleSidekiqJobsFailed(ctx context.Context, staleBefore time.Time) (int64, error)
 
 	// Batch jobs - mutable coordination state for delayed batch accounting
-	UpsertBatchJob(ctx context.Context, job *tables.TableBatchJob) error
-	GetBatchJob(ctx context.Context, jobID string) (*tables.TableBatchJob, error)
-	ListDueBatchJobs(ctx context.Context, provider string, now time.Time, limit int) ([]*tables.TableBatchJob, error)
-	ClaimBatchJob(ctx context.Context, jobID, runnerID string, staleBefore time.Time, allowUnpriceable bool) (bool, error)
-	MarkBatchJobAggregateLogWritten(ctx context.Context, jobID, runnerID string) error
-	MarkBatchJobGovernanceReported(ctx context.Context, jobID, runnerID string) error
-	CompleteBatchJob(ctx context.Context, jobID, runnerID string) error
-	MarkBatchJobUnpriceable(ctx context.Context, jobID, runnerID, reason string, err error) error
-	FailBatchJob(ctx context.Context, jobID, runnerID string, err error) error
+	UpsertProviderJob(ctx context.Context, job *tables.TableProviderJob) error
+	GetProviderJob(ctx context.Context, jobID string) (*tables.TableProviderJob, error)
+	ListDueProviderJobs(ctx context.Context, kind, provider string, now time.Time, limit int) ([]*tables.TableProviderJob, error)
+	ClaimProviderJob(ctx context.Context, jobID, runnerID string, staleBefore time.Time, allowUnpriceable bool) (bool, error)
+	MarkProviderJobAggregateLogWritten(ctx context.Context, jobID, runnerID string) error
+	MarkProviderJobGovernanceReported(ctx context.Context, jobID, runnerID string) error
+	CompleteProviderJob(ctx context.Context, jobID, runnerID string) error
+	MarkProviderJobUnpriceable(ctx context.Context, jobID, runnerID, reason string, err error) error
+	FailProviderJob(ctx context.Context, jobID, runnerID string, err error) error
 
 	// Webhook Endpoints
 	GetWebhookEndpoints(ctx context.Context) ([]tables.TableWebhookEndpoint, error)

--- a/framework/configstore/tables/batchjob.go
+++ b/framework/configstore/tables/batchjob.go
@@ -6,19 +6,27 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-// Batch accounting lifecycle states for a TableBatchJob.
+// Provider job kinds. The kind discriminates the job families sharing the
+// batch_jobs table; jobaccounting.ProviderJobKind is the typed view of these.
 const (
-	BatchJobAccountingStatusPending     = "pending"
-	BatchJobAccountingStatusProcessing  = "processing"
-	BatchJobAccountingStatusAccounted   = "accounted"
-	BatchJobAccountingStatusUnpriceable = "unpriceable"
-	BatchJobAccountingStatusError       = "error"
+	ProviderJobKindBatch = "batch"
+	ProviderJobKindVideo = "video"
 )
 
-// TableBatchJob is the mutable coordination record for delayed batch accounting.
+// Accounting lifecycle states for a TableProviderJob.
+const (
+	ProviderJobAccountingStatusPending     = "pending"
+	ProviderJobAccountingStatusProcessing  = "processing"
+	ProviderJobAccountingStatusAccounted   = "accounted"
+	ProviderJobAccountingStatusUnpriceable = "unpriceable"
+	ProviderJobAccountingStatusError       = "error"
+)
+
+// TableProviderJob is the mutable coordination record for delayed accounting of a
+// job the provider runs on its own schedule — a batch, a video generation.
 //
 // It lives in the config store (relational, single-writer-friendly) rather than
-// the log store because the batch lifecycle is a state machine that is UPDATE-d
+// the log store because the job lifecycle is a state machine that is UPDATE-d
 // in place many times (poll rescheduling, claim/ownership, settlement markers) —
 // a poor fit for the append-only log store and its ClickHouse backend. The
 // append-only cost record is written separately as an aggregate row in the logs
@@ -29,12 +37,24 @@ const (
 // claim token) — a job stuck in "processing" past the caller's stale threshold
 // can be re-claimed by another runner, and every advance/complete is fenced on
 // RunnerID so a former owner cannot stomp a re-claimed job.
-type TableBatchJob struct {
-	ID       string `gorm:"primaryKey;type:varchar(512)" json:"id"`
-	Provider string `gorm:"type:varchar(255);uniqueIndex:idx_batch_jobs_identity,priority:1;index:idx_batch_jobs_sweeper,priority:1;not null" json:"provider"`
-	BatchID  string `gorm:"type:varchar(255);uniqueIndex:idx_batch_jobs_identity,priority:2;not null" json:"batch_id"`
+type TableProviderJob struct {
+	ID string `gorm:"primaryKey;type:varchar(512)" json:"id"`
+	// Kind discriminates the job family. Rows written before the column existed
+	// default to batch, which is what every one of them was.
+	Kind     string `gorm:"type:varchar(50);not null;default:'batch';uniqueIndex:idx_batch_jobs_identity_v2,priority:2;index:idx_batch_jobs_sweeper_v2,priority:1" json:"kind"`
+	Provider string `gorm:"type:varchar(255);uniqueIndex:idx_batch_jobs_identity_v2,priority:1;index:idx_batch_jobs_sweeper_v2,priority:2;not null" json:"provider"`
+	// JobID is the provider-side identifier: a batch id, a video id. The column is
+	// still named batch_id — renaming it would break old pods mid-rolling-deploy
+	// for no gain.
+	JobID    string `gorm:"column:batch_id;type:varchar(255);uniqueIndex:idx_batch_jobs_identity_v2,priority:3;not null" json:"batch_id"`
 	Model    string `gorm:"type:varchar(255)" json:"model,omitempty"`
 	Endpoint string `gorm:"type:varchar(255)" json:"endpoint,omitempty"`
+
+	// Params is the kind's JSON-encoded request dimensions, captured at submission.
+	// It is load-bearing for video: a provider's retrieve response usually reports
+	// only that the job finished, so the duration and resolution the price depends
+	// on exist nowhere else by the time settlement runs.
+	Params *string `gorm:"type:text" json:"params,omitempty"`
 
 	ProviderStatus string  `gorm:"type:varchar(50)" json:"provider_status,omitempty"`
 	InputFileID    string  `gorm:"type:varchar(255)" json:"input_file_id,omitempty"`
@@ -42,17 +62,17 @@ type TableBatchJob struct {
 	ErrorFileID    *string `gorm:"type:varchar(255)" json:"error_file_id,omitempty"`
 	ResultsURL     *string `gorm:"type:text" json:"results_url,omitempty"`
 
-	NextCheckAt      *time.Time `gorm:"index:idx_batch_jobs_sweeper,priority:3" json:"next_check_at,omitempty"`
+	NextCheckAt      *time.Time `gorm:"index:idx_batch_jobs_sweeper_v2,priority:4" json:"next_check_at,omitempty"`
 	PollAttempts     int        `gorm:"default:0" json:"poll_attempts"`
-	AccountingStatus string     `gorm:"type:varchar(50);index:idx_batch_jobs_sweeper,priority:2;not null" json:"accounting_status"`
+	AccountingStatus string     `gorm:"type:varchar(50);index:idx_batch_jobs_sweeper_v2,priority:3;not null" json:"accounting_status"`
 
 	// RunnerID fences an in-flight accounting attempt to the runner that claimed it.
 	RunnerID *string `gorm:"type:varchar(255);index" json:"runner_id,omitempty"`
 	// ClaimedAt is when RunnerID took the claim, and is the sole basis for deciding
 	// a claim has gone stale. It is deliberately NOT UpdatedAt: UpdatedAt is
-	// refreshed by UpsertBatchJob, which is unfenced and runs on every poll, so
+	// refreshed by UpsertProviderJob, which is unfenced and runs on every poll, so
 	// using it would let routine polling keep a dead runner's claim looking fresh
-	// forever and make the job unreclaimable. Only ClaimBatchJob sets this, and
+	// forever and make the job unreclaimable. Only ClaimProviderJob sets this, and
 	// only the finishing transitions clear it.
 	ClaimedAt *time.Time `json:"claimed_at,omitempty"`
 
@@ -75,16 +95,25 @@ type TableBatchJob struct {
 	UpdatedAt time.Time `gorm:"not null" json:"updated_at"`
 }
 
-// TableName returns the backing table name for batch jobs.
-func (TableBatchJob) TableName() string {
+// TableName returns the backing table name. It stays "batch_jobs" now that the
+// table holds every provider job kind: renaming it is data-safe but breaks old
+// pods mid-rolling-deploy for no benefit.
+func (TableProviderJob) TableName() string {
 	return "batch_jobs"
 }
 
-// BatchJobID builds the stable primary key for a batch job. The identity is
-// provider + batch ID so the sweeper, user-triggered /results, and future
+// ProviderJobID builds the stable primary key for a provider job. The identity is
+// kind + provider + job ID so the sweeper, user-triggered settlement, and future
 // reconcilers all resolve to the same cluster-safe row.
-func BatchJobID(provider, batchID string) string {
-	return "batch-job:" + provider + ":" + batchID
+//
+// The batch form is byte-identical to the pre-kind formula and must stay that way:
+// it is the primary key of every batch row already in the table, so changing it
+// would orphan them and settle each one a second time under a new id.
+func ProviderJobID(kind, provider, jobID string) string {
+	if kind == "" || kind == ProviderJobKindBatch {
+		return "batch-job:" + provider + ":" + jobID
+	}
+	return kind + "-job:" + provider + ":" + jobID
 }
 
 // IsTerminalBatchProviderStatus reports whether a provider batch status is

--- a/framework/configstore/tables/batchjob_test.go
+++ b/framework/configstore/tables/batchjob_test.go
@@ -1,0 +1,29 @@
+package tables
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestProviderJobIDBatchFormIsFrozen is a regression guard on a primary key, not a
+// style preference. Every batch row already in batch_jobs is keyed by this exact
+// string. If the batch form ever changes, running code stops finding those rows,
+// treats each settled batch as unseen, and bills it a second time.
+func TestProviderJobIDBatchFormIsFrozen(t *testing.T) {
+	assert.Equal(t, "batch-job:openai:batch_abc",
+		ProviderJobID(ProviderJobKindBatch, "openai", "batch_abc"))
+
+	// An absent kind is a pre-kind caller, and must resolve to the same row.
+	assert.Equal(t, ProviderJobID(ProviderJobKindBatch, "openai", "batch_abc"),
+		ProviderJobID("", "openai", "batch_abc"))
+}
+
+// TestProviderJobIDSeparatesKinds pins the other half: a video job must never
+// collide with a batch that happens to carry the same provider-side id.
+func TestProviderJobIDSeparatesKinds(t *testing.T) {
+	batch := ProviderJobID(ProviderJobKindBatch, "openai", "id_123")
+	video := ProviderJobID(ProviderJobKindVideo, "openai", "id_123")
+	assert.NotEqual(t, batch, video)
+	assert.Equal(t, "video-job:openai:id_123", video)
+}

--- a/framework/jobaccounting/batch.go
+++ b/framework/jobaccounting/batch.go
@@ -31,8 +31,8 @@ const defaultProviderPollTimeout = 5 * time.Minute
 const unpriceableReasonTerminalWithoutResults = "terminal_without_results"
 
 type BatchResultFetcher interface {
-	RetrieveBatch(ctx context.Context, job *cstables.TableBatchJob) (*schemas.BifrostBatchRetrieveResponse, error)
-	FetchBatchResults(ctx context.Context, job *cstables.TableBatchJob) (*schemas.BifrostBatchResultsResponse, error)
+	RetrieveBatch(ctx context.Context, job *cstables.TableProviderJob) (*schemas.BifrostBatchRetrieveResponse, error)
+	FetchBatchResults(ctx context.Context, job *cstables.TableProviderJob) (*schemas.BifrostBatchResultsResponse, error)
 }
 
 // BatchPayload is the batch kind's settlement input, carried opaquely by the
@@ -106,19 +106,20 @@ func AccountBatchResults(ctx context.Context, stateStore JobStore, logStore Aggr
 
 	job := req.Job
 	if job == nil {
-		job = &cstables.TableBatchJob{
+		job = &cstables.TableProviderJob{
+			Kind:             cstables.ProviderJobKindBatch,
 			Provider:         string(req.Provider),
-			BatchID:          req.ProviderJobID,
+			JobID:            req.ProviderJobID,
 			Model:            req.FallbackModel,
 			Endpoint:         string(load.Endpoint),
-			AccountingStatus: cstables.BatchJobAccountingStatusPending,
+			AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		}
 	}
 	if job.Endpoint == "" && load.Endpoint != "" {
 		job.Endpoint = string(load.Endpoint)
 	}
 	if job.ID == "" {
-		job.ID = cstables.BatchJobID(string(req.Provider), req.ProviderJobID)
+		job.ID = cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(req.Provider), req.ProviderJobID)
 	}
 	req.Job = job
 
@@ -178,7 +179,7 @@ func (s *BatchSettler) Backoff(attempts int, interval time.Duration) time.Durati
 	return delay
 }
 
-func (s *BatchSettler) Poll(ctx context.Context, job *cstables.TableBatchJob) (*PollResult, error) {
+func (s *BatchSettler) Poll(ctx context.Context, job *cstables.TableProviderJob) (*PollResult, error) {
 	if s.fetcher == nil {
 		return nil, fmt.Errorf("batch result fetcher is nil")
 	}
@@ -189,7 +190,7 @@ func (s *BatchSettler) Poll(ctx context.Context, job *cstables.TableBatchJob) (*
 	if retrieved == nil {
 		return nil, fmt.Errorf("batch retrieve returned nil response for job %s", job.ID)
 	}
-	if retrieved.ID != "" && retrieved.ID != job.BatchID {
+	if retrieved.ID != "" && retrieved.ID != job.JobID {
 		return nil, fmt.Errorf("batch retrieve returned mismatched batch id for job %s", job.ID)
 	}
 
@@ -223,7 +224,7 @@ func (s *BatchSettler) Poll(ctx context.Context, job *cstables.TableBatchJob) (*
 	return settleablePoll(latest, retrieved, results), nil
 }
 
-func settleablePoll(job *cstables.TableBatchJob, retrieved *schemas.BifrostBatchRetrieveResponse, results *schemas.BifrostBatchResultsResponse) *PollResult {
+func settleablePoll(job *cstables.TableProviderJob, retrieved *schemas.BifrostBatchRetrieveResponse, results *schemas.BifrostBatchResultsResponse) *PollResult {
 	endpoint := schemas.BatchEndpoint(job.Endpoint)
 	if results.Endpoint != "" {
 		endpoint = results.Endpoint
@@ -245,13 +246,13 @@ func settleablePoll(job *cstables.TableBatchJob, retrieved *schemas.BifrostBatch
 // The sweep is serial and the sweeper's own context is long-lived with no deadline,
 // so an unbounded provider call would stall every remaining due job. The timeout is
 // derived from the parent, so shutdown cancellation still propagates.
-func (s *BatchSettler) retrieveBatch(ctx context.Context, job *cstables.TableBatchJob) (*schemas.BifrostBatchRetrieveResponse, error) {
+func (s *BatchSettler) retrieveBatch(ctx context.Context, job *cstables.TableProviderJob) (*schemas.BifrostBatchRetrieveResponse, error) {
 	callCtx, cancel := context.WithTimeout(ctx, defaultProviderPollTimeout)
 	defer cancel()
 	return s.fetcher.RetrieveBatch(callCtx, job)
 }
 
-func (s *BatchSettler) fetchBatchResults(ctx context.Context, job *cstables.TableBatchJob) (*schemas.BifrostBatchResultsResponse, error) {
+func (s *BatchSettler) fetchBatchResults(ctx context.Context, job *cstables.TableProviderJob) (*schemas.BifrostBatchResultsResponse, error) {
 	callCtx, cancel := context.WithTimeout(ctx, defaultProviderPollTimeout)
 	defer cancel()
 	return s.fetcher.FetchBatchResults(callCtx, job)
@@ -260,12 +261,12 @@ func (s *BatchSettler) fetchBatchResults(ctx context.Context, job *cstables.Tabl
 // fetchResultsForSettlement returns the batch's results, or ok=false when they
 // could not be obtained. What that means is the caller's to decide: a live batch
 // retries later, a terminal one gives up.
-func (s *BatchSettler) fetchResultsForSettlement(ctx context.Context, job *cstables.TableBatchJob) (*schemas.BifrostBatchResultsResponse, bool) {
+func (s *BatchSettler) fetchResultsForSettlement(ctx context.Context, job *cstables.TableProviderJob) (*schemas.BifrostBatchResultsResponse, bool) {
 	results, err := s.fetchBatchResults(ctx, job)
 	if err != nil || results == nil {
 		return nil, false
 	}
-	if results.BatchID != "" && results.BatchID != job.BatchID {
+	if results.BatchID != "" && results.BatchID != job.JobID {
 		return nil, false
 	}
 	return results, true
@@ -388,7 +389,7 @@ func (s *BatchSettler) HydrateFromLog(entry *logstore.Log, out *Outcome) {
 	}
 }
 
-func batchJobFromRetrieve(existing *cstables.TableBatchJob, retrieved *schemas.BifrostBatchRetrieveResponse) *cstables.TableBatchJob {
+func batchJobFromRetrieve(existing *cstables.TableProviderJob, retrieved *schemas.BifrostBatchRetrieveResponse) *cstables.TableProviderJob {
 	job := *existing
 	job.ProviderStatus = string(retrieved.Status)
 	if retrieved.Endpoint != "" {
@@ -423,7 +424,7 @@ func isTerminalStatus(status schemas.BatchStatus) bool {
 // completed rows worth fetching. Expired and cancelled batches keep the rows that
 // finished; a failed batch only has an output file when the provider says so; a
 // deleted batch has nothing left to read.
-func terminalMayHaveResults(status schemas.BatchStatus, job *cstables.TableBatchJob) bool {
+func terminalMayHaveResults(status schemas.BatchStatus, job *cstables.TableProviderJob) bool {
 	switch status {
 	case schemas.BatchStatusExpired, schemas.BatchStatusCancelled:
 		return true

--- a/framework/jobaccounting/batch_test.go
+++ b/framework/jobaccounting/batch_test.go
@@ -16,7 +16,7 @@ import (
 
 type fakeAccountingStore struct {
 	logs             map[string]*logstore.Log
-	jobs             map[string]*cstables.TableBatchJob
+	jobs             map[string]*cstables.TableProviderJob
 	failCompleteOnce bool
 	// failCompleteAlways models a settlement that keeps failing (a wedged store, a
 	// deleted budget), which is what the accounting retry budget has to bound.
@@ -30,7 +30,7 @@ type fakeAccountingStore struct {
 func newFakeAccountingStore() *fakeAccountingStore {
 	return &fakeAccountingStore{
 		logs: make(map[string]*logstore.Log),
-		jobs: make(map[string]*cstables.TableBatchJob),
+		jobs: make(map[string]*cstables.TableProviderJob),
 	}
 }
 
@@ -52,15 +52,15 @@ func (s *fakeAccountingStore) FindByID(ctx context.Context, id string) (*logstor
 	return &copied, nil
 }
 
-func (s *fakeAccountingStore) UpsertBatchJob(ctx context.Context, job *cstables.TableBatchJob) error {
+func (s *fakeAccountingStore) UpsertProviderJob(ctx context.Context, job *cstables.TableProviderJob) error {
 	if job.ID == "" {
-		job.ID = cstables.BatchJobID(job.Provider, job.BatchID)
+		job.ID = cstables.ProviderJobID(cstables.ProviderJobKindBatch, job.Provider, job.JobID)
 	}
 	existing, ok := s.jobs[job.ID]
 	if !ok {
 		copied := *job
 		if copied.AccountingStatus == "" {
-			copied.AccountingStatus = cstables.BatchJobAccountingStatusPending
+			copied.AccountingStatus = cstables.ProviderJobAccountingStatusPending
 		}
 		s.jobs[job.ID] = &copied
 		return nil
@@ -83,7 +83,7 @@ func (s *fakeAccountingStore) UpsertBatchJob(ctx context.Context, job *cstables.
 	return nil
 }
 
-func (s *fakeAccountingStore) GetBatchJob(ctx context.Context, jobID string) (*cstables.TableBatchJob, error) {
+func (s *fakeAccountingStore) GetProviderJob(ctx context.Context, jobID string) (*cstables.TableProviderJob, error) {
 	if s.failGetOnce {
 		s.failGetOnce = false
 		return nil, errors.New("transient read failure")
@@ -96,21 +96,32 @@ func (s *fakeAccountingStore) GetBatchJob(ctx context.Context, jobID string) (*c
 	return &copied, nil
 }
 
-func (s *fakeAccountingStore) ListDueBatchJobs(ctx context.Context, provider string, now time.Time, limit int) ([]*cstables.TableBatchJob, error) {
-	var jobs []*cstables.TableBatchJob
+func (s *fakeAccountingStore) ListDueProviderJobs(ctx context.Context, kind, provider string, now time.Time, limit int) ([]*cstables.TableProviderJob, error) {
+	var jobs []*cstables.TableProviderJob
+	if kind == "" {
+		kind = cstables.ProviderJobKindBatch
+	}
 	for _, job := range s.jobs {
+		// Mirror the real store: a sweeper only ever sees its own kind's rows.
+		jobKind := job.Kind
+		if jobKind == "" {
+			jobKind = cstables.ProviderJobKindBatch
+		}
+		if jobKind != kind {
+			continue
+		}
 		if provider != "" && job.Provider != provider {
 			continue
 		}
 		if job.NextCheckAt == nil || job.NextCheckAt.After(now) {
 			continue
 		}
-		if job.AccountingStatus == cstables.BatchJobAccountingStatusAccounted || job.AccountingStatus == cstables.BatchJobAccountingStatusUnpriceable {
+		if job.AccountingStatus == cstables.ProviderJobAccountingStatusAccounted || job.AccountingStatus == cstables.ProviderJobAccountingStatusUnpriceable {
 			continue
 		}
 		// Hand back a detached copy: a real store returns rows, not live pointers.
 		// Returning the map pointer would let sweeper mutations persist without an
-		// UpsertBatchJob and hide missing-write bugs.
+		// UpsertProviderJob and hide missing-write bugs.
 		copied := *job
 		jobs = append(jobs, &copied)
 		if limit > 0 && len(jobs) >= limit {
@@ -120,29 +131,35 @@ func (s *fakeAccountingStore) ListDueBatchJobs(ctx context.Context, provider str
 	return jobs, nil
 }
 
-func (s *fakeAccountingStore) ClaimBatchJob(ctx context.Context, jobID, runnerID string, staleBefore time.Time, allowUnpriceable bool) (bool, error) {
+func (s *fakeAccountingStore) ClaimProviderJob(ctx context.Context, jobID, runnerID string, staleBefore time.Time, allowUnpriceable bool) (bool, error) {
+	// Mirror the real store, which refuses a blank runner id. Without this the fake
+	// is more permissive than production and a caller that never claims anything
+	// looks fine in tests while failing against a real database.
+	if runnerID == "" {
+		return false, errors.New("runner id is required")
+	}
 	entry, ok := s.jobs[jobID]
 	if !ok {
 		return false, errors.New("missing batch job")
 	}
-	if entry.AccountingStatus == cstables.BatchJobAccountingStatusAccounted {
+	if entry.AccountingStatus == cstables.ProviderJobAccountingStatusAccounted {
 		return false, nil
 	}
 	// "unpriceable" is a stop-polling marker, not a refusal of money: a caller
 	// holding real results may re-drive it. Mirrors the real store's allowUnpriceable.
-	if entry.AccountingStatus == cstables.BatchJobAccountingStatusUnpriceable && !allowUnpriceable {
+	if entry.AccountingStatus == cstables.ProviderJobAccountingStatusUnpriceable && !allowUnpriceable {
 		return false, nil
 	}
 	// Staleness reads claimed_at, never updated_at — mirroring the real store, where
-	// updated_at is refreshed by the unfenced UpsertBatchJob and so cannot be trusted
+	// updated_at is refreshed by the unfenced UpsertProviderJob and so cannot be trusted
 	// to represent claim age.
-	if entry.AccountingStatus == cstables.BatchJobAccountingStatusProcessing &&
+	if entry.AccountingStatus == cstables.ProviderJobAccountingStatusProcessing &&
 		entry.ClaimedAt != nil && entry.ClaimedAt.After(staleBefore) {
 		return false, nil
 	}
 	now := time.Now().UTC()
 	rid := runnerID
-	entry.AccountingStatus = cstables.BatchJobAccountingStatusProcessing
+	entry.AccountingStatus = cstables.ProviderJobAccountingStatusProcessing
 	entry.RunnerID = &rid
 	entry.ClaimedAt = &now
 	entry.LastError = nil
@@ -150,7 +167,7 @@ func (s *fakeAccountingStore) ClaimBatchJob(ctx context.Context, jobID, runnerID
 	return true, nil
 }
 
-func (s *fakeAccountingStore) ownedJob(id, runnerID string) (*cstables.TableBatchJob, error) {
+func (s *fakeAccountingStore) ownedJob(id, runnerID string) (*cstables.TableProviderJob, error) {
 	entry, ok := s.jobs[id]
 	if !ok {
 		return nil, errors.New("missing batch job")
@@ -161,7 +178,7 @@ func (s *fakeAccountingStore) ownedJob(id, runnerID string) (*cstables.TableBatc
 	return entry, nil
 }
 
-func (s *fakeAccountingStore) MarkBatchJobAggregateLogWritten(ctx context.Context, id, runnerID string) error {
+func (s *fakeAccountingStore) MarkProviderJobAggregateLogWritten(ctx context.Context, id, runnerID string) error {
 	entry, err := s.ownedJob(id, runnerID)
 	if err != nil {
 		return err
@@ -171,7 +188,7 @@ func (s *fakeAccountingStore) MarkBatchJobAggregateLogWritten(ctx context.Contex
 	return nil
 }
 
-func (s *fakeAccountingStore) MarkBatchJobGovernanceReported(ctx context.Context, id, runnerID string) error {
+func (s *fakeAccountingStore) MarkProviderJobGovernanceReported(ctx context.Context, id, runnerID string) error {
 	entry, err := s.ownedJob(id, runnerID)
 	if err != nil {
 		return err
@@ -181,7 +198,7 @@ func (s *fakeAccountingStore) MarkBatchJobGovernanceReported(ctx context.Context
 	return nil
 }
 
-func (s *fakeAccountingStore) CompleteBatchJob(ctx context.Context, id, runnerID string) error {
+func (s *fakeAccountingStore) CompleteProviderJob(ctx context.Context, id, runnerID string) error {
 	entry, err := s.ownedJob(id, runnerID)
 	if err != nil {
 		return err
@@ -193,13 +210,13 @@ func (s *fakeAccountingStore) CompleteBatchJob(ctx context.Context, id, runnerID
 	if s.failCompleteAlways {
 		return errors.New("complete failed")
 	}
-	entry.AccountingStatus = cstables.BatchJobAccountingStatusAccounted
+	entry.AccountingStatus = cstables.ProviderJobAccountingStatusAccounted
 	entry.RunnerID = nil
 	entry.ClaimedAt = nil
 	return nil
 }
 
-func (s *fakeAccountingStore) MarkBatchJobUnpriceable(ctx context.Context, id, runnerID, reason string, err error) error {
+func (s *fakeAccountingStore) MarkProviderJobUnpriceable(ctx context.Context, id, runnerID, reason string, err error) error {
 	if s.failUnpriceable {
 		return errors.New("unpriceable marker write failed")
 	}
@@ -207,21 +224,21 @@ func (s *fakeAccountingStore) MarkBatchJobUnpriceable(ctx context.Context, id, r
 	if ownErr != nil {
 		return ownErr
 	}
-	entry.AccountingStatus = cstables.BatchJobAccountingStatusUnpriceable
+	entry.AccountingStatus = cstables.ProviderJobAccountingStatusUnpriceable
 	entry.UnpriceableReason = &reason
 	entry.RunnerID = nil
 	entry.ClaimedAt = nil
 	return nil
 }
 
-func (s *fakeAccountingStore) FailBatchJob(ctx context.Context, id, runnerID string, err error) error {
-	// Fenced on runnerID like the real finishBatchJob: a stale runner must not be
+func (s *fakeAccountingStore) FailProviderJob(ctx context.Context, id, runnerID string, err error) error {
+	// Fenced on runnerID like the real finishProviderJob: a stale runner must not be
 	// able to release another runner's live claim.
 	entry, ownErr := s.ownedJob(id, runnerID)
 	if ownErr != nil {
 		return ownErr
 	}
-	entry.AccountingStatus = cstables.BatchJobAccountingStatusError
+	entry.AccountingStatus = cstables.ProviderJobAccountingStatusError
 	entry.RunnerID = nil
 	entry.ClaimedAt = nil
 	return nil
@@ -261,7 +278,7 @@ type fakeAggregateLogWriter struct {
 	emitted []*logstore.Log
 }
 
-func (w *fakeAggregateLogWriter) EmitBatchAggregateLog(ctx context.Context, entry *logstore.Log) {
+func (w *fakeAggregateLogWriter) EmitAggregateLog(ctx context.Context, entry *logstore.Log) {
 	copied := *entry
 	w.emitted = append(w.emitted, &copied)
 }
@@ -279,7 +296,7 @@ func (p *requestTypePricing) CalculateBatchCostDetailsForUsage(usage *schemas.Bi
 	return modelcatalog.BatchCostDetails{Cost: float64(usage.PromptTokens), Priced: true}
 }
 
-func (r *fakeUsageReporter) ReportBatchUsage(ctx context.Context, report UsageReport) error {
+func (r *fakeUsageReporter) ReportUsage(ctx context.Context, report UsageReport) error {
 	r.reports = append(r.reports, report)
 	return nil
 }
@@ -376,9 +393,9 @@ func TestAccountBatchResults_MissingModelMarksUnpriceable(t *testing.T) {
 	assert.False(t, summary.Accounted)
 	assert.Equal(t, UnpriceableReasonMissingModel, summary.UnpriceableReason)
 
-	job := store.jobs[cstables.BatchJobID(string(schemas.OpenAI), "batch_missing_model")]
+	job := store.jobs[cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_missing_model")]
 	require.NotNil(t, job)
-	assert.Equal(t, cstables.BatchJobAccountingStatusUnpriceable, job.AccountingStatus)
+	assert.Equal(t, cstables.ProviderJobAccountingStatusUnpriceable, job.AccountingStatus)
 	require.NotNil(t, job.UnpriceableReason)
 	assert.Equal(t, UnpriceableReasonMissingModel, *job.UnpriceableReason)
 
@@ -397,6 +414,7 @@ func TestAccountBatchResults_MissingBatchPricingMarksUnpriceable(t *testing.T) {
 	store := newFakeAccountingStore()
 
 	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+		ClaimedBy:     "test-node",
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "batch_missing_pricing",
 		Payload: BatchPayload{
@@ -408,9 +426,9 @@ func TestAccountBatchResults_MissingBatchPricingMarksUnpriceable(t *testing.T) {
 	assert.False(t, summary.Accounted)
 	assert.Equal(t, UnpriceableReasonMissingBatchPricing, summary.UnpriceableReason)
 
-	job := store.jobs[cstables.BatchJobID(string(schemas.OpenAI), "batch_missing_pricing")]
+	job := store.jobs[cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_missing_pricing")]
 	require.NotNil(t, job)
-	assert.Equal(t, cstables.BatchJobAccountingStatusUnpriceable, job.AccountingStatus)
+	assert.Equal(t, cstables.ProviderJobAccountingStatusUnpriceable, job.AccountingStatus)
 	require.NotNil(t, job.UnpriceableReason)
 	assert.Equal(t, UnpriceableReasonMissingBatchPricing, *job.UnpriceableReason)
 
@@ -471,6 +489,7 @@ func TestAccountBatchResults_ZeroProviderCostIsStillPriced(t *testing.T) {
 	}
 
 	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+		ClaimedBy:     "test-node",
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "batch_zero_cost",
 		Payload: BatchPayload{
@@ -488,6 +507,7 @@ func TestAccountBatchResults_AnthropicAggregatesUsage(t *testing.T) {
 	store := newFakeAccountingStore()
 
 	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+		ClaimedBy:     "test-node",
 		Provider:      schemas.Anthropic,
 		ProviderJobID: "anthropic_batch",
 		Payload: BatchPayload{
@@ -510,6 +530,7 @@ func TestAccountBatchResults_BedrockAggregatesUsageFromResponseBody(t *testing.T
 	store := newFakeAccountingStore()
 
 	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+		ClaimedBy:     "test-node",
 		Provider:      schemas.Bedrock,
 		ProviderJobID: "bedrock_batch",
 		FallbackModel: "amazon.nova-lite-v1:0",
@@ -533,6 +554,7 @@ func TestAccountBatchResults_BedrockIncludesCacheDetailsInPromptUsage(t *testing
 	store := newFakeAccountingStore()
 
 	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+		ClaimedBy:     "test-node",
 		Provider:      schemas.Bedrock,
 		ProviderJobID: "bedrock_cache_batch",
 		FallbackModel: "amazon.nova-lite-v1:0",
@@ -576,6 +598,7 @@ func TestAccountBatchResults_GeminiAggregatesUsageFromResponseBody(t *testing.T)
 	store := newFakeAccountingStore()
 
 	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+		ClaimedBy:     "test-node",
 		Provider:      schemas.Gemini,
 		ProviderJobID: "gemini_batch",
 		FallbackModel: "gemini-2.0-flash",
@@ -601,6 +624,7 @@ func TestAccountBatchResults_UsesAggregateWriterAndUsageReporter(t *testing.T) {
 	reporter := &fakeUsageReporter{}
 
 	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+		ClaimedBy:     "test-node",
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "batch_writer",
 		FallbackModel: "gpt-4o-mini",
@@ -627,6 +651,7 @@ func TestAccountBatchResults_RetryAfterCompleteFailureDoesNotReportGovernanceTwi
 	reporter := &fakeUsageReporter{}
 
 	req := JobRequest{
+		ClaimedBy:     "test-node",
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "batch_retry_governance",
 		FallbackModel: "gpt-4o-mini",
@@ -657,6 +682,7 @@ func TestAccountBatchResults_RecordsPartialPricingMetadata(t *testing.T) {
 	reporter := &fakeUsageReporter{}
 
 	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+		ClaimedBy:     "test-node",
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "batch_partial",
 		UsageReporter: reporter,
@@ -716,12 +742,12 @@ type fakeBatchResultFetcher struct {
 	resultsResp   *schemas.BifrostBatchResultsResponse
 }
 
-func (f *fakeBatchResultFetcher) RetrieveBatch(ctx context.Context, job *cstables.TableBatchJob) (*schemas.BifrostBatchRetrieveResponse, error) {
+func (f *fakeBatchResultFetcher) RetrieveBatch(ctx context.Context, job *cstables.TableProviderJob) (*schemas.BifrostBatchRetrieveResponse, error) {
 	f.retrieveCalls++
 	return f.retrieveResp, nil
 }
 
-func (f *fakeBatchResultFetcher) FetchBatchResults(ctx context.Context, job *cstables.TableBatchJob) (*schemas.BifrostBatchResultsResponse, error) {
+func (f *fakeBatchResultFetcher) FetchBatchResults(ctx context.Context, job *cstables.TableProviderJob) (*schemas.BifrostBatchResultsResponse, error) {
 	f.resultsCalls++
 	return f.resultsResp, nil
 }
@@ -753,15 +779,15 @@ func (s *fakeKVStore) Delete(key string) (bool, error) {
 func TestSweeper_AccountsCompletedOpenAIJob(t *testing.T) {
 	store := newFakeAccountingStore()
 	now := time.Now().UTC().Add(-time.Minute)
-	job := &cstables.TableBatchJob{
-		ID:               cstables.BatchJobID(string(schemas.OpenAI), "batch_sweep"),
+	job := &cstables.TableProviderJob{
+		ID:               cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_sweep"),
 		Provider:         string(schemas.OpenAI),
-		BatchID:          "batch_sweep",
+		JobID:            "batch_sweep",
 		Model:            "gpt-4o-mini",
-		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		NextCheckAt:      &now,
 	}
-	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
 
 	fetcher := &fakeBatchResultFetcher{
 		retrieveResp: &schemas.BifrostBatchRetrieveResponse{
@@ -784,24 +810,24 @@ func TestSweeper_AccountsCompletedOpenAIJob(t *testing.T) {
 
 	assert.Equal(t, 1, fetcher.retrieveCalls)
 	assert.Equal(t, 1, fetcher.resultsCalls)
-	accounted := store.jobs[cstables.BatchJobID(string(schemas.OpenAI), "batch_sweep")]
+	accounted := store.jobs[cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_sweep")]
 	require.NotNil(t, accounted)
-	assert.Equal(t, cstables.BatchJobAccountingStatusAccounted, accounted.AccountingStatus)
+	assert.Equal(t, cstables.ProviderJobAccountingStatusAccounted, accounted.AccountingStatus)
 	assert.Len(t, store.logs, 1)
 }
 
 func TestSweeper_AccountsCompletedAnthropicJob(t *testing.T) {
 	store := newFakeAccountingStore()
 	now := time.Now().UTC().Add(-time.Minute)
-	job := &cstables.TableBatchJob{
-		ID:               cstables.BatchJobID(string(schemas.Anthropic), "anthropic_sweep"),
+	job := &cstables.TableProviderJob{
+		ID:               cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.Anthropic), "anthropic_sweep"),
 		Provider:         string(schemas.Anthropic),
-		BatchID:          "anthropic_sweep",
+		JobID:            "anthropic_sweep",
 		Model:            "claude-3-5-haiku",
-		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		NextCheckAt:      &now,
 	}
-	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
 
 	fetcher := &fakeBatchResultFetcher{
 		retrieveResp: &schemas.BifrostBatchRetrieveResponse{
@@ -823,23 +849,23 @@ func TestSweeper_AccountsCompletedAnthropicJob(t *testing.T) {
 
 	assert.Equal(t, 1, fetcher.retrieveCalls)
 	assert.Equal(t, 1, fetcher.resultsCalls)
-	accounted := store.jobs[cstables.BatchJobID(string(schemas.Anthropic), "anthropic_sweep")]
+	accounted := store.jobs[cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.Anthropic), "anthropic_sweep")]
 	require.NotNil(t, accounted)
-	assert.Equal(t, cstables.BatchJobAccountingStatusAccounted, accounted.AccountingStatus)
+	assert.Equal(t, cstables.ProviderJobAccountingStatusAccounted, accounted.AccountingStatus)
 }
 
 func TestSweeper_AccountsCompletedGeminiJob(t *testing.T) {
 	store := newFakeAccountingStore()
 	now := time.Now().UTC().Add(-time.Minute)
-	job := &cstables.TableBatchJob{
-		ID:               cstables.BatchJobID(string(schemas.Gemini), "gemini_sweep"),
+	job := &cstables.TableProviderJob{
+		ID:               cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.Gemini), "gemini_sweep"),
 		Provider:         string(schemas.Gemini),
-		BatchID:          "gemini_sweep",
+		JobID:            "gemini_sweep",
 		Model:            "gemini-2.0-flash",
-		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		NextCheckAt:      &now,
 	}
-	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
 
 	fetcher := &fakeBatchResultFetcher{
 		retrieveResp: &schemas.BifrostBatchRetrieveResponse{
@@ -861,23 +887,23 @@ func TestSweeper_AccountsCompletedGeminiJob(t *testing.T) {
 
 	assert.Equal(t, 1, fetcher.retrieveCalls)
 	assert.Equal(t, 1, fetcher.resultsCalls)
-	accounted := store.jobs[cstables.BatchJobID(string(schemas.Gemini), "gemini_sweep")]
+	accounted := store.jobs[cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.Gemini), "gemini_sweep")]
 	require.NotNil(t, accounted)
-	assert.Equal(t, cstables.BatchJobAccountingStatusAccounted, accounted.AccountingStatus)
+	assert.Equal(t, cstables.ProviderJobAccountingStatusAccounted, accounted.AccountingStatus)
 }
 
 func TestSweeper_SkipsProviderPollWhenKVLeaseIsHeld(t *testing.T) {
 	store := newFakeAccountingStore()
 	now := time.Now().UTC().Add(-time.Minute)
-	job := &cstables.TableBatchJob{
-		ID:               cstables.BatchJobID(string(schemas.OpenAI), "batch_sweep_lease"),
+	job := &cstables.TableProviderJob{
+		ID:               cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_sweep_lease"),
 		Provider:         string(schemas.OpenAI),
-		BatchID:          "batch_sweep_lease",
+		JobID:            "batch_sweep_lease",
 		Model:            "gpt-4o-mini",
-		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		NextCheckAt:      &now,
 	}
-	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
 
 	fetcher := &fakeBatchResultFetcher{}
 	kv := &fakeKVStore{setNXAllowed: false}
@@ -898,17 +924,17 @@ func TestSweeper_SkipsProviderPollWhenKVLeaseIsHeld(t *testing.T) {
 func TestSweeper_ReleasesProviderPollLeaseAfterSuccessfulPoll(t *testing.T) {
 	store := newFakeAccountingStore()
 	now := time.Now().UTC().Add(-time.Minute)
-	job := &cstables.TableBatchJob{
-		ID:               cstables.BatchJobID(string(schemas.OpenAI), "batch_release_lease"),
+	job := &cstables.TableProviderJob{
+		ID:               cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_release_lease"),
 		Provider:         string(schemas.OpenAI),
-		BatchID:          "batch_release_lease",
-		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		JobID:            "batch_release_lease",
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		NextCheckAt:      &now,
 	}
-	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
 
 	fetcher := &fakeBatchResultFetcher{retrieveResp: &schemas.BifrostBatchRetrieveResponse{
-		ID:     job.BatchID,
+		ID:     job.JobID,
 		Status: schemas.BatchStatusInProgress,
 	}}
 	kv := &fakeKVStore{setNXAllowed: true}
@@ -927,16 +953,16 @@ func TestSweeper_ReleasesProviderPollLeaseAfterSuccessfulPoll(t *testing.T) {
 func TestSweeper_RescheduleUsesBackoffAndJitter(t *testing.T) {
 	store := newFakeAccountingStore()
 	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
-	job := &cstables.TableBatchJob{
-		ID:               cstables.BatchJobID(string(schemas.OpenAI), "batch_backoff"),
+	job := &cstables.TableProviderJob{
+		ID:               cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_backoff"),
 		Provider:         string(schemas.OpenAI),
-		BatchID:          "batch_backoff",
+		JobID:            "batch_backoff",
 		Model:            "gpt-4o-mini",
-		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		PollAttempts:     9,
 		NextCheckAt:      &now,
 	}
-	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
 
 	fetcher := &fakeBatchResultFetcher{
 		retrieveResp: &schemas.BifrostBatchRetrieveResponse{
@@ -964,13 +990,13 @@ func TestSweeper_RescheduleUsesBackoffAndJitter(t *testing.T) {
 func TestSweeper_ExpiredBatchSettlesTheRowsThatCompleted(t *testing.T) {
 	store := newFakeAccountingStore()
 	due := time.Now().UTC().Add(-time.Minute)
-	jobID := cstables.BatchJobID(string(schemas.OpenAI), "batch_expired")
-	require.NoError(t, store.UpsertBatchJob(context.Background(), &cstables.TableBatchJob{
+	jobID := cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_expired")
+	require.NoError(t, store.UpsertProviderJob(context.Background(), &cstables.TableProviderJob{
 		ID:               jobID,
 		Provider:         string(schemas.OpenAI),
-		BatchID:          "batch_expired",
+		JobID:            "batch_expired",
 		Model:            "gpt-4o-mini",
-		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		NextCheckAt:      &due,
 	}))
 
@@ -990,19 +1016,19 @@ func TestSweeper_ExpiredBatchSettlesTheRowsThatCompleted(t *testing.T) {
 
 	assert.Equal(t, 1, fetcher.resultsCalls, "a terminal batch must still be asked for its results")
 	require.Len(t, store.logs, 1)
-	assert.Equal(t, cstables.BatchJobAccountingStatusAccounted, store.jobs[jobID].AccountingStatus)
+	assert.Equal(t, cstables.ProviderJobAccountingStatusAccounted, store.jobs[jobID].AccountingStatus)
 }
 
 // With nothing to fetch, the terminal batch ends where it always did.
 func TestSweeper_ExpiredBatchWithoutResultsIsTerminalWithoutResults(t *testing.T) {
 	store := newFakeAccountingStore()
 	due := time.Now().UTC().Add(-time.Minute)
-	jobID := cstables.BatchJobID(string(schemas.OpenAI), "batch_expired_empty")
-	require.NoError(t, store.UpsertBatchJob(context.Background(), &cstables.TableBatchJob{
+	jobID := cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_expired_empty")
+	require.NoError(t, store.UpsertProviderJob(context.Background(), &cstables.TableProviderJob{
 		ID:               jobID,
 		Provider:         string(schemas.OpenAI),
-		BatchID:          "batch_expired_empty",
-		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		JobID:            "batch_expired_empty",
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		NextCheckAt:      &due,
 	}))
 
@@ -1020,7 +1046,7 @@ func TestSweeper_ExpiredBatchWithoutResultsIsTerminalWithoutResults(t *testing.T
 	assert.Empty(t, store.logs)
 	job := store.jobs[jobID]
 	require.NotNil(t, job)
-	assert.Equal(t, cstables.BatchJobAccountingStatusUnpriceable, job.AccountingStatus)
+	assert.Equal(t, cstables.ProviderJobAccountingStatusUnpriceable, job.AccountingStatus)
 	require.NotNil(t, job.UnpriceableReason)
 	assert.Equal(t, "terminal_without_results", *job.UnpriceableReason)
 }
@@ -1029,11 +1055,11 @@ func TestSweeper_ExpiredBatchWithoutResultsIsTerminalWithoutResults(t *testing.T
 func TestSweeper_DeletedBatchDoesNotFetchResults(t *testing.T) {
 	store := newFakeAccountingStore()
 	due := time.Now().UTC().Add(-time.Minute)
-	require.NoError(t, store.UpsertBatchJob(context.Background(), &cstables.TableBatchJob{
-		ID:               cstables.BatchJobID(string(schemas.OpenAI), "batch_deleted"),
+	require.NoError(t, store.UpsertProviderJob(context.Background(), &cstables.TableProviderJob{
+		ID:               cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_deleted"),
 		Provider:         string(schemas.OpenAI),
-		BatchID:          "batch_deleted",
-		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		JobID:            "batch_deleted",
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		NextCheckAt:      &due,
 	}))
 
@@ -1049,23 +1075,23 @@ func TestSweeper_DeletedBatchDoesNotFetchResults(t *testing.T) {
 }
 
 // A settlement that keeps failing used to re-download the whole results payload and
-// re-fail every sweep, forever: FailBatchJob left next_check_at in the past and never
+// re-fail every sweep, forever: FailProviderJob left next_check_at in the past and never
 // advanced poll_attempts. It has to consume the same retry budget as any other failure.
 func TestSweeper_ReschedulesAfterSettlementFailure(t *testing.T) {
 	store := newFakeAccountingStore()
 	store.failCompleteAlways = true
 	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
-	jobID := cstables.BatchJobID(string(schemas.OpenAI), "batch_settle_fail")
-	job := &cstables.TableBatchJob{
+	jobID := cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_settle_fail")
+	job := &cstables.TableProviderJob{
 		ID:               jobID,
 		Provider:         string(schemas.OpenAI),
-		BatchID:          "batch_settle_fail",
+		JobID:            "batch_settle_fail",
 		Model:            "gpt-4o-mini",
-		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		PollAttempts:     9,
 		NextCheckAt:      &now,
 	}
-	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
 
 	fetcher := &fakeBatchResultFetcher{
 		retrieveResp: &schemas.BifrostBatchRetrieveResponse{
@@ -1097,17 +1123,17 @@ func TestSweeper_SettlementFailureHitsPollAttemptCap(t *testing.T) {
 	store := newFakeAccountingStore()
 	store.failCompleteAlways = true
 	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
-	jobID := cstables.BatchJobID(string(schemas.OpenAI), "batch_settle_cap")
-	job := &cstables.TableBatchJob{
+	jobID := cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_settle_cap")
+	job := &cstables.TableProviderJob{
 		ID:               jobID,
 		Provider:         string(schemas.OpenAI),
-		BatchID:          "batch_settle_cap",
+		JobID:            "batch_settle_cap",
 		Model:            "gpt-4o-mini",
-		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		PollAttempts:     MaxPollAttempts - 1,
 		NextCheckAt:      &now,
 	}
-	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
 
 	fetcher := &fakeBatchResultFetcher{
 		retrieveResp: &schemas.BifrostBatchRetrieveResponse{
@@ -1128,7 +1154,7 @@ func TestSweeper_SettlementFailureHitsPollAttemptCap(t *testing.T) {
 
 	updated := store.jobs[jobID]
 	require.NotNil(t, updated)
-	assert.Equal(t, cstables.BatchJobAccountingStatusUnpriceable, updated.AccountingStatus)
+	assert.Equal(t, cstables.ProviderJobAccountingStatusUnpriceable, updated.AccountingStatus)
 	require.NotNil(t, updated.UnpriceableReason)
 	assert.Equal(t, UnpriceableReasonMaxPollAttempts, *updated.UnpriceableReason)
 }
@@ -1228,10 +1254,10 @@ func TestAccountBatchResults_ExternalBatchWithoutRow(t *testing.T) {
 	assert.True(t, summary.Accounted)
 	assert.Greater(t, summary.Cost, 0.0)
 
-	jobID := cstables.BatchJobID(string(schemas.OpenAI), "ext-batch-no-job")
+	jobID := cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "ext-batch-no-job")
 	job, ok := store.jobs[jobID]
 	require.True(t, ok, "batch_jobs row should be created for externally-created batch")
-	assert.Equal(t, cstables.BatchJobAccountingStatusAccounted, job.AccountingStatus)
+	assert.Equal(t, cstables.ProviderJobAccountingStatusAccounted, job.AccountingStatus)
 }
 
 func TestAccountBatchResults_EmbeddingEndpointUsesEmbeddingPricing(t *testing.T) {
@@ -1371,9 +1397,9 @@ func TestAccountBatchResults_PersistedJobReadFailureFailsClosed(t *testing.T) {
 	assert.Empty(t, reporter.reports, "no usage should be reported")
 
 	// The claim is released so a later attempt can retry without waiting out the TTL.
-	job := store.jobs[cstables.BatchJobID(string(schemas.OpenAI), "read-failure")]
+	job := store.jobs[cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "read-failure")]
 	require.NotNil(t, job)
-	assert.Equal(t, cstables.BatchJobAccountingStatusError, job.AccountingStatus)
+	assert.Equal(t, cstables.ProviderJobAccountingStatusError, job.AccountingStatus)
 	assert.Nil(t, job.RunnerID)
 }
 
@@ -1404,9 +1430,9 @@ func TestAccountBatchResults_ParseErrorsStillPriceTheParsedRows(t *testing.T) {
 	assert.Equal(t, 30, summary.Usage.PromptTokens)
 	assert.Equal(t, 9, summary.Usage.CompletionTokens)
 
-	job := store.jobs[cstables.BatchJobID(string(schemas.OpenAI), "malformed-results")]
+	job := store.jobs[cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "malformed-results")]
 	require.NotNil(t, job)
-	assert.Equal(t, cstables.BatchJobAccountingStatusAccounted, job.AccountingStatus)
+	assert.Equal(t, cstables.ProviderJobAccountingStatusAccounted, job.AccountingStatus)
 
 	logged := store.logs[AccountingLogID(ProviderJobKindBatch, schemas.OpenAI, "malformed-results")]
 	require.NotNil(t, logged)
@@ -1443,9 +1469,9 @@ func TestAccountBatchResults_AllRowsUnparseableMarksUnpriceable(t *testing.T) {
 	require.NotNil(t, summary)
 	assert.False(t, summary.Accounted)
 	assert.Equal(t, UnpriceableReasonResultParseErrors, summary.UnpriceableReason)
-	job := store.jobs[cstables.BatchJobID(string(schemas.OpenAI), "all-malformed")]
+	job := store.jobs[cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "all-malformed")]
 	require.NotNil(t, job)
-	assert.Equal(t, cstables.BatchJobAccountingStatusUnpriceable, job.AccountingStatus)
+	assert.Equal(t, cstables.ProviderJobAccountingStatusUnpriceable, job.AccountingStatus)
 	require.NotNil(t, job.UnpriceableReason)
 	assert.Equal(t, UnpriceableReasonResultParseErrors, *job.UnpriceableReason)
 	assert.Empty(t, store.logs)
@@ -1493,9 +1519,9 @@ func TestAccountBatchResults_PartiallyPricedBatchKeepsCostUnknown(t *testing.T) 
 	assert.Nil(t, breakdowns["unknown-model"].Cost)
 
 	// Parked, not closed: the job stops being polled but stays re-drivable.
-	job := store.jobs[cstables.BatchJobID(string(schemas.OpenAI), "batch_half_priced")]
+	job := store.jobs[cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_half_priced")]
 	require.NotNil(t, job)
-	assert.Equal(t, cstables.BatchJobAccountingStatusUnpriceable, job.AccountingStatus)
+	assert.Equal(t, cstables.ProviderJobAccountingStatusUnpriceable, job.AccountingStatus)
 	require.NotNil(t, job.UnpriceableReason)
 	assert.Equal(t, UnpriceableReasonMissingBatchPricing, *job.UnpriceableReason)
 }
@@ -1510,17 +1536,17 @@ func TestAccountBatchResults_PrefersBatchJobAttributionOverFetcher(t *testing.T)
 	creatorBudgets := `["budget-creator"]`
 	fetcherVK := "vk-fetcher"
 
-	job := &cstables.TableBatchJob{
-		ID:               cstables.BatchJobID(string(schemas.OpenAI), "batch_attribution"),
+	job := &cstables.TableProviderJob{
+		ID:               cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_attribution"),
 		Provider:         string(schemas.OpenAI),
-		BatchID:          "batch_attribution",
+		JobID:            "batch_attribution",
 		Model:            "gpt-4o-mini",
-		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		SelectedKeyID:    "key-creator",
 		VirtualKeyID:     &creatorVK,
 		BudgetIDs:        &creatorBudgets,
 	}
-	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
 
 	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
 		Provider:      schemas.OpenAI,
@@ -1583,18 +1609,18 @@ func TestAccountBatchResults_FillsNamesFromSourceLog(t *testing.T) {
 		TeamName:       strPtr("Team One"),
 	}
 
-	job := &cstables.TableBatchJob{
-		ID:               cstables.BatchJobID(string(schemas.OpenAI), "batch_same_vk"),
+	job := &cstables.TableProviderJob{
+		ID:               cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_same_vk"),
 		Provider:         string(schemas.OpenAI),
-		BatchID:          "batch_same_vk",
-		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		JobID:            "batch_same_vk",
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		SelectedKeyID:    "key-1",
 		VirtualKeyID:     &sharedVK,
 		UserID:           strPtr("user-creator"),
 		TeamID:           strPtr("team-1"),
 		SourceLogID:      &sourceLogID,
 	}
-	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
 
 	_, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
 		Provider:      schemas.OpenAI,
@@ -1642,18 +1668,18 @@ func TestAccountBatchResults_SharedVirtualKeyKeepsUsersApart(t *testing.T) {
 		UserName:       strPtr("Alice"),
 	}
 
-	job := &cstables.TableBatchJob{
-		ID:               cstables.BatchJobID(string(schemas.OpenAI), "batch_shared_vk"),
+	job := &cstables.TableProviderJob{
+		ID:               cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_shared_vk"),
 		Provider:         string(schemas.OpenAI),
-		BatchID:          "batch_shared_vk",
-		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		JobID:            "batch_shared_vk",
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		SelectedKeyID:    "key-1",
 		VirtualKeyID:     &sharedVK,
 		UserID:           strPtr("user-alice"),
 		BudgetIDs:        &creatorBudgets,
 		SourceLogID:      &sourceLogID,
 	}
-	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
 
 	// Bob fetches Alice's results. Same access-profile virtual key, different person.
 	_, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
@@ -1707,18 +1733,18 @@ func TestAccountBatchResults_SweeperPathKeepsUserAttribution(t *testing.T) {
 		TeamName:     strPtr("Team One"),
 	}
 
-	job := &cstables.TableBatchJob{
-		ID:               cstables.BatchJobID(string(schemas.OpenAI), "batch_sweeper"),
+	job := &cstables.TableProviderJob{
+		ID:               cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_sweeper"),
 		Provider:         string(schemas.OpenAI),
-		BatchID:          "batch_sweeper",
-		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		JobID:            "batch_sweeper",
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		SelectedKeyID:    "key-1",
 		VirtualKeyID:     &vk,
 		UserID:           strPtr("user-alice"),
 		TeamID:           strPtr("team-1"),
 		SourceLogID:      &sourceLogID,
 	}
-	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
 
 	// No BaseLog: this is the sweeper, hours after the request that created the batch.
 	_, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
@@ -1790,14 +1816,14 @@ func TestAccountBatchResults_WithoutJobAttributionUsesBaseLog(t *testing.T) {
 // permanently.
 func TestAccountBatchResults_ReclaimsUnpriceableJobWhenResultsArrive(t *testing.T) {
 	store := newFakeAccountingStore()
-	jobID := cstables.BatchJobID(string(schemas.OpenAI), "batch_reclaim")
+	jobID := cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_reclaim")
 	reason := UnpriceableReasonMaxPollAttempts
-	require.NoError(t, store.UpsertBatchJob(context.Background(), &cstables.TableBatchJob{
+	require.NoError(t, store.UpsertProviderJob(context.Background(), &cstables.TableProviderJob{
 		ID:                jobID,
 		Provider:          string(schemas.OpenAI),
-		BatchID:           "batch_reclaim",
+		JobID:             "batch_reclaim",
 		Model:             "gpt-4o-mini",
-		AccountingStatus:  cstables.BatchJobAccountingStatusUnpriceable,
+		AccountingStatus:  cstables.ProviderJobAccountingStatusUnpriceable,
 		UnpriceableReason: &reason,
 	}))
 
@@ -1814,7 +1840,7 @@ func TestAccountBatchResults_ReclaimsUnpriceableJobWhenResultsArrive(t *testing.
 	require.NotNil(t, summary)
 	assert.True(t, summary.Claimed)
 	assert.True(t, summary.Accounted)
-	assert.Equal(t, cstables.BatchJobAccountingStatusAccounted, store.jobs[jobID].AccountingStatus)
+	assert.Equal(t, cstables.ProviderJobAccountingStatusAccounted, store.jobs[jobID].AccountingStatus)
 	assert.Len(t, store.logs, 1)
 }
 
@@ -1823,14 +1849,14 @@ func TestAccountBatchResults_ReclaimsUnpriceableJobWhenResultsArrive(t *testing.
 // zero-valued rather than erroring, so a caller displays "not priced yet".
 func TestAccountBatchResults_LosingClaimWithNoExistingLogMirrorsNothing(t *testing.T) {
 	store := newFakeAccountingStore()
-	jobID := cstables.BatchJobID(string(schemas.OpenAI), "batch_in_flight")
+	jobID := cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_in_flight")
 	now := time.Now().UTC()
-	store.jobs[jobID] = &cstables.TableBatchJob{
+	store.jobs[jobID] = &cstables.TableProviderJob{
 		ID:               jobID,
 		Provider:         string(schemas.OpenAI),
-		BatchID:          "batch_in_flight",
+		JobID:            "batch_in_flight",
 		Model:            "gpt-4o-mini",
-		AccountingStatus: cstables.BatchJobAccountingStatusProcessing,
+		AccountingStatus: cstables.ProviderJobAccountingStatusProcessing,
 		RunnerID:         schemas.Ptr("other-node"),
 		ClaimedAt:        &now,
 	}
@@ -1863,9 +1889,9 @@ func TestAccountBatchResults_StatusPersistsAndMirrorsOnRepeatCall(t *testing.T) 
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "batch_status",
 		FallbackModel: "gpt-4o-mini",
-		Job: &cstables.TableBatchJob{
+		Job: &cstables.TableProviderJob{
 			Provider:       string(schemas.OpenAI),
-			BatchID:        "batch_status",
+			JobID:          "batch_status",
 			Model:          "gpt-4o-mini",
 			ProviderStatus: string(schemas.BatchStatusEnded),
 		},
@@ -1902,21 +1928,21 @@ func TestAccountBatchResults_TerminalJobsStayClosedWithoutResults(t *testing.T) 
 		name   string
 		status string
 	}{
-		{"unpriceable without results", cstables.BatchJobAccountingStatusUnpriceable},
-		{"accounted", cstables.BatchJobAccountingStatusAccounted},
+		{"unpriceable without results", cstables.ProviderJobAccountingStatusUnpriceable},
+		{"accounted", cstables.ProviderJobAccountingStatusAccounted},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			store := newFakeAccountingStore()
-			jobID := cstables.BatchJobID(string(schemas.OpenAI), "batch_closed")
-			require.NoError(t, store.UpsertBatchJob(context.Background(), &cstables.TableBatchJob{
+			jobID := cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_closed")
+			require.NoError(t, store.UpsertProviderJob(context.Background(), &cstables.TableProviderJob{
 				ID:               jobID,
 				Provider:         string(schemas.OpenAI),
-				BatchID:          "batch_closed",
+				JobID:            "batch_closed",
 				AccountingStatus: tc.status,
 			}))
 
 			results := []schemas.BatchResultItem{openAIResult(200, "gpt-4o-mini", 10, 5)}
-			if tc.status == cstables.BatchJobAccountingStatusUnpriceable {
+			if tc.status == cstables.ProviderJobAccountingStatusUnpriceable {
 				results = nil
 			}
 			summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
@@ -1950,13 +1976,13 @@ func TestAccountBatchResults_PersistedIdentityOverridesFetcherBuiltJob(t *testin
 	creatorBudgets := `["budget-creator"]`
 	fetcherVK := "vk-fetcher"
 	fetcherBudgets := `["budget-fetcher"]`
-	jobID := cstables.BatchJobID(string(schemas.OpenAI), "batch_merge")
+	jobID := cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_merge")
 
-	require.NoError(t, store.UpsertBatchJob(context.Background(), &cstables.TableBatchJob{
+	require.NoError(t, store.UpsertProviderJob(context.Background(), &cstables.TableProviderJob{
 		ID:               jobID,
 		Provider:         string(schemas.OpenAI),
-		BatchID:          "batch_merge",
-		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		JobID:            "batch_merge",
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		SelectedKeyID:    "key-creator",
 		VirtualKeyID:     &creatorVK,
 		UserID:           strPtr("user-creator"),
@@ -1965,11 +1991,11 @@ func TestAccountBatchResults_PersistedIdentityOverridesFetcherBuiltJob(t *testin
 
 	// What plugins/logging builds on the /results path: a job derived from the
 	// fetcher's log entry, carrying the fetcher's identity end to end.
-	fetcherBuiltJob := &cstables.TableBatchJob{
+	fetcherBuiltJob := &cstables.TableProviderJob{
 		ID:               jobID,
 		Provider:         string(schemas.OpenAI),
-		BatchID:          "batch_merge",
-		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		JobID:            "batch_merge",
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		SelectedKeyID:    "key-fetcher",
 		VirtualKeyID:     &fetcherVK,
 		UserID:           strPtr("user-fetcher"),
@@ -2019,9 +2045,9 @@ func TestAccountBatchResults_UnpriceableMarkerFailureReleasesTheClaim(t *testing
 	})
 	require.Error(t, err)
 
-	job := store.jobs[cstables.BatchJobID(string(schemas.OpenAI), "batch_unpriceable_release")]
+	job := store.jobs[cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_unpriceable_release")]
 	require.NotNil(t, job)
-	assert.NotEqual(t, cstables.BatchJobAccountingStatusProcessing, job.AccountingStatus,
+	assert.NotEqual(t, cstables.ProviderJobAccountingStatusProcessing, job.AccountingStatus,
 		"the fence must be released, not left held by a runner that gave up")
 	assert.Nil(t, job.RunnerID)
 }
@@ -2035,14 +2061,15 @@ func TestAccountBatchResults_UnpriceableMarkerFailureReleasesTheClaim(t *testing
 func TestSweeper_FailedBatchKeepsPersistedOutputFileWhenRetrieveOmitsIt(t *testing.T) {
 	store := newFakeAccountingStore()
 	due := time.Now().UTC().Add(-time.Minute)
-	jobID := cstables.BatchJobID(string(schemas.OpenAI), "batch_failed_partial")
+	jobID := cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_failed_partial")
 	outputFileID := "file-partial-output"
-	require.NoError(t, store.UpsertBatchJob(context.Background(), &cstables.TableBatchJob{
+	require.NoError(t, store.UpsertProviderJob(context.Background(), &cstables.TableProviderJob{
 		ID:               jobID,
 		Provider:         string(schemas.OpenAI),
-		BatchID:          "batch_failed_partial",
+		Kind:             cstables.ProviderJobKindBatch,
+		JobID:            "batch_failed_partial",
 		Model:            "gpt-4o-mini",
-		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		NextCheckAt:      &due,
 		// Recorded by an earlier poll, when the provider did report it.
 		OutputFileID: &outputFileID,
@@ -2069,7 +2096,81 @@ func TestSweeper_FailedBatchKeepsPersistedOutputFileWhenRetrieveOmitsIt(t *testi
 
 	settled := store.jobs[jobID]
 	require.NotNil(t, settled)
-	assert.Equal(t, cstables.BatchJobAccountingStatusAccounted, settled.AccountingStatus)
+	assert.Equal(t, cstables.ProviderJobAccountingStatusAccounted, settled.AccountingStatus)
 	require.NotNil(t, settled.OutputFileID)
 	assert.Equal(t, outputFileID, *settled.OutputFileID)
+}
+
+// paramsRecordingSettler captures the coordination row the engine hands to Settle,
+// so a test can assert what the engine actually restored onto it.
+type paramsRecordingSettler struct{ seenParams *string }
+
+func (p *paramsRecordingSettler) Kind() ProviderJobKind                       { return ProviderJobKindBatch }
+func (p *paramsRecordingSettler) SupportsProvider(schemas.ModelProvider) bool { return true }
+func (p *paramsRecordingSettler) Backoff(int, time.Duration) time.Duration    { return time.Minute }
+func (p *paramsRecordingSettler) HydrateFromLog(*logstore.Log, *Outcome)      {}
+func (p *paramsRecordingSettler) Poll(context.Context, *cstables.TableProviderJob) (*PollResult, error) {
+	return nil, errors.New("not polled in this test")
+}
+
+func (p *paramsRecordingSettler) Settle(ctx context.Context, pricing PricingManager, req JobRequest) (*Settlement, error) {
+	if req.Job != nil {
+		p.seenParams = req.Job.Params
+	}
+	return &Settlement{Priced: true, Complete: true, Cost: 1, Model: "m", Object: schemas.BatchResultsRequest}, nil
+}
+
+// Params is the persisted pricing basis — for video, the duration and resolution
+// that exist nowhere else by settlement time. UpsertProviderJob deliberately leaves
+// it alone when a caller passes nil, so the row keeps it; the engine must then put
+// it back on the copy it hands to Settle, or a caller that rebuilt its coordination
+// row from scratch would settle against nothing.
+func TestAccountJob_RestoresPersistedParamsForSettlement(t *testing.T) {
+	store := newFakeAccountingStore()
+	captured := `{"seconds":8,"size":"1920x1080"}`
+	persisted := &cstables.TableProviderJob{
+		ID:               cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "job_params"),
+		Kind:             cstables.ProviderJobKindBatch,
+		Provider:         string(schemas.OpenAI),
+		JobID:            "job_params",
+		Params:           &captured,
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
+	}
+	require.NoError(t, store.UpsertProviderJob(context.Background(), persisted))
+
+	// A caller holding a row it built itself: same identity, no params.
+	bare := *persisted
+	bare.Params = nil
+
+	settler := &paramsRecordingSettler{}
+	out, err := AccountJob(context.Background(), store, store, fakeBatchPricing{}, settler, JobRequest{
+		Provider:      schemas.OpenAI,
+		ProviderJobID: "job_params",
+		Job:           &bare,
+		ClaimedBy:     "node-1",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.NotNil(t, settler.seenParams, "the engine must restore the persisted params before settling")
+	assert.Equal(t, captured, *settler.seenParams)
+}
+
+// The runner id is the ownership fence every later transition is keyed on, so a
+// settlement that supplies none can never claim its job. Reject it before anything
+// is written, rather than defaulting: a shared default would let two callers both
+// believe they own the same job, which is the double-settlement the fence prevents.
+func TestAccountJob_RequiresARunnerID(t *testing.T) {
+	store := newFakeAccountingStore()
+
+	_, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+		Provider:      schemas.OpenAI,
+		ProviderJobID: "batch_no_runner",
+		Payload:       BatchPayload{Results: []schemas.BatchResultItem{openAIResult(200, "gpt-4o-mini", 18, 9)}},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "runner id")
+	assert.Empty(t, store.jobs,
+		"the rejection must land before the coordination row is written, or an unclaimable job is left behind")
+	assert.Empty(t, store.logs)
 }

--- a/framework/jobaccounting/batchpricing_test.go
+++ b/framework/jobaccounting/batchpricing_test.go
@@ -25,18 +25,18 @@ func loadPricingFromFile(t *testing.T) *modelcatalog.ModelCatalog {
 	return modelcatalog.NewTestCatalogWithDatasheet(ds)
 }
 
-func assertSweeperAccountsBatchWithPricing(t *testing.T, mc *modelcatalog.ModelCatalog, job *cstables.TableBatchJob, results []schemas.BatchResultItem, expectedCost float64) {
+func assertSweeperAccountsBatchWithPricing(t *testing.T, mc *modelcatalog.ModelCatalog, job *cstables.TableProviderJob, results []schemas.BatchResultItem, expectedCost float64) {
 	t.Helper()
 	store := newFakeAccountingStore()
-	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
 
 	fetcher := &fakeBatchResultFetcher{
 		retrieveResp: &schemas.BifrostBatchRetrieveResponse{
-			ID:     job.BatchID,
+			ID:     job.JobID,
 			Status: schemas.BatchStatusCompleted,
 		},
 		resultsResp: &schemas.BifrostBatchResultsResponse{
-			BatchID: job.BatchID,
+			BatchID: job.JobID,
 			Results: results,
 		},
 	}
@@ -54,11 +54,11 @@ func assertSweeperAccountsBatchWithPricing(t *testing.T, mc *modelcatalog.ModelC
 
 	accounted := store.jobs[job.ID]
 	require.NotNil(t, accounted, "batch job should exist in store")
-	assert.Equal(t, cstables.BatchJobAccountingStatusAccounted, accounted.AccountingStatus,
+	assert.Equal(t, cstables.ProviderJobAccountingStatusAccounted, accounted.AccountingStatus,
 		"batch job should be accounted, got status=%s", accounted.AccountingStatus)
 
 	assert.Len(t, store.logs, 1, "one aggregate log should be written")
-	logEntry := store.logs[AccountingLogID(ProviderJobKindBatch, schemas.ModelProvider(job.Provider), job.BatchID)]
+	logEntry := store.logs[AccountingLogID(ProviderJobKindBatch, schemas.ModelProvider(job.Provider), job.JobID)]
 	require.NotNil(t, logEntry, "aggregate log entry should exist")
 	require.NotNil(t, logEntry.Cost, "log entry should have a cost")
 	assert.InDelta(t, expectedCost, *logEntry.Cost, 1e-12,
@@ -73,12 +73,12 @@ func assertSweeperAccountsBatchWithPricing(t *testing.T, mc *modelcatalog.ModelC
 func TestBatchPricing_ClaudeSonnet5_Anthropic(t *testing.T) {
 	mc := loadPricingFromFile(t)
 	now := time.Now().UTC().Add(-time.Minute)
-	job := &cstables.TableBatchJob{
-		ID:               cstables.BatchJobID(string(schemas.Anthropic), "batch_claude_sonnet_5"),
+	job := &cstables.TableProviderJob{
+		ID:               cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.Anthropic), "batch_claude_sonnet_5"),
 		Provider:         string(schemas.Anthropic),
-		BatchID:          "batch_claude_sonnet_5",
+		JobID:            "batch_claude_sonnet_5",
 		Model:            "claude-sonnet-5",
-		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		NextCheckAt:      &now,
 	}
 	results := []schemas.BatchResultItem{
@@ -90,12 +90,12 @@ func TestBatchPricing_ClaudeSonnet5_Anthropic(t *testing.T) {
 func TestBatchPricing_Gemini25Flash(t *testing.T) {
 	mc := loadPricingFromFile(t)
 	now := time.Now().UTC().Add(-time.Minute)
-	job := &cstables.TableBatchJob{
-		ID:               cstables.BatchJobID(string(schemas.Gemini), "batch_gemini_25_flash"),
+	job := &cstables.TableProviderJob{
+		ID:               cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.Gemini), "batch_gemini_25_flash"),
 		Provider:         string(schemas.Gemini),
-		BatchID:          "batch_gemini_25_flash",
+		JobID:            "batch_gemini_25_flash",
 		Model:            "gemini-2.5-flash",
-		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		NextCheckAt:      &now,
 	}
 	results := []schemas.BatchResultItem{
@@ -107,12 +107,12 @@ func TestBatchPricing_Gemini25Flash(t *testing.T) {
 func TestBatchPricing_ClaudeSonnet46_Bedrock(t *testing.T) {
 	mc := loadPricingFromFile(t)
 	now := time.Now().UTC().Add(-time.Minute)
-	job := &cstables.TableBatchJob{
-		ID:               cstables.BatchJobID(string(schemas.Bedrock), "batch_claude_sonnet_46"),
+	job := &cstables.TableProviderJob{
+		ID:               cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.Bedrock), "batch_claude_sonnet_46"),
 		Provider:         string(schemas.Bedrock),
-		BatchID:          "batch_claude_sonnet_46",
+		JobID:            "batch_claude_sonnet_46",
 		Model:            "anthropic.claude-sonnet-4-6",
-		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		NextCheckAt:      &now,
 	}
 	results := []schemas.BatchResultItem{
@@ -124,12 +124,12 @@ func TestBatchPricing_ClaudeSonnet46_Bedrock(t *testing.T) {
 func TestBatchPricing_GlobalClaudeSonnet46_Bedrock(t *testing.T) {
 	mc := loadPricingFromFile(t)
 	now := time.Now().UTC().Add(-time.Minute)
-	job := &cstables.TableBatchJob{
-		ID:               cstables.BatchJobID(string(schemas.Bedrock), "batch_global_claude_sonnet_46"),
+	job := &cstables.TableProviderJob{
+		ID:               cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.Bedrock), "batch_global_claude_sonnet_46"),
 		Provider:         string(schemas.Bedrock),
-		BatchID:          "batch_global_claude_sonnet_46",
+		JobID:            "batch_global_claude_sonnet_46",
 		Model:            "global.anthropic.claude-sonnet-4-6",
-		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		NextCheckAt:      &now,
 	}
 	results := []schemas.BatchResultItem{
@@ -146,12 +146,12 @@ func TestBatchPricing_GlobalClaudeSonnet46_Bedrock(t *testing.T) {
 func TestBatchPricing_ClaudeHaiku45_DefaultsToHalfStandardRate(t *testing.T) {
 	mc := loadPricingFromFile(t)
 	now := time.Now().UTC().Add(-time.Minute)
-	job := &cstables.TableBatchJob{
-		ID:               cstables.BatchJobID(string(schemas.Anthropic), "batch_haiku_45"),
+	job := &cstables.TableProviderJob{
+		ID:               cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.Anthropic), "batch_haiku_45"),
 		Provider:         string(schemas.Anthropic),
-		BatchID:          "batch_haiku_45",
+		JobID:            "batch_haiku_45",
 		Model:            "claude-haiku-4-5",
-		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		NextCheckAt:      &now,
 	}
 	results := []schemas.BatchResultItem{
@@ -166,17 +166,17 @@ func TestBatchPricing_ClaudeHaiku45_DefaultsToHalfStandardRate(t *testing.T) {
 func TestBatchPricing_UnknownModel_StillUnpriceable(t *testing.T) {
 	mc := loadPricingFromFile(t)
 	now := time.Now().UTC().Add(-time.Minute)
-	job := &cstables.TableBatchJob{
-		ID:               cstables.BatchJobID(string(schemas.Anthropic), "batch_unknown_model"),
+	job := &cstables.TableProviderJob{
+		ID:               cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.Anthropic), "batch_unknown_model"),
 		Provider:         string(schemas.Anthropic),
-		BatchID:          "batch_unknown_model",
+		JobID:            "batch_unknown_model",
 		Model:            "totally-unknown-model-xyz",
-		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		NextCheckAt:      &now,
 	}
 
 	store := newFakeAccountingStore()
-	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
 
 	fetcher := &fakeBatchResultFetcher{
 		retrieveResp: &schemas.BifrostBatchRetrieveResponse{
@@ -202,7 +202,7 @@ func TestBatchPricing_UnknownModel_StillUnpriceable(t *testing.T) {
 
 	unpriced := store.jobs[job.ID]
 	require.NotNil(t, unpriced)
-	assert.Equal(t, cstables.BatchJobAccountingStatusUnpriceable, unpriced.AccountingStatus,
+	assert.Equal(t, cstables.ProviderJobAccountingStatusUnpriceable, unpriced.AccountingStatus,
 		"batch with no pricing at all should be marked unpriceable")
 	require.NotNil(t, unpriced.UnpriceableReason)
 	assert.Equal(t, UnpriceableReasonMissingBatchPricing, *unpriced.UnpriceableReason,
@@ -229,17 +229,17 @@ func TestBatchPricing_UnknownModel_StillUnpriceable(t *testing.T) {
 func TestBatchPricing_MultiModel(t *testing.T) {
 	mc := loadPricingFromFile(t)
 	now := time.Now().UTC().Add(-time.Minute)
-	job := &cstables.TableBatchJob{
-		ID:               cstables.BatchJobID(string(schemas.Bedrock), "batch_multimodel"),
+	job := &cstables.TableProviderJob{
+		ID:               cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.Bedrock), "batch_multimodel"),
 		Provider:         string(schemas.Bedrock),
-		BatchID:          "batch_multimodel",
+		JobID:            "batch_multimodel",
 		Model:            "anthropic.claude-sonnet-4-6",
-		AccountingStatus: cstables.BatchJobAccountingStatusPending,
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
 		NextCheckAt:      &now,
 	}
 
 	store := newFakeAccountingStore()
-	require.NoError(t, store.UpsertBatchJob(context.Background(), job))
+	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
 
 	fetcher := &fakeBatchResultFetcher{
 		retrieveResp: &schemas.BifrostBatchRetrieveResponse{
@@ -266,7 +266,7 @@ func TestBatchPricing_MultiModel(t *testing.T) {
 
 	accounted := store.jobs[job.ID]
 	require.NotNil(t, accounted)
-	assert.Equal(t, cstables.BatchJobAccountingStatusAccounted, accounted.AccountingStatus)
+	assert.Equal(t, cstables.ProviderJobAccountingStatusAccounted, accounted.AccountingStatus)
 
 	require.Len(t, store.logs, 1)
 	logEntry := store.logs[AccountingLogID(ProviderJobKindBatch, schemas.Bedrock, "batch_multimodel")]

--- a/framework/jobaccounting/doc.go
+++ b/framework/jobaccounting/doc.go
@@ -37,7 +37,7 @@
 // The aggregate cost log is genuinely idempotent: CreateIfNotExists keys on a
 // deterministic id, so replaying it is a no-op.
 //
-// Governance reporting is not, and the gap is deliberate. If ReportBatchUsage
+// Governance reporting is not, and the gap is deliberate. If ReportUsage
 // succeeds but the GovernanceReportedAt marker write then fails, the job is left
 // retryable with the report already applied. Two things narrow this, neither
 // closes it:
@@ -74,7 +74,7 @@
 // # Ownership fencing
 //
 // Delayed accounting can run concurrently across nodes (the sweeper on one node,
-// a user-triggered settlement on another). ClaimBatchJob transitions a job to
+// a user-triggered settlement on another). ClaimProviderJob transitions a job to
 // "processing" under a runner id; every subsequent advance/complete is fenced on
 // that runner id, and a job stuck in "processing" past a stale threshold can be
 // re-claimed. This mirrors the sidekiq job runner rather than using a separate

--- a/framework/jobaccounting/engine.go
+++ b/framework/jobaccounting/engine.go
@@ -40,6 +40,9 @@ func AccountJob(ctx context.Context, stateStore JobStore, logStore AggregateLogS
 	if req.Job == nil {
 		return nil, fmt.Errorf("job accounting coordination row is nil")
 	}
+	if req.ClaimedBy == "" {
+		return nil, fmt.Errorf("job accounting runner id (ClaimedBy) is required")
+	}
 
 	now := req.Now
 	if now.IsZero() {
@@ -47,7 +50,7 @@ func AccountJob(ctx context.Context, stateStore JobStore, logStore AggregateLogS
 	}
 
 	job := req.Job
-	if err := stateStore.UpsertBatchJob(ctx, job); err != nil {
+	if err := stateStore.UpsertProviderJob(ctx, job); err != nil {
 		return nil, err
 	}
 
@@ -59,7 +62,7 @@ func AccountJob(ctx context.Context, stateStore JobStore, logStore AggregateLogS
 	}
 
 	runnerID := req.ClaimedBy
-	claimed, err := stateStore.ClaimBatchJob(ctx, job.ID, runnerID, now.Add(-defaultClaimTTL), req.ForceClaim)
+	claimed, err := stateStore.ClaimProviderJob(ctx, job.ID, runnerID, now.Add(-defaultClaimTTL), req.ForceClaim)
 	if err != nil {
 		return nil, err
 	}
@@ -79,9 +82,9 @@ func AccountJob(ctx context.Context, stateStore JobStore, logStore AggregateLogS
 	// partially-settled job from a new one — proceeding would re-report usage that
 	// already landed. Fail closed, releasing the claim so a later attempt can retry
 	// cleanly rather than waiting out the claim TTL.
-	persisted, err := stateStore.GetBatchJob(ctx, job.ID)
+	persisted, err := stateStore.GetProviderJob(ctx, job.ID)
 	if err != nil {
-		_ = stateStore.FailBatchJob(ctx, job.ID, runnerID, err)
+		_ = stateStore.FailProviderJob(ctx, job.ID, runnerID, err)
 		return nil, err
 	}
 	if persisted != nil {
@@ -99,7 +102,7 @@ func AccountJob(ctx context.Context, stateStore JobStore, logStore AggregateLogS
 
 	settlement, err := settler.Settle(ctx, pricing, req)
 	if err != nil {
-		_ = stateStore.FailBatchJob(ctx, job.ID, runnerID, err)
+		_ = stateStore.FailProviderJob(ctx, job.ID, runnerID, err)
 		return nil, err
 	}
 	if settlement == nil {
@@ -129,12 +132,12 @@ func AccountJob(ctx context.Context, stateStore JobStore, logStore AggregateLogS
 				return nil, err
 			}
 		}
-		if err := stateStore.MarkBatchJobUnpriceable(ctx, job.ID, runnerID, settlement.UnpriceableReason, settlement.ReasonErr); err != nil {
+		if err := stateStore.MarkProviderJobUnpriceable(ctx, job.ID, runnerID, settlement.UnpriceableReason, settlement.ReasonErr); err != nil {
 			// Release the fence like every other failure path here. Best-effort by
 			// nature: the mark above is itself a store write, so if it failed this one
 			// probably will too — but leaving the job "processing" under a runner that
 			// has already given up strands it for the whole claim TTL.
-			_ = stateStore.FailBatchJob(ctx, job.ID, runnerID, err)
+			_ = stateStore.FailProviderJob(ctx, job.ID, runnerID, err)
 			return nil, err
 		}
 		return out, nil
@@ -167,24 +170,24 @@ func AccountJob(ctx context.Context, stateStore JobStore, logStore AggregateLogS
 		// which stops polling but stays claimable by a settlement holding inputs (see
 		// ForceClaim) — so recalculation plus a re-drive remain the recovery path.
 		out.UnpriceableReason = settlement.UnpriceableReason
-		if err := stateStore.MarkBatchJobUnpriceable(ctx, job.ID, runnerID, out.UnpriceableReason, nil); err != nil {
-			_ = stateStore.FailBatchJob(ctx, job.ID, runnerID, err)
+		if err := stateStore.MarkProviderJobUnpriceable(ctx, job.ID, runnerID, out.UnpriceableReason, nil); err != nil {
+			_ = stateStore.FailProviderJob(ctx, job.ID, runnerID, err)
 			return nil, err
 		}
 		return out, nil
 	}
 	if req.UsageReporter != nil && job.GovernanceReportedAt == nil {
-		if err := req.UsageReporter.ReportBatchUsage(ctx, usageReportFor(req.Provider, entry, out)); err != nil {
-			_ = stateStore.FailBatchJob(ctx, job.ID, runnerID, err)
+		if err := req.UsageReporter.ReportUsage(ctx, usageReportFor(req.Provider, entry, out)); err != nil {
+			_ = stateStore.FailProviderJob(ctx, job.ID, runnerID, err)
 			return nil, err
 		}
-		if err := stateStore.MarkBatchJobGovernanceReported(ctx, job.ID, runnerID); err != nil {
-			_ = stateStore.FailBatchJob(ctx, job.ID, runnerID, err)
+		if err := stateStore.MarkProviderJobGovernanceReported(ctx, job.ID, runnerID); err != nil {
+			_ = stateStore.FailProviderJob(ctx, job.ID, runnerID, err)
 			return nil, err
 		}
 	}
-	if err := stateStore.CompleteBatchJob(ctx, job.ID, runnerID); err != nil {
-		_ = stateStore.FailBatchJob(ctx, job.ID, runnerID, err)
+	if err := stateStore.CompleteProviderJob(ctx, job.ID, runnerID); err != nil {
+		_ = stateStore.FailProviderJob(ctx, job.ID, runnerID, err)
 		return nil, err
 	}
 	out.Accounted = true
@@ -193,17 +196,17 @@ func AccountJob(ctx context.Context, stateStore JobStore, logStore AggregateLogS
 
 // writeAggregateLog persists the aggregate row, marks the job, and emits. Any
 // failure releases the claim so a later attempt can retry cleanly.
-func writeAggregateLog(ctx context.Context, stateStore JobStore, logStore AggregateLogStore, req JobRequest, job *cstables.TableBatchJob, runnerID string, entry *logstore.Log) error {
+func writeAggregateLog(ctx context.Context, stateStore JobStore, logStore AggregateLogStore, req JobRequest, job *cstables.TableProviderJob, runnerID string, entry *logstore.Log) error {
 	if err := logStore.CreateIfNotExists(ctx, entry); err != nil {
-		_ = stateStore.FailBatchJob(ctx, job.ID, runnerID, err)
+		_ = stateStore.FailProviderJob(ctx, job.ID, runnerID, err)
 		return err
 	}
-	if err := stateStore.MarkBatchJobAggregateLogWritten(ctx, job.ID, runnerID); err != nil {
-		_ = stateStore.FailBatchJob(ctx, job.ID, runnerID, err)
+	if err := stateStore.MarkProviderJobAggregateLogWritten(ctx, job.ID, runnerID); err != nil {
+		_ = stateStore.FailProviderJob(ctx, job.ID, runnerID, err)
 		return err
 	}
 	if req.Emitter != nil {
-		req.Emitter.EmitBatchAggregateLog(ctx, entry)
+		req.Emitter.EmitAggregateLog(ctx, entry)
 	}
 	return nil
 }
@@ -235,7 +238,7 @@ func populateOutcomeFromExistingLog(ctx context.Context, logStore AggregateLogSt
 	settler.HydrateFromLog(entry, out)
 }
 
-func mergeJobHints(dst *cstables.TableBatchJob, src *cstables.TableBatchJob) {
+func mergeJobHints(dst *cstables.TableProviderJob, src *cstables.TableProviderJob) {
 	if dst == nil || src == nil {
 		return
 	}
@@ -244,6 +247,10 @@ func mergeJobHints(dst *cstables.TableBatchJob, src *cstables.TableBatchJob) {
 	}
 	if dst.Endpoint == "" {
 		dst.Endpoint = src.Endpoint
+	}
+
+	if dst.Params == nil {
+		dst.Params = src.Params
 	}
 	dst.AggregateLogWrittenAt = src.AggregateLogWrittenAt
 	dst.GovernanceReportedAt = src.GovernanceReportedAt
@@ -257,7 +264,7 @@ func mergeJobHints(dst *cstables.TableBatchJob, src *cstables.TableBatchJob) {
 	dst.SourceLogID = src.SourceLogID
 }
 
-func pricingScopesForJob(scopes *modelcatalog.PricingLookupScopes, provider schemas.ModelProvider, job *cstables.TableBatchJob) *modelcatalog.PricingLookupScopes {
+func pricingScopesForJob(scopes *modelcatalog.PricingLookupScopes, provider schemas.ModelProvider, job *cstables.TableProviderJob) *modelcatalog.PricingLookupScopes {
 	if scopes == nil {
 		scopes = &modelcatalog.PricingLookupScopes{}
 	} else {
@@ -451,7 +458,7 @@ func buildAggregateLog(req JobRequest, settlement *Settlement, out *Outcome, now
 // display names the coordination row does not carry. Best-effort by design: the
 // names are cosmetic, the ids on the job are what bills, so a log row that has been
 // rotated away or cannot be read costs nothing but the labels.
-func resolveSourceLog(ctx context.Context, logStore AggregateLogStore, job *cstables.TableBatchJob, baseLog *logstore.Log) *logstore.Log {
+func resolveSourceLog(ctx context.Context, logStore AggregateLogStore, job *cstables.TableProviderJob, baseLog *logstore.Log) *logstore.Log {
 	if job == nil || job.SourceLogID == nil || *job.SourceLogID == "" {
 		return nil
 	}
@@ -467,7 +474,7 @@ func resolveSourceLog(ctx context.Context, logStore AggregateLogStore, job *csta
 
 // hasJobAttribution reports whether the job captured who to bill at create time.
 // Jobs created outside Bifrost (first seen at settlement) carry none.
-func hasJobAttribution(job *cstables.TableBatchJob) bool {
+func hasJobAttribution(job *cstables.TableProviderJob) bool {
 	if job.SelectedKeyID != "" || (job.VirtualKeyID != nil && *job.VirtualKeyID != "") {
 		return true
 	}
@@ -515,7 +522,7 @@ func applyLogDenormalizations(entry *logstore.Log, source *logstore.Log) {
 	entry.AliasModelFamily = source.AliasModelFamily
 }
 
-func applyJobAttribution(entry *logstore.Log, job *cstables.TableBatchJob) {
+func applyJobAttribution(entry *logstore.Log, job *cstables.TableProviderJob) {
 	entry.SelectedKeyID = job.SelectedKeyID
 	entry.VirtualKeyID = job.VirtualKeyID
 	entry.BudgetIDs = job.BudgetIDs

--- a/framework/jobaccounting/sweeper.go
+++ b/framework/jobaccounting/sweeper.go
@@ -53,7 +53,7 @@ func NewSweeper(store SweepStore, logStore AggregateLogStore, pricing PricingMan
 	}
 	if config.ClaimedBy == "" {
 		// Never default to a bare constant: ClaimedBy becomes the runner id that
-		// ClaimBatchJob and every ownership fence key on, so two sweepers sharing a
+		// ClaimProviderJob and every ownership fence key on, so two sweepers sharing a
 		// database and a default would be indistinguishable — each able to advance
 		// the other's in-flight job. Callers should pass a stable per-node id; if
 		// they don't, a per-instance id at least keeps the fence meaningful.
@@ -107,7 +107,7 @@ func (s *Sweeper) SweepOnce(ctx context.Context) {
 		return
 	}
 	now := time.Now().UTC()
-	jobs, err := s.store.ListDueBatchJobs(ctx, string(s.config.Provider), now, s.config.Limit)
+	jobs, err := s.store.ListDueProviderJobs(ctx, string(s.settler.Kind()), string(s.config.Provider), now, s.config.Limit)
 	if err != nil {
 		s.warn("%s accounting sweeper failed to find due jobs: %v", s.settler.Kind(), err)
 		return
@@ -123,13 +123,13 @@ func (s *Sweeper) SweepOnce(ctx context.Context) {
 }
 
 // sweepJob polls and settles a single due job.
-func (s *Sweeper) sweepJob(ctx context.Context, job *cstables.TableBatchJob, now time.Time) {
+func (s *Sweeper) sweepJob(ctx context.Context, job *cstables.TableProviderJob, now time.Time) {
 	if job == nil || !s.settler.SupportsProvider(schemas.ModelProvider(job.Provider)) {
 		return
 	}
 	locked, err := s.acquireProviderPollLease(job)
 	if err != nil {
-		s.warn("%s accounting sweeper failed to acquire poll lease provider=%s job=%s job_id=%s: %v", s.settler.Kind(), job.Provider, job.BatchID, job.ID, err)
+		s.warn("%s accounting sweeper failed to acquire poll lease provider=%s job=%s job_id=%s: %v", s.settler.Kind(), job.Provider, job.JobID, job.ID, err)
 		return
 	}
 	if !locked {
@@ -140,9 +140,9 @@ func (s *Sweeper) sweepJob(ctx context.Context, job *cstables.TableBatchJob, now
 	poll, err := s.settler.Poll(ctx, job)
 	if err != nil || poll == nil {
 		if err != nil {
-			s.warn("%s accounting sweeper poll failed provider=%s job=%s job_id=%s: %v", s.settler.Kind(), job.Provider, job.BatchID, job.ID, err)
+			s.warn("%s accounting sweeper poll failed provider=%s job=%s job_id=%s: %v", s.settler.Kind(), job.Provider, job.JobID, job.ID, err)
 		} else {
-			s.warn("%s accounting sweeper poll returned nil result provider=%s job=%s job_id=%s", s.settler.Kind(), job.Provider, job.BatchID, job.ID)
+			s.warn("%s accounting sweeper poll returned nil result provider=%s job=%s job_id=%s", s.settler.Kind(), job.Provider, job.JobID, job.ID)
 		}
 		s.reschedule(ctx, job, now)
 		return
@@ -152,8 +152,8 @@ func (s *Sweeper) sweepJob(ctx context.Context, job *cstables.TableBatchJob, now
 	// advanced the provider status records it even when settlement cannot proceed.
 	latest := job
 	if poll.Job != nil {
-		if err := s.store.UpsertBatchJob(ctx, poll.Job); err != nil {
-			s.warn("%s accounting sweeper failed to upsert polled job provider=%s job=%s job_id=%s: %v", s.settler.Kind(), poll.Job.Provider, poll.Job.BatchID, poll.Job.ID, err)
+		if err := s.store.UpsertProviderJob(ctx, poll.Job); err != nil {
+			s.warn("%s accounting sweeper failed to upsert polled job provider=%s job=%s job_id=%s: %v", s.settler.Kind(), poll.Job.Provider, poll.Job.JobID, poll.Job.ID, err)
 			return
 		}
 		latest = poll.Job
@@ -169,10 +169,10 @@ func (s *Sweeper) sweepJob(ctx context.Context, job *cstables.TableBatchJob, now
 	}
 }
 
-func (s *Sweeper) settle(ctx context.Context, job *cstables.TableBatchJob, poll *PollResult, now time.Time) {
+func (s *Sweeper) settle(ctx context.Context, job *cstables.TableProviderJob, poll *PollResult, now time.Time) {
 	if _, err := AccountJob(ctx, s.store, s.logStore, s.pricing, s.settler, JobRequest{
 		Provider:      schemas.ModelProvider(job.Provider),
-		ProviderJobID: job.BatchID,
+		ProviderJobID: job.JobID,
 		FallbackModel: job.Model,
 		Job:           job,
 		Payload:       poll.Payload,
@@ -182,7 +182,7 @@ func (s *Sweeper) settle(ctx context.Context, job *cstables.TableBatchJob, poll 
 		Scopes:        s.config.Scopes,
 		Now:           now,
 	}); err != nil {
-		s.warn("%s accounting sweeper accounting failed provider=%s job=%s job_id=%s: %v", s.settler.Kind(), job.Provider, job.BatchID, job.ID, err)
+		s.warn("%s accounting sweeper accounting failed provider=%s job=%s job_id=%s: %v", s.settler.Kind(), job.Provider, job.JobID, job.ID, err)
 		// Settlement failures were the one retry path with no budget: next_check_at
 		// stayed in the past and poll_attempts never moved, so every sweep re-did the
 		// entire settlement and re-failed, forever. Reschedule like any other retry so
@@ -191,7 +191,7 @@ func (s *Sweeper) settle(ctx context.Context, job *cstables.TableBatchJob, poll 
 	}
 }
 
-func (s *Sweeper) reschedule(ctx context.Context, job *cstables.TableBatchJob, now time.Time) {
+func (s *Sweeper) reschedule(ctx context.Context, job *cstables.TableProviderJob, now time.Time) {
 	job.PollAttempts++
 	if job.PollAttempts >= MaxPollAttempts {
 		s.markTerminalAsUnpriceable(ctx, job, UnpriceableReasonMaxPollAttempts)
@@ -199,29 +199,29 @@ func (s *Sweeper) reschedule(ctx context.Context, job *cstables.TableBatchJob, n
 	}
 	next := s.nextCheckAt(job, now)
 	job.NextCheckAt = &next
-	if err := s.store.UpsertBatchJob(ctx, job); err != nil {
-		s.warn("%s accounting sweeper failed to reschedule provider=%s job=%s job_id=%s: %v", s.settler.Kind(), job.Provider, job.BatchID, job.ID, err)
+	if err := s.store.UpsertProviderJob(ctx, job); err != nil {
+		s.warn("%s accounting sweeper failed to reschedule provider=%s job=%s job_id=%s: %v", s.settler.Kind(), job.Provider, job.JobID, job.ID, err)
 		return
 	}
 }
 
-func (s *Sweeper) markTerminalAsUnpriceable(ctx context.Context, job *cstables.TableBatchJob, reason string) {
+func (s *Sweeper) markTerminalAsUnpriceable(ctx context.Context, job *cstables.TableProviderJob, reason string) {
 	runnerID := s.config.ClaimedBy
 	// allowUnpriceable=false: this path is giving up on a job, not settling one, so
 	// it has no business re-opening one that already reached that state.
-	claimed, err := s.store.ClaimBatchJob(ctx, job.ID, runnerID, time.Now().UTC().Add(-defaultClaimTTL), false)
+	claimed, err := s.store.ClaimProviderJob(ctx, job.ID, runnerID, time.Now().UTC().Add(-defaultClaimTTL), false)
 	if err != nil || !claimed {
 		if err != nil {
-			s.warn("%s accounting sweeper failed to claim for unpriceable provider=%s job=%s job_id=%s reason=%s: %v", s.settler.Kind(), job.Provider, job.BatchID, job.ID, reason, err)
+			s.warn("%s accounting sweeper failed to claim for unpriceable provider=%s job=%s job_id=%s reason=%s: %v", s.settler.Kind(), job.Provider, job.JobID, job.ID, reason, err)
 		}
 		return
 	}
-	if err := s.store.MarkBatchJobUnpriceable(ctx, job.ID, runnerID, reason, nil); err != nil {
-		s.warn("%s accounting sweeper failed to mark unpriceable provider=%s job=%s job_id=%s reason=%s: %v", s.settler.Kind(), job.Provider, job.BatchID, job.ID, reason, err)
+	if err := s.store.MarkProviderJobUnpriceable(ctx, job.ID, runnerID, reason, nil); err != nil {
+		s.warn("%s accounting sweeper failed to mark unpriceable provider=%s job=%s job_id=%s reason=%s: %v", s.settler.Kind(), job.Provider, job.JobID, job.ID, reason, err)
 	}
 }
 
-func (s *Sweeper) acquireProviderPollLease(job *cstables.TableBatchJob) (bool, error) {
+func (s *Sweeper) acquireProviderPollLease(job *cstables.TableProviderJob) (bool, error) {
 	if s.config.KVStore == nil {
 		return true, nil
 	}
@@ -232,26 +232,26 @@ func (s *Sweeper) acquireProviderPollLease(job *cstables.TableBatchJob) (bool, e
 	return s.config.KVStore.SetNXWithTTL(s.pollLeaseKey(job), value, s.config.KVLeaseTTL)
 }
 
-func (s *Sweeper) deletePollLease(job *cstables.TableBatchJob) {
+func (s *Sweeper) deletePollLease(job *cstables.TableProviderJob) {
 	if s.config.KVStore == nil {
 		return
 	}
 	if _, err := s.config.KVStore.Delete(s.pollLeaseKey(job)); err != nil {
-		s.warn("%s accounting sweeper failed to release poll lease provider=%s job=%s job_id=%s: %v", s.settler.Kind(), job.Provider, job.BatchID, job.ID, err)
+		s.warn("%s accounting sweeper failed to release poll lease provider=%s job=%s job_id=%s: %v", s.settler.Kind(), job.Provider, job.JobID, job.ID, err)
 	}
 }
 
 // pollLeaseKey keeps the batch kind's historical key prefix so a rolling deploy
 // does not let an old and a new node poll the same batch concurrently.
-func (s *Sweeper) pollLeaseKey(job *cstables.TableBatchJob) string {
+func (s *Sweeper) pollLeaseKey(job *cstables.TableProviderJob) string {
 	prefix := string(s.settler.Kind())
 	if s.settler.Kind() == ProviderJobKindBatch {
 		prefix = "batch-accounting"
 	}
-	return fmt.Sprintf("%s:poll:%s:%s", prefix, job.Provider, job.BatchID)
+	return fmt.Sprintf("%s:poll:%s:%s", prefix, job.Provider, job.JobID)
 }
 
-func (s *Sweeper) nextCheckAt(job *cstables.TableBatchJob, now time.Time) time.Time {
+func (s *Sweeper) nextCheckAt(job *cstables.TableProviderJob, now time.Time) time.Time {
 	delay := s.settler.Backoff(job.PollAttempts, s.config.Interval)
 	if delay < s.config.Interval {
 		delay = s.config.Interval

--- a/framework/jobaccounting/types.go
+++ b/framework/jobaccounting/types.go
@@ -18,28 +18,26 @@ const defaultClaimTTL = 5 * time.Minute
 // which is a different thing entirely — these are jobs the *provider* runs.
 type ProviderJobKind string
 
-const ProviderJobKindBatch ProviderJobKind = "batch"
+const ProviderJobKindBatch ProviderJobKind = cstables.ProviderJobKindBatch
 
 // JobStore is the mutable coordination-state store for delayed settlement. It is
 // satisfied by configstore.ConfigStore.
-//
-// The method names still say "BatchJob" because the backing table and its store
-// methods have not been renamed yet; both sides move together in a later change.
 type JobStore interface {
-	UpsertBatchJob(ctx context.Context, job *cstables.TableBatchJob) error
-	GetBatchJob(ctx context.Context, jobID string) (*cstables.TableBatchJob, error)
-	ClaimBatchJob(ctx context.Context, jobID, runnerID string, staleBefore time.Time, allowUnpriceable bool) (bool, error)
-	MarkBatchJobAggregateLogWritten(ctx context.Context, jobID, runnerID string) error
-	MarkBatchJobGovernanceReported(ctx context.Context, jobID, runnerID string) error
-	CompleteBatchJob(ctx context.Context, jobID, runnerID string) error
-	MarkBatchJobUnpriceable(ctx context.Context, jobID, runnerID, reason string, err error) error
-	FailBatchJob(ctx context.Context, jobID, runnerID string, err error) error
+	UpsertProviderJob(ctx context.Context, job *cstables.TableProviderJob) error
+	GetProviderJob(ctx context.Context, jobID string) (*cstables.TableProviderJob, error)
+	ClaimProviderJob(ctx context.Context, jobID, runnerID string, staleBefore time.Time, allowUnpriceable bool) (bool, error)
+	MarkProviderJobAggregateLogWritten(ctx context.Context, jobID, runnerID string) error
+	MarkProviderJobGovernanceReported(ctx context.Context, jobID, runnerID string) error
+	CompleteProviderJob(ctx context.Context, jobID, runnerID string) error
+	MarkProviderJobUnpriceable(ctx context.Context, jobID, runnerID, reason string, err error) error
+	FailProviderJob(ctx context.Context, jobID, runnerID string, err error) error
 }
 
-// SweepStore adds the due-job scan the sweeper needs.
+// SweepStore adds the due-job scan the sweeper needs. The scan is per kind: a
+// sweeper must never be handed a kind its settler cannot talk to.
 type SweepStore interface {
 	JobStore
-	ListDueBatchJobs(ctx context.Context, provider string, now time.Time, limit int) ([]*cstables.TableBatchJob, error)
+	ListDueProviderJobs(ctx context.Context, kind, provider string, now time.Time, limit int) ([]*cstables.TableProviderJob, error)
 }
 
 // AggregateLogStore writes the append-only aggregate cost record. It is satisfied
@@ -55,7 +53,7 @@ type AggregateLogStore interface {
 }
 
 type AggregateLogEmitter interface {
-	EmitBatchAggregateLog(ctx context.Context, entry *logstore.Log)
+	EmitAggregateLog(ctx context.Context, entry *logstore.Log)
 }
 
 // UsageReporter receives the settled usage/cost for a job so it can be billed.
@@ -64,11 +62,8 @@ type AggregateLogEmitter interface {
 // at-least-once, so the same report can be delivered more than once when the
 // durable "reported" marker fails to persist after a successful report. See the
 // package doc for the exact window and its limits.
-//
-// The method name still says "BatchUsage" because the governance plugin satisfies
-// this interface today; renaming it moves both sides at once.
 type UsageReporter interface {
-	ReportBatchUsage(ctx context.Context, usage UsageReport) error
+	ReportUsage(ctx context.Context, usage UsageReport) error
 }
 
 type UsageReport struct {
@@ -107,7 +102,7 @@ type Settler interface {
 
 	// Poll fetches current provider state. Returning an error asks the engine to
 	// reschedule; see PollResult for the non-error outcomes.
-	Poll(ctx context.Context, job *cstables.TableBatchJob) (*PollResult, error)
+	Poll(ctx context.Context, job *cstables.TableProviderJob) (*PollResult, error)
 
 	// Settle prices a job the poll (or an inline caller) says is ready.
 	Settle(ctx context.Context, pricing PricingManager, req JobRequest) (*Settlement, error)
@@ -130,7 +125,7 @@ type PollResult struct {
 	// Job is the updated coordination row to persist. Nil leaves the row untouched.
 	// It is persisted before any Retry/Terminal decision, so a poll that advanced
 	// the provider status records that even when settlement cannot proceed.
-	Job *cstables.TableBatchJob
+	Job *cstables.TableProviderJob
 	// Terminal reports that the provider will not advance this job further.
 	Terminal bool
 	// Settleable reports that the payload below is sufficient to price the job.
@@ -188,7 +183,7 @@ type JobRequest struct {
 	ProviderJobID string
 	FallbackModel string
 
-	Job       *cstables.TableBatchJob
+	Job       *cstables.TableProviderJob
 	BaseLog   *logstore.Log
 	SourceLog *logstore.Log
 

--- a/plugins/governance/accounting_test.go
+++ b/plugins/governance/accounting_test.go
@@ -21,7 +21,7 @@ type accountingFixture struct {
 	tracker *UsageTracker
 }
 
-func TestReportBatchUsage_IdempotentPerAggregateAndTarget(t *testing.T) {
+func TestReportUsage_IdempotentPerAggregateAndTarget(t *testing.T) {
 	f := newAccountingFixture(t)
 	plugin := &GovernancePlugin{store: f.store, tracker: f.tracker}
 	report := jobaccounting.UsageReport{
@@ -34,8 +34,8 @@ func TestReportBatchUsage_IdempotentPerAggregateAndTarget(t *testing.T) {
 		RateLimitIDs: []string{"rl1"},
 	}
 
-	require.NoError(t, plugin.ReportBatchUsage(context.Background(), report))
-	require.NoError(t, plugin.ReportBatchUsage(context.Background(), report))
+	require.NoError(t, plugin.ReportUsage(context.Background(), report))
+	require.NoError(t, plugin.ReportUsage(context.Background(), report))
 	assert.Equal(t, 12.5, f.cost())
 	assert.Equal(t, int64(123), f.tokens())
 	assert.Equal(t, int64(1), f.requests())
@@ -224,7 +224,7 @@ func TestAccounting_ZeroCostFailureNotBilled(t *testing.T) {
 // store methods, because those are not on the GovernanceStore interface at all —
 // the plugin cannot reach them, so a spy could never observe anything and would
 // pass no matter what the code did.
-func TestReportBatchUsage_UserOnReportDoesNotAddASecondCharge(t *testing.T) {
+func TestReportUsage_UserOnReportDoesNotAddASecondCharge(t *testing.T) {
 	newReport := func(requestID, userID string) jobaccounting.UsageReport {
 		return jobaccounting.UsageReport{
 			RequestID:    requestID,
@@ -241,12 +241,12 @@ func TestReportBatchUsage_UserOnReportDoesNotAddASecondCharge(t *testing.T) {
 	withUser := newAccountingFixture(t)
 	withUserPlugin := &GovernancePlugin{store: withUser.store, tracker: withUser.tracker}
 	// Settlement is at-least-once, so a repeated report must not double-charge either.
-	require.NoError(t, withUserPlugin.ReportBatchUsage(context.Background(), newReport("batch-cost:openai:with-user", "user-alice")))
-	require.NoError(t, withUserPlugin.ReportBatchUsage(context.Background(), newReport("batch-cost:openai:with-user", "user-alice")))
+	require.NoError(t, withUserPlugin.ReportUsage(context.Background(), newReport("batch-cost:openai:with-user", "user-alice")))
+	require.NoError(t, withUserPlugin.ReportUsage(context.Background(), newReport("batch-cost:openai:with-user", "user-alice")))
 
 	withoutUser := newAccountingFixture(t)
 	withoutUserPlugin := &GovernancePlugin{store: withoutUser.store, tracker: withoutUser.tracker}
-	require.NoError(t, withoutUserPlugin.ReportBatchUsage(context.Background(), newReport("batch-cost:openai:no-user", "")))
+	require.NoError(t, withoutUserPlugin.ReportUsage(context.Background(), newReport("batch-cost:openai:no-user", "")))
 
 	assert.Equal(t, 12.5, withUser.cost(), "the grant's ids are charged exactly once")
 	assert.Equal(t, withoutUser.cost(), withUser.cost(),
@@ -296,7 +296,7 @@ func (f *modelScopedFixture) budgetUsage(id string) float64 {
 	return f.store.GetGovernanceData(context.Background()).Budgets[id].CurrentUsage
 }
 
-func TestReportBatchUsage_ChargesPerModelBudgets(t *testing.T) {
+func TestReportUsage_ChargesPerModelBudgets(t *testing.T) {
 	f := newModelScopedFixture(t)
 	plugin := &GovernancePlugin{store: f.store, tracker: f.tracker}
 
@@ -316,19 +316,19 @@ func TestReportBatchUsage_ChargesPerModelBudgets(t *testing.T) {
 	}
 
 	// Settlement is at-least-once, so a repeat must not double-charge.
-	require.NoError(t, plugin.ReportBatchUsage(context.Background(), report))
-	require.NoError(t, plugin.ReportBatchUsage(context.Background(), report))
+	require.NoError(t, plugin.ReportUsage(context.Background(), report))
+	require.NoError(t, plugin.ReportUsage(context.Background(), report))
 
 	assert.Equal(t, 20.0, f.budgetUsage("model-budget"), "the gpt-5 budget takes gpt-5's share, not the batch total")
 	assert.Equal(t, 30.0, f.budgetUsage("wildcard-budget"), "an already-charged budget must not be charged again per model")
 }
 
 // A batch whose models carry no per-model config must behave exactly as before.
-func TestReportBatchUsage_PerModelChargingIsInertWithoutModelConfigs(t *testing.T) {
+func TestReportUsage_PerModelChargingIsInertWithoutModelConfigs(t *testing.T) {
 	f := newModelScopedFixture(t)
 	plugin := &GovernancePlugin{store: f.store, tracker: f.tracker}
 
-	require.NoError(t, plugin.ReportBatchUsage(context.Background(), jobaccounting.UsageReport{
+	require.NoError(t, plugin.ReportUsage(context.Background(), jobaccounting.UsageReport{
 		RequestID:  "batch-cost:openai:batch-nomodels",
 		Provider:   schemas.OpenAI,
 		Cost:       12.0,

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -1512,7 +1512,7 @@ func (p *GovernancePlugin) GetGovernanceStore() GovernanceStore {
 	return p.store
 }
 
-func (p *GovernancePlugin) ReportBatchUsage(ctx context.Context, usage jobaccounting.UsageReport) error {
+func (p *GovernancePlugin) ReportUsage(ctx context.Context, usage jobaccounting.UsageReport) error {
 	var errs []error
 
 	if usage.Cost > 0 {

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -479,7 +479,7 @@ func attachBatchResultsDisplay(entry *logstore.Log, batchResp *schemas.BifrostBa
 	entry.BatchDebugParsed = debug
 }
 
-func (p *LoggerPlugin) EmitBatchAggregateLog(ctx context.Context, entry *logstore.Log) {
+func (p *LoggerPlugin) EmitAggregateLog(ctx context.Context, entry *logstore.Log) {
 	p.makePostWriteCallback(nil)(entry)
 }
 
@@ -488,7 +488,7 @@ func (p *LoggerPlugin) recordBatchJobLifecycle(entry *logstore.Log, result *sche
 		return
 	}
 
-	var job *tables.TableBatchJob
+	var job *tables.TableProviderJob
 	now := time.Now().UTC()
 	switch {
 	case result.BatchCreateResponse != nil:
@@ -511,7 +511,7 @@ func (p *LoggerPlugin) recordBatchJobLifecycle(entry *logstore.Log, result *sche
 		return
 	}
 
-	if job.BatchID == "" {
+	if job.JobID == "" {
 		return
 	}
 	if !tables.IsTerminalBatchProviderStatus(job.ProviderStatus) {
@@ -521,8 +521,8 @@ func (p *LoggerPlugin) recordBatchJobLifecycle(entry *logstore.Log, result *sche
 		job.ProviderStatus == string(schemas.BatchStatusEnded) {
 		job.NextCheckAt = &now
 	}
-	if err := p.batchStore.UpsertBatchJob(p.ctx, job); err != nil {
-		p.logger.Warn("failed to record batch job lifecycle for provider=%s batch_id=%s: %v", job.Provider, job.BatchID, err)
+	if err := p.batchStore.UpsertProviderJob(p.ctx, job); err != nil {
+		p.logger.Warn("failed to record batch job lifecycle for provider=%s batch_id=%s: %v", job.Provider, job.JobID, err)
 	}
 }
 
@@ -542,14 +542,15 @@ func addBatchDetailToLog(entry *logstore.Log, batchID string, status string, cou
 	entry.BatchDebugParsed = debug
 }
 
-func batchJobFromEntry(entry *logstore.Log, batchID string, model string, endpoint string, status string) *tables.TableBatchJob {
-	job := &tables.TableBatchJob{
+func batchJobFromEntry(entry *logstore.Log, batchID string, model string, endpoint string, status string) *tables.TableProviderJob {
+	job := &tables.TableProviderJob{
+		Kind:             tables.ProviderJobKindBatch,
 		Provider:         entry.Provider,
-		BatchID:          batchID,
+		JobID:            batchID,
 		Model:            model,
 		Endpoint:         endpoint,
 		ProviderStatus:   status,
-		AccountingStatus: tables.BatchJobAccountingStatusPending,
+		AccountingStatus: tables.ProviderJobAccountingStatusPending,
 		SelectedKeyID:    entry.SelectedKeyID,
 		VirtualKeyID:     entry.VirtualKeyID,
 		UserID:           entry.UserID,
@@ -562,8 +563,8 @@ func batchJobFromEntry(entry *logstore.Log, batchID string, model string, endpoi
 		sourceLogID := entry.ID
 		job.SourceLogID = &sourceLogID
 	}
-	if job.ID == "" && job.Provider != "" && job.BatchID != "" {
-		job.ID = tables.BatchJobID(job.Provider, job.BatchID)
+	if job.ID == "" && job.Provider != "" && job.JobID != "" {
+		job.ID = tables.ProviderJobID(tables.ProviderJobKindBatch, job.Provider, job.JobID)
 	}
 	return job
 }

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -33,22 +33,22 @@ func (testLogger) LogHTTPRequest(schemas.LogLevel, string) schemas.LogEventBuild
 
 // fakeBatchStore is an in-memory jobaccounting.SweepStore for logging tests.
 type fakeBatchStore struct {
-	jobs map[string]*cstables.TableBatchJob
+	jobs map[string]*cstables.TableProviderJob
 }
 
 func newFakeBatchStore() *fakeBatchStore {
-	return &fakeBatchStore{jobs: make(map[string]*cstables.TableBatchJob)}
+	return &fakeBatchStore{jobs: make(map[string]*cstables.TableProviderJob)}
 }
 
-func (s *fakeBatchStore) UpsertBatchJob(ctx context.Context, job *cstables.TableBatchJob) error {
+func (s *fakeBatchStore) UpsertProviderJob(ctx context.Context, job *cstables.TableProviderJob) error {
 	if job.ID == "" {
-		job.ID = cstables.BatchJobID(job.Provider, job.BatchID)
+		job.ID = cstables.ProviderJobID(cstables.ProviderJobKindBatch, job.Provider, job.JobID)
 	}
 	existing, ok := s.jobs[job.ID]
 	if !ok {
 		copied := *job
 		if copied.AccountingStatus == "" {
-			copied.AccountingStatus = cstables.BatchJobAccountingStatusPending
+			copied.AccountingStatus = cstables.ProviderJobAccountingStatusPending
 		}
 		s.jobs[job.ID] = &copied
 		return nil
@@ -76,7 +76,7 @@ func (s *fakeBatchStore) UpsertBatchJob(ctx context.Context, job *cstables.Table
 	return nil
 }
 
-func (s *fakeBatchStore) GetBatchJob(ctx context.Context, jobID string) (*cstables.TableBatchJob, error) {
+func (s *fakeBatchStore) GetProviderJob(ctx context.Context, jobID string) (*cstables.TableProviderJob, error) {
 	job, ok := s.jobs[jobID]
 	if !ok {
 		return nil, errors.New("missing batch job")
@@ -85,16 +85,27 @@ func (s *fakeBatchStore) GetBatchJob(ctx context.Context, jobID string) (*cstabl
 	return &copied, nil
 }
 
-func (s *fakeBatchStore) ListDueBatchJobs(ctx context.Context, provider string, now time.Time, limit int) ([]*cstables.TableBatchJob, error) {
-	var jobs []*cstables.TableBatchJob
+func (s *fakeBatchStore) ListDueProviderJobs(ctx context.Context, kind, provider string, now time.Time, limit int) ([]*cstables.TableProviderJob, error) {
+	var jobs []*cstables.TableProviderJob
+	if kind == "" {
+		kind = cstables.ProviderJobKindBatch
+	}
 	for _, job := range s.jobs {
+		// Mirror the real store: a sweeper only ever sees its own kind's rows.
+		jobKind := job.Kind
+		if jobKind == "" {
+			jobKind = cstables.ProviderJobKindBatch
+		}
+		if jobKind != kind {
+			continue
+		}
 		if provider != "" && job.Provider != provider {
 			continue
 		}
 		if job.NextCheckAt == nil || job.NextCheckAt.After(now) {
 			continue
 		}
-		if job.AccountingStatus == cstables.BatchJobAccountingStatusAccounted || job.AccountingStatus == cstables.BatchJobAccountingStatusUnpriceable {
+		if job.AccountingStatus == cstables.ProviderJobAccountingStatusAccounted || job.AccountingStatus == cstables.ProviderJobAccountingStatusUnpriceable {
 			continue
 		}
 		jobs = append(jobs, job)
@@ -102,23 +113,30 @@ func (s *fakeBatchStore) ListDueBatchJobs(ctx context.Context, provider string, 
 	return jobs, nil
 }
 
-func (s *fakeBatchStore) ClaimBatchJob(ctx context.Context, jobID, runnerID string, staleBefore time.Time, allowUnpriceable bool) (bool, error) {
+func (s *fakeBatchStore) ClaimProviderJob(ctx context.Context, jobID, runnerID string, staleBefore time.Time, allowUnpriceable bool) (bool, error) {
 	entry, ok := s.jobs[jobID]
 	if !ok {
 		return false, errors.New("missing batch job")
 	}
-	if entry.AccountingStatus == cstables.BatchJobAccountingStatusAccounted || entry.AccountingStatus == cstables.BatchJobAccountingStatusUnpriceable {
+	if entry.AccountingStatus == cstables.ProviderJobAccountingStatusAccounted {
+		return false, nil
+	}
+	// "unpriceable" is a stop-polling marker, not a refusal of money: a caller
+	// holding real results may re-drive it. Mirrors the real store's allowUnpriceable,
+	// which this fake previously ignored — hiding the result-driven re-accounting path
+	// from every test using it.
+	if entry.AccountingStatus == cstables.ProviderJobAccountingStatusUnpriceable && !allowUnpriceable {
 		return false, nil
 	}
 	// Claim staleness reads claimed_at, not updated_at — updated_at is refreshed by
-	// the unfenced UpsertBatchJob, so it cannot represent claim age.
-	if entry.AccountingStatus == cstables.BatchJobAccountingStatusProcessing &&
+	// the unfenced UpsertProviderJob, so it cannot represent claim age.
+	if entry.AccountingStatus == cstables.ProviderJobAccountingStatusProcessing &&
 		entry.ClaimedAt != nil && entry.ClaimedAt.After(staleBefore) {
 		return false, nil
 	}
 	now := time.Now().UTC()
 	rid := runnerID
-	entry.AccountingStatus = cstables.BatchJobAccountingStatusProcessing
+	entry.AccountingStatus = cstables.ProviderJobAccountingStatusProcessing
 	entry.RunnerID = &rid
 	entry.ClaimedAt = &now
 	entry.UpdatedAt = now
@@ -139,7 +157,7 @@ func (s *fakeBatchStore) markTerminal(id, status, reason string) error {
 	return nil
 }
 
-func (s *fakeBatchStore) MarkBatchJobAggregateLogWritten(ctx context.Context, id, runnerID string) error {
+func (s *fakeBatchStore) MarkProviderJobAggregateLogWritten(ctx context.Context, id, runnerID string) error {
 	entry, ok := s.jobs[id]
 	if !ok {
 		return errors.New("missing batch job")
@@ -149,7 +167,7 @@ func (s *fakeBatchStore) MarkBatchJobAggregateLogWritten(ctx context.Context, id
 	return nil
 }
 
-func (s *fakeBatchStore) MarkBatchJobGovernanceReported(ctx context.Context, id, runnerID string) error {
+func (s *fakeBatchStore) MarkProviderJobGovernanceReported(ctx context.Context, id, runnerID string) error {
 	entry, ok := s.jobs[id]
 	if !ok {
 		return errors.New("missing batch job")
@@ -159,16 +177,16 @@ func (s *fakeBatchStore) MarkBatchJobGovernanceReported(ctx context.Context, id,
 	return nil
 }
 
-func (s *fakeBatchStore) CompleteBatchJob(ctx context.Context, id, runnerID string) error {
-	return s.markTerminal(id, cstables.BatchJobAccountingStatusAccounted, "")
+func (s *fakeBatchStore) CompleteProviderJob(ctx context.Context, id, runnerID string) error {
+	return s.markTerminal(id, cstables.ProviderJobAccountingStatusAccounted, "")
 }
 
-func (s *fakeBatchStore) MarkBatchJobUnpriceable(ctx context.Context, id, runnerID, reason string, err error) error {
-	return s.markTerminal(id, cstables.BatchJobAccountingStatusUnpriceable, reason)
+func (s *fakeBatchStore) MarkProviderJobUnpriceable(ctx context.Context, id, runnerID, reason string, err error) error {
+	return s.markTerminal(id, cstables.ProviderJobAccountingStatusUnpriceable, reason)
 }
 
-func (s *fakeBatchStore) FailBatchJob(ctx context.Context, id, runnerID string, err error) error {
-	return s.markTerminal(id, cstables.BatchJobAccountingStatusError, "")
+func (s *fakeBatchStore) FailProviderJob(ctx context.Context, id, runnerID string, err error) error {
+	return s.markTerminal(id, cstables.ProviderJobAccountingStatusError, "")
 }
 
 func newTestStore(t *testing.T) logstore.LogStore {
@@ -458,7 +476,7 @@ func TestPostLLMHookNoPendingErrorPreservesMetadata(t *testing.T) {
 	}
 }
 
-func TestEmitBatchAggregateLogRunsCallback(t *testing.T) {
+func TestEmitAggregateLogRunsCallback(t *testing.T) {
 	store := newTestStore(t)
 	plugin := &LoggerPlugin{
 		ctx:   context.Background(),
@@ -477,7 +495,7 @@ func TestEmitBatchAggregateLogRunsCallback(t *testing.T) {
 		Model:     "gpt-4o-mini",
 		Status:    "success",
 	}
-	plugin.EmitBatchAggregateLog(context.Background(), entry)
+	plugin.EmitAggregateLog(context.Background(), entry)
 	if callbacks != 1 {
 		t.Fatalf("callback count after emit = %d, want 1", callbacks)
 	}
@@ -2726,12 +2744,12 @@ func TestRecordBatchJobLifecycle_CompletedSetsNextCheckAt(t *testing.T) {
 			}
 			plugin.recordBatchJobLifecycle(entry, result)
 
-			job, err := bs.GetBatchJob(context.Background(), cstables.BatchJobID("openai", batchID))
+			job, err := bs.GetProviderJob(context.Background(), cstables.ProviderJobID(cstables.ProviderJobKindBatch, "openai", batchID))
 			if err != nil {
-				t.Fatalf("GetBatchJob() error = %v", err)
+				t.Fatalf("GetProviderJob() error = %v", err)
 			}
-			if job.BatchID != batchID {
-				t.Fatalf("expected batch_id %s, got %s", batchID, job.BatchID)
+			if job.JobID != batchID {
+				t.Fatalf("expected batch_id %s, got %s", batchID, job.JobID)
 			}
 			if job.ProviderStatus != tt.status {
 				t.Fatalf("expected status %s, got %s", tt.status, job.ProviderStatus)
@@ -2787,9 +2805,9 @@ func TestRecordBatchJobLifecycle_CreatePersistsModel(t *testing.T) {
 	}
 	plugin.recordBatchJobLifecycle(entry, result)
 
-	job, err := bs.GetBatchJob(context.Background(), cstables.BatchJobID("openai", "batch-create-123"))
+	job, err := bs.GetProviderJob(context.Background(), cstables.ProviderJobID(cstables.ProviderJobKindBatch, "openai", "batch-create-123"))
 	if err != nil {
-		t.Fatalf("GetBatchJob() error = %v", err)
+		t.Fatalf("GetProviderJob() error = %v", err)
 	}
 	if job.Model != "gpt-4o" {
 		t.Fatalf("expected model %s, got %s", "gpt-4o", job.Model)
@@ -2797,8 +2815,8 @@ func TestRecordBatchJobLifecycle_CreatePersistsModel(t *testing.T) {
 	if job.InputFileID != "file-abc" {
 		t.Fatalf("expected input_file_id %s, got %s", "file-abc", job.InputFileID)
 	}
-	if job.AccountingStatus != cstables.BatchJobAccountingStatusPending {
-		t.Fatalf("expected accounting_status %s, got %s", cstables.BatchJobAccountingStatusPending, job.AccountingStatus)
+	if job.AccountingStatus != cstables.ProviderJobAccountingStatusPending {
+		t.Fatalf("expected accounting_status %s, got %s", cstables.ProviderJobAccountingStatusPending, job.AccountingStatus)
 	}
 }
 
@@ -2827,9 +2845,9 @@ func TestAccountBatchResults_NonResultsResponseIsNoop(t *testing.T) {
 	plugin.accountBatchResults(entry, nonResultsResult, nil)
 
 	// Verify no batch_jobs rows were created
-	jobs, err := bs.ListDueBatchJobs(context.Background(), "openai", time.Now().UTC().Add(time.Hour), 100)
+	jobs, err := bs.ListDueProviderJobs(context.Background(), cstables.ProviderJobKindBatch, "openai", time.Now().UTC().Add(time.Hour), 100)
 	if err != nil {
-		t.Fatalf("ListDueBatchJobs() error = %v", err)
+		t.Fatalf("ListDueProviderJobs() error = %v", err)
 	}
 	if len(jobs) > 0 {
 		t.Fatalf("expected no batch jobs from non-batch-response, got %d", len(jobs))
@@ -2861,12 +2879,12 @@ func TestAccountBatchResults_EmptyResultsMarksUnpriceable(t *testing.T) {
 
 	plugin.accountBatchResults(entry, result, nil)
 
-	job, err := bs.GetBatchJob(context.Background(), cstables.BatchJobID("openai", "batch-empty-results"))
+	job, err := bs.GetProviderJob(context.Background(), cstables.ProviderJobID(cstables.ProviderJobKindBatch, "openai", "batch-empty-results"))
 	if err != nil {
-		t.Fatalf("GetBatchJob() error = %v", err)
+		t.Fatalf("GetProviderJob() error = %v", err)
 	}
-	if job.AccountingStatus != cstables.BatchJobAccountingStatusUnpriceable {
-		t.Fatalf("expected accounting_status %s, got %s", cstables.BatchJobAccountingStatusUnpriceable, job.AccountingStatus)
+	if job.AccountingStatus != cstables.ProviderJobAccountingStatusUnpriceable {
+		t.Fatalf("expected accounting_status %s, got %s", cstables.ProviderJobAccountingStatusUnpriceable, job.AccountingStatus)
 	}
 	if job.UnpriceableReason == nil || *job.UnpriceableReason != jobaccounting.UnpriceableReasonNoResults {
 		t.Fatalf("expected unpriceable_reason %s, got %#v", jobaccounting.UnpriceableReasonNoResults, job.UnpriceableReason)
@@ -2958,11 +2976,11 @@ func TestAccountBatchResults_RepeatedFetchDisplaysPriceWithoutBilling(t *testing
 // provider: the point of the test below is that it is never reached.
 type noopBatchFetcher struct{}
 
-func (noopBatchFetcher) RetrieveBatch(context.Context, *cstables.TableBatchJob) (*schemas.BifrostBatchRetrieveResponse, error) {
+func (noopBatchFetcher) RetrieveBatch(context.Context, *cstables.TableProviderJob) (*schemas.BifrostBatchRetrieveResponse, error) {
 	return nil, nil
 }
 
-func (noopBatchFetcher) FetchBatchResults(context.Context, *cstables.TableBatchJob) (*schemas.BifrostBatchResultsResponse, error) {
+func (noopBatchFetcher) FetchBatchResults(context.Context, *cstables.TableProviderJob) (*schemas.BifrostBatchResultsResponse, error) {
 	return nil, nil
 }
 
@@ -3031,9 +3049,9 @@ func TestRecordBatchJobLifecycle_CreatePersistsRequesterIdentity(t *testing.T) {
 		},
 	})
 
-	job, err := bs.GetBatchJob(context.Background(), cstables.BatchJobID("openai", "batch-identity-123"))
+	job, err := bs.GetProviderJob(context.Background(), cstables.ProviderJobID(cstables.ProviderJobKindBatch, "openai", "batch-identity-123"))
 	if err != nil {
-		t.Fatalf("GetBatchJob() error = %v", err)
+		t.Fatalf("GetProviderJob() error = %v", err)
 	}
 	if job.UserID == nil || *job.UserID != userID {
 		t.Fatalf("expected user_id %s, got %v", userID, job.UserID)

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1748,39 +1748,39 @@ func (m *MockConfigStore) SyncRoutingRules(ctx context.Context, toAdd []tables.T
 }
 
 // Batch jobs
-func (m *MockConfigStore) UpsertBatchJob(ctx context.Context, job *tables.TableBatchJob) error {
+func (m *MockConfigStore) UpsertProviderJob(ctx context.Context, job *tables.TableProviderJob) error {
 	return nil
 }
 
-func (m *MockConfigStore) GetBatchJob(ctx context.Context, jobID string) (*tables.TableBatchJob, error) {
+func (m *MockConfigStore) GetProviderJob(ctx context.Context, jobID string) (*tables.TableProviderJob, error) {
 	return nil, nil
 }
 
-func (m *MockConfigStore) ListDueBatchJobs(ctx context.Context, provider string, now time.Time, limit int) ([]*tables.TableBatchJob, error) {
+func (m *MockConfigStore) ListDueProviderJobs(ctx context.Context, kind, provider string, now time.Time, limit int) ([]*tables.TableProviderJob, error) {
 	return nil, nil
 }
 
-func (m *MockConfigStore) ClaimBatchJob(ctx context.Context, jobID, runnerID string, staleBefore time.Time, allowUnpriceable bool) (bool, error) {
+func (m *MockConfigStore) ClaimProviderJob(ctx context.Context, jobID, runnerID string, staleBefore time.Time, allowUnpriceable bool) (bool, error) {
 	return false, nil
 }
 
-func (m *MockConfigStore) MarkBatchJobAggregateLogWritten(ctx context.Context, jobID, runnerID string) error {
+func (m *MockConfigStore) MarkProviderJobAggregateLogWritten(ctx context.Context, jobID, runnerID string) error {
 	return nil
 }
 
-func (m *MockConfigStore) MarkBatchJobGovernanceReported(ctx context.Context, jobID, runnerID string) error {
+func (m *MockConfigStore) MarkProviderJobGovernanceReported(ctx context.Context, jobID, runnerID string) error {
 	return nil
 }
 
-func (m *MockConfigStore) CompleteBatchJob(ctx context.Context, jobID, runnerID string) error {
+func (m *MockConfigStore) CompleteProviderJob(ctx context.Context, jobID, runnerID string) error {
 	return nil
 }
 
-func (m *MockConfigStore) MarkBatchJobUnpriceable(ctx context.Context, jobID, runnerID, reason string, err error) error {
+func (m *MockConfigStore) MarkProviderJobUnpriceable(ctx context.Context, jobID, runnerID, reason string, err error) error {
 	return nil
 }
 
-func (m *MockConfigStore) FailBatchJob(ctx context.Context, jobID, runnerID string, err error) error {
+func (m *MockConfigStore) FailProviderJob(ctx context.Context, jobID, runnerID string, err error) error {
 	return nil
 }
 

--- a/transports/bifrost-http/server/batch_accounting.go
+++ b/transports/bifrost-http/server/batch_accounting.go
@@ -19,7 +19,7 @@ type bifrostBatchResultFetcher struct {
 	client *bifrost.Bifrost
 }
 
-func (f *bifrostBatchResultFetcher) RetrieveBatch(ctx context.Context, job *cstables.TableBatchJob) (*schemas.BifrostBatchRetrieveResponse, error) {
+func (f *bifrostBatchResultFetcher) RetrieveBatch(ctx context.Context, job *cstables.TableProviderJob) (*schemas.BifrostBatchRetrieveResponse, error) {
 	if f == nil || f.client == nil {
 		return nil, fmt.Errorf("bifrost client is nil")
 	}
@@ -29,7 +29,7 @@ func (f *bifrostBatchResultFetcher) RetrieveBatch(ctx context.Context, job *csta
 	resp, bifrostErr := f.client.BatchRetrieveRequest(internalBatchContext(ctx), &schemas.BifrostBatchRetrieveRequest{
 		Provider: schemas.ModelProvider(job.Provider),
 		Model:    modelPtr(job.Model),
-		BatchID:  job.BatchID,
+		BatchID:  job.JobID,
 	})
 	if bifrostErr != nil {
 		return nil, fmt.Errorf("%s", bifrostErr.GetErrorString())
@@ -37,7 +37,7 @@ func (f *bifrostBatchResultFetcher) RetrieveBatch(ctx context.Context, job *csta
 	return resp, nil
 }
 
-func (f *bifrostBatchResultFetcher) FetchBatchResults(ctx context.Context, job *cstables.TableBatchJob) (*schemas.BifrostBatchResultsResponse, error) {
+func (f *bifrostBatchResultFetcher) FetchBatchResults(ctx context.Context, job *cstables.TableProviderJob) (*schemas.BifrostBatchResultsResponse, error) {
 	if f == nil || f.client == nil {
 		return nil, fmt.Errorf("bifrost client is nil")
 	}
@@ -47,7 +47,7 @@ func (f *bifrostBatchResultFetcher) FetchBatchResults(ctx context.Context, job *
 	resp, bifrostErr := f.client.BatchResultsRequest(internalBatchContext(ctx), &schemas.BifrostBatchResultsRequest{
 		Provider: schemas.ModelProvider(job.Provider),
 		Model:    modelPtr(job.Model),
-		BatchID:  job.BatchID,
+		BatchID:  job.JobID,
 	})
 	if bifrostErr != nil {
 		return nil, fmt.Errorf("%s", bifrostErr.GetErrorString())


### PR DESCRIPTION
## Summary

Generalises the `batch_jobs` table and its surrounding machinery from a batch-only concept to a shared `provider_job` abstraction that can hold any kind of provider-side async job (batch, video, etc.). This is the prerequisite for video generation accounting, which needs the same poll-claim-settle lifecycle that batch accounting already has.

## Changes

- Renamed `TableBatchJob` → `TableProviderJob`, `BatchJobID` → `ProviderJobID`, and all `BatchJob*` constants to `ProviderJob*` equivalents across the store, interfaces, engine, sweeper, and plugins.
- Added a `kind` column (`VARCHAR(50) NOT NULL DEFAULT 'batch'`) and a `params` column (`TEXT`) to `batch_jobs`. The `kind` default backfills every pre-existing row as `batch` with no `UPDATE` required.
- Widened the identity unique index from `(provider, batch_id)` to `(provider, kind, batch_id)` so a video job can legitimately carry the same provider-side id as a batch without a uniqueness collision. The sweeper index gains `kind` as its leading column.
- `ListDueProviderJobs` now takes a mandatory `kind` argument. Each sweeper only ever sees rows for its own kind, preventing a batch sweeper from polling video rows with the wrong client.
- `ProviderJobID` preserves the exact `"batch-job:<provider>:<id>"` format for batch rows so no existing primary key is orphaned.
- Renamed `EmitBatchAggregateLog` → `EmitAggregateLog`, `ReportBatchUsage` → `ReportUsage` on the `AggregateLogEmitter` and `UsageReporter` interfaces.
- Added a migration (`add_provider_job_kind_columns`) with a guarded rollback that refuses to proceed if non-batch rows exist, since dropping `kind` over mixed data would merge them into the batch namespace and cause double-settlement.
- Added `ProviderJobKindVideo` constant alongside `ProviderJobKindBatch`.
- Added regression tests pinning the batch primary key format as frozen, and tests verifying that `ListDueProviderJobs` filters strictly by kind.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/... ./framework/jobaccounting/... ./plugins/governance/... ./plugins/logging/... ./transports/bifrost-http/...
```

The migration tests cover both SQLite and Postgres (Postgres is skipped automatically if unavailable). Key scenarios validated:

- Pre-existing batch rows gain `kind='batch'` via column default with no row-level `UPDATE`.
- The widened identity index allows a video job to share a provider-side id with a batch.
- The rollback refuses while non-batch rows exist and leaves the schema untouched on refusal.
- `ListDueProviderJobs` with `kind='batch'` never returns video rows and vice versa.
- The batch primary key format `"batch-job:<provider>:<id>"` is byte-identical before and after.

## Breaking changes

- [x] Yes
- [ ] No

Any code implementing `JobStore`, `SweepStore`, `AggregateLogEmitter`, or `UsageReporter` must be updated to use the renamed methods (`UpsertProviderJob`, `ListDueProviderJobs` with the new `kind` parameter, `EmitAggregateLog`, `ReportUsage`). The `TableBatchJob` type and `BatchJob*` constants are gone; callers must use `TableProviderJob` and `ProviderJob*`. The `BatchID` field on the struct is now `JobID` (the backing column name `batch_id` is unchanged for rolling-deploy safety).

## Related issues

Prerequisite for video generation accounting.

## Security considerations

None beyond the existing accounting isolation guarantees. The runner-id ownership fence and claim staleness logic are unchanged.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable