### PR TITLE
fix: propagate grant from submit context into async job's background context via explicit `SetGrant` call

### DIFF
--- a/framework/logstore/asyncjob.go
+++ b/framework/logstore/asyncjob.go
@@ -148,21 +148,32 @@ func (e *AsyncJobExecutor) SubmitJob(bifrostCtx *schemas.BifrostContext, resultT
 	}
 
 	var contextValues map[any]any
+	var g schemas.Grant
 	if bifrostCtx != nil {
 		contextValues = bifrostCtx.GetUserValues()
+		g = bifrostCtx.Grant()
 	}
-	go e.executeJob(job, operation, contextValues)
+	go e.executeJob(job, operation, contextValues, g)
 
 	return job, nil
 }
 
 // executeJob runs the operation in the background and updates the job record.
-func (e *AsyncJobExecutor) executeJob(job *AsyncJob, operation AsyncOperation, contextValues map[any]any) {
+func (e *AsyncJobExecutor) executeJob(job *AsyncJob, operation AsyncOperation, contextValues map[any]any, g schemas.Grant) {
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
 	// Restore original request context values (virtual key, tracing headers, etc.)
 	for k, v := range contextValues {
 		ctx.SetValue(k, v)
+	}
+
+	// The job is the submit call's request, run later: it carries that request's grant, not a
+	// copy, the same way a realtime turn carries its session's grant (see
+	// newRealtimeTurnContext). GetUserValues above does not include it — Grant is held on its own
+	// field, not the user-values map — so without this, governance sees a context nobody settled
+	// an identity on and refuses it outright.
+	if g != nil {
+		ctx.SetGrant(g)
 	}
 
 	// Clear trace context inherited from the original HTTP request.

--- a/framework/logstore/asyncjob_test.go
+++ b/framework/logstore/asyncjob_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/maximhq/bifrost/core/schemas"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/grant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
@@ -115,6 +116,39 @@ func TestSubmitJob_PropagatesContextValues(t *testing.T) {
 	assert.Equal(t, "production", capturedCtx.Value(schemas.BifrostContextKey("x-bf-prom-env")))
 	assert.Equal(t, "custom-value", capturedCtx.Value(schemas.BifrostContextKey("x-bf-eh-custom")))
 	assert.Equal(t, true, capturedCtx.Value(schemas.BifrostIsAsyncRequest))
+}
+
+// TestSubmitJob_PropagatesGrant covers the same gap realtime turn contexts already guard against
+// (see newRealtimeTurnContext): the background context executeJob builds is new, so a grant
+// settled on the submit call's context must be carried over explicitly, not assumed to survive
+// GetUserValues — Grant lives on its own field, not the user-values map.
+func TestSubmitJob_PropagatesGrant(t *testing.T) {
+	executor := newTestAsyncExecutor(t)
+
+	submitCtx := schemas.NewBifrostContext(context.Background(), time.Now().Add(1*time.Minute))
+	submitCtx.SetValue(schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
+	g := grant.New()
+	g.SetIdentity(grant.NewIdentity(grant.NewCredential(grant.CredentialVirtualKey, "sk-bf-test"), nil, nil, nil, nil, nil, nil))
+	require.True(t, submitCtx.SetGrant(g))
+
+	var gotGrant schemas.Grant
+	var done atomic.Bool
+
+	operation := func(bgCtx *schemas.BifrostContext) (interface{}, *schemas.BifrostError) {
+		gotGrant = bgCtx.Grant()
+		done.Store(true)
+		return map[string]string{"status": "ok"}, nil
+	}
+
+	job, err := executor.SubmitJob(submitCtx, 3600, operation, schemas.ChatCompletionRequest)
+	require.NoError(t, err)
+	require.NotNil(t, job)
+
+	waitForJobCompletion(t, &done)
+
+	require.NotNil(t, gotGrant, "background context lost the grant settled on the submit call's context")
+	assert.Same(t, g, gotGrant, "background context must carry the submit call's grant, not a copy")
+	assert.Equal(t, "sk-bf-test", gotGrant.Identity().Credential().Value)
 }
 
 func TestSubmitJob_StoresRequestID(t *testing.T) {


### PR DESCRIPTION
## Summary

When an async job is submitted, the background goroutine builds a fresh `BifrostContext`. Previously, the grant settled on the original submit call's context was not carried over to this new context because `GetUserValues` does not include the grant — it lives on its own field, not in the user-values map. As a result, governance checks in the background execution saw a context with no settled identity and refused the request outright.

## Changes

- The grant is now extracted from the submit call's `BifrostContext` and explicitly passed into `executeJob`, where it is applied to the newly constructed background context via `SetGrant`.
- This mirrors the same pattern already used in `newRealtimeTurnContext` for realtime turns, where the session's grant must be explicitly forwarded to each turn's context.
- A test (`TestSubmitJob_PropagatesGrant`) was added to assert that the background context receives the exact same grant instance that was settled on the submit call's context.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/logstore/...
```

The new `TestSubmitJob_PropagatesGrant` test verifies that a grant settled on the submit call's context is present and identical (not a copy) in the background execution context.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This fix ensures that identity and authorization context established at request time is correctly propagated to background async job execution. Without it, governance checks would see an unauthenticated context, which could cause legitimate requests to be incorrectly rejected.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable