### PR TITLE
feat(ui): add request ID search mode to logs with UUID auto-detection, `id:` prefix support, and ID badge

### DIFF
--- a/docs/features/observability/default.mdx
+++ b/docs/features/observability/default.mdx
@@ -318,7 +318,9 @@ curl 'http://localhost:8080/api/logs?' \
   A log's ID **is** its request ID, so `request_id` is an exact primary-key lookup rather than a text
   search. It takes precedence over the time range — `start_time`, `end_time`, and `period` are ignored
   when it is set, so a request is found wherever it falls. `roots_only` is ignored too, so an ID naming
-  a fallback child returns that child rather than collapsing it into its root.
+  a fallback child returns that child rather than collapsing it into its root. In the dashboard, pasting
+  a request ID into the logs search box switches to this lookup automatically; prefix it with `id:` for
+  request IDs that aren't UUIDs (any string supplied via the `x-request-id` header).
 </Note>
 
 **Response Format**

--- a/tests/e2e/features/logs/logs.spec.ts
+++ b/tests/e2e/features/logs/logs.spec.ts
@@ -409,6 +409,29 @@ test.describe('LLM Logs', () => {
       expect(decodeURIComponent(url)).toContain('persistent-search')
     })
 
+    test('should look up a pasted request ID by id instead of content', async ({ logsPage }) => {
+      const searchVisible = await logsPage.searchInput.isVisible().catch(() => false)
+      if (!searchVisible) return
+
+      // A log's primary key is its request ID, so a UUID-shaped query switches
+      // the search box from free-text content search to an exact ID lookup.
+      const requestId = '018f2c3d-4e5f-4a6b-8c9d-0e1f2a3b4c5d'
+      await logsPage.searchLogs(requestId)
+
+      await expect
+        .poll(
+          () => logsPage.page.url(),
+          { timeout: 8000, intervals: [300, 500, 500] }
+        )
+        .toContain('request_id=')
+      const url = logsPage.page.url()
+      expect(decodeURIComponent(url)).toContain(requestId)
+      expect(url).not.toContain('content_search=')
+
+      // The mode switch is surfaced to the user.
+      await expect(logsPage.page.locator('[data-testid="logs-search-id-badge"]')).toBeVisible()
+    })
+
     test('should restore state from URL', async ({ logsPage, page }) => {
       // Logs page uses start_time and end_time (unix timestamps), not period
       const endTime = Math.floor(Date.now() / 1000)

--- a/tests/e2e/features/logs/pages/logs.page.ts
+++ b/tests/e2e/features/logs/pages/logs.page.ts
@@ -50,7 +50,9 @@ export class LogsPage extends BasePage {
     this.statusFilter = page.locator('[data-testid="filter-status"]').or(
       page.locator('button').filter({ hasText: /Status/i })
     )
-    this.searchInput = page.locator('[data-testid="filter-search"]').or(
+    this.searchInput = page.locator('[data-testid="logs-search-input"]').or(
+      page.locator('[data-testid="filter-search"]')
+    ).or(
       page.getByPlaceholder('Search logs')
     )
     this.dateRangePicker = page.locator('[data-testid="filter-date-range"]').or(

--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -95,6 +95,7 @@ export default function LogsPage() {
 			customer_ids: parseAsSafeArrayOf.withDefault([]),
 			business_unit_ids: parseAsSafeArrayOf.withDefault([]),
 			content_search: parseAsSafeString.withDefault(""),
+			request_id: parseAsSafeString.withDefault(""),
 			start_time: parseAsInteger.withDefault(defaultTimeRange.startTime),
 			end_time: parseAsInteger.withDefault(defaultTimeRange.endTime),
 			limit: parseAsInteger.withDefault(25), // Default fallback, actual value calculated based on table height
@@ -144,6 +145,7 @@ export default function LogsPage() {
 			customer_ids: urlState.customer_ids,
 			business_unit_ids: urlState.business_unit_ids,
 			content_search: urlState.content_search,
+			request_id: urlState.request_id,
 			missing_cost_only: urlState.missing_cost_only,
 			cache_hit_types: urlState.cache_hit_types,
 			metadata_filters: urlState.metadata_filters
@@ -182,6 +184,7 @@ export default function LogsPage() {
 			urlState.customer_ids,
 			urlState.business_unit_ids,
 			urlState.content_search,
+			urlState.request_id,
 			urlState.parent_request_id,
 			urlState.missing_cost_only,
 			urlState.cache_hit_types,
@@ -241,6 +244,7 @@ export default function LogsPage() {
 				customer_ids: newFilters.customer_ids || [],
 				business_unit_ids: newFilters.business_unit_ids || [],
 				content_search: newFilters.content_search || "",
+				request_id: newFilters.request_id || "",
 				missing_cost_only: newFilters.missing_cost_only ?? false,
 				cache_hit_types: newFilters.cache_hit_types || [],
 				metadata_filters: newFilters.metadata_filters ? JSON.stringify(newFilters.metadata_filters) : "",

--- a/ui/app/workspace/logs/views/logsHeaderView.tsx
+++ b/ui/app/workspace/logs/views/logsHeaderView.tsx
@@ -1,4 +1,5 @@
 import { ColumnConfigDropdown, type ColumnConfigEntry } from "@/components/table";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Command, CommandItem, CommandList } from "@/components/ui/command";
 import { DateTimePickerWithRange } from "@/components/ui/datePickerWithRange";
@@ -10,6 +11,7 @@ import { getErrorMessage } from "@/lib/store";
 import { useCancelRecalculateCostJobMutation, useGetRecalculateCostStatusQuery } from "@/lib/store/apis/logsApi";
 import { getActiveTempToken } from "@/lib/store/apis/tempToken";
 import type { LogFilters as LogFiltersType, RecalcJobStatus } from "@/lib/types/logs";
+import { formatLogSearchInput, isLogIdSearch, parseLogSearchInput } from "@/lib/utils/logSearch";
 import { getApiBaseUrl } from "@/lib/utils/port";
 import { getRangeForPeriod, TIME_PERIODS } from "@/lib/utils/timeRange";
 import { Calculator, ListTree, MoreVertical, Radio, RefreshCw, Search } from "lucide-react";
@@ -90,7 +92,7 @@ export function LogsHeaderView({
 	// the worker finishes the batch it is in the middle of.
 	const [recalcCancelRequested, setRecalcCancelRequested] = useState(false);
 	const isRecalcRunning = !!activeRecalcJobId;
-	const [localSearch, setLocalSearch] = useState(filters.content_search || "");
+	const [localSearch, setLocalSearch] = useState(() => formatLogSearchInput(filters));
 	const searchTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
 	const filtersRef = useRef<LogFiltersType>(filters);
 
@@ -108,9 +110,10 @@ export function LogsHeaderView({
 		filtersRef.current = filters;
 	}, [filters]);
 
+	const { content_search: contentSearchFilter, request_id: requestIDFilter } = filters;
 	useEffect(() => {
-		setLocalSearch(filters.content_search || "");
-	}, [filters.content_search]);
+		setLocalSearch(formatLogSearchInput({ content_search: contentSearchFilter, request_id: requestIDFilter }));
+	}, [contentSearchFilter, requestIDFilter]);
 
 	useEffect(() => {
 		return () => {
@@ -254,12 +257,22 @@ export function LogsHeaderView({
 		(value: string) => {
 			setLocalSearch(value);
 			if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
-			searchTimeoutRef.current = setTimeout(() => {
-				onFiltersChange({ ...filtersRef.current, content_search: value });
-			}, 500);
+			// A pasted request ID resolves to an exact primary-key lookup; there is
+			// nothing to debounce for it, so only free text waits for the typist.
+			const { request_id = "", content_search = "" } = parseLogSearchInput(value);
+			searchTimeoutRef.current = setTimeout(
+				() => {
+					onFiltersChange({ ...filtersRef.current, request_id, content_search });
+				},
+				request_id ? 0 : 500,
+			);
 		},
 		[onFiltersChange],
 	);
+
+	// Derived from the live input rather than the filters, so the badge appears as
+	// soon as an ID is pasted instead of after the round trip.
+	const isIdSearch = isLogIdSearch(localSearch);
 
 	return (
 		<div className="flex grow flex-wrap items-center justify-between gap-2">
@@ -312,11 +325,24 @@ export function LogsHeaderView({
 				<Search className="mr-0.5 ml-2 size-4" />
 				<Input
 					type="text"
+					data-testid="logs-search-input"
 					className="!h-7 rounded-tl-none rounded-tr-sm rounded-br-sm rounded-bl-none border-none bg-slate-50 shadow-none outline-none focus-visible:ring-0"
-					placeholder="Search logs"
+					placeholder="Search logs or paste a request ID"
 					value={localSearch}
 					onChange={(e) => handleSearchChange(e.target.value)}
 				/>
+				{isIdSearch && (
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Badge variant="secondary" className="mr-2 shrink-0 px-1.5 py-0 text-[10px]" data-testid="logs-search-id-badge">
+								ID
+							</Badge>
+						</TooltipTrigger>
+						<TooltipContent sideOffset={6} className="max-w-64">
+							Looking up this request ID exactly. The selected time range is ignored so the request is found wherever it falls.
+						</TooltipContent>
+					</Tooltip>
+				)}
 			</div>
 
 			<DateTimePickerWithRange

--- a/ui/components/filters/logsFilterSidebar.tsx
+++ b/ui/components/filters/logsFilterSidebar.tsx
@@ -51,7 +51,7 @@ export function LogsFilterSidebar({ filters, onFiltersChange }: LogsSidebarProps
 	}, []);
 
 	const activeFilterCount = useMemo(() => {
-		const excludedKeys = ["start_time", "end_time", "content_search", "metadata_filters", "period", "polling"];
+		const excludedKeys = ["start_time", "end_time", "content_search", "request_id", "metadata_filters", "period", "polling"];
 		let count = Object.entries(filters).reduce((c, [key, value]) => {
 			if (excludedKeys.includes(key)) return c;
 			if (Array.isArray(value)) return c + value.length;

--- a/ui/lib/store/apis/logsApi.ts
+++ b/ui/lib/store/apis/logsApi.ts
@@ -77,6 +77,7 @@ function buildFilterParams(filters: LogFilters): Record<string, string | number>
 		params.cache_hit_types = filters.cache_hit_types.join(",");
 	}
 	if (filters.content_search) params.content_search = filters.content_search;
+	if (filters.request_id) params.request_id = filters.request_id;
 	if (filters.user_ids && filters.user_ids.length > 0) {
 		params.user_ids = filters.user_ids.join(",");
 	}

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -725,6 +725,8 @@ export interface LogFilters {
 	providers?: string[];
 	models?: string[];
 	aliases?: string[];
+	/** Exact lookup on the log primary key (which is the request ID). Bypasses the time range. */
+	request_id?: string;
 	parent_request_id?: string;
 	selected_key_ids?: string[];
 	virtual_key_ids?: string[];

--- a/ui/lib/utils/logSearch.test.ts
+++ b/ui/lib/utils/logSearch.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { formatLogSearchInput, isLogIdSearch, parseLogSearchInput } from "./logSearch";
+
+const UUID = "018f2c3d-4e5f-4a6b-8c9d-0e1f2a3b4c5d";
+
+describe("parseLogSearchInput", () => {
+	it("treats a bare UUID as a request ID", () => {
+		expect(parseLogSearchInput(UUID)).toEqual({ request_id: UUID });
+	});
+
+	it("trims surrounding whitespace from a pasted id", () => {
+		expect(parseLogSearchInput(`  ${UUID}\n`)).toEqual({ request_id: UUID });
+	});
+
+	it("accepts an uppercase UUID", () => {
+		const upper = UUID.toUpperCase();
+		expect(parseLogSearchInput(upper)).toEqual({ request_id: upper });
+	});
+
+	it("strips the id: prefix for non-UUID request IDs", () => {
+		expect(parseLogSearchInput("id:my-custom-req-7")).toEqual({ request_id: "my-custom-req-7" });
+		expect(parseLogSearchInput("ID: my-custom-req-7")).toEqual({ request_id: "my-custom-req-7" });
+	});
+
+	it("searches nothing while only the prefix has been typed", () => {
+		expect(parseLogSearchInput("id:")).toEqual({});
+		expect(parseLogSearchInput("")).toEqual({});
+		expect(parseLogSearchInput("   ")).toEqual({});
+	});
+
+	it("falls through to content search for free text", () => {
+		expect(parseLogSearchInput("summarize this")).toEqual({ content_search: "summarize this" });
+		// A non-UUID id without the prefix is indistinguishable from free text.
+		expect(parseLogSearchInput("my-custom-req-7")).toEqual({ content_search: "my-custom-req-7" });
+	});
+});
+
+describe("formatLogSearchInput", () => {
+	it("round-trips a UUID unchanged", () => {
+		expect(formatLogSearchInput({ request_id: UUID })).toBe(UUID);
+		expect(parseLogSearchInput(formatLogSearchInput({ request_id: UUID }))).toEqual({ request_id: UUID });
+	});
+
+	it("re-adds the prefix for a non-UUID id", () => {
+		expect(formatLogSearchInput({ request_id: "my-custom-req-7" })).toBe("id:my-custom-req-7");
+		expect(parseLogSearchInput("id:my-custom-req-7")).toEqual({ request_id: "my-custom-req-7" });
+	});
+
+	it("prefers the id over content search and defaults to empty", () => {
+		expect(formatLogSearchInput({ request_id: UUID, content_search: "hello" })).toBe(UUID);
+		expect(formatLogSearchInput({ content_search: "hello" })).toBe("hello");
+		expect(formatLogSearchInput({})).toBe("");
+	});
+});
+
+describe("isLogIdSearch", () => {
+	it("reports the mode the input will resolve to", () => {
+		expect(isLogIdSearch(UUID)).toBe(true);
+		expect(isLogIdSearch("id:abc")).toBe(true);
+		expect(isLogIdSearch("id:")).toBe(false);
+		expect(isLogIdSearch("hello")).toBe(false);
+	});
+});

--- a/ui/lib/utils/logSearch.ts
+++ b/ui/lib/utils/logSearch.ts
@@ -1,0 +1,48 @@
+import type { LogFilters } from "@/lib/types/logs";
+
+/** Explicit prefix that forces an ID lookup for request IDs that aren't UUID-shaped. */
+const ID_PREFIX = "id:";
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export type LogSearchTerms = Pick<LogFilters, "request_id" | "content_search">;
+
+/**
+ * Splits what was typed in the logs search box into the two mutually exclusive
+ * search modes. A log row's primary key *is* its request ID, so a pasted ID is
+ * an exact PK lookup rather than a content-summary text scan.
+ *
+ * Request IDs are usually UUIDs, but a caller can supply any string via the
+ * `x-request-id` header — hence the explicit `id:` prefix as an escape hatch.
+ */
+export function parseLogSearchInput(raw: string): LogSearchTerms {
+	const value = raw.trim();
+	if (!value) return {};
+
+	if (value.toLowerCase().startsWith(ID_PREFIX)) {
+		const id = value.slice(ID_PREFIX.length).trim();
+		// A bare "id:" is still being typed — search nothing rather than everything.
+		return id ? { request_id: id } : {};
+	}
+
+	if (UUID_REGEX.test(value)) return { request_id: value };
+
+	return { content_search: value };
+}
+
+/**
+ * Inverse of {@link parseLogSearchInput}, used to rebuild the input's display
+ * value from the URL-backed filters. The `id:` prefix is re-added only for
+ * non-UUID ids, so a pasted UUID round-trips unchanged.
+ */
+export function formatLogSearchInput(filters: LogSearchTerms): string {
+	if (filters.request_id) {
+		return UUID_REGEX.test(filters.request_id) ? filters.request_id : `${ID_PREFIX}${filters.request_id}`;
+	}
+	return filters.content_search || "";
+}
+
+/** True when the current input targets a request ID — drives the "ID" badge. */
+export function isLogIdSearch(raw: string): boolean {
+	return !!parseLogSearchInput(raw).request_id;
+}


### PR DESCRIPTION
## Summary

Pasting a request ID into the logs search box now performs an exact primary-key lookup instead of a free-text content search. UUID-shaped input is detected automatically; non-UUID request IDs (those supplied via the `x-request-id` header) can be looked up using the `id:` prefix. An "ID" badge appears in the search box to confirm the mode switch, and a tooltip explains that the selected time range is ignored for ID lookups.

## Changes

- Added `ui/lib/utils/logSearch.ts` with three exported helpers — `parseLogSearchInput`, `formatLogSearchInput`, and `isLogIdSearch` — that handle the two mutually exclusive search modes (ID lookup vs. content search).
- The logs search input now routes UUID-shaped or `id:`-prefixed queries to `request_id` and everything else to `content_search`, with zero debounce delay for ID lookups since there is nothing to wait for.
- `request_id` is wired into the URL state, filter object, dependency arrays, and the API query builder so it round-trips correctly through the URL and is sent to the backend.
- An "ID" badge with a tooltip is rendered inside the search input whenever the current value resolves to an ID lookup, driven from the live input rather than the round-tripped filter to avoid a visible delay.
- The search input's `data-testid` was changed to `logs-search-input` and the page object updated to prefer it.
- `request_id` is excluded from the active filter count in the sidebar, consistent with `content_search`.
- Documentation updated to describe the dashboard behaviour and the `id:` prefix escape hatch.
- Unit tests added for all three `logSearch` helpers covering UUID detection, prefix stripping, whitespace trimming, round-tripping, and edge cases.
- An E2E test added that pastes a UUID into the search box and asserts the URL contains `request_id=` (not `content_search=`) and that the ID badge is visible.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
# UI unit tests
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build

# E2E
pnpm exec playwright test tests/e2e/features/logs/logs.spec.ts
```

1. Open the logs dashboard.
2. Paste a UUID (e.g. `018f2c3d-4e5f-4a6b-8c9d-0e1f2a3b4c5d`) into the search box — the URL should update to `?request_id=<uuid>` with no `content_search` parameter, and an "ID" badge should appear in the input.
3. Type `id:my-custom-req` — the URL should update to `?request_id=my-custom-req`.
4. Type free text — the URL should update to `?content_search=<text>` with no `request_id` parameter.
5. Reload the page with a `request_id` in the URL — the search box should display the UUID (or `id:<value>` for non-UUIDs) and the badge should be visible.

## Screenshots/Recordings

The "ID" badge appears inline in the search box as soon as a UUID is pasted, before the network request completes.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new auth, secrets, or PII surface. The `request_id` value is passed as a query parameter to the existing logs API endpoint, which already accepts and handles it.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable