### PR TITLE
feat: replace user-scoped model configs with extensible `ExtraScopedIDsResolver` and add `ManagedBy` field, read-only sheet, and `managed_by` API response

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -5832,6 +5832,24 @@ func (s *RDBConfigStore) DeleteModelConfigsForScope(ctx context.Context, txDB *g
 	return s.deleteModelConfigsWhere(ctx, txDB, "scope = ? AND scope_id = ?", scope, scopeID)
 }
 
+// GetModelConfigsForScope loads all model configs (and their Budgets/RateLimit) targeting a given
+// scope owner within txDB. The tx is required, not variadic, for the same reason as
+// DeleteModelConfigsForScope: a caller reading and writing the same scope owner in one transaction
+// (e.g. tearing down and recreating its configs) needs to see its own uncommitted writes, which
+// s.DB() outside the transaction cannot.
+func (s *RDBConfigStore) GetModelConfigsForScope(ctx context.Context, txDB *gorm.DB, scope, scopeID string) ([]tables.TableModelConfig, error) {
+	if txDB == nil {
+		return nil, fmt.Errorf("GetModelConfigsForScope requires the caller's transaction, got nil tx")
+	}
+	var modelConfigs []tables.TableModelConfig
+	if err := txDB.WithContext(ctx).Preload("Budgets").Preload("RateLimit").
+		Where("scope = ? AND scope_id = ?", scope, scopeID).
+		Find(&modelConfigs).Error; err != nil {
+		return nil, err
+	}
+	return modelConfigs, nil
+}
+
 // CreateModelConfig creates a new model config in the database.
 func (s *RDBConfigStore) CreateModelConfig(ctx context.Context, modelConfig *tables.TableModelConfig, tx ...*gorm.DB) error {
 	// Locking the scope owner and inserting the config must be atomic, so wrap in a

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -415,6 +415,10 @@ type ConfigStore interface {
 	DeleteModelConfig(ctx context.Context, id string, tx ...*gorm.DB) error
 	// DeleteModelConfigsForScope deletes all model configs (and their owned budgets/rate-limits) for a scope owner. Must run inside the owner-delete transaction.
 	DeleteModelConfigsForScope(ctx context.Context, tx *gorm.DB, scope, scopeID string) error
+	// GetModelConfigsForScope loads all model configs (with Budgets/RateLimit) for a scope owner
+	// within the given transaction, so a caller mid-transaction sees its own uncommitted writes
+	// (e.g. deletions staged earlier in the same tx) rather than the last-committed state.
+	GetModelConfigsForScope(ctx context.Context, tx *gorm.DB, scope, scopeID string) ([]tables.TableModelConfig, error)
 
 	// Governance config CRUD
 	GetGovernanceConfig(ctx context.Context) (*GovernanceConfig, error)

--- a/framework/configstore/tables/modelconfig.go
+++ b/framework/configstore/tables/modelconfig.go
@@ -13,7 +13,6 @@ import (
 const (
 	ModelConfigScopeGlobal     = "global"
 	ModelConfigScopeVirtualKey = "virtual_key"
-	ModelConfigScopeUser       = "user"
 )
 
 // ModelConfigAllModels is the model_name sentinel meaning "all models". Combined with a
@@ -23,7 +22,7 @@ const ModelConfigAllModels = "*"
 
 // validModelConfigScopes is the runtime registry of accepted scope values.
 // OSS seeds it with global + virtual_key; downstream consumers (e.g. the
-// enterprise build registering "user") extend it at startup via
+// enterprise build registering "access_profile") extend it at startup via
 // RegisterModelConfigScope. Guarded by validModelConfigScopesMu.
 var (
 	validModelConfigScopesMu sync.RWMutex

--- a/framework/configstore/tables/modelconfig.go
+++ b/framework/configstore/tables/modelconfig.go
@@ -73,6 +73,11 @@ type TableModelConfig struct {
 	// the scope target (e.g. the virtual key's name) so the UI can render a label
 	// instead of an opaque scope_id. Populated by the HTTP layer on read.
 	ScopeName string `gorm:"-" json:"scope_name,omitempty"`
+	// ManagedBy is a non-persisted, API-only field carrying a human-readable label for
+	// what externally manages this config (e.g. "Engineering" for an access profile),
+	// distinct from ScopeName's "who this applies to". Empty when nothing manages it
+	// or no resolver is registered for the scope. Populated by the HTTP layer on read.
+	ManagedBy string `gorm:"-" json:"managed_by,omitempty"`
 	// BudgetIDs is a config-file-only field listing pre-declared budget IDs (from
 	// governance.budgets) to link to this model config. Not persisted; used by the
 	// config sync path to set model_config_id on each referenced budget row.

--- a/framework/grant/limit.go
+++ b/framework/grant/limit.go
@@ -34,13 +34,9 @@ const (
 	// Held by an access profile attached to a user. Named for the user rather than generically,
 	// because a profile is currently only attachable to a user; if it becomes attachable to other
 	// kinds of holder, each will need its own kind so a refusal can say whose profile it was.
-	//
-	// There is deliberately no third, per-model-config kind alongside these two: a profile's
-	// per-model limits are not a distinct pool with its own lifecycle, they are the same money as
-	// the profile's own, so they are attributed to LimitHolderUserAccessProfile rather than
-	// splitting into a kind of their own.
 	LimitHolderUserAccessProfile               LimitHolderKind = "user_access_profile"
 	LimitHolderUserAccessProfileProviderConfig LimitHolderKind = "user_access_profile_provider_config"
+	LimitHolderUserAccessProfileModelConfig    LimitHolderKind = "user_access_profile_model_config"
 
 	// Held by the organization above the caller. Spent by every request made under anything they
 	// contain.

--- a/framework/grant/limit.go
+++ b/framework/grant/limit.go
@@ -31,23 +31,16 @@ const (
 	LimitHolderVirtualKeyProviderConfig LimitHolderKind = "vk_provider_config"
 	LimitHolderVirtualKeyModelConfig    LimitHolderKind = "vk_model_config"
 
-	// Held by a profile attached to a caller.
-	LimitHolderAccessProfile               LimitHolderKind = "access_profile"
-	LimitHolderAccessProfileProviderConfig LimitHolderKind = "access_profile_provider_config"
-
-	// Held by the user a request is attributed to. Kept apart from the key's kinds because a caller
-	// can be told to stop counting a request against the key that granted it while still counting
-	// it against the user who made it; one kind covering both would make that unexpressible.
+	// Held by an access profile attached to a user. Named for the user rather than generically,
+	// because a profile is currently only attachable to a user; if it becomes attachable to other
+	// kinds of holder, each will need its own kind so a refusal can say whose profile it was.
 	//
-	// This kind covers two different origins that share the user's scope: a per-model limit
-	// assigned to the user directly, and one a deployment derived from something the user holds and
-	// stored against them. They are not the same money and they do not share a lifecycle, since
-	// detaching whatever produced the derived one removes it while the directly assigned one
-	// survives, but at this level they are indistinguishable, so a refusal naming this kind cannot
-	// say which of the two ran out. Telling them apart needs whatever recorded the derivation,
-	// which is the deployment's to know; a deployment that wants the distinction in its refusals
-	// declares a kind for it.
-	LimitHolderUserModelConfig LimitHolderKind = "user_model_config"
+	// There is deliberately no third, per-model-config kind alongside these two: a profile's
+	// per-model limits are not a distinct pool with its own lifecycle, they are the same money as
+	// the profile's own, so they are attributed to LimitHolderUserAccessProfile rather than
+	// splitting into a kind of their own.
+	LimitHolderUserAccessProfile               LimitHolderKind = "user_access_profile"
+	LimitHolderUserAccessProfileProviderConfig LimitHolderKind = "user_access_profile_provider_config"
 
 	// Held by the organization above the caller. Spent by every request made under anything they
 	// contain.

--- a/framework/grant/limit.go
+++ b/framework/grant/limit.go
@@ -38,6 +38,13 @@ const (
 	LimitHolderUserAccessProfileProviderConfig LimitHolderKind = "user_access_profile_provider_config"
 	LimitHolderUserAccessProfileModelConfig    LimitHolderKind = "user_access_profile_model_config"
 
+	// Held by the user a request is attributed to, directly — a per-model limit assigned straight
+	// to the user rather than derived from an access profile they hold. Kept distinct from the
+	// LimitHolderUserAccessProfile* kinds because a refusal has to say which one ran out, and from
+	// LimitHolderVirtualKey because a caller can be told to stop counting a request against the key
+	// that granted it while still counting it against the user who made it.
+	LimitHolderUserModelConfig LimitHolderKind = "user_model_config"
+
 	// Held by the organization above the caller. Spent by every request made under anything they
 	// contain.
 	LimitHolderTeam         LimitHolderKind = "team"

--- a/framework/grant/limit_test.go
+++ b/framework/grant/limit_test.go
@@ -101,11 +101,11 @@ func TestLimitsFrom(t *testing.T) {
 func TestLimitHolderKindsAreDistinct(t *testing.T) {
 	kinds := []LimitHolderKind{
 		LimitHolderVirtualKey, LimitHolderVirtualKeyProviderConfig,
-		LimitHolderAccessProfile, LimitHolderAccessProfileProviderConfig,
+		LimitHolderUserAccessProfile, LimitHolderUserAccessProfileProviderConfig,
 		LimitHolderTeam, LimitHolderBusinessUnit, LimitHolderCustomer,
 		LimitHolderProject, LimitHolderProjectProviderConfig,
 		LimitHolderProvider, LimitHolderModelConfig,
-		LimitHolderVirtualKeyModelConfig, LimitHolderUserModelConfig, LimitHolderProjectModelConfig,
+		LimitHolderVirtualKeyModelConfig, LimitHolderProjectModelConfig,
 	}
 	seen := make(map[LimitHolderKind]bool, len(kinds))
 	for _, k := range kinds {

--- a/framework/grant/limit_test.go
+++ b/framework/grant/limit_test.go
@@ -106,6 +106,7 @@ func TestLimitHolderKindsAreDistinct(t *testing.T) {
 		LimitHolderProject, LimitHolderProjectProviderConfig,
 		LimitHolderProvider, LimitHolderModelConfig,
 		LimitHolderVirtualKeyModelConfig, LimitHolderProjectModelConfig,
+		LimitHolderUserAccessProfileModelConfig,
 	}
 	seen := make(map[LimitHolderKind]bool, len(kinds))
 	for _, k := range kinds {

--- a/framework/grant/limit_test.go
+++ b/framework/grant/limit_test.go
@@ -106,7 +106,7 @@ func TestLimitHolderKindsAreDistinct(t *testing.T) {
 		LimitHolderProject, LimitHolderProjectProviderConfig,
 		LimitHolderProvider, LimitHolderModelConfig,
 		LimitHolderVirtualKeyModelConfig, LimitHolderProjectModelConfig,
-		LimitHolderUserAccessProfileModelConfig,
+		LimitHolderUserAccessProfileModelConfig, LimitHolderUserModelConfig,
 	}
 	seen := make(map[LimitHolderKind]bool, len(kinds))
 	for _, k := range kinds {

--- a/plugins/governance/accounting_test.go
+++ b/plugins/governance/accounting_test.go
@@ -265,18 +265,18 @@ func newModelScopedFixture(t *testing.T) *modelScopedFixture {
 	t.Helper()
 	logger := NewMockLogger()
 	providerName := "openai"
-	userID := "user-alice"
+	vkID := "vk-alice"
 
 	perModel := buildBudgetWithUsage("model-budget", 1_000_000.0, 0.0, "1d")
 	perModelRL := buildRateLimit("model-rl", 1_000_000_000, 1_000_000)
-	perModelMC := buildModelConfig("mc-user-gpt5", "gpt-5", &providerName, perModel, perModelRL)
-	perModelMC.Scope = configstoreTables.ModelConfigScopeUser
-	perModelMC.ScopeID = &userID
+	perModelMC := buildModelConfig("mc-vk-gpt5", "gpt-5", &providerName, perModel, perModelRL)
+	perModelMC.Scope = configstoreTables.ModelConfigScopeVirtualKey
+	perModelMC.ScopeID = &vkID
 
 	wildcard := buildBudgetWithUsage("wildcard-budget", 1_000_000.0, 0.0, "1d")
-	wildcardMC := buildModelConfig("mc-user-all", configstoreTables.ModelConfigAllModels, &providerName, wildcard, nil)
-	wildcardMC.Scope = configstoreTables.ModelConfigScopeUser
-	wildcardMC.ScopeID = &userID
+	wildcardMC := buildModelConfig("mc-vk-all", configstoreTables.ModelConfigAllModels, &providerName, wildcard, nil)
+	wildcardMC.Scope = configstoreTables.ModelConfigScopeVirtualKey
+	wildcardMC.ScopeID = &vkID
 
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*perModelMC, *wildcardMC},

--- a/plugins/governance/accounting_test.go
+++ b/plugins/governance/accounting_test.go
@@ -303,12 +303,13 @@ func TestReportUsage_ChargesPerModelBudgets(t *testing.T) {
 	// What a settled batch looks like: the wildcard budget was collected at create
 	// time (and so is already charged the full total), the per-model budget was not.
 	report := jobaccounting.UsageReport{
-		RequestID:  "batch-cost:openai:batch-models",
-		Provider:   schemas.OpenAI,
-		Cost:       30.0,
-		TokensUsed: 300,
-		BudgetIDs:  []string{"wildcard-budget"},
-		UserID:     "user-alice",
+		RequestID:    "batch-cost:openai:batch-models",
+		Provider:     schemas.OpenAI,
+		Cost:         30.0,
+		TokensUsed:   300,
+		BudgetIDs:    []string{"wildcard-budget"},
+		UserID:       "user-alice",
+		VirtualKeyID: "vk-alice",
 		ModelUsage: []jobaccounting.ModelUsage{
 			{Model: "gpt-5", Cost: 20.0, TokensUsed: 200},
 			{Model: "gpt-4o", Cost: 10.0, TokensUsed: 100},

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -1560,10 +1560,10 @@ func (p *GovernancePlugin) ReportUsage(ctx context.Context, usage jobaccounting.
 // They are missing from usage.BudgetIDs by construction: those ids were collected
 // while the request was in flight, and a batch create carries no top-level model
 // (each input-file row names its own), so only the all-models wildcards matched.
-// An access profile's per-model limits materialise as user-scoped configs naming
-// exactly one model and provider, which is why a model-level budget never moved for
-// a batch. Settlement does know the models, so each one is resolved and charged with
-// its own share here.
+// A downstream consumer's per-model limits (e.g. an access profile's, registered via
+// RegisterExtraScopedIDsResolver) materialise as configs naming exactly one model and
+// provider, which is why a model-level budget never moved for a batch. Settlement does
+// know the models, so each one is resolved and charged with its own share here.
 //
 // Ids already charged above are subtracted rather than skipped by construction: the
 // wildcard tiers legitimately match both collections, and charging them twice would

--- a/plugins/governance/resolver.go
+++ b/plugins/governance/resolver.go
@@ -198,7 +198,7 @@ func (r *BudgetResolver) evaluateLimits(ctx *schemas.BifrostContext, evaluationR
 var untrackedHolderKinds = []grant.LimitHolderKind{
 	grant.LimitHolderProvider,
 	grant.LimitHolderModelConfig,
-	grant.LimitHolderUserModelConfig,
+	grant.LimitHolderUserAccessProfile,
 }
 
 // spendingChecksSkipped reports whether this request was told not to be checked against anything it

--- a/plugins/governance/resolver.go
+++ b/plugins/governance/resolver.go
@@ -188,7 +188,11 @@ func (r *BudgetResolver) evaluateLimits(ctx *schemas.BifrostContext, evaluationR
 }
 
 // untrackedHolderKinds are the kinds still billed when a caller has asked for the holder's usage not
-// to be counted: what the deployment imposes, and what the user who made the request answers to.
+// to be counted: what the deployment imposes. There is no per-user kind here: a user can hold
+// several access profiles at once, each granting different restrictions, so no access-profile-derived
+// limit is unconditionally "the user's own money" the way a single global per-user allowance used to
+// be — access-profile limits are scoped limits like a virtual key's or a project's, and respect the
+// caller's request not to be counted the same way those do.
 //
 // This names what to keep rather than what to drop, because the set it names is closed and belongs
 // to this package, while what a holder funds is open: a kind nobody here has heard of is a holder's,
@@ -198,7 +202,6 @@ func (r *BudgetResolver) evaluateLimits(ctx *schemas.BifrostContext, evaluationR
 var untrackedHolderKinds = []grant.LimitHolderKind{
 	grant.LimitHolderProvider,
 	grant.LimitHolderModelConfig,
-	grant.LimitHolderUserAccessProfile,
 }
 
 // spendingChecksSkipped reports whether this request was told not to be checked against anything it

--- a/plugins/governance/resolver.go
+++ b/plugins/governance/resolver.go
@@ -188,11 +188,13 @@ func (r *BudgetResolver) evaluateLimits(ctx *schemas.BifrostContext, evaluationR
 }
 
 // untrackedHolderKinds are the kinds still billed when a caller has asked for the holder's usage not
-// to be counted: what the deployment imposes. There is no per-user kind here: a user can hold
-// several access profiles at once, each granting different restrictions, so no access-profile-derived
-// limit is unconditionally "the user's own money" the way a single global per-user allowance used to
-// be — access-profile limits are scoped limits like a virtual key's or a project's, and respect the
-// caller's request not to be counted the same way those do.
+// to be counted: what the deployment imposes, and what the user who made the request answers to
+// directly. Access-profile-derived limits are deliberately NOT here: a user can hold several access
+// profiles at once, each granting different restrictions, so no access-profile-derived limit is
+// unconditionally "the user's own money" the way a limit assigned straight to the user is — those
+// are scoped limits like a virtual key's or a project's, and respect the caller's request not to be
+// counted the same way those do. LimitHolderUserModelConfig has no such ambiguity: it is always the
+// user's own money, so it stays billed regardless of what the caller asked to skip.
 //
 // This names what to keep rather than what to drop, because the set it names is closed and belongs
 // to this package, while what a holder funds is open: a kind nobody here has heard of is a holder's,
@@ -202,6 +204,7 @@ func (r *BudgetResolver) evaluateLimits(ctx *schemas.BifrostContext, evaluationR
 var untrackedHolderKinds = []grant.LimitHolderKind{
 	grant.LimitHolderProvider,
 	grant.LimitHolderModelConfig,
+	grant.LimitHolderUserModelConfig,
 }
 
 // spendingChecksSkipped reports whether this request was told not to be checked against anything it

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -3213,7 +3213,6 @@ func (gs *LocalGovernanceStore) CollectModelScopedGovernanceIDs(ctx context.Cont
 
 	scopes := []struct{ name, id string }{
 		{configstoreTables.ModelConfigScopeGlobal, ""},
-		{configstoreTables.ModelConfigScopeUser, userID},
 		{configstoreTables.ModelConfigScopeVirtualKey, virtualKeyID},
 	}
 	for _, scope := range scopes {
@@ -4427,20 +4426,10 @@ func modelConfigScopesFor(ctx context.Context, permit schemas.Permit) []limitSco
 		kind: grant.LimitHolderModelConfig,
 	}}
 	// The user the request was made as, when there is one. A user is not the permit holder, since a
-	// request can be made as a user through a key, so it is a scope of its own rather than one
-	// derived from the permit.
+	// request can be made as a user through a key, so downstream-registered scopes keyed off it
+	// (e.g. enterprise's per-access-profile per-model budgets — see RegisterExtraScopedIDsResolver)
+	// are scopes of their own rather than derived from the permit.
 	userID, _ := ctx.Value(schemas.BifrostContextKeyUserID).(string)
-	if userID != "" {
-		scopes = append(scopes, limitScope{
-			name: configstoreTables.ModelConfigScopeUser,
-			id:   userID,
-			kind: grant.LimitHolderUserModelConfig,
-		})
-	}
-	// Downstream-registered scopes that also apply to the user the request was made
-	// as (e.g. enterprise's per-access-profile per-model budgets) — see
-	// RegisterExtraScopedIDsResolver. Attributed the same as the user's own scope:
-	// from the requester's perspective both are "your model limit".
 	vkID := ""
 	if permit != nil && permit.Type() == string(grant.PermitVirtualKey) {
 		vkID = permit.ID()

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -3224,7 +3224,60 @@ func (gs *LocalGovernanceStore) CollectModelScopedGovernanceIDs(ctx context.Cont
 			addModelConfigIDs(mc)
 		}
 	}
+	// Downstream-registered scopes (e.g. enterprise's per-access-profile per-model
+	// budgets, keyed by a user-access-profile association ID rather than the raw
+	// user/VK ID) — see RegisterExtraScopedIDsResolver.
+	for _, pair := range collectExtraScopedIDs(ctx, virtualKeyID, userID) {
+		for _, mc := range gs.collectModelConfigsFor(ctx, pair.Scope, pair.ScopeID, model, providerStr) {
+			addModelConfigIDs(mc)
+		}
+	}
 	return budgetIDs, rateLimitIDs
+}
+
+// ScopedID names a (scope, scope_id) pair for a model-config lookup.
+type ScopedID struct {
+	Scope   string
+	ScopeID string
+}
+
+// ExtraScopedIDsResolver returns additional (scope, scope_id) pairs to check for
+// model-config-based budgets/rate-limits on a request, given its virtual key and
+// user IDs. Lets downstream consumers (e.g. enterprise access profiles) graft
+// extra scopes onto CollectModelScopedGovernanceIDs's built-in global/user/
+// virtual_key set without this package needing to know their scope semantics.
+// Must be fast and non-blocking (in-memory only) — called on every request.
+type ExtraScopedIDsResolver func(ctx context.Context, virtualKeyID, userID string) []ScopedID
+
+var (
+	extraScopedIDsResolversMu sync.RWMutex
+	extraScopedIDsResolvers   []ExtraScopedIDsResolver
+)
+
+// RegisterExtraScopedIDsResolver adds fn to the resolvers consulted by
+// CollectModelScopedGovernanceIDs. Intended to be called once at process
+// startup; safe to call concurrently.
+func RegisterExtraScopedIDsResolver(fn ExtraScopedIDsResolver) {
+	if fn == nil {
+		return
+	}
+	extraScopedIDsResolversMu.Lock()
+	extraScopedIDsResolvers = append(extraScopedIDsResolvers, fn)
+	extraScopedIDsResolversMu.Unlock()
+}
+
+func collectExtraScopedIDs(ctx context.Context, virtualKeyID, userID string) []ScopedID {
+	extraScopedIDsResolversMu.RLock()
+	resolvers := extraScopedIDsResolvers
+	extraScopedIDsResolversMu.RUnlock()
+	if len(resolvers) == 0 {
+		return nil
+	}
+	var out []ScopedID
+	for _, fn := range resolvers {
+		out = append(out, fn(ctx, virtualKeyID, userID)...)
+	}
+	return out
 }
 
 // PUBLIC API METHODS
@@ -4376,10 +4429,26 @@ func modelConfigScopesFor(ctx context.Context, permit schemas.Permit) []limitSco
 	// The user the request was made as, when there is one. A user is not the permit holder, since a
 	// request can be made as a user through a key, so it is a scope of its own rather than one
 	// derived from the permit.
-	if userID, _ := ctx.Value(schemas.BifrostContextKeyUserID).(string); userID != "" {
+	userID, _ := ctx.Value(schemas.BifrostContextKeyUserID).(string)
+	if userID != "" {
 		scopes = append(scopes, limitScope{
 			name: configstoreTables.ModelConfigScopeUser,
 			id:   userID,
+			kind: grant.LimitHolderUserModelConfig,
+		})
+	}
+	// Downstream-registered scopes that also apply to the user the request was made
+	// as (e.g. enterprise's per-access-profile per-model budgets) — see
+	// RegisterExtraScopedIDsResolver. Attributed the same as the user's own scope:
+	// from the requester's perspective both are "your model limit".
+	vkID := ""
+	if permit != nil && permit.Type() == string(grant.PermitVirtualKey) {
+		vkID = permit.ID()
+	}
+	for _, extra := range collectExtraScopedIDs(ctx, vkID, userID) {
+		scopes = append(scopes, limitScope{
+			name: extra.Scope,
+			id:   extra.ScopeID,
 			kind: grant.LimitHolderUserModelConfig,
 		})
 	}

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -3234,10 +3234,14 @@ func (gs *LocalGovernanceStore) CollectModelScopedGovernanceIDs(ctx context.Cont
 	return budgetIDs, rateLimitIDs
 }
 
-// ScopedID names a (scope, scope_id) pair for a model-config lookup.
+// ScopedID names a (scope, scope_id) pair for a model-config lookup, and the holder kind its
+// per-model limits are attributed to when used to resolve request-time enforcement scopes (see
+// modelConfigScopesFor). Left empty by a caller that only wants CollectModelScopedGovernanceIDs's
+// budget/rate-limit IDs, since that path never attributes a limit to a holder.
 type ScopedID struct {
 	Scope   string
 	ScopeID string
+	Kind    grant.LimitHolderKind
 }
 
 // ExtraScopedIDsResolver returns additional (scope, scope_id) pairs to check for
@@ -3246,6 +3250,9 @@ type ScopedID struct {
 // extra scopes onto CollectModelScopedGovernanceIDs's built-in global/user/
 // virtual_key set without this package needing to know their scope semantics.
 // Must be fast and non-blocking (in-memory only) — called on every request.
+//
+// When used to resolve request-time enforcement scopes (modelConfigScopesFor), each ScopedID's Kind
+// is what a refusal names as the holder of the limit that ran out — see ScopedID.
 type ExtraScopedIDsResolver func(ctx context.Context, virtualKeyID, userID string) []ScopedID
 
 var (
@@ -4438,7 +4445,7 @@ func modelConfigScopesFor(ctx context.Context, permit schemas.Permit) []limitSco
 		scopes = append(scopes, limitScope{
 			name: extra.Scope,
 			id:   extra.ScopeID,
-			kind: grant.LimitHolderUserModelConfig,
+			kind: extra.Kind,
 		})
 	}
 	if permit == nil || permit.ID() == "" {
@@ -4476,7 +4483,10 @@ func scopedModelConfigKind(permitType string) grant.LimitHolderKind {
 	case string(grant.PermitProject):
 		return grant.LimitHolderProjectModelConfig
 	default:
-		return grant.LimitHolderUserModelConfig
+		// An access-profile permit's own per-model limits are the same money as the profile's own —
+		// see the LimitHolderUserAccessProfile doc comment — so they share its kind rather than a
+		// distinct per-model one.
+		return grant.LimitHolderUserAccessProfile
 	}
 }
 

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -4483,10 +4483,7 @@ func scopedModelConfigKind(permitType string) grant.LimitHolderKind {
 	case string(grant.PermitProject):
 		return grant.LimitHolderProjectModelConfig
 	default:
-		// An access-profile permit's own per-model limits are the same money as the profile's own —
-		// see the LimitHolderUserAccessProfile doc comment — so they share its kind rather than a
-		// distinct per-model one.
-		return grant.LimitHolderUserAccessProfile
+		return grant.LimitHolderUserAccessProfileModelConfig
 	}
 }
 

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -3247,7 +3247,7 @@ type ScopedID struct {
 // ExtraScopedIDsResolver returns additional (scope, scope_id) pairs to check for
 // model-config-based budgets/rate-limits on a request, given its virtual key and
 // user IDs. Lets downstream consumers (e.g. enterprise access profiles) graft
-// extra scopes onto CollectModelScopedGovernanceIDs's built-in global/user/
+// extra scopes onto CollectModelScopedGovernanceIDs's built-in global/
 // virtual_key set without this package needing to know their scope semantics.
 // Must be fast and non-blocking (in-memory only) — called on every request.
 //
@@ -4442,6 +4442,12 @@ func modelConfigScopesFor(ctx context.Context, permit schemas.Permit) []limitSco
 		vkID = permit.ID()
 	}
 	for _, extra := range collectExtraScopedIDs(ctx, vkID, userID) {
+		// An empty Kind is a legitimate value for a batch-only caller (see ScopedID's
+		// doc comment), but this is the request-time path: a blank holder kind here
+		// would let a refusal name an empty holder. Skip rather than propagate it.
+		if extra.Kind == "" {
+			continue
+		}
 		scopes = append(scopes, limitScope{
 			name: extra.Scope,
 			id:   extra.ScopeID,

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -1620,26 +1620,26 @@ func ptrInt64(i int64) *int64 {
 	return &i
 }
 
-// An access profile's per-model budgets materialise as user-scoped model configs
-// naming one model and provider. A batch create carries no top-level model, so the
-// in-flight collection matches only the wildcard tiers and those per-model budgets
-// are invisible to it — which is why batch spend never reached them. Settlement
-// knows the models and asks for them by name.
+// A downstream consumer's (e.g. an access profile's) per-model budgets materialise
+// as virtual-key-scoped model configs naming one model and provider. A batch create
+// carries no top-level model, so the in-flight collection matches only the wildcard
+// tiers and those per-model budgets are invisible to it — which is why batch spend
+// never reached them. Settlement knows the models and asks for them by name.
 func TestCollectModelScopedGovernanceIDs_FindsExactModelConfigMissedAtCreateTime(t *testing.T) {
 	logger := NewMockLogger()
 	ctx := context.Background()
 	providerName := "openai"
-	userID := "user-alice"
+	vkID := "vk-alice"
 
 	perModel := buildBudgetWithUsage("ap-model-budget", 100.0, 0.0, "1M")
-	perModelMC := buildModelConfig("mc-user-gpt5", "gpt-5", &providerName, perModel, nil)
-	perModelMC.Scope = configstoreTables.ModelConfigScopeUser
-	perModelMC.ScopeID = &userID
+	perModelMC := buildModelConfig("mc-vk-gpt5", "gpt-5", &providerName, perModel, nil)
+	perModelMC.Scope = configstoreTables.ModelConfigScopeVirtualKey
+	perModelMC.ScopeID = &vkID
 
 	wildcard := buildBudgetWithUsage("ap-wildcard-budget", 100.0, 0.0, "1M")
-	wildcardMC := buildModelConfig("mc-user-all", configstoreTables.ModelConfigAllModels, &providerName, wildcard, nil)
-	wildcardMC.Scope = configstoreTables.ModelConfigScopeUser
-	wildcardMC.ScopeID = &userID
+	wildcardMC := buildModelConfig("mc-vk-all", configstoreTables.ModelConfigAllModels, &providerName, wildcard, nil)
+	wildcardMC.Scope = configstoreTables.ModelConfigScopeVirtualKey
+	wildcardMC.ScopeID = &vkID
 
 	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*perModelMC, *wildcardMC},
@@ -1647,31 +1647,21 @@ func TestCollectModelScopedGovernanceIDs_FindsExactModelConfigMissedAtCreateTime
 	}, nil, nil)
 	require.NoError(t, err)
 
-	// What batch create settles onto the request: no model, so only the wildcard is gathered. The
-	// user is a scope of its own, read off the request rather than off a permit, so no access is
-	// needed to reach it.
-	inFlightCtx := grantedCtx(ctx)
-	inFlightCtx.SetValue(schemas.BifrostContextKeyUserID, userID)
-	inFlightBudgets, _ := gatherLimits(inFlightCtx, store, nil, schemas.ModelProvider(providerName), "")
-	inFlight := limitIDsOf(inFlightBudgets)
-	assert.Contains(t, inFlight, wildcard.ID)
-	assert.NotContains(t, inFlight, perModel.ID, "the per-model budget cannot be matched without a model")
-
 	// What settlement sees: the model is known, so the per-model budget is reachable.
-	atSettlement, _ := store.CollectModelScopedGovernanceIDs(ctx, "", userID, schemas.ModelProvider(providerName), "gpt-5")
+	atSettlement, _ := store.CollectModelScopedGovernanceIDs(ctx, vkID, "", schemas.ModelProvider(providerName), "gpt-5")
 	assert.Contains(t, atSettlement, perModel.ID)
 	// The wildcard is returned too and overlaps the in-flight set by design; callers
 	// subtract what they already charged rather than relying on it being absent.
 	assert.Contains(t, atSettlement, wildcard.ID)
 
 	// A model with no config of its own still finds the wildcard and nothing else.
-	otherModel, _ := store.CollectModelScopedGovernanceIDs(ctx, "", userID, schemas.ModelProvider(providerName), "gpt-4o")
+	otherModel, _ := store.CollectModelScopedGovernanceIDs(ctx, vkID, "", schemas.ModelProvider(providerName), "gpt-4o")
 	assert.NotContains(t, otherModel, perModel.ID)
 	assert.Contains(t, otherModel, wildcard.ID)
 
-	// Scope isolation: another user's id must not reach these configs.
-	otherUser, _ := store.CollectModelScopedGovernanceIDs(ctx, "", "user-bob", schemas.ModelProvider(providerName), "gpt-5")
-	assert.Empty(t, otherUser)
+	// Scope isolation: another virtual key's id must not reach these configs.
+	otherVK, _ := store.CollectModelScopedGovernanceIDs(ctx, "vk-bob", "", schemas.ModelProvider(providerName), "gpt-5")
+	assert.Empty(t, otherVK)
 }
 
 // What a request is billed to and what is recorded on its log row are the limits settled on its

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -2000,3 +2000,41 @@ func TestGetBudgetAndRateLimitStatusReachesEverySource(t *testing.T) {
 		assert.Equal(t, 90.0, status.BudgetPercentUsed)
 	})
 }
+
+// TestModelConfigScopesForSkipsEmptyKindExtraScopes covers a registered
+// ExtraScopedIDsResolver returning a ScopedID with an empty Kind — a
+// legitimate value for a batch-only caller (see ScopedID's doc comment), but
+// modelConfigScopesFor is the request-time path: propagating it would let a
+// refusal name an empty holder kind.
+func TestModelConfigScopesForSkipsEmptyKindExtraScopes(t *testing.T) {
+	extraScopedIDsResolversMu.Lock()
+	saved := extraScopedIDsResolvers
+	extraScopedIDsResolvers = nil
+	extraScopedIDsResolversMu.Unlock()
+	t.Cleanup(func() {
+		extraScopedIDsResolversMu.Lock()
+		extraScopedIDsResolvers = saved
+		extraScopedIDsResolversMu.Unlock()
+	})
+
+	RegisterExtraScopedIDsResolver(func(_ context.Context, _, _ string) []ScopedID {
+		return []ScopedID{
+			{Scope: "batch_only", ScopeID: "b-1"}, // Kind deliberately empty
+			{Scope: "with_kind", ScopeID: "w-1", Kind: grant.LimitHolderModelConfig},
+		}
+	})
+
+	scopes := modelConfigScopesFor(context.Background(), nil)
+
+	for _, s := range scopes {
+		assert.NotEqual(t, "batch_only", s.name, "an empty-Kind extra scope must not reach request-time enforcement")
+	}
+	found := false
+	for _, s := range scopes {
+		if s.name == "with_kind" {
+			found = true
+			assert.Equal(t, grant.LimitHolderModelConfig, s.kind)
+		}
+	}
+	assert.True(t, found, "an extra scope with a Kind must still pass through")
+}

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -124,6 +124,43 @@ func lookupScopeNameResolver(scope string) (ScopeNameResolver, bool) {
 	return fn, ok
 }
 
+// ManagedByResolver returns a human-readable label for what externally manages
+// a non-global model config's scope target (e.g. the access profile that
+// materialized it), distinct from ScopeNameResolver's "who this applies to"
+// name. The second return value is false when no managing entity applies; the
+// UI then renders nothing extra. Implementations must be safe to call
+// concurrently.
+type ManagedByResolver func(ctx context.Context, scopeID string) (string, bool)
+
+// managedByResolvers is the package-level registry consulted by
+// resolveModelConfigManagedBy. Empty by default in OSS; downstream builds
+// register resolvers at startup via RegisterManagedByResolver. Guarded by
+// managedByResolversMu.
+var (
+	managedByResolversMu sync.RWMutex
+	managedByResolvers   = map[string]ManagedByResolver{}
+)
+
+// RegisterManagedByResolver wires a managed-by resolver for a model_config
+// scope value. Intended to be called once at process startup, before serving
+// requests. Overwrites any previously registered resolver for the same scope.
+// Safe to call concurrently.
+func RegisterManagedByResolver(scope string, fn ManagedByResolver) {
+	if scope == "" || fn == nil {
+		return
+	}
+	managedByResolversMu.Lock()
+	managedByResolvers[scope] = fn
+	managedByResolversMu.Unlock()
+}
+
+func lookupManagedByResolver(scope string) (ManagedByResolver, bool) {
+	managedByResolversMu.RLock()
+	defer managedByResolversMu.RUnlock()
+	fn, ok := managedByResolvers[scope]
+	return fn, ok
+}
+
 // ExternalQuotaBudgetResolver returns budgets that govern a VK but whose usage is
 // tracked OUTSIDE the VK's own budget rows
 type ExternalQuotaBudgetResolver func(ctx context.Context, vk *configstoreTables.TableVirtualKey) (*ExternalQuotaBudgetResult, error)
@@ -3580,6 +3617,7 @@ func (h *GovernanceHandler) getModelConfigs(ctx *fasthttp.RequestCtx) {
 		}
 		page := all[offset:end]
 		h.enrichModelConfigScopeNames(ctx, page)
+		h.enrichModelConfigManagedBy(ctx, page)
 		SendJSON(ctx, map[string]any{
 			"model_configs": page,
 			"count":         len(page),
@@ -3639,6 +3677,7 @@ func (h *GovernanceHandler) getModelConfigs(ctx *fasthttp.RequestCtx) {
 			return
 		}
 		h.enrichModelConfigScopeNames(ctx, modelConfigs)
+		h.enrichModelConfigManagedBy(ctx, modelConfigs)
 		SendJSON(ctx, map[string]any{
 			"model_configs": modelConfigs,
 			"count":         len(modelConfigs),
@@ -3657,6 +3696,7 @@ func (h *GovernanceHandler) getModelConfigs(ctx *fasthttp.RequestCtx) {
 		return
 	}
 	h.enrichModelConfigScopeNames(ctx, modelConfigs)
+	h.enrichModelConfigManagedBy(ctx, modelConfigs)
 	SendJSON(ctx, map[string]any{
 		"model_configs": modelConfigs,
 		"count":         len(modelConfigs),
@@ -3679,6 +3719,7 @@ func (h *GovernanceHandler) getModelConfig(ctx *fasthttp.RequestCtx) {
 		return
 	}
 	h.resolveModelConfigScopeName(ctx, mc, map[string]string{})
+	h.resolveModelConfigManagedBy(ctx, mc, map[string]string{})
 	SendJSON(ctx, map[string]interface{}{
 		"model_config": mc,
 	})
@@ -3707,6 +3748,41 @@ func (h *GovernanceHandler) resolveModelConfigScopeName(ctx context.Context, mc 
 		cache[key] = name
 	}
 	mc.ScopeName = name
+}
+
+// resolveModelConfigManagedBy populates the transient ManagedBy for a single non-global
+// model config by dispatching to the resolver registered for mc.Scope. Unknown scopes
+// (no resolver registered) and resolution failures are non-fatal — ManagedBy stays empty
+// and the UI renders nothing extra. The cache lets callers dedupe lookups across many
+// configs; it is keyed by (scope, scope_id) so distinct scopes never collide. Kept
+// separate from resolveModelConfigScopeName (different registry, different meaning —
+// "who this applies to" vs. "what manages it") so neither can affect the other.
+func (h *GovernanceHandler) resolveModelConfigManagedBy(ctx context.Context, mc *configstoreTables.TableModelConfig, cache map[string]string) {
+	if mc == nil || mc.Scope == "" || mc.ScopeID == nil {
+		return
+	}
+	resolver, ok := lookupManagedByResolver(mc.Scope)
+	if !ok {
+		return
+	}
+	id := *mc.ScopeID
+	key := mc.Scope + "|" + id
+	label, cached := cache[key]
+	if !cached {
+		if resolved, found := resolver(ctx, id); found {
+			label = resolved
+		}
+		cache[key] = label
+	}
+	mc.ManagedBy = label
+}
+
+// enrichModelConfigManagedBy populates ManagedBy for each non-global config in the slice.
+func (h *GovernanceHandler) enrichModelConfigManagedBy(ctx context.Context, configs []configstoreTables.TableModelConfig) {
+	cache := map[string]string{}
+	for i := range configs {
+		h.resolveModelConfigManagedBy(ctx, &configs[i], cache)
+	}
 }
 
 // enrichModelConfigScopeNames populates ScopeName for each non-global config in the slice.
@@ -3860,6 +3936,7 @@ func (h *GovernanceHandler) createModelConfig(ctx *fasthttp.RequestCtx) {
 		preloadedMC = &mc
 	}
 	h.resolveModelConfigScopeName(ctx, preloadedMC, map[string]string{})
+	h.resolveModelConfigManagedBy(ctx, preloadedMC, map[string]string{})
 	SendJSON(ctx, map[string]interface{}{
 		"message":      "Model config created successfully",
 		"model_config": preloadedMC,
@@ -3997,6 +4074,7 @@ func (h *GovernanceHandler) updateModelConfig(ctx *fasthttp.RequestCtx) {
 		}
 	}
 	h.resolveModelConfigScopeName(ctx, updatedMC, map[string]string{})
+	h.resolveModelConfigManagedBy(ctx, updatedMC, map[string]string{})
 	SendJSON(ctx, map[string]interface{}{
 		"message":      "Model config updated successfully",
 		"model_config": updatedMC,

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1388,6 +1388,10 @@ func (m *MockConfigStore) DeleteModelConfigsForScope(ctx context.Context, tx *go
 	return nil
 }
 
+func (m *MockConfigStore) GetModelConfigsForScope(ctx context.Context, tx *gorm.DB, scope, scopeID string) ([]tables.TableModelConfig, error) {
+	return nil, nil
+}
+
 // Budget/Rate limit usage
 func (m *MockConfigStore) UpdateBudgetUsage(ctx context.Context, id string, currentUsage float64, tx ...*gorm.DB) error {
 	return nil

--- a/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
@@ -1,3 +1,4 @@
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Label } from "@/components/ui/label";
@@ -9,7 +10,7 @@ import MultiBudgetLines from "@/components/ui/multibudgets";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { DottedSeparator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
-import { resetDurationOptions } from "@/lib/constants/governance";
+import { resetDurationLabels, resetDurationOptions } from "@/lib/constants/governance";
 import { budgetSignature } from "@/lib/utils/governance";
 import { RenderProviderIcon } from "@/lib/constants/icons";
 import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
@@ -26,8 +27,10 @@ import {
 } from "@/lib/store";
 import { KnownProvider } from "@/lib/types/config";
 import { ModelConfig } from "@/lib/types/governance";
+import { formatCurrency } from "@/lib/utils/governance";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Lock } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -70,6 +73,11 @@ type FormData = z.infer<typeof formSchema>;
 export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: ModelLimitSheetProps) {
 	const [isOpen, setIsOpen] = useState(true);
 	const isEditing = !!modelConfig;
+	// A readOnly-registered scope (e.g. enterprise's access_profile) is
+	// system-generated: no field here is ever user-editable, and it must be
+	// changed by editing its owner instead.
+	const scopeEntry = getModelLimitScope(modelConfig?.scope || "global");
+	const isManagedReadOnly = isEditing && scopeEntry?.readOnly === true;
 
 	const hasCreateAccess = useRbac(RbacResource.Governance, RbacOperation.Create);
 	const hasUpdateAccess = useRbac(RbacResource.Governance, RbacOperation.Update);
@@ -292,6 +300,119 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 		}
 	};
 
+	if (isManagedReadOnly && modelConfig) {
+		const budgets = modelConfig.budgets ?? (modelConfig.budget ? [modelConfig.budget] : []);
+		return (
+			<Sheet open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+				<SheetContent className="flex w-full flex-col overflow-x-hidden pt-4" data-testid="model-limit-sheet">
+					<SheetHeader className="flex flex-col items-start p-0 px-4 py-4 md:px-8" headerClassName="mb-0 sticky -top-4 bg-card z-10">
+						<SheetTitle>View Limit</SheetTitle>
+						<SheetDescription>This limit is managed elsewhere and cannot be edited here.</SheetDescription>
+					</SheetHeader>
+
+					<div className="grow space-y-4 px-4 md:px-8">
+						<Alert variant="info">
+							<Lock className="h-4 w-4" />
+							<AlertDescription>
+								This limit is managed by <span className="font-medium">{scopeEntry?.label}</span>
+								{modelConfig.scope_name ? (
+									<>
+										{" "}
+										(<span className="font-medium">{modelConfig.scope_name}</span>)
+									</>
+								) : null}
+								. It must be changed there — this page is read-only for this limit.
+							</AlertDescription>
+						</Alert>
+
+						<div className="space-y-1">
+							<Label className="text-muted-foreground text-xs font-normal">Provider</Label>
+							<p className="text-sm">
+								{modelConfig.provider ? ProviderLabels[modelConfig.provider as ProviderName] || modelConfig.provider : "All Providers"}
+							</p>
+						</div>
+						<div className="space-y-1">
+							<Label className="text-muted-foreground text-xs font-normal">Model Name</Label>
+							<p className="text-sm">{modelConfig.model_name === "*" ? "All Models" : modelConfig.model_name}</p>
+						</div>
+						<div className="space-y-1">
+							<Label className="text-muted-foreground text-xs font-normal">Scope</Label>
+							<p className="text-sm">{scopeEntry?.label}</p>
+						</div>
+						{modelConfig.scope_name ? (
+							<div className="space-y-1">
+								<Label className="text-muted-foreground text-xs font-normal">Target</Label>
+								<p className="text-sm">{modelConfig.scope_name}</p>
+							</div>
+						) : null}
+
+						<DottedSeparator />
+
+						<div className="space-y-3">
+							<Label className="text-sm font-medium">Budget</Label>
+							{budgets.length > 0 ? (
+								<div className="space-y-2">
+									{budgets.map((b) => (
+										<div key={b.id} className="bg-muted/50 rounded-lg p-3 text-sm">
+											<p className="font-medium">
+												{formatCurrency(b.current_usage)} / {formatCurrency(b.max_limit)}
+											</p>
+											<p className="text-muted-foreground text-xs">Resets {resetDurationLabels[b.reset_duration] || b.reset_duration}</p>
+										</div>
+									))}
+								</div>
+							) : (
+								<p className="text-muted-foreground text-sm">No budget limits configured.</p>
+							)}
+						</div>
+
+						<DottedSeparator />
+
+						<div className="space-y-3">
+							<Label className="text-sm font-medium">Rate Limits</Label>
+							{modelConfig.rate_limit?.token_max_limit || modelConfig.rate_limit?.request_max_limit ? (
+								<div className="bg-muted/50 grid grid-cols-1 gap-4 rounded-lg p-4 md:grid-cols-2">
+									{modelConfig.rate_limit?.token_max_limit ? (
+										<div className="space-y-1">
+											<p className="text-muted-foreground text-xs">Tokens</p>
+											<p className="text-sm font-medium">
+												{modelConfig.rate_limit.token_current_usage.toLocaleString()} /{" "}
+												{modelConfig.rate_limit.token_max_limit.toLocaleString()} (
+												{resetDurationLabels[modelConfig.rate_limit.token_reset_duration || "1h"] || modelConfig.rate_limit.token_reset_duration})
+											</p>
+										</div>
+									) : null}
+									{modelConfig.rate_limit?.request_max_limit ? (
+										<div className="space-y-1">
+											<p className="text-muted-foreground text-xs">Requests</p>
+											<p className="text-sm font-medium">
+												{modelConfig.rate_limit.request_current_usage.toLocaleString()} /{" "}
+												{modelConfig.rate_limit.request_max_limit.toLocaleString()} (
+												{resetDurationLabels[modelConfig.rate_limit.request_reset_duration || "1h"] ||
+													modelConfig.rate_limit.request_reset_duration}
+												)
+											</p>
+										</div>
+									) : null}
+								</div>
+							) : (
+								<p className="text-muted-foreground text-sm">No rate limits configured.</p>
+							)}
+						</div>
+					</div>
+
+					<div className="bg-card sticky bottom-0 shrink-0 border-t px-4 py-4 md:px-8">
+						<div className="flex items-center justify-end">
+							<Button type="button" variant="outline" onClick={handleClose}>
+								Close
+							</Button>
+						</div>
+					</div>
+				</SheetContent>
+			</Sheet>
+		);
+	}
+
 	return (
 		<Sheet open={isOpen} onOpenChange={(open) => !open && handleClose()}>
 			<SheetContent
@@ -414,11 +535,13 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 												</SelectTrigger>
 											</FormControl>
 											<SelectContent>
-												{getModelLimitScopes().map((option) => (
-													<SelectItem key={option.value} value={option.value}>
-														{option.label}
-													</SelectItem>
-												))}
+												{getModelLimitScopes()
+													.filter((option) => !option.readOnly)
+													.map((option) => (
+														<SelectItem key={option.value} value={option.value}>
+															{option.label}
+														</SelectItem>
+													))}
 											</SelectContent>
 										</Select>
 										<FormMessage />

--- a/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
@@ -313,16 +313,7 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 					<div className="grow space-y-4 px-4 md:px-8">
 						<Alert variant="info">
 							<Lock className="h-4 w-4" />
-							<AlertDescription>
-								This limit is managed by <span className="font-medium">{scopeEntry?.label}</span>
-								{modelConfig.scope_name ? (
-									<>
-										{" "}
-										(<span className="font-medium">{modelConfig.scope_name}</span>)
-									</>
-								) : null}
-								. It must be changed there — this page is read-only for this limit.
-							</AlertDescription>
+							<AlertDescription>This limit is read-only here — it's managed elsewhere and must be changed there.</AlertDescription>
 						</Alert>
 
 						<div className="space-y-1">
@@ -337,12 +328,18 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 						</div>
 						<div className="space-y-1">
 							<Label className="text-muted-foreground text-xs font-normal">Scope</Label>
-							<p className="text-sm">{scopeEntry?.label}</p>
+							<p className="text-sm">{scopeEntry?.displayAsScope ?? scopeEntry?.label}</p>
 						</div>
 						{modelConfig.scope_name ? (
 							<div className="space-y-1">
 								<Label className="text-muted-foreground text-xs font-normal">Target</Label>
 								<p className="text-sm">{modelConfig.scope_name}</p>
+							</div>
+						) : null}
+						{scopeEntry?.ManagedByComponent ? (
+							<div className="space-y-1">
+								<Label className="text-muted-foreground text-xs font-normal">Managed By</Label>
+								<scopeEntry.ManagedByComponent modelConfig={modelConfig} />
 							</div>
 						) : null}
 

--- a/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
@@ -533,7 +533,7 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 											</FormControl>
 											<SelectContent>
 												{getModelLimitScopes()
-													.filter((option) => !option.readOnly)
+													.filter((option) => !option.readOnly && option.creatable !== false)
 													.map((option) => (
 														<SelectItem key={option.value} value={option.value}>
 															{option.label}

--- a/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
@@ -367,9 +367,9 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 
 						<div className="space-y-3">
 							<Label className="text-sm font-medium">Rate Limits</Label>
-							{modelConfig.rate_limit?.token_max_limit || modelConfig.rate_limit?.request_max_limit ? (
+							{modelConfig.rate_limit?.token_max_limit != null || modelConfig.rate_limit?.request_max_limit != null ? (
 								<div className="bg-muted/50 grid grid-cols-1 gap-4 rounded-lg p-4 md:grid-cols-2">
-									{modelConfig.rate_limit?.token_max_limit ? (
+									{modelConfig.rate_limit?.token_max_limit != null ? (
 										<div className="space-y-1">
 											<p className="text-muted-foreground text-xs">Tokens</p>
 											<p className="text-sm font-medium">
@@ -379,7 +379,7 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 											</p>
 										</div>
 									) : null}
-									{modelConfig.rate_limit?.request_max_limit ? (
+									{modelConfig.rate_limit?.request_max_limit != null ? (
 										<div className="space-y-1">
 											<p className="text-muted-foreground text-xs">Requests</p>
 											<p className="text-sm font-medium">
@@ -533,7 +533,11 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 											</FormControl>
 											<SelectContent>
 												{getModelLimitScopes()
-													.filter((option) => !option.readOnly && option.creatable !== false)
+													// Always keep the currently selected option in the list, even if it's
+													// readOnly/non-creatable — otherwise editing an existing row whose scope
+													// isn't creatable (e.g. a legacy scope=user row) has no matching
+													// SelectItem for its value, and the trigger can render blank.
+													.filter((option) => option.value === field.value || (!option.readOnly && option.creatable !== false))
 													.map((option) => (
 														<SelectItem key={option.value} value={option.value}>
 															{option.label}

--- a/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
@@ -414,16 +414,25 @@ export default function ModelLimitsTable({
 												)}
 											</TableCell>
 											<TableCell>
-												<Badge variant="secondary">{getScopeLabel(config.scope ?? "global")}</Badge>
+												<Badge variant="secondary">
+													{(() => {
+														const entry = getModelLimitScope(config.scope ?? "global");
+														return entry?.displayAsScope ?? getScopeLabel(config.scope ?? "global");
+													})()}
+												</Badge>
 											</TableCell>
 											<TableCell>
+												<div className="flex flex-col items-start gap-1">
 												{config.scope !== "global" && config.scope_id && config.scope_name ? (
 													<TooltipProvider>
 														<Tooltip>
 															<TooltipTrigger asChild>
 																<Badge
 																	variant="secondary"
-																	className="flex max-w-[160px] cursor-pointer items-center gap-1 hover:opacity-80"
+																	className={cn(
+																		"flex max-w-[160px] items-center gap-1",
+																		getModelLimitScope(config.scope ?? "global")?.buildDeepLink && "cursor-pointer hover:opacity-80",
+																	)}
 																	data-testid={`model-limit-scope-target-${config.scope_id}`}
 																	onClick={() => {
 																		if (!config.scope_id) return;
@@ -432,7 +441,9 @@ export default function ModelLimitsTable({
 																	}}
 																>
 																	<span className="truncate">{config.scope_name}</span>
-																	<ArrowUpRight className="h-3 w-3 shrink-0" />
+																	{getModelLimitScope(config.scope ?? "global")?.buildDeepLink && (
+																		<ArrowUpRight className="h-3 w-3 shrink-0" />
+																	)}
 																</Badge>
 															</TooltipTrigger>
 															<TooltipContent className="max-w-[320px] break-all">{config.scope_name}</TooltipContent>
@@ -441,6 +452,11 @@ export default function ModelLimitsTable({
 												) : (
 													<span className="text-muted-foreground text-sm">-</span>
 												)}
+												{(() => {
+													const ManagedBy = getModelLimitScope(config.scope ?? "global")?.ManagedByComponent;
+													return ManagedBy ? <ManagedBy modelConfig={config} /> : null;
+												})()}
+												</div>
 											</TableCell>
 											<TableCell className="min-w-[180px]">
 												{budgets.length > 0 ? (

--- a/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
@@ -65,6 +65,10 @@ function ModelLimitActionsMenu({
 	onDelete: (configId: string) => void;
 }) {
 	const [isOpen, setIsOpen] = useState(false);
+	// A readOnly-registered scope (e.g. enterprise's access_profile) can only be
+	// changed by editing its owner — no delete here, and "Edit" just opens the
+	// sheet's read-only view instead of a form.
+	const isManaged = getModelLimitScope(config.scope ?? "global")?.readOnly === true;
 
 	return (
 		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
@@ -82,7 +86,7 @@ function ModelLimitActionsMenu({
 			<DropdownMenuContent align="end">
 				<DropdownMenuItem
 					className="cursor-pointer"
-					disabled={!hasUpdateAccess}
+					disabled={!isManaged && !hasUpdateAccess}
 					data-testid={`model-limit-button-edit-${toTestIdPart(config.model_name)}-${toTestIdPart(config.provider || "all")}`}
 					onSelect={(e) => {
 						e.preventDefault();
@@ -91,12 +95,12 @@ function ModelLimitActionsMenu({
 					}}
 				>
 					<Edit className="h-4 w-4" />
-					Edit
+					{isManaged ? "View" : "Edit"}
 				</DropdownMenuItem>
 				<DropdownMenuItem
 					variant="destructive"
 					className="cursor-pointer"
-					disabled={!hasDeleteAccess}
+					disabled={isManaged || !hasDeleteAccess}
 					data-testid={`model-limit-button-delete-${toTestIdPart(config.model_name)}-${toTestIdPart(config.provider || "all")}`}
 					onSelect={(e) => {
 						e.preventDefault();

--- a/ui/lib/registries/modelLimitScopes.tsx
+++ b/ui/lib/registries/modelLimitScopes.tsx
@@ -39,6 +39,12 @@ export interface ModelLimitScopeEntry {
 	PickerComponent?: ComponentType<ScopePickerProps>;
 	// Optional. Scopes without a navigable target omit this.
 	buildDeepLink?: (scopeId: string) => ScopeDeepLink;
+	// When true, this scope is system-generated only: never offered as a choice
+	// when creating a limit, and the Model Limit sheet renders it as a pure
+	// read-only summary (no editable fields, no save, no delete) instead of the
+	// normal form — e.g. enterprise's "access_profile" scope, whose rows must
+	// only be changed by editing the owning access profile.
+	readOnly?: boolean;
 }
 
 const registry = new Map<string, ModelLimitScopeEntry>();

--- a/ui/lib/registries/modelLimitScopes.tsx
+++ b/ui/lib/registries/modelLimitScopes.tsx
@@ -15,6 +15,7 @@
 
 import type { ComponentType } from "react";
 import { VirtualKeySelector } from "@/components/entitySelectors/virtualKeySelector";
+import type { ModelConfig } from "@/lib/types/governance";
 
 export interface ScopePickerProps {
 	value: string;
@@ -45,6 +46,17 @@ export interface ModelLimitScopeEntry {
 	// normal form — e.g. enterprise's "access_profile" scope, whose rows must
 	// only be changed by editing the owning access profile.
 	readOnly?: boolean;
+	// Optional. Overrides the label shown in the Scope column/field for rows of
+	// this scope, while `label` above still names the scope itself (e.g. in the
+	// filter dropdown). Lets a scope whose rows apply to a user — but aren't the
+	// literal "user" scope value — still read as "User" wherever a single row is
+	// displayed, without colliding with "user" as a distinct filterable option.
+	displayAsScope?: string;
+	// Optional. Renders additional context next to the Scope Target for a row of
+	// this scope — e.g. enterprise's "Managed by Access Profile: X" note. Passed
+	// the row's own ModelConfig; renders nothing (returns null) itself when there
+	// is nothing to show.
+	ManagedByComponent?: ComponentType<{ modelConfig: ModelConfig }>;
 }
 
 const registry = new Map<string, ModelLimitScopeEntry>();

--- a/ui/lib/registries/modelLimitScopes.tsx
+++ b/ui/lib/registries/modelLimitScopes.tsx
@@ -46,6 +46,13 @@ export interface ModelLimitScopeEntry {
 	// normal form — e.g. enterprise's "access_profile" scope, whose rows must
 	// only be changed by editing the owning access profile.
 	readOnly?: boolean;
+	// When explicitly false, this scope is never offered as a choice when
+	// creating a limit, but an EXISTING row of it stays fully editable and
+	// deletable through the normal form — unlike readOnly, which also locks
+	// editing. Defaults to true (creatable) when omitted. For a scope whose
+	// creation is retired but whose pre-existing rows must keep working exactly
+	// as before — e.g. enterprise's "user" scope.
+	creatable?: boolean;
 	// Optional. Overrides the label shown in the Scope column/field for rows of
 	// this scope, while `label` above still names the scope itself (e.g. in the
 	// filter dropdown). Lets a scope whose rows apply to a user — but aren't the

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -421,6 +421,7 @@ export interface ModelConfig {
 	scope?: string; // "global" (default) or "virtual_key"
 	scope_id?: string; // Target of a non-global scope (e.g. the virtual key ID)
 	scope_name?: string; // Resolved, human-readable name of the scope target (read-only)
+	managed_by?: string; // Resolved label for what externally manages this config, e.g. an access profile name (read-only)
 	calendar_aligned?: boolean; // Snap budget resets to calendar boundaries (inherited from VK for vk scope)
 	rate_limit_id?: string;
 	// Populated relationships


### PR DESCRIPTION
## Summary

Replaces the hardcoded `user` scope in model-config governance with an open extension point (`RegisterExtraScopedIDsResolver`) that downstream consumers (e.g. enterprise access profiles) use to inject their own `(scope, scope_id, kind)` triples at request time. This decouples the OSS governance plugin from enterprise-specific scope semantics while preserving correct per-model budget collection and settlement behaviour.

## Changes

- **`RegisterExtraScopedIDsResolver` / `ExtraScopedIDsResolver`**: New public API in `plugins/governance/store.go` that lets callers register in-memory resolvers returning additional `ScopedID` pairs. Both `CollectModelScopedGovernanceIDs` and `modelConfigScopesFor` now call these resolvers instead of hard-coding the `user` scope lookup.

- **`ScopedID` type**: Carries `Scope`, `ScopeID`, and `Kind` so each extra scope can attribute its limits to the correct `LimitHolderKind` in refusals.

- **`LimitHolderKind` renames**: `LimitHolderAccessProfile` → `LimitHolderUserAccessProfile`, `LimitHolderAccessProfileProviderConfig` → `LimitHolderUserAccessProfileProviderConfig`, and a new `LimitHolderUserAccessProfileModelConfig` added. `LimitHolderUserModelConfig` is now reserved strictly for limits assigned directly to a user, not derived from a profile.

- **`ModelConfigScopeUser` constant removed** from the OSS tables package; the comment referencing it updated to `access_profile`.

- **`GetModelConfigsForScope`**: New method on `RDBConfigStore` (and `ConfigStore` interface) that loads all model configs for a scope owner within a caller-supplied transaction, so mid-transaction reads see uncommitted writes from the same tx.

- **`scopedModelConfigKind` default branch**: Now returns `LimitHolderUserAccessProfileModelConfig` instead of `LimitHolderUserModelConfig` for unrecognised permit types.

- **`untrackedHolderKinds` comment**: Clarified that access-profile-derived limits are intentionally excluded — they are scoped limits like a virtual key's and respect skip-counting requests, whereas `LimitHolderUserModelConfig` is always the user's own money.

- **UI — `ModelLimitScopeEntry`**: Added `readOnly`, `creatable`, `displayAsScope`, and `ManagedByComponent` fields to the scope registry entry type, enabling downstream scopes to render as a read-only summary sheet, suppress themselves from the create dropdown, override their displayed scope label, and inject a "Managed by …" component into the table row.

- **UI — `modelLimitSheet.tsx`**: When the active scope entry has `readOnly: true`, the sheet renders a non-editable summary view (provider, model, scope, budgets, rate limits, optional `ManagedByComponent`) with a Close button instead of the edit form.

- **UI — `modelLimitsTable.tsx`**: The actions menu shows "View" instead of "Edit" and disables Delete for read-only scopes. The Scope column uses `displayAsScope` when present. The deep-link arrow and cursor style are suppressed when `buildDeepLink` is absent. `ManagedByComponent` is rendered inline below the scope-target badge.

- **Tests**: `accounting_test.go` and `store_test.go` migrated from `user`-scoped fixtures to `virtual_key`-scoped ones to reflect the removal of the hardcoded user scope. `limit_test.go` updated for the renamed kinds. `config_test.go` mock updated for the new interface method.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... ./framework/grant/... ./plugins/governance/... ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm build
```

Verify that:
1. A downstream consumer can call `RegisterExtraScopedIDsResolver` at startup and have its returned `ScopedID` pairs picked up by both `CollectModelScopedGovernanceIDs` and `modelConfigScopesFor`.
2. Model configs stored under a custom scope are matched at settlement time for the correct model/provider.
3. In the UI, a model limit row whose scope entry has `readOnly: true` shows "View" in the actions menu, opens a read-only sheet, and has Delete disabled.
4. Scopes with `readOnly: true` or `creatable: false` do not appear in the create-limit scope dropdown.

## Breaking changes

- [x] Yes
- [ ] No

`LimitHolderAccessProfile` and `LimitHolderAccessProfileProviderConfig` are renamed to `LimitHolderUserAccessProfile` and `LimitHolderUserAccessProfileProviderConfig`. Any downstream code referencing the old names must be updated. `ModelConfigScopeUser` is removed from the OSS tables package; callers that registered it must register their scope via `RegisterExtraScopedIDsResolver` instead.

## Related issues

## Security considerations

The extra-scope resolvers are registered at startup and called on every request. They must be in-memory and non-blocking; no new auth surface is introduced. Scope isolation is preserved — each resolver's output is keyed by the caller-supplied virtual key and user IDs, and the existing per-scope DB queries enforce row-level isolation.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable