### PR TITLE
feat: add Projects governance page with RBAC gating and sidebar entry

### DIFF
--- a/ui/app/_fallbacks/enterprise/components/projects/projectsIndexView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/projects/projectsIndexView.tsx
@@ -1,0 +1,17 @@
+import { FolderKanban } from "lucide-react";
+import ContactUsView from "../views/contactUsView";
+
+export default function ProjectsIndexView() {
+	return (
+		<div className="h-full w-full">
+			<ContactUsView
+				className="mx-auto min-h-[80vh]"
+				icon={<FolderKanban className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
+				title="Unlock projects for scoped access and spend"
+				description="This feature is a part of the Bifrost enterprise license. A project is something a request opts into: it grants access alongside what the caller already holds, and decides whose ledger the spend lands on."
+				readmeLink="https://docs.getbifrost.ai/enterprise/projects"
+				testIdPrefix="projects"
+			/>
+		</div>
+	);
+}

--- a/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
+++ b/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
@@ -28,6 +28,7 @@ export enum RbacResource {
 	PromptRepository = "PromptRepository",
 	PromptDeploymentStrategy = "PromptDeploymentStrategy",
 	AccessProfiles = "AccessProfiles",
+	Projects = "Projects",
 	APIKeys = "APIKeys",
 	Inference = "Inference",
 	Metrics = "Metrics",

--- a/ui/app/workspace/governance/projects/layout.tsx
+++ b/ui/app/workspace/governance/projects/layout.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import ProjectsPage from "./page";
+
+export const Route = createFileRoute("/workspace/governance/projects")({
+	component: ProjectsPage,
+});

--- a/ui/app/workspace/governance/projects/page.tsx
+++ b/ui/app/workspace/governance/projects/page.tsx
@@ -1,0 +1,17 @@
+import { NoPermissionView } from "@/components/noPermissionView";
+import ProjectsIndexView from "@enterprise/components/projects/projectsIndexView";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+
+export default function ProjectsPage() {
+	const hasProjectsAccess = useRbac(RbacResource.Projects, RbacOperation.View);
+
+	if (!hasProjectsAccess) {
+		return <NoPermissionView entity="projects" />;
+	}
+
+	return (
+		<div className="no-padding-parent mx-auto flex h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))] w-full flex-col p-4">
+			<ProjectsIndexView />
+		</div>
+	);
+}

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -15,6 +15,7 @@ import {
 	DatabaseZap,
 	Flag,
 	FolderGit,
+	FolderKanban,
 	Gavel,
 	GitCompareArrows,
 	Globe,
@@ -558,6 +559,7 @@ export default function AppSidebar() {
 	const hasEdgeConfigAccess = useRbac(RbacResource.EdgeConfig, RbacOperation.View);
 	const hasAnyEdgeControlAccess = hasDevicesAccess || hasInventoryAccess || hasEdgeConfigAccess;
 	const hasAccessProfilesAccess = useRbac(RbacResource.AccessProfiles, RbacOperation.View);
+	const hasProjectsAccess = useRbac(RbacResource.Projects, RbacOperation.View);
 	const hasAnyGovernanceAccess =
 		hasVirtualKeysAccess ||
 		hasTeamsAccess ||
@@ -566,6 +568,7 @@ export default function AppSidebar() {
 		hasBusinessUnitsAccess ||
 		hasRbacAccess ||
 		hasAccessProfilesAccess ||
+		hasProjectsAccess ||
 		hasGovernanceLegacyAccess;
 	const { data: coreConfig } = useGetCoreConfigQuery({});
 	const isDbConnected = coreConfig?.is_db_connected ?? false;
@@ -858,6 +861,13 @@ export default function AppSidebar() {
 						hasAccess: hasAccessProfilesAccess,
 					},
 					{
+						title: "Projects",
+						url: "/workspace/governance/projects",
+						icon: FolderKanban,
+						description: "Scope requests to a project's access and budget",
+						hasAccess: hasProjectsAccess,
+					},
+					{
 						title: "Audit Logs",
 						url: "/workspace/audit-logs",
 						icon: ScrollText,
@@ -1093,6 +1103,7 @@ export default function AppSidebar() {
 			hasPromptRepositoryAccess,
 			hasSkillsRepositoryAccess,
 			hasAccessProfilesAccess,
+			hasProjectsAccess,
 			hasFeatureFlagsAccess,
 			hasDevicesAccess,
 			hasInventoryAccess,

--- a/ui/components/ui/providerConfigCard.tsx
+++ b/ui/components/ui/providerConfigCard.tsx
@@ -43,7 +43,7 @@ export interface ProviderConfigCardValue {
 	keyIds: string[];
 	budgets: ProviderConfigBudgetLine[];
 	rateLimit?: ProviderConfigRateLimit | null;
-	/** Only rendered when `showModelBudgets` is set (Access Profile only). */
+	/** Only rendered when `showModelBudgets` is set. */
 	modelBudgets?: ProviderConfigModelBudget[];
 }
 
@@ -61,7 +61,7 @@ interface ProviderConfigCardBaseProps {
 	iconProvider: ProviderIconType;
 	/** Keys available for this provider. `null` = still loading (keep section visible). */
 	providerKeys: ProviderKeyInfo[] | null;
-	/** Renders the per-model budgets tree (Access Profile). Off for Virtual Keys. */
+	/** Renders the per-model budgets tree when `showModelBudgets` is enabled. */
 	showModelBudgets?: boolean;
 	/** Read-only global provider cap shown on the Provider budget row (Access Profile). */
 	globalProviderCap?: { max_limit: number; reset_duration?: string };

--- a/ui/lib/store/apis/baseApi.ts
+++ b/ui/lib/store/apis/baseApi.ts
@@ -185,6 +185,7 @@ export const baseApi = createApi({
 		"Versions",
 		"Sessions",
 		"AccessProfiles",
+		"Projects",
 		"BusinessUnits",
 		"PromptDeployments",
 		"AuthType",


### PR DESCRIPTION
## Summary

Adds a Projects section to the Governance area of the UI, enabling scoped access and spend tracking per project. When the enterprise license does not include this feature, a fallback "Contact Us" view is shown instead.

## Changes

- Added a `Projects` entry to the `RbacResource` enum so RBAC checks can gate access to the new section
- Added a `Projects` cache tag to the base API for future project-related queries
- Created a fallback `ProjectsIndexView` component that renders a "Contact Us" upsell screen for non-enterprise users
- Added the `/workspace/governance/projects` route and page, which enforces the `Projects` RBAC view permission before rendering
- Added a "Projects" sidebar entry under Governance with the `FolderKanban` icon, visible only to users with the appropriate access
- Updated `ProviderConfigCard` comments to reflect that `showModelBudgets` applies to both Access Profiles and Projects

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Start the UI against a non-enterprise Bifrost instance and navigate to **Governance → Projects**. The "Contact Us" upsell view should appear.
2. Start the UI against an enterprise instance with the Projects feature enabled. The Projects index view should render.
3. Log in as a user without the `Projects` view permission. The "No Permission" view should be shown instead.

```sh
cd ui
pnpm i
pnpm build
```

## Screenshots/Recordings

_Add before/after screenshots of the Governance sidebar and the Projects page (upsell and enterprise views)._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Access to the Projects page is gated behind the `Projects` RBAC resource with a `View` operation check, consistent with how other Governance resources are protected. Users without the permission see a no-permission view rather than any project data.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable