### PR TITLE
feat: add `displayAsScope` and `ManagedByComponent` to model limit scope registry with read-only sheet and table support

### DIFF
--- a/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
@@ -313,16 +313,7 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 					<div className="grow space-y-4 px-4 md:px-8">
 						<Alert variant="info">
 							<Lock className="h-4 w-4" />
-							<AlertDescription>
-								This limit is managed by <span className="font-medium">{scopeEntry?.label}</span>
-								{modelConfig.scope_name ? (
-									<>
-										{" "}
-										(<span className="font-medium">{modelConfig.scope_name}</span>)
-									</>
-								) : null}
-								. It must be changed there — this page is read-only for this limit.
-							</AlertDescription>
+							<AlertDescription>This limit is read-only here — it's managed elsewhere and must be changed there.</AlertDescription>
 						</Alert>
 
 						<div className="space-y-1">
@@ -337,12 +328,18 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 						</div>
 						<div className="space-y-1">
 							<Label className="text-muted-foreground text-xs font-normal">Scope</Label>
-							<p className="text-sm">{scopeEntry?.label}</p>
+							<p className="text-sm">{scopeEntry?.displayAsScope ?? scopeEntry?.label}</p>
 						</div>
 						{modelConfig.scope_name ? (
 							<div className="space-y-1">
 								<Label className="text-muted-foreground text-xs font-normal">Target</Label>
 								<p className="text-sm">{modelConfig.scope_name}</p>
+							</div>
+						) : null}
+						{scopeEntry?.ManagedByComponent ? (
+							<div className="space-y-1">
+								<Label className="text-muted-foreground text-xs font-normal">Managed By</Label>
+								<scopeEntry.ManagedByComponent modelConfig={modelConfig} />
 							</div>
 						) : null}
 

--- a/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
@@ -414,16 +414,25 @@ export default function ModelLimitsTable({
 												)}
 											</TableCell>
 											<TableCell>
-												<Badge variant="secondary">{getScopeLabel(config.scope ?? "global")}</Badge>
+												<Badge variant="secondary">
+													{(() => {
+														const entry = getModelLimitScope(config.scope ?? "global");
+														return entry?.displayAsScope ?? getScopeLabel(config.scope ?? "global");
+													})()}
+												</Badge>
 											</TableCell>
 											<TableCell>
+												<div className="flex flex-col items-start gap-1">
 												{config.scope !== "global" && config.scope_id && config.scope_name ? (
 													<TooltipProvider>
 														<Tooltip>
 															<TooltipTrigger asChild>
 																<Badge
 																	variant="secondary"
-																	className="flex max-w-[160px] cursor-pointer items-center gap-1 hover:opacity-80"
+																	className={cn(
+																		"flex max-w-[160px] items-center gap-1",
+																		getModelLimitScope(config.scope ?? "global")?.buildDeepLink && "cursor-pointer hover:opacity-80",
+																	)}
 																	data-testid={`model-limit-scope-target-${config.scope_id}`}
 																	onClick={() => {
 																		if (!config.scope_id) return;
@@ -432,7 +441,9 @@ export default function ModelLimitsTable({
 																	}}
 																>
 																	<span className="truncate">{config.scope_name}</span>
-																	<ArrowUpRight className="h-3 w-3 shrink-0" />
+																	{getModelLimitScope(config.scope ?? "global")?.buildDeepLink && (
+																		<ArrowUpRight className="h-3 w-3 shrink-0" />
+																	)}
 																</Badge>
 															</TooltipTrigger>
 															<TooltipContent className="max-w-[320px] break-all">{config.scope_name}</TooltipContent>
@@ -441,6 +452,11 @@ export default function ModelLimitsTable({
 												) : (
 													<span className="text-muted-foreground text-sm">-</span>
 												)}
+												{(() => {
+													const ManagedBy = getModelLimitScope(config.scope ?? "global")?.ManagedByComponent;
+													return ManagedBy ? <ManagedBy modelConfig={config} /> : null;
+												})()}
+												</div>
 											</TableCell>
 											<TableCell className="min-w-[180px]">
 												{budgets.length > 0 ? (

--- a/ui/lib/registries/modelLimitScopes.tsx
+++ b/ui/lib/registries/modelLimitScopes.tsx
@@ -15,6 +15,7 @@
 
 import type { ComponentType } from "react";
 import { VirtualKeySelector } from "@/components/entitySelectors/virtualKeySelector";
+import type { ModelConfig } from "@/lib/types/governance";
 
 export interface ScopePickerProps {
 	value: string;
@@ -45,6 +46,17 @@ export interface ModelLimitScopeEntry {
 	// normal form — e.g. enterprise's "access_profile" scope, whose rows must
 	// only be changed by editing the owning access profile.
 	readOnly?: boolean;
+	// Optional. Overrides the label shown in the Scope column/field for rows of
+	// this scope, while `label` above still names the scope itself (e.g. in the
+	// filter dropdown). Lets a scope whose rows apply to a user — but aren't the
+	// literal "user" scope value — still read as "User" wherever a single row is
+	// displayed, without colliding with "user" as a distinct filterable option.
+	displayAsScope?: string;
+	// Optional. Renders additional context next to the Scope Target for a row of
+	// this scope — e.g. enterprise's "Managed by Access Profile: X" note. Passed
+	// the row's own ModelConfig; renders nothing (returns null) itself when there
+	// is nothing to show.
+	ManagedByComponent?: ComponentType<{ modelConfig: ModelConfig }>;
 }
 
 const registry = new Map<string, ModelLimitScopeEntry>();


### PR DESCRIPTION
## Summary

Briefly explain the purpose of this PR and the problem it solves.

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


