### PR TITLE
feat(governance): retire the built-in "user" model-config scope

### DIFF
--- a/framework/configstore/tables/modelconfig.go
+++ b/framework/configstore/tables/modelconfig.go
@@ -13,7 +13,6 @@ import (
 const (
 	ModelConfigScopeGlobal     = "global"
 	ModelConfigScopeVirtualKey = "virtual_key"
-	ModelConfigScopeUser       = "user"
 )
 
 // ModelConfigAllModels is the model_name sentinel meaning "all models". Combined with a
@@ -23,7 +22,7 @@ const ModelConfigAllModels = "*"
 
 // validModelConfigScopes is the runtime registry of accepted scope values.
 // OSS seeds it with global + virtual_key; downstream consumers (e.g. the
-// enterprise build registering "user") extend it at startup via
+// enterprise build registering "access_profile") extend it at startup via
 // RegisterModelConfigScope. Guarded by validModelConfigScopesMu.
 var (
 	validModelConfigScopesMu sync.RWMutex

--- a/plugins/governance/accounting_test.go
+++ b/plugins/governance/accounting_test.go
@@ -214,9 +214,9 @@ func TestAccounting_ZeroCostFailureNotBilled(t *testing.T) {
 	assert.Equal(t, int64(0), f.tokens(), "no-usage failure counts no tokens")
 }
 
-// modelScopedFixture wires a user-scoped per-model budget (how an access profile's
-// model-level limits are stored) alongside a user-scoped all-models wildcard, so a
-// settlement can be checked for charging the first and not double-charging the second.
+// modelScopedFixture wires a virtual-key-scoped per-model budget alongside a
+// virtual-key-scoped all-models wildcard, so a settlement can be checked for
+// charging the first and not double-charging the second.
 type modelScopedFixture struct {
 	store   GovernanceStore
 	tracker *UsageTracker
@@ -226,18 +226,18 @@ func newModelScopedFixture(t *testing.T) *modelScopedFixture {
 	t.Helper()
 	logger := NewMockLogger()
 	providerName := "openai"
-	userID := "user-alice"
+	vkID := "vk-alice"
 
 	perModel := buildBudgetWithUsage("model-budget", 1_000_000.0, 0.0, "1d")
 	perModelRL := buildRateLimit("model-rl", 1_000_000_000, 1_000_000)
-	perModelMC := buildModelConfig("mc-user-gpt5", "gpt-5", &providerName, perModel, perModelRL)
-	perModelMC.Scope = configstoreTables.ModelConfigScopeUser
-	perModelMC.ScopeID = &userID
+	perModelMC := buildModelConfig("mc-vk-gpt5", "gpt-5", &providerName, perModel, perModelRL)
+	perModelMC.Scope = configstoreTables.ModelConfigScopeVirtualKey
+	perModelMC.ScopeID = &vkID
 
 	wildcard := buildBudgetWithUsage("wildcard-budget", 1_000_000.0, 0.0, "1d")
-	wildcardMC := buildModelConfig("mc-user-all", configstoreTables.ModelConfigAllModels, &providerName, wildcard, nil)
-	wildcardMC.Scope = configstoreTables.ModelConfigScopeUser
-	wildcardMC.ScopeID = &userID
+	wildcardMC := buildModelConfig("mc-vk-all", configstoreTables.ModelConfigAllModels, &providerName, wildcard, nil)
+	wildcardMC.Scope = configstoreTables.ModelConfigScopeVirtualKey
+	wildcardMC.ScopeID = &vkID
 
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*perModelMC, *wildcardMC},
@@ -264,12 +264,12 @@ func TestReportBatchUsage_ChargesPerModelBudgets(t *testing.T) {
 	// What a settled batch looks like: the wildcard budget was collected at create
 	// time (and so is already charged the full total), the per-model budget was not.
 	report := batchaccounting.BatchUsageReport{
-		RequestID:  "batch-cost:openai:batch-models",
-		Provider:   schemas.OpenAI,
-		Cost:       30.0,
-		TokensUsed: 300,
-		BudgetIDs:  []string{"wildcard-budget"},
-		UserID:     "user-alice",
+		RequestID:    "batch-cost:openai:batch-models",
+		Provider:     schemas.OpenAI,
+		Cost:         30.0,
+		TokensUsed:   300,
+		BudgetIDs:    []string{"wildcard-budget"},
+		VirtualKeyID: "vk-alice",
 		ModelUsage: []batchaccounting.BatchModelUsage{
 			{Model: "gpt-5", Cost: 20.0, TokensUsed: 200},
 			{Model: "gpt-4o", Cost: 10.0, TokensUsed: 100},
@@ -290,13 +290,13 @@ func TestReportBatchUsage_PerModelChargingIsInertWithoutModelConfigs(t *testing.
 	plugin := &GovernancePlugin{store: f.store, tracker: f.tracker}
 
 	require.NoError(t, plugin.ReportBatchUsage(context.Background(), batchaccounting.BatchUsageReport{
-		RequestID:  "batch-cost:openai:batch-nomodels",
-		Provider:   schemas.OpenAI,
-		Cost:       12.0,
-		TokensUsed: 100,
-		BudgetIDs:  []string{"wildcard-budget"},
-		UserID:     "user-alice",
-		ModelUsage: []batchaccounting.BatchModelUsage{{Model: "gpt-4o", Cost: 12.0, TokensUsed: 100}},
+		RequestID:    "batch-cost:openai:batch-nomodels",
+		Provider:     schemas.OpenAI,
+		Cost:         12.0,
+		TokensUsed:   100,
+		BudgetIDs:    []string{"wildcard-budget"},
+		VirtualKeyID: "vk-alice",
+		ModelUsage:   []batchaccounting.BatchModelUsage{{Model: "gpt-4o", Cost: 12.0, TokensUsed: 100}},
 	}))
 
 	assert.Equal(t, 0.0, f.budgetUsage("model-budget"), "a model with no config of its own charges nothing extra")

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -1556,10 +1556,10 @@ func (p *GovernancePlugin) ReportBatchUsage(ctx context.Context, usage batchacco
 // They are missing from usage.BudgetIDs by construction: those ids were collected
 // while the request was in flight, and a batch create carries no top-level model
 // (each input-file row names its own), so only the all-models wildcards matched.
-// An access profile's per-model limits materialise as user-scoped configs naming
-// exactly one model and provider, which is why a model-level budget never moved for
-// a batch. Settlement does know the models, so each one is resolved and charged with
-// its own share here.
+// A downstream consumer's per-model limits (e.g. an access profile's, registered via
+// RegisterExtraScopedIDsResolver) materialise as configs naming exactly one model and
+// provider, which is why a model-level budget never moved for a batch. Settlement does
+// know the models, so each one is resolved and charged with its own share here.
 //
 // Ids already charged above are subtracted rather than skipped by construction: the
 // wildcard tiers legitimately match both collections, and charging them twice would

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -3213,7 +3213,6 @@ func (gs *LocalGovernanceStore) CollectModelScopedGovernanceIDs(ctx context.Cont
 
 	scopes := []struct{ name, id string }{
 		{configstoreTables.ModelConfigScopeGlobal, ""},
-		{configstoreTables.ModelConfigScopeUser, userID},
 		{configstoreTables.ModelConfigScopeVirtualKey, virtualKeyID},
 	}
 	for _, scope := range scopes {
@@ -4427,20 +4426,10 @@ func modelConfigScopesFor(ctx context.Context, permit schemas.Permit) []limitSco
 		kind: grant.LimitHolderModelConfig,
 	}}
 	// The user the request was made as, when there is one. A user is not the permit holder, since a
-	// request can be made as a user through a key, so it is a scope of its own rather than one
-	// derived from the permit.
+	// request can be made as a user through a key, so downstream-registered scopes keyed off it
+	// (e.g. enterprise's per-access-profile per-model budgets — see RegisterExtraScopedIDsResolver)
+	// are scopes of their own rather than derived from the permit.
 	userID, _ := ctx.Value(schemas.BifrostContextKeyUserID).(string)
-	if userID != "" {
-		scopes = append(scopes, limitScope{
-			name: configstoreTables.ModelConfigScopeUser,
-			id:   userID,
-			kind: grant.LimitHolderUserModelConfig,
-		})
-	}
-	// Downstream-registered scopes that also apply to the user the request was made
-	// as (e.g. enterprise's per-access-profile per-model budgets) — see
-	// RegisterExtraScopedIDsResolver. Attributed the same as the user's own scope:
-	// from the requester's perspective both are "your model limit".
 	vkID := ""
 	if permit != nil && permit.Type() == string(grant.PermitVirtualKey) {
 		vkID = permit.ID()

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -1620,26 +1620,26 @@ func ptrInt64(i int64) *int64 {
 	return &i
 }
 
-// An access profile's per-model budgets materialise as user-scoped model configs
-// naming one model and provider. A batch create carries no top-level model, so the
-// in-flight collection matches only the wildcard tiers and those per-model budgets
-// are invisible to it — which is why batch spend never reached them. Settlement
-// knows the models and asks for them by name.
+// A downstream consumer's (e.g. an access profile's) per-model budgets materialise
+// as virtual-key-scoped model configs naming one model and provider. A batch create
+// carries no top-level model, so the in-flight collection matches only the wildcard
+// tiers and those per-model budgets are invisible to it — which is why batch spend
+// never reached them. Settlement knows the models and asks for them by name.
 func TestCollectModelScopedGovernanceIDs_FindsExactModelConfigMissedAtCreateTime(t *testing.T) {
 	logger := NewMockLogger()
 	ctx := context.Background()
 	providerName := "openai"
-	userID := "user-alice"
+	vkID := "vk-alice"
 
 	perModel := buildBudgetWithUsage("ap-model-budget", 100.0, 0.0, "1M")
-	perModelMC := buildModelConfig("mc-user-gpt5", "gpt-5", &providerName, perModel, nil)
-	perModelMC.Scope = configstoreTables.ModelConfigScopeUser
-	perModelMC.ScopeID = &userID
+	perModelMC := buildModelConfig("mc-vk-gpt5", "gpt-5", &providerName, perModel, nil)
+	perModelMC.Scope = configstoreTables.ModelConfigScopeVirtualKey
+	perModelMC.ScopeID = &vkID
 
 	wildcard := buildBudgetWithUsage("ap-wildcard-budget", 100.0, 0.0, "1M")
-	wildcardMC := buildModelConfig("mc-user-all", configstoreTables.ModelConfigAllModels, &providerName, wildcard, nil)
-	wildcardMC.Scope = configstoreTables.ModelConfigScopeUser
-	wildcardMC.ScopeID = &userID
+	wildcardMC := buildModelConfig("mc-vk-all", configstoreTables.ModelConfigAllModels, &providerName, wildcard, nil)
+	wildcardMC.Scope = configstoreTables.ModelConfigScopeVirtualKey
+	wildcardMC.ScopeID = &vkID
 
 	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*perModelMC, *wildcardMC},
@@ -1647,31 +1647,21 @@ func TestCollectModelScopedGovernanceIDs_FindsExactModelConfigMissedAtCreateTime
 	}, nil, nil)
 	require.NoError(t, err)
 
-	// What batch create settles onto the request: no model, so only the wildcard is gathered. The
-	// user is a scope of its own, read off the request rather than off a permit, so no access is
-	// needed to reach it.
-	inFlightCtx := grantedCtx(ctx)
-	inFlightCtx.SetValue(schemas.BifrostContextKeyUserID, userID)
-	inFlightBudgets, _ := gatherLimits(inFlightCtx, store, nil, schemas.ModelProvider(providerName), "")
-	inFlight := limitIDsOf(inFlightBudgets)
-	assert.Contains(t, inFlight, wildcard.ID)
-	assert.NotContains(t, inFlight, perModel.ID, "the per-model budget cannot be matched without a model")
-
 	// What settlement sees: the model is known, so the per-model budget is reachable.
-	atSettlement, _ := store.CollectModelScopedGovernanceIDs(ctx, "", userID, schemas.ModelProvider(providerName), "gpt-5")
+	atSettlement, _ := store.CollectModelScopedGovernanceIDs(ctx, vkID, "", schemas.ModelProvider(providerName), "gpt-5")
 	assert.Contains(t, atSettlement, perModel.ID)
 	// The wildcard is returned too and overlaps the in-flight set by design; callers
 	// subtract what they already charged rather than relying on it being absent.
 	assert.Contains(t, atSettlement, wildcard.ID)
 
 	// A model with no config of its own still finds the wildcard and nothing else.
-	otherModel, _ := store.CollectModelScopedGovernanceIDs(ctx, "", userID, schemas.ModelProvider(providerName), "gpt-4o")
+	otherModel, _ := store.CollectModelScopedGovernanceIDs(ctx, vkID, "", schemas.ModelProvider(providerName), "gpt-4o")
 	assert.NotContains(t, otherModel, perModel.ID)
 	assert.Contains(t, otherModel, wildcard.ID)
 
-	// Scope isolation: another user's id must not reach these configs.
-	otherUser, _ := store.CollectModelScopedGovernanceIDs(ctx, "", "user-bob", schemas.ModelProvider(providerName), "gpt-5")
-	assert.Empty(t, otherUser)
+	// Scope isolation: another virtual key's id must not reach these configs.
+	otherVK, _ := store.CollectModelScopedGovernanceIDs(ctx, "vk-bob", "", schemas.ModelProvider(providerName), "gpt-5")
+	assert.Empty(t, otherVK)
 }
 
 // What a request is billed to and what is recorded on its log row are the limits settled on its


### PR DESCRIPTION
## Summary

Briefly explain the purpose of this PR and the problem it solves.

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


