### PR TITLE
chore: rename `virtual_key_not_found`/`virtual_key_blocked` error codes to `access_not_found`/`access_blocked` in e2e test assertions

### DIFF
--- a/tests/e2e/api/collections/bifrost-v1-auth-matrix.postman_collection.json
+++ b/tests/e2e/api/collections/bifrost-v1-auth-matrix.postman_collection.json
@@ -34,7 +34,7 @@
                   "});",
                   "pm.test('VK inference response carries no virtual_key rejection', function () {",
                   "  pm.expect(pm.response.text()).to.not.include('virtual_key_required');",
-                  "  pm.expect(pm.response.text()).to.not.include('virtual_key_not_found');",
+                  "  pm.expect(pm.response.text()).to.not.include('access_not_found');",
                   "});"
                 ]
               }

--- a/tests/e2e/api/collections/bifrost-v1-vk-expiry.postman_collection.json
+++ b/tests/e2e/api/collections/bifrost-v1-vk-expiry.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Bifrost V1 - Virtual Key Expiry",
-    "description": "Virtual key expiry tests. Covers create/update validation (future-only timestamps, RFC3339 parsing, empty-string clear, omit-leaves-unchanged) and runtime enforcement (unexpired passes, expired blocks with 403 virtual_key_blocked, inactive wins before expired, clearing expiry restores access). Self-provisions VKs and cleans up.",
+    "description": "Virtual key expiry tests. Covers create/update validation (future-only timestamps, RFC3339 parsing, empty-string clear, omit-leaves-unchanged) and runtime enforcement (unexpired passes, expired blocks with 403 access_blocked, inactive wins before expired, clearing expiry restores access). Self-provisions VKs and cleans up.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "variable": [
@@ -1038,7 +1038,7 @@
                   "// guards that governance does not reject an unexpired VK.",
                   "pm.test('Response carries no expiry rejection', function() {",
                   "  pm.expect(pm.response.text()).to.not.include('Virtual key has expired');",
-                  "  pm.expect(pm.response.text()).to.not.include('virtual_key_blocked');",
+                  "  pm.expect(pm.response.text()).to.not.include('access_blocked');",
                   "});"
                 ]
               }
@@ -1083,7 +1083,7 @@
                 "exec": [
                   "if (!pm.collectionVariables.get('mcp_tool_name')) { pm.test('Skipped: no connected MCP client with tools', function() { pm.expect(true).to.be.true; }); } else {",
                   "  pm.test('Unexpired VK MCP execution carries no governance rejection', function() {",
-                  "    pm.expect(pm.response.text(), 'body: ' + pm.response.text()).to.not.include('virtual_key_blocked');",
+                  "    pm.expect(pm.response.text(), 'body: ' + pm.response.text()).to.not.include('access_blocked');",
                   "  });",
                   "}"
                 ]
@@ -1201,8 +1201,8 @@
                   "pm.test('Expired VK inference returns 403', function() {",
                   "  pm.expect(pm.response.code, 'body: ' + pm.response.text()).to.equal(403);",
                   "});",
-                  "pm.test('Rejection is virtual_key_blocked with expired reason', function() {",
-                  "  pm.expect(pm.response.text()).to.include('virtual_key_blocked');",
+                  "pm.test('Rejection is access_blocked with expired reason', function() {",
+                  "  pm.expect(pm.response.text()).to.include('access_blocked');",
                   "  pm.expect(pm.response.text().toLowerCase()).to.include('expired');",
                   "});"
                 ]
@@ -1250,8 +1250,8 @@
                   "  pm.test('Expired VK MCP execution returns 403', function() {",
                   "    pm.expect(pm.response.code, 'body: ' + pm.response.text()).to.equal(403);",
                   "  });",
-                  "  pm.test('Rejection is virtual_key_blocked with expired reason', function() {",
-                  "    pm.expect(pm.response.text()).to.include('virtual_key_blocked');",
+                  "  pm.test('Rejection is access_blocked with expired reason', function() {",
+                  "    pm.expect(pm.response.text()).to.include('access_blocked');",
                   "    pm.expect(pm.response.text().toLowerCase()).to.include('expired');",
                   "  });",
                   "}"
@@ -1558,7 +1558,7 @@
                   "  pm.expect(pm.response.code, 'body: ' + pm.response.text()).to.equal(403);",
                   "});",
                   "pm.test('Rejection is still the expired reason', function() {",
-                  "  pm.expect(pm.response.text()).to.include('virtual_key_blocked');",
+                  "  pm.expect(pm.response.text()).to.include('access_blocked');",
                   "  pm.expect(pm.response.text().toLowerCase()).to.include('expired');",
                   "});"
                 ]
@@ -1691,7 +1691,7 @@
                 "type": "text/javascript",
                 "exec": [
                   "pm.test('Extension restores access (no expiry rejection)', function() {",
-                  "  pm.expect(pm.response.text()).to.not.include('virtual_key_blocked');",
+                  "  pm.expect(pm.response.text()).to.not.include('access_blocked');",
                   "  pm.expect(pm.response.text()).to.not.include('Virtual key has expired');",
                   "});"
                 ]
@@ -1775,7 +1775,7 @@
                 "type": "text/javascript",
                 "exec": [
                   "pm.test('Response carries no governance rejection', function() {",
-                  "  pm.expect(pm.response.text()).to.not.include('virtual_key_blocked');",
+                  "  pm.expect(pm.response.text()).to.not.include('access_blocked');",
                   "  pm.expect(pm.response.text()).to.not.include('Virtual key has expired');",
                   "});"
                 ]

--- a/tests/e2e/api/collections/bifrost-v1-vk-rotation-cooldown.postman_collection.json
+++ b/tests/e2e/api/collections/bifrost-v1-vk-rotation-cooldown.postman_collection.json
@@ -791,7 +791,7 @@
                 "type": "text/javascript",
                 "exec": [
                   "pm.test('Old value inference returns 401', function() { pm.expect(pm.response.code, 'body: ' + pm.response.text()).to.equal(401); });",
-                  "pm.test('Rejection is virtual_key_not_found', function() { pm.expect(pm.response.text()).to.include('virtual_key_not_found'); });"
+                  "pm.test('Rejection is access_not_found', function() { pm.expect(pm.response.text()).to.include('access_not_found'); });"
                 ]
               }
             }
@@ -1983,7 +1983,7 @@
                 "type": "text/javascript",
                 "exec": [
                   "pm.test('Oldest VK C value returns 401', function() { pm.expect(pm.response.code, 'body: ' + pm.response.text()).to.equal(401); });",
-                  "pm.test('Rejection is virtual_key_not_found', function() { pm.expect(pm.response.text()).to.include('virtual_key_not_found'); });"
+                  "pm.test('Rejection is access_not_found', function() { pm.expect(pm.response.text()).to.include('access_not_found'); });"
                 ]
               }
             }
@@ -2038,7 +2038,7 @@
                   "// The provider call itself may fail in some environments; this test only",
                   "// guards that governance does not reject the presented value as unknown.",
                   "pm.test('Latest retired VK C value: response carries no virtual-key rejection', function() {",
-                  "  pm.expect(pm.response.text()).to.not.include('virtual_key_not_found');",
+                  "  pm.expect(pm.response.text()).to.not.include('access_not_found');",
                   "});"
                 ]
               }
@@ -2140,7 +2140,7 @@
                   "// The provider call itself may fail in some environments; this test only",
                   "// guards that governance does not reject the presented value as unknown.",
                   "pm.test('Old VK A value: response carries no virtual-key rejection', function() {",
-                  "  pm.expect(pm.response.text()).to.not.include('virtual_key_not_found');",
+                  "  pm.expect(pm.response.text()).to.not.include('access_not_found');",
                   "});"
                 ]
               }
@@ -2196,7 +2196,7 @@
                   "// The provider call itself may fail in some environments; this test only",
                   "// guards that governance does not reject the presented value as unknown.",
                   "pm.test('New VK A value: response carries no virtual-key rejection', function() {",
-                  "  pm.expect(pm.response.text()).to.not.include('virtual_key_not_found');",
+                  "  pm.expect(pm.response.text()).to.not.include('access_not_found');",
                   "});"
                 ]
               }
@@ -2415,7 +2415,7 @@
                 "type": "text/javascript",
                 "exec": [
                   "pm.test('Expired VK A grace value returns 401', function() { pm.expect(pm.response.code, 'body: ' + pm.response.text()).to.equal(401); });",
-                  "pm.test('Rejection is virtual_key_not_found', function() { pm.expect(pm.response.text()).to.include('virtual_key_not_found'); });"
+                  "pm.test('Rejection is access_not_found', function() { pm.expect(pm.response.text()).to.include('access_not_found'); });"
                 ]
               }
             }
@@ -2516,7 +2516,7 @@
                   "// The provider call itself may fail in some environments; this test only",
                   "// guards that governance does not reject the presented value as unknown.",
                   "pm.test('New VK A value post-expiry: response carries no virtual-key rejection', function() {",
-                  "  pm.expect(pm.response.text()).to.not.include('virtual_key_not_found');",
+                  "  pm.expect(pm.response.text()).to.not.include('access_not_found');",
                   "});"
                 ]
               }
@@ -2687,7 +2687,7 @@
                 "type": "text/javascript",
                 "exec": [
                   "pm.test('Expired VK B grace value returns 401', function() { pm.expect(pm.response.code, 'body: ' + pm.response.text()).to.equal(401); });",
-                  "pm.test('Rejection is virtual_key_not_found', function() { pm.expect(pm.response.text()).to.include('virtual_key_not_found'); });"
+                  "pm.test('Rejection is access_not_found', function() { pm.expect(pm.response.text()).to.include('access_not_found'); });"
                 ]
               }
             }
@@ -2788,7 +2788,7 @@
                   "// The provider call itself may fail in some environments; this test only",
                   "// guards that governance does not reject the presented value as unknown.",
                   "pm.test('New VK B value post-expiry: response carries no virtual-key rejection', function() {",
-                  "  pm.expect(pm.response.text()).to.not.include('virtual_key_not_found');",
+                  "  pm.expect(pm.response.text()).to.not.include('access_not_found');",
                   "});"
                 ]
               }
@@ -3007,7 +3007,7 @@
                 "type": "text/javascript",
                 "exec": [
                   "pm.test('Old VK D value returns 401', function() { pm.expect(pm.response.code, 'body: ' + pm.response.text()).to.equal(401); });",
-                  "pm.test('Rejection is virtual_key_not_found', function() { pm.expect(pm.response.text()).to.include('virtual_key_not_found'); });"
+                  "pm.test('Rejection is access_not_found', function() { pm.expect(pm.response.text()).to.include('access_not_found'); });"
                 ]
               }
             }
@@ -3108,7 +3108,7 @@
                   "// The provider call itself may fail in some environments; this test only",
                   "// guards that governance does not reject the presented value as unknown.",
                   "pm.test('New VK D value: response carries no virtual-key rejection', function() {",
-                  "  pm.expect(pm.response.text()).to.not.include('virtual_key_not_found');",
+                  "  pm.expect(pm.response.text()).to.not.include('access_not_found');",
                   "});"
                 ]
               }
@@ -3464,7 +3464,7 @@
                 "type": "text/javascript",
                 "exec": [
                   "pm.test('Previously-live VK E grace value returns 401', function() { pm.expect(pm.response.code, 'body: ' + pm.response.text()).to.equal(401); });",
-                  "pm.test('Rejection is virtual_key_not_found', function() { pm.expect(pm.response.text()).to.include('virtual_key_not_found'); });"
+                  "pm.test('Rejection is access_not_found', function() { pm.expect(pm.response.text()).to.include('access_not_found'); });"
                 ]
               }
             }
@@ -3563,7 +3563,7 @@
                 "type": "text/javascript",
                 "exec": [
                   "pm.test('Just-retired VK E value returns 401', function() { pm.expect(pm.response.code, 'body: ' + pm.response.text()).to.equal(401); });",
-                  "pm.test('Rejection is virtual_key_not_found', function() { pm.expect(pm.response.text()).to.include('virtual_key_not_found'); });"
+                  "pm.test('Rejection is access_not_found', function() { pm.expect(pm.response.text()).to.include('access_not_found'); });"
                 ]
               }
             }


### PR DESCRIPTION
## Summary

Renames error codes in the E2E test assertions to align with updated API error identifiers. `virtual_key_not_found` is replaced with `access_not_found`, and `virtual_key_blocked` is replaced with `access_blocked` across all affected Postman collections.

## Changes

- Replaced all assertions checking for `virtual_key_not_found` with `access_not_found` in the auth matrix, VK rotation/cooldown, and VK expiry collections.
- Replaced all assertions checking for `virtual_key_blocked` with `access_blocked` in the VK expiry collection.
- Updated the VK expiry collection description to reflect the new `access_blocked` error code.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the updated Postman collections against a running Bifrost instance and confirm all renamed assertions pass with the new error codes.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. These are test-only changes updating error code string matching.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable