### PR TITLE
fix: relay terminal stream frame when a Responses turn is Incomplete

### DIFF
--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -3690,7 +3690,7 @@ func toAnthropicResponsesStreamEvents(ctx *schemas.BifrostContext, bifrostResp *
 	case schemas.ResponsesStreamResponseTypePing:
 		streamResp.Type = AnthropicStreamEventTypePing
 
-	case schemas.ResponsesStreamResponseTypeCompleted:
+	case schemas.ResponsesStreamResponseTypeCompleted, schemas.ResponsesStreamResponseTypeIncomplete:
 		streamResp.Type = AnthropicStreamEventTypeMessageStop
 		// If a message_delta was already emitted from the upstream event, only emit message_stop
 		// to avoid sending a duplicate message_delta to the client.

--- a/core/providers/anthropic/serversidefallback_test.go
+++ b/core/providers/anthropic/serversidefallback_test.go
@@ -733,6 +733,53 @@ func TestToAnthropicResponsesStreamResponse_CompletedWithStopDetails(t *testing.
 	}
 }
 
+func TestToAnthropicResponsesStreamResponse_IncompleteEmitsMessageStop(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	// A turn truncated by max_output_tokens (or content filter) surfaces as
+	// ResponsesStreamResponseTypeIncomplete, not Completed. Before this fix,
+	// the switch in toAnthropicResponsesStreamEvents had no case for
+	// Incomplete, so it fell through to `default: return nil` and the client
+	// never received message_delta/message_stop for a truncated turn — the
+	// stream just ended after content_block_stop with a bare HTTP 200
+	// (maximhq/bifrost#6081).
+	bifrostResp := &schemas.BifrostResponsesStreamResponse{
+		Type: schemas.ResponsesStreamResponseTypeIncomplete,
+		Response: &schemas.BifrostResponsesResponse{
+			ID:         schemas.Ptr("resp_incomplete"),
+			Model:      "claude-sonnet-5",
+			StopReason: schemas.Ptr("max_tokens"),
+			Status:     schemas.Ptr(schemas.ResponsesResponseStatusIncomplete),
+			IncompleteDetails: &schemas.ResponsesResponseIncompleteDetails{
+				Reason: schemas.ResponsesResponseIncompleteReasonMaxOutputTokens,
+			},
+			Usage: &schemas.ResponsesResponseUsage{InputTokens: 55, OutputTokens: 4096},
+		},
+	}
+
+	events := ToAnthropicResponsesStreamResponse(ctx, bifrostResp)
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events (message_delta + message_stop), got %d: %+v", len(events), events)
+	}
+	delta := events[0]
+	if delta.Type != AnthropicStreamEventTypeMessageDelta || delta.Delta == nil {
+		t.Fatalf("event[0] = %+v, want message_delta with Delta", delta)
+	}
+	if delta.Delta.StopReason == nil || *delta.Delta.StopReason != AnthropicStopReasonMaxTokens {
+		t.Errorf("event[0].Delta.StopReason = %v, want max_tokens", delta.Delta.StopReason)
+	}
+	if delta.Usage == nil || delta.Usage.OutputTokens != 4096 {
+		t.Errorf("event[0].Usage = %+v, want OutputTokens=4096", delta.Usage)
+	}
+	stop := events[1]
+	if stop.Type != AnthropicStreamEventTypeMessageStop {
+		t.Fatalf("event[1].Type = %v, want message_stop", stop.Type)
+	}
+}
+
 // --- Fallback credit (fallback-credit-2026-06-01 / -09 on AWS) ---
 
 func TestFallbackCredit_StopDetailsRoundTrip(t *testing.T) {

--- a/core/providers/bedrock/cache_points_test.go
+++ b/core/providers/bedrock/cache_points_test.go
@@ -267,6 +267,44 @@ func TestToBedrockConverseStreamResponse_CopiesCacheTokens(t *testing.T) {
 	}
 }
 
+// TestToBedrockConverseStreamResponse_IncompleteEmitsTerminalEvent guards
+// against maximhq/bifrost#6081: a turn truncated by max_output_tokens (or
+// content filter) surfaces as ResponsesStreamResponseTypeIncomplete, not
+// Completed. Before this fix, the switch here had no case for Incomplete
+// and fell through to `default: return nil, nil`, so the Bedrock-native
+// ConverseStream ingress silently dropped messageStop/metadata for a
+// truncated turn instead of relaying the stopReason AWS itself sends.
+func TestToBedrockConverseStreamResponse_IncompleteEmitsTerminalEvent(t *testing.T) {
+	resp := &schemas.BifrostResponsesStreamResponse{
+		Type: schemas.ResponsesStreamResponseTypeIncomplete,
+		Response: &schemas.BifrostResponsesResponse{
+			StopReason: schemas.Ptr("max_tokens"),
+			IncompleteDetails: &schemas.ResponsesResponseIncompleteDetails{
+				Reason: schemas.ResponsesResponseIncompleteReasonMaxOutputTokens,
+			},
+			Usage: &schemas.ResponsesResponseUsage{
+				InputTokens:  55,
+				OutputTokens: 4096,
+				TotalTokens:  4151,
+			},
+		},
+	}
+
+	event, err := ToBedrockConverseStreamResponse(resp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event == nil {
+		t.Fatal("expected a terminal event, got nil (Incomplete silently dropped)")
+	}
+	if event.StopReason == nil || *event.StopReason != "max_tokens" {
+		t.Errorf("StopReason: want max_tokens, got %v", event.StopReason)
+	}
+	if event.Usage == nil || event.Usage.OutputTokens != 4096 {
+		t.Errorf("Usage: want OutputTokens=4096, got %+v", event.Usage)
+	}
+}
+
 // TestBuildBedrockTokenUsage_StreamMatchesNonStream asserts the streaming and non-streaming
 // Converse converters report identical usage from the same Responses usage — the drift that
 // caused issue #4746. Exercises cache write + 5m/1h breakdown in addition to cache read.

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -1862,7 +1862,7 @@ func ToBedrockConverseStreamResponse(bifrostResp *schemas.BifrostResponsesStream
 		event.ContentBlockIndex = &contentBlockIndex
 		event.ContentBlockStop = true
 
-	case schemas.ResponsesStreamResponseTypeCompleted:
+	case schemas.ResponsesStreamResponseTypeCompleted, schemas.ResponsesStreamResponseTypeIncomplete:
 		// Message stop - always set stopReason
 		stopReason := "end_turn"
 		if bifrostResp.Response != nil {


### PR DESCRIPTION
Fixes #6081.

## Problem

Both stream encoders switch on `schemas.ResponsesStreamResponseType` and only handle `Completed`:

- `toAnthropicResponsesStreamEvents` (`core/providers/anthropic/responses.go`) — feeds the Anthropic-compatible `/v1/messages` streaming endpoint.
- `ToBedrockConverseStreamResponse` (`core/providers/bedrock/responses.go`) — feeds the Bedrock-native `ConverseStream` ingress.

A turn truncated by `max_output_tokens` or a content filter surfaces as `Incomplete`, not `Completed`. Both switches fall through to their `default` branch (`return nil` / `return nil, nil`) for that type, silently dropping the terminal frame:

- Anthropic surface: no `message_delta` + `message_stop` after the last `content_block_stop`.
- Bedrock-native surface: no `messageStop` + `metadata` after the last `contentBlockStop`.

The client gets a clean HTTP 200 that just stops — no error, no way to distinguish truncation from a hung/dropped connection.

## Confirming the drop is introduced by Bifrost

Same prompt, two paths:

- **Direct to AWS Bedrock** (`boto3` `converse_stream`, bypassing Bifrost entirely): `messageStop{stopReason: end_turn}` + `metadata{usage:...}` always present.
- **Through Bifrost's `/anthropic/v1/messages`**: prompting for a long adaptive-thinking turn that exhausts its budget before producing any text reliably ends at `content_block_stop` with no `message_delta`/`message_stop`, on a real `stop_reason: max_tokens` truncation — matching the exact shape in #6081, and confirmed present against a locally built `main`.

## Fix

Fold `Incomplete` into the existing `Completed` case in both switches. Each case body already derives `stopReason`/`stop_reason` from `Response.IncompleteDetails.Reason` when `Response.StopReason` is absent — that logic predates this fix and was simply unreachable for `Incomplete` because the case label never matched it. No new branching needed.

```diff
-case schemas.ResponsesStreamResponseTypeCompleted:
+case schemas.ResponsesStreamResponseTypeCompleted, schemas.ResponsesStreamResponseTypeIncomplete:
```
(applied identically in both files)

## Tests

Added one regression test per encoder, each written to fail against the pre-fix code:

- `TestToAnthropicResponsesStreamResponse_IncompleteEmitsMessageStop`: pre-fix gets `0` events; post-fix gets `message_delta` (with `stop_reason: max_tokens` and usage) + `message_stop`.
- `TestToBedrockConverseStreamResponse_IncompleteEmitsTerminalEvent`: pre-fix gets `nil`; post-fix gets the terminal event with `StopReason`/`Usage` populated.

Verified both fail with the exact "0 events"/"nil" symptom on the unfixed switch, and pass with the one-line fix. Also ran the full `providers/anthropic` and `providers/bedrock` package suites (excluding two pre-existing, unrelated `failed to load aws config" failures present on a clean checkout with no local AWS credentials) — all green.

I reviewed the full diff: this is a one-line case-label fix per encoder plus tests; no unrelated changes.