### PR TITLE
feat(core): support input_video chat content blocks (pass-through)

### DIFF
--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -1259,6 +1259,7 @@ const (
 	ChatContentBlockTypeText       ChatContentBlockType = "text"
 	ChatContentBlockTypeImage      ChatContentBlockType = "image_url"
 	ChatContentBlockTypeInputAudio ChatContentBlockType = "input_audio"
+	ChatContentBlockTypeInputVideo ChatContentBlockType = "input_video"
 	ChatContentBlockTypeFile       ChatContentBlockType = "file"
 	ChatContentBlockTypeRefusal    ChatContentBlockType = "refusal"
 )
@@ -1270,6 +1271,7 @@ type ChatContentBlock struct {
 	Refusal        *string              `json:"refusal,omitempty"`
 	ImageURLStruct *ChatInputImage      `json:"image_url,omitempty"`
 	InputAudio     *ChatInputAudio      `json:"input_audio,omitempty"`
+	InputVideo     *ChatInputVideo      `json:"input_video,omitempty"`
 	File           *ChatInputFile       `json:"file,omitempty"`
 
 	// Not in OpenAI's schemas, but sent by a few providers (Anthropic, Bedrock are some of them)
@@ -1507,6 +1509,16 @@ type ChatInputImage struct {
 // Format is optional (e.g., "wav", "mp3"); when nil, providers may attempt auto-detection.
 type ChatInputAudio struct {
 	Data   string  `json:"data"`
+	Format *string `json:"format,omitempty"`
+}
+
+// ChatInputVideo represents video data in a message ("input_video" content block,
+// as accepted by OpenAI-compatible backends such as llama.cpp server).
+// Data carries the video payload (e.g., raw base64 or data URL); URL points to a
+// remote source the provider fetches itself. Format is optional (e.g., "mp4").
+type ChatInputVideo struct {
+	Data   *string `json:"data,omitempty"`
+	URL    *string `json:"url,omitempty"`
 	Format *string `json:"format,omitempty"`
 }
 

--- a/core/schemas/inputvideo_test.go
+++ b/core/schemas/inputvideo_test.go
@@ -1,0 +1,93 @@
+package schemas
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// input_video content blocks (llama.cpp-style OpenAI-compatible dialect) must
+// round-trip through schemas.Unmarshal/Marshal without losing their payload,
+// so gateways can pass them through to backends that support video input.
+
+func TestSonic_ChatContentBlock_InputVideo_RoundTrip(t *testing.T) {
+	input := `{"type":"input_video","input_video":{"data":"AAAA","format":"mp4"}}`
+
+	var b ChatContentBlock
+	err := Unmarshal([]byte(input), &b)
+	require.NoError(t, err)
+
+	assert.Equal(t, ChatContentBlockTypeInputVideo, b.Type)
+	require.NotNil(t, b.InputVideo)
+	require.NotNil(t, b.InputVideo.Data)
+	assert.Equal(t, "AAAA", *b.InputVideo.Data)
+	require.NotNil(t, b.InputVideo.Format)
+	assert.Equal(t, "mp4", *b.InputVideo.Format)
+	assert.Nil(t, b.InputVideo.URL)
+
+	output, err := Marshal(b)
+	require.NoError(t, err)
+
+	// Structural round-trip: re-unmarshal the marshaled output and verify the
+	// nested payload survived (string containment alone can pass on type only).
+	var b2 ChatContentBlock
+	require.NoError(t, Unmarshal(output, &b2))
+	assert.Equal(t, ChatContentBlockTypeInputVideo, b2.Type)
+	require.NotNil(t, b2.InputVideo)
+	require.NotNil(t, b2.InputVideo.Data)
+	assert.Equal(t, "AAAA", *b2.InputVideo.Data)
+	require.NotNil(t, b2.InputVideo.Format)
+	assert.Equal(t, "mp4", *b2.InputVideo.Format)
+}
+
+func TestSonic_ChatContentBlock_InputVideo_URLVariant(t *testing.T) {
+	input := `{"type":"input_video","input_video":{"url":"https://example.com/clip.mp4"}}`
+
+	var b ChatContentBlock
+	err := Unmarshal([]byte(input), &b)
+	require.NoError(t, err)
+
+	assert.Equal(t, ChatContentBlockTypeInputVideo, b.Type)
+	require.NotNil(t, b.InputVideo)
+	require.NotNil(t, b.InputVideo.URL)
+	assert.Equal(t, "https://example.com/clip.mp4", *b.InputVideo.URL)
+	assert.Nil(t, b.InputVideo.Data)
+
+	output, err := Marshal(b)
+	require.NoError(t, err)
+
+	var b2 ChatContentBlock
+	require.NoError(t, Unmarshal(output, &b2))
+	require.NotNil(t, b2.InputVideo)
+	require.NotNil(t, b2.InputVideo.URL)
+	assert.Equal(t, "https://example.com/clip.mp4", *b2.InputVideo.URL)
+	assert.Nil(t, b2.InputVideo.Data)
+}
+
+func TestChatToResponses_InputVideo_PayloadPreserved(t *testing.T) {
+	data := "AAAA"
+	format := "mp4"
+	msg := ChatMessage{
+		Role: ChatMessageRoleUser,
+		Content: &ChatMessageContent{
+			ContentBlocks: []ChatContentBlock{{
+				Type:       ChatContentBlockTypeInputVideo,
+				InputVideo: &ChatInputVideo{Data: &data, Format: &format},
+			}},
+		},
+	}
+
+	respMsgs := msg.ToResponsesMessages()
+	require.Len(t, respMsgs, 1)
+	require.NotNil(t, respMsgs[0].Content)
+	require.Len(t, respMsgs[0].Content.ContentBlocks, 1)
+
+	block := respMsgs[0].Content.ContentBlocks[0]
+	assert.Equal(t, ResponsesInputMessageContentBlockTypeVideo, block.Type)
+	require.NotNil(t, block.Video, "video payload must survive Chat→Responses conversion")
+	require.NotNil(t, block.Video.Data)
+	assert.Equal(t, "AAAA", *block.Video.Data)
+	require.NotNil(t, block.Video.Format)
+	assert.Equal(t, "mp4", *block.Video.Format)
+}

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -230,6 +230,15 @@ func (cm *ChatMessage) ToResponsesToolMessage() *ResponsesMessage {
 						Format: format,
 					}
 				}
+
+				// Map video
+				if block.InputVideo != nil {
+					respBlocks[i].Video = &ResponsesInputMessageContentBlockVideo{
+						Data:   block.InputVideo.Data,
+						URL:    block.InputVideo.URL,
+						Format: block.InputVideo.Format,
+					}
+				}
 			}
 			respMsg.ResponsesToolMessage.Output = &ResponsesToolMessageOutputStruct{
 				ResponsesFunctionToolCallOutputBlocks: respBlocks,
@@ -600,6 +609,8 @@ func (cm *ChatMessage) ToResponsesMessages() []ResponsesMessage {
 					blockType = ResponsesInputMessageContentBlockTypeFile
 				case ChatContentBlockTypeInputAudio:
 					blockType = ResponsesInputMessageContentBlockTypeAudio
+				case ChatContentBlockTypeInputVideo:
+					blockType = ResponsesInputMessageContentBlockTypeVideo
 				}
 
 				responseBlocks[i] = ResponsesMessageContentBlock{
@@ -631,6 +642,13 @@ func (cm *ChatMessage) ToResponsesMessages() []ResponsesMessage {
 					responseBlocks[i].Audio = &ResponsesInputMessageContentBlockAudio{
 						Data:   block.InputAudio.Data,
 						Format: format,
+					}
+				}
+				if block.InputVideo != nil {
+					responseBlocks[i].Video = &ResponsesInputMessageContentBlockVideo{
+						Data:   block.InputVideo.Data,
+						URL:    block.InputVideo.URL,
+						Format: block.InputVideo.Format,
 					}
 				}
 			}
@@ -701,6 +719,15 @@ func (cm *ChatMessage) ToResponsesMessages() []ResponsesMessage {
 						respBlocks[i].Audio = &ResponsesInputMessageContentBlockAudio{
 							Data:   block.InputAudio.Data,
 							Format: format,
+						}
+					}
+
+					// Map video
+					if block.InputVideo != nil {
+						respBlocks[i].Video = &ResponsesInputMessageContentBlockVideo{
+							Data:   block.InputVideo.Data,
+							URL:    block.InputVideo.URL,
+							Format: block.InputVideo.Format,
 						}
 					}
 				}
@@ -923,6 +950,8 @@ func ToChatMessages(rms []ResponsesMessage) []ChatMessage {
 						chatBlockType = ChatContentBlockTypeFile // "input_file" -> "file"
 					case ResponsesInputMessageContentBlockTypeAudio:
 						chatBlockType = ChatContentBlockTypeInputAudio // "input_audio" -> "input_audio" (same)
+					case ResponsesInputMessageContentBlockTypeVideo:
+						chatBlockType = ChatContentBlockTypeInputVideo // "input_video" -> "input_video" (same)
 					default:
 						// For unknown types, fall back to direct conversion
 						chatBlockType = ChatContentBlockType(block.Type)
@@ -957,6 +986,13 @@ func ToChatMessages(rms []ResponsesMessage) []ChatMessage {
 						}
 						if block.Audio.Format != "" {
 							chatBlocks[i].InputAudio.Format = &block.Audio.Format
+						}
+					}
+					if block.Video != nil {
+						chatBlocks[i].InputVideo = &ChatInputVideo{
+							Data:   block.Video.Data,
+							URL:    block.Video.URL,
+							Format: block.Video.Format,
 						}
 					}
 				}

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -1752,6 +1752,7 @@ const (
 	ResponsesInputMessageContentBlockTypeImage     ResponsesMessageContentBlockType = "input_image"
 	ResponsesInputMessageContentBlockTypeFile      ResponsesMessageContentBlockType = "input_file"
 	ResponsesInputMessageContentBlockTypeAudio     ResponsesMessageContentBlockType = "input_audio"
+	ResponsesInputMessageContentBlockTypeVideo     ResponsesMessageContentBlockType = "input_video"
 	ResponsesInputMessageContentBlockTypeContainer ResponsesMessageContentBlockType = "input_container" // Anthropic-only: file staged into the code-execution container input dir
 
 	ResponsesOutputMessageContentTypeText      ResponsesMessageContentBlockType = "output_text"
@@ -1782,6 +1783,7 @@ type ResponsesMessageContentBlock struct {
 	*ResponsesInputMessageContentBlockImage
 	*ResponsesInputMessageContentBlockFile
 	Audio *ResponsesInputMessageContentBlockAudio `json:"input_audio,omitempty"`
+	Video *ResponsesInputMessageContentBlockVideo `json:"input_video,omitempty"`
 
 	*ResponsesOutputMessageContentText            // Normal text output from the model
 	*ResponsesOutputMessageContentRefusal         // Model refusal to answer
@@ -1833,6 +1835,12 @@ type ResponsesInputMessageContentBlockFile struct {
 type ResponsesInputMessageContentBlockAudio struct {
 	Format string `json:"format"` // "mp3" or "wav"
 	Data   string `json:"data"`   // base64 encoded audio data
+}
+
+type ResponsesInputMessageContentBlockVideo struct {
+	Data   *string `json:"data,omitempty"`   // base64 encoded video data
+	URL    *string `json:"url,omitempty"`    // remote video URL
+	Format *string `json:"format,omitempty"` // e.g., "mp4"
 }
 
 // =============================================================================

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -889,6 +889,23 @@ func deepCopyChatContentBlock(original ChatContentBlock) ChatContentBlock {
 		copy.InputAudio = &copyAudio
 	}
 
+	if original.InputVideo != nil {
+		copyVideo := ChatInputVideo{}
+		if original.InputVideo.Data != nil {
+			copyData := *original.InputVideo.Data
+			copyVideo.Data = &copyData
+		}
+		if original.InputVideo.URL != nil {
+			copyURL := *original.InputVideo.URL
+			copyVideo.URL = &copyURL
+		}
+		if original.InputVideo.Format != nil {
+			copyFormat := *original.InputVideo.Format
+			copyVideo.Format = &copyFormat
+		}
+		copy.InputVideo = &copyVideo
+	}
+
 	if original.File != nil {
 		copyFile := ChatInputFile{}
 		if original.File.FileData != nil {
@@ -1572,6 +1589,24 @@ func deepCopyResponsesMessageContentBlock(original ResponsesMessageContentBlock)
 			Data:   original.Audio.Data,
 		}
 		copy.Audio = copyAudio
+	}
+
+	// Deep copy Video
+	if original.Video != nil {
+		copyVideo := &ResponsesInputMessageContentBlockVideo{}
+		if original.Video.Data != nil {
+			copyData := *original.Video.Data
+			copyVideo.Data = &copyData
+		}
+		if original.Video.URL != nil {
+			copyURL := *original.Video.URL
+			copyVideo.URL = &copyURL
+		}
+		if original.Video.Format != nil {
+			copyFormat := *original.Video.Format
+			copyVideo.Format = &copyFormat
+		}
+		copy.Video = copyVideo
 	}
 
 	// Deep copy ResponsesOutputMessageContentText

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -1063,6 +1063,7 @@
                                       "input_image",
                                       "input_file",
                                       "input_audio",
+                                      "input_video",
                                       "output_text",
                                       "refusal",
                                       "reasoning_text"
@@ -1110,6 +1111,20 @@
                                         ]
                                       },
                                       "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "input_video": {
+                                    "type": "object",
+                                    "properties": {
+                                      "data": {
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      },
+                                      "format": {
                                         "type": "string"
                                       }
                                     }
@@ -1239,6 +1254,7 @@
                                       "input_image",
                                       "input_file",
                                       "input_audio",
+                                      "input_video",
                                       "output_text",
                                       "refusal",
                                       "reasoning_text"
@@ -1286,6 +1302,20 @@
                                         ]
                                       },
                                       "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "input_video": {
+                                    "type": "object",
+                                    "properties": {
+                                      "data": {
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      },
+                                      "format": {
                                         "type": "string"
                                       }
                                     }
@@ -1466,6 +1496,7 @@
                             "input_image",
                             "input_file",
                             "input_audio",
+                            "input_video",
                             "output_text",
                             "refusal",
                             "reasoning_text"
@@ -1513,6 +1544,20 @@
                               ]
                             },
                             "data": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "input_video": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "format": {
                               "type": "string"
                             }
                           }
@@ -5307,6 +5352,7 @@
                                           "input_image",
                                           "input_file",
                                           "input_audio",
+                                          "input_video",
                                           "output_text",
                                           "refusal",
                                           "reasoning_text"
@@ -5354,6 +5400,20 @@
                                             ]
                                           },
                                           "data": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "input_video": {
+                                        "type": "object",
+                                        "properties": {
+                                          "data": {
+                                            "type": "string"
+                                          },
+                                          "url": {
+                                            "type": "string"
+                                          },
+                                          "format": {
                                             "type": "string"
                                           }
                                         }
@@ -5483,6 +5543,7 @@
                                           "input_image",
                                           "input_file",
                                           "input_audio",
+                                          "input_video",
                                           "output_text",
                                           "refusal",
                                           "reasoning_text"
@@ -5530,6 +5591,20 @@
                                             ]
                                           },
                                           "data": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "input_video": {
+                                        "type": "object",
+                                        "properties": {
+                                          "data": {
+                                            "type": "string"
+                                          },
+                                          "url": {
+                                            "type": "string"
+                                          },
+                                          "format": {
                                             "type": "string"
                                           }
                                         }
@@ -5819,6 +5894,7 @@
                                         "input_image",
                                         "input_file",
                                         "input_audio",
+                                        "input_video",
                                         "output_text",
                                         "refusal",
                                         "reasoning_text"
@@ -5866,6 +5942,20 @@
                                           ]
                                         },
                                         "data": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "input_video": {
+                                      "type": "object",
+                                      "properties": {
+                                        "data": {
+                                          "type": "string"
+                                        },
+                                        "url": {
+                                          "type": "string"
+                                        },
+                                        "format": {
                                           "type": "string"
                                         }
                                       }
@@ -5995,6 +6085,7 @@
                                         "input_image",
                                         "input_file",
                                         "input_audio",
+                                        "input_video",
                                         "output_text",
                                         "refusal",
                                         "reasoning_text"
@@ -6042,6 +6133,20 @@
                                           ]
                                         },
                                         "data": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "input_video": {
+                                      "type": "object",
+                                      "properties": {
+                                        "data": {
+                                          "type": "string"
+                                        },
+                                        "url": {
+                                          "type": "string"
+                                        },
+                                        "format": {
                                           "type": "string"
                                         }
                                       }
@@ -6531,6 +6636,7 @@
                                       "input_image",
                                       "input_file",
                                       "input_audio",
+                                      "input_video",
                                       "output_text",
                                       "refusal",
                                       "reasoning_text"
@@ -6578,6 +6684,20 @@
                                         ]
                                       },
                                       "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "input_video": {
+                                    "type": "object",
+                                    "properties": {
+                                      "data": {
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      },
+                                      "format": {
                                         "type": "string"
                                       }
                                     }
@@ -6707,6 +6827,7 @@
                                       "input_image",
                                       "input_file",
                                       "input_audio",
+                                      "input_video",
                                       "output_text",
                                       "refusal",
                                       "reasoning_text"
@@ -6754,6 +6875,20 @@
                                         ]
                                       },
                                       "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "input_video": {
+                                    "type": "object",
+                                    "properties": {
+                                      "data": {
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      },
+                                      "format": {
                                         "type": "string"
                                       }
                                     }
@@ -6934,6 +7069,7 @@
                             "input_image",
                             "input_file",
                             "input_audio",
+                            "input_video",
                             "output_text",
                             "refusal",
                             "reasoning_text"
@@ -6981,6 +7117,20 @@
                               ]
                             },
                             "data": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "input_video": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "format": {
                               "type": "string"
                             }
                           }
@@ -13583,6 +13733,7 @@
                                       "input_image",
                                       "input_file",
                                       "input_audio",
+                                      "input_video",
                                       "output_text",
                                       "refusal",
                                       "reasoning_text"
@@ -13630,6 +13781,20 @@
                                         ]
                                       },
                                       "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "input_video": {
+                                    "type": "object",
+                                    "properties": {
+                                      "data": {
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      },
+                                      "format": {
                                         "type": "string"
                                       }
                                     }
@@ -13759,6 +13924,7 @@
                                       "input_image",
                                       "input_file",
                                       "input_audio",
+                                      "input_video",
                                       "output_text",
                                       "refusal",
                                       "reasoning_text"
@@ -13806,6 +13972,20 @@
                                         ]
                                       },
                                       "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "input_video": {
+                                    "type": "object",
+                                    "properties": {
+                                      "data": {
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      },
+                                      "format": {
                                         "type": "string"
                                       }
                                     }
@@ -13986,6 +14166,7 @@
                             "input_image",
                             "input_file",
                             "input_audio",
+                            "input_video",
                             "output_text",
                             "refusal",
                             "reasoning_text"
@@ -14033,6 +14214,20 @@
                               ]
                             },
                             "data": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "input_video": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "format": {
                               "type": "string"
                             }
                           }
@@ -14533,6 +14728,7 @@
                                       "input_image",
                                       "input_file",
                                       "input_audio",
+                                      "input_video",
                                       "output_text",
                                       "refusal",
                                       "reasoning_text"
@@ -14580,6 +14776,20 @@
                                         ]
                                       },
                                       "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "input_video": {
+                                    "type": "object",
+                                    "properties": {
+                                      "data": {
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      },
+                                      "format": {
                                         "type": "string"
                                       }
                                     }
@@ -14709,6 +14919,7 @@
                                       "input_image",
                                       "input_file",
                                       "input_audio",
+                                      "input_video",
                                       "output_text",
                                       "refusal",
                                       "reasoning_text"
@@ -14756,6 +14967,20 @@
                                         ]
                                       },
                                       "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "input_video": {
+                                    "type": "object",
+                                    "properties": {
+                                      "data": {
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      },
+                                      "format": {
                                         "type": "string"
                                       }
                                     }
@@ -14936,6 +15161,7 @@
                             "input_image",
                             "input_file",
                             "input_audio",
+                            "input_video",
                             "output_text",
                             "refusal",
                             "reasoning_text"
@@ -14983,6 +15209,20 @@
                               ]
                             },
                             "data": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "input_video": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "format": {
                               "type": "string"
                             }
                           }
@@ -15520,6 +15760,7 @@
                                       "input_image",
                                       "input_file",
                                       "input_audio",
+                                      "input_video",
                                       "output_text",
                                       "refusal",
                                       "reasoning_text"
@@ -15567,6 +15808,20 @@
                                         ]
                                       },
                                       "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "input_video": {
+                                    "type": "object",
+                                    "properties": {
+                                      "data": {
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      },
+                                      "format": {
                                         "type": "string"
                                       }
                                     }
@@ -15696,6 +15951,7 @@
                                       "input_image",
                                       "input_file",
                                       "input_audio",
+                                      "input_video",
                                       "output_text",
                                       "refusal",
                                       "reasoning_text"
@@ -15743,6 +15999,20 @@
                                         ]
                                       },
                                       "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "input_video": {
+                                    "type": "object",
+                                    "properties": {
+                                      "data": {
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      },
+                                      "format": {
                                         "type": "string"
                                       }
                                     }
@@ -15923,6 +16193,7 @@
                             "input_image",
                             "input_file",
                             "input_audio",
+                            "input_video",
                             "output_text",
                             "refusal",
                             "reasoning_text"
@@ -15970,6 +16241,20 @@
                               ]
                             },
                             "data": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "input_video": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "format": {
                               "type": "string"
                             }
                           }
@@ -16628,6 +16913,7 @@
                                           "input_image",
                                           "input_file",
                                           "input_audio",
+                                          "input_video",
                                           "output_text",
                                           "refusal",
                                           "reasoning_text"
@@ -16675,6 +16961,20 @@
                                             ]
                                           },
                                           "data": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "input_video": {
+                                        "type": "object",
+                                        "properties": {
+                                          "data": {
+                                            "type": "string"
+                                          },
+                                          "url": {
+                                            "type": "string"
+                                          },
+                                          "format": {
                                             "type": "string"
                                           }
                                         }
@@ -16804,6 +17104,7 @@
                                           "input_image",
                                           "input_file",
                                           "input_audio",
+                                          "input_video",
                                           "output_text",
                                           "refusal",
                                           "reasoning_text"
@@ -16851,6 +17152,20 @@
                                             ]
                                           },
                                           "data": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "input_video": {
+                                        "type": "object",
+                                        "properties": {
+                                          "data": {
+                                            "type": "string"
+                                          },
+                                          "url": {
+                                            "type": "string"
+                                          },
+                                          "format": {
                                             "type": "string"
                                           }
                                         }
@@ -17140,6 +17455,7 @@
                                         "input_image",
                                         "input_file",
                                         "input_audio",
+                                        "input_video",
                                         "output_text",
                                         "refusal",
                                         "reasoning_text"
@@ -17187,6 +17503,20 @@
                                           ]
                                         },
                                         "data": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "input_video": {
+                                      "type": "object",
+                                      "properties": {
+                                        "data": {
+                                          "type": "string"
+                                        },
+                                        "url": {
+                                          "type": "string"
+                                        },
+                                        "format": {
                                           "type": "string"
                                         }
                                       }
@@ -17316,6 +17646,7 @@
                                         "input_image",
                                         "input_file",
                                         "input_audio",
+                                        "input_video",
                                         "output_text",
                                         "refusal",
                                         "reasoning_text"
@@ -17363,6 +17694,20 @@
                                           ]
                                         },
                                         "data": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "input_video": {
+                                      "type": "object",
+                                      "properties": {
+                                        "data": {
+                                          "type": "string"
+                                        },
+                                        "url": {
+                                          "type": "string"
+                                        },
+                                        "format": {
                                           "type": "string"
                                         }
                                       }
@@ -30657,6 +31002,7 @@
                                       "input_image",
                                       "input_file",
                                       "input_audio",
+                                      "input_video",
                                       "output_text",
                                       "refusal",
                                       "reasoning_text"
@@ -30704,6 +31050,20 @@
                                         ]
                                       },
                                       "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "input_video": {
+                                    "type": "object",
+                                    "properties": {
+                                      "data": {
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      },
+                                      "format": {
                                         "type": "string"
                                       }
                                     }
@@ -30833,6 +31193,7 @@
                                       "input_image",
                                       "input_file",
                                       "input_audio",
+                                      "input_video",
                                       "output_text",
                                       "refusal",
                                       "reasoning_text"
@@ -30880,6 +31241,20 @@
                                         ]
                                       },
                                       "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "input_video": {
+                                    "type": "object",
+                                    "properties": {
+                                      "data": {
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      },
+                                      "format": {
                                         "type": "string"
                                       }
                                     }
@@ -31060,6 +31435,7 @@
                             "input_image",
                             "input_file",
                             "input_audio",
+                            "input_video",
                             "output_text",
                             "refusal",
                             "reasoning_text"
@@ -31107,6 +31483,20 @@
                               ]
                             },
                             "data": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "input_video": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "format": {
                               "type": "string"
                             }
                           }
@@ -33796,6 +34186,7 @@
                                       "input_image",
                                       "input_file",
                                       "input_audio",
+                                      "input_video",
                                       "output_text",
                                       "refusal",
                                       "reasoning_text"
@@ -33843,6 +34234,20 @@
                                         ]
                                       },
                                       "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "input_video": {
+                                    "type": "object",
+                                    "properties": {
+                                      "data": {
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      },
+                                      "format": {
                                         "type": "string"
                                       }
                                     }
@@ -33972,6 +34377,7 @@
                                       "input_image",
                                       "input_file",
                                       "input_audio",
+                                      "input_video",
                                       "output_text",
                                       "refusal",
                                       "reasoning_text"
@@ -34019,6 +34425,20 @@
                                         ]
                                       },
                                       "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "input_video": {
+                                    "type": "object",
+                                    "properties": {
+                                      "data": {
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      },
+                                      "format": {
                                         "type": "string"
                                       }
                                     }
@@ -34199,6 +34619,7 @@
                             "input_image",
                             "input_file",
                             "input_audio",
+                            "input_video",
                             "output_text",
                             "refusal",
                             "reasoning_text"
@@ -34246,6 +34667,20 @@
                               ]
                             },
                             "data": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "input_video": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "format": {
                               "type": "string"
                             }
                           }
@@ -37049,6 +37484,7 @@
                                       "input_image",
                                       "input_file",
                                       "input_audio",
+                                      "input_video",
                                       "output_text",
                                       "refusal",
                                       "reasoning_text"
@@ -37096,6 +37532,20 @@
                                         ]
                                       },
                                       "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "input_video": {
+                                    "type": "object",
+                                    "properties": {
+                                      "data": {
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      },
+                                      "format": {
                                         "type": "string"
                                       }
                                     }
@@ -37225,6 +37675,7 @@
                                       "input_image",
                                       "input_file",
                                       "input_audio",
+                                      "input_video",
                                       "output_text",
                                       "refusal",
                                       "reasoning_text"
@@ -37272,6 +37723,20 @@
                                         ]
                                       },
                                       "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "input_video": {
+                                    "type": "object",
+                                    "properties": {
+                                      "data": {
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      },
+                                      "format": {
                                         "type": "string"
                                       }
                                     }
@@ -37452,6 +37917,7 @@
                             "input_image",
                             "input_file",
                             "input_audio",
+                            "input_video",
                             "output_text",
                             "refusal",
                             "reasoning_text"
@@ -37499,6 +37965,20 @@
                               ]
                             },
                             "data": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "input_video": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "format": {
                               "type": "string"
                             }
                           }
@@ -43691,6 +44171,7 @@
                                       "input_image",
                                       "input_file",
                                       "input_audio",
+                                      "input_video",
                                       "output_text",
                                       "refusal",
                                       "reasoning_text"
@@ -43738,6 +44219,20 @@
                                         ]
                                       },
                                       "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "input_video": {
+                                    "type": "object",
+                                    "properties": {
+                                      "data": {
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      },
+                                      "format": {
                                         "type": "string"
                                       }
                                     }
@@ -43867,6 +44362,7 @@
                                       "input_image",
                                       "input_file",
                                       "input_audio",
+                                      "input_video",
                                       "output_text",
                                       "refusal",
                                       "reasoning_text"
@@ -43914,6 +44410,20 @@
                                         ]
                                       },
                                       "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "input_video": {
+                                    "type": "object",
+                                    "properties": {
+                                      "data": {
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      },
+                                      "format": {
                                         "type": "string"
                                       }
                                     }
@@ -82753,6 +83263,7 @@
                         "text",
                         "image_url",
                         "input_audio",
+                        "input_video",
                         "file",
                         "refusal"
                       ]
@@ -82789,6 +83300,20 @@
                       ],
                       "properties": {
                         "data": {
+                          "type": "string"
+                        },
+                        "format": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "input_video": {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "string"
+                        },
+                        "url": {
                           "type": "string"
                         },
                         "format": {
@@ -83441,6 +83966,7 @@
                                   "input_image",
                                   "input_file",
                                   "input_audio",
+                                  "input_video",
                                   "output_text",
                                   "refusal",
                                   "reasoning_text"
@@ -83488,6 +84014,20 @@
                                     ]
                                   },
                                   "data": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "input_video": {
+                                "type": "object",
+                                "properties": {
+                                  "data": {
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  },
+                                  "format": {
                                     "type": "string"
                                   }
                                 }
@@ -83617,6 +84157,7 @@
                                   "input_image",
                                   "input_file",
                                   "input_audio",
+                                  "input_video",
                                   "output_text",
                                   "refusal",
                                   "reasoning_text"
@@ -83664,6 +84205,20 @@
                                     ]
                                   },
                                   "data": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "input_video": {
+                                "type": "object",
+                                "properties": {
+                                  "data": {
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  },
+                                  "format": {
                                     "type": "string"
                                   }
                                 }
@@ -84346,6 +84901,7 @@
                               "input_image",
                               "input_file",
                               "input_audio",
+                              "input_video",
                               "output_text",
                               "refusal",
                               "reasoning_text"
@@ -84393,6 +84949,20 @@
                                 ]
                               },
                               "data": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "input_video": {
+                            "type": "object",
+                            "properties": {
+                              "data": {
+                                "type": "string"
+                              },
+                              "url": {
+                                "type": "string"
+                              },
+                              "format": {
                                 "type": "string"
                               }
                             }
@@ -84522,6 +85092,7 @@
                               "input_image",
                               "input_file",
                               "input_audio",
+                              "input_video",
                               "output_text",
                               "refusal",
                               "reasoning_text"
@@ -84569,6 +85140,20 @@
                                 ]
                               },
                               "data": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "input_video": {
+                            "type": "object",
+                            "properties": {
+                              "data": {
+                                "type": "string"
+                              },
+                              "url": {
+                                "type": "string"
+                              },
+                              "format": {
                                 "type": "string"
                               }
                             }
@@ -85269,6 +85854,7 @@
                               "input_image",
                               "input_file",
                               "input_audio",
+                              "input_video",
                               "output_text",
                               "refusal",
                               "reasoning_text"
@@ -85316,6 +85902,20 @@
                                 ]
                               },
                               "data": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "input_video": {
+                            "type": "object",
+                            "properties": {
+                              "data": {
+                                "type": "string"
+                              },
+                              "url": {
+                                "type": "string"
+                              },
+                              "format": {
                                 "type": "string"
                               }
                             }
@@ -85445,6 +86045,7 @@
                               "input_image",
                               "input_file",
                               "input_audio",
+                              "input_video",
                               "output_text",
                               "refusal",
                               "reasoning_text"
@@ -85492,6 +86093,20 @@
                                 ]
                               },
                               "data": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "input_video": {
+                            "type": "object",
+                            "properties": {
+                              "data": {
+                                "type": "string"
+                              },
+                              "url": {
+                                "type": "string"
+                              },
+                              "format": {
                                 "type": "string"
                               }
                             }
@@ -86349,6 +86964,7 @@
                               "input_image",
                               "input_file",
                               "input_audio",
+                              "input_video",
                               "output_text",
                               "refusal",
                               "reasoning_text"
@@ -86396,6 +87012,20 @@
                                 ]
                               },
                               "data": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "input_video": {
+                            "type": "object",
+                            "properties": {
+                              "data": {
+                                "type": "string"
+                              },
+                              "url": {
+                                "type": "string"
+                              },
+                              "format": {
                                 "type": "string"
                               }
                             }
@@ -86525,6 +87155,7 @@
                               "input_image",
                               "input_file",
                               "input_audio",
+                              "input_video",
                               "output_text",
                               "refusal",
                               "reasoning_text"
@@ -86572,6 +87203,20 @@
                                 ]
                               },
                               "data": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "input_video": {
+                            "type": "object",
+                            "properties": {
+                              "data": {
+                                "type": "string"
+                              },
+                              "url": {
+                                "type": "string"
+                              },
+                              "format": {
                                 "type": "string"
                               }
                             }
@@ -88238,6 +88883,7 @@
                         "text",
                         "image_url",
                         "input_audio",
+                        "input_video",
                         "file",
                         "refusal"
                       ]
@@ -88274,6 +88920,20 @@
                       ],
                       "properties": {
                         "data": {
+                          "type": "string"
+                        },
+                        "format": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "input_video": {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "string"
+                        },
+                        "url": {
                           "type": "string"
                         },
                         "format": {
@@ -88573,6 +89233,7 @@
                                   "input_image",
                                   "input_file",
                                   "input_audio",
+                                  "input_video",
                                   "output_text",
                                   "refusal",
                                   "reasoning_text"
@@ -88620,6 +89281,20 @@
                                     ]
                                   },
                                   "data": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "input_video": {
+                                "type": "object",
+                                "properties": {
+                                  "data": {
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  },
+                                  "format": {
                                     "type": "string"
                                   }
                                 }
@@ -88749,6 +89424,7 @@
                                   "input_image",
                                   "input_file",
                                   "input_audio",
+                                  "input_video",
                                   "output_text",
                                   "refusal",
                                   "reasoning_text"
@@ -88796,6 +89472,20 @@
                                     ]
                                   },
                                   "data": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "input_video": {
+                                "type": "object",
+                                "properties": {
+                                  "data": {
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  },
+                                  "format": {
                                     "type": "string"
                                   }
                                 }
@@ -99775,6 +100465,7 @@
                               "input_image",
                               "input_file",
                               "input_audio",
+                              "input_video",
                               "output_text",
                               "refusal",
                               "reasoning_text"
@@ -99822,6 +100513,20 @@
                                 ]
                               },
                               "data": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "input_video": {
+                            "type": "object",
+                            "properties": {
+                              "data": {
+                                "type": "string"
+                              },
+                              "url": {
+                                "type": "string"
+                              },
+                              "format": {
                                 "type": "string"
                               }
                             }
@@ -99951,6 +100656,7 @@
                               "input_image",
                               "input_file",
                               "input_audio",
+                              "input_video",
                               "output_text",
                               "refusal",
                               "reasoning_text"
@@ -99998,6 +100704,20 @@
                                 ]
                               },
                               "data": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "input_video": {
+                            "type": "object",
+                            "properties": {
+                              "data": {
+                                "type": "string"
+                              },
+                              "url": {
+                                "type": "string"
+                              },
+                              "format": {
                                 "type": "string"
                               }
                             }
@@ -100236,6 +100956,7 @@
                               "input_image",
                               "input_file",
                               "input_audio",
+                              "input_video",
                               "output_text",
                               "refusal",
                               "reasoning_text"
@@ -100283,6 +101004,20 @@
                                 ]
                               },
                               "data": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "input_video": {
+                            "type": "object",
+                            "properties": {
+                              "data": {
+                                "type": "string"
+                              },
+                              "url": {
+                                "type": "string"
+                              },
+                              "format": {
                                 "type": "string"
                               }
                             }
@@ -100412,6 +101147,7 @@
                               "input_image",
                               "input_file",
                               "input_audio",
+                              "input_video",
                               "output_text",
                               "refusal",
                               "reasoning_text"
@@ -100459,6 +101195,20 @@
                                 ]
                               },
                               "data": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "input_video": {
+                            "type": "object",
+                            "properties": {
+                              "data": {
+                                "type": "string"
+                              },
+                              "url": {
+                                "type": "string"
+                              },
+                              "format": {
                                 "type": "string"
                               }
                             }

--- a/docs/openapi/schemas/inference/chat.yaml
+++ b/docs/openapi/schemas/inference/chat.yaml
@@ -166,7 +166,7 @@ ChatContentBlock:
   properties:
     type:
       type: string
-      enum: [text, image_url, input_audio, file, refusal]
+      enum: [text, image_url, input_audio, input_video, file, refusal]
     text:
       type: string
     refusal:
@@ -175,6 +175,8 @@ ChatContentBlock:
       $ref: '#/ChatInputImage'
     input_audio:
       $ref: '#/ChatInputAudio'
+    input_video:
+      $ref: '#/ChatInputVideo'
     file:
       $ref: '#/ChatInputFile'
     cache_control:
@@ -197,6 +199,16 @@ ChatInputAudio:
     - data
   properties:
     data:
+      type: string
+    format:
+      type: string
+
+ChatInputVideo:
+  type: object
+  properties:
+    data:
+      type: string
+    url:
       type: string
     format:
       type: string

--- a/docs/openapi/schemas/inference/responses.yaml
+++ b/docs/openapi/schemas/inference/responses.yaml
@@ -212,6 +212,7 @@ ResponsesMessageContentBlock:
           input_image,
           input_file,
           input_audio,
+          input_video,
           output_text,
           refusal,
           reasoning_text,
@@ -236,6 +237,8 @@ ResponsesMessageContentBlock:
       type: string
     input_audio:
       $ref: "#/ResponsesInputMessageContentBlockAudio"
+    input_video:
+      $ref: "#/ResponsesInputMessageContentBlockVideo"
     annotations:
       type: array
       items:
@@ -259,6 +262,16 @@ ResponsesInputMessageContentBlockAudio:
       type: string
       enum: [mp3, wav]
     data:
+      type: string
+
+ResponsesInputMessageContentBlockVideo:
+  type: object
+  properties:
+    data:
+      type: string
+    url:
+      type: string
+    format:
       type: string
 
 ResponsesOutputMessageContentTextAnnotation:

--- a/framework/logstore/payload.go
+++ b/framework/logstore/payload.go
@@ -612,6 +612,16 @@ func stripChatMessageAttachments(msg *schemas.ChatMessage) schemas.ChatMessage {
 			audioCopy.Data = attachmentStrippedPlaceholder
 			blocks[i].InputAudio = &audioCopy
 		}
+		if video := blocks[i].InputVideo; video != nil && (video.Data != nil || video.URL != nil) {
+			videoCopy := *video
+			if videoCopy.Data != nil {
+				videoCopy.Data = schemas.Ptr(attachmentStrippedPlaceholder)
+			}
+			if videoCopy.URL != nil {
+				videoCopy.URL = schemas.Ptr(attachmentStrippedPlaceholder)
+			}
+			blocks[i].InputVideo = &videoCopy
+		}
 		if file := blocks[i].File; file != nil && (file.FileData != nil || file.FileURL != nil) {
 			fileCopy := *file
 			if fileCopy.FileData != nil {
@@ -658,6 +668,16 @@ func stripResponsesMessageAttachments(msg *schemas.ResponsesMessage) schemas.Res
 			audioCopy := *audio
 			audioCopy.Data = attachmentStrippedPlaceholder
 			blocks[i].Audio = &audioCopy
+		}
+		if video := blocks[i].Video; video != nil && (video.Data != nil || video.URL != nil) {
+			videoCopy := *video
+			if videoCopy.Data != nil {
+				videoCopy.Data = schemas.Ptr(attachmentStrippedPlaceholder)
+			}
+			if videoCopy.URL != nil {
+				videoCopy.URL = schemas.Ptr(attachmentStrippedPlaceholder)
+			}
+			blocks[i].Video = &videoCopy
 		}
 	}
 	content := *msg.Content


### PR DESCRIPTION
## Summary

OpenAI-compatible backends such as **llama.cpp server** accept video input via an `"input_video"` chat content block. Bifrost's `ChatContentBlock` has no field for it, so the payload key is **silently dropped at unmarshal** while the `type` string survives. The backend then receives `{"type":"input_video"}` with no payload and fails with a confusing error (llama.cpp: `500 "Invalid base64 value"`), even though the client request was well-formed. This makes video input unusable through Bifrost for any provider that supports it.

This PR adds `input_video` as a pass-through content block so the payload reaches OpenAI-compatible upstreams intact.

## Changes

- **`core/schemas/chatcompletions.go`** — add `ChatContentBlockTypeInputVideo` and a `ChatInputVideo` pass-through field (`data`/`url`/`format`) on `ChatContentBlock`. The OpenAI-compatible provider path marshals the schema struct directly, so no provider-layer changes are needed for the primary path.
- **`core/schemas/responses.go` + `core/schemas/mux.go`** — mirror the block in the Responses schema (`ResponsesInputMessageContentBlockVideo`) and carry the payload through the Chat↔Responses conversions in both directions, so request-type conversion does not silently lose the payload.
- **`framework/logstore/payload.go`** — strip `input_video` payloads in the hybrid logstore DB preview alongside image/audio/file attachments, so multi-MB base64 video never lands in the DB row (the untouched original still goes to object storage).
- **`core/schemas/utils.go`** — include the new field in `deepCopyChatContentBlock` and the Responses content block deep copy.
- **`docs/openapi`** — document `input_video` in the chat and responses schemas; bundle regenerated with `bundle.py` (spec invariants pass).
- **`core/schemas/inputvideo_test.go`** — structural round-trip tests (data and URL variants, re-unmarshal of marshaled output) and a Chat→Responses conversion test asserting the payload survives.

Design notes:
- Providers with typed content-block switches (Bedrock, Gemini, Anthropic, Cohere) are intentionally untouched: Bedrock already rejects unsupported blocks explicitly, and the others keep their existing skip-unknown behavior. This PR only makes the payload *available*; per-provider video support can be layered on separately.
- `ChatInputVideo.Data`/`URL` are pointers so the block marshals exactly as the client sent it.

## Type of change

- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Plugins (framework/logstore)
- [x] Docs

## How to test

```sh
cd core && go test ./schemas/
cd framework && go test ./logstore/
cd docs/openapi && python3 bundle.py && python3 spec_invariants_test.py
```

All pass locally (go 1.27, CGO enabled for logstore). Full `core go test ./...` produces the same failure set as a clean `dev` checkout in my environment (pre-existing MCP/STDIO environment-dependent tests); no new failures are introduced by this change.

End-to-end validation was done against a llama.cpp server (`--mmproj` + video-capable build) behind a Bifrost deployment carrying this patch: an `input_video` (base64 mp4) chat completion returns 200 with correct frame-level understanding, image/text requests unaffected, and the log DB preview stores `[attachment stripped]` instead of the video base64.

## Breaking changes

- [x] No

Additive schema fields only; requests without `input_video` are byte-for-byte unaffected.

## Related issues

None found for `input_video`/chat video input.

## Security considerations

The logstore change *reduces* data-at-rest exposure: video payloads and signed video URLs are no longer persisted into the DB preview row.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXbUUvjxmk1Dh4dAhcSwWX
