### PR TITLE
fix: pass mime type in file responses

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -2573,13 +2573,15 @@ func (provider *AnthropicProvider) FileList(ctx *schemas.BifrostContext, keys []
 	var lastFileID string
 	for _, file := range anthropicResp.Data {
 		files = append(files, schemas.FileObject{
-			ID:        file.ID,
-			Object:    file.Type,
-			Bytes:     file.SizeBytes,
-			CreatedAt: parseAnthropicFileTimestamp(file.CreatedAt),
-			Filename:  file.Filename,
-			Purpose:   schemas.FilePurposeBatch,
-			Status:    schemas.FileStatusProcessed,
+			ID:           file.ID,
+			Object:       file.Type,
+			Bytes:        file.SizeBytes,
+			CreatedAt:    parseAnthropicFileTimestamp(file.CreatedAt),
+			Filename:     file.Filename,
+			ContentType:  file.MimeType,
+			Downloadable: file.Downloadable,
+			Purpose:      schemas.FilePurposeBatch,
+			Status:       schemas.FileStatusProcessed,
 		})
 		lastFileID = file.ID
 	}

--- a/core/providers/anthropic/file_test.go
+++ b/core/providers/anthropic/file_test.go
@@ -1,0 +1,86 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// Verbatim body from api.anthropic.com GET /v1/files/{file_id} for a
+// code-execution generated PDF.
+const anthropicFileRetrieveBody = `{"type":"file","id":"file_01AAXwcM7Z9Kbo6BR3vTL6Da","size_bytes":3889,"created_at":"2026-08-31T11:32:41.893769Z","filename":"sample.pdf","mime_type":"application/pdf","downloadable":true}`
+
+func TestAnthropicFileMetadataRoundTrip(t *testing.T) {
+	var upstream AnthropicFileResponse
+	if err := json.Unmarshal([]byte(anthropicFileRetrieveBody), &upstream); err != nil {
+		t.Fatalf("unmarshal upstream: %v", err)
+	}
+
+	t.Run("retrieve", func(t *testing.T) {
+		out := ToAnthropicFileRetrieveResponse(upstream.ToBifrostFileRetrieveResponse(0, false, false, nil, nil))
+		if out.MimeType != "application/pdf" {
+			t.Errorf("mime_type = %q, want application/pdf", out.MimeType)
+		}
+		if out.Downloadable == nil || !*out.Downloadable {
+			t.Errorf("downloadable = %v, want true", out.Downloadable)
+		}
+	})
+
+	t.Run("upload", func(t *testing.T) {
+		out := ToAnthropicFileUploadResponse(upstream.ToBifrostFileUploadResponse(0, false, false, nil, nil))
+		if out.MimeType != "application/pdf" {
+			t.Errorf("mime_type = %q, want application/pdf", out.MimeType)
+		}
+		if out.Downloadable == nil || !*out.Downloadable {
+			t.Errorf("downloadable = %v, want true", out.Downloadable)
+		}
+	})
+
+	t.Run("list", func(t *testing.T) {
+		out := ToAnthropicFileListResponse(&schemas.BifrostFileListResponse{
+			Data: []schemas.FileObject{{
+				ID:           upstream.ID,
+				Object:       upstream.Type,
+				Filename:     upstream.Filename,
+				ContentType:  upstream.MimeType,
+				Downloadable: upstream.Downloadable,
+			}},
+		})
+		if len(out.Data) != 1 {
+			t.Fatalf("got %d files, want 1", len(out.Data))
+		}
+		if out.Data[0].MimeType != "application/pdf" {
+			t.Errorf("mime_type = %q, want application/pdf", out.Data[0].MimeType)
+		}
+		if out.Data[0].Downloadable == nil || !*out.Data[0].Downloadable {
+			t.Errorf("downloadable = %v, want true", out.Data[0].Downloadable)
+		}
+	})
+}
+
+// A provider that does not report these fields must omit them rather than
+// claim an empty mime type and a non-downloadable file.
+func TestAnthropicFileMetadataOmittedWhenUnreported(t *testing.T) {
+	out := ToAnthropicFileRetrieveResponse(&schemas.BifrostFileRetrieveResponse{
+		ID:       "file_abc",
+		Object:   "file",
+		Filename: "sample.pdf",
+	})
+
+	body, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := decoded["mime_type"]; ok {
+		t.Errorf("mime_type present in %s, want omitted", body)
+	}
+	if _, ok := decoded["downloadable"]; ok {
+		t.Errorf("downloadable present in %s, want omitted", body)
+	}
+}

--- a/core/providers/anthropic/files.go
+++ b/core/providers/anthropic/files.go
@@ -9,12 +9,13 @@ import (
 // ToAnthropicFileUploadResponse converts a Bifrost file upload response to Anthropic format.
 func ToAnthropicFileUploadResponse(resp *schemas.BifrostFileUploadResponse) *AnthropicFileResponse {
 	return &AnthropicFileResponse{
-		ID:        resp.ID,
-		Type:      resp.Object,
-		Filename:  resp.Filename,
-		MimeType:  "",
-		SizeBytes: resp.Bytes,
-		CreatedAt: formatAnthropicFileTimestamp(resp.CreatedAt),
+		ID:           resp.ID,
+		Type:         resp.Object,
+		Filename:     resp.Filename,
+		MimeType:     resp.ContentType,
+		SizeBytes:    resp.Bytes,
+		CreatedAt:    formatAnthropicFileTimestamp(resp.CreatedAt),
+		Downloadable: resp.Downloadable,
 	}
 }
 
@@ -23,12 +24,13 @@ func ToAnthropicFileListResponse(resp *schemas.BifrostFileListResponse) *Anthrop
 	data := make([]AnthropicFileResponse, len(resp.Data))
 	for i, file := range resp.Data {
 		data[i] = AnthropicFileResponse{
-			ID:        file.ID,
-			Type:      file.Object,
-			Filename:  file.Filename,
-			MimeType:  "",
-			SizeBytes: file.Bytes,
-			CreatedAt: formatAnthropicFileTimestamp(file.CreatedAt),
+			ID:           file.ID,
+			Type:         file.Object,
+			Filename:     file.Filename,
+			MimeType:     file.ContentType,
+			SizeBytes:    file.Bytes,
+			CreatedAt:    formatAnthropicFileTimestamp(file.CreatedAt),
+			Downloadable: file.Downloadable,
 		}
 	}
 
@@ -41,12 +43,13 @@ func ToAnthropicFileListResponse(resp *schemas.BifrostFileListResponse) *Anthrop
 // ToAnthropicFileRetrieveResponse converts a Bifrost file retrieve response to Anthropic format.
 func ToAnthropicFileRetrieveResponse(resp *schemas.BifrostFileRetrieveResponse) *AnthropicFileResponse {
 	return &AnthropicFileResponse{
-		ID:        resp.ID,
-		Type:      resp.Object,
-		Filename:  resp.Filename,
-		MimeType:  "", // Not supported in Bifrost responses
-		SizeBytes: resp.Bytes,
-		CreatedAt: formatAnthropicFileTimestamp(resp.CreatedAt),
+		ID:           resp.ID,
+		Type:         resp.Object,
+		Filename:     resp.Filename,
+		MimeType:     resp.ContentType,
+		SizeBytes:    resp.Bytes,
+		CreatedAt:    formatAnthropicFileTimestamp(resp.CreatedAt),
+		Downloadable: resp.Downloadable,
 	}
 }
 

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -2158,10 +2158,10 @@ type AnthropicFileResponse struct {
 	ID           string `json:"id"`
 	Type         string `json:"type"`
 	Filename     string `json:"filename"`
-	MimeType     string `json:"mime_type"`
+	MimeType     string `json:"mime_type,omitempty"`
 	SizeBytes    int64  `json:"size_bytes"`
 	CreatedAt    string `json:"created_at"`
-	Downloadable bool   `json:"downloadable"`
+	Downloadable *bool  `json:"downloadable,omitempty"`
 }
 
 // AnthropicFileListResponse represents the response from listing files.
@@ -2186,6 +2186,8 @@ func (r *AnthropicFileResponse) ToBifrostFileUploadResponse(latency time.Duratio
 		Bytes:          r.SizeBytes,
 		CreatedAt:      parseAnthropicFileTimestamp(r.CreatedAt),
 		Filename:       r.Filename,
+		ContentType:    r.MimeType,
+		Downloadable:   r.Downloadable,
 		Purpose:        schemas.FilePurposeBatch, // We hardcode as purpose is not supported by Anthropic
 		Status:         schemas.FileStatusProcessed,
 		StorageBackend: schemas.FileStorageAPI,
@@ -2213,6 +2215,8 @@ func (r *AnthropicFileResponse) ToBifrostFileRetrieveResponse(latency time.Durat
 		Bytes:          r.SizeBytes,
 		CreatedAt:      parseAnthropicFileTimestamp(r.CreatedAt),
 		Filename:       r.Filename,
+		ContentType:    r.MimeType,
+		Downloadable:   r.Downloadable,
 		Purpose:        schemas.FilePurposeBatch,
 		Status:         schemas.FileStatusProcessed,
 		StorageBackend: schemas.FileStorageAPI,

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -3530,6 +3530,7 @@ func (provider *GeminiProvider) FileUpload(ctx *schemas.BifrostContext, key sche
 		Bytes:          sizeBytes,
 		CreatedAt:      createdAt,
 		Filename:       geminiResp.DisplayName,
+		ContentType:    geminiResp.MimeType,
 		Purpose:        request.Purpose,
 		Status:         ToBifrostFileStatus(geminiResp.State),
 		StorageBackend: schemas.FileStorageAPI,
@@ -3628,15 +3629,16 @@ func (provider *GeminiProvider) fileListByKey(ctx *schemas.BifrostContext, key s
 		}
 
 		bifrostResp.Data[i] = schemas.FileObject{
-			ID:        file.Name,
-			Object:    "file",
-			Bytes:     sizeBytes,
-			CreatedAt: createdAt,
-			UpdatedAt: updatedAt,
-			Filename:  file.DisplayName,
-			Purpose:   schemas.FilePurposeVision,
-			Status:    ToBifrostFileStatus(file.State),
-			ExpiresAt: expiresAt,
+			ID:          file.Name,
+			Object:      "file",
+			Bytes:       sizeBytes,
+			CreatedAt:   createdAt,
+			UpdatedAt:   updatedAt,
+			Filename:    file.DisplayName,
+			ContentType: file.MimeType,
+			Purpose:     schemas.FilePurposeVision,
+			Status:      ToBifrostFileStatus(file.State),
+			ExpiresAt:   expiresAt,
 		}
 	}
 
@@ -3783,6 +3785,7 @@ func (provider *GeminiProvider) fileRetrieveByKey(ctx *schemas.BifrostContext, k
 		CreatedAt:      createdAt,
 		UpdatedAt:      updatedAt,
 		Filename:       geminiResp.DisplayName,
+		ContentType:    geminiResp.MimeType,
 		Purpose:        schemas.FilePurposeVision,
 		Status:         ToBifrostFileStatus(geminiResp.State),
 		StorageBackend: schemas.FileStorageAPI,

--- a/core/schemas/files.go
+++ b/core/schemas/files.go
@@ -45,6 +45,8 @@ type FileObject struct {
 	CreatedAt     int64       `json:"created_at"`
 	UpdatedAt     int64       `json:"updated_at,omitempty"`
 	Filename      string      `json:"filename"`
+	ContentType   string      `json:"content_type,omitempty"` // MIME type reported by the provider
+	Downloadable  *bool       `json:"downloadable,omitempty"` // Nil when the provider does not report downloadability
 	Purpose       FilePurpose `json:"purpose"`
 	Status        FileStatus  `json:"status,omitempty"`
 	StatusDetails *string     `json:"status_details,omitempty"`
@@ -105,6 +107,8 @@ type BifrostFileUploadResponse struct {
 	Bytes         int64       `json:"bytes"`
 	CreatedAt     int64       `json:"created_at"`
 	Filename      string      `json:"filename"`
+	ContentType   string      `json:"content_type,omitempty"` // MIME type reported by the provider
+	Downloadable  *bool       `json:"downloadable,omitempty"` // Nil when the provider does not report downloadability
 	Purpose       FilePurpose `json:"purpose"`
 	Status        FileStatus  `json:"status,omitempty"`
 	StatusDetails *string     `json:"status_details,omitempty"`
@@ -187,6 +191,8 @@ type BifrostFileRetrieveResponse struct {
 	CreatedAt     int64       `json:"created_at"`
 	UpdatedAt     int64       `json:"updated_at,omitempty"`
 	Filename      string      `json:"filename"`
+	ContentType   string      `json:"content_type,omitempty"` // MIME type reported by the provider
+	Downloadable  *bool       `json:"downloadable,omitempty"` // Nil when the provider does not report downloadability
 	Purpose       FilePurpose `json:"purpose"`
 	Status        FileStatus  `json:"status,omitempty"`
 	StatusDetails *string     `json:"status_details,omitempty"`

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -1058,13 +1058,13 @@ func CreateAnthropicFilesRouteConfigs(pathPrefix string, handlerStore lib.Handle
 		PreCallback: extractAnthropicFileListQueryParams,
 	})
 
-	// Retrieve file endpoint - GET /v1/files/{file_id}
+	// Retrieve file metadata endpoint - GET /v1/files/{file_id}
 	routes = append(routes, RouteConfig{
 		Type:   RouteConfigTypeAnthropic,
-		Path:   pathPrefix + "/v1/files/{file_id}/content",
+		Path:   pathPrefix + "/v1/files/{file_id}",
 		Method: "GET",
 		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
-			return schemas.FileContentRequest
+			return schemas.FileRetrieveRequest
 		},
 		GetRequestTypeInstance: func(ctx context.Context) interface{} {
 			return &anthropic.AnthropicFileRetrieveRequest{}
@@ -1091,6 +1091,41 @@ func CreateAnthropicFilesRouteConfigs(pathPrefix string, handlerStore lib.Handle
 				return resp.ExtraFields.RawResponse, nil
 			}
 			return anthropic.ToAnthropicFileRetrieveResponse(resp), nil
+		},
+		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+			return anthropic.ToAnthropicChatCompletionError(err)
+		},
+		PreCallback: extractAnthropicFileIDFromPath,
+	})
+
+	// Download file content endpoint - GET /v1/files/{file_id}/content
+	// No response converter: the router streams the raw bytes with the provider's content type.
+	routes = append(routes, RouteConfig{
+		Type:   RouteConfigTypeAnthropic,
+		Path:   pathPrefix + "/v1/files/{file_id}/content",
+		Method: "GET",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.FileContentRequest
+		},
+		GetRequestTypeInstance: func(ctx context.Context) interface{} {
+			return &anthropic.AnthropicFileContentRequest{}
+		},
+		FileRequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*FileRequest, error) {
+			if contentReq, ok := req.(*anthropic.AnthropicFileContentRequest); ok {
+				provider := ctx.Value(bifrostContextKeyProvider).(schemas.ModelProvider)
+				// Handle file id conversion for Gemini
+				if provider == schemas.Gemini {
+					contentReq.FileID = strings.Replace(contentReq.FileID, "files-", "files/", 1)
+				}
+				return &FileRequest{
+					Type: schemas.FileContentRequest,
+					ContentRequest: &schemas.BifrostFileContentRequest{
+						FileID:   contentReq.FileID,
+						Provider: provider,
+					},
+				}, nil
+			}
+			return nil, errors.New("invalid file content request type")
 		},
 		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 			return anthropic.ToAnthropicChatCompletionError(err)


### PR DESCRIPTION
## Summary

Adds `ContentType` (MIME type) and `Downloadable` fields to Bifrost file schemas and propagates these values through the Anthropic and Gemini provider integrations. Previously, MIME type was hardcoded to an empty string in Anthropic file conversion functions, and neither provider surfaced downloadability information.

## Changes

- Added `ContentType` and `Downloadable` fields to `FileObject`, `BifrostFileUploadResponse`, and `BifrostFileRetrieveResponse` schemas, both omitted from JSON output when not set by the provider
- Changed `Downloadable` in `AnthropicFileResponse` from `bool` to `*bool` with `omitempty` to correctly represent cases where the provider does not report downloadability
- Made `MimeType` in `AnthropicFileResponse` use `omitempty` to avoid serializing empty strings
- Wired `MimeType` and `Downloadable` from Anthropic API responses into Bifrost file objects across upload, list, and retrieve operations
- Wired `MimeType` from Gemini API responses into Bifrost file objects across upload, list, and retrieve operations

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

Verify that file upload, list, and retrieve responses from Anthropic and Gemini now include `content_type` in the JSON output, and that Anthropic responses include `downloadable` when the field is present in the provider response.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. These are read-only metadata fields surfaced from provider responses.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable