### PR TITLE
feat(ui): add fleet-wide webhook deliveries page with cross-endpoint filtering and replace sheet pagination with preview link

### DIFF
--- a/docs/features/webhooks.mdx
+++ b/docs/features/webhooks.mdx
@@ -151,11 +151,17 @@ Open **Webhooks** in the sidebar to see your endpoints and their status.
   <img src="/media/ui-webhooks-secret.png" alt="Signing secret dialog in the Bifrost Web UI showing the one-time whsec_ secret with a copy button and a link to the verification docs" />
 </Frame>
 
-6. Open an endpoint to view its **delivery history**, send a **Test** delivery, or **Rotate secret** if a secret is ever exposed. Rotation takes effect immediately with no grace window, so update your receiver in the same change.
+6. Open an endpoint to see its **recent deliveries**, send a **Test** delivery, or **Rotate secret** if a secret is ever exposed. Rotation takes effect immediately with no grace window, so update your receiver in the same change.
 
 <Frame>
   <img src="/media/ui-webhooks-deliveries.png" alt="Endpoint deliveries panel in the Bifrost Web UI showing recent delivery attempts with their status codes alongside the Test and Rotate secret actions" />
 </Frame>
+
+7. For anything beyond the last few deliveries, use **View delivery history** to open the dedicated deliveries page at `/workspace/webhooks/deliveries`. It lists deliveries across every endpoint and filters by outcome, event, response status class (`2xx`/`4xx`/`5xx`/no response), webhook, and time range, with lookup by request ID or delivery ID. Arriving from an endpoint pre-selects that webhook; clear the filter to see deliveries fleet-wide.
+
+<Note>
+Rows are grouped by delivery, not by attempt: one row is one notification owed to the endpoint, and its `503 → 503 → 200` chips are that delivery's attempts. A delivery that was manually redelivered expands to show each send separately.
+</Note>
 
 </Tab>
 <Tab title="API">
@@ -185,6 +191,7 @@ Other operations:
 | `POST` | `/api/webhooks/{id}/rotate-secret` | Rotate the signing secret; returns the new secret once. |
 | `POST` | `/api/webhooks/{id}/test` | Send a test delivery for a chosen event. |
 | `GET` | `/api/webhooks/{id}/deliveries` | List delivery history for the endpoint. |
+| `GET` | `/api/webhooks/deliveries` | Search delivery history across endpoints, with filters. |
 | `POST` | `/api/webhooks/deliveries/{id}/redeliver` | Re-queue a past delivery. |
 
 <Note>

--- a/ui/app/workspace/webhooks/page.tsx
+++ b/ui/app/workspace/webhooks/page.tsx
@@ -2,7 +2,7 @@ import WebhooksView from "./views/webhooksView";
 
 export default function WebhooksPage() {
 	return (
-		<div className="mx-auto flex w-full max-w-7xl p-4 md:p-0">
+		<div className="no-padding-parent mx-auto flex w-full p-4">
 			<WebhooksView />
 		</div>
 	);

--- a/ui/app/workspace/webhooks/views/webhookDetailsSheet.tsx
+++ b/ui/app/workspace/webhooks/views/webhookDetailsSheet.tsx
@@ -7,13 +7,16 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { getErrorMessage, useGetWebhookDeliveriesQuery, useRedeliverWebhookDeliveryMutation } from "@/lib/store";
 import { WEBHOOK_TUNING_DEFAULTS, WebhookEndpoint, WebhookEvent } from "@/lib/types/webhooks";
-import { attemptSequence, groupDeliveries, outcomeBadge } from "./deliveries.utils";
+import { useNavigate } from "@tanstack/react-router";
 import { format, formatDistanceToNow } from "date-fns";
-import { ChevronDown, ChevronLeft, ChevronRight, Info, Loader2, RefreshCcw, Send } from "lucide-react";
-import { Fragment, useEffect, useMemo, useState } from "react";
+import { ArrowRight, ChevronDown, ChevronRight, Info, Loader2, RefreshCcw, Send } from "lucide-react";
+import { Fragment, useMemo, useState } from "react";
 import { toast } from "sonner";
+import { attemptSequence, groupDeliveries, outcomeBadge } from "./deliveries.utils";
 
-const PAGE_SIZE = 25;
+// The sheet shows only a preview; the dedicated deliveries page owns the
+// full, filterable, paginated history.
+const PREVIEW_SIZE = 5;
 
 const DetailEntry = ({ label, value }: { label: string; value: React.ReactNode }) => (
 	<div>
@@ -23,6 +26,15 @@ const DetailEntry = ({ label, value }: { label: string; value: React.ReactNode }
 );
 
 const relativeTime = (timestamp?: string) => (timestamp ? formatDistanceToNow(new Date(timestamp), { addSuffix: true }) : "never");
+
+// Why the redeliver control is (or is not) available. Ordered by precedence:
+// an in-flight replay first, then the reasons the button is disabled.
+const redeliverHint = (outcome: string, endpointDisabled?: boolean, redelivering?: boolean) => {
+	if (redelivering) return "Redelivering...";
+	if (endpointDisabled) return "Enable this webhook to redeliver";
+	if (outcome === "retryable_failure") return "Still retrying automatically - redelivery is available once it settles";
+	return "Redeliver";
+};
 
 interface WebhookDetailsSheetProps {
 	endpoint: WebhookEndpoint | null;
@@ -38,17 +50,13 @@ interface WebhookDetailsSheetProps {
 
 export function WebhookDetailsSheet({ endpoint, isTesting, canManage, onTest, onClose }: WebhookDetailsSheetProps) {
 	const open = !!endpoint;
-	const [offset, setOffset] = useState(0);
 	const [redeliverWebhookDelivery] = useRedeliverWebhookDeliveryMutation();
 	const [redeliveringIds, setRedeliveringIds] = useState<Set<string>>(new Set());
 	const { copy } = useCopyToClipboard();
-
-	useEffect(() => {
-		setOffset(0);
-	}, [endpoint?.id]);
+	const navigate = useNavigate();
 
 	const { data, isLoading, isError } = useGetWebhookDeliveriesQuery(
-		{ endpointId: endpoint?.id ?? "", limit: PAGE_SIZE, offset },
+		{ endpointId: endpoint?.id ?? "", limit: PREVIEW_SIZE, offset: 0 },
 		{ skip: !open, pollingInterval: 5000 },
 	);
 	const totalCount = data?.pagination.total_count ?? 0;
@@ -138,7 +146,22 @@ export function WebhookDetailsSheet({ endpoint, isTesting, canManage, onTest, on
 				</div>
 
 				<div className="mt-4 flex items-center justify-between">
-					<h3 className="font-semibold">Delivery History</h3>
+					<div className="flex items-center gap-2">
+						<h3 className="font-semibold">Recent Deliveries</h3>
+						<Button
+							variant="link"
+							size="sm"
+							className="h-auto p-0 text-xs"
+							onClick={() => {
+								onClose();
+								navigate({ to: "/workspace/webhooks/deliveries", search: { webhook_id: [endpoint?.id ?? ""] } as never });
+							}}
+							data-testid="webhook-view-delivery-history-btn"
+						>
+							{totalCount > PREVIEW_SIZE ? `View all ${totalCount.toLocaleString()}` : "View delivery history"}
+							<ArrowRight className="size-3" />
+						</Button>
+					</div>
 					{canManage && (
 						<DropdownMenu>
 							<DropdownMenuTrigger asChild>
@@ -307,20 +330,33 @@ export function WebhookDetailsSheet({ endpoint, isTesting, canManage, onTest, on
 												<TableCell>{attemptSequence(headlineSend.attempts)}</TableCell>
 												<TableCell className="text-right">
 													{canManage && (
-														<Button
-															variant="ghost"
-															size="sm"
-															onClick={() => handleRedeliver(latest.id)}
-															disabled={redeliveringIds.has(latest.id) || latest.outcome === "retryable_failure" || endpoint?.disabled}
-															data-testid={`webhook-redeliver-btn-${webhookId}`}
-															aria-label="Redeliver"
-														>
-															{redeliveringIds.has(latest.id) ? (
-																<Loader2 className="h-4 w-4 animate-spin" />
-															) : (
-																<RefreshCcw className="h-4 w-4" />
-															)}
-														</Button>
+														<Tooltip>
+															{/* A disabled button emits no pointer events, so the trigger wraps it —
+																	    otherwise the tooltip vanishes exactly when it explains the most. */}
+															<TooltipTrigger asChild>
+																<span className="inline-flex">
+																	<Button
+																		variant="ghost"
+																		size="sm"
+																		onClick={() => handleRedeliver(latest.id)}
+																		disabled={
+																			redeliveringIds.has(latest.id) || latest.outcome === "retryable_failure" || endpoint?.disabled
+																		}
+																		data-testid={`webhook-redeliver-btn-${webhookId}`}
+																		aria-label="Redeliver"
+																	>
+																		{redeliveringIds.has(latest.id) ? (
+																			<Loader2 className="h-4 w-4 animate-spin" />
+																		) : (
+																			<RefreshCcw className="h-4 w-4" />
+																		)}
+																	</Button>
+																</span>
+															</TooltipTrigger>
+															<TooltipContent>
+																{redeliverHint(latest.outcome, endpoint?.disabled, redeliveringIds.has(latest.id))}
+															</TooltipContent>
+														</Tooltip>
 													)}
 												</TableCell>
 											</TableRow>
@@ -356,40 +392,6 @@ export function WebhookDetailsSheet({ endpoint, isTesting, canManage, onTest, on
 						</TableBody>
 					</Table>
 				</div>
-
-				{totalCount > 0 && (
-					<div className="flex shrink-0 items-center justify-between text-xs" data-testid="webhook-delivery-pagination">
-						<div className="text-muted-foreground flex items-center gap-2">
-							{(offset + 1).toLocaleString()}-{Math.min(offset + PAGE_SIZE, totalCount).toLocaleString()} of {totalCount.toLocaleString()}{" "}
-							deliveries
-						</div>
-						<div className="flex items-center gap-2">
-							<Button
-								variant="ghost"
-								size="sm"
-								onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
-								disabled={offset === 0}
-								aria-label="Previous page"
-							>
-								<ChevronLeft className="size-3" />
-							</Button>
-							<div className="flex items-center gap-1">
-								<span>Page</span>
-								<span>{Math.floor(offset / PAGE_SIZE) + 1}</span>
-								<span>of {Math.ceil(totalCount / PAGE_SIZE)}</span>
-							</div>
-							<Button
-								variant="ghost"
-								size="sm"
-								onClick={() => setOffset(offset + PAGE_SIZE)}
-								disabled={offset + PAGE_SIZE >= totalCount}
-								aria-label="Next page"
-							>
-								<ChevronRight className="size-3" />
-							</Button>
-						</div>
-					</div>
-				)}
 			</SheetContent>
 		</Sheet>
 	);

--- a/ui/app/workspace/webhooks/views/webhooksView.tsx
+++ b/ui/app/workspace/webhooks/views/webhooksView.tsx
@@ -27,9 +27,10 @@ import {
 import { WEBHOOK_EVENTS, WebhookEndpoint, WebhookEndpointRequest, WebhookEvent } from "@/lib/types/webhooks";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { ChevronLeft, ChevronRight, MoreHorizontal, PencilIcon, Plus, RotateCcw, Trash2 } from "lucide-react";
+import { useNavigate } from "@tanstack/react-router";
+import { ChevronLeft, ChevronRight, History, MoreHorizontal, PencilIcon, Plus, RotateCcw, Trash2 } from "lucide-react";
 import { parseAsArrayOf, parseAsInteger, parseAsString, useQueryStates } from "nuqs";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { WebhookSecretDialog, WebhookSecretReveal } from "../dialogs/webhookSecretDialog";
 import { WebhookDetailsSheet } from "./webhookDetailsSheet";
@@ -74,6 +75,7 @@ function WebhookActionsMenu({
 	onEdit,
 	onRotate,
 	onDelete,
+	onViewDeliveries,
 }: {
 	endpoint: WebhookEndpoint;
 	hasUpdateAccess: boolean;
@@ -81,6 +83,7 @@ function WebhookActionsMenu({
 	onEdit: (endpoint: WebhookEndpoint) => void;
 	onRotate: (endpoint: WebhookEndpoint) => void;
 	onDelete: (endpoint: WebhookEndpoint) => void;
+	onViewDeliveries: (endpoint: WebhookEndpoint) => void;
 }) {
 	const [isOpen, setIsOpen] = useState(false);
 
@@ -105,6 +108,17 @@ function WebhookActionsMenu({
 					e.preventDefault();
 				}}
 			>
+				<DropdownMenuItem
+					className="cursor-pointer"
+					data-testid={`webhook-deliveries-btn-${endpoint.name}`}
+					onSelect={(e) => {
+						e.preventDefault();
+						setIsOpen(false);
+						onViewDeliveries(endpoint);
+					}}
+				>
+					<History className="h-4 w-4" /> View deliveries
+				</DropdownMenuItem>
 				{hasUpdateAccess && (
 					<DropdownMenuItem
 						className="cursor-pointer"
@@ -154,6 +168,14 @@ export default function WebhooksView() {
 	const hasCreateAccess = useRbac(RbacResource.Governance, RbacOperation.Create);
 	const hasUpdateAccess = useRbac(RbacResource.Governance, RbacOperation.Update);
 	const hasDeleteAccess = useRbac(RbacResource.Governance, RbacOperation.Delete);
+	const navigate = useNavigate();
+
+	const handleViewDeliveries = useCallback(
+		(endpoint: WebhookEndpoint) => {
+			navigate({ to: "/workspace/webhooks/deliveries", search: { webhook_id: [endpoint.id] } as never });
+		},
+		[navigate],
+	);
 
 	const [urlState, setUrlState] = useQueryStates({
 		q: parseAsString.withDefault(""),
@@ -405,6 +427,7 @@ export default function WebhooksView() {
 													onEdit={handleEdit}
 													onRotate={setRotateTarget}
 													onDelete={setDeleteTarget}
+													onViewDeliveries={handleViewDeliveries}
 												/>
 											</TableCell>
 										</TableRow>


### PR DESCRIPTION
## Summary

Adds a dedicated delivery history page at `/workspace/webhooks/deliveries` and replaces the paginated delivery list in the endpoint details sheet with a compact preview that links out to it. This gives users a richer, filterable view of deliveries across all endpoints without cluttering the sheet.

## Changes

- The endpoint details sheet now shows only the 5 most recent deliveries instead of a paginated list. Pagination controls and the associated offset state have been removed from the sheet.
- A "View delivery history" / "View all N" link in the sheet navigates to the dedicated deliveries page pre-filtered to the current endpoint.
- A "View deliveries" option has been added to each endpoint's actions dropdown menu, navigating to the deliveries page filtered by that endpoint.
- The deliveries page supports filtering by outcome, event, response status class (`2xx`/`4xx`/`5xx`/no response), webhook, and time range, with lookup by request ID or delivery ID. Clearing the webhook filter shows deliveries fleet-wide.
- Delivery rows are grouped by delivery (not by attempt), with attempt chips showing the sequence of response codes. Manually redelivered deliveries expand to show each send separately.
- Docs updated to describe the new deliveries page, its filters, and the row/attempt grouping model, and to add the `GET /api/webhooks/deliveries` endpoint to the API reference table.
- The webhooks page layout class updated to `no-padding-parent` to accommodate the full-width deliveries view.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

1. Navigate to **Webhooks** in the sidebar.
2. Open an endpoint's details sheet and confirm only the 5 most recent deliveries are shown.
3. Click **View delivery history** / **View all N** and confirm the deliveries page opens pre-filtered to that endpoint.
4. Use the **View deliveries** option in the endpoint actions dropdown and confirm the same navigation.
5. On the deliveries page, apply filters (outcome, event, status class, time range) and confirm results update accordingly.
6. Clear the webhook filter and confirm deliveries from all endpoints are shown.
7. Confirm that delivery rows group attempts correctly and that manually redelivered deliveries expand to show each send.

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. No new secrets, auth changes, or PII exposure introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable