### PR TITLE
fix: revert `ResolveAccess` side-effect in `PreMCPConnectionHook` with direct VK lookup to populate identity context keys

### DIFF
--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -1357,36 +1357,40 @@ func (p *GovernancePlugin) PostMCPHook(ctx *schemas.BifrostContext, resp *schema
 // row ID, and per-user auth types (per_user_oauth, per_user_headers) key
 // their stored credentials by it.
 //
-// The hook is intentionally narrow: it decides nothing. Resolving the access records the identity
-// context keys (row ID, name, team / customer fan-out) and stops there. Policy checks (budget, rate
-// limit, tool allow-list) stay on PreMCPHook for the actual CallTool: Connect is transport setup, not
-// the gated operation.
+// The hook is intentionally narrow: it ONLY populates the identity context
+// keys (VK row ID, name, team / customer fan-out). Policy checks (budget,
+// rate limit, tool allow-list) stay on PreMCPHook for the actual CallTool —
+// Connect is transport setup, not the gated operation.
 //
 // No short-circuit returned even when the VK isn't recognized: bad-VK
 // rejection belongs on the tool-call path so the caller gets a stable
 // error format. An unknown VK here simply leaves the row ID empty, and the
 // resolver will surface the "requires an identity" error itself.
 func (p *GovernancePlugin) PreMCPConnectionHook(ctx *schemas.BifrostContext, req *schemas.BifrostMCPConnectRequest) (*schemas.BifrostMCPConnectRequest, *schemas.MCPConnectionShortCircuit, error) {
-	// Resolving the request's access is what completes its identity and stamps its scope on ctx, so
-	// the row ID the credential resolver needs arrives as a side effect of asking the same question
-	// every other path asks. Doing it here rather than reading the key directly is what keeps one
-	// answer to "whose request is this".
-	//
-	// A credential that resolves to nothing leaves the identity incomplete, as before: the resolver
-	// surfaces the error on the per-user auth path, and shared-connection auth types never read it. A
-	// context with no grant is reported the same way: the connect path is transport setup, and the
-	// tool call that follows is where a wiring fault is refused.
-	//
-	// A context carrying BifrostContextKeyMCPHealthCheckRequest is Bifrost's own connection check,
-	// not a caller's request — the periodic checker and the admin verification probe both build a
-	// fresh context with no grant by design, since there is no caller to have one. Warning on that
-	// every tick is not a wiring fault surfaced, it is log volume with nothing to act on.
-	if _, err := p.ResolveAccess(ctx); err != nil {
-		if isHealthCheck, _ := ctx.Value(schemas.BifrostContextKeyMCPHealthCheckRequest).(bool); isHealthCheck {
-			p.logger.Debug("governance: %v", err)
-		} else {
-			p.logger.Warn("governance: %v", err)
+	virtualKeyValue := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyVirtualKey)
+	if virtualKeyValue == "" {
+		return req, nil, nil
+	}
+	vk, ok := p.store.GetVirtualKey(ctx, virtualKeyValue)
+	if !ok || vk == nil {
+		// Unknown VK — leave identity unset; the resolver will surface the
+		// appropriate error on the per-user auth path. For shared-connection
+		// auth types this is a no-op (they don't read these keys).
+		return req, nil, nil
+	}
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceVirtualKeyID, vk.ID)
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceVirtualKeyName, vk.Name)
+	if vk.Team != nil {
+		ctx.SetValue(schemas.BifrostContextKeyGovernanceTeamID, vk.Team.ID)
+		ctx.SetValue(schemas.BifrostContextKeyGovernanceTeamName, vk.Team.Name)
+		if vk.Team.Customer != nil {
+			ctx.SetValue(schemas.BifrostContextKeyGovernanceCustomerID, vk.Team.Customer.ID)
+			ctx.SetValue(schemas.BifrostContextKeyGovernanceCustomerName, vk.Team.Customer.Name)
 		}
+	}
+	if vk.Customer != nil {
+		ctx.SetValue(schemas.BifrostContextKeyGovernanceCustomerID, vk.Customer.ID)
+		ctx.SetValue(schemas.BifrostContextKeyGovernanceCustomerName, vk.Customer.Name)
 	}
 	return req, nil, nil
 }


### PR DESCRIPTION
## Summary

`PreMCPConnectionHook` previously populated identity context keys by calling `ResolveAccess`, which was a heavy, side-effect-driven approach that also triggered warning logs on health check connections. This PR replaces that with a direct, focused lookup that reads the virtual key from the store and stamps only the identity context keys needed for downstream resolution.

## Changes

- Replaced the `ResolveAccess` call in `PreMCPConnectionHook` with a direct `store.GetVirtualKey` lookup, setting `GovernanceVirtualKeyID`, `GovernanceVirtualKeyName`, team, and customer context keys explicitly.
- Removed the health-check log suppression workaround that was needed to avoid noisy warnings from the old approach — it is no longer necessary since the new path returns early when no virtual key is present.
- Unknown or missing virtual keys now silently leave identity unset (same behavior as before), with the resolver surfacing errors on the tool-call path where appropriate.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/...
```

- Connect an MCP client with a valid virtual key and confirm identity context keys are populated correctly before any tool call is made.
- Connect with an unknown or missing virtual key and confirm no error is returned at connect time, with the appropriate error surfacing only on the subsequent tool call.
- Trigger a health check connection and confirm no warnings are logged.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Identity context keys are now populated directly from the store rather than as a side effect of access resolution. Policy enforcement (budget, rate limits, tool allow-list) remains exclusively on the `PreMCPHook` tool-call path and is unaffected by this change.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable