### PR TITLE
feat(logstore): add `request_id` exact PK lookup filter, bypassing time-range constraints

### DIFF
--- a/docs/features/observability/default.mdx
+++ b/docs/features/observability/default.mdx
@@ -311,7 +311,15 @@ curl 'http://localhost:8080/api/logs?' \
 | `min_tokens` / `max_tokens` | Token usage range | `10` to `1000` |
 | `min_cost` / `max_cost` | Cost range (USD) | `0.001` to `10` |
 | `content_search` | Search in messages | `"error handling"` |
+| `request_id` | Exact lookup on a log ID | `018f2c3d-4e5f-4a6b-8c9d-0e1f2a3b4c5d` |
 | `limit` / `offset` | Pagination | `100`, `200` |
+
+<Note>
+  A log's ID **is** its request ID, so `request_id` is an exact primary-key lookup rather than a text
+  search. It takes precedence over the time range — `start_time`, `end_time`, and `period` are ignored
+  when it is set, so a request is found wherever it falls. `roots_only` is ignored too, so an ID naming
+  a fallback child returns that child rather than collapsing it into its root.
+</Note>
 
 **Response Format**
 

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -70052,6 +70052,14 @@
             }
           },
           {
+            "name": "request_id",
+            "in": "query",
+            "description": "Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "limit",
             "in": "query",
             "description": "Number of logs to return (default 50, max 1000)",
@@ -70630,6 +70638,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "request_id",
+            "in": "query",
+            "description": "Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "security": [
@@ -70905,6 +70921,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "request_id",
+            "in": "query",
+            "description": "Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "security": [
@@ -71132,6 +71156,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "request_id",
+            "in": "query",
+            "description": "Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "security": [
@@ -71356,6 +71388,14 @@
             "name": "content_search",
             "in": "query",
             "description": "Search in request/response content",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "request_id",
+            "in": "query",
+            "description": "Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root.",
             "schema": {
               "type": "string"
             }
@@ -71588,6 +71628,14 @@
             "name": "content_search",
             "in": "query",
             "description": "Search in request/response content",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "request_id",
+            "in": "query",
+            "description": "Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root.",
             "schema": {
               "type": "string"
             }
@@ -71834,6 +71882,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "request_id",
+            "in": "query",
+            "description": "Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "security": [
@@ -72065,6 +72121,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "request_id",
+            "in": "query",
+            "description": "Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "security": [
@@ -72293,6 +72357,14 @@
             "name": "content_search",
             "in": "query",
             "description": "Search in request/response content",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "request_id",
+            "in": "query",
+            "description": "Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root.",
             "schema": {
               "type": "string"
             }
@@ -72536,6 +72608,14 @@
             "name": "content_search",
             "in": "query",
             "description": "Search in request/response content",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "request_id",
+            "in": "query",
+            "description": "Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root.",
             "schema": {
               "type": "string"
             }
@@ -72803,6 +72883,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "request_id",
+            "in": "query",
+            "description": "Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "security": [
@@ -73059,6 +73147,14 @@
             "name": "content_search",
             "in": "query",
             "description": "Search in request/response content",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "request_id",
+            "in": "query",
+            "description": "Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root.",
             "schema": {
               "type": "string"
             }
@@ -73329,6 +73425,14 @@
             "name": "content_search",
             "in": "query",
             "description": "Search in request/response content",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "request_id",
+            "in": "query",
+            "description": "Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root.",
             "schema": {
               "type": "string"
             }
@@ -73777,6 +73881,14 @@
             }
           },
           {
+            "name": "request_id",
+            "in": "query",
+            "description": "Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "limit",
             "in": "query",
             "description": "Maximum number of ranked rows to return. Defaults to 100. Ignored when\n`all=true`.\n",
@@ -74135,6 +74247,14 @@
             "name": "content_search",
             "in": "query",
             "description": "Search in request/response content",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "request_id",
+            "in": "query",
+            "description": "Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root.",
             "schema": {
               "type": "string"
             }

--- a/docs/openapi/paths/management/logging.yaml
+++ b/docs/openapi/paths/management/logging.yaml
@@ -99,6 +99,11 @@ logs:
         description: Search in request/response content
         schema:
           type: string
+      - name: request_id
+        in: query
+        description: 'Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root.'
+        schema:
+          type: string
       - name: limit
         in: query
         description: Number of logs to return (default 50, max 1000)
@@ -266,6 +271,11 @@ logs-stats:
         description: Search in request/response content
         schema:
           type: string
+      - name: request_id
+        in: query
+        description: 'Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root.'
+        schema:
+          type: string
     security:
       - ManagementBearerAuth: []
     responses:
@@ -385,6 +395,7 @@ logs-histogram:
       - $ref: '#/_histogram-parameters/parent_request_id'
       - $ref: '#/_histogram-parameters/metadata_key'
       - $ref: '#/_histogram-parameters/content_search'
+      - $ref: '#/_histogram-parameters/request_id'
     security:
       - ManagementBearerAuth: []
     responses:
@@ -425,6 +436,7 @@ logs-histogram-tokens:
       - $ref: '#/_histogram-parameters/max_cost'
       - $ref: '#/_histogram-parameters/missing_cost_only'
       - $ref: '#/_histogram-parameters/content_search'
+      - $ref: '#/_histogram-parameters/request_id'
     security:
       - ManagementBearerAuth: []
     responses:
@@ -465,6 +477,7 @@ logs-histogram-cost:
       - $ref: '#/_histogram-parameters/max_cost'
       - $ref: '#/_histogram-parameters/missing_cost_only'
       - $ref: '#/_histogram-parameters/content_search'
+      - $ref: '#/_histogram-parameters/request_id'
     security:
       - ManagementBearerAuth: []
     responses:
@@ -505,6 +518,7 @@ logs-histogram-models:
       - $ref: '#/_histogram-parameters/max_cost'
       - $ref: '#/_histogram-parameters/missing_cost_only'
       - $ref: '#/_histogram-parameters/content_search'
+      - $ref: '#/_histogram-parameters/request_id'
     security:
       - ManagementBearerAuth: []
     responses:
@@ -545,6 +559,7 @@ logs-histogram-latency:
       - $ref: '#/_histogram-parameters/max_cost'
       - $ref: '#/_histogram-parameters/missing_cost_only'
       - $ref: '#/_histogram-parameters/content_search'
+      - $ref: '#/_histogram-parameters/request_id'
     security:
       - ManagementBearerAuth: []
     responses:
@@ -585,6 +600,7 @@ logs-histogram-cost-by-provider:
       - $ref: '#/_histogram-parameters/max_cost'
       - $ref: '#/_histogram-parameters/missing_cost_only'
       - $ref: '#/_histogram-parameters/content_search'
+      - $ref: '#/_histogram-parameters/request_id'
     security:
       - ManagementBearerAuth: []
     responses:
@@ -625,6 +641,7 @@ logs-histogram-tokens-by-provider:
       - $ref: '#/_histogram-parameters/max_cost'
       - $ref: '#/_histogram-parameters/missing_cost_only'
       - $ref: '#/_histogram-parameters/content_search'
+      - $ref: '#/_histogram-parameters/request_id'
     security:
       - ManagementBearerAuth: []
     responses:
@@ -665,6 +682,7 @@ logs-histogram-latency-by-provider:
       - $ref: '#/_histogram-parameters/max_cost'
       - $ref: '#/_histogram-parameters/missing_cost_only'
       - $ref: '#/_histogram-parameters/content_search'
+      - $ref: '#/_histogram-parameters/request_id'
     security:
       - ManagementBearerAuth: []
     responses:
@@ -849,6 +867,12 @@ _histogram-parameters:
     name: content_search
     in: query
     description: Search in request/response content
+    schema:
+      type: string
+  request_id:
+    name: request_id
+    in: query
+    description: 'Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root.'
     schema:
       type: string
 
@@ -1323,6 +1347,7 @@ logs-rankings:
       - $ref: '#/_histogram-parameters/parent_request_id'
       - $ref: '#/_histogram-parameters/metadata_key'
       - $ref: '#/_histogram-parameters/content_search'
+      - $ref: '#/_histogram-parameters/request_id'
       - $ref: '#/_ranking-parameters/limit'
       - $ref: '#/_ranking-parameters/all'
     security:
@@ -1387,6 +1412,7 @@ logs-dashboard:
       - $ref: '#/_histogram-parameters/parent_request_id'
       - $ref: '#/_histogram-parameters/metadata_key'
       - $ref: '#/_histogram-parameters/content_search'
+      - $ref: '#/_histogram-parameters/request_id'
       - name: tool_names
         in: query
         description: Comma-separated list of MCP tool names to filter the MCP section by
@@ -1448,6 +1474,7 @@ logs-histogram-cost-by-dimension:
       - $ref: '#/_histogram-parameters/max_cost'
       - $ref: '#/_histogram-parameters/missing_cost_only'
       - $ref: '#/_histogram-parameters/content_search'
+      - $ref: '#/_histogram-parameters/request_id'
     security:
       - ManagementBearerAuth: []
     responses:
@@ -1496,6 +1523,7 @@ logs-histogram-tokens-by-dimension:
       - $ref: '#/_histogram-parameters/max_cost'
       - $ref: '#/_histogram-parameters/missing_cost_only'
       - $ref: '#/_histogram-parameters/content_search'
+      - $ref: '#/_histogram-parameters/request_id'
     security:
       - ManagementBearerAuth: []
     responses:
@@ -1544,6 +1572,7 @@ logs-histogram-latency-by-dimension:
       - $ref: '#/_histogram-parameters/max_cost'
       - $ref: '#/_histogram-parameters/missing_cost_only'
       - $ref: '#/_histogram-parameters/content_search'
+      - $ref: '#/_histogram-parameters/request_id'
     security:
       - ManagementBearerAuth: []
     responses:

--- a/framework/logstore/logstoreparity_test.go
+++ b/framework/logstore/logstoreparity_test.go
@@ -580,6 +580,11 @@ func TestLogStoreParity(t *testing.T) {
 		"metadata":        {MetadataFilters: map[string]string{"env": "prod"}},
 		"content_search":  {ContentSearch: "charlie"},
 		"parent_request":  {ParentRequestID: "sess1"},
+		"request_id":      {RequestID: "p4"},
+		// An ID lookup is an exact PK match that deliberately ignores the window,
+		// so p4 must come back even though the range excludes its timestamp.
+		"request_id_outside_window": {RequestID: "p4", StartTime: timePtrP(base.Add(-10 * time.Second)), EndTime: timePtrP(base)},
+		"request_id_unknown":        {RequestID: "no-such-id"},
 	}
 	for name, filters := range searchCases {
 		t.Run("SearchLogs/"+name, func(t *testing.T) {

--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -955,10 +955,11 @@ func startMatViewRefresher(ctx context.Context, db *gorm.DB, interval, timeout t
 }
 
 // canUseMatViewFilters returns true if the given filters can be served from
-// mv_logs_hourly. Per-row filters (content search, parent request ID, metadata,
-// numeric ranges) require the raw logs table.
+// mv_logs_hourly. Per-row filters (content search, request ID, parent request ID,
+// metadata, numeric ranges) require the raw logs table.
 func canUseMatViewFilters(f SearchFilters) bool {
 	return f.ContentSearch == "" &&
+		f.RequestID == "" &&
 		f.ParentRequestID == "" &&
 		!f.RootsOnly &&
 		len(f.MetadataFilters) == 0 &&

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -307,7 +307,9 @@ func (s *RDBLogStore) applyFilters(baseQuery *gorm.DB, filters SearchFilters) *g
 		// a self-referencing row already lists as a root (see applyRootsOnlyFilter),
 		// so without this it would also appear inside its own expansion.
 		baseQuery = baseQuery.Where("parent_request_id = ? AND id <> parent_request_id", filters.ParentRequestID)
-	} else if filters.RootsOnly {
+	} else if filters.RootsOnly && filters.RequestID == "" {
+		// An explicit ID lookup targets exactly one row; collapsing it as a
+		// non-root would hide the very row that was pasted.
 		baseQuery = s.applyRootsOnlyFilter(baseQuery, filters)
 	}
 	if len(filters.SelectedKeyIDs) > 0 {
@@ -398,11 +400,18 @@ func (s *RDBLogStore) applyFilters(baseQuery *gorm.DB, filters SearchFilters) *g
 			}
 		}
 	}
-	if filters.StartTime != nil {
-		baseQuery = baseQuery.Where("timestamp >= ?", *filters.StartTime)
-	}
-	if filters.EndTime != nil {
-		baseQuery = baseQuery.Where("timestamp <= ?", *filters.EndTime)
+	if filters.RequestID != "" {
+		// The log primary key is the request ID, so this is an exact PK lookup. A
+		// unique ID must not be hidden by the selected window, so the time-range
+		// clauses are skipped for it.
+		baseQuery = baseQuery.Where("id = ?", filters.RequestID)
+	} else {
+		if filters.StartTime != nil {
+			baseQuery = baseQuery.Where("timestamp >= ?", *filters.StartTime)
+		}
+		if filters.EndTime != nil {
+			baseQuery = baseQuery.Where("timestamp <= ?", *filters.EndTime)
+		}
 	}
 	if filters.MinLatency != nil {
 		baseQuery = baseQuery.Where("latency >= ?", *filters.MinLatency)

--- a/framework/logstore/rdb_requestid_test.go
+++ b/framework/logstore/rdb_requestid_test.go
@@ -1,0 +1,66 @@
+package logstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A log row's primary key is the request ID, so a pasted ID is an exact PK
+// lookup rather than a content-summary text scan. It deliberately ignores the
+// selected time window — an ID is unique, and hiding it behind the window is
+// the usual reason a pasted ID appears to match nothing.
+func TestSearchLogsRequestID(t *testing.T) {
+	s, now := newRootsOnlyStore(t)
+	ctx := context.Background()
+
+	t.Run("returns only the matching row", func(t *testing.T) {
+		result, err := s.SearchLogs(ctx, SearchFilters{RequestID: "root-b"}, PaginationOptions{Limit: 50})
+		require.NoError(t, err)
+		require.Equal(t, []string{"root-b"}, logIDs(result.Logs))
+		require.EqualValues(t, 1, result.Pagination.TotalCount)
+	})
+
+	t.Run("ignores the time window", func(t *testing.T) {
+		// A window that excludes every seeded row.
+		past := now.Add(-48 * time.Hour)
+		filters := SearchFilters{
+			RequestID: "root-b",
+			StartTime: &past,
+			EndTime:   timePtr(past.Add(time.Hour)),
+		}
+		result, err := s.SearchLogs(ctx, filters, PaginationOptions{Limit: 50})
+		require.NoError(t, err)
+		require.Equal(t, []string{"root-b"}, logIDs(result.Logs))
+	})
+
+	t.Run("surfaces a fallback child that roots_only would hide", func(t *testing.T) {
+		result, err := s.SearchLogs(ctx, SearchFilters{RequestID: "child-a1", RootsOnly: true}, PaginationOptions{Limit: 50})
+		require.NoError(t, err)
+		require.Equal(t, []string{"child-a1"}, logIDs(result.Logs))
+	})
+
+	t.Run("still honors the other filters", func(t *testing.T) {
+		result, err := s.SearchLogs(ctx, SearchFilters{RequestID: "root-b", Providers: []string{"anthropic"}}, PaginationOptions{Limit: 50})
+		require.NoError(t, err)
+		require.Empty(t, result.Logs)
+	})
+
+	t.Run("unknown id matches nothing", func(t *testing.T) {
+		result, err := s.SearchLogs(ctx, SearchFilters{RequestID: "no-such-id"}, PaginationOptions{Limit: 50})
+		require.NoError(t, err)
+		require.Empty(t, result.Logs)
+		require.EqualValues(t, 0, result.Pagination.TotalCount)
+	})
+}
+
+// mv_logs_hourly is a per-hour rollup with no id column, so an ID lookup must
+// fall back to the raw logs table.
+func TestCanUseMatViewFiltersRejectsRequestID(t *testing.T) {
+	require.True(t, canUseMatViewFilters(SearchFilters{}))
+	require.False(t, canUseMatViewFilters(SearchFilters{RequestID: "root-b"}))
+}
+
+func timePtr(v time.Time) *time.Time { return &v }

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -53,6 +53,7 @@ type SearchFilters struct {
 	StopReasons       []string          `json:"stop_reasons,omitempty"` // For filtering by stop reason (stop, length, content_filter, refusal, tool_calls, etc.)
 	Objects           []string          `json:"objects,omitempty"`      // For filtering by request type (chat.completion, text.completion, embedding)
 	ParentRequestID   string            `json:"parent_request_id,omitempty"`
+	RequestID         string            `json:"request_id,omitempty"` // Exact match on the log primary key, which is the request ID. Time-range filters are skipped for it so a unique ID is never hidden by the selected window.
 	RootsOnly         bool              `json:"roots_only,omitempty"` // Hide rows whose parent_request_id points at another row matching these same filters, so each chain lists as its root request only. Ignored when ParentRequestID is set.
 	SelectedKeyIDs    []string          `json:"selected_key_ids,omitempty"`
 	VirtualKeyIDs     []string          `json:"virtual_key_ids,omitempty"`

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -719,6 +719,9 @@ func (h *LoggingHandler) getLogs(ctx *fasthttp.RequestCtx) {
 	if contentSearch := string(ctx.QueryArgs().Peek("content_search")); contentSearch != "" {
 		filters.ContentSearch = contentSearch
 	}
+	if requestID := string(ctx.QueryArgs().Peek("request_id")); requestID != "" {
+		filters.RequestID = requestID
+	}
 	if rootsOnly := string(ctx.QueryArgs().Peek("roots_only")); rootsOnly != "" {
 		if val, err := strconv.ParseBool(rootsOnly); err == nil {
 			filters.RootsOnly = val
@@ -980,6 +983,9 @@ func (h *LoggingHandler) getLogsStats(ctx *fasthttp.RequestCtx) {
 	if contentSearch := string(ctx.QueryArgs().Peek("content_search")); contentSearch != "" {
 		filters.ContentSearch = contentSearch
 	}
+	if requestID := string(ctx.QueryArgs().Peek("request_id")); requestID != "" {
+		filters.RequestID = requestID
+	}
 	parseMetadataFilters(ctx, filters)
 
 	stats, err := h.logManager.GetStats(ctx, filters)
@@ -1144,6 +1150,9 @@ func parseHistogramFilters(ctx *fasthttp.RequestCtx) *logstore.SearchFilters {
 	}
 	if contentSearch := string(ctx.QueryArgs().Peek("content_search")); contentSearch != "" {
 		filters.ContentSearch = contentSearch
+	}
+	if requestID := string(ctx.QueryArgs().Peek("request_id")); requestID != "" {
+		filters.RequestID = requestID
 	}
 	parseMetadataFilters(ctx, filters)
 


### PR DESCRIPTION
## Summary

Adds a `request_id` query parameter to the logs API endpoints that performs an exact primary-key lookup on a log entry. Because a log's ID is its request ID, this allows callers to retrieve a specific log directly without being constrained by the selected time window — `start_time`, `end_time`, and `period` are ignored when `request_id` is set.

## Changes

- Added `RequestID` field to `SearchFilters` with an exact `id = ?` WHERE clause in the RDB query builder. Time-range filters are skipped when this field is set so a unique ID is never hidden by the selected window.
- Skipped the `roots_only` filter when `RequestID` is set, preventing a child row targeted by an explicit ID lookup from being collapsed and hidden.
- Excluded `RequestID` from the materialized view fast path (`canUseMatViewFilters`), since `mv_logs_hourly` has no `id` column and requires a raw table scan.
- Wired `request_id` query argument parsing into the `getLogs`, `getLogsStats`, and `parseHistogramFilters` HTTP handlers.
- Added the `request_id` parameter to all relevant OpenAPI spec endpoints and the logging YAML path definitions.
- Documented the parameter in the observability docs with a note clarifying that it is a primary-key lookup and takes precedence over the time range.
- Added `TestSearchLogsRequestID` covering: exact match, time-window bypass, surfacing a child row that `roots_only` would otherwise hide, combined filter interaction, and unknown ID returning empty results.
- Added `TestCanUseMatViewFiltersRejectsRequestID` to confirm the materialized view path is correctly bypassed.
- Extended the parity test suite with `request_id`, `request_id_outside_window`, and `request_id_unknown` cases.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./framework/logstore/... ./transports/bifrost-http/...
```

To validate end-to-end, query the logs endpoint with a known request ID:

```sh
curl 'http://localhost:8080/api/logs?request_id=<your-request-id>'
```

Expected: the single matching log entry is returned regardless of the default time window. Supplying an unknown ID returns an empty list with `total_count: 0`.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The `request_id` parameter is an exact string match against the log primary key. No additional access control changes are introduced beyond what already governs the logs endpoints.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable