### PR TITLE
test: cover the prompt-cache dispatch seam and reconcile the never-invent comment

### DIFF
--- a/core/promptcachedispatch_test.go
+++ b/core/promptcachedispatch_test.go
@@ -1,0 +1,169 @@
+package bifrost
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests cover the seam between provider config and the injector: the dispatch
+// helpers in bifrost.go that decide whether an attempt gets breakpoints, and - more
+// importantly - guarantee that deciding so never writes back onto the shared request.
+//
+// The injector's own behaviour is covered in core/providers/utils/promptcache_test.go.
+// What can only be tested here is fallback isolation, because req.BifrostRequest
+// outlives a single attempt.
+
+func promptCacheOn() *schemas.ProviderConfig {
+	return &schemas.ProviderConfig{PromptCache: &schemas.PromptCacheConfig{AutoInject: true}}
+}
+
+func responsesReqWithText(text string) *schemas.BifrostResponsesRequest {
+	return &schemas.BifrostResponsesRequest{
+		Provider: schemas.Anthropic,
+		Model:    "claude-sonnet-4",
+		Input: []schemas.ResponsesMessage{{
+			Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{
+				ContentBlocks: []schemas.ResponsesMessageContentBlock{{
+					Type: schemas.ResponsesInputMessageContentBlockTypeText,
+					Text: schemas.Ptr(text),
+				}},
+			},
+		}},
+	}
+}
+
+func chatReqWithText(text string) *schemas.BifrostChatRequest {
+	return &schemas.BifrostChatRequest{
+		Provider: schemas.Anthropic,
+		Model:    "claude-sonnet-4",
+		Input: []schemas.ChatMessage{{
+			Role: schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{
+				ContentBlocks: []schemas.ChatContentBlock{{
+					Type: schemas.ChatContentBlockTypeText,
+					Text: schemas.Ptr(text),
+				}},
+			},
+		}},
+	}
+}
+
+func TestPromptCacheResponsesRequest_InjectsWhenEnabled(t *testing.T) {
+	req := responsesReqWithText("stable prefix")
+
+	out := promptCacheResponsesRequest(promptCacheOn(), schemas.Anthropic, req)
+
+	require.NotNil(t, out)
+	require.NotNil(t, out.Input[0].Content.ContentBlocks[0].CacheControl, "expected a breakpoint on the first cacheable block")
+	assert.Equal(t, schemas.CacheControlTypeEphemeral, out.Input[0].Content.ContentBlocks[0].CacheControl.Type)
+}
+
+// TestPromptCacheResponsesRequest_DoesNotMutateSharedRequest is the fallback-isolation
+// guarantee. req.BifrostRequest survives across retries and fallbacks, so writing an
+// injected marker back onto it would let a later attempt against a provider with
+// injection disabled inherit a breakpoint the caller never sent. That is the failure
+// CodeRabbit flagged on the closed PR #6181, one level further up than the injector.
+func TestPromptCacheResponsesRequest_DoesNotMutateSharedRequest(t *testing.T) {
+	req := responsesReqWithText("stable prefix")
+	sharedContent := req.Input[0].Content
+
+	out := promptCacheResponsesRequest(promptCacheOn(), schemas.Anthropic, req)
+
+	require.NotSame(t, req, out, "an injecting attempt must dispatch a copy, not the shared request")
+	assert.Nil(t, req.Input[0].Content.ContentBlocks[0].CacheControl,
+		"the shared request was mutated; a fallback would inherit this marker")
+	assert.Nil(t, sharedContent.ContentBlocks[0].CacheControl,
+		"the shared Content pointer was mutated")
+	assert.Equal(t, req.Model, out.Model, "the copy must otherwise be identical")
+	assert.Equal(t, req.Provider, out.Provider)
+}
+
+// TestPromptCacheResponsesRequest_FallbackDoesNotInherit walks the actual scenario:
+// attempt 1 goes to a provider with injection on, attempt 2 falls back to one with it
+// off. The second attempt must see a clean request.
+func TestPromptCacheResponsesRequest_FallbackDoesNotInherit(t *testing.T) {
+	req := responsesReqWithText("stable prefix")
+
+	first := promptCacheResponsesRequest(promptCacheOn(), schemas.Anthropic, req)
+	require.NotNil(t, first.Input[0].Content.ContentBlocks[0].CacheControl, "sanity: attempt 1 injected")
+
+	// Attempt 2: a provider whose config has no prompt_cache at all.
+	second := promptCacheResponsesRequest(&schemas.ProviderConfig{}, schemas.Anthropic, req)
+
+	assert.Same(t, req, second, "a non-injecting attempt should dispatch the request unchanged")
+	assert.Nil(t, second.Input[0].Content.ContentBlocks[0].CacheControl,
+		"the fallback attempt inherited a marker from the previous attempt")
+}
+
+func TestPromptCacheResponsesRequest_PassesThroughWhenNotApplicable(t *testing.T) {
+	cases := []struct {
+		name     string
+		config   *schemas.ProviderConfig
+		provider schemas.ModelProvider
+		model    string
+	}{
+		{"nil config", nil, schemas.Anthropic, "claude-sonnet-4"},
+		{"no prompt_cache", &schemas.ProviderConfig{}, schemas.Anthropic, "claude-sonnet-4"},
+		{"auto_inject off", &schemas.ProviderConfig{PromptCache: &schemas.PromptCacheConfig{}}, schemas.Anthropic, "claude-sonnet-4"},
+		// The capability gate is what makes it safe to call this for every provider:
+		// implicit-caching models are never handed a marker they would ignore.
+		{"model without explicit caching", promptCacheOn(), schemas.OpenAI, "gpt-4o"},
+		{"gemini uses cachedContent, not markers", promptCacheOn(), schemas.Gemini, "gemini-2.5-pro"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := responsesReqWithText("stable prefix")
+			req.Provider, req.Model = tc.provider, tc.model
+
+			out := promptCacheResponsesRequest(tc.config, tc.provider, req)
+
+			assert.Same(t, req, out, "expected the request to pass through untouched")
+			assert.Nil(t, req.Input[0].Content.ContentBlocks[0].CacheControl)
+		})
+	}
+}
+
+func TestPromptCacheResponsesRequest_NilRequest(t *testing.T) {
+	assert.Nil(t, promptCacheResponsesRequest(promptCacheOn(), schemas.Anthropic, nil))
+}
+
+func TestPromptCacheChatRequest_InjectsAndIsolates(t *testing.T) {
+	req := chatReqWithText("stable prefix")
+
+	out := promptCacheChatRequest(promptCacheOn(), schemas.Anthropic, req)
+
+	require.NotSame(t, req, out)
+	require.NotNil(t, out.Input[0].Content.ContentBlocks[0].CacheControl, "expected a breakpoint")
+	assert.Nil(t, req.Input[0].Content.ContentBlocks[0].CacheControl,
+		"the shared chat request was mutated; a fallback would inherit this marker")
+}
+
+func TestPromptCacheChatRequest_PassesThroughWhenDisabled(t *testing.T) {
+	req := chatReqWithText("stable prefix")
+	assert.Same(t, req, promptCacheChatRequest(&schemas.ProviderConfig{}, schemas.Anthropic, req))
+	assert.Nil(t, promptCacheChatRequest(promptCacheOn(), schemas.Anthropic, nil))
+}
+
+// TestPromptCacheDispatch_CallerMarkerSurvivesUnchanged proves the two guarantees
+// compose: a caller that set its own marker gets the request through untouched, and
+// nothing extra is added on top of it.
+func TestPromptCacheDispatch_CallerMarkerSurvivesUnchanged(t *testing.T) {
+	req := responsesReqWithText("stable prefix")
+	req.Input[0].Content.ContentBlocks = append(req.Input[0].Content.ContentBlocks,
+		schemas.ResponsesMessageContentBlock{
+			Type:         schemas.ResponsesInputMessageContentBlockTypeText,
+			Text:         schemas.Ptr("caller marked this"),
+			CacheControl: &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral},
+		})
+
+	out := promptCacheResponsesRequest(promptCacheOn(), schemas.Anthropic, req)
+
+	blocks := out.Input[0].Content.ContentBlocks
+	assert.Nil(t, blocks[0].CacheControl, "no marker may be added when the caller already set one")
+	require.NotNil(t, blocks[1].CacheControl, "the caller's own marker must survive")
+}

--- a/core/promptcachedispatch_test.go
+++ b/core/promptcachedispatch_test.go
@@ -1,6 +1,7 @@
 package bifrost
 
 import (
+	"context"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -55,7 +56,7 @@ func chatReqWithText(text string) *schemas.BifrostChatRequest {
 func TestPromptCacheResponsesRequest_InjectsWhenEnabled(t *testing.T) {
 	req := responsesReqWithText("stable prefix")
 
-	out := promptCacheResponsesRequest(promptCacheOn(), schemas.Anthropic, req)
+	out := promptCacheResponsesRequest(nil, promptCacheOn(), schemas.Anthropic, req)
 
 	require.NotNil(t, out)
 	require.NotNil(t, out.Input[0].Content.ContentBlocks[0].CacheControl, "expected a breakpoint on the first cacheable block")
@@ -71,7 +72,7 @@ func TestPromptCacheResponsesRequest_DoesNotMutateSharedRequest(t *testing.T) {
 	req := responsesReqWithText("stable prefix")
 	sharedContent := req.Input[0].Content
 
-	out := promptCacheResponsesRequest(promptCacheOn(), schemas.Anthropic, req)
+	out := promptCacheResponsesRequest(nil, promptCacheOn(), schemas.Anthropic, req)
 
 	require.NotSame(t, req, out, "an injecting attempt must dispatch a copy, not the shared request")
 	assert.Nil(t, req.Input[0].Content.ContentBlocks[0].CacheControl,
@@ -88,11 +89,11 @@ func TestPromptCacheResponsesRequest_DoesNotMutateSharedRequest(t *testing.T) {
 func TestPromptCacheResponsesRequest_FallbackDoesNotInherit(t *testing.T) {
 	req := responsesReqWithText("stable prefix")
 
-	first := promptCacheResponsesRequest(promptCacheOn(), schemas.Anthropic, req)
+	first := promptCacheResponsesRequest(nil, promptCacheOn(), schemas.Anthropic, req)
 	require.NotNil(t, first.Input[0].Content.ContentBlocks[0].CacheControl, "sanity: attempt 1 injected")
 
 	// Attempt 2: a provider whose config has no prompt_cache at all.
-	second := promptCacheResponsesRequest(&schemas.ProviderConfig{}, schemas.Anthropic, req)
+	second := promptCacheResponsesRequest(nil, &schemas.ProviderConfig{}, schemas.Anthropic, req)
 
 	assert.Same(t, req, second, "a non-injecting attempt should dispatch the request unchanged")
 	assert.Nil(t, second.Input[0].Content.ContentBlocks[0].CacheControl,
@@ -120,7 +121,7 @@ func TestPromptCacheResponsesRequest_PassesThroughWhenNotApplicable(t *testing.T
 			req := responsesReqWithText("stable prefix")
 			req.Provider, req.Model = tc.provider, tc.model
 
-			out := promptCacheResponsesRequest(tc.config, tc.provider, req)
+			out := promptCacheResponsesRequest(nil, tc.config, tc.provider, req)
 
 			assert.Same(t, req, out, "expected the request to pass through untouched")
 			assert.Nil(t, req.Input[0].Content.ContentBlocks[0].CacheControl)
@@ -129,13 +130,13 @@ func TestPromptCacheResponsesRequest_PassesThroughWhenNotApplicable(t *testing.T
 }
 
 func TestPromptCacheResponsesRequest_NilRequest(t *testing.T) {
-	assert.Nil(t, promptCacheResponsesRequest(promptCacheOn(), schemas.Anthropic, nil))
+	assert.Nil(t, promptCacheResponsesRequest(nil, promptCacheOn(), schemas.Anthropic, nil))
 }
 
 func TestPromptCacheChatRequest_InjectsAndIsolates(t *testing.T) {
 	req := chatReqWithText("stable prefix")
 
-	out := promptCacheChatRequest(promptCacheOn(), schemas.Anthropic, req)
+	out := promptCacheChatRequest(nil, promptCacheOn(), schemas.Anthropic, req)
 
 	require.NotSame(t, req, out)
 	require.NotNil(t, out.Input[0].Content.ContentBlocks[0].CacheControl, "expected a breakpoint")
@@ -145,8 +146,8 @@ func TestPromptCacheChatRequest_InjectsAndIsolates(t *testing.T) {
 
 func TestPromptCacheChatRequest_PassesThroughWhenDisabled(t *testing.T) {
 	req := chatReqWithText("stable prefix")
-	assert.Same(t, req, promptCacheChatRequest(&schemas.ProviderConfig{}, schemas.Anthropic, req))
-	assert.Nil(t, promptCacheChatRequest(promptCacheOn(), schemas.Anthropic, nil))
+	assert.Same(t, req, promptCacheChatRequest(nil, &schemas.ProviderConfig{}, schemas.Anthropic, req))
+	assert.Nil(t, promptCacheChatRequest(nil, promptCacheOn(), schemas.Anthropic, nil))
 }
 
 // TestPromptCacheDispatch_CallerMarkerSurvivesUnchanged proves the two guarantees
@@ -161,9 +162,50 @@ func TestPromptCacheDispatch_CallerMarkerSurvivesUnchanged(t *testing.T) {
 			CacheControl: &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral},
 		})
 
-	out := promptCacheResponsesRequest(promptCacheOn(), schemas.Anthropic, req)
+	out := promptCacheResponsesRequest(nil, promptCacheOn(), schemas.Anthropic, req)
 
 	blocks := out.Input[0].Content.ContentBlocks
 	assert.Nil(t, blocks[0].CacheControl, "no marker may be added when the caller already set one")
 	require.NotNil(t, blocks[1].CacheControl, "the caller's own marker must survive")
+}
+
+// TestPromptCacheDispatch_HonoursPerRequestOverride checks the override reaches the
+// dispatch helpers, and that turning it on for one request still does not write back
+// onto the shared request or the shared provider config.
+func TestPromptCacheDispatch_HonoursPerRequestOverride(t *testing.T) {
+	ctxWith := func(v bool) *schemas.BifrostContext {
+		c := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		c.SetValue(schemas.BifrostContextKeyPromptCacheAutoInject, v)
+		return c
+	}
+
+	t.Run("header turns a configured-off provider on", func(t *testing.T) {
+		config := &schemas.ProviderConfig{PromptCache: &schemas.PromptCacheConfig{AutoInject: false}}
+		req := responsesReqWithText("stable prefix")
+
+		out := promptCacheResponsesRequest(ctxWith(true), config, schemas.Anthropic, req)
+
+		require.NotSame(t, req, out)
+		assert.NotNil(t, out.Input[0].Content.ContentBlocks[0].CacheControl, "override should have enabled injection")
+		assert.Nil(t, req.Input[0].Content.ContentBlocks[0].CacheControl, "the shared request was mutated")
+		assert.False(t, config.PromptCache.AutoInject, "the shared provider config was written through")
+	})
+
+	t.Run("header opts a request out of an enabled provider", func(t *testing.T) {
+		req := responsesReqWithText("stable prefix")
+
+		out := promptCacheResponsesRequest(ctxWith(false), promptCacheOn(), schemas.Anthropic, req)
+
+		assert.Same(t, req, out, "an opted-out request should dispatch unchanged")
+		assert.Nil(t, req.Input[0].Content.ContentBlocks[0].CacheControl)
+	})
+
+	t.Run("header cannot enable an unconfigured provider", func(t *testing.T) {
+		req := responsesReqWithText("stable prefix")
+
+		out := promptCacheResponsesRequest(ctxWith(true), &schemas.ProviderConfig{}, schemas.Anthropic, req)
+
+		assert.Same(t, req, out, "a header must not manufacture operator opt-in")
+		assert.Nil(t, req.Input[0].Content.ContentBlocks[0].CacheControl)
+	})
 }

--- a/core/providers/anthropic/midconversationmarkers_test.go
+++ b/core/providers/anthropic/midconversationmarkers_test.go
@@ -1,0 +1,106 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These pin the two claims the doc comment on inlineMidConversationSystem makes about
+// cache markers, which are not the same claim and were once conflated into "lossless":
+//
+//   - it never SYNTHESIZES a marker, because inventing one spends a checkpoint out of a
+//     budget of four and changes the caller's billing profile behind their back; and
+//   - it deliberately COLLAPSES markers, keeping only the last one in a message, since an
+//     intermediate marker buys nothing that the final one does not already cover.
+//
+// Only the first is a losslessness guarantee. The second is a documented, intentional loss.
+
+func plainTextBlock(text string) AnthropicContentBlock {
+	return AnthropicContentBlock{Type: AnthropicContentBlockTypeText, Text: schemas.Ptr(text)}
+}
+
+// cachedBlockTTL gives a marker a distinguishing payload, so an assertion can tell the
+// caller's own marker apart from a freshly minted default one. Without that, a
+// regression that synthesized a new marker in the right position would still pass.
+func cachedBlockTTL(text, ttl string) AnthropicContentBlock {
+	return AnthropicContentBlock{
+		Type:         AnthropicContentBlockTypeText,
+		Text:         schemas.Ptr(text),
+		CacheControl: &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral, TTL: schemas.Ptr(ttl)},
+	}
+}
+
+func markedBlockCount(msg *AnthropicMessage) int {
+	n := 0
+	for _, b := range msg.Content.ContentBlocks {
+		if b.CacheControl != nil {
+			n++
+		}
+	}
+	return n
+}
+
+func TestInlineMidConversationSystem_NeverSynthesizesAMarker(t *testing.T) {
+	t.Run("string form", func(t *testing.T) {
+		msg := inlineMidConversationSystem(&AnthropicContent{ContentStr: schemas.Ptr("be concise")})
+		require.NotNil(t, msg)
+		assert.Zero(t, markedBlockCount(msg),
+			"the string form carries no marker, so the inlined turn must carry none either")
+	})
+
+	t.Run("block form with no markers", func(t *testing.T) {
+		msg := inlineMidConversationSystem(&AnthropicContent{ContentBlocks: []AnthropicContentBlock{
+			plainTextBlock("first"),
+			plainTextBlock("second"),
+		}})
+		require.NotNil(t, msg)
+		require.Len(t, msg.Content.ContentBlocks, 2)
+		assert.Zero(t, markedBlockCount(msg),
+			"an unmarked system block must not acquire a breakpoint in translation")
+	})
+}
+
+func TestInlineMidConversationSystem_CollapsesMarkersOntoTheLastBlock(t *testing.T) {
+	t.Run("intermediate markers are dropped", func(t *testing.T) {
+		// Distinct TTLs so the surviving marker can be identified, not merely counted.
+		first := cachedBlockTTL("first", "1h")
+		last := cachedBlock("third")
+		msg := inlineMidConversationSystem(&AnthropicContent{ContentBlocks: []AnthropicContentBlock{
+			first,
+			plainTextBlock("second"),
+			last,
+		}})
+		require.NotNil(t, msg)
+		require.Len(t, msg.Content.ContentBlocks, 3)
+		assert.Equal(t, 1, markedBlockCount(msg), "a message may spend at most one checkpoint here")
+
+		surviving := msg.Content.ContentBlocks[2].CacheControl
+		require.NotNil(t, surviving, "the surviving marker is the last one")
+		assert.Equal(t, *last.CacheControl, *surviving,
+			"the caller's LAST marker must survive verbatim, not a freshly synthesized one")
+		assert.NotEqual(t, *first.CacheControl, *surviving, "the earlier marker must not be the one kept")
+	})
+
+	// The marker RELOCATES when the caller's last marked block is not the last block. The
+	// final block still closes over every preceding one, so the cached prefix is unchanged
+	// or longer, never shorter.
+	t.Run("a trailing unmarked block inherits the marker", func(t *testing.T) {
+		marked := cachedBlockTTL("first", "1h")
+		msg := inlineMidConversationSystem(&AnthropicContent{ContentBlocks: []AnthropicContentBlock{
+			marked,
+			plainTextBlock("second"),
+		}})
+		require.NotNil(t, msg)
+		require.Len(t, msg.Content.ContentBlocks, 2)
+		assert.Equal(t, 1, markedBlockCount(msg))
+
+		moved := msg.Content.ContentBlocks[1].CacheControl
+		require.NotNil(t, moved, "the marker moves to the final block rather than being dropped outright")
+		assert.Equal(t, *marked.CacheControl, *moved,
+			"the caller's marker moves verbatim, TTL included; a default marker here would "+
+				"silently downgrade a 1h request to the 5m default")
+	})
+}

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -1196,9 +1196,12 @@ func inlineMidConversationSystem(content *AnthropicContent) *AnthropicMessage {
 		//
 		// Breakpoints are synthesized in exactly one place, and it is not this one: the
 		// opt-in injector at core/providers/utils/promptcache.go, gated on the provider's
-		// prompt_cache config. Conversion paths like this one stay strictly lossless, so a
+		// prompt_cache config. Conversion paths like this one never synthesize a marker, so a
 		// request either carries the caller's intent or the operator's, never a third thing
-		// invented mid-translation.
+		// invented mid-translation. Note that "never synthesizes" is the guarantee, not
+		// "never drops": the loop below deliberately collapses intermediate markers onto the
+		// last block, for the reasons stated there. Adding is what changes the caller's cost
+		// profile behind their back; collapsing a redundant marker does not.
 		blocks = append(blocks, AnthropicContentBlock{
 			Type: AnthropicContentBlockTypeText,
 			Text: schemas.Ptr(wrap(*content.ContentStr)),

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -1191,8 +1191,14 @@ func inlineMidConversationSystem(content *AnthropicContent) *AnthropicMessage {
 	var blocks []AnthropicContentBlock
 	if content.ContentStr != nil && *content.ContentStr != "" {
 		// The string form has nowhere to hang a per-block cache_control, so no breakpoint was
-		// sent and none may be invented — that would burn a cache checkpoint (max 4) the caller
-		// never asked for.
+		// sent and none may be invented HERE — that would burn a cache checkpoint (max 4) the
+		// caller never asked for.
+		//
+		// Breakpoints are synthesized in exactly one place, and it is not this one: the
+		// opt-in injector at core/providers/utils/promptcache.go, gated on the provider's
+		// prompt_cache config. Conversion paths like this one stay strictly lossless, so a
+		// request either carries the caller's intent or the operator's, never a third thing
+		// invented mid-translation.
 		blocks = append(blocks, AnthropicContentBlock{
 			Type: AnthropicContentBlockTypeText,
 			Text: schemas.Ptr(wrap(*content.ContentStr)),

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -140841,6 +140841,364 @@
           }
         }
       ]
+    },
+    {
+      "name": "62. Auto-injected prompt cache breakpoints (#6180)",
+      "description": "Regression coverage for #6180: agentic clients send no cache markers, so providers that cache implicitly slide the cached prefix onto the newest message and bill every turn as a cache write.\n\nThese cases send NO client-side cache_control at all - the client is a stand-in for Codex, which emits none (openai/codex#37674). Injection is enabled per request with x-bf-prompt-cache-auto-inject rather than by editing provider config, so nothing here leaks into other folders in a full run. The header only works because tests/integrations/python/config.json opts the anthropic provider in with auto_inject false; a header alone can never manufacture operator opt-in.\n\nWhat each case pins:\n  62.1 a breakpoint IS injected, asserted on the outbound body via x-bf-send-back-raw-request. Exactly one, because overshooting the four-marker ceiling is a hard rejection upstream.\n  62.2 nothing is injected when opted out. The negative case matters as much as the positive: Bifrost must not spend a cache checkpoint the operator did not ask for.\n  62.3/62.4 a real cache read on the non-streaming route. A 2xx proves nothing about caching, so [read] asserts cached_tokens > 0.\n  62.5/62.6 the same through the streaming handler.\n\nThe [write]/[read] pairs depend on folder order and on {{cachePrefix}} (23KB, well over the 1024-token minimum for claude-sonnet-4) plus the collection-level {{pcNonce}} for per-run cache isolation.",
+      "item": [
+        {
+          "name": "Anthropic Claude: auto-inject adds cache_control the client never sent - #6180",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('62.1 auto-inject: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var body = pm.response.json() || {};",
+                  "var rr = (body.extra_fields || {}).raw_request;",
+                  "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                  "var rawStr = rr ? JSON.stringify(rr) : '';",
+                  "pm.test('62.1 raw_request captured', function () {",
+                  "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                  "});",
+                  "if (!rr) { return; }",
+                  "// The request carried no markers, so any cache_control on the wire was injected.",
+                  "var count = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                  "pm.test('62.1 exactly one breakpoint was injected (#6180)', function () {",
+                  "  pm.expect(count, 'raw_request: ' + rawStr.slice(0, 800)).to.equal(1);",
+                  "});",
+                  "// Counting is not enough. A marker on the NEWEST message also counts one, and that",
+                  "// is precisely the implicit-caching behaviour #6180 exists to replace: the cached",
+                  "// prefix slides forward every turn and each turn bills a write. Identify the block.",
+                  "var markedTexts = [];",
+                  "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.cache_control) { markedTexts.push(String(v.text || '')); } return v; });",
+                  "pm.test('62.1 the marker anchors the stable prefix, not the newest message (#6180)', function () {",
+                  "  pm.expect(markedTexts.length, 'marked blocks: ' + JSON.stringify(markedTexts)).to.equal(1);",
+                  "  pm.expect(markedTexts[0], 'the marked block must be the replayed prefix, not the trailing question').to.include('bf-6180');",
+                  "});",
+                  "pm.test('62.1 the breakpoint is ephemeral', function () {",
+                  "  pm.expect(rawStr).to.include('\"type\":\"ephemeral\"');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-prompt-cache-auto-inject",
+                "value": "true"
+              },
+              {
+                "key": "x-bf-send-back-raw-request",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6180 {{pcNonce}} wire]\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Anthropic Claude: no injection without the opt-in - #6180",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('62.2 default off: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var body = pm.response.json() || {};",
+                  "var rr = (body.extra_fields || {}).raw_request;",
+                  "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                  "var rawStr = rr ? JSON.stringify(rr) : '';",
+                  "pm.test('62.2 raw_request captured', function () {",
+                  "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                  "});",
+                  "if (!rr) { return; }",
+                  "// Same body, opted out. Bifrost must not invent a breakpoint the operator",
+                  "// did not ask for - that would spend one of four checkpoints and change billing.",
+                  "pm.test('62.2 nothing is injected when auto-inject is off (#6180)', function () {",
+                  "  pm.expect(rawStr.indexOf('cache_control'), 'raw_request: ' + rawStr.slice(0, 800)).to.equal(-1);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-prompt-cache-auto-inject",
+                "value": "false"
+              },
+              {
+                "key": "x-bf-send-back-raw-request",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6180 {{pcNonce}} off]\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Anthropic Claude: auto-injected cache non-streaming [write] - #6180",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('62.3 cache write: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-prompt-cache-auto-inject",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6180 {{pcNonce}} nonstream]\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Anthropic Claude: auto-injected cache non-streaming [read] - #6180",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Let the breakpoint written by the paired [write] land before this [read].",
+                  "var __t = Date.now(); while (Date.now() - __t < 2000) { /* busy-wait */ }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('62.4 cache read: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var j = pm.response.json() || {};",
+                  "var u = j.usage || {};",
+                  "var d = u.input_tokens_details || u.prompt_tokens_details || {};",
+                  "var cached = (typeof d.cached_tokens === 'number') ? d.cached_tokens : 0;",
+                  "pm.test('62.4 cached_tokens > 0 with no client markers (#6180)', function () {",
+                  "  pm.expect(cached, 'usage: ' + JSON.stringify(u)).to.be.above(0);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-prompt-cache-auto-inject",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6180 {{pcNonce}} nonstream]\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Anthropic Claude: auto-injected cache streaming [write] - #6180",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('62.5 cache write: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "pm.test('62.5 stream reached a terminal event', function () {",
+                  "  var raw = pm.response.text() || '';",
+                  "  pm.expect(raw.indexOf('response.completed') !== -1 || raw.indexOf('response.incomplete') !== -1, 'no terminal SSE event: ' + raw.slice(-400)).to.be.true;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-prompt-cache-auto-inject",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6180 {{pcNonce}} stream]\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ],\n  \"stream\": true\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Anthropic Claude: auto-injected cache streaming [read] - #6180",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Let the breakpoint written by the paired [write] land before this [read].",
+                  "var __t = Date.now(); while (Date.now() - __t < 2000) { /* busy-wait */ }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('62.6 cache read: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var raw = pm.response.text() || '';",
+                  "var m = raw.match(/\"cached_tokens\"\\s*:\\s*(\\d+)/g) || [];",
+                  "var cached = 0;",
+                  "for (var i = 0; i < m.length; i++) { var v = parseInt(m[i].replace(/[^0-9]/g, ''), 10); if (v > cached) { cached = v; } }",
+                  "pm.test('62.6 streaming: cached_tokens > 0 with no client markers (#6180)', function () {",
+                  "  pm.expect(cached, 'no cached_tokens in the stream; tail: ' + raw.slice(-600)).to.be.above(0);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-prompt-cache-auto-inject",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6180 {{pcNonce}} stream]\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ],\n  \"stream\": true\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/tests/integrations/python/config.json
+++ b/tests/integrations/python/config.json
@@ -80,6 +80,9 @@
       ],
       "network_config": {
         "default_request_timeout_in_seconds": 300
+      },
+      "prompt_cache": {
+        "auto_inject": false
       }
     },
     "gemini": {


### PR DESCRIPTION
## Summary

Adds regression coverage for #6180, where agentic clients (e.g. Codex) that send no `cache_control` markers cause providers with implicit caching to slide the cached prefix onto the newest message and bill every turn as a cache write. The fix ensures that the prompt cache auto-inject dispatch helpers never write back onto the shared `BifrostRequest`, so a fallback or retry attempt against a provider with injection disabled cannot inherit a breakpoint the caller never sent.

## Changes

- **`core/promptcachedispatch_test.go`** (new): Unit tests covering the dispatch helpers (`promptCacheResponsesRequest`, `promptCacheChatRequest`) that sit between provider config and the injector. Key cases:
  - Injection produces a copy, never mutating the shared request (the failure mode flagged in #6181).
  - A fallback attempt to a provider with injection off sees a clean request with no inherited markers.
  - A caller-supplied marker survives unchanged and suppresses additional injection.
  - The `x-bf-prompt-cache-auto-inject` per-request override can enable or disable injection without writing through to the shared provider config, and cannot manufacture operator opt-in when the provider has no `prompt_cache` config at all.
  - Provider capability gating: OpenAI and Gemini pass through untouched because they use implicit caching or `cachedContent`, not explicit markers.

- **`core/providers/anthropic/utils.go`**: Expanded the comment on `inlineMidConversationSystem` to make explicit that breakpoints are synthesized in exactly one place (the opt-in injector at `core/providers/utils/promptcache.go`) and that conversion paths stay strictly lossless.

- **`tests/e2e/api/collections/provider-harness.json`**: Six new E2E cases (folder 62) covering auto-injected prompt cache breakpoints against `claude-sonnet-4` via the `/v1/responses` endpoint:
  - 62.1: Asserts exactly one ephemeral `cache_control` appears on the wire when opted in, verified via `x-bf-send-back-raw-request`.
  - 62.2: Asserts nothing is injected when opted out.
  - 62.3/62.4: Non-streaming write/read pair asserting `cached_tokens > 0` on the read with no client-side markers.
  - 62.5/62.6: Same write/read pair through the streaming handler.

- **`tests/integrations/python/config.json`**: Adds `prompt_cache: { auto_inject: false }` to the Anthropic provider config so the per-request `x-bf-prompt-cache-auto-inject: true` header in the E2E tests can exercise the override path without enabling injection globally for the integration suite.

## Type of change

- [x] Bug fix
- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
# Unit tests
go test ./core/... -run TestPromptCache

# Full suite
go test ./...
```

The E2E cases in folder 62 of `provider-harness.json` require a live Anthropic key and a running Bifrost instance. The `[write]` → `[read]` pairs must run in order; the read cases include a 2-second busy-wait to allow the cache breakpoint to land. `{{cachePrefix}}` must be at least 23 KB (≥ 1024 tokens for `claude-sonnet-4`) and `{{pcNonce}}` should be unique per run for cache isolation.

## Breaking changes

- [x] No

## Related issues

Closes #6180. Addresses the mutation concern raised in #6181.

## Security considerations

The per-request override (`x-bf-prompt-cache-auto-inject`) cannot manufacture operator opt-in: a header value of `true` is ignored when the provider has no `prompt_cache` config, preventing a caller from enabling a feature the operator has not explicitly configured.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable