### PR TITLE
perf: add focused usage snapshot

### DIFF
--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -125,6 +125,7 @@ type BudgetAndRateLimitStatus struct {
 //     DB-backed) and prevents retry loops on policy violations.
 type GovernanceStore interface {
 	GetGovernanceData(ctx context.Context) *GovernanceData
+	GetGovernanceUsageData(ctx context.Context) *GovernanceData
 	GetVirtualKey(ctx context.Context, vkValue string) (*configstoreTables.TableVirtualKey, bool)
 	GetVirtualKeyByID(ctx context.Context, vkID string) (*configstoreTables.TableVirtualKey, bool)
 	// ResolvePermits reports the permits a request carries: the ones its caller holds, the permit
@@ -841,6 +842,33 @@ func (gs *LocalGovernanceStore) RebaseRateLimit(ctx context.Context, rateLimitID
 		if gs.rateLimits.CompareAndSwap(rateLimitID, raw, &clone) {
 			return &clone, true
 		}
+	}
+}
+
+// GetGovernanceUsageData returns a snapshot containing only budgets and rate limits.
+// Use this when callers do not require the complete governance state.
+func (gs *LocalGovernanceStore) GetGovernanceUsageData(_ context.Context) *GovernanceData {
+	budgets := make(map[string]*configstoreTables.TableBudget)
+	gs.budgets.Range(func(key, value interface{}) bool {
+		budget, ok := value.(*configstoreTables.TableBudget)
+		if ok && budget != nil {
+			budgets[key.(string)] = budget
+		}
+		return true
+	})
+
+	rateLimits := make(map[string]*configstoreTables.TableRateLimit)
+	gs.rateLimits.Range(func(key, value interface{}) bool {
+		rateLimit, ok := value.(*configstoreTables.TableRateLimit)
+		if ok && rateLimit != nil {
+			rateLimits[key.(string)] = rateLimit
+		}
+		return true
+	})
+
+	return &GovernanceData{
+		Budgets:    budgets,
+		RateLimits: rateLimits,
 	}
 }
 

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -15,6 +15,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestLocalGovernanceStore_GetGovernanceUsageDataExcludesUnrelatedState(t *testing.T) {
+	logger := NewMockLogger()
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{
+			*buildVirtualKey("vk1", "sk-bf-test1", "Test VK 1", true),
+		},
+		Budgets:    []configstoreTables.TableBudget{{ID: "budget1"}},
+		RateLimits: []configstoreTables.TableRateLimit{{ID: "rate-limit1"}},
+	}, nil)
+	require.NoError(t, err)
+
+	data := store.GetGovernanceUsageData(context.Background())
+	require.NotNil(t, data)
+	assert.Contains(t, data.Budgets, "budget1")
+	assert.Contains(t, data.RateLimits, "rate-limit1")
+	assert.Nil(t, data.VirtualKeys)
+	assert.Nil(t, data.Teams)
+	assert.Nil(t, data.Customers)
+	assert.Nil(t, data.Users)
+	assert.Nil(t, data.ModelConfigs)
+	assert.Nil(t, data.Providers)
+}
+
 // TestGovernanceStore_GetVirtualKey tests lock-free VK retrieval
 func TestGovernanceStore_GetVirtualKey(t *testing.T) {
 	logger := NewMockLogger()


### PR DESCRIPTION
## Summary

Add a focused governance-store snapshot containing only budgets and rate limits.

## Changes

- Added `GetGovernanceUsageData` to the `GovernanceStore` interface.
- Implemented the focused snapshot in `LocalGovernanceStore`.
- Added regression coverage for the narrowed snapshot contract.
- Left the existing complete snapshot behavior unchanged.

## Problem

A caller that needs only budgets and rate limits should not need to copy
unrelated governance state.

```text
Requested data:
  budgets
  rate limits

Complete snapshot additionally contains:
  virtual keys
  teams
  customers
  users
  model configurations
  providers
```

As governance state grows, copying fields that a caller does not consume adds
avoidable allocation and processing work.

## Solution

Expose a narrower operation through the existing governance-store abstraction:

```text
Need complete state?  -> GetGovernanceData()
Need usage data only? -> GetGovernanceUsageData()
                              |
                              +-- budgets
                              +-- rate limits
```

The focused operation copies the budget and rate-limit maps into a new
`GovernanceData` value. Unrelated fields remain empty.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```bash
go test ./plugins/governance
```

The regression test verifies that the focused snapshot:

1. Includes budgets.
2. Includes rate limits.
3. Excludes unrelated governance collections.

No configuration or environment changes are required.

## Screenshots/Recordings

Not applicable; this change has no UI impact.

## Breaking changes

- [ ] Yes
- [x] No

The existing complete snapshot operation remains available and unchanged.

## Related issues

No issue linked.

## Security considerations

This introduces no new external interface, authentication path, secret handling,
or data category. The focused operation returns a subset of the state already
available through the complete snapshot operation.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified the relevant Go tests and builds succeed
- [x] I verified the CI pipeline passes locally if applicable
