### PR TITLE
fix(ui): refetch config after password login

### DIFF
--- a/tests/e2e/features/auth/login-config-cache.spec.ts
+++ b/tests/e2e/features/auth/login-config-cache.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test'
+
+test('login invalidates a cached core-config error', async ({ page }) => {
+  let authenticated = false
+  let configRequests = 0
+
+  await page.route('**/api/session/is-auth-enabled', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ is_auth_enabled: true, has_valid_token: authenticated, auth_type: 'password' }),
+    })
+  })
+  await page.route('**/api/session/login', async (route) => {
+    authenticated = true
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ message: 'Login successful' }),
+    })
+  })
+  await page.route('**/api/config?**', async (route) => {
+    configRequests++
+    await route.fulfill({
+      status: authenticated ? 200 : 401,
+      contentType: 'application/json',
+      body: authenticated
+        ? JSON.stringify({ is_db_connected: true, is_logs_connected: true })
+        : JSON.stringify({ error: { message: 'Unauthorized' } }),
+    })
+  })
+
+  // Keep the rejected config query subscribed while the login mutation runs.
+  await page.goto('/login')
+
+  const firstResult = await page.evaluate(async () => {
+    const storePath = '/lib/store/store.ts'
+    const configPath = '/lib/store/apis/configApi.ts'
+    const [{ store }, { configApi }] = await Promise.all([import(storePath), import(configPath)])
+    const result = await store.dispatch(configApi.endpoints.getCoreConfig.initiate({}))
+    return result.status
+  })
+  expect(firstResult).toBe('rejected')
+  expect(configRequests).toBe(1)
+
+  await page.evaluate(async () => {
+    const storePath = '/lib/store/store.ts'
+    const sessionPath = '/lib/store/apis/sessionApi.ts'
+    const [{ store }, { sessionApi }] = await Promise.all([import(storePath), import(sessionPath)])
+    await store.dispatch(sessionApi.endpoints.login.initiate({ username: 'admin', password: 'password' }))
+  })
+
+  await expect.poll(() => configRequests).toBe(2)
+})

--- a/ui/lib/store/apis/sessionApi.ts
+++ b/ui/lib/store/apis/sessionApi.ts
@@ -37,7 +37,7 @@ export const sessionApi = baseApi.injectEndpoints({
 				method: "POST",
 				body: credentials,
 			}),
-			invalidatesTags: ["Sessions"],
+			invalidatesTags: ["Sessions", "Config"],
 		}),
 
 		// Logout endpoint


### PR DESCRIPTION
Before login, the dashboard can cache a `401` from `/api/config`. A successful password login only invalidates the session cache, so the active config query remains rejected and the dashboard shows the misleading "Config store setup is missing" banner until the page reloads.

This invalidates the `Config` tag after login so active config queries refetch with the new HTTP-only session cookie. The Playwright regression keeps a rejected config query subscribed during login and verifies the endpoint is requested again.

Validation:
- Focused Playwright regression passes with the fix
- The same test fails without it: expected 2 config requests, received 1
- `oxfmt --check` passes for both changed files
