### PR TITLE
feat: video costs wired in job accounting

### DIFF
--- a/framework/jobaccounting/batch_test.go
+++ b/framework/jobaccounting/batch_test.go
@@ -54,7 +54,7 @@ func (s *fakeAccountingStore) FindByID(ctx context.Context, id string) (*logstor
 
 func (s *fakeAccountingStore) UpsertProviderJob(ctx context.Context, job *cstables.TableProviderJob) error {
 	if job.ID == "" {
-		job.ID = cstables.ProviderJobID(cstables.ProviderJobKindBatch, job.Provider, job.JobID)
+		job.ID = cstables.ProviderJobID(job.Kind, job.Provider, job.JobID)
 	}
 	existing, ok := s.jobs[job.ID]
 	if !ok {
@@ -244,9 +244,29 @@ func (s *fakeAccountingStore) FailProviderJob(ctx context.Context, id, runnerID 
 	return nil
 }
 
-type fakeBatchPricing struct{}
+type fakePricing struct{}
 
-func (fakeBatchPricing) CalculateBatchCostDetailsForUsage(usage *schemas.BifrostLLMUsage, provider schemas.ModelProvider, model string, requestType schemas.RequestType, scopes *modelcatalog.PricingLookupScopes) modelcatalog.BatchCostDetails {
+// Video rates for the settler tests: a per-second, per-clip rate for one known
+// model, banded on 1080p, and nothing at all for anything else — enough to
+// exercise priced / unpriced / provider-cost-wins without a real catalog.
+func (fakePricing) CalculateVideoCostDetails(dims modelcatalog.VideoPricingDimensions, provider schemas.ModelProvider, scopes *modelcatalog.PricingLookupScopes) modelcatalog.VideoCostDetails {
+	if dims.ProviderCost != nil && *dims.ProviderCost > 0 {
+		return modelcatalog.VideoCostDetails{Cost: *dims.ProviderCost, Priced: true, ProviderCostUsed: true}
+	}
+	if dims.Model != "sora-2-pro" || dims.Seconds == nil || *dims.Seconds <= 0 {
+		return modelcatalog.VideoCostDetails{}
+	}
+	rate := 0.30
+	if dims.Size == "1920x1080" {
+		rate = 0.70
+	}
+	return modelcatalog.VideoCostDetails{
+		Cost:   float64(*dims.Seconds) * rate * float64(max(1, dims.OutputCount)),
+		Priced: true,
+	}
+}
+
+func (fakePricing) CalculateBatchCostDetailsForUsage(usage *schemas.BifrostLLMUsage, provider schemas.ModelProvider, model string, requestType schemas.RequestType, scopes *modelcatalog.PricingLookupScopes) modelcatalog.BatchCostDetails {
 	if usage == nil || requestType != schemas.BatchResultsRequest {
 		return modelcatalog.BatchCostDetails{}
 	}
@@ -296,6 +316,11 @@ func (p *requestTypePricing) CalculateBatchCostDetailsForUsage(usage *schemas.Bi
 	return modelcatalog.BatchCostDetails{Cost: float64(usage.PromptTokens), Priced: true}
 }
 
+// This fake exists to record batch request types; video pricing is fakePricing's job.
+func (p *requestTypePricing) CalculateVideoCostDetails(dims modelcatalog.VideoPricingDimensions, provider schemas.ModelProvider, scopes *modelcatalog.PricingLookupScopes) modelcatalog.VideoCostDetails {
+	return modelcatalog.VideoCostDetails{}
+}
+
 func (r *fakeUsageReporter) ReportUsage(ctx context.Context, report UsageReport) error {
 	r.reports = append(r.reports, report)
 	return nil
@@ -328,7 +353,7 @@ func TestAccountBatchResults_OpenAIAggregatesAndWritesOnce(t *testing.T) {
 		},
 	}
 
-	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, req)
+	summary, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, req)
 	require.NoError(t, err)
 	require.NotNil(t, summary)
 	assert.True(t, summary.Accounted)
@@ -364,7 +389,7 @@ func TestAccountBatchResults_OpenAIAggregatesAndWritesOnce(t *testing.T) {
 	// A repeat call (e.g. a second /results fetch) does not win the claim and
 	// writes nothing new, but still mirrors the already-settled price so the
 	// caller can display it.
-	second, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, req)
+	second, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, req)
 	require.NoError(t, err)
 	require.NotNil(t, second)
 	assert.False(t, second.Claimed)
@@ -380,7 +405,7 @@ func TestAccountBatchResults_MissingModelMarksUnpriceable(t *testing.T) {
 	store := newFakeAccountingStore()
 	result := openAIResult(200, "", 18, 9)
 
-	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	summary, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "batch_missing_model",
 		ClaimedBy:     "test-node",
@@ -413,7 +438,7 @@ func TestAccountBatchResults_MissingModelMarksUnpriceable(t *testing.T) {
 func TestAccountBatchResults_MissingBatchPricingMarksUnpriceable(t *testing.T) {
 	store := newFakeAccountingStore()
 
-	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	summary, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		ClaimedBy:     "test-node",
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "batch_missing_pricing",
@@ -463,7 +488,7 @@ func TestAccountBatchResults_ProviderCostPassthrough(t *testing.T) {
 		"total_cost": 0.123,
 	}
 
-	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	summary, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "batch_provider_cost",
 		ClaimedBy:     "test-node",
@@ -488,7 +513,7 @@ func TestAccountBatchResults_ZeroProviderCostIsStillPriced(t *testing.T) {
 		"total_cost": 0.0,
 	}
 
-	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	summary, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		ClaimedBy:     "test-node",
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "batch_zero_cost",
@@ -506,7 +531,7 @@ func TestAccountBatchResults_ZeroProviderCostIsStillPriced(t *testing.T) {
 func TestAccountBatchResults_AnthropicAggregatesUsage(t *testing.T) {
 	store := newFakeAccountingStore()
 
-	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	summary, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		ClaimedBy:     "test-node",
 		Provider:      schemas.Anthropic,
 		ProviderJobID: "anthropic_batch",
@@ -529,7 +554,7 @@ func TestAccountBatchResults_AnthropicAggregatesUsage(t *testing.T) {
 func TestAccountBatchResults_BedrockAggregatesUsageFromResponseBody(t *testing.T) {
 	store := newFakeAccountingStore()
 
-	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	summary, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		ClaimedBy:     "test-node",
 		Provider:      schemas.Bedrock,
 		ProviderJobID: "bedrock_batch",
@@ -553,7 +578,7 @@ func TestAccountBatchResults_BedrockAggregatesUsageFromResponseBody(t *testing.T
 func TestAccountBatchResults_BedrockIncludesCacheDetailsInPromptUsage(t *testing.T) {
 	store := newFakeAccountingStore()
 
-	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	summary, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		ClaimedBy:     "test-node",
 		Provider:      schemas.Bedrock,
 		ProviderJobID: "bedrock_cache_batch",
@@ -597,7 +622,7 @@ func TestAccountBatchResults_BedrockIncludesCacheDetailsInPromptUsage(t *testing
 func TestAccountBatchResults_GeminiAggregatesUsageFromResponseBody(t *testing.T) {
 	store := newFakeAccountingStore()
 
-	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	summary, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		ClaimedBy:     "test-node",
 		Provider:      schemas.Gemini,
 		ProviderJobID: "gemini_batch",
@@ -623,7 +648,7 @@ func TestAccountBatchResults_UsesAggregateWriterAndUsageReporter(t *testing.T) {
 	writer := &fakeAggregateLogWriter{}
 	reporter := &fakeUsageReporter{}
 
-	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	summary, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		ClaimedBy:     "test-node",
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "batch_writer",
@@ -662,13 +687,13 @@ func TestAccountBatchResults_RetryAfterCompleteFailureDoesNotReportGovernanceTwi
 		},
 	}
 
-	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, req)
+	summary, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, req)
 	require.Error(t, err)
 	require.Nil(t, summary)
 	require.Len(t, writer.emitted, 1)
 	require.Len(t, reporter.reports, 1)
 
-	summary, err = AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, req)
+	summary, err = AccountBatchResults(context.Background(), store, store, fakePricing{}, req)
 	require.NoError(t, err)
 	require.NotNil(t, summary)
 	assert.True(t, summary.Accounted)
@@ -681,7 +706,7 @@ func TestAccountBatchResults_RecordsPartialPricingMetadata(t *testing.T) {
 	store := newFakeAccountingStore()
 	reporter := &fakeUsageReporter{}
 
-	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	summary, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		ClaimedBy:     "test-node",
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "batch_partial",
@@ -801,7 +826,7 @@ func TestSweeper_AccountsCompletedOpenAIJob(t *testing.T) {
 			},
 		},
 	}
-	sweeper := NewBatchSweeper(store, store, fakeBatchPricing{}, fetcher, nil, nil, SweeperConfig{
+	sweeper := NewBatchSweeper(store, store, fakePricing{}, fetcher, nil, nil, SweeperConfig{
 		Provider: schemas.OpenAI,
 		Limit:    10,
 	})
@@ -841,7 +866,7 @@ func TestSweeper_AccountsCompletedAnthropicJob(t *testing.T) {
 			},
 		},
 	}
-	sweeper := NewBatchSweeper(store, store, fakeBatchPricing{}, fetcher, nil, nil, SweeperConfig{
+	sweeper := NewBatchSweeper(store, store, fakePricing{}, fetcher, nil, nil, SweeperConfig{
 		Limit: 10,
 	})
 
@@ -879,7 +904,7 @@ func TestSweeper_AccountsCompletedGeminiJob(t *testing.T) {
 			},
 		},
 	}
-	sweeper := NewBatchSweeper(store, store, fakeBatchPricing{}, fetcher, nil, nil, SweeperConfig{
+	sweeper := NewBatchSweeper(store, store, fakePricing{}, fetcher, nil, nil, SweeperConfig{
 		Limit: 10,
 	})
 
@@ -907,7 +932,7 @@ func TestSweeper_SkipsProviderPollWhenKVLeaseIsHeld(t *testing.T) {
 
 	fetcher := &fakeBatchResultFetcher{}
 	kv := &fakeKVStore{setNXAllowed: false}
-	sweeper := NewBatchSweeper(store, store, fakeBatchPricing{}, fetcher, nil, nil, SweeperConfig{
+	sweeper := NewBatchSweeper(store, store, fakePricing{}, fetcher, nil, nil, SweeperConfig{
 		Provider: schemas.OpenAI,
 		Limit:    10,
 		KVStore:  kv,
@@ -938,7 +963,7 @@ func TestSweeper_ReleasesProviderPollLeaseAfterSuccessfulPoll(t *testing.T) {
 		Status: schemas.BatchStatusInProgress,
 	}}
 	kv := &fakeKVStore{setNXAllowed: true}
-	sweeper := NewBatchSweeper(store, store, fakeBatchPricing{}, fetcher, nil, nil, SweeperConfig{
+	sweeper := NewBatchSweeper(store, store, fakePricing{}, fetcher, nil, nil, SweeperConfig{
 		Provider: schemas.OpenAI,
 		Limit:    10,
 		KVStore:  kv,
@@ -970,7 +995,7 @@ func TestSweeper_RescheduleUsesBackoffAndJitter(t *testing.T) {
 			Status: schemas.BatchStatusInProgress,
 		},
 	}
-	sweeper := NewBatchSweeper(store, store, fakeBatchPricing{}, fetcher, nil, nil, SweeperConfig{
+	sweeper := NewBatchSweeper(store, store, fakePricing{}, fetcher, nil, nil, SweeperConfig{
 		Interval: time.Minute,
 		Limit:    10,
 	})
@@ -1010,7 +1035,7 @@ func TestSweeper_ExpiredBatchSettlesTheRowsThatCompleted(t *testing.T) {
 			Results: []schemas.BatchResultItem{openAIResult(200, "gpt-4o-mini", 18, 9)},
 		},
 	}
-	sweeper := NewBatchSweeper(store, store, fakeBatchPricing{}, fetcher, nil, nil, SweeperConfig{Limit: 10})
+	sweeper := NewBatchSweeper(store, store, fakePricing{}, fetcher, nil, nil, SweeperConfig{Limit: 10})
 
 	sweeper.SweepOnce(context.Background())
 
@@ -1039,7 +1064,7 @@ func TestSweeper_ExpiredBatchWithoutResultsIsTerminalWithoutResults(t *testing.T
 		},
 		resultsResp: &schemas.BifrostBatchResultsResponse{BatchID: "batch_expired_empty"},
 	}
-	sweeper := NewBatchSweeper(store, store, fakeBatchPricing{}, fetcher, nil, nil, SweeperConfig{Limit: 10})
+	sweeper := NewBatchSweeper(store, store, fakePricing{}, fetcher, nil, nil, SweeperConfig{Limit: 10})
 
 	sweeper.SweepOnce(context.Background())
 
@@ -1067,7 +1092,7 @@ func TestSweeper_DeletedBatchDoesNotFetchResults(t *testing.T) {
 		ID:     "batch_deleted",
 		Status: schemas.BatchStatusDeleted,
 	}}
-	sweeper := NewBatchSweeper(store, store, fakeBatchPricing{}, fetcher, nil, nil, SweeperConfig{Limit: 10})
+	sweeper := NewBatchSweeper(store, store, fakePricing{}, fetcher, nil, nil, SweeperConfig{Limit: 10})
 
 	sweeper.SweepOnce(context.Background())
 
@@ -1103,7 +1128,7 @@ func TestSweeper_ReschedulesAfterSettlementFailure(t *testing.T) {
 			Results: []schemas.BatchResultItem{openAIResult(200, "gpt-4o-mini", 18, 9)},
 		},
 	}
-	sweeper := NewBatchSweeper(store, store, fakeBatchPricing{}, fetcher, nil, nil, SweeperConfig{
+	sweeper := NewBatchSweeper(store, store, fakePricing{}, fetcher, nil, nil, SweeperConfig{
 		Interval: time.Minute,
 		Limit:    10,
 	})
@@ -1145,7 +1170,7 @@ func TestSweeper_SettlementFailureHitsPollAttemptCap(t *testing.T) {
 			Results: []schemas.BatchResultItem{openAIResult(200, "gpt-4o-mini", 18, 9)},
 		},
 	}
-	sweeper := NewBatchSweeper(store, store, fakeBatchPricing{}, fetcher, nil, nil, SweeperConfig{
+	sweeper := NewBatchSweeper(store, store, fakePricing{}, fetcher, nil, nil, SweeperConfig{
 		Interval: time.Minute,
 		Limit:    10,
 	})
@@ -1236,7 +1261,7 @@ func TestAccountBatchResults_ExternalBatchWithoutRow(t *testing.T) {
 	writer := &fakeAggregateLogWriter{}
 	reporter := &fakeUsageReporter{}
 
-	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	summary, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "ext-batch-no-job",
 		FallbackModel: "gpt-4o-mini",
@@ -1325,7 +1350,7 @@ func TestUsageFromValue_CacheTokenConventions(t *testing.T) {
 func TestAccountBatchResults_MixedMissingModelIsNotAttributed(t *testing.T) {
 	store := newFakeAccountingStore()
 
-	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	summary, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "batch_mixed_unpriced",
 		ClaimedBy:     "test",
@@ -1357,15 +1382,15 @@ func TestNewSweeperDefaultsToDistinctRunnerIDs(t *testing.T) {
 	store := newFakeAccountingStore()
 	cfg := SweeperConfig{Interval: time.Minute}
 
-	a := NewBatchSweeper(store, store, fakeBatchPricing{}, &fakeBatchResultFetcher{}, nil, nil, cfg)
-	b := NewBatchSweeper(store, store, fakeBatchPricing{}, &fakeBatchResultFetcher{}, nil, nil, cfg)
+	a := NewBatchSweeper(store, store, fakePricing{}, &fakeBatchResultFetcher{}, nil, nil, cfg)
+	b := NewBatchSweeper(store, store, fakePricing{}, &fakeBatchResultFetcher{}, nil, nil, cfg)
 
 	assert.NotEmpty(t, a.config.ClaimedBy)
 	assert.NotEqual(t, a.config.ClaimedBy, b.config.ClaimedBy,
 		"two sweepers defaulting ClaimedBy must not share a runner identity")
 
 	// An explicit id is still honored untouched.
-	explicit := NewBatchSweeper(store, store, fakeBatchPricing{}, &fakeBatchResultFetcher{}, nil, nil,
+	explicit := NewBatchSweeper(store, store, fakePricing{}, &fakeBatchResultFetcher{}, nil, nil,
 		SweeperConfig{Interval: time.Minute, ClaimedBy: "node-7"})
 	assert.Equal(t, "node-7", explicit.config.ClaimedBy)
 }
@@ -1378,7 +1403,7 @@ func TestAccountBatchResults_PersistedJobReadFailureFailsClosed(t *testing.T) {
 	reporter := &fakeUsageReporter{}
 	store.failGetOnce = true
 
-	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	summary, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "read-failure",
 		FallbackModel: "gpt-4o-mini",
@@ -1409,7 +1434,7 @@ func TestAccountBatchResults_PersistedJobReadFailureFailsClosed(t *testing.T) {
 func TestAccountBatchResults_ParseErrorsStillPriceTheParsedRows(t *testing.T) {
 	store := newFakeAccountingStore()
 	reporter := &fakeUsageReporter{}
-	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	summary, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "malformed-results",
 		FallbackModel: "gpt-4o-mini",
@@ -1453,7 +1478,7 @@ func TestAccountBatchResults_ParseErrorsStillPriceTheParsedRows(t *testing.T) {
 // they stay the reason the batch is unpriceable.
 func TestAccountBatchResults_AllRowsUnparseableMarksUnpriceable(t *testing.T) {
 	store := newFakeAccountingStore()
-	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	summary, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "all-malformed",
 		FallbackModel: "gpt-4o-mini",
@@ -1484,7 +1509,7 @@ func TestAccountBatchResults_PartiallyPricedBatchKeepsCostUnknown(t *testing.T) 
 	store := newFakeAccountingStore()
 	reporter := &fakeUsageReporter{}
 
-	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	summary, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "batch_half_priced",
 		UsageReporter: reporter,
@@ -1548,7 +1573,7 @@ func TestAccountBatchResults_PrefersBatchJobAttributionOverFetcher(t *testing.T)
 	}
 	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
 
-	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	summary, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "batch_attribution",
 		FallbackModel: "gpt-4o-mini",
@@ -1622,7 +1647,7 @@ func TestAccountBatchResults_FillsNamesFromSourceLog(t *testing.T) {
 	}
 	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
 
-	_, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	_, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "batch_same_vk",
 		FallbackModel: "gpt-4o-mini",
@@ -1682,7 +1707,7 @@ func TestAccountBatchResults_SharedVirtualKeyKeepsUsersApart(t *testing.T) {
 	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
 
 	// Bob fetches Alice's results. Same access-profile virtual key, different person.
-	_, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	_, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "batch_shared_vk",
 		FallbackModel: "gpt-4o-mini",
@@ -1747,7 +1772,7 @@ func TestAccountBatchResults_SweeperPathKeepsUserAttribution(t *testing.T) {
 	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
 
 	// No BaseLog: this is the sweeper, hours after the request that created the batch.
-	_, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	_, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "batch_sweeper",
 		FallbackModel: "gpt-4o-mini",
@@ -1781,7 +1806,7 @@ func TestAccountBatchResults_WithoutJobAttributionUsesBaseLog(t *testing.T) {
 	reporter := &fakeUsageReporter{}
 	fetcherVK := "vk-fetcher"
 
-	_, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	_, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "batch_external",
 		FallbackModel: "gpt-4o-mini",
@@ -1827,7 +1852,7 @@ func TestAccountBatchResults_ReclaimsUnpriceableJobWhenResultsArrive(t *testing.
 		UnpriceableReason: &reason,
 	}))
 
-	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	summary, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "batch_reclaim",
 		FallbackModel: "gpt-4o-mini",
@@ -1861,7 +1886,7 @@ func TestAccountBatchResults_LosingClaimWithNoExistingLogMirrorsNothing(t *testi
 		ClaimedAt:        &now,
 	}
 
-	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	summary, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "batch_in_flight",
 		FallbackModel: "gpt-4o-mini",
@@ -1901,7 +1926,7 @@ func TestAccountBatchResults_StatusPersistsAndMirrorsOnRepeatCall(t *testing.T) 
 		},
 	}
 
-	summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, req)
+	summary, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, req)
 	require.NoError(t, err)
 	require.NotNil(t, summary)
 	assert.True(t, summary.Accounted)
@@ -1914,7 +1939,7 @@ func TestAccountBatchResults_StatusPersistsAndMirrorsOnRepeatCall(t *testing.T) 
 
 	// A repeat call loses the claim; it must mirror the persisted status rather
 	// than re-deriving it from this call's own (possibly different) BatchJob hint.
-	second, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, req)
+	second, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, req)
 	require.NoError(t, err)
 	require.NotNil(t, second)
 	assert.False(t, second.Claimed)
@@ -1945,7 +1970,7 @@ func TestAccountBatchResults_TerminalJobsStayClosedWithoutResults(t *testing.T) 
 			if tc.status == cstables.ProviderJobAccountingStatusUnpriceable {
 				results = nil
 			}
-			summary, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+			summary, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 				Provider:      schemas.OpenAI,
 				ProviderJobID: "batch_closed",
 				ClaimedBy:     "test",
@@ -2002,7 +2027,7 @@ func TestAccountBatchResults_PersistedIdentityOverridesFetcherBuiltJob(t *testin
 		BudgetIDs:        &fetcherBudgets,
 	}
 
-	_, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	_, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "batch_merge",
 		FallbackModel: "gpt-4o-mini",
@@ -2037,7 +2062,7 @@ func TestAccountBatchResults_UnpriceableMarkerFailureReleasesTheClaim(t *testing
 	store.failUnpriceable = true
 
 	// No results: settlement is unpriceable, so it takes the marker path.
-	_, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	_, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "batch_unpriceable_release",
 		ClaimedBy:     "node-1",
@@ -2086,7 +2111,7 @@ func TestSweeper_FailedBatchKeepsPersistedOutputFileWhenRetrieveOmitsIt(t *testi
 			Results: []schemas.BatchResultItem{openAIResult(200, "gpt-4o-mini", 18, 9)},
 		},
 	}
-	sweeper := NewBatchSweeper(store, store, fakeBatchPricing{}, fetcher, nil, nil, SweeperConfig{Limit: 10})
+	sweeper := NewBatchSweeper(store, store, fakePricing{}, fetcher, nil, nil, SweeperConfig{Limit: 10})
 
 	sweeper.SweepOnce(context.Background())
 
@@ -2143,7 +2168,7 @@ func TestAccountJob_RestoresPersistedParamsForSettlement(t *testing.T) {
 	bare.Params = nil
 
 	settler := &paramsRecordingSettler{}
-	out, err := AccountJob(context.Background(), store, store, fakeBatchPricing{}, settler, JobRequest{
+	out, err := AccountJob(context.Background(), store, store, fakePricing{}, settler, JobRequest{
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "job_params",
 		Job:           &bare,
@@ -2162,7 +2187,7 @@ func TestAccountJob_RestoresPersistedParamsForSettlement(t *testing.T) {
 func TestAccountJob_RequiresARunnerID(t *testing.T) {
 	store := newFakeAccountingStore()
 
-	_, err := AccountBatchResults(context.Background(), store, store, fakeBatchPricing{}, JobRequest{
+	_, err := AccountBatchResults(context.Background(), store, store, fakePricing{}, JobRequest{
 		Provider:      schemas.OpenAI,
 		ProviderJobID: "batch_no_runner",
 		Payload:       BatchPayload{Results: []schemas.BatchResultItem{openAIResult(200, "gpt-4o-mini", 18, 9)}},

--- a/framework/jobaccounting/types.go
+++ b/framework/jobaccounting/types.go
@@ -88,6 +88,7 @@ type ModelUsage struct {
 
 type PricingManager interface {
 	CalculateBatchCostDetailsForUsage(usage *schemas.BifrostLLMUsage, provider schemas.ModelProvider, model string, requestType schemas.RequestType, scopes *modelcatalog.PricingLookupScopes) modelcatalog.BatchCostDetails
+	CalculateVideoCostDetails(dims modelcatalog.VideoPricingDimensions, provider schemas.ModelProvider, scopes *modelcatalog.PricingLookupScopes) modelcatalog.VideoCostDetails
 }
 
 // Settler supplies everything about a job kind that the engine does not know: how

--- a/framework/jobaccounting/video.go
+++ b/framework/jobaccounting/video.go
@@ -1,0 +1,287 @@
+package jobaccounting
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/google/uuid"
+	"github.com/maximhq/bifrost/core/schemas"
+	cstables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/logstore"
+	"github.com/maximhq/bifrost/framework/modelcatalog"
+)
+
+const ProviderJobKindVideo ProviderJobKind = cstables.ProviderJobKindVideo
+
+const (
+	UnpriceableReasonMissingVideoPricing = "missing_video_pricing"
+	// UnpriceableReasonVideoGone is a job the provider no longer knows about.
+	// Generated assets expire, so this is an ordinary end state, not an error.
+	UnpriceableReasonVideoGone = "video_gone"
+	// UnpriceableReasonContentFiltered is deliberately not a price. A safety-filtered
+	// job consumed real compute, but whether the provider bills for it is a
+	// per-provider policy none of them document consistently. Guessing free
+	// under-bills and guessing billable over-bills; parking it costs nothing, keeps
+	// the job re-drivable, and the existing missing-cost backfill can settle it in
+	// bulk once the policy is actually known.
+	UnpriceableReasonContentFiltered = "content_filtered_policy_unknown"
+)
+
+// videoLogNamespace keys the aggregate cost row for a settled video. It is its own
+// namespace so a video can never collide with a batch that happens to share a
+// provider-side id, and it is fixed forever: it is both the aggregate write's
+// idempotency key and the governance dedupe key.
+var videoLogNamespace = uuid.MustParse("b1e0f7c4-2a63-4d18-9f5b-6c0a3d8e41d7")
+
+func init() { RegisterLogNamespace(ProviderJobKindVideo, videoLogNamespace) }
+
+// videoProviders is the set Bifrost can actually settle video for. Every provider
+// implements the VideoGeneration method, so method presence proves nothing — this
+// is the list with a real implementation behind it.
+var videoProviders = map[schemas.ModelProvider]struct{}{
+	schemas.OpenAI:    {},
+	schemas.Gemini:    {},
+	schemas.Vertex:    {},
+	schemas.Replicate: {},
+	schemas.Runway:    {},
+	schemas.Runware:   {},
+}
+
+// VideoRetriever is the provider call the video settler needs: given a job row,
+// report where that job now stands.
+type VideoRetriever interface {
+	RetrieveVideo(ctx context.Context, job *cstables.TableProviderJob) (*schemas.BifrostVideoGenerationResponse, error)
+}
+
+// VideoSettler prices provider video jobs. It is the Settler for
+// ProviderJobKindVideo.
+//
+// retriever may be nil on the inline settlement path, where the caller already
+// holds a terminal response and never polls.
+type VideoSettler struct {
+	retriever VideoRetriever
+}
+
+func NewVideoSettler(retriever VideoRetriever) *VideoSettler {
+	return &VideoSettler{retriever: retriever}
+}
+
+// VideoPayload is the video kind's settlement input, carried opaquely by the engine
+// from Poll (or an inline caller) into Settle.
+type VideoPayload struct {
+	Response *schemas.BifrostVideoGenerationResponse
+}
+
+func (s *VideoSettler) Kind() ProviderJobKind { return ProviderJobKindVideo }
+
+func (s *VideoSettler) SupportsProvider(provider schemas.ModelProvider) bool {
+	_, ok := videoProviders[provider]
+	return ok
+}
+
+// Backoff is minutes where batch's is hours. A video job typically finishes in one
+// to five minutes, so the batch ladder would leave a finished job unsettled — and
+// its assets unreadable — for a quarter of an hour after it was ready.
+func (s *VideoSettler) Backoff(attempts int, interval time.Duration) time.Duration {
+	delay := interval
+	switch {
+	case attempts >= 40:
+		delay = maxDuration(delay, 5*time.Minute)
+	case attempts >= 20:
+		delay = maxDuration(delay, 2*time.Minute)
+	}
+	return delay
+}
+
+func (s *VideoSettler) Poll(ctx context.Context, job *cstables.TableProviderJob) (*PollResult, error) {
+	if s.retriever == nil {
+		return nil, fmt.Errorf("video retriever is nil")
+	}
+	callCtx, cancel := context.WithTimeout(ctx, defaultProviderPollTimeout)
+	defer cancel()
+
+	resp, err := s.retriever.RetrieveVideo(callCtx, job)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("video retrieve returned nil response for job %s", job.ID)
+	}
+	if resp.ID != "" && resp.ID != job.JobID {
+		return nil, fmt.Errorf("video retrieve returned mismatched video id for job %s", job.ID)
+	}
+
+	latest := videoJobFromResponse(job, resp)
+	if !isTerminalVideoStatus(resp.Status) {
+		return &PollResult{Job: latest}, nil
+	}
+	return &PollResult{
+		Job:        latest,
+		Terminal:   true,
+		Settleable: true,
+		Payload:    VideoPayload{Response: resp},
+	}, nil
+}
+
+// Settle prices one video job from its merged dimensions: what was ordered, as
+// recorded on the job row at submission, overlaid with what the terminal response
+// says actually happened.
+//
+// The merge is the whole design. Most providers' retrieve reports little beyond a
+// status and a URL, so the request captured at submission is usually the only place
+// the duration and resolution exist by the time this runs.
+func (s *VideoSettler) Settle(ctx context.Context, pricing PricingManager, jobReq JobRequest) (*Settlement, error) {
+	load, _ := jobReq.Payload.(VideoPayload)
+	resp := load.Response
+
+	captured := VideoDimensionsFromJob(jobReq.Job)
+	dims := captured.MergedWith(modelcatalog.VideoDimensionsFromResponse(resp))
+	if dims.Model == "" && jobReq.FallbackModel != "" {
+		dims.Model = jobReq.FallbackModel
+	}
+
+	settlement := &Settlement{
+		Model:  dims.Model,
+		Object: videoObjectFor(dims.RequestType),
+	}
+
+	if resp != nil && resp.ContentFilter != nil && resp.ContentFilter.FilteredCount > 0 {
+		settlement.UnpriceableReason = UnpriceableReasonContentFiltered
+		return settlement, nil
+	}
+
+	// A failed generation is priced, at zero. Providers are explicit that an
+	// unsuccessful video is not billed, and that is a final answer about the money —
+	// not an absence of one. Recording it as unpriceable instead would leave free
+	// work parked in the sweeper forever.
+	if resp != nil && resp.Status == schemas.VideoStatusFailed {
+		settlement.Priced = true
+		settlement.Complete = true
+		return settlement, nil
+	}
+
+	details := pricing.CalculateVideoCostDetails(dims, jobReq.Provider, jobReq.Scopes)
+	if !details.Priced {
+		settlement.UnpriceableReason = UnpriceableReasonMissingVideoPricing
+		// Keep the row so the usage stays visible and the backfill can reprice it
+		// once the rate lands, rather than dropping the job's cost entirely.
+		settlement.RecordUnpriced = true
+		settlement.UnpricedModel = dims.Model
+		return settlement, nil
+	}
+
+	settlement.Priced = true
+	settlement.Complete = true
+	settlement.Cost = details.Cost
+	return settlement, nil
+}
+
+// HydrateFromLog is a no-op: video carries no kind-specific detail on the aggregate
+// row yet, and the engine reads cost and usage off the row itself.
+func (s *VideoSettler) HydrateFromLog(entry *logstore.Log, out *Outcome) {}
+
+// VideoDimensionsFromJob reads the pricing dimensions captured on the job row at
+// submission. An unreadable blob yields empty dimensions rather than an error: the
+// response may still carry enough to price the job, and refusing to settle over a
+// malformed params column would strand real money.
+func VideoDimensionsFromJob(job *cstables.TableProviderJob) modelcatalog.VideoPricingDimensions {
+	if job == nil || job.Params == nil || *job.Params == "" {
+		return modelcatalog.VideoPricingDimensions{}
+	}
+	var dims modelcatalog.VideoPricingDimensions
+	if err := sonic.Unmarshal([]byte(*job.Params), &dims); err != nil {
+		return modelcatalog.VideoPricingDimensions{}
+	}
+	return dims
+}
+
+// MarshalVideoDimensions renders dimensions for the job row's params column.
+func MarshalVideoDimensions(dims modelcatalog.VideoPricingDimensions) (*string, error) {
+	data, err := sonic.Marshal(dims)
+	if err != nil {
+		return nil, err
+	}
+	encoded := string(data)
+	return &encoded, nil
+}
+
+// AccountVideoJob settles a video from a terminal response the caller already holds.
+// It is the retrieve path's inline settlement — the counterpart to
+// AccountBatchResults on /v1/batches/{id}/results.
+//
+// It exists to avoid throwing away work: a user polling GET /v1/videos/{id} has
+// already fetched the terminal response, cost included for providers that report
+// one, and waiting for the sweeper to fetch it again costs both a provider call and
+// up to a full sweep interval of delay.
+//
+// Two things separate it from the batch entry point:
+//
+// It never creates the coordination row. A video submitted before this build was
+// charged at submission, so settling one whose row we never wrote would bill it a
+// second time. No row means we did not see the submission — leave it alone.
+//
+// It does not force the claim. A caller holding batch results has something the
+// parked job lacked and may re-drive it; a video retrieve carries no more than the
+// settlement that parked the job already saw, and clients poll it repeatedly, so
+// re-driving on every poll would be churn. An already-settled or parked job takes
+// the engine's mirror path and reports the price it already has.
+func AccountVideoJob(ctx context.Context, stateStore JobStore, logStore AggregateLogStore, pricing PricingManager, req JobRequest) (*Outcome, error) {
+	if stateStore == nil {
+		return nil, fmt.Errorf("video accounting state store is nil")
+	}
+	if req.Provider == "" || req.ProviderJobID == "" {
+		return nil, nil
+	}
+
+	load, _ := req.Payload.(VideoPayload)
+	if load.Response == nil || !isTerminalVideoStatus(load.Response.Status) {
+		// Still running: nothing to settle, and the sweeper is already scheduled.
+		return nil, nil
+	}
+
+	job, err := stateStore.GetProviderJob(ctx, cstables.ProviderJobID(cstables.ProviderJobKindVideo, string(req.Provider), req.ProviderJobID))
+	if err != nil || job == nil {
+		return nil, nil
+	}
+	req.Job = job
+	return AccountJob(ctx, stateStore, logStore, pricing, NewVideoSettler(nil), req)
+}
+
+// NewVideoSweeper binds the generic sweeper to the video settler.
+func NewVideoSweeper(store SweepStore, logStore AggregateLogStore, pricing PricingManager, retriever VideoRetriever, emitter AggregateLogEmitter, usageReporter UsageReporter, config SweeperConfig) *Sweeper {
+	if config.ClaimedBy == "" {
+		config.ClaimedBy = "video-sweeper:" + newInstanceID()
+	}
+	return NewSweeper(store, logStore, pricing, NewVideoSettler(retriever), emitter, usageReporter, config)
+}
+
+func videoJobFromResponse(existing *cstables.TableProviderJob, resp *schemas.BifrostVideoGenerationResponse) *cstables.TableProviderJob {
+	job := *existing
+	job.ProviderStatus = string(resp.Status)
+	if resp.Model != "" {
+		job.Model = resp.Model
+	}
+	return &job
+}
+
+func isTerminalVideoStatus(status schemas.VideoStatus) bool {
+	switch status {
+	case schemas.VideoStatusCompleted, schemas.VideoStatusFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+// videoObjectFor labels the aggregate row with the request type that created the
+// job, so a later repricing pass reaches the same rates this settlement used.
+func videoObjectFor(requestType schemas.RequestType) schemas.RequestType {
+	switch requestType {
+	case schemas.VideoRemixRequest, schemas.VideoEditRequest:
+		return requestType
+	default:
+		return schemas.VideoGenerationRequest
+	}
+}

--- a/framework/jobaccounting/video_test.go
+++ b/framework/jobaccounting/video_test.go
@@ -1,0 +1,477 @@
+package jobaccounting
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	cstables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/modelcatalog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeVideoRetriever struct {
+	resp  *schemas.BifrostVideoGenerationResponse
+	err   error
+	calls int
+}
+
+func (f *fakeVideoRetriever) RetrieveVideo(ctx context.Context, job *cstables.TableProviderJob) (*schemas.BifrostVideoGenerationResponse, error) {
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.resp, nil
+}
+
+// videoJob builds a submitted video job row carrying the dimensions the request
+// asked for — the state recordVideoJobLifecycle leaves behind.
+func videoJob(t *testing.T, videoID string, dims modelcatalog.VideoPricingDimensions) *cstables.TableProviderJob {
+	t.Helper()
+	params, err := MarshalVideoDimensions(dims)
+	require.NoError(t, err)
+	return &cstables.TableProviderJob{
+		ID:               cstables.ProviderJobID(cstables.ProviderJobKindVideo, string(schemas.OpenAI), videoID),
+		Kind:             cstables.ProviderJobKindVideo,
+		Provider:         string(schemas.OpenAI),
+		JobID:            videoID,
+		Model:            dims.Model,
+		Params:           params,
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
+	}
+}
+
+func generationDims(model, size string, seconds int) modelcatalog.VideoPricingDimensions {
+	return modelcatalog.VideoPricingDimensions{
+		Model:       model,
+		RequestType: schemas.VideoGenerationRequest,
+		Seconds:     &seconds,
+		Size:        size,
+	}
+}
+
+func settleVideo(t *testing.T, job *cstables.TableProviderJob, resp *schemas.BifrostVideoGenerationResponse) *Settlement {
+	t.Helper()
+	settlement, err := NewVideoSettler(nil).Settle(context.Background(), fakePricing{}, JobRequest{
+		Provider:      schemas.OpenAI,
+		ProviderJobID: job.JobID,
+		FallbackModel: job.Model,
+		Job:           job,
+		Payload:       VideoPayload{Response: resp},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, settlement)
+	return settlement
+}
+
+func TestVideoDimensionsRoundTripThroughJobParams(t *testing.T) {
+	audio := true
+	dims := generationDims("sora-2-pro", "1920x1080", 8)
+	dims.Audio = &audio
+	dims.Extra = map[string]any{"sample_count": float64(2)}
+
+	got := VideoDimensionsFromJob(videoJob(t, "vid_round", dims))
+	assert.Equal(t, "sora-2-pro", got.Model)
+	assert.Equal(t, "1920x1080", got.Size)
+	require.NotNil(t, got.Seconds)
+	assert.Equal(t, 8, *got.Seconds)
+	require.NotNil(t, got.Audio)
+	assert.True(t, *got.Audio)
+	assert.Equal(t, float64(2), got.Extra["sample_count"],
+		"the research hatch must survive the round trip even though nothing prices on it yet")
+}
+
+func TestVideoDimensionsFromJob_MalformedParamsDoNotBlockSettlement(t *testing.T) {
+	// A params blob we cannot read must not strand the job: the response may still
+	// carry enough to price it.
+	garbage := "{not json"
+	job := &cstables.TableProviderJob{Kind: cstables.ProviderJobKindVideo, Params: &garbage}
+	assert.Equal(t, modelcatalog.VideoPricingDimensions{}, VideoDimensionsFromJob(job))
+}
+
+func TestVideoSettle_PricesFromCapturedParamsWhenResponseIsSilent(t *testing.T) {
+	// The common provider: a retrieve that reports a status and nothing else.
+	job := videoJob(t, "vid_silent", generationDims("sora-2-pro", "1920x1080", 8))
+	settlement := settleVideo(t, job, &schemas.BifrostVideoGenerationResponse{
+		Status: schemas.VideoStatusCompleted,
+		Videos: []schemas.VideoOutput{{Type: schemas.VideoOutputTypeURL}},
+	})
+
+	assert.True(t, settlement.Priced)
+	assert.True(t, settlement.Complete)
+	assert.InDelta(t, 8*0.70, settlement.Cost, 1e-12,
+		"the submitted request is the only place the duration and size still exist")
+	assert.Equal(t, schemas.VideoGenerationRequest, settlement.Object)
+}
+
+func TestVideoSettle_ResponseOverridesCapturedParams(t *testing.T) {
+	// The provider downscaled: the bill follows what was produced, not what was asked.
+	job := videoJob(t, "vid_downscaled", generationDims("sora-2-pro", "1920x1080", 8))
+	settlement := settleVideo(t, job, &schemas.BifrostVideoGenerationResponse{
+		Status:  schemas.VideoStatusCompleted,
+		Seconds: bifrost.Ptr("4"),
+		Size:    "1280x720",
+		Videos:  []schemas.VideoOutput{{Type: schemas.VideoOutputTypeURL}},
+	})
+
+	require.True(t, settlement.Priced)
+	assert.InDelta(t, 4*0.30, settlement.Cost, 1e-12)
+}
+
+func TestVideoSettle_BillsEveryReturnedClip(t *testing.T) {
+	job := videoJob(t, "vid_multi", generationDims("sora-2-pro", "1280x720", 8))
+	settlement := settleVideo(t, job, &schemas.BifrostVideoGenerationResponse{
+		Status: schemas.VideoStatusCompleted,
+		Videos: []schemas.VideoOutput{
+			{Type: schemas.VideoOutputTypeURL},
+			{Type: schemas.VideoOutputTypeURL},
+			{Type: schemas.VideoOutputTypeURL},
+		},
+	})
+
+	require.True(t, settlement.Priced)
+	assert.InDelta(t, 3*8*0.30, settlement.Cost, 1e-12)
+}
+
+func TestVideoSettle_ProviderReportedCostWins(t *testing.T) {
+	job := videoJob(t, "vid_provider_cost", generationDims("sora-2-pro", "1920x1080", 8))
+	settlement := settleVideo(t, job, &schemas.BifrostVideoGenerationResponse{
+		Status: schemas.VideoStatusCompleted,
+		Videos: []schemas.VideoOutput{{Type: schemas.VideoOutputTypeURL}},
+		Usage:  &schemas.VideoUsage{Cost: &schemas.BifrostCost{TotalCost: 0.42}},
+	})
+
+	require.True(t, settlement.Priced)
+	assert.InDelta(t, 0.42, settlement.Cost, 1e-12,
+		"a provider that reports its own figure is never overridden by an estimate")
+}
+
+// A failed generation is a real price of zero, not an absence of one. Recording it
+// as unpriceable would leave free work parked in the sweeper forever.
+func TestVideoSettle_FailedJobIsPricedAtZero(t *testing.T) {
+	job := videoJob(t, "vid_failed", generationDims("sora-2-pro", "1920x1080", 8))
+	settlement := settleVideo(t, job, &schemas.BifrostVideoGenerationResponse{
+		Status: schemas.VideoStatusFailed,
+		Error:  &schemas.VideoCreateError{Code: "generation_failed"},
+	})
+
+	assert.True(t, settlement.Priced, "failure is a final answer about the money")
+	assert.True(t, settlement.Complete)
+	assert.Zero(t, settlement.Cost)
+	assert.Empty(t, settlement.UnpriceableReason)
+}
+
+// Content filtering is the one case we refuse to guess: real compute was spent, and
+// whether the provider bills for it is undocumented. Parking it keeps the job
+// re-drivable instead of over- or under-charging.
+func TestVideoSettle_ContentFilteredParksRatherThanGuesses(t *testing.T) {
+	job := videoJob(t, "vid_filtered", generationDims("sora-2-pro", "1920x1080", 8))
+	settlement := settleVideo(t, job, &schemas.BifrostVideoGenerationResponse{
+		Status:        schemas.VideoStatusFailed,
+		ContentFilter: &schemas.ContentFilterInfo{FilteredCount: 1, Reasons: []string{"safety"}},
+	})
+
+	assert.False(t, settlement.Priced)
+	assert.Equal(t, UnpriceableReasonContentFiltered, settlement.UnpriceableReason)
+	assert.Zero(t, settlement.Cost)
+}
+
+func TestVideoSettle_NoRateRecordsUnpricedRatherThanFree(t *testing.T) {
+	job := videoJob(t, "vid_norate", generationDims("some-unknown-model", "1920x1080", 8))
+	settlement := settleVideo(t, job, &schemas.BifrostVideoGenerationResponse{
+		Status: schemas.VideoStatusCompleted,
+		Videos: []schemas.VideoOutput{{Type: schemas.VideoOutputTypeURL}},
+	})
+
+	assert.False(t, settlement.Priced, "no rate must never read as free")
+	assert.True(t, settlement.RecordUnpriced, "the row must stay visible so backfill can reprice it")
+	assert.Equal(t, UnpriceableReasonMissingVideoPricing, settlement.UnpriceableReason)
+	assert.Equal(t, "some-unknown-model", settlement.UnpricedModel)
+}
+
+func TestVideoPoll_InProgressJobIsNotSettleable(t *testing.T) {
+	job := videoJob(t, "vid_running", generationDims("sora-2-pro", "1920x1080", 8))
+	retriever := &fakeVideoRetriever{resp: &schemas.BifrostVideoGenerationResponse{
+		ID:     "vid_running",
+		Status: schemas.VideoStatusInProgress,
+	}}
+
+	poll, err := NewVideoSettler(retriever).Poll(context.Background(), job)
+	require.NoError(t, err)
+	require.NotNil(t, poll)
+	assert.False(t, poll.Terminal)
+	assert.False(t, poll.Settleable)
+	require.NotNil(t, poll.Job)
+	assert.Equal(t, string(schemas.VideoStatusInProgress), poll.Job.ProviderStatus)
+}
+
+func TestVideoPoll_MismatchedIDIsAnError(t *testing.T) {
+	job := videoJob(t, "vid_expected", generationDims("sora-2-pro", "1920x1080", 8))
+	retriever := &fakeVideoRetriever{resp: &schemas.BifrostVideoGenerationResponse{
+		ID:     "vid_someone_elses",
+		Status: schemas.VideoStatusCompleted,
+	}}
+
+	_, err := NewVideoSettler(retriever).Poll(context.Background(), job)
+	require.Error(t, err, "settling another job's response would bill the wrong request")
+}
+
+func TestVideoPoll_RetrieveErrorReschedules(t *testing.T) {
+	job := videoJob(t, "vid_err", generationDims("sora-2-pro", "1920x1080", 8))
+	retriever := &fakeVideoRetriever{err: errors.New("upstream unavailable")}
+
+	_, err := NewVideoSettler(retriever).Poll(context.Background(), job)
+	require.Error(t, err)
+}
+
+// Video jobs finish in minutes; the batch ladder would leave a finished one
+// unsettled for a quarter of an hour.
+func TestVideoBackoffStaysInMinutes(t *testing.T) {
+	settler := NewVideoSettler(nil)
+	base := time.Minute
+	assert.Equal(t, time.Minute, settler.Backoff(1, base))
+	assert.Equal(t, 2*time.Minute, settler.Backoff(20, base))
+	assert.Equal(t, 5*time.Minute, settler.Backoff(40, base))
+	assert.Less(t, settler.Backoff(40, base), NewBatchSettler(nil).Backoff(40, base))
+}
+
+func TestVideoSettlerSupportsOnlyRealVideoProviders(t *testing.T) {
+	settler := NewVideoSettler(nil)
+	for _, provider := range []schemas.ModelProvider{schemas.OpenAI, schemas.Gemini, schemas.Vertex, schemas.Replicate, schemas.Runway, schemas.Runware} {
+		assert.True(t, settler.SupportsProvider(provider), string(provider))
+	}
+	// Every provider implements the VideoGeneration method, so a real allowlist is
+	// the only thing keeping the sweeper from burning attempts on providers that
+	// merely return "unsupported".
+	assert.False(t, settler.SupportsProvider(schemas.Anthropic))
+	assert.False(t, settler.SupportsProvider(schemas.Cohere))
+}
+
+// The video namespace must never collide with batch: the id is both the aggregate
+// write's idempotency key and the governance dedupe key.
+func TestVideoAccountingLogIDIsDistinctFromBatch(t *testing.T) {
+	video := AccountingLogID(ProviderJobKindVideo, schemas.OpenAI, "same_id")
+	batch := AccountingLogID(ProviderJobKindBatch, schemas.OpenAI, "same_id")
+	assert.NotEqual(t, video, batch)
+	assert.Equal(t, video, AccountingLogID(ProviderJobKindVideo, schemas.OpenAI, "same_id"), "the id must be deterministic")
+}
+
+// End to end through the shared engine: the sweeper picks up a due video job,
+// settles it exactly once, and reports it exactly once.
+func TestVideoSweeper_SettlesCompletedJobOnce(t *testing.T) {
+	store := newFakeAccountingStore()
+	due := time.Now().UTC().Add(-time.Minute)
+	job := videoJob(t, "vid_sweep", generationDims("sora-2-pro", "1920x1080", 8))
+	job.NextCheckAt = &due
+	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
+
+	// A batch job sitting in the same table must be left entirely alone.
+	batchDue := due
+	require.NoError(t, store.UpsertProviderJob(context.Background(), &cstables.TableProviderJob{
+		ID:               cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_untouched"),
+		Kind:             cstables.ProviderJobKindBatch,
+		Provider:         string(schemas.OpenAI),
+		JobID:            "batch_untouched",
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
+		NextCheckAt:      &batchDue,
+	}))
+
+	retriever := &fakeVideoRetriever{resp: &schemas.BifrostVideoGenerationResponse{
+		ID:     "vid_sweep",
+		Status: schemas.VideoStatusCompleted,
+		Videos: []schemas.VideoOutput{{Type: schemas.VideoOutputTypeURL}},
+	}}
+	reporter := &fakeUsageReporter{}
+	sweeper := NewVideoSweeper(store, store, fakePricing{}, retriever, nil, reporter, SweeperConfig{
+		Provider: schemas.OpenAI,
+		Limit:    10,
+	})
+
+	sweeper.SweepOnce(context.Background())
+
+	assert.Equal(t, 1, retriever.calls, "the video sweeper must not poll the batch row")
+	settled := store.jobs[cstables.ProviderJobID(cstables.ProviderJobKindVideo, string(schemas.OpenAI), "vid_sweep")]
+	require.NotNil(t, settled)
+	assert.Equal(t, cstables.ProviderJobAccountingStatusAccounted, settled.AccountingStatus)
+
+	logID := AccountingLogID(ProviderJobKindVideo, schemas.OpenAI, "vid_sweep")
+	entry := store.logs[logID]
+	require.NotNil(t, entry, "the aggregate cost row must be keyed by the video namespace")
+	require.NotNil(t, entry.Cost)
+	assert.InDelta(t, 8*0.70, *entry.Cost, 1e-12)
+	assert.Equal(t, string(schemas.VideoGenerationRequest), entry.Object)
+	require.Len(t, reporter.reports, 1)
+	assert.Equal(t, logID, reporter.reports[0].RequestID)
+
+	untouched := store.jobs[cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_untouched")]
+	require.NotNil(t, untouched)
+	assert.Equal(t, cstables.ProviderJobAccountingStatusPending, untouched.AccountingStatus,
+		"a batch row must never be settled by the video sweeper")
+
+	// Settlement is at-least-once by design, so a second sweep must be inert.
+	sweeper.SweepOnce(context.Background())
+	assert.Len(t, store.logs, 1)
+	assert.Len(t, reporter.reports, 1, "governance must be told exactly once")
+}
+
+// --- Inline settlement on the retrieve path ---
+
+func accountVideoInline(t *testing.T, store *fakeAccountingStore, reporter *fakeUsageReporter, videoID string, resp *schemas.BifrostVideoGenerationResponse) *Outcome {
+	t.Helper()
+	out, err := AccountVideoJob(context.Background(), store, store, fakePricing{}, JobRequest{
+		Provider:      schemas.OpenAI,
+		ProviderJobID: videoID,
+		FallbackModel: "sora-2-pro",
+		UsageReporter: reporter,
+		ClaimedBy:     "logging-node",
+		Payload:       VideoPayload{Response: resp},
+	})
+	require.NoError(t, err)
+	return out
+}
+
+// A user polling GET /v1/videos/{id} has already fetched the terminal response.
+// Settling from it saves a provider call and a full sweep interval of delay.
+func TestAccountVideoJob_SettlesFromTheCallersTerminalResponse(t *testing.T) {
+	store := newFakeAccountingStore()
+	reporter := &fakeUsageReporter{}
+	job := videoJob(t, "vid_inline", generationDims("sora-2-pro", "1920x1080", 8))
+	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
+
+	out := accountVideoInline(t, store, reporter, "vid_inline", &schemas.BifrostVideoGenerationResponse{
+		ID:     "vid_inline",
+		Status: schemas.VideoStatusCompleted,
+		Videos: []schemas.VideoOutput{{Type: schemas.VideoOutputTypeURL}},
+	})
+
+	require.NotNil(t, out)
+	assert.True(t, out.Accounted)
+	assert.InDelta(t, 8*0.70, out.Cost, 1e-12)
+
+	settled := store.jobs[cstables.ProviderJobID(cstables.ProviderJobKindVideo, string(schemas.OpenAI), "vid_inline")]
+	require.NotNil(t, settled)
+	assert.Equal(t, cstables.ProviderJobAccountingStatusAccounted, settled.AccountingStatus)
+	assert.Len(t, store.logs, 1)
+	require.Len(t, reporter.reports, 1)
+}
+
+// A video submitted before this build was charged at submission. Settling it now,
+// off a row we never wrote, would bill it a second time.
+func TestAccountVideoJob_RefusesAJobWeNeverSawSubmitted(t *testing.T) {
+	store := newFakeAccountingStore()
+	reporter := &fakeUsageReporter{}
+
+	out := accountVideoInline(t, store, reporter, "vid_pre_upgrade", &schemas.BifrostVideoGenerationResponse{
+		ID:     "vid_pre_upgrade",
+		Status: schemas.VideoStatusCompleted,
+		Videos: []schemas.VideoOutput{{Type: schemas.VideoOutputTypeURL}},
+	})
+
+	assert.Nil(t, out, "no coordination row means we never saw the submission")
+	assert.Empty(t, store.logs, "nothing may be billed for a job we did not record")
+	assert.Empty(t, reporter.reports)
+}
+
+// Clients poll a running job repeatedly; only a terminal response is settlement
+// input.
+func TestAccountVideoJob_IgnoresAStillRunningJob(t *testing.T) {
+	store := newFakeAccountingStore()
+	reporter := &fakeUsageReporter{}
+	job := videoJob(t, "vid_running_inline", generationDims("sora-2-pro", "1920x1080", 8))
+	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
+
+	for _, status := range []schemas.VideoStatus{schemas.VideoStatusQueued, schemas.VideoStatusInProgress} {
+		out := accountVideoInline(t, store, reporter, "vid_running_inline", &schemas.BifrostVideoGenerationResponse{
+			ID:     "vid_running_inline",
+			Status: status,
+		})
+		assert.Nil(t, out, string(status))
+	}
+	assert.Empty(t, store.logs)
+	assert.Empty(t, reporter.reports)
+}
+
+// Polling is not billing. A client that keeps calling retrieve after the job
+// finished must not be charged again on every call.
+func TestAccountVideoJob_RepeatedRetrievesBillOnce(t *testing.T) {
+	store := newFakeAccountingStore()
+	reporter := &fakeUsageReporter{}
+	job := videoJob(t, "vid_repoll", generationDims("sora-2-pro", "1280x720", 8))
+	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
+
+	resp := &schemas.BifrostVideoGenerationResponse{
+		ID:     "vid_repoll",
+		Status: schemas.VideoStatusCompleted,
+		Videos: []schemas.VideoOutput{{Type: schemas.VideoOutputTypeURL}},
+	}
+	first := accountVideoInline(t, store, reporter, "vid_repoll", resp)
+	require.NotNil(t, first)
+	assert.True(t, first.Accounted)
+
+	for i := 0; i < 3; i++ {
+		again := accountVideoInline(t, store, reporter, "vid_repoll", resp)
+		require.NotNil(t, again)
+		assert.False(t, again.Claimed, "a settled job must not be re-claimed")
+		// The caller still wants a price to display, mirrored off the written row.
+		assert.InDelta(t, first.Cost, again.Cost, 1e-12)
+	}
+	assert.Len(t, store.logs, 1)
+	assert.Len(t, reporter.reports, 1, "governance must be told exactly once")
+}
+
+// The Runware case: the retrieve the caller already holds carries the provider's
+// own figure, so inline settlement prices exactly without any datasheet rate.
+func TestAccountVideoJob_UsesProviderReportedCostFromTheRetrieve(t *testing.T) {
+	store := newFakeAccountingStore()
+	reporter := &fakeUsageReporter{}
+	// No duration and an unknown model: nothing here is priceable from the catalog.
+	job := videoJob(t, "vid_runware", modelcatalog.VideoPricingDimensions{
+		Model:       "runware:tripo-v3.1",
+		RequestType: schemas.VideoGenerationRequest,
+	})
+	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
+
+	out := accountVideoInline(t, store, reporter, "vid_runware", &schemas.BifrostVideoGenerationResponse{
+		ID:     "vid_runware",
+		Status: schemas.VideoStatusCompleted,
+		Videos: []schemas.VideoOutput{{Type: schemas.VideoOutputTypeURL}},
+		Usage:  &schemas.VideoUsage{Cost: &schemas.BifrostCost{TotalCost: 0.4}},
+	})
+
+	require.NotNil(t, out)
+	assert.True(t, out.Accounted)
+	assert.InDelta(t, 0.4, out.Cost, 1e-12,
+		"a provider-reported cost settles a job the catalog cannot price at all")
+}
+
+// Settling inline and settling from the sweeper must land on the same row, or the
+// two paths would each write their own cost record for one video.
+func TestAccountVideoJob_SharesTheSweepersAggregateRow(t *testing.T) {
+	store := newFakeAccountingStore()
+	reporter := &fakeUsageReporter{}
+	due := time.Now().UTC().Add(-time.Minute)
+	job := videoJob(t, "vid_both", generationDims("sora-2-pro", "1280x720", 8))
+	job.NextCheckAt = &due
+	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
+
+	resp := &schemas.BifrostVideoGenerationResponse{
+		ID:     "vid_both",
+		Status: schemas.VideoStatusCompleted,
+		Videos: []schemas.VideoOutput{{Type: schemas.VideoOutputTypeURL}},
+	}
+	require.NotNil(t, accountVideoInline(t, store, reporter, "vid_both", resp))
+
+	retriever := &fakeVideoRetriever{resp: resp}
+	NewVideoSweeper(store, store, fakePricing{}, retriever, nil, reporter, SweeperConfig{
+		Provider: schemas.OpenAI,
+		Limit:    10,
+	}).SweepOnce(context.Background())
+
+	assert.Len(t, store.logs, 1, "one video, one cost row, whichever path got there first")
+	assert.Len(t, reporter.reports, 1)
+	assert.Equal(t, 0, retriever.calls, "an accounted job is no longer due, so the sweeper skips it")
+}

--- a/framework/modelcatalog/datasheet/cost.go
+++ b/framework/modelcatalog/datasheet/cost.go
@@ -418,6 +418,19 @@ func (s *Store) calculateBaseCost(result *schemas.BifrostResponse, scopes Lookup
 	// Extract usage data from the response (passthrough and native paths unified)
 	input := extractCostInput(result)
 
+	// A video is billed once, at settlement — the job may still be queued, may
+	// produce different dimensions than were asked for, and may fail outright. This
+	// gate sits *ahead* of the provider-cost short-circuit below rather than in the
+	// modality switch, because a provider-reported cost on a job that has not
+	// finished is a quote, not a bill, and would otherwise be returned here before
+	// any status was consulted.
+	//
+	// An absent status means the provider does not report one, so there is nothing
+	// to gate on and pricing proceeds as before.
+	if input.videoStatus != "" && input.videoStatus != schemas.VideoStatusCompleted {
+		return nil
+	}
+
 	// If provider already computed cost, use it
 	if input.usage != nil && input.usage.Cost != nil && input.usage.Cost.TotalCost > 0 {
 		return input.usage.Cost
@@ -651,6 +664,7 @@ func extractCostInput(result *schemas.BifrostResponse) costInput {
 
 	case result.VideoGenerationResponse != nil:
 		video := result.VideoGenerationResponse
+		input.videoStatus = video.Status
 		if video.Usage != nil && video.Usage.Cost != nil {
 			// Provider-reported cost (e.g. Runware's per-task cost). Routed through input.usage.Cost so
 			// the provider-cost short-circuit in computeCost uses it verbatim; covers task types (3D,

--- a/framework/modelcatalog/datasheet/cost_test.go
+++ b/framework/modelcatalog/datasheet/cost_test.go
@@ -5322,3 +5322,220 @@ func TestParseImageDimensions(t *testing.T) {
 		assert.Equal(t, 0, h, bad)
 	}
 }
+
+// --- Video pricing dimensions (the settlement-time pricing basis) ---
+
+// newVideoDimensionTestStore is a catalog carrying the resolution-banded video
+// rates, so dimension-driven pricing is exercised against real lookup rather than
+// a hand-held pricing row.
+func newVideoDimensionTestStore(t *testing.T) *Store {
+	t.Helper()
+	banded := sizedVideoPricing()
+	banded.Model = "sora-2-pro"
+	banded.Provider = "openai"
+	banded.Mode = "video_generation"
+	return testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("sora-2-pro", "openai", "video_generation"): banded,
+	})
+}
+
+func TestVideoPricingDimensions_MergedWithPrefersObserved(t *testing.T) {
+	eight, twelve := 8, 12
+	audio := true
+	captured := VideoPricingDimensions{
+		Model:       "veo-3.1",
+		RequestType: schemas.VideoGenerationRequest,
+		Seconds:     &eight,
+		Size:        "1920x1080",
+		Audio:       &audio,
+		Extra:       map[string]any{"sample_count": 2},
+	}
+	// The provider clamped the duration and downscaled: what actually happened
+	// wins, because that is what the bill is for.
+	observed := VideoPricingDimensions{Seconds: &twelve, Size: "1280x720", OutputCount: 3}
+
+	merged := captured.MergedWith(observed)
+	require.NotNil(t, merged.Seconds)
+	assert.Equal(t, 12, *merged.Seconds)
+	assert.Equal(t, "1280x720", merged.Size)
+	assert.Equal(t, 3, merged.OutputCount)
+	// Everything the response stayed silent about survives from the request —
+	// which for most providers is nearly all of it.
+	assert.Equal(t, "veo-3.1", merged.Model)
+	assert.Equal(t, schemas.VideoGenerationRequest, merged.RequestType)
+	require.NotNil(t, merged.Audio)
+	assert.True(t, *merged.Audio)
+	assert.Equal(t, 2, merged.Extra["sample_count"])
+}
+
+func TestVideoPricingDimensions_MergedWithKeepsCapturedWhenResponseIsSilent(t *testing.T) {
+	eight := 8
+	captured := VideoPricingDimensions{Model: "veo-3.1", Seconds: &eight, Size: "1920x1080"}
+
+	// The common case: a retrieve that reports nothing but "done".
+	merged := captured.MergedWith(VideoPricingDimensions{})
+	require.NotNil(t, merged.Seconds)
+	assert.Equal(t, 8, *merged.Seconds)
+	assert.Equal(t, "1920x1080", merged.Size)
+	assert.Equal(t, "veo-3.1", merged.Model)
+	assert.Zero(t, merged.OutputCount, "a silent response must not claim the job produced clips")
+}
+
+func TestVideoDimensionsFromResponse(t *testing.T) {
+	seconds := "8"
+	resp := &schemas.BifrostVideoGenerationResponse{
+		Model:   "sora-2-pro",
+		Seconds: &seconds,
+		Size:    "1920x1080",
+		Videos:  []schemas.VideoOutput{{Type: schemas.VideoOutputTypeURL}, {Type: schemas.VideoOutputTypeURL}},
+	}
+	dims := VideoDimensionsFromResponse(resp)
+	assert.Equal(t, "sora-2-pro", dims.Model)
+	require.NotNil(t, dims.Seconds)
+	assert.Equal(t, 8, *dims.Seconds)
+	assert.Equal(t, "1920x1080", dims.Size)
+	assert.Equal(t, 2, dims.OutputCount)
+	assert.Nil(t, dims.ProviderCost)
+}
+
+func TestVideoDimensionsFromResponse_CarriesProviderCost(t *testing.T) {
+	resp := &schemas.BifrostVideoGenerationResponse{
+		Model: "runware-video",
+		Usage: &schemas.VideoUsage{Cost: &schemas.BifrostCost{TotalCost: 1.23}},
+	}
+	dims := VideoDimensionsFromResponse(resp)
+	require.NotNil(t, dims.ProviderCost)
+	assert.InDelta(t, 1.23, *dims.ProviderCost, 1e-12)
+}
+
+func TestCalculateVideoCostDetails_ProviderCostWinsOverCatalogRate(t *testing.T) {
+	store := newVideoDimensionTestStore(t)
+	seconds := 8
+	providerCost := 0.42
+	dims := VideoPricingDimensions{
+		Model:        "sora-2-pro",
+		RequestType:  schemas.VideoGenerationRequest,
+		Seconds:      &seconds,
+		Size:         "1920x1080",
+		OutputCount:  1,
+		ProviderCost: &providerCost,
+	}
+	details := store.CalculateVideoCostDetails(dims, schemas.OpenAI, nil)
+	assert.True(t, details.Priced)
+	assert.True(t, details.ProviderCostUsed)
+	assert.InDelta(t, 0.42, details.Cost, 1e-12,
+		"a provider that reports its own figure is never overridden by an estimate")
+}
+
+func TestCalculateVideoCostDetails_UsesResolutionBandedRate(t *testing.T) {
+	store := newVideoDimensionTestStore(t)
+	seconds := 8
+	dims := VideoPricingDimensions{
+		Model:       "sora-2-pro",
+		RequestType: schemas.VideoGenerationRequest,
+		Seconds:     &seconds,
+		Size:        "1920x1080",
+		OutputCount: 1,
+	}
+	details := store.CalculateVideoCostDetails(dims, schemas.OpenAI, nil)
+	require.True(t, details.Priced)
+	assert.False(t, details.ProviderCostUsed)
+	assert.InDelta(t, 8*0.70, details.Cost, 1e-12)
+}
+
+func TestCalculateVideoCostDetails_BillsEveryClip(t *testing.T) {
+	store := newVideoDimensionTestStore(t)
+	seconds := 8
+	dims := VideoPricingDimensions{
+		Model:       "sora-2-pro",
+		RequestType: schemas.VideoGenerationRequest,
+		Seconds:     &seconds,
+		Size:        "1280x720",
+		OutputCount: 3,
+	}
+	details := store.CalculateVideoCostDetails(dims, schemas.OpenAI, nil)
+	require.True(t, details.Priced)
+	assert.InDelta(t, 3*8*0.30, details.Cost, 1e-12)
+}
+
+func TestCalculateVideoCostDetails_UnknownModelIsUnpriced(t *testing.T) {
+	store := newVideoDimensionTestStore(t)
+	seconds := 8
+	dims := VideoPricingDimensions{Model: "no-such-model", Seconds: &seconds, Size: "1920x1080"}
+
+	details := store.CalculateVideoCostDetails(dims, schemas.OpenAI, nil)
+	assert.False(t, details.Priced, "no rate must read as unpriced, never as free")
+	assert.Zero(t, details.Cost)
+}
+
+func TestCalculateVideoCostDetails_NoDurationIsUnpriced(t *testing.T) {
+	store := newVideoDimensionTestStore(t)
+	// An upscale job: no duration basis, and no upscale rate published yet. It must
+	// park as unpriced rather than be billed as a zero-length generation.
+	upscale := "upscale"
+	factor := 4
+	dims := VideoPricingDimensions{
+		Model:         "sora-2-pro",
+		RequestType:   schemas.VideoEditRequest,
+		Type:          &upscale,
+		UpscaleFactor: &factor,
+	}
+	details := store.CalculateVideoCostDetails(dims, schemas.OpenAI, nil)
+	assert.False(t, details.Priced)
+	assert.Zero(t, details.Cost)
+}
+
+// A queued video has produced nothing and may never produce anything. Billing it
+// at submission is the bug the job settler exists to fix: the charge belongs at
+// settlement, where the outcome is known.
+func TestCalculateCost_QueuedVideoIsNotBilledAtSubmission(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("sora-2-pro", "openai", "video_generation"): {
+			Model: "sora-2-pro", Provider: "openai", Mode: "video_generation",
+			OutputCostPerVideoPerSecond:      bifrost.Ptr(0.30),
+			OutputCostPerVideoPerSecond1080p: bifrost.Ptr(0.70),
+		},
+	})
+
+	newResp := func(status schemas.VideoStatus) *schemas.BifrostResponse {
+		return &schemas.BifrostResponse{
+			VideoGenerationResponse: &schemas.BifrostVideoGenerationResponse{
+				Status:  status,
+				Seconds: bifrost.Ptr("8"),
+				Size:    "1920x1080",
+				ExtraFields: schemas.BifrostResponseExtraFields{
+					RequestType: schemas.VideoGenerationRequest,
+					RoutingInfo: routingInfoFor(schemas.OpenAI, "sora-2-pro"),
+				},
+			},
+		}
+	}
+
+	// Failed is included deliberately: it used to fall through to computeVideoCost,
+	// which bills max(1, clips) — so a failed 8s job was charged for a full clip,
+	// while VideoSettler.Settle recorded the same job at zero.
+	for _, status := range []schemas.VideoStatus{schemas.VideoStatusQueued, schemas.VideoStatusInProgress, schemas.VideoStatusFailed} {
+		assert.Zero(t, s.CalculateCost(newResp(status), nil), string(status))
+	}
+
+	// A provider-reported cost on an unfinished job is a quote, not a bill. This is
+	// the path that bypassed the gate entirely: extractCostInput routes VideoUsage
+	// into input.usage.Cost, which the provider-cost short-circuit returns before
+	// any status is consulted.
+	for _, status := range []schemas.VideoStatus{schemas.VideoStatusQueued, schemas.VideoStatusInProgress, schemas.VideoStatusFailed} {
+		quoted := newResp(status)
+		quoted.VideoGenerationResponse.Usage = &schemas.VideoUsage{Cost: &schemas.BifrostCost{TotalCost: 3.21}}
+		assert.Zero(t, s.CalculateCost(quoted, nil), "provider cost on %s must not bill at submission", status)
+	}
+
+	// A completed job still honours the provider's own figure verbatim.
+	priced := newResp(schemas.VideoStatusCompleted)
+	priced.VideoGenerationResponse.Videos = []schemas.VideoOutput{{Type: schemas.VideoOutputTypeURL}}
+	priced.VideoGenerationResponse.Usage = &schemas.VideoUsage{Cost: &schemas.BifrostCost{TotalCost: 3.21}}
+	assert.InDelta(t, 3.21, s.CalculateCost(priced, nil), 1e-9)
+
+	// A terminal response still prices inline — that is what settlement drives.
+	terminal := newResp(schemas.VideoStatusCompleted)
+	terminal.VideoGenerationResponse.Videos = []schemas.VideoOutput{{Type: schemas.VideoOutputTypeURL}}
+	assert.InDelta(t, 5.60, s.CalculateCost(terminal, nil), 1e-9)
+}

--- a/framework/modelcatalog/datasheet/types.go
+++ b/framework/modelcatalog/datasheet/types.go
@@ -341,8 +341,11 @@ type costInput struct {
 	videoSeconds        *int
 	videoSize           string // e.g. "1920x1080", used for resolution-banded video pricing
 	videoCount          int    // generated clips on the response; 0 until the job returns them
-	ocrProcessedPages   *int
-	ocrIsAnnotated      *bool
+	// videoStatus is the job's lifecycle status. A video is billed at settlement,
+	// not at submission, so a non-terminal status prices to nothing.
+	videoStatus       schemas.VideoStatus
+	ocrProcessedPages *int
+	ocrIsAnnotated    *bool
 	// containerIdentifierString, when non-empty, replaces the actual requested/resolved
 	// model names during pricing lookup. Used for request types whose cost is not
 	// tied to a specific model. Currently only used for container creates.

--- a/framework/modelcatalog/datasheet/videopricing.go
+++ b/framework/modelcatalog/datasheet/videopricing.go
@@ -1,0 +1,187 @@
+package datasheet
+
+import (
+	"strconv"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// VideoPricingDimensions is every factor that can move the price of one video job.
+//
+// It exists because a video is billed long after it is asked for. The request says
+// what was ordered, the terminal response says what was actually produced, and
+// neither alone is enough: most providers' retrieve response reports little beyond
+// "done", so a dimension not captured at submission is usually unrecoverable by the
+// time settlement runs.
+//
+// Adding a dimension is deliberately cheap. The whole struct is persisted as JSON
+// in a single TEXT column, so a new field needs no migration and no capture-side
+// change beyond setting it — which is the point: the provider rate cards are not
+// fully mapped yet, and a factor worth capturing should not have to wait for one.
+// Fields that no rate reads yet are still worth recording.
+type VideoPricingDimensions struct {
+	// Model is the resolved model, which matters because several providers never
+	// echo it back on retrieve.
+	Model string `json:"model,omitempty"`
+	// RequestType distinguishes generation from remix and edit. They can price on
+	// different bases even for the same model.
+	RequestType schemas.RequestType `json:"request_type,omitempty"`
+
+	// Seconds and Size are the two dimensions every published video rate card uses
+	// today. Size is "WxH"; the rate is banded on its short edge.
+	Seconds *int   `json:"seconds,omitempty"`
+	Size    string `json:"size,omitempty"`
+
+	// Type is the operation selector ("upscale", "3d"). These do not bill per
+	// second of output at all, so a rate keyed only on duration is wrong for them.
+	Type *string `json:"type,omitempty"`
+	// UpscaleFactor and TargetMegapixels are the upscale operation's own basis;
+	// they are mutually exclusive.
+	UpscaleFactor    *int `json:"upscale_factor,omitempty"`
+	TargetMegapixels *int `json:"target_megapixels,omitempty"`
+
+	// Audio: Veo publishes distinct with- and without-audio rates.
+	Audio *bool `json:"audio,omitempty"`
+
+	// OutputCount is how many clips the job actually returned. It is 0 until the
+	// job produces them, and a job that has not finished still owes one clip's
+	// worth rather than nothing — see computeVideoCost.
+	OutputCount int `json:"output_count,omitempty"`
+
+	// ProviderCost is the provider's own figure for the job, when it reports one
+	// (Runware does). It wins over every rate below.
+	ProviderCost *float64 `json:"provider_cost,omitempty"`
+
+	// Extra carries request knobs that are not modeled above yet. It is the
+	// research hatch: capture a provider-specific parameter here as soon as it
+	// looks price-relevant, and promote it to a typed field once its rate is
+	// actually published. Nothing reads it during pricing today.
+	Extra map[string]any `json:"extra,omitempty"`
+}
+
+// MergedWith layers observed dimensions over captured ones: whatever the argument
+// actually knows wins, and the receiver fills every remaining gap.
+//
+// The direction matters at settlement. The request is a statement of intent — a
+// provider may clamp a duration, downscale a resolution, or return fewer clips than
+// asked for — so the terminal response is authoritative wherever it says anything
+// at all, and the submitted request is the fallback for everything it stays silent
+// about (which, for most providers, is nearly everything).
+func (d VideoPricingDimensions) MergedWith(observed VideoPricingDimensions) VideoPricingDimensions {
+	out := d
+	if observed.Model != "" {
+		out.Model = observed.Model
+	}
+	if observed.RequestType != "" {
+		out.RequestType = observed.RequestType
+	}
+	if observed.Seconds != nil {
+		out.Seconds = observed.Seconds
+	}
+	if observed.Size != "" {
+		out.Size = observed.Size
+	}
+	if observed.Type != nil {
+		out.Type = observed.Type
+	}
+	if observed.UpscaleFactor != nil {
+		out.UpscaleFactor = observed.UpscaleFactor
+	}
+	if observed.TargetMegapixels != nil {
+		out.TargetMegapixels = observed.TargetMegapixels
+	}
+	if observed.Audio != nil {
+		out.Audio = observed.Audio
+	}
+	// A finished job reporting zero clips is a job that produced nothing, not a job
+	// we lack a count for — but only the response can say that, so it only ever
+	// overwrites upward from the request, which never carries a count.
+	if observed.OutputCount > 0 {
+		out.OutputCount = observed.OutputCount
+	}
+	if observed.ProviderCost != nil {
+		out.ProviderCost = observed.ProviderCost
+	}
+	for key, value := range observed.Extra {
+		if out.Extra == nil {
+			out.Extra = map[string]any{}
+		}
+		out.Extra[key] = value
+	}
+	return out
+}
+
+// VideoCostDetails is the outcome of pricing one video job. Priced separates "this
+// costs nothing" from "no rate could be found", which the settlement engine treats
+// as entirely different states.
+type VideoCostDetails struct {
+	Cost             float64
+	Priced           bool
+	ProviderCostUsed bool
+	Breakdown        *schemas.BifrostCost
+}
+
+// CalculateVideoCostDetails prices a video job from its merged dimensions.
+//
+// Resolution order is provider-reported cost, then the catalog rate, then nothing.
+// A provider that hands back an exact figure is always right about its own bill, so
+// no estimate is allowed to override it.
+func (s *Store) CalculateVideoCostDetails(dims VideoPricingDimensions, provider schemas.ModelProvider, scopes *LookupScopes) VideoCostDetails {
+	if dims.ProviderCost != nil && *dims.ProviderCost > 0 {
+		return VideoCostDetails{
+			Cost:             *dims.ProviderCost,
+			Priced:           true,
+			ProviderCostUsed: true,
+			Breakdown:        &schemas.BifrostCost{TotalCost: *dims.ProviderCost},
+		}
+	}
+
+	requestType := dims.RequestType
+	if requestType == "" {
+		requestType = schemas.VideoGenerationRequest
+	}
+
+	var lookupScopes LookupScopes
+	if scopes != nil {
+		lookupScopes = *scopes
+	}
+	pricing := s.resolvePricing(schemas.RoutingInfo{Provider: provider, Model: dims.Model}, requestType, lookupScopes)
+	if pricing == nil {
+		return VideoCostDetails{}
+	}
+
+	// Duration is the only basis wired today. Operation-selector jobs (upscale, 3d)
+	// bill on factor or megapixels instead, and no rate for those is published to
+	// the catalog yet — so they resolve to unpriced rather than being silently
+	// billed as if they were a per-second generation of the same length.
+	breakdown := computeVideoCost(pricing, nil, dims.Seconds, dims.Size, dims.OutputCount, serviceTier{})
+	if breakdown == nil || breakdown.TotalCost <= 0 {
+		return VideoCostDetails{}
+	}
+	return VideoCostDetails{Cost: breakdown.TotalCost, Priced: true, Breakdown: breakdown}
+}
+
+// VideoDimensionsFromResponse reads back everything a terminal video response
+// actually reports. What that amounts to varies enormously by provider — OpenAI
+// echoes model, duration and size; several others report only a status and a URL —
+// which is precisely why the submitted request is kept as the fallback.
+func VideoDimensionsFromResponse(resp *schemas.BifrostVideoGenerationResponse) VideoPricingDimensions {
+	if resp == nil {
+		return VideoPricingDimensions{}
+	}
+	dims := VideoPricingDimensions{
+		Model:       resp.Model,
+		Size:        resp.Size,
+		OutputCount: len(resp.Videos),
+	}
+	if resp.Seconds != nil {
+		if seconds, err := strconv.Atoi(*resp.Seconds); err == nil {
+			dims.Seconds = &seconds
+		}
+	}
+	if resp.Usage != nil && resp.Usage.Cost != nil && resp.Usage.Cost.TotalCost > 0 {
+		total := resp.Usage.Cost.TotalCost
+		dims.ProviderCost = &total
+	}
+	return dims
+}

--- a/framework/modelcatalog/pricing.go
+++ b/framework/modelcatalog/pricing.go
@@ -10,6 +10,13 @@ import (
 
 type BatchCostDetails = datasheet.BatchCostDetails
 
+type (
+	// VideoPricingDimensions is the request+response pricing basis for one video
+	// job. See the datasheet type for why it is captured at submission.
+	VideoPricingDimensions = datasheet.VideoPricingDimensions
+	VideoCostDetails       = datasheet.VideoCostDetails
+)
+
 // GetModelCapabilityEntryForModel returns capability metadata for a
 // (model, provider) pair. Alias lookups try the canonical model name, wire
 // model ID, and original alias key in that order. Within each model, chat,
@@ -122,4 +129,17 @@ func (mc *ModelCatalog) UpsertPricingOverrides(rows ...*configstoreTables.TableP
 
 func (mc *ModelCatalog) DeletePricingOverride(id string) {
 	mc.datasheet.DeleteOverride(id)
+}
+
+// CalculateVideoCostDetails prices a video job from its merged request/response
+// dimensions, preferring a provider-reported cost over any catalog rate.
+func (mc *ModelCatalog) CalculateVideoCostDetails(dims VideoPricingDimensions, provider schemas.ModelProvider, scopes *PricingLookupScopes) VideoCostDetails {
+	return mc.datasheet.CalculateVideoCostDetails(dims, provider, (*datasheet.LookupScopes)(scopes))
+}
+
+// VideoDimensionsFromResponse reads the pricing dimensions a terminal video
+// response reports; what it omits is filled from the dimensions captured at
+// submission.
+func VideoDimensionsFromResponse(resp *schemas.BifrostVideoGenerationResponse) VideoPricingDimensions {
+	return datasheet.VideoDimensionsFromResponse(resp)
 }

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -367,10 +367,10 @@ func (p *LoggerPlugin) sleepCtx(d time.Duration) bool {
 	}
 }
 
-// batchAccountingTimeout bounds inline batch settlement on the /results response
+// jobAccountingTimeout bounds inline batch settlement on the /results response
 // path so a stalled store or reporter cannot hang the caller. Anything that times
 // out is not lost: the job stays due and the sweeper re-drives it.
-const batchAccountingTimeout = 30 * time.Second
+const jobAccountingTimeout = 30 * time.Second
 
 // batchRunnerProcessID distinguishes this process when no cluster node id is set.
 // Deliberately random rather than PID-based: two replicas on different hosts can
@@ -419,7 +419,7 @@ func (p *LoggerPlugin) accountBatchResults(entry *logstore.Log, result *schemas.
 	// would hang the caller's HTTP response indefinitely. Bound the whole
 	// settlement instead; the sweeper re-drives anything that times out, since a
 	// job left un-accounted stays due.
-	ctx, cancel := context.WithTimeout(p.ctx, batchAccountingTimeout)
+	ctx, cancel := context.WithTimeout(p.ctx, jobAccountingTimeout)
 	defer cancel()
 
 	claimedBy := p.batchRunnerID("logging")
@@ -451,6 +451,52 @@ func (p *LoggerPlugin) accountBatchResults(entry *logstore.Log, result *schemas.
 		p.logger.Info("accounted batch results for provider=%s batch_id=%s cost=%f log_id=%s", entry.Provider, batchResp.BatchID, summary.Cost, summary.LogID)
 	}
 	attachBatchResultsDisplay(entry, batchResp, summary)
+}
+
+// accountVideoResults settles a video inline from a terminal retrieve the caller
+// just fetched, rather than leaving it for the sweeper to fetch all over again.
+//
+// The retrieve row itself stays free — calculateBaseCost returns nil for
+// VideoRetrieveRequest, so polling is never billed. This writes the job's own
+// aggregate cost row instead, exactly once, under the same claim the sweeper uses.
+func (p *LoggerPlugin) accountVideoResults(entry *logstore.Log, result *schemas.BifrostResponse, pricingScopes *modelcatalog.PricingLookupScopes) {
+	if entry == nil || result == nil || p.pricingManager == nil || p.batchStore == nil {
+		return
+	}
+	resp := result.VideoGenerationResponse
+	if resp == nil || resp.ID == "" {
+		return
+	}
+
+	// Bound the whole settlement: it touches the config store, the log store and the
+	// governance reporter, and p.ctx has no deadline, so any one of them stalling
+	// would hang the caller's HTTP response. The sweeper re-drives anything that
+	// times out, since an un-accounted job stays due.
+	ctx, cancel := context.WithTimeout(p.ctx, jobAccountingTimeout)
+	defer cancel()
+
+	p.mu.Lock()
+	usageReporter := p.batchUsageReporter
+	p.mu.Unlock()
+
+	outcome, err := jobaccounting.AccountVideoJob(ctx, p.batchStore, p.store, p.pricingManager, jobaccounting.JobRequest{
+		Provider:      schemas.ModelProvider(entry.Provider),
+		ProviderJobID: resp.ID,
+		FallbackModel: entry.Model,
+		BaseLog:       entry,
+		Emitter:       p,
+		UsageReporter: usageReporter,
+		ClaimedBy:     p.batchRunnerID("logging"),
+		Scopes:        pricingScopes,
+		Payload:       jobaccounting.VideoPayload{Response: resp},
+	})
+	if err != nil {
+		p.logger.Warn("failed to account video results for provider=%s video_id=%s: %v", entry.Provider, resp.ID, err)
+		return
+	}
+	if outcome != nil && outcome.Accounted {
+		p.logger.Info("accounted video results for provider=%s video_id=%s cost=%f log_id=%s", entry.Provider, resp.ID, outcome.Cost, outcome.LogID)
+	}
 }
 
 func attachBatchResultsDisplay(entry *logstore.Log, batchResp *schemas.BifrostBatchResultsResponse, summary *jobaccounting.Outcome) {
@@ -523,6 +569,173 @@ func (p *LoggerPlugin) recordBatchJobLifecycle(entry *logstore.Log, result *sche
 	}
 	if err := p.batchStore.UpsertProviderJob(p.ctx, job); err != nil {
 		p.logger.Warn("failed to record batch job lifecycle for provider=%s batch_id=%s: %v", job.Provider, job.JobID, err)
+	}
+}
+
+// isVideoJobRequestType reports whether a request type either starts a video job or
+// reports on one, and therefore has coordination state worth persisting.
+func isVideoJobRequestType(requestType schemas.RequestType) bool {
+	switch requestType {
+	case schemas.VideoGenerationRequest, schemas.VideoEditRequest, schemas.VideoRemixRequest, schemas.VideoRetrieveRequest:
+		return true
+	default:
+		return false
+	}
+}
+
+// recordVideoJobLifecycle persists the coordination row for a video job, and with
+// it the pricing dimensions the request asked for.
+//
+// Capturing those dimensions is the point. A video is billed at settlement, minutes
+// later, and most providers' retrieve response reports little beyond a status — so
+// the duration and resolution the price depends on exist nowhere else by then. The
+// request is the only witness, and this is the only moment it is in hand.
+func (p *LoggerPlugin) recordVideoJobLifecycle(entry *logstore.Log, result *schemas.BifrostResponse, requestType schemas.RequestType) {
+	if entry == nil || result == nil || p.batchStore == nil {
+		return
+	}
+	resp := result.VideoGenerationResponse
+	if resp == nil || resp.ID == "" {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(p.ctx, jobAccountingTimeout)
+	defer cancel()
+
+	// A retrieve may only advance a job we already know about; it must never create
+	// one. A video submitted before this build was charged at submission time, and
+	// creating its row here would hand it to the sweeper to be settled and charged a
+	// second time. No row means we never saw the submission — leave it alone.
+	if requestType == schemas.VideoRetrieveRequest {
+		jobID := tables.ProviderJobID(tables.ProviderJobKindVideo, entry.Provider, resp.ID)
+		if existing, err := p.batchStore.GetProviderJob(ctx, jobID); err != nil || existing == nil {
+			return
+		}
+	}
+
+	// The response is authoritative wherever it says anything; the request fills the
+	// rest, which for most providers is nearly all of it.
+	dims := videoDimensionsFromEntryParams(entry, requestType).
+		MergedWith(modelcatalog.VideoDimensionsFromResponse(resp))
+	if dims.Model == "" {
+		dims.Model = entry.Model
+	}
+
+	job := &tables.TableProviderJob{
+		Kind:             tables.ProviderJobKindVideo,
+		Provider:         entry.Provider,
+		JobID:            resp.ID,
+		Model:            dims.Model,
+		ProviderStatus:   string(resp.Status),
+		AccountingStatus: tables.ProviderJobAccountingStatusPending,
+		SelectedKeyID:    entry.SelectedKeyID,
+		VirtualKeyID:     entry.VirtualKeyID,
+		UserID:           entry.UserID,
+		TeamID:           entry.TeamID,
+		CustomerID:       entry.CustomerID,
+		BudgetIDs:        stringSlicePtr(entry.BudgetIDsParsed),
+		RateLimitIDs:     stringSlicePtr(entry.RateLimitIDsParsed),
+	}
+	job.ID = tables.ProviderJobID(tables.ProviderJobKindVideo, job.Provider, job.JobID)
+	if entry.ID != "" {
+		sourceLogID := entry.ID
+		job.SourceLogID = &sourceLogID
+	}
+	// A retrieve must not overwrite the dimensions the submission captured with the
+	// thinner set a poll reports; UpsertProviderJob merges non-zero fields only, and
+	// params is written on the submission that created the row.
+	if params, err := jobaccounting.MarshalVideoDimensions(dims); err == nil {
+		job.Params = params
+	} else {
+		p.logger.Warn("failed to encode video pricing params for provider=%s video_id=%s: %v", job.Provider, job.JobID, err)
+	}
+
+	now := time.Now().UTC()
+	switch resp.Status {
+	case schemas.VideoStatusCompleted, schemas.VideoStatusFailed:
+		job.NextCheckAt = &now
+	default:
+		// Video jobs finish in minutes, so the first poll is soon.
+		next := now.Add(30 * time.Second)
+		job.NextCheckAt = &next
+	}
+
+	if err := p.batchStore.UpsertProviderJob(ctx, job); err != nil {
+		p.logger.Warn("failed to record video job lifecycle for provider=%s video_id=%s: %v", job.Provider, job.JobID, err)
+	}
+}
+
+// videoDimensionsFromEntryParams reads the pricing-relevant request parameters off
+// the log entry. The parameters arrive as the typed struct the request carried, but
+// a rehydrated entry can present them as a decoded map, so both shapes are handled.
+func videoDimensionsFromEntryParams(entry *logstore.Log, requestType schemas.RequestType) modelcatalog.VideoPricingDimensions {
+	dims := modelcatalog.VideoPricingDimensions{RequestType: requestType}
+	if requestType == schemas.VideoRetrieveRequest {
+		// A retrieve carries no request dimensions of its own; the submission's row
+		// already holds them.
+		dims.RequestType = ""
+	}
+
+	switch params := entry.ParamsParsed.(type) {
+	case *schemas.VideoGenerationParameters:
+		if params == nil {
+			return dims
+		}
+		dims.Size = params.Size
+		dims.Type = params.Type
+		dims.Audio = params.Audio
+		dims.UpscaleFactor = params.UpscaleFactor
+		dims.TargetMegapixels = params.TargetMegapixels
+		if params.Seconds != nil {
+			if seconds, err := strconv.Atoi(*params.Seconds); err == nil {
+				dims.Seconds = &seconds
+			}
+		}
+		// Anything not modeled yet still gets captured: a knob that turns out to be
+		// price-relevant is then already on the row, with no backfill needed.
+		if len(params.ExtraParams) > 0 {
+			dims.Extra = params.ExtraParams
+		}
+	case *schemas.VideoEditParameters:
+		if params == nil {
+			return dims
+		}
+		dims.Type = params.Type
+		dims.UpscaleFactor = params.UpscaleFactor
+		dims.TargetMegapixels = params.TargetMegapixels
+		if len(params.ExtraParams) > 0 {
+			dims.Extra = params.ExtraParams
+		}
+	case map[string]any:
+		applyVideoDimensionsFromMap(&dims, params)
+	}
+	return dims
+}
+
+// applyVideoDimensionsFromMap decodes the same fields off a rehydrated entry whose
+// params came back as JSON rather than the original struct.
+func applyVideoDimensionsFromMap(dims *modelcatalog.VideoPricingDimensions, params map[string]any) {
+	if size, ok := params["size"].(string); ok {
+		dims.Size = size
+	}
+	if operation, ok := params["type"].(string); ok {
+		dims.Type = &operation
+	}
+	if audio, ok := params["audio"].(bool); ok {
+		dims.Audio = &audio
+	}
+	if seconds, ok := params["seconds"].(string); ok {
+		if parsed, err := strconv.Atoi(seconds); err == nil {
+			dims.Seconds = &parsed
+		}
+	}
+	if factor, ok := params["upscale_factor"].(float64); ok {
+		rounded := int(factor)
+		dims.UpscaleFactor = &rounded
+	}
+	if megapixels, ok := params["target_megapixels"].(float64); ok {
+		rounded := int(megapixels)
+		dims.TargetMegapixels = &rounded
 	}
 }
 
@@ -838,6 +1051,7 @@ type LoggerPlugin struct {
 	batchCtx                     context.Context       // Cancelled by Cleanup to stop the batchWriter goroutine before any further DB work
 	batchCancel                  context.CancelFunc    // Cancels batchCtx
 	batchSweeperCancel           context.CancelFunc    // Cancels the batch accounting sweeper, when enabled
+	videoSweeperCancel           context.CancelFunc    // Cancels the video accounting sweeper, when enabled
 	batchWriterDone              chan struct{}         // Closed by batchWriter on exit; receiving from it transfers writeQueue ownership to Cleanup
 	recoveredBatch               []*writeQueueEntry    // batchWriter parks its in-memory batch here before exiting; safe to read after batchWriterDone closes (happens-before)
 	userAgentMappings            atomic.Value          // []compiledUserAgentMapping, read from request hot paths
@@ -1068,6 +1282,49 @@ func (p *LoggerPlugin) StartBatchAccountingSweeper(fetcher jobaccounting.BatchRe
 	sweeper := jobaccounting.NewBatchSweeper(p.batchStore, p.store, p.pricingManager, fetcher, p, usageReporter, jobaccounting.SweeperConfig{
 		Interval:  interval,
 		ClaimedBy: claimedBy,
+		KVStore:   kvStore,
+		Logger:    p.logger,
+	})
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		sweeper.Run(ctx)
+	}()
+	return cancel
+}
+
+// StartVideoAccountingSweeper runs the video job sweeper. It is a second sweeper
+// rather than a second kind on the batch one: each kind polls its provider through
+// its own client, and the two run on very different clocks — a batch is checked
+// every few minutes for hours, a video every thirty seconds for a few minutes.
+func (p *LoggerPlugin) StartVideoAccountingSweeper(retriever jobaccounting.VideoRetriever, interval time.Duration, kvStore schemas.KVStore) context.CancelFunc {
+	if retriever == nil || p.store == nil || p.batchStore == nil || p.pricingManager == nil {
+		if p.logger != nil {
+			p.logger.Warn("video accounting sweeper not started: missing retriever, store, job store, or pricing manager")
+		}
+		return func() {}
+	}
+	ctx, cancel := context.WithCancel(p.ctx)
+	p.mu.Lock()
+	// Same shutdown race as the batch sweeper: Cleanup sets closed and cancels under
+	// this lock before reaching wg.Wait().
+	if p.closed.Load() {
+		p.mu.Unlock()
+		cancel()
+		if p.logger != nil {
+			p.logger.Warn("video accounting sweeper not started: logging plugin is shutting down")
+		}
+		return func() {}
+	}
+	if p.videoSweeperCancel != nil {
+		p.videoSweeperCancel()
+	}
+	p.videoSweeperCancel = cancel
+	usageReporter := p.batchUsageReporter
+	p.mu.Unlock()
+	sweeper := jobaccounting.NewVideoSweeper(p.batchStore, p.store, p.pricingManager, retriever, p, usageReporter, jobaccounting.SweeperConfig{
+		Interval:  interval,
+		ClaimedBy: p.batchRunnerID("video-sweeper"),
 		KVStore:   kvStore,
 		Logger:    p.logger,
 	})
@@ -1873,6 +2130,9 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	if bifrostErr == nil && (requestType == schemas.BatchCreateRequest || requestType == schemas.BatchRetrieveRequest) {
 		p.recordBatchJobLifecycle(entry, result)
 	}
+	if bifrostErr == nil && isVideoJobRequestType(requestType) {
+		p.recordVideoJobLifecycle(entry, result, requestType)
+	}
 
 	// Calculate cost
 	var cacheDebug *schemas.BifrostCacheDebug
@@ -1905,6 +2165,12 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			result != nil &&
 			result.BatchResultsResponse != nil {
 			p.accountBatchResults(entry, result, pricingScopes)
+		}
+		if bifrostErr == nil &&
+			requestType == schemas.VideoRetrieveRequest &&
+			result != nil &&
+			result.VideoGenerationResponse != nil {
+			p.accountVideoResults(entry, result, pricingScopes)
 		}
 	}
 
@@ -1948,6 +2214,11 @@ func (p *LoggerPlugin) Cleanup() error {
 		if p.batchSweeperCancel != nil {
 			p.batchSweeperCancel()
 			p.batchSweeperCancel = nil
+		}
+		// Both sweepers hold a wg slot; leaving this one running would hang wg.Wait().
+		if p.videoSweeperCancel != nil {
+			p.videoSweeperCancel()
+			p.videoSweeperCancel = nil
 		}
 		p.mu.Unlock()
 		if p.cleanupTicker != nil {

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -3066,3 +3066,210 @@ func TestRecordBatchJobLifecycle_CreatePersistsRequesterIdentity(t *testing.T) {
 		t.Fatalf("expected source_log_id %s, got %v", entry.ID, job.SourceLogID)
 	}
 }
+
+// newVideoLifecyclePlugin is the minimal plugin a video lifecycle record needs.
+func newVideoLifecyclePlugin(t *testing.T) (*LoggerPlugin, *fakeBatchStore) {
+	t.Helper()
+	bs := newFakeBatchStore()
+	return &LoggerPlugin{
+		ctx:        context.Background(),
+		store:      newTestStore(t),
+		batchStore: bs,
+		logger:     testLogger{},
+	}, bs
+}
+
+// The request is the only witness to duration and resolution for most providers,
+// and it is in hand exactly once — here. If it is not written down now, settlement
+// minutes later has nothing to price from.
+func TestRecordVideoJobLifecycle_CapturesRequestPricingDimensions(t *testing.T) {
+	plugin, bs := newVideoLifecyclePlugin(t)
+
+	audio := true
+	eightSeconds := "8"
+	entry := &logstore.Log{
+		ID:            "req-video-1",
+		Provider:      string(schemas.OpenAI),
+		Model:         "sora-2-pro",
+		SelectedKeyID: "key-abc",
+		ParamsParsed: &schemas.VideoGenerationParameters{
+			Seconds: &eightSeconds,
+			Size:    "1920x1080",
+			Audio:   &audio,
+		},
+	}
+	result := &schemas.BifrostResponse{
+		VideoGenerationResponse: &schemas.BifrostVideoGenerationResponse{
+			ID:     "vid_abc",
+			Status: schemas.VideoStatusQueued,
+		},
+	}
+	plugin.recordVideoJobLifecycle(entry, result, schemas.VideoGenerationRequest)
+
+	job, err := bs.GetProviderJob(context.Background(), cstables.ProviderJobID(cstables.ProviderJobKindVideo, "openai", "vid_abc"))
+	if err != nil {
+		t.Fatalf("expected a video job row: %v", err)
+	}
+	if job.Kind != cstables.ProviderJobKindVideo {
+		t.Fatalf("kind = %q, want %q", job.Kind, cstables.ProviderJobKindVideo)
+	}
+	if job.Model != "sora-2-pro" {
+		t.Fatalf("model = %q, want sora-2-pro", job.Model)
+	}
+	if job.NextCheckAt == nil {
+		t.Fatal("a queued video must be scheduled for a poll")
+	}
+	// The sweeper pins its poll to this key. An OpenAI video id is visible only to
+	// the key that created it, so a row without one can only be polled by whatever
+	// key core happens to pick — which will be told the video does not exist.
+	if job.SelectedKeyID != "key-abc" {
+		t.Fatalf("selected key id = %q, want key-abc", job.SelectedKeyID)
+	}
+
+	dims := jobaccounting.VideoDimensionsFromJob(job)
+	if dims.Seconds == nil || *dims.Seconds != 8 {
+		t.Fatalf("seconds = %v, want 8", dims.Seconds)
+	}
+	if dims.Size != "1920x1080" {
+		t.Fatalf("size = %q, want 1920x1080", dims.Size)
+	}
+	if dims.Audio == nil || !*dims.Audio {
+		t.Fatalf("audio = %v, want true", dims.Audio)
+	}
+	if dims.RequestType != schemas.VideoGenerationRequest {
+		t.Fatalf("request type = %q, want %q", dims.RequestType, schemas.VideoGenerationRequest)
+	}
+}
+
+// A video submitted before this build was already charged at submission. Creating
+// its row on a later retrieve would hand it to the sweeper and charge it twice.
+func TestRecordVideoJobLifecycle_RetrieveDoesNotCreateRowForPreUpgradeJob(t *testing.T) {
+	plugin, bs := newVideoLifecyclePlugin(t)
+
+	entry := &logstore.Log{ID: "req-video-retrieve", Provider: string(schemas.OpenAI), Model: "sora-2-pro"}
+	result := &schemas.BifrostResponse{
+		VideoGenerationResponse: &schemas.BifrostVideoGenerationResponse{
+			ID:     "vid_pre_upgrade",
+			Status: schemas.VideoStatusCompleted,
+		},
+	}
+	plugin.recordVideoJobLifecycle(entry, result, schemas.VideoRetrieveRequest)
+
+	if _, err := bs.GetProviderJob(context.Background(), cstables.ProviderJobID(cstables.ProviderJobKindVideo, "openai", "vid_pre_upgrade")); err == nil {
+		t.Fatal("a retrieve must never create a job row we did not see submitted")
+	}
+}
+
+// A retrieve on a job we did submit must still advance it, without losing the
+// dimensions the submission captured.
+func TestRecordVideoJobLifecycle_RetrieveAdvancesKnownJob(t *testing.T) {
+	plugin, bs := newVideoLifecyclePlugin(t)
+
+	eightSeconds := "8"
+	entry := &logstore.Log{
+		ID:           "req-video-2",
+		Provider:     string(schemas.OpenAI),
+		Model:        "sora-2-pro",
+		ParamsParsed: &schemas.VideoGenerationParameters{Seconds: &eightSeconds, Size: "1280x720"},
+	}
+	submitted := &schemas.BifrostResponse{
+		VideoGenerationResponse: &schemas.BifrostVideoGenerationResponse{ID: "vid_known", Status: schemas.VideoStatusQueued},
+	}
+	plugin.recordVideoJobLifecycle(entry, submitted, schemas.VideoGenerationRequest)
+
+	retrieved := &schemas.BifrostResponse{
+		VideoGenerationResponse: &schemas.BifrostVideoGenerationResponse{ID: "vid_known", Status: schemas.VideoStatusCompleted},
+	}
+	plugin.recordVideoJobLifecycle(entry, retrieved, schemas.VideoRetrieveRequest)
+
+	job, err := bs.GetProviderJob(context.Background(), cstables.ProviderJobID(cstables.ProviderJobKindVideo, "openai", "vid_known"))
+	if err != nil {
+		t.Fatalf("expected the submitted job row: %v", err)
+	}
+	if job.ProviderStatus != string(schemas.VideoStatusCompleted) {
+		t.Fatalf("provider status = %q, want completed", job.ProviderStatus)
+	}
+
+	dims := jobaccounting.VideoDimensionsFromJob(job)
+	if dims.Seconds == nil || *dims.Seconds != 8 {
+		t.Fatalf("the submission's dimensions must survive a retrieve that reports none: %v", dims.Seconds)
+	}
+	if dims.Size != "1280x720" {
+		t.Fatalf("size = %q, want 1280x720", dims.Size)
+	}
+}
+
+// The retrieve path settles inline off the response the caller already fetched,
+// instead of leaving the sweeper to fetch it a second time up to a sweep interval
+// later. The submission is recorded first, then the terminal poll settles it.
+func TestAccountVideoResults_SettlesTheJobTheSubmissionRecorded(t *testing.T) {
+	store := newTestStore(t)
+	bs := newFakeBatchStore()
+	plugin := &LoggerPlugin{
+		ctx:            context.Background(),
+		store:          store,
+		batchStore:     bs,
+		logger:         testLogger{},
+		pricingManager: newTestPricingManager(t),
+	}
+
+	eightSeconds := "8"
+	entry := &logstore.Log{
+		ID:           "req-video-inline",
+		Provider:     string(schemas.OpenAI),
+		Model:        "sora-2-pro",
+		ParamsParsed: &schemas.VideoGenerationParameters{Seconds: &eightSeconds, Size: "1280x720"},
+	}
+	submitted := &schemas.BifrostResponse{
+		VideoGenerationResponse: &schemas.BifrostVideoGenerationResponse{ID: "vid_inline_wired", Status: schemas.VideoStatusQueued},
+	}
+	plugin.recordVideoJobLifecycle(entry, submitted, schemas.VideoGenerationRequest)
+
+	terminal := &schemas.BifrostResponse{
+		VideoGenerationResponse: &schemas.BifrostVideoGenerationResponse{
+			ID:     "vid_inline_wired",
+			Status: schemas.VideoStatusCompleted,
+			Videos: []schemas.VideoOutput{{Type: schemas.VideoOutputTypeURL}},
+			Usage:  &schemas.VideoUsage{Cost: &schemas.BifrostCost{TotalCost: 0.75}},
+		},
+	}
+	plugin.recordVideoJobLifecycle(entry, terminal, schemas.VideoRetrieveRequest)
+	plugin.accountVideoResults(entry, terminal, nil)
+
+	job, err := bs.GetProviderJob(context.Background(), cstables.ProviderJobID(cstables.ProviderJobKindVideo, "openai", "vid_inline_wired"))
+	if err != nil {
+		t.Fatalf("GetProviderJob() error = %v", err)
+	}
+	if job.AccountingStatus != cstables.ProviderJobAccountingStatusAccounted {
+		t.Fatalf("accounting_status = %s, want %s", job.AccountingStatus, cstables.ProviderJobAccountingStatusAccounted)
+	}
+}
+
+// A video submitted before this build was charged at submission; settling it now
+// would bill it twice. With no coordination row, the inline path must do nothing.
+func TestAccountVideoResults_SkipsAJobWithNoCoordinationRow(t *testing.T) {
+	store := newTestStore(t)
+	bs := newFakeBatchStore()
+	plugin := &LoggerPlugin{
+		ctx:            context.Background(),
+		store:          store,
+		batchStore:     bs,
+		logger:         testLogger{},
+		pricingManager: newTestPricingManager(t),
+	}
+
+	entry := &logstore.Log{ID: "req-video-orphan", Provider: string(schemas.OpenAI), Model: "sora-2-pro"}
+	terminal := &schemas.BifrostResponse{
+		VideoGenerationResponse: &schemas.BifrostVideoGenerationResponse{
+			ID:     "vid_orphan",
+			Status: schemas.VideoStatusCompleted,
+			Videos: []schemas.VideoOutput{{Type: schemas.VideoOutputTypeURL}},
+			Usage:  &schemas.VideoUsage{Cost: &schemas.BifrostCost{TotalCost: 0.75}},
+		},
+	}
+	plugin.accountVideoResults(entry, terminal, nil)
+
+	if _, err := bs.GetProviderJob(context.Background(), cstables.ProviderJobID(cstables.ProviderJobKindVideo, "openai", "vid_orphan")); err == nil {
+		t.Fatal("inline settlement must not create a job row for a video we never saw submitted")
+	}
+}

--- a/transports/bifrost-http/server/batch_accounting.go
+++ b/transports/bifrost-http/server/batch_accounting.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -26,11 +27,12 @@ func (f *bifrostBatchResultFetcher) RetrieveBatch(ctx context.Context, job *csta
 	if job == nil {
 		return nil, fmt.Errorf("batch job is nil")
 	}
-	resp, bifrostErr := f.client.BatchRetrieveRequest(internalBatchContext(ctx), &schemas.BifrostBatchRetrieveRequest{
+	req := &schemas.BifrostBatchRetrieveRequest{
 		Provider: schemas.ModelProvider(job.Provider),
 		Model:    modelPtr(job.Model),
 		BatchID:  job.JobID,
-	})
+	}
+	resp, bifrostErr := f.client.BatchRetrieveRequest(internalJobContext(ctx, job.SelectedKeyID), req)
 	if bifrostErr != nil {
 		return nil, fmt.Errorf("%s", bifrostErr.GetErrorString())
 	}
@@ -44,22 +46,44 @@ func (f *bifrostBatchResultFetcher) FetchBatchResults(ctx context.Context, job *
 	if job == nil {
 		return nil, fmt.Errorf("batch job is nil")
 	}
-	resp, bifrostErr := f.client.BatchResultsRequest(internalBatchContext(ctx), &schemas.BifrostBatchResultsRequest{
+	req := &schemas.BifrostBatchResultsRequest{
 		Provider: schemas.ModelProvider(job.Provider),
 		Model:    modelPtr(job.Model),
 		BatchID:  job.JobID,
-	})
+	}
+	resp, bifrostErr := f.client.BatchResultsRequest(internalJobContext(ctx, job.SelectedKeyID), req)
 	if bifrostErr != nil {
 		return nil, fmt.Errorf("%s", bifrostErr.GetErrorString())
 	}
 	return resp, nil
 }
 
-func internalBatchContext(parent context.Context) *schemas.BifrostContext {
+// internalJobContext builds the context the sweeper polls a provider job with,
+// pinned to the key that created the job when the row recorded one.
+//
+// The sweeper skips the plugin pipeline, so nothing upstream resolves a key for it
+// and core is otherwise free to pick any key registered for the provider. On OpenAI
+// a video id is scoped to its creating key, so an unpinned poll asks a key that has
+// never heard of the job and is told it does not exist.
+//
+// There is deliberately no unpinned retry when a pinned poll fails, for either kind.
+// It would fire on every transient error — a provider outage, a rate limit — and so
+// double the load on an upstream already in trouble, to rescue only the rare case of
+// a key deleted mid-flight. That case already has two better answers: the job parks
+// as unpriceable, which is visible and re-drivable, and a user hitting
+// /v1/batches/{id}/results settles it inline with their own key.
+//
+// BifrostContextKeyAPIKeyID pins by id through the registered pool rather than
+// injecting a raw secret, and it is only write-blocked while the plugin pipeline
+// holds restricted writes — which is exactly the phase this context never enters.
+func internalJobContext(parent context.Context, selectedKeyID string) *schemas.BifrostContext {
 	ctx := schemas.NewBifrostContext(parent, schemas.NoDeadline)
 	ctx.SetValue(schemas.BifrostContextKeyRequestID, uuid.NewString())
 	ctx.SetValue(schemas.BifrostContextKeySkipPluginPipeline, true)
 	ctx.SetValue(schemas.BifrostContextKeySkipBudgetAndRateLimits, true)
+	if selectedKeyID = strings.TrimSpace(selectedKeyID); selectedKeyID != "" {
+		ctx.SetValue(schemas.BifrostContextKeyAPIKeyID, selectedKeyID)
+	}
 	return ctx
 }
 
@@ -91,4 +115,28 @@ func (s *BifrostHTTPServer) WireBatchAccountingSweeper() {
 	}
 	loggerPlugin.SetBatchUsageReporter(usageReporter)
 	loggerPlugin.StartBatchAccountingSweeper(&bifrostBatchResultFetcher{client: s.Client}, time.Minute, s.Config.KVStore)
+	// Video jobs finish in minutes, not hours, so their sweeper runs on a much
+	// tighter tick than the batch one.
+	loggerPlugin.StartVideoAccountingSweeper(&bifrostVideoRetriever{client: s.Client}, 30*time.Second, s.Config.KVStore)
+}
+
+type bifrostVideoRetriever struct {
+	client *bifrost.Bifrost
+}
+
+func (f *bifrostVideoRetriever) RetrieveVideo(ctx context.Context, job *cstables.TableProviderJob) (*schemas.BifrostVideoGenerationResponse, error) {
+	if f == nil || f.client == nil {
+		return nil, fmt.Errorf("bifrost client is nil")
+	}
+	if job == nil {
+		return nil, fmt.Errorf("video job is nil")
+	}
+	resp, bifrostErr := f.client.VideoRetrieveRequest(internalJobContext(ctx, job.SelectedKeyID), &schemas.BifrostVideoRetrieveRequest{
+		Provider: schemas.ModelProvider(job.Provider),
+		ID:       job.JobID,
+	})
+	if bifrostErr != nil {
+		return nil, fmt.Errorf("%s", bifrostErr.GetErrorString())
+	}
+	return resp, nil
 }

--- a/transports/bifrost-http/server/batch_accounting_test.go
+++ b/transports/bifrost-http/server/batch_accounting_test.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// The sweeper skips the plugin pipeline, so nothing upstream resolves a key for it.
+// Pinning to the key that created the job is what stops core from polling with an
+// arbitrary one — which for a video is not a preference but a correctness matter:
+// OpenAI scopes a video id to its creating key.
+func TestInternalJobContextPinsTheCreatingKey(t *testing.T) {
+	ctx := internalJobContext(context.Background(), "key-abc")
+
+	keyID, ok := ctx.Value(schemas.BifrostContextKeyAPIKeyID).(string)
+	if !ok || keyID != "key-abc" {
+		t.Fatalf("api key id = %q (ok=%v), want key-abc", keyID, ok)
+	}
+}
+
+// BifrostContextKeyAPIKeyID is a reserved key: writes to it are dropped while the
+// plugin pipeline holds restricted writes. This context never enters that phase, so
+// the write must land — if that ever changes, the pin silently stops working and
+// the sweeper goes back to polling with whatever key core picks.
+func TestInternalJobContextReservedWriteIsNotDropped(t *testing.T) {
+	ctx := internalJobContext(context.Background(), "key-reserved")
+	if _, ok := ctx.Value(schemas.BifrostContextKeyAPIKeyID).(string); !ok {
+		t.Fatal("a reserved-key write on a fresh sweeper context must not be dropped")
+	}
+	// Same reasoning as the skip flags this context has always set.
+	if skip, ok := ctx.Value(schemas.BifrostContextKeySkipBudgetAndRateLimits).(bool); !ok || !skip {
+		t.Fatal("expected the sweeper context to keep skipping budgets")
+	}
+}
+
+// A job row written before the key was recorded, or by a path that never had one,
+// must still poll rather than pin to the empty string and match nothing.
+func TestInternalJobContextWithoutKeyLeavesSelectionOpen(t *testing.T) {
+	for _, selectedKeyID := range []string{"", "   "} {
+		ctx := internalJobContext(context.Background(), selectedKeyID)
+		if _, ok := ctx.Value(schemas.BifrostContextKeyAPIKeyID).(string); ok {
+			t.Fatalf("selectedKeyID %q must leave key selection unpinned", selectedKeyID)
+		}
+	}
+}
+
+// The sweeper's own invariants must survive the pin.
+func TestInternalJobContextKeepsSweeperInvariants(t *testing.T) {
+	ctx := internalJobContext(context.Background(), "key-abc")
+
+	if skip, ok := ctx.Value(schemas.BifrostContextKeySkipPluginPipeline).(bool); !ok || !skip {
+		t.Fatal("the sweeper must not re-enter the plugin pipeline")
+	}
+	if requestID, ok := ctx.Value(schemas.BifrostContextKeyRequestID).(string); !ok || requestID == "" {
+		t.Fatal("every sweeper call needs its own request id")
+	}
+}
+
+// Both job kinds poll through the same pinned context. An earlier revision gave
+// batch an unpinned retry on failure, on the theory that a batch id is org-scoped
+// so any key could rescue it. That fires on every transient error — an outage, a
+// rate limit — doubling load on an upstream already failing, to cover only a key
+// deleted mid-flight; and that case is already answered by the job parking as
+// unpriceable and by /v1/batches/{id}/results settling inline with the caller's own
+// key. One code path, no retry.
+func TestInternalJobContextIsTheOnlySweeperContext(t *testing.T) {
+	batchCtx := internalJobContext(context.Background(), "key-batch")
+	videoCtx := internalJobContext(context.Background(), "key-video")
+
+	for name, ctx := range map[string]*schemas.BifrostContext{"batch": batchCtx, "video": videoCtx} {
+		if _, ok := ctx.Value(schemas.BifrostContextKeyAPIKeyID).(string); !ok {
+			t.Fatalf("%s: both kinds must poll pinned to their creating key", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds deferred billing for asynchronous video generation jobs. Previously, video costs were charged at submission time — before the job had produced anything and before it could fail. This PR moves video billing to settlement time (when the job reaches a terminal state), matching the existing pattern used for batch jobs.

## Changes

- **`framework/modelcatalog/datasheet/videopricing.go`** (new): Introduces `VideoPricingDimensions`, a struct capturing every factor that can affect a video job's price (model, duration, resolution, clip count, provider-reported cost, etc.). Persisted as JSON at submission so settlement has the request's dimensions available even when the provider's retrieve response reports only a status. Includes `MergedWith` to overlay observed response dimensions over captured request dimensions, `VideoDimensionsFromResponse` to extract what a terminal response actually reports, and `CalculateVideoCostDetails` to price from merged dimensions with provider-reported cost taking precedence over catalog rates.

- **`framework/modelcatalog/datasheet/cost.go`**: Non-terminal video statuses (`queued`, `in_progress`) now return `nil` from `computeCostFromInput`, preventing charges at submission. Terminal responses still price inline, which is what settlement drives.

- **`framework/jobaccounting/video.go`** (new): `VideoSettler` implements the `Settler` interface for video jobs. Uses a shorter backoff ladder than batch (minutes vs. hours) since video jobs typically finish in one to five minutes. `AccountVideoJob` provides inline settlement from a terminal retrieve response the caller already holds, avoiding a redundant provider call and a full sweep interval of delay. `NewVideoSweeper` binds the generic sweeper engine to the video settler.

- **`framework/jobaccounting/types.go`**: Adds `CalculateVideoCostDetails` to the `PricingManager` interface.

- **`plugins/logging/main.go`**: `recordVideoJobLifecycle` captures the coordination row and pricing dimensions at submission. `accountVideoResults` settles inline on a terminal retrieve response. `StartVideoAccountingSweeper` runs the video sweeper on a 30-second tick. Retrieve requests guard against creating rows for jobs submitted before this build (which were already charged at submission), preventing double-billing.

- **`transports/bifrost-http/server/batch_accounting.go`**: Renames `internalBatchContext` to `internalJobContext` and adds key pinning via `BifrostContextKeyAPIKeyID`. The sweeper now polls using the key that created the job, which is a correctness requirement for OpenAI where a video ID is scoped to its creating key. Adds `bifrostVideoRetriever` and wires the video sweeper in `WireBatchAccountingSweeper`.

- **Test fakes**: `fakeBatchPricing` renamed to `fakePricing` and extended with `CalculateVideoCostDetails` to satisfy the updated `PricingManager` interface. `requestTypePricing` similarly extended.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/jobaccounting/...
go test ./framework/modelcatalog/...
go test ./plugins/logging/...
go test ./transports/bifrost-http/server/...
```

Key scenarios covered by the new tests:
- Pricing dimensions round-trip through the job row's params column
- Settlement prices from captured request params when the retrieve response is silent
- Response dimensions override captured ones when the provider reports them
- Provider-reported cost wins over catalog rates
- Failed jobs are priced at zero (not unpriceable), preventing them from parking in the sweeper indefinitely
- Content-filtered jobs park as unpriceable rather than being guessed free or billable
- Jobs with no catalog rate record as unpriced (not free) for later backfill
- Inline settlement and sweeper settlement land on the same aggregate row
- Retrieve requests never create rows for jobs submitted before this build
- Sweeper polls are pinned to the creating key; empty key IDs leave selection open

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Sweeper poll contexts skip the plugin pipeline and budget/rate-limit checks, consistent with the existing batch sweeper. Key pinning uses `BifrostContextKeyAPIKeyID` to select from the registered key pool rather than injecting a raw secret. The reserved-key write is intentionally performed on a fresh context that never enters the restricted-write phase of the plugin pipeline.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable