### PR TITLE
feat: add project dimension to governance context, log tables, filters, and permit evaluation with refusal when a named project goes unscoped

### DIFF
--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -263,6 +263,8 @@ const (
 	BifrostContextKeyGovernanceCustomerIDs               BifrostContextKey = "bifrost-governance-customer-ids"        // []string (distinct customers a user/team request belongs to; set by enterprise governance plugin - DO NOT SET THIS MANUALLY)
 	BifrostContextKeyGovernanceCustomerNames             BifrostContextKey = "bifrost-governance-customer-names"      // []string (display names, aligned with customer-ids; set by enterprise governance plugin - DO NOT SET THIS MANUALLY)
 	BifrostContextKeyGovernanceScopedCustomerID          BifrostContextKey = "bifrost-governance-scoped-customer-id"  // string (resolved customer the request is scoped to via the x-bf-customer-id / x-bf-customer-name header on a team-VK path; set by the enterprise governance plugin - DO NOT SET THIS MANUALLY)
+	BifrostContextKeyGovernanceProjectID                 BifrostContextKey = "bifrost-governance-project-id"          // string (the project a request is scoped to, once resolved and checked; every consumer reads the resolved value rather than the caller's header - DO NOT SET THIS MANUALLY)
+	BifrostContextKeyGovernanceProjectName               BifrostContextKey = "bifrost-governance-project-name"        // string (display name, aligned with project-id - DO NOT SET THIS MANUALLY)
 	BifrostContextKeyGovernanceRoutingRuleID             BifrostContextKey = "bifrost-governance-routing-rule-id"     // string (to store the routing rule ID (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyGovernanceRoutingRuleName           BifrostContextKey = "bifrost-governance-routing-rule-name"   // string (to store the routing rule name (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyRoutingPinnedAPIKeyID               BifrostContextKey = "bifrost-routing-pinned-api-key-id"      // string (provider key ID pinned by a matched routing rule target; resolved against the configured key pool during key selection and takes precedence over a caller-supplied pin (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
@@ -418,6 +420,18 @@ const (
 	BifrostContextKeyAsyncWebhookEndpoint                BifrostContextKey = "bifrost-async-webhook-endpoint" // string (webhook endpoint name to notify when an async job finishes - carried as-is from the x-bf-async-webhook header; the submit path resolves and validates it before the job is created)
 	BifrostContextKeyUpstreamLatency                     BifrostContextKey = "bifrost-upstream-latency"       // *atomic.Int64 nanoseconds (set by bifrost - DO NOT SET THIS MANUALLY) - cumulative time blocked on provider sockets across every attempt; subtract from total to get Bifrost overhead
 	BifrostContextKeyStreamOverhead                      BifrostContextKey = "bifrost-stream-overhead"        // *streamOverhead (set by bifrost - DO NOT SET THIS MANUALLY) - per-chunk stream conversion CPU and downstream backpressure, carved out of the overhead breakdown's "core" bucket
+)
+
+// Headers a request uses to name the project it asks to be scoped by. The id takes precedence over
+// the name.
+//
+// Declared here rather than wherever projects are resolved, because two things read them: whatever
+// resolves the project, and the governance funnel, which refuses a request that named one and ended
+// up scoped by none. Two copies of these names would let those two disagree about what a request
+// asked for.
+const (
+	HeaderGovernanceProjectID   = "x-bf-project-id"
+	HeaderGovernanceProjectName = "x-bf-project-name"
 )
 
 const (

--- a/framework/configstore/tables/modelconfig.go
+++ b/framework/configstore/tables/modelconfig.go
@@ -13,6 +13,7 @@ import (
 const (
 	ModelConfigScopeGlobal     = "global"
 	ModelConfigScopeVirtualKey = "virtual_key"
+	ModelConfigScopeProject    = "project"
 )
 
 // ModelConfigAllModels is the model_name sentinel meaning "all models". Combined with a
@@ -29,6 +30,7 @@ var (
 	validModelConfigScopes   = map[string]bool{
 		ModelConfigScopeGlobal:     true,
 		ModelConfigScopeVirtualKey: true,
+		ModelConfigScopeProject:    true,
 	}
 )
 

--- a/framework/configstore/tables/modelconfig_test.go
+++ b/framework/configstore/tables/modelconfig_test.go
@@ -1,0 +1,21 @@
+package tables
+
+import "testing"
+
+// TestBeforeSave_ProjectScope verifies that a project-scoped model config is accepted by
+// BeforeSave. ModelConfigScopeProject is read by the governance store's scope resolution
+// (plugins/governance/store.go's modelConfigScopeFor), so it must be a valid, creatable
+// scope in its own right, not just a constant referenced for reads.
+func TestBeforeSave_ProjectScope(t *testing.T) {
+	scopeID := "proj-123"
+	mc := &TableModelConfig{
+		ID:        "mc-1",
+		ModelName: "gpt-4o",
+		Scope:     ModelConfigScopeProject,
+		ScopeID:   &scopeID,
+	}
+
+	if err := mc.BeforeSave(nil); err != nil {
+		t.Fatalf("BeforeSave rejected a project-scoped model config: %v", err)
+	}
+}

--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -974,6 +974,7 @@ func canUseMatViewFilters(f SearchFilters) bool {
 		len(f.UserAgents) == 0 &&
 		len(f.TeamIDs) == 0 &&
 		len(f.BusinessUnitIDs) == 0 &&
+		len(f.ProjectIDs) == 0 &&
 		len(f.CustomerIDs) == 0
 }
 

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -296,6 +296,8 @@ var logstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"logs_add_overhead_breakdown_column"}, run: migrationAddOverheadBreakdownColumn},
 	{IDs: []string{"webhook_deliveries_add_filter_indexes_v1"}, run: migrationAddWebhookDeliveryFilterIndexes},
 	{IDs: []string{"logs_add_video_debug_column"}, run: migrationAddVideoDebugColumn},
+	{IDs: []string{"logs_add_project_columns"}, run: migrationAddProjectColumns},
+	{IDs: []string{"mcp_tool_logs_add_project_columns"}, run: migrationAddProjectColumnsToMCPToolLogs},
 }
 
 // areThereAnyPendingMigrations returns true if there are any pending migrations to be applied.
@@ -2945,6 +2947,16 @@ var performanceIndexes = []performanceIndexDef{
 		name:  "idx_webhook_deliveries_request_id",
 		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_webhook_deliveries_request_id ON webhook_deliveries(request_id)",
 	},
+	{
+		table: "logs",
+		name:  "idx_logs_project_id",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_project_id ON logs(project_id)",
+	},
+	{
+		table: "mcp_tool_logs",
+		name:  "idx_mcp_logs_project_id",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_project_id ON mcp_tool_logs(project_id)",
+	},
 }
 
 // ensurePerformanceIndexes checks whether each performance GIN index exists and is
@@ -3417,6 +3429,90 @@ func migrationAddGovernanceContextColumns(ctx context.Context, db *gorm.DB, logg
 // the full deduped set of teams / business units a request belongs to (enterprise
 // user/AP path). The scalar team_id/business_unit_id remain the primary; these
 // power display, multi-team filtering (jsonb @> + GIN), and fan-out aggregation.
+// migrationAddProjectColumns adds the project dimension to the request log. A request records the
+// project it was scoped to the way it records the team or business unit it was made under: as the
+// resolved id and its display name, so a log row still reads correctly after the project is renamed
+// or deleted.
+//
+// Indexed on the id alone, because that is what filtering and rollups ask about; the name is only
+// ever read back off a row that has already been found. The index is built CONCURRENTLY by
+// ensurePerformanceIndexes (an entry appended to performanceIndexes), since addColumnIfNotExists
+// adds only the column and an in-migration build would block writes on a populated table.
+func migrationAddProjectColumns(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "logs_add_project_columns"
+	logger.Info("[logstore] starting migration %s", migrationName)
+	defer logger.Info("[logstore] finished migration %s", migrationName)
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+
+	columns := []string{"project_id", "project_name"}
+
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			for _, col := range columns {
+				if err := addColumnIfNotExists(tx, logger, &Log{}, col); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			for _, col := range columns {
+				if err := dropColumnIfExists(tx, logger, &Log{}, col); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while adding project columns: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddProjectColumnsToMCPToolLogs is the same dimension on the tool log, so a tool call made
+// inside a project is attributable to it exactly as a model call is. Its index is likewise built by
+// ensurePerformanceIndexes rather than here.
+func migrationAddProjectColumnsToMCPToolLogs(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "mcp_tool_logs_add_project_columns"
+	logger.Info("[logstore] starting migration %s", migrationName)
+	defer logger.Info("[logstore] finished migration %s", migrationName)
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+
+	columns := []string{"project_id", "project_name"}
+
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			for _, col := range columns {
+				if err := addColumnIfNotExists(tx, logger, &MCPToolLog{}, col); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			for _, col := range columns {
+				if err := dropColumnIfExists(tx, logger, &MCPToolLog{}, col); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while adding project columns to mcp tool logs: %s", err.Error())
+	}
+	return nil
+}
+
 func migrationAddMultiTeamBusinessUnitColumns(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
 	migrationName := "logs_add_multi_team_business_unit_columns"
 	logger.Info("[logstore] starting migration %s", migrationName)

--- a/framework/logstore/migrations_test.go
+++ b/framework/logstore/migrations_test.go
@@ -494,3 +494,17 @@ func TestMigrationAddMetadataGINIndex_EdgeCases(t *testing.T) {
 	// Verify the GIN index was created
 	assert.True(t, indexExists(t, db, "idx_logs_metadata_gin"), "GIN index should be created")
 }
+
+// TestPerformanceIndexesCoverProjectIDs pins the project indexes to the ensurePerformanceIndexes
+// list: the project column migrations add only the columns (addColumnIfNotExists never creates a
+// field's index), so an upgraded deployment scans logs by project_id unindexed unless the
+// background builder carries both entries. A fresh database gets them from the model's index tags
+// at table creation.
+func TestPerformanceIndexesCoverProjectIDs(t *testing.T) {
+	tables := map[string]string{}
+	for _, idx := range performanceIndexes {
+		tables[idx.name] = idx.table
+	}
+	assert.Equal(t, "logs", tables["idx_logs_project_id"])
+	assert.Equal(t, "mcp_tool_logs", tables["idx_mcp_logs_project_id"])
+}

--- a/framework/logstore/multi_team_filter_test.go
+++ b/framework/logstore/multi_team_filter_test.go
@@ -88,5 +88,8 @@ func TestCanUseMatViewFilters_ExcludesTeamBU(t *testing.T) {
 	assert.False(t, canUseMatViewFilters(SearchFilters{TeamIDs: []string{"t1"}}), "team filter must force the raw path")
 	assert.False(t, canUseMatViewFilters(SearchFilters{BusinessUnitIDs: []string{"bu1"}}), "BU filter must force the raw path")
 	assert.False(t, canUseMatViewFilters(SearchFilters{CustomerIDs: []string{"c1"}}), "customer filter must force the raw path")
+	// The matview carries no project column at all, so it cannot answer a project filter: the
+	// query would name a column that does not exist. The raw log table is the only path that can.
+	assert.False(t, canUseMatViewFilters(SearchFilters{ProjectIDs: []string{"p1"}}), "project filter must force the raw path")
 	assert.False(t, canUseMatViewFilters(SearchFilters{ParentRequestID: "req-1"}), "parent request filter has no matview dimension and must force the raw path")
 }

--- a/framework/logstore/projectdimension_test.go
+++ b/framework/logstore/projectdimension_test.go
@@ -1,0 +1,85 @@
+package logstore
+
+import (
+	"testing"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// newProjectDimensionStore builds an in-memory store over the real log table, so the project
+// columns are exercised as the migration will create them rather than as a struct literal.
+func newProjectDimensionStore(t *testing.T) *RDBLogStore {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&Log{}))
+	return &RDBLogStore{db: db, logger: bifrost.NewDefaultLogger(schemas.LogLevelInfo)}
+}
+
+// A project filter has to actually narrow the rows. A filter the caller sets and the query drops
+// returns more than was asked for, and nothing about that surfaces as an error; the caller simply
+// sees another project's traffic in their own report.
+func TestProjectFilterNarrowsTheRawQuery(t *testing.T) {
+	s := newProjectDimensionStore(t)
+
+	for _, row := range []struct{ id, project string }{
+		{"req-1", "proj-a"},
+		{"req-2", "proj-a"},
+		{"req-3", "proj-b"},
+		{"req-4", ""}, // no project: the shape every request has today
+	} {
+		entry := &Log{ID: row.id, Status: "success"}
+		if row.project != "" {
+			p := row.project
+			entry.ProjectID = &p
+		}
+		require.NoError(t, s.db.Create(entry).Error)
+	}
+
+	countWith := func(f SearchFilters) int64 {
+		var n int64
+		require.NoError(t, s.applyFilters(s.db.Model(&Log{}), f).Count(&n).Error)
+		return n
+	}
+
+	assert.EqualValues(t, 2, countWith(SearchFilters{ProjectIDs: []string{"proj-a"}}))
+	assert.EqualValues(t, 1, countWith(SearchFilters{ProjectIDs: []string{"proj-b"}}))
+	assert.EqualValues(t, 3, countWith(SearchFilters{ProjectIDs: []string{"proj-a", "proj-b"}}),
+		"several projects union, they do not intersect")
+	assert.EqualValues(t, 4, countWith(SearchFilters{}),
+		"no project filter must not hide the requests that carry no project")
+	assert.EqualValues(t, 0, countWith(SearchFilters{ProjectIDs: []string{"proj-missing"}}))
+}
+
+// The project is stored as the resolved id plus its display name, so a row still reads correctly
+// after the project is renamed or deleted, the same reason the team and business-unit dimensions
+// keep a name column of their own.
+func TestProjectColumnsRoundTrip(t *testing.T) {
+	s := newProjectDimensionStore(t)
+
+	id, name := "proj-a", "gpt-migration"
+	require.NoError(t, s.db.Create(&Log{ID: "req-1", Status: "success", ProjectID: &id, ProjectName: &name}).Error)
+
+	var stored Log
+	require.NoError(t, s.db.First(&stored, "id = ?", "req-1").Error)
+	require.NotNil(t, stored.ProjectID)
+	require.NotNil(t, stored.ProjectName)
+	assert.Equal(t, "proj-a", *stored.ProjectID)
+	assert.Equal(t, "gpt-migration", *stored.ProjectName)
+
+	// A request with no project stores neither, so "no project" and "a project named empty" stay
+	// distinguishable.
+	require.NoError(t, s.db.Create(&Log{ID: "req-2", Status: "success"}).Error)
+	var bare Log
+	require.NoError(t, s.db.First(&bare, "id = ?", "req-2").Error)
+	assert.Nil(t, bare.ProjectID)
+	assert.Nil(t, bare.ProjectName)
+}

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -340,6 +340,11 @@ func (s *RDBLogStore) applyFilters(baseQuery *gorm.DB, filters SearchFilters) *g
 	if len(filters.UserIDs) > 0 {
 		baseQuery = baseQuery.Where("user_id IN ?", filters.UserIDs)
 	}
+	// Scalar, unlike the team, customer and business-unit dimensions: a request is scoped to at most
+	// one project, so there is no array column to OR against.
+	if len(filters.ProjectIDs) > 0 {
+		baseQuery = baseQuery.Where("project_id IN ?", filters.ProjectIDs)
+	}
 	if len(filters.BusinessUnitIDs) > 0 {
 		if s.db.Dialector.Name() == "postgres" {
 			sql, args := multiValueDimensionFilterSQL("business_unit_id", "business_unit_ids", filters.BusinessUnitIDs)

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -62,6 +62,7 @@ type SearchFilters struct {
 	CustomerIDs       []string          `json:"customer_ids,omitempty"`
 	UserIDs           []string          `json:"user_ids,omitempty"`
 	BusinessUnitIDs   []string          `json:"business_unit_ids,omitempty"`
+	ProjectIDs        []string          `json:"project_ids,omitempty"`
 	RoutingEngineUsed []string          `json:"routing_engine_used,omitempty"` // For filtering by routing engine (routing-rule, governance, loadbalancing)
 	Apps              []string          `json:"apps,omitempty"`                // Backend-detected client apps
 	UserAgents        []string          `json:"user_agents,omitempty"`         // Raw User-Agent strings; kept for compatibility/debug filtering
@@ -217,6 +218,8 @@ type Log struct {
 	CustomerName            *string   `gorm:"type:varchar(255)" json:"customer_name"`
 	BusinessUnitID          *string   `gorm:"type:varchar(255);index:idx_logs_business_unit_id" json:"business_unit_id"`
 	BusinessUnitName        *string   `gorm:"type:varchar(255)" json:"business_unit_name"`
+	ProjectID               *string   `gorm:"type:varchar(255);index:idx_logs_project_id" json:"project_id"`
+	ProjectName             *string   `gorm:"type:varchar(255)" json:"project_name"`
 	TeamIDs                 *string   `gorm:"type:text" json:"-"`
 	TeamNames               *string   `gorm:"type:text" json:"-"`
 	CustomerIDs             *string   `gorm:"type:text" json:"-"`
@@ -1282,6 +1285,8 @@ type MCPToolLog struct {
 	TeamID         *string   `gorm:"type:varchar(255);index:idx_mcp_logs_team_id" json:"team_id"`
 	CustomerID     *string   `gorm:"type:varchar(255);index:idx_mcp_logs_customer_id" json:"customer_id"`
 	BusinessUnitID *string   `gorm:"type:varchar(255);index:idx_mcp_logs_business_unit_id" json:"business_unit_id"`
+	ProjectID      *string   `gorm:"type:varchar(255);index:idx_mcp_logs_project_id" json:"project_id"`
+	ProjectName    *string   `gorm:"type:varchar(255)" json:"project_name"`
 	UserAgent      *string   `gorm:"type:varchar(512);index:idx_mcp_logs_user_agent" json:"user_agent,omitempty"` // Raw HTTP User-Agent of the calling client
 	App            *string   `gorm:"type:varchar(128);index:idx_mcp_logs_app" json:"app,omitempty"`               // Backend-detected client app derived from user_agent
 	Arguments      string    `gorm:"type:text" json:"-"`                                                          // JSON serialized tool arguments

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -581,6 +581,36 @@ func (p *GovernancePlugin) PublishRoutingAllowlist(ctx *schemas.BifrostContext, 
 	ctx.SetValue(schemas.BifrostContextKeyRoutingAllowedProviders, modelProviders(access.GrantedProvidersForModel(modelStr)))
 }
 
+// namedProjectNothingScoped reports whether the request named a project and ended up scoped by
+// none, and what it named it.
+//
+// The same shape as presentedGrantBearingCredential above, for the same reason: what the request
+// asked for is read off its own input, and only comparing that against what resolution produced can
+// tell "asked for nothing" from "asked for something that is not there". A project named with no
+// resolved project behind it was not granted (it does not exist, or it does not admit this caller),
+// and those are not told apart here, exactly as a credential that resolves to nothing does not say
+// whether it never existed or was revoked.
+//
+// A header that arrived empty still counts as having asked. It named no project, so no project can
+// be resolved from it, and treating it as not having asked would serve the request against the
+// caller's own access instead of refusing a scope it could not be given.
+//
+// The resolved id rather than the scoping slot, because that id is set at exactly the moment a
+// project is admitted. Reading the slot would answer this question wrongly the moment anything other
+// than a project fills it.
+func namedProjectNothingScoped(ctx *schemas.BifrostContext) (string, bool) {
+	if bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceProjectID) != "" {
+		return "", false
+	}
+	headers, _ := ctx.Value(schemas.BifrostContextKeyRequestHeaders).(map[string]string)
+	for _, header := range []string{schemas.HeaderGovernanceProjectID, schemas.HeaderGovernanceProjectName} {
+		if named, sent := headers[header]; sent {
+			return strings.TrimSpace(named), true
+		}
+	}
+	return "", false
+}
+
 // Evaluate is the governance verdict for a request: whether it may proceed, and why not when it
 // may not. It is the one entry point: every hook and every caller outside the pipeline arrives
 // here, which is also why it resolves what the request may reach if nothing has yet.
@@ -660,6 +690,20 @@ func (p *GovernancePlugin) Evaluate(ctx *schemas.BifrostContext, evaluationReque
 	// than resolving a key again. A caller that presented a credential no permit could be built for
 	// is refused here: no permit means nothing authorised the request, which is a different answer
 	// from having presented nothing.
+	//
+	// Two ways a request can end up with nothing where it expected something, and they are the same
+	// question asked of each slot: it presented a credential and nothing granted it, or it named a
+	// project and nothing scoped it. Neither is reported by whatever resolved it: a resolver answers
+	// with what it found, and this is where not finding it becomes a refusal.
+	//
+	// The second is why a project the request may not use cannot simply be dropped: doing that would
+	// serve the request against the caller's own access, which is more than they asked for and not
+	// what they asked for. Like the first, it does not say which of "no such project" and "not
+	// yours" it was, because a caller who may not use a project has no business learning it exists.
+	//
+	// This is the funnel every pipeline passes through, including the streaming, realtime-turn and
+	// MCP ones that run no request hook, so refusing here is what makes the answer the same on all
+	// of them.
 	if refusal := unusablePermit(access); refusal != nil {
 		return p.decide(ctx, refusal)
 	}
@@ -667,6 +711,15 @@ func (p *GovernancePlugin) Evaluate(ctx *schemas.BifrostContext, evaluationReque
 		return p.decide(ctx, &EvaluationResult{
 			Decision: DecisionAccessNotFound,
 			Reason:   "access not found. The provided credential does not exist or has been revoked.",
+		})
+	}
+	// Blocked rather than not-found, though the shape of the question is the same. A credential that
+	// resolves to nothing is an authentication failure and says so; a caller who authenticated fine
+	// and named a project they may not have is being refused, not asked to identify themselves again.
+	if named, nothingScoped := namedProjectNothingScoped(ctx); nothingScoped {
+		return p.decide(ctx, &EvaluationResult{
+			Decision: DecisionAccessBlocked,
+			Reason:   fmt.Sprintf("project %q not found. It does not exist or does not admit this request.", named),
 		})
 	}
 
@@ -708,25 +761,36 @@ func (p *GovernancePlugin) Evaluate(ctx *schemas.BifrostContext, evaluationReque
 	return p.decide(ctx, result)
 }
 
-// unusablePermit is the refusal for a request whose caller holds a permit that may not be used:
-// one that is inactive, or has expired. Whether it may be used is settled when the permit is built,
-// so this reads the answer off it. Nil when every permit the caller holds may be used, or they hold
+// unusablePermit is the refusal for a request that carries a permit that may not be used: one that
+// is inactive, or has expired. Whether it may be used is settled when the permit is built, so this
+// reads the answer off it. Nil when every permit the request carries may be used, or it carries
 // none, which the funnel answers separately by what was presented.
+//
+// Every slot is judged, because a request scoped by a second permit answers to both, and a permit
+// that has been deactivated or has expired grants nothing whichever slot it sits in. Nothing in the
+// fold reads either flag (it answers what a permit enumerates, not whether the permit may still be
+// used), so a scoping permit nobody checked here would go on permitting everything it names.
 func unusablePermit(access schemas.Access) *EvaluationResult {
 	if access == nil {
 		return nil
 	}
-	for _, base := range access.Bases() {
-		if !base.IsActive() {
+	permits := make([]schemas.Permit, 0, len(access.Bases())+1)
+	permits = append(permits, access.Bases()...)
+	permits = append(permits, access.Scoping())
+	for _, permit := range permits {
+		if permit == nil {
+			continue
+		}
+		if !permit.IsActive() {
 			return &EvaluationResult{
 				Decision: DecisionAccessBlocked,
-				Reason:   fmt.Sprintf("%s is inactive", grant.PermitType(base.Type()).PrettyString()),
+				Reason:   fmt.Sprintf("%s is inactive", grant.PermitType(permit.Type()).PrettyString()),
 			}
 		}
-		if base.IsExpired() {
+		if permit.IsExpired() {
 			return &EvaluationResult{
 				Decision: DecisionAccessBlocked,
-				Reason:   fmt.Sprintf("%s has expired", grant.PermitType(base.Type()).PrettyString()),
+				Reason:   fmt.Sprintf("%s has expired", grant.PermitType(permit.Type()).PrettyString()),
 			}
 		}
 	}

--- a/plugins/governance/permits_test.go
+++ b/plugins/governance/permits_test.go
@@ -1334,3 +1334,161 @@ func TestPermitFindsItsOwnScopedModelConfigs(t *testing.T) {
 		}
 	}
 }
+
+// TestEvaluateJudgesEveryPermit covers the state check on the permit scoping a request, not just
+// on the ones its caller holds.
+//
+// A scoping permit that has been deactivated or has expired grants nothing, exactly as a base permit
+// in that state does. Nothing in the fold reads either flag (it answers what a permit enumerates,
+// not whether the permit may still be used), so if this step asks only about the bases, a dead
+// scoping permit goes on permitting everything it names, with nothing anywhere to catch it.
+func TestEvaluateJudgesEveryPermit(t *testing.T) {
+	vk := buildVKForMCPStamping([]string{"read_file"})
+	base := permitWithProviders("other", "h1", "Holder", "openai")
+	request := &EvaluationRequest{Provider: schemas.OpenAI, Model: "gpt-4o"}
+
+	scopingIn := func(isActive, isExpired bool) *permitStore {
+		providers := permitWithProviders("scope", "s1", "Scope", "openai").ProviderPermits()
+		scoping := grant.NewPermit("scope", "s1", "Scope", isActive, isExpired, providers, nil)
+		return &permitStore{baseOverride: base, scoping: scoping, mode: grant.Intersect}
+	}
+
+	for name, tc := range map[string]struct {
+		isActive  bool
+		isExpired bool
+		want      string
+	}{
+		"deactivated": {isActive: false, isExpired: false, want: "scope is inactive"},
+		"expired":     {isActive: true, isExpired: true, want: "scope has expired"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			plugin := newAccessTestPlugin(t, vk, scopingIn(tc.isActive, tc.isExpired))
+
+			result, bifrostErr := plugin.Evaluate(emptyCtx(), request)
+
+			require.NotNil(t, bifrostErr, "a scoping permit that can no longer be used still scoped the request")
+			assert.Equal(t, DecisionAccessBlocked, result.Decision)
+			assert.Equal(t, tc.want, result.Reason)
+		})
+	}
+
+	t.Run("a scoping permit in good standing is left alone", func(t *testing.T) {
+		plugin := newAccessTestPlugin(t, vk, scopingIn(true, false))
+
+		result, bifrostErr := plugin.Evaluate(emptyCtx(), request)
+
+		assert.Nil(t, bifrostErr)
+		assert.Equal(t, DecisionAllow, result.Decision)
+	})
+}
+
+// TestEvaluateRefusesARequestNothingScoped is the mirror of the credential rule beside it: a
+// request that named a project and ended up scoped by nothing is refused, not served.
+//
+// Dropping the project instead would serve the request against the caller's own access, which is
+// more than they asked for and not what they asked for. The refusal does not say whether the project
+// was missing or merely not theirs, for the same reason the credential one does not distinguish
+// "does not exist" from "has been revoked".
+func TestEvaluateRefusesARequestNothingScoped(t *testing.T) {
+	vk := buildVKForMCPStamping([]string{"read_file"})
+	base := permitWithProviders("other", "h1", "Holder", "openai")
+
+	// A request names a project by header, and whatever resolves it stamps the resolved id once the
+	// project has admitted the caller. Those two facts, and the gap between them, are the whole
+	// mechanism, so the test supplies them the way a request does.
+	newCtx := func(headers map[string]string, resolvedProjectID string) *schemas.BifrostContext {
+		ctx := emptyCtx()
+		if headers != nil {
+			ctx.SetValue(schemas.BifrostContextKeyRequestHeaders, headers)
+		}
+		if resolvedProjectID != "" {
+			ctx.SetValue(schemas.BifrostContextKeyGovernanceProjectID, resolvedProjectID)
+		}
+		return ctx
+	}
+	named := map[string]string{schemas.HeaderGovernanceProjectName: "Atlas"}
+	chat := &EvaluationRequest{Provider: schemas.OpenAI, Model: "gpt-4o"}
+
+	t.Run("named a project and nothing scoped it", func(t *testing.T) {
+		plugin := newAccessTestPlugin(t, vk, &permitStore{baseOverride: base})
+
+		result, bifrostErr := plugin.Evaluate(newCtx(named, ""), chat)
+
+		require.NotNil(t, bifrostErr, "a request whose project went missing was served against the caller's own access")
+		assert.Equal(t, DecisionAccessBlocked, result.Decision)
+		assert.Equal(t, `project "Atlas" not found. It does not exist or does not admit this request.`, result.Reason)
+		require.NotNil(t, bifrostErr.StatusCode)
+		assert.Equal(t, 403, *bifrostErr.StatusCode, "the caller authenticated fine; what they asked for is refused")
+	})
+
+	t.Run("named a project and it scoped the request", func(t *testing.T) {
+		scoping := permitWithProviders(grant.PermitProject, "s1", "Atlas", "openai")
+		plugin := newAccessTestPlugin(t, vk, &permitStore{
+			baseOverride: base, scoping: scoping, mode: grant.Intersect,
+		})
+
+		result, bifrostErr := plugin.Evaluate(newCtx(named, "s1"), chat)
+
+		assert.Nil(t, bifrostErr)
+		assert.Equal(t, DecisionAllow, result.Decision)
+	})
+
+	t.Run("named no project", func(t *testing.T) {
+		// Every ordinary request carries no scoping permit, so the rule must key off having named one
+		// rather than off the empty slot, or it refuses everything.
+		plugin := newAccessTestPlugin(t, vk, &permitStore{baseOverride: base})
+
+		result, bifrostErr := plugin.Evaluate(newCtx(nil, ""), chat)
+
+		assert.Nil(t, bifrostErr)
+		assert.Equal(t, DecisionAllow, result.Decision)
+	})
+
+	t.Run("named a project with an empty header", func(t *testing.T) {
+		// It named no project, so none can be resolved from it. Treating that as not having asked
+		// would serve the request against the caller's own access.
+		plugin := newAccessTestPlugin(t, vk, &permitStore{baseOverride: base})
+
+		result, bifrostErr := plugin.Evaluate(newCtx(map[string]string{schemas.HeaderGovernanceProjectID: ""}, ""), chat)
+
+		require.NotNil(t, bifrostErr)
+		assert.Equal(t, DecisionAccessBlocked, result.Decision)
+	})
+}
+
+// A project fills the scoping slot, and limits are gathered for every permit a request carries, so a
+// project's own per-model limits come off its permit the way any other holder's do. The scope name
+// and the holder kind are the project's, so its per-model spend is looked up where it is stored and
+// attributed to the project rather than to somebody else.
+//
+// The permit is only ever built once a project has been resolved and admitted, so a request that
+// named one it may not use is refused before this ever runs.
+func TestModelConfigScopesIncludeTheProjectScopingARequest(t *testing.T) {
+	scopeNamed := func(scopes []limitScope, name string) (limitScope, bool) {
+		for _, scope := range scopes {
+			if scope.name == name {
+				return scope, true
+			}
+		}
+		return limitScope{}, false
+	}
+
+	t.Run("the project's permit", func(t *testing.T) {
+		project := permitWithProviders(grant.PermitProject, "proj-1", "Atlas", "openai")
+
+		scope, found := scopeNamed(modelConfigScopesFor(emptyCtx(), project), configstoreTables.ModelConfigScopeProject)
+
+		require.True(t, found, "a request running inside a project answers to none of its per-model limits")
+		assert.Equal(t, "proj-1", scope.id)
+		assert.Equal(t, grant.LimitHolderProjectModelConfig, scope.kind,
+			"a project's per-model spend would be attributed to somebody else")
+	})
+
+	t.Run("a permit that is not a project's", func(t *testing.T) {
+		key := permitWithProviders(grant.PermitVirtualKey, "vk-1", "Key", "openai")
+
+		_, found := scopeNamed(modelConfigScopesFor(emptyCtx(), key), configstoreTables.ModelConfigScopeProject)
+
+		assert.False(t, found, "a request outside every project was held to a project's per-model limits")
+	})
+}

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -142,6 +142,12 @@ type GovernanceStore interface {
 	// Answering with nothing means one of two things the funnel tells apart by what was presented: a
 	// request that presented nothing carries no access and is governed as unrestricted, and one that
 	// presented something this store resolves permits from, which resolved to nothing, is refused.
+	//
+	// A store that resolves a project the request named answers the same way about that: the scoping
+	// slot is filled when the request may be scoped by the project it named, and left empty when it
+	// may not. Which of those happened is not this store's to report: the funnel refuses a request
+	// that named a project and carries no scoping permit, exactly as it refuses one that presented a
+	// credential nothing granted.
 	ResolvePermits(ctx *schemas.BifrostContext) (bases []schemas.Permit, scoping schemas.Permit, mode grant.CompositionMode)
 	// ProviderAndModelLimits reports the deployment's own limits on a provider plus whichever model
 	// configs cover the pair, for the deployment and for the permit's holder. Resolved per attempt
@@ -4475,6 +4481,8 @@ func modelConfigScopeFor(permitType string) string {
 	switch permitType {
 	case string(grant.PermitVirtualKey):
 		return configstoreTables.ModelConfigScopeVirtualKey
+	case string(grant.PermitProject):
+		return configstoreTables.ModelConfigScopeProject
 	default:
 		return permitType
 	}

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -230,6 +230,8 @@ func applyMCPGovernanceFieldsToEntry(ctx *schemas.BifrostContext, entry *logstor
 	teamID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceTeamID)
 	customerID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceCustomerID)
 	businessUnitID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceBusinessUnitID)
+	projectID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceProjectID)
+	projectName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceProjectName)
 	if userID != "" {
 		entry.UserID = &userID
 	}
@@ -241,6 +243,12 @@ func applyMCPGovernanceFieldsToEntry(ctx *schemas.BifrostContext, entry *logstor
 	}
 	if businessUnitID != "" {
 		entry.BusinessUnitID = &businessUnitID
+	}
+	if projectID != "" {
+		entry.ProjectID = &projectID
+	}
+	if projectName != "" {
+		entry.ProjectName = &projectName
 	}
 }
 
@@ -1799,6 +1807,12 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 				}
 				entry.MetadataParsed["isAsyncRequest"] = true
 			}
+			if projectID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceProjectID); projectID != "" {
+				entry.ProjectID = &projectID
+			}
+			if projectName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceProjectName); projectName != "" {
+				entry.ProjectName = &projectName
+			}
 			applyModelAlias(entry, originalModelRequested, resolvedModelUsed)
 			applyResolvedAliasInfo(entry, resolvedKeyAlias)
 			entry.ErrorDetailsParsed = sanitizeErrorForLogging(bifrostErr, contentLoggingEnabled, shouldStoreRaw)
@@ -1875,6 +1889,8 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	businessUnitName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceBusinessUnitName)
 	numberOfRetries := bifrost.GetIntFromContext(ctx, schemas.BifrostContextKeyNumberOfRetries)
 	attemptTrail, _ := ctx.Value(schemas.BifrostContextKeyAttemptTrail).([]schemas.KeyAttemptRecord)
+	projectID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceProjectID)
+	projectName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceProjectName)
 
 	// Extract routing engine logs from context before entering goroutine
 	routingEngineLogs := formatRoutingEngineLogs(ctx.GetRoutingEngineLogs())
@@ -1921,7 +1937,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			entry.ServerSideFallbackModel = &m
 		}
 	}
-	applyOutputFieldsToEntry(entry, selectedKeyID, selectedKeyName, virtualKeyID, virtualKeyName, routingRuleID, routingRuleName, selectedPromptID, selectedPromptName, selectedPromptVersion, teamID, teamName, customerID, customerName, userID, userName, businessUnitID, businessUnitName, numberOfRetries, latency, upstreamLatency, overheadLatency, attemptTrail)
+	applyOutputFieldsToEntry(entry, selectedKeyID, selectedKeyName, virtualKeyID, virtualKeyName, routingRuleID, routingRuleName, selectedPromptID, selectedPromptName, selectedPromptVersion, teamID, teamName, customerID, customerName, userID, userName, businessUnitID, businessUnitName, projectID, projectName, numberOfRetries, latency, upstreamLatency, overheadLatency, attemptTrail)
 	applyResolvedAliasInfo(entry, resolvedKeyAlias)
 	// Attach cluster governance metadata for disconnected node usage recovery
 	if nodeID, _ := p.clusterNodeID.Load().(string); nodeID != "" {

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -430,6 +430,8 @@ func TestPostLLMHookNoPendingErrorPreservesMetadata(t *testing.T) {
 		"region": "us-east",
 	})
 	ctx.SetValue(schemas.BifrostIsAsyncRequest, true)
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceProjectID, "proj-1")
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceProjectName, "Project One")
 
 	statusCode := 500
 	bifrostErr := &schemas.BifrostError{
@@ -473,6 +475,12 @@ func TestPostLLMHookNoPendingErrorPreservesMetadata(t *testing.T) {
 	}
 	if got := logEntry.MetadataParsed["isAsyncRequest"]; got != true {
 		t.Fatalf("expected async metadata true, got %#v", got)
+	}
+	if logEntry.ProjectID == nil || *logEntry.ProjectID != "proj-1" {
+		t.Fatalf("expected project ID proj-1 on the minimal-error entry, got %v", logEntry.ProjectID)
+	}
+	if logEntry.ProjectName == nil || *logEntry.ProjectName != "Project One" {
+		t.Fatalf("expected project name %q on the minimal-error entry, got %v", "Project One", logEntry.ProjectName)
 	}
 }
 

--- a/plugins/logging/writer.go
+++ b/plugins/logging/writer.go
@@ -574,6 +574,7 @@ func applyOutputFieldsToEntry(
 	customerID, customerName string,
 	userID, userName string,
 	businessUnitID, businessUnitName string,
+	projectID, projectName string,
 	numberOfRetries int,
 	latency int64,
 	upstreamLatency, overheadLatency *int64,
@@ -625,6 +626,12 @@ func applyOutputFieldsToEntry(
 	}
 	if businessUnitName != "" {
 		entry.BusinessUnitName = &businessUnitName
+	}
+	if projectID != "" {
+		entry.ProjectID = &projectID
+	}
+	if projectName != "" {
+		entry.ProjectName = &projectName
 	}
 	if numberOfRetries != 0 {
 		entry.NumberOfRetries = numberOfRetries

--- a/transports/bifrost-http/handlers/webrtc_realtime.go
+++ b/transports/bifrost-http/handlers/webrtc_realtime.go
@@ -1127,6 +1127,8 @@ func newRealtimeRelayContext(requestCtx *schemas.BifrostContext) (*schemas.Bifro
 		schemas.BifrostContextKeyGovernanceCustomerName,
 		schemas.BifrostContextKeyGovernanceTeamID,
 		schemas.BifrostContextKeyGovernanceTeamName,
+		schemas.BifrostContextKeyGovernanceProjectID,
+		schemas.BifrostContextKeyGovernanceProjectName,
 		schemas.BifrostContextKeyUserID,
 		schemas.BifrostContextKeyUserName,
 		schemas.BifrostContextKeyGovernanceIncludeOnlyKeys,

--- a/transports/bifrost-http/handlers/wsrealtime.go
+++ b/transports/bifrost-http/handlers/wsrealtime.go
@@ -872,6 +872,8 @@ var realtimeMiddlewareKeys = []any{
 	schemas.BifrostContextKeyGovernanceTeamName,
 	schemas.BifrostContextKeyGovernanceBusinessUnitID,
 	schemas.BifrostContextKeyGovernanceBusinessUnitName,
+	schemas.BifrostContextKeyGovernanceProjectID,
+	schemas.BifrostContextKeyGovernanceProjectName,
 	schemas.BifrostContextKeyGovernanceIncludeOnlyKeys,
 	schemas.BifrostContextKeyGovernancePluginName,
 	schemas.BifrostContextKeyRoutingEnginesUsed,


### PR DESCRIPTION
## Summary

Introduces a project dimension across the governance, logging, and log-store layers. A request can now be scoped to a project by supplying `x-bf-project-id` or `x-bf-project-name` headers. Once resolved and admitted, the project id and name are stamped onto the context and flow through to every log entry. A request that names a project but ends up scoped by none is refused at the governance funnel rather than silently served against the caller's own access.

## Changes

- Added `BifrostContextKeyGovernanceProjectID` and `BifrostContextKeyGovernanceProjectName` context keys, and `HeaderGovernanceProjectID` / `HeaderGovernanceProjectName` header constants to the core schema. The header constants live in the schema package so the resolver and the funnel read the same names.
- Added `ModelConfigScopeProject` so per-model limits stored against a project permit are looked up and attributed correctly.
- Added `ProjectID` and `ProjectName` columns (nullable, indexed on id) to both the `Log` and `MCPToolLog` tables, with migrations for each. A project filter on `SearchFilters` bypasses the materialized-view path because the matview carries no project column.
- Extended `unusablePermit` to check the scoping permit in addition to the base permits. Previously a deactivated or expired scoping permit would go on granting everything it named because nothing checked its active/expired flags.
- Added `namedProjectNothingScoped` in the governance plugin, which detects when a request supplied a project header but no project was resolved into the context. The `Evaluate` funnel refuses such requests with a 403 rather than falling through to the caller's own access.
- Extended `modelConfigScopeFor` to map `PermitProject` to `ModelConfigScopeProject`, so a project's per-model spend is attributed to the project rather than falling through to the default.
- Propagated `projectID` / `projectName` through `applyOutputFieldsToEntry` and `applyMCPGovernanceFieldsToEntry` in the logging plugin so both the standard and MCP tool log paths record the project.
- Added `BifrostContextKeyGovernanceProjectID` and `BifrostContextKeyGovernanceProjectName` to the WebRTC and WebSocket realtime middleware key lists so the project context is carried into relay sub-contexts.
- Added `projectdimension_test.go` with round-trip and filter-narrowing tests for the new columns, and extended `permits_test.go` with tests covering scoping-permit state checks, the named-but-not-scoped refusal, and project model-config scope attribution.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/... ./framework/logstore/... ./plugins/governance/... ./plugins/logging/...
```

- Send a request with `x-bf-project-name: Atlas` and no matching project; expect a 403 with `project "Atlas" not found`.
- Send the same request with a valid, admitted project; expect a 200 and confirm `project_id` / `project_name` appear on the resulting log row.
- Send a request with no project header; expect normal access without any project refusal.
- Deactivate or expire a scoping permit and confirm the request is refused with the appropriate inactive/expired message.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

A request that names a project it may not use is refused with a 403 rather than silently downgraded to the caller's own access. The refusal message does not distinguish "project does not exist" from "project does not admit this caller", consistent with how credential failures are reported, to avoid leaking information about project existence to unauthorised callers.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable