### PR TITLE
feat(core): synthesize prompt-cache breakpoints for clients that send none

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -7374,23 +7374,36 @@ func drainAbandonedStream(stream chan *schemas.BifrostStreamChunk) {
 // Injection is per-attempt by design: a fallback re-evaluates against the new
 // provider's own config and capabilities rather than carrying the previous one's
 // decision.
-func promptCacheResponsesRequest(config *schemas.ProviderConfig, provider schemas.ModelProvider, r *schemas.BifrostResponsesRequest) *schemas.BifrostResponsesRequest {
-	if r == nil || config == nil || !providerUtils.PromptCacheInjectionEnabled(config.PromptCache, provider, r.Model) {
+//
+// The capability gate runs against the BASE provider, not the key the provider
+// reports. A custom provider surfaces its own key ("my-anthropic"), which no
+// capability switch knows, so gating on it unresolved would answer false and quietly
+// deny injection to every custom provider wrapping a cache_control backend.
+func promptCacheResponsesRequest(ctx *schemas.BifrostContext, config *schemas.ProviderConfig, provider schemas.ModelProvider, r *schemas.BifrostResponsesRequest) *schemas.BifrostResponsesRequest {
+	if r == nil || config == nil {
+		return r
+	}
+	promptCache := providerUtils.ResolvePromptCacheConfig(ctx, config.PromptCache)
+	if !providerUtils.PromptCacheInjectionEnabled(promptCache, schemas.ResolveBaseProvider(ctx, provider), r.Model) {
 		return r
 	}
 	cp := *r
-	cp.Input = providerUtils.InjectResponsesCacheBreakpoints(config.PromptCache, r.Input)
+	cp.Input = providerUtils.InjectResponsesCacheBreakpoints(promptCache, r.Input)
 	return &cp
 }
 
 // promptCacheChatRequest is the Chat Completions parallel of
 // promptCacheResponsesRequest, with the same copy-on-write guarantee.
-func promptCacheChatRequest(config *schemas.ProviderConfig, provider schemas.ModelProvider, r *schemas.BifrostChatRequest) *schemas.BifrostChatRequest {
-	if r == nil || config == nil || !providerUtils.PromptCacheInjectionEnabled(config.PromptCache, provider, r.Model) {
+func promptCacheChatRequest(ctx *schemas.BifrostContext, config *schemas.ProviderConfig, provider schemas.ModelProvider, r *schemas.BifrostChatRequest) *schemas.BifrostChatRequest {
+	if r == nil || config == nil {
+		return r
+	}
+	promptCache := providerUtils.ResolvePromptCacheConfig(ctx, config.PromptCache)
+	if !providerUtils.PromptCacheInjectionEnabled(promptCache, schemas.ResolveBaseProvider(ctx, provider), r.Model) {
 		return r
 	}
 	cp := *r
-	cp.Input = providerUtils.InjectChatCacheBreakpoints(config.PromptCache, r.Input)
+	cp.Input = providerUtils.InjectChatCacheBreakpoints(promptCache, r.Input)
 	return &cp
 }
 
@@ -7409,7 +7422,7 @@ func (bifrost *Bifrost) handleProviderRequest(provider schemas.Provider, config 
 		if changeType, ok := req.Context.Value(schemas.BifrostContextKeyChangeRequestType).(schemas.RequestType); ok && changeType == schemas.ChatCompletionRequest {
 			chatRequest := req.BifrostRequest.TextCompletionRequest.ToBifrostChatRequest()
 			if chatRequest != nil {
-				chatRequest = promptCacheChatRequest(config, provider.GetProviderKey(), chatRequest)
+				chatRequest = promptCacheChatRequest(req.Context, config, provider.GetProviderKey(), chatRequest)
 				chatCompletionResponse, bifrostError := provider.ChatCompletion(req.Context, key, chatRequest)
 				if bifrostError != nil {
 					return nil, bifrostError
@@ -7427,7 +7440,7 @@ func (bifrost *Bifrost) handleProviderRequest(provider schemas.Provider, config 
 		if changeType, ok := req.Context.Value(schemas.BifrostContextKeyChangeRequestType).(schemas.RequestType); ok && changeType == schemas.ResponsesRequest {
 			responsesRequest := req.BifrostRequest.ChatRequest.ToResponsesRequest()
 			if responsesRequest != nil {
-				responsesRequest = promptCacheResponsesRequest(config, provider.GetProviderKey(), responsesRequest)
+				responsesRequest = promptCacheResponsesRequest(req.Context, config, provider.GetProviderKey(), responsesRequest)
 				responsesResponse, bifrostError := provider.Responses(req.Context, key, responsesRequest)
 				if bifrostError != nil {
 					return nil, bifrostError
@@ -7436,7 +7449,7 @@ func (bifrost *Bifrost) handleProviderRequest(provider schemas.Provider, config 
 				break
 			}
 		}
-		chatCompletionResponse, bifrostError := provider.ChatCompletion(req.Context, key, promptCacheChatRequest(config, provider.GetProviderKey(), req.BifrostRequest.ChatRequest))
+		chatCompletionResponse, bifrostError := provider.ChatCompletion(req.Context, key, promptCacheChatRequest(req.Context, config, provider.GetProviderKey(), req.BifrostRequest.ChatRequest))
 		if bifrostError != nil {
 			return nil, bifrostError
 		}
@@ -7456,7 +7469,7 @@ func (bifrost *Bifrost) handleProviderRequest(provider schemas.Provider, config 
 				break
 			}
 		}
-		responsesResponse, bifrostError := provider.Responses(req.Context, key, promptCacheResponsesRequest(config, provider.GetProviderKey(), req.BifrostRequest.ResponsesRequest))
+		responsesResponse, bifrostError := provider.Responses(req.Context, key, promptCacheResponsesRequest(req.Context, config, provider.GetProviderKey(), req.BifrostRequest.ResponsesRequest))
 		if bifrostError != nil {
 			return nil, bifrostError
 		}
@@ -7806,7 +7819,7 @@ func (bifrost *Bifrost) handleProviderStreamRequest(provider schemas.Provider, c
 		if changeType, ok := req.Context.Value(schemas.BifrostContextKeyChangeRequestType).(schemas.RequestType); ok && changeType == schemas.ChatCompletionRequest {
 			chatRequest := req.BifrostRequest.TextCompletionRequest.ToBifrostChatRequest()
 			if chatRequest != nil {
-				return provider.ChatCompletionStream(req.Context, wrapConvertedStreamPostHookRunner(postHookRunner, schemas.ChatCompletionRequest), postHookSpanFinalizer, key, promptCacheChatRequest(config, provider.GetProviderKey(), chatRequest))
+				return provider.ChatCompletionStream(req.Context, wrapConvertedStreamPostHookRunner(postHookRunner, schemas.ChatCompletionRequest), postHookSpanFinalizer, key, promptCacheChatRequest(req.Context, config, provider.GetProviderKey(), chatRequest))
 			}
 		}
 		return provider.TextCompletionStream(req.Context, postHookRunner, postHookSpanFinalizer, key, req.BifrostRequest.TextCompletionRequest)
@@ -7814,11 +7827,12 @@ func (bifrost *Bifrost) handleProviderStreamRequest(provider schemas.Provider, c
 		if changeType, ok := req.Context.Value(schemas.BifrostContextKeyChangeRequestType).(schemas.RequestType); ok && changeType == schemas.ResponsesRequest {
 			responsesRequest := req.BifrostRequest.ChatRequest.ToResponsesRequest()
 			if responsesRequest != nil {
-				return provider.ResponsesStream(req.Context, wrapConvertedStreamPostHookRunner(postHookRunner, schemas.ResponsesRequest), postHookSpanFinalizer, key, promptCacheResponsesRequest(config, provider.GetProviderKey(), responsesRequest))
+				return provider.ResponsesStream(req.Context, wrapConvertedStreamPostHookRunner(postHookRunner, schemas.ResponsesRequest), postHookSpanFinalizer, key, promptCacheResponsesRequest(req.Context, config, provider.GetProviderKey(), responsesRequest))
 			}
 		}
-		return provider.ChatCompletionStream(req.Context, postHookRunner, postHookSpanFinalizer, key, promptCacheChatRequest(config, provider.GetProviderKey(), req.BifrostRequest.ChatRequest))
+		return provider.ChatCompletionStream(req.Context, postHookRunner, postHookSpanFinalizer, key, promptCacheChatRequest(req.Context, config, provider.GetProviderKey(), req.BifrostRequest.ChatRequest))
 	case schemas.ResponsesStreamRequest:
+<<<<<<< HEAD
 <<<<<<< HEAD
 		if changeType, ok := req.Context.Value(schemas.BifrostContextKeyChangeRequestType).(schemas.RequestType); ok && changeType == schemas.ChatCompletionRequest {
 			chatRequest := req.BifrostRequest.ResponsesRequest.ToChatRequest()
@@ -7833,6 +7847,9 @@ func (bifrost *Bifrost) handleProviderStreamRequest(provider schemas.Provider, c
 =======
 		return provider.ResponsesStream(req.Context, postHookRunner, postHookSpanFinalizer, key, promptCacheResponsesRequest(config, provider.GetProviderKey(), req.BifrostRequest.ResponsesRequest))
 >>>>>>> 292462875 (feat(core): synthesize prompt-cache breakpoints for clients that send none)
+=======
+		return provider.ResponsesStream(req.Context, postHookRunner, postHookSpanFinalizer, key, promptCacheResponsesRequest(req.Context, config, provider.GetProviderKey(), req.BifrostRequest.ResponsesRequest))
+>>>>>>> ae7141190 (feat: add x-bf-prompt-cache-auto-inject per-request override)
 	case schemas.ResponsesRetrieveStreamRequest:
 		lifecycle, ok := provider.(schemas.ResponsesLifecycleProvider)
 		if !ok {

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -7185,7 +7185,7 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 					})
 				}
 				lastAttemptFinalizer = postHookSpanFinalizer
-				streamCh, streamErr := bifrost.handleProviderStreamRequest(provider, req, k, postHookRunner, postHookSpanFinalizer)
+				streamCh, streamErr := bifrost.handleProviderStreamRequest(provider, config, req, k, postHookRunner, postHookSpanFinalizer)
 				// If stream setup failed before any provider goroutine started,
 				// no deferred finalizer will run — release the pipeline directly
 				// so a retry doesn't inherit a leaked pool entry.
@@ -7335,6 +7335,7 @@ func (bifrost *Bifrost) billAbandonedTerminal(req *ChannelMessage, result *schem
 	drainAndAttachPluginLogs(req.Context)
 }
 
+<<<<<<< HEAD
 // drainAbandonedStream consumes a stream that will never reach the caller, so
 // the provider goroutine feeding it can finish.
 //
@@ -7361,6 +7362,38 @@ func drainAbandonedStream(stream chan *schemas.BifrostStreamChunk) {
 	}()
 }
 
+// promptCacheResponsesRequest returns the Responses request to dispatch, with
+// prompt-cache breakpoints synthesized when the provider is configured for it.
+//
+// The result is a SHALLOW COPY whenever injection is enabled, never the shared
+// request. That matters for exactly one reason: req.BifrostRequest survives across
+// retries and fallbacks. Writing an injected marker back onto it would let an attempt
+// against a provider with injection disabled inherit a breakpoint the caller never
+// sent — the same request-isolation leak that sank PR #6181, one level further up.
+//
+// Injection is per-attempt by design: a fallback re-evaluates against the new
+// provider's own config and capabilities rather than carrying the previous one's
+// decision.
+func promptCacheResponsesRequest(config *schemas.ProviderConfig, provider schemas.ModelProvider, r *schemas.BifrostResponsesRequest) *schemas.BifrostResponsesRequest {
+	if r == nil || config == nil || !providerUtils.PromptCacheInjectionEnabled(config.PromptCache, provider, r.Model) {
+		return r
+	}
+	cp := *r
+	cp.Input = providerUtils.InjectResponsesCacheBreakpoints(config.PromptCache, r.Input)
+	return &cp
+}
+
+// promptCacheChatRequest is the Chat Completions parallel of
+// promptCacheResponsesRequest, with the same copy-on-write guarantee.
+func promptCacheChatRequest(config *schemas.ProviderConfig, provider schemas.ModelProvider, r *schemas.BifrostChatRequest) *schemas.BifrostChatRequest {
+	if r == nil || config == nil || !providerUtils.PromptCacheInjectionEnabled(config.PromptCache, provider, r.Model) {
+		return r
+	}
+	cp := *r
+	cp.Input = providerUtils.InjectChatCacheBreakpoints(config.PromptCache, r.Input)
+	return &cp
+}
+
 // handleProviderRequest handles the request to the provider based on the request type
 // key is used for single-key operations, keys is used for batch/file operations that need multiple keys
 func (bifrost *Bifrost) handleProviderRequest(provider schemas.Provider, config *schemas.ProviderConfig, req *ChannelMessage, key schemas.Key, keys []schemas.Key) (*schemas.BifrostResponse, *schemas.BifrostError) {
@@ -7376,6 +7409,7 @@ func (bifrost *Bifrost) handleProviderRequest(provider schemas.Provider, config 
 		if changeType, ok := req.Context.Value(schemas.BifrostContextKeyChangeRequestType).(schemas.RequestType); ok && changeType == schemas.ChatCompletionRequest {
 			chatRequest := req.BifrostRequest.TextCompletionRequest.ToBifrostChatRequest()
 			if chatRequest != nil {
+				chatRequest = promptCacheChatRequest(config, provider.GetProviderKey(), chatRequest)
 				chatCompletionResponse, bifrostError := provider.ChatCompletion(req.Context, key, chatRequest)
 				if bifrostError != nil {
 					return nil, bifrostError
@@ -7393,6 +7427,7 @@ func (bifrost *Bifrost) handleProviderRequest(provider schemas.Provider, config 
 		if changeType, ok := req.Context.Value(schemas.BifrostContextKeyChangeRequestType).(schemas.RequestType); ok && changeType == schemas.ResponsesRequest {
 			responsesRequest := req.BifrostRequest.ChatRequest.ToResponsesRequest()
 			if responsesRequest != nil {
+				responsesRequest = promptCacheResponsesRequest(config, provider.GetProviderKey(), responsesRequest)
 				responsesResponse, bifrostError := provider.Responses(req.Context, key, responsesRequest)
 				if bifrostError != nil {
 					return nil, bifrostError
@@ -7401,7 +7436,7 @@ func (bifrost *Bifrost) handleProviderRequest(provider schemas.Provider, config 
 				break
 			}
 		}
-		chatCompletionResponse, bifrostError := provider.ChatCompletion(req.Context, key, req.BifrostRequest.ChatRequest)
+		chatCompletionResponse, bifrostError := provider.ChatCompletion(req.Context, key, promptCacheChatRequest(config, provider.GetProviderKey(), req.BifrostRequest.ChatRequest))
 		if bifrostError != nil {
 			return nil, bifrostError
 		}
@@ -7421,7 +7456,7 @@ func (bifrost *Bifrost) handleProviderRequest(provider schemas.Provider, config 
 				break
 			}
 		}
-		responsesResponse, bifrostError := provider.Responses(req.Context, key, req.BifrostRequest.ResponsesRequest)
+		responsesResponse, bifrostError := provider.Responses(req.Context, key, promptCacheResponsesRequest(config, provider.GetProviderKey(), req.BifrostRequest.ResponsesRequest))
 		if bifrostError != nil {
 			return nil, bifrostError
 		}
@@ -7765,13 +7800,13 @@ func (bifrost *Bifrost) handleProviderRequest(provider schemas.Provider, config 
 }
 
 // handleProviderStreamRequest handles the stream request to the provider based on the request type
-func (bifrost *Bifrost) handleProviderStreamRequest(provider schemas.Provider, req *ChannelMessage, key schemas.Key, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context)) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+func (bifrost *Bifrost) handleProviderStreamRequest(provider schemas.Provider, config *schemas.ProviderConfig, req *ChannelMessage, key schemas.Key, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context)) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
 	switch req.RequestType {
 	case schemas.TextCompletionStreamRequest:
 		if changeType, ok := req.Context.Value(schemas.BifrostContextKeyChangeRequestType).(schemas.RequestType); ok && changeType == schemas.ChatCompletionRequest {
 			chatRequest := req.BifrostRequest.TextCompletionRequest.ToBifrostChatRequest()
 			if chatRequest != nil {
-				return provider.ChatCompletionStream(req.Context, wrapConvertedStreamPostHookRunner(postHookRunner, schemas.ChatCompletionRequest), postHookSpanFinalizer, key, chatRequest)
+				return provider.ChatCompletionStream(req.Context, wrapConvertedStreamPostHookRunner(postHookRunner, schemas.ChatCompletionRequest), postHookSpanFinalizer, key, promptCacheChatRequest(config, provider.GetProviderKey(), chatRequest))
 			}
 		}
 		return provider.TextCompletionStream(req.Context, postHookRunner, postHookSpanFinalizer, key, req.BifrostRequest.TextCompletionRequest)
@@ -7779,11 +7814,12 @@ func (bifrost *Bifrost) handleProviderStreamRequest(provider schemas.Provider, r
 		if changeType, ok := req.Context.Value(schemas.BifrostContextKeyChangeRequestType).(schemas.RequestType); ok && changeType == schemas.ResponsesRequest {
 			responsesRequest := req.BifrostRequest.ChatRequest.ToResponsesRequest()
 			if responsesRequest != nil {
-				return provider.ResponsesStream(req.Context, wrapConvertedStreamPostHookRunner(postHookRunner, schemas.ResponsesRequest), postHookSpanFinalizer, key, responsesRequest)
+				return provider.ResponsesStream(req.Context, wrapConvertedStreamPostHookRunner(postHookRunner, schemas.ResponsesRequest), postHookSpanFinalizer, key, promptCacheResponsesRequest(config, provider.GetProviderKey(), responsesRequest))
 			}
 		}
-		return provider.ChatCompletionStream(req.Context, postHookRunner, postHookSpanFinalizer, key, req.BifrostRequest.ChatRequest)
+		return provider.ChatCompletionStream(req.Context, postHookRunner, postHookSpanFinalizer, key, promptCacheChatRequest(config, provider.GetProviderKey(), req.BifrostRequest.ChatRequest))
 	case schemas.ResponsesStreamRequest:
+<<<<<<< HEAD
 		if changeType, ok := req.Context.Value(schemas.BifrostContextKeyChangeRequestType).(schemas.RequestType); ok && changeType == schemas.ChatCompletionRequest {
 			chatRequest := req.BifrostRequest.ResponsesRequest.ToChatRequest()
 			if chatRequest != nil {
@@ -7794,6 +7830,9 @@ func (bifrost *Bifrost) handleProviderStreamRequest(provider schemas.Provider, r
 			}
 		}
 		return provider.ResponsesStream(req.Context, postHookRunner, postHookSpanFinalizer, key, req.BifrostRequest.ResponsesRequest)
+=======
+		return provider.ResponsesStream(req.Context, postHookRunner, postHookSpanFinalizer, key, promptCacheResponsesRequest(config, provider.GetProviderKey(), req.BifrostRequest.ResponsesRequest))
+>>>>>>> 292462875 (feat(core): synthesize prompt-cache breakpoints for clients that send none)
 	case schemas.ResponsesRetrieveStreamRequest:
 		lifecycle, ok := provider.(schemas.ResponsesLifecycleProvider)
 		if !ok {

--- a/core/internal/llmtests/prompt_caching.go
+++ b/core/internal/llmtests/prompt_caching.go
@@ -455,12 +455,73 @@ func RunPromptCachingToolBlocksTest(t *testing.T, client *bifrost.Bifrost, ctx c
 			require.GreaterOrEqual(t, cacheControlCount, 3,
 				"Expected at least 3 cache_control markers (system + tool_use + tool_result), got %d", cacheControlCount)
 
+		case schemas.OpenRouter:
+			// OpenRouter does not expose per-block cache_control through /v1/responses.
+			// Bifrost converts a marked input_text block into prompt_cache_breakpoint,
+			// which OpenRouter turns back into an Anthropic breakpoint (#6290).
+			// This scenario marks three places: the system input_text block, the
+			// function_call message, and the function_call_output message. Only the
+			// first has a Responses representation, so exactly one breakpoint should
+			// reach the wire and no cache_control should survive at all.
+			cacheControlCount := strings.Count(rawStr, `"cache_control"`)
+			breakpointCount := strings.Count(rawStr, `"prompt_cache_breakpoint"`)
+			t.Logf("  OpenRouter: found %d cache_control markers, %d prompt_cache_breakpoint markers in raw request",
+				cacheControlCount, breakpointCount)
+
+			require.Equal(t, 0, cacheControlCount,
+				"OpenRouter Responses does not accept per-block cache_control; it must be translated, not forwarded (got %d)", cacheControlCount)
+			require.Equal(t, 1, breakpointCount,
+				"Expected exactly 1 prompt_cache_breakpoint (system input_text only; message-level markers on function_call/function_call_output have no Responses representation), got %d", breakpointCount)
+
 		default:
-			t.Logf("  Provider %s: skipping raw request cache marker validation (not Anthropic/Bedrock/Vertex)", testConfig.Provider)
+			t.Logf("  Provider %s: skipping raw request cache marker validation (not Anthropic/Bedrock/Vertex/OpenRouter)", testConfig.Provider)
 		}
 
 		t.Logf("  Prompt caching tool blocks test completed!")
 	})
+}
+
+// cacheReadPolicy describes how strictly a provider's per-turn cache reads are
+// asserted in the multi-turn prompt-caching scenarios. Providers differ in how
+// much of a growing request stays cacheable, so the rules live here rather than
+// inline, where a provider silently falling into the generic branch is easy to
+// miss.
+type cacheReadPolicy struct {
+	// aggregateOnly reports that per-turn reads are only counted towards an
+	// aggregate hit rate checked after every turn, never asserted per turn.
+	aggregateOnly bool
+	// minReadPercentage is the per-turn floor on cache_read/input_tokens. Zero
+	// means only a non-zero cache read is required.
+	minReadPercentage float64
+	// requireStableRead reports that cache_read must stay within half of the
+	// previous turn's value as the conversation grows.
+	requireStableRead bool
+}
+
+// cacheReadPolicyFor returns the cache-read rules for a provider.
+func cacheReadPolicyFor(provider schemas.ModelProvider) cacheReadPolicy {
+	switch provider {
+	case schemas.OpenAI:
+		// Automatic best-effort caching: individual turns may miss due to
+		// server-side load or cache eviction, so only the aggregate is asserted.
+		return cacheReadPolicy{aggregateOnly: true}
+	case schemas.OpenRouter:
+		// OpenRouter converts only input_text blocks into
+		// prompt_cache_breakpoint, so the per-turn checkpoint these scenarios
+		// move around survives on a user turn but not on a function_call
+		// (marked at message level) or an assistant turn (output_text). The
+		// surviving set therefore oscillates between the system breakpoint
+		// alone and system plus one, and the cached prefix collapses and
+		// regrows with it. Both a percentage floor and a turn-over-turn halving
+		// check would read that as a prefix mismatch when it is the documented
+		// conversion rule. Assert caching happened at all.
+		// See TestApplyOpenRouterCacheBreakpoints_OnlyInputTextConverts.
+		return cacheReadPolicy{}
+	default:
+		// Explicit caching providers (Anthropic, Vertex, Bedrock) keep a stable
+		// cacheable prefix, so most of a growing request should be a cache read.
+		return cacheReadPolicy{minReadPercentage: 0.50, requireStableRead: true}
+	}
 }
 
 // RunPromptCachingMultipleToolCallsTest verifies prompt caching across a 10-turn
@@ -834,31 +895,34 @@ func RunPromptCachingMultipleToolCallsTest(t *testing.T, client *bifrost.Bifrost
 					t.Logf("  %s: cache_read=%.2f%%, total_cached=%.2f%%",
 						turnName, readPercentage*100, totalCachedPercentage*100)
 
-					switch testConfig.Provider {
-					case schemas.OpenAI:
+					policy := cacheReadPolicyFor(testConfig.Provider)
+
+					if policy.aggregateOnly {
 						// OpenAI uses automatic best-effort caching — individual turns may
 						// miss due to server-side load or cache eviction. Track hits for
 						// aggregate validation after all turns complete.
 						if totalCachedPercentage >= 0.50 {
 							turnsWithCacheHit++
 						}
-					default:
-						// Explicit caching providers (Anthropic, Vertex, Bedrock):
-						// cache_read > 0 proves prefix reuse is working.
+					} else {
+						// Explicit caching providers: cache_read > 0 proves prefix reuse
+						// is working.
 						require.Greater(t, cacheRead, 0,
 							"%s should reuse an existing prefix; got cache_read=0 and cache_write=%d",
 							turnName, cacheWrite)
-						require.GreaterOrEqual(t, readPercentage, 0.50,
-							"%s should have >= 50%% cache reads (got %.2f%%). "+
-								"If this fails, tool_use input key ordering may be broken — "+
-								"the cache prefix diverges at the first tool_use block. "+
-								"cache_read=%d, cache_write=%d, input_tokens=%d",
-							turnName, readPercentage*100, cacheRead, cacheWrite, inputTokens)
+						if policy.minReadPercentage > 0 {
+							require.GreaterOrEqual(t, readPercentage, policy.minReadPercentage,
+								"%s should have >= %.0f%%%% cache reads (got %.2f%%%%). "+
+									"If this fails, tool_use input key ordering may be broken — "+
+									"the cache prefix diverges at the first tool_use block. "+
+									"cache_read=%d, cache_write=%d, input_tokens=%d",
+								turnName, policy.minReadPercentage*100, readPercentage*100,
+								cacheRead, cacheWrite, inputTokens)
+						}
 					}
 
 					// cache_read should grow (or stay comparable) as conversation grows
-					// (skip for OpenAI where individual turns may miss)
-					if testConfig.Provider != schemas.OpenAI && i >= 2 && prevCacheRead > 0 {
+					if policy.requireStableRead && i >= 2 && prevCacheRead > 0 {
 						// Allow some variance but cache_read should not dramatically drop
 						assert.GreaterOrEqual(t, cacheRead, prevCacheRead/2,
 							"%s: cache_read dropped significantly from previous turn (%d -> %d), "+
@@ -870,7 +934,7 @@ func RunPromptCachingMultipleToolCallsTest(t *testing.T, client *bifrost.Bifrost
 				if i == 0 {
 					rawReq := response.ExtraFields.RawRequest
 					switch testConfig.Provider {
-					case schemas.Anthropic, schemas.Vertex, schemas.Bedrock:
+					case schemas.Anthropic, schemas.Vertex, schemas.Bedrock, schemas.OpenRouter:
 						require.NotNil(t, rawReq,
 							"Raw request should be present for %s prompt-caching validation",
 							testConfig.Provider)
@@ -908,6 +972,22 @@ func RunPromptCachingMultipleToolCallsTest(t *testing.T, client *bifrost.Bifrost
 						t.Logf("  Bedrock: found %d cachePoint blocks", cachePointCount)
 						require.GreaterOrEqual(t, cachePointCount, 2,
 							"Expected at least 2 cachePoint blocks (system + last tool_use), got %d", cachePointCount)
+
+					case schemas.OpenRouter:
+						// See the OpenRouter case in RunPromptCachingToolBlocksTest (#6290).
+						// The per-turn cache checkpoint lands on a function_call, an input_text
+						// block, or an output_text block depending on where the walk stops, and
+						// only input_text converts - so the breakpoint count varies by turn. The
+						// system input_text block is always marked, so assert at least one.
+						// cache_control must never survive on this route.
+						ccCount := strings.Count(rawStr, `"cache_control"`)
+						bpCount := strings.Count(rawStr, `"prompt_cache_breakpoint"`)
+						t.Logf("  OpenRouter: found %d cache_control markers, %d prompt_cache_breakpoint markers", ccCount, bpCount)
+
+						require.Equal(t, 0, ccCount,
+							"OpenRouter Responses does not accept per-block cache_control; it must be translated, not forwarded (got %d)", ccCount)
+						require.GreaterOrEqual(t, bpCount, 1,
+							"Expected at least 1 prompt_cache_breakpoint (system input_text block), got %d", bpCount)
 						}
 					}
 				}

--- a/core/internal/llmtests/promptcachingpolicy_test.go
+++ b/core/internal/llmtests/promptcachingpolicy_test.go
@@ -1,0 +1,54 @@
+package llmtests
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCacheReadPolicyFor pins the per-provider cache-read rules used by the
+// multi-turn prompt-caching scenarios. The rules are asserted here rather than
+// only through the live scenarios because a provider that silently falls into
+// the generic branch fails intermittently, and only against a real endpoint.
+func TestCacheReadPolicyFor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OpenAI is aggregate only", func(t *testing.T) {
+		t.Parallel()
+
+		policy := cacheReadPolicyFor(schemas.OpenAI)
+		assert.True(t, policy.aggregateOnly,
+			"OpenAI caches automatically and best-effort, so individual turns must not be asserted")
+		assert.False(t, policy.requireStableRead,
+			"an individual OpenAI turn may miss, so turn-over-turn stability must not be asserted")
+	})
+
+	t.Run("OpenRouter requires only a non-zero read", func(t *testing.T) {
+		t.Parallel()
+
+		policy := cacheReadPolicyFor(schemas.OpenRouter)
+		assert.False(t, policy.aggregateOnly,
+			"OpenRouter forwards explicit breakpoints, so every turn should read from the cache")
+		assert.Zero(t, policy.minReadPercentage,
+			"OpenRouter converts only input_text blocks into prompt_cache_breakpoint, so the "+
+				"surviving prefix collapses to the system breakpoint alone on function_call and "+
+				"assistant turns and can be well under half of a growing request")
+		assert.False(t, policy.requireStableRead,
+			"the same oscillation makes a turn-over-turn halving check read a documented "+
+				"conversion rule as a prefix mismatch")
+	})
+
+	t.Run("explicit caching providers keep the strict rules", func(t *testing.T) {
+		t.Parallel()
+
+		for _, provider := range []schemas.ModelProvider{schemas.Anthropic, schemas.Vertex, schemas.Bedrock} {
+			policy := cacheReadPolicyFor(provider)
+			assert.False(t, policy.aggregateOnly, "%s caches explicitly", provider)
+			assert.Equal(t, 0.50, policy.minReadPercentage,
+				"%s keeps a stable cacheable prefix, so a drop below half signals broken key ordering", provider)
+			assert.True(t, policy.requireStableRead,
+				"%s should not lose its cached prefix as the conversation grows", provider)
+		}
+	})
+}

--- a/core/promptcache_test.go
+++ b/core/promptcache_test.go
@@ -1,0 +1,108 @@
+package bifrost
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A custom provider surfaces its own key wherever a ModelProvider is reported, so
+// GetProviderKey() answers "my-anthropic", not schemas.Anthropic. Every capability
+// lookup that takes a raw provider key therefore has to resolve through the base
+// provider Bifrost records on the context, or the switch in ModelSupportsPromptCaching
+// falls through to its default and injection silently never runs for these providers.
+const customAnthropicProviderKey = schemas.ModelProvider("my-anthropic")
+
+const customOpenAIProviderKey = schemas.ModelProvider("my-openai")
+
+func baseProviderCtx(base schemas.ModelProvider) *schemas.BifrostContext {
+	return schemas.NewBifrostContextWithValue(context.Background(), schemas.NoDeadline, schemas.BifrostContextKeyBaseProviderType, base)
+}
+
+func autoInjectingConfig() *schemas.ProviderConfig {
+	return &schemas.ProviderConfig{PromptCache: &schemas.PromptCacheConfig{AutoInject: true}}
+}
+
+func responsesReqFor(model, text string) *schemas.BifrostResponsesRequest {
+	return &schemas.BifrostResponsesRequest{
+		Model: model,
+		Input: []schemas.ResponsesMessage{{
+			Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{
+				ContentBlocks: []schemas.ResponsesMessageContentBlock{{
+					Type: schemas.ResponsesInputMessageContentBlockTypeText,
+					Text: schemas.Ptr(text),
+				}},
+			},
+		}},
+	}
+}
+
+func chatReqFor(model, text string) *schemas.BifrostChatRequest {
+	return &schemas.BifrostChatRequest{
+		Model: model,
+		Input: []schemas.ChatMessage{{
+			Role: schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{
+				ContentBlocks: []schemas.ChatContentBlock{{
+					Type: schemas.ChatContentBlockTypeText,
+					Text: schemas.Ptr(text),
+				}},
+			},
+		}},
+	}
+}
+
+func TestPromptCacheResponsesRequest_CustomProviderResolvesBaseProvider(t *testing.T) {
+	ctx := baseProviderCtx(schemas.Anthropic)
+	req := responsesReqFor("claude-sonnet-4", "stable prefix")
+
+	out := promptCacheResponsesRequest(ctx, autoInjectingConfig(), customAnthropicProviderKey, req)
+
+	require.NotNil(t, out)
+	require.NotNil(t, out.Input[0].Content.ContentBlocks[0].CacheControl,
+		"a custom provider wrapping Anthropic must receive injected breakpoints")
+	assert.Equal(t, schemas.CacheControlTypeEphemeral, out.Input[0].Content.ContentBlocks[0].CacheControl.Type)
+	assert.Nil(t, req.Input[0].Content.ContentBlocks[0].CacheControl,
+		"the shared request must not be written through")
+}
+
+func TestPromptCacheChatRequest_CustomProviderResolvesBaseProvider(t *testing.T) {
+	ctx := baseProviderCtx(schemas.Anthropic)
+	req := chatReqFor("claude-sonnet-4", "stable prefix")
+
+	out := promptCacheChatRequest(ctx, autoInjectingConfig(), customAnthropicProviderKey, req)
+
+	require.NotNil(t, out)
+	require.NotNil(t, out.Input[0].Content.ContentBlocks[0].CacheControl,
+		"a custom provider wrapping Anthropic must receive injected breakpoints")
+	assert.Nil(t, req.Input[0].Content.ContentBlocks[0].CacheControl,
+		"the shared request must not be written through")
+}
+
+// Resolving the base provider must not turn the capability gate into a rubber stamp.
+// A custom provider wrapping OpenAI on a model with no per-block marker support is
+// still left alone, exactly as the built-in OpenAI key would be.
+func TestPromptCacheResponsesRequest_BaseResolutionStillHonoursCapability(t *testing.T) {
+	ctx := baseProviderCtx(schemas.OpenAI)
+	req := responsesReqFor("gpt-4o", "stable prefix")
+
+	out := promptCacheResponsesRequest(ctx, autoInjectingConfig(), customOpenAIProviderKey, req)
+
+	require.NotNil(t, out)
+	assert.Nil(t, out.Input[0].Content.ContentBlocks[0].CacheControl,
+		"a model without explicit caching must not be marked")
+}
+
+// With no base provider on the context (direct calls, tests), the passed key stands.
+func TestPromptCacheResponsesRequest_NoBaseProviderOnContextUsesPassedKey(t *testing.T) {
+	req := responsesReqFor("claude-sonnet-4", "stable prefix")
+
+	out := promptCacheResponsesRequest(nil, autoInjectingConfig(), schemas.Anthropic, req)
+
+	require.NotNil(t, out)
+	require.NotNil(t, out.Input[0].Content.ContentBlocks[0].CacheControl)
+}

--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -84,6 +84,118 @@ func hoistAdditionalTools(message schemas.ResponsesMessage) []schemas.ResponsesT
 	return tools
 }
 
+// PromptCacheBreakpointModeExplicit is the only mode a prompt_cache_breakpoint
+// accepts. OpenAI defined the field for gpt-5.6+; OpenRouter reuses it as the
+// Responses-shaped spelling of an Anthropic cache breakpoint.
+const PromptCacheBreakpointModeExplicit = "explicit"
+
+// openRouterMaxCacheBreakpoints mirrors the ceiling the Anthropic Messages API
+// enforces on blocks carrying cache_control. Exceeding it is a hard rejection
+// rather than a degradation ("A maximum of 4 blocks with cache_control may be
+// provided. Found 5."), and it binds here because OpenRouter converts every
+// prompt_cache_breakpoint it receives back into an Anthropic breakpoint before
+// dispatching to Claude. Kept local rather than imported from the anthropic
+// provider so this package takes on no provider-to-provider dependency; see
+// AnthropicMaxCacheBreakpoints in core/providers/anthropic/utils.go for the
+// live verification behind the number.
+const openRouterMaxCacheBreakpoints = 4
+
+// applyOpenRouterCacheBreakpoints rewrites Anthropic-style per-block
+// cache_control markers into the representation OpenRouter's Responses endpoint
+// actually accepts.
+//
+// OpenRouter does not expose per-block cache_control through /v1/responses. The
+// documented equivalent is prompt_cache_breakpoint on an individual input_text
+// block, which OpenRouter converts back into a default Anthropic breakpoint when
+// the request routes to Claude:
+// https://openrouter.ai/docs/features/prompt-caching#anthropic-claude
+//
+// Without this, OpenAIResponsesRequestInput.MarshalJSON deletes the marker and
+// puts nothing in its place, so Claude prompt caching never activates on the
+// Responses path (#6290). The Chat path needs no equivalent: OpenRouter accepts
+// cache_control verbatim there, so OpenAIChatRequest.MarshalJSON simply keeps it
+// behind its keepCacheControl branch (#4203).
+//
+// Two deliberate limits, both forced by the wire format rather than chosen:
+//
+//   - Only input_text blocks are marked. The OpenRouter doc places the
+//     breakpoint on a text content block and names input_text as its Responses
+//     spelling. Marking output_text would be an unverified capability claim, and
+//     a rejected field costs more than the miss it would fix.
+//   - Tool definitions and function_call_output blocks are not marked.
+//     schemas.ResponsesTool has no PromptCacheBreakpoint field and OpenRouter
+//     documents no tool-level Responses breakpoint, while a text-only
+//     function_call_output block array is collapsed into a single string by
+//     isFunctionCallOutputBlocksFlattenable before it reaches the wire, which
+//     would discard any breakpoint set on it.
+//
+// messages is this function's own slice, but each element's Content pointer and
+// the block array beneath it still alias bifrostReq.Input, which plugins and the
+// fallback chain reuse. Both are copied before a marker is written.
+func applyOpenRouterCacheBreakpoints(messages []schemas.ResponsesMessage) {
+	// Locate every markable block in render order, and count the breakpoints the
+	// caller already set, before anything is copied.
+	type blockRef struct{ msg, block int }
+	var refs []blockRef
+	existing := 0
+	for i := range messages {
+		if messages[i].Content == nil {
+			continue
+		}
+		for j, block := range messages[i].Content.ContentBlocks {
+			if block.PromptCacheBreakpoint != nil {
+				existing++
+				continue
+			}
+			// "ephemeral" is the only cache type Anthropic defines, and nothing
+			// upstream of here validates it. Converting an empty or unknown type
+			// would manufacture a valid breakpoint out of a malformed marker and
+			// spend clamp budget on it, so require the documented value.
+			if block.CacheControl == nil ||
+				block.CacheControl.Type != schemas.CacheControlTypeEphemeral ||
+				block.Text == nil ||
+				block.Type != schemas.ResponsesInputMessageContentBlockTypeText {
+				continue
+			}
+			refs = append(refs, blockRef{msg: i, block: j})
+		}
+	}
+	if len(refs) == 0 {
+		return
+	}
+
+	// Spend only the budget the caller's own breakpoints leave behind. A caller
+	// who sets more than the ceiling by hand owns that request and its upstream
+	// error; Bifrost declines to manufacture one on top.
+	budget := openRouterMaxCacheBreakpoints - existing
+	if budget <= 0 {
+		return
+	}
+	// Caching is cumulative up to each breakpoint, so a marker later in render
+	// order anchors a strictly longer prefix. When over budget, drop the
+	// EARLIEST markers and keep the longest cached prefix, matching the
+	// trade-off clampAnthropicCacheBreakpoints makes for the direct path.
+	if len(refs) > budget {
+		refs = refs[len(refs)-budget:]
+	}
+
+	copiedContent := make(map[int]bool, len(refs))
+	for _, ref := range refs {
+		if !copiedContent[ref.msg] {
+			contentCopy := *messages[ref.msg].Content
+			contentCopy.ContentBlocks = append(
+				make([]schemas.ResponsesMessageContentBlock, 0, len(messages[ref.msg].Content.ContentBlocks)),
+				messages[ref.msg].Content.ContentBlocks...,
+			)
+			messages[ref.msg].Content = &contentCopy
+			copiedContent[ref.msg] = true
+		}
+		messages[ref.msg].Content.ContentBlocks[ref.block].PromptCacheBreakpoint = &schemas.PromptCacheBreakpoint{
+			Mode: schemas.Ptr(PromptCacheBreakpointModeExplicit),
+		}
+	}
+}
+
 // ToOpenAIResponsesRequest converts a Bifrost responses request to OpenAI format
 func ToOpenAIResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.BifrostResponsesRequest) *OpenAIResponsesRequest {
 	if bifrostReq == nil || bifrostReq.Input == nil {
@@ -293,6 +405,11 @@ func ToOpenAIResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.B
 			messages = append(messages, message)
 		}
 	}
+	// OpenRouter accepts the caching intent only in its Responses-shaped form.
+	if bifrostReq.Provider == schemas.OpenRouter {
+		applyOpenRouterCacheBreakpoints(messages)
+	}
+
 	// Updating params
 	params := bifrostReq.Params
 	// Create the responses request with properly mapped parameters

--- a/core/providers/openai/responsesmarshal_test.go
+++ b/core/providers/openai/responsesmarshal_test.go
@@ -1158,3 +1158,354 @@ func TestEffortPredicatesAgainstCatalogIDs(t *testing.T) {
 		}
 	}
 }
+
+// TestToOpenAIResponsesRequest_OpenRouterCacheControlBreakpoint is the
+// Responses-path parallel of TestToOpenAIChatRequest_CacheControl_OpenRouterOnly
+// (added by the Chat-path fix in #4203). Regression test for #6290.
+//
+// OpenRouter does NOT expose Anthropic-style per-block cache_control through
+// /v1/responses. The documented Responses equivalent is prompt_cache_breakpoint
+// on an individual input_text block, which OpenRouter converts into a default
+// Anthropic cache_control breakpoint when the request routes to Claude:
+// https://openrouter.ai/docs/features/prompt-caching#anthropic-claude
+//
+// Both OpenRouterProvider.Responses and OpenRouterProvider.ResponsesStream build
+// their outbound body through ToOpenAIResponsesRequest + MarshalJSON, so
+// asserting on the marshalled body covers streaming and non-streaming alike.
+func TestToOpenAIResponsesRequest_OpenRouterCacheControlBreakpoint(t *testing.T) {
+	newBifrostReq := func(provider schemas.ModelProvider, model string) *schemas.BifrostResponsesRequest {
+		return &schemas.BifrostResponsesRequest{
+			Provider: provider,
+			Model:    model,
+			Input: []schemas.ResponsesMessage{
+				{
+					Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+					Content: &schemas.ResponsesMessageContent{
+						ContentBlocks: []schemas.ResponsesMessageContentBlock{
+							{
+								Type:         schemas.ResponsesInputMessageContentBlockTypeText,
+								Text:         schemas.Ptr("REUSABLE_PREFIX"),
+								CacheControl: &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral},
+							},
+							{
+								Type: schemas.ResponsesInputMessageContentBlockTypeText,
+								Text: schemas.Ptr("Reply with OK."),
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	// contentBlocks marshals the request and digs out input[0].content[] so the
+	// assertions read against the exact bytes that go on the wire.
+	contentBlocks := func(t *testing.T, bifrostReq *schemas.BifrostResponsesRequest) ([]any, string) {
+		t.Helper()
+		request := ToOpenAIResponsesRequest(nil, bifrostReq)
+		if request == nil {
+			t.Fatal("expected non-nil request")
+		}
+		jsonBytes, err := request.MarshalJSON()
+		if err != nil {
+			t.Fatalf("failed to marshal responses request: %v", err)
+		}
+		raw := string(jsonBytes)
+
+		var jsonMap map[string]any
+		if err := sonic.Unmarshal(jsonBytes, &jsonMap); err != nil {
+			t.Fatalf("failed to parse marshaled JSON: %v\nraw=%s", err, raw)
+		}
+		input, ok := jsonMap["input"].([]any)
+		if !ok || len(input) == 0 {
+			t.Fatalf("expected input array on the wire; raw=%s", raw)
+		}
+		msg, ok := input[0].(map[string]any)
+		if !ok {
+			t.Fatalf("expected input[0] to be an object; raw=%s", raw)
+		}
+		blocks, ok := msg["content"].([]any)
+		if !ok || len(blocks) != 2 {
+			t.Fatalf("expected 2 content blocks on input[0]; raw=%s", raw)
+		}
+		return blocks, raw
+	}
+
+	t.Run("openrouter converts cache_control to prompt_cache_breakpoint", func(t *testing.T) {
+		blocks, raw := contentBlocks(t, newBifrostReq(schemas.OpenRouter, "anthropic/claude-sonnet-4"))
+
+		marked, ok := blocks[0].(map[string]any)
+		if !ok {
+			t.Fatalf("expected content[0] to be an object; raw=%s", raw)
+		}
+
+		// The caching intent must survive in the form OpenRouter's Responses
+		// endpoint actually accepts.
+		bp, ok := marked["prompt_cache_breakpoint"].(map[string]any)
+		if !ok {
+			t.Fatalf("OpenRouter Responses: cache_control must be converted to prompt_cache_breakpoint on the marked text block; raw=%s", raw)
+		}
+		if mode, _ := bp["mode"].(string); mode != "explicit" {
+			t.Errorf("prompt_cache_breakpoint.mode = %q, want \"explicit\"; raw=%s", mode, raw)
+		}
+
+		// Per-block cache_control is not exposed through the Responses API, so
+		// it must not remain on the wire once translated.
+		if _, present := marked["cache_control"]; present {
+			t.Errorf("OpenRouter Responses: per-block cache_control must not be forwarded; raw=%s", raw)
+		}
+
+		// Only the marked block becomes a breakpoint; an unmarked block must
+		// not acquire one (that would move the cached prefix boundary).
+		unmarked, ok := blocks[1].(map[string]any)
+		if !ok {
+			t.Fatalf("expected content[1] to be an object; raw=%s", raw)
+		}
+		if _, present := unmarked["prompt_cache_breakpoint"]; present {
+			t.Errorf("unmarked block must not receive a prompt_cache_breakpoint; raw=%s", raw)
+		}
+	})
+
+	t.Run("openai still strips cache_control and adds no breakpoint", func(t *testing.T) {
+		blocks, raw := contentBlocks(t, newBifrostReq(schemas.OpenAI, "gpt-4o"))
+
+		for i, b := range blocks {
+			block, ok := b.(map[string]any)
+			if !ok {
+				t.Fatalf("expected content[%d] to be an object; raw=%s", i, raw)
+			}
+			if _, present := block["cache_control"]; present {
+				t.Errorf("OpenAI Responses: cache_control must still be stripped on content[%d]; raw=%s", i, raw)
+			}
+			if _, present := block["prompt_cache_breakpoint"]; present {
+				t.Errorf("OpenAI Responses: no prompt_cache_breakpoint may be synthesized on content[%d]; raw=%s", i, raw)
+			}
+		}
+	})
+}
+
+// openRouterCacheReq builds a single user message whose input_text blocks each
+// carry an Anthropic cache_control marker, one per entry in texts.
+func openRouterCacheReq(texts ...string) *schemas.BifrostResponsesRequest {
+	blocks := make([]schemas.ResponsesMessageContentBlock, 0, len(texts))
+	for _, text := range texts {
+		blocks = append(blocks, schemas.ResponsesMessageContentBlock{
+			Type:         schemas.ResponsesInputMessageContentBlockTypeText,
+			Text:         schemas.Ptr(text),
+			CacheControl: &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral},
+		})
+	}
+	return &schemas.BifrostResponsesRequest{
+		Provider: schemas.OpenRouter,
+		Model:    "anthropic/claude-sonnet-4",
+		Input: []schemas.ResponsesMessage{
+			{
+				Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+				Content: &schemas.ResponsesMessageContent{ContentBlocks: blocks},
+			},
+		},
+	}
+}
+
+// breakpointModes returns the prompt_cache_breakpoint.mode of every block in
+// input[0].content, using "" for a block that carries no breakpoint.
+func breakpointModes(t *testing.T, bifrostReq *schemas.BifrostResponsesRequest) ([]string, string) {
+	t.Helper()
+	request := ToOpenAIResponsesRequest(nil, bifrostReq)
+	if request == nil {
+		t.Fatal("expected non-nil request")
+	}
+	jsonBytes, err := request.MarshalJSON()
+	if err != nil {
+		t.Fatalf("failed to marshal responses request: %v", err)
+	}
+	raw := string(jsonBytes)
+
+	var jsonMap map[string]any
+	if err := sonic.Unmarshal(jsonBytes, &jsonMap); err != nil {
+		t.Fatalf("failed to parse marshaled JSON: %v\nraw=%s", err, raw)
+	}
+	input, _ := jsonMap["input"].([]any)
+	if len(input) == 0 {
+		t.Fatalf("expected input array; raw=%s", raw)
+	}
+	msg, _ := input[0].(map[string]any)
+	blocks, _ := msg["content"].([]any)
+	modes := make([]string, 0, len(blocks))
+	for _, b := range blocks {
+		block, _ := b.(map[string]any)
+		bp, ok := block["prompt_cache_breakpoint"].(map[string]any)
+		if !ok {
+			modes = append(modes, "")
+			continue
+		}
+		mode, _ := bp["mode"].(string)
+		modes = append(modes, mode)
+	}
+	return modes, raw
+}
+
+// TestToOpenAIResponsesRequest_OpenRouterClampsCacheBreakpoints pins the clamp
+// that makes the #6290 fix safe to ship. OpenRouter turns each
+// prompt_cache_breakpoint into an Anthropic cache_control block, and Anthropic
+// rejects a request carrying more than four outright ("A maximum of 4 blocks
+// with cache_control may be provided. Found 5.") rather than degrading. Before
+// the fix, unconditional stripping hid that; converting every marker without a
+// clamp would turn today's silent cache miss into a hard upstream error.
+//
+// The earliest markers are the ones dropped: caching is cumulative up to each
+// breakpoint, so a later marker anchors a strictly longer prefix.
+func TestToOpenAIResponsesRequest_OpenRouterClampsCacheBreakpoints(t *testing.T) {
+	modes, raw := breakpointModes(t, openRouterCacheReq("p1", "p2", "p3", "p4", "p5"))
+	if len(modes) != 5 {
+		t.Fatalf("expected 5 content blocks, got %d; raw=%s", len(modes), raw)
+	}
+
+	want := []string{"", "explicit", "explicit", "explicit", "explicit"}
+	for i, wantMode := range want {
+		if modes[i] != wantMode {
+			t.Errorf("block %d breakpoint mode = %q, want %q (earliest marker must be the one dropped); raw=%s",
+				i, modes[i], wantMode, raw)
+		}
+	}
+}
+
+// TestToOpenAIResponsesRequest_OpenRouterRespectsCallerBreakpoints verifies the
+// conversion neither overwrites a breakpoint the caller set explicitly nor
+// spends budget the caller has already committed. A caller who fills the
+// four-breakpoint ceiling by hand gets their request forwarded as written; the
+// converter declines to push it over the edge.
+func TestToOpenAIResponsesRequest_OpenRouterRespectsCallerBreakpoints(t *testing.T) {
+	t.Run("caller breakpoint is not overwritten", func(t *testing.T) {
+		bifrostReq := openRouterCacheReq("p1", "p2")
+		// Caller marked the first block themselves, and also left a cache_control
+		// on it; the explicit breakpoint wins and is left untouched.
+		bifrostReq.Input[0].Content.ContentBlocks[0].PromptCacheBreakpoint = &schemas.PromptCacheBreakpoint{
+			Mode: schemas.Ptr(PromptCacheBreakpointModeExplicit),
+		}
+
+		modes, raw := breakpointModes(t, bifrostReq)
+		if len(modes) != 2 {
+			t.Fatalf("expected 2 content blocks, got %d; raw=%s", len(modes), raw)
+		}
+		for i, mode := range modes {
+			if mode != "explicit" {
+				t.Errorf("block %d breakpoint mode = %q, want \"explicit\"; raw=%s", i, mode, raw)
+			}
+		}
+	})
+
+	t.Run("caller-filled ceiling leaves no budget", func(t *testing.T) {
+		// Five blocks: the first four already carry caller breakpoints, so the
+		// fifth block's cache_control has no budget left and must not be
+		// converted. Converting it would make five, which Anthropic rejects.
+		bifrostReq := openRouterCacheReq("p1", "p2", "p3", "p4", "p5")
+		for i := 0; i < 4; i++ {
+			bifrostReq.Input[0].Content.ContentBlocks[i].CacheControl = nil
+			bifrostReq.Input[0].Content.ContentBlocks[i].PromptCacheBreakpoint = &schemas.PromptCacheBreakpoint{
+				Mode: schemas.Ptr(PromptCacheBreakpointModeExplicit),
+			}
+		}
+
+		modes, raw := breakpointModes(t, bifrostReq)
+		want := []string{"explicit", "explicit", "explicit", "explicit", ""}
+		for i, wantMode := range want {
+			if modes[i] != wantMode {
+				t.Errorf("block %d breakpoint mode = %q, want %q; raw=%s", i, modes[i], wantMode, raw)
+			}
+		}
+	})
+}
+
+// TestToOpenAIResponsesRequest_OpenRouterDoesNotMutateInput guards the
+// copy-on-write in applyOpenRouterCacheBreakpoints. The ResponsesMessage
+// Content pointer and its block array are shared with the caller's
+// BifrostResponsesRequest, which plugins and the fallback chain reuse. Writing a
+// breakpoint in place would leak an OpenRouter-only field into a retry against a
+// different provider.
+func TestToOpenAIResponsesRequest_OpenRouterDoesNotMutateInput(t *testing.T) {
+	bifrostReq := openRouterCacheReq("p1", "p2")
+
+	request := ToOpenAIResponsesRequest(nil, bifrostReq)
+	if request == nil {
+		t.Fatal("expected non-nil request")
+	}
+	if _, err := request.MarshalJSON(); err != nil {
+		t.Fatalf("failed to marshal responses request: %v", err)
+	}
+
+	for i, block := range bifrostReq.Input[0].Content.ContentBlocks {
+		if block.PromptCacheBreakpoint != nil {
+			t.Errorf("caller input block %d was mutated: prompt_cache_breakpoint written back onto the source request", i)
+		}
+		if block.CacheControl == nil {
+			t.Errorf("caller input block %d was mutated: cache_control removed from the source request", i)
+		}
+	}
+}
+
+// TestToOpenAIResponsesRequest_OpenRouterIgnoresNonEphemeralCacheControl pins the
+// type guard on the conversion. "ephemeral" is the only cache type Anthropic
+// defines, and nothing upstream of ToOpenAIResponsesRequest validates the field -
+// schemas.CacheControl.Type is a bare string with no allowed-value check. Without
+// the guard, a malformed marker such as {"cache_control": {}} would be upgraded
+// into a valid prompt_cache_breakpoint that the caller never asked for, and would
+// consume budget against the four-breakpoint ceiling.
+//
+// The Chat path forwards cache_control verbatim and lets upstream reject a bad
+// value; the Responses path must not be more permissive just because it rewrites
+// the field.
+func TestToOpenAIResponsesRequest_OpenRouterIgnoresNonEphemeralCacheControl(t *testing.T) {
+	cases := []struct {
+		name string
+		cc   *schemas.CacheControl
+		want string // expected prompt_cache_breakpoint.mode, "" for none
+	}{
+		{name: "empty type is not converted", cc: &schemas.CacheControl{}, want: ""},
+		{name: "unknown type is not converted", cc: &schemas.CacheControl{Type: "persistent"}, want: ""},
+		{name: "ephemeral type is converted", cc: &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral}, want: "explicit"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bifrostReq := openRouterCacheReq("p1")
+			bifrostReq.Input[0].Content.ContentBlocks[0].CacheControl = tc.cc
+
+			modes, raw := breakpointModes(t, bifrostReq)
+			if len(modes) != 1 {
+				t.Fatalf("expected 1 content block, got %d; raw=%s", len(modes), raw)
+			}
+			if modes[0] != tc.want {
+				t.Errorf("breakpoint mode = %q, want %q for cache_control %+v; raw=%s",
+					modes[0], tc.want, tc.cc, raw)
+			}
+
+			// Whatever the type, the marker itself must never reach the wire:
+			// per-block cache_control is not exposed on OpenRouter Responses.
+			if strings.Contains(raw, "cache_control") {
+				t.Errorf("cache_control must not be forwarded regardless of type; raw=%s", raw)
+			}
+		})
+	}
+}
+
+// TestToOpenAIResponsesRequest_OpenRouterNonEphemeralDoesNotSpendClampBudget
+// verifies the type guard also keeps malformed markers from displacing valid
+// ones. Five blocks carry cache_control but only the last four are ephemeral, so
+// all four valid markers must survive - a naive nil-only guard would count the
+// malformed first block toward the ceiling and drop a real breakpoint.
+func TestToOpenAIResponsesRequest_OpenRouterNonEphemeralDoesNotSpendClampBudget(t *testing.T) {
+	bifrostReq := openRouterCacheReq("p1", "p2", "p3", "p4", "p5")
+	bifrostReq.Input[0].Content.ContentBlocks[0].CacheControl = &schemas.CacheControl{Type: "bogus"}
+
+	modes, raw := breakpointModes(t, bifrostReq)
+	want := []string{"", "explicit", "explicit", "explicit", "explicit"}
+	if len(modes) != len(want) {
+		t.Fatalf("expected %d content blocks, got %d; raw=%s", len(want), len(modes), raw)
+	}
+	for i, wantMode := range want {
+		if modes[i] != wantMode {
+			t.Errorf("block %d breakpoint mode = %q, want %q; raw=%s", i, modes[i], wantMode, raw)
+		}
+	}
+}

--- a/core/providers/openai/responsesmarshal_test.go
+++ b/core/providers/openai/responsesmarshal_test.go
@@ -1509,3 +1509,106 @@ func TestToOpenAIResponsesRequest_OpenRouterNonEphemeralDoesNotSpendClampBudget(
 		}
 	}
 }
+
+// TestApplyOpenRouterCacheBreakpoints_OnlyInputTextConverts pins the mechanism behind
+// the OpenRouter carve-out in RunPromptCachingMultipleToolCallsTest.
+//
+// That scenario moves a cache checkpoint each turn, landing it on whichever message
+// the walk stops at: a function_call (marked at MESSAGE level), an assistant turn
+// (output_text), or a user turn (input_text). Only the last of those has a Responses
+// representation here, so the set of surviving breakpoints oscillates between one and
+// two as the conversation grows - and with it the size of the cached prefix.
+//
+// That makes a turn-over-turn "cache_read must not halve" assertion unsound for
+// OpenRouter specifically: a drop is the expected consequence of this conversion rule,
+// not evidence of a cache-prefix mismatch.
+func TestApplyOpenRouterCacheBreakpoints_OnlyInputTextConverts(t *testing.T) {
+	ephemeral := func() *schemas.CacheControl {
+		return &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral}
+	}
+	countBreakpoints := func(msgs []schemas.ResponsesMessage) int {
+		n := 0
+		for i := range msgs {
+			if msgs[i].Content == nil {
+				continue
+			}
+			for j := range msgs[i].Content.ContentBlocks {
+				if msgs[i].Content.ContentBlocks[j].PromptCacheBreakpoint != nil {
+					n++
+				}
+			}
+		}
+		return n
+	}
+	// The system block is marked every turn and always converts, so it is the floor.
+	systemMsg := func() schemas.ResponsesMessage {
+		return schemas.ResponsesMessage{
+			Role: schemas.Ptr(schemas.ResponsesInputMessageRoleSystem),
+			Content: &schemas.ResponsesMessageContent{
+				ContentBlocks: []schemas.ResponsesMessageContentBlock{{
+					Type:         schemas.ResponsesInputMessageContentBlockTypeText,
+					Text:         schemas.Ptr("stable system prefix"),
+					CacheControl: ephemeral(),
+				}},
+			},
+		}
+	}
+
+	cases := []struct {
+		name       string
+		checkpoint schemas.ResponsesMessage
+		want       int // system breakpoint + (1 if the checkpoint converts)
+	}{
+		{
+			name: "checkpoint on a user input_text block converts",
+			checkpoint: schemas.ResponsesMessage{
+				Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+				Content: &schemas.ResponsesMessageContent{
+					ContentBlocks: []schemas.ResponsesMessageContentBlock{{
+						Type:         schemas.ResponsesInputMessageContentBlockTypeText,
+						Text:         schemas.Ptr("turn text"),
+						CacheControl: ephemeral(),
+					}},
+				},
+			},
+			want: 2,
+		},
+		{
+			name: "checkpoint on an assistant output_text block does not convert",
+			checkpoint: schemas.ResponsesMessage{
+				Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+				Content: &schemas.ResponsesMessageContent{
+					ContentBlocks: []schemas.ResponsesMessageContentBlock{{
+						Type:         schemas.ResponsesOutputMessageContentTypeText,
+						Text:         schemas.Ptr("assistant turn"),
+						CacheControl: ephemeral(),
+					}},
+				},
+			},
+			want: 1,
+		},
+		{
+			name: "message-level marker on a function_call does not convert",
+			checkpoint: schemas.ResponsesMessage{
+				Type:         schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+				CacheControl: ephemeral(),
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					CallID:    schemas.Ptr("call_1"),
+					Name:      schemas.Ptr("get_weather"),
+					Arguments: schemas.Ptr(`{"city":"Paris"}`),
+				},
+			},
+			want: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msgs := []schemas.ResponsesMessage{systemMsg(), tc.checkpoint}
+			applyOpenRouterCacheBreakpoints(msgs)
+			if got := countBreakpoints(msgs); got != tc.want {
+				t.Errorf("breakpoints = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/core/providers/openrouter/openrouter_test.go
+++ b/core/providers/openrouter/openrouter_test.go
@@ -30,6 +30,7 @@ func TestOpenRouter(t *testing.T) {
 		TextModel:            "google/gemini-2.5-flash",
 		EmbeddingModel:       "qwen/qwen3-embedding-4b",
 		ReasoningModel:       "openai/gpt-oss-120b",
+		PromptCachingModel:   "anthropic/claude-sonnet-4", // Claude is the only OpenRouter model with explicit caching; its Responses half was broken until #6290
 		TranscriptionModel:   "openai/gpt-4o-mini-transcribe",
 		SpeechSynthesisModel: "openai/gpt-audio-mini",
 		Scenarios: llmtests.TestScenarios{
@@ -50,6 +51,7 @@ func TestOpenRouter(t *testing.T) {
 			FileURL:                    false, // Responses API times out (300s+) with file input
 			CompleteEnd2End:            false, // OpenRouter's responses API is in Beta
 			Reasoning:                  true,
+			PromptCaching:              true, // Gates the three tool-block scenarios; two of them issue Responses requests, which is what #6290 broke
 			ListModels:                 true,
 			StructuredOutputs:          true, // Structured outputs with nullable enum support
 			Embedding:                  true,

--- a/core/providers/utils/promptcache.go
+++ b/core/providers/utils/promptcache.go
@@ -1,0 +1,358 @@
+package utils
+
+import (
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// MaxInjectedCacheBreakpoints caps how many markers injection may create.
+//
+// Anthropic rejects a request carrying more than four blocks with cache_control
+// outright ("A maximum of 4 blocks with cache_control may be provided. Found 5."),
+// and every downstream dialect derives from that ceiling. The per-provider clamps
+// (clampAnthropicCacheBreakpoints, clampBedrockCachePoints) are the backstop, but
+// injection must not rely on them: a clamp silently discards the earliest marker,
+// so overshooting here would quietly throw away work rather than fail loudly.
+const MaxInjectedCacheBreakpoints = 4
+
+// PromptCacheInjectionEnabled reports whether breakpoint injection should run for
+// this provider and model.
+//
+// Two gates, and both must pass. The operator has to have opted in (Bifrost never
+// invents a breakpoint by default — the four-marker budget is scarce and spending one
+// is a cost decision that belongs to them), and the model has to be able to act on a
+// per-block marker at all. The capability gate is what makes this safe to call
+// unconditionally for all providers: implicit-caching endpoints answer false and are
+// never sent a marker they would reject or ignore.
+func PromptCacheInjectionEnabled(cfg *schemas.PromptCacheConfig, provider schemas.ModelProvider, model string) bool {
+	if cfg == nil || (!cfg.AutoInject && len(cfg.InjectionPoints) == 0) {
+		return false
+	}
+	caps := schemas.ResolveModelCaps(provider, model)
+	return caps.SupportsPromptCaching(schemas.ModelSupportsPromptCaching(provider, model))
+}
+
+// InjectResponsesCacheBreakpoints returns input with cache_control markers added
+// where the config asks for them, or input unchanged when it does not apply.
+//
+// The returned slice is safe to hand to a provider: messages that are marked are
+// deep-copied first. The caller's slice, its ResponsesMessageContent pointers and the
+// block arrays beneath them are never written to. That matters because
+// bifrostReq.Input is shared with the plugin pipeline and the fallback chain — the
+// in-place mutation in the closed PR #6181 is what leaked provider-specific cache
+// settings into reused requests.
+//
+// A caller that supplied any marker of its own is left completely alone. Injection is
+// a default for clients that say nothing, never an override of a client that spoke.
+func InjectResponsesCacheBreakpoints(cfg *schemas.PromptCacheConfig, input []schemas.ResponsesMessage) []schemas.ResponsesMessage {
+	if cfg == nil || len(input) == 0 || responsesHasCacheMarker(input) {
+		return input
+	}
+
+	targets := responsesInjectionTargets(cfg, input)
+	if len(targets) == 0 {
+		return input
+	}
+
+	marker := &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral, TTL: cfg.TTL}
+	out := make([]schemas.ResponsesMessage, len(input))
+	copy(out, input)
+	copied := make(map[int]bool, len(targets))
+	for _, t := range targets {
+		if !copied[t.msg] {
+			out[t.msg] = schemas.DeepCopyResponsesMessage(input[t.msg])
+			copied[t.msg] = true
+		}
+		msg := &out[t.msg]
+		if t.promoteStr {
+			// A bare string has nowhere to hang a marker, so it becomes a single
+			// text block. Deterministic: the same message always renders the same
+			// way, so the cached prefix stays byte-identical across turns.
+			text := *msg.Content.ContentStr
+			msg.Content.ContentStr = nil
+			msg.Content.ContentBlocks = []schemas.ResponsesMessageContentBlock{{
+				Type: schemas.ResponsesInputMessageContentBlockTypeText,
+				Text: &text,
+			}}
+			msg.Content.ContentBlocks[0].CacheControl = marker
+			continue
+		}
+		msg.Content.ContentBlocks[t.block].CacheControl = marker
+	}
+	return out
+}
+
+// InjectChatCacheBreakpoints is the Chat Completions parallel of
+// InjectResponsesCacheBreakpoints. Same rules, same copy-on-write guarantee.
+func InjectChatCacheBreakpoints(cfg *schemas.PromptCacheConfig, input []schemas.ChatMessage) []schemas.ChatMessage {
+	if cfg == nil || len(input) == 0 || chatHasCacheMarker(input) {
+		return input
+	}
+
+	targets := chatInjectionTargets(cfg, input)
+	if len(targets) == 0 {
+		return input
+	}
+
+	marker := &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral, TTL: cfg.TTL}
+	out := make([]schemas.ChatMessage, len(input))
+	copy(out, input)
+	copied := make(map[int]bool, len(targets))
+	for _, t := range targets {
+		if !copied[t.msg] {
+			out[t.msg] = schemas.DeepCopyChatMessage(input[t.msg])
+			copied[t.msg] = true
+		}
+		msg := &out[t.msg]
+		if t.promoteStr {
+			text := *msg.Content.ContentStr
+			msg.Content.ContentStr = nil
+			msg.Content.ContentBlocks = []schemas.ChatContentBlock{{
+				Type: schemas.ChatContentBlockTypeText,
+				Text: &text,
+			}}
+			msg.Content.ContentBlocks[0].CacheControl = marker
+			continue
+		}
+		msg.Content.ContentBlocks[t.block].CacheControl = marker
+	}
+	return out
+}
+
+// injectionTarget names one place to write a marker. promoteStr means the message
+// carries a bare ContentStr that must become a block first, in which case block is
+// meaningless.
+type injectionTarget struct {
+	msg        int
+	block      int
+	promoteStr bool
+}
+
+// responsesHasCacheMarker reports whether the caller already expressed caching
+// intent anywhere — either dialect counts, since a request that already carries
+// prompt_cache_breakpoint is just as much an explicit statement as cache_control.
+func responsesHasCacheMarker(input []schemas.ResponsesMessage) bool {
+	for i := range input {
+		if input[i].CacheControl != nil {
+			return true
+		}
+		if input[i].Content == nil {
+			continue
+		}
+		for j := range input[i].Content.ContentBlocks {
+			b := &input[i].Content.ContentBlocks[j]
+			if b.CacheControl != nil || b.PromptCacheBreakpoint != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func chatHasCacheMarker(input []schemas.ChatMessage) bool {
+	for i := range input {
+		if input[i].Content == nil {
+			continue
+		}
+		for j := range input[i].Content.ContentBlocks {
+			b := &input[i].Content.ContentBlocks[j]
+			if b.CacheControl != nil || b.PromptCacheBreakpoint != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// responsesInjectionTargets resolves the configured strategy into concrete positions.
+// InjectionPoints replaces AutoInject rather than adding to it, so an operator who
+// configures explicit points gets exactly those and no surprise extra marker.
+func responsesInjectionTargets(cfg *schemas.PromptCacheConfig, input []schemas.ResponsesMessage) []injectionTarget {
+	if len(cfg.InjectionPoints) > 0 {
+		return responsesPointTargets(cfg.InjectionPoints, input)
+	}
+	if !cfg.AutoInject {
+		return nil
+	}
+	// Default strategy: the FIRST cacheable block. That is the prefix an agent loop
+	// replays verbatim every turn, so the cached region stays stable and turn 2
+	// onward is a read. Marking the last block instead would move the boundary every
+	// turn and bill a write each time — the exact failure #6180 reported.
+	for i := range input {
+		if input[i].Content == nil {
+			continue
+		}
+		if s := input[i].Content.ContentStr; s != nil && *s != "" {
+			return []injectionTarget{{msg: i, promoteStr: true}}
+		}
+		for j := range input[i].Content.ContentBlocks {
+			if isCacheableResponsesBlock(input[i].Content.ContentBlocks[j].Type) {
+				return []injectionTarget{{msg: i, block: j}}
+			}
+		}
+	}
+	return nil
+}
+
+func chatInjectionTargets(cfg *schemas.PromptCacheConfig, input []schemas.ChatMessage) []injectionTarget {
+	if len(cfg.InjectionPoints) > 0 {
+		return chatPointTargets(cfg.InjectionPoints, input)
+	}
+	if !cfg.AutoInject {
+		return nil
+	}
+	for i := range input {
+		if input[i].Content == nil {
+			continue
+		}
+		if s := input[i].Content.ContentStr; s != nil && *s != "" {
+			return []injectionTarget{{msg: i, promoteStr: true}}
+		}
+		for j := range input[i].Content.ContentBlocks {
+			if isCacheableChatBlock(input[i].Content.ContentBlocks[j].Type) {
+				return []injectionTarget{{msg: i, block: j}}
+			}
+		}
+	}
+	return nil
+}
+
+// responsesPointTargets applies LiteLLM's injection-point semantics: match messages
+// by role and/or index, and mark the LAST content block of each match. Last rather
+// than first here because a point names a message the operator wants cached through
+// to its end, unlike the default strategy which names a prefix boundary.
+func responsesPointTargets(points []schemas.CacheControlInjectionPoint, input []schemas.ResponsesMessage) []injectionTarget {
+	var out []injectionTarget
+	seen := make(map[int]bool)
+	for _, p := range points {
+		for _, idx := range matchMessageIndices(p, len(input), func(i int) string {
+			if input[i].Role == nil {
+				return ""
+			}
+			return string(*input[i].Role)
+		}) {
+			if seen[idx] || len(out) >= MaxInjectedCacheBreakpoints {
+				continue
+			}
+			msg := input[idx]
+			if msg.Content == nil {
+				continue
+			}
+			if s := msg.Content.ContentStr; s != nil && *s != "" {
+				out = append(out, injectionTarget{msg: idx, promoteStr: true})
+				seen[idx] = true
+				continue
+			}
+			if b := lastCacheableResponsesBlock(msg.Content.ContentBlocks); b >= 0 {
+				out = append(out, injectionTarget{msg: idx, block: b})
+				seen[idx] = true
+			}
+		}
+	}
+	return out
+}
+
+func chatPointTargets(points []schemas.CacheControlInjectionPoint, input []schemas.ChatMessage) []injectionTarget {
+	var out []injectionTarget
+	seen := make(map[int]bool)
+	for _, p := range points {
+		for _, idx := range matchMessageIndices(p, len(input), func(i int) string {
+			return string(input[i].Role)
+		}) {
+			if seen[idx] || len(out) >= MaxInjectedCacheBreakpoints {
+				continue
+			}
+			msg := input[idx]
+			if msg.Content == nil {
+				continue
+			}
+			if s := msg.Content.ContentStr; s != nil && *s != "" {
+				out = append(out, injectionTarget{msg: idx, promoteStr: true})
+				seen[idx] = true
+				continue
+			}
+			if b := lastCacheableChatBlock(msg.Content.ContentBlocks); b >= 0 {
+				out = append(out, injectionTarget{msg: idx, block: b})
+				seen[idx] = true
+			}
+		}
+	}
+	return out
+}
+
+// matchMessageIndices resolves one injection point to message positions. A point
+// with neither Role nor Index matches nothing: it is almost certainly a
+// misconfiguration, and marking every message would burn the whole budget.
+//
+// Out-of-range indices match nothing rather than clamping. A conversation shorter
+// than the configured index is ordinary — early turns of a session that will grow —
+// so clamping would silently mark a different message than the operator named.
+func matchMessageIndices(p schemas.CacheControlInjectionPoint, n int, roleAt func(int) string) []int {
+	if p.Location != "" && p.Location != schemas.CacheControlInjectionLocationMessage {
+		return nil
+	}
+	if p.Index != nil {
+		idx := *p.Index
+		if idx < 0 {
+			idx += n
+		}
+		if idx < 0 || idx >= n {
+			return nil
+		}
+		if p.Role != nil && roleAt(idx) != *p.Role {
+			return nil
+		}
+		return []int{idx}
+	}
+	if p.Role == nil {
+		return nil
+	}
+	var out []int
+	for i := 0; i < n; i++ {
+		if roleAt(i) == *p.Role {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+// isCacheableResponsesBlock reports whether a marker on this block type means
+// anything upstream. Text, image and file blocks carry prompt content and count
+// toward the cached prefix; reasoning, refusal and tool-call plumbing do not.
+func isCacheableResponsesBlock(t schemas.ResponsesMessageContentBlockType) bool {
+	switch t {
+	case schemas.ResponsesInputMessageContentBlockTypeText,
+		schemas.ResponsesInputMessageContentBlockTypeImage,
+		schemas.ResponsesInputMessageContentBlockTypeFile,
+		schemas.ResponsesOutputMessageContentTypeText:
+		return true
+	default:
+		return false
+	}
+}
+
+func isCacheableChatBlock(t schemas.ChatContentBlockType) bool {
+	switch t {
+	case schemas.ChatContentBlockTypeText, schemas.ChatContentBlockTypeImage:
+		return true
+	default:
+		return false
+	}
+}
+
+func lastCacheableResponsesBlock(blocks []schemas.ResponsesMessageContentBlock) int {
+	for i := len(blocks) - 1; i >= 0; i-- {
+		if isCacheableResponsesBlock(blocks[i].Type) {
+			return i
+		}
+	}
+	return -1
+}
+
+func lastCacheableChatBlock(blocks []schemas.ChatContentBlock) int {
+	for i := len(blocks) - 1; i >= 0; i-- {
+		if isCacheableChatBlock(blocks[i].Type) {
+			return i
+		}
+	}
+	return -1
+}

--- a/core/providers/utils/promptcache.go
+++ b/core/providers/utils/promptcache.go
@@ -31,6 +31,37 @@ func PromptCacheInjectionEnabled(cfg *schemas.PromptCacheConfig, provider schema
 	return caps.SupportsPromptCaching(schemas.ModelSupportsPromptCaching(provider, model))
 }
 
+// ResolvePromptCacheConfig applies a per-request override of auto_inject on top of the
+// provider config, mirroring how the raw-capture flags resolve.
+//
+// The override cannot manufacture opt-in. A provider with no prompt_cache config at all
+// is one whose operator has expressed no opinion, and a request header must not spend a
+// cache checkpoint — or change the billing profile — on their behalf. Once the operator
+// has configured prompt_cache, the header flips auto_inject in either direction: on for
+// a single request without a config change, or off for a request that should not be
+// touched.
+//
+// Only auto_inject is overridable. Injection points stay a config-level decision, since
+// a caller that wants specific placement can simply send the markers itself. The model
+// capability gate applies either way, so a header cannot force a marker onto a model
+// that has no use for one.
+//
+// The returned config is a copy whenever the override changes anything: the provider
+// config is shared across every request to that provider and must never be written
+// through.
+func ResolvePromptCacheConfig(ctx *schemas.BifrostContext, cfg *schemas.PromptCacheConfig) *schemas.PromptCacheConfig {
+	if ctx == nil || cfg == nil {
+		return cfg
+	}
+	override, ok := ctx.Value(schemas.BifrostContextKeyPromptCacheAutoInject).(bool)
+	if !ok || cfg.AutoInject == override {
+		return cfg
+	}
+	cp := *cfg
+	cp.AutoInject = override
+	return &cp
+}
+
 // InjectResponsesCacheBreakpoints returns input with cache_control markers added
 // where the config asks for them, or input unchanged when it does not apply.
 //

--- a/core/providers/utils/promptcache_test.go
+++ b/core/providers/utils/promptcache_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -430,5 +431,59 @@ func TestInjectChat_Basics(t *testing.T) {
 			}
 			return n
 		}(), "no extra marker may be added")
+	})
+}
+
+// TestResolvePromptCacheConfig covers the per-request override, whose most important
+// property is what it CANNOT do: a request header must never enable injection for a
+// provider whose operator never configured it. Spending a cache checkpoint changes the
+// billing profile, and that decision belongs to the operator, not to a caller.
+func TestResolvePromptCacheConfig(t *testing.T) {
+	ctxWith := func(v any) *schemas.BifrostContext {
+		c := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		if v != nil {
+			c.SetValue(schemas.BifrostContextKeyPromptCacheAutoInject, v)
+		}
+		return c
+	}
+
+	t.Run("no operator config means the header cannot enable", func(t *testing.T) {
+		assert.Nil(t, ResolvePromptCacheConfig(ctxWith(true), nil),
+			"a header must not manufacture opt-in for a provider the operator never configured")
+	})
+
+	t.Run("header turns a configured-off provider on for one request", func(t *testing.T) {
+		cfg := &schemas.PromptCacheConfig{AutoInject: false}
+		got := ResolvePromptCacheConfig(ctxWith(true), cfg)
+		require.NotNil(t, got)
+		assert.True(t, got.AutoInject)
+		assert.False(t, cfg.AutoInject, "the shared provider config was written through")
+		assert.NotSame(t, cfg, got, "an overridden config must be a copy")
+	})
+
+	t.Run("header opts a single request out", func(t *testing.T) {
+		cfg := &schemas.PromptCacheConfig{AutoInject: true}
+		got := ResolvePromptCacheConfig(ctxWith(false), cfg)
+		require.NotNil(t, got)
+		assert.False(t, got.AutoInject)
+		assert.True(t, cfg.AutoInject, "the shared provider config was written through")
+	})
+
+	t.Run("passes through untouched", func(t *testing.T) {
+		cfg := &schemas.PromptCacheConfig{AutoInject: true}
+		assert.Same(t, cfg, ResolvePromptCacheConfig(ctxWith(nil), cfg), "no header set")
+		assert.Same(t, cfg, ResolvePromptCacheConfig(ctxWith(true), cfg), "header agrees with config")
+		assert.Same(t, cfg, ResolvePromptCacheConfig(nil, cfg), "nil context")
+	})
+
+	t.Run("injection points are not overridable", func(t *testing.T) {
+		cfg := &schemas.PromptCacheConfig{
+			InjectionPoints: []schemas.CacheControlInjectionPoint{
+				{Location: schemas.CacheControlInjectionLocationMessage, Role: schemas.Ptr("system")},
+			},
+		}
+		got := ResolvePromptCacheConfig(ctxWith(false), cfg)
+		require.NotNil(t, got)
+		assert.Len(t, got.InjectionPoints, 1, "the header only flips auto_inject; points remain config-level")
 	})
 }

--- a/core/providers/utils/promptcache_test.go
+++ b/core/providers/utils/promptcache_test.go
@@ -1,0 +1,434 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func autoInject() *schemas.PromptCacheConfig {
+	return &schemas.PromptCacheConfig{AutoInject: true}
+}
+
+func blockMsg(role schemas.ResponsesMessageRoleType, blocks ...schemas.ResponsesMessageContentBlock) schemas.ResponsesMessage {
+	return schemas.ResponsesMessage{
+		Role:    schemas.Ptr(role),
+		Content: &schemas.ResponsesMessageContent{ContentBlocks: blocks},
+	}
+}
+
+func strMsg(role schemas.ResponsesMessageRoleType, text string) schemas.ResponsesMessage {
+	return schemas.ResponsesMessage{
+		Role:    schemas.Ptr(role),
+		Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr(text)},
+	}
+}
+
+func textBlock(text string) schemas.ResponsesMessageContentBlock {
+	return schemas.ResponsesMessageContentBlock{
+		Type: schemas.ResponsesInputMessageContentBlockTypeText,
+		Text: schemas.Ptr(text),
+	}
+}
+
+// markers returns, per message, the indices of blocks carrying cache_control.
+func markers(msgs []schemas.ResponsesMessage) map[int][]int {
+	out := map[int][]int{}
+	for i := range msgs {
+		if msgs[i].Content == nil {
+			continue
+		}
+		for j := range msgs[i].Content.ContentBlocks {
+			if msgs[i].Content.ContentBlocks[j].CacheControl != nil {
+				out[i] = append(out[i], j)
+			}
+		}
+	}
+	return out
+}
+
+func countMarkers(msgs []schemas.ResponsesMessage) int {
+	n := 0
+	for _, idxs := range markers(msgs) {
+		n += len(idxs)
+	}
+	return n
+}
+
+// TestInjectResponses_FirstCacheableBlock pins the default strategy. The FIRST
+// cacheable block is the prefix an agent loop replays verbatim every turn, so marking
+// it keeps the cached region stable and makes turn 2 onward a read. Marking the last
+// block instead would move the boundary each turn and bill a cache write every time,
+// which is the failure #6180 reported.
+func TestInjectResponses_FirstCacheableBlock(t *testing.T) {
+	cases := []struct {
+		name       string
+		blockType  schemas.ResponsesMessageContentBlockType
+		wantMarked bool
+	}{
+		{"input_text", schemas.ResponsesInputMessageContentBlockTypeText, true},
+		{"input_image", schemas.ResponsesInputMessageContentBlockTypeImage, true},
+		{"input_file", schemas.ResponsesInputMessageContentBlockTypeFile, true},
+		{"refusal is not cacheable", schemas.ResponsesOutputMessageContentTypeRefusal, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := []schemas.ResponsesMessage{
+				blockMsg(schemas.ResponsesInputMessageRoleUser,
+					schemas.ResponsesMessageContentBlock{Type: tc.blockType, Text: schemas.Ptr("a")},
+				),
+			}
+			out := InjectResponsesCacheBreakpoints(autoInject(), in)
+			if tc.wantMarked {
+				require.Equal(t, 1, countMarkers(out), "expected the block to be marked")
+				assert.Equal(t, schemas.CacheControlTypeEphemeral, out[0].Content.ContentBlocks[0].CacheControl.Type)
+			} else {
+				assert.Equal(t, 0, countMarkers(out), "non-cacheable block must not be marked")
+			}
+		})
+	}
+}
+
+func TestInjectResponses_MarksFirstNotLast(t *testing.T) {
+	in := []schemas.ResponsesMessage{
+		blockMsg(schemas.ResponsesInputMessageRoleSystem, textBlock("stable prefix")),
+		blockMsg(schemas.ResponsesInputMessageRoleUser, textBlock("turn 1")),
+	}
+	out := InjectResponsesCacheBreakpoints(autoInject(), in)
+
+	require.Equal(t, map[int][]int{0: {0}}, markers(out),
+		"only the first cacheable block may be marked; a later marker slides with the conversation")
+}
+
+// TestInjectResponses_PromotesContentStr covers the bare-string case. A string has
+// nowhere to hang a marker, so it becomes a single text block. This is safe only
+// because it is deterministic: the same message always renders the same way, so the
+// cached prefix stays byte-identical across turns.
+func TestInjectResponses_PromotesContentStr(t *testing.T) {
+	in := []schemas.ResponsesMessage{strMsg(schemas.ResponsesInputMessageRoleUser, "stable prefix")}
+
+	out := InjectResponsesCacheBreakpoints(autoInject(), in)
+
+	require.Len(t, out[0].Content.ContentBlocks, 1)
+	assert.Nil(t, out[0].Content.ContentStr, "the string form must be replaced, not duplicated")
+	require.NotNil(t, out[0].Content.ContentBlocks[0].Text)
+	assert.Equal(t, "stable prefix", *out[0].Content.ContentBlocks[0].Text, "text must survive promotion")
+	assert.NotNil(t, out[0].Content.ContentBlocks[0].CacheControl)
+}
+
+// TestInjectResponses_CallerMarkerWins is the "never fight the caller" rule.
+// Injection is a default for clients that say nothing, never an override of a client
+// that spoke. Both marker dialects count as speaking.
+func TestInjectResponses_CallerMarkerWins(t *testing.T) {
+	ephemeral := &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral}
+	explicit := schemas.Ptr("explicit")
+
+	cases := []struct {
+		name string
+		in   []schemas.ResponsesMessage
+	}{
+		{
+			name: "block cache_control",
+			in: []schemas.ResponsesMessage{
+				blockMsg(schemas.ResponsesInputMessageRoleUser, textBlock("a")),
+				blockMsg(schemas.ResponsesInputMessageRoleUser,
+					schemas.ResponsesMessageContentBlock{
+						Type: schemas.ResponsesInputMessageContentBlockTypeText,
+						Text: schemas.Ptr("b"), CacheControl: ephemeral,
+					}),
+			},
+		},
+		{
+			name: "block prompt_cache_breakpoint",
+			in: []schemas.ResponsesMessage{
+				blockMsg(schemas.ResponsesInputMessageRoleUser, textBlock("a")),
+				blockMsg(schemas.ResponsesInputMessageRoleUser,
+					schemas.ResponsesMessageContentBlock{
+						Type:                  schemas.ResponsesInputMessageContentBlockTypeText,
+						Text:                  schemas.Ptr("b"),
+						PromptCacheBreakpoint: &schemas.PromptCacheBreakpoint{Mode: explicit},
+					}),
+			},
+		},
+		{
+			name: "message-level cache_control",
+			in: []schemas.ResponsesMessage{
+				func() schemas.ResponsesMessage {
+					m := blockMsg(schemas.ResponsesInputMessageRoleUser, textBlock("a"))
+					m.CacheControl = ephemeral
+					return m
+				}(),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := InjectResponsesCacheBreakpoints(autoInject(), tc.in)
+			assert.Equal(t, &tc.in[0], &out[0], "a request that already expresses caching intent must be returned untouched")
+			for i := range out {
+				if out[i].Content == nil {
+					continue
+				}
+				for j := range out[i].Content.ContentBlocks {
+					if tc.in[i].Content.ContentBlocks[j].CacheControl == nil {
+						assert.Nil(t, out[i].Content.ContentBlocks[j].CacheControl,
+							"no marker may be added when the caller supplied one elsewhere")
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestInjectResponses_DoesNotMutateInput is the assertion that would have caught the
+// defect that sank PR #6181. bifrostReq.Input is shared with the plugin pipeline and
+// the fallback chain, so writing a marker in place leaks provider-specific cache
+// settings into a retry against a different provider.
+func TestInjectResponses_DoesNotMutateInput(t *testing.T) {
+	sharedContent := &schemas.ResponsesMessageContent{
+		ContentBlocks: []schemas.ResponsesMessageContentBlock{textBlock("stable prefix")},
+	}
+	in := []schemas.ResponsesMessage{{
+		Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+		Content: sharedContent,
+	}}
+
+	out := InjectResponsesCacheBreakpoints(autoInject(), in)
+
+	require.Equal(t, 1, countMarkers(out), "sanity: the call must actually have injected something")
+	assert.Nil(t, in[0].Content.ContentBlocks[0].CacheControl,
+		"caller's block was mutated in place - this is the #6181 leak")
+	assert.Nil(t, sharedContent.ContentBlocks[0].CacheControl,
+		"caller's Content pointer was mutated - aliased state escaped the copy")
+	assert.NotSame(t, sharedContent, out[0].Content,
+		"a marked message must not share its Content pointer with the caller")
+}
+
+func TestInjectResponses_ContentStrPromotionDoesNotMutateInput(t *testing.T) {
+	in := []schemas.ResponsesMessage{strMsg(schemas.ResponsesInputMessageRoleUser, "stable prefix")}
+
+	out := InjectResponsesCacheBreakpoints(autoInject(), in)
+
+	require.Len(t, out[0].Content.ContentBlocks, 1)
+	require.NotNil(t, in[0].Content.ContentStr, "caller's string form must survive")
+	assert.Equal(t, "stable prefix", *in[0].Content.ContentStr)
+	assert.Empty(t, in[0].Content.ContentBlocks, "promotion must not write blocks back onto the caller")
+}
+
+func TestInjectResponses_Disabled(t *testing.T) {
+	in := []schemas.ResponsesMessage{blockMsg(schemas.ResponsesInputMessageRoleUser, textBlock("a"))}
+
+	for _, tc := range []struct {
+		name string
+		cfg  *schemas.PromptCacheConfig
+	}{
+		{"nil config", nil},
+		{"auto_inject false, no points", &schemas.PromptCacheConfig{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, 0, countMarkers(InjectResponsesCacheBreakpoints(tc.cfg, in)))
+		})
+	}
+}
+
+func TestInjectResponses_TTLCarried(t *testing.T) {
+	cfg := &schemas.PromptCacheConfig{AutoInject: true, TTL: schemas.Ptr("1h")}
+	in := []schemas.ResponsesMessage{blockMsg(schemas.ResponsesInputMessageRoleUser, textBlock("a"))}
+
+	out := InjectResponsesCacheBreakpoints(cfg, in)
+
+	cc := out[0].Content.ContentBlocks[0].CacheControl
+	require.NotNil(t, cc)
+	require.NotNil(t, cc.TTL)
+	assert.Equal(t, "1h", *cc.TTL)
+}
+
+// TestInjectResponses_InjectionPoints covers the LiteLLM-parity override. Points
+// replace the default strategy rather than adding to it, and mark the LAST cacheable
+// block of each match.
+func TestInjectResponses_InjectionPoints(t *testing.T) {
+	convo := func() []schemas.ResponsesMessage {
+		return []schemas.ResponsesMessage{
+			blockMsg(schemas.ResponsesInputMessageRoleSystem, textBlock("sys a"), textBlock("sys b")),
+			blockMsg(schemas.ResponsesInputMessageRoleUser, textBlock("u1")),
+			blockMsg(schemas.ResponsesInputMessageRoleAssistant, textBlock("a1")),
+			blockMsg(schemas.ResponsesInputMessageRoleUser, textBlock("u2")),
+		}
+	}
+	point := func(role string, index *int) schemas.CacheControlInjectionPoint {
+		p := schemas.CacheControlInjectionPoint{Location: schemas.CacheControlInjectionLocationMessage, Index: index}
+		if role != "" {
+			p.Role = schemas.Ptr(role)
+		}
+		return p
+	}
+
+	cases := []struct {
+		name   string
+		points []schemas.CacheControlInjectionPoint
+		want   map[int][]int
+	}{
+		{
+			name:   "role system marks the last block of the system message",
+			points: []schemas.CacheControlInjectionPoint{point("system", nil)},
+			want:   map[int][]int{0: {1}},
+		},
+		{
+			name:   "role user matches every user message",
+			points: []schemas.CacheControlInjectionPoint{point("user", nil)},
+			want:   map[int][]int{1: {0}, 3: {0}},
+		},
+		{
+			name:   "index -1 is the last message",
+			points: []schemas.CacheControlInjectionPoint{point("", schemas.Ptr(-1))},
+			want:   map[int][]int{3: {0}},
+		},
+		{
+			name:   "index 0 is the first message",
+			points: []schemas.CacheControlInjectionPoint{point("", schemas.Ptr(0))},
+			want:   map[int][]int{0: {1}},
+		},
+		{
+			name:   "index beyond the end matches nothing",
+			points: []schemas.CacheControlInjectionPoint{point("", schemas.Ptr(99))},
+			want:   map[int][]int{},
+		},
+		{
+			name:   "negative index beyond the start matches nothing",
+			points: []schemas.CacheControlInjectionPoint{point("", schemas.Ptr(-99))},
+			want:   map[int][]int{},
+		},
+		{
+			name:   "role and index must both match",
+			points: []schemas.CacheControlInjectionPoint{point("assistant", schemas.Ptr(1))},
+			want:   map[int][]int{},
+		},
+		{
+			name:   "a point with neither role nor index matches nothing",
+			points: []schemas.CacheControlInjectionPoint{point("", nil)},
+			want:   map[int][]int{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &schemas.PromptCacheConfig{InjectionPoints: tc.points}
+			assert.Equal(t, tc.want, markers(InjectResponsesCacheBreakpoints(cfg, convo())))
+		})
+	}
+}
+
+func TestInjectResponses_PointsReplaceAutoInject(t *testing.T) {
+	cfg := &schemas.PromptCacheConfig{
+		AutoInject: true,
+		InjectionPoints: []schemas.CacheControlInjectionPoint{
+			{Location: schemas.CacheControlInjectionLocationMessage, Index: schemas.Ptr(-1)},
+		},
+	}
+	in := []schemas.ResponsesMessage{
+		blockMsg(schemas.ResponsesInputMessageRoleSystem, textBlock("sys")),
+		blockMsg(schemas.ResponsesInputMessageRoleUser, textBlock("u1")),
+	}
+
+	assert.Equal(t, map[int][]int{1: {0}}, markers(InjectResponsesCacheBreakpoints(cfg, in)),
+		"injection points replace the default strategy; the first block must not also be marked")
+}
+
+// TestInjectResponses_NeverExceedsFour guards the Anthropic ceiling. Exceeding it is a
+// hard rejection, and relying on the downstream clamp would silently discard the
+// earliest marker instead of failing loudly.
+func TestInjectResponses_NeverExceedsFour(t *testing.T) {
+	in := make([]schemas.ResponsesMessage, 10)
+	for i := range in {
+		in[i] = blockMsg(schemas.ResponsesInputMessageRoleUser, textBlock("turn"))
+	}
+	cfg := &schemas.PromptCacheConfig{
+		InjectionPoints: []schemas.CacheControlInjectionPoint{
+			{Location: schemas.CacheControlInjectionLocationMessage, Role: schemas.Ptr("user")},
+		},
+	}
+
+	out := InjectResponsesCacheBreakpoints(cfg, in)
+
+	assert.LessOrEqual(t, countMarkers(out), MaxInjectedCacheBreakpoints,
+		"ten matching messages must still yield at most four markers")
+	assert.Equal(t, MaxInjectedCacheBreakpoints, countMarkers(out), "and it should spend the full budget")
+}
+
+// TestPromptCacheInjectionEnabled proves the capability gate, which is what makes it
+// safe to call the injector for every provider. Implicit-caching endpoints answer
+// false and are never sent a marker they would reject or ignore.
+func TestPromptCacheInjectionEnabled(t *testing.T) {
+	on := autoInject()
+
+	cases := []struct {
+		name     string
+		cfg      *schemas.PromptCacheConfig
+		provider schemas.ModelProvider
+		model    string
+		want     bool
+	}{
+		{"anthropic claude", on, schemas.Anthropic, "claude-sonnet-4", true},
+		{"openrouter claude", on, schemas.OpenRouter, "anthropic/claude-sonnet-4", true},
+		{"bedrock claude", on, schemas.Bedrock, "anthropic.claude-sonnet-4", true},
+		{"vertex claude", on, schemas.Vertex, "claude-sonnet-4", true},
+		{"openai gpt-5.6", on, schemas.OpenAI, "gpt-5.6-sol", true},
+
+		{"openai pre-5.6 is implicit", on, schemas.OpenAI, "gpt-4o", false},
+		{"openrouter non-claude", on, schemas.OpenRouter, "openai/gpt-4o", false},
+		{"vertex gemini uses cachedContent", on, schemas.Vertex, "gemini-2.5-pro", false},
+		{"gemini is not markable", on, schemas.Gemini, "gemini-2.5-pro", false},
+		{"deepseek is provider-managed", on, schemas.DeepSeek, "deepseek-chat", false},
+		{"groq is provider-managed", on, schemas.Groq, "llama-3.3-70b", false},
+
+		{"disabled config short-circuits", &schemas.PromptCacheConfig{}, schemas.Anthropic, "claude-sonnet-4", false},
+		{"nil config short-circuits", nil, schemas.Anthropic, "claude-sonnet-4", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, PromptCacheInjectionEnabled(tc.cfg, tc.provider, tc.model))
+		})
+	}
+}
+
+// TestInjectChat_Basics keeps the Chat path honest; it shares every rule with the
+// Responses path, so this covers the shape rather than re-testing the semantics.
+func TestInjectChat_Basics(t *testing.T) {
+	mk := func() []schemas.ChatMessage {
+		return []schemas.ChatMessage{{
+			Role: schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{
+				ContentBlocks: []schemas.ChatContentBlock{{
+					Type: schemas.ChatContentBlockTypeText, Text: schemas.Ptr("stable prefix"),
+				}},
+			},
+		}}
+	}
+
+	t.Run("marks the first cacheable block", func(t *testing.T) {
+		in := mk()
+		out := InjectChatCacheBreakpoints(autoInject(), in)
+		require.NotNil(t, out[0].Content.ContentBlocks[0].CacheControl)
+		assert.Nil(t, in[0].Content.ContentBlocks[0].CacheControl, "caller's input was mutated")
+	})
+
+	t.Run("caller marker wins", func(t *testing.T) {
+		in := mk()
+		in[0].Content.ContentBlocks[0].CacheControl = &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral}
+		out := InjectChatCacheBreakpoints(autoInject(), in)
+		assert.Equal(t, 1, func() int {
+			n := 0
+			for _, b := range out[0].Content.ContentBlocks {
+				if b.CacheControl != nil {
+					n++
+				}
+			}
+			return n
+		}(), "no extra marker may be added")
+	})
+}

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -296,6 +296,7 @@ const (
 	BifrostContextKeyRawStreamTextCodec                  BifrostContextKey = "bifrost-raw-stream-text-codec"                    // RawStreamTextCodec (set by native integrations whose client response forwards provider-native stream events)
 	BifrostContextKeyChangeRequestType                   BifrostContextKey = "bifrost-change-request-type"                      // RequestType (set by plugins to trigger request type conversion in core, e.g. text->chat or chat->responses)
 	BifrostContextKeySendBackRawRequest                  BifrostContextKey = "bifrost-send-back-raw-request"                    // bool (per-request override — read by bifrost.go, never overwritten)
+	BifrostContextKeyPromptCacheAutoInject               BifrostContextKey = "bifrost-prompt-cache-auto-inject"                 // bool (per-request override of prompt_cache.auto_inject — read by bifrost.go, never overwritten)
 	BifrostContextKeySendBackRawResponse                 BifrostContextKey = "bifrost-send-back-raw-response"                   // bool (per-request override — read by bifrost.go, never overwritten)
 	BifrostContextKeyIntegrationType                     BifrostContextKey = "bifrost-integration-type"                         // integration used in gateway (e.g. openai, anthropic, bedrock, etc.)
 	BifrostContextKeyIsResponsesToChatCompletionFallback BifrostContextKey = "bifrost-is-responses-to-chat-completion-fallback" // bool (set by bifrost - DO NOT SET THIS MANUALLY)

--- a/core/schemas/modelcaps.go
+++ b/core/schemas/modelcaps.go
@@ -253,6 +253,21 @@ func (c ModelCaps) SupportsCachePoint(fallback bool) bool {
 	return fallback
 }
 
+// SupportsPromptCaching reports whether the model supports explicit prompt caching
+// at all. It is the base feature that SupportsPromptCachingScope and
+// SupportsExtendedCacheTTL refine, and it is what gates breakpoint injection: a
+// model that answers false must never be sent a marker it did not ask for.
+//
+// The datasheet field existed before this accessor did, so callers must pass a
+// meaningful fallback (see ModelSupportsPromptCaching) rather than relying on
+// datasheet coverage.
+func (c ModelCaps) SupportsPromptCaching(fallback bool) bool {
+	if c.record != nil && c.record.SupportsPromptCaching != nil {
+		return *c.record.SupportsPromptCaching
+	}
+	return fallback
+}
+
 // SupportsPromptCachingScope reports whether the model accepts
 // cache_control.scope (Anthropic's prompt-caching-scope beta). Distinct from
 // SupportsExtendedCacheTTL, which gates the cache TTL rather than its scope.

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -561,7 +561,51 @@ type ProviderConfig struct {
 	StoreRawRequestResponse bool                  `json:"store_raw_request_response"` // Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)
 	CustomProviderConfig    *CustomProviderConfig `json:"custom_provider_config,omitempty"`
 	OpenAIConfig            *OpenAIConfig         `json:"openai_config,omitempty"`
+	PromptCache             *PromptCacheConfig    `json:"prompt_cache,omitempty"`
 }
+
+// PromptCacheConfig opts a provider into synthesizing prompt-cache breakpoints for
+// requests that carry none.
+//
+// Agentic clients (Codex above all) send no cache markers, so providers that default
+// to implicit caching slide the cached prefix onto the latest message: every turn
+// rewrites the whole growing prompt at the cache-write rate and reads almost nothing
+// back. On Anthropic models nothing caches at all without an explicit marker.
+//
+// This is off by default and deliberately so. Bifrost otherwise never invents a
+// breakpoint - the four-marker ceiling is scarce and spending one the caller did not
+// ask for is a cost decision that belongs to the operator, not to the gateway. See
+// clampAnthropicCacheBreakpoints in core/providers/anthropic/utils.go.
+type PromptCacheConfig struct {
+	// AutoInject marks the first cacheable content block when the caller supplied no
+	// markers of its own. The first block is the prefix an agent loop replays verbatim
+	// every turn, which is what makes turn 2 onward a cache read rather than a write.
+	AutoInject bool `json:"auto_inject"`
+	// TTL is the lifetime requested for injected markers ("1h"). Empty means the
+	// provider default (5m on Anthropic). Providers that cannot carry a TTL ignore it.
+	TTL *string `json:"ttl,omitempty"`
+	// InjectionPoints targets specific messages instead of the first cacheable block.
+	// When non-empty it REPLACES the AutoInject strategy rather than adding to it.
+	// Mirrors LiteLLM's cache_control_injection_points.
+	InjectionPoints []CacheControlInjectionPoint `json:"cache_control_injection_points,omitempty"`
+}
+
+// CacheControlInjectionPoint names one place to mark. A point must carry at least one
+// of Role or Index; a point with neither matches nothing and is skipped.
+type CacheControlInjectionPoint struct {
+	// Location is "message". Reserved for future targets (tools, system) so the config
+	// shape does not have to change when they arrive.
+	Location string `json:"location"`
+	// Role matches messages by role ("system", "user", "assistant", "developer").
+	Role *string `json:"role,omitempty"`
+	// Index matches by position. Negative values count from the end, so -1 is the last
+	// message. Out-of-range indices match nothing rather than erroring - a conversation
+	// shorter than the configured index is normal, not a misconfiguration.
+	Index *int `json:"index,omitempty"`
+}
+
+// CacheControlInjectionLocationMessage is the only Location value currently honoured.
+const CacheControlInjectionLocationMessage = "message"
 
 // OpenAIConfig holds OpenAI-specific provider configuration.
 type OpenAIConfig struct {

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -1701,12 +1701,29 @@ func IsDeepSeekModel(model string) bool {
 //
 // Substring-matched on the full dot-revision, deliberately. Catalog IDs carry region
 // and vendor namespaces ("azure/eu/gpt-5.6", "openai.gpt-5.6-terra"), so a prefix test
-// would miss them; and because the needle includes the revision it cannot over-match
-// gpt-5.5 or an earlier model the way a bare "gpt-5" test would. This mirrors the
-// gating in core/providers/openai/utils.go, restated here because core/schemas cannot
-// import a provider package.
+// would miss them. Including the revision in the needle rules out gpt-5.5 and earlier,
+// but not a longer one: a bare Contains also answers true for gpt-5.60, a different
+// model that never declared support. Hence the trailing boundary - the character after
+// the needle must be absent or non-numeric. This mirrors the gating in
+// core/providers/openai/utils.go, restated here because core/schemas cannot import a
+// provider package.
 func IsGPT56Model(model string) bool {
-	return strings.Contains(strings.ToLower(model), "gpt-5.6")
+	const needle = "gpt-5.6"
+	lower := strings.ToLower(model)
+	for start := 0; start < len(lower); {
+		idx := strings.Index(lower[start:], needle)
+		if idx < 0 {
+			return false
+		}
+		end := start + idx + len(needle)
+		if end == len(lower) || lower[end] < '0' || lower[end] > '9' {
+			return true
+		}
+		// A digit here means a longer dot-revision; keep scanning, since a
+		// namespaced id may carry the real match further along.
+		start = end
+	}
+	return false
 }
 
 // IsAnthropicModel checks if the model is an Anthropic model.

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -1696,6 +1696,19 @@ func IsDeepSeekModel(model string) bool {
 	return strings.Contains(strings.ToLower(model), "deepseek")
 }
 
+// IsGPT56Model reports whether the model belongs to the gpt-5.6 family, which is the
+// first OpenAI generation to accept prompt_cache_options / prompt_cache_breakpoint.
+//
+// Substring-matched on the full dot-revision, deliberately. Catalog IDs carry region
+// and vendor namespaces ("azure/eu/gpt-5.6", "openai.gpt-5.6-terra"), so a prefix test
+// would miss them; and because the needle includes the revision it cannot over-match
+// gpt-5.5 or an earlier model the way a bare "gpt-5" test would. This mirrors the
+// gating in core/providers/openai/utils.go, restated here because core/schemas cannot
+// import a provider package.
+func IsGPT56Model(model string) bool {
+	return strings.Contains(strings.ToLower(model), "gpt-5.6")
+}
+
 // IsAnthropicModel checks if the model is an Anthropic model.
 func IsAnthropicModel(model string) bool {
 	return strings.Contains(model, "anthropic.") || strings.Contains(model, "claude")
@@ -1763,6 +1776,33 @@ func IsElevenlabsSoundModel(model string) bool {
 // explicit prompt-caching cache points in the Converse API request.
 func BedrockModelSupportsCachePoints(model string) bool {
 	return IsAnthropicModel(model) || IsNovaModel(model)
+}
+
+// ModelSupportsPromptCaching is the datasheet-independent fallback for
+// ModelCaps.SupportsPromptCaching. It answers the narrower question the breakpoint
+// injector needs: can a marker placed on a content block actually do anything here?
+//
+// It is deliberately conservative. Providers whose caching is implicit and
+// provider-managed (OpenAI pre-5.6, DeepSeek, xAI, Groq, and the OpenAI-compatible
+// long tail) answer false, so injection is a no-op for them and no marker is ever
+// sent to an endpoint that would reject it. Gemini also answers false: its caching is
+// a server-side cachedContent resource with its own lifecycle, not a per-block
+// marker, so a breakpoint there would be inert.
+func ModelSupportsPromptCaching(provider ModelProvider, model string) bool {
+	switch provider {
+	case Anthropic, OpenRouter:
+		return IsAnthropicModel(model)
+	case Bedrock, BedrockMantle:
+		return BedrockModelSupportsCachePoints(model) || IsGPT56Model(model)
+	case Vertex:
+		// Vertex serves Claude (cache_control) and Gemini (cachedContent) side by
+		// side; only the former is markable.
+		return IsAnthropicModel(model)
+	case Azure, OpenAI:
+		return IsGPT56Model(model)
+	default:
+		return false
+	}
 }
 
 // BedrockModelSupportsExtendedCacheTTL reports whether the Bedrock model supports

--- a/core/schemas/utils_test.go
+++ b/core/schemas/utils_test.go
@@ -134,3 +134,30 @@ func TestSanitizeImageURLAcceptsDataURLWithParameters(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid data URL format")
 }
+
+// TestIsGPT56ModelRequiresRevisionBoundary pins both halves of the family check.
+// The substring form is deliberate - catalog ids carry region and vendor
+// namespaces, so a prefix test would miss them - but the needle has to end on a
+// revision boundary, or a later dot-revision such as gpt-5.60 is mistaken for a
+// member of the family and is handed a prompt_cache_breakpoint it never declared.
+func TestIsGPT56ModelRequiresRevisionBoundary(t *testing.T) {
+	for _, model := range []string{
+		"gpt-5.6",
+		"GPT-5.6",
+		"azure/eu/gpt-5.6",
+		"openai.gpt-5.6-terra",
+		"gpt-5.6-mini",
+	} {
+		assert.True(t, IsGPT56Model(model), "expected %q to resolve as gpt-5.6 family", model)
+	}
+
+	for _, model := range []string{
+		"gpt-5.60",
+		"gpt-5.61-preview",
+		"azure/eu/gpt-5.65",
+		"gpt-5.5",
+		"gpt-5",
+	} {
+		assert.False(t, IsGPT56Model(model), "expected %q NOT to resolve as gpt-5.6 family", model)
+	}
+}

--- a/docs/openapi/schemas/management/providers.yaml
+++ b/docs/openapi/schemas/management/providers.yaml
@@ -333,6 +333,8 @@ ProviderResponse:
       type: boolean
     custom_provider_config:
       $ref: '#/CustomProviderConfig'
+    prompt_cache:
+      $ref: '#/PromptCacheConfig'
     provider_status:
       $ref: '#/ProviderStatus'
     status:
@@ -378,6 +380,41 @@ AddProviderRequest:
       type: boolean
     custom_provider_config:
       $ref: '#/CustomProviderConfig'
+    prompt_cache:
+      $ref: '#/PromptCacheConfig'
+
+CacheControlInjectionPoint:
+  type: object
+  description: One place to add a cache breakpoint. Must set role, index, or both.
+  properties:
+    location:
+      type: string
+      enum: [message]
+    role:
+      type: string
+      enum: [system, developer, user, assistant]
+    index:
+      type: integer
+      description: Negative values count from the end, so -1 is the last message.
+
+PromptCacheConfig:
+  type: object
+  description: >-
+    Synthesize prompt-cache breakpoints for requests that carry none. Off by default.
+    Requests that already carry their own cache markers are never modified.
+  properties:
+    auto_inject:
+      type: boolean
+      description: Mark the first cacheable content block, keeping the cached prefix stable across agent turns.
+    ttl:
+      type: string
+      enum: ["1h"]
+      description: Lifetime for injected markers. Omit for the provider default.
+    cache_control_injection_points:
+      type: array
+      description: Target specific messages instead. When set, replaces auto_inject rather than adding to it.
+      items:
+        $ref: '#/CacheControlInjectionPoint'
 
 UpdateProviderRequest:
   type: object
@@ -397,6 +434,8 @@ UpdateProviderRequest:
       type: boolean
     custom_provider_config:
       $ref: '#/CustomProviderConfig'
+    prompt_cache:
+      $ref: '#/PromptCacheConfig'
 
 ListProviderKeysResponse:
   type: object

--- a/docs/providers/supported-providers/openrouter.mdx
+++ b/docs/providers/supported-providers/openrouter.mdx
@@ -122,33 +122,92 @@ OpenRouter supports extended thinking on compatible models:
 
 **Reasoning Models:** gpt-oss-120b and compatible models with special handling for reasoning content.
 
-### Cache Control Stripping
+### Prompt Caching
 
-Anthropic-specific cache control directives are automatically removed:
+Bifrost forwards Anthropic-style cache breakpoints to OpenRouter, but the two API
+surfaces take them in different shapes. Bifrost translates automatically, so you
+send `cache_control` either way.
 
-```go
-// Bifrost supports cache control from Anthropic
+**Chat Completions** accepts per-block `cache_control` directly, and Bifrost
+passes it through unchanged:
+
+```json
 {
   "messages": [{
     "role": "user",
     "content": [{
       "type": "text",
-      "text": "...",
-      "cache_control": {"type": "ephemeral"}  // ← Stripped
+      "text": "<REUSABLE_PREFIX>",
+      "cache_control": {"type": "ephemeral"}
     }]
   }]
 }
-
-// Sent to OpenRouter without cache directives
 ```
+
+**Responses** does not expose per-block `cache_control`. Bifrost converts each
+marked `input_text` block into the `prompt_cache_breakpoint` that OpenRouter
+turns back into an Anthropic breakpoint:
+
+```json
+// You send
+{"input": [{"role": "user", "content": [
+  {"type": "input_text", "text": "<REUSABLE_PREFIX>",
+   "cache_control": {"type": "ephemeral"}}
+]}]}
+
+// Bifrost sends to OpenRouter
+{"input": [{"role": "user", "content": [
+  {"type": "input_text", "text": "<REUSABLE_PREFIX>",
+   "prompt_cache_breakpoint": {"mode": "explicit"}}
+]}]}
+```
+
+<Note>
+Anthropic accepts at most **four** cache breakpoints per request and rejects a
+fifth outright. On the Responses path Bifrost limits only the markers it
+**converts** from `cache_control`, and only to the capacity your own
+`prompt_cache_breakpoint` values leave free. When it has to trim, it drops the
+**earliest** converted markers, because caching is cumulative and a later
+breakpoint anchors a longer prefix.
+
+Breakpoints you set yourself are never modified or dropped. If you supply four or
+more of them, Bifrost converts nothing further; if you supply more than four, they
+are forwarded as written and OpenRouter's upstream will reject the request.
+</Note>
+
+<Note>
+A converted breakpoint carries no TTL. OpenRouter turns `prompt_cache_breakpoint`
+into a **default** Anthropic breakpoint, so `{"type": "ephemeral", "ttl": "1h"}`
+caches for the default 5 minutes on the Responses path. Use Chat Completions,
+which forwards `cache_control` verbatim, when you need the 1-hour TTL.
+
+Only `"type": "ephemeral"` is converted. It is the sole cache type Anthropic
+defines, so a `cache_control` carrying any other value is dropped rather than
+turned into a breakpoint.
+</Note>
+
+Two markers have no Responses representation and are still dropped: `cache_control`
+on tool definitions (OpenRouter documents no tool-level Responses breakpoint) and on
+`function_call_output` blocks (a text-only output array is collapsed to a single
+string before it reaches the wire). Put your breakpoints on `input_text` blocks.
+
+Verify caching worked by reading `cached_tokens` in the response usage. A `200`
+alone does not mean the cache was hit.
+
+See [OpenRouter prompt caching](https://openrouter.ai/docs/features/prompt-caching#anthropic-claude)
+for the upstream contract.
 
 ### Filtered Parameters
 
 Removed for OpenRouter compatibility:
-- `prompt_cache_key` - Not supported
 - `verbosity` - Anthropic-specific
 - `store` - Not supported
 - `service_tier` - OpenAI-specific
+
+`prompt_cache_key` is forwarded on the Responses path, and on Chat Completions
+only when the model's datasheet marks it supported. Either way it is not a
+caching switch: OpenRouter uses it as a sticky-routing key, so it does not enable
+Anthropic prompt caching on its own. Use a cache breakpoint for that.
 
 OpenRouter supports all standard OpenAI message types, tools, responses, and streaming formats. For details on message handling, tool conversion, responses, and streaming, refer to [OpenAI Chat Completions](/providers/supported-providers/openai#1-chat-completions).
 

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -485,6 +485,7 @@ type ProviderConfig struct {
 	StoreRawRequestResponse  bool                              `json:"store_raw_request_response"`            // Capture raw request/response for internal logging only; strip from API responses returned to clients
 	CustomProviderConfig     *schemas.CustomProviderConfig     `json:"custom_provider_config,omitempty"`      // Custom provider configuration
 	OpenAIConfig             *schemas.OpenAIConfig             `json:"openai_config,omitempty"`               // OpenAI-specific configuration
+	PromptCache              *schemas.PromptCacheConfig        `json:"prompt_cache,omitempty"`                // Prompt-cache breakpoint injection
 	ConfigHash               string                            `json:"config_hash,omitempty"`                 // Hash of config.json version, used for change detection
 	Status                   string                            `json:"status,omitempty"`                      // Model discovery status for keyless providers
 	Description              string                            `json:"description,omitempty"`                 // Model discovery error message for keyless providers
@@ -505,6 +506,7 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 		StoreRawRequestResponse:  p.StoreRawRequestResponse,
 		CustomProviderConfig:     p.CustomProviderConfig,
 		OpenAIConfig:             p.OpenAIConfig,
+		PromptCache:              p.PromptCache,
 		ConfigHash:               p.ConfigHash,
 		Status:                   p.Status,
 		Description:              p.Description,
@@ -776,6 +778,15 @@ func (p *ProviderConfig) GenerateConfigHash(providerName string) (string, error)
 	// Hash OpenAIConfig
 	if p.OpenAIConfig != nil {
 		data, err := sonic.Marshal(p.OpenAIConfig)
+		if err != nil {
+			return "", err
+		}
+		hash.Write(data)
+	}
+
+	// Hash PromptCache
+	if p.PromptCache != nil {
+		data, err := sonic.Marshal(p.PromptCache)
 		if err != nil {
 			return "", err
 		}

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -490,6 +490,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_mcp_client_endpoint_slug"}, run: migrationAddMCPClientEndpointSlug},
 	{IDs: []string{"add_allow_all_providers_to_virtual_key"}, run: migrationAddAllowAllProvidersToVirtualKey},
 	{IDs: []string{"backfill_vk_allow_all_providers_hash"}, run: migrationBackfillVirtualKeyAllowAllProvidersHash},
+	{IDs: []string{"add_prompt_cache_json_column"}, run: migrationAddPromptCacheJSONColumn},
 }
 
 // videoResolutionPricingColumns are the resolution-banded video output rate columns.
@@ -7442,6 +7443,39 @@ func migrationAddOpenAIConfigJSONColumn(ctx context.Context, db *gorm.DB, logger
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while running add_open_ai_config_json_column migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddPromptCacheJSONColumn adds the prompt_cache_json column to the provider
+// table, backing ProviderConfig.PromptCache.
+//
+// Provider config is stored as one text column per sub-struct rather than a single
+// JSON blob, so a new config struct needs its own column. Without this the field
+// round-trips through the API and the UI but is dropped at the database boundary.
+func migrationAddPromptCacheJSONColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_prompt_cache_json_column"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if err := addColumnIfNotExists(tx, logger, &tables.TableProvider{}, "PromptCacheJSON"); err != nil {
+				return err
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if err := dropColumnIfExists(tx, logger, &tables.TableProvider{}, "prompt_cache_json"); err != nil {
+				return err
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running add_prompt_cache_json_column migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -705,6 +705,7 @@ func (s *RDBConfigStore) UpdateProvidersConfig(ctx context.Context, providers ma
 			StoreRawRequestResponse:  providerConfig.StoreRawRequestResponse,
 			CustomProviderConfig:     providerConfig.CustomProviderConfig,
 			OpenAIConfig:             providerConfig.OpenAIConfig,
+			PromptCache:              providerConfig.PromptCache,
 			ConfigHash:               providerConfig.ConfigHash,
 			Status:                   providerConfig.Status,
 			Description:              providerConfig.Description,
@@ -947,6 +948,7 @@ func (s *RDBConfigStore) UpdateProvider(ctx context.Context, provider schemas.Mo
 	dbProvider.StoreRawRequestResponse = configCopy.StoreRawRequestResponse
 	dbProvider.CustomProviderConfig = configCopy.CustomProviderConfig
 	dbProvider.OpenAIConfig = configCopy.OpenAIConfig
+	dbProvider.PromptCache = configCopy.PromptCache
 	dbProvider.ConfigHash = configCopy.ConfigHash
 
 	// Save the updated provider
@@ -1132,6 +1134,7 @@ func (s *RDBConfigStore) AddProvider(ctx context.Context, provider schemas.Model
 		StoreRawRequestResponse:  configCopy.StoreRawRequestResponse,
 		CustomProviderConfig:     configCopy.CustomProviderConfig,
 		OpenAIConfig:             configCopy.OpenAIConfig,
+		PromptCache:              configCopy.PromptCache,
 		ConfigHash:               configCopy.ConfigHash,
 	}
 	// Create the provider
@@ -1305,6 +1308,7 @@ func (s *RDBConfigStore) GetProvidersConfig(ctx context.Context) (map[schemas.Mo
 			StoreRawRequestResponse:  dbProvider.StoreRawRequestResponse,
 			CustomProviderConfig:     dbProvider.CustomProviderConfig,
 			OpenAIConfig:             dbProvider.OpenAIConfig,
+			PromptCache:              dbProvider.PromptCache,
 			ConfigHash:               dbProvider.ConfigHash,
 			Status:                   dbProvider.Status,
 			Description:              dbProvider.Description,
@@ -1338,6 +1342,7 @@ func (s *RDBConfigStore) GetProviderConfig(ctx context.Context, provider schemas
 		StoreRawRequestResponse:  dbProvider.StoreRawRequestResponse,
 		CustomProviderConfig:     dbProvider.CustomProviderConfig,
 		OpenAIConfig:             dbProvider.OpenAIConfig,
+		PromptCache:              dbProvider.PromptCache,
 		ConfigHash:               dbProvider.ConfigHash,
 		Status:                   dbProvider.Status,
 		Description:              dbProvider.Description,

--- a/framework/configstore/tables/provider.go
+++ b/framework/configstore/tables/provider.go
@@ -22,6 +22,7 @@ type TableProvider struct {
 	ProxyConfigJSON          string    `gorm:"type:text" json:"-"`                                // JSON serialized schemas.ProxyConfig
 	CustomProviderConfigJSON string    `gorm:"type:text" json:"-"`                                // JSON serialized schemas.CustomProviderConfig
 	OpenAIConfigJSON         string    `gorm:"type:text" json:"-"`                                // JSON serialized schemas.OpenAIConfig
+	PromptCacheJSON          string    `gorm:"type:text" json:"-"`                                // JSON serialized schemas.PromptCacheConfig
 	SendBackRawRequest       bool      `json:"send_back_raw_request"`
 	SendBackRawResponse      bool      `json:"send_back_raw_response"`
 	StoreRawRequestResponse  bool      `json:"store_raw_request_response"`
@@ -39,6 +40,7 @@ type TableProvider struct {
 	// Custom provider fields
 	CustomProviderConfig *schemas.CustomProviderConfig `gorm:"-" json:"custom_provider_config,omitempty"`
 	OpenAIConfig         *schemas.OpenAIConfig         `gorm:"-" json:"openai_config,omitempty"`
+	PromptCache          *schemas.PromptCacheConfig    `gorm:"-" json:"prompt_cache,omitempty"`
 
 	// Foreign keys
 	Models []TableModel `gorm:"foreignKey:ProviderID;constraint:OnDelete:CASCADE" json:"models"`
@@ -108,6 +110,15 @@ func (p *TableProvider) BeforeSave(tx *gorm.DB) error {
 		p.OpenAIConfigJSON = string(data)
 	} else {
 		p.OpenAIConfigJSON = ""
+	}
+	if p.PromptCache != nil {
+		data, err := json.Marshal(p.PromptCache)
+		if err != nil {
+			return err
+		}
+		p.PromptCacheJSON = string(data)
+	} else {
+		p.PromptCacheJSON = ""
 	}
 	// Validate governance fields
 	if p.BudgetID != nil && strings.TrimSpace(*p.BudgetID) == "" {
@@ -180,6 +191,13 @@ func (p *TableProvider) AfterFind(tx *gorm.DB) error {
 		p.OpenAIConfig = &openaiConfig
 	}
 
+	if p.PromptCacheJSON != "" {
+		var promptCache schemas.PromptCacheConfig
+		if err := json.Unmarshal([]byte(p.PromptCacheJSON), &promptCache); err != nil {
+			return err
+		}
+		p.PromptCache = &promptCache
+	}
+
 	return nil
 }
-

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -2116,6 +2116,33 @@
                   },
                   "store_raw_request_response": {
                     "type": "boolean"
+                  },
+                  "prompt_cache": {
+                    "type": "object",
+                    "description": "Synthesize prompt-cache breakpoints for requests that carry none. Off by default; requests that already carry their own cache markers are never modified.",
+                    "properties": {
+                      "auto_inject": {
+                        "type": "boolean",
+                        "description": "Mark the first cacheable content block, keeping the cached prefix stable across agent turns"
+                      },
+                      "ttl": {
+                        "type": "string",
+                        "enum": ["1h"],
+                        "description": "Lifetime for injected markers; omit for the provider default"
+                      },
+                      "cache_control_injection_points": {
+                        "type": "array",
+                        "description": "Target specific messages instead. When set, replaces auto_inject rather than adding to it.",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "location": { "type": "string", "enum": ["message"] },
+                            "role": { "type": "string", "enum": ["system", "developer", "user", "assistant"] },
+                            "index": { "type": "integer", "description": "Negative values count from the end" }
+                          }
+                        }
+                      }
+                    }
                   }
                 },
                 "required": ["name"]
@@ -5827,6 +5854,33 @@
         "store_raw_request_response": {
           "type": "boolean",
           "description": "Capture raw request/response for plugins only; stripped before returning to client"
+        },
+        "prompt_cache": {
+          "type": "object",
+          "description": "Synthesize prompt-cache breakpoints for requests that carry none. Off by default; requests that already carry their own cache markers are never modified.",
+          "properties": {
+            "auto_inject": {
+              "type": "boolean",
+              "description": "Mark the first cacheable content block, keeping the cached prefix stable across agent turns"
+            },
+            "ttl": {
+              "type": "string",
+              "enum": ["1h"],
+              "description": "Lifetime for injected markers; omit for the provider default"
+            },
+            "cache_control_injection_points": {
+              "type": "array",
+              "description": "Target specific messages instead. When set, replaces auto_inject rather than adding to it.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "location": { "type": "string", "enum": ["message"] },
+                  "role": { "type": "string", "enum": ["system", "developer", "user", "assistant"] },
+                  "index": { "type": "integer", "description": "Negative values count from the end" }
+                }
+              }
+            }
+          }
         },
         "custom_provider_config": {
           "type": "object",

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -140504,6 +140504,343 @@
           ]
         }
       ]
+    },
+    {
+      "name": "69. OpenRouter Claude prompt caching on Responses (#6290)",
+      "description": "Regression coverage for #6290: OpenRouter Claude prompt caching was still broken on the Responses API after #4203 fixed Chat Completions.\n\nProduction path: OpenRouterProvider.Responses / ResponsesStream -> openai.HandleOpenAIResponses* -> ToOpenAIResponsesRequest -> POST {OpenRouter}/v1/responses.\n\nBefore the fix, OpenAIResponsesRequestInput.MarshalJSON deleted every message- and block-level cache_control and put nothing in its place, so Claude caching never activated on this route. Unlike Chat Completions, OpenRouter does NOT expose per-block cache_control through /v1/responses; the documented equivalent is prompt_cache_breakpoint on an input_text block, which OpenRouter converts back into an Anthropic breakpoint (https://openrouter.ai/docs/features/prompt-caching#anthropic-claude).\n\nFolder 13 covers the same feature on /v1/chat/completions and is Chat-only; these cases pin the Responses half.\n\nWhat each case pins:\n  69.1 the translation itself, asserted on the outbound body via x-bf-send-back-raw-request (deterministic, independent of whether Anthropic actually cached).\n  69.2/69.3 a real cache read on the non-streaming route. A 2xx alone does not prove caching, so [read] asserts cached_tokens > 0.\n  69.4/69.5 the same invariant through the streaming handler, which the issue calls out separately.\n  69.6 the four-breakpoint clamp. Anthropic hard-rejects a fifth cache_control block, and OpenRouter converts every breakpoint into one, so translating without clamping would turn a silent cache miss into a 400.\n\nThe [write]/[read] pairs depend on folder order and on {{cachePrefix}} (23KB, comfortably over the 1024-token minimum for claude-sonnet-4) plus the collection-level {{pcNonce}} for per-run cache isolation.",
+      "item": [
+        {
+          "name": "OpenRouter Claude Responses: cache_control becomes prompt_cache_breakpoint on the wire - #6290",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('69.1 openrouter responses cache_control: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var body = pm.response.json() || {};",
+                  "var rr = (body.extra_fields || {}).raw_request;",
+                  "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                  "pm.test('69.1 raw_request captured', function () {",
+                  "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                  "});",
+                  "if (!rr || typeof rr !== 'object') { return; }",
+                  "var inp = JSON.stringify(rr.input || []);",
+                  "var blk = ((((rr.input || [])[0] || {}).content || [])[0]) || {};",
+                  "pm.test('69.1 marked input_text carries prompt_cache_breakpoint mode=explicit (#6290)', function () {",
+                  "  pm.expect(blk.prompt_cache_breakpoint, 'input[0].content[0]: ' + JSON.stringify(blk).slice(0, 400)).to.be.an('object');",
+                  "  pm.expect((blk.prompt_cache_breakpoint || {}).mode).to.eql('explicit');",
+                  "});",
+                  "pm.test('69.1 per-block cache_control is not forwarded (not exposed on OpenRouter Responses)', function () {",
+                  "  pm.expect(inp.indexOf('cache_control'), 'cache_control must be translated, not forwarded: ' + inp.slice(0, 500)).to.equal(-1);",
+                  "});",
+                  "pm.test('69.1 unmarked block does not acquire a breakpoint', function () {",
+                  "  var b2 = ((((rr.input || [])[0] || {}).content || [])[1]) || {};",
+                  "  pm.expect(b2.prompt_cache_breakpoint, 'unmarked block: ' + JSON.stringify(b2).slice(0, 300)).to.be.undefined;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-send-back-raw-request",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"openrouter/anthropic/claude-sonnet-4\",\n  \"max_output_tokens\": 16,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"You are a meticulous assistant. Answer tersely.\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Reply with OK.\"\n        }\n      ]\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "OpenRouter Claude Responses: prompt caching non-streaming [write] - #6290",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('69.2 openrouter responses cache write: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"openrouter/anthropic/claude-sonnet-4\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6290 {{pcNonce}} nonstream]\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "OpenRouter Claude Responses: prompt caching non-streaming [read] - #6290",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Let the breakpoint written by the paired [write] land before this [read].",
+                  "var __t = Date.now(); while (Date.now() - __t < 2000) { /* busy-wait for cache propagation */ }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('69.3 openrouter responses cache read: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var j = pm.response.json() || {};",
+                  "var u = j.usage || {};",
+                  "var d = u.input_tokens_details || u.prompt_tokens_details || {};",
+                  "var cached = (typeof d.cached_tokens === 'number') ? d.cached_tokens : 0;",
+                  "pm.test('69.3 cache read: cached_tokens > 0 (#6290)', function () {",
+                  "  pm.expect(cached, 'usage: ' + JSON.stringify(u)).to.be.above(0);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"openrouter/anthropic/claude-sonnet-4\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6290 {{pcNonce}} nonstream]\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "OpenRouter Claude Responses: prompt caching streaming [write] - #6290",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('69.4 openrouter responses cache write: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "pm.test('69.4 stream reached a terminal event', function () {",
+                  "  var raw = pm.response.text() || '';",
+                  "  pm.expect(raw.indexOf('response.completed') !== -1 || raw.indexOf('response.incomplete') !== -1, 'no terminal SSE event: ' + raw.slice(-400)).to.be.true;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"openrouter/anthropic/claude-sonnet-4\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6290 {{pcNonce}} stream]\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ],\n  \"stream\": true\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "OpenRouter Claude Responses: prompt caching streaming [read] - #6290",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Let the breakpoint written by the paired [write] land before this [read].",
+                  "var __t = Date.now(); while (Date.now() - __t < 2000) { /* busy-wait for cache propagation */ }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('69.5 openrouter responses cache read: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "// Terminal usage rides the final SSE event; scan the whole stream for the",
+                  "// largest cached_tokens rather than guessing which event carries usage.",
+                  "var raw = pm.response.text() || '';",
+                  "var m = raw.match(/\"cached_tokens\"\\s*:\\s*(\\d+)/g) || [];",
+                  "var cached = 0;",
+                  "for (var i = 0; i < m.length; i++) { var v = parseInt(m[i].replace(/[^0-9]/g, ''), 10); if (v > cached) { cached = v; } }",
+                  "pm.test('69.5 streaming cache read: cached_tokens > 0 (#6290)', function () {",
+                  "  pm.expect(cached, 'no cached_tokens in the stream; tail: ' + raw.slice(-600)).to.be.above(0);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"openrouter/anthropic/claude-sonnet-4\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6290 {{pcNonce}} stream]\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ],\n  \"stream\": true\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "OpenRouter Claude Responses: five cache_control markers clamp to four - #6290",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "// A 400 here IS the regression signature (Anthropic: 'A maximum of 4 blocks",
+                  "// with cache_control may be provided. Found 5.') - never guard it away.",
+                  "pm.test('69.6 five markers must not 400 (clamped to four) - #6290', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var body = pm.response.json() || {};",
+                  "var rr = (body.extra_fields || {}).raw_request;",
+                  "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                  "pm.test('69.6 raw_request captured', function () {",
+                  "  pm.expect(rr, 'raw_request missing').to.be.an('object');",
+                  "});",
+                  "if (!rr || typeof rr !== 'object') { return; }",
+                  "var blocks = (((rr.input || [])[0] || {}).content) || [];",
+                  "var bps = 0;",
+                  "for (var i = 0; i < blocks.length; i++) { if (blocks[i] && blocks[i].prompt_cache_breakpoint) { bps++; } }",
+                  "pm.test('69.6 exactly four breakpoints reach the wire', function () {",
+                  "  pm.expect(bps, 'blocks: ' + JSON.stringify(blocks.map(function (b) { return !!(b && b.prompt_cache_breakpoint); }))).to.equal(4);",
+                  "});",
+                  "pm.test('69.6 the earliest marker is the one dropped (later breakpoints anchor longer prefixes)', function () {",
+                  "  pm.expect(!!(blocks[0] && blocks[0].prompt_cache_breakpoint), 'block 0 must lose its marker').to.be.false;",
+                  "  pm.expect(!!(blocks[4] && blocks[4].prompt_cache_breakpoint), 'block 4 must keep its marker').to.be.true;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-send-back-raw-request",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"openrouter/anthropic/claude-sonnet-4\",\n  \"max_output_tokens\": 16,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6290 {{pcNonce}} clamp]\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Section two of the manual.\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Section three of the manual.\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Section four of the manual.\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Section five of the manual.\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Reply with OK.\"\n        }\n      ]\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/transports/bifrost-http/handlers/providerconfigmerge_test.go
+++ b/transports/bifrost-http/handlers/providerconfigmerge_test.go
@@ -1,0 +1,75 @@
+package handlers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// PUT /api/providers/{provider} is a partial update, not a full replace. A client that
+// predates a nested config block omits it, and erasing saved settings on an unrelated
+// update is data loss the caller never asked for. Omission means "leave this alone";
+// an explicit null is the request that clears a block, and stays supported so a block
+// added by mistake can still be removed through the API.
+func decodeUpdate(t *testing.T, body string) (*providerUpdatePayload, map[string]json.RawMessage) {
+	t.Helper()
+	var payload providerUpdatePayload
+	require.NoError(t, sonic.Unmarshal([]byte(body), &payload))
+	var fields map[string]json.RawMessage
+	require.NoError(t, sonic.Unmarshal([]byte(body), &fields))
+	return &payload, fields
+}
+
+func savedConfig() configstore.ProviderConfig {
+	return configstore.ProviderConfig{
+		ProxyConfig:          &schemas.ProxyConfig{Type: schemas.HTTPProxy},
+		CustomProviderConfig: &schemas.CustomProviderConfig{BaseProviderType: schemas.Anthropic},
+		OpenAIConfig:         &schemas.OpenAIConfig{DisableStore: true},
+		PromptCache:          &schemas.PromptCacheConfig{AutoInject: true, TTL: schemas.Ptr("1h")},
+	}
+}
+
+func TestApplyProviderConfigUpdates_OmittedBlocksArePreserved(t *testing.T) {
+	config := savedConfig()
+	// The shape an older client sends: it knows nothing of these blocks.
+	payload, fields := decodeUpdate(t, `{"network_config":{},"concurrency_and_buffer_size":{"concurrency":1,"buffer_size":2}}`)
+
+	applyProviderConfigUpdates(&config, payload, fields)
+
+	assert.NotNil(t, config.ProxyConfig, "an omitted proxy_config must survive an unrelated update")
+	assert.NotNil(t, config.CustomProviderConfig, "an omitted custom_provider_config must survive")
+	assert.NotNil(t, config.OpenAIConfig, "an omitted openai_config must survive")
+	require.NotNil(t, config.PromptCache, "an omitted prompt_cache must survive")
+	assert.True(t, config.PromptCache.AutoInject)
+	require.NotNil(t, config.PromptCache.TTL)
+	assert.Equal(t, "1h", *config.PromptCache.TTL)
+}
+
+func TestApplyProviderConfigUpdates_ExplicitNullClears(t *testing.T) {
+	config := savedConfig()
+	payload, fields := decodeUpdate(t, `{"proxy_config":null,"custom_provider_config":null,"openai_config":null,"prompt_cache":null}`)
+
+	applyProviderConfigUpdates(&config, payload, fields)
+
+	assert.Nil(t, config.ProxyConfig, "an explicit null is how a block is cleared")
+	assert.Nil(t, config.CustomProviderConfig)
+	assert.Nil(t, config.OpenAIConfig)
+	assert.Nil(t, config.PromptCache)
+}
+
+func TestApplyProviderConfigUpdates_PresentBlocksAreReplaced(t *testing.T) {
+	config := savedConfig()
+	payload, fields := decodeUpdate(t, `{"prompt_cache":{"auto_inject":false}}`)
+
+	applyProviderConfigUpdates(&config, payload, fields)
+
+	require.NotNil(t, config.PromptCache)
+	assert.False(t, config.PromptCache.AutoInject, "a supplied block replaces the saved one wholesale")
+	assert.Nil(t, config.PromptCache.TTL, "replacement is not a field-level merge")
+	assert.NotNil(t, config.ProxyConfig, "the blocks this request did not mention are untouched")
+}

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -4,6 +4,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -144,6 +145,43 @@ type providerUpdatePayload struct {
 	CustomProviderConfig     *schemas.CustomProviderConfig    `json:"custom_provider_config,omitempty"`
 	OpenAIConfig             *schemas.OpenAIConfig            `json:"openai_config,omitempty"` // OpenAI-specific configuration
 	PromptCache              *schemas.PromptCacheConfig       `json:"prompt_cache,omitempty"`  // Prompt-cache breakpoint injection
+}
+
+// applyProviderConfigUpdates copies onto config only the nested config blocks the
+// request actually carried, leaving the rest as they were saved.
+//
+// PUT on this endpoint is a partial update. These blocks were added to the payload one
+// release at a time, so a client written against an earlier shape simply does not send
+// the newer ones; assigning unconditionally erased whichever blocks that client had
+// never heard of, on every unrelated update. Omission means "leave this alone".
+//
+// An explicit null still clears a block, which is why presence is read from the raw
+// body rather than inferred from a nil pointer: both decode to nil, and only one of
+// them is a request to delete anything.
+//
+// Replacement stays wholesale. A supplied block overwrites the saved one entirely
+// rather than merging field by field, so clearing one setting inside a block does not
+// require a separate delete verb.
+//
+// Split out of the update handler so this rule is testable without standing up a
+// router and a store.
+func applyProviderConfigUpdates(config *configstore.ProviderConfig, payload *providerUpdatePayload, bodyFields map[string]json.RawMessage) {
+	carried := func(field string) bool {
+		_, ok := bodyFields[field]
+		return ok
+	}
+	if carried("proxy_config") {
+		config.ProxyConfig = payload.ProxyConfig
+	}
+	if carried("custom_provider_config") {
+		config.CustomProviderConfig = payload.CustomProviderConfig
+	}
+	if carried("openai_config") {
+		config.OpenAIConfig = payload.OpenAIConfig
+	}
+	if carried("prompt_cache") {
+		config.PromptCache = payload.PromptCache
+	}
 }
 
 // RegisterRoutes registers all provider management routes
@@ -348,6 +386,13 @@ func (h *ProviderHandler) addProvider(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid custom provider config: %v", err))
 		return
 	}
+	// The config-file path validates prompt_cache against config.schema.json; this is the
+	// same contract on the API path, so a TTL the file would reject cannot be stored here
+	// and then rejected by the provider at request time instead.
+	if err := lib.ValidatePromptCache(config.PromptCache); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid prompt cache config: %v", err))
+		return
+	}
 	// Add provider to store (env vars will be processed by store)
 	if err := h.inMemoryStore.AddProvider(ctx, payload.Provider, config); err != nil {
 		logger.Warn("Failed to add provider %s: %v", payload.Provider, err)
@@ -417,6 +462,16 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 	}{}
 
 	if err := sonic.Unmarshal(ctx.PostBody(), &payload); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "Invalid request payload")
+		return
+	}
+
+	// Which top-level keys the body actually carried. A nested config block decodes to
+	// nil both when it is omitted and when it is explicitly null, and those are
+	// different requests: omitting means "leave this alone", null means "clear it".
+	// Only a second pass over the raw body can tell them apart.
+	var bodyFields map[string]json.RawMessage
+	if err := sonic.Unmarshal(ctx.PostBody(), &bodyFields); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Invalid request payload")
 		return
 	}
@@ -498,6 +553,10 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid custom provider config: %v", err))
 		return
 	}
+	if err := lib.ValidatePromptCache(payload.PromptCache); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid prompt cache config: %v", err))
+		return
+	}
 
 	nc := payload.NetworkConfig
 
@@ -537,10 +596,7 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 		}
 	}
 
-	config.ProxyConfig = payload.ProxyConfig
-	config.CustomProviderConfig = payload.CustomProviderConfig
-	config.OpenAIConfig = payload.OpenAIConfig
-	config.PromptCache = payload.PromptCache
+	applyProviderConfigUpdates(&config, &payload.providerUpdatePayload, bodyFields)
 	if payload.SendBackRawRequest != nil {
 		config.SendBackRawRequest = *payload.SendBackRawRequest
 	}

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -102,6 +102,7 @@ type ProviderResponse struct {
 	StoreRawRequestResponse  bool                             `json:"store_raw_request_response"`       // Capture raw request/response for internal logging only
 	CustomProviderConfig     *schemas.CustomProviderConfig    `json:"custom_provider_config,omitempty"` // Custom provider configuration
 	OpenAIConfig             *schemas.OpenAIConfig            `json:"openai_config,omitempty"`          // OpenAI-specific configuration
+	PromptCache              *schemas.PromptCacheConfig       `json:"prompt_cache,omitempty"`           // Prompt-cache breakpoint injection
 	ProviderStatus           ProviderStatus                   `json:"provider_status"`                  // Health/initialization status of the provider
 	Status                   string                           `json:"status,omitempty"`                 // Operational status (e.g., list_models_failed)
 	Description              string                           `json:"description,omitempty"`            // Error/status description
@@ -130,6 +131,7 @@ type providerCreatePayload struct {
 	StoreRawRequestResponse  *bool                             `json:"store_raw_request_response,omitempty"`
 	CustomProviderConfig     *schemas.CustomProviderConfig     `json:"custom_provider_config,omitempty"`
 	OpenAIConfig             *schemas.OpenAIConfig             `json:"openai_config,omitempty"` // OpenAI-specific configuration
+	PromptCache              *schemas.PromptCacheConfig        `json:"prompt_cache,omitempty"`  // Prompt-cache breakpoint injection
 }
 
 type providerUpdatePayload struct {
@@ -141,6 +143,7 @@ type providerUpdatePayload struct {
 	StoreRawRequestResponse  *bool                            `json:"store_raw_request_response,omitempty"`
 	CustomProviderConfig     *schemas.CustomProviderConfig    `json:"custom_provider_config,omitempty"`
 	OpenAIConfig             *schemas.OpenAIConfig            `json:"openai_config,omitempty"` // OpenAI-specific configuration
+	PromptCache              *schemas.PromptCacheConfig       `json:"prompt_cache,omitempty"`  // Prompt-cache breakpoint injection
 }
 
 // RegisterRoutes registers all provider management routes
@@ -338,6 +341,7 @@ func (h *ProviderHandler) addProvider(ctx *fasthttp.RequestCtx) {
 		StoreRawRequestResponse:  payload.StoreRawRequestResponse != nil && *payload.StoreRawRequestResponse,
 		CustomProviderConfig:     payload.CustomProviderConfig,
 		OpenAIConfig:             payload.OpenAIConfig,
+		PromptCache:              payload.PromptCache,
 	}
 	// Validate custom provider configuration before persisting
 	if err := lib.ValidateCustomProvider(config, payload.Provider); err != nil {
@@ -380,6 +384,8 @@ func (h *ProviderHandler) addProvider(ctx *fasthttp.RequestCtx) {
 			SendBackRawResponse:      config.SendBackRawResponse,
 			StoreRawRequestResponse:  config.StoreRawRequestResponse,
 			CustomProviderConfig:     config.CustomProviderConfig,
+			OpenAIConfig:             config.OpenAIConfig,
+			PromptCache:              config.PromptCache,
 			Status:                   config.Status,
 			Description:              config.Description,
 		}, ProviderStatusActive)
@@ -465,6 +471,7 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 		ProxyConfig:              oldConfigRaw.ProxyConfig,
 		CustomProviderConfig:     oldConfigRaw.CustomProviderConfig,
 		OpenAIConfig:             oldConfigRaw.OpenAIConfig,
+		PromptCache:              oldConfigRaw.PromptCache,
 		StoreRawRequestResponse:  oldConfigRaw.StoreRawRequestResponse,
 		Status:                   oldConfigRaw.Status,
 		Description:              oldConfigRaw.Description,
@@ -533,6 +540,7 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 	config.ProxyConfig = payload.ProxyConfig
 	config.CustomProviderConfig = payload.CustomProviderConfig
 	config.OpenAIConfig = payload.OpenAIConfig
+	config.PromptCache = payload.PromptCache
 	if payload.SendBackRawRequest != nil {
 		config.SendBackRawRequest = *payload.SendBackRawRequest
 	}
@@ -601,6 +609,8 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 			SendBackRawResponse:      config.SendBackRawResponse,
 			StoreRawRequestResponse:  config.StoreRawRequestResponse,
 			CustomProviderConfig:     config.CustomProviderConfig,
+			OpenAIConfig:             config.OpenAIConfig,
+			PromptCache:              config.PromptCache,
 			Status:                   config.Status,
 			Description:              config.Description,
 		}, ProviderStatusActive)
@@ -1399,6 +1409,7 @@ func (h *ProviderHandler) getProviderResponseFromConfig(provider schemas.ModelPr
 		StoreRawRequestResponse:  config.StoreRawRequestResponse,
 		CustomProviderConfig:     config.CustomProviderConfig,
 		OpenAIConfig:             config.OpenAIConfig,
+		PromptCache:              config.PromptCache,
 		ProviderStatus:           status,
 		Status:                   config.Status,
 		Description:              config.Description,

--- a/transports/bifrost-http/lib/account.go
+++ b/transports/bifrost-http/lib/account.go
@@ -101,5 +101,8 @@ func (baseAccount *BaseAccount) GetConfigForProvider(providerKey schemas.ModelPr
 	if config.OpenAIConfig != nil {
 		providerConfig.OpenAIConfig = config.OpenAIConfig
 	}
+	if config.PromptCache != nil {
+		providerConfig.PromptCache = config.PromptCache
+	}
 	return providerConfig, nil
 }

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -7525,6 +7525,53 @@ func ValidateCustomProvider(config configstore.ProviderConfig, provider schemas.
 	return nil
 }
 
+// PromptCacheTTLExtended is the only explicit prompt-cache TTL the gateway accepts.
+// It mirrors the enum on prompt_cache.ttl in config.schema.json.
+const PromptCacheTTLExtended = "1h"
+
+// promptCacheInjectionRoles mirrors the role enum on cache_control_injection_point in
+// config.schema.json. TestValidatePromptCachePointEnumsMatchConfigSchema keeps the two
+// in step.
+var promptCacheInjectionRoles = []string{"system", "developer", "user", "assistant"}
+
+// ValidatePromptCache validates the prompt-cache configuration arriving over the
+// management API.
+//
+// The config-file path is checked against config.schema.json, which declares
+// prompt_cache.ttl as an enum. The API path had no equivalent check, so the same field
+// carried two different contracts depending on which door it came through: a TTL the
+// file would reject was stored and then forwarded verbatim as cache_control.ttl,
+// surfacing as a provider 400 at request time rather than a rejected config write.
+// TestValidatePromptCacheMatchesConfigSchemaEnum keeps the two doors in sync.
+//
+// Omitting ttl (nil) is how a caller asks for the provider default. An explicit empty
+// string is not the same request and is rejected rather than silently treated as one.
+func ValidatePromptCache(cfg *schemas.PromptCacheConfig) error {
+	if cfg == nil {
+		return nil
+	}
+	if cfg.TTL != nil && *cfg.TTL != PromptCacheTTLExtended {
+		return fmt.Errorf("prompt cache validation failed: unsupported ttl %q (supported: %q, or omit ttl for the provider default)", *cfg.TTL, PromptCacheTTLExtended)
+	}
+	for i, point := range cfg.InjectionPoints {
+		// Location is optional in the schema, so only a value that is present and
+		// outside the enum is a violation.
+		if point.Location != "" && point.Location != schemas.CacheControlInjectionLocationMessage {
+			return fmt.Errorf("prompt cache validation failed: injection point %d has unsupported location %q (supported: %q)",
+				i, point.Location, schemas.CacheControlInjectionLocationMessage)
+		}
+		if point.Role != nil && !slices.Contains(promptCacheInjectionRoles, *point.Role) {
+			return fmt.Errorf("prompt cache validation failed: injection point %d has unsupported role %q (supported: %s)",
+				i, *point.Role, strings.Join(promptCacheInjectionRoles, ", "))
+		}
+	}
+	// Deliberately unchecked: the count of injection points, since config.schema.json
+	// declares no maxItems and the injector clamps emitted markers at four on its own;
+	// and a point carrying neither role nor index, which matchMessageIndices documents
+	// as matching nothing on purpose rather than as a misconfiguration to reject.
+	return nil
+}
+
 // ValidateCustomProviderUpdate validates that immutable fields in CustomProviderConfig are not changed during updates
 func ValidateCustomProviderUpdate(newConfig, existingConfig configstore.ProviderConfig, provider schemas.ModelProvider) error {
 	// If neither config has CustomProviderConfig, no validation needed

--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -229,6 +229,7 @@ func ResolveSessionIDFromRequest(h *fasthttp.RequestHeader) string {
 //
 // 9. Raw Capture Headers (per-request override of provider config; accepts "true" or "false"):
 //   - x-bf-send-back-raw-request: include raw provider request in the BifrostResponse returned to the caller
+//   - x-bf-prompt-cache-auto-inject: override prompt_cache.auto_inject for this request
 //   - x-bf-send-back-raw-response: include raw provider response in the BifrostResponse returned to the caller
 //   - x-bf-store-raw-request-response: capture raw request/response for logging only (stripped from client response)
 
@@ -629,6 +630,16 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, store HandlerStore) (*sch
 		if keyStr == "x-bf-send-back-raw-request" {
 			if b, err := strconv.ParseBool(string(value)); err == nil {
 				bifrostCtx.SetValue(schemas.BifrostContextKeySendBackRawRequest, b)
+			}
+			return true
+		}
+		// Per-request override of prompt_cache.auto_inject. Fully overrides the
+		// provider config for this request in both directions, so a caller can opt a
+		// single request in without changing config, or opt one out when the provider
+		// has it on. The model capability gate still applies.
+		if keyStr == "x-bf-prompt-cache-auto-inject" {
+			if b, err := strconv.ParseBool(string(value)); err == nil {
+				bifrostCtx.SetValue(schemas.BifrostContextKeyPromptCacheAutoInject, b)
 			}
 			return true
 		}

--- a/transports/bifrost-http/lib/promptcachevalidation_test.go
+++ b/transports/bifrost-http/lib/promptcachevalidation_test.go
@@ -1,0 +1,126 @@
+package lib
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidatePromptCacheTTL(t *testing.T) {
+	assert.NoError(t, ValidatePromptCache(nil), "no prompt_cache block is not a misconfiguration")
+	assert.NoError(t, ValidatePromptCache(&schemas.PromptCacheConfig{AutoInject: true}),
+		"an absent TTL means the provider default")
+	assert.NoError(t, ValidatePromptCache(&schemas.PromptCacheConfig{TTL: schemas.Ptr("1h")}))
+
+	for _, bad := range []string{"42m", "5 minutes", "1H", "3600", ""} {
+		assert.Error(t, ValidatePromptCache(&schemas.PromptCacheConfig{TTL: schemas.Ptr(bad)}),
+			"expected TTL %q to be rejected before it reaches the provider", bad)
+	}
+}
+
+// The config file and the management API are two doors onto the same field, and only
+// the file had a contract in front of it. This pins them together: whatever
+// config.schema.json declares for prompt_cache.ttl is exactly what the API accepts, so
+// the two cannot drift apart silently.
+func TestValidatePromptCacheMatchesConfigSchemaEnum(t *testing.T) {
+	var schema struct {
+		Defs struct {
+			PromptCache struct {
+				Properties struct {
+					TTL struct {
+						Enum []string `json:"enum"`
+					} `json:"ttl"`
+				} `json:"properties"`
+			} `json:"prompt_cache"`
+		} `json:"$defs"`
+	}
+	require.NoError(t, json.Unmarshal(loadLocalSchema(t), &schema))
+
+	allowed := schema.Defs.PromptCache.Properties.TTL.Enum
+	require.NotEmpty(t, allowed, "config.schema.json must declare an enum for prompt_cache.ttl")
+
+	for _, ttl := range allowed {
+		assert.NoError(t, ValidatePromptCache(&schemas.PromptCacheConfig{TTL: schemas.Ptr(ttl)}),
+			"schema declares %q valid, so the API must accept it", ttl)
+	}
+	assert.Error(t, ValidatePromptCache(&schemas.PromptCacheConfig{TTL: schemas.Ptr("not-in-the-enum")}),
+		"a value the schema rejects must not pass the API")
+}
+
+// An injection point whose location or role falls outside the schema's enums is not
+// rejected at runtime, it silently matches nothing (matchMessageIndices in
+// core/providers/utils/promptcache.go). A typo like "messages" or "sytem" is therefore
+// stored, reported back as saved, and quietly never fires. The config-file path already
+// rejects both; the API path must agree.
+func TestValidatePromptCacheInjectionPoints(t *testing.T) {
+	point := func(location string, role *string) *schemas.PromptCacheConfig {
+		return &schemas.PromptCacheConfig{
+			InjectionPoints: []schemas.CacheControlInjectionPoint{
+				{Location: location, Role: role, Index: schemas.Ptr(0)},
+			},
+		}
+	}
+
+	assert.NoError(t, ValidatePromptCache(point("message", nil)))
+	assert.NoError(t, ValidatePromptCache(point("", nil)),
+		"location is optional in the schema, so an absent one is not a violation")
+	for _, role := range []string{"system", "developer", "user", "assistant"} {
+		assert.NoError(t, ValidatePromptCache(point("message", schemas.Ptr(role))), "role %q is in the schema enum", role)
+	}
+
+	assert.Error(t, ValidatePromptCache(point("messages", nil)), "a near-miss location must not be stored silently")
+	assert.Error(t, ValidatePromptCache(point("tools", nil)), "only message targets exist today")
+	assert.Error(t, ValidatePromptCache(point("message", schemas.Ptr("sytem"))), "a misspelled role must not be stored silently")
+	assert.Error(t, ValidatePromptCache(point("message", schemas.Ptr("tool"))), "tool is not one of the four roles")
+
+	// Deliberately NOT rejected: the schema declares no maxItems, and the injector caps
+	// emitted markers at four on its own. Nor is a point with neither role nor index,
+	// which matchMessageIndices documents as matching nothing on purpose.
+	many := &schemas.PromptCacheConfig{}
+	for i := 0; i < 6; i++ {
+		many.InjectionPoints = append(many.InjectionPoints, schemas.CacheControlInjectionPoint{Location: "message", Index: schemas.Ptr(i)})
+	}
+	assert.NoError(t, ValidatePromptCache(many), "the schema sets no maxItems; the injector clamps instead")
+	assert.NoError(t, ValidatePromptCache(&schemas.PromptCacheConfig{
+		InjectionPoints: []schemas.CacheControlInjectionPoint{{Location: "message"}},
+	}), "a point with neither role nor index matches nothing by design, it is not invalid")
+}
+
+// The companion to TestValidatePromptCacheMatchesConfigSchemaEnum, for the injection
+// point enums. Both doors onto these fields must accept the same values.
+func TestValidatePromptCachePointEnumsMatchConfigSchema(t *testing.T) {
+	var schema struct {
+		Defs struct {
+			Point struct {
+				Properties struct {
+					Location struct {
+						Enum []string `json:"enum"`
+					} `json:"location"`
+					Role struct {
+						Enum []string `json:"enum"`
+					} `json:"role"`
+				} `json:"properties"`
+			} `json:"cache_control_injection_point"`
+		} `json:"$defs"`
+	}
+	require.NoError(t, json.Unmarshal(loadLocalSchema(t), &schema))
+
+	locations := schema.Defs.Point.Properties.Location.Enum
+	roles := schema.Defs.Point.Properties.Role.Enum
+	require.NotEmpty(t, locations, "config.schema.json must declare a location enum")
+	require.NotEmpty(t, roles, "config.schema.json must declare a role enum")
+
+	for _, loc := range locations {
+		assert.NoError(t, ValidatePromptCache(&schemas.PromptCacheConfig{
+			InjectionPoints: []schemas.CacheControlInjectionPoint{{Location: loc, Index: schemas.Ptr(0)}},
+		}), "schema declares location %q valid, so the API must accept it", loc)
+	}
+	for _, role := range roles {
+		assert.NoError(t, ValidatePromptCache(&schemas.PromptCacheConfig{
+			InjectionPoints: []schemas.CacheControlInjectionPoint{{Location: "message", Role: schemas.Ptr(role)}},
+		}), "schema declares role %q valid, so the API must accept it", role)
+	}
+}

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1114,6 +1114,9 @@
               },
               "openai_config": {
                 "$ref": "#/$defs/openai_config"
+              },
+              "prompt_cache": {
+                "$ref": "#/$defs/prompt_cache"
               }
             },
             "required": ["name"]
@@ -4390,6 +4393,50 @@
       },
       "additionalProperties": false
     },
+    "cache_control_injection_point": {
+      "type": "object",
+      "description": "One place to add a cache breakpoint. Must set role, index, or both; a point with neither matches nothing.",
+      "properties": {
+        "location": {
+          "type": "string",
+          "enum": ["message"],
+          "description": "What to target. Only conversation messages are supported today."
+        },
+        "role": {
+          "type": "string",
+          "enum": ["system", "developer", "user", "assistant"],
+          "description": "Match messages with this role."
+        },
+        "index": {
+          "type": "integer",
+          "description": "Match the message at this position. Negative values count from the end, so -1 is the last message. An index past either end matches nothing."
+        }
+      },
+      "additionalProperties": false
+    },
+    "prompt_cache": {
+      "type": "object",
+      "description": "Synthesize prompt-cache breakpoints for requests that carry none. Off by default. Agentic clients such as Codex send no cache markers, so providers that cache implicitly slide the cached prefix onto the latest message and bill a cache write every turn. Requests that already carry their own cache_control or prompt_cache_breakpoint are never modified.",
+      "properties": {
+        "auto_inject": {
+          "type": "boolean",
+          "description": "Mark the first cacheable content block. That block is the prefix an agent loop replays verbatim each turn, so the cached region stays stable and turn 2 onward is a cache read."
+        },
+        "ttl": {
+          "type": "string",
+          "enum": ["1h"],
+          "description": "Lifetime for injected markers. Omit for the provider default (5 minutes on Anthropic). Providers that cannot carry a TTL ignore it."
+        },
+        "cache_control_injection_points": {
+          "type": "array",
+          "description": "Target specific messages instead of the first cacheable block. When set, this REPLACES auto_inject rather than adding to it. At most four markers are injected, matching the Anthropic ceiling.",
+          "items": {
+            "$ref": "#/$defs/cache_control_injection_point"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "concurrency_and_buffer_size": {
       "type": "object",
       "properties": {
@@ -5059,6 +5106,9 @@
         },
         "openai_config": {
           "$ref": "#/$defs/openai_config"
+        },
+        "prompt_cache": {
+          "$ref": "#/$defs/prompt_cache"
         },
         "network_config": {
           "$ref": "#/$defs/network_config"

--- a/ui/app/workspace/providers/dialogs/providerConfigSheet.tsx
+++ b/ui/app/workspace/providers/dialogs/providerConfigSheet.tsx
@@ -12,6 +12,7 @@ import {
 	ProxyFormFragment,
 } from "../fragments";
 import { DebuggingFormFragment } from "../fragments/debuggingFormFragment";
+import { PromptCacheFormFragment } from "../fragments/promptCacheFormFragment";
 import { NetworkFormFragment } from "../fragments/networkFormFragment";
 import { PerformanceFormFragment } from "../fragments/performanceFormFragment";
 
@@ -55,6 +56,10 @@ const availableTabs = (hasCustomProviderConfig: boolean, hasGovernanceAccess: bo
 			label: "Beta Headers",
 		});
 	}
+	tabs.push({
+		id: "prompt-cache",
+		label: "Prompt Caching",
+	});
 	tabs.push({
 		id: "debugging",
 		label: "Debugging",
@@ -146,6 +151,9 @@ export default function ProviderConfigSheet({ show, onCancel, provider }: Props)
 							</TabsContent>
 							<TabsContent value="beta-headers">
 								<BetaHeadersFormFragment provider={provider} />
+							</TabsContent>
+							<TabsContent value="prompt-cache">
+								<PromptCacheFormFragment provider={provider} />
 							</TabsContent>
 							<TabsContent value="debugging">
 								<DebuggingFormFragment provider={provider} />

--- a/ui/app/workspace/providers/fragments/index.ts
+++ b/ui/app/workspace/providers/fragments/index.ts
@@ -7,5 +7,6 @@ export { GovernanceFormFragment } from "./governanceFormFragment";
 export { OpenAIConfigFormFragment } from "./openaiConfigFormFragment";
 export { NetworkFormFragment } from "./networkFormFragment";
 export { PerformanceFormFragment } from "./performanceFormFragment";
+export { PromptCacheFormFragment } from "./promptCacheFormFragment";
 export { PerformanceFormFragment as PerformanceTab } from "./performanceFormFragment";
 export { ProxyFormFragment } from "./proxyFormFragment";

--- a/ui/app/workspace/providers/fragments/promptCacheFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/promptCacheFormFragment.tsx
@@ -47,8 +47,6 @@ export function PromptCacheFormFragment({ provider }: PromptCacheFormFragmentPro
 		name: "cache_control_injection_points",
 	});
 
-	const autoInject = form.watch("auto_inject");
-
 	useEffect(() => {
 		dispatch(setProviderFormDirtyState(form.formState.isDirty));
 	}, [form.formState.isDirty, dispatch]);
@@ -94,10 +92,10 @@ export function PromptCacheFormFragment({ provider }: PromptCacheFormFragmentPro
 									<div className="space-y-0.5">
 										<FormLabel>Auto-inject cache breakpoints</FormLabel>
 										<p className="text-muted-foreground text-xs">
-											Agentic clients such as Codex send no cache markers, so the cached prefix follows the newest message and every
-											turn is billed as a cache write. Turning this on marks the first cacheable block instead, which keeps the cached
-											region stable so turn 2 onward is a cache read. Requests that already carry their own cache markers are never
-											modified, and models without explicit caching are left alone.
+											Agentic clients such as Codex send no cache markers, so the cached prefix follows the newest message and every turn is
+											billed as a cache write. Turning this on marks the first cacheable block instead, which keeps the cached region stable
+											so turn 2 onward is a cache read. Requests that already carry their own cache markers are never modified, and models
+											without explicit caching are left alone.
 										</p>
 									</div>
 									<FormControl>
@@ -118,122 +116,117 @@ export function PromptCacheFormFragment({ provider }: PromptCacheFormFragmentPro
 						)}
 					/>
 
-					{autoInject && (
-						<>
-							<FormField
-								control={form.control}
-								name="ttl"
-								render={({ field }) => (
-									<FormItem>
-										<FormLabel>Cache TTL</FormLabel>
-										<Select value={field.value ?? TTL_DEFAULT} onValueChange={field.onChange} disabled={!hasUpdateProviderAccess}>
+					<FormField
+						control={form.control}
+						name="ttl"
+						render={({ field }) => (
+							<FormItem>
+								<FormLabel>Cache TTL</FormLabel>
+								<Select value={field.value ?? TTL_DEFAULT} onValueChange={field.onChange} disabled={!hasUpdateProviderAccess}>
+									<FormControl>
+										<SelectTrigger data-testid="provider-prompt-cache-ttl-select" className="w-56">
+											<SelectValue />
+										</SelectTrigger>
+									</FormControl>
+									<SelectContent>
+										<SelectItem value={TTL_DEFAULT}>Provider default (5 minutes)</SelectItem>
+										<SelectItem value="1h">1 hour</SelectItem>
+									</SelectContent>
+								</Select>
+								<p className="text-muted-foreground text-xs">
+									A longer TTL costs more per cache write but survives gaps between turns. Providers that cannot carry a TTL ignore this.
+								</p>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+
+					<div className="space-y-3">
+						<div className="space-y-0.5">
+							<FormLabel>Injection points</FormLabel>
+							<p className="text-muted-foreground text-xs">
+								Optional. Target specific messages instead of the first cacheable block. Adding any point{" "}
+								<span className="font-medium">replaces</span> the default strategy rather than adding to it. Each point needs a role, an
+								index, or both. At most four markers are injected, matching the provider ceiling.
+							</p>
+						</div>
+
+						{fields.map((row, index) => (
+							<div key={row.id} className="flex items-end gap-2" data-testid={`provider-prompt-cache-point-${index}`}>
+								<FormField
+									control={form.control}
+									name={`cache_control_injection_points.${index}.role`}
+									render={({ field }) => (
+										<FormItem className="flex-1">
+											<FormLabel className="text-xs">Role</FormLabel>
+											<Select
+												value={field.value ?? ""}
+												onValueChange={(v) => field.onChange(v === "" ? undefined : v)}
+												disabled={!hasUpdateProviderAccess}
+											>
+												<FormControl>
+													<SelectTrigger>
+														<SelectValue placeholder="Any role" />
+													</SelectTrigger>
+												</FormControl>
+												<SelectContent>
+													{ROLES.map((role) => (
+														<SelectItem key={role} value={role}>
+															{role}
+														</SelectItem>
+													))}
+												</SelectContent>
+											</Select>
+										</FormItem>
+									)}
+								/>
+								<FormField
+									control={form.control}
+									name={`cache_control_injection_points.${index}.index`}
+									render={({ field }) => (
+										<FormItem className="flex-1">
+											<FormLabel className="text-xs">Index</FormLabel>
 											<FormControl>
-												<SelectTrigger data-testid="provider-prompt-cache-ttl-select" className="w-56">
-													<SelectValue />
-												</SelectTrigger>
+												<Input
+													type="number"
+													placeholder="e.g. -1 for last"
+													value={field.value ?? ""}
+													disabled={!hasUpdateProviderAccess}
+													onChange={(e) => field.onChange(e.target.value === "" ? undefined : Number(e.target.value))}
+												/>
 											</FormControl>
-											<SelectContent>
-												<SelectItem value={TTL_DEFAULT}>Provider default (5 minutes)</SelectItem>
-												<SelectItem value="1h">1 hour</SelectItem>
-											</SelectContent>
-										</Select>
-										<p className="text-muted-foreground text-xs">
-											A longer TTL costs more per cache write but survives gaps between turns. Providers that cannot carry a TTL ignore
-											this.
-										</p>
-										<FormMessage />
-									</FormItem>
-								)}
-							/>
-
-							<div className="space-y-3">
-								<div className="space-y-0.5">
-									<FormLabel>Injection points</FormLabel>
-									<p className="text-muted-foreground text-xs">
-										Optional. Target specific messages instead of the first cacheable block. Adding any point{" "}
-										<span className="font-medium">replaces</span> the default strategy rather than adding to it. Each point needs a role,
-										an index, or both. At most four markers are injected, matching the provider ceiling.
-									</p>
-								</div>
-
-								{fields.map((row, index) => (
-									<div key={row.id} className="flex items-end gap-2" data-testid={`provider-prompt-cache-point-${index}`}>
-										<FormField
-											control={form.control}
-											name={`cache_control_injection_points.${index}.role`}
-											render={({ field }) => (
-												<FormItem className="flex-1">
-													<FormLabel className="text-xs">Role</FormLabel>
-													<Select
-														value={field.value ?? ""}
-														onValueChange={(v) => field.onChange(v === "" ? undefined : v)}
-														disabled={!hasUpdateProviderAccess}
-													>
-														<FormControl>
-															<SelectTrigger>
-																<SelectValue placeholder="Any role" />
-															</SelectTrigger>
-														</FormControl>
-														<SelectContent>
-															{ROLES.map((role) => (
-																<SelectItem key={role} value={role}>
-																	{role}
-																</SelectItem>
-															))}
-														</SelectContent>
-													</Select>
-												</FormItem>
-											)}
-										/>
-										<FormField
-											control={form.control}
-											name={`cache_control_injection_points.${index}.index`}
-											render={({ field }) => (
-												<FormItem className="flex-1">
-													<FormLabel className="text-xs">Index</FormLabel>
-													<FormControl>
-														<Input
-															type="number"
-															placeholder="e.g. -1 for last"
-															value={field.value ?? ""}
-															disabled={!hasUpdateProviderAccess}
-															onChange={(e) => field.onChange(e.target.value === "" ? undefined : Number(e.target.value))}
-														/>
-													</FormControl>
-												</FormItem>
-											)}
-										/>
-										<Button
-											type="button"
-											variant="outline"
-											size="icon"
-											disabled={!hasUpdateProviderAccess}
-											onClick={() => remove(index)}
-											data-testid={`provider-prompt-cache-point-remove-${index}`}
-										>
-											<Trash2 className="h-4 w-4" />
-										</Button>
-									</div>
-								))}
-
-								{form.formState.errors.cache_control_injection_points && (
-									<p className="text-destructive text-xs">Each point needs a role, an index, or both.</p>
-								)}
-
+										</FormItem>
+									)}
+								/>
 								<Button
 									type="button"
 									variant="outline"
-									size="sm"
+									size="icon"
 									disabled={!hasUpdateProviderAccess}
-									onClick={() => append({ location: "message", role: undefined, index: undefined })}
-									data-testid="provider-prompt-cache-point-add"
+									onClick={() => remove(index)}
+									data-testid={`provider-prompt-cache-point-remove-${index}`}
 								>
-									<Plus className="mr-1 h-4 w-4" />
-									Add injection point
+									<Trash2 className="h-4 w-4" />
 								</Button>
 							</div>
-						</>
-					)}
+						))}
+
+						{form.formState.errors.cache_control_injection_points && (
+							<p className="text-destructive text-xs">Each point needs a role, an index, or both.</p>
+						)}
+
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							disabled={!hasUpdateProviderAccess}
+							onClick={() => append({ location: "message", role: undefined, index: undefined })}
+							data-testid="provider-prompt-cache-point-add"
+						>
+							<Plus className="mr-1 h-4 w-4" />
+							Add injection point
+						</Button>
+					</div>
 				</div>
 
 				<div className="flex justify-end space-x-2 pb-6">

--- a/ui/app/workspace/providers/fragments/promptCacheFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/promptCacheFormFragment.tsx
@@ -1,0 +1,251 @@
+import { Button } from "@/components/ui/button";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { getErrorMessage, setProviderFormDirtyState, useAppDispatch } from "@/lib/store";
+import { useUpdateProviderMutation } from "@/lib/store/apis/providersApi";
+import type { CacheControlInjectionPoint, ModelProvider } from "@/lib/types/config";
+import { promptCacheFormSchema, type PromptCacheFormSchema } from "@/lib/types/schemas";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Plus, Trash2 } from "lucide-react";
+import { useEffect } from "react";
+import { useFieldArray, useForm, type Resolver } from "react-hook-form";
+import { toast } from "sonner";
+import { buildProviderUpdatePayload } from "../views/utils";
+
+interface PromptCacheFormFragmentProps {
+	provider: ModelProvider;
+}
+
+// Sentinel for "no TTL set", since a Select cannot hold undefined as a value.
+const TTL_DEFAULT = "default";
+
+const ROLES = ["system", "developer", "user", "assistant"] as const;
+
+const toFormValues = (provider: ModelProvider): PromptCacheFormSchema => ({
+	auto_inject: provider.prompt_cache?.auto_inject ?? false,
+	ttl: provider.prompt_cache?.ttl ?? TTL_DEFAULT,
+	cache_control_injection_points: provider.prompt_cache?.cache_control_injection_points ?? [],
+});
+
+export function PromptCacheFormFragment({ provider }: PromptCacheFormFragmentProps) {
+	const dispatch = useAppDispatch();
+	const hasUpdateProviderAccess = useRbac(RbacResource.ModelProvider, RbacOperation.Update);
+	const [updateProvider, { isLoading: isUpdatingProvider }] = useUpdateProviderMutation();
+
+	const form = useForm<PromptCacheFormSchema, any, PromptCacheFormSchema>({
+		resolver: zodResolver(promptCacheFormSchema) as Resolver<PromptCacheFormSchema, any, PromptCacheFormSchema>,
+		mode: "onChange",
+		reValidateMode: "onChange",
+		defaultValues: toFormValues(provider),
+	});
+
+	const { fields, append, remove } = useFieldArray({
+		control: form.control,
+		name: "cache_control_injection_points",
+	});
+
+	const autoInject = form.watch("auto_inject");
+
+	useEffect(() => {
+		dispatch(setProviderFormDirtyState(form.formState.isDirty));
+	}, [form.formState.isDirty, dispatch]);
+
+	useEffect(() => {
+		form.reset(toFormValues(provider));
+	}, [form, provider.name, provider.prompt_cache]);
+
+	const onSubmit = (data: PromptCacheFormSchema) => {
+		const points = (data.cache_control_injection_points ?? []) as CacheControlInjectionPoint[];
+		updateProvider(
+			buildProviderUpdatePayload(provider, {
+				prompt_cache: {
+					auto_inject: data.auto_inject,
+					// Send nothing rather than the sentinel, so the provider default applies.
+					ttl: data.ttl === TTL_DEFAULT ? undefined : data.ttl,
+					cache_control_injection_points: points.length > 0 ? points : undefined,
+				},
+			}),
+		)
+			.unwrap()
+			.then(() => {
+				toast.success("Prompt caching updated successfully");
+				form.reset(data);
+			})
+			.catch((err) => {
+				toast.error("Failed to update prompt caching", {
+					description: getErrorMessage(err),
+				});
+			});
+	};
+
+	return (
+		<Form {...form}>
+			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 px-4 md:px-6" data-testid="provider-config-prompt-cache-content">
+				<div className="space-y-4">
+					<FormField
+						control={form.control}
+						name="auto_inject"
+						render={({ field }) => (
+							<FormItem>
+								<div className="flex items-center justify-between space-x-2">
+									<div className="space-y-0.5">
+										<FormLabel>Auto-inject cache breakpoints</FormLabel>
+										<p className="text-muted-foreground text-xs">
+											Agentic clients such as Codex send no cache markers, so the cached prefix follows the newest message and every
+											turn is billed as a cache write. Turning this on marks the first cacheable block instead, which keeps the cached
+											region stable so turn 2 onward is a cache read. Requests that already carry their own cache markers are never
+											modified, and models without explicit caching are left alone.
+										</p>
+									</div>
+									<FormControl>
+										<Switch
+											data-testid="provider-prompt-cache-auto-inject-switch"
+											size="md"
+											checked={field.value}
+											disabled={!hasUpdateProviderAccess}
+											onCheckedChange={(checked) => {
+												field.onChange(checked);
+												form.trigger("auto_inject");
+											}}
+										/>
+									</FormControl>
+								</div>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+
+					{autoInject && (
+						<>
+							<FormField
+								control={form.control}
+								name="ttl"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>Cache TTL</FormLabel>
+										<Select value={field.value ?? TTL_DEFAULT} onValueChange={field.onChange} disabled={!hasUpdateProviderAccess}>
+											<FormControl>
+												<SelectTrigger data-testid="provider-prompt-cache-ttl-select" className="w-56">
+													<SelectValue />
+												</SelectTrigger>
+											</FormControl>
+											<SelectContent>
+												<SelectItem value={TTL_DEFAULT}>Provider default (5 minutes)</SelectItem>
+												<SelectItem value="1h">1 hour</SelectItem>
+											</SelectContent>
+										</Select>
+										<p className="text-muted-foreground text-xs">
+											A longer TTL costs more per cache write but survives gaps between turns. Providers that cannot carry a TTL ignore
+											this.
+										</p>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+
+							<div className="space-y-3">
+								<div className="space-y-0.5">
+									<FormLabel>Injection points</FormLabel>
+									<p className="text-muted-foreground text-xs">
+										Optional. Target specific messages instead of the first cacheable block. Adding any point{" "}
+										<span className="font-medium">replaces</span> the default strategy rather than adding to it. Each point needs a role,
+										an index, or both. At most four markers are injected, matching the provider ceiling.
+									</p>
+								</div>
+
+								{fields.map((row, index) => (
+									<div key={row.id} className="flex items-end gap-2" data-testid={`provider-prompt-cache-point-${index}`}>
+										<FormField
+											control={form.control}
+											name={`cache_control_injection_points.${index}.role`}
+											render={({ field }) => (
+												<FormItem className="flex-1">
+													<FormLabel className="text-xs">Role</FormLabel>
+													<Select
+														value={field.value ?? ""}
+														onValueChange={(v) => field.onChange(v === "" ? undefined : v)}
+														disabled={!hasUpdateProviderAccess}
+													>
+														<FormControl>
+															<SelectTrigger>
+																<SelectValue placeholder="Any role" />
+															</SelectTrigger>
+														</FormControl>
+														<SelectContent>
+															{ROLES.map((role) => (
+																<SelectItem key={role} value={role}>
+																	{role}
+																</SelectItem>
+															))}
+														</SelectContent>
+													</Select>
+												</FormItem>
+											)}
+										/>
+										<FormField
+											control={form.control}
+											name={`cache_control_injection_points.${index}.index`}
+											render={({ field }) => (
+												<FormItem className="flex-1">
+													<FormLabel className="text-xs">Index</FormLabel>
+													<FormControl>
+														<Input
+															type="number"
+															placeholder="e.g. -1 for last"
+															value={field.value ?? ""}
+															disabled={!hasUpdateProviderAccess}
+															onChange={(e) => field.onChange(e.target.value === "" ? undefined : Number(e.target.value))}
+														/>
+													</FormControl>
+												</FormItem>
+											)}
+										/>
+										<Button
+											type="button"
+											variant="outline"
+											size="icon"
+											disabled={!hasUpdateProviderAccess}
+											onClick={() => remove(index)}
+											data-testid={`provider-prompt-cache-point-remove-${index}`}
+										>
+											<Trash2 className="h-4 w-4" />
+										</Button>
+									</div>
+								))}
+
+								{form.formState.errors.cache_control_injection_points && (
+									<p className="text-destructive text-xs">Each point needs a role, an index, or both.</p>
+								)}
+
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									disabled={!hasUpdateProviderAccess}
+									onClick={() => append({ location: "message", role: undefined, index: undefined })}
+									data-testid="provider-prompt-cache-point-add"
+								>
+									<Plus className="mr-1 h-4 w-4" />
+									Add injection point
+								</Button>
+							</div>
+						</>
+					)}
+				</div>
+
+				<div className="flex justify-end space-x-2 pb-6">
+					<Button
+						type="submit"
+						disabled={!form.formState.isDirty || !form.formState.isValid || !hasUpdateProviderAccess || isUpdatingProvider}
+						isLoading={isUpdatingProvider}
+					>
+						Save Prompt Caching
+					</Button>
+				</div>
+			</form>
+		</Form>
+	);
+}

--- a/ui/app/workspace/providers/views/utils.ts
+++ b/ui/app/workspace/providers/views/utils.ts
@@ -14,5 +14,6 @@ export const buildProviderUpdatePayload = (provider: ModelProvider, updates: Par
 		store_raw_request_response: updates.store_raw_request_response ?? provider.store_raw_request_response,
 		custom_provider_config: updates.custom_provider_config ?? provider.custom_provider_config,
 		openai_config: updates.openai_config ?? provider.openai_config,
+		prompt_cache: updates.prompt_cache ?? provider.prompt_cache,
 	};
 };

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -449,6 +449,24 @@ export interface OpenAIConfig {
 	disable_store?: boolean;
 }
 
+// CacheControlInjectionPoint names one place to add a cache breakpoint.
+// A point must set role, index, or both; a point with neither matches nothing.
+export interface CacheControlInjectionPoint {
+	location: "message";
+	role?: "system" | "developer" | "user" | "assistant";
+	// Negative values count from the end, so -1 is the last message.
+	index?: number;
+}
+
+// PromptCacheConfig opts a provider into synthesizing cache breakpoints for requests
+// that carry none. Off by default; requests that already carry their own markers are
+// never modified.
+export interface PromptCacheConfig {
+	auto_inject?: boolean;
+	ttl?: string;
+	cache_control_injection_points?: CacheControlInjectionPoint[];
+}
+
 // ProviderConfig matching Go's lib.ProviderConfig
 export interface ModelProviderConfig {
 	network_config?: NetworkConfig;
@@ -459,6 +477,7 @@ export interface ModelProviderConfig {
 	store_raw_request_response?: boolean;
 	custom_provider_config?: CustomProviderConfig;
 	openai_config?: OpenAIConfig;
+	prompt_cache?: PromptCacheConfig;
 	status?: "unknown" | "success" | "list_models_failed";
 	description?: string;
 }
@@ -487,6 +506,7 @@ export interface AddProviderRequest {
 	store_raw_request_response?: boolean;
 	custom_provider_config?: CustomProviderConfig;
 	openai_config?: OpenAIConfig;
+	prompt_cache?: PromptCacheConfig;
 }
 
 // UpdateProviderRequest matching Go's UpdateProviderRequest
@@ -499,6 +519,7 @@ export interface UpdateProviderRequest {
 	store_raw_request_response?: boolean;
 	custom_provider_config?: CustomProviderConfig;
 	openai_config?: OpenAIConfig;
+	prompt_cache?: PromptCacheConfig;
 }
 
 export interface CreateProviderKeyRequest extends ModelProviderKey {}

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -758,6 +758,25 @@ export const openaiConfigFormSchema = z.object({
 
 export type OpenAIConfigFormSchema = z.infer<typeof openaiConfigFormSchema>;
 
+// Prompt cache tab
+export const cacheControlInjectionPointSchema = z
+	.object({
+		location: z.literal("message"),
+		role: z.enum(["system", "developer", "user", "assistant"]).optional(),
+		index: z.number().int().optional(),
+	})
+	.refine((p) => p.role !== undefined || p.index !== undefined, {
+		message: "Set a role, an index, or both - a point with neither matches nothing",
+	});
+
+export const promptCacheFormSchema = z.object({
+	auto_inject: z.boolean(),
+	ttl: z.string().optional(),
+	cache_control_injection_points: z.array(cacheControlInjectionPointSchema).optional(),
+});
+
+export type PromptCacheFormSchema = z.infer<typeof promptCacheFormSchema>;
+
 // Allowed requests schema
 export const allowedRequestsSchema = z.object({
 	text_completion: z.boolean(),
@@ -884,6 +903,7 @@ export const addProviderRequestSchema = z.object({
 	store_raw_request_response: z.boolean().optional(),
 	custom_provider_config: customProviderConfigSchema.optional(),
 	openai_config: openaiConfigFormSchema.optional(),
+	prompt_cache: promptCacheFormSchema.optional(),
 });
 
 // Update provider request schema
@@ -897,6 +917,7 @@ export const updateProviderRequestSchema = z.object({
 	store_raw_request_response: z.boolean().optional(),
 	custom_provider_config: customProviderConfigSchema.optional(),
 	openai_config: openaiConfigFormSchema.optional(),
+	prompt_cache: promptCacheFormSchema.optional(),
 });
 
 // Cache config schema


### PR DESCRIPTION
## Summary

Agentic clients (Codex and similar) send no prompt-cache markers, which means providers that cache implicitly slide the cached prefix onto the newest message and bill a cache write on every turn. On Anthropic models nothing caches at all without an explicit marker. This PR adds a `prompt_cache` provider config block that lets operators opt into automatic breakpoint injection — Bifrost synthesizes the marker so the client does not have to.

## Changes

- Added `PromptCacheConfig` to `ProviderConfig` with three knobs: `auto_inject` (mark the first cacheable block), `ttl` (lifetime for injected markers), and `cache_control_injection_points` (target specific messages by role and/or index, replacing the default strategy when set).
- Introduced `promptCacheChatRequest` and `promptCacheResponsesRequest` helpers in `core/bifrost.go` that produce a shallow copy of the request with breakpoints injected. The shared `BifrostRequest` is never written to, so a retry or fallback against a different provider cannot inherit a marker the caller never sent (the mutation leak that sank PR #6181).
- Added `core/providers/utils/promptcache.go` implementing `InjectResponsesCacheBreakpoints`, `InjectChatCacheBreakpoints`, `PromptCacheInjectionEnabled`, and `ResolvePromptCacheConfig`. Injection is copy-on-write throughout: the caller's slice, its content pointers, and the block arrays beneath them are never modified.
- `PromptCacheInjectionEnabled` gates injection on both operator opt-in and a model capability check (`ModelSupportsPromptCaching`), so the injector is safe to call unconditionally for all providers. Implicit-caching endpoints (OpenAI pre-5.6, DeepSeek, Groq, Gemini) answer false and are never sent a marker.
- Added `ModelSupportsPromptCaching` fallback in `core/schemas/utils.go` and a `SupportsPromptCaching` accessor on `ModelCaps`.
- Added `IsGPT56Model` helper for the first OpenAI generation that accepts explicit cache markers.
- Injection is capped at four markers (`MaxInjectedCacheBreakpoints`) matching the Anthropic ceiling, enforced before any downstream clamp can silently discard work.
- Added a `BifrostContextKeyPromptCacheAutoInject` context key and `x-bf-prompt-cache-auto-inject` HTTP header so callers can flip `auto_inject` for a single request without a config change. The header cannot manufacture opt-in for a provider the operator never configured.
- Wired `PromptCache` through the full persistence stack: database column (`prompt_cache_json`), migration, GORM hooks, config store read/write paths, HTTP handler payloads, and config hash.
- Added a "Prompt Caching" tab to the provider config sheet in the UI with a form for `auto_inject`, TTL, and injection points.
- Added comprehensive tests in `core/providers/utils/promptcache_test.go` covering the default strategy, string promotion, caller-marker-wins rule, mutation isolation, injection points, the four-marker ceiling, capability gating, and the per-request override.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
# Core/Transports
go test ./core/providers/utils/... -run TestInject
go test ./core/providers/utils/... -run TestPromptCache
go test ./core/providers/utils/... -run TestResolvePromptCache
go test ./...

# UI
cd ui
pnpm i
pnpm build
```

Configure a provider with `prompt_cache: { auto_inject: true }` and send a Chat Completions or Responses request with no `cache_control` markers. Confirm the outgoing request to the provider carries a marker on the first cacheable block. Send a second request with an existing `cache_control` marker and confirm it is forwarded unchanged.

To test the per-request override, set `x-bf-prompt-cache-auto-inject: false` on a request to a provider with `auto_inject: true` and confirm no marker is injected.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #6180, supersedes #6181

## Security considerations

The injected marker is derived entirely from operator-controlled config and model capability metadata. No caller-supplied data influences which block is marked. The per-request header can only flip `auto_inject` within the bounds the operator already established; it cannot enable injection for a provider the operator never configured, and it cannot alter billing scope beyond what the operator's `PromptCacheConfig` permits.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable