### PR TITLE
feat: add `project_id`/`project_name` governance dimensions to span attributes, enrichment dims, metrics labels, and log payloads

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6369,6 +6369,12 @@ func executeRequestWithRetries[T any](
 		if businessUnitName, ok := ctx.Value(schemas.BifrostContextKeyGovernanceBusinessUnitName).(string); ok && businessUnitName != "" {
 			span.SetAttribute(schemas.AttrBifrostBusinessUnitName, businessUnitName)
 		}
+		if projectID, ok := ctx.Value(schemas.BifrostContextKeyGovernanceProjectID).(string); ok && projectID != "" {
+			span.SetAttribute(schemas.AttrBifrostProjectID, projectID)
+		}
+		if projectName, ok := ctx.Value(schemas.BifrostContextKeyGovernanceProjectName).(string); ok && projectName != "" {
+			span.SetAttribute(schemas.AttrBifrostProjectName, projectName)
+		}
 		if teamIDs, ok := ctx.Value(schemas.BifrostContextKeyGovernanceTeamIDs).([]string); ok && len(teamIDs) > 0 {
 			span.SetAttribute(schemas.AttrBifrostTeamIDs, teamIDs)
 		}

--- a/core/mcp/pluginpipeline.go
+++ b/core/mcp/pluginpipeline.go
@@ -581,4 +581,6 @@ func setMCPGovernanceSpanAttrs(tracer schemas.Tracer, handle schemas.SpanHandle,
 	setIfPresent(schemas.BifrostContextKeyGovernanceCustomerName, schemas.AttrBifrostCustomerName)
 	setIfPresent(schemas.BifrostContextKeyGovernanceBusinessUnitID, schemas.AttrBifrostBusinessUnitID)
 	setIfPresent(schemas.BifrostContextKeyGovernanceBusinessUnitName, schemas.AttrBifrostBusinessUnitName)
+	setIfPresent(schemas.BifrostContextKeyGovernanceProjectID, schemas.AttrBifrostProjectID)
+	setIfPresent(schemas.BifrostContextKeyGovernanceProjectName, schemas.AttrBifrostProjectName)
 }

--- a/core/schemas/allocfix_bench_test.go
+++ b/core/schemas/allocfix_bench_test.go
@@ -165,7 +165,8 @@ var loggingIdentityKeys = []any{
 	BifrostContextKeyGovernanceTeamName, BifrostContextKeyGovernanceCustomerID,
 	BifrostContextKeyGovernanceCustomerName, BifrostContextKeyUserID,
 	BifrostContextKeyUserName, BifrostContextKeyGovernanceBusinessUnitID,
-	BifrostContextKeyGovernanceBusinessUnitName, BifrostContextKeyNumberOfRetries,
+	BifrostContextKeyGovernanceBusinessUnitName, BifrostContextKeyGovernanceProjectID,
+	BifrostContextKeyGovernanceProjectName, BifrostContextKeyNumberOfRetries,
 	BifrostContextKeyAttemptTrail,
 }
 

--- a/core/schemas/enrichment.go
+++ b/core/schemas/enrichment.go
@@ -72,6 +72,10 @@ var EnrichmentDims = []EnrichmentDim{
 	{Name: "customer_name", SpanAttr: AttrBifrostCustomerName, MetricSafe: true},
 	{Name: "business_unit_id", SpanAttr: AttrBifrostBusinessUnitID, MetricSafe: true},
 	{Name: "business_unit_name", SpanAttr: AttrBifrostBusinessUnitName, MetricSafe: true},
+	// A request is scoped to at most one project, so unlike team/customer/business
+	// unit there is no array form of this dimension.
+	{Name: "project_id", SpanAttr: AttrBifrostProjectID, MetricSafe: true},
+	{Name: "project_name", SpanAttr: AttrBifrostProjectName, MetricSafe: true},
 	{Name: "fallback_index", SpanAttr: AttrBifrostFallbackIndex, MetricSafe: true},
 
 	// --- Record/trace tier only: high cardinality, NOT metric-safe. Present on

--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -959,6 +959,8 @@ const (
 	AttrBifrostCustomerName        = "bifrost.customer.name"
 	AttrBifrostBusinessUnitID      = "bifrost.business_unit.id"
 	AttrBifrostBusinessUnitName    = "bifrost.business_unit.name"
+	AttrBifrostProjectID           = "bifrost.project.id"
+	AttrBifrostProjectName         = "bifrost.project.name"
 	AttrBifrostTeamIDs             = "bifrost.team.ids"
 	AttrBifrostTeamNames           = "bifrost.team.names"
 	AttrBifrostCustomerIDs         = "bifrost.customer.ids"

--- a/framework/logstore/payload.go
+++ b/framework/logstore/payload.go
@@ -126,6 +126,8 @@ func ExtractPayload(l *Log) map[string]string {
 	putIfPresent(m, "business_unit_name", l.BusinessUnitName)
 	putIfPresent(m, "business_unit_ids", l.BusinessUnitIDs)
 	putIfPresent(m, "business_unit_names", l.BusinessUnitNames)
+	putIfPresent(m, "project_id", l.ProjectID)
+	putIfPresent(m, "project_name", l.ProjectName)
 	if l.Cost != nil {
 		m["cost"] = strconv.FormatFloat(*l.Cost, 'f', -1, 64)
 	}

--- a/framework/tracing/llmspan.go
+++ b/framework/tracing/llmspan.go
@@ -214,6 +214,7 @@ func PopulateContextAttributes(
 	teamID, teamName string,
 	customerID, customerName string,
 	businessUnitID, businessUnitName string,
+	projectID, projectName string,
 	userID, userName, userEmail string,
 	numberOfRetries, fallbackIndex int,
 ) {
@@ -246,6 +247,12 @@ func PopulateContextAttributes(
 	}
 	if businessUnitName != "" {
 		attrs[schemas.AttrBifrostBusinessUnitName] = businessUnitName
+	}
+	if projectID != "" {
+		attrs[schemas.AttrBifrostProjectID] = projectID
+	}
+	if projectName != "" {
+		attrs[schemas.AttrBifrostProjectName] = projectName
 	}
 	if userID != "" {
 		attrs[schemas.AttrBifrostUserID] = userID

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -1048,6 +1048,8 @@ func buildSpanAttrs(span *schemas.Span) []attribute.KeyValue {
 		customerNames,
 		buIDs,
 		buNames,
+		getStringAttr(attrs, schemas.AttrBifrostProjectID),
+		getStringAttr(attrs, schemas.AttrBifrostProjectName),
 	)
 }
 
@@ -1078,6 +1080,8 @@ func buildContextAttrs(ctx context.Context, resp *schemas.BifrostResponse, bifro
 		customerNames,
 		buIDs,
 		buNames,
+		bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceProjectID),
+		bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceProjectName),
 	)
 }
 
@@ -1113,6 +1117,8 @@ var mcpGovernanceLabelMap = map[string]string{
 	schemas.AttrBifrostCustomerName:     "customer_name",
 	schemas.AttrBifrostBusinessUnitID:   "business_unit_id",
 	schemas.AttrBifrostBusinessUnitName: "business_unit_name",
+	schemas.AttrBifrostProjectID:        "project_id",
+	schemas.AttrBifrostProjectName:      "project_name",
 }
 
 // recordMCPMetricsFromTrace records the duration metric once per MCP client span. Called

--- a/plugins/otel/mcp_metrics_test.go
+++ b/plugins/otel/mcp_metrics_test.go
@@ -55,7 +55,7 @@ func TestBuildMCPSpanAttrsSemconvAndGovernance(t *testing.T) {
 		t.Error("error.type must not be present on a non-error span's attrs")
 	}
 	// Absent optional governance dims must not appear as empty labels.
-	for _, absent := range []string{"customer_id", "business_unit_id", "team_id"} {
+	for _, absent := range []string{"customer_id", "business_unit_id", "project_id", "team_id"} {
 		if _, ok := got[absent]; ok {
 			t.Errorf("absent dimension %q should be omitted, got %q", absent, got[absent])
 		}

--- a/plugins/otel/metrics.go
+++ b/plugins/otel/metrics.go
@@ -605,8 +605,9 @@ func resolveServiceInstanceID() string {
 }
 
 // team/customer/businessUnit args are canonical comma-joined sets; label names stay
-// singular (team_id, ...) for dashboard compatibility.
-func BuildBifrostAttributes(provider, model, method, virtualKeyID, virtualKeyName, selectedKeyID, selectedKeyName string, fallbackIndex int, teamIDs, teamNames, customerIDs, customerNames, businessUnitIDs, businessUnitNames string) []attribute.KeyValue {
+// singular (team_id, ...) for dashboard compatibility. A request is scoped to at most
+// one project, so projectID/projectName are plain scalars.
+func BuildBifrostAttributes(provider, model, method, virtualKeyID, virtualKeyName, selectedKeyID, selectedKeyName string, fallbackIndex int, teamIDs, teamNames, customerIDs, customerNames, businessUnitIDs, businessUnitNames, projectID, projectName string) []attribute.KeyValue {
 	return []attribute.KeyValue{
 		attribute.String("provider", provider),
 		attribute.String("model", model),
@@ -622,6 +623,8 @@ func BuildBifrostAttributes(provider, model, method, virtualKeyID, virtualKeyNam
 		attribute.String("customer_name", customerNames),
 		attribute.String("business_unit_id", businessUnitIDs),
 		attribute.String("business_unit_name", businessUnitNames),
+		attribute.String("project_id", projectID),
+		attribute.String("project_name", projectName),
 		attribute.String("service_instance_id", serviceInstanceID),
 	}
 }

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -280,6 +280,8 @@ var defaultBifrostLabelNames = []string{
 	"customer_name",
 	"business_unit_id",
 	"business_unit_name",
+	"project_id",
+	"project_name",
 }
 
 // defaultMCPLabelNames is the label set for bifrost_mcp_* metrics: the MCP semconv
@@ -298,6 +300,8 @@ var defaultMCPLabelNames = []string{
 	"customer_name",
 	"business_unit_id",
 	"business_unit_name",
+	"project_id",
+	"project_name",
 }
 
 // mcpOperationDurationBuckets: the OTel MCP semconv boundaries, matching plugins/otel
@@ -833,6 +837,8 @@ func (p *PrometheusPlugin) PostMCPHook(ctx *schemas.BifrostContext, resp *schema
 		"customer_name":      bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceCustomerName),
 		"business_unit_id":   bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceBusinessUnitID),
 		"business_unit_name": bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceBusinessUnitName),
+		"project_id":         bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceProjectID),
+		"project_name":       bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceProjectName),
 	}
 	p.applyCustomLabels(ctx, labelValues)
 
@@ -962,6 +968,9 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 	teamIDs, teamNames := canonicalEntitySet(ctx, schemas.BifrostContextKeyGovernanceTeamIDs, schemas.BifrostContextKeyGovernanceTeamNames, schemas.BifrostContextKeyGovernanceTeamID, schemas.BifrostContextKeyGovernanceTeamName)
 	customerID, customerName := canonicalEntitySet(ctx, schemas.BifrostContextKeyGovernanceCustomerIDs, schemas.BifrostContextKeyGovernanceCustomerNames, schemas.BifrostContextKeyGovernanceCustomerID, schemas.BifrostContextKeyGovernanceCustomerName)
 	businessUnitID, businessUnitName := canonicalEntitySet(ctx, schemas.BifrostContextKeyGovernanceBusinessUnitIDs, schemas.BifrostContextKeyGovernanceBusinessUnitNames, schemas.BifrostContextKeyGovernanceBusinessUnitID, schemas.BifrostContextKeyGovernanceBusinessUnitName)
+	// A request is scoped to at most one project, so there is no plural form to canonicalize.
+	projectID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceProjectID)
+	projectName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceProjectName)
 
 	// Extract ALL context values BEFORE spawning the goroutine.
 	labelValues := map[string]string{
@@ -983,6 +992,8 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 		"customer_name":       customerName,
 		"business_unit_id":    businessUnitID,
 		"business_unit_name":  businessUnitName,
+		"project_id":          projectID,
+		"project_name":        projectName,
 	}
 
 	// Get all custom prometheus labels from context BEFORE the goroutine.


### PR DESCRIPTION
## Summary

Adds `project_id` and `project_name` as first-class governance dimensions across tracing, metrics, and log enrichment. Unlike teams, customers, and business units — which can be multi-valued — a request is scoped to at most one project, so these are plain scalar fields with no plural/array form.

## Changes

- Added `AttrBifrostProjectID` and `AttrBifrostProjectName` span attribute constants and wired them into `executeRequestWithRetries` and the MCP plugin pipeline span attribute helpers.
- Registered `project_id` and `project_name` as enrichment dimensions in `EnrichmentDims`, marked metric-safe.
- Extended `PopulateContextAttributes` to accept and set `projectID`/`projectName` span attributes.
- Added `project_id` and `project_name` to `BuildBifrostAttributes` in the OTel plugin, and to `buildSpanAttrs`/`buildContextAttrs` call sites.
- Added `project_id` and `project_name` to the Prometheus plugin's default label sets for both LLM and MCP metrics, and populated them from context in `PostLLMHook` and `PostMCPHook`.
- Added `project_id` and `project_name` to `mcpGovernanceLabelMap` for MCP metric label translation.
- Propagated `ProjectID`/`ProjectName` through `applyLogDenormalizations` in batch accounting and included them in `ExtractPayload` for log store payloads.
- Updated the benchmark identity key slice and MCP metrics test to include the new context keys and assert absence of `project_id` when not set.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

- Set `BifrostContextKeyGovernanceProjectID` and `BifrostContextKeyGovernanceProjectName` on a request context and confirm that:
  - The resulting trace span carries `bifrost.project.id` and `bifrost.project.name` attributes.
  - Prometheus metrics for LLM and MCP requests include `project_id` and `project_name` labels with the expected values.
  - Log store payloads contain `project_id` and `project_name` fields.
  - Spans and metrics for requests without a project set do not emit empty `project_id`/`project_name` labels.

## Breaking changes

- [x] Yes
- [ ] No

`BuildBifrostAttributes` and `PopulateContextAttributes` have new required parameters (`projectID`, `projectName`). Any callers outside this repository must be updated to pass these additional arguments.

## Related issues

## Security considerations

`project_id` and `project_name` are governance metadata supplied by the caller via context. They are treated the same as existing governance dimensions (team, customer, business unit) with respect to PII handling — callers are responsible for ensuring values are appropriate for inclusion in traces and metrics.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable