### PR TITLE
feat(ui): replace in-page back button on webhook deliveries with topbar breadcrumb trail

### DIFF
--- a/ui/app/workspace/webhooks/deliveries/page.tsx
+++ b/ui/app/workspace/webhooks/deliveries/page.tsx
@@ -1,8 +1,8 @@
 import { groupDeliveries } from "@/app/workspace/webhooks/views/deliveries.utils";
 import { WebhookDeliveriesFilterSidebar } from "@/components/filters/webhookDeliveriesFilterSidebar";
+import PageTitle from "@/components/pageTitle";
 import { useColumnConfig } from "@/components/table";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Button } from "@/components/ui/button";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import {
 	getErrorMessage,
@@ -15,7 +15,7 @@ import { parseAsSafeArrayOf, parseAsSafeString } from "@/lib/queryParamsParser";
 import type { WebhookDeliveryFilters, WebhookDeliveryOutcome, WebhookDeliveryStatusClass, WebhookEvent } from "@/lib/types/webhooks";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { useNavigate } from "@tanstack/react-router";
-import { AlertCircle, ArrowLeft } from "lucide-react";
+import { AlertCircle } from "lucide-react";
 import { parseAsBoolean, parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -236,20 +236,13 @@ export default function WebhookDeliveriesPage() {
 
 	return (
 		<div className="no-padding-parent no-border-parent bg-background flex h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))] w-full gap-3">
+			{/* The trail replaces the old in-page back button: navigating up is the
+			    topbar's job, and it frees the header row for the filters. */}
+			<PageTitle breadcrumbs={[{ label: "Webhooks", to: "/workspace/webhooks" }, { label: "Deliveries" }]} />
 			<WebhookDeliveriesFilterSidebar filters={filters} onFiltersChange={setFilters} />
 
 			<div className="bg-card flex min-w-0 flex-1 flex-col gap-2 overflow-hidden rounded-md border">
 				<div className="flex items-center gap-2 p-4 pb-0">
-					<Button
-						variant="ghost"
-						size="sm"
-						className="h-7.5 shrink-0"
-						onClick={() => navigate({ to: "/workspace/webhooks" })}
-						data-testid="webhook-deliveries-back-btn"
-					>
-						<ArrowLeft className="size-4" />
-						Webhooks
-					</Button>
 					<DeliveriesHeaderView
 						filters={filters}
 						onFiltersChange={setFilters}

--- a/ui/components/pageTitle.tsx
+++ b/ui/components/pageTitle.tsx
@@ -1,6 +1,7 @@
 import { Badge } from "@/components/ui/badge";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hoverCard";
 import { useDescriptionSlot, useSetTopbarTitle } from "@/lib/contexts/topbarContext";
+import type { Breadcrumb } from "@/lib/contexts/topbarContext.utils";
 import { Info } from "lucide-react";
 import { createPortal } from "react-dom";
 
@@ -28,17 +29,37 @@ import { createPortal } from "react-dom";
  * `beta` marks the page as in beta, rendering a badge beside the title:
  *
  *   <PageTitle title="Alert Rules" beta>Create rules that…</PageTitle>
+ *
+ * `breadcrumbs` replaces the title with a trail for a page nested under
+ * another. Ancestor crumbs are muted and clickable; the last one is the
+ * current page and is never a link:
+ *
+ *   <PageTitle breadcrumbs={[{ label: "Webhooks", to: "/workspace/webhooks" }, { label: "Deliveries" }]} />
+ *
+ * It takes precedence over `title` when both are given.
  */
-export default function PageTitle({ title, beta, children }: { title?: string; beta?: boolean; children?: React.ReactNode }) {
-	useSetTopbarTitle(title);
+export default function PageTitle({
+	title,
+	beta,
+	breadcrumbs,
+	children,
+}: {
+	title?: string;
+	beta?: boolean;
+	breadcrumbs?: Breadcrumb[];
+	children?: React.ReactNode;
+}) {
+	useSetTopbarTitle(breadcrumbs?.length ? breadcrumbs : title);
 	const slot = useDescriptionSlot();
+	// The badge's label needs a name; with a trail that is the current page.
+	const label = title ?? breadcrumbs?.at(-1)?.label;
 
 	if (!slot || (!children && !beta)) return null;
 
 	return createPortal(
 		<>
 			{beta && (
-				<Badge className="shrink-0" aria-label={title ? `${title} is in beta` : "This page is in beta"}>
+				<Badge className="shrink-0" aria-label={label ? `${label} is in beta` : "This page is in beta"}>
 					Beta
 				</Badge>
 			)}

--- a/ui/components/topbar.tsx
+++ b/ui/components/topbar.tsx
@@ -13,15 +13,17 @@ import {
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { IS_ENTERPRISE } from "@/lib/constants/config";
 import { useDescriptionSlotRef, useMobileFilterSlotRef, useTopbarTitle } from "@/lib/contexts/topbarContext";
+import type { TopbarTitleValue } from "@/lib/contexts/topbarContext.utils";
 import { useBranding } from "@/lib/hooks/useBranding";
 import { useGetCoreConfigQuery, useGetVersionQuery, useLogoutMutation } from "@/lib/store";
+import { cn } from "@/lib/utils";
 import type { UserInfo } from "@enterprise/lib/store/utils/tokenManager";
 import { getUserInfo } from "@enterprise/lib/store/utils/tokenManager";
 import { BooksIcon, DiscordLogoIcon, GithubLogoIcon } from "@phosphor-icons/react";
 import { useLocation, useNavigate } from "@tanstack/react-router";
 import { BugIcon, ChevronDown, LogOut, Menu, User } from "lucide-react";
 import { useTheme } from "next-themes";
-import { useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 
 // External links that used to live in the sidebar footer icon row. They now
 // render as labelled rows inside the topbar menu, which is both more legible
@@ -34,29 +36,29 @@ const externalLinks: {
 	icon: React.ComponentType<Record<string, unknown>>;
 	strokeWidth?: number;
 }[] = [
-	{
-		title: "Discord Server",
-		url: "https://discord.gg/exN5KAydbU",
-		icon: DiscordLogoIcon,
-	},
-	{
-		title: "GitHub Repository",
-		url: "https://github.com/maximhq/bifrost",
-		icon: GithubLogoIcon,
-	},
-	{
-		title: "Report a bug",
-		url: "https://github.com/maximhq/bifrost/issues/new?title=[Bug Report]&labels=bug&type=bug&projects=maximhq/1",
-		icon: BugIcon,
-		strokeWidth: 1.5,
-	},
-	{
-		title: "Full Documentation",
-		url: "https://docs.getbifrost.ai",
-		icon: BooksIcon,
-		strokeWidth: 1,
-	},
-];
+		{
+			title: "Discord Server",
+			url: "https://discord.gg/exN5KAydbU",
+			icon: DiscordLogoIcon,
+		},
+		{
+			title: "GitHub Repository",
+			url: "https://github.com/maximhq/bifrost",
+			icon: GithubLogoIcon,
+		},
+		{
+			title: "Report a bug",
+			url: "https://github.com/maximhq/bifrost/issues/new?title=[Bug Report]&labels=bug&type=bug&projects=maximhq/1",
+			icon: BugIcon,
+			strokeWidth: 1.5,
+		},
+		{
+			title: "Full Documentation",
+			url: "https://docs.getbifrost.ai",
+			icon: BooksIcon,
+			strokeWidth: 1,
+		},
+	];
 
 /**
  * Resolves the topbar title. A page can name itself via useSetTopbarTitle();
@@ -68,6 +70,47 @@ function usePageTitle() {
 	const override = useTopbarTitle();
 	const derived = useMemo(() => deriveTitleFromPathname(pathname), [pathname]);
 	return override ?? derived;
+}
+
+/**
+ * Renders the topbar heading — either a plain title or a breadcrumb trail.
+ *
+ * The trail keeps the same `text-lg font-semibold` scale as a plain title, so a
+ * nested page doesn't read as visually demoted; only the ancestor crumbs are
+ * muted, leaving the current page as the emphasised one.
+ */
+function TopbarHeading({ title }: { title: TopbarTitleValue }) {
+	const navigate = useNavigate();
+
+	if (!Array.isArray(title)) {
+		return <h1 className="hidden truncate text-lg font-semibold md:block">{title}</h1>;
+	}
+
+	return (
+		<h1 className="hidden min-w-0 items-center gap-1.5 text-lg font-semibold md:flex" data-testid="topbar-breadcrumbs">
+			{title.map((crumb, index) => {
+				const isLast = index === title.length - 1;
+				return (
+					<Fragment key={`${crumb.label}-${index}`}>
+						{index > 0 && <span className="text-muted-foreground/50 shrink-0 font-normal">/</span>}
+						{crumb.to && !isLast ? (
+							<button
+								type="button"
+								onClick={() => navigate({ to: crumb.to })}
+								className="text-muted-foreground hover:text-foreground shrink-0 cursor-pointer transition-colors"
+								data-testid={`topbar-breadcrumb-${index}`}
+							>
+								{crumb.label}
+							</button>
+						) : (
+							// The current page is never a link, even if a `to` was supplied.
+							<span className={cn("truncate", !isLast && "text-muted-foreground")}>{crumb.label}</span>
+						)}
+					</Fragment>
+				);
+			})}
+		</h1>
+	);
 }
 
 /**
@@ -129,7 +172,7 @@ export default function Topbar() {
 				<img className="h-[22px] w-auto max-w-[120px] object-contain md:hidden" src={logoSrc} alt={logoAlt} width={70} height={70} />
 				{/* text-lg font-semibold is the existing in-page <h1> scale, so hoisting
 				    the title here doesn't visually demote it. */}
-				<h1 className="hidden truncate text-lg font-semibold md:block">{title}</h1>
+				<TopbarHeading title={title} />
 				{/* Anchor for <PageTitle>'s description popover. Pages portal into
 				    this node, so the topbar never has to know their content. */}
 				<span ref={setDescriptionSlot} className="hidden shrink-0 items-center gap-2 md:flex" />

--- a/ui/lib/contexts/topbarContext.tsx
+++ b/ui/lib/contexts/topbarContext.tsx
@@ -1,9 +1,9 @@
 import { createContext, useContext, useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from "react";
-import { EMPTY_TITLE_ENTRY, claimTitle, releaseTitle, type TopbarTitleEntry } from "./topbarContext.utils";
+import { EMPTY_TITLE_ENTRY, claimTitle, releaseTitle, type TopbarTitleEntry, type TopbarTitleValue } from "./topbarContext.utils";
 
 interface TopbarContextValue {
 	/** Page-supplied title override; null means "fall back to the route-derived title". */
-	title: string | null;
+	title: TopbarTitleValue | null;
 	/** Write side, ownership-aware. Prefer useSetTopbarTitle over calling this directly. */
 	setTitleEntry: Dispatch<SetStateAction<TopbarTitleEntry>>;
 	/**
@@ -33,7 +33,7 @@ export function TopbarProvider({ children }: { children: React.ReactNode }) {
 }
 
 /** Read side — used by <Topbar>. Returns null outside a provider so the topbar still renders. */
-export function useTopbarTitle(): string | null {
+export function useTopbarTitle(): TopbarTitleValue | null {
 	return useContext(TopbarContext)?.title ?? null;
 }
 
@@ -63,6 +63,10 @@ export function useMobileFilterSlot(): HTMLElement | null {
  *
  *   useSetTopbarTitle("Budgets & Limits");
  *
+ * It also accepts a breadcrumb trail for a page nested under another:
+ *
+ *   useSetTopbarTitle([{ label: "Webhooks", to: "/workspace/webhooks" }, { label: "Deliveries" }]);
+ *
  * Pass undefined/null to leave the route-derived fallback in place.
  *
  * The title is cleared on unmount, but only if this caller still owns it:
@@ -72,9 +76,15 @@ export function useMobileFilterSlot(): HTMLElement | null {
  * text, because two routes may legitimately share a title string — see
  * topbarContext.utils.ts.
  */
-export function useSetTopbarTitle(title: string | null | undefined) {
+export function useSetTopbarTitle(title: TopbarTitleValue | null | undefined) {
 	const setTitleEntry = useContext(TopbarContext)?.setTitleEntry;
 	const resolved = title ?? null;
+	// A breadcrumb trail is a fresh array literal each render, so the effect
+	// keys off its content rather than its identity — otherwise it would refire
+	// on every parent render.
+	const titleKey = Array.isArray(resolved) ? JSON.stringify(resolved) : resolved;
+	const resolvedRef = useRef(resolved);
+	resolvedRef.current = resolved;
 	// One token per hook instance, stable for its whole lifetime.
 	const ownerRef = useRef<symbol | null>(null);
 	if (ownerRef.current === null) ownerRef.current = Symbol("topbar-title");
@@ -82,8 +92,8 @@ export function useSetTopbarTitle(title: string | null | undefined) {
 
 	useEffect(() => {
 		if (!setTitleEntry) return;
-		setTitleEntry((current) => claimTitle(current, owner, resolved));
-	}, [setTitleEntry, owner, resolved]);
+		setTitleEntry((current) => claimTitle(current, owner, resolvedRef.current));
+	}, [setTitleEntry, owner, titleKey]);
 
 	useEffect(() => {
 		if (!setTitleEntry) return;

--- a/ui/lib/contexts/topbarContext.utils.ts
+++ b/ui/lib/contexts/topbarContext.utils.ts
@@ -11,18 +11,43 @@
  * comparison cannot tell "the page I replaced" from "the page that replaced
  * me".
  */
+/** One hop in a breadcrumb trail. `to` makes it a link; the last crumb (the
+ * current page) normally has none. */
+export interface Breadcrumb {
+	label: string;
+	to?: string;
+}
+
+/**
+ * A page names itself either with a plain title or with a breadcrumb trail.
+ * The trail is data, not JSX, so the topbar keeps full control of the styling
+ * and no page can smuggle its own markup into the shell.
+ */
+export type TopbarTitleValue = string | Breadcrumb[];
+
 export interface TopbarTitleEntry {
 	/** null means "fall back to the route-derived title". */
-	value: string | null;
+	value: TopbarTitleValue | null;
 	/** Opaque token identifying the caller that set `value`. */
 	owner: symbol | null;
+}
+
+/**
+ * Structural equality, because a breadcrumb trail is almost always a fresh
+ * array literal on every render. Identity comparison would make claimTitle's
+ * "nothing changed" guard never fire and set state on every render.
+ */
+export function sameTitle(a: TopbarTitleValue | null, b: TopbarTitleValue | null): boolean {
+	if (a === b) return true;
+	if (!Array.isArray(a) || !Array.isArray(b)) return false;
+	return a.length === b.length && a.every((crumb, i) => crumb.label === b[i].label && crumb.to === b[i].to);
 }
 
 export const EMPTY_TITLE_ENTRY: TopbarTitleEntry = { value: null, owner: null };
 
 /** A caller takes the title, becoming its owner. */
-export function claimTitle(current: TopbarTitleEntry, owner: symbol, value: string | null): TopbarTitleEntry {
-	if (current.value === value && current.owner === owner) return current;
+export function claimTitle(current: TopbarTitleEntry, owner: symbol, value: TopbarTitleValue | null): TopbarTitleEntry {
+	if (sameTitle(current.value, value) && current.owner === owner) return current;
 	return { value, owner };
 }
 


### PR DESCRIPTION
## Summary

Replaces the in-page "← Webhooks" back button on the Webhook Deliveries page with a breadcrumb trail rendered in the topbar. Navigation up the hierarchy is now the topbar's responsibility, freeing the header row for filters and keeping navigation consistent across the app.

## Changes

- Added a `Breadcrumb` type and `TopbarTitleValue` union (`string | Breadcrumb[]`) to `topbarContext.utils.ts`, allowing pages to supply either a plain title or a structured trail to the topbar.
- Added `sameTitle()` for structural equality of breadcrumb arrays, preventing unnecessary state updates caused by fresh array literals on every render.
- Updated `useSetTopbarTitle` to accept `TopbarTitleValue`, keying its effect off serialized content rather than array identity.
- Added a `TopbarHeading` component to the topbar that renders either a plain `<h1>` or a breadcrumb trail with muted, clickable ancestor crumbs and an emphasised current-page label — all at the same `text-lg font-semibold` scale so nested pages aren't visually demoted.
- Extended `PageTitle` with a `breadcrumbs` prop that passes the trail to `useSetTopbarTitle`. When both `title` and `breadcrumbs` are provided, the trail takes precedence. The beta badge's accessible label falls back to the last crumb's label when no explicit title is given.
- Removed the `<Button>` back button, `ArrowLeft` icon, and the `navigate` call from `WebhookDeliveriesPage`, replacing them with `<PageTitle breadcrumbs={[...]} />`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to **Workspace → Webhooks → Deliveries**.
2. Confirm the topbar shows `Webhooks / Deliveries` as a breadcrumb trail instead of a plain title.
3. Click the `Webhooks` crumb and confirm it navigates back to `/workspace/webhooks`.
4. Confirm the `Deliveries` label is not a link.
5. Confirm the old in-page back button is gone and the filter header row is unobstructed.
6. Confirm no other pages that use `PageTitle` with a plain `title` are affected.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before: An "← Webhooks" ghost button appeared inside the deliveries card header.  
After: The topbar displays `Webhooks / Deliveries` where `Webhooks` is a muted, clickable crumb and `Deliveries` is the emphasised current-page label.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable