### PR TITLE
feat: extend prompt-cache breakpoint translation to the gpt-5.6 family

### DIFF
--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -89,7 +89,7 @@ func hoistAdditionalTools(message schemas.ResponsesMessage) []schemas.ResponsesT
 // Responses-shaped spelling of an Anthropic cache breakpoint.
 const PromptCacheBreakpointModeExplicit = "explicit"
 
-// openRouterMaxCacheBreakpoints mirrors the ceiling the Anthropic Messages API
+// maxResponsesCacheBreakpoints mirrors the ceiling the Anthropic Messages API
 // enforces on blocks carrying cache_control. Exceeding it is a hard rejection
 // rather than a degradation ("A maximum of 4 blocks with cache_control may be
 // provided. Found 5."), and it binds here because OpenRouter converts every
@@ -98,17 +98,79 @@ const PromptCacheBreakpointModeExplicit = "explicit"
 // provider so this package takes on no provider-to-provider dependency; see
 // AnthropicMaxCacheBreakpoints in core/providers/anthropic/utils.go for the
 // live verification behind the number.
-const openRouterMaxCacheBreakpoints = 4
+const maxResponsesCacheBreakpoints = 4
 
-// applyOpenRouterCacheBreakpoints rewrites Anthropic-style per-block
-// cache_control markers into the representation OpenRouter's Responses endpoint
-// actually accepts.
+// responsesUsesPromptCacheBreakpoints reports whether this provider and model take
+// caching intent as prompt_cache_breakpoint on a content block rather than as
+// Anthropic-style per-block cache_control.
+//
+// Two unrelated families landed on the same field. OpenRouter does not expose
+// per-block cache_control through /v1/responses and converts a breakpoint back into
+// an Anthropic one (#6290). OpenAI defined the field for gpt-5.6, where it pairs with
+// request-level prompt_cache_options; Azure and Bedrock Mantle serve the same models
+// through the same wire format, so they inherit it (#6180).
+//
+// Everything else either accepts cache_control directly or caches implicitly, and for
+// those the serializer's existing strip is the correct behaviour.
+func responsesUsesPromptCacheBreakpoints(provider schemas.ModelProvider, model string) bool {
+	switch provider {
+	case schemas.OpenRouter:
+		return true
+	case schemas.OpenAI, schemas.Azure, schemas.BedrockMantle:
+		return schemas.IsGPT56Model(model)
+	default:
+		return false
+	}
+}
+
+// responsesHasPromptCacheBreakpoint reports whether any content block carries a
+// breakpoint. Used to decide whether explicit cache mode is warranted: switching a
+// request to explicit mode with no breakpoint anywhere opts it out of caching
+// entirely, which is strictly worse than the implicit default it replaced.
+func responsesHasPromptCacheBreakpoint(messages []schemas.ResponsesMessage) bool {
+	for i := range messages {
+		if messages[i].Content == nil {
+			continue
+		}
+		for j := range messages[i].Content.ContentBlocks {
+			if messages[i].Content.ContentBlocks[j].PromptCacheBreakpoint != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// responsesUsesPromptCacheOptions reports whether the target also needs request-level
+// prompt_cache_options to honour an explicit breakpoint.
+//
+// This is the gpt-5.6 half only. Those models default to IMPLICIT caching, which puts
+// the breakpoint on the latest message - so an agent loop rewrites the whole growing
+// prompt every turn at the cache-write rate. The block marker alone does not switch
+// that off; mode=explicit does. OpenRouter has no equivalent field and needs none.
+func responsesUsesPromptCacheOptions(provider schemas.ModelProvider, model string) bool {
+	switch provider {
+	case schemas.OpenAI, schemas.Azure, schemas.BedrockMantle:
+		return schemas.IsGPT56Model(model)
+	default:
+		return false
+	}
+}
+
+// applyResponsesCacheBreakpoints rewrites Anthropic-style per-block cache_control
+// markers into the prompt_cache_breakpoint representation the target actually accepts.
 //
 // OpenRouter does not expose per-block cache_control through /v1/responses. The
 // documented equivalent is prompt_cache_breakpoint on an individual input_text
 // block, which OpenRouter converts back into a default Anthropic breakpoint when
 // the request routes to Claude:
 // https://openrouter.ai/docs/features/prompt-caching#anthropic-claude
+//
+// The gpt-5.6 family reaches the same field from the other direction: OpenAI defined
+// prompt_cache_breakpoint natively, and callers arriving through an Anthropic-shaped
+// surface (or through breakpoint injection, which writes the neutral marker) express
+// the same intent as cache_control. Translating here means one implementation serves
+// both, and callers do not have to know which dialect their target speaks.
 //
 // Without this, OpenAIResponsesRequestInput.MarshalJSON deletes the marker and
 // puts nothing in its place, so Claude prompt caching never activates on the
@@ -129,10 +191,20 @@ const openRouterMaxCacheBreakpoints = 4
 //     isFunctionCallOutputBlocksFlattenable before it reaches the wire, which
 //     would discard any breakpoint set on it.
 //
+// A marker's TTL is not carried across, and there is nowhere to carry it to. The
+// only request-level field on this path is prompt_cache_options.ttl, whose "only
+// supported value, 30m, is also the default"
+// (https://developers.openai.com/api/docs/guides/prompt-caching) - so writing it
+// changes nothing, while the values cache_control actually carries (absent for 5m,
+// or "1h": https://platform.claude.com/docs/en/build-with-claude/prompt-caching) are
+// rejected there outright. OpenRouter, the one target where a "1h" marker would mean
+// something, exposes no equivalent field at all, so its Claude requests fall back to
+// the default breakpoint lifetime. Another limit forced by the wire format.
+//
 // messages is this function's own slice, but each element's Content pointer and
 // the block array beneath it still alias bifrostReq.Input, which plugins and the
 // fallback chain reuse. Both are copied before a marker is written.
-func applyOpenRouterCacheBreakpoints(messages []schemas.ResponsesMessage) {
+func applyResponsesCacheBreakpoints(messages []schemas.ResponsesMessage) {
 	// Locate every markable block in render order, and count the breakpoints the
 	// caller already set, before anything is copied.
 	type blockRef struct{ msg, block int }
@@ -167,7 +239,7 @@ func applyOpenRouterCacheBreakpoints(messages []schemas.ResponsesMessage) {
 	// Spend only the budget the caller's own breakpoints leave behind. A caller
 	// who sets more than the ceiling by hand owns that request and its upstream
 	// error; Bifrost declines to manufacture one on top.
-	budget := openRouterMaxCacheBreakpoints - existing
+	budget := maxResponsesCacheBreakpoints - existing
 	if budget <= 0 {
 		return
 	}
@@ -405,9 +477,13 @@ func ToOpenAIResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.B
 			messages = append(messages, message)
 		}
 	}
-	// OpenRouter accepts the caching intent only in its Responses-shaped form.
-	if bifrostReq.Provider == schemas.OpenRouter {
-		applyOpenRouterCacheBreakpoints(messages)
+	// Targets that speak prompt_cache_breakpoint need the caching intent translated
+	// out of cache_control, which their serializer would otherwise strip.
+	needsExplicitPromptCacheMode := false
+	if responsesUsesPromptCacheBreakpoints(bifrostReq.Provider, capModel) {
+		applyResponsesCacheBreakpoints(messages)
+		needsExplicitPromptCacheMode = responsesUsesPromptCacheOptions(bifrostReq.Provider, capModel) &&
+			responsesHasPromptCacheBreakpoint(messages)
 	}
 
 	// Updating params
@@ -497,6 +573,17 @@ func ToOpenAIResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.B
 		}
 		if topPUnsupported(caps, capModel, effort) {
 			req.ResponsesParameters.TopP = nil
+		}
+	}
+
+	// gpt-5.6 defaults to IMPLICIT caching, which anchors the breakpoint on the latest
+	// message - so an agent loop rewrites the whole growing prompt every turn at the
+	// cache-write rate and reads almost nothing back (#6180). A block marker alone does
+	// not switch that off; mode=explicit does. Runs after the params assignment above so
+	// a caller that set prompt_cache_options themselves is visible, and wins.
+	if needsExplicitPromptCacheMode && req.ResponsesParameters.PromptCacheOptions == nil {
+		req.ResponsesParameters.PromptCacheOptions = &schemas.PromptCacheOptions{
+			Mode: schemas.Ptr(PromptCacheBreakpointModeExplicit),
 		}
 	}
 

--- a/core/providers/openai/responsesmarshal_test.go
+++ b/core/providers/openai/responsesmarshal_test.go
@@ -1510,105 +1510,208 @@ func TestToOpenAIResponsesRequest_OpenRouterNonEphemeralDoesNotSpendClampBudget(
 	}
 }
 
-// TestApplyOpenRouterCacheBreakpoints_OnlyInputTextConverts pins the mechanism behind
-// the OpenRouter carve-out in RunPromptCachingMultipleToolCallsTest.
-//
-// That scenario moves a cache checkpoint each turn, landing it on whichever message
-// the walk stops at: a function_call (marked at MESSAGE level), an assistant turn
-// (output_text), or a user turn (input_text). Only the last of those has a Responses
-// representation here, so the set of surviving breakpoints oscillates between one and
-// two as the conversation grows - and with it the size of the cached prefix.
-//
-// That makes a turn-over-turn "cache_read must not halve" assertion unsound for
-// OpenRouter specifically: a drop is the expected consequence of this conversion rule,
-// not evidence of a cache-prefix mismatch.
-func TestApplyOpenRouterCacheBreakpoints_OnlyInputTextConverts(t *testing.T) {
-	ephemeral := func() *schemas.CacheControl {
-		return &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral}
-	}
-	countBreakpoints := func(msgs []schemas.ResponsesMessage) int {
-		n := 0
-		for i := range msgs {
-			if msgs[i].Content == nil {
-				continue
-			}
-			for j := range msgs[i].Content.ContentBlocks {
-				if msgs[i].Content.ContentBlocks[j].PromptCacheBreakpoint != nil {
-					n++
-				}
-			}
-		}
-		return n
-	}
-	// The system block is marked every turn and always converts, so it is the floor.
-	systemMsg := func() schemas.ResponsesMessage {
-		return schemas.ResponsesMessage{
-			Role: schemas.Ptr(schemas.ResponsesInputMessageRoleSystem),
+// gpt56CacheReq builds a Responses request whose first input_text block carries an
+// Anthropic-style cache_control marker, with no prompt_cache_options of its own.
+func gpt56CacheReq(provider schemas.ModelProvider, model string) *schemas.BifrostResponsesRequest {
+	return &schemas.BifrostResponsesRequest{
+		Provider: provider,
+		Model:    model,
+		Input: []schemas.ResponsesMessage{{
+			Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
 			Content: &schemas.ResponsesMessageContent{
-				ContentBlocks: []schemas.ResponsesMessageContentBlock{{
-					Type:         schemas.ResponsesInputMessageContentBlockTypeText,
-					Text:         schemas.Ptr("stable system prefix"),
-					CacheControl: ephemeral(),
-				}},
-			},
-		}
-	}
-
-	cases := []struct {
-		name       string
-		checkpoint schemas.ResponsesMessage
-		want       int // system breakpoint + (1 if the checkpoint converts)
-	}{
-		{
-			name: "checkpoint on a user input_text block converts",
-			checkpoint: schemas.ResponsesMessage{
-				Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
-				Content: &schemas.ResponsesMessageContent{
-					ContentBlocks: []schemas.ResponsesMessageContentBlock{{
+				ContentBlocks: []schemas.ResponsesMessageContentBlock{
+					{
 						Type:         schemas.ResponsesInputMessageContentBlockTypeText,
-						Text:         schemas.Ptr("turn text"),
-						CacheControl: ephemeral(),
-					}},
+						Text:         schemas.Ptr("REUSABLE_PREFIX"),
+						CacheControl: &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral},
+					},
+					{
+						Type: schemas.ResponsesInputMessageContentBlockTypeText,
+						Text: schemas.Ptr("Reply with OK."),
+					},
 				},
 			},
-			want: 2,
-		},
-		{
-			name: "checkpoint on an assistant output_text block does not convert",
-			checkpoint: schemas.ResponsesMessage{
-				Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
-				Content: &schemas.ResponsesMessageContent{
-					ContentBlocks: []schemas.ResponsesMessageContentBlock{{
-						Type:         schemas.ResponsesOutputMessageContentTypeText,
-						Text:         schemas.Ptr("assistant turn"),
-						CacheControl: ephemeral(),
-					}},
-				},
-			},
-			want: 1,
-		},
-		{
-			name: "message-level marker on a function_call does not convert",
-			checkpoint: schemas.ResponsesMessage{
-				Type:         schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
-				CacheControl: ephemeral(),
-				ResponsesToolMessage: &schemas.ResponsesToolMessage{
-					CallID:    schemas.Ptr("call_1"),
-					Name:      schemas.Ptr("get_weather"),
-					Arguments: schemas.Ptr(`{"city":"Paris"}`),
-				},
-			},
-			want: 1,
-		},
+		}},
 	}
+}
 
-	for _, tc := range cases {
+// marshalResponses returns the outbound body as a generic map plus the raw bytes.
+func marshalResponses(t *testing.T, bifrostReq *schemas.BifrostResponsesRequest) (map[string]any, string) {
+	t.Helper()
+	request := ToOpenAIResponsesRequest(nil, bifrostReq)
+	if request == nil {
+		t.Fatal("expected non-nil request")
+	}
+	jsonBytes, err := request.MarshalJSON()
+	if err != nil {
+		t.Fatalf("failed to marshal responses request: %v", err)
+	}
+	raw := string(jsonBytes)
+	var m map[string]any
+	if err := sonic.Unmarshal(jsonBytes, &m); err != nil {
+		t.Fatalf("failed to parse marshaled JSON: %v\nraw=%s", err, raw)
+	}
+	return m, raw
+}
+
+// firstBlock digs out input[0].content[idx].
+func firstBlock(t *testing.T, m map[string]any, idx int, raw string) map[string]any {
+	t.Helper()
+	input, ok := m["input"].([]any)
+	if !ok || len(input) == 0 {
+		t.Fatalf("expected input array; raw=%s", raw)
+	}
+	msg, _ := input[0].(map[string]any)
+	blocks, ok := msg["content"].([]any)
+	if !ok || idx >= len(blocks) {
+		t.Fatalf("expected content block %d; raw=%s", idx, raw)
+	}
+	block, _ := blocks[idx].(map[string]any)
+	return block
+}
+
+// TestToOpenAIResponsesRequest_GPT56CacheBreakpoint extends the #6290 OpenRouter
+// translation to the gpt-5.6 family (#6180). These models define
+// prompt_cache_breakpoint natively but default to IMPLICIT caching, which anchors the
+// breakpoint on the latest message - so an agent loop rewrites the whole growing
+// prompt every turn at the cache-write rate. Translating the marker is only half the
+// fix; prompt_cache_options.mode=explicit is what actually pins the prefix.
+func TestToOpenAIResponsesRequest_GPT56CacheBreakpoint(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		provider schemas.ModelProvider
+		model    string
+	}{
+		{"openai", schemas.OpenAI, "gpt-5.6-sol"},
+		{"azure", schemas.Azure, "eu/gpt-5.6-sol"},
+		{"bedrock mantle", schemas.BedrockMantle, "openai.gpt-5.6-terra"},
+	} {
 		t.Run(tc.name, func(t *testing.T) {
-			msgs := []schemas.ResponsesMessage{systemMsg(), tc.checkpoint}
-			applyOpenRouterCacheBreakpoints(msgs)
-			if got := countBreakpoints(msgs); got != tc.want {
-				t.Errorf("breakpoints = %d, want %d", got, tc.want)
+			m, raw := marshalResponses(t, gpt56CacheReq(tc.provider, tc.model))
+
+			marked := firstBlock(t, m, 0, raw)
+			bp, ok := marked["prompt_cache_breakpoint"].(map[string]any)
+			if !ok {
+				t.Fatalf("cache_control must be translated to prompt_cache_breakpoint on gpt-5.6; raw=%s", raw)
+			}
+			if mode, _ := bp["mode"].(string); mode != "explicit" {
+				t.Errorf("prompt_cache_breakpoint.mode = %q, want \"explicit\"; raw=%s", mode, raw)
+			}
+			if _, present := marked["cache_control"]; present {
+				t.Errorf("cache_control must not be forwarded to an OpenAI-shaped endpoint; raw=%s", raw)
+			}
+
+			opts, ok := m["prompt_cache_options"].(map[string]any)
+			if !ok {
+				t.Fatalf("gpt-5.6 needs prompt_cache_options.mode=explicit; the block marker alone leaves implicit caching on. raw=%s", raw)
+			}
+			if mode, _ := opts["mode"].(string); mode != "explicit" {
+				t.Errorf("prompt_cache_options.mode = %q, want \"explicit\"; raw=%s", mode, raw)
+			}
+
+			unmarked := firstBlock(t, m, 1, raw)
+			if _, present := unmarked["prompt_cache_breakpoint"]; present {
+				t.Errorf("unmarked block must not receive a breakpoint; raw=%s", raw)
 			}
 		})
+	}
+}
+
+// TestToOpenAIResponsesRequest_PreGPT56Unaffected pins the negative. Earlier OpenAI
+// models have no prompt_cache_breakpoint field at all, so translating into it would
+// send an unknown key; the serializer's existing strip is the right behaviour there.
+func TestToOpenAIResponsesRequest_PreGPT56Unaffected(t *testing.T) {
+	for _, model := range []string{"gpt-4o", "gpt-5.5", "gpt-5"} {
+		t.Run(model, func(t *testing.T) {
+			m, raw := marshalResponses(t, gpt56CacheReq(schemas.OpenAI, model))
+
+			marked := firstBlock(t, m, 0, raw)
+			if _, present := marked["prompt_cache_breakpoint"]; present {
+				t.Errorf("%s predates prompt_cache_breakpoint; nothing may be synthesized. raw=%s", model, raw)
+			}
+			if _, present := marked["cache_control"]; present {
+				t.Errorf("cache_control must still be stripped for %s; raw=%s", model, raw)
+			}
+			if _, present := m["prompt_cache_options"]; present {
+				t.Errorf("%s must not gain prompt_cache_options; raw=%s", model, raw)
+			}
+		})
+	}
+}
+
+// TestToOpenAIResponsesRequest_GPT56RespectsCallerCacheOptions verifies Bifrost does
+// not overwrite a caller that already made a caching decision.
+func TestToOpenAIResponsesRequest_GPT56RespectsCallerCacheOptions(t *testing.T) {
+	req := gpt56CacheReq(schemas.OpenAI, "gpt-5.6-sol")
+	req.Params = &schemas.ResponsesParameters{
+		PromptCacheOptions: &schemas.PromptCacheOptions{
+			Mode: schemas.Ptr("implicit"),
+			TTL:  schemas.Ptr("30m"),
+		},
+	}
+
+	m, raw := marshalResponses(t, req)
+
+	opts, ok := m["prompt_cache_options"].(map[string]any)
+	if !ok {
+		t.Fatalf("caller's prompt_cache_options disappeared; raw=%s", raw)
+	}
+	if mode, _ := opts["mode"].(string); mode != "implicit" {
+		t.Errorf("caller's mode was overwritten: got %q, want \"implicit\"; raw=%s", mode, raw)
+	}
+	if ttl, _ := opts["ttl"].(string); ttl != "30m" {
+		t.Errorf("caller's ttl was lost: got %q; raw=%s", ttl, raw)
+	}
+}
+
+// TestToOpenAIResponsesRequest_GPT56NoBreakpointNoExplicitMode guards a footgun:
+// switching a request to explicit mode with no breakpoint anywhere opts it out of
+// caching entirely, which is strictly worse than the implicit default it replaced.
+func TestToOpenAIResponsesRequest_GPT56NoBreakpointNoExplicitMode(t *testing.T) {
+	req := gpt56CacheReq(schemas.OpenAI, "gpt-5.6-sol")
+	req.Input[0].Content.ContentBlocks[0].CacheControl = nil // nothing to translate
+
+	m, raw := marshalResponses(t, req)
+
+	if _, present := m["prompt_cache_options"]; present {
+		t.Errorf("explicit mode without a breakpoint disables caching outright; raw=%s", raw)
+	}
+}
+
+// TestToOpenAIResponsesRequest_GPT56MarkerTTLIsNotCarried pins the decision NOT to
+// translate a marker's TTL onto prompt_cache_options.ttl, which is a request-wide
+// field and not a per-block one.
+//
+// There is no valid value to carry. OpenAI documents that on prompt_cache_options.ttl
+// "The only supported value, 30m, is also the default"
+// (https://developers.openai.com/api/docs/guides/prompt-caching), while a cache_control
+// marker carries either nothing (5m) or "1h"
+// (https://platform.claude.com/docs/en/build-with-claude/prompt-caching). So "30m"
+// never arrives and would be inert if it did, and forwarding the "1h" that does arrive
+// would send a value OpenAI rejects, turning a working request into a 400.
+//
+// The mode must still be set: that is what pins the prefix, and it is unrelated to TTL.
+func TestToOpenAIResponsesRequest_GPT56MarkerTTLIsNotCarried(t *testing.T) {
+	req := gpt56CacheReq(schemas.OpenAI, "gpt-5.6-sol")
+	req.Input[0].Content.ContentBlocks[0].CacheControl = &schemas.CacheControl{
+		Type: schemas.CacheControlTypeEphemeral,
+		TTL:  schemas.Ptr("1h"),
+	}
+
+	m, raw := marshalResponses(t, req)
+
+	opts, ok := m["prompt_cache_options"].(map[string]any)
+	if !ok {
+		t.Fatalf("the explicit-mode option must still be set; raw=%s", raw)
+	}
+	if mode, _ := opts["mode"].(string); mode != "explicit" {
+		t.Errorf("prompt_cache_options.mode = %q, want \"explicit\"; raw=%s", mode, raw)
+	}
+	if ttl, present := opts["ttl"]; present {
+		t.Errorf("a marker TTL must not become prompt_cache_options.ttl (got %v); OpenAI accepts "+
+			"only \"30m\" there and rejects \"1h\"; raw=%s", ttl, raw)
+	}
+	if strings.Contains(raw, "\"ttl\"") {
+		t.Errorf("no ttl may reach an OpenAI-shaped endpoint from a cache_control marker; raw=%s", raw)
 	}
 }

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -141197,6 +141197,131 @@
               ]
             }
           }
+        },
+        {
+          "name": "OpenAI gpt-5.6: cache_control becomes prompt_cache_breakpoint plus explicit mode - #6180",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('62.7 gpt-5.6 translation: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var body = pm.response.json() || {};",
+                  "var rr = (body.extra_fields || {}).raw_request;",
+                  "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                  "pm.test('62.7 raw_request captured', function () { pm.expect(rr).to.be.an('object'); });",
+                  "if (!rr) { return; }",
+                  "var rawStr = JSON.stringify(rr);",
+                  "pm.test('62.7 breakpoint reaches the wire', function () {",
+                  "  pm.expect(rawStr, 'raw_request: ' + rawStr.slice(0, 800)).to.include('prompt_cache_breakpoint');",
+                  "});",
+                  "// The block marker alone leaves implicit caching on, which anchors the prefix",
+                  "// to the newest message and bills a write every turn. mode=explicit pins it.",
+                  "pm.test('62.7 explicit cache mode is set alongside it (#6180)', function () {",
+                  "  var opts = rr.prompt_cache_options || {};",
+                  "  pm.expect(opts.mode, 'prompt_cache_options: ' + JSON.stringify(opts)).to.eql('explicit');",
+                  "});",
+                  "pm.test('62.7 cache_control is not forwarded to an OpenAI-shaped endpoint', function () {",
+                  "  pm.expect(rawStr.indexOf('cache_control')).to.equal(-1);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-send-back-raw-request",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"openai/gpt-5.6-sol\",\n  \"max_output_tokens\": 16,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"You are a meticulous assistant. Answer tersely.\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Reply with OK.\"\n        }\n      ]\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "OpenAI gpt-4o: pre-5.6 models gain no cache fields - #6180",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('62.8 pre-5.6: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var body = pm.response.json() || {};",
+                  "var rr = (body.extra_fields || {}).raw_request;",
+                  "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                  "pm.test('62.8 raw_request captured', function () { pm.expect(rr).to.be.an('object'); });",
+                  "if (!rr) { return; }",
+                  "var rawStr = JSON.stringify(rr);",
+                  "// gpt-4o has no prompt_cache_breakpoint field at all, so synthesizing one would",
+                  "// send an unknown key. Stripping cache_control remains the correct behaviour.",
+                  "pm.test('62.8 no breakpoint is synthesized for a pre-5.6 model (#6180)', function () {",
+                  "  pm.expect(rawStr.indexOf('prompt_cache_breakpoint'), 'raw_request: ' + rawStr.slice(0, 800)).to.equal(-1);",
+                  "});",
+                  "pm.test('62.8 no prompt_cache_options is added', function () {",
+                  "  pm.expect(rawStr.indexOf('prompt_cache_options')).to.equal(-1);",
+                  "});",
+                  "pm.test('62.8 cache_control is still stripped', function () {",
+                  "  pm.expect(rawStr.indexOf('cache_control')).to.equal(-1);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-send-back-raw-request",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"openai/gpt-4o\",\n  \"max_output_tokens\": 16,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"You are a meticulous assistant. Answer tersely.\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Reply with OK.\"\n        }\n      ]\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
         }
       ]
     }


### PR DESCRIPTION
## Summary

The existing `cache_control` → `prompt_cache_breakpoint` translation that was introduced for OpenRouter (#6290) is extended to the `gpt-5.6` model family (OpenAI, Azure, BedrockMantle). These models define `prompt_cache_breakpoint` natively but default to **implicit** caching, which anchors the breakpoint on the latest message — causing an agent loop to bill a cache write on every turn and read almost nothing back. Translating the block marker is only half the fix; `prompt_cache_options.mode=explicit` is what actually pins the prefix to the intended position (#6180).

## Changes

- `responsesUsesPromptCacheBreakpoints` replaces the previous OpenRouter-only guard, routing `gpt-5.6` models on OpenAI, Azure, and BedrockMantle through the same translation path.
- `responsesUsesPromptCacheOptions` identifies the targets that additionally need `prompt_cache_options.mode=explicit` to disable implicit caching (gpt-5.6 only; OpenRouter has no equivalent field and needs none).
- `responsesHasPromptCacheBreakpoint` prevents the footgun of switching a request to explicit mode when no breakpoint exists anywhere, which would opt it out of caching entirely — strictly worse than the implicit default.
- `applyOpenRouterCacheBreakpoints` and `openRouterMaxCacheBreakpoints` are renamed to `applyResponsesCacheBreakpoints` and `maxResponsesCacheBreakpoints` to reflect that the logic now serves multiple providers.
- `ToOpenAIResponsesRequest` injects `prompt_cache_options` only when a breakpoint is actually present and the caller has not already set their own `prompt_cache_options`, so caller intent is always respected.
- Unit tests cover: correct translation for all three gpt-5.6 providers, no synthesis for pre-5.6 models (`gpt-4o`, `gpt-5.5`, `gpt-5`), caller-supplied `prompt_cache_options` are preserved, and no explicit mode is injected when there is no breakpoint.
- E2E Postman collection gains two new cases: one verifying the full translation for `gpt-5.6-sol`, and one pinning the negative for `gpt-4o`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/openai/... -run TestToOpenAIResponsesRequest_GPT56
go test ./core/providers/openai/... -run TestToOpenAIResponsesRequest_PreGPT56Unaffected
go test ./core/providers/openai/... -run TestToOpenAIResponsesRequest_GPT56RespectsCallerCacheOptions
go test ./core/providers/openai/... -run TestToOpenAIResponsesRequest_GPT56NoBreakpointNoExplicitMode
go test ./...
```

For live verification, send a `/v1/responses` request with `model: openai/gpt-5.6-sol` and a `cache_control: {type: ephemeral}` block using `x-bf-send-back-raw-request: true`. The raw outbound request should contain `prompt_cache_breakpoint` with `mode: explicit`, `prompt_cache_options.mode: explicit`, and no `cache_control` key. Repeat with `model: openai/gpt-4o` and confirm none of those fields appear.

## Breaking changes

- [x] No

## Related issues

Closes #6180
Related: #6290

## Security considerations

None. This change affects only how caching intent is serialized before it leaves Bifrost; no credentials, secrets, or user PII are involved.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable