### PR TITLE
community: add Magic Hour to MCP library

### DIFF
--- a/community/mcp-library/servers.json
+++ b/community/mcp-library/servers.json
@@ -2297,6 +2297,27 @@
         "automation"
       ],
       "icon_url": "https://xquik.com/icons/mcp/xquik.png"
+    },
+    {
+      "name": "Magic Hour",
+      "description": "Create and edit images, videos, and audio through Magic Hour's hosted Streamable HTTP MCP server.",
+      "category": "AI Tools",
+      "connection_type": "http",
+      "connection_url": "https://mcp.magichour.ai/",
+      "auth_type": "per_user_headers",
+      "required_header_keys": [
+        "Authorization"
+      ],
+      "docs_url": "https://magichour.ai/mcp",
+      "publisher": "Magic Hour AI, Inc.",
+      "tags": [
+        "image-generation",
+        "video-generation",
+        "audio",
+        "media",
+        "hosted"
+      ],
+      "icon_url": "https://magichour.ai/logo.png"
     }
   ]
 }

--- a/ui/app/workspace/mcp-registry/library/views/mcpLibraryInstallSheet.tsx
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibraryInstallSheet.tsx
@@ -22,6 +22,7 @@ import {
 } from "../../views/mcpClientFormFields";
 import { MCPHeadersAuthorizer } from "../../views/mcpHeadersAuthorizer";
 import { OAuth2Authorizer } from "../../views/oauth2Authorizer";
+import { shouldSeedHeaders } from "./mcpLibraryInstallSheet.utils";
 import { authLabel, MCP_ICON_FALLBACK, transportIcon, transportLabel } from "./mcpLibraryServerCard";
 
 interface MCPLibraryInstallSheetProps {
@@ -56,7 +57,7 @@ export function sanitizeServerName(name: string): string {
 function buildInitialValues(server: MCPLibraryEntry): CreateMCPClientRequest {
 	const authType = (server.auth_type || "none") as MCPAuthType;
 	const isStdio = server.connection_type === "stdio";
-	// A "headers" entry declares which header names it needs; prefill them as
+	// A header-auth entry declares which header names it needs; prefill them as
 	// empty rows so the installer only has to fill in values.
 	const declaredHeaders = server.required_header_keys?.length
 		? Object.fromEntries(server.required_header_keys.map((key) => [key, { ...emptySecretVar }]))
@@ -74,7 +75,7 @@ function buildInitialValues(server: MCPLibraryEntry): CreateMCPClientRequest {
 		// not validate auth_type against connection_type, so an entry can still
 		// declare one; ignore it rather than seeding state nothing can edit.
 		auth_type: isStdio ? "none" : authType,
-		headers: !isStdio && authType === "headers" ? declaredHeaders : undefined,
+		headers: shouldSeedHeaders(authType, isStdio) ? declaredHeaders : undefined,
 	};
 }
 

--- a/ui/app/workspace/mcp-registry/library/views/mcpLibraryInstallSheet.utils.test.ts
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibraryInstallSheet.utils.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { shouldSeedHeaders } from "./mcpLibraryInstallSheet.utils";
+
+describe("shouldSeedHeaders", () => {
+	it("includes per-user header authentication", () => {
+		expect(shouldSeedHeaders("headers", false)).toBe(true);
+		expect(shouldSeedHeaders("per_user_headers", false)).toBe(true);
+		expect(shouldSeedHeaders("per_user_headers", true)).toBe(false);
+	});
+});

--- a/ui/app/workspace/mcp-registry/library/views/mcpLibraryInstallSheet.utils.ts
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibraryInstallSheet.utils.ts
@@ -1,0 +1,5 @@
+import { MCPAuthType } from "@/lib/types/mcp";
+
+export function shouldSeedHeaders(authType: MCPAuthType, isStdio: boolean): boolean {
+	return !isStdio && (authType === "headers" || authType === "per_user_headers");
+}


### PR DESCRIPTION
## Summary

Adds the official Magic Hour hosted MCP server to Bifrost’s community library so users can connect media-generation tools with their own credentials.

## Changes

- Added one `AI Tools` catalog entry for Magic Hour.
- Configured the canonical Streamable HTTP endpoint with per-user `Authorization` headers.
- Added canonical documentation, publisher, tags, and square icon metadata.

## Type of change

- [x] Feature

## Affected areas

- [x] MCP community library

## How to test

```sh
jq empty community/mcp-library/servers.json
npx --yes ajv-cli validate -s community/mcp-library/schema.json -d community/mcp-library/servers.json --spec=draft7
```

Both validations pass. The live endpoint returned HTTP 200 to an MCP `initialize` request with protocol `2025-06-18`, server name `magic-hour`, and version `0.1.0`. The docs and icon URLs return HTTP 200.

## Screenshots/Recordings

Not applicable; catalog metadata only.

## Breaking changes

- [x] No

## Related issues

Closes #6690

## Security considerations

No secrets or credential values are included. The entry declares only the `Authorization` header name and uses `per_user_headers`, so each user supplies their own Magic Hour API key. Generation calls may consume that user’s account credits.

## Checklist

- [x] Read the repository contribution guidance and MCP Library README.
- [x] No duplicate Magic Hour entry exists in `servers.json` or open/closed PR history.
- [x] Added one server and no unrelated changes.
- [x] JSON and schema validation pass.
- [x] Live endpoint, docs, and icon were verified.