### PR TITLE
openrouter prompt cache fixes

### DIFF
--- a/core/internal/llmtests/prompt_caching.go
+++ b/core/internal/llmtests/prompt_caching.go
@@ -455,12 +455,73 @@ func RunPromptCachingToolBlocksTest(t *testing.T, client *bifrost.Bifrost, ctx c
 			require.GreaterOrEqual(t, cacheControlCount, 3,
 				"Expected at least 3 cache_control markers (system + tool_use + tool_result), got %d", cacheControlCount)
 
+		case schemas.OpenRouter:
+			// OpenRouter does not expose per-block cache_control through /v1/responses.
+			// Bifrost converts a marked input_text block into prompt_cache_breakpoint,
+			// which OpenRouter turns back into an Anthropic breakpoint (#6290).
+			// This scenario marks three places: the system input_text block, the
+			// function_call message, and the function_call_output message. Only the
+			// first has a Responses representation, so exactly one breakpoint should
+			// reach the wire and no cache_control should survive at all.
+			cacheControlCount := strings.Count(rawStr, `"cache_control"`)
+			breakpointCount := strings.Count(rawStr, `"prompt_cache_breakpoint"`)
+			t.Logf("  OpenRouter: found %d cache_control markers, %d prompt_cache_breakpoint markers in raw request",
+				cacheControlCount, breakpointCount)
+
+			require.Equal(t, 0, cacheControlCount,
+				"OpenRouter Responses does not accept per-block cache_control; it must be translated, not forwarded (got %d)", cacheControlCount)
+			require.Equal(t, 1, breakpointCount,
+				"Expected exactly 1 prompt_cache_breakpoint (system input_text only; message-level markers on function_call/function_call_output have no Responses representation), got %d", breakpointCount)
+
 		default:
-			t.Logf("  Provider %s: skipping raw request cache marker validation (not Anthropic/Bedrock/Vertex)", testConfig.Provider)
+			t.Logf("  Provider %s: skipping raw request cache marker validation (not Anthropic/Bedrock/Vertex/OpenRouter)", testConfig.Provider)
 		}
 
 		t.Logf("  Prompt caching tool blocks test completed!")
 	})
+}
+
+// cacheReadPolicy describes how strictly a provider's per-turn cache reads are
+// asserted in the multi-turn prompt-caching scenarios. Providers differ in how
+// much of a growing request stays cacheable, so the rules live here rather than
+// inline, where a provider silently falling into the generic branch is easy to
+// miss.
+type cacheReadPolicy struct {
+	// aggregateOnly reports that per-turn reads are only counted towards an
+	// aggregate hit rate checked after every turn, never asserted per turn.
+	aggregateOnly bool
+	// minReadPercentage is the per-turn floor on cache_read/input_tokens. Zero
+	// means only a non-zero cache read is required.
+	minReadPercentage float64
+	// requireStableRead reports that cache_read must stay within half of the
+	// previous turn's value as the conversation grows.
+	requireStableRead bool
+}
+
+// cacheReadPolicyFor returns the cache-read rules for a provider.
+func cacheReadPolicyFor(provider schemas.ModelProvider) cacheReadPolicy {
+	switch provider {
+	case schemas.OpenAI:
+		// Automatic best-effort caching: individual turns may miss due to
+		// server-side load or cache eviction, so only the aggregate is asserted.
+		return cacheReadPolicy{aggregateOnly: true}
+	case schemas.OpenRouter:
+		// OpenRouter converts only input_text blocks into
+		// prompt_cache_breakpoint, so the per-turn checkpoint these scenarios
+		// move around survives on a user turn but not on a function_call
+		// (marked at message level) or an assistant turn (output_text). The
+		// surviving set therefore oscillates between the system breakpoint
+		// alone and system plus one, and the cached prefix collapses and
+		// regrows with it. Both a percentage floor and a turn-over-turn halving
+		// check would read that as a prefix mismatch when it is the documented
+		// conversion rule. Assert caching happened at all.
+		// See TestApplyOpenRouterCacheBreakpoints_OnlyInputTextConverts.
+		return cacheReadPolicy{}
+	default:
+		// Explicit caching providers (Anthropic, Vertex, Bedrock) keep a stable
+		// cacheable prefix, so most of a growing request should be a cache read.
+		return cacheReadPolicy{minReadPercentage: 0.50, requireStableRead: true}
+	}
 }
 
 // RunPromptCachingMultipleToolCallsTest verifies prompt caching across a 10-turn
@@ -834,31 +895,34 @@ func RunPromptCachingMultipleToolCallsTest(t *testing.T, client *bifrost.Bifrost
 					t.Logf("  %s: cache_read=%.2f%%, total_cached=%.2f%%",
 						turnName, readPercentage*100, totalCachedPercentage*100)
 
-					switch testConfig.Provider {
-					case schemas.OpenAI:
+					policy := cacheReadPolicyFor(testConfig.Provider)
+
+					if policy.aggregateOnly {
 						// OpenAI uses automatic best-effort caching — individual turns may
 						// miss due to server-side load or cache eviction. Track hits for
 						// aggregate validation after all turns complete.
 						if totalCachedPercentage >= 0.50 {
 							turnsWithCacheHit++
 						}
-					default:
-						// Explicit caching providers (Anthropic, Vertex, Bedrock):
-						// cache_read > 0 proves prefix reuse is working.
+					} else {
+						// Explicit caching providers: cache_read > 0 proves prefix reuse
+						// is working.
 						require.Greater(t, cacheRead, 0,
 							"%s should reuse an existing prefix; got cache_read=0 and cache_write=%d",
 							turnName, cacheWrite)
-						require.GreaterOrEqual(t, readPercentage, 0.50,
-							"%s should have >= 50%% cache reads (got %.2f%%). "+
-								"If this fails, tool_use input key ordering may be broken — "+
-								"the cache prefix diverges at the first tool_use block. "+
-								"cache_read=%d, cache_write=%d, input_tokens=%d",
-							turnName, readPercentage*100, cacheRead, cacheWrite, inputTokens)
+						if policy.minReadPercentage > 0 {
+							require.GreaterOrEqual(t, readPercentage, policy.minReadPercentage,
+								"%s should have >= %.0f%%%% cache reads (got %.2f%%%%). "+
+									"If this fails, tool_use input key ordering may be broken — "+
+									"the cache prefix diverges at the first tool_use block. "+
+									"cache_read=%d, cache_write=%d, input_tokens=%d",
+								turnName, policy.minReadPercentage*100, readPercentage*100,
+								cacheRead, cacheWrite, inputTokens)
+						}
 					}
 
 					// cache_read should grow (or stay comparable) as conversation grows
-					// (skip for OpenAI where individual turns may miss)
-					if testConfig.Provider != schemas.OpenAI && i >= 2 && prevCacheRead > 0 {
+					if policy.requireStableRead && i >= 2 && prevCacheRead > 0 {
 						// Allow some variance but cache_read should not dramatically drop
 						assert.GreaterOrEqual(t, cacheRead, prevCacheRead/2,
 							"%s: cache_read dropped significantly from previous turn (%d -> %d), "+
@@ -870,7 +934,7 @@ func RunPromptCachingMultipleToolCallsTest(t *testing.T, client *bifrost.Bifrost
 				if i == 0 {
 					rawReq := response.ExtraFields.RawRequest
 					switch testConfig.Provider {
-					case schemas.Anthropic, schemas.Vertex, schemas.Bedrock:
+					case schemas.Anthropic, schemas.Vertex, schemas.Bedrock, schemas.OpenRouter:
 						require.NotNil(t, rawReq,
 							"Raw request should be present for %s prompt-caching validation",
 							testConfig.Provider)
@@ -908,6 +972,22 @@ func RunPromptCachingMultipleToolCallsTest(t *testing.T, client *bifrost.Bifrost
 						t.Logf("  Bedrock: found %d cachePoint blocks", cachePointCount)
 						require.GreaterOrEqual(t, cachePointCount, 2,
 							"Expected at least 2 cachePoint blocks (system + last tool_use), got %d", cachePointCount)
+
+					case schemas.OpenRouter:
+						// See the OpenRouter case in RunPromptCachingToolBlocksTest (#6290).
+						// The per-turn cache checkpoint lands on a function_call, an input_text
+						// block, or an output_text block depending on where the walk stops, and
+						// only input_text converts - so the breakpoint count varies by turn. The
+						// system input_text block is always marked, so assert at least one.
+						// cache_control must never survive on this route.
+						ccCount := strings.Count(rawStr, `"cache_control"`)
+						bpCount := strings.Count(rawStr, `"prompt_cache_breakpoint"`)
+						t.Logf("  OpenRouter: found %d cache_control markers, %d prompt_cache_breakpoint markers", ccCount, bpCount)
+
+						require.Equal(t, 0, ccCount,
+							"OpenRouter Responses does not accept per-block cache_control; it must be translated, not forwarded (got %d)", ccCount)
+						require.GreaterOrEqual(t, bpCount, 1,
+							"Expected at least 1 prompt_cache_breakpoint (system input_text block), got %d", bpCount)
 						}
 					}
 				}

--- a/core/internal/llmtests/promptcachingpolicy_test.go
+++ b/core/internal/llmtests/promptcachingpolicy_test.go
@@ -1,0 +1,54 @@
+package llmtests
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCacheReadPolicyFor pins the per-provider cache-read rules used by the
+// multi-turn prompt-caching scenarios. The rules are asserted here rather than
+// only through the live scenarios because a provider that silently falls into
+// the generic branch fails intermittently, and only against a real endpoint.
+func TestCacheReadPolicyFor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OpenAI is aggregate only", func(t *testing.T) {
+		t.Parallel()
+
+		policy := cacheReadPolicyFor(schemas.OpenAI)
+		assert.True(t, policy.aggregateOnly,
+			"OpenAI caches automatically and best-effort, so individual turns must not be asserted")
+		assert.False(t, policy.requireStableRead,
+			"an individual OpenAI turn may miss, so turn-over-turn stability must not be asserted")
+	})
+
+	t.Run("OpenRouter requires only a non-zero read", func(t *testing.T) {
+		t.Parallel()
+
+		policy := cacheReadPolicyFor(schemas.OpenRouter)
+		assert.False(t, policy.aggregateOnly,
+			"OpenRouter forwards explicit breakpoints, so every turn should read from the cache")
+		assert.Zero(t, policy.minReadPercentage,
+			"OpenRouter converts only input_text blocks into prompt_cache_breakpoint, so the "+
+				"surviving prefix collapses to the system breakpoint alone on function_call and "+
+				"assistant turns and can be well under half of a growing request")
+		assert.False(t, policy.requireStableRead,
+			"the same oscillation makes a turn-over-turn halving check read a documented "+
+				"conversion rule as a prefix mismatch")
+	})
+
+	t.Run("explicit caching providers keep the strict rules", func(t *testing.T) {
+		t.Parallel()
+
+		for _, provider := range []schemas.ModelProvider{schemas.Anthropic, schemas.Vertex, schemas.Bedrock} {
+			policy := cacheReadPolicyFor(provider)
+			assert.False(t, policy.aggregateOnly, "%s caches explicitly", provider)
+			assert.Equal(t, 0.50, policy.minReadPercentage,
+				"%s keeps a stable cacheable prefix, so a drop below half signals broken key ordering", provider)
+			assert.True(t, policy.requireStableRead,
+				"%s should not lose its cached prefix as the conversation grows", provider)
+		}
+	})
+}

--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -84,6 +84,118 @@ func hoistAdditionalTools(message schemas.ResponsesMessage) []schemas.ResponsesT
 	return tools
 }
 
+// PromptCacheBreakpointModeExplicit is the only mode a prompt_cache_breakpoint
+// accepts. OpenAI defined the field for gpt-5.6+; OpenRouter reuses it as the
+// Responses-shaped spelling of an Anthropic cache breakpoint.
+const PromptCacheBreakpointModeExplicit = "explicit"
+
+// openRouterMaxCacheBreakpoints mirrors the ceiling the Anthropic Messages API
+// enforces on blocks carrying cache_control. Exceeding it is a hard rejection
+// rather than a degradation ("A maximum of 4 blocks with cache_control may be
+// provided. Found 5."), and it binds here because OpenRouter converts every
+// prompt_cache_breakpoint it receives back into an Anthropic breakpoint before
+// dispatching to Claude. Kept local rather than imported from the anthropic
+// provider so this package takes on no provider-to-provider dependency; see
+// AnthropicMaxCacheBreakpoints in core/providers/anthropic/utils.go for the
+// live verification behind the number.
+const openRouterMaxCacheBreakpoints = 4
+
+// applyOpenRouterCacheBreakpoints rewrites Anthropic-style per-block
+// cache_control markers into the representation OpenRouter's Responses endpoint
+// actually accepts.
+//
+// OpenRouter does not expose per-block cache_control through /v1/responses. The
+// documented equivalent is prompt_cache_breakpoint on an individual input_text
+// block, which OpenRouter converts back into a default Anthropic breakpoint when
+// the request routes to Claude:
+// https://openrouter.ai/docs/features/prompt-caching#anthropic-claude
+//
+// Without this, OpenAIResponsesRequestInput.MarshalJSON deletes the marker and
+// puts nothing in its place, so Claude prompt caching never activates on the
+// Responses path (#6290). The Chat path needs no equivalent: OpenRouter accepts
+// cache_control verbatim there, so OpenAIChatRequest.MarshalJSON simply keeps it
+// behind its keepCacheControl branch (#4203).
+//
+// Two deliberate limits, both forced by the wire format rather than chosen:
+//
+//   - Only input_text blocks are marked. The OpenRouter doc places the
+//     breakpoint on a text content block and names input_text as its Responses
+//     spelling. Marking output_text would be an unverified capability claim, and
+//     a rejected field costs more than the miss it would fix.
+//   - Tool definitions and function_call_output blocks are not marked.
+//     schemas.ResponsesTool has no PromptCacheBreakpoint field and OpenRouter
+//     documents no tool-level Responses breakpoint, while a text-only
+//     function_call_output block array is collapsed into a single string by
+//     isFunctionCallOutputBlocksFlattenable before it reaches the wire, which
+//     would discard any breakpoint set on it.
+//
+// messages is this function's own slice, but each element's Content pointer and
+// the block array beneath it still alias bifrostReq.Input, which plugins and the
+// fallback chain reuse. Both are copied before a marker is written.
+func applyOpenRouterCacheBreakpoints(messages []schemas.ResponsesMessage) {
+	// Locate every markable block in render order, and count the breakpoints the
+	// caller already set, before anything is copied.
+	type blockRef struct{ msg, block int }
+	var refs []blockRef
+	existing := 0
+	for i := range messages {
+		if messages[i].Content == nil {
+			continue
+		}
+		for j, block := range messages[i].Content.ContentBlocks {
+			if block.PromptCacheBreakpoint != nil {
+				existing++
+				continue
+			}
+			// "ephemeral" is the only cache type Anthropic defines, and nothing
+			// upstream of here validates it. Converting an empty or unknown type
+			// would manufacture a valid breakpoint out of a malformed marker and
+			// spend clamp budget on it, so require the documented value.
+			if block.CacheControl == nil ||
+				block.CacheControl.Type != schemas.CacheControlTypeEphemeral ||
+				block.Text == nil ||
+				block.Type != schemas.ResponsesInputMessageContentBlockTypeText {
+				continue
+			}
+			refs = append(refs, blockRef{msg: i, block: j})
+		}
+	}
+	if len(refs) == 0 {
+		return
+	}
+
+	// Spend only the budget the caller's own breakpoints leave behind. A caller
+	// who sets more than the ceiling by hand owns that request and its upstream
+	// error; Bifrost declines to manufacture one on top.
+	budget := openRouterMaxCacheBreakpoints - existing
+	if budget <= 0 {
+		return
+	}
+	// Caching is cumulative up to each breakpoint, so a marker later in render
+	// order anchors a strictly longer prefix. When over budget, drop the
+	// EARLIEST markers and keep the longest cached prefix, matching the
+	// trade-off clampAnthropicCacheBreakpoints makes for the direct path.
+	if len(refs) > budget {
+		refs = refs[len(refs)-budget:]
+	}
+
+	copiedContent := make(map[int]bool, len(refs))
+	for _, ref := range refs {
+		if !copiedContent[ref.msg] {
+			contentCopy := *messages[ref.msg].Content
+			contentCopy.ContentBlocks = append(
+				make([]schemas.ResponsesMessageContentBlock, 0, len(messages[ref.msg].Content.ContentBlocks)),
+				messages[ref.msg].Content.ContentBlocks...,
+			)
+			messages[ref.msg].Content = &contentCopy
+			copiedContent[ref.msg] = true
+		}
+		messages[ref.msg].Content.ContentBlocks[ref.block].PromptCacheBreakpoint = &schemas.PromptCacheBreakpoint{
+			Mode: schemas.Ptr(PromptCacheBreakpointModeExplicit),
+		}
+	}
+}
+
 // ToOpenAIResponsesRequest converts a Bifrost responses request to OpenAI format
 func ToOpenAIResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.BifrostResponsesRequest) *OpenAIResponsesRequest {
 	if bifrostReq == nil || bifrostReq.Input == nil {
@@ -293,6 +405,11 @@ func ToOpenAIResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.B
 			messages = append(messages, message)
 		}
 	}
+	// OpenRouter accepts the caching intent only in its Responses-shaped form.
+	if bifrostReq.Provider == schemas.OpenRouter {
+		applyOpenRouterCacheBreakpoints(messages)
+	}
+
 	// Updating params
 	params := bifrostReq.Params
 	// Create the responses request with properly mapped parameters

--- a/core/providers/openai/responsesmarshal_test.go
+++ b/core/providers/openai/responsesmarshal_test.go
@@ -1158,3 +1158,354 @@ func TestEffortPredicatesAgainstCatalogIDs(t *testing.T) {
 		}
 	}
 }
+
+// TestToOpenAIResponsesRequest_OpenRouterCacheControlBreakpoint is the
+// Responses-path parallel of TestToOpenAIChatRequest_CacheControl_OpenRouterOnly
+// (added by the Chat-path fix in #4203). Regression test for #6290.
+//
+// OpenRouter does NOT expose Anthropic-style per-block cache_control through
+// /v1/responses. The documented Responses equivalent is prompt_cache_breakpoint
+// on an individual input_text block, which OpenRouter converts into a default
+// Anthropic cache_control breakpoint when the request routes to Claude:
+// https://openrouter.ai/docs/features/prompt-caching#anthropic-claude
+//
+// Both OpenRouterProvider.Responses and OpenRouterProvider.ResponsesStream build
+// their outbound body through ToOpenAIResponsesRequest + MarshalJSON, so
+// asserting on the marshalled body covers streaming and non-streaming alike.
+func TestToOpenAIResponsesRequest_OpenRouterCacheControlBreakpoint(t *testing.T) {
+	newBifrostReq := func(provider schemas.ModelProvider, model string) *schemas.BifrostResponsesRequest {
+		return &schemas.BifrostResponsesRequest{
+			Provider: provider,
+			Model:    model,
+			Input: []schemas.ResponsesMessage{
+				{
+					Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+					Content: &schemas.ResponsesMessageContent{
+						ContentBlocks: []schemas.ResponsesMessageContentBlock{
+							{
+								Type:         schemas.ResponsesInputMessageContentBlockTypeText,
+								Text:         schemas.Ptr("REUSABLE_PREFIX"),
+								CacheControl: &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral},
+							},
+							{
+								Type: schemas.ResponsesInputMessageContentBlockTypeText,
+								Text: schemas.Ptr("Reply with OK."),
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	// contentBlocks marshals the request and digs out input[0].content[] so the
+	// assertions read against the exact bytes that go on the wire.
+	contentBlocks := func(t *testing.T, bifrostReq *schemas.BifrostResponsesRequest) ([]any, string) {
+		t.Helper()
+		request := ToOpenAIResponsesRequest(nil, bifrostReq)
+		if request == nil {
+			t.Fatal("expected non-nil request")
+		}
+		jsonBytes, err := request.MarshalJSON()
+		if err != nil {
+			t.Fatalf("failed to marshal responses request: %v", err)
+		}
+		raw := string(jsonBytes)
+
+		var jsonMap map[string]any
+		if err := sonic.Unmarshal(jsonBytes, &jsonMap); err != nil {
+			t.Fatalf("failed to parse marshaled JSON: %v\nraw=%s", err, raw)
+		}
+		input, ok := jsonMap["input"].([]any)
+		if !ok || len(input) == 0 {
+			t.Fatalf("expected input array on the wire; raw=%s", raw)
+		}
+		msg, ok := input[0].(map[string]any)
+		if !ok {
+			t.Fatalf("expected input[0] to be an object; raw=%s", raw)
+		}
+		blocks, ok := msg["content"].([]any)
+		if !ok || len(blocks) != 2 {
+			t.Fatalf("expected 2 content blocks on input[0]; raw=%s", raw)
+		}
+		return blocks, raw
+	}
+
+	t.Run("openrouter converts cache_control to prompt_cache_breakpoint", func(t *testing.T) {
+		blocks, raw := contentBlocks(t, newBifrostReq(schemas.OpenRouter, "anthropic/claude-sonnet-4"))
+
+		marked, ok := blocks[0].(map[string]any)
+		if !ok {
+			t.Fatalf("expected content[0] to be an object; raw=%s", raw)
+		}
+
+		// The caching intent must survive in the form OpenRouter's Responses
+		// endpoint actually accepts.
+		bp, ok := marked["prompt_cache_breakpoint"].(map[string]any)
+		if !ok {
+			t.Fatalf("OpenRouter Responses: cache_control must be converted to prompt_cache_breakpoint on the marked text block; raw=%s", raw)
+		}
+		if mode, _ := bp["mode"].(string); mode != "explicit" {
+			t.Errorf("prompt_cache_breakpoint.mode = %q, want \"explicit\"; raw=%s", mode, raw)
+		}
+
+		// Per-block cache_control is not exposed through the Responses API, so
+		// it must not remain on the wire once translated.
+		if _, present := marked["cache_control"]; present {
+			t.Errorf("OpenRouter Responses: per-block cache_control must not be forwarded; raw=%s", raw)
+		}
+
+		// Only the marked block becomes a breakpoint; an unmarked block must
+		// not acquire one (that would move the cached prefix boundary).
+		unmarked, ok := blocks[1].(map[string]any)
+		if !ok {
+			t.Fatalf("expected content[1] to be an object; raw=%s", raw)
+		}
+		if _, present := unmarked["prompt_cache_breakpoint"]; present {
+			t.Errorf("unmarked block must not receive a prompt_cache_breakpoint; raw=%s", raw)
+		}
+	})
+
+	t.Run("openai still strips cache_control and adds no breakpoint", func(t *testing.T) {
+		blocks, raw := contentBlocks(t, newBifrostReq(schemas.OpenAI, "gpt-4o"))
+
+		for i, b := range blocks {
+			block, ok := b.(map[string]any)
+			if !ok {
+				t.Fatalf("expected content[%d] to be an object; raw=%s", i, raw)
+			}
+			if _, present := block["cache_control"]; present {
+				t.Errorf("OpenAI Responses: cache_control must still be stripped on content[%d]; raw=%s", i, raw)
+			}
+			if _, present := block["prompt_cache_breakpoint"]; present {
+				t.Errorf("OpenAI Responses: no prompt_cache_breakpoint may be synthesized on content[%d]; raw=%s", i, raw)
+			}
+		}
+	})
+}
+
+// openRouterCacheReq builds a single user message whose input_text blocks each
+// carry an Anthropic cache_control marker, one per entry in texts.
+func openRouterCacheReq(texts ...string) *schemas.BifrostResponsesRequest {
+	blocks := make([]schemas.ResponsesMessageContentBlock, 0, len(texts))
+	for _, text := range texts {
+		blocks = append(blocks, schemas.ResponsesMessageContentBlock{
+			Type:         schemas.ResponsesInputMessageContentBlockTypeText,
+			Text:         schemas.Ptr(text),
+			CacheControl: &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral},
+		})
+	}
+	return &schemas.BifrostResponsesRequest{
+		Provider: schemas.OpenRouter,
+		Model:    "anthropic/claude-sonnet-4",
+		Input: []schemas.ResponsesMessage{
+			{
+				Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+				Content: &schemas.ResponsesMessageContent{ContentBlocks: blocks},
+			},
+		},
+	}
+}
+
+// breakpointModes returns the prompt_cache_breakpoint.mode of every block in
+// input[0].content, using "" for a block that carries no breakpoint.
+func breakpointModes(t *testing.T, bifrostReq *schemas.BifrostResponsesRequest) ([]string, string) {
+	t.Helper()
+	request := ToOpenAIResponsesRequest(nil, bifrostReq)
+	if request == nil {
+		t.Fatal("expected non-nil request")
+	}
+	jsonBytes, err := request.MarshalJSON()
+	if err != nil {
+		t.Fatalf("failed to marshal responses request: %v", err)
+	}
+	raw := string(jsonBytes)
+
+	var jsonMap map[string]any
+	if err := sonic.Unmarshal(jsonBytes, &jsonMap); err != nil {
+		t.Fatalf("failed to parse marshaled JSON: %v\nraw=%s", err, raw)
+	}
+	input, _ := jsonMap["input"].([]any)
+	if len(input) == 0 {
+		t.Fatalf("expected input array; raw=%s", raw)
+	}
+	msg, _ := input[0].(map[string]any)
+	blocks, _ := msg["content"].([]any)
+	modes := make([]string, 0, len(blocks))
+	for _, b := range blocks {
+		block, _ := b.(map[string]any)
+		bp, ok := block["prompt_cache_breakpoint"].(map[string]any)
+		if !ok {
+			modes = append(modes, "")
+			continue
+		}
+		mode, _ := bp["mode"].(string)
+		modes = append(modes, mode)
+	}
+	return modes, raw
+}
+
+// TestToOpenAIResponsesRequest_OpenRouterClampsCacheBreakpoints pins the clamp
+// that makes the #6290 fix safe to ship. OpenRouter turns each
+// prompt_cache_breakpoint into an Anthropic cache_control block, and Anthropic
+// rejects a request carrying more than four outright ("A maximum of 4 blocks
+// with cache_control may be provided. Found 5.") rather than degrading. Before
+// the fix, unconditional stripping hid that; converting every marker without a
+// clamp would turn today's silent cache miss into a hard upstream error.
+//
+// The earliest markers are the ones dropped: caching is cumulative up to each
+// breakpoint, so a later marker anchors a strictly longer prefix.
+func TestToOpenAIResponsesRequest_OpenRouterClampsCacheBreakpoints(t *testing.T) {
+	modes, raw := breakpointModes(t, openRouterCacheReq("p1", "p2", "p3", "p4", "p5"))
+	if len(modes) != 5 {
+		t.Fatalf("expected 5 content blocks, got %d; raw=%s", len(modes), raw)
+	}
+
+	want := []string{"", "explicit", "explicit", "explicit", "explicit"}
+	for i, wantMode := range want {
+		if modes[i] != wantMode {
+			t.Errorf("block %d breakpoint mode = %q, want %q (earliest marker must be the one dropped); raw=%s",
+				i, modes[i], wantMode, raw)
+		}
+	}
+}
+
+// TestToOpenAIResponsesRequest_OpenRouterRespectsCallerBreakpoints verifies the
+// conversion neither overwrites a breakpoint the caller set explicitly nor
+// spends budget the caller has already committed. A caller who fills the
+// four-breakpoint ceiling by hand gets their request forwarded as written; the
+// converter declines to push it over the edge.
+func TestToOpenAIResponsesRequest_OpenRouterRespectsCallerBreakpoints(t *testing.T) {
+	t.Run("caller breakpoint is not overwritten", func(t *testing.T) {
+		bifrostReq := openRouterCacheReq("p1", "p2")
+		// Caller marked the first block themselves, and also left a cache_control
+		// on it; the explicit breakpoint wins and is left untouched.
+		bifrostReq.Input[0].Content.ContentBlocks[0].PromptCacheBreakpoint = &schemas.PromptCacheBreakpoint{
+			Mode: schemas.Ptr(PromptCacheBreakpointModeExplicit),
+		}
+
+		modes, raw := breakpointModes(t, bifrostReq)
+		if len(modes) != 2 {
+			t.Fatalf("expected 2 content blocks, got %d; raw=%s", len(modes), raw)
+		}
+		for i, mode := range modes {
+			if mode != "explicit" {
+				t.Errorf("block %d breakpoint mode = %q, want \"explicit\"; raw=%s", i, mode, raw)
+			}
+		}
+	})
+
+	t.Run("caller-filled ceiling leaves no budget", func(t *testing.T) {
+		// Five blocks: the first four already carry caller breakpoints, so the
+		// fifth block's cache_control has no budget left and must not be
+		// converted. Converting it would make five, which Anthropic rejects.
+		bifrostReq := openRouterCacheReq("p1", "p2", "p3", "p4", "p5")
+		for i := 0; i < 4; i++ {
+			bifrostReq.Input[0].Content.ContentBlocks[i].CacheControl = nil
+			bifrostReq.Input[0].Content.ContentBlocks[i].PromptCacheBreakpoint = &schemas.PromptCacheBreakpoint{
+				Mode: schemas.Ptr(PromptCacheBreakpointModeExplicit),
+			}
+		}
+
+		modes, raw := breakpointModes(t, bifrostReq)
+		want := []string{"explicit", "explicit", "explicit", "explicit", ""}
+		for i, wantMode := range want {
+			if modes[i] != wantMode {
+				t.Errorf("block %d breakpoint mode = %q, want %q; raw=%s", i, modes[i], wantMode, raw)
+			}
+		}
+	})
+}
+
+// TestToOpenAIResponsesRequest_OpenRouterDoesNotMutateInput guards the
+// copy-on-write in applyOpenRouterCacheBreakpoints. The ResponsesMessage
+// Content pointer and its block array are shared with the caller's
+// BifrostResponsesRequest, which plugins and the fallback chain reuse. Writing a
+// breakpoint in place would leak an OpenRouter-only field into a retry against a
+// different provider.
+func TestToOpenAIResponsesRequest_OpenRouterDoesNotMutateInput(t *testing.T) {
+	bifrostReq := openRouterCacheReq("p1", "p2")
+
+	request := ToOpenAIResponsesRequest(nil, bifrostReq)
+	if request == nil {
+		t.Fatal("expected non-nil request")
+	}
+	if _, err := request.MarshalJSON(); err != nil {
+		t.Fatalf("failed to marshal responses request: %v", err)
+	}
+
+	for i, block := range bifrostReq.Input[0].Content.ContentBlocks {
+		if block.PromptCacheBreakpoint != nil {
+			t.Errorf("caller input block %d was mutated: prompt_cache_breakpoint written back onto the source request", i)
+		}
+		if block.CacheControl == nil {
+			t.Errorf("caller input block %d was mutated: cache_control removed from the source request", i)
+		}
+	}
+}
+
+// TestToOpenAIResponsesRequest_OpenRouterIgnoresNonEphemeralCacheControl pins the
+// type guard on the conversion. "ephemeral" is the only cache type Anthropic
+// defines, and nothing upstream of ToOpenAIResponsesRequest validates the field -
+// schemas.CacheControl.Type is a bare string with no allowed-value check. Without
+// the guard, a malformed marker such as {"cache_control": {}} would be upgraded
+// into a valid prompt_cache_breakpoint that the caller never asked for, and would
+// consume budget against the four-breakpoint ceiling.
+//
+// The Chat path forwards cache_control verbatim and lets upstream reject a bad
+// value; the Responses path must not be more permissive just because it rewrites
+// the field.
+func TestToOpenAIResponsesRequest_OpenRouterIgnoresNonEphemeralCacheControl(t *testing.T) {
+	cases := []struct {
+		name string
+		cc   *schemas.CacheControl
+		want string // expected prompt_cache_breakpoint.mode, "" for none
+	}{
+		{name: "empty type is not converted", cc: &schemas.CacheControl{}, want: ""},
+		{name: "unknown type is not converted", cc: &schemas.CacheControl{Type: "persistent"}, want: ""},
+		{name: "ephemeral type is converted", cc: &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral}, want: "explicit"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bifrostReq := openRouterCacheReq("p1")
+			bifrostReq.Input[0].Content.ContentBlocks[0].CacheControl = tc.cc
+
+			modes, raw := breakpointModes(t, bifrostReq)
+			if len(modes) != 1 {
+				t.Fatalf("expected 1 content block, got %d; raw=%s", len(modes), raw)
+			}
+			if modes[0] != tc.want {
+				t.Errorf("breakpoint mode = %q, want %q for cache_control %+v; raw=%s",
+					modes[0], tc.want, tc.cc, raw)
+			}
+
+			// Whatever the type, the marker itself must never reach the wire:
+			// per-block cache_control is not exposed on OpenRouter Responses.
+			if strings.Contains(raw, "cache_control") {
+				t.Errorf("cache_control must not be forwarded regardless of type; raw=%s", raw)
+			}
+		})
+	}
+}
+
+// TestToOpenAIResponsesRequest_OpenRouterNonEphemeralDoesNotSpendClampBudget
+// verifies the type guard also keeps malformed markers from displacing valid
+// ones. Five blocks carry cache_control but only the last four are ephemeral, so
+// all four valid markers must survive - a naive nil-only guard would count the
+// malformed first block toward the ceiling and drop a real breakpoint.
+func TestToOpenAIResponsesRequest_OpenRouterNonEphemeralDoesNotSpendClampBudget(t *testing.T) {
+	bifrostReq := openRouterCacheReq("p1", "p2", "p3", "p4", "p5")
+	bifrostReq.Input[0].Content.ContentBlocks[0].CacheControl = &schemas.CacheControl{Type: "bogus"}
+
+	modes, raw := breakpointModes(t, bifrostReq)
+	want := []string{"", "explicit", "explicit", "explicit", "explicit"}
+	if len(modes) != len(want) {
+		t.Fatalf("expected %d content blocks, got %d; raw=%s", len(want), len(modes), raw)
+	}
+	for i, wantMode := range want {
+		if modes[i] != wantMode {
+			t.Errorf("block %d breakpoint mode = %q, want %q; raw=%s", i, modes[i], wantMode, raw)
+		}
+	}
+}

--- a/core/providers/openai/responsesmarshal_test.go
+++ b/core/providers/openai/responsesmarshal_test.go
@@ -1509,3 +1509,106 @@ func TestToOpenAIResponsesRequest_OpenRouterNonEphemeralDoesNotSpendClampBudget(
 		}
 	}
 }
+
+// TestApplyOpenRouterCacheBreakpoints_OnlyInputTextConverts pins the mechanism behind
+// the OpenRouter carve-out in RunPromptCachingMultipleToolCallsTest.
+//
+// That scenario moves a cache checkpoint each turn, landing it on whichever message
+// the walk stops at: a function_call (marked at MESSAGE level), an assistant turn
+// (output_text), or a user turn (input_text). Only the last of those has a Responses
+// representation here, so the set of surviving breakpoints oscillates between one and
+// two as the conversation grows - and with it the size of the cached prefix.
+//
+// That makes a turn-over-turn "cache_read must not halve" assertion unsound for
+// OpenRouter specifically: a drop is the expected consequence of this conversion rule,
+// not evidence of a cache-prefix mismatch.
+func TestApplyOpenRouterCacheBreakpoints_OnlyInputTextConverts(t *testing.T) {
+	ephemeral := func() *schemas.CacheControl {
+		return &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral}
+	}
+	countBreakpoints := func(msgs []schemas.ResponsesMessage) int {
+		n := 0
+		for i := range msgs {
+			if msgs[i].Content == nil {
+				continue
+			}
+			for j := range msgs[i].Content.ContentBlocks {
+				if msgs[i].Content.ContentBlocks[j].PromptCacheBreakpoint != nil {
+					n++
+				}
+			}
+		}
+		return n
+	}
+	// The system block is marked every turn and always converts, so it is the floor.
+	systemMsg := func() schemas.ResponsesMessage {
+		return schemas.ResponsesMessage{
+			Role: schemas.Ptr(schemas.ResponsesInputMessageRoleSystem),
+			Content: &schemas.ResponsesMessageContent{
+				ContentBlocks: []schemas.ResponsesMessageContentBlock{{
+					Type:         schemas.ResponsesInputMessageContentBlockTypeText,
+					Text:         schemas.Ptr("stable system prefix"),
+					CacheControl: ephemeral(),
+				}},
+			},
+		}
+	}
+
+	cases := []struct {
+		name       string
+		checkpoint schemas.ResponsesMessage
+		want       int // system breakpoint + (1 if the checkpoint converts)
+	}{
+		{
+			name: "checkpoint on a user input_text block converts",
+			checkpoint: schemas.ResponsesMessage{
+				Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+				Content: &schemas.ResponsesMessageContent{
+					ContentBlocks: []schemas.ResponsesMessageContentBlock{{
+						Type:         schemas.ResponsesInputMessageContentBlockTypeText,
+						Text:         schemas.Ptr("turn text"),
+						CacheControl: ephemeral(),
+					}},
+				},
+			},
+			want: 2,
+		},
+		{
+			name: "checkpoint on an assistant output_text block does not convert",
+			checkpoint: schemas.ResponsesMessage{
+				Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+				Content: &schemas.ResponsesMessageContent{
+					ContentBlocks: []schemas.ResponsesMessageContentBlock{{
+						Type:         schemas.ResponsesOutputMessageContentTypeText,
+						Text:         schemas.Ptr("assistant turn"),
+						CacheControl: ephemeral(),
+					}},
+				},
+			},
+			want: 1,
+		},
+		{
+			name: "message-level marker on a function_call does not convert",
+			checkpoint: schemas.ResponsesMessage{
+				Type:         schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+				CacheControl: ephemeral(),
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					CallID:    schemas.Ptr("call_1"),
+					Name:      schemas.Ptr("get_weather"),
+					Arguments: schemas.Ptr(`{"city":"Paris"}`),
+				},
+			},
+			want: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msgs := []schemas.ResponsesMessage{systemMsg(), tc.checkpoint}
+			applyOpenRouterCacheBreakpoints(msgs)
+			if got := countBreakpoints(msgs); got != tc.want {
+				t.Errorf("breakpoints = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/core/providers/openrouter/openrouter_test.go
+++ b/core/providers/openrouter/openrouter_test.go
@@ -30,6 +30,7 @@ func TestOpenRouter(t *testing.T) {
 		TextModel:            "google/gemini-2.5-flash",
 		EmbeddingModel:       "qwen/qwen3-embedding-4b",
 		ReasoningModel:       "openai/gpt-oss-120b",
+		PromptCachingModel:   "anthropic/claude-sonnet-4", // Claude is the only OpenRouter model with explicit caching; its Responses half was broken until #6290
 		TranscriptionModel:   "openai/gpt-4o-mini-transcribe",
 		SpeechSynthesisModel: "openai/gpt-audio-mini",
 		Scenarios: llmtests.TestScenarios{
@@ -50,6 +51,7 @@ func TestOpenRouter(t *testing.T) {
 			FileURL:                    false, // Responses API times out (300s+) with file input
 			CompleteEnd2End:            false, // OpenRouter's responses API is in Beta
 			Reasoning:                  true,
+			PromptCaching:              true, // Gates the three tool-block scenarios; two of them issue Responses requests, which is what #6290 broke
 			ListModels:                 true,
 			StructuredOutputs:          true, // Structured outputs with nullable enum support
 			Embedding:                  true,

--- a/docs/providers/supported-providers/openrouter.mdx
+++ b/docs/providers/supported-providers/openrouter.mdx
@@ -122,33 +122,92 @@ OpenRouter supports extended thinking on compatible models:
 
 **Reasoning Models:** gpt-oss-120b and compatible models with special handling for reasoning content.
 
-### Cache Control Stripping
+### Prompt Caching
 
-Anthropic-specific cache control directives are automatically removed:
+Bifrost forwards Anthropic-style cache breakpoints to OpenRouter, but the two API
+surfaces take them in different shapes. Bifrost translates automatically, so you
+send `cache_control` either way.
 
-```go
-// Bifrost supports cache control from Anthropic
+**Chat Completions** accepts per-block `cache_control` directly, and Bifrost
+passes it through unchanged:
+
+```json
 {
   "messages": [{
     "role": "user",
     "content": [{
       "type": "text",
-      "text": "...",
-      "cache_control": {"type": "ephemeral"}  // ← Stripped
+      "text": "<REUSABLE_PREFIX>",
+      "cache_control": {"type": "ephemeral"}
     }]
   }]
 }
-
-// Sent to OpenRouter without cache directives
 ```
+
+**Responses** does not expose per-block `cache_control`. Bifrost converts each
+marked `input_text` block into the `prompt_cache_breakpoint` that OpenRouter
+turns back into an Anthropic breakpoint:
+
+```json
+// You send
+{"input": [{"role": "user", "content": [
+  {"type": "input_text", "text": "<REUSABLE_PREFIX>",
+   "cache_control": {"type": "ephemeral"}}
+]}]}
+
+// Bifrost sends to OpenRouter
+{"input": [{"role": "user", "content": [
+  {"type": "input_text", "text": "<REUSABLE_PREFIX>",
+   "prompt_cache_breakpoint": {"mode": "explicit"}}
+]}]}
+```
+
+<Note>
+Anthropic accepts at most **four** cache breakpoints per request and rejects a
+fifth outright. On the Responses path Bifrost limits only the markers it
+**converts** from `cache_control`, and only to the capacity your own
+`prompt_cache_breakpoint` values leave free. When it has to trim, it drops the
+**earliest** converted markers, because caching is cumulative and a later
+breakpoint anchors a longer prefix.
+
+Breakpoints you set yourself are never modified or dropped. If you supply four or
+more of them, Bifrost converts nothing further; if you supply more than four, they
+are forwarded as written and OpenRouter's upstream will reject the request.
+</Note>
+
+<Note>
+A converted breakpoint carries no TTL. OpenRouter turns `prompt_cache_breakpoint`
+into a **default** Anthropic breakpoint, so `{"type": "ephemeral", "ttl": "1h"}`
+caches for the default 5 minutes on the Responses path. Use Chat Completions,
+which forwards `cache_control` verbatim, when you need the 1-hour TTL.
+
+Only `"type": "ephemeral"` is converted. It is the sole cache type Anthropic
+defines, so a `cache_control` carrying any other value is dropped rather than
+turned into a breakpoint.
+</Note>
+
+Two markers have no Responses representation and are still dropped: `cache_control`
+on tool definitions (OpenRouter documents no tool-level Responses breakpoint) and on
+`function_call_output` blocks (a text-only output array is collapsed to a single
+string before it reaches the wire). Put your breakpoints on `input_text` blocks.
+
+Verify caching worked by reading `cached_tokens` in the response usage. A `200`
+alone does not mean the cache was hit.
+
+See [OpenRouter prompt caching](https://openrouter.ai/docs/features/prompt-caching#anthropic-claude)
+for the upstream contract.
 
 ### Filtered Parameters
 
 Removed for OpenRouter compatibility:
-- `prompt_cache_key` - Not supported
 - `verbosity` - Anthropic-specific
 - `store` - Not supported
 - `service_tier` - OpenAI-specific
+
+`prompt_cache_key` is forwarded on the Responses path, and on Chat Completions
+only when the model's datasheet marks it supported. Either way it is not a
+caching switch: OpenRouter uses it as a sticky-routing key, so it does not enable
+Anthropic prompt caching on its own. Use a cache breakpoint for that.
 
 OpenRouter supports all standard OpenAI message types, tools, responses, and streaming formats. For details on message handling, tool conversion, responses, and streaming, refer to [OpenAI Chat Completions](/providers/supported-providers/openai#1-chat-completions).
 

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -140504,6 +140504,343 @@
           ]
         }
       ]
+    },
+    {
+      "name": "69. OpenRouter Claude prompt caching on Responses (#6290)",
+      "description": "Regression coverage for #6290: OpenRouter Claude prompt caching was still broken on the Responses API after #4203 fixed Chat Completions.\n\nProduction path: OpenRouterProvider.Responses / ResponsesStream -> openai.HandleOpenAIResponses* -> ToOpenAIResponsesRequest -> POST {OpenRouter}/v1/responses.\n\nBefore the fix, OpenAIResponsesRequestInput.MarshalJSON deleted every message- and block-level cache_control and put nothing in its place, so Claude caching never activated on this route. Unlike Chat Completions, OpenRouter does NOT expose per-block cache_control through /v1/responses; the documented equivalent is prompt_cache_breakpoint on an input_text block, which OpenRouter converts back into an Anthropic breakpoint (https://openrouter.ai/docs/features/prompt-caching#anthropic-claude).\n\nFolder 13 covers the same feature on /v1/chat/completions and is Chat-only; these cases pin the Responses half.\n\nWhat each case pins:\n  69.1 the translation itself, asserted on the outbound body via x-bf-send-back-raw-request (deterministic, independent of whether Anthropic actually cached).\n  69.2/69.3 a real cache read on the non-streaming route. A 2xx alone does not prove caching, so [read] asserts cached_tokens > 0.\n  69.4/69.5 the same invariant through the streaming handler, which the issue calls out separately.\n  69.6 the four-breakpoint clamp. Anthropic hard-rejects a fifth cache_control block, and OpenRouter converts every breakpoint into one, so translating without clamping would turn a silent cache miss into a 400.\n\nThe [write]/[read] pairs depend on folder order and on {{cachePrefix}} (23KB, comfortably over the 1024-token minimum for claude-sonnet-4) plus the collection-level {{pcNonce}} for per-run cache isolation.",
+      "item": [
+        {
+          "name": "OpenRouter Claude Responses: cache_control becomes prompt_cache_breakpoint on the wire - #6290",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('69.1 openrouter responses cache_control: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var body = pm.response.json() || {};",
+                  "var rr = (body.extra_fields || {}).raw_request;",
+                  "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                  "pm.test('69.1 raw_request captured', function () {",
+                  "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                  "});",
+                  "if (!rr || typeof rr !== 'object') { return; }",
+                  "var inp = JSON.stringify(rr.input || []);",
+                  "var blk = ((((rr.input || [])[0] || {}).content || [])[0]) || {};",
+                  "pm.test('69.1 marked input_text carries prompt_cache_breakpoint mode=explicit (#6290)', function () {",
+                  "  pm.expect(blk.prompt_cache_breakpoint, 'input[0].content[0]: ' + JSON.stringify(blk).slice(0, 400)).to.be.an('object');",
+                  "  pm.expect((blk.prompt_cache_breakpoint || {}).mode).to.eql('explicit');",
+                  "});",
+                  "pm.test('69.1 per-block cache_control is not forwarded (not exposed on OpenRouter Responses)', function () {",
+                  "  pm.expect(inp.indexOf('cache_control'), 'cache_control must be translated, not forwarded: ' + inp.slice(0, 500)).to.equal(-1);",
+                  "});",
+                  "pm.test('69.1 unmarked block does not acquire a breakpoint', function () {",
+                  "  var b2 = ((((rr.input || [])[0] || {}).content || [])[1]) || {};",
+                  "  pm.expect(b2.prompt_cache_breakpoint, 'unmarked block: ' + JSON.stringify(b2).slice(0, 300)).to.be.undefined;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-send-back-raw-request",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"openrouter/anthropic/claude-sonnet-4\",\n  \"max_output_tokens\": 16,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"You are a meticulous assistant. Answer tersely.\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Reply with OK.\"\n        }\n      ]\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "OpenRouter Claude Responses: prompt caching non-streaming [write] - #6290",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('69.2 openrouter responses cache write: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"openrouter/anthropic/claude-sonnet-4\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6290 {{pcNonce}} nonstream]\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "OpenRouter Claude Responses: prompt caching non-streaming [read] - #6290",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Let the breakpoint written by the paired [write] land before this [read].",
+                  "var __t = Date.now(); while (Date.now() - __t < 2000) { /* busy-wait for cache propagation */ }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('69.3 openrouter responses cache read: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var j = pm.response.json() || {};",
+                  "var u = j.usage || {};",
+                  "var d = u.input_tokens_details || u.prompt_tokens_details || {};",
+                  "var cached = (typeof d.cached_tokens === 'number') ? d.cached_tokens : 0;",
+                  "pm.test('69.3 cache read: cached_tokens > 0 (#6290)', function () {",
+                  "  pm.expect(cached, 'usage: ' + JSON.stringify(u)).to.be.above(0);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"openrouter/anthropic/claude-sonnet-4\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6290 {{pcNonce}} nonstream]\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "OpenRouter Claude Responses: prompt caching streaming [write] - #6290",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('69.4 openrouter responses cache write: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "pm.test('69.4 stream reached a terminal event', function () {",
+                  "  var raw = pm.response.text() || '';",
+                  "  pm.expect(raw.indexOf('response.completed') !== -1 || raw.indexOf('response.incomplete') !== -1, 'no terminal SSE event: ' + raw.slice(-400)).to.be.true;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"openrouter/anthropic/claude-sonnet-4\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6290 {{pcNonce}} stream]\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ],\n  \"stream\": true\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "OpenRouter Claude Responses: prompt caching streaming [read] - #6290",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Let the breakpoint written by the paired [write] land before this [read].",
+                  "var __t = Date.now(); while (Date.now() - __t < 2000) { /* busy-wait for cache propagation */ }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('69.5 openrouter responses cache read: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "// Terminal usage rides the final SSE event; scan the whole stream for the",
+                  "// largest cached_tokens rather than guessing which event carries usage.",
+                  "var raw = pm.response.text() || '';",
+                  "var m = raw.match(/\"cached_tokens\"\\s*:\\s*(\\d+)/g) || [];",
+                  "var cached = 0;",
+                  "for (var i = 0; i < m.length; i++) { var v = parseInt(m[i].replace(/[^0-9]/g, ''), 10); if (v > cached) { cached = v; } }",
+                  "pm.test('69.5 streaming cache read: cached_tokens > 0 (#6290)', function () {",
+                  "  pm.expect(cached, 'no cached_tokens in the stream; tail: ' + raw.slice(-600)).to.be.above(0);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"openrouter/anthropic/claude-sonnet-4\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6290 {{pcNonce}} stream]\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ],\n  \"stream\": true\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "OpenRouter Claude Responses: five cache_control markers clamp to four - #6290",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "// A 400 here IS the regression signature (Anthropic: 'A maximum of 4 blocks",
+                  "// with cache_control may be provided. Found 5.') - never guard it away.",
+                  "pm.test('69.6 five markers must not 400 (clamped to four) - #6290', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var body = pm.response.json() || {};",
+                  "var rr = (body.extra_fields || {}).raw_request;",
+                  "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                  "pm.test('69.6 raw_request captured', function () {",
+                  "  pm.expect(rr, 'raw_request missing').to.be.an('object');",
+                  "});",
+                  "if (!rr || typeof rr !== 'object') { return; }",
+                  "var blocks = (((rr.input || [])[0] || {}).content) || [];",
+                  "var bps = 0;",
+                  "for (var i = 0; i < blocks.length; i++) { if (blocks[i] && blocks[i].prompt_cache_breakpoint) { bps++; } }",
+                  "pm.test('69.6 exactly four breakpoints reach the wire', function () {",
+                  "  pm.expect(bps, 'blocks: ' + JSON.stringify(blocks.map(function (b) { return !!(b && b.prompt_cache_breakpoint); }))).to.equal(4);",
+                  "});",
+                  "pm.test('69.6 the earliest marker is the one dropped (later breakpoints anchor longer prefixes)', function () {",
+                  "  pm.expect(!!(blocks[0] && blocks[0].prompt_cache_breakpoint), 'block 0 must lose its marker').to.be.false;",
+                  "  pm.expect(!!(blocks[4] && blocks[4].prompt_cache_breakpoint), 'block 4 must keep its marker').to.be.true;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-send-back-raw-request",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"openrouter/anthropic/claude-sonnet-4\",\n  \"max_output_tokens\": 16,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6290 {{pcNonce}} clamp]\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Section two of the manual.\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Section three of the manual.\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Section four of the manual.\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Section five of the manual.\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Reply with OK.\"\n        }\n      ]\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fixes #6290: Claude prompt caching was silently broken on the OpenRouter Responses API path. After #4203 fixed Chat Completions by passing `cache_control` through verbatim, the Responses path remained broken because `OpenAIResponsesRequestInput.MarshalJSON` stripped every `cache_control` marker and put nothing in its place. OpenRouter's `/v1/responses` endpoint does not accept per-block `cache_control`; the documented equivalent is `prompt_cache_breakpoint` on an `input_text` block, which OpenRouter converts back into an Anthropic breakpoint before dispatching to Claude.

## Changes

- **`applyOpenRouterCacheBreakpoints`** — new function in `core/providers/openai/responses.go` that rewrites Anthropic-style `cache_control` markers on `input_text` blocks into `prompt_cache_breakpoint: {mode: "explicit"}` before the request is marshalled. Called from `ToOpenAIResponsesRequest` only when the provider is OpenRouter, leaving all other providers unaffected.
- **Four-breakpoint clamp** — Anthropic hard-rejects a request carrying more than four `cache_control` blocks. Because OpenRouter converts every `prompt_cache_breakpoint` back into one, translating without a ceiling would turn a previously silent cache miss into a hard upstream 400. When more than four markable blocks are present, the earliest markers are dropped; a later breakpoint anchors a strictly longer cached prefix, matching the trade-off `clampAnthropicCacheBreakpoints` makes on the direct Anthropic path.
- **Copy-on-write** — `applyOpenRouterCacheBreakpoints` copies both the `ResponsesMessageContent` struct and its block slice before writing any breakpoint, so the caller's `BifrostResponsesRequest` is never mutated. This matters because plugins and the fallback chain reuse the same input across retries against different providers.
- **Unit tests** — `responsesmarshal_test.go` (renamed from `responses_marshal_test.go`) adds four test functions covering: the translation itself, the four-breakpoint clamp with correct drop-earliest behaviour, caller-set breakpoints being respected and counted against the budget, and the copy-on-write invariant.
- **E2E collection** — folder 61 in `provider-harness.json` adds six cases: wire-format assertion via `x-bf-send-back-raw-request`, non-streaming write/read pair asserting `cached_tokens > 0`, streaming write/read pair with the same assertion, and a clamp case asserting exactly four breakpoints reach the wire and the earliest is the one dropped.
- **Docs** — `openrouter.mdx` replaces the "Cache Control Stripping" section with a "Prompt Caching" section that documents the Chat vs. Responses translation, the four-breakpoint ceiling and drop-earliest behaviour, which block types are and are not marked, and how to verify a cache hit via `cached_tokens`. Clarifies that `prompt_cache_key` is a sticky-routing key, not a caching switch.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./core/providers/openai/... -run TestToOpenAIResponsesRequest_OpenRouter
```

Expected: all four new test functions pass.

For end-to-end validation, run folder 61 of `provider-harness.json` against a Bifrost instance configured with an OpenRouter key and a `{{cachePrefix}}` variable containing at least 1024 tokens of text. Cases 61.3 and 61.5 assert `cached_tokens > 0`; 61.6 asserts exactly four breakpoints on the wire and a 2xx response when five markers are submitted.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #6290

## Security considerations

None. The change rewrites a field on the outbound request body; no credentials, PII, or trust boundaries are involved.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable